### PR TITLE
fix(deploy): block Worker-name collisions at first deploy (#740)

### DIFF
--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -9,9 +9,9 @@ import AnglesiteCore
 ///   - `.succeeded` → deployed URL with Copy / Open buttons + log
 ///   - `.failed`   → reason banner + log + Copy-log
 ///
-/// The `.blocked` phase is rendered by `BlockedDeploySheetView` (modal), not here — by the time
-/// this drawer is on screen, the deploy has either reached wrangler or failed in a way the user
-/// might want to read about.
+/// The `.blocked` and `.workerNameConflict` phases are each rendered by their own modal sheet,
+/// not here — by the time this drawer is on screen, the deploy has either reached wrangler or
+/// failed in a way the user might want to read about.
 struct DeployDrawerView: View {
     @Bindable var model: DeployModel
     let siteName: String
@@ -82,7 +82,7 @@ struct DeployDrawerView: View {
             Image(systemName: "exclamationmark.octagon.fill")
                 .foregroundStyle(.red).font(.title3)
                 .accessibilityHidden(true)
-        case .idle, .blocked:
+        case .idle, .blocked, .workerNameConflict:
             Image(systemName: "shippingbox").font(.title3)
                 .accessibilityHidden(true)
         }
@@ -93,7 +93,7 @@ struct DeployDrawerView: View {
         case .running: return "Deploying \(siteName)…"
         case .succeeded(let url, _): return url.absoluteString
         case .failed: return "Deploy failed"
-        case .idle, .blocked: return siteName
+        case .idle, .blocked, .workerNameConflict: return siteName
         }
     }
 
@@ -212,14 +212,15 @@ struct DeployDrawerView: View {
     }
 
     /// Collapses the app-target `DeployModel.Phase` onto the announceable substrate the decider
-    /// understands. `idle` and `blocked` are both pre-output states → `.inactive`.
+    /// understands. `idle`, `blocked`, and `workerNameConflict` are all pre-output states →
+    /// `.inactive`.
     private func activity(for phase: DeployModel.Phase) -> LiveRegionAnnouncer.DeployActivity {
         switch phase {
         case .running: return .running(site: siteName)
         case .succeeded(let url, _): return .succeeded(url: url.absoluteString)
         case .failed(let reason, let exit):
             return .failed(reason: exit.map { "\(reason) (exit \($0))" } ?? reason)
-        case .idle, .blocked: return .inactive
+        case .idle, .blocked, .workerNameConflict: return .inactive
         }
     }
 

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -278,6 +278,16 @@ final class DeployModel {
         }
         do {
             try WorkerNameRename.apply(newName: newName, siteDirectory: pending.siteDirectory)
+        } catch let error as WorkerNameRename.RenameError {
+            switch error {
+            case .invalidName:
+                workerNameConflictError = "Worker names can only contain letters, numbers, hyphens, and underscores."
+            case .wranglerConfigMissing:
+                workerNameConflictError = "Couldn't find this site's wrangler.toml — try deploying again."
+            case .nameLineNotFound:
+                workerNameConflictError = "This site's wrangler.toml is missing its Worker name — try deploying again."
+            }
+            return
         } catch {
             workerNameConflictError = "Couldn't rename the Worker: \(error)"
             return

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -17,6 +17,7 @@ final class DeployModel {
         case succeeded(url: URL, duration: TimeInterval)
         case failed(reason: String, exitCode: Int32?)
         case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning])
+        case workerNameConflict(name: String)
     }
 
     private(set) var phase: Phase = .idle
