### PR TITLE
refactor(themes): move theme catalog data to shared JSON, drop TS regex scrape

### DIFF
--- a/Resources/Template/scripts/scaffold.sh
+++ b/Resources/Template/scripts/scaffold.sh
@@ -39,6 +39,7 @@ mkdir -p "$TARGET"
 rsync -a \
     --exclude='scripts/scaffold.sh' \
     --exclude='scripts/themes.ts' \
+    --exclude='scripts/themes.json' \
     --exclude='scripts/*.test.ts' \
     --exclude='integrations/' \
     --exclude='node_modules/' \

--- a/Resources/Template/scripts/themes.json
+++ b/Resources/Template/scripts/themes.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "classic",
+    "displayName": "Classic",
+    "description": "Traditional, trustworthy, professional",
+    "bestFor": ["legal", "finance", "consulting"],
+    "vars": {
+      "color-primary": "#1e3a5f",
+      "color-accent": "#c8a951",
+      "font-heading": "Georgia, 'Times New Roman', serif",
+      "font-body": "system-ui, -apple-system, sans-serif"
+    }
+  },
+  {
+    "id": "elegant",
+    "displayName": "Elegant",
+    "description": "Refined and sophisticated with a modern edge",
+    "bestFor": ["photography", "luxury", "personal"],
+    "vars": {
+      "color-primary": "#2d2d2d",
+      "color-accent": "#b08d57",
+      "font-heading": "'Palatino Linotype', 'Book Antiqua', serif",
+      "font-body": "system-ui, -apple-system, sans-serif"
+    }
+  },
+  {
+    "id": "warm",
+    "displayName": "Warm",
+    "description": "Friendly, inviting, approachable",
+    "bestFor": ["blog", "cafe", "bakery", "lifestyle"],
+    "vars": {
+      "color-primary": "#8b4513",
+      "color-accent": "#d4956a",
+      "font-heading": "Georgia, 'Times New Roman', serif",
+      "font-body": "system-ui, -apple-system, sans-serif"
+    }
+  },
+  {
+    "id": "bold",
+    "displayName": "Bold",
+    "description": "High contrast, confident, striking",
+    "bestFor": ["portfolio", "agency", "startup"],
+    "vars": {
+      "color-primary": "#1a1a2e",
+      "color-accent": "#e94560",
+      "font-heading": "system-ui, -apple-system, sans-serif",
+      "font-body": "system-ui, -apple-system, sans-serif"
+    }
+  },
+  {
+    "id": "community",
+    "displayName": "Community",
+    "description": "Open, inclusive, collaborative",
+    "bestFor": ["nonprofit", "organization", "club"],
+    "vars": {
+      "color-primary": "#2e7d32",
+      "color-accent": "#ff8f00",
+      "font-heading": "system-ui, -apple-system, sans-serif",
+      "font-body": "system-ui, -apple-system, sans-serif"
+    }
+  },
+  {
+    "id": "studio",
+    "displayName": "Studio",
+    "description": "Dark mode for creative coders",
+    "bestFor": ["generative-art", "developer", "creative"],
+    "vars": {
+      "color-primary": "#00ff88",
+      "color-accent": "#00ff88",
+      "font-heading": "monospace",
+      "font-body": "monospace"
+    }
+  },
+  {
+    "id": "coastal",
+    "displayName": "Coastal",
+    "description": "Calm, breezy, ocean-inspired",
+    "bestFor": ["wellness", "travel", "retreat"],
+    "vars": {
+      "color-primary": "#1a5276",
+      "color-accent": "#48c9b0",
+      "font-heading": "system-ui, -apple-system, sans-serif",
+      "font-body": "system-ui, -apple-system, sans-serif"
+    }
+  },
+  {
+    "id": "minimal",
+    "displayName": "Minimal",
+    "description": "Clean, focused, distraction-free",
+    "bestFor": ["writer", "researcher", "documentation"],
+    "vars": {
+      "color-primary": "#333333",
+      "color-accent": "#0066cc",
+      "font-heading": "system-ui, -apple-system, sans-serif",
+      "font-body": "system-ui, -apple-system, sans-serif"
+    }
+  }
+]

