### PR TITLE
refactor(core): unify frontmatter parsing on Frontmatter's helpers

### DIFF
--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -165,6 +165,31 @@ public enum Frontmatter {
         return s
     }
 
+    /// The index of the closing `---` fence line in an LF-normalized `lines` array whose first
+    /// element is the opening fence — or `nil` when the content doesn't start with a fence or the
+    /// fence is unterminated. Line-based companion to `parse`'s regex for the in-place editors
+    /// (`FrontmatterDocument`, `PageTitleEditor`, `SyndicationFrontmatter`) that need *line
+    /// indices*, not just the block text. Fences are exact `---` lines; normalize CRLF away
+    /// before splitting.
+    static func closingFenceIndex(of lines: [String]) -> Int? {
+        guard lines.first == "---" else { return nil }
+        // `dropFirst()` yields an `ArraySlice`, so the returned index is valid in `lines`.
+        return lines.dropFirst().firstIndex(of: "---")
+    }
+
+    /// Render a scalar as a double-quoted YAML value that `parse`/`unquote` reads back verbatim.
+    /// Order matters: backslash first, then the quote, then control characters — a literal
+    /// newline in the value (e.g. a pasted multi-line title or description) must become `\n`, or
+    /// it would break `---` fence detection on re-parse. `decodeDoubleQuoted` reverses each of
+    /// these. Shared by every frontmatter writer (`FrontmatterDocument`, `PageTitleEditor`).
+    static func doubleQuoted(_ s: String) -> String {
+        let escaped = s.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+        return "\"\(escaped)\""
+    }
+
     /// Single-pass YAML double-quoted escape decoder. Processes each character once so that
     /// `\\n` (two source chars) decodes to `\` + `n` (not newline), guarding the chained-replace
     /// pitfall.

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -81,16 +81,9 @@ public struct FrontmatterDocument: Equatable, Sendable {
         let newline = source.contains("\r\n") ? "\r\n" : "\n"
         let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
 
-        guard normalized.hasPrefix("---\n") else {
-            return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
-                                       newline: newline, hadFrontmatter: false, hasBodySection: false)
-        }
         let all = normalized.components(separatedBy: "\n")
