### PR TITLE
test(core): make InvisiblePublishQueue debounce timing deterministic

### DIFF
--- a/Sources/AnglesiteCore/InvisiblePublishQueue.swift
+++ b/Sources/AnglesiteCore/InvisiblePublishQueue.swift
@@ -27,6 +27,10 @@ public actor InvisiblePublishQueue {
 
     public typealias Publisher = @Sendable () async -> Result
     public typealias StateObserver = @Sendable (State) -> Void
+    /// Debounce timer seam. Production always uses `Task.sleep`; tests can substitute a
+    /// manually-triggered gate so the debounce "elapses" only when the test says so, instead of
+    /// racing a real timer against actor scheduling under CI load (#762).
+    public typealias Sleep = @Sendable (Duration) async throws -> Void
 
     private struct Record: Codable {
         static let currentVersion = 1
@@ -43,6 +47,7 @@ public actor InvisiblePublishQueue {
     private let publisher: Publisher
     private let onStateChange: StateObserver?
     private let now: @Sendable () -> Date
+    private let sleep: Sleep
 
     private var state: State = .idle
     private var isOnline = false
@@ -57,13 +62,15 @@ public actor InvisiblePublishQueue {
         debounce: Duration = .seconds(3),
         publisher: @escaping Publisher,
         onStateChange: StateObserver? = nil,
-        now: @escaping @Sendable () -> Date = { Date.now }
+        now: @escaping @Sendable () -> Date = { Date.now },
+        sleep: @escaping Sleep = { try await Task.sleep(for: $0) }
     ) {
         self.recordURL = configDirectory.appendingPathComponent(Self.filename)
         self.debounce = debounce
         self.publisher = publisher
         self.onStateChange = onStateChange
         self.now = now
+        self.sleep = sleep
     }
 
     /// Loads a pending marker from disk and begins scheduling against the current connectivity.
@@ -136,9 +143,9 @@ public actor InvisiblePublishQueue {
         debounceTask?.cancel()
         transition(to: .debouncing)
         let delay = debounce
-        debounceTask = Task { [weak self] in
+        debounceTask = Task { [weak self, sleep] in
             do {
-                try await Task.sleep(for: delay)
+                try await sleep(delay)
             } catch {
                 return
             }

--- a/Tests/AnglesiteCoreTests/InvisiblePublishQueueTests.swift
+++ b/Tests/AnglesiteCoreTests/InvisiblePublishQueueTests.swift
@@ -38,9 +38,36 @@ private actor GatedPublishProbe {
     }
 }
 
-// Serialized: each test drives real debounce timers, and running them
-// concurrently with each other amplifies scheduler starvation under
-// `swift test --parallel` on loaded CI runners (#762).
+/// A manually-triggered stand-in for `InvisiblePublishQueue`'s debounce timer. Each
+/// `recordEdit()` that schedules a debounce parks here instead of racing a real `Task.sleep`
+/// against the queue actor's own scheduling — under CI's parallel-suite load, that race let a
+/// stalled scheduler either miss the debounce window entirely or let it fire mid-edit-sequence
+/// and split edits into two publishes, even with a generous real-time margin (#762).
+///
+/// A test drives it by waiting for `armedCount()` to reach the number of `recordEdit()` calls it
+/// made, then calling `release()`. Stale timers from edits that were superseded by a later one
+/// stay armed (this gate doesn't model cancellation) and get released too, but that's harmless:
+/// `InvisiblePublishQueue.beginPublish()` guards on `publishTask == nil`, so only the first
+/// released timer actually starts a publish.
+private actor ManualDebounceGate {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func sleep() async {
+        await withCheckedContinuation { continuations.append($0) }
+    }
+
+    func armedCount() -> Int { continuations.count }
+
+    func release() {
+        let pending = continuations
+        continuations.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+// Serialized: each test drives the queue's debounce scheduling, and running them concurrently
+// with each other amplifies scheduler starvation under `swift test --parallel` on loaded CI
+// runners (#762).
 @Suite("Invisible publish queue", .serialized)
 struct InvisiblePublishQueueTests {
     @Test("idle edits debounce into one publish")
@@ -48,21 +75,23 @@ struct InvisiblePublishQueueTests {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let probe = PublishProbe()
-        // The debounce window must be comfortably wider than the sleeps
-        // between edits, or a stalled scheduler can let the timer fire
-        // mid-sequence and split the edits into two publishes (#762).
+        let gate = ManualDebounceGate()
         let queue = InvisiblePublishQueue(
             configDirectory: directory,
             debounce: .milliseconds(250),
-            publisher: { await probe.publish() }
+            publisher: { await probe.publish() },
+            sleep: { _ in await gate.sleep() }
         )
 
         await queue.start(isOnline: true)
         await queue.recordEdit()
-        try await Task.sleep(for: .milliseconds(10))
         await queue.recordEdit()
-        try await Task.sleep(for: .milliseconds(10))
         await queue.recordEdit()
+        // All three edits are on the actor before any debounce "elapses" — release only once
+        // every recordEdit() has armed its timer, so coalescing is verified by construction
+        // rather than by racing real sleeps against actor scheduling (#762).
+        try await waitUntil { await gate.armedCount() == 3 }
+        await gate.release()
         try await waitUntil {
             let calls = await probe.calls
             let pending = await queue.hasPendingPublish()
@@ -119,13 +148,17 @@ struct InvisiblePublishQueueTests {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let probe = PublishProbe(result: .blocked(failureCount: 2))
+        let gate = ManualDebounceGate()
         let queue = InvisiblePublishQueue(
             configDirectory: directory,
             debounce: .milliseconds(10),
-            publisher: { await probe.publish() }
+            publisher: { await probe.publish() },
+            sleep: { _ in await gate.sleep() }
         )
         await queue.start(isOnline: true)
         await queue.recordEdit()
+        try await waitUntil { await gate.armedCount() == 1 }
+        await gate.release()
         try await waitUntil { await queue.currentState() == .blocked(failureCount: 2) }
 
         #expect(await queue.hasPendingPublish())
@@ -139,16 +172,25 @@ struct InvisiblePublishQueueTests {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let probe = GatedPublishProbe()
+        let gate = ManualDebounceGate()
         let queue = InvisiblePublishQueue(
             configDirectory: directory,
             debounce: .milliseconds(20),
-            publisher: { await probe.publish() }
+            publisher: { await probe.publish() },
+            sleep: { _ in await gate.sleep() }
         )
         await queue.start(isOnline: true)
         await queue.recordEdit()
+        try await waitUntil { await gate.armedCount() == 1 }
+        await gate.release()
         await probe.waitUntilFirstPublishStarts()
         await queue.recordEdit()
         await probe.finishFirstPublish()
+
+        // The completed publish covered the pre-edit generation, so it schedules a second
+        // debounce for the edit that landed mid-publish — release that one too.
+        try await waitUntil { await gate.armedCount() == 1 }
+        await gate.release()
 
         try await waitUntil {
             let calls = await probe.calls


### PR DESCRIPTION
## Summary

- `InvisiblePublishQueueTests`'s `idle edits debounce into one publish` recurred as a CI flake on #819 (twice in a row) even after #770's stabilization — the 30s `waitUntil` still timed out under CI's parallel-suite load (2000+ tests / 300+ suites).
- Root cause: the test raced a real `Task.sleep`-driven debounce timer against the queue actor's own scheduling. Widening the margin (#770) reduced the odds but couldn't close the race, since actor-hop delays under heavy CI contention aren't bounded by any fixed real-time window.
- Fix: add an injectable `Sleep` seam to `InvisiblePublishQueue` (defaults to `Task.sleep`, so production is unchanged) and drive the three tests that exercise the debounce timer through a `ManualDebounceGate` test double the test releases explicitly — so coalescing/timing behavior is verified by construction instead of by racing real sleeps against actor scheduling.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`. Swift/test-only — no MCP message schema or plugin-skill changes, so no paired sidecar PR is needed.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path . --filter InvisiblePublishQueueTests` — 4/4 pass, suite runs in ~0.1s (down from relying on real 250ms/20ms/10ms sleeps)
- [x] Repeated the filtered run 15x back-to-back — 15/15 pass
- [x] Full `swift test -c debug --parallel` (matches CI's `build-test` job invocation exactly) — 2153 tests / 304 suites, zero recorded issues; `Invisible publish queue` suite passes in ~1.3s while contending with the full parallel run
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**. `InvisiblePublishQueue`'s public init gained a new defaulted `sleep:` param; confirmed `SiteWindowModel.swift`'s call site (the only app-target consumer) still compiles unchanged.
- [x] Read `CONTRIBUTING.md` in this worktree before making changes

Fixes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)