--- a/Resources/Template/scripts/themes.test.ts
+++ b/Resources/Template/scripts/themes.test.ts
@@ -1,0 +1,49 @@
+// Run: npx tsx --test scripts/themes.test.ts
+//
+// Guards the themes.json → THEMES re-export (themes.ts). The app side has its own
+// drift guard (AnglesiteCoreTests/ThemeCatalogTests decodes the same JSON); this is
+// the template-side counterpart so a themes.json edit that breaks the JS shape is
+// caught here rather than relying on astro check's structural typing alone.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { THEMES } from "./themes";
+import themesData from "./themes.json";
+
+const EXPECTED_IDS = [
+  "classic",
+  "elegant",
+  "warm",
+  "bold",
+  "community",
+  "studio",
+  "coastal",
+  "minimal",
+];
+
+const REQUIRED_VARS = ["color-primary", "color-accent", "font-heading", "font-body"];
+
+test("THEMES exposes the 8 built-in themes under their expected ids", () => {
+  assert.deepEqual(Object.keys(THEMES), EXPECTED_IDS);
+});
+
+test("themes.json ids are unique (a duplicate would silently collide in Object.fromEntries)", () => {
+  const ids = themesData.map((theme) => theme.id);
+  assert.equal(new Set(ids).size, ids.length, `duplicate id in themes.json: ${ids.join(", ")}`);
+  // And the derived record kept every entry — nothing was swallowed by a key collision.
+  assert.equal(Object.keys(THEMES).length, themesData.length);
+});
+
+test("every theme is complete: displayName, description, bestFor, and required vars", () => {
+  for (const [id, theme] of Object.entries(THEMES)) {
+    assert.ok(theme.displayName.length > 0, `${id}: empty displayName`);
+    assert.ok(theme.description.length > 0, `${id}: empty description`);
+    assert.ok(theme.bestFor.length > 0, `${id}: empty bestFor`);
+    for (const tag of theme.bestFor) {
+      assert.ok(tag.length > 0, `${id}: empty bestFor entry`);
+    }
+    for (const key of REQUIRED_VARS) {
+      const value = theme.vars[key];
+      assert.ok(value !== undefined && value.length > 0, `${id}: missing or empty --${key}`);
+    }
+  }
+});