-        // all[0] == "---"; find the closing fence.
-        var close = -1
-        var i = 1
-        while i < all.count { if all[i] == "---" { close = i; break }; i += 1 }
-        guard close >= 0 else {
+        // No leading fence, or an unterminated one — treat the whole source as body.
+        guard let close = Frontmatter.closingFenceIndex(of: all) else {
             return FrontmatterDocument(segments: [], indexByKey: [:], body: normalized,
                                        newline: newline, hadFrontmatter: false, hasBodySection: false)
         }
@@ -150,7 +143,7 @@ public struct FrontmatterDocument: Equatable, Sendable {
     private static func render(key: String, value: FrontmatterValue) -> String {
         switch value {
         case .string(let s):
-            return "\(key): \"\(escape(s))\""
+            return "\(key): \(Frontmatter.doubleQuoted(s))"
         case .bool(let b):
             // Bool fields canonicalize to true/false on write. YAML also accepts yes/no/on/off/1/0,
             // but we intentionally normalize here (matching ContentScaffold) — an edited bool loses
@@ -168,18 +161,7 @@ public struct FrontmatterDocument: Equatable, Sendable {
             return "\(key): \(s)"
         case .array(let items):
             if items.isEmpty { return "\(key): []" }
-            return ([ "\(key):" ] + items.map { "  - \"\(escape($0))\"" }).joined(separator: "\n")
+            return ([ "\(key):" ] + items.map { "  - \(Frontmatter.doubleQuoted($0))" }).joined(separator: "\n")
         }
-    }
-
-    /// Escapes a scalar for a double-quoted YAML value. Order matters: backslash first, then the
-    /// quote, then control characters — a literal newline in a `text`-kind field (e.g. a pasted
-    /// multi-line description) must become `\n`, or it would break `---` fence detection on
-    /// re-parse. `Frontmatter.unquote`'s decoder reverses each of these.
-    private static func escape(_ s: String) -> String {
-        s.replacingOccurrences(of: "\\", with: "\\\\")
-         .replacingOccurrences(of: "\"", with: "\\\"")
-         .replacingOccurrences(of: "\n", with: "\\n")
-         .replacingOccurrences(of: "\r", with: "\\r")
     }
 }

--- a/Sources/AnglesiteCore/PageTitleEditor.swift
+++ b/Sources/AnglesiteCore/PageTitleEditor.swift
@@ -33,9 +33,11 @@ public enum PageTitleEditor {
     // MARK: - Markdown frontmatter
 
     /// Replace the `title:` line inside a leading `---` block, insert one if the block lacks it,
-    /// or synthesize a block at the top of the file.
+    /// or synthesize a block at the top of the file. Fence detection, key matching, and scalar
+    /// quoting delegate to `Frontmatter`'s helpers; only the line-level splice — which preserves
+    /// the file's existing formatting — lives here.
     private static func rewriteMarkdown(_ contents: String, title: String) -> String {
-        let yaml = "title: \(yamlQuoted(title))"
+        let yaml = "title: \(Frontmatter.doubleQuoted(title))"
 
         // Work in LF internally so the line logic is newline-agnostic, then restore CRLF on output
         // if the source used it. (A trailing `\r` left on each split line would make `lines[0]`
@@ -46,40 +48,20 @@ public enum PageTitleEditor {
             usesCRLF ? s.replacingOccurrences(of: "\n", with: "\r\n") : s
         }
 
-        // A frontmatter block must start at byte 0 with `---` on its own line.
-        guard normalized.hasPrefix("---\n") || normalized == "---" else {
-            return finish("---\n\(yaml)\n---\n\n\(normalized)")
-        }
-
         var lines = normalized.components(separatedBy: "\n")
-        // lines[0] == "---". Find the closing fence.
-        guard let close = lines.dropFirst().firstIndex(of: "---") else {
-            // Malformed (no closing fence) — treat as no frontmatter and prepend a fresh block.
+        // No leading fence, or an unterminated (malformed) one — prepend a fresh block.
+        guard let close = Frontmatter.closingFenceIndex(of: lines) else {
             return finish("---\n\(yaml)\n---\n\n\(normalized)")
         }
 
-        // Look for an existing top-level `title:` between the fences.
-        if let titleIdx = (1..<close).first(where: { lineKey(lines[$0]) == "title" }) {
+        // Look for an existing top-level `title:` between the fences, using the canonical key
+        // reader so the editor only rewrites a line `Frontmatter.parse` reads as the title.
+        if let titleIdx = (1..<close).first(where: { Frontmatter.splitKeyValue(lines[$0])?.key == "title" }) {
             lines[titleIdx] = yaml
         } else {
             lines.insert(yaml, at: 1)
         }
         return finish(lines.joined(separator: "\n"))
-    }
-
-    /// The top-level key of a frontmatter line (`title: "x"` → `title`), or nil for indented /
-    /// keyless lines. Mirrors `Frontmatter`'s "top-level keys only" rule.
-    private static func lineKey(_ line: String) -> String? {
-        guard let first = line.first, first != " ", first != "\t" else { return nil }
-        guard let colon = line.firstIndex(of: ":") else { return nil }
-        return String(line[line.startIndex..<colon]).trimmingCharacters(in: .whitespaces)
-    }
-
-    /// Double-quote a YAML scalar, escaping `\` then `"`.
-    private static func yamlQuoted(_ s: String) -> String {
-        let escaped = s.replacingOccurrences(of: "\\", with: "\\\\")
-                       .replacingOccurrences(of: "\"", with: "\\\"")
-        return "\"\(escaped)\""
     }
 
     // MARK: - Attribute (astro / html)

--- a/Sources/AnglesiteCore/SyndicationFrontmatter.swift
+++ b/Sources/AnglesiteCore/SyndicationFrontmatter.swift
@@ -2,18 +2,30 @@ import Foundation
 
 /// Deterministic POSSE trail (#465): records published-copy URLs in the post's `syndication:`
 /// frontmatter list (the u-syndication source the mf2 layer projects). Pure string → string.
+///
+/// Fence detection and value parsing delegate to `Frontmatter`'s helpers so what this writer
+/// edits is exactly what the canonical reader (`Frontmatter.parse`) sees; only the line-level
+/// splicing — which must preserve the file's existing formatting — lives here.
 public enum SyndicationFrontmatter {
     public static func adding(urls: [String], to contents: String) -> String {
         let newURLs = urls.map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
         guard !newURLs.isEmpty else { return contents }
-        var lines = contents.components(separatedBy: "\n")
 
-        // No frontmatter at all: synthesize a fence around the syndication block.
-        guard lines.first?.trimmingCharacters(in: .whitespaces) == "---",
-              let closing = lines.dropFirst().firstIndex(where: { $0.trimmingCharacters(in: .whitespaces) == "---" })
-        else {
+        // Work in LF internally so fence/key scanning matches canonical `Frontmatter` semantics,
+        // restoring CRLF on output if the source used it (mirrors `PageTitleEditor`).
+        let usesCRLF = contents.contains("\r\n")
+        let normalized = usesCRLF ? contents.replacingOccurrences(of: "\r\n", with: "\n") : contents
+        func finish(_ s: String) -> String {
+            usesCRLF ? s.replacingOccurrences(of: "\n", with: "\r\n") : s
+        }
+
+        var lines = normalized.components(separatedBy: "\n")
+
+        // No leading fence (or an unterminated one): synthesize a fence around the syndication
+        // block so the canonical reader actually sees the URLs.
+        guard let closing = Frontmatter.closingFenceIndex(of: lines) else {
             let block = ["---", "syndication:"] + newURLs.map { "  - \($0)" } + ["---"]
-            return (block + [contents]).joined(separator: "\n")
+            return finish((block + [normalized]).joined(separator: "\n"))
         }
 
         guard let keyIndex = lines[..<closing].firstIndex(where: {
@@ -21,7 +33,7 @@ public enum SyndicationFrontmatter {
         }) else {
             // No syndication key yet: nothing to dedup against.
             lines.insert(contentsOf: ["syndication:"] + newURLs.map { "  - \($0)" }, at: closing)
-            return lines.joined(separator: "\n")
+            return finish(lines.joined(separator: "\n"))
         }
 
         if let inlineItems = inlineListItems(lines[keyIndex]) {
@@ -34,50 +46,38 @@ public enum SyndicationFrontmatter {
             guard !toAdd.isEmpty else { return contents }
             let blockLines = ["syndication:"] + (inlineItems + toAdd).map { "  - \($0)" }
             lines.replaceSubrange(keyIndex...keyIndex, with: blockLines)
-            return lines.joined(separator: "\n")
+            return finish(lines.joined(separator: "\n"))
         }
 
-        // Block form: existing items are the consecutive "  - item" lines right after the key.
+        // Block form: existing items are the consecutive `- item` lines right after the key,
+        // read with the canonical item/unquote semantics so quoted items still dedup.
         var itemEnd = keyIndex + 1
-        while itemEnd < closing, lines[itemEnd].trimmingCharacters(in: .whitespaces).hasPrefix("- ") {
+        var existing = Set<String>()
+        while itemEnd < closing, let item = Frontmatter.blockArrayItem(lines[itemEnd]) {
+            existing.insert(Frontmatter.unquote(item))
             itemEnd += 1
         }
-        let existing = Set(lines[(keyIndex + 1)..<itemEnd]
-            .map { $0.trimmingCharacters(in: .whitespaces).dropFirst(2).trimmingCharacters(in: .whitespaces) })
         let toAdd = newURLs.filter { !existing.contains($0) }
         guard !toAdd.isEmpty else { return contents }
         lines.insert(contentsOf: toAdd.map { "  - \($0)" }, at: itemEnd)
-        return lines.joined(separator: "\n")
+        return finish(lines.joined(separator: "\n"))
     }
 
     /// Parses the inline value(s) of a `syndication:` key line that already carries content —
     /// either an inline array (`syndication: [a, b]`) or a bare scalar
     /// (`syndication: https://a.test/1`), the latter written by hand or another tool. Returns
     /// `nil` for a bare `syndication:` key with nothing after the colon (block form, or empty).
+    /// Value parsing delegates to `Frontmatter.parseScalarOrArray` so quoting and inline-array
+    /// semantics match the canonical reader.
     private static func inlineListItems(_ line: String) -> [String]? {
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        guard trimmed.hasPrefix("syndication:") else { return nil }
-        let rest = trimmed.dropFirst("syndication:".count).trimmingCharacters(in: .whitespaces)
-        guard !rest.isEmpty else { return nil }
-        guard rest.hasPrefix("[") else {
-            // Bare scalar value on the key line itself — a single existing item.
-            return [unquoted(rest)].filter { !$0.isEmpty }
+        guard let (key, raw) = Frontmatter.splitKeyValue(line.trimmingCharacters(in: .whitespaces)),
+              key == "syndication", !raw.isEmpty
+        else { return nil }
+        switch Frontmatter.parseScalarOrArray(raw) {
+        case .array(let items): return items.filter { !$0.isEmpty }
+        case .string(let s): return s.isEmpty ? [] : [s]
+        case .bool(let b): return [b ? "true" : "false"]
+        case .number, .date: return nil  // write-only cases; parseScalarOrArray never produces them
         }
-        var inner = rest
-        if inner.hasSuffix("]") { inner.removeLast() }
-        inner.removeFirst()
-        let items = inner.split(separator: ",").map { unquoted($0.trimmingCharacters(in: .whitespaces)) }
-        return items.filter { !$0.isEmpty }
-    }
-
-    /// Strips a single layer of matching `"`/`'` quotes from a YAML scalar.
-    private static func unquoted(_ value: String) -> String {
-        var value = value
-        if value.count >= 2,
-           (value.hasPrefix("\"") && value.hasSuffix("\"")) || (value.hasPrefix("'") && value.hasSuffix("'")) {
-            value.removeFirst()
-            value.removeLast()
-        }
-        return value
     }
 }

--- a/Sources/AnglesiteCore/SyndicationFrontmatter.swift
+++ b/Sources/AnglesiteCore/SyndicationFrontmatter.swift
@@ -28,8 +28,11 @@ public enum SyndicationFrontmatter {
             return finish((block + [normalized]).joined(separator: "\n"))
         }
 
+        // Only a *top-level* `syndication:` key counts — `Frontmatter.splitKeyValue` rejects
+        // indented lines, so a `syndication:` nested under another key (which the canonical
+        // reader ignores) is never spliced into.
         guard let keyIndex = lines[..<closing].firstIndex(where: {
-            $0.trimmingCharacters(in: .whitespaces) == "syndication:" || $0.hasPrefix("syndication:")
+            Frontmatter.splitKeyValue($0)?.key == "syndication"
         }) else {
             // No syndication key yet: nothing to dedup against.
             lines.insert(contentsOf: ["syndication:"] + newURLs.map { "  - \($0)" }, at: closing)
@@ -70,7 +73,7 @@ public enum SyndicationFrontmatter {
     /// Value parsing delegates to `Frontmatter.parseScalarOrArray` so quoting and inline-array
     /// semantics match the canonical reader.
     private static func inlineListItems(_ line: String) -> [String]? {
-        guard let (key, raw) = Frontmatter.splitKeyValue(line.trimmingCharacters(in: .whitespaces)),
+        guard let (key, raw) = Frontmatter.splitKeyValue(line),
               key == "syndication", !raw.isEmpty
         else { return nil }
         switch Frontmatter.parseScalarOrArray(raw) {

--- a/Tests/AnglesiteCoreTests/FrontmatterTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterTests.swift
@@ -128,4 +128,25 @@ struct FrontmatterTests {
         let src = "---\ntitle: x\nno closing fence"
         #expect(Frontmatter.body(src) == src)
     }
+
+    // MARK: - Shared line-based helpers (frontmatter-parsing unification)
+
+    @Test("closingFenceIndex: exact `---` lines only, index into the original array")
+    func closingFence() {
+        #expect(Frontmatter.closingFenceIndex(of: ["---", "title: x", "---", "body"]) == 2)
+        #expect(Frontmatter.closingFenceIndex(of: ["---", "---"]) == 1)
+        #expect(Frontmatter.closingFenceIndex(of: ["---", "title: x"]) == nil)     // unterminated
+        #expect(Frontmatter.closingFenceIndex(of: ["--- ", "x", "---"]) == nil)    // trailing space
+        #expect(Frontmatter.closingFenceIndex(of: ["---"]) == nil)                 // lone fence
+        #expect(Frontmatter.closingFenceIndex(of: ["body"]) == nil)                // no fence
+        #expect(Frontmatter.closingFenceIndex(of: []) == nil)
+    }
+
+    @Test("doubleQuoted round-trips through parse, including newlines")
+    func doubleQuotedRoundTrip() {
+        for original in ["plain", "a\"b\\c", "line1\nline2", "cr\rlf", "tab\there", ""] {
+            let fm = Frontmatter.parse("---\ntitle: \(Frontmatter.doubleQuoted(original))\n---")
+            #expect(fm["title"] == .string(original), "round-trip failed for \(original.debugDescription)")
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/PageTitleEditorTests.swift
@@ -138,4 +138,38 @@ struct PageTitleEditorTests {
         // The description value is untouched.
         #expect(out.contains("description: \"has a title: suffix\""))
     }
+
+    // MARK: - Characterization: fence and key edges shared with `Frontmatter`
+
+    @Test("markdown: unterminated fence → treated as no frontmatter, fresh block prepended")
+    func mdUnterminatedFence() {
+        let src = "---\ntitle: \"Old\"\nno closing fence\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "md", newTitle: "New"))
+        #expect(out == "---\ntitle: \"New\"\n---\n\n" + src)
+    }
+
+    @Test("markdown: empty frontmatter block gains a title line")
+    func mdEmptyBlock() {
+        let out = ok(PageTitleEditor.rewrite(contents: "---\n---\nBody\n", fileExtension: "md", newTitle: "New"))
+        #expect(out == "---\ntitle: \"New\"\n---\nBody\n")
+    }
+
+    @Test("markdown: newline inside the new title is escaped, keeping the file parseable")
+    func mdNewlineInTitle() {
+        let out = ok(PageTitleEditor.rewrite(
+            contents: "---\ntitle: \"x\"\n---\nBody\n", fileExtension: "md", newTitle: "line1\nline2"))
+        #expect(out.contains("title: \"line1\\nline2\""))
+        #expect(Frontmatter.parse(out)["title"] == .string("line1\nline2"))
+    }
+
+    @Test("markdown: `title :` with a space before the colon is not a canonical key")
+    func mdSpacedColonKey() {
+        // `Frontmatter.splitKeyValue` (the canonical key reader) rejects `title :`, so the editor
+        // inserts a fresh canonical `title:` line rather than editing a line the scanner never
+        // reads as the title. The stale spaced line stays verbatim.
+        let src = "---\ntitle : \"Old\"\n---\nBody\n"
+        let out = ok(PageTitleEditor.rewrite(contents: src, fileExtension: "md", newTitle: "New"))
+        #expect(Frontmatter.parse(out)["title"] == .string("New"))
+        #expect(out.contains("title : \"Old\""))
+    }
 }

--- a/Tests/AnglesiteCoreTests/SyndicationFrontmatterTests.swift
+++ b/Tests/AnglesiteCoreTests/SyndicationFrontmatterTests.swift
@@ -1,0 +1,77 @@
+// Tests/AnglesiteCoreTests/SyndicationFrontmatterTests.swift
+import Testing
+@testable import AnglesiteCore
+
+/// Characterization tests pinning `SyndicationFrontmatter.adding` to the canonical `Frontmatter`
+/// parsing semantics it delegates to (fence detection, key splitting, item unquoting). The
+/// end-to-end POSSE flows stay covered by `RepurposeCoreTests` and `POSSESyndicationTests`;
+/// these pin the string transform's edges.
+@Suite("SyndicationFrontmatter")
+struct SyndicationFrontmatterTests {
+
+    @Test("empty and whitespace-only URLs are a no-op")
+    func emptyURLs() {
+        let src = "---\ntitle: T\n---\nBody.\n"
+        #expect(SyndicationFrontmatter.adding(urls: [], to: src) == src)
+        #expect(SyndicationFrontmatter.adding(urls: ["  ", ""], to: src) == src)
+    }
+
+    @Test("empty frontmatter block gains the syndication key")
+    func emptyBlock() {
+        let out = SyndicationFrontmatter.adding(urls: ["https://a.test/1"], to: "---\n---\nBody.\n")
+        #expect(out == "---\nsyndication:\n  - https://a.test/1\n---\nBody.\n")
+    }
+
+    @Test("unterminated fence: treated as no frontmatter, fresh block prepended")
+    func unterminatedFence() {
+        let src = "---\ntitle: T\nno closing fence\n"
+        let out = SyndicationFrontmatter.adding(urls: ["https://a.test/1"], to: src)
+        #expect(out.hasPrefix("---\nsyndication:\n  - https://a.test/1\n---\n"))
+        #expect(out.hasSuffix(src))
+    }
+
+    @Test("multi-item inline array converts to block form, deduping each item")
+    func multiItemInlineArray() {
+        let src = "---\ntitle: T\nsyndication: [https://a.test/1, https://b.test/2]\n---\nBody.\n"
+        let out = SyndicationFrontmatter.adding(urls: ["https://b.test/2", "https://c.test/3"], to: src)
+        #expect(out.contains(
+            "syndication:\n  - https://a.test/1\n  - https://b.test/2\n  - https://c.test/3"))
+        #expect(out.components(separatedBy: "https://b.test/2").count == 2) // deduped
+        #expect(out.contains("Body."))
+    }
+
+    @Test("fully-deduplicated add returns the contents unchanged")
+    func fullyDeduplicated() {
+        let src = "---\nsyndication: [https://a.test/1]\n---\nBody.\n"
+        #expect(SyndicationFrontmatter.adding(urls: ["https://a.test/1"], to: src) == src)
+    }
+
+    @Test("quoted inline items dedup against unquoted URLs")
+    func quotedInlineItems() {
+        let src = "---\nsyndication: [\"https://a.test/1\"]\n---\nBody.\n"
+        #expect(SyndicationFrontmatter.adding(urls: ["https://a.test/1"], to: src) == src)
+    }
+
+    @Test("quoted block items dedup against unquoted URLs (canonical unquote semantics)")
+    func quotedBlockItems() {
+        let src = "---\nsyndication:\n  - \"https://a.test/1\"\n---\nBody.\n"
+        #expect(SyndicationFrontmatter.adding(urls: ["https://a.test/1"], to: src) == src)
+    }
+
+    @Test("CRLF file: inserts into the existing frontmatter, preserving CRLF endings")
+    func crlfInsertsInPlace() {
+        let src = "---\r\ntitle: T\r\n---\r\nBody.\r\n"
+        let out = SyndicationFrontmatter.adding(urls: ["https://a.test/1"], to: src)
+        #expect(out == "---\r\ntitle: T\r\nsyndication:\r\n  - https://a.test/1\r\n---\r\nBody.\r\n")
+    }
+
+    @Test("fence with trailing whitespace is not a fence (canonical): fresh block prepended")
+    func trailingWhitespaceFence() {
+        // Canonical `Frontmatter.parse` would not read a `--- ` fence either, so the URLs must
+        // land in a well-formed block the reader actually sees.
+        let src = "--- \ntitle: T\n---\nBody.\n"
+        let out = SyndicationFrontmatter.adding(urls: ["https://a.test/1"], to: src)
+        #expect(out.hasPrefix("---\nsyndication:\n  - https://a.test/1\n---\n"))
+        #expect(Frontmatter.parse(out)["syndication"] == .array(["https://a.test/1"]))
+    }
+}

--- a/Tests/AnglesiteCoreTests/SyndicationFrontmatterTests.swift
+++ b/Tests/AnglesiteCoreTests/SyndicationFrontmatterTests.swift
@@ -65,6 +65,18 @@ struct SyndicationFrontmatterTests {
         #expect(out == "---\r\ntitle: T\r\nsyndication:\r\n  - https://a.test/1\r\n---\r\nBody.\r\n")
     }
 
+    @Test("indented syndication: nested under another key is not the top-level key (canonical)")
+    func nestedSyndicationKeyIgnored() {
+        // Canonical `Frontmatter.parse` reads top-level keys only, so a nested `syndication:`
+        // must not be spliced into — the URLs would be invisible to the reader. A proper
+        // top-level block is added instead; the nested line stays verbatim.
+        let src = "---\ntitle: T\nmeta:\n  syndication:\n---\nBody.\n"
+        let out = SyndicationFrontmatter.adding(urls: ["https://a.test/1"], to: src)
+        #expect(out.contains("meta:\n  syndication:\n"))
+        #expect(out.contains("\nsyndication:\n  - https://a.test/1\n---"))
+        #expect(Frontmatter.parse(out)["syndication"] == .array(["https://a.test/1"]))
+    }
+
     @Test("fence with trailing whitespace is not a fence (canonical): fresh block prepended")
     func trailingWhitespaceFence() {
         // Canonical `Frontmatter.parse` would not read a `--- ` fence either, so the URLs must


### PR DESCRIPTION
## Summary

- Makes `Frontmatter` the single source of `---`-fence YAML-subset parsing: `SyndicationFrontmatter` and `PageTitleEditor` (markdown read path) now delegate fence detection, key splitting, item parsing, and double-quoted rendering to `Frontmatter`'s helpers instead of carrying private near-copies; `FrontmatterDocument` picks up the same shared helpers for its fence scan and writer-side escape.
- `Frontmatter` gains two internal helpers: `closingFenceIndex(of:)` (line-based fence scan for the in-place editors, which need line *indices* to preserve file formatting) and `doubleQuoted(_:)` (the escape+quote writer, moved from `FrontmatterDocument`). The canonical `parse`/`body` semantics are untouched.
- `ContentScanner.readFrontmatter` already delegated to `Frontmatter.parse` on main — no change needed there. The formatting-preserving *write* splices in `SyndicationFrontmatter`/`PageTitleEditor` intentionally stay line-based; only their read/parse halves were unified.

### Behavioral differences found (all resolved toward canonical `Frontmatter` semantics, pinned by new tests)

| Site | Before | After |
|---|---|---|
| `SyndicationFrontmatter` quoted **block** items | dedup compared quoted text (`- "url"` vs `url`) → duplicates were appended | items unquote via `Frontmatter.unquote` before dedup (inline items already unquoted) |
| `SyndicationFrontmatter` on CRLF files | fence never matched (`---\r`) → duplicate LF-fenced block prepended, mixed endings | LF-normalize/restore (same pattern as `PageTitleEditor`); key inserted into the existing block, CRLF preserved |
| `SyndicationFrontmatter` fence with trailing whitespace (`--- `) | trimmed match accepted it and edited that block — which canonical `parse` never reads | canonical: not a fence; a fresh well-formed block is prepended so the reader actually sees the URLs |
| `SyndicationFrontmatter` malformed inline array (`syndication: [a, b` — no `]`) | tolerant: parsed as 2 items | canonical `parseScalarOrArray`: a string scalar, i.e. one item (malformed YAML either way) |
| `PageTitleEditor` `title :` (space before colon) | replaced that line (canonical `parse` never reads it as `title`) | canonical `splitKeyValue`: not a key; a fresh `title:` line is inserted, stale line left verbatim, `parse` reads the new title either way |
| `PageTitleEditor` newline inside a new title | written unescaped → broke fence detection on re-parse | escaped as `\n` via shared `doubleQuoted` (matches `FrontmatterDocument`) |
| `SyndicationFrontmatter` indented `syndication:` nested under another key (review follow-up, 53e6b49b) | ad-hoc key match spliced URLs into the nested line, invisible to canonical `parse` | key search delegates to `Frontmatter.splitKeyValue` (top-level only); a proper top-level block is inserted instead |

Preserved-behavior characterization tests (unterminated fences, empty blocks, inline/bare-scalar syndication values, dedup no-ops, empty-URL no-ops, all existing suites) were written first and pass unchanged before and after the refactor.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: N/A — app-only, no MCP schema or template changes.

## Test plan

- [x] `swift test --package-path .` — full suite green: 2168 tests / 305 suites (AnglesiteCoreTests) plus all other Swift Testing targets and XCTest holdouts, 0 failures. Gated e2e suites skipped as designed. (One earlier run hit a signal-11 in `VsockTCPProxyTests` under full parallel load; it passed in isolation and in two subsequent full runs — unrelated flake, no frontmatter involvement.)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] Manual smoke (if UI-touching): N/A — no UI changes, no user-visible strings added (no String Catalog delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
