### PR TITLE
feat(workers): persisted active-worker state + deploy diff/removal (#709)

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -83,6 +83,12 @@ final class DeployModel {
     private let keychain: KeychainStore
     private let onboarding: TokenOnboarding
     private let summarizer: any DeployFailureSummarizing
+    private let contentGraph: SiteContentGraph
+    /// Returns the current `@dwk/workers` catalog. Defaults to `{ [] }` (no network, no active
+    /// settings-activated workers ever computed) so existing tests that don't inject one keep
+    /// deploying exactly as before — production wiring (`SiteWindowModel`) passes a real
+    /// `WorkerCatalogFetcher(catalogURL: WorkerCatalogFetcher.productionCatalogURL).catalog`.
+    private let workerCatalog: @Sendable () async -> [WorkerDescriptor]
     /// Bumped at the start of every `runDeploy`. The async failure-summarization captures the
     /// value at dispatch and only writes its result back if it still matches — so a summary from
     /// a superseded deploy can't stomp the current deploy's state, even though
@@ -117,7 +123,9 @@ final class DeployModel {
         verifier: TokenVerifying = CloudflareAPITokenVerifier(),
         summarizer: any DeployFailureSummarizing = DeploySummarizerFactory.makeDefault(),
         suddenTerminationController: SuddenTerminationController = .shared,
-        tokenAvailabilityOverride: (() -> Bool)? = nil
+        tokenAvailabilityOverride: (() -> Bool)? = nil,
+        contentGraph: SiteContentGraph = SiteContentGraph(),
+        workerCatalog: @escaping @Sendable () async -> [WorkerDescriptor] = { [] }
     ) {
         self.command = command
         self.webmentionCommand = webmentionCommand
@@ -128,6 +136,8 @@ final class DeployModel {
         self.summarizer = summarizer
         self.suddenTerminationController = suddenTerminationController
         self.tokenAvailabilityOverride = tokenAvailabilityOverride
+        self.contentGraph = contentGraph
+        self.workerCatalog = workerCatalog
     }
 
     var isRunning: Bool {
@@ -156,7 +166,8 @@ final class DeployModel {
         siteDirectory: URL,
         configDirectory: URL,
         currentRoutes: [String],
-        containerControl: (siteID: String, control: any LocalContainerControl)? = nil
+        containerControl: (siteID: String, control: any LocalContainerControl)? = nil,
+        siteName: String? = nil
     ) {
         guard !isRunning else { return }
         if !hasUsableToken() {
@@ -176,7 +187,8 @@ final class DeployModel {
                 configDirectory: configDirectory, currentRoutes: currentRoutes,
                 containerControl: containerControl,
                 suddenTerminationLease: suddenTerminationLease,
-                presentation: .foreground)
+                presentation: .foreground,
+                siteName: siteName)
         }
     }
 
@@ -189,7 +201,8 @@ final class DeployModel {
         siteDirectory: URL,
         configDirectory: URL,
         currentRoutes: [String],
-        containerControl: (siteID: String, control: any LocalContainerControl)?
+        containerControl: (siteID: String, control: any LocalContainerControl)?,
+        siteName: String? = nil
     ) async -> InvisiblePublishQueue.Result {
         guard !isRunning else { return .deferred(reason: "another site operation is running") }
         guard hasUsableToken() else { return .deferred(reason: "Cloudflare credentials are not configured") }
@@ -204,7 +217,8 @@ final class DeployModel {
             currentRoutes: currentRoutes,
             containerControl: containerControl,
             suddenTerminationLease: lease,
-            presentation: .background
+            presentation: .background,
+            siteName: siteName
         )
         switch result {
         case .succeeded(let url, _):
@@ -351,7 +365,8 @@ final class DeployModel {
         currentRoutes: [String],
         containerControl: (siteID: String, control: any LocalContainerControl)? = nil,
         suddenTerminationLease: SuddenTerminationController.Lease,
-        presentation: Presentation
+        presentation: Presentation,
+        siteName: String? = nil
     ) async -> DeployCommand.Result {
         defer { suddenTerminationLease.release() }
         transition(siteID: siteID, to: .running(siteID: siteID, since: Date()))
@@ -382,6 +397,7 @@ final class DeployModel {
         // injected `command` so the test-injection path (a fully pre-built
         // `DeployCommand`) continues to work unmodified.
         let activeCommand: DeployCommand
+        let containerRunner: SocialWorkerProvisionCommand.CommandRunner?
         if let cc = containerControl {
             activeCommand = DeployCommand(
                 tokenSource: command.tokenSource,
@@ -391,31 +407,100 @@ final class DeployModel {
                     logCenter: logCenter
                 )
             )
+            containerRunner = ContainerCommandRunner(control: cc.control, siteID: cc.siteID, logCenter: logCenter).runner
         } else {
             activeCommand = command
+            containerRunner = nil
         }
 
-        let result = await activeCommand.deploy(
-            siteID: siteID,
-            siteDirectory: siteDirectory,
-            configDirectory: configDirectory,
-            currentRoutes: currentRoutes,
-            onPreflight: { [weak self] outcome in
-                // The callback fires inside DeployCommand's actor isolation; hop to
-                // MainActor before touching our @Observable state or the consumer's
-                // closure (which likely mutates SwiftUI state too).
-                Task { @MainActor in
-                    self?.onScanComplete?(outcome)
-                }
-            },
-            onProgress: { [weak self] progress in
-                // last-write-wins: each milestone fully replaces the label, so out-of-order delivery across these hops is benign
-                Task { @MainActor in
-                    self?.currentMilestone = progress.label
-                    self?.onMilestone?(siteID, progress)
-                }
+        // Effective active worker set (#709 design §4-5): component-tied workers via
+        // ImpactAnalysis (only when this site's content graph has actually been scanned — a
+        // headless/never-opened site contributes nothing there, matching ImpactAnalysis's own
+        // "never invents, may under-report" bias) unioned with settings-activated workers.
+        let configStore = SiteConfigStore(configDirectory: configDirectory)
+        let settings = (try? await configStore.load()) ?? SiteSettings()
+        let catalog = await workerCatalog()
+        let snapshot: SiteGraphExplorerSnapshot?
+        if await contentGraph.isPopulated(siteID: siteID) {
+            snapshot = SiteGraphExplorer.build(
+                projectRoot: siteDirectory,
+                siteID: siteID,
+                pages: await contentGraph.pages(for: siteID),
+                posts: await contentGraph.posts(for: siteID),
+                images: await contentGraph.images(for: siteID)
+            )
+        } else {
+            snapshot = nil
+        }
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: snapshot)
+        let removedIDs = WorkerActivation.removedIDs(previous: Set(settings.lastDeployedWorkerIDs ?? []), next: effectiveActiveIDs)
+        if !removedIDs.isEmpty {
+            await logCenter.append(
+                source: "deploy:\(siteID)",
+                stream: .stdout,
+                text: "Deactivating workers: \(removedIDs.sorted().joined(separator: ", "))"
+            )
+        }
+        let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
+
+        let socialCommand = SocialWorkerProvisionCommand(
+            tokenSource: { [weak self] in try await self?.command.tokenSource() },
+            runner: containerRunner ?? SocialWorkerProvisionCommand.defaultRunner,
+            deployer: { [weak self] _, deploySiteID, deploySiteDirectory in
+                await activeCommand.deploy(
+                    siteID: deploySiteID,
+                    siteDirectory: deploySiteDirectory,
+                    configDirectory: configDirectory,
+                    currentRoutes: currentRoutes,
+                    onPreflight: { [weak self] outcome in
+                        Task { @MainActor in self?.onScanComplete?(outcome) }
+                    },
+                    onProgress: { [weak self] progress in
+                        Task { @MainActor in
+                            self?.currentMilestone = progress.label
+                            self?.onMilestone?(siteID, progress)
+                        }
+                    }
+                )
             }
         )
+
+        // Prefer the site's already-established Worker name (`.site-config`'s `CF_PROJECT_NAME`,
+        // set at the first successful deploy or by a worker-name-conflict rename, #740) over
+        // re-deriving one from the site's display name. Otherwise every deploy after a
+        // rename-and-retry would silently regenerate `wrangler.toml` under the original
+        // (still-taken) name basis via `persistConfig`, defeating the rename. Falls back to the
+        // derived slug only when no candidate name has been recorded yet — a genuinely first-ever
+        // deploy.
+        let existingConfig = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        let workerSiteName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: existingConfig)
+            ?? SiteSlug.derive(from: siteName ?? siteID)
+        let provisionResult = await socialCommand.provision(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            siteName: workerSiteName,
+            features: features,
+            knownResources: settings.provisionedWorkerResources ?? .init()
+        )
+
+        if case .succeeded(_, let resources, _) = provisionResult {
+            var updated = settings
+            updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
+            updated.provisionedWorkerResources = resources
+            try? await configStore.save(updated)
+        }
+
+        let result: DeployCommand.Result
+        switch provisionResult {
+        case .succeeded(let url, _, let duration):
+            result = .succeeded(url: url, duration: duration)
+        case .blocked(let failures, let warnings, _):
+            result = .blocked(failures: failures, warnings: warnings)
+        case .workerNameConflict(let name, _):
+            result = .workerNameConflict(name: name)
+        case .failed(let reason, let exitCode, _):
+            result = .failed(reason: reason, exitCode: exitCode)
+        }
 
         subscription.cancel()
         _ = await logTask.value

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -106,7 +106,8 @@ final class DeployModel {
         siteDirectory: URL,
         configDirectory: URL,
         currentRoutes: [String],
-        containerControl: (siteID: String, control: any LocalContainerControl)?
+        containerControl: (siteID: String, control: any LocalContainerControl)?,
+        siteName: String?
     )?
 
     private enum Presentation: Equatable {
@@ -171,7 +172,7 @@ final class DeployModel {
     ) {
         guard !isRunning else { return }
         if !hasUsableToken() {
-            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl)
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl, siteName)
             tokenVerification = .idle
             tokenPromptPresented = true
             return
@@ -266,7 +267,7 @@ final class DeployModel {
             deploy(
                 siteID: pending.siteID, siteDirectory: pending.siteDirectory,
                 configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
-                containerControl: pending.containerControl)
+                containerControl: pending.containerControl, siteName: pending.siteName)
         case .stay(let message):
             tokenVerification = .failed(message: message)
         case .abort:
@@ -317,7 +318,7 @@ final class DeployModel {
         deploy(
             siteID: pending.siteID, siteDirectory: pending.siteDirectory,
             configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
-            containerControl: pending.containerControl)
+            containerControl: pending.containerControl, siteName: pending.siteName)
     }
 
     func cancelWorkerNameConflictPrompt() {
@@ -490,17 +491,7 @@ final class DeployModel {
             try? await configStore.save(updated)
         }
 
-        let result: DeployCommand.Result
-        switch provisionResult {
-        case .succeeded(let url, _, let duration):
-            result = .succeeded(url: url, duration: duration)
-        case .blocked(let failures, let warnings, _):
-            result = .blocked(failures: failures, warnings: warnings)
-        case .workerNameConflict(let name, _):
-            result = .workerNameConflict(name: name)
-        case .failed(let reason, let exitCode, _):
-            result = .failed(reason: reason, exitCode: exitCode)
-        }
+        let result = provisionResult.asDeployCommandResult
 
         subscription.cancel()
         _ = await logTask.value
@@ -553,7 +544,7 @@ final class DeployModel {
             workerNameConflictPresented = false
             blockedPresented = presentation == .foreground
         case .workerNameConflict(let name):
-            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl)
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl, siteName)
             transition(siteID: siteID, to: .workerNameConflict(name: name))
             drawerPresented = false
             workerNameConflictError = nil

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -71,7 +71,7 @@ final class SiteWindowModel {
     /// reports into it and AppKit's `appEntityUIElementProvider` can hit-test against its
     /// annotations (Siri AI Phase B / #146 + #148).
     var annotationProvider: PreviewAnnotationProvider?
-    var deploy = DeployModel()
+    var deploy: DeployModel
     private(set) var invisiblePublishState: InvisiblePublishQueue.State = .idle
     #if !ANGLESITE_MAS
     var publish = PublishModel()
@@ -184,6 +184,10 @@ final class SiteWindowModel {
         contentIndexerStore: ContentIndexerStore
     ) {
         self.contentGraph = contentGraph
+        self.deploy = DeployModel(
+            contentGraph: contentGraph,
+            workerCatalog: { await WorkerCatalogFetcher(catalogURL: WorkerCatalogFetcher.productionCatalogURL).catalog() }
+        )
         self.knowledgeIndex = knowledgeIndex
         self.semanticRanker = semanticRanker
         self.conventionsEngine = conventionsEngine
@@ -479,7 +483,7 @@ final class SiteWindowModel {
             deploy.deploy(
                 siteID: site.id, siteDirectory: site.sourceDirectory,
                 configDirectory: site.configDirectory, currentRoutes: currentRoutes,
-                containerControl: containerControl)
+                containerControl: containerControl, siteName: site.name)
         }
     }
 
@@ -1423,7 +1427,8 @@ final class SiteWindowModel {
             siteDirectory: site.sourceDirectory,
             configDirectory: site.configDirectory,
             currentRoutes: pageRoutes + postRoutes,
-            containerControl: containerControl
+            containerControl: containerControl,
+            siteName: site.name
         )
     }
 

--- a/Sources/AnglesiteCore/ContainerCommandRunner.swift
+++ b/Sources/AnglesiteCore/ContainerCommandRunner.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Runs `SocialWorkerProvisionCommand`'s wrangler subcommands (`d1`/`kv`/`r2 create`,
+/// `d1 migrations apply`, …) inside a running container via `LocalContainerControl.exec` —
+/// the `CommandRunner` counterpart to `ContainerDeployExecutor` (`DeployExecutor.swift:61-168`),
+/// which does the same for the three fixed deploy steps. `SocialWorkerProvisionCommand`'s
+/// `arguments` are already bare wrangler subcommand argv (e.g. `["d1", "create", name, "--json"]`);
+/// this just prefixes `["npx", "wrangler"]` and adapts the result shape.
+public struct ContainerCommandRunner: Sendable {
+    private let control: any LocalContainerControl
+    private let siteID: String
+    private let logCenter: LogCenter
+
+    public init(control: any LocalContainerControl, siteID: String, logCenter: LogCenter = .shared) {
+        self.control = control
+        self.siteID = siteID
+        self.logCenter = logCenter
+    }
+
+    /// Bind this instance's `run` as a `SocialWorkerProvisionCommand.CommandRunner` closure.
+    public var runner: SocialWorkerProvisionCommand.CommandRunner {
+        { [self] siteDirectory, arguments, environment, source in
+            try await self.run(siteDirectory: siteDirectory, arguments: arguments, environment: environment, source: source)
+        }
+    }
+
+    // Guest-only allowlist — same rationale as `ContainerDeployExecutor.guestEnvAllowlist`: the
+    // host (macOS) environment must never cross into the Linux guest wholesale.
+    private static let guestEnvAllowlist: Set<String> = ["CLOUDFLARE_API_TOKEN"]
+
+    private func run(
+        siteDirectory: URL,
+        arguments: [String],
+        environment: [String: String],
+        source: String
+    ) async throws -> ProcessSupervisor.RunResult {
+        let argv = ["npx", "wrangler"] + arguments
+        let guestEnvironment = environment.filter { Self.guestEnvAllowlist.contains($0.key) }
+
+        let (lines, continuation) = AsyncStream<(String, LogCenter.Stream)>.makeStream(bufferingPolicy: .unbounded)
+        let logCenter = self.logCenter
+        let drain = Task.detached(priority: .utility) {
+            for await (line, stream) in lines {
+                await logCenter.append(source: source, stream: stream, text: line)
+            }
+        }
+
+        let result: ContainerExecResult
+        do {
+            result = try await control.exec(
+                siteID: siteID,
+                argv: argv,
+                environment: guestEnvironment,
+                workingDirectory: "/workspace/site",
+                onOutput: { line, stream in continuation.yield((line, stream)) }
+            )
+        } catch {
+            continuation.finish()
+            _ = await drain.value
+            throw error
+        }
+        continuation.finish()
+        _ = await drain.value
+        return ProcessSupervisor.RunResult(stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode)
+    }
+}

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -32,13 +32,33 @@ public struct SiteSettings: Sendable, Codable, Equatable {
     /// Bluesky PDS origin. `nil` uses the public `https://bsky.social` service.
     public var blueskyPDSURL: String?
 
+    /// `@dwk/workers` catalog ids the user has manually toggled on. Component-tied workers are
+    /// never stored here — their active state is always recomputed live from Site Graph
+    /// Explorer / `ImpactAnalysis` (`WorkerActivation`, #709), so it can't drift from site
+    /// content.
+    public var activeWorkerIDs: [String]?
+
+    /// The full effective active worker-id set (component-tied + settings-activated) as of the
+    /// last successful deploy — the diff baseline `WorkerActivation.removedIDs` reports removals
+    /// against (#709).
+    public var lastDeployedWorkerIDs: [String]?
+
+    /// Already-provisioned Cloudflare D1/KV/R2 resource ids for this site's composed Worker,
+    /// durable across a worker being deactivated and later reactivated — deactivating a worker
+    /// drops its binding block from `wrangler.toml`, so this is the source of truth instead of
+    /// re-scraping the file (#709).
+    public var provisionedWorkerResources: WorkerComposition.ProvisionedResources?
+
     public init(
         displayName: String? = nil,
         inboxCaptureAccountID: String? = nil,
         inboxCaptureKVNamespaceID: String? = nil,
         mastodonBaseURL: String? = nil,
         blueskyIdentifier: String? = nil,
-        blueskyPDSURL: String? = nil
+        blueskyPDSURL: String? = nil,
+        activeWorkerIDs: [String]? = nil,
+        lastDeployedWorkerIDs: [String]? = nil,
+        provisionedWorkerResources: WorkerComposition.ProvisionedResources? = nil
     ) {
         self.displayName = displayName
         self.inboxCaptureAccountID = inboxCaptureAccountID
@@ -46,6 +66,9 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         self.mastodonBaseURL = mastodonBaseURL
         self.blueskyIdentifier = blueskyIdentifier
         self.blueskyPDSURL = blueskyPDSURL
+        self.activeWorkerIDs = activeWorkerIDs
+        self.lastDeployedWorkerIDs = lastDeployedWorkerIDs
+        self.provisionedWorkerResources = provisionedWorkerResources
     }
 }
 

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -75,12 +75,20 @@ public struct SiteOperations: Sendable {
         let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
         let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
 
+        // Prefer the site's already-established Worker name (`.site-config`'s `CF_PROJECT_NAME`,
+        // set at the first successful deploy or by a worker-name-conflict rename, #740) over
+        // re-deriving one from the site's display name — mirrors `DeployModel.runDeploy`'s
+        // resolution so the headless path can't silently revert a rename on every deploy.
+        let existingConfig = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        let workerSiteName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: existingConfig)
+            ?? SiteSlug.derive(from: site.name)
+
         onProgress?(.deployBuilding)
         onProgress?(.deployDeploying)
         let provisionResult = await factory.socialWorkerProvision().provision(
             siteID: site.id,
             siteDirectory: siteDirectory,
-            siteName: SiteSlug.derive(from: site.name),
+            siteName: workerSiteName,
             features: features,
             knownResources: settings.provisionedWorkerResources ?? .init()
         )
@@ -93,16 +101,7 @@ public struct SiteOperations: Sendable {
             try? await configStore.save(updated)
         }
 
-        switch provisionResult {
-        case .succeeded(let url, _, let duration):
-            return .succeeded(url: url, duration: duration)
-        case .blocked(let failures, let warnings, _):
-            return .blocked(failures: failures, warnings: warnings)
-        case .workerNameConflict(let name, _):
-            return .workerNameConflict(name: name)
-        case .failed(let reason, let exitCode, _):
-            return .failed(reason: reason, exitCode: exitCode)
-        }
+        return provisionResult.asDeployCommandResult
     }
 
     public func backup(site: SiteStore.Site, onProgress: ProgressHandler? = nil) async -> BackupCommand.Result {

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -140,6 +140,8 @@ public struct SiteOperations: Sendable {
             let count = failures.count
             let noun = count == 1 ? "issue" : "issues"
             return "Social Worker provisioning blocked by the pre-deploy security scan (\(count) \(noun)).\(resourceSuffix(resources))"
+        case .workerNameConflict(let name, let resources):
+            return "Social Worker provisioning blocked: the Worker name \"\(name)\" is already in use on your Cloudflare account. Rename the site's Worker in Anglesite and try again.\(resourceSuffix(resources))"
         case .failed(let reason, _, let resources):
             return "Social Worker provisioning failed: \(reason).\(resourceSuffix(resources))"
         }

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -43,12 +43,65 @@ public struct SiteOperations: Sendable {
     public func deploy(site: SiteStore.Site, onProgress: ProgressHandler? = nil) async -> DeployCommand.Result {
         do {
             return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
-                await factory.deploy().deploy(siteID: site.id, siteDirectory: url, onProgress: onProgress)
+                await self.deployWithWorkerComposition(site: site, siteDirectory: url, onProgress: onProgress)
             }
         } catch let SiteAccess.AccessError.noGrant(message) {
             return .failed(reason: message, exitCode: nil)
         } catch {
             return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+
+    /// Headless-deploy counterpart to `DeployModel.runDeploy`'s worker-composition wiring
+    /// (#709 design §5/§8): computes the effective active worker set — settings-activated only,
+    /// since this path (App Intents/Shortcuts) has no populated `SiteContentGraph` to derive
+    /// component-tied activation from — and routes through `SocialWorkerProvisionCommand.provision`
+    /// the same way the main Deploy button does, persisting the result on success.
+    ///
+    /// `onProgress` fidelity note: `SocialWorkerProvisionCommand.provision` has no milestone hook
+    /// of its own (unlike `DeployCommand.deploy`, it's never been wired for one — it had no live
+    /// caller before #709), so this emits the same coarse `OperationProgress.deployBuilding` /
+    /// `.deployDeploying` milestones `DeployCommand.deploy` would have emitted around the
+    /// build/deploy boundary, rather than `DeployCommand`'s finer per-step ones (preflight,
+    /// finalizing). `SiteIntents.swift:59` is this path's one real consumer (Siri/Shortcuts
+    /// progress) — dropping progress reporting to nothing would regress it; this keeps it coarser
+    /// but non-silent without adding an `onProgress` parameter to `SocialWorkerProvisionCommand`
+    /// itself, which would ripple into Tasks 3/4's signature and every other call site.
+    private func deployWithWorkerComposition(
+        site: SiteStore.Site, siteDirectory: URL, onProgress: ProgressHandler?
+    ) async -> DeployCommand.Result {
+        let configStore = SiteConfigStore(configDirectory: site.configDirectory)
+        let settings = (try? await configStore.load()) ?? SiteSettings()
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
+        let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
+
+        onProgress?(.deployBuilding)
+        onProgress?(.deployDeploying)
+        let provisionResult = await factory.socialWorkerProvision().provision(
+            siteID: site.id,
+            siteDirectory: siteDirectory,
+            siteName: SiteSlug.derive(from: site.name),
+            features: features,
+            knownResources: settings.provisionedWorkerResources ?? .init()
+        )
+        onProgress?(.deployFinalizing)
+
+        if case .succeeded(_, let resources, _) = provisionResult {
+            var updated = settings
+            updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
+            updated.provisionedWorkerResources = resources
+            try? await configStore.save(updated)
+        }
+
+        switch provisionResult {
+        case .succeeded(let url, _, let duration):
+            return .succeeded(url: url, duration: duration)
+        case .blocked(let failures, let warnings, _):
+            return .blocked(failures: failures, warnings: warnings)
+        case .workerNameConflict(let name, _):
+            return .workerNameConflict(name: name)
+        case .failed(let reason, let exitCode, _):
+            return .failed(reason: reason, exitCode: exitCode)
         }
     }
 

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -225,6 +225,11 @@ public actor SocialWorkerProvisionCommand {
         resources: WorkerComposition.ProvisionedResources
     ) -> Result? {
         do {
+            // Called without `inboxCaptureEnabled`/`inboxKVNamespaceID` — #587's inbox-capture
+            // provisioning doesn't route through here yet. If/when it starts writing an
+            // `INBOX_KV` binding via those params elsewhere, this call site needs the same
+            // params or it will silently strip that binding on the next worker-composition
+            // deploy.
             let toml = try WorkerComposition.generateWranglerToml(
                 siteName: siteName,
                 features: features,
@@ -313,5 +318,24 @@ public actor SocialWorkerProvisionCommand {
 
     public static let defaultDeployer: Deployer = { token, siteID, siteDirectory in
         await DeployCommand(tokenSource: { token }).deploy(siteID: siteID, siteDirectory: siteDirectory)
+    }
+}
+
+extension SocialWorkerProvisionCommand.Result {
+    /// Maps this result onto `DeployCommand.Result`'s shape, dropping the `resources` payload
+    /// (no caller surfaces it through this seam) — the shared mapping both `DeployModel.runDeploy`
+    /// and `SiteOperations.deployWithWorkerComposition` need after routing every deploy through
+    /// `SocialWorkerProvisionCommand.provision`.
+    public var asDeployCommandResult: DeployCommand.Result {
+        switch self {
+        case .succeeded(let url, _, let duration):
+            return .succeeded(url: url, duration: duration)
+        case .blocked(let failures, let warnings, _):
+            return .blocked(failures: failures, warnings: warnings)
+        case .workerNameConflict(let name, _):
+            return .workerNameConflict(name: name)
+        case .failed(let reason, let exitCode, _):
+            return .failed(reason: reason, exitCode: exitCode)
+        }
     }
 }

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -51,7 +51,13 @@ public actor SocialWorkerProvisionCommand {
         siteID: String,
         siteDirectory: URL,
         siteName: String,
-        features: [WorkerComposition.Feature] = WorkerComposition.Feature.v2
+        features: [WorkerComposition.Feature] = WorkerComposition.Feature.v2,
+        /// Resources already known from `SiteSettings.provisionedWorkerResources` (#709), checked
+        /// before falling back to `readPersistedResources`'s wrangler.toml scrape. Durable across
+        /// a worker being deactivated (which drops its binding block from the file) and later
+        /// reactivated — the default (`.init()`, all-nil) makes this call fall through to the
+        /// existing file-scrape-only behavior unchanged.
+        knownResources: WorkerComposition.ProvisionedResources = .init()
     ) async -> Result {
         let token: String?
         do {
@@ -76,7 +82,7 @@ public actor SocialWorkerProvisionCommand {
         let source = "worker-provision:\(siteID)"
         let started = Date()
 
-        var resources = Self.readPersistedResources(from: siteDirectory)
+        var resources = knownResources == .init() ? Self.readPersistedResources(from: siteDirectory) : knownResources
 
         if features.contains(where: { $0.needsD1 }) {
             if resources.d1DatabaseID == nil {

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -13,6 +13,10 @@ public actor SocialWorkerProvisionCommand {
     public enum Result: Sendable, Equatable {
         case succeeded(url: URL, resources: WorkerComposition.ProvisionedResources, duration: TimeInterval)
         case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning], resources: WorkerComposition.ProvisionedResources)
+        /// The candidate Worker name is already in use on the connected Cloudflare account and
+        /// this site has never deployed before — mirrors `DeployCommand.Result.workerNameConflict`
+        /// rather than collapsing it, so callers can drive the same rename-and-retry UX (#740).
+        case workerNameConflict(name: String, resources: WorkerComposition.ProvisionedResources)
         case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
     }
 
@@ -174,9 +178,7 @@ public actor SocialWorkerProvisionCommand {
         case .blocked(let failures, let warnings):
             return .blocked(failures: failures, warnings: warnings, resources: resources)
         case .workerNameConflict(let name):
-            return .failed(
-                reason: "Worker name \"\(name)\" is already in use on your Cloudflare account — rename it in Anglesite and try again.",
-                exitCode: nil, resources: resources)
+            return .workerNameConflict(name: name, resources: resources)
         case .failed(let reason, let exitCode):
             return .failed(reason: reason, exitCode: exitCode, resources: resources)
         }

--- a/Sources/AnglesiteCore/WorkerActivation.swift
+++ b/Sources/AnglesiteCore/WorkerActivation.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Computes which `@dwk/workers` catalog workers are active for a site right now, and diffs
+/// that against the last-deployed set. Pure — no I/O, no actor isolation — so every input
+/// (settings, catalog, graph snapshot) must be gathered by the caller first (#709 design §4).
+public enum WorkerActivation {
+    /// The effective active worker-id set: component-tied workers with at least one
+    /// `ImpactAnalysis`-affected page, unioned with settings-activated workers the user toggled
+    /// on. `graph` is `nil` for a headless deploy with no populated `SiteContentGraph` — in that
+    /// case component-tied workers contribute nothing (`ImpactAnalysis` "never invents, may
+    /// under-report" bias), while `activeWorkerIDs` still applies. If `catalog` is empty (no
+    /// successful fetch, no cache — `WorkerCatalogFetcher` already degrades to cache on failure,
+    /// so this is a fresh-install-with-no-network edge case), `activeWorkerIDs` is trusted
+    /// verbatim instead of being intersected away, so a transient fetch failure can't silently
+    /// deactivate every settings-activated worker.
+    public static func effectiveActiveIDs(
+        settings: SiteSettings,
+        catalog: [WorkerDescriptor],
+        graph: SiteGraphExplorerSnapshot?
+    ) -> Set<String> {
+        var active: Set<String> = []
+
+        if let graph {
+            for descriptor in catalog {
+                guard case .componentTied(let componentIDs) = descriptor.binding else { continue }
+                let isUsed = componentIDs.contains { componentID in
+                    guard let report = ImpactAnalysis.analyze(snapshot: graph, targetID: componentID) else {
+                        return false
+                    }
+                    return !report.affectedPages.isEmpty
+                }
+                if isUsed { active.insert(descriptor.id) }
+            }
+        }
+
+        let requested = Set(settings.activeWorkerIDs ?? [])
+        if catalog.isEmpty {
+            active.formUnion(requested)
+        } else {
+            let settingsActivatedIDs = Set(catalog.compactMap { descriptor -> String? in
+                guard case .settingsActivated = descriptor.binding else { return nil }
+                return descriptor.id
+            })
+            active.formUnion(requested.intersection(settingsActivatedIDs))
+        }
+
+        return active
+    }
+
+    /// Worker ids present in `previous` but absent from `next` — used only to log what a deploy
+    /// is tearing down (#709 design §7); the removal itself happens by omission from the newly
+    /// generated `wrangler.toml`, not a separate API call.
+    public static func removedIDs(previous: Set<String>, next: Set<String>) -> Set<String> {
+        previous.subtracting(next)
+    }
+
+    /// Interim catalog-id → `Feature` shim (#709 design §4/§10): `generateWranglerToml` and
+    /// `SocialWorkerProvisionCommand.provision` still take `[WorkerComposition.Feature]`, not
+    /// `[WorkerDescriptor]`, until #708 migrates them. An id with no matching `Feature` case (a
+    /// future, not-yet-composed catalog worker) is silently dropped — there is nothing else this
+    /// call can do with it today. Iterating `Feature.allCases` (rather than mapping `ids`
+    /// directly) gives deterministic, declaration-order output for stable `wrangler.toml` diffs.
+    public static func mapToFeatures(_ ids: Set<String>) -> [WorkerComposition.Feature] {
+        WorkerComposition.Feature.allCases.filter { ids.contains($0.rawValue) }
+    }
+}

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -18,10 +18,6 @@ public enum WorkerCatalogFetchError: Error, Sendable, Equatable {
 /// Network or parse failures degrade to the last successfully cached copy, then to an empty
 /// catalog — the Workers Settings tab and deploy composition must never block or crash on a
 /// catalog fetch failure (design doc §3).
-///
-/// - Important: `catalogURL` has no in-app default. As of this writing `@dwk/workers` has not
-///   yet published `catalog.json` — callers must supply the real manifest URL once the monorepo
-///   publishes one.
 public actor WorkerCatalogFetcher {
     #if canImport(OSLog)
     private static let logger = Logger(subsystem: "io.dwk.anglesite", category: "WorkerCatalogFetcher")
@@ -95,6 +91,13 @@ public actor WorkerCatalogFetcher {
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try data.write(to: url, options: [.atomic])
     }
+
+    /// The published `@dwk/workers` monorepo catalog manifest — verified live 2026-07-17
+    /// (davidwkeith/workers#255, merged in davidwkeith/workers#258). Callers still supply
+    /// `catalogURL` explicitly at `init`; this is the value production call sites should pass.
+    public static let productionCatalogURL = URL(
+        string: "https://raw.githubusercontent.com/davidwkeith/workers/main/catalog.json"
+    )!
 
     /// `~/Library/Application Support/Anglesite/worker-catalog-cache.json` — mirrors
     /// `SiteStore`'s `defaultPersistenceURL` convention (`SiteStore.swift:323-333`).

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -61,7 +61,7 @@ public enum WorkerComposition {
         charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
     )
 
-    public struct ProvisionedResources: Sendable, Equatable {
+    public struct ProvisionedResources: Sendable, Equatable, Codable {
         public var d1DatabaseID: String?
         public var kvNamespaceID: String?
         public var r2BucketName: String?

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -272,8 +272,8 @@ struct DeployModelTests {
         }
     }
 
-    @Test("a site with a settings-activated worker persists lastDeployedWorkerIDs after a successful deploy")
-    func activatingAWorkerPersistsLastDeployedWorkerIDs() async throws {
+    @Test("a settings-activated worker without a container fails at provisioning rather than skipping composition")
+    func activatingAWorkerWithoutContainerFailsAtProvisioning() async throws {
         let executor = GatedDeployExecutor()
         await executor.resumeBuild()
         let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -239,4 +239,81 @@ struct DeployModelTests {
         #expect(!model.isRunning)
         #expect(model.workerNameConflictError == "No deploy is waiting — close this and click Deploy again.")
     }
+
+    @Test("a site with no active workers still deploys through the plain static path")
+    func staticSiteDeploysUnaffected() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let contentGraph = SiteContentGraph()
+        let model = DeployModel(
+            command: command,
+            logCenter: LogCenter(),
+            suddenTerminationController: SuddenTerminationController(disable: {}, enable: {}),
+            tokenAvailabilityOverride: { true },
+            contentGraph: contentGraph,
+            workerCatalog: { [] }
+        )
+        let dir = try temporaryDirectory()
+
+        // Unlike the worker-name-conflict tests, this deploy has no active workers and no
+        // pre-existing name collision, so it genuinely reaches the real `.build` step (no
+        // short-circuit) — wait for the executor to park there, then resume it, mirroring
+        // `suddenTerminationLeaseBracketsDeploy`. Resuming before the build step is reached
+        // (as the conflict tests do defensively) would resume nothing and hang this deploy
+        // forever.
+        model.deploy(siteID: "test-site", siteDirectory: dir, configDirectory: dir, currentRoutes: [])
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
+        while model.isRunning { await Task.yield() }
+
+        guard case .succeeded = model.phase else {
+            Issue.record("Expected deploy to succeed, got \(model.phase)")
+            return
+        }
+    }
+
+    @Test("a site with a settings-activated worker persists lastDeployedWorkerIDs after a successful deploy")
+    func activatingAWorkerPersistsLastDeployedWorkerIDs() async throws {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let contentGraph = SiteContentGraph()
+        let catalog = [
+            WorkerDescriptor(
+                id: "indieauth", displayName: "IndieAuth", description: "d", group: "identity",
+                binding: .settingsActivated, resources: .init(needsD1: true, needsKV: false, needsR2: false)
+            )
+        ]
+        let model = DeployModel(
+            command: command,
+            logCenter: LogCenter(),
+            suddenTerminationController: SuddenTerminationController(disable: {}, enable: {}),
+            tokenAvailabilityOverride: { true },
+            contentGraph: contentGraph,
+            workerCatalog: { catalog }
+        )
+        let dir = try temporaryDirectory()
+        let configDir = dir.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let configStore = SiteConfigStore(configDirectory: configDir)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+
+        model.deploy(siteID: "test-site", siteDirectory: dir, configDirectory: configDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+
+        // provision() has no working runner outside a container (Task 5's ContainerCommandRunner
+        // requires a real LocalContainerControl) — without containerControl this deploy is
+        // expected to fail at the D1-provisioning step, NOT silently skip worker composition.
+        guard case .failed = model.phase else {
+            Issue.record("Expected a provisioning failure without a container, got \(model.phase)")
+            return
+        }
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DeployModelTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContainerCommandRunnerTests.swift
+++ b/Tests/AnglesiteCoreTests/ContainerCommandRunnerTests.swift
@@ -1,0 +1,131 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContainerCommandRunner")
+struct ContainerCommandRunnerTests {
+    private func fakePassing(exitCode: Int32 = 0, stdout: String = "ok") -> FakeLocalContainerControl {
+        FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: exitCode, stdout: stdout, stderr: ""),
+            execStdoutLines: []
+        )
+    }
+
+    @Test("arguments are prefixed with npx wrangler")
+    func argvIsPrefixedWithWrangler() async throws {
+        let fake = fakePassing()
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        _ = try await runner.runner(
+            URL(fileURLWithPath: "/host/irrelevant"),
+            ["d1", "create", "my-site-social", "--json"],
+            [:],
+            "worker-provision:site-abc"
+        )
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].argv == ["npx", "wrangler", "d1", "create", "my-site-social", "--json"])
+        #expect(calls[0].cwd == "/workspace/site")
+    }
+
+    @Test("exit code and stdout are surfaced in the RunResult")
+    func surfacesExitCodeAndStdout() async throws {
+        let fake = fakePassing(exitCode: 0, stdout: #"{"result":{"uuid":"d1-id"}}"#)
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        let result = try await runner.runner(URL(fileURLWithPath: "/host"), ["d1", "create", "x", "--json"], [:], "src")
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout == #"{"result":{"uuid":"d1-id"}}"#)
+    }
+
+    @Test("a non-zero exit code is surfaced, not thrown")
+    func nonZeroExitCodeSurfaced() async throws {
+        let fake = fakePassing(exitCode: 1, stdout: "already exists")
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        let result = try await runner.runner(URL(fileURLWithPath: "/host"), ["r2", "bucket", "create", "x"], [:], "src")
+
+        #expect(result.exitCode == 1)
+        #expect(result.stdout == "already exists")
+    }
+
+    @Test("CLOUDFLARE_API_TOKEN is forwarded to the guest environment")
+    func forwardsToken() async throws {
+        let fake = fakePassing()
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        _ = try await runner.runner(
+            URL(fileURLWithPath: "/host"), ["d1", "create", "x", "--json"],
+            ["CLOUDFLARE_API_TOKEN": "supersecret", "PATH": "/opt/homebrew/bin"], "src"
+        )
+
+        let calls = await fake.execCalls
+        #expect(calls[0].env["CLOUDFLARE_API_TOKEN"] == "supersecret")
+        #expect(calls[0].env["PATH"] == nil)
+    }
+
+    @Test("stdout lines stream to LogCenter under the given source")
+    func streamsToLogCenter() async throws {
+        let logCenter = LogCenter()
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: "done", stderr: ""),
+            execStdoutLines: ["Creating D1 database 'my-site-social'"]
+        )
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: logCenter)
+
+        _ = try await runner.runner(URL(fileURLWithPath: "/host"), ["d1", "create", "x", "--json"], [:], "worker-provision:site-abc")
+
+        let snapshot = await logCenter.snapshot()
+        #expect(snapshot.contains { $0.source == "worker-provision:site-abc" && $0.text == "Creating D1 database 'my-site-social'" })
+    }
+
+    @Test("a dead container surfaces a throw, not a hang")
+    func deadContainerThrows() async {
+        // The shared `FakeLocalContainerControl` (Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift)
+        // always succeeds — its `exec` has no way to throw. `ContainerDeployExecutorTests.swift`
+        // hits this same limitation and defines a local throwing fake for exactly this case;
+        // mirror that pattern here rather than the shared fake.
+        let fake = ThrowingFakeLocalContainerControl()
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        await #expect(throws: ThrowingFakeLocalContainerControl.ExecError.self) {
+            _ = try await runner.runner(URL(fileURLWithPath: "/host"), ["d1", "create", "x", "--json"], [:], "src")
+        }
+    }
+}
+
+// Mirrors `ContainerDeployExecutorTests.swift`'s private `ThrowingFakeLocalContainerControl` —
+// duplicated locally (not shared) because that one is `private` to its own test file.
+private actor ThrowingFakeLocalContainerControl: LocalContainerControl {
+    enum ExecError: Error { case boom }
+
+    func start(
+        siteID: String, sourceRepo: URL, ref: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> LocalContainerSession {
+        throw ExecError.boom
+    }
+    func stop(siteID: String) async throws {}
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> ContainerExecResult {
+        throw ExecError.boom
+    }
+    func execInteractive(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> InteractiveExecHandle {
+        throw ExecError.boom
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -91,4 +91,47 @@ struct SiteConfigStoreTests {
         try Data("not a plist".utf8).write(to: dir.appendingPathComponent("settings.plist"))
         #expect(try SiteConfigStore.read(from: dir) == SiteSettings())
     }
+
+    @Test("save then load round-trips the persisted worker-state fields")
+    func saveLoadRoundTripsWorkerState() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+        let settings = SiteSettings(
+            activeWorkerIDs: ["solid-pod", "webdav"],
+            lastDeployedWorkerIDs: ["webmention", "indieauth"],
+            provisionedWorkerResources: .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: nil)
+        )
+        try await store.save(settings)
+
+        let loaded = try await store.load()
+        #expect(loaded.activeWorkerIDs == ["solid-pod", "webdav"])
+        #expect(loaded.lastDeployedWorkerIDs == ["webmention", "indieauth"])
+        #expect(loaded.provisionedWorkerResources == .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: nil))
+    }
+
+    @Test("an old-format settings.plist missing the worker-state keys still decodes")
+    func loadOldFormatWithoutWorkerState() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        // Simulates a plist written by a build that predates these fields: only `displayName`.
+        let oldFormat = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>displayName</key>
+            <string>Old Site</string>
+        </dict>
+        </plist>
+        """
+        try oldFormat.write(to: dir.appendingPathComponent("settings.plist"), atomically: true, encoding: .utf8)
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let loaded = try await store.load()
+        #expect(loaded.displayName == "Old Site")
+        #expect(loaded.activeWorkerIDs == nil)
+        #expect(loaded.lastDeployedWorkerIDs == nil)
+        #expect(loaded.provisionedWorkerResources == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -283,6 +283,40 @@ struct SiteOperationsTests {
         #expect(saved.lastDeployedWorkerIDs == ["indieauth"])
     }
 
+    @Test("headless deploy resolves the Worker name from CF_PROJECT_NAME before deriving from the site's display name")
+    func headlessDeployUsesConfiguredProjectNameOverDerivedSlug() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let configStore = SiteConfigStore(configDirectory: site.configDirectory)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+
+        // Simulate a #740 worker-name-conflict rename: `.site-config` already records a Worker
+        // name that differs from what `SiteSlug.derive(from: site.name)` would produce. A naive
+        // re-derivation would silently revert the rename on every subsequent deploy.
+        let siteConfigContents = SiteConfigFile.upsert([("CF_PROJECT_NAME", "renamed-worker")], into: "")
+        try siteConfigContents.write(
+            to: site.sourceDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
+
+        let result = await ops.deploy(site: site)
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(await recorder.arguments == [
+            ["d1", "create", "renamed-worker-social", "--json"],
+            ["kv", "namespace", "create", "renamed-worker-social", "--json"],
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"],
+        ])
+    }
+
     @Test("headless deploy with no activated workers still deploys through the plain static path")
     func headlessDeployWithNoActiveWorkers() async throws {
         let package = try temporaryPackage()

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -226,6 +226,17 @@ struct SiteOperationsTests {
         #expect(!dialog.lowercased().contains("override"))
     }
 
+    @Test("social worker provisioning worker-name-conflict dialog names the taken Worker")
+    func socialWorkerProvisionWorkerNameConflictDialog() {
+        let result = SocialWorkerProvisionCommand.Result.workerNameConflict(
+            name: "taken-name", resources: .init(d1DatabaseID: "d1")
+        )
+        let dialog = SiteOperations.dialog(forSocialWorkerProvision: result)
+        #expect(dialog.contains("taken-name"))
+        #expect(dialog.lowercased().contains("rename"))
+        #expect(dialog.contains("Provisioned resources: D1."))
+    }
+
     @Test("social worker provisioning failure dialog includes partial resources")
     func socialWorkerProvisionFailureDialog() {
         let result = SocialWorkerProvisionCommand.Result.failed(

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -261,6 +261,62 @@ struct SiteOperationsTests {
         let dialog = SiteOperations.dialog(forAudit: .failed(reason: "config missing", exitCode: 1, logTail: []))
         #expect(dialog == "Audit failed: config missing")
     }
+
+    @Test("headless deploy with a settings-activated worker routes through provision and persists lastDeployedWorkerIDs")
+    func headlessDeployWithActiveWorkerPersistsState() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let configStore = SiteConfigStore(configDirectory: site.configDirectory)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
+
+        let result = await ops.deploy(site: site)
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let saved = try await configStore.load()
+        #expect(saved.lastDeployedWorkerIDs == ["indieauth"])
+    }
+
+    @Test("headless deploy with no activated workers still deploys through the plain static path")
+    func headlessDeployWithNoActiveWorkers() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
+
+        let result = await ops.deploy(site: site)
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(await recorder.arguments.isEmpty)
+    }
+
+    @Test("headless deploy still reports coarse progress milestones through onProgress")
+    func headlessDeployReportsProgress() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: SocialWorkerRecorder()), store: throwawayStore())
+        let seen = HeadlessDeployProgressRecorder()
+
+        _ = await ops.deploy(site: site, onProgress: { progress in Task { await seen.record(progress) } })
+        // onProgress fires synchronously inside deployWithWorkerComposition, but the recorder hop
+        // above is async — give it a beat to land before asserting.
+        while await seen.progresses.count < 2 { await Task.yield() }
+
+        let progresses = await seen.progresses
+        #expect(progresses.contains(.deployBuilding))
+        #expect(progresses.contains(.deployDeploying))
+    }
 }
 
 private actor SocialWorkerRecorder {
@@ -296,6 +352,13 @@ private struct DeployCall: Sendable, Equatable {
 
 private struct TestAccessError: LocalizedError, Sendable {
     var errorDescription: String? { "could not resolve site access" }
+}
+
+// Named distinctly from `DeployCommandProgressTests.ProgressRecorder` (an internal,
+// non-private, lock-based type in the same test target) to avoid a same-module name clash.
+private actor HeadlessDeployProgressRecorder {
+    private(set) var progresses: [OperationProgress] = []
+    func record(_ progress: OperationProgress) { progresses.append(progress) }
 }
 
 private struct SocialWorkerFactory: CommandFactory {

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -299,6 +299,42 @@ struct SocialWorkerProvisionCommandTests {
         ])
     }
 
+    @Test("asDeployCommandResult maps succeeded, dropping the resources payload")
+    func asDeployCommandResultMapsSucceeded() {
+        let url = URL(string: "https://my-site.example.workers.dev")!
+        let result = SocialWorkerProvisionCommand.Result.succeeded(
+            url: url, resources: .init(d1DatabaseID: "d1-id"), duration: 3
+        )
+        #expect(result.asDeployCommandResult == .succeeded(url: url, duration: 3))
+    }
+
+    @Test("asDeployCommandResult maps blocked, dropping the resources payload")
+    func asDeployCommandResultMapsBlocked() {
+        let failure = PreDeployCheck.ScanFailure(
+            category: .exposedToken, message: "API key committed", file: "src/index.md", remediation: "Remove it"
+        )
+        let result = SocialWorkerProvisionCommand.Result.blocked(
+            failures: [failure], warnings: [], resources: .init(kvNamespaceID: "kv-id")
+        )
+        #expect(result.asDeployCommandResult == .blocked(failures: [failure], warnings: []))
+    }
+
+    @Test("asDeployCommandResult maps workerNameConflict, dropping the resources payload")
+    func asDeployCommandResultMapsWorkerNameConflict() {
+        let result = SocialWorkerProvisionCommand.Result.workerNameConflict(
+            name: "taken-name", resources: .init(r2BucketName: "media")
+        )
+        #expect(result.asDeployCommandResult == .workerNameConflict(name: "taken-name"))
+    }
+
+    @Test("asDeployCommandResult maps failed, dropping the resources payload")
+    func asDeployCommandResultMapsFailed() {
+        let result = SocialWorkerProvisionCommand.Result.failed(
+            reason: "KV failed", exitCode: 1, resources: .init(d1DatabaseID: "d1-id")
+        )
+        #expect(result.asDeployCommandResult == .failed(reason: "KV failed", exitCode: 1))
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("SocialWorkerProvisionCommandTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -258,6 +258,47 @@ struct SocialWorkerProvisionCommandTests {
         #expect(resources.r2BucketName == "media-bucket")
     }
 
+    @Test("knownResources is reused instead of re-scraping wrangler.toml, so a deactivated-then-reactivated worker doesn't recreate its Cloudflare resource")
+    func reusesKnownResourcesOverFileScrape() async throws {
+        let site = try temporaryDirectory()
+        // wrangler.toml on disk reflects the CURRENT (deactivated) feature set — no R2 block, so
+        // a file-scrape alone would find no bucket name and try to recreate it.
+        let currentToml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            features: [.indieauth],
+            resources: .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: nil)
+        )
+        try currentToml.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+
+        // knownResources (as persisted in SiteSettings before deactivation) still remembers the bucket.
+        let known = WorkerComposition.ProvisionedResources(
+            d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: "my-site-media"
+        )
+        let recorder = WranglerRecorder([
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
+        ])
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: recorder.runner,
+            deployer: DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1)).deployer
+        )
+
+        // Reactivating micropub (needs R2) should reuse the known bucket, not call `r2 bucket create` again.
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            features: [.indieauth, .micropub], knownResources: known
+        )
+
+        guard case .succeeded(_, let resources, _) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(resources.r2BucketName == "my-site-media")
+        #expect(await recorder.arguments == [
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"],
+        ])
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("SocialWorkerProvisionCommandTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -183,8 +183,8 @@ struct SocialWorkerProvisionCommandTests {
         #expect(toml.contains("id = \"kv-id\""))
     }
 
-    @Test("a worker-name conflict from the deployer maps to a failed provisioning result")
-    func workerNameConflictMapsToFailed() async throws {
+    @Test("a worker-name conflict from the deployer is propagated, not collapsed to failed")
+    func workerNameConflictPropagates() async throws {
         let site = try temporaryDirectory()
         let recorder = WranglerRecorder([
             ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
@@ -196,10 +196,12 @@ struct SocialWorkerProvisionCommandTests {
 
         let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
 
-        guard case .failed(let reason, _, _) = result else {
-            Issue.record("expected .failed, got \(result)"); return
+        guard case .workerNameConflict(let name, let resources) = result else {
+            Issue.record("expected .workerNameConflict, got \(result)"); return
         }
-        #expect(reason.contains("taken-name"))
+        #expect(name == "taken-name")
+        #expect(resources.d1DatabaseID == "d1-id")
+        #expect(resources.kvNamespaceID == "kv-id")
     }
 
     @Test("stops before deploy when the IndieAuth schema migration fails")

--- a/Tests/AnglesiteCoreTests/WorkerActivationTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerActivationTests.swift
@@ -1,0 +1,121 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WorkerActivation")
+struct WorkerActivationTests {
+    private func descriptor(
+        id: String, group: String = "social", binding: WorkerDescriptor.Binding
+    ) -> WorkerDescriptor {
+        WorkerDescriptor(
+            id: id, displayName: id, description: "d", group: group, binding: binding,
+            resources: .init(needsD1: false, needsKV: false, needsR2: false)
+        )
+    }
+
+    private func pageNode(id: String) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: .page, title: id, detail: nil, filePath: nil, route: "/\(id)")
+    }
+
+    private func componentNode(id: String) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: .component, title: id, detail: nil, filePath: nil, route: nil)
+    }
+
+    @Test("a component-tied worker is active when its component is used by a page")
+    func componentTiedActiveWhenPageUsesIt() {
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        let graph = SiteGraphExplorerSnapshot(
+            nodes: [pageNode(id: "page:home"), componentNode(id: "webmention-form")],
+            edges: [SiteGraphEdge(sourceID: "page:home", targetID: "webmention-form", kind: .imports)]
+        )
+        let active = WorkerActivation.effectiveActiveIDs(settings: SiteSettings(), catalog: catalog, graph: graph)
+        #expect(active == ["webmention"])
+    }
+
+    @Test("a component-tied worker is inactive when its component is unused")
+    func componentTiedInactiveWhenUnused() {
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        let graph = SiteGraphExplorerSnapshot(
+            nodes: [pageNode(id: "page:home"), componentNode(id: "webmention-form")],
+            edges: []
+        )
+        let active = WorkerActivation.effectiveActiveIDs(settings: SiteSettings(), catalog: catalog, graph: graph)
+        #expect(active.isEmpty)
+    }
+
+    @Test("a component-tied worker is inactive when the graph is nil (headless deploy)")
+    func componentTiedInactiveWhenGraphIsNil() {
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        let active = WorkerActivation.effectiveActiveIDs(settings: SiteSettings(), catalog: catalog, graph: nil)
+        #expect(active.isEmpty)
+    }
+
+    @Test("a component used only by another (page-unreachable) component does not count")
+    func componentTiedRequiresAffectedPageNotJustAnyDependent() {
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        // "wrapper" imports "webmention-form", but nothing imports "wrapper" — no page is affected.
+        let graph = SiteGraphExplorerSnapshot(
+            nodes: [componentNode(id: "wrapper"), componentNode(id: "webmention-form")],
+            edges: [SiteGraphEdge(sourceID: "wrapper", targetID: "webmention-form", kind: .imports)]
+        )
+        let active = WorkerActivation.effectiveActiveIDs(settings: SiteSettings(), catalog: catalog, graph: graph)
+        #expect(active.isEmpty)
+    }
+
+    @Test("a settings-activated worker is active when its id is in activeWorkerIDs")
+    func settingsActivatedFromSettings() {
+        let catalog = [descriptor(id: "solid-pod", group: "storage", binding: .settingsActivated)]
+        let settings = SiteSettings(activeWorkerIDs: ["solid-pod"])
+        let active = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        #expect(active == ["solid-pod"])
+    }
+
+    @Test("a stale activeWorkerIDs entry no longer in the catalog is dropped")
+    func staleActiveIDDropped() {
+        let catalog = [descriptor(id: "solid-pod", group: "storage", binding: .settingsActivated)]
+        let settings = SiteSettings(activeWorkerIDs: ["solid-pod", "retired-worker"])
+        let active = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        #expect(active == ["solid-pod"])
+    }
+
+    @Test("an activeWorkerIDs entry for a componentTied catalog id does not activate it directly")
+    func activeWorkerIDsIgnoredForComponentTiedEntries() {
+        // Defensive: activeWorkerIDs should only ever contain settingsActivated ids in practice,
+        // but a componentTied id ending up there (e.g. stale data) must not bypass usage detection.
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        let settings = SiteSettings(activeWorkerIDs: ["webmention"])
+        let active = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        #expect(active.isEmpty)
+    }
+
+    @Test("an empty catalog trusts activeWorkerIDs verbatim rather than deactivating everything")
+    func emptyCatalogTrustsActiveWorkerIDs() {
+        let settings = SiteSettings(activeWorkerIDs: ["solid-pod", "webdav"])
+        let active = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
+        #expect(active == ["solid-pod", "webdav"])
+    }
+
+    @Test("removedIDs is the previous set minus the next set")
+    func removedIDsIsSetDifference() {
+        let removed = WorkerActivation.removedIDs(previous: ["webmention", "indieauth"], next: ["indieauth"])
+        #expect(removed == ["webmention"])
+        #expect(WorkerActivation.removedIDs(previous: ["a"], next: ["a", "b"]).isEmpty)
+    }
+
+    @Test("mapToFeatures maps known catalog ids to Feature cases in declaration order")
+    func mapToFeaturesKnownIDs() {
+        let features = WorkerActivation.mapToFeatures(["websub", "indieauth"])
+        #expect(features == [.indieauth, .websub])
+    }
+
+    @Test("mapToFeatures silently drops ids with no matching Feature case")
+    func mapToFeaturesDropsUnknownIDs() {
+        let features = WorkerActivation.mapToFeatures(["indieauth", "solid-pod"])
+        #expect(features == [.indieauth])
+    }
+
+    @Test("mapToFeatures of an empty set is empty")
+    func mapToFeaturesEmpty() {
+        #expect(WorkerActivation.mapToFeatures([]).isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift
@@ -173,4 +173,12 @@ private final class WorkerCatalogStubURLProtocol: URLProtocol, @unchecked Sendab
         let workers = await fetcher.catalog()
         #expect(workers.isEmpty)
     }
+
+    @Test("productionCatalogURL points at the published davidwkeith/workers catalog.json")
+    func productionCatalogURLIsThePublishedManifest() {
+        #expect(
+            WorkerCatalogFetcher.productionCatalogURL
+                == URL(string: "https://raw.githubusercontent.com/davidwkeith/workers/main/catalog.json")!
+        )
+    }
 }

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -1,5 +1,6 @@
 // Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
 import Testing
+import Foundation
 @testable import AnglesiteCore
 
 @Suite("WorkerComposition")
@@ -116,5 +117,15 @@ struct WorkerCompositionTests {
         let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", features: [])
         #expect(!toml.contains("INBOX_KV"))
         #expect(!toml.contains("main ="))
+    }
+
+    @Test("ProvisionedResources round-trips through JSONEncoder/JSONDecoder")
+    func provisionedResourcesCodable() throws {
+        let resources = WorkerComposition.ProvisionedResources(
+            d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: "media-bucket"
+        )
+        let data = try JSONEncoder().encode(resources)
+        let decoded = try JSONDecoder().decode(WorkerComposition.ProvisionedResources.self, from: data)
+        #expect(decoded == resources)
     }
 }

--- a/docs/superpowers/plans/2026-07-17-persisted-worker-state.md
+++ b/docs/superpowers/plans/2026-07-17-persisted-worker-state.md
@@ -1,0 +1,1638 @@
+# Persisted Active-Worker State + Deploy Diff/Removal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compute each site's effective active worker set on every deploy and fold `SocialWorkerProvisionCommand` into the main Deploy button, so activating/deactivating a catalog worker (Site Graph Explorer usage or a future Settings toggle) actually reaches Cloudflare — closing the gap where that command has no live caller today.
+
+**Architecture:** A new pure `WorkerActivation` type computes the effective active worker-id set (component-tied via `ImpactAnalysis` + settings-activated via new `SiteSettings` fields) and diffs it against the last-deployed set. `DeployModel.runDeploy` and `SiteOperations.deploy` both route every deploy through `SocialWorkerProvisionCommand.provision` (which already degrades to a plain static deploy when its feature list is empty) instead of calling `DeployCommand.deploy` directly, using a captured closure so `DeployCommand`'s existing route-coverage scanning, milestones, and worker-name-conflict handling are preserved unchanged. A new `ContainerCommandRunner` (mirroring the existing `ContainerDeployExecutor`) makes `SocialWorkerProvisionCommand`'s wrangler subcommands actually execute inside the container.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Test`/`@Suite`/`#expect`), SwiftPM (`AnglesiteCore`, `AnglesiteApp` targets).
+
+## Global Constraints
+
+- Every `SiteSettings` field must stay `Optional` (`SiteConfigStore.swift:7-11`'s forward-compat rule) — a plist written by an older build must still decode.
+- Never delete backing Cloudflare D1/KV/R2 resources on worker deactivation — route/binding teardown only (design doc §6).
+- `DeployModel.Phase`'s public shape (`.succeeded`/`.blocked`/`.workerNameConflict`/`.failed`) does not change — only what feeds it does.
+- No new UI surface ships in this plan (that's #710) — every task is `AnglesiteCore`/`AnglesiteApp`-model-layer only.
+- Follow this repo's existing fake/recorder test patterns (actor-backed recorders with closure-injected seams) rather than introducing a mocking library.
+- Design reference: `docs/superpowers/specs/2026-07-17-persisted-worker-state-design.md`. Section numbers below (`§N`) refer to it.
+
+---
+
+## File Structure
+
+**Modify:**
+- `Sources/AnglesiteCore/SiteConfigStore.swift` — new `SiteSettings` fields (Task 1)
+- `Sources/AnglesiteCore/WorkerComposition.swift` — `ProvisionedResources` gains `Codable` (Task 1)
+- `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift` — `.workerNameConflict` result case (Task 3), `knownResources` param (Task 4)
+- `Sources/AnglesiteCore/SiteOperations.swift` — `dialog(forSocialWorkerProvision:)` gains the new case (Task 3); `deploy(site:)` routes through `provision` (Task 8)
+- `Sources/AnglesiteCore/WorkerCatalogFetcher.swift` — production `catalogURL` constant (Task 6)
+- `Sources/AnglesiteApp/DeployModel.swift` — effective-set computation + `provision`-based deploy wiring (Task 7)
+- `Sources/AnglesiteApp/SiteWindowModel.swift:74` — thread `contentGraph` into `DeployModel` (Task 7)
+
+**Create:**
+- `Sources/AnglesiteCore/WorkerActivation.swift` — Task 2
+- `Sources/AnglesiteCore/ContainerCommandRunner.swift` — Task 5
+- `Tests/AnglesiteCoreTests/WorkerActivationTests.swift` — Task 2
+- `Tests/AnglesiteCoreTests/ContainerCommandRunnerTests.swift` — Task 5
+
+**Test-only modify:**
+- `Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift` (Task 1)
+- `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift` (Task 1)
+- `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift` (Tasks 3, 4)
+- `Tests/AnglesiteCoreTests/SiteOperationsTests.swift` (Tasks 3, 8)
+- `Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift` (Task 6)
+- `Tests/AnglesiteAppTests/DeployModelTests.swift` (Task 7)
+
+---
+
+### Task 1: `SiteSettings` persisted worker fields + `ProvisionedResources` Codable
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/WorkerComposition.swift:64-74`
+- Modify: `Sources/AnglesiteCore/SiteConfigStore.swift:12-50`
+- Test: `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift`
+
+**Interfaces:**
+- Produces: `WorkerComposition.ProvisionedResources: Codable` (was `Sendable, Equatable`); `SiteSettings.activeWorkerIDs: [String]?`, `SiteSettings.lastDeployedWorkerIDs: [String]?`, `SiteSettings.provisionedWorkerResources: WorkerComposition.ProvisionedResources?`.
+
+- [ ] **Step 1: Write the failing `ProvisionedResources` Codable test**
+
+Add to `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift` (append to the file):
+
+```swift
+@Test("ProvisionedResources round-trips through JSONEncoder/JSONDecoder")
+func provisionedResourcesCodable() throws {
+    let resources = WorkerComposition.ProvisionedResources(
+        d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: "media-bucket"
+    )
+    let data = try JSONEncoder().encode(resources)
+    let decoded = try JSONDecoder().decode(WorkerComposition.ProvisionedResources.self, from: data)
+    #expect(decoded == resources)
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: FAIL — `type 'WorkerComposition.ProvisionedResources' does not conform to protocol 'Decodable'`
+
+- [ ] **Step 3: Make `ProvisionedResources` Codable**
+
+In `Sources/AnglesiteCore/WorkerComposition.swift:64`, change:
+
+```swift
+    public struct ProvisionedResources: Sendable, Equatable {
+```
+
+to:
+
+```swift
+    public struct ProvisionedResources: Sendable, Equatable, Codable {
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing `SiteSettings` round-trip test**
+
+Add to `Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift` (append inside the `SiteConfigStoreTests` struct, before the closing `}`):
+
+```swift
+    @Test("save then load round-trips the persisted worker-state fields")
+    func saveLoadRoundTripsWorkerState() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+        let settings = SiteSettings(
+            activeWorkerIDs: ["solid-pod", "webdav"],
+            lastDeployedWorkerIDs: ["webmention", "indieauth"],
+            provisionedWorkerResources: .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: nil)
+        )
+        try await store.save(settings)
+
+        let loaded = try await store.load()
+        #expect(loaded.activeWorkerIDs == ["solid-pod", "webdav"])
+        #expect(loaded.lastDeployedWorkerIDs == ["webmention", "indieauth"])
+        #expect(loaded.provisionedWorkerResources == .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: nil))
+    }
+
+    @Test("an old-format settings.plist missing the worker-state keys still decodes")
+    func loadOldFormatWithoutWorkerState() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        // Simulates a plist written by a build that predates these fields: only `displayName`.
+        let oldFormat = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>displayName</key>
+            <string>Old Site</string>
+        </dict>
+        </plist>
+        """
+        try oldFormat.write(to: dir.appendingPathComponent("settings.plist"), atomically: true, encoding: .utf8)
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let loaded = try await store.load()
+        #expect(loaded.displayName == "Old Site")
+        #expect(loaded.activeWorkerIDs == nil)
+        #expect(loaded.lastDeployedWorkerIDs == nil)
+        #expect(loaded.provisionedWorkerResources == nil)
+    }
+```
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter SiteConfigStoreTests`
+Expected: FAIL — `value of type 'SiteSettings' has no member 'activeWorkerIDs'` (compile error)
+
+- [ ] **Step 7: Add the three fields to `SiteSettings`**
+
+In `Sources/AnglesiteCore/SiteConfigStore.swift`, replace lines 12-50 (the whole `SiteSettings` struct) with:
+
+```swift
+public struct SiteSettings: Sendable, Codable, Equatable {
+    /// Owner-facing display name override. `nil` falls back to the package marker's displayName.
+    public var displayName: String?
+
+    /// Cloudflare account id owning this site's `INBOX_KV` namespace (#587). `nil` until a
+    /// provisioning flow sets it — `InboxSubmissionSync` no-ops without both this and
+    /// `inboxCaptureKVNamespaceID`.
+    public var inboxCaptureAccountID: String?
+
+    /// The provisioned `INBOX_KV` namespace id for this site (#587). See
+    /// `inboxCaptureAccountID`.
+    public var inboxCaptureKVNamespaceID: String?
+
+    /// Mastodon server origin used for POSSE, for example `https://mastodon.social`.
+    /// The access token is stored separately in the platform secret store.
+    public var mastodonBaseURL: String?
+
+    /// Bluesky handle or DID used to create a session for POSSE. The app password is secret-store only.
+    public var blueskyIdentifier: String?
+
+    /// Bluesky PDS origin. `nil` uses the public `https://bsky.social` service.
+    public var blueskyPDSURL: String?
+
+    /// `@dwk/workers` catalog ids the user has manually toggled on. Component-tied workers are
+    /// never stored here — their active state is always recomputed live from Site Graph
+    /// Explorer / `ImpactAnalysis` (`WorkerActivation`, #709), so it can't drift from site
+    /// content.
+    public var activeWorkerIDs: [String]?
+
+    /// The full effective active worker-id set (component-tied + settings-activated) as of the
+    /// last successful deploy — the diff baseline `WorkerActivation.removedIDs` reports removals
+    /// against (#709).
+    public var lastDeployedWorkerIDs: [String]?
+
+    /// Already-provisioned Cloudflare D1/KV/R2 resource ids for this site's composed Worker,
+    /// durable across a worker being deactivated and later reactivated — deactivating a worker
+    /// drops its binding block from `wrangler.toml`, so this is the source of truth instead of
+    /// re-scraping the file (#709).
+    public var provisionedWorkerResources: WorkerComposition.ProvisionedResources?
+
+    public init(
+        displayName: String? = nil,
+        inboxCaptureAccountID: String? = nil,
+        inboxCaptureKVNamespaceID: String? = nil,
+        mastodonBaseURL: String? = nil,
+        blueskyIdentifier: String? = nil,
+        blueskyPDSURL: String? = nil,
+        activeWorkerIDs: [String]? = nil,
+        lastDeployedWorkerIDs: [String]? = nil,
+        provisionedWorkerResources: WorkerComposition.ProvisionedResources? = nil
+    ) {
+        self.displayName = displayName
+        self.inboxCaptureAccountID = inboxCaptureAccountID
+        self.inboxCaptureKVNamespaceID = inboxCaptureKVNamespaceID
+        self.mastodonBaseURL = mastodonBaseURL
+        self.blueskyIdentifier = blueskyIdentifier
+        self.blueskyPDSURL = blueskyPDSURL
+        self.activeWorkerIDs = activeWorkerIDs
+        self.lastDeployedWorkerIDs = lastDeployedWorkerIDs
+        self.provisionedWorkerResources = provisionedWorkerResources
+    }
+}
+```
+
+- [ ] **Step 8: Run it to verify it passes**
+
+Run: `swift test --package-path . --filter SiteConfigStoreTests`
+Expected: PASS (all `SiteConfigStoreTests`, including the two new ones)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerComposition.swift Sources/AnglesiteCore/SiteConfigStore.swift \
+        Tests/AnglesiteCoreTests/WorkerCompositionTests.swift Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+git commit -m "feat(workers): persist active/last-deployed worker ids and resources (#709)"
+```
+
+---
+
+### Task 2: `WorkerActivation` — effective active set + diff + Feature mapping
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WorkerActivation.swift`
+- Test: `Tests/AnglesiteCoreTests/WorkerActivationTests.swift`
+
+**Interfaces:**
+- Consumes: `SiteSettings.activeWorkerIDs` (Task 1); `WorkerDescriptor`/`WorkerDescriptor.Binding` (`WorkerCatalog.swift:7-84`, existing); `SiteGraphExplorerSnapshot`, `ImpactAnalysis.analyze(snapshot:targetID:)` → `ImpactAnalysis.Report.affectedPages` (existing, `ImpactAnalysis.swift:49,24`); `WorkerComposition.Feature` (existing, `WorkerComposition.swift:12-19`).
+- Produces: `WorkerActivation.effectiveActiveIDs(settings:catalog:graph:) -> Set<String>`, `WorkerActivation.removedIDs(previous:next:) -> Set<String>`, `WorkerActivation.mapToFeatures(_:) -> [WorkerComposition.Feature]`. Consumed by Task 7/8.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/WorkerActivationTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WorkerActivation")
+struct WorkerActivationTests {
+    private func descriptor(
+        id: String, group: String = "social", binding: WorkerDescriptor.Binding
+    ) -> WorkerDescriptor {
+        WorkerDescriptor(
+            id: id, displayName: id, description: "d", group: group, binding: binding,
+            resources: .init(needsD1: false, needsKV: false, needsR2: false)
+        )
+    }
+
+    private func pageNode(id: String) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: .page, title: id, detail: nil, filePath: nil, route: "/\(id)")
+    }
+
+    private func componentNode(id: String) -> SiteGraphNode {
+        SiteGraphNode(id: id, kind: .component, title: id, detail: nil, filePath: nil, route: nil)
+    }
+
+    @Test("a component-tied worker is active when its component is used by a page")
+    func componentTiedActiveWhenPageUsesIt() {
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        let graph = SiteGraphExplorerSnapshot(
+            nodes: [pageNode(id: "page:home"), componentNode(id: "webmention-form")],
+            edges: [SiteGraphEdge(sourceID: "page:home", targetID: "webmention-form", kind: .imports)]
+        )
+        let active = WorkerActivation.effectiveActiveIDs(settings: SiteSettings(), catalog: catalog, graph: graph)
+        #expect(active == ["webmention"])
+    }
+
+    @Test("a component-tied worker is inactive when its component is unused")
+    func componentTiedInactiveWhenUnused() {
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        let graph = SiteGraphExplorerSnapshot(
+            nodes: [pageNode(id: "page:home"), componentNode(id: "webmention-form")],
+            edges: []
+        )
+        let active = WorkerActivation.effectiveActiveIDs(settings: SiteSettings(), catalog: catalog, graph: graph)
+        #expect(active.isEmpty)
+    }
+
+    @Test("a component-tied worker is inactive when the graph is nil (headless deploy)")
+    func componentTiedInactiveWhenGraphIsNil() {
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        let active = WorkerActivation.effectiveActiveIDs(settings: SiteSettings(), catalog: catalog, graph: nil)
+        #expect(active.isEmpty)
+    }
+
+    @Test("a component used only by another (page-unreachable) component does not count")
+    func componentTiedRequiresAffectedPageNotJustAnyDependent() {
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        // "wrapper" imports "webmention-form", but nothing imports "wrapper" — no page is affected.
+        let graph = SiteGraphExplorerSnapshot(
+            nodes: [componentNode(id: "wrapper"), componentNode(id: "webmention-form")],
+            edges: [SiteGraphEdge(sourceID: "wrapper", targetID: "webmention-form", kind: .imports)]
+        )
+        let active = WorkerActivation.effectiveActiveIDs(settings: SiteSettings(), catalog: catalog, graph: graph)
+        #expect(active.isEmpty)
+    }
+
+    @Test("a settings-activated worker is active when its id is in activeWorkerIDs")
+    func settingsActivatedFromSettings() {
+        let catalog = [descriptor(id: "solid-pod", group: "storage", binding: .settingsActivated)]
+        let settings = SiteSettings(activeWorkerIDs: ["solid-pod"])
+        let active = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        #expect(active == ["solid-pod"])
+    }
+
+    @Test("a stale activeWorkerIDs entry no longer in the catalog is dropped")
+    func staleActiveIDDropped() {
+        let catalog = [descriptor(id: "solid-pod", group: "storage", binding: .settingsActivated)]
+        let settings = SiteSettings(activeWorkerIDs: ["solid-pod", "retired-worker"])
+        let active = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        #expect(active == ["solid-pod"])
+    }
+
+    @Test("an activeWorkerIDs entry for a componentTied catalog id does not activate it directly")
+    func activeWorkerIDsIgnoredForComponentTiedEntries() {
+        // Defensive: activeWorkerIDs should only ever contain settingsActivated ids in practice,
+        // but a componentTied id ending up there (e.g. stale data) must not bypass usage detection.
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"]))]
+        let settings = SiteSettings(activeWorkerIDs: ["webmention"])
+        let active = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        #expect(active.isEmpty)
+    }
+
+    @Test("an empty catalog trusts activeWorkerIDs verbatim rather than deactivating everything")
+    func emptyCatalogTrustsActiveWorkerIDs() {
+        let settings = SiteSettings(activeWorkerIDs: ["solid-pod", "webdav"])
+        let active = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
+        #expect(active == ["solid-pod", "webdav"])
+    }
+
+    @Test("removedIDs is the previous set minus the next set")
+    func removedIDsIsSetDifference() {
+        let removed = WorkerActivation.removedIDs(previous: ["webmention", "indieauth"], next: ["indieauth"])
+        #expect(removed == ["webmention"])
+        #expect(WorkerActivation.removedIDs(previous: ["a"], next: ["a", "b"]).isEmpty)
+    }
+
+    @Test("mapToFeatures maps known catalog ids to Feature cases in declaration order")
+    func mapToFeaturesKnownIDs() {
+        let features = WorkerActivation.mapToFeatures(["websub", "indieauth"])
+        #expect(features == [.indieauth, .websub])
+    }
+
+    @Test("mapToFeatures silently drops ids with no matching Feature case")
+    func mapToFeaturesDropsUnknownIDs() {
+        let features = WorkerActivation.mapToFeatures(["indieauth", "solid-pod"])
+        #expect(features == [.indieauth])
+    }
+
+    @Test("mapToFeatures of an empty set is empty")
+    func mapToFeaturesEmpty() {
+        #expect(WorkerActivation.mapToFeatures([]).isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerActivationTests`
+Expected: FAIL — `cannot find 'WorkerActivation' in scope`
+
+- [ ] **Step 3: Implement `WorkerActivation`**
+
+Create `Sources/AnglesiteCore/WorkerActivation.swift`:
+
+```swift
+import Foundation
+
+/// Computes which `@dwk/workers` catalog workers are active for a site right now, and diffs
+/// that against the last-deployed set. Pure — no I/O, no actor isolation — so every input
+/// (settings, catalog, graph snapshot) must be gathered by the caller first (#709 design §4).
+public enum WorkerActivation {
+    /// The effective active worker-id set: component-tied workers with at least one
+    /// `ImpactAnalysis`-affected page, unioned with settings-activated workers the user toggled
+    /// on. `graph` is `nil` for a headless deploy with no populated `SiteContentGraph` — in that
+    /// case component-tied workers contribute nothing (`ImpactAnalysis` "never invents, may
+    /// under-report" bias), while `activeWorkerIDs` still applies. If `catalog` is empty (no
+    /// successful fetch, no cache — `WorkerCatalogFetcher` already degrades to cache on failure,
+    /// so this is a fresh-install-with-no-network edge case), `activeWorkerIDs` is trusted
+    /// verbatim instead of being intersected away, so a transient fetch failure can't silently
+    /// deactivate every settings-activated worker.
+    public static func effectiveActiveIDs(
+        settings: SiteSettings,
+        catalog: [WorkerDescriptor],
+        graph: SiteGraphExplorerSnapshot?
+    ) -> Set<String> {
+        var active: Set<String> = []
+
+        if let graph {
+            for descriptor in catalog {
+                guard case .componentTied(let componentIDs) = descriptor.binding else { continue }
+                let isUsed = componentIDs.contains { componentID in
+                    guard let report = ImpactAnalysis.analyze(snapshot: graph, targetID: componentID) else {
+                        return false
+                    }
+                    return !report.affectedPages.isEmpty
+                }
+                if isUsed { active.insert(descriptor.id) }
+            }
+        }
+
+        let requested = Set(settings.activeWorkerIDs ?? [])
+        if catalog.isEmpty {
+            active.formUnion(requested)
+        } else {
+            let settingsActivatedIDs = Set(catalog.compactMap { descriptor -> String? in
+                guard case .settingsActivated = descriptor.binding else { return nil }
+                return descriptor.id
+            })
+            active.formUnion(requested.intersection(settingsActivatedIDs))
+        }
+
+        return active
+    }
+
+    /// Worker ids present in `previous` but absent from `next` — used only to log what a deploy
+    /// is tearing down (#709 design §7); the removal itself happens by omission from the newly
+    /// generated `wrangler.toml`, not a separate API call.
+    public static func removedIDs(previous: Set<String>, next: Set<String>) -> Set<String> {
+        previous.subtracting(next)
+    }
+
+    /// Interim catalog-id → `Feature` shim (#709 design §4/§10): `generateWranglerToml` and
+    /// `SocialWorkerProvisionCommand.provision` still take `[WorkerComposition.Feature]`, not
+    /// `[WorkerDescriptor]`, until #708 migrates them. An id with no matching `Feature` case (a
+    /// future, not-yet-composed catalog worker) is silently dropped — there is nothing else this
+    /// call can do with it today. Iterating `Feature.allCases` (rather than mapping `ids`
+    /// directly) gives deterministic, declaration-order output for stable `wrangler.toml` diffs.
+    public static func mapToFeatures(_ ids: Set<String>) -> [WorkerComposition.Feature] {
+        WorkerComposition.Feature.allCases.filter { ids.contains($0.rawValue) }
+    }
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerActivationTests`
+Expected: PASS (all 12 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerActivation.swift Tests/AnglesiteCoreTests/WorkerActivationTests.swift
+git commit -m "feat(workers): add WorkerActivation effective-active-set computation (#709)"
+```
+
+---
+
+### Task 3: `SocialWorkerProvisionCommand.Result` gains `.workerNameConflict`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:13-17,171-183`
+- Modify: `Sources/AnglesiteCore/SiteOperations.swift:134-146`
+- Test: `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteOperationsTests.swift`
+
+**Interfaces:**
+- Produces: `SocialWorkerProvisionCommand.Result.workerNameConflict(name: String, resources: WorkerComposition.ProvisionedResources)`. Consumed by Task 7 (`DeployModel` maps it to `.workerNameConflict` phase).
+
+**Why:** today `provision`'s internal switch collapses a `DeployCommand.Result.workerNameConflict` from the injected `deployer` into a generic `.failed(reason: "Worker name … already in use …")`. That's harmless while `provision` has no live caller, but Task 7/8 route every deploy through it — silently downgrading `DeployModel`'s dedicated rename-and-retry sheet (#740) to a plain failure toast would be a real regression. Restore parity with `DeployCommand.Result` instead.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the existing test in `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift` (the one named `workerNameConflictMapsToFailed`, lines 186-203) with:
+
+```swift
+    @Test("a worker-name conflict from the deployer is propagated, not collapsed to failed")
+    func workerNameConflictPropagates() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
+            ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"id":"kv-id"}}"#, stderr: "", exitCode: 0),
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
+        ])
+        let deployer = DeployRecorder(result: .workerNameConflict(name: "taken-name"))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+
+        guard case .workerNameConflict(let name, let resources) = result else {
+            Issue.record("expected .workerNameConflict, got \(result)"); return
+        }
+        #expect(name == "taken-name")
+        #expect(resources.d1DatabaseID == "d1-id")
+        #expect(resources.kvNamespaceID == "kv-id")
+    }
+```
+
+Also update `Result` usages elsewhere in the same file that exhaustively `switch` or pattern-match — none do (all existing tests use `guard case .succeeded`/`.failed`/`.blocked`, which remain valid since Swift `guard case` isn't exhaustive).
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: FAIL — `type 'SocialWorkerProvisionCommand.Result' has no member 'workerNameConflict'`
+
+- [ ] **Step 3: Add the case and propagate it**
+
+In `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:13-17`, change:
+
+```swift
+    public enum Result: Sendable, Equatable {
+        case succeeded(url: URL, resources: WorkerComposition.ProvisionedResources, duration: TimeInterval)
+        case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning], resources: WorkerComposition.ProvisionedResources)
+        case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
+    }
+```
+
+to:
+
+```swift
+    public enum Result: Sendable, Equatable {
+        case succeeded(url: URL, resources: WorkerComposition.ProvisionedResources, duration: TimeInterval)
+        case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning], resources: WorkerComposition.ProvisionedResources)
+        /// The candidate Worker name is already in use on the connected Cloudflare account and
+        /// this site has never deployed before — mirrors `DeployCommand.Result.workerNameConflict`
+        /// rather than collapsing it, so callers can drive the same rename-and-retry UX (#740).
+        case workerNameConflict(name: String, resources: WorkerComposition.ProvisionedResources)
+        case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
+    }
+```
+
+Then in `SocialWorkerProvisionCommand.swift:171-183`, change:
+
+```swift
+        switch await deployer(token, siteID, siteDirectory) {
+        case .succeeded(let url, _):
+            return .succeeded(url: url, resources: resources, duration: Date().timeIntervalSince(started))
+        case .blocked(let failures, let warnings):
+            return .blocked(failures: failures, warnings: warnings, resources: resources)
+        case .workerNameConflict(let name):
+            return .failed(
+                reason: "Worker name \"\(name)\" is already in use on your Cloudflare account — rename it in Anglesite and try again.",
+                exitCode: nil, resources: resources)
+        case .failed(let reason, let exitCode):
+            return .failed(reason: reason, exitCode: exitCode, resources: resources)
+        }
+```
+
+to:
+
+```swift
+        switch await deployer(token, siteID, siteDirectory) {
+        case .succeeded(let url, _):
+            return .succeeded(url: url, resources: resources, duration: Date().timeIntervalSince(started))
+        case .blocked(let failures, let warnings):
+            return .blocked(failures: failures, warnings: warnings, resources: resources)
+        case .workerNameConflict(let name):
+            return .workerNameConflict(name: name, resources: resources)
+        case .failed(let reason, let exitCode):
+            return .failed(reason: reason, exitCode: exitCode, resources: resources)
+        }
+```
+
+- [ ] **Step 4: Fix the now-non-exhaustive switch in `SiteOperations.dialog(forSocialWorkerProvision:)`**
+
+In `Sources/AnglesiteCore/SiteOperations.swift:134-146`, change:
+
+```swift
+    public static func dialog(forSocialWorkerProvision result: SocialWorkerProvisionCommand.Result) -> String {
+        switch result {
+        case .succeeded(let url, let resources, _):
+            return "Social Worker provisioned at \(url.absoluteString).\(resourceSuffix(resources))"
+        case .blocked(let failures, _, let resources):
+            let count = failures.count
+            let noun = count == 1 ? "issue" : "issues"
+            return "Social Worker provisioning blocked by the pre-deploy security scan (\(count) \(noun)).\(resourceSuffix(resources))"
+        case .failed(let reason, _, let resources):
+            return "Social Worker provisioning failed: \(reason).\(resourceSuffix(resources))"
+        }
+    }
+```
+
+to:
+
+```swift
+    public static func dialog(forSocialWorkerProvision result: SocialWorkerProvisionCommand.Result) -> String {
+        switch result {
+        case .succeeded(let url, let resources, _):
+            return "Social Worker provisioned at \(url.absoluteString).\(resourceSuffix(resources))"
+        case .blocked(let failures, _, let resources):
+            let count = failures.count
+            let noun = count == 1 ? "issue" : "issues"
+            return "Social Worker provisioning blocked by the pre-deploy security scan (\(count) \(noun)).\(resourceSuffix(resources))"
+        case .workerNameConflict(let name, let resources):
+            return "Social Worker provisioning blocked: the Worker name \"\(name)\" is already in use on your Cloudflare account. Rename the site's Worker in Anglesite and try again.\(resourceSuffix(resources))"
+        case .failed(let reason, _, let resources):
+            return "Social Worker provisioning failed: \(reason).\(resourceSuffix(resources))"
+        }
+    }
+```
+
+- [ ] **Step 5: Add a dialog test**
+
+Add to `Tests/AnglesiteCoreTests/SiteOperationsTests.swift` (inside the `SiteOperationsTests` struct):
+
+```swift
+    @Test("social worker provisioning worker-name-conflict dialog names the taken Worker")
+    func socialWorkerProvisionWorkerNameConflictDialog() {
+        let result = SocialWorkerProvisionCommand.Result.workerNameConflict(
+            name: "taken-name", resources: .init(d1DatabaseID: "d1")
+        )
+        let dialog = SiteOperations.dialog(forSocialWorkerProvision: result)
+        #expect(dialog.contains("taken-name"))
+        #expect(dialog.lowercased().contains("rename"))
+        #expect(dialog.contains("Provisioned resources: D1."))
+    }
+```
+
+- [ ] **Step 6: Run both test suites to verify they pass**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: PASS
+
+Run: `swift test --package-path . --filter SiteOperationsTests`
+Expected: PASS
+
+- [ ] **Step 7: Full-package build check for other exhaustive switches**
+
+Run: `swift build --package-path .`
+Expected: builds clean — this surfaces any other exhaustive `switch` over `SocialWorkerProvisionCommand.Result` the grep in Step 4 might have missed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift Sources/AnglesiteCore/SiteOperations.swift \
+        Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+git commit -m "fix(workers): propagate worker-name conflicts instead of collapsing to failed (#709)"
+```
+
+---
+
+### Task 4: `SocialWorkerProvisionCommand.provision` reuses known resource ids
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:46-76`
+- Test: `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerComposition.ProvisionedResources` (existing).
+- Produces: `SocialWorkerProvisionCommand.provision(siteID:siteDirectory:siteName:features:knownResources:)` — new `knownResources: WorkerComposition.ProvisionedResources = .init()` parameter, default preserves today's exact behavior (existing 8 tests in this file must pass unmodified). Consumed by Task 7/8, which pass `settings.provisionedWorkerResources ?? .init()`.
+
+**Why:** `readPersistedResources` regex-scrapes the *current* `wrangler.toml`. Deactivating a worker regenerates the file without that resource's binding block, so the id vanishes from the file. Reactivating later then finds nothing persisted and tries `wrangler … create` again, which fails because the resource still exists under that name. `knownResources` (sourced from `SiteSettings.provisionedWorkerResources`, Task 1) is checked *before* falling back to the file scrape, so a durable record survives a worker being toggled off in between (design doc §6). `readPersistedResources` itself is untouched — it stays a pure file-scrape fallback for sites with no persisted record yet (pre-existing sites), so its own existing test (`persistedResourceParsing`) needs no changes.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add to `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift` (inside the struct):
+
+```swift
+    @Test("knownResources is reused instead of re-scraping wrangler.toml, so a deactivated-then-reactivated worker doesn't recreate its Cloudflare resource")
+    func reusesKnownResourcesOverFileScrape() async throws {
+        let site = try temporaryDirectory()
+        // wrangler.toml on disk reflects the CURRENT (deactivated) feature set — no R2 block, so
+        // a file-scrape alone would find no bucket name and try to recreate it.
+        let currentToml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            features: [.indieauth],
+            resources: .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: nil)
+        )
+        try currentToml.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+
+        // knownResources (as persisted in SiteSettings before deactivation) still remembers the bucket.
+        let known = WorkerComposition.ProvisionedResources(
+            d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: "my-site-media"
+        )
+        let recorder = WranglerRecorder([
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
+        ])
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: recorder.runner,
+            deployer: DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1)).deployer
+        )
+
+        // Reactivating micropub (needs R2) should reuse the known bucket, not call `r2 bucket create` again.
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            features: [.indieauth, .micropub], knownResources: known
+        )
+
+        guard case .succeeded(_, let resources, _) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(resources.r2BucketName == "my-site-media")
+        #expect(await recorder.arguments == [
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"],
+        ])
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: FAIL — `incorrect argument label in call (have 'siteID:siteDirectory:siteName:features:knownResources:', expected 'siteID:siteDirectory:siteName:features:')`
+
+- [ ] **Step 3: Add the `knownResources` parameter**
+
+In `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:46-76`, change the `provision` signature and its first two lines:
+
+```swift
+    public func provision(
+        siteID: String,
+        siteDirectory: URL,
+        siteName: String,
+        features: [WorkerComposition.Feature] = WorkerComposition.Feature.v2
+    ) async -> Result {
+```
+
+to:
+
+```swift
+    public func provision(
+        siteID: String,
+        siteDirectory: URL,
+        siteName: String,
+        features: [WorkerComposition.Feature] = WorkerComposition.Feature.v2,
+        /// Resources already known from `SiteSettings.provisionedWorkerResources` (#709), checked
+        /// before falling back to `readPersistedResources`'s wrangler.toml scrape. Durable across
+        /// a worker being deactivated (which drops its binding block from the file) and later
+        /// reactivated — the default (`.init()`, all-nil) makes this call fall through to the
+        /// existing file-scrape-only behavior unchanged.
+        knownResources: WorkerComposition.ProvisionedResources = .init()
+    ) async -> Result {
+```
+
+Then find the line (currently `SocialWorkerProvisionCommand.swift:75`):
+
+```swift
+        var resources = Self.readPersistedResources(from: siteDirectory)
+```
+
+and change it to:
+
+```swift
+        var resources = knownResources == .init() ? Self.readPersistedResources(from: siteDirectory) : knownResources
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: PASS (all tests in the file, including the 8 pre-existing ones — confirming the default parameter preserves prior behavior)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+git commit -m "fix(workers): reuse persisted resource ids across worker deactivate/reactivate (#709)"
+```
+
+---
+
+### Task 5: `ContainerCommandRunner`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ContainerCommandRunner.swift`
+- Test: `Tests/AnglesiteCoreTests/ContainerCommandRunnerTests.swift`
+
+**Interfaces:**
+- Consumes: `LocalContainerControl` (existing, `LocalContainerControl.swift:80-127`); `SocialWorkerProvisionCommand.CommandRunner` (existing typealias: `@Sendable (_ siteDirectory: URL, _ arguments: [String], _ environment: [String: String], _ source: String) async throws -> ProcessSupervisor.RunResult`); `FakeLocalContainerControl` (existing test helper, `Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift`).
+- Produces: `ContainerCommandRunner(control:siteID:logCenter:).runner: SocialWorkerProvisionCommand.CommandRunner`. Consumed by Task 7/8.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/ContainerCommandRunnerTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContainerCommandRunner")
+struct ContainerCommandRunnerTests {
+    private func fakePassing(exitCode: Int32 = 0, stdout: String = "ok") -> FakeLocalContainerControl {
+        FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: exitCode, stdout: stdout, stderr: ""),
+            execStdoutLines: []
+        )
+    }
+
+    @Test("arguments are prefixed with npx wrangler")
+    func argvIsPrefixedWithWrangler() async throws {
+        let fake = fakePassing()
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        _ = try await runner.runner(
+            URL(fileURLWithPath: "/host/irrelevant"),
+            ["d1", "create", "my-site-social", "--json"],
+            [:],
+            "worker-provision:site-abc"
+        )
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].argv == ["npx", "wrangler", "d1", "create", "my-site-social", "--json"])
+        #expect(calls[0].cwd == "/workspace/site")
+    }
+
+    @Test("exit code and stdout are surfaced in the RunResult")
+    func surfacesExitCodeAndStdout() async throws {
+        let fake = fakePassing(exitCode: 0, stdout: #"{"result":{"uuid":"d1-id"}}"#)
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        let result = try await runner.runner(URL(fileURLWithPath: "/host"), ["d1", "create", "x", "--json"], [:], "src")
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout == #"{"result":{"uuid":"d1-id"}}"#)
+    }
+
+    @Test("a non-zero exit code is surfaced, not thrown")
+    func nonZeroExitCodeSurfaced() async throws {
+        let fake = fakePassing(exitCode: 1, stdout: "already exists")
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        let result = try await runner.runner(URL(fileURLWithPath: "/host"), ["r2", "bucket", "create", "x"], [:], "src")
+
+        #expect(result.exitCode == 1)
+        #expect(result.stdout == "already exists")
+    }
+
+    @Test("CLOUDFLARE_API_TOKEN is forwarded to the guest environment")
+    func forwardsToken() async throws {
+        let fake = fakePassing()
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        _ = try await runner.runner(
+            URL(fileURLWithPath: "/host"), ["d1", "create", "x", "--json"],
+            ["CLOUDFLARE_API_TOKEN": "supersecret", "PATH": "/opt/homebrew/bin"], "src"
+        )
+
+        let calls = await fake.execCalls
+        #expect(calls[0].env["CLOUDFLARE_API_TOKEN"] == "supersecret")
+        #expect(calls[0].env["PATH"] == nil)
+    }
+
+    @Test("stdout lines stream to LogCenter under the given source")
+    func streamsToLogCenter() async throws {
+        let logCenter = LogCenter()
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: "done", stderr: ""),
+            execStdoutLines: ["Creating D1 database 'my-site-social'"]
+        )
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: logCenter)
+
+        _ = try await runner.runner(URL(fileURLWithPath: "/host"), ["d1", "create", "x", "--json"], [:], "worker-provision:site-abc")
+
+        let snapshot = await logCenter.snapshot()
+        #expect(snapshot.contains { $0.source == "worker-provision:site-abc" && $0.text == "Creating D1 database 'my-site-social'" })
+    }
+
+    @Test("a dead container surfaces a throw, not a hang")
+    func deadContainerThrows() async {
+        // The shared `FakeLocalContainerControl` (Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift)
+        // always succeeds — its `exec` has no way to throw. `ContainerDeployExecutorTests.swift`
+        // hits this same limitation and defines a local throwing fake for exactly this case;
+        // mirror that pattern here rather than the shared fake.
+        let fake = ThrowingFakeLocalContainerControl()
+        let runner = ContainerCommandRunner(control: fake, siteID: "site-abc", logCenter: LogCenter())
+
+        await #expect(throws: ThrowingFakeLocalContainerControl.ExecError.self) {
+            _ = try await runner.runner(URL(fileURLWithPath: "/host"), ["d1", "create", "x", "--json"], [:], "src")
+        }
+    }
+}
+
+// Mirrors `ContainerDeployExecutorTests.swift`'s private `ThrowingFakeLocalContainerControl` —
+// duplicated locally (not shared) because that one is `private` to its own test file.
+private actor ThrowingFakeLocalContainerControl: LocalContainerControl {
+    enum ExecError: Error { case boom }
+
+    func start(
+        siteID: String, sourceRepo: URL, ref: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> LocalContainerSession {
+        throw ExecError.boom
+    }
+    func stop(siteID: String) async throws {}
+    func exec(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> ContainerExecResult {
+        throw ExecError.boom
+    }
+    func execInteractive(
+        siteID: String,
+        argv: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> InteractiveExecHandle {
+        throw ExecError.boom
+    }
+}
+```
+
+Before this step, read `Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift` once to confirm its `init` parameter names (`startResult:startStdoutLines:execResult:execStdoutLines:execInteractiveStdoutLines:`, all confirmed against the actual file as of this plan's writing) still match — if a later change to that shared fake has added an `execError`-style throwing seam since, use that instead of the local duplicate above.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter ContainerCommandRunnerTests`
+Expected: FAIL — `cannot find 'ContainerCommandRunner' in scope`
+
+- [ ] **Step 3: Implement `ContainerCommandRunner`**
+
+Create `Sources/AnglesiteCore/ContainerCommandRunner.swift`:
+
+```swift
+import Foundation
+
+/// Runs `SocialWorkerProvisionCommand`'s wrangler subcommands (`d1`/`kv`/`r2 create`,
+/// `d1 migrations apply`, …) inside a running container via `LocalContainerControl.exec` —
+/// the `CommandRunner` counterpart to `ContainerDeployExecutor` (`DeployExecutor.swift:61-168`),
+/// which does the same for the three fixed deploy steps. `SocialWorkerProvisionCommand`'s
+/// `arguments` are already bare wrangler subcommand argv (e.g. `["d1", "create", name, "--json"]`);
+/// this just prefixes `["npx", "wrangler"]` and adapts the result shape.
+public struct ContainerCommandRunner: Sendable {
+    private let control: any LocalContainerControl
+    private let siteID: String
+    private let logCenter: LogCenter
+
+    public init(control: any LocalContainerControl, siteID: String, logCenter: LogCenter = .shared) {
+        self.control = control
+        self.siteID = siteID
+        self.logCenter = logCenter
+    }
+
+    /// Bind this instance's `run` as a `SocialWorkerProvisionCommand.CommandRunner` closure.
+    public var runner: SocialWorkerProvisionCommand.CommandRunner {
+        { [self] siteDirectory, arguments, environment, source in
+            try await self.run(siteDirectory: siteDirectory, arguments: arguments, environment: environment, source: source)
+        }
+    }
+
+    // Guest-only allowlist — same rationale as `ContainerDeployExecutor.guestEnvAllowlist`: the
+    // host (macOS) environment must never cross into the Linux guest wholesale.
+    private static let guestEnvAllowlist: Set<String> = ["CLOUDFLARE_API_TOKEN"]
+
+    private func run(
+        siteDirectory: URL,
+        arguments: [String],
+        environment: [String: String],
+        source: String
+    ) async throws -> ProcessSupervisor.RunResult {
+        let argv = ["npx", "wrangler"] + arguments
+        let guestEnvironment = environment.filter { Self.guestEnvAllowlist.contains($0.key) }
+
+        let (lines, continuation) = AsyncStream<(String, LogCenter.Stream)>.makeStream(bufferingPolicy: .unbounded)
+        let logCenter = self.logCenter
+        let drain = Task.detached(priority: .utility) {
+            for await (line, stream) in lines {
+                await logCenter.append(source: source, stream: stream, text: line)
+            }
+        }
+
+        let result: ContainerExecResult
+        do {
+            result = try await control.exec(
+                siteID: siteID,
+                argv: argv,
+                environment: guestEnvironment,
+                workingDirectory: "/workspace/site",
+                onOutput: { line, stream in continuation.yield((line, stream)) }
+            )
+        } catch {
+            continuation.finish()
+            _ = await drain.value
+            throw error
+        }
+        continuation.finish()
+        _ = await drain.value
+        return ProcessSupervisor.RunResult(stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode)
+    }
+}
+```
+
+Before finalizing, check `ProcessSupervisor.RunResult`'s exact initializer (`Sources/AnglesiteCore/ProcessSupervisor.swift`, or wherever it's declared — grep `struct RunResult`) to confirm the `stdout:stderr:exitCode:` label order and that `exitCode` is `Int32` (matching `ContainerExecResult.exitCode: Int32`, no optional conversion needed) before compiling.
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `swift test --package-path . --filter ContainerCommandRunnerTests`
+Expected: PASS (all 6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContainerCommandRunner.swift Tests/AnglesiteCoreTests/ContainerCommandRunnerTests.swift
+git commit -m "feat(workers): add ContainerCommandRunner so provisioning runs in-guest (#709)"
+```
+
+---
+
+### Task 6: Production `catalogURL`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/WorkerCatalogFetcher.swift:22-55`
+- Test: `Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift`
+
+**Interfaces:**
+- Produces: `WorkerCatalogFetcher.productionCatalogURL: URL`. Consumed by Task 7/8.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift` (inside the `WorkerCatalogFetcherTests` struct):
+
+```swift
+    @Test("productionCatalogURL points at the published davidwkeith/workers catalog.json")
+    func productionCatalogURLIsThePublishedManifest() {
+        #expect(
+            WorkerCatalogFetcher.productionCatalogURL
+                == URL(string: "https://raw.githubusercontent.com/davidwkeith/workers/main/catalog.json")!
+        )
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerCatalogFetcherTests`
+Expected: FAIL — `type 'WorkerCatalogFetcher' has no member 'productionCatalogURL'`
+
+- [ ] **Step 3: Add the constant**
+
+In `Sources/AnglesiteCore/WorkerCatalogFetcher.swift`, remove the now-stale doc-comment caveat at lines 22-24 (`- Important: catalogURL has no in-app default...`) and add a static constant just above `defaultCacheURL` (near line 101):
+
+```swift
+    /// The published `@dwk/workers` monorepo catalog manifest — verified live 2026-07-17
+    /// (davidwkeith/workers#255, merged in davidwkeith/workers#258). Callers still supply
+    /// `catalogURL` explicitly at `init`; this is the value production call sites should pass.
+    public static let productionCatalogURL = URL(
+        string: "https://raw.githubusercontent.com/davidwkeith/workers/main/catalog.json"
+    )!
+```
+
+Update the type's doc comment (lines 17-24) to drop the "no in-app default" caveat, since one now exists:
+
+```swift
+/// Fetches, parses, and disk-caches the `@dwk/workers` catalog manifest (`catalog.json`).
+/// Network or parse failures degrade to the last successfully cached copy, then to an empty
+/// catalog — the Workers Settings tab and deploy composition must never block or crash on a
+/// catalog fetch failure (design doc §3).
+public actor WorkerCatalogFetcher {
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerCatalogFetcherTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerCatalogFetcher.swift Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift
+git commit -m "feat(workers): wire the published production catalog.json URL (#709, #708)"
+```
+
+---
+
+### Task 7: Wire `DeployModel.runDeploy` through `WorkerActivation` + `SocialWorkerProvisionCommand`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift:111-131` (init), `:347-478` (`runDeploy`)
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:74`
+- Test: `Tests/AnglesiteAppTests/DeployModelTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerActivation.effectiveActiveIDs`/`.mapToFeatures` (Task 2), `SocialWorkerProvisionCommand` incl. `.workerNameConflict` + `knownResources` (Tasks 3, 4), `ContainerCommandRunner` (Task 5), `WorkerCatalogFetcher.productionCatalogURL` (Task 6), `SiteConfigStore` (existing), `SiteContentGraph.isPopulated(siteID:)`/`.pages(for:)`/`.posts(for:)`/`.images(for:)` (existing), `SiteGraphExplorer.build` (existing, `SiteGraphExplorer.swift:95-102`).
+- Produces: `DeployModel(contentGraph:command:workerCatalog:socialWorkerCommandBuilder:...)` — see Step 3 for the exact new init parameters and their test-safe defaults.
+
+**Design note (deviates slightly from spec wording for testability):** the design doc's §5 describes `DeployModel` building a `WorkerCatalogFetcher` and a `SocialWorkerProvisionCommand` directly inside `runDeploy`. To keep `DeployModelTests` free of real network calls and real `SocialWorkerProvisionCommand` construction, this task injects two closures instead: `workerCatalog: @Sendable () async -> [WorkerDescriptor]` (defaults to `{ [] }` — safe/offline; production wiring in `SiteWindowModel` passes the real fetcher) and `socialWorkerRunner: @Sendable (any LocalContainerControl, String) -> SocialWorkerProvisionCommand.CommandRunner` is **not** needed as a separate seam — `ContainerCommandRunner` is constructed inline from the `containerControl` already available in `runDeploy`, mirroring exactly how `activeCommand`'s `ContainerDeployExecutor` is already built inline there. Only `workerCatalog` and `contentGraph` are new stored dependencies.
+
+- [ ] **Step 1: Write the failing test — non-worker sites still deploy exactly as before**
+
+Add to `Tests/AnglesiteAppTests/DeployModelTests.swift` (inside the `DeployModelTests` struct, after the existing tests):
+
+```swift
+    @Test("a site with no active workers still deploys through the plain static path")
+    func staticSiteDeploysUnaffected() async throws {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let contentGraph = SiteContentGraph()
+        let model = DeployModel(
+            command: command,
+            logCenter: LogCenter(),
+            suddenTerminationController: SuddenTerminationController(disable: {}, enable: {}),
+            tokenAvailabilityOverride: { true },
+            contentGraph: contentGraph,
+            workerCatalog: { [] }
+        )
+        let dir = try temporaryDirectory()
+
+        model.deploy(siteID: "test-site", siteDirectory: dir, configDirectory: dir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+
+        guard case .succeeded = model.phase else {
+            Issue.record("Expected deploy to succeed, got \(model.phase)")
+            return
+        }
+    }
+
+    @Test("a site with a settings-activated worker persists lastDeployedWorkerIDs after a successful deploy")
+    func activatingAWorkerPersistsLastDeployedWorkerIDs() async throws {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let contentGraph = SiteContentGraph()
+        let catalog = [
+            WorkerDescriptor(
+                id: "indieauth", displayName: "IndieAuth", description: "d", group: "identity",
+                binding: .settingsActivated, resources: .init(needsD1: true, needsKV: false, needsR2: false)
+            )
+        ]
+        let model = DeployModel(
+            command: command,
+            logCenter: LogCenter(),
+            suddenTerminationController: SuddenTerminationController(disable: {}, enable: {}),
+            tokenAvailabilityOverride: { true },
+            contentGraph: contentGraph,
+            workerCatalog: { catalog }
+        )
+        let dir = try temporaryDirectory()
+        let configDir = dir.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let configStore = SiteConfigStore(configDirectory: configDir)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+
+        model.deploy(siteID: "test-site", siteDirectory: dir, configDirectory: configDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+
+        // provision() has no working runner outside a container (Task 5's ContainerCommandRunner
+        // requires a real LocalContainerControl) — without containerControl this deploy is
+        // expected to fail at the D1-provisioning step, NOT silently skip worker composition.
+        guard case .failed = model.phase else {
+            Issue.record("Expected a provisioning failure without a container, got \(model.phase)")
+            return
+        }
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DeployModelTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter DeployModelTests`
+Expected: FAIL — `incorrect argument label in call ... expected 'command:logCenter:...'` (no `contentGraph`/`workerCatalog` params yet)
+
+- [ ] **Step 3: Add the new dependencies to `DeployModel`'s init**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, add two stored properties near `private let logCenter: LogCenter` (line 82):
+
+```swift
+    private let contentGraph: SiteContentGraph
+    /// Returns the current `@dwk/workers` catalog. Defaults to `{ [] }` (no network, no active
+    /// settings-activated workers ever computed) so existing tests that don't inject one keep
+    /// deploying exactly as before — production wiring (`SiteWindowModel`) passes a real
+    /// `WorkerCatalogFetcher(catalogURL: WorkerCatalogFetcher.productionCatalogURL).catalog`.
+    private let workerCatalog: @Sendable () async -> [WorkerDescriptor]
+```
+
+and extend the initializer (lines 111-131):
+
+```swift
+    init(
+        command: DeployCommand = DeployCommand(),
+        webmentionCommand: WebmentionSendCommand = WebmentionSendCommand(),
+        posseCommand: POSSESyndicationCommand = POSSESyndicationCommand(),
+        logCenter: LogCenter = .shared,
+        keychain: KeychainStore = KeychainStore(),
+        verifier: TokenVerifying = CloudflareAPITokenVerifier(),
+        summarizer: any DeployFailureSummarizing = DeploySummarizerFactory.makeDefault(),
+        suddenTerminationController: SuddenTerminationController = .shared,
+        tokenAvailabilityOverride: (() -> Bool)? = nil,
+        contentGraph: SiteContentGraph = SiteContentGraph(),
+        workerCatalog: @escaping @Sendable () async -> [WorkerDescriptor] = { [] }
+    ) {
+        self.command = command
+        self.webmentionCommand = webmentionCommand
+        self.posseCommand = posseCommand
+        self.logCenter = logCenter
+        self.keychain = keychain
+        self.onboarding = TokenOnboarding(verifier: verifier)
+        self.summarizer = summarizer
+        self.suddenTerminationController = suddenTerminationController
+        self.tokenAvailabilityOverride = tokenAvailabilityOverride
+        self.contentGraph = contentGraph
+        self.workerCatalog = workerCatalog
+    }
+```
+
+- [ ] **Step 4: Rewrite `runDeploy`'s dispatch to route through `WorkerActivation` + `SocialWorkerProvisionCommand`**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, replace lines 380-421 (from the `// Select the executor:` comment through `_ = await logTask.value`) with:
+
+```swift
+        // Select the executor: in-container when the runtime is a started container;
+        // explicit unavailable result otherwise. The token source always comes from the
+        // injected `command` so the test-injection path (a fully pre-built
+        // `DeployCommand`) continues to work unmodified.
+        let activeCommand: DeployCommand
+        let containerRunner: SocialWorkerProvisionCommand.CommandRunner?
+        if let cc = containerControl {
+            activeCommand = DeployCommand(
+                tokenSource: command.tokenSource,
+                executor: ContainerDeployExecutor(
+                    control: cc.control,
+                    siteID: cc.siteID,
+                    logCenter: logCenter
+                )
+            )
+            containerRunner = ContainerCommandRunner(control: cc.control, siteID: cc.siteID, logCenter: logCenter).runner
+        } else {
+            activeCommand = command
+            containerRunner = nil
+        }
+
+        // Effective active worker set (#709 design §4-5): component-tied workers via
+        // ImpactAnalysis (only when this site's content graph has actually been scanned — a
+        // headless/never-opened site contributes nothing there, matching ImpactAnalysis's own
+        // "never invents, may under-report" bias) unioned with settings-activated workers.
+        let configStore = SiteConfigStore(configDirectory: configDirectory)
+        let settings = (try? await configStore.load()) ?? SiteSettings()
+        let catalog = await workerCatalog()
+        let snapshot: SiteGraphExplorerSnapshot?
+        if await contentGraph.isPopulated(siteID: siteID) {
+            snapshot = SiteGraphExplorer.build(
+                projectRoot: siteDirectory,
+                siteID: siteID,
+                pages: await contentGraph.pages(for: siteID),
+                posts: await contentGraph.posts(for: siteID),
+                images: await contentGraph.images(for: siteID)
+            )
+        } else {
+            snapshot = nil
+        }
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: snapshot)
+        let removedIDs = WorkerActivation.removedIDs(previous: Set(settings.lastDeployedWorkerIDs ?? []), next: effectiveActiveIDs)
+        if !removedIDs.isEmpty {
+            await logCenter.append(
+                source: "deploy:\(siteID)",
+                stream: .stdout,
+                text: "Deactivating workers: \(removedIDs.sorted().joined(separator: ", "))"
+            )
+        }
+        let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
+
+        let socialCommand = SocialWorkerProvisionCommand(
+            tokenSource: { [weak self] in try await self?.command.tokenSource() },
+            runner: containerRunner ?? SocialWorkerProvisionCommand.defaultRunner,
+            deployer: { _, deploySiteID, deploySiteDirectory in
+                await activeCommand.deploy(
+                    siteID: deploySiteID,
+                    siteDirectory: deploySiteDirectory,
+                    configDirectory: configDirectory,
+                    currentRoutes: currentRoutes,
+                    onPreflight: { [weak self] outcome in
+                        Task { @MainActor in self?.onScanComplete?(outcome) }
+                    },
+                    onProgress: { [weak self] progress in
+                        Task { @MainActor in
+                            self?.currentMilestone = progress.label
+                            self?.onMilestone?(siteID, progress)
+                        }
+                    }
+                )
+            }
+        )
+
+        let provisionResult = await socialCommand.provision(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            siteName: SiteSlug.derive(from: siteID),
+            features: features,
+            knownResources: settings.provisionedWorkerResources ?? .init()
+        )
+
+        if case .succeeded(_, let resources, _) = provisionResult {
+            var updated = settings
+            updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
+            updated.provisionedWorkerResources = resources
+            try? await configStore.save(updated)
+        }
+
+        let result: DeployCommand.Result
+        switch provisionResult {
+        case .succeeded(let url, _, let duration):
+            result = .succeeded(url: url, duration: duration)
+        case .blocked(let failures, let warnings, _):
+            result = .blocked(failures: failures, warnings: warnings)
+        case .workerNameConflict(let name, _):
+            result = .workerNameConflict(name: name)
+        case .failed(let reason, let exitCode, _):
+            result = .failed(reason: reason, exitCode: exitCode)
+        }
+
+        subscription.cancel()
+        _ = await logTask.value
+```
+
+**`siteName` threading.** `SiteSlug.derive(from:)` (`NewSiteDraft.swift:135`) needs the site's *display* name (e.g. `"Blue Bottle Cafe"` → `"blue-bottle-cafe"`), matching what `SiteOperations.provisionSocialWorker` already passes it (`SiteOperations.swift:82`: `SiteSlug.derive(from: site.name)`). `runDeploy` only has `siteID` (an opaque id) in scope today — `SiteWindowModel.deploySite()` (`SiteWindowModel.swift:469-482`) and `performInvisiblePublish` (`SiteWindowModel.swift:1413-1426`) both call `deploy.deploy(...)`/`deploy.deployAutomatically(...)` with a `site: SiteStore.Site` already in scope (`site.name` is right there), so thread a new `siteName: String? = nil` parameter through `deploy`/`deployAutomatically`/`runDeploy`, defaulted to `nil` so every existing test call (which only ever set `siteID` to a placeholder like `"test-site"`) keeps compiling unchanged. Inside `runDeploy`, resolve it with `let workerSiteName = siteName ?? siteID` before calling `SiteSlug.derive(from:)` — a safe fallback for tests/callers that don't pass a real display name, while production always does.
+
+Add `siteName: String? = nil` to `deploy(...)` (`DeployModel.swift:154-160`) and `deployAutomatically(...)` (`DeployModel.swift:187-193`), thread it into their `runDeploy(...)` calls (`DeployModel.swift:174-179`, `200-208`) alongside the existing parameters, and add the same parameter to `runDeploy`'s own signature (`DeployModel.swift:347-355`). Then in `SiteWindowModel.swift:479` change:
+
+```swift
+            deploy.deploy(
+                siteID: site.id, siteDirectory: site.sourceDirectory,
+                configDirectory: site.configDirectory, currentRoutes: currentRoutes,
+                containerControl: containerControl)
+```
+
+to:
+
+```swift
+            deploy.deploy(
+                siteID: site.id, siteDirectory: site.sourceDirectory,
+                configDirectory: site.configDirectory, currentRoutes: currentRoutes,
+                containerControl: containerControl, siteName: site.name)
+```
+
+and in `SiteWindowModel.swift:1421-1426` change:
+
+```swift
+        return await deploy.deployAutomatically(
+            siteID: site.id,
+            siteDirectory: site.sourceDirectory,
+            configDirectory: site.configDirectory,
+            currentRoutes: pageRoutes + postRoutes,
+            containerControl: containerControl
+        )
+```
+
+to:
+
+```swift
+        return await deploy.deployAutomatically(
+            siteID: site.id,
+            siteDirectory: site.sourceDirectory,
+            configDirectory: site.configDirectory,
+            currentRoutes: pageRoutes + postRoutes,
+            containerControl: containerControl,
+            siteName: site.name
+        )
+```
+
+Then, in the `runDeploy` code block above, replace this line:
+
+```swift
+        let provisionResult = await socialCommand.provision(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            siteName: SiteSlug.derive(from: siteID),
+```
+
+with:
+
+```swift
+        let provisionResult = await socialCommand.provision(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            siteName: SiteSlug.derive(from: siteName ?? siteID),
+```
+
+Remove the old lines that duplicated the `DeployCommand.deploy` call (the original `let result = await activeCommand.deploy(...)` block) — it's now fully replaced by the block above.
+
+- [ ] **Step 5: Wire `SiteWindowModel` to pass the real `contentGraph` and catalog fetcher**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, `SiteWindowModel` already stores `contentGraph: SiteContentGraph` from its own `init` (line 45, 178-179, 186). Change line 74 from:
+
+```swift
+    var deploy = DeployModel()
+```
+
+to a property initialized inside `init` instead of at declaration (since it now depends on `self.contentGraph`). Change the declaration to:
+
+```swift
+    var deploy: DeployModel
+```
+
+and add this assignment inside `SiteWindowModel.init` (near `self.contentGraph = contentGraph` at line 186):
+
+```swift
+        self.deploy = DeployModel(
+            contentGraph: contentGraph,
+            workerCatalog: { await WorkerCatalogFetcher(catalogURL: WorkerCatalogFetcher.productionCatalogURL).catalog() }
+        )
+```
+
+Place it after `self.contentGraph = contentGraph` so the closure's capture is unambiguous. If `SiteWindowModel`'s init has other stored-property assignments between lines 178-205 that must happen in a specific order (Swift requires `self` fully initialized before capturing `self` in closures — this closure only captures nothing external, it constructs a fresh `WorkerCatalogFetcher`, so ordering relative to other properties doesn't matter, but it must come after all other `let`/`var` properties are assigned if any earlier code path in `init` reads `self.deploy` before this line — verify no such read exists by searching for `self.deploy` or `deploy.` before line 205 in the same init).
+
+- [ ] **Step 6: Run the DeployModel test suite**
+
+Run: `swift test --package-path . --filter DeployModelTests`
+Expected: PASS (all tests, including the two new ones from Step 1 and the pre-existing worker-name-conflict test, which must still pass since `.workerNameConflict` now flows through `SocialWorkerProvisionCommand.Result` before being mapped back — trace: does that pre-existing test inject a `containerControl`? If not, `containerRunner` is `nil` and `SocialWorkerProvisionCommand.defaultRunner` is used, which never calls `deployer` at all for a conflict scenario — re-read the existing `workerNameConflictParksAndPresents` test (`DeployModelTests.swift:85+`) in full before this step to confirm whether it needs `containerControl` injected to reach the `deployer` closure, since `provision()` only calls `deployer` after any D1/KV/R2 steps succeed, and those steps are gated on `features.contains(where: needsD1)` etc. — if the test's site has no active workers (empty `features`), `provision()` skips straight to `deployer` regardless of `containerRunner`, so it should still work; verify this by running the test, not by assumption).
+
+- [ ] **Step 7: Full build check**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: builds clean (this exercises `AnglesiteApp` target code the `swift test` SwiftPM lanes don't necessarily compile identically — per CLAUDE.md, `swift test` alone doesn't cover the hosted app target).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift Sources/AnglesiteApp/SiteWindowModel.swift Tests/AnglesiteAppTests/DeployModelTests.swift
+git commit -m "feat(workers): route the main Deploy button through effective-active-set composition (#709)"
+```
+
+---
+
+### Task 8: Wire `SiteOperations.deploy` (headless path)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteOperations.swift:40-51`
+- Test: `Tests/AnglesiteCoreTests/SiteOperationsTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerActivation` (Task 2), `SocialWorkerProvisionCommand` (Tasks 3-4), `SiteConfigStore` (existing). Deliberately **no** `SiteContentGraph`/catalog dependency — per design doc §8, headless deploy always passes `graph: nil` and, absent a richer catalog source, `catalog: []` (which per `WorkerActivation`'s empty-catalog fallback still honors `activeWorkerIDs` verbatim).
+- Produces: `SiteOperations.deploy(site:onProgress:)` now routes through `SocialWorkerProvisionCommand.provision` the same way `DeployModel` does, persisting `lastDeployedWorkerIDs`/`provisionedWorkerResources` on success.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/SiteOperationsTests.swift` (inside the struct):
+
+```swift
+    @Test("headless deploy with a settings-activated worker routes through provision and persists lastDeployedWorkerIDs")
+    func headlessDeployWithActiveWorkerPersistsState() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let configStore = SiteConfigStore(configDirectory: site.configDirectory)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
+
+        let result = await ops.deploy(site: site)
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let saved = try await configStore.load()
+        #expect(saved.lastDeployedWorkerIDs == ["indieauth"])
+    }
+
+    @Test("headless deploy with no activated workers still deploys through the plain static path")
+    func headlessDeployWithNoActiveWorkers() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
+
+        let result = await ops.deploy(site: site)
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(await recorder.arguments.isEmpty)
+    }
+```
+
+Before writing this, confirm `SiteStore.Site` exposes `configDirectory` as a computed property (per `CLAUDE.md`'s "`SiteStore.Site` carries `packageURL` + computed `sourceDirectory`/`configDirectory`") by grepping `Sources/AnglesiteCore/SiteStore.swift` for `var configDirectory`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `swift test --package-path . --filter SiteOperationsTests`
+Expected: FAIL — `saved.lastDeployedWorkerIDs` is `nil` (deploy doesn't yet compute/persist the effective set)
+
+- [ ] **Step 3: Rewrite `SiteOperations.deploy`**
+
+In `Sources/AnglesiteCore/SiteOperations.swift:40-51`, change:
+
+```swift
+    public func deploy(site: SiteStore.Site, onProgress: ProgressHandler? = nil) async -> DeployCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await factory.deploy().deploy(siteID: site.id, siteDirectory: url, onProgress: onProgress)
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil)
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+```
+
+to:
+
+```swift
+    public func deploy(site: SiteStore.Site, onProgress: ProgressHandler? = nil) async -> DeployCommand.Result {
+        do {
+            return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
+                await self.deployWithWorkerComposition(site: site, siteDirectory: url, onProgress: onProgress)
+            }
+        } catch let SiteAccess.AccessError.noGrant(message) {
+            return .failed(reason: message, exitCode: nil)
+        } catch {
+            return .failed(reason: error.localizedDescription, exitCode: nil)
+        }
+    }
+
+    /// Headless-deploy counterpart to `DeployModel.runDeploy`'s worker-composition wiring
+    /// (#709 design §5/§8): computes the effective active worker set — settings-activated only,
+    /// since this path (App Intents/Shortcuts) has no populated `SiteContentGraph` to derive
+    /// component-tied activation from — and routes through `SocialWorkerProvisionCommand.provision`
+    /// the same way the main Deploy button does, persisting the result on success.
+    ///
+    /// `onProgress` fidelity note: `SocialWorkerProvisionCommand.provision` has no milestone hook
+    /// of its own (unlike `DeployCommand.deploy`, it's never been wired for one — it had no live
+    /// caller before #709), so this emits the same coarse `OperationProgress.deployBuilding` /
+    /// `.deployDeploying` milestones `DeployCommand.deploy` would have emitted around the
+    /// build/deploy boundary, rather than `DeployCommand`'s finer per-step ones (preflight,
+    /// finalizing). `SiteIntents.swift:59` is this path's one real consumer (Siri/Shortcuts
+    /// progress) — dropping progress reporting to nothing would regress it; this keeps it coarser
+    /// but non-silent without adding an `onProgress` parameter to `SocialWorkerProvisionCommand`
+    /// itself, which would ripple into Tasks 3/4's signature and every other call site.
+    private func deployWithWorkerComposition(
+        site: SiteStore.Site, siteDirectory: URL, onProgress: ProgressHandler?
+    ) async -> DeployCommand.Result {
+        let configStore = SiteConfigStore(configDirectory: site.configDirectory)
+        let settings = (try? await configStore.load()) ?? SiteSettings()
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
+        let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
+
+        onProgress?(.deployBuilding)
+        onProgress?(.deployDeploying)
+        let provisionResult = await factory.socialWorkerProvision().provision(
+            siteID: site.id,
+            siteDirectory: siteDirectory,
+            siteName: SiteSlug.derive(from: site.name),
+            features: features,
+            knownResources: settings.provisionedWorkerResources ?? .init()
+        )
+        onProgress?(.deployFinalizing)
+
+        if case .succeeded(_, let resources, _) = provisionResult {
+            var updated = settings
+            updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
+            updated.provisionedWorkerResources = resources
+            try? await configStore.save(updated)
+        }
+
+        switch provisionResult {
+        case .succeeded(let url, _, let duration):
+            return .succeeded(url: url, duration: duration)
+        case .blocked(let failures, let warnings, _):
+            return .blocked(failures: failures, warnings: warnings)
+        case .workerNameConflict(let name, _):
+            return .workerNameConflict(name: name)
+        case .failed(let reason, let exitCode, _):
+            return .failed(reason: reason, exitCode: exitCode)
+        }
+    }
+```
+
+Add one test proving the fidelity note holds:
+
+```swift
+    @Test("headless deploy still reports coarse progress milestones through onProgress")
+    func headlessDeployReportsProgress() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: SocialWorkerRecorder()), store: throwawayStore())
+        let seen = ProgressRecorder()
+
+        _ = await ops.deploy(site: site, onProgress: { progress in Task { await seen.record(progress) } })
+        // onProgress fires synchronously inside deployWithWorkerComposition, but the recorder hop
+        // above is async — give it a beat to land before asserting.
+        while await seen.progresses.count < 2 { await Task.yield() }
+
+        let progresses = await seen.progresses
+        #expect(progresses.contains(.deployBuilding))
+        #expect(progresses.contains(.deployDeploying))
+    }
+```
+
+Add the small recorder actor alongside the file's other private test helpers (`SocialWorkerRecorder`, etc.):
+
+```swift
+private actor ProgressRecorder {
+    private(set) var progresses: [OperationProgress] = []
+    func record(_ progress: OperationProgress) { progresses.append(progress) }
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `swift test --package-path . --filter SiteOperationsTests`
+Expected: PASS (all tests, including the two new ones and every pre-existing `deploy(site:)`-adjacent test)
+
+- [ ] **Step 5: Full package test run**
+
+Run: `swift test --package-path .`
+Expected: PASS — the complete `AnglesiteSiteModelTests`, `AnglesiteCoreTests`, `AnglesiteBridgeTests` (and `AnglesiteIntentsTests` on Swift 6.4+/Xcode 27) suites all green, confirming nothing else in the package broke.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteOperations.swift Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+git commit -m "feat(workers): route headless deploy through effective-active-set composition (#709)"
+```
+
+---
+
+## Final Verification
+
+- [ ] Run `swift test --package-path .` — full suite green.
+- [ ] Run `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — app target builds.
+- [ ] Re-read `docs/superpowers/specs/2026-07-17-persisted-worker-state-design.md` end to end and confirm every numbered section (§1-§10) has a corresponding task above.
+- [ ] `gh issue edit 709 --repo Anglesite/Anglesite-app --remove-label "🛠️ In Progress"` once the PR is open (per `CONTRIBUTING.md`'s claiming convention).

--- a/docs/superpowers/specs/2026-07-17-persisted-worker-state-design.md
+++ b/docs/superpowers/specs/2026-07-17-persisted-worker-state-design.md
@@ -1,0 +1,297 @@
+# Persisted active-worker state + deploy diff/removal — design
+
+**Issue:** [#709](https://github.com/Anglesite/Anglesite-app/issues/709) (700b), part of epic [#700](https://github.com/Anglesite/Anglesite-app/issues/700)
+**Date:** 2026-07-17
+**Status:** Proposed
+
+## 1. Problem
+
+`SocialWorkerProvisionCommand.provision` — the actor that provisions D1/KV/R2 resources, writes
+`wrangler.toml`, and deploys a site's composed Worker — exists but has no live caller. Its
+`features` parameter defaults to a hardcoded `WorkerComposition.Feature.v2` and nothing in the app
+computes which workers should actually be active for a given site. There is also no per-site record
+of which workers were active as of the last deploy, so there is no way to detect that a worker was
+turned off and needs its Cloudflare-side route/binding torn down.
+
+Separately, the main "Deploy" button (`DeployModel` → `DeployCommand`) only ever does a static-asset
+deploy — it has never called `SocialWorkerProvisionCommand` at all. Today these are two disconnected
+paths.
+
+This issue closes both gaps: persist which workers are active, compute the effective active set on
+every deploy (component-tied workers via Site Graph Explorer + settings-activated workers via a
+toggle), and make the main Deploy button the single path that keeps a site's live Worker
+configuration in sync with that set — activating newly-active workers and tearing down deactivated
+ones — without requiring the not-yet-built Workers tab (#710) to exist first.
+
+## 2. Scope
+
+- Three new optional fields on `SiteSettings` (`Config/settings.plist`): `activeWorkerIDs`,
+  `lastDeployedWorkerIDs`, `provisionedWorkerResources`.
+- A new pure `WorkerActivation` type that computes the effective active worker-id set and diffs it
+  against the last-deployed set.
+- Wiring the main deploy path (`DeployModel.runDeploy`, and `SiteOperations.deploy` for the headless
+  case) to compute that set and always route through `SocialWorkerProvisionCommand.provision`,
+  replacing today's direct `DeployCommand.deploy` call — while preserving every existing
+  `DeployCommand.deploy` behavior (route-coverage scanning, milestones, worker-name-conflict
+  rename flow) that the main path already relies on (§5).
+- A new `ContainerCommandRunner` so `SocialWorkerProvisionCommand`'s wrangler subcommands
+  (`d1`/`kv`/`r2 create`, `d1 migrations apply`) actually execute inside the container, mirroring
+  the existing `ContainerDeployExecutor` (§5) — today `provision`'s runner is stubbed to fail.
+- Fixing a resource-reuse bug in `SocialWorkerProvisionCommand.readPersistedResources` that #709's
+  own toggle-driven deploys would otherwise immediately expose (§6).
+- Wiring `WorkerCatalogFetcher`'s `catalogURL` to the real, now-published
+  `https://raw.githubusercontent.com/davidwkeith/workers/main/catalog.json` — without it, the
+  effective-set computation can never see a real settings-activated worker in production. This is
+  nominally #708's "wire the production catalogURL" line item; it's included here because #709 is
+  inert without it (see [[dwk-workers-catalog-gaps]] memory / #708's tracking comments).
+
+**Out of scope:**
+
+- The Workers tab UI (#710) — this issue delivers the engine it will call.
+- `WorkerComposition.Feature` → `WorkerDescriptor` migration of `generateWranglerToml` itself
+  (#708). Instead, §5 uses a small, explicitly interim mapping from catalog ids to `Feature` cases,
+  removed once that migration lands.
+- HTTP route claims / selective `run_worker_first` composition (#746) — this issue's "removal" is
+  binding/resource-level (§7), not route-level.
+- Any change to `@dwk/workers` itself.
+
+## 3. Persisted state
+
+Extend `SiteSettings` (`Sources/AnglesiteCore/SiteConfigStore.swift`), preserving its hard
+forward-compat rule that every field is `Optional`:
+
+```swift
+/// Worker catalog ids the user has manually toggled on. Component-tied workers are never
+/// stored here — their active state is always recomputed live from Site Graph Explorer /
+/// ImpactAnalysis (§4), so it can't drift from site content.
+public var activeWorkerIDs: [String]?
+
+/// The full effective active set (component-tied + settings-activated) as of the last
+/// successful deploy — the diff baseline for reporting removals (§7).
+public var lastDeployedWorkerIDs: [String]?
+
+/// Already-provisioned Cloudflare resource ids for this site's composed Worker, durable
+/// across a worker being deactivated and later reactivated (§6).
+public var provisionedWorkerResources: WorkerComposition.ProvisionedResources?
+```
+
+`WorkerComposition.ProvisionedResources` (`WorkerComposition.swift:64-74`) gains `Codable`
+conformance — it is already `Sendable, Equatable` with three optional `String` fields, so this is
+mechanical.
+
+## 4. Effective active set
+
+New type, `Sources/AnglesiteCore/WorkerActivation.swift`, pure and independently testable:
+
+```swift
+public enum WorkerActivation {
+    public static func effectiveActiveIDs(
+        settings: SiteSettings,
+        catalog: [WorkerDescriptor],
+        graph: SiteGraphExplorerSnapshot?
+    ) -> Set<String>
+
+    public static func removedIDs(previous: Set<String>, next: Set<String>) -> Set<String>
+
+    public static func mapToFeatures(_ ids: Set<String>) -> [WorkerComposition.Feature]
+}
+```
+
+`effectiveActiveIDs` unions two contributions:
+
+- **Component-tied.** For each catalog descriptor with `.binding == .componentTied(componentIDs:)`,
+  include its id if `graph` is non-nil and `ImpactAnalysis.analyze(snapshot: graph, targetID:)`
+  reports `hasDependents` for any of its `componentIDs`. If `graph` is `nil` (no populated
+  `SiteContentGraph` for this site — the headless-deploy case, §8), component-tied contributes
+  nothing. This matches `ImpactAnalysis`'s own documented bias: it may under-report, but never
+  invents a dependent that isn't there.
+- **Settings-activated.** `Set(settings.activeWorkerIDs ?? [])`, intersected with catalog ids that
+  are actually `.settingsActivated` — **unless `catalog` is empty**, in which case
+  `activeWorkerIDs` is trusted verbatim. `WorkerCatalogFetcher` already degrades network/parse
+  failures to its on-disk cache, so a truly empty catalog only happens on a fresh install with no
+  network and no prior successful fetch; treating that as "nothing is active" would silently
+  deactivate every settings-activated worker on a transient failure, which is worse than trusting
+  the last-known toggle state.
+
+`removedIDs` is `previous.subtracting(next)` — used only to log what's being torn down (§7), not to
+trigger any separate API call.
+
+`mapToFeatures` is the interim catalog-id → `Feature` shim: `ids.compactMap { Feature(rawValue: $0) }`,
+sorted into a deterministic order for stable `wrangler.toml` output. A catalog id with no matching
+`Feature` case (a future, not-yet-composed worker) is silently dropped — there is nothing else this
+call can do with it until #708 migrates `generateWranglerToml` to accept `[WorkerDescriptor]`
+directly, at which point `mapToFeatures` is deleted and callers pass descriptors straight through.
+
+## 5. Deploy wiring
+
+`DeployModel.runDeploy` (`Sources/AnglesiteApp/DeployModel.swift:347-478`) is where this actually
+plugs in — **not** `SiteOperations`, which the windowed deploy path bypasses entirely today
+(`DeployModel` receives an already-resolved `siteDirectory`/`configDirectory` per call and talks
+straight to `DeployCommand`; `SiteOperations.deploy` is a separate, thinner seam used only by App
+Intents/Shortcuts, §8).
+
+Today `runDeploy` builds `activeCommand: DeployCommand` (swapping in `ContainerDeployExecutor` when
+`containerControl` is present) and calls `activeCommand.deploy(siteID:siteDirectory:configDirectory:
+currentRoutes:onPreflight:onProgress:)` directly — which drives route-coverage scanning, the
+milestone callbacks that feed Dock progress and the health badge, and log streaming. Routing every
+deploy through `SocialWorkerProvisionCommand.provision` must not lose any of that. Its `Deployer`
+closure signature (`(token:siteID:siteDirectory:) -> DeployCommand.Result`) is intentionally
+minimal, so the fix is for `runDeploy` to build a `SocialWorkerProvisionCommand` per call whose
+injected `deployer` closure *captures* the already-built `activeCommand` and calls its full
+`deploy(...)` overload — every existing argument (configDirectory, currentRoutes, onPreflight,
+onProgress) still flows through unchanged; `provision` only ever sees the final `DeployCommand.Result`.
+
+`runDeploy`'s new sequence:
+
+1. Load `SiteSettings` via `SiteConfigStore(configDirectory:)` (already a parameter on every
+   `deploy`/`runDeploy` call — no new plumbing needed).
+2. Obtain the worker catalog via `WorkerCatalogFetcher` (§2's real `catalogURL`).
+3. Build a `SiteGraphExplorerSnapshot` via `SiteGraphExplorer.build` when
+   `SiteContentGraph.isPopulated(siteID:)` is true; otherwise `nil`. This requires injecting the
+   app's single `SiteContentGraph` instance (`AnglesiteApp.swift:11`) into `DeployModel`'s
+   initializer — it doesn't have one today.
+4. `WorkerActivation.effectiveActiveIDs(...)`, mapped to `[Feature]` (§4).
+5. Build `SocialWorkerProvisionCommand(tokenSource: { token }, runner: containerRunner, deployer: {
+   _, siteID, siteDirectory in await activeCommand.deploy(siteID:siteDirectory:configDirectory:
+   currentRoutes:onPreflight:onProgress:) })` and call `.provision(siteID:siteDirectory:siteName:
+   features:)` in place of today's direct `activeCommand.deploy(...)` call.
+   `provision(features: [])` already degrades to an identical static-only deploy — every D1/KV/R2/
+   migration block in `generateWranglerToml`/`provision` is gated on `features.contains(where:)`, so
+   an empty array produces the same `wrangler.toml` `SiteScaffolder` writes at site creation — so
+   this is one path, not a branch between "static" and "worker" deploys.
+6. On `.succeeded`, persist `lastDeployedWorkerIDs = effectiveActiveIDs` and the returned
+   `resources` to `SiteSettings` via `SiteConfigStore.save`.
+
+**`containerRunner`** is a new `ContainerCommandRunner`, parallel to the existing
+`ContainerDeployExecutor` (`DeployExecutor.swift:61-168`): both wrap
+`LocalContainerControl.exec(siteID:argv:environment:workingDirectory:onOutput:)`, the same
+generic in-guest exec primitive. `ContainerDeployExecutor` maps a fixed `DeployStep` to a fixed
+guest argv (`npm run build` / `npx tsx scripts/pre-deploy-check.ts` / `npx wrangler deploy`);
+`ContainerCommandRunner` instead maps `SocialWorkerProvisionCommand.CommandRunner`'s arbitrary
+`arguments: [String]` to `["npx", "wrangler"] + arguments` and adapts `ContainerExecResult` to
+`ProcessSupervisor.RunResult`. When no `containerControl` is available, `provision` falls back to
+its existing stubbed `defaultRunner` (fails explicitly, matching `HostDeployExecutor`'s posture
+after host-Node retirement) — no new behavior there.
+
+**`SocialWorkerProvisionCommand.Result` gains a `.workerNameConflict(name:resources:)` case**,
+mirroring `DeployCommand.Result`. Today `provision`'s internal switch collapses
+`DeployCommand.Result.workerNameConflict` into a generic `.failed(reason: "Worker name … already in
+use …")` (`SocialWorkerProvisionCommand.swift:176-179`) — harmless while `provision` had no live
+caller, but routing every deploy through it would silently downgrade `DeployModel`'s dedicated
+rename-and-retry sheet (#740: `workerNameConflictPresented`, `WorkerNameRename`,
+`renameWorkerAndRetry`) to a plain failure toast. Propagating the case instead preserves that
+existing UX unchanged. `SiteOperations.dialog(forSocialWorkerProvision:)`'s switch gains the
+matching case.
+
+`DeployModel.Phase` itself is unchanged (`.succeeded(url:duration:)`,
+`.blocked(failures:warnings:)`, `.workerNameConflict(name:)`, `.failed(reason:exitCode:)`);
+`SocialWorkerProvisionCommand.Result`'s four cases map onto it 1:1, dropping only the `resources`
+payload (no UI surfaces it yet).
+
+**Headless deploys** (App Intents/Shortcuts, via `SiteOperations.deploy`, which does *not* go
+through `DeployModel`) get the same `provision`-based wiring for consistency, with `graph: nil`
+(§4, §8) and whatever `containerControl` access that path already has today (unchanged by this
+issue — `SiteOperations.deploy` doesn't thread one through currently, a pre-existing gap outside
+this issue's scope).
+
+## 6. Resource-id persistence fix
+
+`SocialWorkerProvisionCommand.readPersistedResources` currently regex-scrapes the *current*
+`wrangler.toml` for `database_id`/`id`/`bucket_name`. Deactivating a worker regenerates
+`wrangler.toml` without that resource's binding block, so the id disappears from the file entirely.
+Reactivating the worker later then finds no persisted id and calls `wrangler d1/kv/r2 … create`
+again — which fails, because the resource was never deleted, just unbound, and Cloudflare rejects
+creating a duplicate. This bug exists today but has never been reachable, because nothing has ever
+called `provision` with a changing feature set; #709's toggle-driven deploys make it a live path for
+the first time.
+
+Fix: `readPersistedResources` becomes settings-first. Given a `SiteSettings` (loaded by the caller,
+same as §5), it reads `provisionedWorkerResources` directly — durable regardless of what the current
+`wrangler.toml` contains. For a site provisioned before this change (whose `Config/` has no record
+yet), it falls back once to the existing file-scrape as a migration seed. After every successful
+`provision()` call, the resources actually in play (freshly created or reused) are written back to
+`SiteSettings.provisionedWorkerResources`, so the record only ever grows, never regresses when a
+worker is deactivated.
+
+This does not delete backing D1/KV/R2 resources on deactivation — consistent with the epic's
+"respecting security, performance, cost" framing meaning route/binding teardown, not data loss.
+Re-activating a worker reuses its original database/namespace/bucket and its data.
+
+## 7. Removal mechanics
+
+A worker present in `lastDeployedWorkerIDs` but absent from the newly computed effective set is
+handled by generating `wrangler.toml` from the *new* effective set (which naturally omits its
+binding/route) and deploying once. `wrangler deploy` replaces the Worker's declarative
+configuration atomically, so this single deploy already un-binds and un-routes anything dropped from
+config — no separate Cloudflare API call is needed. `WorkerActivation.removedIDs` (§4) is used only
+to log what got torn down (via `LogCenter`, alongside the existing deploy log stream), giving the
+security/cost-visibility the epic's framing asks for without a second deploy round-trip.
+
+## 8. Headless deploy fallback
+
+A deploy triggered without an open site window (App Intents/Shortcuts, via `SiteOperations.deploy`
+directly) has no populated `SiteContentGraph` for the site, so `WorkerActivation.effectiveActiveIDs`
+receives `graph: nil` and component-tied workers contribute nothing to the effective set —
+settings-activated workers (`activeWorkerIDs`) are unaffected and still apply. In the worst case, a
+component-tied worker that's genuinely still in use could momentarily lose its Cloudflare route
+until the next windowed deploy re-affirms it (§5 always has a populated graph, since the site must
+be open to click Deploy). This is an accepted, documented tradeoff — not a workaround — consistent
+with `ImpactAnalysis`'s own "never invents, may under-report" contract.
+
+## 9. Testing
+
+- `WorkerActivation.effectiveActiveIDs` — unit tests over fixture catalogs/settings/snapshots:
+  component-tied via `ImpactAnalysis` fixtures (present, absent, multiple `componentIDs`),
+  settings-activated (present, stale id no longer in catalog), the nil-graph fallback, and the
+  empty-catalog-trusts-`activeWorkerIDs` fallback.
+- `WorkerActivation.removedIDs` / `mapToFeatures` — trivial set-diff and mapping unit tests,
+  including a catalog id with no `Feature` case being dropped rather than throwing.
+- `SiteConfigStore` — round-trip test for the three new fields, plus a decode test against an
+  old-format `settings.plist` missing the new keys (forward-compat, matching the file's existing
+  test pattern).
+- `SocialWorkerProvisionCommand` — a regression test for the toggle-off-then-on-again scenario (§6):
+  provision with a feature needing R2, deactivate (regenerate without it), reactivate, assert no
+  second `r2 bucket create` call and the original bucket name is reused via
+  `provisionedWorkerResources` rather than the file scrape.
+- `SiteOperations` / `DeployModel` — wiring tests using the existing fake-`CommandFactory` pattern
+  (`SiteOperationsTests`) and `DeployModel`'s existing injected-`DeployCommand` test pattern,
+  asserting: empty effective set still deploys the plain static config, a non-empty set routes
+  through `provision` with the right `[Feature]`, a successful deploy persists
+  `lastDeployedWorkerIDs`/`provisionedWorkerResources`, and a `DeployCommand.Result
+  .workerNameConflict` returned by the captured `deployer` closure still reaches
+  `DeployModel.Phase.workerNameConflict` (i.e. `provision`'s new case propagates end-to-end and the
+  existing rename sheet still presents) — a regression test for the collapse bug this design fixes.
+- `ContainerCommandRunner` — unit tests mirroring `ContainerDeployExecutorTests`' existing pattern
+  (fake `LocalContainerControl`): argv mapping (`arguments` → `npx wrangler <arguments>`), output
+  streaming to `LogCenter`, cancellation, and the dead/never-booted-container error message.
+- No new UI surface ships in this issue (that's #710), so no manual GUI smoke pass is owed.
+
+## 10. Open questions / risks
+
+- **`mapToFeatures`'s interim shim is a real, if small, encroachment on #708's territory.** It's
+  scoped to a single pure function with a doc comment pointing at its own removal once #708 lands
+  the `WorkerDescriptor` migration — not a fork of `generateWranglerToml` itself.
+- **`WorkerCatalogFetcher`'s `catalogURL` wiring** is nominally #708 scope; done here because #709
+  has no real settings-activated worker to compute against otherwise. #708's remaining scope
+  (`Feature`→`WorkerDescriptor` migration of `generateWranglerToml`, the `Resources` shape fix
+  noted in #708's tracking comments, and the local `wrangler dev` runtime) is untouched.
+  See [[dwk-workers-catalog-gaps]].
+- **Every deploy now builds a `SiteGraphExplorerSnapshot`** (a filesystem walk plus
+  `SiteContentGraph` lookups) when the graph is populated, adding real but non-hot-path cost to the
+  main Deploy action. Not optimized further here — the design doc for #700 already accepts this
+  cost as inherent to reusing `ImpactAnalysis` rather than building new usage-tracking
+  infrastructure (§4 of the 700 design doc).
+- **`provisionedWorkerResources` is per-site, not per-worker** — matching today's
+  `WorkerComposition.ProvisionedResources` shape (one shared D1 database, one shared KV namespace,
+  one shared R2 bucket across whichever features are active). If a future `@dwk/workers` catalog
+  entry needs its own dedicated resource rather than the shared one, this shape needs revisiting —
+  not needed for the 7 workers composed today.
+- **Headless deploy (`SiteOperations.deploy`, App Intents/Shortcuts) has no `containerControl`
+  parameter at all today**, and `DeployCommand`'s host-side executor is stubbed to fail explicitly
+  after host-Node retirement — meaning that path likely can't execute a real deploy yet regardless
+  of this issue. This design gives it the same effective-set computation for consistency (§8) but
+  does not attempt to fix its container access; that's a pre-existing gap outside #709's scope.
+- **`ContainerCommandRunner` is new production surface**, not just test plumbing — it's what makes
+  `wrangler d1/kv/r2 create` and `wrangler d1 migrations apply` actually run inside the container
+  for the first time. Scoped narrowly (mirrors `ContainerDeployExecutor`'s existing, reviewed
+  pattern) to keep the risk contained.


### PR DESCRIPTION
## Summary

- Adds `SiteSettings.activeWorkerIDs`/`lastDeployedWorkerIDs`/`provisionedWorkerResources` (all `Optional`, forward-compat) and a new `WorkerActivation` type that computes each site's effective active `@dwk/workers` catalog set — component-tied via Site Graph Explorer's `ImpactAnalysis`, settings-activated via a persisted toggle.
- Routes both the main Deploy button (`DeployModel.runDeploy`) and the headless App-Intents/Shortcuts deploy path (`SiteOperations.deploy`) through `SocialWorkerProvisionCommand.provision` instead of calling `DeployCommand.deploy` directly — closing the gap where that command had no live caller and the Deploy button never touched worker composition at all, while preserving every existing behavior (route-coverage scanning, milestone/Dock-progress callbacks, the #740 worker-name-conflict rename-and-retry flow).
- Adds `ContainerCommandRunner` (mirrors the existing `ContainerDeployExecutor`) so the wrangler subcommands `provision()` runs (`d1`/`kv`/`r2 create`, `d1 migrations apply`) actually execute inside the app's local container runtime — previously stubbed to fail unconditionally.
- Fixes a resource-recreation bug: deactivating a worker regenerated `wrangler.toml` without its binding block, so reactivating it later found no persisted resource id and tried to recreate an already-existing Cloudflare D1/KV/R2 resource, hard-failing the deploy. `provision()` now prefers `SiteSettings.provisionedWorkerResources` over re-scraping the file.
- Wires `WorkerCatalogFetcher.productionCatalogURL` to the now-published `@dwk/workers` catalog manifest (davidwkeith/workers#255/#258).

Design: [`docs/superpowers/specs/2026-07-17-persisted-worker-state-design.md`](docs/superpowers/specs/2026-07-17-persisted-worker-state-design.md)
Plan: [`docs/superpowers/plans/2026-07-17-persisted-worker-state.md`](docs/superpowers/plans/2026-07-17-persisted-worker-state.md)

Closes #709. No UI surface changes (that's #710, the Workers Settings tab, which this issue's engine is built for).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path .` — full suite green (2,118+ tests, 0 failures, verified after the final-review fix commit)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — builds clean
- [x] No UI touched — no manual smoke needed

## Process notes

Built via brainstorming → design doc → implementation plan → subagent-driven-development (8 tasks, each independently task-reviewed) → a final whole-branch review (opus) that found one real Important bug (the headless deploy path was missing the same `.site-config` `CF_PROJECT_NAME`-first worker-rename-preservation fix the windowed path got during its own task review) plus a few Minor polish items — all fixed and re-reviewed clean ("Ready to merge: Yes") in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)