--- a/Resources/Template/scripts/themes.ts
+++ b/Resources/Template/scripts/themes.ts
@@ -1,3 +1,8 @@
+// Theme DATA lives in themes.json — the single shared source of truth. The app's
+// AnglesiteCore/ThemeCatalog decodes the same file, so edits there flow to both sides.
+// This module just re-exposes it with the historical typed `THEMES` record shape.
+import themesData from "./themes.json";
+
 export interface Theme {
   displayName: string;
   description: string;
@@ -5,93 +10,6 @@ export interface Theme {
   vars: Record<string, string>;
 }
 
-export const THEMES: Record<string, Theme> = {
-  classic: {
-    displayName: "Classic",
-    description: "Traditional, trustworthy, professional",
-    bestFor: ["legal", "finance", "consulting"],
-    vars: {
-      "color-primary": "#1e3a5f",
-      "color-accent": "#c8a951",
-      "font-heading": "Georgia, 'Times New Roman', serif",
-      "font-body": "system-ui, -apple-system, sans-serif",
-    },
-  },
-  elegant: {
-    displayName: "Elegant",
-    description: "Refined and sophisticated with a modern edge",
-    bestFor: ["photography", "luxury", "personal"],
-    vars: {
-      "color-primary": "#2d2d2d",
-      "color-accent": "#b08d57",
-      "font-heading": "'Palatino Linotype', 'Book Antiqua', serif",
-      "font-body": "system-ui, -apple-system, sans-serif",
-    },
-  },
-  warm: {
-    displayName: "Warm",
-    description: "Friendly, inviting, approachable",
-    bestFor: ["blog", "cafe", "bakery", "lifestyle"],
-    vars: {
-      "color-primary": "#8b4513",
-      "color-accent": "#d4956a",
-      "font-heading": "Georgia, 'Times New Roman', serif",
-      "font-body": "system-ui, -apple-system, sans-serif",
-    },
-  },
-  bold: {
-    displayName: "Bold",
-    description: "High contrast, confident, striking",
-    bestFor: ["portfolio", "agency", "startup"],
-    vars: {
-      "color-primary": "#1a1a2e",
-      "color-accent": "#e94560",
-      "font-heading": "system-ui, -apple-system, sans-serif",
-      "font-body": "system-ui, -apple-system, sans-serif",
-    },
-  },
-  community: {
-    displayName: "Community",
-    description: "Open, inclusive, collaborative",
-    bestFor: ["nonprofit", "organization", "club"],
-    vars: {
-      "color-primary": "#2e7d32",
-      "color-accent": "#ff8f00",
-      "font-heading": "system-ui, -apple-system, sans-serif",
-      "font-body": "system-ui, -apple-system, sans-serif",
-    },
-  },
-  studio: {
-    displayName: "Studio",
-    description: "Dark mode for creative coders",
-    bestFor: ["generative-art", "developer", "creative"],
-    vars: {
-      "color-primary": "#00ff88",
-      "color-accent": "#00ff88",
-      "font-heading": "monospace",
-      "font-body": "monospace",
-    },
-  },
-  coastal: {
-    displayName: "Coastal",
-    description: "Calm, breezy, ocean-inspired",
-    bestFor: ["wellness", "travel", "retreat"],
-    vars: {
-      "color-primary": "#1a5276",
-      "color-accent": "#48c9b0",
-      "font-heading": "system-ui, -apple-system, sans-serif",
-      "font-body": "system-ui, -apple-system, sans-serif",
-    },
-  },
-  minimal: {
-    displayName: "Minimal",
-    description: "Clean, focused, distraction-free",
-    bestFor: ["writer", "researcher", "documentation"],
-    vars: {
-      "color-primary": "#333333",
-      "color-accent": "#0066cc",
-      "font-heading": "system-ui, -apple-system, sans-serif",
-      "font-body": "system-ui, -apple-system, sans-serif",
-    },
-  },
-};
+export const THEMES: Record<string, Theme> = Object.fromEntries(
+  themesData.map(({ id, ...theme }) => [id, theme]),
+);

--- a/Sources/AnglesiteCore/DesignTokenWriter.swift
+++ b/Sources/AnglesiteCore/DesignTokenWriter.swift
@@ -22,8 +22,8 @@ public enum DesignTokenWriter {
         ]
     }
 
-    /// A built-in ``Theme``'s `cssVars` already use the template's naming scheme (parsed from
-    /// `Resources/Template/scripts/themes.ts`) — pass through unchanged.
+    /// A built-in ``Theme``'s `cssVars` already use the template's naming scheme (decoded from
+    /// `Resources/Template/scripts/themes.json`) — pass through unchanged.
     public static func templateCSSVars(for theme: Theme) -> [String: String] { theme.cssVars }
 
     /// Human-readable `DESIGN.md` rationale, ported from `generateDesignRationale` in

