### PR TITLE
fix(#785): reap the VM stranded inside a failed LinuxContainer.create() (containerization#804 workaround)

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -317,7 +317,10 @@ public struct ContainerizationControl: LocalContainerControl {
         // 2. Boot the container: Apple-Silicon VZ-backed VM, NAT outbound, auto vsock device.
         do {
             let kernel = Kernel(path: kernelURL, platform: .linuxArm)
-            let vmm = VZVirtualMachineManager(kernel: kernel, initialFilesystem: initfs)
+            // Wrapped so a failure inside `container.create()` can reap the VM upstream strands
+            // there (apple/containerization#804) — see `OrphanReapingVirtualMachineManager`.
+            let vmm = OrphanReapingVirtualMachineManager(
+                wrapping: VZVirtualMachineManager(kernel: kernel, initialFilesystem: initfs))
 
             // Let vmnet choose an available shared-mode subnet. Hard-coding 192.168.64.0/24
             // works only while this is the first vmnet consumer on the host: Apple's container
@@ -391,7 +394,13 @@ public struct ContainerizationControl: LocalContainerControl {
                     onOutput(
                         "[boot] VM finished booting after its \(Self.vmBootTimeout) timeout already failed "
                         + "this request; stopping it now to avoid an orphaned VM", .stderr)
-                    Task { await self.stopBareContainer(lateContainer, siteID: siteID) }
+                    Task {
+                        await self.stopBareContainer(lateContainer, siteID: siteID)
+                        // If `container.stop()` failed inside (it's best-effort `try?`), the VM is
+                        // still `.running` and the reap catches it; otherwise the reap sees
+                        // `.stopped` and does nothing.
+                        await vmm.reapStranded(onOutput: onOutput)
+                    }
                 }
             ) {
                 do {
@@ -407,6 +416,11 @@ public struct ContainerizationControl: LocalContainerControl {
                     // VM in `.created` state, and only an explicit `stop()` releases it instead of
                     // leaking it until the app quits.
                     await stopBareContainer(container, siteID: siteID)
+                    // And when `create()` itself threw at its internal `vm.start()`, the container
+                    // never reached `.created`, so the `container.stop()` above can't touch the VM
+                    // — that's the upstream gap (apple/containerization#804). The wrapper holds the
+                    // only other reference to it; stop it through that.
+                    await vmm.reapStranded(onOutput: onOutput)
                     throw error
                 }
             }

--- a/Sources/AnglesiteContainer/OrphanReapingVirtualMachineManager.swift
+++ b/Sources/AnglesiteContainer/OrphanReapingVirtualMachineManager.swift
@@ -1,0 +1,84 @@
+import Foundation
+import AnglesiteCore
+import Containerization
+
+/// Retains a reference to every VM instance the wrapped `VirtualMachineManager` creates, so a
+/// failed boot can stop a VM that upstream stranded.
+///
+/// This is the app-side patch for apple/containerization#804 (present in the pinned 0.35 line):
+/// inside `LinuxContainer.create()`, `try await vm.start()` runs *outside* the `do/catch` whose
+/// failure path calls `vm.stop()` (`LinuxContainer.swift:587-591` at 0.35.0), so a start-time
+/// throw strands the freshly created `VZVirtualMachineInstance` as a local variable nothing can
+/// reach. The stranded VM's `com.apple.Virtualization.VirtualMachine.xpc` helper keeps running —
+/// holding the VM's vmnet interface and its 2 vCPU / 2 GB — until someone kills it by PID (#785).
+/// `LinuxContainer.stop()` can never release it either: the `create()` throw means the container
+/// never reached `.created`, so `stop()` bails on its state check before touching the VM.
+///
+/// What's recoverable is the class where the underlying VZ VM did start and `vm.start()` threw
+/// afterwards (the vminitd agent handshake — `waitForAgent` / `Vminitd` init — the same class as
+/// #498's hang-then-late-failure boots): the VM reports `.running`, and `stop()` works. A VM whose
+/// VZ-level start itself failed reports `.stopped` and holds nothing the Containerization API can
+/// release (`VZVirtualMachineInstance.stop()` deliberately throws unless `.running`). That is also
+/// why forking upstream to move `vm.start()` inside its `do/catch` — the fix proposed in
+/// containerization#804 — would recover no more than this wrapper: that patch is the same
+/// `try? await vm.stop()` against the same state guard, and the public `VirtualMachineManager`
+/// seam already lets the app hold the reference upstream drops, without carrying a fork.
+///
+/// Scoped per boot attempt: `makeBareContainer` wraps a fresh `VZVirtualMachineManager` per call
+/// and `LinuxContainer.create()` calls `vmm.create` exactly once, so at most one instance is ever
+/// recorded. `reapStranded` runs only on the failure paths that call `stopBareContainer`, and
+/// always after it — a VM the container *could* stop is `.stopped` by then and skipped; only a
+/// genuinely stranded one is still `.running`.
+final class OrphanReapingVirtualMachineManager: VirtualMachineManager, @unchecked Sendable {
+    private let wrapped: any VirtualMachineManager
+    private let lock = NSLock()
+    private var created: [any VirtualMachineInstance] = []
+
+    init(wrapping wrapped: any VirtualMachineManager) {
+        self.wrapped = wrapped
+    }
+
+    func create(config: some VMCreationConfig) async throws -> any VirtualMachineInstance {
+        let vm = try await wrapped.create(config: config)
+        lock.withLock { created.append(vm) }
+        return vm
+    }
+
+    /// Best-effort stop of every recorded VM the failed boot left `.running`. One-shot: reaped
+    /// instances are dropped from the record, and `.stopped`/`.stopping` ones are skipped silently
+    /// (the normal shape — `stopBareContainer` got there first, or VZ-level start never happened
+    /// and there is nothing to release). Anything else is logged rather than silently leaked
+    /// ("logs are sacred"), including the manual-recovery hint from #785.
+    func reapStranded(onOutput: @Sendable (String, LogCenter.Stream) -> Void) async {
+        let instances = lock.withLock {
+            let snapshot = created
+            created.removeAll()
+            return snapshot
+        }
+        for vm in instances {
+            switch vm.state {
+            case .stopped, .stopping:
+                continue
+            case .running:
+                do {
+                    try await vm.stop()
+                    onOutput(
+                        "[boot] stopped a VM stranded by the failed boot (apple/containerization#804)",
+                        .stderr)
+                } catch {
+                    onOutput(
+                        "[boot] could not stop the VM stranded by the failed boot: \(error) — if "
+                            + "boots keep failing, check for a leftover "
+                            + "com.apple.Virtualization.VirtualMachine.xpc process (#785)",
+                        .stderr)
+                }
+            case .starting, .unknown:
+                onOutput(
+                    "[boot] a VM stranded by the failed boot is in state \(vm.state), which the "
+                        + "Containerization API cannot stop; if boots keep failing, check for a "
+                        + "leftover com.apple.Virtualization.VirtualMachine.xpc process (#785)",
+                    .stderr)
+            }
+        }
+    }
+}

--- a/Tests/AnglesiteContainerLocalTests/OrphanReapingVirtualMachineManagerTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/OrphanReapingVirtualMachineManagerTests.swift
@@ -1,0 +1,162 @@
+import Containerization
+import Foundation
+import Testing
+@testable import AnglesiteContainer
+import AnglesiteCore
+
+/// Unit tests for the apple/containerization#804 workaround. Pure fakes — no Virtualization
+/// framework, no entitlement — so they need only this target's normal `ANGLESITE_CONTAINER_TESTS`
+/// build gate, not `ANGLESITE_CONTAINER_E2E` (same story as `RacingTimeoutTests`).
+struct OrphanReapingVirtualMachineManagerTests {
+    private func makeConfig() -> StandardVMConfig {
+        StandardVMConfig(configuration: VMConfiguration())
+    }
+
+    @Test("a created VM left .running by a failed boot is stopped by the reap")
+    func reapsRunningVM() async throws {
+        let vm = FakeVM(state: .running)
+        let manager = OrphanReapingVirtualMachineManager(wrapping: FakeVMM(vm: vm))
+        _ = try await manager.create(config: makeConfig())
+
+        let log = LogRecorder()
+        await manager.reapStranded { line, stream in log.record(line, stream) }
+
+        #expect(vm.stopCallCount == 1)
+        #expect(vm.state == .stopped)
+        #expect(log.lines.contains { $0.contains("apple/containerization#804") })
+    }
+
+    @Test("an already-stopped VM is skipped silently")
+    func skipsStoppedVM() async throws {
+        let vm = FakeVM(state: .stopped)
+        let manager = OrphanReapingVirtualMachineManager(wrapping: FakeVMM(vm: vm))
+        _ = try await manager.create(config: makeConfig())
+
+        let log = LogRecorder()
+        await manager.reapStranded { line, stream in log.record(line, stream) }
+
+        #expect(vm.stopCallCount == 0)
+        #expect(log.lines.isEmpty)
+    }
+
+    @Test("a stop failure is surfaced in the log with the manual-recovery hint, not swallowed")
+    func logsStopFailure() async throws {
+        let vm = FakeVM(state: .running, stopError: FakeVMError.stopRefused)
+        let manager = OrphanReapingVirtualMachineManager(wrapping: FakeVMM(vm: vm))
+        _ = try await manager.create(config: makeConfig())
+
+        let log = LogRecorder()
+        await manager.reapStranded { line, stream in log.record(line, stream) }
+
+        #expect(vm.stopCallCount == 1)
+        #expect(log.lines.contains { $0.contains("could not stop") })
+        #expect(log.lines.contains { $0.contains("com.apple.Virtualization.VirtualMachine.xpc") })
+    }
+
+    @Test("a VM in a state the API cannot stop is logged rather than silently leaked")
+    func logsUnstoppableState() async throws {
+        let vm = FakeVM(state: .unknown)
+        let manager = OrphanReapingVirtualMachineManager(wrapping: FakeVMM(vm: vm))
+        _ = try await manager.create(config: makeConfig())
+
+        let log = LogRecorder()
+        await manager.reapStranded { line, stream in log.record(line, stream) }
+
+        #expect(vm.stopCallCount == 0)
+        #expect(log.lines.contains { $0.contains("cannot stop") })
+    }
+
+    @Test("the reap is one-shot: a second call finds nothing to stop")
+    func reapIsOneShot() async throws {
+        let vm = FakeVM(state: .running)
+        let manager = OrphanReapingVirtualMachineManager(wrapping: FakeVMM(vm: vm))
+        _ = try await manager.create(config: makeConfig())
+
+        let log = LogRecorder()
+        await manager.reapStranded { line, stream in log.record(line, stream) }
+        await manager.reapStranded { line, stream in log.record(line, stream) }
+
+        #expect(vm.stopCallCount == 1)
+        #expect(log.lines.count == 1)
+    }
+
+    @Test("a create failure records nothing, so the reap has nothing to do")
+    func createFailureRecordsNothing() async throws {
+        let manager = OrphanReapingVirtualMachineManager(wrapping: ThrowingVMM())
+
+        await #expect(throws: FakeVMError.self) {
+            _ = try await manager.create(config: self.makeConfig())
+        }
+
+        let log = LogRecorder()
+        await manager.reapStranded { line, stream in log.record(line, stream) }
+        #expect(log.lines.isEmpty)
+    }
+}
+
+private struct FakeVMM: VirtualMachineManager {
+    let vm: FakeVM
+
+    func create(config: some VMCreationConfig) async throws -> any VirtualMachineInstance {
+        vm
+    }
+}
+
+private struct ThrowingVMM: VirtualMachineManager {
+    func create(config: some VMCreationConfig) async throws -> any VirtualMachineInstance {
+        throw FakeVMError.creationFailed
+    }
+}
+
+/// Minimal `VirtualMachineInstance` whose state and stop behavior the test controls. The dial/
+/// listen members are never reached by the wrapper; they throw `unsupported` to satisfy the
+/// protocol. Mirrors the codebase's NSLock + `@unchecked Sendable` fake idiom
+/// (`FakeNetworkRecorder`, `LineStreamingWriter`).
+private final class FakeVM: VirtualMachineInstance, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _state: VirtualMachineInstanceState
+    private let stopError: Error?
+    private var _stopCalls = 0
+
+    init(state: VirtualMachineInstanceState, stopError: Error? = nil) {
+        self._state = state
+        self.stopError = stopError
+    }
+
+    var stopCallCount: Int { lock.withLock { _stopCalls } }
+
+    var state: VirtualMachineInstanceState { lock.withLock { _state } }
+    var mounts: [String: [AttachedFilesystem]] { [:] }
+
+    func dialAgent() async throws -> Vminitd { throw FakeVMError.unsupported }
+    func dial(_ port: UInt32) async throws -> FileHandle { throw FakeVMError.unsupported }
+    func listen(_ port: UInt32) throws -> VsockListener { throw FakeVMError.unsupported }
+
+    func start() async throws {
+        lock.withLock { _state = .running }
+    }
+
+    func stop() async throws {
+        lock.withLock { _stopCalls += 1 }
+        if let stopError { throw stopError }
+        lock.withLock { _state = .stopped }
+    }
+}
+
+private enum FakeVMError: Error {
+    case unsupported
+    case stopRefused
+    case creationFailed
+}
+
+/// Collects `reapStranded`'s `onOutput` lines for assertions. Same locking idiom as `FakeVM`.
+private final class LogRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _lines: [String] = []
+
+    var lines: [String] { lock.withLock { _lines } }
+
+    func record(_ line: String, _ stream: LogCenter.Stream) {
+        lock.withLock { _lines.append(line) }
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the remaining #785 gap that was root-caused to [apple/containerization#804](https://github.com/apple/containerization/issues/804) (still unfixed upstream on `main` as of today): `LinuxContainer.create()`'s internal `vm.start()` runs outside the `do/catch` that stops the VM on failure, so a start-time throw strands the `VZVirtualMachineInstance` as an unreachable local — its `com.apple.Virtualization.VirtualMachine.xpc` helper keeps holding the vmnet interface and 2 vCPU/2 GB until killed by PID.
- Rather than forking upstream, this exploits the public `VirtualMachineManager` seam the app already supplies: a per-boot `OrphanReapingVirtualMachineManager` records the instance `vmm.create()` returns, and the existing boot-failure paths (the create/start `catch` and the timeout-then-late-success handler) now reap any recorded VM still `.running` after `stopBareContainer` has done what it can. Reap outcomes are logged to the debug pane, including the manual-recovery hint for states the API can't stop.
- A fork was evaluated and deliberately not taken: `VZVirtualMachineInstance.stop()` throws unless the VM is `.running`, so the patch proposed in containerization#804 (`try? await vm.stop()` inside the catch) recovers exactly the same class of leak this wrapper does — the `.running` VMs left by post-VZ-start failures (agent handshake / `waitForAgent`, the #498 hang-then-late-failure class) — while a fork would add permanent rebase burden against a fast-moving upstream. VMs whose VZ-level start itself failed hold nothing the public API can release, fork or no fork.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [ ] `swift test --package-path .`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] `ANGLESITE_CONTAINER_TESTS=1 swift test --filter OrphanReapingVirtualMachineManagerTests` — new unit tests over pure protocol fakes (no Virtualization framework/entitlement needed, so no `ANGLESITE_CONTAINER_E2E` gate, same as `RacingTimeoutTests`)
- [ ] Manual smoke: with a boot forced to fail after VZ start (e.g. the #498 timeout-then-late-failure shape), verify `ps aux | grep Virtualization` shows no lingering `com.apple.Virtualization.VirtualMachine.xpc` after the failure, and the debug pane logs the reap line

> ⚠️ **Not compiled anywhere yet**: this session's Linux container has no Swift toolchain, and CI never builds `AnglesiteContainer` (excluded from all lanes by design). The new code was written against the vendored apple/containerization 0.35.0 sources, but the checklist above needs a run on an Apple-Silicon dev machine before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014C94cxmdzqcwmQBCRv71Rd

---
_Generated by [Claude Code](https://claude.ai/code/session_014C94cxmdzqcwmQBCRv71Rd)_