### PR TITLE
feat(workers): generic HTTP route claims + selective run_worker_first (#746)

### DIFF
--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -167,6 +167,87 @@ async function fetchWorker(request: Request): Promise<Response> {
   return worker.fetch(request, testEnv, createExecutionContext());
 }
 
+// --- Generic route dispatch (#746) ---------------------------------------------------------
+// These run through worker.fetch inside the workerd pool, i.e. the same runtime `wrangler dev`
+// uses, so the dispatch behavior they pin down is what local preview and production serve.
+
+test("routing: undeclared method gets 405 with an Allow header naming the declared methods", async () => {
+  const inbox = await fetchWorker(new Request("https://owner.example/inbox", { method: "GET" }));
+  expect(inbox.status).toBe(405);
+  expect(inbox.headers.get("allow")).toBe("POST");
+
+  const metadata = await fetchWorker(
+    new Request("https://owner.example/.well-known/oauth-authorization-server", { method: "POST" }),
+  );
+  expect(metadata.status).toBe(405);
+  expect(metadata.headers.get("allow")).toBe("GET, HEAD");
+});
+
+test("routing: HEAD mirrors GET's status and headers with an empty body where declared", async () => {
+  const get = await fetchWorker(new Request("https://owner.example/.well-known/oauth-authorization-server"));
+  const head = await fetchWorker(
+    new Request("https://owner.example/.well-known/oauth-authorization-server", { method: "HEAD" }),
+  );
+  expect(head.status).toBe(get.status);
+  expect(head.headers.get("content-type")).toBe(get.headers.get("content-type"));
+  expect(await head.text()).toBe("");
+});
+
+test("routing: query parameters reach the handler unchanged", async () => {
+  // The authorize handler can only render this consent page by reading the query it was sent.
+  const authorize = new URL("https://owner.example/authorize");
+  authorize.search = new URLSearchParams({
+    client_id: "https://client.example/app",
+    redirect_uri: "https://client.example/callback",
+    response_type: "code",
+    state: "state-query-preserved",
+    code_challenge: await pkceChallenge("query-preservation-verifier-that-is-long-enough-to-be-valid"),
+    code_challenge_method: "S256",
+    scope: "create",
+  }).toString();
+  const response = await fetchWorker(new Request(authorize));
+  expect(response.status).toBe(200);
+  const body = await response.text();
+  expect(body).toContain("https://client.example/app");
+  expect(body).toContain("state-query-preserved");
+});
+
+test("routing: unknown well-known names and the bare directory return a plain 404, not HTML", async () => {
+  for (const path of ["/.well-known", "/.well-known/", "/.well-known/does-not-exist"]) {
+    const response = await fetchWorker(new Request(`https://owner.example${path}`));
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+  }
+});
+
+test("routing: case, trailing-slash, and encoded well-known variants return a true 404", async () => {
+  for (const path of [
+    "/.WELL-KNOWN/oauth-authorization-server",
+    "/.well-known/oauth-authorization-server/",
+    "/.well-known/OAuth-Authorization-Server",
+    "/%2Ewell-known/oauth-authorization-server",
+  ]) {
+    const response = await fetchWorker(new Request(`https://owner.example${path}`));
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+  }
+});
+
+test("routing: malformed percent-encoding returns a true 404", async () => {
+  const response = await fetchWorker(new Request("https://owner.example/%E0%A4%A"));
+  expect(response.status).toBe(404);
+  expect(response.headers.get("content-type")).toContain("text/plain");
+});
+
+test("routing: unrelated paths fall through to the asset-first branch", async () => {
+  // The vitest miniflare env deliberately has no ASSETS binding, so reaching the asset branch
+  // surfaces as its 500 sentinel — proving an unclaimed path was neither 404'd nor 405'd by
+  // the dispatcher.
+  const response = await fetchWorker(new Request("https://owner.example/about"));
+  expect(response.status).toBe(500);
+  expect(await response.text()).toBe("No assets binding configured");
+});
+
 test("IndieAuth metadata advertises the authorization and token endpoints", async () => {
   const response = await fetchWorker(new Request("https://owner.example/.well-known/oauth-authorization-server"));
   expect(response.status).toBe(200);

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -427,7 +427,9 @@ export interface WorkerRoute {
   path: string;
   /** `exact` matches only `path`; `prefix` additionally matches `path` + `/…` descendants. */
   match: "exact" | "prefix";
-  /** Declared methods. HEAD is served only when listed, by mirroring GET without a body. */
+  /** Declared methods. HEAD is served only when listed alongside GET — the dispatcher mirrors
+   *  GET's status/headers without a body and never hands handlers a raw HEAD request (catalog
+   *  claims enforce the same GET pairing app-side). */
   methods: readonly string[];
   handler: (request: Request, env: WorkerEnv, ctx: ExecutionContext) => Promise<Response> | Response;
 }

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -17,6 +17,15 @@ import {
  * Static assets are served by the [assets] binding in wrangler.toml; this Worker handles only
  * the social + inbox endpoint paths. When neither is enabled, this file is not referenced
  * (wrangler.toml has no `main` entry and deploys static-only).
+ *
+ * Routing (#746): `ROUTES` below is a declarative table mirroring the generic HTTP route claims
+ * the app's Worker catalog declares for the active workers; Anglesite generates matching
+ * selective `[assets].run_worker_first` entries so only these routes bypass asset-first serving.
+ * The dispatcher is generic: exact/prefix matching, `405` + `Allow` for undeclared methods, HEAD
+ * mirroring GET where declared, queries passed through untouched, and a true (plain-text) 404 —
+ * never an HTML page — for unclaimed `/.well-known/` names, the bare directory, malformed
+ * encodings, and case/trailing-slash variants (RFC 8615: the namespace has no index and no
+ * fallback representation). Every other unmatched path falls through to static assets.
  */
 
 /** Minimal Workers KV surface shared by inbox capture and consent throttling. */
@@ -40,12 +49,6 @@ const MAX_MESSAGE_LENGTH = 10_000;
 const MAX_CONSENT_BODY_BYTES = 16_384;
 const CONSENT_TTL_SECONDS = 300;
 const CONSENT_VERSION = 1;
-const INDIEAUTH_PATHS = new Set([
-  "/.well-known/oauth-authorization-server",
-  "/authorize",
-  "/token",
-  "/revocation",
-]);
 
 interface ConsentGrant {
   v: 1;
@@ -418,18 +421,134 @@ export async function handleInbox(
   return new Response(null, { status: 202 });
 }
 
+/** One dynamic route this Worker serves — the handler-side mirror of a catalog route claim. */
+export interface WorkerRoute {
+  /** Absolute claimed path, e.g. `"/.well-known/oauth-authorization-server"`. */
+  path: string;
+  /** `exact` matches only `path`; `prefix` additionally matches `path` + `/…` descendants. */
+  match: "exact" | "prefix";
+  /** Declared methods. HEAD is served only when listed, by mirroring GET without a body. */
+  methods: readonly string[];
+  handler: (request: Request, env: WorkerEnv, ctx: ExecutionContext) => Promise<Response> | Response;
+}
+
+export const ROUTES: readonly WorkerRoute[] = [
+  {
+    // RFC 8414 authorization-server metadata (linked via rel=indieauth-metadata in BaseLayout).
+    path: "/.well-known/oauth-authorization-server",
+    match: "exact",
+    methods: ["GET", "HEAD"],
+    handler: (request, env, ctx) => indieAuthHandler(request, env)(request, env, ctx),
+  },
+  {
+    // GET renders/redirects the authorization request; POST redeems an authorization code for
+    // profile information (IndieAuth authorization-endpoint code exchange).
+    path: "/authorize",
+    match: "exact",
+    methods: ["GET", "POST"],
+    handler: (request, env, ctx) => indieAuthHandler(request, env)(request, env, ctx),
+  },
+  {
+    // POST is the token grant; GET is IndieAuth token-endpoint access-token verification.
+    path: "/token",
+    match: "exact",
+    methods: ["GET", "POST"],
+    handler: (request, env, ctx) => indieAuthHandler(request, env)(request, env, ctx),
+  },
+  {
+    path: "/revocation",
+    match: "exact",
+    methods: ["POST"],
+    handler: (request, env, ctx) => indieAuthHandler(request, env)(request, env, ctx),
+  },
+  {
+    path: "/indieauth/consent",
+    match: "exact",
+    methods: ["POST"],
+    handler: (request, env) => handleIndieAuthConsent(request, env),
+  },
+  {
+    path: "/inbox",
+    match: "exact",
+    methods: ["POST"],
+    handler: (request, env) => handleInbox(request, env),
+  },
+];
+
+export function matchRoute(pathname: string, routes: readonly WorkerRoute[] = ROUTES): WorkerRoute | null {
+  for (const route of routes) {
+    if (pathname === route.path) return route;
+    if (route.match === "prefix" && pathname.startsWith(`${route.path}/`)) return route;
+  }
+  return null;
+}
+
+/** A protocol-grade 404: correct status, no HTML error page, nothing for a client to mis-parse. */
+function notFound(): Response {
+  return new Response("Not Found", {
+    status: 404,
+    headers: { "content-type": "text/plain; charset=utf-8", "x-content-type-options": "nosniff" },
+  });
+}
+
+/** True for the bare `/.well-known` directory and anything under it, case-insensitively — the
+ *  case fold exists so `/.Well-Known/...` variants get the namespace's true-404 policy instead
+ *  of leaking to an HTML asset 404 (claimed routes themselves match case-sensitively). */
+function isWellKnownNamespace(pathname: string): boolean {
+  const lower = pathname.toLowerCase();
+  return lower === "/.well-known" || lower === "/.well-known/" || lower.startsWith("/.well-known/");
+}
+
 export default {
   async fetch(request: Request, env: WorkerEnv, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
-    if (url.pathname === "/indieauth/consent") {
-      return handleIndieAuthConsent(request, env);
+    const pathname = url.pathname;
+
+    // Malformed percent-encoding can't name any claimed route or asset; answer plainly instead
+    // of handing it to an HTML 404 page.
+    let decoded: string | null;
+    try {
+      decoded = decodeURIComponent(pathname);
+    } catch {
+      decoded = null;
     }
-    if (INDIEAUTH_PATHS.has(url.pathname)) {
-      return indieAuthHandler(request, env)(request, env, ctx);
+    if (decoded === null) {
+      return notFound();
     }
-    if (url.pathname === "/inbox") {
-      return handleInbox(request, env);
+
+    const route = matchRoute(pathname);
+    if (route) {
+      const mirrorsGet = request.method === "HEAD" && route.methods.includes("HEAD") && route.methods.includes("GET");
+      if (mirrorsGet) {
+        // Query string rides along in `request.url`; only the method changes.
+        const getResponse = await route.handler(
+          new Request(request.url, { method: "GET", headers: request.headers }),
+          env,
+          ctx,
+        );
+        return new Response(null, {
+          status: getResponse.status,
+          statusText: getResponse.statusText,
+          headers: getResponse.headers,
+        });
+      }
+      if (!route.methods.includes(request.method)) {
+        return new Response("Method Not Allowed", {
+          status: 405,
+          headers: { allow: route.methods.join(", "), "content-type": "text/plain; charset=utf-8" },
+        });
+      }
+      return route.handler(request, env, ctx);
     }
+
+    // Unclaimed well-known names, the bare directory, and case/trailing-slash or encoded
+    // variants (checked post-decode so `/%2Ewell-known/...` can't slip past) return a true 404
+    // rather than falling through to an HTML asset 404. Genuinely static well-known files (e.g.
+    // security.txt) are served asset-first and never reach this Worker.
+    if (isWellKnownNamespace(pathname) || isWellKnownNamespace(decoded)) {
+      return notFound();
+    }
+
     const assets = env.ASSETS;
     if (!assets) {
       return new Response("No assets binding configured", { status: 500 });

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -449,6 +449,24 @@ final class DeployModel {
         }
         let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
 
+        // Dynamic-route claims of the effective active set (#746). Validation failures (a
+        // malformed path, two active workers claiming overlapping routes) refuse the deploy
+        // before any Cloudflare call — never silently drop a claim and deploy a Worker whose
+        // routes don't match its catalog contract.
+        let routeClaims: [WorkerRouteClaims.OwnedClaim]
+        do {
+            routeClaims = try WorkerRouteClaims.activeClaims(catalog: catalog, activeIDs: effectiveActiveIDs)
+        } catch {
+            let reason = "worker route claims are invalid: \(error)"
+            await logCenter.append(source: "deploy:\(siteID)", stream: .stderr, text: reason)
+            subscription.cancel()
+            _ = await logTask.value
+            currentMilestone = nil
+            workerNameConflictPresented = false
+            transition(siteID: siteID, to: .failed(reason: reason, exitCode: nil))
+            return .failed(reason: reason, exitCode: nil)
+        }
+
         let socialCommand = SocialWorkerProvisionCommand(
             tokenSource: { [weak self] in try await self?.command.tokenSource() },
             runner: containerRunner ?? SocialWorkerProvisionCommand.defaultRunner,
@@ -486,6 +504,7 @@ final class DeployModel {
             siteDirectory: siteDirectory,
             siteName: workerSiteName,
             features: features,
+            routeClaims: routeClaims.map(\.claim),
             knownResources: settings.provisionedWorkerResources ?? .init()
         )
 

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -80,10 +80,20 @@ public struct SiteOperations: Sendable {
         // still lets active workers keep their `run_worker_first` routes — otherwise a headless
         // deploy would silently regenerate wrangler.toml without them. Validation failures refuse
         // the deploy before any Cloudflare call, mirroring `DeployModel.runDeploy`.
+        let cachedCatalog = WorkerCatalogFetcher.cachedCatalog()
+        if cachedCatalog.isEmpty && !effectiveActiveIDs.isEmpty {
+            // The shadowing-protection gap this leaves (an active worker's routes deploy without
+            // their run_worker_first entries) must be visible in the debug pane, not silent.
+            await LogCenter.shared.append(
+                source: "deploy:\(site.id)",
+                stream: .stderr,
+                text: "no cached worker catalog — deploying active workers (\(effectiveActiveIDs.sorted().joined(separator: ", "))) without route claims; run_worker_first will be omitted until a catalog fetch succeeds"
+            )
+        }
         let routeClaims: [WorkerRouteClaims.OwnedClaim]
         do {
             routeClaims = try WorkerRouteClaims.activeClaims(
-                catalog: WorkerCatalogFetcher.cachedCatalog(), activeIDs: effectiveActiveIDs)
+                catalog: cachedCatalog, activeIDs: effectiveActiveIDs)
         } catch {
             return .failed(reason: "worker route claims are invalid: \(error)", exitCode: nil)
         }

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -75,6 +75,19 @@ public struct SiteOperations: Sendable {
         let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
         let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
 
+        // Dynamic-route claims (#746): this path has no catalog fetcher wired (matching the
+        // `catalog: []` activation choice above), but the on-disk cache from a previous GUI fetch
+        // still lets active workers keep their `run_worker_first` routes — otherwise a headless
+        // deploy would silently regenerate wrangler.toml without them. Validation failures refuse
+        // the deploy before any Cloudflare call, mirroring `DeployModel.runDeploy`.
+        let routeClaims: [WorkerRouteClaims.OwnedClaim]
+        do {
+            routeClaims = try WorkerRouteClaims.activeClaims(
+                catalog: WorkerCatalogFetcher.cachedCatalog(), activeIDs: effectiveActiveIDs)
+        } catch {
+            return .failed(reason: "worker route claims are invalid: \(error)", exitCode: nil)
+        }
+
         // Prefer the site's already-established Worker name (`.site-config`'s `CF_PROJECT_NAME`,
         // set at the first successful deploy or by a worker-name-conflict rename, #740) over
         // re-deriving one from the site's display name — mirrors `DeployModel.runDeploy`'s
@@ -90,6 +103,7 @@ public struct SiteOperations: Sendable {
             siteDirectory: siteDirectory,
             siteName: workerSiteName,
             features: features,
+            routeClaims: routeClaims.map(\.claim),
             knownResources: settings.provisionedWorkerResources ?? .init()
         )
         onProgress?(.deployFinalizing)

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -52,6 +52,10 @@ public actor SocialWorkerProvisionCommand {
         siteDirectory: URL,
         siteName: String,
         features: [WorkerComposition.Feature] = WorkerComposition.Feature.v2,
+        /// Effective active dynamic-route claims (#746), pre-validated via
+        /// `WorkerRouteClaims.activeClaims`. Written into `wrangler.toml` as selective
+        /// `[assets].run_worker_first` patterns; empty = no worker-first routes.
+        routeClaims: [WorkerRouteClaim] = [],
         /// Resources already known from `SiteSettings.provisionedWorkerResources` (#709), checked
         /// before falling back to `readPersistedResources`'s wrangler.toml scrape. Durable across
         /// a worker being deactivated (which drops its binding block from the file) and later
@@ -105,7 +109,7 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created D1 database \(name) but no database id was found", exitCode: 0, resources: resources)
                 }
                 resources.d1DatabaseID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources) {
                     return failure
                 }
             }
@@ -132,7 +136,7 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created KV namespace \(name) but no namespace id was found", exitCode: 0, resources: resources)
                 }
                 resources.kvNamespaceID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources) {
                     return failure
                 }
             }
@@ -152,13 +156,13 @@ public actor SocialWorkerProvisionCommand {
                     return failure
                 }
                 resources.r2BucketName = name
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources) {
                     return failure
                 }
             }
         }
 
-        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, resources: resources) {
+        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources) {
             return failure
         }
 
@@ -222,6 +226,7 @@ public actor SocialWorkerProvisionCommand {
         siteDirectory: URL,
         siteName: String,
         features: [WorkerComposition.Feature],
+        routeClaims: [WorkerRouteClaim],
         resources: WorkerComposition.ProvisionedResources
     ) -> Result? {
         do {
@@ -233,6 +238,7 @@ public actor SocialWorkerProvisionCommand {
             let toml = try WorkerComposition.generateWranglerToml(
                 siteName: siteName,
                 features: features,
+                routeClaims: routeClaims,
                 resources: resources
             )
             try toml.write(

--- a/Sources/AnglesiteCore/WorkerCatalog.swift
+++ b/Sources/AnglesiteCore/WorkerCatalog.swift
@@ -130,8 +130,9 @@ public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
     public let path: String
     public let match: Match
     /// Uppercase HTTP methods the handler serves. `HEAD` must be declared explicitly to be
-    /// supported (the handler mirrors `GET` headers without a body); undeclared methods get
-    /// `405` + `Allow` from the Worker's dispatcher.
+    /// supported and requires a paired `GET` (the dispatcher serves HEAD by mirroring GET's
+    /// headers without a body — enforced by `WorkerRouteClaims.validate`); undeclared methods
+    /// get `405` + `Allow` from the Worker's dispatcher.
     public let methods: [String]
     /// Stable handler identity inside the composed Worker script — ties the claim to the code
     /// that answers it.

--- a/Sources/AnglesiteCore/WorkerCatalog.swift
+++ b/Sources/AnglesiteCore/WorkerCatalog.swift
@@ -13,6 +13,13 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
     public let group: String
     public let binding: Binding
     public let resources: Resources
+    /// Generic HTTP route claims this worker's handler serves (#746). Optional so catalogs
+    /// published before the route-claim schema extension still decode; `nil` (or `[]`) means the
+    /// worker claims no dynamic routes and composition emits no `run_worker_first` entry for it.
+    /// Only claims from the *effective active* descriptor set (#709's
+    /// `WorkerActivation.effectiveActiveIDs`) ever reach routing configuration — see
+    /// `WorkerRouteClaims.activeClaims`.
+    public let routes: [WorkerRouteClaim]?
 
     public init(
         id: String,
@@ -20,7 +27,8 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
         description: String,
         group: String,
         binding: Binding,
-        resources: Resources
+        resources: Resources,
+        routes: [WorkerRouteClaim]? = nil
     ) {
         self.id = id
         self.displayName = displayName
@@ -28,6 +36,7 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
         self.group = group
         self.binding = binding
         self.resources = resources
+        self.routes = routes
     }
 
     /// How a worker becomes active. `componentTied` workers are never manually toggled — their
@@ -81,6 +90,94 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
             self.needsKV = needsKV
             self.needsR2 = needsR2
         }
+    }
+}
+
+/// One HTTP route a worker's handler claims, as declared by `catalog.json` (#746, #690 design
+/// §"Dynamic Worker routes"). The claim is metadata about the deployed Worker script's routing —
+/// the handler code itself lives in the composed Worker entry point (the template's
+/// `worker/worker.ts`), whose route table mirrors these claims.
+///
+/// Catalog JSON shape (all route fields; `validatorID` and `specificationURL` optional,
+/// `authorityBinding` defaults to `false`):
+///
+/// ```json
+/// "routes": [
+///   {
+///     "path": "/.well-known/webfinger",
+///     "match": "exact",
+///     "methods": ["GET", "HEAD"],
+///     "handler": "webfinger",
+///     "validatorID": "rfc7033",
+///     "authorityBinding": true,
+///     "specificationURL": "https://www.rfc-editor.org/rfc/rfc7033"
+///   }
+/// ]
+/// ```
+public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
+    /// How requests bind to `path`. `exact` matches only the path itself; `prefix` additionally
+    /// matches descendants (`path` + `/…`) and is valid only for protocols whose specification
+    /// approves child paths (RFC 8615's ACME-style delegation) — enforced by
+    /// `WorkerRouteClaims.validate` requiring `specificationURL` on prefix claims.
+    public enum Match: String, Sendable, Codable {
+        case exact
+        case prefix
+    }
+
+    /// Absolute origin path, e.g. `"/.well-known/webfinger"`. Validated by
+    /// `WorkerRouteClaims.validate` (leading slash, no traversal/encoding/query, no root or bare
+    /// `/.well-known` claims).
+    public let path: String
+    public let match: Match
+    /// Uppercase HTTP methods the handler serves. `HEAD` must be declared explicitly to be
+    /// supported (the handler mirrors `GET` headers without a body); undeclared methods get
+    /// `405` + `Allow` from the Worker's dispatcher.
+    public let methods: [String]
+    /// Stable handler identity inside the composed Worker script — ties the claim to the code
+    /// that answers it.
+    public let handler: String
+    /// Protocol-validator identity (#744's registry). `nil` means the route is inventory-only:
+    /// Anglesite makes no conformance claim for it.
+    public let validatorID: String?
+    /// Whether responses on this route bind an identity/application/policy to the whole origin
+    /// (design doc §"What RFC 8615 provides") — such routes warrant extra care in collision and
+    /// review surfaces.
+    public let authorityBinding: Bool
+    /// The governing protocol specification. Required for `prefix` claims (only a specification
+    /// can approve child paths); recommended for exact claims.
+    public let specificationURL: URL?
+
+    public init(
+        path: String,
+        match: Match,
+        methods: [String],
+        handler: String,
+        validatorID: String? = nil,
+        authorityBinding: Bool = false,
+        specificationURL: URL? = nil
+    ) {
+        self.path = path
+        self.match = match
+        self.methods = methods
+        self.handler = handler
+        self.validatorID = validatorID
+        self.authorityBinding = authorityBinding
+        self.specificationURL = specificationURL
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path, match, methods, handler, validatorID, authorityBinding, specificationURL
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        path = try container.decode(String.self, forKey: .path)
+        match = try container.decode(Match.self, forKey: .match)
+        methods = try container.decode([String].self, forKey: .methods)
+        handler = try container.decode(String.self, forKey: .handler)
+        validatorID = try container.decodeIfPresent(String.self, forKey: .validatorID)
+        authorityBinding = try container.decodeIfPresent(Bool.self, forKey: .authorityBinding) ?? false
+        specificationURL = try container.decodeIfPresent(URL.self, forKey: .specificationURL)
     }
 }
 

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -95,9 +95,16 @@ public actor WorkerCatalogFetcher {
     /// The last successfully cached catalog, without any network fetch — for callers with no
     /// fetcher wiring (the headless deploy path, `SiteOperations`) that still need descriptor
     /// metadata such as route claims (#746). Returns an empty catalog when nothing has ever been
-    /// cached or the cache is unreadable, mirroring `catalog()`'s final degradation step.
+    /// cached or the cache is unreadable, mirroring `catalog()`'s final degradation step — and,
+    /// like `catalog()`, never degrades silently: the fallback is logged so a headless deploy
+    /// that loses route claims to a missing/corrupt cache leaves a diagnostic trace.
     public static func cachedCatalog(cacheURL: URL = WorkerCatalogFetcher.defaultCacheURL()) -> [WorkerDescriptor] {
-        (try? readCache(cacheURL)) ?? []
+        do {
+            return try readCache(cacheURL)
+        } catch {
+            logDegradation("catalog cache read failed, falling back to empty catalog: \(error)")
+            return []
+        }
     }
 
     /// The published `@dwk/workers` monorepo catalog manifest — verified live 2026-07-17

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -92,6 +92,14 @@ public actor WorkerCatalogFetcher {
         try data.write(to: url, options: [.atomic])
     }
 
+    /// The last successfully cached catalog, without any network fetch — for callers with no
+    /// fetcher wiring (the headless deploy path, `SiteOperations`) that still need descriptor
+    /// metadata such as route claims (#746). Returns an empty catalog when nothing has ever been
+    /// cached or the cache is unreadable, mirroring `catalog()`'s final degradation step.
+    public static func cachedCatalog(cacheURL: URL = WorkerCatalogFetcher.defaultCacheURL()) -> [WorkerDescriptor] {
+        (try? readCache(cacheURL)) ?? []
+    }
+
     /// The published `@dwk/workers` monorepo catalog manifest — verified live 2026-07-17
     /// (davidwkeith/workers#255, merged in davidwkeith/workers#258). Callers still supply
     /// `catalogURL` explicitly at `init`; this is the value production call sites should pass.

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -118,9 +118,15 @@ public enum WorkerComposition {
         if inboxCaptureEnabled {
             effectiveClaims.append(inboxCaptureRouteClaim)
         }
+        // Full single-claim validation (not just path syntax), so a future caller that skips
+        // `WorkerRouteClaims.activeClaims` still can't emit an invalid claim into TOML. Cross-
+        // claim overlap detection remains `activeClaims`'s job — it needs owner attribution
+        // this signature doesn't carry.
         for claim in effectiveClaims {
-            if let problem = WorkerRouteClaims.pathProblem(claim.path) {
-                throw ConfigError.invalidRouteClaim(path: claim.path, reason: problem)
+            do {
+                try WorkerRouteClaims.validate(claim, owner: "composition")
+            } catch {
+                throw ConfigError.invalidRouteClaim(path: claim.path, reason: "\(error)")
             }
         }
         var lines: [String] = []

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -55,7 +55,22 @@ public enum WorkerComposition {
 
     public enum ConfigError: Error, Sendable {
         case invalidSiteName(String)
+        /// A route claim reached TOML generation without passing `WorkerRouteClaims` validation
+        /// (callers derive claims via `WorkerRouteClaims.activeClaims`, which validates; this is
+        /// the defense-in-depth backstop so an unvalidated path can never be interpolated into
+        /// the generated file).
+        case invalidRouteClaim(path: String, reason: String)
     }
+
+    /// The bespoke app-side inbox-capture route (#587) — not a `@dwk/workers` catalog worker, so
+    /// its claim lives here rather than in `catalog.json`. Appended automatically when
+    /// `generateWranglerToml` is called with `inboxCaptureEnabled`.
+    public static let inboxCaptureRouteClaim = WorkerRouteClaim(
+        path: "/inbox",
+        match: .exact,
+        methods: ["POST"],
+        handler: "inbox-capture"
+    )
 
     private static let validNameCharacters = CharacterSet(
         charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
@@ -79,18 +94,34 @@ public enum WorkerComposition {
     ///   - siteName: The Worker name (used as the Cloudflare Workers project name).
     ///     Must match `[A-Za-z0-9_-]+`.
     ///   - features: Which `@dwk/*` social endpoints to compose. Empty = static-only deploy.
+    ///   - routeClaims: The effective active dynamic-route claims (#746), already validated by
+    ///     `WorkerRouteClaims.activeClaims`. Emitted as selective `[assets].run_worker_first`
+    ///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
+    ///     longer shadow an active dynamic route, while every unclaimed path keeps Cloudflare's
+    ///     asset-first fallback. Omitted entirely when there are no active dynamic routes.
     /// - Returns: A complete wrangler.toml string.
     /// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
-    ///   characters outside `[A-Za-z0-9_-]`.
+    ///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``
+    ///   for a claim that never passed `WorkerRouteClaims` validation.
     public static func generateWranglerToml(
         siteName: String,
         features: [Feature],
+        routeClaims: [WorkerRouteClaim] = [],
         resources: ProvisionedResources = .init(),
         inboxCaptureEnabled: Bool = false,
         inboxKVNamespaceID: String? = nil
     ) throws -> String {
         guard isValidSiteName(siteName) else {
             throw ConfigError.invalidSiteName(siteName)
+        }
+        var effectiveClaims = routeClaims
+        if inboxCaptureEnabled {
+            effectiveClaims.append(inboxCaptureRouteClaim)
+        }
+        for claim in effectiveClaims {
+            if let problem = WorkerRouteClaims.pathProblem(claim.path) {
+                throw ConfigError.invalidRouteClaim(path: claim.path, reason: problem)
+            }
         }
         var lines: [String] = []
         lines.append("name = \"\(siteName)\"")
@@ -106,7 +137,11 @@ public enum WorkerComposition {
         lines.append("directory = \"dist\"")
         if hasSocialFeatures || inboxCaptureEnabled {
             lines.append("binding = \"ASSETS\"")
-            lines.append("run_worker_first = true")
+            let patterns = WorkerRouteClaims.runWorkerFirstPatterns(effectiveClaims)
+            if !patterns.isEmpty {
+                let list = patterns.map { "\"\($0)\"" }.joined(separator: ", ")
+                lines.append("run_worker_first = [\(list)]")
+            }
         }
 
         if features.contains(where: { $0.needsD1 }) {

--- a/Sources/AnglesiteCore/WorkerRouteClaims.swift
+++ b/Sources/AnglesiteCore/WorkerRouteClaims.swift
@@ -106,6 +106,13 @@ public enum WorkerRouteClaims {
         if Set(claim.methods).count != claim.methods.count {
             throw ValidationError.invalidMethods(owner: owner, path: claim.path, reason: "duplicate method")
         }
+        // The composed Worker serves HEAD by mirroring GET (never by handing handlers a raw
+        // HEAD request), so a HEAD claim with no paired GET is undeliverable.
+        if claim.methods.contains("HEAD") && !claim.methods.contains("GET") {
+            throw ValidationError.invalidMethods(
+                owner: owner, path: claim.path,
+                reason: "HEAD requires a paired GET (HEAD is served by mirroring GET)")
+        }
         if claim.match == .prefix && claim.specificationURL == nil {
             throw ValidationError.undeclaredPrefix(owner: owner, path: claim.path)
         }

--- a/Sources/AnglesiteCore/WorkerRouteClaims.swift
+++ b/Sources/AnglesiteCore/WorkerRouteClaims.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// Validates the generic HTTP route claims declared by `WorkerDescriptor.routes` and derives the
+/// effective active route set a deploy actually exposes (#746, #690 design §"Dynamic Worker
+/// routes"). Pure — no I/O, no actor isolation — mirroring `WorkerActivation`'s shape: callers
+/// gather the catalog and the #709 effective active id set first.
+///
+/// This type owns route *claim* validity and Worker-first route derivation only. Cross-owner
+/// `.well-known` collision enforcement (static vs generated vs dynamic vs runtime-owned) is
+/// #744's `WellKnownInventory`; it consumes `wellKnownClaims(_:)` below as its dynamic-route
+/// input rather than re-deriving activation or re-validating paths itself.
+public enum WorkerRouteClaims {
+    /// A validated claim attributed to the worker (catalog descriptor id) that declared it —
+    /// the attribution #744 needs to name both owners in a collision report.
+    public struct OwnedClaim: Sendable, Equatable, Hashable {
+        public let owner: String
+        public let claim: WorkerRouteClaim
+
+        public init(owner: String, claim: WorkerRouteClaim) {
+            self.owner = owner
+            self.claim = claim
+        }
+    }
+
+    public enum ValidationError: Error, Equatable, CustomStringConvertible {
+        case invalidPath(owner: String, path: String, reason: String)
+        case invalidMethods(owner: String, path: String, reason: String)
+        /// A `prefix` claim with no governing `specificationURL` — only a protocol specification
+        /// can approve child paths (RFC 8615), so an undeclared prefix claim is rejected.
+        case undeclaredPrefix(owner: String, path: String)
+        case duplicateClaim(path: String, owners: [String])
+        case overlappingClaims(path: String, owner: String, otherPath: String, otherOwner: String)
+
+        public var description: String {
+            switch self {
+            case .invalidPath(let owner, let path, let reason):
+                return "worker \"\(owner)\" claims invalid route path \"\(path)\": \(reason)"
+            case .invalidMethods(let owner, let path, let reason):
+                return "worker \"\(owner)\" route \"\(path)\" has invalid methods: \(reason)"
+            case .undeclaredPrefix(let owner, let path):
+                return "worker \"\(owner)\" claims prefix route \"\(path)\" without a governing specificationURL — only a specification-approved prefix may match child paths"
+            case .duplicateClaim(let path, let owners):
+                return "route \"\(path)\" is claimed more than once (by: \(owners.joined(separator: ", ")))"
+            case .overlappingClaims(let path, let owner, let otherPath, let otherOwner):
+                return "route \"\(path)\" (worker \"\(owner)\") overlaps \"\(otherPath)\" (worker \"\(otherOwner)\")"
+            }
+        }
+    }
+
+    /// HTTP methods a claim may declare. A closed set: anything else in a catalog is a manifest
+    /// error, not a forward-compatibility case — new methods need app-side dispatch support anyway.
+    static let allowedMethods: Set<String> = ["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+
+    private static let maxPathLength = 512
+
+    /// RFC 3986 `pchar` minus `pct-encoded`, plus `/`. Percent-encoding is rejected outright —
+    /// claimed protocol paths are literal registered names, and encoded separators (`%2F`,
+    /// `%2E`) are exactly the smuggling vector this exists to block.
+    private static let allowedPathScalars: Set<Unicode.Scalar> = {
+        var scalars = Set<Unicode.Scalar>()
+        for value in UInt8(ascii: "a")...UInt8(ascii: "z") { scalars.insert(Unicode.Scalar(value)) }
+        for value in UInt8(ascii: "A")...UInt8(ascii: "Z") { scalars.insert(Unicode.Scalar(value)) }
+        for value in UInt8(ascii: "0")...UInt8(ascii: "9") { scalars.insert(Unicode.Scalar(value)) }
+        for character in "-._~!$&'()*+,;=:@/" { scalars.formUnion(character.unicodeScalars) }
+        return scalars
+    }()
+
+    /// Returns why `path` is not a valid route-claim path, or `nil` if it is valid.
+    static func pathProblem(_ path: String) -> String? {
+        if path.isEmpty { return "empty path" }
+        if !path.hasPrefix("/") { return "path must be absolute (start with \"/\")" }
+        if path == "/" { return "the origin root cannot be claimed" }
+        if path.count > maxPathLength { return "path exceeds \(maxPathLength) characters" }
+        if path.contains("%") { return "percent-encoding is not allowed in route claims" }
+        if let bad = path.unicodeScalars.first(where: { !allowedPathScalars.contains($0) }) {
+            return "disallowed character \(String(reflecting: Character(bad)))"
+        }
+        // Leading "/" dropped; keep empty subsequences so "//" and a trailing "/" both surface
+        // as empty segments.
+        let segments = path.dropFirst().split(separator: "/", omittingEmptySubsequences: false)
+        if segments.contains(where: \.isEmpty) {
+            return "empty path segment (no doubled or trailing slashes)"
+        }
+        if segments.contains(where: { $0 == "." || $0 == ".." }) {
+            return "path traversal segment"
+        }
+        // RFC 8615: `/.well-known/` itself has no representation — the bare directory is never
+        // claimable, exactly or (which would swallow the whole namespace) as a prefix.
+        if path == "/.well-known" { return "the bare /.well-known directory cannot be claimed" }
+        return nil
+    }
+
+    /// Validates a single claim's path, methods, and prefix declaration.
+    static func validate(_ claim: WorkerRouteClaim, owner: String) throws {
+        if let problem = pathProblem(claim.path) {
+            throw ValidationError.invalidPath(owner: owner, path: claim.path, reason: problem)
+        }
+        if claim.methods.isEmpty {
+            throw ValidationError.invalidMethods(owner: owner, path: claim.path, reason: "no methods declared")
+        }
+        if let unknown = claim.methods.first(where: { !allowedMethods.contains($0) }) {
+            throw ValidationError.invalidMethods(
+                owner: owner, path: claim.path,
+                reason: "unknown or non-uppercase method \"\(unknown)\"")
+        }
+        if Set(claim.methods).count != claim.methods.count {
+            throw ValidationError.invalidMethods(owner: owner, path: claim.path, reason: "duplicate method")
+        }
+        if claim.match == .prefix && claim.specificationURL == nil {
+            throw ValidationError.undeclaredPrefix(owner: owner, path: claim.path)
+        }
+    }
+
+    /// The validated route claims of the effective active descriptor set — the only claims that
+    /// may reach `run_worker_first` or #744's inventory. Deterministic: sorted by path, then
+    /// owner. Throws the first validation or overlap error, naming every owner involved.
+    ///
+    /// Overlap semantics: an exact claim covers its path; a prefix claim covers its path *and*
+    /// all descendants. Any two active claims whose coverage intersects are rejected — there is
+    /// no delegation or precedence here (matching the #690 design's "no collision precedence"),
+    /// regardless of whether both claims come from the same worker.
+    public static func activeClaims(
+        catalog: [WorkerDescriptor],
+        activeIDs: Set<String>
+    ) throws -> [OwnedClaim] {
+        var owned: [OwnedClaim] = []
+        for descriptor in catalog.sorted(by: { $0.id < $1.id }) where activeIDs.contains(descriptor.id) {
+            for claim in descriptor.routes ?? [] {
+                try validate(claim, owner: descriptor.id)
+                owned.append(OwnedClaim(owner: descriptor.id, claim: claim))
+            }
+        }
+
+        var ownersByPath: [String: [String]] = [:]
+        for entry in owned {
+            ownersByPath[entry.claim.path, default: []].append(entry.owner)
+        }
+        if let (path, owners) = ownersByPath.sorted(by: { $0.key < $1.key }).first(where: { $0.value.count > 1 }) {
+            throw ValidationError.duplicateClaim(path: path, owners: owners.sorted())
+        }
+
+        let sorted = owned.sorted {
+            ($0.claim.path, $0.owner) < ($1.claim.path, $1.owner)
+        }
+        for (index, entry) in sorted.enumerated() {
+            guard entry.claim.match == .prefix else { continue }
+            let prefix = entry.claim.path + "/"
+            for other in sorted[(index + 1)...] where other.claim.path.hasPrefix(prefix) {
+                throw ValidationError.overlappingClaims(
+                    path: other.claim.path, owner: other.owner,
+                    otherPath: entry.claim.path, otherOwner: entry.owner)
+            }
+        }
+        return sorted
+    }
+
+    /// The active claims under `/.well-known/` — the dynamic-route input #744's
+    /// `WellKnownInventory` merges alongside user-static files, generators, and runtime
+    /// reservations. Ownership attribution is preserved for collision reporting.
+    public static func wellKnownClaims(_ claims: [OwnedClaim]) -> [OwnedClaim] {
+        claims.filter { $0.claim.path.hasPrefix("/.well-known/") }
+    }
+
+    /// Deterministic `[assets].run_worker_first` patterns for a set of route claims: exact
+    /// claims contribute their path, prefix claims their path plus a `path/*` glob (Cloudflare's
+    /// glob does not match the bare prefix path itself). Sorted and deduplicated so regenerated
+    /// Wrangler configuration diffs are stable.
+    public static func runWorkerFirstPatterns(_ claims: [WorkerRouteClaim]) -> [String] {
+        var patterns = Set<String>()
+        for claim in claims {
+            patterns.insert(claim.path)
+            if claim.match == .prefix {
+                patterns.insert(claim.path + "/*")
+            }
+        }
+        return patterns.sorted()
+    }
+}

--- a/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
@@ -99,4 +99,78 @@ struct WorkerCatalogReaderTests {
             _ = try WorkerCatalogReader.parse(json)
         }
     }
+
+    @Test("a catalog without route claims still parses (routes is nil)")
+    func parsesWithoutRoutes() throws {
+        let workers = try WorkerCatalogReader.parse(sampleJSON)
+        #expect(workers.allSatisfy { $0.routes == nil })
+    }
+
+    @Test("parses generic HTTP route claims, defaulting authorityBinding to false")
+    func parsesRouteClaims() throws {
+        let json = """
+        {
+          "workers": [
+            {
+              "id": "webfinger",
+              "displayName": "WebFinger",
+              "description": "RFC 7033 account discovery",
+              "group": "social",
+              "binding": { "kind": "settingsActivated" },
+              "resources": { "needsD1": false, "needsKV": false, "needsR2": false },
+              "routes": [
+                {
+                  "path": "/.well-known/webfinger",
+                  "match": "exact",
+                  "methods": ["GET", "HEAD"],
+                  "handler": "webfinger",
+                  "validatorID": "rfc7033",
+                  "authorityBinding": true,
+                  "specificationURL": "https://www.rfc-editor.org/rfc/rfc7033"
+                },
+                {
+                  "path": "/webmention",
+                  "match": "exact",
+                  "methods": ["POST"],
+                  "handler": "webmention"
+                }
+              ]
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let workers = try WorkerCatalogReader.parse(json)
+        let routes = try #require(workers.first?.routes)
+        #expect(routes.count == 2)
+
+        let webfinger = try #require(routes.first { $0.path == "/.well-known/webfinger" })
+        #expect(webfinger.match == .exact)
+        #expect(webfinger.methods == ["GET", "HEAD"])
+        #expect(webfinger.handler == "webfinger")
+        #expect(webfinger.validatorID == "rfc7033")
+        #expect(webfinger.authorityBinding)
+        #expect(webfinger.specificationURL == URL(string: "https://www.rfc-editor.org/rfc/rfc7033"))
+
+        let webmention = try #require(routes.first { $0.path == "/webmention" })
+        #expect(webmention.validatorID == nil)
+        #expect(!webmention.authorityBinding)
+        #expect(webmention.specificationURL == nil)
+    }
+
+    @Test("route claims round-trip through JSONEncoder/JSONDecoder")
+    func routeClaimRoundTrip() throws {
+        let claim = WorkerRouteClaim(
+            path: "/.well-known/acme-challenge",
+            match: .prefix,
+            methods: ["GET"],
+            handler: "acme",
+            validatorID: "rfc8555",
+            authorityBinding: true,
+            specificationURL: URL(string: "https://www.rfc-editor.org/rfc/rfc8555")
+        )
+        let decoded = try JSONDecoder().decode(
+            WorkerRouteClaim.self, from: JSONEncoder().encode(claim))
+        #expect(decoded == claim)
+    }
 }

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -173,6 +173,17 @@ struct WorkerCompositionTests {
         }
     }
 
+    @Test("composition runs full claim validation, not just path syntax")
+    func rejectsSemanticallyInvalidRouteClaim() {
+        // Valid path, invalid methods (HEAD without paired GET) — only full validation catches it.
+        let headOnly = WorkerRouteClaim(
+            path: "/status", match: .exact, methods: ["HEAD"], handler: "x")
+        #expect(throws: WorkerComposition.ConfigError.self) {
+            try WorkerComposition.generateWranglerToml(
+                siteName: "my-site", features: [.indieauth], routeClaims: [headOnly])
+        }
+    }
+
     @Test("ProvisionedResources round-trips through JSONEncoder/JSONDecoder")
     func provisionedResourcesCodable() throws {
         let resources = WorkerComposition.ProvisionedResources(

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -32,7 +32,9 @@ struct WorkerCompositionTests {
         #expect(toml.contains("[[kv_namespaces]]"))
         #expect(toml.contains("binding = \"SOCIAL_KV\""))
         #expect(toml.contains("binding = \"ASSETS\""))
-        #expect(toml.contains("run_worker_first = true"))
+        // No route claims → no run_worker_first at all (#746): unclaimed paths stay asset-first,
+        // and the worker still receives its endpoints via Cloudflare's asset-miss fallback.
+        #expect(!toml.contains("run_worker_first"))
         #expect(toml.contains("# Secrets required for IndieAuth (set with `wrangler secret put <NAME>`):"))
         #expect(toml.contains("# TOKEN_SIGNING_KEY, INDIEAUTH_OWNER_PASSWORD"))
         #expect(!toml.contains("[secrets]"))
@@ -117,6 +119,58 @@ struct WorkerCompositionTests {
         let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", features: [])
         #expect(!toml.contains("INBOX_KV"))
         #expect(!toml.contains("main ="))
+    }
+
+    @Test("route claims emit deterministic, sorted, deduplicated run_worker_first entries")
+    func selectiveRunWorkerFirst() throws {
+        let claims = [
+            WorkerRouteClaim(path: "/token", match: .exact, methods: ["POST"], handler: "indieauth"),
+            WorkerRouteClaim(path: "/authorize", match: .exact, methods: ["GET", "POST"], handler: "indieauth"),
+            WorkerRouteClaim(path: "/authorize", match: .exact, methods: ["GET", "POST"], handler: "indieauth"),
+            WorkerRouteClaim(
+                path: "/.well-known/acme-challenge", match: .prefix, methods: ["GET"], handler: "acme",
+                specificationURL: URL(string: "https://www.rfc-editor.org/rfc/rfc8555")),
+        ]
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", features: [.indieauth], routeClaims: claims)
+        #expect(toml.contains(
+            #"run_worker_first = ["/.well-known/acme-challenge", "/.well-known/acme-challenge/*", "/authorize", "/token"]"#
+        ))
+        // Regeneration is byte-stable regardless of claim order.
+        let regenerated = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", features: [.indieauth], routeClaims: claims.reversed())
+        #expect(toml == regenerated)
+    }
+
+    @Test("run_worker_first is omitted entirely when there are no active dynamic routes")
+    func omitsRunWorkerFirstWithoutClaims() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", features: [.webmention, .indieauth])
+        #expect(!toml.contains("run_worker_first"))
+        #expect(toml.contains("binding = \"ASSETS\""))
+    }
+
+    @Test("inbox capture claims /inbox as a worker-first route")
+    func inboxCaptureClaimsRoute() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", features: [], inboxCaptureEnabled: true)
+        #expect(toml.contains(#"run_worker_first = ["/inbox"]"#))
+    }
+
+    @Test("static-only sites emit no run_worker_first")
+    func staticOnlyOmitsRunWorkerFirst() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", features: [])
+        #expect(!toml.contains("run_worker_first"))
+    }
+
+    @Test("an unvalidated route claim path is refused, not interpolated into TOML")
+    func rejectsInvalidRouteClaim() {
+        let hostile = WorkerRouteClaim(
+            path: "/a\"]\ninjected = true", match: .exact, methods: ["GET"], handler: "x")
+        #expect(throws: WorkerComposition.ConfigError.self) {
+            try WorkerComposition.generateWranglerToml(
+                siteName: "my-site", features: [.indieauth], routeClaims: [hostile])
+        }
     }
 
     @Test("ProvisionedResources round-trips through JSONEncoder/JSONDecoder")

--- a/Tests/AnglesiteCoreTests/WorkerRouteClaimsTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerRouteClaimsTests.swift
@@ -1,0 +1,244 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WorkerRouteClaims")
+struct WorkerRouteClaimsTests {
+    private func descriptor(
+        id: String,
+        routes: [WorkerRouteClaim]?
+    ) -> WorkerDescriptor {
+        WorkerDescriptor(
+            id: id,
+            displayName: id,
+            description: "test worker",
+            group: "social",
+            binding: .settingsActivated,
+            resources: .init(needsD1: false, needsKV: false, needsR2: false),
+            routes: routes
+        )
+    }
+
+    private func claim(
+        _ path: String,
+        match: WorkerRouteClaim.Match = .exact,
+        methods: [String] = ["GET"],
+        specificationURL: URL? = nil
+    ) -> WorkerRouteClaim {
+        WorkerRouteClaim(
+            path: path, match: match, methods: methods, handler: "handler",
+            specificationURL: specificationURL)
+    }
+
+    private let spec = URL(string: "https://www.rfc-editor.org/rfc/rfc8555")!
+
+    // MARK: Path validation
+
+    @Test("accepts a well-formed exact claim")
+    func acceptsWellFormedClaim() throws {
+        let claims = try WorkerRouteClaims.activeClaims(
+            catalog: [descriptor(id: "w", routes: [claim("/.well-known/webfinger", methods: ["GET", "HEAD"])])],
+            activeIDs: ["w"])
+        #expect(claims.map(\.claim.path) == ["/.well-known/webfinger"])
+        #expect(claims.map(\.owner) == ["w"])
+    }
+
+    @Test("rejects malformed, traversal, and encoded paths", arguments: [
+        "",                          // empty
+        "webfinger",                 // relative
+        "/",                         // origin root
+        "/.well-known",              // bare directory
+        "/a//b",                     // empty segment
+        "/a/b/",                     // trailing slash
+        "/a/../b",                   // traversal
+        "/a/./b",                    // dot segment
+        "/a%2Fb",                    // encoded separator
+        "/%2E%2E/secrets",           // encoded traversal
+        "/a?x=1",                    // query
+        "/a#frag",                   // fragment
+        "/a b",                      // whitespace
+        "/a\\b",                     // backslash
+        "/a\"b",                     // quote (TOML injection)
+    ])
+    func rejectsBadPaths(path: String) {
+        #expect(throws: WorkerRouteClaims.ValidationError.self) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [descriptor(id: "w", routes: [claim(path)])],
+                activeIDs: ["w"])
+        }
+    }
+
+    @Test("rejects an over-long path")
+    func rejectsOverlongPath() {
+        let path = "/" + String(repeating: "a", count: 600)
+        #expect(throws: WorkerRouteClaims.ValidationError.self) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [descriptor(id: "w", routes: [claim(path)])],
+                activeIDs: ["w"])
+        }
+    }
+
+    // MARK: Method validation
+
+    @Test("rejects empty, unknown, lowercase, and duplicate method lists", arguments: [
+        [String](),
+        ["FETCH"],
+        ["get"],
+        ["GET", "GET"],
+    ])
+    func rejectsBadMethods(methods: [String]) {
+        #expect(throws: WorkerRouteClaims.ValidationError.self) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [descriptor(id: "w", routes: [claim("/a", methods: methods)])],
+                activeIDs: ["w"])
+        }
+    }
+
+    // MARK: Prefix claims
+
+    @Test("rejects a prefix claim with no governing specification (undeclared prefix)")
+    func rejectsUndeclaredPrefix() {
+        #expect(throws: WorkerRouteClaims.ValidationError.undeclaredPrefix(
+            owner: "w", path: "/.well-known/acme-challenge")
+        ) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [descriptor(id: "w", routes: [claim("/.well-known/acme-challenge", match: .prefix)])],
+                activeIDs: ["w"])
+        }
+    }
+
+    @Test("accepts a specification-approved prefix claim")
+    func acceptsSpecApprovedPrefix() throws {
+        let claims = try WorkerRouteClaims.activeClaims(
+            catalog: [descriptor(id: "w", routes: [
+                claim("/.well-known/acme-challenge", match: .prefix, specificationURL: spec)
+            ])],
+            activeIDs: ["w"])
+        #expect(claims.count == 1)
+    }
+
+    // MARK: Overlap rejection
+
+    @Test("rejects two exact claims for the same path, naming both owners")
+    func rejectsDuplicateExact() {
+        #expect(throws: WorkerRouteClaims.ValidationError.duplicateClaim(
+            path: "/.well-known/webfinger", owners: ["a", "b"])
+        ) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [
+                    descriptor(id: "b", routes: [claim("/.well-known/webfinger")]),
+                    descriptor(id: "a", routes: [claim("/.well-known/webfinger")]),
+                ],
+                activeIDs: ["a", "b"])
+        }
+    }
+
+    @Test("rejects an exact claim inside another worker's prefix claim")
+    func rejectsExactInsidePrefix() {
+        #expect(throws: WorkerRouteClaims.ValidationError.self) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [
+                    descriptor(id: "acme", routes: [
+                        claim("/.well-known/acme-challenge", match: .prefix, specificationURL: spec)
+                    ]),
+                    descriptor(id: "rogue", routes: [claim("/.well-known/acme-challenge/token")]),
+                ],
+                activeIDs: ["acme", "rogue"])
+        }
+    }
+
+    @Test("rejects overlapping prefix claims")
+    func rejectsOverlappingPrefixes() {
+        #expect(throws: WorkerRouteClaims.ValidationError.self) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [
+                    descriptor(id: "outer", routes: [claim("/api", match: .prefix, specificationURL: spec)]),
+                    descriptor(id: "inner", routes: [claim("/api/v1", match: .prefix, specificationURL: spec)]),
+                ],
+                activeIDs: ["outer", "inner"])
+        }
+    }
+
+    @Test("disjoint sibling claims from different workers coexist")
+    func acceptsDisjointClaims() throws {
+        let claims = try WorkerRouteClaims.activeClaims(
+            catalog: [
+                descriptor(id: "webfinger", routes: [claim("/.well-known/webfinger")]),
+                descriptor(id: "webmention", routes: [claim("/webmention", methods: ["POST"])]),
+            ],
+            activeIDs: ["webfinger", "webmention"])
+        #expect(claims.count == 2)
+    }
+
+    // MARK: Effective active-set filtering
+
+    @Test("only active workers' claims are exposed; a colliding inactive claim is invisible")
+    func filtersToActiveSet() throws {
+        let catalog = [
+            descriptor(id: "active", routes: [claim("/.well-known/webfinger")]),
+            // Same path — would be a duplicateClaim error if it were active.
+            descriptor(id: "inactive", routes: [claim("/.well-known/webfinger")]),
+        ]
+        let claims = try WorkerRouteClaims.activeClaims(catalog: catalog, activeIDs: ["active"])
+        #expect(claims.map(\.owner) == ["active"])
+    }
+
+    @Test("a descriptor without routes contributes nothing")
+    func noRoutesNoClaims() throws {
+        let claims = try WorkerRouteClaims.activeClaims(
+            catalog: [descriptor(id: "w", routes: nil)], activeIDs: ["w"])
+        #expect(claims.isEmpty)
+    }
+
+    @Test("output order is deterministic regardless of catalog order")
+    func deterministicOrder() throws {
+        let routesA = [claim("/zeta", methods: ["POST"])]
+        let routesB = [claim("/alpha")]
+        let forward = try WorkerRouteClaims.activeClaims(
+            catalog: [descriptor(id: "a", routes: routesA), descriptor(id: "b", routes: routesB)],
+            activeIDs: ["a", "b"])
+        let reversed = try WorkerRouteClaims.activeClaims(
+            catalog: [descriptor(id: "b", routes: routesB), descriptor(id: "a", routes: routesA)],
+            activeIDs: ["a", "b"])
+        #expect(forward == reversed)
+        #expect(forward.map(\.claim.path) == ["/alpha", "/zeta"])
+    }
+
+    // MARK: run_worker_first derivation
+
+    @Test("exact claims map to their path; prefix claims add a glob; sorted and deduplicated")
+    func runWorkerFirstPatterns() {
+        let patterns = WorkerRouteClaims.runWorkerFirstPatterns([
+            claim("/token", methods: ["POST"]),
+            claim("/authorize"),
+            claim("/authorize"),  // duplicate collapses
+            claim("/.well-known/acme-challenge", match: .prefix, specificationURL: spec),
+        ])
+        #expect(patterns == [
+            "/.well-known/acme-challenge",
+            "/.well-known/acme-challenge/*",
+            "/authorize",
+            "/token",
+        ])
+    }
+
+    @Test("no claims yields no patterns")
+    func emptyPatterns() {
+        #expect(WorkerRouteClaims.runWorkerFirstPatterns([]).isEmpty)
+    }
+
+    // MARK: #744 seam
+
+    @Test("wellKnownClaims filters to the /.well-known/ namespace, keeping ownership")
+    func wellKnownFilter() throws {
+        let claims = try WorkerRouteClaims.activeClaims(
+            catalog: [descriptor(id: "w", routes: [
+                claim("/.well-known/webfinger"),
+                claim("/webmention", methods: ["POST"]),
+            ])],
+            activeIDs: ["w"])
+        let wellKnown = WorkerRouteClaims.wellKnownClaims(claims)
+        #expect(wellKnown.map(\.claim.path) == ["/.well-known/webfinger"])
+        #expect(wellKnown.map(\.owner) == ["w"])
+    }
+}

--- a/Tests/AnglesiteCoreTests/WorkerRouteClaimsTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerRouteClaimsTests.swift
@@ -80,11 +80,13 @@ struct WorkerRouteClaimsTests {
 
     // MARK: Method validation
 
-    @Test("rejects empty, unknown, lowercase, and duplicate method lists", arguments: [
+    @Test("rejects empty, unknown, lowercase, duplicate, and unpaired-HEAD method lists", arguments: [
         [String](),
         ["FETCH"],
         ["get"],
         ["GET", "GET"],
+        ["HEAD"],           // HEAD is served by mirroring GET, so it requires a paired GET
+        ["HEAD", "POST"],
     ])
     func rejectsBadMethods(methods: [String]) {
         #expect(throws: WorkerRouteClaims.ValidationError.self) {

--- a/docs/specs/2026-06-29-c2-workers-integration-seam.md
+++ b/docs/specs/2026-06-29-c2-workers-integration-seam.md
@@ -13,15 +13,26 @@ Anglesite integrates `@dwk/workers` as its social/protocol backend by **composin
 
 ### Integration model
 
+> **Route correction (2026-07-19, #690/#746):** this document's original sketches routed
+> IndieAuth at `/.well-known/indieauth` and WebSub at `/.well-known/websub`. Neither path
+> exists in either protocol — IndieAuth discovers a `rel=indieauth-metadata` link (with server
+> metadata at RFC 8414's `/.well-known/oauth-authorization-server`), and WebSub advertises its
+> hub via `rel=hub`/`rel=self` links on each topic, not a well-known URI. The #690 design
+> ([2026-07-14-well-known-support-design.md](../superpowers/specs/2026-07-14-well-known-support-design.md))
+> rejects both routes, and #746 replaced ad-hoc prefix routing with catalog-declared route
+> claims. The sketches below are corrected in place; the integration-seam decision itself is
+> unchanged.
+
 ```
 ┌─────────────────────────────────────────────────┐
 │ Per-site Cloudflare Worker                       │
 │                                                  │
 │   worker.ts (entry point)                        │
-│     ├── @dwk/indieauth  → /.well-known/indieauth│
+│     ├── @dwk/indieauth  → /authorize, /token,    │
+│     │     /.well-known/oauth-authorization-server│
 │     ├── @dwk/webmention → /webmention            │
 │     ├── @dwk/micropub   → /micropub              │
-│     ├── @dwk/websub     → /.well-known/websub    │
+│     ├── @dwk/websub     → /websub (rel=hub link) │
 │     └── env.ASSETS      → /* (static fallback)   │
 │                                                  │
 │   Bindings:                                      │
@@ -31,7 +42,7 @@ Anglesite integrates `@dwk/workers` as its social/protocol backend by **composin
 └─────────────────────────────────────────────────┘
 ```
 
-Each `@dwk/*` package exports a `createXxx({ baseUrl, ... })` factory returning a `fetch`-compatible handler. The Worker entry point routes by path prefix, falling through to static assets for everything else.
+Each `@dwk/*` package exports a `createXxx({ baseUrl, ... })` factory returning a `fetch`-compatible handler. The Worker entry point routes from a declarative table of the routes each package's catalog entry claims (#746), falling through to static assets for everything else.
 
 ### Version pinning
 
@@ -125,9 +136,12 @@ const webmention = createWebmention({ baseUrl });
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
-    if (url.pathname.startsWith("/.well-known/indieauth"))
+    // Routes come from each package's catalog route claims (#746) — exact paths, not
+    // ad-hoc prefixes. See Resources/Template/worker/worker.ts's ROUTES table.
+    if (url.pathname === "/.well-known/oauth-authorization-server"
+      || url.pathname === "/authorize" || url.pathname === "/token")
       return indieauth.fetch(request, env, ctx);
-    if (url.pathname.startsWith("/webmention"))
+    if (url.pathname === "/webmention")
       return webmention.fetch(request, env, ctx);
     return env.ASSETS.fetch(request);
   }

--- a/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-17-blog-markdown-editor-publishing-design.md
@@ -244,7 +244,9 @@ errors.
 ### C.4 The CMS data path (per-site Worker, user's Cloudflare account)
 
 The server side is the pivot's per-site Worker (V-2.1, #353 — `@dwk/micropub` at
-`/micropub`, IndieAuth at `/.well-known/indieauth`, D1 + R2 bindings). Under the
+`/micropub`, IndieAuth at `/authorize` + `/token` with RFC 8414 metadata at
+`/.well-known/oauth-authorization-server` (there is no `/.well-known/indieauth` —
+#690/#746), D1 + R2 bindings). Under the
 Cloudflare-canonical model, a post's life is:
 
 1. **Accept (canonical):** the Micropub endpoint validates the IndieAuth token,


### PR DESCRIPTION
## Summary

- Implements #746: `WorkerDescriptor` gains optional **generic HTTP route claims** (`routes` in `catalog.json` — absolute path, `exact` vs specification-approved `prefix` match, allowed methods, handler identity, optional `validatorID`, `authorityBinding`, `specificationURL`). Catalogs published before the schema extension still decode (`routes` is optional); no well-known-only catalog is introduced.
- New `WorkerRouteClaims` (AnglesiteCore, pure/Linux-portable) validates claims — traversal (`..`/`.` segments), malformed characters, percent-encoded separators, empty segments, trailing slashes, root and bare `/.well-known` claims, bad method lists, prefix claims without a governing specification — and rejects every overlap class (exact/exact, exact-inside-prefix, prefix/prefix) **naming both owners**. Only claims from the **#709 effective active descriptor set** are ever exposed; `wellKnownClaims(_:)` is the attributed dynamic-route feed #744's `WellKnownInventory` will consume (no second collision system here).
- `WorkerComposition.generateWranglerToml` now emits **deterministic, sorted, deduplicated selective `[assets].run_worker_first` entries** for active dynamic routes (exact → path, prefix → path + `path/*` glob), replacing the previous blanket `run_worker_first = true`; the key is **omitted entirely** when no dynamic routes are active, so unrelated static paths stay asset-first. The bespoke `/inbox` capture route (#587) contributes its claim app-side when `inboxCaptureEnabled`. Unvalidated claim paths are refused at generation time (no TOML interpolation of unchecked strings). This one generator serves both today's production deploy path and #708's upcoming local `wrangler dev` runtime.
- Claims thread through `SocialWorkerProvisionCommand.provision` → `wrangler.toml`; `DeployModel.runDeploy` and the headless `SiteOperations` path **refuse the deploy before any Cloudflare call** when claims are invalid or colliding. `SiteOperations` resolves descriptors from the on-disk catalog cache (`WorkerCatalogFetcher.cachedCatalog()`) so a headless deploy can't silently regenerate `wrangler.toml` without the routes a GUI deploy wrote.
- Template worker (`worker/worker.ts`) gains a declarative `ROUTES` table (the handler-side mirror of the catalog claims) and a **generic dispatcher**: undeclared methods → `405` + `Allow`; `HEAD` mirrors `GET` status/headers with an empty body where declared; queries pass through untouched; unknown `/.well-known/` names, the bare directory, malformed percent-encodings, and case/trailing-slash/encoded variants return a **true plain-text 404** (never an HTML page); every other unmatched path keeps the asset-first fallback.
- Removes the invalid future `/.well-known/indieauth` and `/.well-known/websub` route guidance (rejected by the #690 design) from the C.2 integration-seam spec and the blog-publishing design.

### Dependency posture (per the #690 design's sequencing)

- **#709 (effective active set)** — landed; this PR consumes `WorkerActivation.effectiveActiveIDs` as specified.
- **#744 (inventory/collisions)** — not yet landed; this PR ships the exact seam it consumes (`WorkerRouteClaims.activeClaims` / `wellKnownClaims` with per-claim owner attribution) rather than duplicating inventory. The "static/dynamic collision rejected by #744 before Wrangler runs" acceptance completes when #744 lands on top of this.
- **#708 (local `wrangler dev` runtime)** — its runtime process isn't landed yet; the routing behavior tests run through `@cloudflare/vitest-pool-workers` (workerd — the same runtime `wrangler dev --local` uses), and the selective `run_worker_first` generation is in the single shared generator both config paths use.
- **Paired `@dwk/workers` catalog change** — the expected `catalog.json` `routes` schema is documented on `WorkerRouteClaim` in `WorkerCatalog.swift`. The app tolerates catalogs without route claims (they simply contribute no `run_worker_first` entries), so this PR can land first; shadow-protection for the IndieAuth endpoints activates once the catalog publishes their claims.

### Behavior note

Replacing blanket `run_worker_first = true` with selective entries means a request now reaches the Worker either via a claimed worker-first route or via Cloudflare's asset-miss fallback. The current dynamic endpoints have no static-asset counterparts, so serving is unchanged — static pages just stop paying a Worker invocation on every request.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`. (Template changes are app-only; no MCP sidecar/schema changes.)
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

> Cross-repo note: the coordinated change here is in the **`@dwk/workers`** monorepo (`catalog.json` gains optional `routes`), not the MCP sidecar. This PR is forward-compatible with catalogs that don't declare routes yet.

## Test plan

- [x] `Resources/Template`: `npm run test:worker` — **30/30** passing in the workerd pool (7 new routing tests: 405+Allow, HEAD-mirrors-GET, query preservation, true-404 matrix for bare directory/unknown names/case/trailing-slash/encoded variants/malformed encodings, asset-first fallback for unrelated paths).
- [x] `Resources/Template`: `npx tsx --test scripts/pre-deploy-check.test.ts` (33/33) and `scripts/edge-artifacts.test.ts` (19/19) — template untouched elsewhere but re-verified.
- [x] `npx tsc -p tsconfig.json --noEmit`: no diagnostics in `worker/` (pre-existing `src/` errors are Astro generated-type artifacts requiring `astro sync`, unrelated).
- [ ] `swift test --package-path .` — **could not run in this environment (no Swift toolchain in the remote container); CI is the arbiter.** New/updated suites: `WorkerRouteClaimsTests` (validation, overlap, active-set filtering, determinism, pattern derivation, #744 seam), `WorkerCatalogTests` (route-claim parsing incl. no-routes backward compat), `WorkerCompositionTests` (selective/omitted `run_worker_first`, inbox claim, TOML-injection refusal, byte-stable regeneration).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not runnable here (Linux container); CI covers the Linux portable targets, macOS `swift test`, and project-sync checks.
- [ ] Manual smoke: not UI-touching (no new UI strings; deploy-failure reasons use the existing plain-`reason` path).

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYgDAeunQFmaiqX5cAa3LX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYgDAeunQFmaiqX5cAa3LX)_