### PR TITLE
refactor(tests): consolidate site-tree scaffolding into AnglesiteTestSupport

### DIFF
--- a/Tests/AnglesiteCoreTests/AssetUsageReconciliationTests.swift
+++ b/Tests/AnglesiteCoreTests/AssetUsageReconciliationTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 /// Pins SiteGraphExplorer's asset referencedByCount and DeadAssetScanner's referencedPaths to
@@ -10,21 +11,10 @@ import Foundation
 /// detector that silently changes basic src=/href= handling should fail this test.
 @Suite("Asset usage reconciliation")
 struct AssetUsageReconciliationTests {
-    private func makeSite(_ files: [String: String]) throws -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("asset-usage-\(UUID().uuidString)")
-        for (relPath, contents) in files {
-            let url = root.appendingPathComponent(relPath)
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try contents.write(to: url, atomically: true, encoding: .utf8)
-        }
-        return root
-    }
 
     @Test("both detectors agree a referenced image is used and an orphan is not")
     func detectorsAgreeOnBasicCase() throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "asset-usage", [
             "src/pages/index.astro": #"<img src="/images/hero.png" />"#,
         ])
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/AnglesiteCoreTests/BackupCommandInProcessTests.swift
+++ b/Tests/AnglesiteCoreTests/BackupCommandInProcessTests.swift
@@ -1,6 +1,7 @@
 #if canImport(Darwin)
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 /// End-to-end coverage for #653: `BackupCommand` with its **default** seams must run the whole
@@ -11,13 +12,6 @@ import Foundation
 ///
 /// .serialized: libgit2 isn't safe for uncoordinated concurrent use.
 @Suite("BackupCommand in-process defaults", .serialized) struct BackupCommandInProcessTests {
-
-    private func makeTempDir(_ label: String) throws -> URL {
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("backup-e2e-\(label)-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
-    }
 
     @discardableResult
     private func git(_ arguments: [String], in dir: URL) async throws -> String {
@@ -38,14 +32,14 @@ import Foundation
     @Test("default seams run the full backup — add, commit, push — in-process")
     func backupEndToEndInProcess() async throws {
         // Site repo on `draft` with identity, one commit, and a bare file:// origin.
-        let site = try makeTempDir("site")
+        let site = try makeTempDir(prefix: "backup-e2e-site")
         try await git(["init", "-b", "draft"], in: site)
         try await git(["config", "user.name", "Test"], in: site)
         try await git(["config", "user.email", "test@example.com"], in: site)
         try "hello".write(to: site.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
         try await git(["add", "-A"], in: site)
         try await git(["commit", "-m", "first"], in: site)
-        let remote = try makeTempDir("origin")
+        let remote = try makeTempDir(prefix: "backup-e2e-origin")
         try await git(["init", "--bare"], in: remote)
         try await git(["remote", "add", "origin", remote.absoluteString], in: site)
         try await git(["push", "origin", "draft"], in: site)
@@ -78,14 +72,14 @@ import Foundation
 
     @Test("default seams surface a clean tree with no unpushed commits as .noChanges")
     func backupNoChangesInProcess() async throws {
-        let site = try makeTempDir("site")
+        let site = try makeTempDir(prefix: "backup-e2e-site")
         try await git(["init", "-b", "draft"], in: site)
         try await git(["config", "user.name", "Test"], in: site)
         try await git(["config", "user.email", "test@example.com"], in: site)
         try "hello".write(to: site.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
         try await git(["add", "-A"], in: site)
         try await git(["commit", "-m", "first"], in: site)
-        let remote = try makeTempDir("origin")
+        let remote = try makeTempDir(prefix: "backup-e2e-origin")
         try await git(["init", "--bare"], in: remote)
         try await git(["remote", "add", "origin", remote.absoluteString], in: site)
         try await git(["push", "origin", "draft"], in: site)
@@ -96,14 +90,14 @@ import Foundation
 
     @Test("default seams push a stranded commit on a clean tree (#246)")
     func backupPushesStrandedCommit() async throws {
-        let site = try makeTempDir("site")
+        let site = try makeTempDir(prefix: "backup-e2e-site")
         try await git(["init", "-b", "draft"], in: site)
         try await git(["config", "user.name", "Test"], in: site)
         try await git(["config", "user.email", "test@example.com"], in: site)
         try "hello".write(to: site.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
         try await git(["add", "-A"], in: site)
         try await git(["commit", "-m", "first"], in: site)
-        let remote = try makeTempDir("origin")
+        let remote = try makeTempDir(prefix: "backup-e2e-origin")
         try await git(["init", "--bare"], in: remote)
         try await git(["remote", "add", "origin", remote.absoluteString], in: site)
         try await git(["push", "origin", "draft"], in: site)

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -1,22 +1,12 @@
 // Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
 // Hermetic test — no app bundle or TemplateRuntime needed. Resolves the template
-// by walking up from #filePath (Tests/AnglesiteCoreTests/ -> Tests/ -> repo root).
-// Classic URL APIs only (see IntegrationTemplateAssetsTests / PR #283 CI notes).
+// via AnglesiteTestSupport.templateRoot() (a #filePath walk-up to the repo root).
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite struct BlogTemplateAssetsTests {
-
-    private func templateRoot() -> URL {
-        let here = URL(fileURLWithPath: #filePath)
-        let repoRoot = here
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        #expect(FileManager.default.fileExists(atPath: repoRoot.appendingPathComponent("Package.swift").path), "repo-root detection drifted")
-        return repoRoot.appendingPathComponent("Resources/Template")
-    }
 
     @Test func contentConfigDefinesBlogCollection() throws {
         let root = templateRoot()

--- a/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/BlogTemplateAssetsTests.swift
@@ -9,7 +9,7 @@ import AnglesiteTestSupport
 @Suite struct BlogTemplateAssetsTests {
 
     @Test func contentConfigDefinesBlogCollection() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         let cfg = root.appendingPathComponent("src/content.config.ts")
         #expect(FileManager.default.fileExists(atPath: cfg.path), "missing src/content.config.ts")
         let s = try String(contentsOf: cfg, encoding: .utf8)
@@ -25,7 +25,7 @@ import AnglesiteTestSupport
     }
 
     @Test func starterPostExistsWithRequiredFrontmatter() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         let post = root.appendingPathComponent("src/content/blog/welcome-to-your-blog.md")
         #expect(FileManager.default.fileExists(atPath: post.path), "missing starter post")
         let s = try String(contentsOf: post, encoding: .utf8)
@@ -35,7 +35,7 @@ import AnglesiteTestSupport
     }
 
     @Test func postRouteRendersThroughBlogPostLayout() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         let route = root.appendingPathComponent("src/pages/blog/[...slug].astro")
         #expect(FileManager.default.fileExists(atPath: route.path), "missing post route")
         let s = try String(contentsOf: route, encoding: .utf8)
@@ -53,7 +53,7 @@ import AnglesiteTestSupport
     }
 
     @Test func blogPostLayoutRendersTitleAndDate() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         let s = try String(contentsOf: root.appendingPathComponent("src/layouts/BlogPost.astro"), encoding: .utf8)
         // visible heading + publication date in the article body. The heading carries the
         // microformats2 `p-name` (V-1.7 / #349) — the post title is the h-entry's name.
@@ -67,7 +67,7 @@ import AnglesiteTestSupport
     }
 
     @Test func blogIndexListsCollection() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         let index = root.appendingPathComponent("src/pages/blog/index.astro")
         #expect(FileManager.default.fileExists(atPath: index.path), "missing blog index")
         let s = try String(contentsOf: index, encoding: .utf8)
@@ -81,7 +81,7 @@ import AnglesiteTestSupport
     }
 
     @Test func homepageLinksToBlog() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         let s = try String(contentsOf: root.appendingPathComponent("src/pages/index.astro"), encoding: .utf8)
         #expect(s.contains("href=\"/blog/\""), "homepage should link to /blog/")
     }
@@ -90,7 +90,7 @@ import AnglesiteTestSupport
         // MarkerInjector matches the FIRST occurrence of the anchor. If the anchor text
         // also appears in BlogPost.astro's frontmatter doc-comment, giscus injects into
         // the frontmatter and never renders. Guard the real layout against that regression.
-        let root = templateRoot()
+        let root = try templateRoot()
         let src = try String(contentsOf: root.appendingPathComponent("src/layouts/BlogPost.astro"), encoding: .utf8)
         let out = try MarkerInjector.inject(
             snippet: "<Comments />", withID: "comments",

--- a/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
@@ -6,10 +6,7 @@ import AnglesiteTestSupport
 @Suite("Business type render smoke")
 struct BusinessTypeRenderSmokeTests {
 
-    static var templateDir: URL {
-        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            .appendingPathComponent("Resources/Template", isDirectory: true)
-    }
+    static var templateDir: URL { templateRoot() }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
     static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }

--- a/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/BusinessTypeRenderSmokeTests.swift
@@ -6,16 +6,16 @@ import AnglesiteTestSupport
 @Suite("Business type render smoke")
 struct BusinessTypeRenderSmokeTests {
 
-    static var templateDir: URL { templateRoot() }
+    static var templateDir: URL { get throws { try templateRoot() } }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
+    static var buildable: Bool { ((try? templateDir).map { E2EPrerequisites.astroBuildable(templateDir: $0) }) ?? false }
 
     @Test("seeded business types build and render their mf2 classes",
           .enabled(if: BusinessTypeRenderSmokeTests.buildable))
     func rendersMicroformats() async throws {
         let node = try #require(E2EPrerequisites.locateNode())
-        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+        let dist = try Self.templateDir.appendingPathComponent("dist", isDirectory: true)
 
         func html(_ rel: String) throws -> String {
             try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
@@ -8,7 +8,7 @@ struct ContentConfigDriftTests {
 
     /// The committed template config in this checkout.
     static var configFile: URL {
-        templateRoot().appendingPathComponent("src/content.config.ts")
+        get throws { try templateRoot().appendingPathComponent("src/content.config.ts") }
     }
 
     /// Canonical Zod expression for a field kind, or nil for the markdown body (excluded from frontmatter).

--- a/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
@@ -1,14 +1,14 @@
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("content.config.ts drift guard")
 struct ContentConfigDriftTests {
 
-    /// Repo-root-relative path to the committed template config. `swift test` runs with CWD = package root.
+    /// The committed template config in this checkout.
     static var configFile: URL {
-        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            .appendingPathComponent("Resources/Template/src/content.config.ts")
+        templateRoot().appendingPathComponent("src/content.config.ts")
     }
 
     /// Canonical Zod expression for a field kind, or nil for the markdown body (excluded from frontmatter).

--- a/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
@@ -1,29 +1,15 @@
 import Foundation
 import Testing
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("ContentCreationWorkflow")
 struct ContentCreationWorkflowTests {
     private static let siteID = "site-1"
 
-    private func makeSite(_ files: [String: String] = [:]) throws -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("content-workflow-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        for (relativePath, contents) in files {
-            let url = root.appendingPathComponent(relativePath)
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
-
     @Test("successful page create reloads content graph and emits for indexer")
     func createPageRefreshesGraph() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let graph = SiteContentGraph()
         let emissions = Emissions()
         await graph.setChangeHandler { siteID in await emissions.record(siteID) }
@@ -60,7 +46,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("failed create leaves graph unchanged and does not emit")
     func failedCreateDoesNotRefreshGraph() async throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "content-workflow", [
             "src/pages/original.md": "---\ntitle: Original\n---\nBody",
         ])
         let graph = SiteContentGraph()
@@ -99,7 +85,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("successful post create reloads posts through the same workflow")
     func createPostRefreshesGraph() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let graph = SiteContentGraph()
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
@@ -145,7 +131,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("successful typed create refreshes graph and knowledge index")
     func createTypedRefreshesGraphAndKnowledgeIndex() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let graph = SiteContentGraph()
         let knowledgeIndex = SiteKnowledgeIndex()
         let operations = FakeCreateOperations { _, _, _ in
@@ -193,7 +179,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("successful delete reloads content graph so the deleted page is gone")
     func deleteContentRefreshesGraph() async throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "content-workflow", [
             "src/pages/about.astro": ContentScaffold.renderPage(title: "About", layoutImport: "../layouts/BaseLayout.astro"),
         ])
         let graph = SiteContentGraph()
@@ -228,7 +214,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("failed delete leaves content graph unchanged")
     func failedDeleteDoesNotRefreshGraph() async throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "content-workflow", [
             "src/pages/about.astro": ContentScaffold.renderPage(title: "About", layoutImport: "../layouts/BaseLayout.astro"),
         ])
         let graph = SiteContentGraph()
@@ -260,7 +246,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("duplicatePage reloads content graph with the new page")
     func duplicatePageRefreshesGraph() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let graph = SiteContentGraph()
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
@@ -291,7 +277,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("createComponent does not require content graph access and returns the operation's result")
     func createComponentPassesThrough() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
         } createPost: { _, _, _, _ in
@@ -313,7 +299,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("duplicateComponent does not require content graph access and returns the operation's result")
     func duplicateComponentPassesThrough() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
         } createPost: { _, _, _, _ in
@@ -335,7 +321,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("duplicateComponent reports failed when the workflow has no componentDuplicator configured")
     func duplicateComponentUnconfigured() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
         } createPost: { _, _, _, _ in
@@ -352,7 +338,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("deleteContent reports failed when the workflow has no contentDeleter configured")
     func deleteContentUnconfigured() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
         } createPost: { _, _, _, _ in
@@ -369,7 +355,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("successful restoreContent reloads content graph so the restored page reappears")
     func restoreContentRefreshesGraph() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let graph = SiteContentGraph()
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
@@ -400,7 +386,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("failed restoreContent leaves content graph unchanged")
     func failedRestoreContentDoesNotRefreshGraph() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let graph = SiteContentGraph()
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
@@ -424,7 +410,7 @@ struct ContentCreationWorkflowTests {
 
     @Test("restoreContent reports failed when the workflow has no contentRestorer configured")
     func restoreContentUnconfigured() async throws {
-        let root = try makeSite()
+        let root = try makeTempDir(prefix: "content-workflow")
         let operations = FakeCreateOperations { _, _, _ in
             .failed(reason: "unexpected")
         } createPost: { _, _, _, _ in

--- a/Tests/AnglesiteCoreTests/ContentScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScannerTests.swift
@@ -1,6 +1,7 @@
 // Tests/AnglesiteCoreTests/ContentScannerTests.swift
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 /// Native port of `server/list-content.mjs` — scans a site's `Source/` directory into a
@@ -8,24 +9,11 @@ import Foundation
 @Suite("ContentScanner")
 struct ContentScannerTests {
 
-    /// Build a temp site root and write `files` (relative path → contents).
-    private func makeSite(_ files: [String: String]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("content-scan-\(UUID().uuidString)", isDirectory: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            // `try!` so a failed setup write points here, not at a confusing downstream assertion.
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
-
     private let siteID = "site-1"
 
     @Test("pages: route derivation, dynamic-route + non-page skips")
     func pages() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "src/pages/index.astro": "<h1>Home</h1>",
             "src/pages/about.astro": "<h1>About</h1>",
             "src/pages/blog/index.astro": "<h1>Blog</h1>",
@@ -43,7 +31,7 @@ struct ContentScannerTests {
 
     @Test("page title: frontmatter title, then title= prop, else nil")
     func pageTitles() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "src/pages/fm.md": "---\ntitle: From Frontmatter\n---\nbody",
             "src/pages/prop.astro": "---\nimport L from '../layouts/Base.astro';\n---\n<L title=\"From Prop\">x</L>",
             "src/pages/none.astro": "<h1>no title</h1>",
@@ -57,7 +45,7 @@ struct ContentScannerTests {
 
     @Test("posts: article collections only, fields derived from frontmatter")
     func posts() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "src/content/posts/hello-world.md": "---\ntitle: Hello World\npublishDate: 2026-06-01\ndraft: false\ntags: [intro, news]\n---\nBody",
             "src/content/notes/2026-06-05-quick.md": "---\nslug: quick-note\npublishDate: 2026-06-05\ndraft: false\n---\njust a note",
             "src/content/gallery/photo.md": "---\ntitle: Not A Post\n---\nx",  // non-article collection → ignored
@@ -81,7 +69,7 @@ struct ContentScannerTests {
 
     @Test("post slug falls back to filename when frontmatter omits it")
     func postSlugFallback() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "src/content/posts/my-file.mdx": "---\ntitle: T\n---\nx",
         ])
         let posts = ContentScanner.scan(projectRoot: root, siteID: siteID).posts
@@ -90,7 +78,7 @@ struct ContentScannerTests {
 
     @Test("images: public/images scanned with byte size, non-images skipped")
     func images() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "public/images/hero.png": "PNGDATA",
             "public/images/nested/logo.svg": "<svg/>",
             "public/images/readme.txt": "notes",   // non-image → skipped
@@ -106,7 +94,7 @@ struct ContentScannerTests {
 
     @Test("images: usedOnPages is populated from real references, not left empty")
     func usedOnPagesPopulatedFromReferences() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "public/images/hero.png": "PNGDATA",
             "public/images/orphan.png": "PNGDATA",
             "src/pages/index.astro": #"<img src="/images/hero.png" />"#,
@@ -120,7 +108,7 @@ struct ContentScannerTests {
 
     @Test("missing directories yield empty lists, not errors")
     func emptySite() {
-        let root = makeSite(["README.md": "nothing here"])
+        let root = try! writeSiteTree(prefix: "content-scan", ["README.md": "nothing here"])
         let listing = ContentScanner.scan(projectRoot: root, siteID: siteID)
         #expect(listing.pages.isEmpty)
         #expect(listing.posts.isEmpty)
@@ -132,7 +120,7 @@ struct ContentScannerTests {
     @Test("page title: title= attribute HTML entities are decoded")
     func pageTitleAttrEntityDecoding() {
         // Writer emits: title="Tom &amp; &quot;X&quot;"  for original title: Tom & "X"
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "src/pages/test.astro": "<Layout title=\"Tom &amp; &quot;X&quot;\" />"
         ])
         let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
@@ -142,7 +130,7 @@ struct ContentScannerTests {
     @Test("page title: all five emitted entities decode correctly")
     func pageTitleAttrAllEntities() {
         // &amp; &lt; &gt; &quot; &#39;
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "src/pages/ent.astro": "<L title=\"a&amp;b&lt;c&gt;d&quot;e&#39;f\" />"
         ])
         let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
@@ -153,7 +141,7 @@ struct ContentScannerTests {
     func pageTitleAttrAmpLast() {
         // If &amp; is decoded first, &amp;lt; would become &lt; then < — wrong.
         // Correct: &amp;lt; → &lt; (only one decode pass, amp last).
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "content-scan", [
             "src/pages/amp.astro": "<L title=\"&amp;lt;\" />"
         ])
         let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
@@ -170,7 +158,7 @@ struct ContentScannerTests {
         guard case let .success(content) = written else {
             Issue.record("rewrite failed: \(written)"); return
         }
-        let root = makeSite(["src/pages/rt.astro": content])
+        let root = try! writeSiteTree(prefix: "content-scan", ["src/pages/rt.astro": content])
         let pages = ContentScanner.scan(projectRoot: root, siteID: siteID).pages
         #expect(pages.first?.title == original)
     }

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("DeadAssetScanner reference extraction")
@@ -81,20 +82,10 @@ struct DeadAssetScannerExtractionTests {
 
 @Suite("DeadAssetScanner full scan")
 struct DeadAssetScannerScanTests {
-    private func makeSite(_ files: [String: String]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("dead-asset-scan-\(UUID().uuidString)", isDirectory: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
 
     @Test("dead component is flagged, imported component is not")
     func componentDetection() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": "---\nimport Header from '../components/Header.astro';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
             "src/components/Orphan.astro": "<div>never imported</div>",
@@ -107,7 +98,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("layout referenced only via frontmatter is not flagged")
     func layoutFrontmatterReference() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/content/posts/hello.md": "---\ntitle: Hello\nlayout: ../../layouts/Post.astro\n---\nBody",
             "src/layouts/Post.astro": "<slot />",
             "src/layouts/Unused.astro": "<slot />",
@@ -120,7 +111,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("Astro.glob-covered directory suppresses false positives for every file inside it")
     func globCoveredDirectory() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": "---\nconst widgets = await Astro.glob('../components/widgets/*.astro');\n---\n<div></div>",
             "src/components/widgets/Card.astro": "<div>card</div>",
         ])
@@ -130,7 +121,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("unused image (public path) is flagged; referenced image is not")
     func imageDetection() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": #"<img src="/images/hero.png">"#,
         ])
         let images = [
@@ -151,13 +142,13 @@ struct DeadAssetScannerScanTests {
 
     @Test("empty project produces no candidates")
     func emptyProject() {
-        let root = makeSite([:])
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [:])
         #expect(DeadAssetScanner.scan(projectRoot: root, images: []).isEmpty)
     }
 
     @Test("path alias from tsconfig.json paths resolves to the real file, suppressing a false-unused flag")
     func tsconfigPathAlias() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "tsconfig.json": #"{"compilerOptions": {"paths": {"@components/*": ["src/components/*"]}}}"#,
             "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
@@ -168,7 +159,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("KNOWN LIMITATION: an alias with no matching tsconfig/jsconfig paths entry (e.g. vite.resolve.alias in astro.config.mjs) still produces a false-positive unused flag")
     func aliasWithNoPathsEntryIsNotResolved() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
         ])
@@ -178,7 +169,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("baseUrl-relative path alias resolves to the real file")
     func tsconfigBaseURLAlias() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "tsconfig.json": #"{"compilerOptions": {"baseUrl": "./src", "paths": {"@components/*": ["components/*"]}}}"#,
             "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
@@ -189,7 +180,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("exact (non-wildcard) path alias resolves to the real file")
     func tsconfigExactAlias() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "tsconfig.json": #"{"compilerOptions": {"paths": {"@header": ["src/components/Header.astro"]}}}"#,
             "src/pages/index.astro": "---\nimport Header from '@header';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
@@ -200,7 +191,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("path alias inherited through an extends chain resolves to the real file")
     func tsconfigExtendsChain() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "tsconfig.base.json": #"{"compilerOptions": {"paths": {"@components/*": ["src/components/*"]}}}"#,
             "tsconfig.json": #"{"extends": "./tsconfig.base.json"}"#,
             "src/pages/index.astro": "---\nimport Header from '@components/Header.astro';\n---\n<Header />",
@@ -212,7 +203,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("reference matching is case-insensitive (default APFS is case-insensitive-but-case-preserving)")
     func caseInsensitiveMatch() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": "---\nimport Header from '../components/header.astro';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
         ])
@@ -222,7 +213,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("multi-target path alias: a component under a later target is still resolved")
     func tsconfigMultiTargetAlias() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "tsconfig.json": #"{"compilerOptions": {"paths": {"@shared/*": ["src/nonexistent/*", "src/components/*"]}}}"#,
             "src/pages/index.astro": "---\nimport Header from '@shared/Header.astro';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
@@ -233,7 +224,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("import.meta.glob (array of patterns) marks the resolved directories, not exact files")
     func importMetaGlobDirectory() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": "---\nconst modules = import.meta.glob([\"../components/**/*.astro\", \"../layouts/**/*.astro\"]);\n---\n<div></div>",
             "src/components/Card.astro": "<div>card</div>",
             "src/layouts/Post.astro": "<slot />",
@@ -246,7 +237,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("import.meta.glob with a root-relative pattern (leading slash) resolves against the project root, not public/")
     func importMetaGlobRootRelative() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": "---\nconst modules = import.meta.glob(\"/src/components/**/*.astro\");\n---\n<div></div>",
             "src/components/Card.astro": "<div>card</div>",
         ])
@@ -256,7 +247,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("top-level scripts/ (dev-harness glob) does not contribute glob-directory coverage")
     func scriptsDirectoryExcluded() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "scripts/harness/component.astro": "---\nconst modules = import.meta.glob([\"/src/components/**/*.astro\", \"/src/layouts/**/*.astro\"]);\n---\n<div></div>",
             "src/pages/index.astro": "<div>no imports here</div>",
             "src/components/Orphan.astro": "<div>never imported</div>",
@@ -267,7 +258,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("a discrete (non-glob) reference from a top-level scripts/ file is still credited")
     func scriptsDirectoryDiscreteReferenceStillCredited() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "scripts/catalog.ts": "import Header from '../src/components/Header.astro';",
             "src/components/Header.astro": "<header>Site</header>",
         ])
@@ -277,7 +268,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("a nested src/scripts/ directory (not the top-level dev-tooling one) is still scanned")
     func nestedScriptsDirectoryStillScanned() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/scripts/analytics.js": "import Icon from '../components/Icon.astro';",
             "src/components/Icon.astro": "<svg></svg>",
         ])
@@ -287,7 +278,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("components referenced only from a .tsx file are not flagged as unused")
     func referencedFromTypeScriptFile() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/components/Icon.astro": "<svg></svg>",
             "src/widgets/Widget.tsx": "import Icon from '../components/Icon.astro';\nexport default function Widget() { return null; }",
         ])
@@ -297,7 +288,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("images referenced only from a .jsx island's src attribute are not flagged as unused")
     func imageReferencedFromJSXIsland() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/islands/Hero.jsx": "export default function Hero() { return <img src=\"/images/hero.png\" />; }",
         ])
         let images = [
@@ -312,7 +303,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("layout: frontmatter alias resolves the same way body references do")
     func layoutFrontmatterAlias() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "tsconfig.json": #"{"compilerOptions": {"paths": {"@layouts/*": ["src/layouts/*"]}}}"#,
             "src/content/posts/hello.md": "---\ntitle: Hello\nlayout: @layouts/Post.astro\n---\nBody",
             "src/layouts/Post.astro": "<slot />",
@@ -323,7 +314,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("non-layout frontmatter fields (image:, cover:, gallery array) are scanned as references too")
     func frontmatterImageFieldsScanned() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/content/posts/hello.md": "---\ntitle: Hello\nimage: /images/cover.png\ngallery: [/images/one.png, /images/two.png]\n---\nBody",
         ])
         let images = ["cover.png", "one.png", "two.png", "unused.png"].map { name in
@@ -342,7 +333,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("overlapping alias patterns resolve deterministically to the more specific (longer literal prefix) one")
     func overlappingAliasPatternsPreferMoreSpecific() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "tsconfig.json": #"{"compilerOptions": {"paths": {"@/*": ["src/wrong/*"], "@/components/*": ["src/components/*"]}}}"#,
             "src/pages/index.astro": "---\nimport Header from '@/components/Header.astro';\n---\n<Header />",
             "src/components/Header.astro": "<header>Site</header>",
@@ -356,7 +347,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("a same-directory glob pattern (./*.astro) suppresses false positives for files beside it")
     func globSameDirectorySuppressesCandidate() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/components/index.astro": "---\nconst modules = import.meta.glob('./*.astro');\n---\n<div></div>",
             "src/components/Card.astro": "<div>card</div>",
         ])
@@ -366,7 +357,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("top-level scripts/ exclusion is case-insensitive")
     func scriptsDirectoryExclusionCaseInsensitive() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "Scripts/harness/component.astro": "---\nconst modules = import.meta.glob([\"/src/components/**/*.astro\", \"/src/layouts/**/*.astro\"]);\n---\n<div></div>",
             "src/pages/index.astro": "<div>no imports here</div>",
             "src/components/Orphan.astro": "<div>never imported</div>",
@@ -377,7 +368,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("referencedPaths attributes a shared asset to every referencing source file")
     func referencedPathsAttributesMultipleSources() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": #"<img src="/images/hero.png" />"#,
             "src/pages/about.astro": #"<img src="/images/hero.png" />"#,
         ])
@@ -391,7 +382,7 @@ struct DeadAssetScannerScanTests {
 
     @Test("referencedPaths attributes a glob-only-covered file to the file that declared the glob — matching scan()'s glob-directory floor instead of contradicting it")
     func referencedPathsIncludesGlobCoveredFiles() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "dead-asset-scan", [
             "src/pages/index.astro": "---\nconst widgets = await Astro.glob('../components/widgets/*.astro');\n---\n<div></div>",
             "src/components/widgets/Card.astro": "<div>card</div>",
         ])

--- a/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DeadAssetScannerTests.swift
@@ -142,6 +142,9 @@ struct DeadAssetScannerScanTests {
 
     @Test("empty project produces no candidates")
     func emptyProject() {
+        // Unlike the old per-file makeSite, writeSiteTree creates the root even for an empty
+        // file dictionary — `root` here exists but is empty, where it used to not exist at all.
+        // DeadAssetScanner.scan returns no candidates for both, so the assertion is unchanged.
         let root = try! writeSiteTree(prefix: "dead-asset-scan", [:])
         #expect(DeadAssetScanner.scan(projectRoot: root, images: []).isEmpty)
     }

--- a/Tests/AnglesiteCoreTests/DraftContentRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/DraftContentRenderSmokeTests.swift
@@ -6,10 +6,7 @@ import AnglesiteTestSupport
 @Suite("Draft content render smoke")
 struct DraftContentRenderSmokeTests {
 
-    static var templateDir: URL {
-        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            .appendingPathComponent("Resources/Template", isDirectory: true)
-    }
+    static var templateDir: URL { templateRoot() }
 
     static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
 

--- a/Tests/AnglesiteCoreTests/DraftContentRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/DraftContentRenderSmokeTests.swift
@@ -6,9 +6,9 @@ import AnglesiteTestSupport
 @Suite("Draft content render smoke")
 struct DraftContentRenderSmokeTests {
 
-    static var templateDir: URL { templateRoot() }
+    static var templateDir: URL { get throws { try templateRoot() } }
 
-    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
+    static var buildable: Bool { ((try? templateDir).map { E2EPrerequisites.astroBuildable(templateDir: $0) }) ?? false }
 
     /// One temporary draft entry per draft-bearing collection, with distinguishable slugs/titles
     /// so a leak into `dist/` is unambiguous. `blog` uses `pubDate`; every post-family type uses
@@ -28,12 +28,12 @@ struct DraftContentRenderSmokeTests {
           .enabled(if: DraftContentRenderSmokeTests.buildable))
     func draftsNeverBuild() async throws {
         let node = try #require(E2EPrerequisites.locateNode())
-        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+        let dist = try Self.templateDir.appendingPathComponent("dist", isDirectory: true)
         let fm = FileManager.default
 
         var writtenFiles: [URL] = []
         for fixture in Self.draftFixtures {
-            let dir = Self.templateDir.appendingPathComponent("src/content/\(fixture.collection)", isDirectory: true)
+            let dir = try Self.templateDir.appendingPathComponent("src/content/\(fixture.collection)", isDirectory: true)
             let file = dir.appendingPathComponent("\(fixture.slug).md")
             let contents = "---\n\(fixture.frontmatter)\n---\n\nDraft smoke fixture; must not build.\n"
             try contents.write(to: file, atomically: true, encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
@@ -7,10 +7,7 @@ import AnglesiteTestSupport
 struct FeedsRenderSmokeTests {
 
     /// Repo-root-relative path to the committed template. `swift test` runs with CWD = package root.
-    static var templateDir: URL {
-        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            .appendingPathComponent("Resources/Template", isDirectory: true)
-    }
+    static var templateDir: URL { templateRoot() }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
     static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }

--- a/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
@@ -7,16 +7,16 @@ import AnglesiteTestSupport
 struct FeedsRenderSmokeTests {
 
     /// Repo-root-relative path to the committed template. `swift test` runs with CWD = package root.
-    static var templateDir: URL { templateRoot() }
+    static var templateDir: URL { get throws { try templateRoot() } }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
+    static var buildable: Bool { ((try? templateDir).map { E2EPrerequisites.astroBuildable(templateDir: $0) }) ?? false }
 
     @Test("collections emit RSS/Atom/JSON and a combined feed",
           .enabled(if: FeedsRenderSmokeTests.buildable))
     func rendersFeeds() async throws {
         let node = try #require(E2EPrerequisites.locateNode())
-        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+        let dist = try Self.templateDir.appendingPathComponent("dist", isDirectory: true)
 
         func exists(_ rel: String) -> Bool {
             FileManager.default.fileExists(atPath: dist.appendingPathComponent(rel).path)

--- a/Tests/AnglesiteCoreTests/HTTPRepoProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPRepoProviderTests.swift
@@ -1,6 +1,7 @@
 #if canImport(Darwin)
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 /// `HTTPRepoProvider` replaces `GHRepoProvider` on Darwin (#654): REST API repo creation
@@ -12,12 +13,6 @@ import Foundation
 /// .serialized: libgit2 isn't safe for uncoordinated concurrent use (see the fork's specs, and
 /// `InProcessGitTests`, which follows the same fixture style this file mirrors).
 @Suite("HTTPRepoProvider", .serialized) struct HTTPRepoProviderTests {
-    private func makeTempDir(_ label: String) throws -> URL {
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("http-repo-provider-\(label)-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
-    }
 
     @discardableResult
     private func git(_ arguments: [String], in dir: URL) async throws -> String {
@@ -38,7 +33,7 @@ import Foundation
     /// A repo on `main` with local identity configured and one commit — mirrors `ensureCommittable`
     /// having already run by the time `createAndPush` is called in the real `publish` flow.
     private func makeRepo() async throws -> URL {
-        let dir = try makeTempDir("work")
+        let dir = try makeTempDir(prefix: "http-repo-provider-work")
         try await git(["init", "-b", "main"], in: dir)
         try await git(["config", "user.name", "Test"], in: dir)
         try await git(["config", "user.email", "test@example.com"], in: dir)
@@ -51,7 +46,7 @@ import Foundation
     /// Empty bare repo standing in for the "GitHub repo" `createRepo`'s mocked transport reports
     /// as created — `addRemote`/`push` target this for real.
     private func makeBareRemote() async throws -> URL {
-        let dir = try makeTempDir("origin")
+        let dir = try makeTempDir(prefix: "http-repo-provider-origin")
         try await git(["init", "--bare"], in: dir)
         return dir
     }
@@ -129,7 +124,7 @@ import Foundation
     func createAndPushSurfacesCreatedURLWhenSourceIsNotARepo() async throws {
         // The remote repository now genuinely exists on GitHub even though the local push can't
         // happen — the failure message must say so, not read like nothing happened.
-        let notARepo = try makeTempDir("not-a-repo")
+        let notARepo = try makeTempDir(prefix: "http-repo-provider-not-a-repo")
         let client = HTTPGitHubClient(transport: transport(
             status: 201,
             json: #"{"name":"site","html_url":"https://github.com/acme/site","owner":{"login":"acme"}}"#))

--- a/Tests/AnglesiteCoreTests/InProcessGitTests.swift
+++ b/Tests/AnglesiteCoreTests/InProcessGitTests.swift
@@ -1,6 +1,7 @@
 #if canImport(Darwin)
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 /// `InProcessGit` executes `BackupCommand`'s exact git vocabulary via SwiftGit2 (in-process
@@ -16,13 +17,6 @@ import Foundation
 @Suite("InProcessGit", .serialized) struct InProcessGitTests {
 
     // MARK: - Fixtures (subprocess git — tests are unsandboxed)
-
-    private func makeTempDir(_ label: String) throws -> URL {
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("inprocessgit-\(label)-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
-    }
 
     @discardableResult
     private func git(_ arguments: [String], in dir: URL) async throws -> String {
@@ -42,7 +36,7 @@ import Foundation
 
     /// Repo on branch `draft` with local identity configured and one commit of `hello.txt`.
     private func makeRepo() async throws -> URL {
-        let dir = try makeTempDir("work")
+        let dir = try makeTempDir(prefix: "inprocessgit-work")
         try await git(["init", "-b", "draft"], in: dir)
         try await git(["config", "user.name", "Test"], in: dir)
         try await git(["config", "user.email", "test@example.com"], in: dir)
@@ -54,7 +48,7 @@ import Foundation
 
     /// Bare repo registered as `origin` of `repo`, with the current `draft` already pushed.
     private func addPushedOrigin(to repo: URL) async throws -> URL {
-        let remote = try makeTempDir("origin")
+        let remote = try makeTempDir(prefix: "inprocessgit-origin")
         try await git(["init", "--bare"], in: remote)
         try await git(["remote", "add", "origin", remote.absoluteString], in: repo)
         try await git(["push", "origin", "draft"], in: repo)
@@ -69,7 +63,7 @@ import Foundation
         let inRepo = await InProcessGit.run(siteDirectory: repo, arguments: ["rev-parse", "--is-inside-work-tree"])
         #expect(inRepo.exitCode == 0)
 
-        let plain = try makeTempDir("plain")
+        let plain = try makeTempDir(prefix: "inprocessgit-plain")
         let outside = await InProcessGit.run(siteDirectory: plain, arguments: ["rev-parse", "--is-inside-work-tree"])
         #expect(outside.exitCode != 0)
     }
@@ -226,7 +220,7 @@ import Foundation
         let remote = try await addPushedOrigin(to: repo)
 
         // Move the remote ahead behind our back, so our next push can't fast-forward.
-        let other = try makeTempDir("other")
+        let other = try makeTempDir(prefix: "inprocessgit-other")
         try await git(["clone", remote.absoluteString, "checkout"], in: other)
         let otherRepo = other.appendingPathComponent("checkout")
         try await git(["config", "user.name", "Other"], in: otherRepo)

--- a/Tests/AnglesiteCoreTests/IncrementalReindexTests.swift
+++ b/Tests/AnglesiteCoreTests/IncrementalReindexTests.swift
@@ -1,21 +1,10 @@
 import Foundation
 import Testing
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("IncrementalReindex")
 struct IncrementalReindexTests {
-    /// Create a temp site `Source/` dir; `files` maps relative path → contents.
-    private func makeSite(_ files: [String: String] = [:]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("reindex-\(UUID().uuidString)", isDirectory: true)
-        try! FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
 
     private let exists: @Sendable (URL) -> Bool = { FileManager.default.fileExists(atPath: $0.path) }
 
@@ -36,7 +25,7 @@ struct IncrementalReindexTests {
 
     @Test("apply upserts a newly created file into the index")
     func applyUpsertsNewFile() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "s", projectRoot: root)
         #expect(await index.documents(siteID: "s").contains { $0.path == "src/pages/about.astro" } == false)
@@ -51,7 +40,7 @@ struct IncrementalReindexTests {
 
     @Test("apply removes a deleted file from the index")
     func applyRemovesDeletedFile() async {
-        let root = makeSite(["src/pages/gone.astro": "---\ntitle: Gone\n---\nbody"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/gone.astro": "---\ntitle: Gone\n---\nbody"])
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "s", projectRoot: root)
         #expect(await index.documents(siteID: "s").contains { $0.path == "src/pages/gone.astro" })
@@ -65,7 +54,7 @@ struct IncrementalReindexTests {
 
     @Test("apply ignores skipped-directory paths")
     func applyIgnoresSkippedDirs() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "s", projectRoot: root)
         let before = await index.documents(siteID: "s").count
@@ -81,7 +70,7 @@ struct IncrementalReindexTests {
 
     @Test("apply with needsFullRescan rebuilds and picks up files absent from the batch")
     func applyFullRescan() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "s", projectRoot: root)
 
@@ -125,7 +114,7 @@ struct IncrementalReindexTests {
 
     @Test("apply embeds a newly created file into the ranker")
     func applyUpsertsRankerForNewFile() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let (index, ranker) = await seededIndexAndRanker(root)
         #expect(await ranker.vectorCount(siteID: "s") == 1)
 
@@ -139,7 +128,7 @@ struct IncrementalReindexTests {
 
     @Test("apply drops a deleted file's vector from the ranker")
     func applyRemovesRankerVectorForDeletedFile() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "reindex", [
             "src/pages/index.astro": "---\ntitle: Home\n---\n# Home",
             "src/pages/gone.astro": "---\ntitle: Gone\n---\nbody",
         ])
@@ -156,7 +145,7 @@ struct IncrementalReindexTests {
 
     @Test("apply re-embeds a changed file so the ranker reflects new content")
     func applyReembedsChangedFile() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let provider = CountingFake()
         let (index, ranker) = await seededIndexAndRanker(root, provider: provider)
         let baseline = provider.calls
@@ -172,7 +161,7 @@ struct IncrementalReindexTests {
 
     @Test("apply does not re-embed when a touched file's content is unchanged")
     func applySkipsReembedForUnchangedFile() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let provider = CountingFake()
         let (index, ranker) = await seededIndexAndRanker(root, provider: provider)
         let baseline = provider.calls
@@ -189,7 +178,7 @@ struct IncrementalReindexTests {
 
     @Test("apply with needsFullRescan re-syncs the ranker with files absent from the batch")
     func applyFullRescanResyncsRanker() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let (index, ranker) = await seededIndexAndRanker(root)
         #expect(await ranker.vectorCount(siteID: "s") == 1)
 
@@ -206,7 +195,7 @@ struct IncrementalReindexTests {
         // A file exists on disk (so fileExists is true and it isn't in a skipped dir) but its kind
         // is not indexed (.png) — `upsertFile` runs yet persists no document. Exercises the branch
         // where the ranker still holds a vector for that path and must drop it.
-        let root = makeSite([:])
+        let root = try! writeSiteTree(prefix: "reindex", [:])
         let pngPath = "assets/logo.png"
         let pngURL = root.appendingPathComponent(pngPath)
         try! FileManager.default.createDirectory(at: pngURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -232,7 +221,7 @@ struct IncrementalReindexTests {
 
     @Test("apply with a nil ranker still updates the index (back-compat)")
     func applyWithNilRankerUpdatesIndex() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "s", projectRoot: root)
 
@@ -246,7 +235,7 @@ struct IncrementalReindexTests {
 
     @Test("apply deduplicates repeated paths within a single batch")
     func applyDeduplicatesRepeatedPaths() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "s", projectRoot: root)
 

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -1,32 +1,13 @@
 // Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
 // Hermetic test — no app bundle or TemplateRuntime needed.
-// Resolves the template by walking up from #filePath:
-//   .../Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
-//   → deletingLastPathComponent x3 → repo root
-//   → appending "Resources/Template"
+// Resolves the template via AnglesiteTestSupport.templateRoot() (a #filePath
+// walk-up to the repo root; see that helper for the PR #283 classic-URL-API note).
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite struct IntegrationTemplateAssetsTests {
-
-    private func templateRoot() -> URL {
-        // NOTE: use the classic URL APIs (fileURLWithPath / appendingPathComponent / .path), NOT the
-        // newer URL(filePath:) / appending(path:) / path(percentEncoded:). The latter are vended by
-        // the swift-foundation overlay (libswift_DarwinFoundation3.dylib), which the macOS-26 CI
-        // runners don't ship — a test bundle that links it can't load there. See PR #283 CI notes.
-        let here = URL(fileURLWithPath: #filePath)
-        // here      = .../Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
-        // parent[0] = .../Tests/AnglesiteCoreTests/
-        // parent[1] = .../Tests/
-        // parent[2] = repo root
-        let repoRoot = here
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        #expect(FileManager.default.fileExists(atPath: repoRoot.appendingPathComponent("Package.swift").path), "repo-root detection drifted")
-        return repoRoot.appendingPathComponent("Resources/Template")
-    }
 
     @Test func configHelperExists() {
         #expect(FileManager.default.fileExists(atPath: templateRoot().appendingPathComponent("scripts/config.ts").path))

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -9,12 +9,12 @@ import AnglesiteTestSupport
 
 @Suite struct IntegrationTemplateAssetsTests {
 
-    @Test func configHelperExists() {
-        #expect(FileManager.default.fileExists(atPath: templateRoot().appendingPathComponent("scripts/config.ts").path))
+    @Test func configHelperExists() throws {
+        #expect(FileManager.default.fileExists(atPath: try templateRoot().appendingPathComponent("scripts/config.ts").path))
     }
 
-    @Test func onDemandAssetsAreStagedNotInSrc() {
-        let root = templateRoot()
+    @Test func onDemandAssetsAreStagedNotInSrc() throws {
+        let root = try templateRoot()
         // staged (copied on-demand):
         for p in ["integrations/components/BookingWidget.astro", "integrations/components/DonationButton.astro",
                   "integrations/components/Comments.astro", "integrations/components/ContactForm.astro",
@@ -117,7 +117,7 @@ import AnglesiteTestSupport
                 descriptor: descriptor,
                 answers: answers,
                 sourceDirectory: source,
-                templateDirectory: templateRoot()
+                templateDirectory: try templateRoot()
             ).get()
             guard case .createFile(let path, let contents) = plan.steps.first else {
                 Issue.record("expected carbon.txt create step")
@@ -131,7 +131,7 @@ import AnglesiteTestSupport
     }
 
     @Test func layoutsHaveImportAndBodyAnchors() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         let base = try String(contentsOf: root.appendingPathComponent("src/layouts/BaseLayout.astro"), encoding: .utf8)
         #expect(base.contains("// anglesite:imports"))
         #expect(base.contains("<!-- anglesite:nav -->"))
@@ -144,14 +144,14 @@ import AnglesiteTestSupport
     }
 
     @Test func homepageHasImportAndHeroAnchors() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         let index = try String(contentsOf: root.appendingPathComponent("src/pages/index.astro"), encoding: .utf8)
         #expect(index.contains("// anglesite:imports"))
         #expect(index.contains("<!-- anglesite:hero-cta -->"))
     }
 
     @Test func onDemandPagesUseReadConfigNotImportMetaEnv() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
         for p in ["integrations/pages/book.astro", "integrations/pages/donate.astro", "integrations/pages/contact.astro",
                   "integrations/pages/subscribe.astro", "integrations/pages/offline.astro",
                   "integrations/pages/manifest.webmanifest.ts"] {
@@ -162,7 +162,7 @@ import AnglesiteTestSupport
     }
 
     @Test func scaffoldExcludesIntegrationsDir() throws {
-        let s = try String(contentsOf: templateRoot().appendingPathComponent("scripts/scaffold.sh"), encoding: .utf8)
+        let s = try String(contentsOf: try templateRoot().appendingPathComponent("scripts/scaffold.sh"), encoding: .utf8)
         #expect(s.contains("--exclude='integrations/'"))
     }
 
@@ -193,7 +193,7 @@ import AnglesiteTestSupport
     }
 
     @Test func scaffoldDoesNotExcludeConfigTs() throws {
-        let s = try String(contentsOf: templateRoot().appendingPathComponent("scripts/scaffold.sh"), encoding: .utf8)
+        let s = try String(contentsOf: try templateRoot().appendingPathComponent("scripts/scaffold.sh"), encoding: .utf8)
         // config.ts must ship to scaffolded sites — ensure it's not excluded.
         #expect(!s.contains("config.ts"), "scaffold.sh must not exclude config.ts")
         // The only excludes should be the known set.
@@ -205,7 +205,7 @@ import AnglesiteTestSupport
     }
 
     @Test func astroConfigRegistersRedirectsIntegration() throws {
-        let configURL = templateRoot().appendingPathComponent("astro.config.ts")
+        let configURL = try templateRoot().appendingPathComponent("astro.config.ts")
         let source = try String(contentsOf: configURL, encoding: .utf8)
         #expect(source.contains("import redirects from \"./scripts/redirects.ts\""))
         #expect(source.contains("redirects()"))
@@ -215,7 +215,7 @@ import AnglesiteTestSupport
     /// keys that its descriptor writes via .writeConfig operations.
     /// This catches mismatches like DONATIONS_LABEL (page) vs DONATIONS_BUTTON_TEXT (descriptor).
     @Test func pageEnvKeysAreWrittenByDescriptors() throws {
-        let root = templateRoot()
+        let root = try templateRoot()
 
         // Booking: integrations/pages/book.astro
         let bookURL = root.appendingPathComponent("integrations/pages/book.astro")

--- a/Tests/AnglesiteCoreTests/JsonLdRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/JsonLdRenderSmokeTests.swift
@@ -9,16 +9,16 @@ import AnglesiteTestSupport
 @Suite("JSON-LD render smoke")
 struct JsonLdRenderSmokeTests {
 
-    static var templateDir: URL { templateRoot() }
+    static var templateDir: URL { get throws { try templateRoot() } }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
+    static var buildable: Bool { ((try? templateDir).map { E2EPrerequisites.astroBuildable(templateDir: $0) }) ?? false }
 
     @Test("seeded types emit schema.org JSON-LD with the expected @type",
           .enabled(if: JsonLdRenderSmokeTests.buildable))
     func emitsJsonLd() async throws {
         let node = try #require(E2EPrerequisites.locateNode())
-        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+        let dist = try Self.templateDir.appendingPathComponent("dist", isDirectory: true)
 
         func html(_ rel: String) throws -> String {
             try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/JsonLdRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/JsonLdRenderSmokeTests.swift
@@ -9,10 +9,7 @@ import AnglesiteTestSupport
 @Suite("JSON-LD render smoke")
 struct JsonLdRenderSmokeTests {
 
-    static var templateDir: URL {
-        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            .appendingPathComponent("Resources/Template", isDirectory: true)
-    }
+    static var templateDir: URL { templateRoot() }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
     static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeReindexTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeReindexTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 /// #307: `LocalContainerSiteRuntime` wires the filesystem watcher the same way the retired host runtime
@@ -15,18 +16,6 @@ struct LocalContainerSiteRuntimeReindexTests {
         previewURL: URL(string: "http://127.0.0.1:51001")!,
         mcpURL: URL(string: "http://127.0.0.1:51002/mcp")!)
 
-    private func makeSite(_ files: [String: String]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("container-reindex-\(UUID().uuidString)", isDirectory: true)
-        try! FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
-
     /// Wait until `condition` holds or `timeout` elapses (state settles across actor hops).
     private func poll(_ timeout: TimeInterval, _ condition: @Sendable () async -> Bool) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
@@ -39,7 +28,7 @@ struct LocalContainerSiteRuntimeReindexTests {
 
     @Test("container runtime starts the watcher after rebuild and routes a batch to the index")
     func routesBatchToIndex() async {
-        let root = makeSite(["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
+        let root = try! writeSiteTree(prefix: "container-reindex", ["src/pages/index.astro": "---\ntitle: Home\n---\n# Home"])
         let index = SiteKnowledgeIndex()
         let watcher = ControllableWatcher()
         let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
@@ -69,7 +58,7 @@ struct LocalContainerSiteRuntimeReindexTests {
 
     @Test("container runtime rebuilds and re-scans project conventions the same way it does the knowledge index")
     func routesBatchToConventionsEngine() async {
-        let root = makeSite(["src/pages/index.astro": "# Home\n"])
+        let root = try! writeSiteTree(prefix: "container-reindex", ["src/pages/index.astro": "# Home\n"])
         let index = SiteKnowledgeIndex()
         let conventions = ProjectConventionsEngine()
         let watcher = ControllableWatcher()

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -6,6 +6,7 @@ import Foundation
 // These tests need no live model: the tools' `call(...)` is pure mapping/routing/query logic.
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
+import AnglesiteTestSupport
 
 /// Records the EditMessage it receives and returns a canned reply.
 private actor FakeEditRouter: EditRouter {
@@ -260,20 +261,10 @@ struct SearchContentToolTests {
 
 @Suite("On-device tools: SearchKnowledgeTool")
 struct SearchKnowledgeToolTests {
-    private func makeSite(_ files: [String: String]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("knowledge-tool-\(UUID().uuidString)", isDirectory: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
 
     @Test("formats cited project excerpts")
     func formatsCitedProjectExcerpts() async throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "knowledge-tool", [
             "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nTeam plans mention annual billing.",
         ])
         let index = SiteKnowledgeIndex()

--- a/Tests/AnglesiteCoreTests/POSSESyndicationTests.swift
+++ b/Tests/AnglesiteCoreTests/POSSESyndicationTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import FoundationNetworking
 #endif
 import Testing
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("POSSE syndication")
@@ -175,8 +176,7 @@ struct POSSESyndicationTests {
 
     @Test("template accepts POSSE metadata and projects returned URLs as u-syndication")
     func templateContract() throws {
-        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            .appendingPathComponent("Resources/Template/src", isDirectory: true)
+        let root = templateRoot().appendingPathComponent("src", isDirectory: true)
         let config = try String(contentsOf: root.appendingPathComponent("content.config.ts"), encoding: .utf8)
         let links = try String(
             contentsOf: root.appendingPathComponent("components/SyndicationLinks.astro"), encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/POSSESyndicationTests.swift
+++ b/Tests/AnglesiteCoreTests/POSSESyndicationTests.swift
@@ -176,7 +176,7 @@ struct POSSESyndicationTests {
 
     @Test("template accepts POSSE metadata and projects returned URLs as u-syndication")
     func templateContract() throws {
-        let root = templateRoot().appendingPathComponent("src", isDirectory: true)
+        let root = try templateRoot().appendingPathComponent("src", isDirectory: true)
         let config = try String(contentsOf: root.appendingPathComponent("content.config.ts"), encoding: .utf8)
         let links = try String(
             contentsOf: root.appendingPathComponent("components/SyndicationLinks.astro"), encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/PersonalTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/PersonalTypeRenderSmokeTests.swift
@@ -7,16 +7,16 @@ import AnglesiteTestSupport
 struct PersonalTypeRenderSmokeTests {
 
     /// Repo-root-relative path to the committed template. `swift test` runs with CWD = package root.
-    static var templateDir: URL { templateRoot() }
+    static var templateDir: URL { get throws { try templateRoot() } }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
+    static var buildable: Bool { ((try? templateDir).map { E2EPrerequisites.astroBuildable(templateDir: $0) }) ?? false }
 
     @Test("seeded personal types build and render their mf2 classes",
           .enabled(if: PersonalTypeRenderSmokeTests.buildable))
     func rendersMicroformats() async throws {
         let node = try #require(E2EPrerequisites.locateNode())
-        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+        let dist = try Self.templateDir.appendingPathComponent("dist", isDirectory: true)
 
         func html(_ rel: String) throws -> String {
             try String(contentsOf: dist.appendingPathComponent(rel), encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/PersonalTypeRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/PersonalTypeRenderSmokeTests.swift
@@ -7,10 +7,7 @@ import AnglesiteTestSupport
 struct PersonalTypeRenderSmokeTests {
 
     /// Repo-root-relative path to the committed template. `swift test` runs with CWD = package root.
-    static var templateDir: URL {
-        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            .appendingPathComponent("Resources/Template", isDirectory: true)
-    }
+    static var templateDir: URL { templateRoot() }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
     static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }

--- a/Tests/AnglesiteCoreTests/ProjectConventionsEngineTests.swift
+++ b/Tests/AnglesiteCoreTests/ProjectConventionsEngineTests.swift
@@ -1,23 +1,14 @@
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("ProjectConventionsEngine")
 struct ProjectConventionsEngineTests {
-    private func makeSite(_ files: [String: String]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("conventions-engine-\(UUID().uuidString)", isDirectory: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
 
     @Test("rebuild scans matching files and skips build artifacts")
     func rebuildScansFiles() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "conventions-engine", [
             "src/pages/about.astro": "# About Us\n",
             "node_modules/pkg/index.js": "<ShouldNotCount />",
         ])
@@ -31,7 +22,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("upsertFile incorporates a single changed file without a full rescan")
     func upsertFileIncorporatesChange() async {
-        let root = makeSite(["src/pages/about.astro": "# About Us\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "# About Us\n"])
         let engine = ProjectConventionsEngine()
         await engine.rebuild(siteID: "site-1", projectRoot: root)
 
@@ -45,7 +36,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("removeFile drops a file's contribution")
     func removeFileDropsContribution() async {
-        let root = makeSite(["src/pages/about.astro": "# About Us\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "# About Us\n"])
         let engine = ProjectConventionsEngine()
         await engine.rebuild(siteID: "site-1", projectRoot: root)
 
@@ -57,7 +48,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("rebuild preserves a user override across re-learning")
     func rebuildPreservesOverride() async {
-        let root = makeSite(["src/pages/about.astro": "# About Us\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "# About Us\n"])
         let engine = ProjectConventionsEngine()
         await engine.rebuild(siteID: "site-1", projectRoot: root)
         await engine.applyOverride(siteID: "site-1", value: .altTextAverageLength(99))
@@ -72,7 +63,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("clearOverride reverts a field to inferred")
     func clearOverrideReverts() async {
-        let root = makeSite(["src/pages/about.astro": "# About Us\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "# About Us\n"])
         let engine = ProjectConventionsEngine()
         await engine.rebuild(siteID: "site-1", projectRoot: root)
         await engine.applyOverride(siteID: "site-1", value: .altTextAverageLength(99))
@@ -86,7 +77,7 @@ struct ProjectConventionsEngineTests {
     @Test("clearOverride followed by a rebuild recomputes the field fresh, not left at the stale overridden value")
     func clearOverrideThenRebuildRecomputesFresh() async {
         // "short" is 5 characters — the true learned average once the override is gone.
-        let root = makeSite(["src/pages/about.astro": "![short](x.png)\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "![short](x.png)\n"])
         let engine = ProjectConventionsEngine()
         await engine.rebuild(siteID: "site-1", projectRoot: root)
         let learned = await engine.conventions(siteID: "site-1")
@@ -107,7 +98,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("seed sets a starting value that a subsequent rebuild's merge respects")
     func seedIsRespectedByRebuild() async {
-        let root = makeSite(["src/pages/about.astro": "# About Us\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "# About Us\n"])
         let engine = ProjectConventionsEngine()
         var seeded = ProjectConventions.empty
         seeded.apply(.altTextAverageLength(7))
@@ -121,7 +112,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("frontmatter collections come from content.config.ts, not the extractor")
     func frontmatterComesFromSchemaReader() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "conventions-engine", [
             "src/content.config.ts": """
             import { defineCollection } from "astro:content";
             import { z } from "astro/zod";
@@ -138,7 +129,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("rebuild(forceEnrichment: true) calls the enricher and fills tone/brand fields")
     func forcedEnrichmentFillsFields() async {
-        let root = makeSite(["src/pages/about.astro": "# About Us\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "# About Us\n"])
         let engine = ProjectConventionsEngine(
             enrich: { _, _ in (toneDescriptors: ["concise", "friendly"], brandTerms: ["Anglesite"]) },
             now: { Date(timeIntervalSince1970: 0) }
@@ -153,7 +144,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("a second rebuild within the throttle window does not call the enricher again")
     func throttleSkipsSecondCall() async {
-        let root = makeSite(["src/pages/about.astro": "# About Us\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "# About Us\n"])
         let callCount = CallCounter()
         var currentTime = Date(timeIntervalSince1970: 0)
         let engine = ProjectConventionsEngine(
@@ -173,7 +164,7 @@ struct ProjectConventionsEngineTests {
 
     @Test("an overridden tone/brand field survives enrichment")
     func enrichmentPreservesOverride() async {
-        let root = makeSite(["src/pages/about.astro": "# About Us\n"])
+        let root = try! writeSiteTree(prefix: "conventions-engine", ["src/pages/about.astro": "# About Us\n"])
         let engine = ProjectConventionsEngine(
             enrich: { _, _ in (toneDescriptors: ["concise"], brandTerms: ["fresh-from-model"]) },
             now: { Date(timeIntervalSince1970: 0) }

--- a/Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
+++ b/Tests/AnglesiteCoreTests/SearchKnowledgeToolHybridTests.swift
@@ -7,19 +7,10 @@ import Testing
 // embedding providers below are deterministic test doubles.
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
+import AnglesiteTestSupport
 
 @Suite("SearchKnowledgeTool hybrid")
 struct SearchKnowledgeToolHybridTests {
-    private func makeSite(_ files: [String: String]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("khybrid-\(UUID().uuidString)", isDirectory: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
 
     /// Returns the index of a path token in the formatted tool output, or `Int.max` if absent —
     /// so `<` comparisons express "ranked earlier".
@@ -46,7 +37,7 @@ struct SearchKnowledgeToolHybridTests {
         // Both pages match the query term "team" in their body equally, so lexical scoring ties and
         // breaks by path: aaa before zzz. Semantically, only zzz is "near" the query, so the blend
         // must lift zzz above aaa — a flip a lexical-only run can never produce.
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "khybrid", [
             "src/pages/aaa.astro": "---\ntitle: AAA\n---\nOur team works far from the topic.",
             "src/pages/zzz.astro": "---\ntitle: ZZZ\n---\nOur team works near the topic.",
         ])
@@ -67,7 +58,7 @@ struct SearchKnowledgeToolHybridTests {
 
     @Test("hybrid mode tolerates a fake provider and still returns matching results")
     func hybridRanksWithFakeProvider() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "khybrid", [
             "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nSubscription plans for teams.",
             "src/pages/about.astro": "---\ntitle: About\n---\n# About\nOur team story.",
         ])
@@ -83,7 +74,7 @@ struct SearchKnowledgeToolHybridTests {
 
     @Test("a nil ranker yields pure lexical output")
     func lexicalFallback() async {
-        let root = makeSite(["src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nPlans."])
+        let root = try! writeSiteTree(prefix: "khybrid", ["src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nPlans."])
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "s", projectRoot: root)
         let lexicalOnly = SearchKnowledgeTool(index: index, siteID: "s")

--- a/Tests/AnglesiteCoreTests/SiteFileTreeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteFileTreeTests.swift
@@ -1,14 +1,9 @@
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 struct SiteFileTreeTests {
-    private func makeTempDir() throws -> URL {
-        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            .appendingPathComponent("anglesite-filetree-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
-    }
 
     private func write(_ relative: String, under root: URL) throws {
         let url = root.appendingPathComponent(relative)
@@ -18,7 +13,7 @@ struct SiteFileTreeTests {
 
     @Test("plain (non-package) site resolves layout to the site root, no config")
     func plainLayout() throws {
-        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let root = try makeTempDir(prefix: "anglesite-filetree"); defer { try? FileManager.default.removeItem(at: root) }
         let layout = SiteFileTree.layout(for: root)
         #expect(layout.sourceDir == root)
         #expect(layout.configDir == nil)
@@ -27,7 +22,7 @@ struct SiteFileTreeTests {
 
     @Test("package site resolves layout to Source/ and Config/")
     func packageLayout() throws {
-        let parent = try makeTempDir(); defer { try? FileManager.default.removeItem(at: parent) }
+        let parent = try makeTempDir(prefix: "anglesite-filetree"); defer { try? FileManager.default.removeItem(at: parent) }
         let pkgURL = parent.appendingPathComponent("Acme.anglesite", isDirectory: true)
         let pkg = AnglesitePackage(url: pkgURL)
         try FileManager.default.createDirectory(at: pkg.sourceURL, withIntermediateDirectories: true)
@@ -42,7 +37,7 @@ struct SiteFileTreeTests {
 
     @Test("scan groups components, styles, and metadata; excludes plumbing")
     func scanGroups() throws {
-        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let root = try makeTempDir(prefix: "anglesite-filetree"); defer { try? FileManager.default.removeItem(at: root) }
         try write("src/layouts/BaseLayout.astro", under: root)
         try write("src/components/Card.astro", under: root)
         try write("src/styles/global.css", under: root)
@@ -63,7 +58,7 @@ struct SiteFileTreeTests {
 
     @Test("empty groups are absent from the result")
     func emptyGroupsAbsent() throws {
-        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let root = try makeTempDir(prefix: "anglesite-filetree"); defer { try? FileManager.default.removeItem(at: root) }
         try write("src/styles/only.css", under: root)
         let groups = SiteFileTree.scan(siteRoot: root)
         #expect(groups[.styles]?.count == 1)
@@ -72,7 +67,7 @@ struct SiteFileTreeTests {
 
     @Test("feedCollections finds collections with an rss.xml.ts route and ignores everything else")
     func feedCollections() throws {
-        let root = try makeTempDir(); defer { try? FileManager.default.removeItem(at: root) }
+        let root = try makeTempDir(prefix: "anglesite-filetree"); defer { try? FileManager.default.removeItem(at: root) }
         // notes has a feed; photos has a directory but no rss route; the root rss.xml.ts is site-wide.
         try write("src/pages/notes/rss.xml.ts", under: root)
         try FileManager.default.createDirectory(at: root.appendingPathComponent("src/pages/photos"),

--- a/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteGraphExplorerTests.swift
@@ -1,25 +1,15 @@
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("SiteGraphExplorer")
 struct SiteGraphExplorerTests {
     private let siteID = "site-graph"
 
-    private func makeSite(_ files: [String: String]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("site-graph-\(UUID().uuidString)", isDirectory: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
-
     @Test("pages, layouts, components, collections, entries, and assets become graph nodes")
     func nodeKinds() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/index.astro": "---\nimport Base from '../layouts/Base.astro';\n---\n<Base />",
             "src/layouts/Base.astro": "---\nimport Nav from '../components/Nav.astro';\n---\n<Nav />",
             "src/components/Nav.astro": "<nav />",
@@ -46,7 +36,7 @@ struct SiteGraphExplorerTests {
 
     @Test("imports create layout and component dependency edges")
     func importEdges() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/index.astro": "---\nimport Base from '../layouts/Base.astro';\n---\n<Base />",
             "src/layouts/Base.astro": "---\nimport Nav from '../components/Nav.astro';\n---\n<Nav />",
             "src/components/Nav.astro": "<nav />",
@@ -75,7 +65,7 @@ struct SiteGraphExplorerTests {
 
     @Test("content collections contain their entries")
     func collectionEdges() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/content/posts/hello.md": "---\ntitle: Hello\n---\nBody",
         ])
         defer { try? FileManager.default.removeItem(at: root) }
@@ -96,7 +86,7 @@ struct SiteGraphExplorerTests {
 
     @Test("public image src references create asset edges while unused images remain visible")
     func assetEdgesAndUnusedAssets() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/index.astro": "<img src=\"/images/hero.png\" />",
             "public/images/hero.png": "PNG",
             "public/images/unused.png": "PNG",
@@ -122,7 +112,7 @@ struct SiteGraphExplorerTests {
 
     @Test("source image imports create asset reference edges")
     func sourceImageImportEdges() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/index.astro": "---\nimport hero from '../assets/hero.png';\n---\n<img src={hero.src} />",
             "src/assets/hero.png": "PNG",
         ])
@@ -146,7 +136,7 @@ struct SiteGraphExplorerTests {
 
     @Test("relative src asset references resolve from source files")
     func relativeAssetReferences() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/components/Hero.astro": "<img src=\"../assets/hero.webp\" />",
             "src/assets/hero.webp": "WEBP",
         ])
@@ -169,7 +159,7 @@ struct SiteGraphExplorerTests {
 
     @Test("bare relative src asset references resolve from source files")
     func bareRelativeAssetReferences() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/components/Hero.astro": "<img src=\"hero.png\" />",
             "src/components/hero.png": "PNG",
         ])
@@ -192,7 +182,7 @@ struct SiteGraphExplorerTests {
 
     @Test("src references with a trailing query string or fragment still resolve")
     func queryStringAssetReferences() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/index.astro": "<img src=\"/images/hero.png?width=400\" />",
             "public/images/hero.png": "PNG",
         ])
@@ -216,7 +206,7 @@ struct SiteGraphExplorerTests {
 
     @Test("protocol-relative asset URLs are not treated as public-root paths")
     func protocolRelativeAssetReferences() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/index.astro": "<img src=\"//cdn.example.com/hero.png\" />",
         ])
         defer { try? FileManager.default.removeItem(at: root) }
@@ -234,7 +224,7 @@ struct SiteGraphExplorerTests {
 
     @Test("@ alias imports resolve to src-relative nodes")
     func aliasImports() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/index.astro": "---\nimport Nav from '@/components/Nav.astro';\n---\n<Nav />",
             "src/components/Nav.astro": "<nav />",
         ])
@@ -257,7 +247,7 @@ struct SiteGraphExplorerTests {
 
     @Test("dynamic imports create dependency edges")
     func dynamicImports() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/index.astro": "<script>const Card = await import('../components/Card.astro')</script>",
             "src/components/Card.astro": "<article />",
         ])
@@ -280,7 +270,7 @@ struct SiteGraphExplorerTests {
 
     @Test("markdown frontmatter layout fields create usesLayout edges")
     func frontmatterLayoutEdges() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/about.md": "---\ntitle: About\nlayout: ../layouts/Base.astro\n---\nBody",
             "src/layouts/Base.astro": "<slot />",
         ])
@@ -303,7 +293,7 @@ struct SiteGraphExplorerTests {
 
     @Test("markdown without frontmatter creates no layout edge")
     func markdownWithoutFrontmatter() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/pages/plain.md": "Just a body, no frontmatter block.",
             "src/layouts/Base.astro": "<slot />",
         ])
@@ -323,7 +313,7 @@ struct SiteGraphExplorerTests {
 
     @Test("unresolvable frontmatter layout references are skipped, not guessed")
     func unresolvableFrontmatterLayout() throws {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             // A bare specifier and a relative path to a file that doesn't exist — neither may
             // produce an edge (`resolveImport` returns nil for both, never a best-effort guess).
             "src/pages/bare.md": "---\ntitle: Bare\nlayout: some-package-layout\n---\nBody",
@@ -347,7 +337,7 @@ struct SiteGraphExplorerTests {
 
     @Test("src styles files become style nodes")
     func styleNodes() {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "site-graph", [
             "src/styles/global.css": "body { color: black; }",
         ])
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
@@ -6,18 +6,18 @@ import AnglesiteTestSupport
 @Suite("Site identity h-card render smoke")
 struct SiteIdentityRenderSmokeTests {
 
-    static var templateDir: URL { templateRoot() }
+    static var templateDir: URL { get throws { try templateRoot() } }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
-    static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }
+    static var buildable: Bool { ((try? templateDir).map { E2EPrerequisites.astroBuildable(templateDir: $0) }) ?? false }
 
     @Test("footer h-card renders per profile kind, and nothing when unconfigured",
           .enabled(if: SiteIdentityRenderSmokeTests.buildable))
     func rendersFooterHcard() async throws {
         let node = try #require(E2EPrerequisites.locateNode())
-        let dataDir = Self.templateDir.appendingPathComponent("src/data", isDirectory: true)
+        let dataDir = try Self.templateDir.appendingPathComponent("src/data", isDirectory: true)
         let profile = dataDir.appendingPathComponent("profile.json")
-        let dist = Self.templateDir.appendingPathComponent("dist", isDirectory: true)
+        let dist = try Self.templateDir.appendingPathComponent("dist", isDirectory: true)
 
         func build() async throws {
             try? FileManager.default.removeItem(at: dist)

--- a/Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteIdentityRenderSmokeTests.swift
@@ -6,10 +6,7 @@ import AnglesiteTestSupport
 @Suite("Site identity h-card render smoke")
 struct SiteIdentityRenderSmokeTests {
 
-    static var templateDir: URL {
-        URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            .appendingPathComponent("Resources/Template", isDirectory: true)
-    }
+    static var templateDir: URL { templateRoot() }
 
     /// True when the template can actually be built: a Node binary plus an installed Astro.
     static var buildable: Bool { E2EPrerequisites.astroBuildable(templateDir: templateDir) }

--- a/Tests/AnglesiteCoreTests/SiteKnowledgeIndexTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteKnowledgeIndexTests.swift
@@ -1,23 +1,14 @@
 import Foundation
 import Testing
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("SiteKnowledgeIndex")
 struct SiteKnowledgeIndexTests {
-    private func makeSite(_ files: [String: String]) -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("knowledge-index-\(UUID().uuidString)", isDirectory: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try! FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try! Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
 
     @Test("rebuild indexes pages, components, layouts, config, and skips build artifacts")
     func rebuildIndexesProjectKnowledge() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "knowledge-index", [
             "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Plans\n<a href=\"/contact\">Talk to sales</a>",
             "src/components/CTA.astro": "<button>Talk to sales</button>",
             "src/layouts/BaseLayout.astro": "<slot />",
@@ -43,7 +34,7 @@ struct SiteKnowledgeIndexTests {
 
     @Test("search ranks title and path matches above body-only matches")
     func searchRanksUsefulMatches() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "knowledge-index", [
             "src/pages/pricing.astro": "---\ntitle: Pricing\n---\n# Pricing\nSimple plans for teams.",
             "src/components/Footer.astro": "<footer>See pricing for details.</footer>",
             "src/pages/about.astro": "# About\nNothing relevant.",
@@ -62,7 +53,7 @@ struct SiteKnowledgeIndexTests {
 
     @Test("formatted context includes citations and line numbers")
     func formattedContextIncludesCitations() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "knowledge-index", [
             "src/content/docs/about.md": "# About\n\nOur docs explain the launch checklist.",
         ])
         let index = SiteKnowledgeIndex()
@@ -77,7 +68,7 @@ struct SiteKnowledgeIndexTests {
 
     @Test("upsert and remove update a single indexed file")
     func upsertAndRemove() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "knowledge-index", [
             "src/pages/index.astro": "# Home",
         ])
         let index = SiteKnowledgeIndex()
@@ -99,7 +90,7 @@ struct SiteKnowledgeIndexTests {
     @Test("rebuild stores bounded excerpts instead of full source")
     func rebuildStoresBoundedExcerpts() async {
         let longBody = String(repeating: "a", count: 9_000)
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "knowledge-index", [
             "src/pages/long.astro": "# Long\n\(longBody)",
         ])
         let index = SiteKnowledgeIndex()
@@ -112,7 +103,7 @@ struct SiteKnowledgeIndexTests {
 
     @Test("search scores frontmatter separately from body text")
     func searchDoesNotDoubleCountFrontmatter() async {
-        let root = makeSite([
+        let root = try! writeSiteTree(prefix: "knowledge-index", [
             "src/content/example.md": "---\nsummary: launchword\n---\nNo body match here.",
         ])
         let index = SiteKnowledgeIndex()
@@ -126,8 +117,8 @@ struct SiteKnowledgeIndexTests {
 
     @Test("unload removes only the requested site")
     func unloadRemovesOnlyRequestedSite() async {
-        let rootA = makeSite(["src/pages/a.astro": "# Alpha"])
-        let rootB = makeSite(["src/pages/b.astro": "# Beta"])
+        let rootA = try! writeSiteTree(prefix: "knowledge-index", ["src/pages/a.astro": "# Alpha"])
+        let rootB = try! writeSiteTree(prefix: "knowledge-index", ["src/pages/b.astro": "# Beta"])
         let index = SiteKnowledgeIndex()
         await index.rebuild(siteID: "a", projectRoot: rootA)
         await index.rebuild(siteID: "b", projectRoot: rootB)

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import os
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 final class SiteScaffolderTests: XCTestCase {
@@ -200,9 +201,7 @@ final class SiteScaffolderTests: XCTestCase {
 
     func testHappyPathWritesADependencyBaselineAndStampsTheRealAppVersion() async throws {
         let root = tmpDir()
-        let repoRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-        let templateURL = repoRoot.appendingPathComponent("Resources/Template", isDirectory: true)
+        let templateURL = try templateRoot()
         let calls = CallRecorder()
         let scaffolder = SiteScaffolder(
             sitesRoot: root, templateURL: templateURL, catalog: ThemeCatalog(themes: [theme]),

--- a/Tests/AnglesiteCoreTests/SocialPublishPlanTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialPublishPlanTests.swift
@@ -1,28 +1,15 @@
 import Foundation
 import Testing
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite("SocialPublishPlan")
 struct SocialPublishPlanTests {
     private let referenceDate = Date(timeIntervalSince1970: 1_782_777_600) // 2026-06-30T00:00:00Z
 
-    private func makeSite(_ files: [String: String]) throws -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("social-plan-\(UUID().uuidString)", isDirectory: true)
-        for (rel, contents) in files {
-            let url = root.appendingPathComponent(rel)
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try Data(contents.utf8).write(to: url)
-        }
-        return root
-    }
-
     @Test("collects webmention targets from mf2 frontmatter and body links")
     func webmentionTargets() throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "social-plan", [
             "src/content/replies/hello.md": """
             ---
             slug: reply-to-someone
@@ -52,7 +39,7 @@ struct SocialPublishPlanTests {
 
     @Test("collects requested POSSE destinations without requiring outbound links")
     func posseTargets() throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "social-plan", [
             "src/content/notes/today.md": """
             ---
             publishDate: 2026-06-29
@@ -78,7 +65,7 @@ struct SocialPublishPlanTests {
 
     @Test("skips drafts and entries with no outbound social work")
     func skipsNonPublishableEntries() throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "social-plan", [
             "src/content/notes/draft.md": """
             ---
             draft: "yes"
@@ -107,7 +94,7 @@ struct SocialPublishPlanTests {
 
     @Test("nested content paths keep their collection-relative slug")
     func nestedContentPathSlug() throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "social-plan", [
             "src/content/notes/2026/june/hello.md": """
             ---
             publishDate: 2026-06-29
@@ -128,7 +115,7 @@ struct SocialPublishPlanTests {
 
     @Test("body URL scan ignores unrelated frontmatter URLs")
     func ignoresUnrelatedFrontmatterURLs() throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "social-plan", [
             "src/content/articles/photo-credit.md": """
             ---
             publishDate: 2026-06-29
@@ -154,7 +141,7 @@ struct SocialPublishPlanTests {
 
     @Test("skips future-dated content")
     func skipsFutureDatedContent() throws {
-        let root = try makeSite([
+        let root = try writeSiteTree(prefix: "social-plan", [
             "src/content/notes/tomorrow.md": """
             ---
             publishDate: 2026-07-01

--- a/Tests/AnglesiteTestSupport/TestFixtures.swift
+++ b/Tests/AnglesiteTestSupport/TestFixtures.swift
@@ -1,0 +1,72 @@
+// Tests/AnglesiteTestSupport/TestFixtures.swift
+// Shared filesystem scaffolding for test suites. Consolidates the private
+// `makeSite(_:)` / `makeTempDir(_:)` / `templateRoot()` helpers that used to be
+// copy-pasted across ~15 files in AnglesiteCoreTests.
+import Foundation
+
+// MARK: - Temp-dir / site-tree scaffolding
+
+/// Creates (and returns) a unique scratch directory under the system temp directory.
+///
+/// - Parameter prefix: Human-readable marker baked into the directory name so leaked
+///   scratch dirs can be traced back to a suite (e.g. `"backup-e2e-push"`).
+public func makeTempDir(prefix: String = "anglesite-test") throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+}
+
+/// Writes a fake site tree of UTF-8 files under a fresh unique temp root and returns the root.
+///
+/// Every intermediate directory is created; `files` maps root-relative paths to file contents.
+/// The root itself always exists, even for an empty `files` dictionary.
+///
+/// `prefix` comes first so the (typically multi-line) file dictionary can trail the call like
+/// a closure:
+///
+///     let root = try writeSiteTree(prefix: "site-graph", [
+///         "src/pages/index.astro": "...",
+///     ])
+public func writeSiteTree(prefix: String = "anglesite-test", _ files: [String: String]) throws -> URL {
+    let root = try makeTempDir(prefix: prefix)
+    for (relativePath, contents) in files {
+        let url = root.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(contents.utf8).write(to: url)
+    }
+    return root
+}
+
+// MARK: - In-repo template resolution
+
+/// The repo root of this checkout, resolved by walking up from `#filePath`.
+///
+/// Robust to the test process's CWD (Xcode-hosted runs don't start in the package root; the
+/// older `FileManager.default.currentDirectoryPath` approach only worked under `swift test`).
+///
+/// NOTE: classic URL APIs only (`fileURLWithPath` / `appendingPathComponent` / `.path`), NOT the
+/// newer `URL(filePath:)` / `appending(path:)` / `path(percentEncoded:)`. The latter are vended
+/// by the swift-foundation overlay (`libswift_DarwinFoundation3.dylib`), which the macOS-26 CI
+/// runners don't ship — a test bundle that links it can't load there. See PR #283 CI notes.
+public func packageRepoRoot() -> URL {
+    let here = URL(fileURLWithPath: #filePath)
+    // here      = .../Tests/AnglesiteTestSupport/TestFixtures.swift
+    // parent[0] = .../Tests/AnglesiteTestSupport/
+    // parent[1] = .../Tests/
+    // parent[2] = repo root
+    let root = here
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    precondition(
+        FileManager.default.fileExists(atPath: root.appendingPathComponent("Package.swift").path),
+        "repo-root detection drifted: \(root.path)")
+    return root
+}
+
+/// The committed website template (`Resources/Template/`) in this checkout.
+public func templateRoot() -> URL {
+    packageRepoRoot().appendingPathComponent("Resources/Template", isDirectory: true)
+}

--- a/Tests/AnglesiteTestSupport/TestFixtures.swift
+++ b/Tests/AnglesiteTestSupport/TestFixtures.swift
@@ -41,16 +41,25 @@ public func writeSiteTree(prefix: String = "anglesite-test", _ files: [String: S
 
 // MARK: - In-repo template resolution
 
+/// Failure surfaced by the fixture resolvers. Thrown (not trapped) so a drifted checkout fails
+/// the calling test with a readable message and the rest of the run continues — matching the
+/// soft-fail semantics of the old per-file `#expect` guards these helpers replaced.
+public struct TestFixtureError: Error, CustomStringConvertible {
+    public let description: String
+    public init(_ description: String) { self.description = description }
+}
+
 /// The repo root of this checkout, resolved by walking up from `#filePath`.
 ///
 /// Robust to the test process's CWD (Xcode-hosted runs don't start in the package root; the
 /// older `FileManager.default.currentDirectoryPath` approach only worked under `swift test`).
+/// Throws `TestFixtureError` if the walk-up no longer lands on `Package.swift`.
 ///
 /// NOTE: classic URL APIs only (`fileURLWithPath` / `appendingPathComponent` / `.path`), NOT the
 /// newer `URL(filePath:)` / `appending(path:)` / `path(percentEncoded:)`. The latter are vended
 /// by the swift-foundation overlay (`libswift_DarwinFoundation3.dylib`), which the macOS-26 CI
 /// runners don't ship — a test bundle that links it can't load there. See PR #283 CI notes.
-public func packageRepoRoot() -> URL {
+public func packageRepoRoot() throws -> URL {
     let here = URL(fileURLWithPath: #filePath)
     // here      = .../Tests/AnglesiteTestSupport/TestFixtures.swift
     // parent[0] = .../Tests/AnglesiteTestSupport/
@@ -60,13 +69,14 @@ public func packageRepoRoot() -> URL {
         .deletingLastPathComponent()
         .deletingLastPathComponent()
         .deletingLastPathComponent()
-    precondition(
-        FileManager.default.fileExists(atPath: root.appendingPathComponent("Package.swift").path),
-        "repo-root detection drifted: \(root.path)")
+    guard FileManager.default.fileExists(atPath: root.appendingPathComponent("Package.swift").path) else {
+        throw TestFixtureError(
+            "repo-root detection drifted: no Package.swift at \(root.path) (walked up from \(here.path))")
+    }
     return root
 }
 
 /// The committed website template (`Resources/Template/`) in this checkout.
-public func templateRoot() -> URL {
-    packageRepoRoot().appendingPathComponent("Resources/Template", isDirectory: true)
+public func templateRoot() throws -> URL {
+    try packageRepoRoot().appendingPathComponent("Resources/Template", isDirectory: true)
 }


### PR DESCRIPTION
## Summary

- Adds `Tests/AnglesiteTestSupport/TestFixtures.swift` with three shared test helpers: `writeSiteTree(prefix:_:)` (unique temp root + intermediate dirs + UTF-8 files), `makeTempDir(prefix:)`, and a canonical `packageRepoRoot()` / `templateRoot()` resolver (`#filePath` walk-up — robust to test CWD, unlike the `currentDirectoryPath` copies; classic URL APIs only per the PR #283 CI notes). Per review: the resolvers **throw** a `TestFixtureError` on repo-root drift rather than trapping, so a drifted checkout fails the calling test with a readable message and the run continues (the old per-file `#expect` soft-fail semantics); render-smoke suites read resolution failure as "not buildable" and skip.
- Migrates the 12 near-identical private `makeSite(_ files:)` copies (DeadAssetScanner, ContentScanner, IncrementalReindex, SiteGraphExplorer, SiteKnowledgeIndex, ProjectConventionsEngine, LocalContainerSiteRuntimeReindex, SearchKnowledgeToolHybrid, OnDeviceTools, AssetUsageReconciliation, ContentCreationWorkflow, SocialPublishPlan), the 4 `makeTempDir` clones (BackupCommandInProcess, InProcessGit, HTTPRepoProvider, SiteFileTree), and 11 template-root call sites (BlogTemplateAssets, IntegrationTemplateAssets, the 6 render-smoke suites, ContentConfigDrift, POSSESyndication's inline copy, and SiteScaffolderTests' inline walk-up flagged in review) to the shared helpers, deleting the now-unused private ones. Per-suite temp-dir prefixes are preserved at the call sites.
- Deliberately **not** migrated (they differ meaningfully): helpers that also build `.anglesite` packages or git fixtures (`DesignApplyServiceTests`, `POSSESyndicationTests.makeSite`, `WebmentionSendCommandTests`, `DesignInterviewModelTests`, `ThemeApplyWizardModelTests`, `CombinedAugmentedAssistantTests`, `KnowledgeAugmentedAssistantTests`, `DependencySyncCheckerTests`, `WorkerNameRenameTests`, `CrawlerPolicyAssetTests`, `DeployCommandTests`, `SiteOperationsTests`), `BundleSyncTests`' error-swallowing `try?` variant, and the resolvers that return specific template file URLs (`HeroImageTests`, `ThemeCatalogTests`, `HomepageWriterTests`, `SiteScaffolderTests.realScaffoldScriptURL`, `PreDeployCheckFixtureTests`). Behavior notes: `writeSiteTree` creates the root even for an empty file dict (the old `DeadAssetScannerTests` helper didn't; documented at its `emptyProject` call site — `scan` tolerates both). Test-only change — no `Sources/` edits; `Package.swift` untouched (AnglesiteCoreTests already depends on AnglesiteTestSupport).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: N/A — app-only, tests-only.

## Test plan

- [x] `swift test --package-path .` — full suite green on both commits: all bundles passed (2153 tests / 304 suites in AnglesiteCoreTests plus siblings), 0 failures, 0 recorded issues; 25 expected gated skips (render-smoke suites without template `node_modules`, container/webmention/MCP e2e gates). One earlier run hung mid-suite while another agent's `swift test` ran concurrently on the same machine (on-device Foundation Models contention); quiet reruns were fully green.
- [x] `swift test --filter '<all migrated suites>'` — 202 tests / 32 suites passed (first round); 68 tests / 13 suites re-run after the review changes.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED (unaffected by this change; test targets only).
- [ ] Manual smoke (if UI-touching): N/A — test infrastructure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)