@@ -39,6 +40,13 @@ final class DeployModel {
     /// flow. Set when `deploy(...)` is invoked without a token in either the env or the
     /// Keychain; cleared when the user saves a token (which then retries the deploy) or cancels.
     var tokenPromptPresented: Bool = false
+    /// Bound to a `.sheet` in `SiteWindow` for the `.workerNameConflict` outcome — the Worker
+    /// name is already taken on the connected Cloudflare account and this is the site's first
+    /// deploy. Reuses `pendingDeploy` (below) to park and retry, same as the token-prompt flow.
+    var workerNameConflictPresented: Bool = false
+    /// Set when a rename attempt itself fails (invalid name, or no parked deploy). Cleared on
+    /// every fresh presentation and on a successful rename-and-retry.
+    private(set) var workerNameConflictError: String?
 
     /// Progress of verifying a pasted token, consumed by `CloudflareTokenPromptView`'s status line
     /// and button-enabled logic. A token is only written to the Keychain once verification reaches
@@ -83,9 +91,10 @@ final class DeployModel {
     private var inFlight: Task<Void, Never>?
     private let suddenTerminationController: SuddenTerminationController
     private let tokenAvailabilityOverride: (() -> Bool)?
-    /// Site to retry once the user pastes a token. `nil` outside the prompt flow.
-    /// Carries the container control (if any) so the parked-then-retried deploy
-    /// uses the same executor as the original dispatch.
+    /// Site to retry once the user takes the action a parked deploy is waiting on — either
+    /// pasting a Cloudflare token (`verifyAndSaveToken`) or renaming a taken Worker name
+    /// (`renameWorkerAndRetry`). `nil` outside both prompt flows. Carries the container control
+    /// (if any) so the parked-then-retried deploy uses the same executor as the original dispatch.
     private var pendingDeploy: (
         siteID: String,
         siteDirectory: URL,
@@ -202,6 +211,8 @@ final class DeployModel {
             return .succeeded(url: url)
         case .blocked(let failures, _):
             return .blocked(failureCount: failures.count)
+        case .workerNameConflict(let name):
+            return .failed(reason: "Worker name \"\(name)\" is already in use on your Cloudflare account — rename it in the app and deploy again.")
         case .failed(let reason, _):
             return .failed(reason: reason)
         }
@@ -408,6 +419,12 @@ final class DeployModel {
             // streaming-log drawer would just be noise.
             drawerPresented = false
             blockedPresented = presentation == .foreground
+        case .workerNameConflict(let name):
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl)
+            transition(siteID: siteID, to: .workerNameConflict(name: name))
+            drawerPresented = false
+            workerNameConflictError = nil
+            workerNameConflictPresented = presentation == .foreground
         }
         return result
     }

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -267,6 +267,36 @@ final class DeployModel {
         tokenVerification = .idle
     }
 
+    /// Called by the worker-name-conflict sheet's "Rename & retry" button. Applies the rename to
+    /// `wrangler.toml`/`.site-config` via `WorkerNameRename.apply`, then retries the parked
+    /// deploy — which re-runs the collision check against the new name and loops back to this
+    /// same sheet if it's also taken.
+    func renameWorkerAndRetry(_ newName: String) async {
+        guard let pending = pendingDeploy else {
+            workerNameConflictError = "No deploy is waiting — close this and click Deploy again."
+            return
+        }
+        do {
+            try WorkerNameRename.apply(newName: newName, siteDirectory: pending.siteDirectory)
+        } catch {
+            workerNameConflictError = "Couldn't rename the Worker: \(error)"
+            return
+        }
+        pendingDeploy = nil
+        workerNameConflictPresented = false
+        workerNameConflictError = nil
+        deploy(
+            siteID: pending.siteID, siteDirectory: pending.siteDirectory,
+            configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
+            containerControl: pending.containerControl)
+    }
+
+    func cancelWorkerNameConflictPrompt() {
+        pendingDeploy = nil
+        workerNameConflictPresented = false
+        workerNameConflictError = nil
+    }
+
     func dismissDrawer() {
         drawerPresented = false
     }

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -293,8 +293,13 @@ final class DeployModel {
             return
         }
         pendingDeploy = nil
-        workerNameConflictPresented = false
         workerNameConflictError = nil
+        // Deliberately NOT clearing `workerNameConflictPresented` here — the sheet stays open
+        // (showing its current content) while the retried deploy runs. `runDeploy`'s `.succeeded`/
+        // `.failed`/`.blocked` cases dismiss it once the outcome is known; its `.workerNameConflict`
+        // case leaves it presented with the new taken name. Clearing it eagerly here, before the
+        // retry even starts, would dismiss-then-re-present the sheet on a loop-back (the new name
+        // is also taken) — a visible flash instead of the taken-name text updating in place.
         deploy(
             siteID: pending.siteID, siteDirectory: pending.siteDirectory,
             configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
@@ -436,8 +441,10 @@ final class DeployModel {
                 siteBase: url
             )
             currentMilestone = nil
+            workerNameConflictPresented = false
             transition(siteID: siteID, to: .succeeded(url: url, duration: duration))
         case .failed(let reason, let exit):
+            workerNameConflictPresented = false
             transition(siteID: siteID, to: .failed(reason: reason, exitCode: exit))
             guard presentation == .foreground else { return result }
             let capturedLog = logText   // snapshot before the suspension; a later deploy clears logLines
@@ -458,6 +465,7 @@ final class DeployModel {
             // For the blocked outcome the modal sheet carries the actionable info; the
             // streaming-log drawer would just be noise.
             drawerPresented = false
+            workerNameConflictPresented = false
             blockedPresented = presentation == .foreground
         case .workerNameConflict(let name):
             pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -500,6 +500,13 @@ struct SiteWindow: View {
                 model.deploy.cancelTokenPrompt()
             }
         }
+        .sheet(isPresented: $bindableModel.deploy.workerNameConflictPresented) {
+            if case .workerNameConflict(let name) = model.deploy.phase {
+                WorkerNameConflictSheetView(model: model.deploy, takenName: name) {
+                    model.deploy.cancelWorkerNameConflictPrompt()
+                }
+            }
+        }
         .sheet(isPresented: $bindableModel.audit.sheetPresented) {
             AuditSheetView(
                 model: model.audit,

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1477,6 +1477,11 @@ final class SiteWindowModel {
                         siteName: name, siteID: siteID, outcome: .blocked(failureCount: failures.count)
                     )
                 }
+            case .workerNameConflict:
+                // The conflict sheet (wired separately) carries the actionable info, and the
+                // deploy is parked rather than finished — no completion notice, just stop
+                // showing progress on the Dock tile.
+                DockProgressController.shared.clear(token: dockToken)
             }
         }
         deploy.onMilestone = { siteID, progress in

--- a/Sources/AnglesiteApp/WorkerNameConflictSheetView.swift
+++ b/Sources/AnglesiteApp/WorkerNameConflictSheetView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Sheet shown when `DeployCommand` detects that this site's Worker name already exists on the
+/// connected Cloudflare account, and this site has never deployed before (#740) — refusing to
+/// silently let `wrangler deploy` take over an unrelated (or stale) Worker. Offers a text field
+/// to pick a different name, prefilled with a `<name>-2` suggestion, then retries the deploy.
+struct WorkerNameConflictSheetView: View {
+    let model: DeployModel
+    let takenName: String
+    let onCancel: () -> Void
+
+    @State private var newName: String = ""
+    @FocusState private var fieldFocused: Bool
+
+    private var trimmedName: String {
+        newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSubmit: Bool {
+        !trimmedName.isEmpty && trimmedName != takenName
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Worker name already in use")
+                    .font(.headline)
+                Text("“\(takenName)” already exists on your connected Cloudflare account. Choose a different name to deploy this site under.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            TextField("Worker name", text: $newName)
+                .textFieldStyle(.roundedBorder)
+                .focused($fieldFocused)
+                .onSubmit { submit() }
+
+            if let error = model.workerNameConflictError {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Rename & retry") { submit() }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canSubmit)
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+        .task {
+            newName = "\(takenName)-2"
+            fieldFocused = true
+        }
+    }
+
+    private func submit() {
+        guard canSubmit else { return }
+        Task { await model.renameWorkerAndRetry(trimmedName) }
+    }
+}
+
+#Preview {
+    WorkerNameConflictSheetView(model: DeployModel(), takenName: "my-site", onCancel: {})
+}

--- a/Sources/AnglesiteCore/CloudflareReading.swift
+++ b/Sources/AnglesiteCore/CloudflareReading.swift
@@ -45,6 +45,9 @@ public protocol CloudflareReading: Sendable {
     /// Full DNS record listing for a zone — distinct from `zoneState`'s narrow security-relevant
     /// subset (CAA/MX/SPF/DMARC only). Used by the Domain DNS management feature.
     func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord]
+    /// Every Worker script name (the `id` field) visible to the token's first account. Used to
+    /// detect a Worker-name collision before a site's first deploy (#740).
+    func workerScriptNames(apiToken: String) async throws -> [String]
 }
 
 /// Injectable HTTP boundary — identical shape to `CloudflareAPITokenVerifier.Transport`.

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -30,6 +30,12 @@ public actor DeployCommand {
         /// The pre-deploy security scan refused the deploy. Carries the structured
         /// failures (and any warnings) so the UI can render a sheet with no override.
         case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning])
+        /// The candidate Worker name (`.site-config`'s `CF_PROJECT_NAME`) already exists on the
+        /// connected Cloudflare account, and this site has never deployed before
+        /// (`CF_WORKER_DEPLOYED` is not yet set in `.site-config`) — refusing to silently let
+        /// `wrangler deploy` take over an unrelated (or stale) Worker. Carries the taken name for
+        /// the UI's rename prompt (#740).
+        case workerNameConflict(name: String)
         /// `exitCode` is `nil` for pre-spawn refusals (no token, no wrangler) and for spawn
         /// failures; otherwise it's the failing subprocess's exit code (including `0` for the
         /// "wrangler exited cleanly but we couldn't find a URL" case).
@@ -57,14 +63,22 @@ public actor DeployCommand {
     /// cases where deploy() returns .failed afterwards.
     public typealias PreflightObserver = @Sendable (PreDeployCheck.Outcome) -> Void
 
+    /// Returns the account's existing Worker script names for the given token. Production
+    /// callers use `DeployCommand.defaultWorkerScriptNames` (`HTTPCloudflareClient`); tests
+    /// inject a fake list or a throwing closure.
+    public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
+
     public nonisolated let tokenSource: TokenSource
+    private let workerScriptNamesSource: WorkerScriptNamesSource
     private let executor: any DeployExecutor
 
     public init(
         tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
+        workerScriptNamesSource: @escaping WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,
         executor: any DeployExecutor = HostDeployExecutor()
     ) {
         self.tokenSource = tokenSource
+        self.workerScriptNamesSource = workerScriptNamesSource
         self.executor = executor
     }
 
@@ -95,6 +109,12 @@ public actor DeployCommand {
         }
         guard let token, !token.isEmpty else {
             return .failed(reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var", exitCode: nil)
+        }
+
+        if let conflict = await Self.checkWorkerNameConflict(
+            siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
+        ) {
+            return conflict
         }
 
         // Curated environment for the non-secret steps: a safe subset of the host process env,
@@ -275,6 +295,26 @@ public actor DeployCommand {
         try? updated.write(to: configURL, atomically: true, encoding: .utf8)
     }
 
+    /// Checks whether `.site-config`'s `CF_PROJECT_NAME` collides with an existing Worker on the
+    /// connected Cloudflare account, but only on a site's first deploy (`CF_WORKER_DEPLOYED` not
+    /// yet set). Returns `.workerNameConflict` on a confirmed collision, or `nil` when the check
+    /// doesn't apply (redeploy, no candidate name) or can't be confirmed — a Cloudflare API
+    /// failure here must never block a deploy that would otherwise succeed (fail open).
+    static func checkWorkerNameConflict(
+        siteDirectory: URL,
+        apiToken: String,
+        workerScriptNamesSource: WorkerScriptNamesSource
+    ) async -> Result? {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
+              let candidateName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config)
+        else { return nil }
+        guard let names = try? await workerScriptNamesSource(apiToken) else { return nil }
+        guard names.contains(candidateName) else { return nil }
+        return .workerNameConflict(name: candidateName)
+    }
+
     // MARK: Host environment curation
 
     /// Keys that a host-path build or preflight step legitimately needs. The allowlist is
@@ -343,6 +383,12 @@ public actor DeployCommand {
             return env
         }
         return try PlatformSecretStore.make().readCloudflareToken()
+    }
+
+    /// Default `WorkerScriptNamesSource` for production: the account's Worker script names via
+    /// `HTTPCloudflareClient`.
+    public static let defaultWorkerScriptNames: WorkerScriptNamesSource = { apiToken in
+        try await HTTPCloudflareClient().workerScriptNames(apiToken: apiToken)
     }
 
     /// Default `PreflightChecker`: host-side preflight was retired with embedded Node. Container

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -195,6 +195,7 @@ public actor DeployCommand {
                     try? DeployedRoutesSnapshot.save(currentRoutes, to: configDirectory)
                 }
                 Self.persistSiteURL(url, siteDirectory: siteDirectory)
+                Self.persistWorkerDeployed(siteDirectory: siteDirectory)
                 return .succeeded(url: url, duration: duration)
             }
             return .failed(reason: "wrangler exited cleanly but no deployed URL was found in its output", exitCode: 0)
@@ -258,6 +259,19 @@ public actor DeployCommand {
         else { return }
         let updated = SiteConfigFile.upsert([("SITE_URL", url.absoluteString)], into: config)
         guard updated != config else { return }
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Marks this site as having successfully deployed at least once, via `.site-config`'s
+    /// `CF_WORKER_DEPLOYED` — the signal `checkWorkerNameConflict` uses to skip the collision
+    /// check on every deploy after the first (#740). Written unconditionally, unlike
+    /// `persistSiteURL` (which skips when a custom domain is already configured) — deploy
+    /// history isn't confounded by domain choice. Best-effort, matching `persistSiteURL`.
+    static func persistWorkerDeployed(siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil else { return }
+        let updated = SiteConfigFile.upsert([("CF_WORKER_DEPLOYED", "true")], into: config)
         try? updated.write(to: configURL, atomically: true, encoding: .utf8)
     }
 

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -56,6 +56,8 @@ private struct CFFullDNSRecord: Decodable, Sendable {
     let ttl: Int
     let proxied: Bool?
 }
+private struct CFAccount: Decodable, Sendable { let id: String }
+private struct CFWorkerScript: Decodable, Sendable { let id: String }
 
 /// Body for DELETE requests, which Cloudflare's API doesn't require but tolerates.
 private struct CFEmptyBody: Encodable, Sendable {}
@@ -265,6 +267,16 @@ public struct HTTPCloudflareClient: CloudflareReading {
             DNSRecord(id: $0.id, type: $0.type, name: $0.name, content: $0.content,
                       ttl: $0.ttl, proxied: $0.proxied ?? false)
         }
+    }
+
+    public func workerScriptNames(apiToken: String) async throws -> [String] {
+        let accounts = try await get("/accounts?per_page=1", apiToken: apiToken, as: [CFAccount].self)
+        guard let accountID = accounts.first?.id else {
+            throw CloudflareError.api(message: "no Cloudflare account visible to this token")
+        }
+        let scripts = try await paginated(
+            "/accounts/\(accountID)/workers/scripts?per_page=100", apiToken: apiToken, as: CFWorkerScript.self)
+        return scripts.map(\.id)
     }
 
     // MARK: - Write helpers

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -102,6 +102,8 @@ public struct SiteOperations: Sendable {
             let count = failures.count
             let noun = count == 1 ? "issue" : "issues"
             return "Deploy blocked by the pre-deploy security scan (\(count) \(noun)). Resolve these in Anglesite first."
+        case .workerNameConflict(let name):
+            return "Deploy blocked: the Worker name \"\(name)\" is already in use on your Cloudflare account. Rename the site's Worker in Anglesite and try again."
         case .failed(let reason, _):
             return "Deploy failed: \(reason)"
         }

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -173,6 +173,10 @@ public actor SocialWorkerProvisionCommand {
             return .succeeded(url: url, resources: resources, duration: Date().timeIntervalSince(started))
         case .blocked(let failures, let warnings):
             return .blocked(failures: failures, warnings: warnings, resources: resources)
+        case .workerNameConflict(let name):
+            return .failed(
+                reason: "Worker name \"\(name)\" is already in use on your Cloudflare account — rename it in Anglesite and try again.",
+                exitCode: nil, resources: resources)
         case .failed(let reason, let exitCode):
             return .failed(reason: reason, exitCode: exitCode, resources: resources)
         }

--- a/Sources/AnglesiteCore/WorkerNameRename.swift
+++ b/Sources/AnglesiteCore/WorkerNameRename.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Applies a Worker-name change to an already-scaffolded site's `wrangler.toml` and
+/// `.site-config`, after a Worker-name collision is detected at first deploy (#740).
+///
+/// Only the `name = "..."` line in `wrangler.toml` is rewritten — not a full regenerate via
+/// `WorkerComposition.generateWranglerToml` — because there is no reader that reconstructs the
+/// `[Feature]` list or provisioned D1/KV resource IDs from an already-written file, and a full
+/// regenerate would silently drop any social-feature config a user provisioned (via
+/// `SocialWorkerProvisionCommand`) before their first deploy.
+public enum WorkerNameRename {
+    public enum RenameError: Error, Equatable, Sendable {
+        case invalidName(String)
+        case wranglerConfigMissing
+        case nameLineNotFound
+    }
+
+    /// Rewrites `wrangler.toml`'s `name = "..."` line and `.site-config`'s `CF_PROJECT_NAME` to
+    /// `newName`. Throws `.invalidName` before touching any file if `newName` doesn't match
+    /// `WorkerComposition`'s `[A-Za-z0-9_-]+` constraint, so a rejected name never gets partially
+    /// written.
+    public static func apply(newName: String, siteDirectory: URL, fileManager: FileManager = .default) throws {
+        guard WorkerComposition.isValidSiteName(newName) else {
+            throw RenameError.invalidName(newName)
+        }
+
+        let wranglerURL = siteDirectory.appendingPathComponent("wrangler.toml")
+        guard fileManager.fileExists(atPath: wranglerURL.path) else {
+            throw RenameError.wranglerConfigMissing
+        }
+        let toml = try String(contentsOf: wranglerURL, encoding: .utf8)
+        var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard let nameLineIndex = lines.firstIndex(where: { $0.hasPrefix("name = \"") }) else {
+            throw RenameError.nameLineNotFound
+        }
+        lines[nameLineIndex] = "name = \"\(newName)\""
+        try lines.joined(separator: "\n").write(to: wranglerURL, atomically: true, encoding: .utf8)
+
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let updated = SiteConfigFile.upsert([("CF_PROJECT_NAME", newName)], into: config)
+        try updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+}

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -79,4 +79,30 @@ struct DeployModelTests {
             return
         }
     }
+
+    @Test("A worker-name conflict parks the deploy and presents the conflict sheet")
+    func workerNameConflictParksAndPresents() async {
+        let executor = GatedDeployExecutor()
+        // Never reached — the conflict short-circuits before the build step — but present so a
+        // regression that skips the gate doesn't hang the test on the gated continuation.
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+
+        guard case .workerNameConflict(let name) = model.phase else {
+            Issue.record("expected .workerNameConflict, got \(model.phase)"); return
+        }
+        #expect(name == "my-site")
+        #expect(model.workerNameConflictPresented)
+    }
 }

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -109,6 +109,8 @@ struct DeployModelTests {
     @Test("Renaming and retrying rewrites wrangler.toml/.site-config and re-deploys under the new name")
     func renameAndRetrySucceedsUnderNewName() async {
         let executor = GatedDeployExecutor()
+        // Never reached — the conflict short-circuits before the build step — but present so a
+        // regression that skips the gate doesn't hang the test on the gated continuation.
         await executor.resumeBuild()
         let command = DeployCommand(
             tokenSource: { "test-token" },
@@ -128,7 +130,12 @@ struct DeployModelTests {
             Issue.record("expected .workerNameConflict before renaming, got \(model.phase)"); return
         }
 
+        // Unlike the initial deploy above, the retried deploy's new name is free, so it proceeds
+        // into the real pipeline and parks on a fresh build continuation — wait for it, then
+        // resume it, mirroring `suddenTerminationLeaseBracketsDeploy`'s synchronization.
         await model.renameWorkerAndRetry("my-site-2")
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
         while model.isRunning { await Task.yield() }
 
         guard case .succeeded = model.phase else {
@@ -162,5 +169,6 @@ struct DeployModelTests {
         // A subsequent rename attempt with nothing parked must fail gracefully, not crash.
         await model.renameWorkerAndRetry("anything")
         #expect(!model.isRunning)
+        #expect(model.workerNameConflictError == "No deploy is waiting — close this and click Deploy again.")
     }
 }

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -146,6 +146,74 @@ struct DeployModelTests {
         #expect(toml.contains(#"name = "my-site-2""#))
     }
 
+    @Test("Renaming to a name that's also taken loops back to the conflict sheet under the new name")
+    func renameToAlsoTakenNameLoopsBackToConflict() async {
+        let executor = GatedDeployExecutor()
+        // Never reached — both the initial and retried collision checks short-circuit before the
+        // build step — but present so a regression that skips the gate doesn't hang the test on
+        // the gated continuation.
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            // Both "my-site" (the original name) and "my-site-2" (the rename target) are taken.
+            workerScriptNamesSource: { _ in ["my-site", "my-site-2"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+        guard case .workerNameConflict(let firstName) = model.phase else {
+            Issue.record("expected .workerNameConflict before renaming, got \(model.phase)"); return
+        }
+        #expect(firstName == "my-site")
+
+        // "my-site-2" is also taken, so the retried deploy's collision check fires again — it's a
+        // pre-spawn check that short-circuits before `.build`, so no build-continuation
+        // synchronization is needed for this retry (unlike `renameAndRetrySucceedsUnderNewName`,
+        // where the retry's name is free and genuinely reaches the build step).
+        await model.renameWorkerAndRetry("my-site-2")
+        while model.isRunning { await Task.yield() }
+
+        guard case .workerNameConflict(let secondName) = model.phase else {
+            Issue.record("expected .workerNameConflict again after renaming to a taken name, got \(model.phase)"); return
+        }
+        #expect(secondName == "my-site-2")
+        #expect(model.workerNameConflictPresented)
+    }
+
+    @Test("An invalid rename target surfaces a plain-language error instead of the raw error enum")
+    func renameWithInvalidNameSurfacesPlainLanguageError() async {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+        guard case .workerNameConflict = model.phase else {
+            Issue.record("expected .workerNameConflict before renaming, got \(model.phase)"); return
+        }
+
+        await model.renameWorkerAndRetry("bad name!")
+
+        #expect(!model.isRunning)
+        #expect(model.workerNameConflictPresented)
+        #expect(model.workerNameConflictError == "Worker names can only contain letters, numbers, hyphens, and underscores.")
+    }
+
     @Test("Cancelling the conflict prompt clears the parked deploy and dismisses the sheet")
     func cancelClearsPendingDeploy() async {
         let executor = GatedDeployExecutor()

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -105,4 +105,62 @@ struct DeployModelTests {
         #expect(name == "my-site")
         #expect(model.workerNameConflictPresented)
     }
+
+    @Test("Renaming and retrying rewrites wrangler.toml/.site-config and re-deploys under the new name")
+    func renameAndRetrySucceedsUnderNewName() async {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            // "my-site" is taken; "my-site-2" (what the sheet will submit) is free.
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+        guard case .workerNameConflict = model.phase else {
+            Issue.record("expected .workerNameConflict before renaming, got \(model.phase)"); return
+        }
+
+        await model.renameWorkerAndRetry("my-site-2")
+        while model.isRunning { await Task.yield() }
+
+        guard case .succeeded = model.phase else {
+            Issue.record("expected .succeeded after rename-and-retry, got \(model.phase)"); return
+        }
+        #expect(!model.workerNameConflictPresented)
+        let toml = try! String(contentsOf: siteDir.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains(#"name = "my-site-2""#))
+    }
+
+    @Test("Cancelling the conflict prompt clears the parked deploy and dismisses the sheet")
+    func cancelClearsPendingDeploy() async {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+
+        model.cancelWorkerNameConflictPrompt()
+
+        #expect(!model.workerNameConflictPresented)
+        // A subsequent rename attempt with nothing parked must fail gracefully, not crash.
+        await model.renameWorkerAndRetry("anything")
+        #expect(!model.isRunning)
+    }
 }

--- a/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareClientTests.swift
@@ -110,6 +110,62 @@ func unauthorizedMaps() async {
     }
 }
 
+@Test("workerScriptNames returns every script id across the account's first page")
+func workerScriptNamesReturnsIds() async throws {
+    let accountsJSON = #"{"success":true,"errors":[],"messages":[],"result":[{"id":"acct123"}]}"#
+    let scriptsJSON = """
+    {"success":true,"errors":[],"messages":[],"result":[{"id":"my-site"},{"id":"other-site"}],
+     "result_info":{"page":1,"total_pages":1}}
+    """
+    let client = HTTPCloudflareClient(transport: fakeTransport([
+        "/accounts?per_page=1": (200, accountsJSON),
+        "/workers/scripts?per_page=100": (200, scriptsJSON),
+    ]))
+    let names = try await client.workerScriptNames(apiToken: "t")
+    #expect(names == ["my-site", "other-site"])
+}
+
+@Test("workerScriptNames pages through more than 100 scripts")
+func workerScriptNamesPaginates() async throws {
+    let accountsJSON = #"{"success":true,"errors":[],"messages":[],"result":[{"id":"acct123"}]}"#
+    let page1 = """
+    {"success":true,"errors":[],"messages":[],"result":[{"id":"page1-site"}],
+     "result_info":{"page":1,"total_pages":2}}
+    """
+    let page2 = """
+    {"success":true,"errors":[],"messages":[],"result":[{"id":"page2-site"}],
+     "result_info":{"page":2,"total_pages":2}}
+    """
+    let client = HTTPCloudflareClient(transport: { request in
+        let url = request.url!.absoluteString
+        let (status, body): (Int, String)
+        if url.contains("/accounts?per_page=1") {
+            (status, body) = (200, accountsJSON)
+        } else if url.contains("page=2") {
+            (status, body) = (200, page2)
+        } else if url.contains("/workers/scripts?per_page=100") {
+            (status, body) = (200, page1)
+        } else {
+            (status, body) = (404, "{\"success\":false}")
+        }
+        let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+        return (Data(body.utf8), resp)
+    })
+    let names = try await client.workerScriptNames(apiToken: "t")
+    #expect(names == ["page1-site", "page2-site"])
+}
+
+@Test("workerScriptNames throws when the token has no visible account")
+func workerScriptNamesNoAccount() async {
+    let emptyAccountsJSON = #"{"success":true,"errors":[],"messages":[],"result":[]}"#
+    let client = HTTPCloudflareClient(transport: fakeTransport([
+        "/accounts?per_page=1": (200, emptyAccountsJSON),
+    ]))
+    await #expect(throws: CloudflareError.self) {
+        try await client.workerScriptNames(apiToken: "t")
+    }
+}
+
 @Test("zoneState assembles DNSSEC, settings, DNS records, bot mode, and WAF rules")
 func zoneStateAssembles() async throws {
     let env = { (r: String) in "{\"success\":true,\"errors\":[],\"messages\":[],\"result\":\(r)}" }

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -370,6 +370,103 @@ struct DeployCommandTests {
         #expect(SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == "true", "but CF_WORKER_DEPLOYED must still be written")
     }
 
+    /// Writes `.site-config` with the given `CF_PROJECT_NAME` and, if `deployedBefore`, a
+    /// `CF_WORKER_DEPLOYED=true` marker — the two inputs `checkWorkerNameConflict` reads.
+    private func makeSiteDirectory(projectName: String?, deployedBefore: Bool) -> URL {
+        let dir = makeSiteDirectory()
+        var lines: [String] = []
+        if let projectName { lines.append("CF_PROJECT_NAME=\(projectName)") }
+        if deployedBefore { lines.append("CF_WORKER_DEPLOYED=true") }
+        if !lines.isEmpty {
+            try? (lines.joined(separator: "\n") + "\n")
+                .write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    @Test("First deploy with a name that already exists remotely returns .workerNameConflict before any step runs")
+    func firstDeployNameTakenReturnsConflict() async {
+        let siteDir = makeSiteDirectory(projectName: "taken-name", deployedBefore: false)
+        let exec = FakeExecutor().onRun(.build, { Issue.record("build must not run on a worker-name conflict") })
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            workerScriptNamesSource: { _ in ["taken-name", "other-site"] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .workerNameConflict(let name) = result else {
+            Issue.record("expected .workerNameConflict, got \(result)"); return
+        }
+        #expect(name == "taken-name")
+        #expect(!exec.ran(.build))
+    }
+
+    @Test("First deploy with a name that's free proceeds to build")
+    func firstDeployNameFreeProceeds() async {
+        let siteDir = makeSiteDirectory(projectName: "my-new-site", deployedBefore: false)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            workerScriptNamesSource: { _ in ["some-other-site"] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        #expect(exec.ran(.build))
+    }
+
+    @Test("No CF_PROJECT_NAME in .site-config skips the check entirely (fail open)")
+    func noProjectNameSkipsCheck() async {
+        let siteDir = makeSiteDirectory(projectName: nil, deployedBefore: false)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            workerScriptNamesSource: { _ in Issue.record("must not be called when CF_PROJECT_NAME is absent"); return [] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+    }
+
+    @Test("CF_WORKER_DEPLOYED already set skips the check regardless of remote state (no regression on redeploys)")
+    func alreadyDeployedSkipsCheck() async {
+        let siteDir = makeSiteDirectory(projectName: "my-site", deployedBefore: true)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            // Even though the name is "taken" by this same call, a redeploy must not be blocked.
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+    }
+
+    @Test("A thrown error from workerScriptNamesSource fails open and proceeds to build")
+    func availabilityCheckErrorFailsOpen() async {
+        let siteDir = makeSiteDirectory(projectName: "my-new-site", deployedBefore: false)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            workerScriptNamesSource: { _ in throw CloudflareError.http(status: 500) },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded (fail open), got \(result)"); return }
+    }
+
     // MARK: Scan report parsing helper
 
     @Test("parseScanReport maps ok/blocked/error correctly")

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -328,6 +328,48 @@ struct DeployCommandTests {
         #expect(url.host == "angle-app.example.workers.dev")
     }
 
+    // MARK: Worker-name collision (#740)
+
+    /// A fresh, empty subdirectory under the system temp dir — distinct from the shared `tmpDir`
+    /// (which is the temp root itself, used elsewhere only as a `cd`-able path) because these
+    /// tests write real `.site-config` contents that must not leak between test runs.
+    private func makeSiteDirectory() -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("A successful deploy writes CF_WORKER_DEPLOYED=true to .site-config")
+    func successfulDeployMarksWorkerDeployed() async {
+        let siteDir = makeSiteDirectory()
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        let config = (try? String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)) ?? ""
+        #expect(SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == "true")
+    }
+
+    @Test("CF_WORKER_DEPLOYED is written even for a .transfer-domain site (where SITE_URL is not)")
+    func workerDeployedMarkerNotConfoundedByCustomDomain() async {
+        let siteDir = makeSiteDirectory()
+        let configURL = siteDir.appendingPathComponent(".site-config")
+        try? "DOMAIN=example.com\n".write(to: configURL, atomically: true, encoding: .utf8)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        let config = try! String(contentsOf: configURL, encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_URL", in: config) == nil, "SITE_URL is skipped when DOMAIN is set")
+        #expect(SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == "true", "but CF_WORKER_DEPLOYED must still be written")
+    }
+
     // MARK: Scan report parsing helper
 
     @Test("parseScanReport maps ok/blocked/error correctly")

--- a/Tests/AnglesiteCoreTests/DomainOperationsServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainOperationsServiceTests.swift
@@ -129,6 +129,7 @@ final class FakeReader: CloudflareReading, @unchecked Sendable {
         if let listError { throw listError }
         return records
     }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
 }
 
 final class FakeWriter: CloudflareWriting, @unchecked Sendable {

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -128,6 +128,7 @@ final class MockCloudflareReader: CloudflareReading, @unchecked Sendable {
         return state
     }
     func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] { [] }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
 }
 
 final class MockCloudflareWriter: CloudflareWriting, @unchecked Sendable {

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -130,6 +130,13 @@ struct SiteOperationsTests {
         #expect(dialog == "Deploy failed: network down")
     }
 
+    @Test("deploy worker-name-conflict dialog names the taken Worker and asks for a rename")
+    func deployWorkerNameConflictDialog() {
+        let dialog = SiteOperations.dialog(forDeploy: .workerNameConflict(name: "taken-name"))
+        #expect(dialog.contains("taken-name"))
+        #expect(dialog.lowercased().contains("rename"))
+    }
+
     @Test("social worker provisioning runs through SiteOperations and slugifies the worker name")
     func socialWorkerProvisionOperation() async throws {
         let package = try temporaryPackage()

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -183,6 +183,25 @@ struct SocialWorkerProvisionCommandTests {
         #expect(toml.contains("id = \"kv-id\""))
     }
 
+    @Test("a worker-name conflict from the deployer maps to a failed provisioning result")
+    func workerNameConflictMapsToFailed() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
+            ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"id":"kv-id"}}"#, stderr: "", exitCode: 0),
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
+        ])
+        let deployer = DeployRecorder(result: .workerNameConflict(name: "taken-name"))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+
+        guard case .failed(let reason, _, _) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(reason.contains("taken-name"))
+    }
+
     @Test("stops before deploy when the IndieAuth schema migration fails")
     func migrationFailureStopsDeploy() async throws {
         let site = try temporaryDirectory()

--- a/Tests/AnglesiteCoreTests/WorkerNameRenameTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerNameRenameTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct WorkerNameRenameTests {
+    private func makeSiteDirectory(wranglerToml: String, siteConfig: String = "") -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try! wranglerToml.write(to: dir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        if !siteConfig.isEmpty {
+            try! siteConfig.write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    @Test("Rewrites only the name line, leaving the rest of wrangler.toml untouched")
+    func rewritesNameLineOnly() throws {
+        let toml = """
+        name = "old-name"
+        compatibility_date = "2026-07-15"
+        compatibility_flags = ["nodejs_compat"]
+
+        [assets]
+        directory = "dist"
+        """
+        let dir = makeSiteDirectory(wranglerToml: toml, siteConfig: "CF_PROJECT_NAME=old-name\nSITE_NAME=My Site\n")
+
+        try WorkerNameRename.apply(newName: "new-name", siteDirectory: dir)
+
+        let updatedToml = try String(contentsOf: dir.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(updatedToml.contains(#"name = "new-name""#))
+        #expect(updatedToml.contains(#"compatibility_date = "2026-07-15""#))
+        #expect(updatedToml.contains("[assets]"))
+    }
+
+    @Test("Updates CF_PROJECT_NAME in .site-config without disturbing other keys")
+    func updatesSiteConfig() throws {
+        let dir = makeSiteDirectory(
+            wranglerToml: #"name = "old-name""#,
+            siteConfig: "CF_PROJECT_NAME=old-name\nSITE_NAME=My Site\n"
+        )
+
+        try WorkerNameRename.apply(newName: "new-name", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "new-name")
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "My Site")
+    }
+
+    @Test("Rejects an invalid name before touching any file")
+    func rejectsInvalidName() throws {
+        let dir = makeSiteDirectory(wranglerToml: #"name = "old-name""#, siteConfig: "CF_PROJECT_NAME=old-name\n")
+
+        #expect(throws: WorkerNameRename.RenameError.invalidName("bad name!")) {
+            try WorkerNameRename.apply(newName: "bad name!", siteDirectory: dir)
+        }
+
+        let toml = try String(contentsOf: dir.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains(#"name = "old-name""#), "wrangler.toml must be untouched on rejection")
+    }
+
+    @Test("Throws .wranglerConfigMissing when there's no wrangler.toml")
+    func missingWranglerConfig() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        #expect(throws: WorkerNameRename.RenameError.wranglerConfigMissing) {
+            try WorkerNameRename.apply(newName: "new-name", siteDirectory: dir)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/WorkerNameRenameTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerNameRenameTests.swift
@@ -68,4 +68,23 @@ struct WorkerNameRenameTests {
             try WorkerNameRename.apply(newName: "new-name", siteDirectory: dir)
         }
     }
+
+    @Test("Throws .nameLineNotFound when wrangler.toml exists but has no name line (e.g. hand-edited)")
+    func nameLineNotFound() throws {
+        let toml = """
+        compatibility_date = "2026-07-15"
+        compatibility_flags = ["nodejs_compat"]
+
+        [assets]
+        directory = "dist"
+        """
+        let dir = makeSiteDirectory(wranglerToml: toml, siteConfig: "CF_PROJECT_NAME=old-name\n")
+
+        #expect(throws: WorkerNameRename.RenameError.nameLineNotFound) {
+            try WorkerNameRename.apply(newName: "new-name", siteDirectory: dir)
+        }
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "old-name", ".site-config must be untouched when the name line can't be found")
+    }
 }

--- a/docs/superpowers/plans/2026-07-16-worker-name-collision-check.md
+++ b/docs/superpowers/plans/2026-07-16-worker-name-collision-check.md
@@ -1,0 +1,1122 @@
+# Worker-name collision check at first deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect a Worker-name collision against the connected Cloudflare account before a site's first deploy, and block with a rename-and-retry prompt instead of letting `wrangler deploy` silently take over an unrelated Worker.
+
+**Architecture:** `DeployCommand` gains a pre-spawn check (right after the existing token gate) that lists the Cloudflare account's Worker script names and compares against `.site-config`'s `CF_PROJECT_NAME`, but only when `.site-config` has no `CF_WORKER_DEPLOYED` marker (i.e. this is the site's first deploy). A collision returns a new `Result.workerNameConflict(name:)` case. `DeployModel` parks the deploy (reusing its existing `pendingDeploy` field) and presents a new sheet; submitting a new name rewrites `wrangler.toml`'s `name` line and `.site-config`'s `CF_PROJECT_NAME` in place (no full regenerate, so provisioned social-feature config survives), then retries.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Test`/`#expect`), SwiftUI. No new dependencies.
+
+## Global Constraints
+
+- Design source of truth: [`docs/superpowers/specs/2026-07-16-worker-name-collision-check-design.md`](../specs/2026-07-16-worker-name-collision-check-design.md) — re-read it if a task here seems ambiguous.
+- `swift test --package-path .` needs `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` in this environment (the default CommandLineTools `swift` is too old) — every test command below is prefixed with it. Drop the prefix if your environment's default toolchain is already Swift 6.4+.
+- Conventional commits, referencing #740 in the subject, per `CONTRIBUTING.md`.
+- No new third-party dependencies — everything here uses Foundation + existing in-repo seams (`CloudflareReading`, `SiteConfigFile`, `WorkerComposition`).
+- A Cloudflare API failure during the collision check must never block a deploy that would otherwise succeed (fail open) — this invariant is load-bearing for every task that touches `checkWorkerNameConflict`.
+- Every task's commit must leave the package building — a task that only adds a case to a public, non-frozen enum without updating every existing exhaustive `switch` over it is not done (this is why Task 3 below bundles the new `Result` case with the two switches it would otherwise break).
+
+---
+
+### Task 1: `CloudflareReading.workerScriptNames` + `HTTPCloudflareClient` implementation
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/CloudflareReading.swift`
+- Modify: `Sources/AnglesiteCore/HTTPCloudflareClient.swift`
+- Modify: `Tests/AnglesiteCoreTests/DomainOperationsServiceTests.swift:107-132` (`FakeReader` — add stub conformance)
+- Modify: `Tests/AnglesiteCoreTests/HardenExecutorTests.swift:111-130` (`MockCloudflareReader` — add stub conformance)
+- Test: `Tests/AnglesiteCoreTests/CloudflareClientTests.swift`
+
+**Interfaces:**
+- Produces: `CloudflareReading.workerScriptNames(apiToken: String) async throws -> [String]` — every Worker script name visible to the token's first account. Throws `CloudflareError.api` (via `get`) if the token has no visible account, or any other `CloudflareError` case the existing `get`/`paginated` helpers already throw.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/CloudflareClientTests.swift` (after the existing `unauthorizedMaps` test, before its closing brace context — append as new top-level `@Test` functions in the same file):
+
+```swift
+@Test("workerScriptNames returns every script id across the account's first page")
+func workerScriptNamesReturnsIds() async throws {
+    let accountsJSON = #"{"success":true,"errors":[],"messages":[],"result":[{"id":"acct123"}]}"#
+    let scriptsJSON = """
+    {"success":true,"errors":[],"messages":[],"result":[{"id":"my-site"},{"id":"other-site"}],
+     "result_info":{"page":1,"total_pages":1}}
+    """
+    let client = HTTPCloudflareClient(transport: fakeTransport([
+        "/accounts?per_page=1": (200, accountsJSON),
+        "/workers/scripts?per_page=100": (200, scriptsJSON),
+    ]))
+    let names = try await client.workerScriptNames(apiToken: "t")
+    #expect(names == ["my-site", "other-site"])
+}
+
+@Test("workerScriptNames pages through more than 100 scripts")
+func workerScriptNamesPaginates() async throws {
+    let accountsJSON = #"{"success":true,"errors":[],"messages":[],"result":[{"id":"acct123"}]}"#
+    let page1 = """
+    {"success":true,"errors":[],"messages":[],"result":[{"id":"page1-site"}],
+     "result_info":{"page":1,"total_pages":2}}
+    """
+    let page2 = """
+    {"success":true,"errors":[],"messages":[],"result":[{"id":"page2-site"}],
+     "result_info":{"page":2,"total_pages":2}}
+    """
+    let client = HTTPCloudflareClient(transport: { request in
+        let url = request.url!.absoluteString
+        let (status, body): (Int, String)
+        if url.contains("/accounts?per_page=1") {
+            (status, body) = (200, accountsJSON)
+        } else if url.contains("page=2") {
+            (status, body) = (200, page2)
+        } else if url.contains("/workers/scripts?per_page=100") {
+            (status, body) = (200, page1)
+        } else {
+            (status, body) = (404, "{\"success\":false}")
+        }
+        let resp = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+        return (Data(body.utf8), resp)
+    })
+    let names = try await client.workerScriptNames(apiToken: "t")
+    #expect(names == ["page1-site", "page2-site"])
+}
+
+@Test("workerScriptNames throws when the token has no visible account")
+func workerScriptNamesNoAccount() async {
+    let emptyAccountsJSON = #"{"success":true,"errors":[],"messages":[],"result":[]}"#
+    let client = HTTPCloudflareClient(transport: fakeTransport([
+        "/accounts?per_page=1": (200, emptyAccountsJSON),
+    ]))
+    await #expect(throws: CloudflareError.self) {
+        _ = try await client.workerScriptNames(apiToken: "t")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (compile error — method doesn't exist yet)**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter CloudflareClientTests`
+Expected: FAIL — build error, `value of type 'HTTPCloudflareClient' has no member 'workerScriptNames'`.
+
+- [ ] **Step 3: Add the protocol method**
+
+In `Sources/AnglesiteCore/CloudflareReading.swift`, add to the `CloudflareReading` protocol (after `listDNSRecords`, before the closing `}` at line 47):
+
+```swift
+    /// Every Worker script name (the `id` field) visible to the token's first account. Used to
+    /// detect a Worker-name collision before a site's first deploy (#740).
+    func workerScriptNames(apiToken: String) async throws -> [String]
+```
+
+- [ ] **Step 4: Implement it in `HTTPCloudflareClient`**
+
+In `Sources/AnglesiteCore/HTTPCloudflareClient.swift`, add a private decode struct near the other private structs (after `private struct CFFullDNSRecord`, around line 58):
+
+```swift
+private struct CFAccount: Decodable, Sendable { let id: String }
+private struct CFWorkerScript: Decodable, Sendable { let id: String }
+```
+
+Then add the method to the `HTTPCloudflareClient` struct, after `listDNSRecords` (after line 268, before `// MARK: - Write helpers`):
+
+```swift
+    public func workerScriptNames(apiToken: String) async throws -> [String] {
+        let accounts = try await get("/accounts?per_page=1", apiToken: apiToken, as: [CFAccount].self)
+        guard let accountID = accounts.first?.id else {
+            throw CloudflareError.api(message: "no Cloudflare account visible to this token")
+        }
+        let scripts = try await paginated(
+            "/accounts/\(accountID)/workers/scripts?per_page=100", apiToken: apiToken, as: CFWorkerScript.self)
+        return scripts.map(\.id)
+    }
+```
+
+- [ ] **Step 5: Add stub conformance to the two existing test fakes**
+
+In `Tests/AnglesiteCoreTests/DomainOperationsServiceTests.swift`, inside `final class FakeReader: CloudflareReading` (after the existing `listDNSRecords` method, around line 130):
+
+```swift
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
+```
+
+In `Tests/AnglesiteCoreTests/HardenExecutorTests.swift`, inside `final class MockCloudflareReader: CloudflareReading` (after the existing `listDNSRecords` method, around line 130):
+
+```swift
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter CloudflareClientTests`
+Expected: PASS (all 3 new tests, plus the existing ones in the file).
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DomainOperationsServiceTests`
+Expected: PASS (confirms `FakeReader` still compiles/conforms).
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter HardenExecutorTests`
+Expected: PASS (confirms `MockCloudflareReader` still compiles/conforms).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CloudflareReading.swift Sources/AnglesiteCore/HTTPCloudflareClient.swift \
+        Tests/AnglesiteCoreTests/CloudflareClientTests.swift \
+        Tests/AnglesiteCoreTests/DomainOperationsServiceTests.swift \
+        Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+git commit -m "feat(deploy): add CloudflareReading.workerScriptNames (#740)"
+```
+
+---
+
+### Task 2: `DeployCommand` persists a `CF_WORKER_DEPLOYED` marker on success
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DeployCommand.swift`
+- Test: `Tests/AnglesiteCoreTests/DeployCommandTests.swift`
+
+**Interfaces:**
+- Produces: `DeployCommand.persistWorkerDeployed(siteDirectory: URL)` — a `static func`, same visibility (`static`, not `public`) as the existing `persistSiteURL`, called from `deploy(...)`'s success path.
+- Consumes: `WebsiteAnalyticsAsset.configRelativePath` (`.site-config`), `SiteConfigFile.upsert(_:into:)`, `SiteConfigFile.value(forKey:in:)` — all already exist.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/DeployCommandTests.swift`, in a new `// MARK: Worker-name collision (#740)` section (place it after the existing `// MARK: Wrangler failure surfacing` tests, i.e. after the `ignoresURLsBeforeAnchor` test around line 330):
+
+```swift
+    // MARK: Worker-name collision (#740)
+
+    /// A fresh, empty subdirectory under the system temp dir — distinct from the shared `tmpDir`
+    /// (which is the temp root itself, used elsewhere only as a `cd`-able path) because these
+    /// tests write real `.site-config` contents that must not leak between test runs.
+    private func makeSiteDirectory() -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("A successful deploy writes CF_WORKER_DEPLOYED=true to .site-config")
+    func successfulDeployMarksWorkerDeployed() async {
+        let siteDir = makeSiteDirectory()
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        let config = (try? String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)) ?? ""
+        #expect(SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == "true")
+    }
+
+    @Test("CF_WORKER_DEPLOYED is written even for a .transfer-domain site (where SITE_URL is not)")
+    func workerDeployedMarkerNotConfoundedByCustomDomain() async {
+        let siteDir = makeSiteDirectory()
+        let configURL = siteDir.appendingPathComponent(".site-config")
+        try? "DOMAIN=example.com\n".write(to: configURL, atomically: true, encoding: .utf8)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        let config = try! String(contentsOf: configURL, encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_URL", in: config) == nil, "SITE_URL is skipped when DOMAIN is set")
+        #expect(SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == "true", "but CF_WORKER_DEPLOYED must still be written")
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DeployCommandTests`
+Expected: FAIL — both new tests fail their `CF_WORKER_DEPLOYED` assertion (`nil` vs `"true"`), since nothing writes that key yet.
+
+- [ ] **Step 3: Implement `persistWorkerDeployed` and call it on success**
+
+In `Sources/AnglesiteCore/DeployCommand.swift`, add a new static method right after `persistSiteURL` (after line 262):
+
+```swift
+    /// Marks this site as having successfully deployed at least once, via `.site-config`'s
+    /// `CF_WORKER_DEPLOYED` — the signal `checkWorkerNameConflict` uses to skip the collision
+    /// check on every deploy after the first (#740). Written unconditionally, unlike
+    /// `persistSiteURL` (which skips when a custom domain is already configured) — deploy
+    /// history isn't confounded by domain choice. Best-effort, matching `persistSiteURL`.
+    static func persistWorkerDeployed(siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil else { return }
+        let updated = SiteConfigFile.upsert([("CF_WORKER_DEPLOYED", "true")], into: config)
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+```
+
+Then call it right after `Self.persistSiteURL(url, siteDirectory: siteDirectory)` in the success branch (line 197):
+
+```swift
+                Self.persistSiteURL(url, siteDirectory: siteDirectory)
+                Self.persistWorkerDeployed(siteDirectory: siteDirectory)
+                return .succeeded(url: url, duration: duration)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DeployCommandTests`
+Expected: PASS (all tests in the file, including the two new ones and all pre-existing ones — none of the existing tests write a `.site-config` file, so they're unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DeployCommand.swift Tests/AnglesiteCoreTests/DeployCommandTests.swift
+git commit -m "feat(deploy): persist CF_WORKER_DEPLOYED marker on successful deploy (#740)"
+```
+
+---
+
+### Task 3: `DeployCommand.Result.workerNameConflict`, the collision gate, and the two switches it breaks
+
+This task bundles three things into one commit-worthy unit because they are not independently buildable: adding a case to a public `Result` enum without updating every existing exhaustive `switch` over it leaves the package in a state that will not compile (see this plan's Global Constraints).
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DeployCommand.swift`
+- Modify: `Sources/AnglesiteCore/SiteOperations.swift:97-107`
+- Modify: `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:170-177`
+- Test: `Tests/AnglesiteCoreTests/DeployCommandTests.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteOperationsTests.swift`
+- Test: `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`
+
+**Interfaces:**
+- Consumes: `CloudflareReading.workerScriptNames` (Task 1), `SiteConfigFile.value(forKey:in:)`.
+- Produces: `DeployCommand.Result.workerNameConflict(name: String)`; `DeployCommand.WorkerScriptNamesSource` typealias (`@Sendable (_ apiToken: String) async throws -> [String]`); `DeployCommand.init(tokenSource:workerScriptNamesSource:executor:)` (new middle parameter, defaulted — existing call sites using only `tokenSource:`/`executor:` labels are unaffected); `DeployCommand.defaultWorkerScriptNames: WorkerScriptNamesSource`. Also updates `SiteOperations.dialog(forDeploy:)` and `SocialWorkerProvisionCommand`'s `switch await deployer(...)` mapping to handle the new case.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/DeployCommandTests.swift`, in the `// MARK: Worker-name collision (#740)` section added in Task 2 (append after `workerDeployedMarkerNotConfoundedByCustomDomain`):
+
+```swift
+    /// Writes `.site-config` with the given `CF_PROJECT_NAME` and, if `deployedBefore`, a
+    /// `CF_WORKER_DEPLOYED=true` marker — the two inputs `checkWorkerNameConflict` reads.
+    private func makeSiteDirectory(projectName: String?, deployedBefore: Bool) -> URL {
+        let dir = makeSiteDirectory()
+        var lines: [String] = []
+        if let projectName { lines.append("CF_PROJECT_NAME=\(projectName)") }
+        if deployedBefore { lines.append("CF_WORKER_DEPLOYED=true") }
+        if !lines.isEmpty {
+            try? (lines.joined(separator: "\n") + "\n")
+                .write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    @Test("First deploy with a name that already exists remotely returns .workerNameConflict before any step runs")
+    func firstDeployNameTakenReturnsConflict() async {
+        let siteDir = makeSiteDirectory(projectName: "taken-name", deployedBefore: false)
+        let exec = FakeExecutor().onRun(.build, { Issue.record("build must not run on a worker-name conflict") })
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            workerScriptNamesSource: { _ in ["taken-name", "other-site"] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .workerNameConflict(let name) = result else {
+            Issue.record("expected .workerNameConflict, got \(result)"); return
+        }
+        #expect(name == "taken-name")
+        #expect(!exec.ran(.build))
+    }
+
+    @Test("First deploy with a name that's free proceeds to build")
+    func firstDeployNameFreeProceeds() async {
+        let siteDir = makeSiteDirectory(projectName: "my-new-site", deployedBefore: false)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            workerScriptNamesSource: { _ in ["some-other-site"] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        #expect(exec.ran(.build))
+    }
+
+    @Test("No CF_PROJECT_NAME in .site-config skips the check entirely (fail open)")
+    func noProjectNameSkipsCheck() async {
+        let siteDir = makeSiteDirectory(projectName: nil, deployedBefore: false)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            workerScriptNamesSource: { _ in Issue.record("must not be called when CF_PROJECT_NAME is absent"); return [] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+    }
+
+    @Test("CF_WORKER_DEPLOYED already set skips the check regardless of remote state (no regression on redeploys)")
+    func alreadyDeployedSkipsCheck() async {
+        let siteDir = makeSiteDirectory(projectName: "my-site", deployedBefore: true)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            // Even though the name is "taken" by this same call, a redeploy must not be blocked.
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+    }
+
+    @Test("A thrown error from workerScriptNamesSource fails open and proceeds to build")
+    func availabilityCheckErrorFailsOpen() async {
+        let siteDir = makeSiteDirectory(projectName: "my-new-site", deployedBefore: false)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            workerScriptNamesSource: { _ in throw CloudflareError.http(status: 500) },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded (fail open), got \(result)"); return }
+    }
+```
+
+Add to `Tests/AnglesiteCoreTests/SiteOperationsTests.swift`, right after the existing `deployFailureDialog` test (after line 131):
+
+```swift
+    @Test("deploy worker-name-conflict dialog names the taken Worker and asks for a rename")
+    func deployWorkerNameConflictDialog() {
+        let dialog = SiteOperations.dialog(forDeploy: .workerNameConflict(name: "taken-name"))
+        #expect(dialog.contains("taken-name"))
+        #expect(dialog.lowercased().contains("rename"))
+    }
+```
+
+Add to `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`, following the exact pattern `provisionsV2Worker` (lines 7-41) already uses for its `WranglerRecorder`/`DeployRecorder` setup and its `private func temporaryDirectory() throws -> URL` helper (line 240) — add as its own new `@Test` inside `struct SocialWorkerProvisionCommandTests`, e.g. right after `deployFailureReportsResources`:
+
+```swift
+    @Test("a worker-name conflict from the deployer maps to a failed provisioning result")
+    func workerNameConflictMapsToFailed() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
+            ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"id":"kv-id"}}"#, stderr: "", exitCode: 0),
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
+        ])
+        let deployer = DeployRecorder(result: .workerNameConflict(name: "taken-name"))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+
+        guard case .failed(let reason, _, _) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(reason.contains("taken-name"))
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DeployCommandTests`
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteOperationsTests`
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: all three FAIL with the same underlying build error — `type 'DeployCommand.Result' has no member 'workerNameConflict'` — since none of the tests above can compile until Step 3 adds the case.
+
+- [ ] **Step 3: Add the `Result` case, typealias, init parameter, and gating logic**
+
+In `Sources/AnglesiteCore/DeployCommand.swift`, add the new case to `Result` (after `blocked`, before `failed`, around line 32):
+
+```swift
+        /// The candidate Worker name (`.site-config`'s `CF_PROJECT_NAME`) already exists on the
+        /// connected Cloudflare account, and this site has never deployed before
+        /// (`CF_WORKER_DEPLOYED` is not yet set in `.site-config`) — refusing to silently let
+        /// `wrangler deploy` take over an unrelated (or stale) Worker. Carries the taken name for
+        /// the UI's rename prompt (#740).
+        case workerNameConflict(name: String)
+```
+
+Add the typealias after `PreflightObserver` (after line 58):
+
+```swift
+    /// Returns the account's existing Worker script names for the given token. Production
+    /// callers use `DeployCommand.defaultWorkerScriptNames` (`HTTPCloudflareClient`); tests
+    /// inject a fake list or a throwing closure.
+    public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
+```
+
+Update the stored property and init (replace lines 60-69):
+
+```swift
+    public nonisolated let tokenSource: TokenSource
+    private let workerScriptNamesSource: WorkerScriptNamesSource
+    private let executor: any DeployExecutor
+
+    public init(
+        tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
+        workerScriptNamesSource: @escaping WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,
+        executor: any DeployExecutor = HostDeployExecutor()
+    ) {
+        self.tokenSource = tokenSource
+        self.workerScriptNamesSource = workerScriptNamesSource
+        self.executor = executor
+    }
+```
+
+Insert the gate in `deploy(...)`, right after the existing token guard (after line 98, before the `baseEnvironment` comment):
+
+```swift
+        if let conflict = await Self.checkWorkerNameConflict(
+            siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
+        ) {
+            return conflict
+        }
+```
+
+Add the static helper near `persistWorkerDeployed` (after it, still before `// MARK: Host environment curation`):
+
+```swift
+    /// Checks whether `.site-config`'s `CF_PROJECT_NAME` collides with an existing Worker on the
+    /// connected Cloudflare account, but only on a site's first deploy (`CF_WORKER_DEPLOYED` not
+    /// yet set). Returns `.workerNameConflict` on a confirmed collision, or `nil` when the check
+    /// doesn't apply (redeploy, no candidate name) or can't be confirmed — a Cloudflare API
+    /// failure here must never block a deploy that would otherwise succeed (fail open).
+    static func checkWorkerNameConflict(
+        siteDirectory: URL,
+        apiToken: String,
+        workerScriptNamesSource: WorkerScriptNamesSource
+    ) async -> Result? {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
+              let candidateName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config)
+        else { return nil }
+        guard let names = try? await workerScriptNamesSource(apiToken) else { return nil }
+        guard names.contains(candidateName) else { return nil }
+        return .workerNameConflict(name: candidateName)
+    }
+```
+
+Add the default seam next to `keychainTokenSource` (after line 332, before `defaultPreflight`):
+
+```swift
+    /// Default `WorkerScriptNamesSource` for production: the account's Worker script names via
+    /// `HTTPCloudflareClient`.
+    public static let defaultWorkerScriptNames: WorkerScriptNamesSource = { apiToken in
+        try await HTTPCloudflareClient().workerScriptNames(apiToken: apiToken)
+    }
+```
+
+- [ ] **Step 4: Fix the two switches this case breaks**
+
+In `Sources/AnglesiteCore/SiteOperations.swift`, update `dialog(forDeploy:)` (lines 97-107):
+
+```swift
+    public static func dialog(forDeploy result: DeployCommand.Result) -> String {
+        switch result {
+        case .succeeded(let url, _):
+            return "Deployed to \(url.absoluteString)."
+        case .blocked(let failures, _):
+            let count = failures.count
+            let noun = count == 1 ? "issue" : "issues"
+            return "Deploy blocked by the pre-deploy security scan (\(count) \(noun)). Resolve these in Anglesite first."
+        case .workerNameConflict(let name):
+            return "Deploy blocked: the Worker name \"\(name)\" is already in use on your Cloudflare account. Rename the site's Worker in Anglesite and try again."
+        case .failed(let reason, _):
+            return "Deploy failed: \(reason)"
+        }
+    }
+```
+
+In `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift`, update the `switch await deployer(...)` block (lines 170-177):
+
+```swift
+        switch await deployer(token, siteID, siteDirectory) {
+        case .succeeded(let url, _):
+            return .succeeded(url: url, resources: resources, duration: Date().timeIntervalSince(started))
+        case .blocked(let failures, let warnings):
+            return .blocked(failures: failures, warnings: warnings, resources: resources)
+        case .workerNameConflict(let name):
+            return .failed(
+                reason: "Worker name \"\(name)\" is already in use on your Cloudflare account — rename it in Anglesite and try again.",
+                exitCode: nil, resources: resources)
+        case .failed(let reason, let exitCode):
+            return .failed(reason: reason, exitCode: exitCode, resources: resources)
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DeployCommandTests`
+Expected: PASS (all tests in the file, including this task's five new ones).
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteOperationsTests`
+Expected: PASS.
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DeployCommand.swift Sources/AnglesiteCore/SiteOperations.swift \
+        Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift \
+        Tests/AnglesiteCoreTests/DeployCommandTests.swift Tests/AnglesiteCoreTests/SiteOperationsTests.swift \
+        Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+git commit -m "feat(deploy): add DeployCommand.Result.workerNameConflict and the collision gate (#740)"
+```
+
+---
+
+### Task 4: `WorkerNameRename` — the rename-apply helper
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WorkerNameRename.swift`
+- Test: `Tests/AnglesiteCoreTests/WorkerNameRenameTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerComposition.isValidSiteName(_:)` (internal, same module), `SiteConfigFile.upsert(_:into:)`, `WebsiteAnalyticsAsset.configRelativePath`.
+- Produces: `WorkerNameRename.apply(newName: String, siteDirectory: URL, fileManager: FileManager = .default) throws` and `WorkerNameRename.RenameError` (`.invalidName(String)`, `.wranglerConfigMissing`, `.nameLineNotFound`) — both `public`, consumed by `DeployModel` in Task 6.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/WorkerNameRenameTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct WorkerNameRenameTests {
+    private func makeSiteDirectory(wranglerToml: String, siteConfig: String = "") -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try! wranglerToml.write(to: dir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        if !siteConfig.isEmpty {
+            try! siteConfig.write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    @Test("Rewrites only the name line, leaving the rest of wrangler.toml untouched")
+    func rewritesNameLineOnly() throws {
+        let toml = """
+        name = "old-name"
+        compatibility_date = "2026-07-15"
+        compatibility_flags = ["nodejs_compat"]
+
+        [assets]
+        directory = "dist"
+        """
+        let dir = makeSiteDirectory(wranglerToml: toml, siteConfig: "CF_PROJECT_NAME=old-name\nSITE_NAME=My Site\n")
+
+        try WorkerNameRename.apply(newName: "new-name", siteDirectory: dir)
+
+        let updatedToml = try String(contentsOf: dir.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(updatedToml.contains(#"name = "new-name""#))
+        #expect(updatedToml.contains(#"compatibility_date = "2026-07-15""#))
+        #expect(updatedToml.contains("[assets]"))
+    }
+
+    @Test("Updates CF_PROJECT_NAME in .site-config without disturbing other keys")
+    func updatesSiteConfig() throws {
+        let dir = makeSiteDirectory(
+            wranglerToml: #"name = "old-name""#,
+            siteConfig: "CF_PROJECT_NAME=old-name\nSITE_NAME=My Site\n"
+        )
+
+        try WorkerNameRename.apply(newName: "new-name", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "new-name")
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "My Site")
+    }
+
+    @Test("Rejects an invalid name before touching any file")
+    func rejectsInvalidName() throws {
+        let dir = makeSiteDirectory(wranglerToml: #"name = "old-name""#, siteConfig: "CF_PROJECT_NAME=old-name\n")
+
+        #expect(throws: WorkerNameRename.RenameError.invalidName("bad name!")) {
+            try WorkerNameRename.apply(newName: "bad name!", siteDirectory: dir)
+        }
+
+        let toml = try String(contentsOf: dir.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains(#"name = "old-name""#), "wrangler.toml must be untouched on rejection")
+    }
+
+    @Test("Throws .wranglerConfigMissing when there's no wrangler.toml")
+    func missingWranglerConfig() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        #expect(throws: WorkerNameRename.RenameError.wranglerConfigMissing) {
+            try WorkerNameRename.apply(newName: "new-name", siteDirectory: dir)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter WorkerNameRenameTests`
+Expected: FAIL — build error, no such type `WorkerNameRename`.
+
+- [ ] **Step 3: Implement `WorkerNameRename`**
+
+Create `Sources/AnglesiteCore/WorkerNameRename.swift`:
+
+```swift
+import Foundation
+
+/// Applies a Worker-name change to an already-scaffolded site's `wrangler.toml` and
+/// `.site-config`, after a Worker-name collision is detected at first deploy (#740).
+///
+/// Only the `name = "..."` line in `wrangler.toml` is rewritten — not a full regenerate via
+/// `WorkerComposition.generateWranglerToml` — because there is no reader that reconstructs the
+/// `[Feature]` list or provisioned D1/KV resource IDs from an already-written file, and a full
+/// regenerate would silently drop any social-feature config a user provisioned (via
+/// `SocialWorkerProvisionCommand`) before their first deploy.
+public enum WorkerNameRename {
+    public enum RenameError: Error, Equatable, Sendable {
+        case invalidName(String)
+        case wranglerConfigMissing
+        case nameLineNotFound
+    }
+
+    /// Rewrites `wrangler.toml`'s `name = "..."` line and `.site-config`'s `CF_PROJECT_NAME` to
+    /// `newName`. Throws `.invalidName` before touching any file if `newName` doesn't match
+    /// `WorkerComposition`'s `[A-Za-z0-9_-]+` constraint, so a rejected name never gets partially
+    /// written.
+    public static func apply(newName: String, siteDirectory: URL, fileManager: FileManager = .default) throws {
+        guard WorkerComposition.isValidSiteName(newName) else {
+            throw RenameError.invalidName(newName)
+        }
+
+        let wranglerURL = siteDirectory.appendingPathComponent("wrangler.toml")
+        guard fileManager.fileExists(atPath: wranglerURL.path) else {
+            throw RenameError.wranglerConfigMissing
+        }
+        let toml = try String(contentsOf: wranglerURL, encoding: .utf8)
+        var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard let nameLineIndex = lines.firstIndex(where: { $0.hasPrefix("name = \"") }) else {
+            throw RenameError.nameLineNotFound
+        }
+        lines[nameLineIndex] = "name = \"\(newName)\""
+        try lines.joined(separator: "\n").write(to: wranglerURL, atomically: true, encoding: .utf8)
+
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let updated = SiteConfigFile.upsert([("CF_PROJECT_NAME", newName)], into: config)
+        try updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter WorkerNameRenameTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerNameRename.swift Tests/AnglesiteCoreTests/WorkerNameRenameTests.swift
+git commit -m "feat(deploy): add WorkerNameRename helper for the collision rename flow (#740)"
+```
+
+---
+
+### Task 5: `DeployModel` — `.workerNameConflict` phase and result routing
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift`
+- Test: `Tests/AnglesiteAppTests/DeployModelTests.swift`
+
+**Interfaces:**
+- Consumes: `DeployCommand.Result.workerNameConflict(name:)` (Task 3).
+- Produces: `DeployModel.Phase.workerNameConflict(name: String)`; `DeployModel.workerNameConflictPresented: Bool` (observable, bound to a `.sheet` in Task 7); reuses the existing `pendingDeploy` field (no type change).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteAppTests/DeployModelTests.swift`, as a new `@Test` inside `struct DeployModelTests` (after `suddenTerminationLeaseBracketsDeploy`):
+
+```swift
+    @Test("A worker-name conflict parks the deploy and presents the conflict sheet")
+    func workerNameConflictParksAndPresents() async {
+        let executor = GatedDeployExecutor()
+        // Never reached — the conflict short-circuits before the build step — but present so a
+        // regression that skips the gate doesn't hang the test on the gated continuation.
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+
+        guard case .workerNameConflict(let name) = model.phase else {
+            Issue.record("expected .workerNameConflict, got \(model.phase)"); return
+        }
+        #expect(name == "my-site")
+        #expect(model.workerNameConflictPresented)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DeployModelTests`
+Expected: FAIL — build error: `DeployModel.Phase` has no `.workerNameConflict` case and no `workerNameConflictPresented` property yet (`DeployCommand.init`'s `workerScriptNamesSource:` parameter already exists from Task 3).
+
+- [ ] **Step 3: Add the `Phase` case, presented flag, and result routing**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, add the case to `Phase` (after `blocked`, around line 19):
+
+```swift
+        case workerNameConflict(name: String)
+```
+
+Add the presented flag near `blockedPresented` (after line 37):
+
+```swift
+    /// Bound to a `.sheet` in `SiteWindow` for the `.workerNameConflict` outcome — the Worker
+    /// name is already taken on the connected Cloudflare account and this is the site's first
+    /// deploy. Reuses `pendingDeploy` (below) to park and retry, same as the token-prompt flow.
+    var workerNameConflictPresented: Bool = false
+    /// Set when a rename attempt itself fails (invalid name, or no parked deploy). Cleared on
+    /// every fresh presentation and on a successful rename-and-retry.
+    private(set) var workerNameConflictError: String?
+```
+
+Update the doc comment on `pendingDeploy` to reflect the second consumer (it's currently just above the property, around line 86-88):
+
+```swift
+    /// Site to retry once the user takes the action a parked deploy is waiting on — either
+    /// pasting a Cloudflare token (`verifyAndSaveToken`) or renaming a taken Worker name
+    /// (`renameWorkerAndRetry`). `nil` outside both prompt flows. Carries the container control
+    /// (if any) so the parked-then-retried deploy uses the same executor as the original dispatch.
+```
+
+Add the new case to `runDeploy`'s result switch (after the `.blocked` case, before the closing `}` of the switch — after line 411):
+
+```swift
+        case .workerNameConflict(let name):
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl)
+            transition(siteID: siteID, to: .workerNameConflict(name: name))
+            drawerPresented = false
+            workerNameConflictError = nil
+            workerNameConflictPresented = presentation == .foreground
+```
+
+Add the new case to `deployAutomatically`'s result switch (after `.blocked`, before `.failed`, around line 205):
+
+```swift
+        case .workerNameConflict(let name):
+            return .failed(reason: "Worker name \"\(name)\" is already in use on your Cloudflare account — rename it in the app and deploy again.")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DeployModelTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift Tests/AnglesiteAppTests/DeployModelTests.swift
+git commit -m "feat(deploy): route DeployCommand.Result.workerNameConflict through DeployModel (#740)"
+```
+
+---
+
+### Task 6: `DeployModel` — rename-and-retry / cancel methods
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift`
+- Test: `Tests/AnglesiteAppTests/DeployModelTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerNameRename.apply(newName:siteDirectory:)` (Task 4).
+- Produces: `DeployModel.renameWorkerAndRetry(_ newName: String) async`; `DeployModel.cancelWorkerNameConflictPrompt()` — both consumed by `WorkerNameConflictSheetView` in Task 7.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteAppTests/DeployModelTests.swift`, after `workerNameConflictParksAndPresents`:
+
+```swift
+    @Test("Renaming and retrying rewrites wrangler.toml/.site-config and re-deploys under the new name")
+    func renameAndRetrySucceedsUnderNewName() async {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            // "my-site" is taken; "my-site-2" (what the sheet will submit) is free.
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+        guard case .workerNameConflict = model.phase else {
+            Issue.record("expected .workerNameConflict before renaming, got \(model.phase)"); return
+        }
+
+        await model.renameWorkerAndRetry("my-site-2")
+        while model.isRunning { await Task.yield() }
+
+        guard case .succeeded = model.phase else {
+            Issue.record("expected .succeeded after rename-and-retry, got \(model.phase)"); return
+        }
+        #expect(!model.workerNameConflictPresented)
+        let toml = try! String(contentsOf: siteDir.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains(#"name = "my-site-2""#))
+    }
+
+    @Test("Cancelling the conflict prompt clears the parked deploy and dismisses the sheet")
+    func cancelClearsPendingDeploy() async {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+
+        model.cancelWorkerNameConflictPrompt()
+
+        #expect(!model.workerNameConflictPresented)
+        // A subsequent rename attempt with nothing parked must fail gracefully, not crash.
+        await model.renameWorkerAndRetry("anything")
+        #expect(!model.isRunning)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DeployModelTests`
+Expected: FAIL — build error, no `renameWorkerAndRetry`/`cancelWorkerNameConflictPrompt` methods yet.
+
+- [ ] **Step 3: Implement the two methods**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, add after `cancelTokenPrompt()` (after line 257):
+
+```swift
+    /// Called by the worker-name-conflict sheet's "Rename & retry" button. Applies the rename to
+    /// `wrangler.toml`/`.site-config` via `WorkerNameRename.apply`, then retries the parked
+    /// deploy — which re-runs the collision check against the new name and loops back to this
+    /// same sheet if it's also taken.
+    func renameWorkerAndRetry(_ newName: String) async {
+        guard let pending = pendingDeploy else {
+            workerNameConflictError = "No deploy is waiting — close this and click Deploy again."
+            return
+        }
+        do {
+            try WorkerNameRename.apply(newName: newName, siteDirectory: pending.siteDirectory)
+        } catch {
+            workerNameConflictError = "Couldn't rename the Worker: \(error)"
+            return
+        }
+        pendingDeploy = nil
+        workerNameConflictPresented = false
+        workerNameConflictError = nil
+        deploy(
+            siteID: pending.siteID, siteDirectory: pending.siteDirectory,
+            configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
+            containerControl: pending.containerControl)
+    }
+
+    func cancelWorkerNameConflictPrompt() {
+        pendingDeploy = nil
+        workerNameConflictPresented = false
+        workerNameConflictError = nil
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter DeployModelTests`
+Expected: PASS (all `DeployModelTests`, including Task 5's test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift Tests/AnglesiteAppTests/DeployModelTests.swift
+git commit -m "feat(deploy): add DeployModel.renameWorkerAndRetry/cancelWorkerNameConflictPrompt (#740)"
+```
+
+---
+
+### Task 7: The rename sheet UI and its wiring into `SiteWindow`
+
+**Files:**
+- Create: `Sources/AnglesiteApp/WorkerNameConflictSheetView.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:491-502`
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:1450-1480`
+
+**Interfaces:**
+- Consumes: `DeployModel.workerNameConflictPresented`, `DeployModel.workerNameConflictError`, `DeployModel.renameWorkerAndRetry(_:)`, `DeployModel.cancelWorkerNameConflictPrompt()` (Tasks 5–6), `DeployModel.Phase.workerNameConflict(name:)` (Task 5).
+
+This task is SwiftUI-only (mirrors `CloudflareTokenPromptView`, which has no dedicated test file in this codebase) — verified by building the app target and a manual smoke check, not a Swift Testing suite.
+
+- [ ] **Step 1: Create the sheet view**
+
+Create `Sources/AnglesiteApp/WorkerNameConflictSheetView.swift`:
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// Sheet shown when `DeployCommand` detects that this site's Worker name already exists on the
+/// connected Cloudflare account, and this site has never deployed before (#740) — refusing to
+/// silently let `wrangler deploy` take over an unrelated (or stale) Worker. Offers a text field
+/// to pick a different name, prefilled with a `<name>-2` suggestion, then retries the deploy.
+struct WorkerNameConflictSheetView: View {
+    let model: DeployModel
+    let takenName: String
+    let onCancel: () -> Void
+
+    @State private var newName: String = ""
+    @FocusState private var fieldFocused: Bool
+
+    private var trimmedName: String {
+        newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSubmit: Bool {
+        !trimmedName.isEmpty && trimmedName != takenName
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Worker name already in use")
+                    .font(.headline)
+                Text("“\(takenName)” already exists on your connected Cloudflare account. Choose a different name to deploy this site under.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            TextField("Worker name", text: $newName)
+                .textFieldStyle(.roundedBorder)
+                .focused($fieldFocused)
+                .onSubmit { submit() }
+
+            if let error = model.workerNameConflictError {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Rename & retry") { submit() }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canSubmit)
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+        .task {
+            newName = "\(takenName)-2"
+            fieldFocused = true
+        }
+    }
+
+    private func submit() {
+        guard canSubmit else { return }
+        Task { await model.renameWorkerAndRetry(trimmedName) }
+    }
+}
+
+#Preview {
+    WorkerNameConflictSheetView(model: DeployModel(), takenName: "my-site", onCancel: {})
+}
+```
+
+- [ ] **Step 2: Wire the sheet into `SiteWindow`**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, add a new `.sheet` modifier right after the existing `tokenPromptPresented` one (after line 502):
+
+```swift
+        .sheet(isPresented: $bindableModel.deploy.workerNameConflictPresented) {
+            if case .workerNameConflict(let name) = model.deploy.phase {
+                WorkerNameConflictSheetView(model: model.deploy, takenName: name) {
+                    model.deploy.cancelWorkerNameConflictPrompt()
+                }
+            }
+        }
+```
+
+- [ ] **Step 3: Handle the new `Phase` case in `SiteWindowModel`'s dock/notification switch**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, the `deploy.onPhaseTransition` closure's `switch phase` (around lines 1452-1479) is exhaustive over `DeployModel.Phase` and will now fail to compile. Add a case after `.blocked` (after line 1479, before the closing `}` of the switch):
+
+```swift
+            case .workerNameConflict(let name):
+                // The sheet (SiteWindow) carries the actionable rename UI; the Dock tile and a
+                // completion notice both clear/fire the same way a plain failure would — there's
+                // no separate "conflict" notification affordance.
+                DockProgressController.shared.clear(token: dockToken)
+                Self.postNotice(siteID: siteID) { siteName in
+                    CompletionNoticeBuilder.deploy(
+                        siteName: siteName, siteID: siteID,
+                        outcome: .failed(reason: "Worker name \"\(name)\" is already in use — rename it to continue.")
+                    )
+                }
+```
+
+- [ ] **Step 4: Build the app target to verify everything compiles**
+
+Run: `xcodegen generate` (only if `Anglesite.xcodeproj` is missing or stale in this worktree)
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 5: Manual smoke check**
+
+Launch the app (`open Anglesite.xcodeproj`, run the `Anglesite` scheme), scaffold a new site, and deploy it twice under the same site name from two different local `.anglesite` packages sharing one Cloudflare account (or, faster: manually set `.site-config`'s `CF_PROJECT_NAME` to a Worker name you know already exists on your connected account, and confirm `CF_WORKER_DEPLOYED` is absent) — confirm:
+- The rename sheet appears with the taken name.
+- Submitting a new name rewrites `wrangler.toml`'s `name` line and `.site-config`'s `CF_PROJECT_NAME`, and the deploy proceeds.
+- Cancelling closes the sheet with no changes to either file.
+
+- [ ] **Step 6: Run the full test suite one more time**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path .`
+Expected: PASS — every `AnglesiteCoreTests`, `AnglesiteAppTests` (and other) target passes, confirming nothing in this plan regressed an unrelated suite.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteApp/WorkerNameConflictSheetView.swift Sources/AnglesiteApp/SiteWindow.swift Sources/AnglesiteApp/SiteWindowModel.swift
+git commit -m "feat(deploy): add the Worker-name conflict rename sheet and wire it into SiteWindow (#740)"
+```

--- a/docs/superpowers/specs/2026-07-16-worker-name-collision-check-design.md
+++ b/docs/superpowers/specs/2026-07-16-worker-name-collision-check-design.md
@@ -1,0 +1,183 @@
+# Worker-name collision check at first deploy — design (#740)
+
+- **Date:** 2026-07-16
+- **Status:** Proposed
+- **Issue:** [#740 — Worker-name collision: local slug uniqueness doesn't check the Cloudflare account's actual Workers](https://github.com/Anglesite/Anglesite-app/issues/740)
+- **Related:** follow-up from [PR #739](https://github.com/Anglesite/Anglesite-app/pull/739) review, which made `SiteScaffolder` write a real `wrangler.toml` at scaffold time
+
+## Problem
+
+`SiteScaffolder` derives a Worker name from the site's display name (`SiteSlug.derive(from:)`,
+[NewSiteDraft.swift:132-152](../../../Sources/AnglesiteCore/NewSiteDraft.swift)) and writes it into
+`wrangler.toml` at scaffold time
+([SiteScaffolder.swift:143-148](../../../Sources/AnglesiteCore/SiteScaffolder.swift)). Uniqueness is
+checked only against the local recents registry (`SiteStore`, via the wizard's `slugTaken` closure,
+[NewSiteWizardModel.swift:43-48](../../../Sources/AnglesiteCore/NewSiteWizardModel.swift)) — never
+against the Cloudflare account's actual Worker names. `wrangler deploy` silently takes over any
+existing Worker with a matching name rather than failing, so a collision is a silent deploy-time
+takeover of an unrelated Worker, not an error surfaced to the user. Two scenarios reach this: a site
+deleted locally and later re-scaffolded with the same slug, or two local installs sharing one
+Cloudflare account scaffolding same-named sites independently.
+
+## Decision
+
+Check Worker-name availability against the live Cloudflare account, at first-deploy time (not
+scaffold time), and block with a rename prompt on conflict — mirroring the existing
+"surface failures, no override" pattern the pre-deploy security scan already uses
+(`DeployCommand.Result.blocked`).
+
+### Why first-deploy time, not scaffold time
+
+`SiteScaffolder` is a deliberately offline, deterministic pipeline — no network access, no
+Cloudflare token, by design (its own doc comment: "deterministic new-site pipeline... No Claude").
+The wizard's `slugTaken` check is a synchronous, per-keystroke, `MainActor` closure over local
+state — the wrong shape for a network call. `DeployCommand.deploy(...)` already resolves a live
+Cloudflare API token before doing anything else
+([DeployCommand.swift:90-98](../../../Sources/AnglesiteCore/DeployCommand.swift)), so it's the
+first point in the pipeline with both a token and network access. The check runs there, as another
+pre-spawn refusal alongside the existing token-missing check — before build, before the pre-deploy
+scan, before wrangler.
+
+### Cloudflare API addition
+
+Add one read method, following the existing `CloudflareReading` shape
+([CloudflareReading.swift](../../../Sources/AnglesiteCore/CloudflareReading.swift)):
+
+```swift
+public protocol CloudflareReading: Sendable {
+    // ...existing methods...
+
+    /// Every Worker script name (the `id` field) visible to the token's first account.
+    /// Used to detect a Worker-name collision before a site's first deploy (#740).
+    func workerScriptNames(apiToken: String) async throws -> [String]
+}
+```
+
+`HTTPCloudflareClient`'s implementation mirrors the account-resolution pattern already used in
+`CloudflareWebAnalyticsClient.webAnalyticsSites` ([CloudflareWebAnalyticsClient.swift:57](../../../Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift)):
+resolve the first account id (`GET accounts?per_page=1`), then list scripts
+(`GET accounts/{id}/workers/scripts`, paginated via the existing `paginated<T>` helper — the same
+endpoint `CloudflareCapabilityProber` already probes for the `workers` permission scope, just read
+for its full contents here instead of a bare success/failure check). Decode each entry's `id` field
+(the script name).
+
+### "First deploy" signal
+
+`.site-config` gets a new unconditional marker, `CF_WORKER_DEPLOYED=true`, written via the existing
+`SiteConfigFile.upsert` helper right where `DeployCommand` already persists `SITE_URL` on a
+successful wrangler run ([DeployCommand.swift:197](../../../Sources/AnglesiteCore/DeployCommand.swift)).
+
+This must be a **new, separate** marker rather than reusing `SITE_URL`'s absence: `persistSiteURL`
+only writes `SITE_URL` when neither `DOMAIN` nor `SITE_DOMAIN` is already configured
+([DeployCommand.swift:256-258](../../../Sources/AnglesiteCore/DeployCommand.swift)), and sites
+scaffolded with `domainChoice == .transfer` already have `DOMAIN` set at scaffold time
+([SiteScaffolder.swift:199](../../../Sources/AnglesiteCore/SiteScaffolder.swift)). For those sites,
+`SITE_URL` would never be written on any deploy, so its absence does not mean "never deployed" — it
+would falsely gate every single deploy of a custom-domain site into the collision check.
+`CF_WORKER_DEPLOYED` is written on every successful wrangler run regardless of domain choice, so its
+absence unambiguously means "this site has never deployed before."
+
+The collision check fires when `.site-config` has no `CF_WORKER_DEPLOYED` marker. If
+`.site-config` also has no `CF_PROJECT_NAME` (e.g. a pre-#701 site with a hand-edited
+`wrangler.toml`), the check is skipped — fail open, since there's no reliable candidate name to
+check, and this is no worse than today's behavior.
+
+### `DeployCommand` changes
+
+```swift
+public actor DeployCommand {
+    public enum Result: Sendable, Equatable {
+        // ...existing cases...
+        /// The candidate Worker name already exists on the connected Cloudflare account, and
+        /// this site has never deployed before — refusing to silently take over someone else's
+        /// (or a stale) Worker. Carries the taken name for the UI prompt.
+        case workerNameConflict(name: String)
+    }
+
+    /// Returns the account's existing Worker script names for the given token. Production
+    /// callers use `DeployCommand.defaultWorkerScriptNames` (`HTTPCloudflareClient`); tests
+    /// inject a fake list.
+    public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
+
+    public init(
+        tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
+        workerScriptNamesSource: @escaping WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,
+        executor: any DeployExecutor = HostDeployExecutor()
+    ) { ... }
+}
+```
+
+In `deploy(...)`, immediately after the existing token guard
+([DeployCommand.swift:96-98](../../../Sources/AnglesiteCore/DeployCommand.swift)): read
+`.site-config`; if `CF_WORKER_DEPLOYED` is absent and `CF_PROJECT_NAME` is present, call
+`workerScriptNamesSource(token)` and check membership. A thrown error from the availability check
+(network failure, `.unauthorized`, etc.) is non-fatal to the *check itself* — it's treated as "can't
+confirm, proceed" (fail open) rather than blocking a deploy on a transient API hiccup; this mirrors
+`CloudflareCapabilityProber`'s "a thrown transport error counts as missing — probes are advisory"
+stance. A confirmed match returns `.workerNameConflict(name:)` before any build/preflight/wrangler
+step runs.
+
+### UX: rename sheet
+
+`DeployModel` ([DeployModel.swift](../../../Sources/AnglesiteApp/DeployModel.swift)) handles
+`.workerNameConflict` with a new sheet, in the same family as `CloudflareTokenPromptView` and the
+`.blocked` preflight sheet: explains the name is already taken on the connected Cloudflare account,
+and offers a text field (prefilled with a suggested `<slug>-2`) for a replacement name, validated
+through `SiteSlug.derive`. On submit:
+
+1. Replace just the `name = "..."` line in the existing `wrangler.toml` with the new slug — a
+   targeted in-place string replace, not a full regenerate via `WorkerComposition.generateWranglerToml`.
+   There is no existing reader that reconstructs a `[Feature]` list (or provisioned D1/KV resource
+   IDs) from an already-written `wrangler.toml`, and the collision check can fire after a user has
+   already run `SocialWorkerProvisionCommand` to opt into social features but before their first
+   deploy — regenerating from scratch would silently drop that provisioned config. A single-line
+   replace has no such risk.
+2. Update `.site-config`'s `CF_PROJECT_NAME` via `SiteConfigFile.upsert` (already a replace-or-append
+   helper — no new file-writing code needed).
+3. Retry `deploy(...)`. The collision check re-runs against the new name (still no
+   `CF_WORKER_DEPLOYED` marker) and loops back to the same sheet if the new name is also taken.
+
+The user can also cancel out of the sheet with no changes made — deploy simply doesn't proceed.
+
+### Testing
+
+- `HTTPCloudflareClient.workerScriptNames` — unit tests for a populated list, an empty account,
+  pagination across >100 scripts, and the unauthorized/http-error paths (mirroring existing
+  `CloudflareReading` test patterns).
+- `DeployCommand.deploy` gating — table of cases: no `CF_WORKER_DEPLOYED` + name taken →
+  `.workerNameConflict`; no `CF_WORKER_DEPLOYED` + name free → proceeds to build; no
+  `CF_WORKER_DEPLOYED` + no `CF_PROJECT_NAME` → proceeds (fail open); `CF_WORKER_DEPLOYED` present →
+  always proceeds regardless of remote state (no regression on redeploys); `workerScriptNamesSource`
+  throws → proceeds (fail open, non-fatal).
+- `DeployCommand.deploy` success path — asserts `CF_WORKER_DEPLOYED=true` is written to
+  `.site-config` alongside the existing `SITE_URL` persistence, including for a `.transfer`-domain
+  site (where `SITE_URL` itself is *not* written, per the existing `persistSiteURL` guard).
+- `DeployModel` — sheet presentation on `.workerNameConflict`, rename-and-retry flow (new name
+  written to both `wrangler.toml` and `.site-config`, deploy retried), and the loop-back case where
+  the retry also conflicts.
+
+## Non-goals
+
+- Any attempt to determine whether an existing remote Worker was created by *this* app install vs.
+  a third party — the check only distinguishes "have I (this site, this install) ever successfully
+  deployed" from "does a Worker with this name already exist," which is sufficient to cover both
+  scenarios in the issue without needing Worker-side ownership metadata.
+- Handling the case where a site's `Source/` repo is cloned to a second machine/install that hasn't
+  deployed locally yet, but the Worker already exists from the first machine's deploy — this would
+  surface as a (harmless, if slightly confusing) collision prompt on the second machine's first
+  deploy attempt. Not addressed here; out of scope for this non-blocking follow-up.
+- A dedicated "rename this site's Worker" entry point outside the conflict flow — the rename sheet
+  only appears reactively, on a detected conflict.
+- Auto-suffixing slugs (silently or otherwise) — rejected in favor of an explicit, blocking prompt,
+  consistent with the existing pre-deploy-scan philosophy of surfacing failures rather than working
+  around them.
+
+## Target architecture invariants
+
+- A site's Worker name is never silently reused from an unrelated existing Worker on first deploy.
+- The collision check runs only on a site's first deploy (per-site, per-install) — redeploys never
+  pay the extra API round-trip or risk a false positive from remote state that's actually the site's
+  own prior deploy.
+- A Cloudflare API failure during the collision check never blocks a deploy that would otherwise
+  succeed (fail open) — the check is a safety net, not a hard dependency.
+- `SiteScaffolder` remains fully offline; no Cloudflare coupling is added to the scaffold pipeline.


### PR DESCRIPTION
## Summary

Fixes #740. `wrangler deploy` silently takes over any existing Worker whose name matches `wrangler.toml`'s `name` field — so a scaffolded site whose slug collides with an unrelated (or stale) Worker on the same Cloudflare account would silently clobber it instead of failing. This adds a pre-deploy collision check and a rename-and-retry flow:

- `CloudflareReading.workerScriptNames(apiToken:)` lists every Worker script name visible to the connected account.
- `DeployCommand` now persists a `CF_WORKER_DEPLOYED` marker in `.site-config` on every successful deploy — the "has this site ever deployed" signal, deliberately independent of the pre-existing `SITE_URL` marker (which is skipped for custom-domain sites, so it can't double as this signal).
- On a site's **first** deploy only, `DeployCommand` checks whether its intended Worker name already exists on the account. A collision returns a new `Result.workerNameConflict(name:)` case instead of proceeding — a Cloudflare API failure during this check always fails open (never blocks a deploy that would otherwise succeed).
- `DeployModel` parks the blocked deploy and presents a new sheet (`WorkerNameConflictSheetView`) letting the user pick a different name. Submitting rewrites `wrangler.toml`'s `name` line and `.site-config`'s `CF_PROJECT_NAME` **in place** (not a full regenerate, so any already-provisioned social-feature config survives) and retries — looping back to the same sheet if the new name is also taken.

Design spec: `docs/superpowers/specs/2026-07-16-worker-name-collision-check-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-16-worker-name-collision-check.md`

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: N/A

No MCP message schema changes — this is entirely app-side (`DeployCommand`, `DeployModel`, and the new rename sheet).

## Two known, non-blocking open items (surfaced for the reviewer, not silently glossed over)

1. **`Localizable.xcstrings` wasn't updated** with the new sheet's strings. Confirmed via `git log` that every app-side PR since the CONTRIBUTING.md rule landed (one day before this work) has the same gap — String Catalog extraction needs an Xcode GUI build, which this CLI-driven workflow doesn't produce. Looks like a repo-wide tooling gap rather than something specific to this branch; flagging rather than hand-editing the catalog out of step with how extraction actually works. Tracked separately: #811.
2. **Manual interactive GUI smoke check was not performed** this session (no GUI/computer-use access in this environment). The rename/cancel/retry state machine is covered by `DeployModel` unit tests doing real file I/O against a fake `DeployCommand` (including a loop-back-to-conflict case), but the actual SwiftUI sheet was never driven by a human or a screen.

## Test plan

- [x] `swift test --package-path .` — full unfiltered suite, all suites/tests passing (XCTest 106/106, Swift Testing all green)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`
- [x] New unit coverage: `HTTPCloudflareClient.workerScriptNames` (pagination, no-account error), `DeployCommand`'s collision gate (name-taken/free/no-marker/already-deployed/fail-open), `WorkerNameRename` (targeted rewrite, validation-before-write, including `.nameLineNotFound`), `DeployModel`'s park/present/rename/retry/loop-back/cancel flows
- [ ] Manual GUI smoke of the rename sheet — not performed this session, see open item #2 above

## Review feedback addressed

Per [@davidwkeith's review](https://github.com/Anglesite/Anglesite-app/pull/810#pullrequestreview):
- Added this Paired PR check section (was missing — required by the PR template).
- Filed #811 to track the `Localizable.xcstrings` gap as backlog debt instead of letting it go unrecorded.
- Fixed the worker-name-conflict sheet dismiss/re-present flash on loop-back: it now only closes once the retry's outcome is known (`DeployModel.swift`), instead of closing unconditionally before the retry even starts.
- Added `WorkerNameRenameTests` coverage for `RenameError.nameLineNotFound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
