### PR TITLE
feat(container): add in-app vmnet networking recovery (#812)

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1619,6 +1619,9 @@
     "Restart" : {
 
     },
+    "Restart Networking & Retry" : {
+
+    },
     "Result" : {
 
     },

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -468,6 +468,17 @@ final class PreviewModel {
         return (siteID: snapshot.siteID, control: snapshot.control)
     }
 
+    /// The failure pane's "Restart Networking" action (#812) — unlike `activeContainerControl()`,
+    /// works from a `.failed` state (no live container to snapshot) since
+    /// `LocalContainerSiteRuntime.resetNetworking()` reaches its `control` unconditionally. No-ops
+    /// for other runtime types; the button that calls this is only shown when
+    /// `VmnetFailureRecovery.isRecoverable` recognized the failure, which only the local-container
+    /// path can produce.
+    func resetNetworking() async {
+        guard let containerRuntime = runtime as? LocalContainerSiteRuntime else { return }
+        await containerRuntime.resetNetworking()
+    }
+
     /// True when the preview runtime is ready — used to gate the Deploy button so a user
     /// deploying before the container (or dev server) is up sees a coherent error rather than
     /// a silent `ContainerDeployExecutor` "container isn't running" failure.

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -786,6 +786,13 @@ struct SiteWindow: View {
                     Text(message)
                         .font(.callout).foregroundStyle(.secondary)
                         .multilineTextAlignment(.center).frame(maxWidth: 420)
+                    // Only for the vmnet failures `VmnetFailureRecovery` recognizes — plain Retry
+                    // alone would keep reusing the same wedged network object (#812).
+                    if VmnetFailureRecovery.isRecoverable(failureMessage: message) {
+                        Button("Restart Networking & Retry") {
+                            model.restartNetworkingAndRetry()
+                        }
+                    }
                     Button("Retry") {
                         model.retryPreview()
                     }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -366,6 +366,17 @@ final class SiteWindowModel {
         preview.startDevServer()
     }
 
+    /// The `.failed`-state pane's "Restart Networking" button (#812), shown only when
+    /// `VmnetFailureRecovery.isRecoverable` recognizes the failure. Drops this process's cached
+    /// vmnet network (`PreviewModel.resetNetworking()`) before retrying, so the retry that follows
+    /// doesn't just fail against the same wedged network object.
+    func restartNetworkingAndRetry() {
+        Task {
+            await preview.resetNetworking()
+            retryPreview()
+        }
+    }
+
     func previewStateChanged(_ state: SiteRuntimeState) {
         startup.ingest(state: state)
         guard preview.canDeploy, let invisiblePublishQueue else { return }

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -190,6 +190,16 @@ public struct ContainerizationControl: LocalContainerControl {
         await network.release(siteID: siteID)
     }
 
+    /// `LocalContainerControl.resetNetworking()` conformance (#812): drops this process's cached
+    /// vmnet network so the next boot attempt builds a fresh one, without disturbing any
+    /// currently-running site's container (see `SharedVmnetNetwork.reset()`) and without an app
+    /// relaunch or macOS reboot. Every `ContainerizationControl` value resolves to the same
+    /// `SharedVmnetNetwork.shared` actor, so this is reachable from any instance regardless of
+    /// which site (if any) it booted.
+    public func resetNetworking() async {
+        await network.reset()
+    }
+
     /// Phases 0–2 of `start()`: resolve bundled artifacts, unpack rootfs/initfs, boot the VM.
     /// `sourceRepo: nil` boots a bare container (no virtio-fs share) — used by the vsock e2e test.
     /// Does NOT register the container in `live` — the caller owns its lifecycle (either `start()`'s

--- a/Sources/AnglesiteContainer/SharedVmnetNetwork.swift
+++ b/Sources/AnglesiteContainer/SharedVmnetNetwork.swift
@@ -56,4 +56,26 @@ actor SharedVmnetNetwork {
         try? network.releaseInterface(siteID)
         self.network = network
     }
+
+    /// Discards the cached network so the next `allocate` builds a fresh one via `makeNetwork`,
+    /// instead of reusing whatever this process has been holding since its first boot (#812).
+    ///
+    /// Safe for any currently-running site: `VmnetNetwork.Interface` (Containerization's
+    /// `Network.createInterface` return value, already handed to that site's booted VM as
+    /// `config.interfaces`) carries its own retained copy of the underlying `vmnet_network_ref` —
+    /// `vmnet_network_create` returns it `CF_RETURNS_RETAINED`, so Swift ARC/CF-bridges it like any
+    /// other CF object. Dropping the copy cached here only stops *this* actor from reusing it for
+    /// future allocations; a VM that already attached its own copy keeps running unaffected, and
+    /// the OS-level network only actually tears down once every such holder — including one held by
+    /// this call — releases theirs.
+    ///
+    /// This is a self-heal for state that's stuck *in this process* (e.g. an exhausted allocator, or
+    /// a network object left in a bad state by a partial boot failure). It does NOT reach into vmnet
+    /// state owned by another process: a stranded lease left by a crashed prior launch or another
+    /// app (#753) is invisible to and unrecoverable by this call — the App Sandbox precludes
+    /// inspecting or killing another process's Virtualization XPC VM, matching
+    /// `VmnetFailureRecovery`'s existing constraint.
+    func reset() {
+        network = nil
+    }
 }

--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -124,4 +124,18 @@ public protocol LocalContainerControl: Sendable {
         workingDirectory: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> InteractiveExecHandle
+
+    /// Explicit, scoped network-layer recovery (#812): discards whatever shared network state this
+    /// control's boot path caches, so the *next* boot attempt builds fresh state instead of reusing
+    /// something possibly wedged — without an app relaunch. Surfaced as the failure pane's "Restart
+    /// Networking" button, gated on `VmnetFailureRecovery.isRecoverable`.
+    ///
+    /// Defaults to a no-op below for conformers with no such shared state to reset (Podman on
+    /// Linux, test fakes) — only `ContainerizationControl`'s vmnet-backed network is ever the
+    /// target.
+    func resetNetworking() async
+}
+
+extension LocalContainerControl {
+    public func resetNetworking() async {}
 }

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -103,6 +103,14 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         return (control: control, siteID: id)
     }
 
+    /// `PreviewModel.resetNetworking()`'s target (#812): unlike `containerSnapshot()`, `control` is
+    /// available from construction regardless of `activeSiteID` — a boot failure never sets it, but
+    /// the failure pane's "Restart Networking" button needs to reach this control precisely when
+    /// the most recent boot failed.
+    public func resetNetworking() async {
+        await control.resetNetworking()
+    }
+
     /// Copies one commit produced by the MCP sidecar in `/workspace/site` back into the host's
     /// canonical `Source/` repository without granting the guest write access to that repository.
     ///

--- a/Sources/AnglesiteCore/VmnetFailureRecovery.swift
+++ b/Sources/AnglesiteCore/VmnetFailureRecovery.swift
@@ -3,16 +3,32 @@ import Foundation
 /// Turns the opaque error emitted by `VmnetNetwork()` into an operator-actionable diagnosis.
 ///
 /// The app is sandboxed and must not inspect or terminate another process's Virtualization XPC
-/// VM. In particular, a stale VM can survive its owning container CLI process, so retrying a
-/// network creation cannot reliably repair this system-wide state (#753).
+/// VM. In particular, a stale VM can survive its owning container CLI process, so this alone
+/// cannot reliably repair system-wide vmnet state (#753) — quitting other apps or rebooting may
+/// still be needed. But the failure can also be *this process's own* cached vmnet network stuck in
+/// a bad state, which the "Restart Networking" action the failure pane offers when `isRecoverable`
+/// is true (`ContainerizationControl.resetSharedNetworking()`, #812) can fix without either.
 public enum VmnetFailureRecovery {
+    /// Substring both `message(for:)` and `isRecoverable(failureMessage:)` key off of, kept in one
+    /// place so the two can't drift out of sync.
+    private static let recoveryMarker = "VMNET_MEM_FAILURE"
+
     /// Returns a stable, named recovery message for known vmnet creation failures.
     public static func message(for errorDescription: String) -> String? {
         guard errorDescription.contains("vmnet_return_t(rawValue: 1002)")
         else { return nil }
 
-        return "The macOS vmnet service reported VMNET_MEM_FAILURE (1002). Another VM or a stale "
-            + "Virtualization process may still hold vmnet resources. Quit other VM/container apps and retry. "
-            + "If it persists, restart your Mac to clear the stale Virtualization state."
+        return "The macOS vmnet service reported \(recoveryMarker) (1002). Try Restart Networking below first — "
+            + "it discards this app's cached vmnet network without a relaunch. If it persists, another VM or a "
+            + "stale Virtualization process may still hold vmnet resources: quit other VM/container apps and "
+            + "retry, or restart your Mac to clear the stale Virtualization state."
+    }
+
+    /// True when `failureMessage` (as surfaced by `SiteRuntimeState.failed`) names a vmnet failure
+    /// that `ContainerizationControl.resetSharedNetworking()` can plausibly self-heal. Gates the
+    /// failure pane's "Restart Networking" button — shown only for the failures `message(for:)`
+    /// itself recognizes, not every boot failure.
+    public static func isRecoverable(failureMessage: String) -> Bool {
+        failureMessage.contains(recoveryMarker)
     }
 }

--- a/Sources/AnglesiteCore/VmnetFailureRecovery.swift
+++ b/Sources/AnglesiteCore/VmnetFailureRecovery.swift
@@ -7,7 +7,7 @@ import Foundation
 /// cannot reliably repair system-wide vmnet state (#753) — quitting other apps or rebooting may
 /// still be needed. But the failure can also be *this process's own* cached vmnet network stuck in
 /// a bad state, which the "Restart Networking" action the failure pane offers when `isRecoverable`
-/// is true (`ContainerizationControl.resetSharedNetworking()`, #812) can fix without either.
+/// is true (`ContainerizationControl.resetNetworking()`, #812) can fix without either.
 public enum VmnetFailureRecovery {
     /// Substring both `message(for:)` and `isRecoverable(failureMessage:)` key off of, kept in one
     /// place so the two can't drift out of sync.
@@ -25,7 +25,7 @@ public enum VmnetFailureRecovery {
     }
 
     /// True when `failureMessage` (as surfaced by `SiteRuntimeState.failed`) names a vmnet failure
-    /// that `ContainerizationControl.resetSharedNetworking()` can plausibly self-heal. Gates the
+    /// that `ContainerizationControl.resetNetworking()` can plausibly self-heal. Gates the
     /// failure pane's "Restart Networking" button — shown only for the failures `message(for:)`
     /// itself recognizes, not every boot failure.
     public static func isRecoverable(failureMessage: String) -> Bool {

--- a/Tests/AnglesiteContainerLocalTests/SharedVmnetNetworkTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/SharedVmnetNetworkTests.swift
@@ -43,6 +43,63 @@ struct SharedVmnetNetworkTests {
         #expect(recorder.releaseCalls == ["missing-gateway"])
         #expect(recorder.activeSiteIDs.isEmpty)
     }
+
+    @Test("reset discards the cached network so the next allocate rebuilds it (#812)")
+    func resetForcesRebuild() async throws {
+        // Each factory call gets its own recorder — mirrors real `VmnetNetwork.init` building a
+        // fresh, empty `Allocator` per instance, not one shared across every network this process
+        // ever creates.
+        let factory = RecordingFactory()
+        let allocator = SharedVmnetNetwork {
+            FakeNetwork(recorder: factory.makeRecorder())
+        }
+
+        _ = try await allocator.allocate(siteID: "before-reset")
+        #expect(factory.callCount == 1)
+
+        await allocator.reset()
+
+        // A fresh network's allocator has no memory of the pre-reset siteID, so the same id can be
+        // allocated again without the "already exists" error `FakeNetworkRecorder.allocate` throws
+        // for a live duplicate against the SAME network instance.
+        _ = try await allocator.allocate(siteID: "before-reset")
+        #expect(factory.callCount == 2)
+        #expect(factory.recorderCount == 2)
+    }
+
+    @Test("reset before any allocation is a harmless no-op")
+    func resetWithoutPriorAllocation() async throws {
+        let factory = RecordingFactory()
+        let allocator = SharedVmnetNetwork {
+            FakeNetwork(recorder: factory.makeRecorder())
+        }
+
+        await allocator.reset()
+        _ = try await allocator.allocate(siteID: "first-ever")
+        #expect(factory.callCount == 1)
+    }
+}
+
+/// Hands out a fresh `FakeNetworkRecorder` per factory call while tracking how many were made —
+/// mirrors `FakeNetworkRecorder`'s own locking style below. A plain captured `var` won't compile
+/// here: `SharedVmnetNetwork.NetworkFactory` is `@Sendable`, so the factory closure can't mutate a
+/// non-isolated local.
+private final class RecordingFactory: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls = 0
+    private var recorders: [FakeNetworkRecorder] = []
+
+    var callCount: Int { lock.withLock { calls } }
+    var recorderCount: Int { lock.withLock { recorders.count } }
+
+    func makeRecorder() -> FakeNetworkRecorder {
+        lock.withLock {
+            calls += 1
+            let recorder = FakeNetworkRecorder()
+            recorders.append(recorder)
+            return recorder
+        }
+    }
 }
 
 private struct FakeNetwork: Network {

--- a/Tests/AnglesiteCoreTests/VmnetFailureRecoveryTests.swift
+++ b/Tests/AnglesiteCoreTests/VmnetFailureRecoveryTests.swift
@@ -8,7 +8,8 @@ struct VmnetFailureRecoveryTests {
         let message = VmnetFailureRecovery.message(for: error)
 
         #expect(message?.contains("VMNET_MEM_FAILURE (1002)") == true)
-        #expect(message?.contains("Quit other VM/container apps and retry") == true)
+        #expect(message?.contains("Restart Networking") == true)
+        #expect(message?.contains("quit other VM/container apps and retry") == true)
         #expect(message?.contains("restart your Mac") == true)
     }
 
@@ -18,5 +19,13 @@ struct VmnetFailureRecoveryTests {
         #expect(VmnetFailureRecovery.message(for: "vmnet returned 1001") == nil)
         #expect(VmnetFailureRecovery.message(for: "vmnet_return_t(rawValue: 11002)") == nil)
         #expect(VmnetFailureRecovery.message(for: "vmnet_return_t(rawValue: 10021)") == nil)
+    }
+
+    @Test("isRecoverable matches only the failures message(for:) itself names")
+    func isRecoverableTracksMessage() {
+        let recognized = VmnetFailureRecovery.message(
+            for: "unsupported: failed to create vmnet network with status vmnet_return_t(rawValue: 1002)")!
+        #expect(VmnetFailureRecovery.isRecoverable(failureMessage: recognized))
+        #expect(!VmnetFailureRecovery.isRecoverable(failureMessage: "guest process launch failed: timed out"))
     }
 }


### PR DESCRIPTION
## Summary

- `SharedVmnetNetwork` was already an app-lifetime singleton, so the remaining gap in #812 was a self-heal path for a wedged vmnet network that doesn't dead-end at "quit other apps / reboot your Mac."
- Adds `SharedVmnetNetwork.reset()`, a new `LocalContainerControl.resetNetworking()` protocol member (default no-op for non-Containerization conformers, real implementation in `ContainerizationControl`), threaded through `LocalContainerSiteRuntime`/`PreviewModel` so it's reachable even from a `.failed` boot state (no live container snapshot exists yet at that point).
- The failure pane now offers a "Restart Networking & Retry" button when `VmnetFailureRecovery.isRecoverable` recognizes the failure (currently `VMNET_MEM_FAILURE`).
- Safe for already-running sites: a booted VM's `Interface` carries its own retained copy of the underlying `vmnet_network_ref` (`CF_RETURNS_RETAINED`, confirmed against the vmnet.framework header), so dropping the cached reference here only stops *this* actor from reusing it for future allocations — it never disturbs a container that's already running.
- Does **not** claim to fix a truly OS-level/other-process stranded lease (#753) — the App Sandbox still precludes inspecting or killing another process's Virtualization XPC VM. This is scoped to state stuck in *this* process, per the issue's "concrete win regardless of whether the strand is app-side or OS-side."

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path .` — full suite passes except two pre-existing, unrelated flakes (`InvisiblePublishQueueTests` debounce timing, `GenerableTypesTests` FM token-context overflow); everything touching this change (`VmnetFailureRecoveryTests`, `SharedVmnetNetworkTests`) passes.
- [x] `ANGLESITE_CONTAINER_TESTS=1 swift test --filter SharedVmnetNetworkTests` — passes (4/4, including two new reset tests).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] Manual smoke: not run (reproducing `VMNET_MEM_FAILURE` requires exhausting the host's vmnet resources).

Closes #812.