--- a/Sources/AnglesiteCore/FreedesignmdCatalog.swift
+++ b/Sources/AnglesiteCore/FreedesignmdCatalog.swift
@@ -26,7 +26,7 @@ public enum FreedesignmdCatalogError: Error, Sendable, Equatable {
 /// Browses the freedesignmd.com catalog deterministically. The catalog page has no JSON API, but
 /// server-renders a JSON-LD `ItemList` with every system's slug/name — this parses that block
 /// directly rather than doing LLM-mediated page extraction (unlike the plugin's WebFetch-based
-/// `freedesignmd` skill), following `ThemeCatalog.parse(themesTS:)`'s tolerant-regex pattern.
+/// `freedesignmd` skill), using a tolerant regex over the server-rendered markup.
 public enum FreedesignmdCatalog {
     static let systemsURL = URL(string: "https://freedesignmd.com/systems")!
     static func systemURL(slug: String) -> URL { URL(string: "https://freedesignmd.com/system/\(slug)")! }

--- a/Sources/AnglesiteCore/ThemeCatalog.swift
+++ b/Sources/AnglesiteCore/ThemeCatalog.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// One built-in visual theme, parsed from `Resources/Template/scripts/themes.ts`.
+/// One built-in visual theme, decoded from `Resources/Template/scripts/themes.json`.
 public struct Theme: Sendable, Identifiable, Equatable {
-    public let id: String                    // THEMES record key, e.g. "warm"
+    public let id: String                    // theme id, e.g. "warm"
     public let name: String                  // displayName
     public let blurb: String                 // description
     public let swatch: [String]              // [color-primary, color-accent] for the gallery
@@ -18,8 +18,6 @@ public struct ThemeCatalog: Sendable {
     public let themes: [Theme]
     public init(themes: [Theme]) { self.themes = themes }
 
-    public enum ParseError: Error, Sendable, Equatable { case noThemesDeclaration }
-
     public func theme(id: String) -> Theme? { themes.first { $0.id == id } }
 
     /// App-side default theme per broad site type. Falls back to the first available theme
@@ -34,43 +32,32 @@ public struct ThemeCatalog: Sendable {
         return themes.first?.id ?? want
     }
 
-    /// Load + parse the bundled template's themes.ts. `templateURL` is the template root
-    /// (`TemplateRuntime.resolve().url`); themes.ts lives at scripts/themes.ts.
+    /// Load the bundled template's theme catalog. `templateURL` is the template root
+    /// (`TemplateRuntime.resolve().url`); the data lives at scripts/themes.json — the same
+    /// file the template's `scripts/themes.ts` imports, so both sides share one source of truth.
     public static func load(templateURL: URL) throws -> ThemeCatalog {
-        let url = templateURL.appendingPathComponent("scripts/themes.ts")
-        let ts = try String(contentsOf: url, encoding: .utf8)
-        return ThemeCatalog(themes: try parse(themesTS: ts))
+        let url = templateURL.appendingPathComponent("scripts/themes.json")
+        return ThemeCatalog(themes: try parse(themesJSON: Data(contentsOf: url)))
     }
 
-    /// Tolerant parser keyed on the known field order (displayName, description, bestFor, vars).
-    public static func parse(themesTS: String) throws -> [Theme] {
-        guard themesTS.contains("THEMES") else { throw ParseError.noThemesDeclaration }
-
-        // Per-theme block: id, displayName, description, bestFor[...], vars{...}.
-        // `vars` body uses [^}]* — CSS values inside `vars` must not contain a literal `}`
-        // (the capture stops at the first closing brace). The real themes.ts satisfies this.
-        let themePattern = #"(\w+):\s*\{\s*displayName:\s*"([^"]*)",\s*description:\s*"([^"]*)",\s*bestFor:\s*\[[^\]]*\],\s*vars:\s*\{([^}]*)\}"#
-        let varPattern = #""([^"]+)":\s*"([^"]*)""#
-
-        let themeRE = try NSRegularExpression(pattern: themePattern, options: [.dotMatchesLineSeparators])
-        let varRE = try NSRegularExpression(pattern: varPattern, options: [])
-
-        let ns = themesTS as NSString
-        var result: [Theme] = []
-        for m in themeRE.matches(in: themesTS, range: NSRange(location: 0, length: ns.length)) {
-            let id = ns.substring(with: m.range(at: 1))
-            let name = ns.substring(with: m.range(at: 2))
-            let blurb = ns.substring(with: m.range(at: 3))
-            let varsBody = ns.substring(with: m.range(at: 4))
-
-            var vars: [String: String] = [:]
-            let vns = varsBody as NSString
-            for vm in varRE.matches(in: varsBody, range: NSRange(location: 0, length: vns.length)) {
-                vars[vns.substring(with: vm.range(at: 1))] = vns.substring(with: vm.range(at: 2))
-            }
-            let swatch = ["color-primary", "color-accent"].compactMap { vars[$0] }
-            result.append(Theme(id: id, name: name, blurb: blurb, swatch: swatch, cssVars: vars))
+    /// The shared catalog is an ordered JSON array of theme records; decoding preserves
+    /// the array order (the first entry is the fallback default theme).
+    public static func parse(themesJSON data: Data) throws -> [Theme] {
+        struct Record: Decodable {
+            let id: String
+            let displayName: String
+            let description: String
+            let bestFor: [String]
+            let vars: [String: String]
         }
-        return result
+        return try JSONDecoder().decode([Record].self, from: data).map { record in
+            Theme(
+                id: record.id,
+                name: record.displayName,
+                blurb: record.description,
+                swatch: ["color-primary", "color-accent"].compactMap { record.vars[$0] },
+                cssVars: record.vars
+            )
+        }
     }
 }

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -64,8 +64,8 @@ public enum AnglesiteIntents {
             DomainOperations()
         }
         // `ApplyThemeIntent` (ThemeIntents.swift) resolves `@Dependency private var catalog:
-        // ThemeCatalog` against whatever is registered here. `ThemeCatalog.load` parses the
-        // bundled template's scripts/themes.ts and can throw (missing/unreadable template),
+        // ThemeCatalog` against whatever is registered here. `ThemeCatalog.load` decodes the
+        // bundled template's scripts/themes.json and can throw (missing/unreadable template),
         // so — matching `SitesLauncherView.presentNewSite()`'s handling of the same call —
         // fall back to an empty catalog rather than letting bootstrap throw or the intent trap
         // on an unregistered dependency. `perform()` already has a "I don't recognize that

--- a/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationTemplateAssetsTests.swift
@@ -216,7 +216,7 @@ import Foundation
         // config.ts must ship to scaffolded sites — ensure it's not excluded.
         #expect(!s.contains("config.ts"), "scaffold.sh must not exclude config.ts")
         // The only excludes should be the known set.
-        let allowedExcludes = ["scaffold.sh", "themes.ts", "*.test.ts", "node_modules", ".DS_Store", "integrations"]
+        let allowedExcludes = ["scaffold.sh", "themes.ts", "themes.json", "*.test.ts", "node_modules", ".DS_Store", "integrations"]
         let excludeLines = s.components(separatedBy: "\n").filter { $0.contains("--exclude=") }
         for line in excludeLines {
             #expect(allowedExcludes.contains { line.contains($0) }, "unexpected exclude in scaffold.sh: \(line)")

--- a/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
@@ -75,6 +75,10 @@ struct ThemeCatalogTests {
     @Test func realThemesFileParsesToEightCompleteThemes() throws {
         let themes = try ThemeCatalog.parse(themesJSON: Data(contentsOf: Self.realThemesURL()))
         #expect(themes.count == 8, "expected 8 built-in themes")
+        // A duplicate id would silently collide in theme(id:)'s first{} lookup (and in the
+        // template's Object.fromEntries) — enforce uniqueness at the source.
+        let ids = themes.map(\.id)
+        #expect(Set(ids).count == ids.count, "duplicate theme id in themes.json: \(ids)")
         for theme in themes {
             for key in ["color-primary", "color-accent", "font-heading", "font-body"] {
                 #expect(theme.cssVars[key] != nil, "\(theme.id) missing --\(key)")

--- a/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
@@ -1,88 +1,95 @@
-import XCTest
+import Foundation
+import Testing
 @testable import AnglesiteCore
 
-final class ThemeCatalogTests: XCTestCase {
+struct ThemeCatalogTests {
 
-    // A trimmed fixture mirroring the real themes.ts shape (two themes, varied fonts).
-    private let fixture = """
-    export const THEMES: Record<string, Theme> = {
-      classic: {
-        displayName: "Classic",
-        description: "Traditional, trustworthy, professional",
-        bestFor: ["legal", "finance"],
-        vars: {
+    // A trimmed fixture mirroring the real themes.json shape (two themes, varied fonts).
+    private let fixture = Data("""
+    [
+      {
+        "id": "classic",
+        "displayName": "Classic",
+        "description": "Traditional, trustworthy, professional",
+        "bestFor": ["legal", "finance"],
+        "vars": {
           "color-primary": "#1e3a5f",
           "color-accent": "#c8a951",
           "font-heading": "Georgia, 'Times New Roman', serif",
-          "font-body": "system-ui, -apple-system, sans-serif",
-        },
+          "font-body": "system-ui, -apple-system, sans-serif"
+        }
       },
-      studio: {
-        displayName: "Studio",
-        description: "Dark mode for creative coders",
-        bestFor: ["generative-art"],
-        vars: {
+      {
+        "id": "studio",
+        "displayName": "Studio",
+        "description": "Dark mode for creative coders",
+        "bestFor": ["generative-art"],
+        "vars": {
           "color-primary": "#00ff88",
           "color-accent": "#00ff88",
           "font-heading": "monospace",
-          "font-body": "monospace",
-        },
-      },
-    };
-    """
+          "font-body": "monospace"
+        }
+      }
+    ]
+    """.utf8)
 
-    func testParsesThemesInOrder() throws {
-        let themes = try ThemeCatalog.parse(themesTS: fixture)
-        XCTAssertEqual(themes.map(\.id), ["classic", "studio"])
-        XCTAssertEqual(themes[0].name, "Classic")
-        XCTAssertEqual(themes[0].blurb, "Traditional, trustworthy, professional")
-        XCTAssertEqual(themes[0].cssVars["color-primary"], "#1e3a5f")
+    @Test func parsesThemesInOrder() throws {
+        let themes = try ThemeCatalog.parse(themesJSON: fixture)
+        #expect(themes.map(\.id) == ["classic", "studio"])
+        #expect(themes[0].name == "Classic")
+        #expect(themes[0].blurb == "Traditional, trustworthy, professional")
+        #expect(themes[0].cssVars["color-primary"] == "#1e3a5f")
         // Font value with embedded commas + single quotes survives intact.
-        XCTAssertEqual(themes[0].cssVars["font-heading"], "Georgia, 'Times New Roman', serif")
-        XCTAssertEqual(themes[0].swatch, ["#1e3a5f", "#c8a951"])
+        #expect(themes[0].cssVars["font-heading"] == "Georgia, 'Times New Roman', serif")
+        #expect(themes[0].swatch == ["#1e3a5f", "#c8a951"])
     }
 
-    func testDefaultThemeIDResolvesForEverySiteType() throws {
-        let catalog = ThemeCatalog(themes: try ThemeCatalog.parse(themesTS: fixture))
-        for type in SiteType.allCases {
-            let id = catalog.defaultThemeID(for: type)
-            XCTAssertNotNil(catalog.theme(id: id), "no theme for \(type)")
+    @Test func malformedJSONThrows() {
+        #expect(throws: (any Error).self) {
+            try ThemeCatalog.parse(themesJSON: Data("not json".utf8))
         }
     }
 
-    func testDefaultThemeIDUsesPreferredMappingWhenPresent() {
+    @Test func defaultThemeIDResolvesForEverySiteType() throws {
+        let catalog = ThemeCatalog(themes: try ThemeCatalog.parse(themesJSON: fixture))
+        for type in SiteType.allCases {
+            let id = catalog.defaultThemeID(for: type)
+            #expect(catalog.theme(id: id) != nil, "no theme for \(type)")
+        }
+    }
+
+    @Test func defaultThemeIDUsesPreferredMappingWhenPresent() {
         let ids = ["classic", "elegant", "warm", "bold", "community"]
         let catalog = ThemeCatalog(themes: ids.map {
             Theme(id: $0, name: $0, blurb: "", swatch: [], cssVars: [:])
         })
-        XCTAssertEqual(catalog.defaultThemeID(for: .business), "classic")
-        XCTAssertEqual(catalog.defaultThemeID(for: .personal), "elegant")
-        XCTAssertEqual(catalog.defaultThemeID(for: .blog), "warm")
-        XCTAssertEqual(catalog.defaultThemeID(for: .portfolio), "bold")
-        XCTAssertEqual(catalog.defaultThemeID(for: .organization), "community")
+        #expect(catalog.defaultThemeID(for: .business) == "classic")
+        #expect(catalog.defaultThemeID(for: .personal) == "elegant")
+        #expect(catalog.defaultThemeID(for: .blog) == "warm")
+        #expect(catalog.defaultThemeID(for: .portfolio) == "bold")
+        #expect(catalog.defaultThemeID(for: .organization) == "community")
     }
 
-    // DRIFT GUARD: parse the REAL bundled themes.ts from the in-repo template.
-    func testRealThemesFileParsesToEightCompleteThemes() throws {
-        let url = Self.realThemesURL()
-        let ts = try String(contentsOf: url, encoding: .utf8)
-        let themes = try ThemeCatalog.parse(themesTS: ts)
-        XCTAssertEqual(themes.count, 8, "expected 8 built-in themes")
-        for t in themes {
+    // DRIFT GUARD: decode the REAL bundled themes.json from the in-repo template.
+    @Test func realThemesFileParsesToEightCompleteThemes() throws {
+        let themes = try ThemeCatalog.parse(themesJSON: Data(contentsOf: Self.realThemesURL()))
+        #expect(themes.count == 8, "expected 8 built-in themes")
+        for theme in themes {
             for key in ["color-primary", "color-accent", "font-heading", "font-body"] {
-                XCTAssertNotNil(t.cssVars[key], "\(t.id) missing --\(key)")
+                #expect(theme.cssVars[key] != nil, "\(theme.id) missing --\(key)")
             }
         }
         let catalog = ThemeCatalog(themes: themes)
         for type in SiteType.allCases {
-            XCTAssertNotNil(catalog.theme(id: catalog.defaultThemeID(for: type)))
+            #expect(catalog.theme(id: catalog.defaultThemeID(for: type)) != nil)
         }
     }
 
-    /// Resolve the real themes.ts from the in-repo template (Resources/Template/).
+    /// Resolve the real themes.json from the in-repo template (Resources/Template/).
     static func realThemesURL() -> URL {
         let repoRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-        return repoRoot.appendingPathComponent("Resources/Template/scripts/themes.ts")
+        return repoRoot.appendingPathComponent("Resources/Template/scripts/themes.json")
     }
 }


### PR DESCRIPTION
## Summary

- Move the built-in theme catalog data out of `Resources/Template/scripts/themes.ts` into a shared JSON data file, `Resources/Template/scripts/themes.json` (ordered array of `{id, displayName, description, bestFor, vars}` records — array order is the wizard's fallback-default order).
- `themes.ts` becomes a thin typed wrapper: it imports the JSON (`resolveJsonModule` is already on via Astro's base tsconfig) and re-exposes the historical `THEMES: Record<string, Theme>` shape, so template-side behavior and `TemplateRuntime.isTemplateDirectory`'s `scripts/themes.ts` marker are unchanged. Verified old-vs-new `THEMES` are byte-identical (JSON.stringify parity check, key order included).
- `ThemeCatalog.swift` now `JSONDecode`s `themes.json` (`parse(themesJSON:)`) instead of regex-scraping the TS object literal, which broke on any reformatting of `themes.ts`. This follows the proven `PreDeployCheck.swift` ⇄ `pre-deploy-check.ts` pattern: single source of truth on the template side, Swift only decodes a stable contract. Public API (`Theme`, `ThemeCatalog(themes:)`, `theme(id:)`, `defaultThemeID(for:)`, `load(templateURL:)`) is unchanged, so `SiteScaffolder`, `NewSiteWizardModel`, `ThemeApplyWizardModel`, `SetupThemeTool`, `ThemeIntents`/`ThemeCatalogOverride`, and the app views are untouched.
- `scaffold.sh` excludes `scripts/themes.json` alongside `themes.ts` (theme data is app-consumed, not shipped to scaffolded sites); the Template folder reference in `project.yml` ships the new file in the app bundle automatically.
- Opportunistic cleanup per CONTRIBUTING: `ThemeCatalogTests` migrated from XCTest to Swift Testing (one fewer XCTest holdout in `AnglesiteCoreTests`); drift guard now decodes the real bundled `themes.json`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> N/A — template changes (`Resources/Template/`) are app-only; no MCP schema or sidecar surface touched.

## Test plan

- [x] `swift test --package-path .` — full suite passes (includes the template-coupled suites and the new JSON drift guard)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Template checks (CI-equivalent, Node 24): `npm ci && npm run test:worker && npm run build` (build = `astro check` + `astro build` + microformats check) — all pass with the JSON import
- [x] Parity check: `THEMES` from old themes.ts vs new JSON-backed themes.ts — identical, including key order
- [ ] Manual smoke (if UI-touching): N/A — no UI change; theme gallery reads the same decoded values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
