### PR TITLE
fix(tests): gate render-smoke suites on Astro 6's real CLI entry point

### DIFF
--- a/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
@@ -12,11 +12,7 @@ struct BusinessTypeRenderSmokeTests {
     }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool {
-        guard E2EPrerequisites.locateNode() != nil else { return false }
-        return FileManager.default.isReadableFile(
-            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
-    }
+    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
 
     @Test("seeded business types build and render their mf2 classes",
           .enabled(if: BusinessTypeRenderSmokeTests.buildable))
@@ -36,7 +32,7 @@ struct BusinessTypeRenderSmokeTests {
 
             let result = try await ProcessSupervisor.shared.run(
                 executable: node,
-                arguments: ["node_modules/astro/astro.js", "build"],
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
                 currentDirectoryURL: Self.templateDir)
             try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
 

--- a/Tests/AnglesiteCoreTests/DraftContentRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/DraftContentRenderSmokeTests.swift
@@ -11,11 +11,7 @@ struct DraftContentRenderSmokeTests {
             .appendingPathComponent("Resources/Template", isDirectory: true)
     }
 
-    static var buildable: Bool {
-        guard E2EPrerequisites.locateNode() != nil else { return false }
-        return FileManager.default.isReadableFile(
-            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
-    }
+    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
 
     /// One temporary draft entry per draft-bearing collection, with distinguishable slugs/titles
     /// so a leak into `dist/` is unambiguous. `blog` uses `pubDate`; every post-family type uses
@@ -54,7 +50,7 @@ struct DraftContentRenderSmokeTests {
 
             let result = try await ProcessSupervisor.shared.run(
                 executable: node,
-                arguments: ["node_modules/astro/astro.js", "build"],
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
                 currentDirectoryURL: Self.templateDir)
             try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
 

--- a/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
@@ -13,11 +13,7 @@ struct FeedsRenderSmokeTests {
     }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool {
-        guard E2EPrerequisites.locateNode() != nil else { return false }
-        return FileManager.default.isReadableFile(
-            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
-    }
+    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
 
     @Test("collections emit RSS/Atom/JSON and a combined feed",
           .enabled(if: FeedsRenderSmokeTests.buildable))
@@ -41,7 +37,7 @@ struct FeedsRenderSmokeTests {
 
             let result = try await ProcessSupervisor.shared.run(
                 executable: node,
-                arguments: ["node_modules/astro/astro.js", "build"],
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
                 currentDirectoryURL: Self.templateDir)
             try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
 

--- a/Tests/AnglesiteCoreTests/JsonLdRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/JsonLdRenderSmokeTests.swift
@@ -15,11 +15,7 @@ struct JsonLdRenderSmokeTests {
     }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool {
-        guard E2EPrerequisites.locateNode() != nil else { return false }
-        return FileManager.default.isReadableFile(
-            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
-    }
+    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
 
     @Test("seeded types emit schema.org JSON-LD with the expected @type",
           .enabled(if: JsonLdRenderSmokeTests.buildable))
@@ -39,7 +35,7 @@ struct JsonLdRenderSmokeTests {
 
             let result = try await ProcessSupervisor.shared.run(
                 executable: node,
-                arguments: ["node_modules/astro/astro.js", "build"],
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
                 currentDirectoryURL: Self.templateDir)
             try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
 

--- a/Tests/AnglesiteCoreTests/PersonalTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/PersonalTypeRenderSmokeTests.swift
@@ -13,11 +13,7 @@ struct PersonalTypeRenderSmokeTests {
     }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool {
-        guard E2EPrerequisites.locateNode() != nil else { return false }
-        return FileManager.default.isReadableFile(
-            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
-    }
+    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
 
     @Test("seeded personal types build and render their mf2 classes",
           .enabled(if: PersonalTypeRenderSmokeTests.buildable))
@@ -38,7 +34,7 @@ struct PersonalTypeRenderSmokeTests {
 
             let result = try await ProcessSupervisor.shared.run(
                 executable: node,
-                arguments: ["node_modules/astro/astro.js", "build"],
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
                 currentDirectoryURL: Self.templateDir)
             try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
 

--- a/Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
@@ -12,11 +12,7 @@ struct SiteIdentityRenderSmokeTests {
     }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool {
-        guard E2EPrerequisites.locateNode() != nil else { return false }
-        return FileManager.default.isReadableFile(
-            atPath: templateDir.appendingPathComponent("node_modules/astro/astro.js").path)
-    }
+    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
 
     @Test("footer h-card renders per profile kind, and nothing when unconfigured",
           .enabled(if: SiteIdentityRenderSmokeTests.buildable))
@@ -30,7 +26,7 @@ struct SiteIdentityRenderSmokeTests {
             try? FileManager.default.removeItem(at: dist)
             let result = try await ProcessSupervisor.shared.run(
                 executable: node,
-                arguments: ["node_modules/astro/astro.js", "build"],
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
                 currentDirectoryURL: Self.templateDir)
             try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
         }

--- a/Tests/AnglesiteTestSupport/E2EPrerequisites.swift
+++ b/Tests/AnglesiteTestSupport/E2EPrerequisites.swift
@@ -41,6 +41,19 @@ public enum E2EPrerequisites {
         return candidate
     }
 
+    /// Relative path (from a template checkout's root) to the installed Astro CLI entry point,
+    /// matching the `"bin"` field of the template's pinned `astro` package.json. Astro 6 ships this
+    /// as an ESM `.mjs` file under `bin/` — there is no `astro.js` at the package root.
+    public static let astroCLIRelativePath = "node_modules/astro/bin/astro.mjs"
+
+    /// True when a template checkout can actually be built: a Node binary plus an installed Astro
+    /// CLI at `astroCLIRelativePath`.
+    public static func astroBuildable(templateDir: URL) -> Bool {
+        guard locateNode() != nil else { return false }
+        return FileManager.default.isReadableFile(
+            atPath: templateDir.appendingPathComponent(astroCLIRelativePath).path)
+    }
+
     /// A Node binary: `NODE_BINARY` override, then common install paths, then nvm-managed versions.
     public static func locateNode() -> URL? {
         if let override = ProcessInfo.processInfo.environment["NODE_BINARY"], !override.isEmpty,


### PR DESCRIPTION
## Summary
- `PersonalTypeRenderSmokeTests`, `FeedsRenderSmokeTests`, and `DraftContentRenderSmokeTests` (the latter landed in #816) each gate a real `astro build` behind a `buildable` check that looked for `node_modules/astro/astro.js`.
- The template's pinned Astro (`^6.4.8`) ships its CLI at `node_modules/astro/bin/astro.mjs` per its `package.json` `"bin"` field — there is no `astro.js` at the package root. So `buildable` evaluated `false` and all three suites' `.enabled(if:)` trait silently skipped them instead of actually building and asserting anything.
- Fixed by centralizing the check as `E2EPrerequisites.astroBuildable(templateDir:)` / `.astroCLIRelativePath` in `Tests/AnglesiteTestSupport`, matching the module's existing philosophy of keeping shared e2e-prerequisite logic in one place, and pointing all three suites' build invocations at it instead of duplicating a stale path in each file.
- #816's PR description flagged this exact gap for `DraftContentRenderSmokeTests` ("tracked separately, not introduced here") — this closes that gap for all three affected suites.

## Test plan
- [x] `swift test --package-path . --filter PersonalTypeRenderSmokeTests` — actually builds and passes (was silently skipping before)
- [x] `swift test --package-path . --filter FeedsRenderSmokeTests` — actually builds and passes (was silently skipping before)
- [x] `swift test --package-path . --filter DraftContentRenderSmokeTests` — actually builds and passes (was silently skipping before)
- [x] `swift test --package-path .` — full suite, only failure is a pre-existing, unrelated on-device Foundation Models token-limit issue in `GenerableTypesTests.swift` (already documented as pre-existing in #816's own test plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)