### PR TITLE
refactor(workers): migrate WorkerComposition to WorkerDescriptor (#708)

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -448,16 +448,11 @@ final class DeployModel {
             )
         }
         let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
-        if catalog.isEmpty && !effectiveActiveIDs.isEmpty {
-            // Mirrors SiteOperations.deployWithWorkerComposition's identical warning: with no
-            // catalog data to resolve an active id's resource needs against, this deploy composes
-            // a static-only wrangler.toml — active workers ship with no D1/KV/R2 bindings and no
-            // route claims. Must be visible in the debug pane, not silent (#708).
-            await logCenter.append(
-                source: "deploy:\(siteID)",
-                stream: .stderr,
-                text: "no worker catalog available — deploying active workers (\(effectiveActiveIDs.sorted().joined(separator: ", "))) with no resource bindings or route claims; wrangler.toml will be static-only until a catalog fetch succeeds"
-            )
+        let unresolvedIDs = WorkerActivation.unresolvedActiveIDs(activeIDs: effectiveActiveIDs, resolved: workers)
+        if let warning = WorkerActivation.missingDescriptorWarning(unresolvedIDs: unresolvedIDs) {
+            // Mirrors SiteOperations.deployWithWorkerComposition's identical warning — shared
+            // text via WorkerActivation so the two paths can't drift (#708 review feedback).
+            await logCenter.append(source: "deploy:\(siteID)", stream: .stderr, text: warning)
         }
 
         // Dynamic-route claims of the effective active set (#746). Validation failures (a

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -448,6 +448,17 @@ final class DeployModel {
             )
         }
         let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
+        if catalog.isEmpty && !effectiveActiveIDs.isEmpty {
+            // Mirrors SiteOperations.deployWithWorkerComposition's identical warning: with no
+            // catalog data to resolve an active id's resource needs against, this deploy composes
+            // a static-only wrangler.toml — active workers ship with no D1/KV/R2 bindings and no
+            // route claims. Must be visible in the debug pane, not silent (#708).
+            await logCenter.append(
+                source: "deploy:\(siteID)",
+                stream: .stderr,
+                text: "no worker catalog available — deploying active workers (\(effectiveActiveIDs.sorted().joined(separator: ", "))) with no resource bindings or route claims; wrangler.toml will be static-only until a catalog fetch succeeds"
+            )
+        }
 
         // Dynamic-route claims of the effective active set (#746). Validation failures (a
         // malformed path, two active workers claiming overlapping routes) refuse the deploy

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -447,7 +447,7 @@ final class DeployModel {
                 text: "Deactivating workers: \(removedIDs.sorted().joined(separator: ", "))"
             )
         }
-        let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
+        let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
 
         // Dynamic-route claims of the effective active set (#746). Validation failures (a
         // malformed path, two active workers claiming overlapping routes) refuse the deploy
@@ -503,7 +503,7 @@ final class DeployModel {
             siteID: siteID,
             siteDirectory: siteDirectory,
             siteName: workerSiteName,
-            features: features,
+            workers: workers,
             routeClaims: routeClaims.map(\.claim),
             knownResources: settings.provisionedWorkerResources ?? .init()
         )

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -171,7 +171,7 @@ public struct SiteOperations: Sendable {
             group: "social", binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false)
         ),
         WorkerDescriptor(
-            id: "indieauth", displayName: "IndieAuth", description: "IndieAuth sign-in",
+            id: WorkerComposition.indieauthWorkerID, displayName: "IndieAuth", description: "IndieAuth sign-in",
             group: "social", binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false)
         ),
     ]

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -16,6 +16,11 @@ public struct SiteOperations: Sendable {
     private let factory: CommandFactory
     private let store: SiteStore
     private let socialWorkerAccess: SocialWorkerAccess
+    /// The on-disk cached `@dwk/workers` catalog, consulted by the headless deploy path for
+    /// resource composition and route claims (#708/#746). Injectable so tests can supply fixture
+    /// descriptors instead of touching the real `~/Library/Application Support/Anglesite/`
+    /// cache file `WorkerCatalogFetcher.cachedCatalog` reads from.
+    private let cachedWorkerCatalog: @Sendable () -> [WorkerDescriptor]
 
     public init(factory: CommandFactory = LiveCommandFactory(), store: SiteStore = .shared) {
         self.init(
@@ -27,10 +32,16 @@ public struct SiteOperations: Sendable {
         )
     }
 
-    init(factory: CommandFactory, store: SiteStore, socialWorkerAccess: @escaping SocialWorkerAccess) {
+    init(
+        factory: CommandFactory,
+        store: SiteStore,
+        socialWorkerAccess: @escaping SocialWorkerAccess,
+        cachedWorkerCatalog: @escaping @Sendable () -> [WorkerDescriptor] = { WorkerCatalogFetcher.cachedCatalog() }
+    ) {
         self.factory = factory
         self.store = store
         self.socialWorkerAccess = socialWorkerAccess
+        self.cachedWorkerCatalog = cachedWorkerCatalog
     }
 
     /// Resolve a site id (as carried by `SiteEntity`) to the registry's `Site`.
@@ -78,7 +89,7 @@ public struct SiteOperations: Sendable {
         // data, which the `catalog: []` activation call above deliberately doesn't have (matching
         // the effectiveActiveIDs "settings-activated only" comment above). The on-disk cache from
         // a previous GUI fetch is the only source of that data on this headless path.
-        let cachedCatalog = WorkerCatalogFetcher.cachedCatalog()
+        let cachedCatalog = cachedWorkerCatalog()
         let workers = WorkerActivation.activeDescriptors(catalog: cachedCatalog, activeIDs: effectiveActiveIDs)
         if cachedCatalog.isEmpty && !effectiveActiveIDs.isEmpty {
             // The gap this leaves (an active worker deploys with no D1/KV/R2 bindings and no
@@ -152,13 +163,31 @@ public struct SiteOperations: Sendable {
         }
     }
 
+    /// The fixed V-2 starter pack (webmention + indieauth) this one-button "turn on social
+    /// basics" operation provisions. Unlike `deployWithWorkerComposition`, this isn't driven by
+    /// a site's catalog/effective-active-worker set — it's always the same two workers, matching
+    /// `WorkerComposition.Feature.v2`'s pre-migration default. Fixed literals, not fetched from
+    /// the `@dwk/workers` catalog, since this operation predates catalog-driven composition and
+    /// has no site-settings or catalog input to derive from.
+    private static let v2StarterWorkers: [WorkerDescriptor] = [
+        WorkerDescriptor(
+            id: "webmention", displayName: "Webmentions", description: "Outbound webmention sending",
+            group: "social", binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false)
+        ),
+        WorkerDescriptor(
+            id: "indieauth", displayName: "IndieAuth", description: "IndieAuth sign-in",
+            group: "social", binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false)
+        ),
+    ]
+
     public func provisionSocialWorker(site: SiteStore.Site) async -> SocialWorkerProvisionCommand.Result {
         do {
             return try await socialWorkerAccess(site, store) { url in
                 await factory.socialWorkerProvision().provision(
                     siteID: site.id,
                     siteDirectory: url,
-                    siteName: SiteSlug.derive(from: site.name)
+                    siteName: SiteSlug.derive(from: site.name),
+                    workers: Self.v2StarterWorkers
                 )
             }
         } catch let SiteAccess.AccessError.noGrant(message) {

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -73,21 +73,21 @@ public struct SiteOperations: Sendable {
         let configStore = SiteConfigStore(configDirectory: site.configDirectory)
         let settings = (try? await configStore.load()) ?? SiteSettings()
         let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
-        let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
 
-        // Dynamic-route claims (#746): this path has no catalog fetcher wired (matching the
-        // `catalog: []` activation choice above), but the on-disk cache from a previous GUI fetch
-        // still lets active workers keep their `run_worker_first` routes — otherwise a headless
-        // deploy would silently regenerate wrangler.toml without them. Validation failures refuse
-        // the deploy before any Cloudflare call, mirroring `DeployModel.runDeploy`.
+        // Dynamic-route claims (#746) and resource composition (#708) both need real descriptor
+        // data, which the `catalog: []` activation call above deliberately doesn't have (matching
+        // the effectiveActiveIDs "settings-activated only" comment above). The on-disk cache from
+        // a previous GUI fetch is the only source of that data on this headless path.
         let cachedCatalog = WorkerCatalogFetcher.cachedCatalog()
+        let workers = WorkerActivation.activeDescriptors(catalog: cachedCatalog, activeIDs: effectiveActiveIDs)
         if cachedCatalog.isEmpty && !effectiveActiveIDs.isEmpty {
-            // The shadowing-protection gap this leaves (an active worker's routes deploy without
-            // their run_worker_first entries) must be visible in the debug pane, not silent.
+            // The gap this leaves (an active worker deploys with no D1/KV/R2 bindings and no
+            // run_worker_first entries — there's no catalog data to resolve its active id against)
+            // must be visible in the debug pane, not silent.
             await LogCenter.shared.append(
                 source: "deploy:\(site.id)",
                 stream: .stderr,
-                text: "no cached worker catalog — deploying active workers (\(effectiveActiveIDs.sorted().joined(separator: ", "))) without route claims; run_worker_first will be omitted until a catalog fetch succeeds"
+                text: "no cached worker catalog — deploying active workers (\(effectiveActiveIDs.sorted().joined(separator: ", "))) with no resource bindings or route claims; wrangler.toml will be static-only until a catalog fetch succeeds"
             )
         }
         let routeClaims: [WorkerRouteClaims.OwnedClaim]
@@ -112,7 +112,7 @@ public struct SiteOperations: Sendable {
             siteID: site.id,
             siteDirectory: siteDirectory,
             siteName: workerSiteName,
-            features: features,
+            workers: workers,
             routeClaims: routeClaims.map(\.claim),
             knownResources: settings.provisionedWorkerResources ?? .init()
         )

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -91,15 +91,11 @@ public struct SiteOperations: Sendable {
         // a previous GUI fetch is the only source of that data on this headless path.
         let cachedCatalog = cachedWorkerCatalog()
         let workers = WorkerActivation.activeDescriptors(catalog: cachedCatalog, activeIDs: effectiveActiveIDs)
-        if cachedCatalog.isEmpty && !effectiveActiveIDs.isEmpty {
-            // The gap this leaves (an active worker deploys with no D1/KV/R2 bindings and no
-            // run_worker_first entries — there's no catalog data to resolve its active id against)
-            // must be visible in the debug pane, not silent.
-            await LogCenter.shared.append(
-                source: "deploy:\(site.id)",
-                stream: .stderr,
-                text: "no cached worker catalog — deploying active workers (\(effectiveActiveIDs.sorted().joined(separator: ", "))) with no resource bindings or route claims; wrangler.toml will be static-only until a catalog fetch succeeds"
-            )
+        let unresolvedIDs = WorkerActivation.unresolvedActiveIDs(activeIDs: effectiveActiveIDs, resolved: workers)
+        if let warning = WorkerActivation.missingDescriptorWarning(unresolvedIDs: unresolvedIDs) {
+            // Mirrors DeployModel.runDeploy's identical warning — shared text via
+            // WorkerActivation so the two paths can't drift (#708 review feedback).
+            await LogCenter.shared.append(source: "deploy:\(site.id)", stream: .stderr, text: warning)
         }
         let routeClaims: [WorkerRouteClaims.OwnedClaim]
         do {

--- a/Sources/AnglesiteCore/SiteScaffolder.swift
+++ b/Sources/AnglesiteCore/SiteScaffolder.swift
@@ -183,7 +183,7 @@ public actor SiteScaffolder {
     /// `npx wrangler deploy` with no manual setup. `SocialWorkerProvisionCommand` overwrites this
     /// with a features-enabled config if the owner opts into social features later.
     private func writeWranglerConfig(siteName: String, siteDir: URL) throws {
-        let toml = try WorkerComposition.generateWranglerToml(siteName: siteName, features: [])
+        let toml = try WorkerComposition.generateWranglerToml(siteName: siteName, workers: [])
         try toml.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
     }
 

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -51,7 +51,7 @@ public actor SocialWorkerProvisionCommand {
         siteID: String,
         siteDirectory: URL,
         siteName: String,
-        features: [WorkerComposition.Feature] = WorkerComposition.Feature.v2,
+        workers: [WorkerDescriptor] = [],
         /// Effective active dynamic-route claims (#746), pre-validated via
         /// `WorkerRouteClaims.activeClaims`. Written into `wrangler.toml` as selective
         /// `[assets].run_worker_first` patterns; empty = no worker-first routes.
@@ -88,7 +88,7 @@ public actor SocialWorkerProvisionCommand {
 
         var resources = knownResources == .init() ? Self.readPersistedResources(from: siteDirectory) : knownResources
 
-        if features.contains(where: { $0.needsD1 }) {
+        if workers.contains(where: { $0.resources.needsD1 }) {
             if resources.d1DatabaseID == nil {
                 let name = "\(siteName)-social"
                 let result = await runWrangler(
@@ -109,13 +109,13 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created D1 database \(name) but no database id was found", exitCode: 0, resources: resources)
                 }
                 resources.d1DatabaseID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources) {
                     return failure
                 }
             }
         }
 
-        if features.contains(where: { $0.needsKV }) {
+        if workers.contains(where: { $0.resources.needsKV }) {
             if resources.kvNamespaceID == nil {
                 let name = "\(siteName)-social"
                 let result = await runWrangler(
@@ -136,13 +136,13 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created KV namespace \(name) but no namespace id was found", exitCode: 0, resources: resources)
                 }
                 resources.kvNamespaceID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources) {
                     return failure
                 }
             }
         }
 
-        if features.contains(where: { $0.needsR2 }) {
+        if workers.contains(where: { $0.resources.needsR2 }) {
             if resources.r2BucketName == nil {
                 let name = "\(siteName)-media"
                 let result = await runWrangler(
@@ -156,20 +156,20 @@ public actor SocialWorkerProvisionCommand {
                     return failure
                 }
                 resources.r2BucketName = name
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources) {
                     return failure
                 }
             }
         }
 
-        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources) {
+        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources) {
             return failure
         }
 
         // @dwk/indieauth deliberately keeps schema deployment outside its request handler. Apply
         // the committed D1 migrations after wrangler.toml contains the concrete database id and
         // before publishing code that can receive authorization requests.
-        if features.contains(.indieauth) {
+        if workers.contains(where: { $0.id == "indieauth" }) {
             let result = await runWrangler(
                 siteDirectory: siteDirectory,
                 arguments: ["d1", "migrations", "apply", "AUTH_DB", "--remote"],
@@ -225,7 +225,7 @@ public actor SocialWorkerProvisionCommand {
     private func persistConfig(
         siteDirectory: URL,
         siteName: String,
-        features: [WorkerComposition.Feature],
+        workers: [WorkerDescriptor],
         routeClaims: [WorkerRouteClaim],
         resources: WorkerComposition.ProvisionedResources
     ) -> Result? {
@@ -237,7 +237,7 @@ public actor SocialWorkerProvisionCommand {
             // deploy.
             let toml = try WorkerComposition.generateWranglerToml(
                 siteName: siteName,
-                features: features,
+                workers: workers,
                 routeClaims: routeClaims,
                 resources: resources
             )

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -51,7 +51,7 @@ public actor SocialWorkerProvisionCommand {
         siteID: String,
         siteDirectory: URL,
         siteName: String,
-        workers: [WorkerDescriptor] = [],
+        workers: [WorkerDescriptor],
         /// Effective active dynamic-route claims (#746), pre-validated via
         /// `WorkerRouteClaims.activeClaims`. Written into `wrangler.toml` as selective
         /// `[assets].run_worker_first` patterns; empty = no worker-first routes.
@@ -169,7 +169,7 @@ public actor SocialWorkerProvisionCommand {
         // @dwk/indieauth deliberately keeps schema deployment outside its request handler. Apply
         // the committed D1 migrations after wrangler.toml contains the concrete database id and
         // before publishing code that can receive authorization requests.
-        if workers.contains(where: { $0.id == "indieauth" }) {
+        if workers.contains(where: { $0.id == WorkerComposition.indieauthWorkerID }) {
             let result = await runWrangler(
                 siteDirectory: siteDirectory,
                 arguments: ["d1", "migrations", "apply", "AUTH_DB", "--remote"],

--- a/Sources/AnglesiteCore/WorkerActivation.swift
+++ b/Sources/AnglesiteCore/WorkerActivation.swift
@@ -54,13 +54,13 @@ public enum WorkerActivation {
         previous.subtracting(next)
     }
 
-    /// Interim catalog-id → `Feature` shim (#709 design §4/§10): `generateWranglerToml` and
-    /// `SocialWorkerProvisionCommand.provision` still take `[WorkerComposition.Feature]`, not
-    /// `[WorkerDescriptor]`, until #708 migrates them. An id with no matching `Feature` case (a
-    /// future, not-yet-composed catalog worker) is silently dropped — there is nothing else this
-    /// call can do with it today. Iterating `Feature.allCases` (rather than mapping `ids`
-    /// directly) gives deterministic, declaration-order output for stable `wrangler.toml` diffs.
-    public static func mapToFeatures(_ ids: Set<String>) -> [WorkerComposition.Feature] {
-        WorkerComposition.Feature.allCases.filter { ids.contains($0.rawValue) }
+    /// The effective active worker set as full `WorkerDescriptor`s, resolved by id against
+    /// `catalog` — what `WorkerComposition.generateWranglerToml` and
+    /// `SocialWorkerProvisionCommand.provision` need now that composition is descriptor-driven
+    /// (#708). An id present in `activeIDs` but absent from `catalog` (a stale id, or a catalog
+    /// fetch that hasn't happened yet) is silently dropped — there is no descriptor data to
+    /// compose it with. Mirrors `WorkerRouteClaims.activeClaims(catalog:activeIDs:)`'s shape.
+    public static func activeDescriptors(catalog: [WorkerDescriptor], activeIDs: Set<String>) -> [WorkerDescriptor] {
+        catalog.filter { activeIDs.contains($0.id) }
     }
 }

--- a/Sources/AnglesiteCore/WorkerActivation.swift
+++ b/Sources/AnglesiteCore/WorkerActivation.swift
@@ -63,4 +63,21 @@ public enum WorkerActivation {
     public static func activeDescriptors(catalog: [WorkerDescriptor], activeIDs: Set<String>) -> [WorkerDescriptor] {
         catalog.filter { activeIDs.contains($0.id) }
     }
+
+    /// Active ids `activeDescriptors` couldn't resolve against the catalog — a fully-empty
+    /// catalog (no fetch has ever succeeded) is the common case, but a *partial* catalog missing
+    /// just one active id (a stale id, or an entry a newer `catalog.json` removed) hits this too.
+    /// Both deploy paths (`DeployModel.runDeploy`, `SiteOperations.deployWithWorkerComposition`)
+    /// check this — not just `catalog.isEmpty` — so a partial mismatch isn't silent either.
+    public static func unresolvedActiveIDs(activeIDs: Set<String>, resolved: [WorkerDescriptor]) -> Set<String> {
+        activeIDs.subtracting(Set(resolved.map(\.id)))
+    }
+
+    /// The shared debug-pane warning text for `unresolvedActiveIDs`, so the wording can't drift
+    /// between `DeployModel.swift` and `SiteOperations.swift` the way it already had once (#708
+    /// review feedback). `nil` when there's nothing to warn about.
+    public static func missingDescriptorWarning(unresolvedIDs: Set<String>) -> String? {
+        guard !unresolvedIDs.isEmpty else { return nil }
+        return "no catalog entry for active worker(s) \(unresolvedIDs.sorted().joined(separator: ", ")) — deploying with no resource bindings or route claims for them; wrangler.toml composition will be incomplete until a catalog fetch resolves them"
+    }
 }

--- a/Sources/AnglesiteCore/WorkerActivation.swift
+++ b/Sources/AnglesiteCore/WorkerActivation.swift
@@ -61,7 +61,7 @@ public enum WorkerActivation {
     /// fetch that hasn't happened yet) is silently dropped — there is no descriptor data to
     /// compose it with. Mirrors `WorkerRouteClaims.activeClaims(catalog:activeIDs:)`'s shape.
     public static func activeDescriptors(catalog: [WorkerDescriptor], activeIDs: Set<String>) -> [WorkerDescriptor] {
-        catalog.filter { activeIDs.contains($0.id) }
+        catalog.sorted(by: { $0.id < $1.id }).filter { activeIDs.contains($0.id) }
     }
 
     /// Active ids `activeDescriptors` couldn't resolve against the catalog — a fully-empty

--- a/Sources/AnglesiteCore/WorkerCatalog.swift
+++ b/Sources/AnglesiteCore/WorkerCatalog.swift
@@ -78,8 +78,9 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
         }
     }
 
-    /// Generalizes `WorkerComposition.Feature`'s hand-maintained `needsD1`/`needsKV`/`needsR2`
-    /// switch statements (`WorkerComposition.swift:28-53`) into manifest-driven data.
+    /// Manifest-driven equivalent of the `needsD1`/`needsKV`/`needsR2` flags the old
+    /// `WorkerComposition.Feature` enum used to hand-maintain as switch statements (removed by
+    /// #708's descriptor migration).
     public struct Resources: Sendable, Equatable, Codable {
         public let needsD1: Bool
         public let needsKV: Bool

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -8,50 +8,6 @@ import Foundation
 /// prefixes. This type generates the configuration; `SocialWorkerProvisionCommand` fills the
 /// Cloudflare resource identifiers once provisioning has created the backing stores.
 public enum WorkerComposition {
-    /// A social feature that can be composed into the per-site Worker.
-    public enum Feature: String, CaseIterable, Sendable {
-        case indieauth
-        case webmention
-        case micropub
-        case websub
-        case microsub
-        case webfinger
-        case activitypub
-
-        /// V-2 features: outbound social (webmention send + indieauth).
-        public static let v2: [Feature] = [.webmention, .indieauth]
-        /// V-3 features: V-2 + inbound social (micropub + websub).
-        public static let v3: [Feature] = [.webmention, .indieauth, .micropub, .websub]
-        /// V-4 features: V-3 + federation (activitypub + microsub + webfinger).
-        public static let v4: [Feature] = Array(Feature.allCases)
-
-        var needsD1: Bool {
-            switch self {
-            case .webmention, .micropub, .indieauth, .websub, .microsub, .activitypub:
-                return true
-            case .webfinger:
-                return false
-            }
-        }
-
-        var needsKV: Bool {
-            switch self {
-            case .webmention, .micropub, .indieauth, .websub, .microsub, .activitypub:
-                return true
-            case .webfinger:
-                return false
-            }
-        }
-
-        var needsR2: Bool {
-            switch self {
-            case .micropub:
-                return true
-            default:
-                return false
-            }
-        }
-    }
 
     public enum ConfigError: Error, Sendable {
         case invalidSiteName(String)
@@ -88,12 +44,13 @@ public enum WorkerComposition {
         }
     }
 
-    /// Generates a wrangler.toml for a site with the given features enabled.
+    /// Generates a wrangler.toml for a site with the given workers enabled.
     ///
     /// - Parameters:
     ///   - siteName: The Worker name (used as the Cloudflare Workers project name).
     ///     Must match `[A-Za-z0-9_-]+`.
-    ///   - features: Which `@dwk/*` social endpoints to compose. Empty = static-only deploy.
+    ///   - workers: The effective active `@dwk/workers` catalog descriptors. Empty = static-only
+    ///     deploy.
     ///   - routeClaims: The effective active dynamic-route claims (#746), already validated by
     ///     `WorkerRouteClaims.activeClaims`. Emitted as selective `[assets].run_worker_first`
     ///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
@@ -105,7 +62,7 @@ public enum WorkerComposition {
     ///   for a claim that never passed `WorkerRouteClaims` validation.
     public static func generateWranglerToml(
         siteName: String,
-        features: [Feature],
+        workers: [WorkerDescriptor],
         routeClaims: [WorkerRouteClaim] = [],
         resources: ProvisionedResources = .init(),
         inboxCaptureEnabled: Bool = false,
@@ -129,12 +86,17 @@ public enum WorkerComposition {
                 throw ConfigError.invalidRouteClaim(path: claim.path, reason: "\(error)")
             }
         }
+        // @dwk/indieauth's binding name is part of its public composition contract (see the
+        // AUTH_DB block below) — the one place composition keys off a specific catalog id rather
+        // than generic resource flags.
+        let hasIndieauth = workers.contains(where: { $0.id == "indieauth" })
+
         var lines: [String] = []
         lines.append("name = \"\(siteName)\"")
         lines.append("compatibility_date = \"2026-07-15\"")
         lines.append("compatibility_flags = [\"nodejs_compat\"]")
 
-        let hasSocialFeatures = !features.isEmpty
+        let hasSocialFeatures = !workers.isEmpty
         if hasSocialFeatures || inboxCaptureEnabled {
             lines.append("main = \"worker/worker.ts\"")
         }
@@ -150,7 +112,7 @@ public enum WorkerComposition {
             }
         }
 
-        if features.contains(where: { $0.needsD1 }) {
+        if workers.contains(where: { $0.resources.needsD1 }) {
             lines.append("")
             lines.append("[[d1_databases]]")
             lines.append("binding = \"DB\"")
@@ -162,10 +124,9 @@ public enum WorkerComposition {
             }
         }
 
-        // @dwk/indieauth's binding name is part of its public composition contract. Keep the
-        // generic DB binding above for the other @dwk packages, while binding the same per-site
-        // D1 database under AUTH_DB for authorization codes and issued-token state.
-        if features.contains(.indieauth) {
+        // Keep the generic DB binding above for the other @dwk packages, while binding the same
+        // per-site D1 database under AUTH_DB for authorization codes and issued-token state.
+        if hasIndieauth {
             lines.append("")
             lines.append("[[d1_databases]]")
             lines.append("binding = \"AUTH_DB\"")
@@ -178,7 +139,7 @@ public enum WorkerComposition {
             }
         }
 
-        if features.contains(where: { $0.needsKV }) {
+        if workers.contains(where: { $0.resources.needsKV }) {
             lines.append("")
             lines.append("[[kv_namespaces]]")
             lines.append("binding = \"SOCIAL_KV\"")
@@ -189,7 +150,7 @@ public enum WorkerComposition {
             }
         }
 
-        if features.contains(where: { $0.needsR2 }) {
+        if workers.contains(where: { $0.resources.needsR2 }) {
             lines.append("")
             lines.append("[[r2_buckets]]")
             lines.append("binding = \"MEDIA\"")
@@ -207,7 +168,7 @@ public enum WorkerComposition {
             }
         }
 
-        if features.contains(.indieauth) {
+        if hasIndieauth {
             lines.append("")
             // Wrangler has no schema for declaring required secrets in wrangler.toml — secrets are
             // set with `wrangler secret put <NAME>` and are never read back out of this file. Emit

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -18,6 +18,12 @@ public enum WorkerComposition {
         case invalidRouteClaim(path: String, reason: String)
     }
 
+    /// `@dwk/indieauth`'s catalog id — a magic string composition keys off directly (its binding
+    /// name, `AUTH_DB`, is part of its public contract, unlike every other `@dwk/*` package which
+    /// only needs generic `resources` flags), shared so a typo in one comparison site can't
+    /// silently diverge from another.
+    public static let indieauthWorkerID = "indieauth"
+
     /// The bespoke app-side inbox-capture route (#587) — not a `@dwk/workers` catalog worker, so
     /// its claim lives here rather than in `catalog.json`. Appended automatically when
     /// `generateWranglerToml` is called with `inboxCaptureEnabled`.
@@ -89,7 +95,7 @@ public enum WorkerComposition {
         // @dwk/indieauth's binding name is part of its public composition contract (see the
         // AUTH_DB block below) — the one place composition keys off a specific catalog id rather
         // than generic resource flags.
-        let hasIndieauth = workers.contains(where: { $0.id == "indieauth" })
+        let hasIndieauth = workers.contains(where: { $0.id == indieauthWorkerID })
 
         var lines: [String] = []
         lines.append("name = \"\(siteName)\"")

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -312,6 +312,42 @@ struct DeployModelTests {
         }
     }
 
+    @Test("an active worker with no matching catalog entry logs a warning instead of deploying silently")
+    func emptyCatalogWithActiveWorkerWarnsInDebugPane() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let contentGraph = SiteContentGraph()
+        let logCenter = LogCenter()
+        let model = DeployModel(
+            command: command,
+            logCenter: logCenter,
+            suddenTerminationController: SuddenTerminationController(disable: {}, enable: {}),
+            tokenAvailabilityOverride: { true },
+            contentGraph: contentGraph,
+            workerCatalog: { [] }
+        )
+        let dir = try temporaryDirectory()
+        let configDir = dir.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let configStore = SiteConfigStore(configDirectory: configDir)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+
+        // With no catalog entry to resolve "indieauth" against, `workers` ends up empty — same
+        // D1/KV-free path as a genuinely static site, so this reaches the build step and
+        // succeeds like `staticSiteDeploysUnaffected` — but it must also warn, unlike that case.
+        model.deploy(siteID: "test-site", siteDirectory: dir, configDirectory: configDir, currentRoutes: [])
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
+        while model.isRunning { await Task.yield() }
+
+        guard case .succeeded = model.phase else {
+            Issue.record("Expected deploy to succeed, got \(model.phase)")
+            return
+        }
+        let lines = await logCenter.snapshot()
+        #expect(lines.contains { $0.text.contains("no catalog entry for active worker(s) indieauth") })
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("DeployModelTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -157,7 +157,7 @@ struct SiteOperationsTests {
 
         let result = await ops.provisionSocialWorker(site: site)
 
-        guard case .succeeded(let url, _, _) = result else {
+        guard case .succeeded(let url, let resources, _) = result else {
             Issue.record("expected success, got \(result)")
             return
         }
@@ -170,6 +170,36 @@ struct SiteOperationsTests {
         #expect(await recorder.deployCalls == [
             .init(token: "token", siteID: "s1", siteDirectory: package.appendingPathComponent("Source", isDirectory: true))
         ])
+        #expect(resources.d1DatabaseID == "d1-id")
+        #expect(resources.kvNamespaceID == "kv-id")
+    }
+
+    @Test("provisionSocialWorker's fixed V-2 starter pack (webmention + indieauth) restores the pre-#708 Feature.v2 default")
+    func provisionSocialWorkerRestoresV2Default() async throws {
+        // provisionSocialWorker never accepted a workers/features parameter and always relied on
+        // provision(...)'s default value — Feature.v2 pre-#708, now the fixed v2StarterWorkers
+        // constant. This asserts every observable trace of that default's composition: D1 create
+        // (both webmention and indieauth need it), KV create (same), and the AUTH_DB migration
+        // step that only runs when "indieauth" specifically is among the composed workers.
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
+
+        let result = await ops.provisionSocialWorker(site: site)
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let arguments = await recorder.arguments
+        #expect(arguments.contains(["d1", "create", "blue-bottle-cafe-social", "--json"]))
+        #expect(arguments.contains(["kv", "namespace", "create", "blue-bottle-cafe-social", "--json"]))
+        #expect(arguments.contains(["d1", "migrations", "apply", "AUTH_DB", "--remote"]))
+        let toml = try String(
+            contentsOf: package.appendingPathComponent("Source/wrangler.toml"), encoding: .utf8)
+        #expect(!toml.contains("[[r2_buckets]]"))
     }
 
     @Test("social worker provisioning maps missing folder grants to failed results")

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -71,6 +71,16 @@ struct SiteOperationsTests {
         return package
     }
 
+    /// A fixture `WorkerDescriptor` for the headless-deploy tests below — stands in for what
+    /// `WorkerCatalogFetcher.cachedCatalog()` would return from a real on-disk cache, without
+    /// touching the real `~/Library/Application Support/Anglesite/` cache file from a test.
+    private func descriptor(id: String, d1: Bool = true, kv: Bool = true, r2: Bool = false) -> WorkerDescriptor {
+        WorkerDescriptor(
+            id: id, displayName: id, description: "test fixture", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: d1, needsKV: kv, needsR2: r2)
+        )
+    }
+
     private func finding(_ severity: AuditReport.Finding.Severity) -> AuditReport.Finding {
         AuditReport.Finding(
             category: .seo, severity: severity, title: "t", detail: "d",
@@ -302,7 +312,12 @@ struct SiteOperationsTests {
         )
 
         let recorder = SocialWorkerRecorder()
-        let ops = SiteOperations(factory: SocialWorkerFactory(recorder: recorder), store: throwawayStore())
+        let ops = SiteOperations(
+            factory: SocialWorkerFactory(recorder: recorder),
+            store: throwawayStore(),
+            socialWorkerAccess: { site, store, body in try await SiteAccess.withScopedAccess(to: site, in: store, body) },
+            cachedWorkerCatalog: { [self.descriptor(id: "indieauth")] }
+        )
 
         let result = await ops.deploy(site: site)
 

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -2,6 +2,20 @@ import Foundation
 import Testing
 @testable import AnglesiteCore
 
+private func worker(_ id: String, d1: Bool, kv: Bool, r2: Bool) -> WorkerDescriptor {
+    WorkerDescriptor(
+        id: id, displayName: id, description: "test fixture", group: "test",
+        binding: .settingsActivated, resources: .init(needsD1: d1, needsKV: kv, needsR2: r2)
+    )
+}
+
+private let webmentionWorker = worker("webmention", d1: true, kv: true, r2: false)
+private let indieauthWorker = worker("indieauth", d1: true, kv: true, r2: false)
+private let micropubWorker = worker("micropub", d1: true, kv: true, r2: true)
+private let websubWorker = worker("websub", d1: true, kv: true, r2: false)
+private let v2Workers = [webmentionWorker, indieauthWorker]
+private let v3Workers = [webmentionWorker, indieauthWorker, micropubWorker, websubWorker]
+
 @Suite("SocialWorkerProvisionCommand")
 struct SocialWorkerProvisionCommandTests {
     @Test("provisions V-2 D1 and KV, writes wrangler.toml, then deploys through DeployCommand seam")
@@ -15,7 +29,7 @@ struct SocialWorkerProvisionCommandTests {
         let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
         let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
 
         guard case .succeeded(let url, let resources, _) = result else {
             Issue.record("expected success, got \(result)")
@@ -59,7 +73,7 @@ struct SocialWorkerProvisionCommandTests {
             siteID: "site-1",
             siteDirectory: site,
             siteName: "my-site",
-            features: WorkerComposition.Feature.v3
+            workers: v3Workers
         )
 
         guard case .succeeded(_, let resources, _) = result else {
@@ -95,7 +109,7 @@ struct SocialWorkerProvisionCommandTests {
         let site = try temporaryDirectory()
         let existing = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
-            features: WorkerComposition.Feature.v3,
+            workers: v3Workers,
             resources: .init(d1DatabaseID: "d1-existing", kvNamespaceID: "kv-existing", r2BucketName: "media-existing")
         )
         try existing.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
@@ -113,7 +127,7 @@ struct SocialWorkerProvisionCommandTests {
             siteID: "site-1",
             siteDirectory: site,
             siteName: "my-site",
-            features: WorkerComposition.Feature.v3
+            workers: v3Workers
         )
 
         guard case .succeeded(_, let resources, _) = result else {
@@ -138,7 +152,7 @@ struct SocialWorkerProvisionCommandTests {
         let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
         let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
 
         guard case .failed(let reason, let exitCode, let resources) = result else {
             Issue.record("expected failure, got \(result)")
@@ -168,7 +182,7 @@ struct SocialWorkerProvisionCommandTests {
             deployer: DeployRecorder(result: .failed(reason: "pre-deploy scan could not run", exitCode: nil)).deployer
         )
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
 
         guard case .failed(let reason, nil, let resources) = result else {
             Issue.record("expected deploy failure, got \(result)")
@@ -194,7 +208,7 @@ struct SocialWorkerProvisionCommandTests {
         let deployer = DeployRecorder(result: .workerNameConflict(name: "taken-name"))
         let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
 
         guard case .workerNameConflict(let name, let resources) = result else {
             Issue.record("expected .workerNameConflict, got \(result)"); return
@@ -215,7 +229,7 @@ struct SocialWorkerProvisionCommandTests {
         let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
         let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
 
         guard case .failed(let reason, let exitCode, let resources) = result else {
             Issue.record("expected migration failure, got \(result)")
@@ -265,7 +279,7 @@ struct SocialWorkerProvisionCommandTests {
         // a file-scrape alone would find no bucket name and try to recreate it.
         let currentToml = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
-            features: [.indieauth],
+            workers: [indieauthWorker],
             resources: .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: nil)
         )
         try currentToml.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
@@ -286,7 +300,7 @@ struct SocialWorkerProvisionCommandTests {
         // Reactivating micropub (needs R2) should reuse the known bucket, not call `r2 bucket create` again.
         let result = await command.provision(
             siteID: "site-1", siteDirectory: site, siteName: "my-site",
-            features: [.indieauth, .micropub], knownResources: known
+            workers: [indieauthWorker, micropubWorker], knownResources: known
         )
 
         guard case .succeeded(_, let resources, _) = result else {

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -93,7 +93,7 @@ struct SocialWorkerProvisionCommandTests {
         let recorder = WranglerRecorder([:])
         let command = SocialWorkerProvisionCommand(tokenSource: { nil }, runner: recorder.runner)
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [])
 
         guard case .failed(let reason, nil, let resources) = result else {
             Issue.record("expected token failure, got \(result)")

--- a/Tests/AnglesiteCoreTests/WorkerActivationTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerActivationTests.swift
@@ -102,20 +102,26 @@ struct WorkerActivationTests {
         #expect(WorkerActivation.removedIDs(previous: ["a"], next: ["a", "b"]).isEmpty)
     }
 
-    @Test("mapToFeatures maps known catalog ids to Feature cases in declaration order")
-    func mapToFeaturesKnownIDs() {
-        let features = WorkerActivation.mapToFeatures(["websub", "indieauth"])
-        #expect(features == [.indieauth, .websub])
+    @Test("activeDescriptors resolves known ids against the catalog")
+    func activeDescriptorsKnownIDs() {
+        let webmention = descriptor(id: "webmention", binding: .settingsActivated)
+        let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
+        let resolved = WorkerActivation.activeDescriptors(
+            catalog: [webmention, indieauth], activeIDs: ["indieauth", "webmention"])
+        #expect(Set(resolved.map(\.id)) == ["indieauth", "webmention"])
     }
 
-    @Test("mapToFeatures silently drops ids with no matching Feature case")
-    func mapToFeaturesDropsUnknownIDs() {
-        let features = WorkerActivation.mapToFeatures(["indieauth", "solid-pod"])
-        #expect(features == [.indieauth])
+    @Test("activeDescriptors drops ids with no matching catalog entry")
+    func activeDescriptorsDropsUnknownIDs() {
+        let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
+        let resolved = WorkerActivation.activeDescriptors(
+            catalog: [indieauth], activeIDs: ["indieauth", "solid-pod"])
+        #expect(resolved.map(\.id) == ["indieauth"])
     }
 
-    @Test("mapToFeatures of an empty set is empty")
-    func mapToFeaturesEmpty() {
-        #expect(WorkerActivation.mapToFeatures([]).isEmpty)
+    @Test("activeDescriptors of an empty id set is empty")
+    func activeDescriptorsEmpty() {
+        let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
+        #expect(WorkerActivation.activeDescriptors(catalog: [indieauth], activeIDs: []).isEmpty)
     }
 }

--- a/Tests/AnglesiteCoreTests/WorkerActivationTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerActivationTests.swift
@@ -124,4 +124,38 @@ struct WorkerActivationTests {
         let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
         #expect(WorkerActivation.activeDescriptors(catalog: [indieauth], activeIDs: []).isEmpty)
     }
+
+    @Test("unresolvedActiveIDs is empty when every active id resolved")
+    func unresolvedActiveIDsEmptyWhenFullyResolved() {
+        let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
+        let unresolved = WorkerActivation.unresolvedActiveIDs(activeIDs: ["indieauth"], resolved: [indieauth])
+        #expect(unresolved.isEmpty)
+    }
+
+    @Test("unresolvedActiveIDs catches a fully-empty catalog")
+    func unresolvedActiveIDsFullyEmptyCatalog() {
+        let unresolved = WorkerActivation.unresolvedActiveIDs(activeIDs: ["indieauth", "webmention"], resolved: [])
+        #expect(unresolved == ["indieauth", "webmention"])
+    }
+
+    @Test("unresolvedActiveIDs catches a partial mismatch, not just a fully-empty catalog")
+    func unresolvedActiveIDsPartialMismatch() {
+        let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
+        // "webmention" is active but has no catalog entry — the catalog isn't empty, so a
+        // catalog.isEmpty check alone would miss this.
+        let unresolved = WorkerActivation.unresolvedActiveIDs(
+            activeIDs: ["indieauth", "webmention"], resolved: [indieauth])
+        #expect(unresolved == ["webmention"])
+    }
+
+    @Test("missingDescriptorWarning is nil when nothing is unresolved")
+    func missingDescriptorWarningNilWhenResolved() {
+        #expect(WorkerActivation.missingDescriptorWarning(unresolvedIDs: []) == nil)
+    }
+
+    @Test("missingDescriptorWarning names every unresolved id, sorted")
+    func missingDescriptorWarningNamesUnresolvedIDs() {
+        let warning = WorkerActivation.missingDescriptorWarning(unresolvedIDs: ["webmention", "indieauth"])
+        #expect(warning?.contains("indieauth, webmention") == true)
+    }
 }

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -3,13 +3,27 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
+private func worker(_ id: String, d1: Bool, kv: Bool, r2: Bool) -> WorkerDescriptor {
+    WorkerDescriptor(
+        id: id, displayName: id, description: "test fixture", group: "test",
+        binding: .settingsActivated, resources: .init(needsD1: d1, needsKV: kv, needsR2: r2)
+    )
+}
+
+private let webmentionWorker = worker("webmention", d1: true, kv: true, r2: false)
+private let indieauthWorker = worker("indieauth", d1: true, kv: true, r2: false)
+private let micropubWorker = worker("micropub", d1: true, kv: true, r2: true)
+private let websubWorker = worker("websub", d1: true, kv: true, r2: false)
+private let v2Workers = [webmentionWorker, indieauthWorker]
+private let v3Workers = [webmentionWorker, indieauthWorker, micropubWorker, websubWorker]
+
 @Suite("WorkerComposition")
 struct WorkerCompositionTests {
     @Test("generates wrangler.toml with static assets and no social features")
     func staticOnly() throws {
         let toml = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
-            features: []
+            workers: []
         )
         #expect(toml.contains("name = \"my-site\""))
         #expect(toml.contains("[assets]"))
@@ -21,7 +35,7 @@ struct WorkerCompositionTests {
     func withSocialFeatures() throws {
         let toml = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
-            features: [.webmention, .indieauth]
+            workers: [webmentionWorker, indieauthWorker]
         )
         #expect(toml.contains("name = \"my-site\""))
         #expect(toml.contains("[assets]"))
@@ -42,22 +56,22 @@ struct WorkerCompositionTests {
         #expect(!toml.contains("[[r2_buckets]]"))
     }
 
-    @Test("generates wrangler.toml with V-2 features (D1 yes, R2 no — micropub is V-3)")
+    @Test("generates wrangler.toml with V-2 workers (D1 yes, R2 no — micropub is V-3)")
     func v2Features() throws {
         let toml = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
-            features: WorkerComposition.Feature.v2
+            workers: v2Workers
         )
         #expect(toml.contains("[[d1_databases]]"))
         #expect(toml.contains("[[kv_namespaces]]"))
         #expect(!toml.contains("[[r2_buckets]]"))
     }
 
-    @Test("generates wrangler.toml with V-3 features (D1 + R2 — micropub needs media)")
+    @Test("generates wrangler.toml with V-3 workers (D1 + R2 — micropub needs media)")
     func v3Features() throws {
         let toml = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
-            features: WorkerComposition.Feature.v3
+            workers: v3Workers
         )
         #expect(toml.contains("[[d1_databases]]"))
         #expect(toml.contains("[[kv_namespaces]]"))
@@ -69,7 +83,7 @@ struct WorkerCompositionTests {
     func provisionedResources() throws {
         let toml = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
-            features: WorkerComposition.Feature.v3,
+            workers: v3Workers,
             resources: .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: "custom-media")
         )
 
@@ -83,25 +97,15 @@ struct WorkerCompositionTests {
         #expect(throws: WorkerComposition.ConfigError.self) {
             try WorkerComposition.generateWranglerToml(
                 siteName: "my\"site\ninjected",
-                features: []
+                workers: []
             )
         }
     }
 
-    @Test("feature sets are correctly defined per phase")
-    func featureSets() {
-        #expect(WorkerComposition.Feature.v2.contains(.webmention))
-        #expect(WorkerComposition.Feature.v2.contains(.indieauth))
-        #expect(!WorkerComposition.Feature.v2.contains(.micropub))
-
-        #expect(WorkerComposition.Feature.v3.contains(.micropub))
-        #expect(WorkerComposition.Feature.v3.contains(.websub))
-    }
-
-    @Test("inboxCaptureEnabled adds an INBOX_KV binding and uncomments main even with no @dwk/* features")
+    @Test("inboxCaptureEnabled adds an INBOX_KV binding and uncomments main even with no @dwk/* workers")
     func inboxCaptureAddsKVBinding() throws {
         let toml = try WorkerComposition.generateWranglerToml(
-            siteName: "my-site", features: [], inboxCaptureEnabled: true)
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true)
         #expect(toml.contains("main = \"worker/worker.ts\""))
         #expect(toml.contains("binding = \"INBOX_KV\""))
         #expect(toml.contains("id = \"\"  # filled by provisioning"))
@@ -110,13 +114,13 @@ struct WorkerCompositionTests {
     @Test("inboxCaptureEnabled fills the provisioned namespace id when given")
     func inboxCaptureFillsProvisionedID() throws {
         let toml = try WorkerComposition.generateWranglerToml(
-            siteName: "my-site", features: [], inboxCaptureEnabled: true, inboxKVNamespaceID: "abc123")
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true, inboxKVNamespaceID: "abc123")
         #expect(toml.contains("id = \"abc123\""))
     }
 
     @Test("inboxCaptureEnabled false omits the INBOX_KV binding")
     func inboxCaptureDisabledOmitsBinding() throws {
-        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", features: [])
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [])
         #expect(!toml.contains("INBOX_KV"))
         #expect(!toml.contains("main ="))
     }
@@ -132,20 +136,20 @@ struct WorkerCompositionTests {
                 specificationURL: URL(string: "https://www.rfc-editor.org/rfc/rfc8555")),
         ]
         let toml = try WorkerComposition.generateWranglerToml(
-            siteName: "my-site", features: [.indieauth], routeClaims: claims)
+            siteName: "my-site", workers: [indieauthWorker], routeClaims: claims)
         #expect(toml.contains(
             #"run_worker_first = ["/.well-known/acme-challenge", "/.well-known/acme-challenge/*", "/authorize", "/token"]"#
         ))
         // Regeneration is byte-stable regardless of claim order.
         let regenerated = try WorkerComposition.generateWranglerToml(
-            siteName: "my-site", features: [.indieauth], routeClaims: claims.reversed())
+            siteName: "my-site", workers: [indieauthWorker], routeClaims: claims.reversed())
         #expect(toml == regenerated)
     }
 
     @Test("run_worker_first is omitted entirely when there are no active dynamic routes")
     func omitsRunWorkerFirstWithoutClaims() throws {
         let toml = try WorkerComposition.generateWranglerToml(
-            siteName: "my-site", features: [.webmention, .indieauth])
+            siteName: "my-site", workers: [webmentionWorker, indieauthWorker])
         #expect(!toml.contains("run_worker_first"))
         #expect(toml.contains("binding = \"ASSETS\""))
     }
@@ -153,13 +157,13 @@ struct WorkerCompositionTests {
     @Test("inbox capture claims /inbox as a worker-first route")
     func inboxCaptureClaimsRoute() throws {
         let toml = try WorkerComposition.generateWranglerToml(
-            siteName: "my-site", features: [], inboxCaptureEnabled: true)
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true)
         #expect(toml.contains(#"run_worker_first = ["/inbox"]"#))
     }
 
     @Test("static-only sites emit no run_worker_first")
     func staticOnlyOmitsRunWorkerFirst() throws {
-        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", features: [])
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [])
         #expect(!toml.contains("run_worker_first"))
     }
 
@@ -169,7 +173,7 @@ struct WorkerCompositionTests {
             path: "/a\"]\ninjected = true", match: .exact, methods: ["GET"], handler: "x")
         #expect(throws: WorkerComposition.ConfigError.self) {
             try WorkerComposition.generateWranglerToml(
-                siteName: "my-site", features: [.indieauth], routeClaims: [hostile])
+                siteName: "my-site", workers: [indieauthWorker], routeClaims: [hostile])
         }
     }
 
@@ -180,7 +184,7 @@ struct WorkerCompositionTests {
             path: "/status", match: .exact, methods: ["HEAD"], handler: "x")
         #expect(throws: WorkerComposition.ConfigError.self) {
             try WorkerComposition.generateWranglerToml(
-                siteName: "my-site", features: [.indieauth], routeClaims: [headOnly])
+                siteName: "my-site", workers: [indieauthWorker], routeClaims: [headOnly])
         }
     }
 

--- a/docs/superpowers/plans/2026-07-20-worker-composition-descriptor-migration.md
+++ b/docs/superpowers/plans/2026-07-20-worker-composition-descriptor-migration.md
@@ -1,0 +1,806 @@
+# WorkerComposition.Feature → WorkerDescriptor Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `WorkerComposition.generateWranglerToml` and `SocialWorkerProvisionCommand.provision` from the closed, 7-case `WorkerComposition.Feature` enum to the catalog-driven `WorkerDescriptor` (landed in PR #712), deleting the `WorkerActivation.mapToFeatures` interim shim — the first of #708's two remaining sub-tasks (design doc `docs/superpowers/specs/2026-07-13-workers-local-debugging-design.md` §3).
+
+**Architecture:** `Feature`'s `needsD1`/`needsKV`/`needsR2` switch statements become `WorkerDescriptor.resources.needsD1/needsKV/needsR2` lookups; the one `Feature.indieauth`-specific branch (the `AUTH_DB` binding + IndieAuth secrets comment) becomes an `id == "indieauth"` string check, matching how `WorkerDescriptor`'s own doc comments already describe IndieAuth's binding name as "part of its public composition contract." `WorkerActivation.mapToFeatures(Set<String>) -> [Feature]` is replaced by `WorkerActivation.activeDescriptors(catalog:activeIDs:) -> [WorkerDescriptor]`, mirroring the existing `WorkerRouteClaims.activeClaims(catalog:activeIDs:)` pattern one file over. This also fixes a real (accepted, documented) limitation of the old shim: a catalog worker with no matching `Feature` case used to be silently dropped from composition entirely; post-migration, any catalog-known id composes correctly regardless of whether it existed when `Feature` was written.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Suite`/`@Test`/`#expect`), SwiftPM (`AnglesiteCore` + `AnglesiteCoreTests` targets), Xcode/`xcodebuild` for the `AnglesiteApp` target.
+
+## Global Constraints
+
+- No new dependencies — this is an internal refactor of existing `AnglesiteCore`/`AnglesiteApp` types.
+- Conventional commits (`refactor(workers): …`), reference `#708` in the subject.
+- Every `AnglesiteCoreTests` suite touched must pass via `swift test --package-path .` before moving to the next task.
+- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` must succeed before this plan is considered done (per CONTRIBUTING.md, `swift test` alone doesn't prove the app target links).
+- Do not touch `SocialPublishPlan.swift`, `WorkersConformance.swift`, or `WorkerRouteClaims.swift` — confirmed zero coupling to `WorkerComposition.Feature` during research; touching them is out of scope.
+- This plan covers only the descriptor migration. The second #708 sub-task (`wrangler dev --local` inside `LocalContainerSiteRuntime`) is a separate, independent plan — do not start it from this one.
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `Sources/AnglesiteCore/WorkerComposition.swift` | Delete `Feature` enum; `generateWranglerToml(features:)` → `generateWranglerToml(workers:)` |
+| `Sources/AnglesiteCore/WorkerActivation.swift` | Delete `mapToFeatures`; add `activeDescriptors(catalog:activeIDs:)` |
+| `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift` | `provision(features:)` → `provision(workers:)`; `persistConfig(features:)` → `persistConfig(workers:)` |
+| `Sources/AnglesiteCore/SiteScaffolder.swift` | One call-site param rename (empty array, trivial) |
+| `Sources/AnglesiteCore/SiteOperations.swift` | Replace `mapToFeatures` call with `activeDescriptors`; broaden the existing "no cached catalog" log line to cover resource composition, not just route claims |
+| `Sources/AnglesiteApp/DeployModel.swift` | Replace `mapToFeatures` call with `activeDescriptors` |
+| `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift` | Migrate every fixture from `Feature` cases to `WorkerDescriptor` fixtures; delete the now-pointless `featureSets()` test |
+| `Tests/AnglesiteCoreTests/WorkerActivationTests.swift` | Delete `mapToFeatures*` tests; add `activeDescriptors*` tests |
+| `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift` | Migrate fixtures; add explicit `workers:` to tests that relied on the old `.v2` default |
+
+---
+
+## Task 1: AnglesiteCore — migrate types, composition, provisioning, call sites, and tests
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/WorkerComposition.swift`
+- Modify: `Sources/AnglesiteCore/WorkerActivation.swift`
+- Modify: `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift`
+- Modify: `Sources/AnglesiteCore/SiteScaffolder.swift:186`
+- Modify: `Sources/AnglesiteCore/SiteOperations.swift:75-118`
+- Test: `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift`
+- Test: `Tests/AnglesiteCoreTests/WorkerActivationTests.swift`
+- Test: `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerDescriptor` (id, displayName, description, group, binding, resources: `{needsD1, needsKV, needsR2}`) from `Sources/AnglesiteCore/WorkerCatalog.swift` (already landed, unchanged).
+- Produces: `WorkerComposition.generateWranglerToml(siteName:workers:routeClaims:resources:inboxCaptureEnabled:inboxKVNamespaceID:) throws -> String`; `SocialWorkerProvisionCommand.provision(siteID:siteDirectory:siteName:workers:routeClaims:knownResources:) async -> Result`; `WorkerActivation.activeDescriptors(catalog:activeIDs:) -> [WorkerDescriptor]` — Task 2 (`DeployModel.swift`) consumes all three by name.
+
+- [ ] **Step 1: Update `WorkerCompositionTests.swift` to the target `workers:` API (this will not compile yet — that's expected, it defines the contract Step 2 implements)**
+
+Replace the entire file with:
+
+```swift
+// Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+private func worker(_ id: String, d1: Bool, kv: Bool, r2: Bool) -> WorkerDescriptor {
+    WorkerDescriptor(
+        id: id, displayName: id, description: "test fixture", group: "test",
+        binding: .settingsActivated, resources: .init(needsD1: d1, needsKV: kv, needsR2: r2)
+    )
+}
+
+private let webmentionWorker = worker("webmention", d1: true, kv: true, r2: false)
+private let indieauthWorker = worker("indieauth", d1: true, kv: true, r2: false)
+private let micropubWorker = worker("micropub", d1: true, kv: true, r2: true)
+private let websubWorker = worker("websub", d1: true, kv: true, r2: false)
+private let v2Workers = [webmentionWorker, indieauthWorker]
+private let v3Workers = [webmentionWorker, indieauthWorker, micropubWorker, websubWorker]
+
+@Suite("WorkerComposition")
+struct WorkerCompositionTests {
+    @Test("generates wrangler.toml with static assets and no social features")
+    func staticOnly() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: []
+        )
+        #expect(toml.contains("name = \"my-site\""))
+        #expect(toml.contains("[assets]"))
+        #expect(toml.contains("directory = \"dist\""))
+        #expect(!toml.contains("[[d1_databases]]"))
+    }
+
+    @Test("generates wrangler.toml with webmention + indieauth (D1 + KV yes, R2 no)")
+    func withSocialFeatures() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: [webmentionWorker, indieauthWorker]
+        )
+        #expect(toml.contains("name = \"my-site\""))
+        #expect(toml.contains("[assets]"))
+        #expect(toml.contains("[[d1_databases]]"))
+        #expect(toml.contains("binding = \"DB\""))
+        #expect(toml.contains("binding = \"AUTH_DB\""))
+        #expect(toml.contains("migrations_dir = \"worker/migrations\""))
+        #expect(toml.contains("[[kv_namespaces]]"))
+        #expect(toml.contains("binding = \"SOCIAL_KV\""))
+        #expect(toml.contains("binding = \"ASSETS\""))
+        // No route claims → no run_worker_first at all (#746): unclaimed paths stay asset-first,
+        // and the worker still receives its endpoints via Cloudflare's asset-miss fallback.
+        #expect(!toml.contains("run_worker_first"))
+        #expect(toml.contains("# Secrets required for IndieAuth (set with `wrangler secret put <NAME>`):"))
+        #expect(toml.contains("# TOKEN_SIGNING_KEY, INDIEAUTH_OWNER_PASSWORD"))
+        #expect(!toml.contains("[secrets]"))
+        #expect(toml.contains("[observability]"))
+        #expect(!toml.contains("[[r2_buckets]]"))
+    }
+
+    @Test("generates wrangler.toml with V-2 workers (D1 yes, R2 no — micropub is V-3)")
+    func v2Features() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: v2Workers
+        )
+        #expect(toml.contains("[[d1_databases]]"))
+        #expect(toml.contains("[[kv_namespaces]]"))
+        #expect(!toml.contains("[[r2_buckets]]"))
+    }
+
+    @Test("generates wrangler.toml with V-3 workers (D1 + R2 — micropub needs media)")
+    func v3Features() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: v3Workers
+        )
+        #expect(toml.contains("[[d1_databases]]"))
+        #expect(toml.contains("[[kv_namespaces]]"))
+        #expect(toml.contains("[[r2_buckets]]"))
+        #expect(toml.contains("binding = \"MEDIA\""))
+    }
+
+    @Test("writes provisioned Cloudflare resource ids into wrangler.toml")
+    func provisionedResources() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: v3Workers,
+            resources: .init(d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: "custom-media")
+        )
+
+        #expect(toml.contains("database_id = \"d1-id\""))
+        #expect(toml.contains("id = \"kv-id\""))
+        #expect(toml.contains("bucket_name = \"custom-media\""))
+    }
+
+    @Test("rejects site names containing TOML-unsafe characters")
+    func rejectsInvalidSiteName() {
+        #expect(throws: WorkerComposition.ConfigError.self) {
+            try WorkerComposition.generateWranglerToml(
+                siteName: "my\"site\ninjected",
+                workers: []
+            )
+        }
+    }
+
+    @Test("inboxCaptureEnabled adds an INBOX_KV binding and uncomments main even with no @dwk/* workers")
+    func inboxCaptureAddsKVBinding() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true)
+        #expect(toml.contains("main = \"worker/worker.ts\""))
+        #expect(toml.contains("binding = \"INBOX_KV\""))
+        #expect(toml.contains("id = \"\"  # filled by provisioning"))
+    }
+
+    @Test("inboxCaptureEnabled fills the provisioned namespace id when given")
+    func inboxCaptureFillsProvisionedID() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true, inboxKVNamespaceID: "abc123")
+        #expect(toml.contains("id = \"abc123\""))
+    }
+
+    @Test("inboxCaptureEnabled false omits the INBOX_KV binding")
+    func inboxCaptureDisabledOmitsBinding() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [])
+        #expect(!toml.contains("INBOX_KV"))
+        #expect(!toml.contains("main ="))
+    }
+
+    @Test("route claims emit deterministic, sorted, deduplicated run_worker_first entries")
+    func selectiveRunWorkerFirst() throws {
+        let claims = [
+            WorkerRouteClaim(path: "/token", match: .exact, methods: ["POST"], handler: "indieauth"),
+            WorkerRouteClaim(path: "/authorize", match: .exact, methods: ["GET", "POST"], handler: "indieauth"),
+            WorkerRouteClaim(path: "/authorize", match: .exact, methods: ["GET", "POST"], handler: "indieauth"),
+            WorkerRouteClaim(
+                path: "/.well-known/acme-challenge", match: .prefix, methods: ["GET"], handler: "acme",
+                specificationURL: URL(string: "https://www.rfc-editor.org/rfc/rfc8555")),
+        ]
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [indieauthWorker], routeClaims: claims)
+        #expect(toml.contains(
+            #"run_worker_first = ["/.well-known/acme-challenge", "/.well-known/acme-challenge/*", "/authorize", "/token"]"#
+        ))
+        // Regeneration is byte-stable regardless of claim order.
+        let regenerated = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [indieauthWorker], routeClaims: claims.reversed())
+        #expect(toml == regenerated)
+    }
+
+    @Test("run_worker_first is omitted entirely when there are no active dynamic routes")
+    func omitsRunWorkerFirstWithoutClaims() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [webmentionWorker, indieauthWorker])
+        #expect(!toml.contains("run_worker_first"))
+        #expect(toml.contains("binding = \"ASSETS\""))
+    }
+
+    @Test("inbox capture claims /inbox as a worker-first route")
+    func inboxCaptureClaimsRoute() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [], inboxCaptureEnabled: true)
+        #expect(toml.contains(#"run_worker_first = ["/inbox"]"#))
+    }
+
+    @Test("static-only sites emit no run_worker_first")
+    func staticOnlyOmitsRunWorkerFirst() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [])
+        #expect(!toml.contains("run_worker_first"))
+    }
+
+    @Test("an unvalidated route claim path is refused, not interpolated into TOML")
+    func rejectsInvalidRouteClaim() {
+        let hostile = WorkerRouteClaim(
+            path: "/a\"]\ninjected = true", match: .exact, methods: ["GET"], handler: "x")
+        #expect(throws: WorkerComposition.ConfigError.self) {
+            try WorkerComposition.generateWranglerToml(
+                siteName: "my-site", workers: [indieauthWorker], routeClaims: [hostile])
+        }
+    }
+
+    @Test("composition runs full claim validation, not just path syntax")
+    func rejectsSemanticallyInvalidRouteClaim() {
+        // Valid path, invalid methods (HEAD without paired GET) — only full validation catches it.
+        let headOnly = WorkerRouteClaim(
+            path: "/status", match: .exact, methods: ["HEAD"], handler: "x")
+        #expect(throws: WorkerComposition.ConfigError.self) {
+            try WorkerComposition.generateWranglerToml(
+                siteName: "my-site", workers: [indieauthWorker], routeClaims: [headOnly])
+        }
+    }
+
+    @Test("ProvisionedResources round-trips through JSONEncoder/JSONDecoder")
+    func provisionedResourcesCodable() throws {
+        let resources = WorkerComposition.ProvisionedResources(
+            d1DatabaseID: "d1-id", kvNamespaceID: "kv-id", r2BucketName: "media-bucket"
+        )
+        let data = try JSONEncoder().encode(resources)
+        let decoded = try JSONDecoder().decode(WorkerComposition.ProvisionedResources.self, from: data)
+        #expect(decoded == resources)
+    }
+}
+```
+
+Note: the old `featureSets()` test (asserting `Feature.v2.contains(.webmention)` etc.) is deleted — it tested `Feature`'s own static data, which no longer exists. Phase-list correctness (which npm packages belong to V-2/V-3/V-4) is still covered by `WorkersConformanceTests.swift`'s `v2Gate`/`v3Gate` tests against `WorkersConformanceStatus.phaseRequirements`, which was always npm-package-name-keyed and untouched by this migration.
+
+- [ ] **Step 2: Run the test target to confirm it fails to compile (expected — `WorkerComposition.generateWranglerToml` doesn't have a `workers:` parameter yet)**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: **build error** — `extra argument 'workers' in call` / `incorrect argument label in call (have 'workers:', expected 'features:')`.
+
+- [ ] **Step 3: Migrate `WorkerComposition.swift` — delete `Feature`, retarget `generateWranglerToml` to `[WorkerDescriptor]`**
+
+Delete lines 11-54 (the entire `public enum Feature: String, CaseIterable, Sendable { ... }` block, including its three computed properties and the `v2`/`v3`/`v4` static arrays).
+
+Replace the `generateWranglerToml` function (originally lines 106-229) with:
+
+```swift
+    /// Generates a wrangler.toml for a site with the given workers enabled.
+    ///
+    /// - Parameters:
+    ///   - siteName: The Worker name (used as the Cloudflare Workers project name).
+    ///     Must match `[A-Za-z0-9_-]+`.
+    ///   - workers: The effective active `@dwk/workers` catalog descriptors. Empty = static-only
+    ///     deploy.
+    ///   - routeClaims: The effective active dynamic-route claims (#746), already validated by
+    ///     `WorkerRouteClaims.activeClaims`. Emitted as selective `[assets].run_worker_first`
+    ///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
+    ///     longer shadow an active dynamic route, while every unclaimed path keeps Cloudflare's
+    ///     asset-first fallback. Omitted entirely when there are no active dynamic routes.
+    /// - Returns: A complete wrangler.toml string.
+    /// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
+    ///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``
+    ///   for a claim that never passed `WorkerRouteClaims` validation.
+    public static func generateWranglerToml(
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim] = [],
+        resources: ProvisionedResources = .init(),
+        inboxCaptureEnabled: Bool = false,
+        inboxKVNamespaceID: String? = nil
+    ) throws -> String {
+        guard isValidSiteName(siteName) else {
+            throw ConfigError.invalidSiteName(siteName)
+        }
+        var effectiveClaims = routeClaims
+        if inboxCaptureEnabled {
+            effectiveClaims.append(inboxCaptureRouteClaim)
+        }
+        // Full single-claim validation (not just path syntax), so a future caller that skips
+        // `WorkerRouteClaims.activeClaims` still can't emit an invalid claim into TOML. Cross-
+        // claim overlap detection remains `activeClaims`'s job — it needs owner attribution
+        // this signature doesn't carry.
+        for claim in effectiveClaims {
+            do {
+                try WorkerRouteClaims.validate(claim, owner: "composition")
+            } catch {
+                throw ConfigError.invalidRouteClaim(path: claim.path, reason: "\(error)")
+            }
+        }
+        // @dwk/indieauth's binding name is part of its public composition contract (see the
+        // AUTH_DB block below) — the one place composition keys off a specific catalog id rather
+        // than generic resource flags.
+        let hasIndieauth = workers.contains(where: { $0.id == "indieauth" })
+
+        var lines: [String] = []
+        lines.append("name = \"\(siteName)\"")
+        lines.append("compatibility_date = \"2026-07-15\"")
+        lines.append("compatibility_flags = [\"nodejs_compat\"]")
+
+        let hasSocialFeatures = !workers.isEmpty
+        if hasSocialFeatures || inboxCaptureEnabled {
+            lines.append("main = \"worker/worker.ts\"")
+        }
+        lines.append("")
+        lines.append("[assets]")
+        lines.append("directory = \"dist\"")
+        if hasSocialFeatures || inboxCaptureEnabled {
+            lines.append("binding = \"ASSETS\"")
+            let patterns = WorkerRouteClaims.runWorkerFirstPatterns(effectiveClaims)
+            if !patterns.isEmpty {
+                let list = patterns.map { "\"\($0)\"" }.joined(separator: ", ")
+                lines.append("run_worker_first = [\(list)]")
+            }
+        }
+
+        if workers.contains(where: { $0.resources.needsD1 }) {
+            lines.append("")
+            lines.append("[[d1_databases]]")
+            lines.append("binding = \"DB\"")
+            lines.append("database_name = \"\(siteName)-social\"")
+            if let id = resources.d1DatabaseID, !id.isEmpty {
+                lines.append("database_id = \"\(id)\"")
+            } else {
+                lines.append("database_id = \"\"  # filled by provisioning")
+            }
+        }
+
+        // Keep the generic DB binding above for the other @dwk packages, while binding the same
+        // per-site D1 database under AUTH_DB for authorization codes and issued-token state.
+        if hasIndieauth {
+            lines.append("")
+            lines.append("[[d1_databases]]")
+            lines.append("binding = \"AUTH_DB\"")
+            lines.append("database_name = \"\(siteName)-social\"")
+            lines.append("migrations_dir = \"worker/migrations\"")
+            if let id = resources.d1DatabaseID, !id.isEmpty {
+                lines.append("database_id = \"\(id)\"")
+            } else {
+                lines.append("database_id = \"\"  # filled by provisioning")
+            }
+        }
+
+        if workers.contains(where: { $0.resources.needsKV }) {
+            lines.append("")
+            lines.append("[[kv_namespaces]]")
+            lines.append("binding = \"SOCIAL_KV\"")
+            if let id = resources.kvNamespaceID, !id.isEmpty {
+                lines.append("id = \"\(id)\"")
+            } else {
+                lines.append("id = \"\"  # filled by provisioning")
+            }
+        }
+
+        if workers.contains(where: { $0.resources.needsR2 }) {
+            lines.append("")
+            lines.append("[[r2_buckets]]")
+            lines.append("binding = \"MEDIA\"")
+            lines.append("bucket_name = \"\(resources.r2BucketName ?? "\(siteName)-media")\"")
+        }
+
+        if inboxCaptureEnabled {
+            lines.append("")
+            lines.append("[[kv_namespaces]]")
+            lines.append("binding = \"INBOX_KV\"")
+            if let id = inboxKVNamespaceID, !id.isEmpty {
+                lines.append("id = \"\(id)\"")
+            } else {
+                lines.append("id = \"\"  # filled by provisioning")
+            }
+        }
+
+        if hasIndieauth {
+            lines.append("")
+            // Wrangler has no schema for declaring required secrets in wrangler.toml — secrets are
+            // set with `wrangler secret put <NAME>` and are never read back out of this file. Emit
+            // this as a comment (not a `[secrets]` table) so it can't be mistaken for a config key
+            // wrangler validates or fail on.
+            lines.append("# Secrets required for IndieAuth (set with `wrangler secret put <NAME>`):")
+            lines.append("# TOKEN_SIGNING_KEY, INDIEAUTH_OWNER_PASSWORD")
+        }
+
+        if hasSocialFeatures || inboxCaptureEnabled {
+            lines.append("")
+            lines.append("[observability]")
+            lines.append("enabled = true")
+            lines.append("head_sampling_rate = 1")
+        }
+
+        lines.append("")
+        return lines.joined(separator: "\n")
+    }
+```
+
+- [ ] **Step 4: Run the test target to confirm `WorkerCompositionTests` now passes**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: PASS (16 tests, `featureSets` no longer present).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerComposition.swift Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+git commit -m "refactor(workers): migrate generateWranglerToml from Feature enum to WorkerDescriptor (#708)"
+```
+
+- [ ] **Step 6: Update `WorkerActivationTests.swift` to the target `activeDescriptors` API (will not compile yet)**
+
+In `Tests/AnglesiteCoreTests/WorkerActivationTests.swift`, replace lines 105-120 (the three `mapToFeatures*` tests) with:
+
+```swift
+    @Test("activeDescriptors resolves known ids against the catalog")
+    func activeDescriptorsKnownIDs() {
+        let webmention = descriptor(id: "webmention", binding: .settingsActivated)
+        let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
+        let resolved = WorkerActivation.activeDescriptors(
+            catalog: [webmention, indieauth], activeIDs: ["indieauth", "webmention"])
+        #expect(Set(resolved.map(\.id)) == ["indieauth", "webmention"])
+    }
+
+    @Test("activeDescriptors drops ids with no matching catalog entry")
+    func activeDescriptorsDropsUnknownIDs() {
+        let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
+        let resolved = WorkerActivation.activeDescriptors(
+            catalog: [indieauth], activeIDs: ["indieauth", "solid-pod"])
+        #expect(resolved.map(\.id) == ["indieauth"])
+    }
+
+    @Test("activeDescriptors of an empty id set is empty")
+    func activeDescriptorsEmpty() {
+        let indieauth = descriptor(id: "indieauth", binding: .settingsActivated)
+        #expect(WorkerActivation.activeDescriptors(catalog: [indieauth], activeIDs: []).isEmpty)
+    }
+```
+
+(This reuses the file's existing private `descriptor(id:group:binding:)` helper at lines 7-14 — no new helper needed.)
+
+- [ ] **Step 7: Run the test target to confirm it fails to compile**
+
+Run: `swift test --package-path . --filter WorkerActivationTests`
+Expected: **build error** — `type 'WorkerActivation' has no member 'activeDescriptors'`.
+
+- [ ] **Step 8: Migrate `WorkerActivation.swift` — delete `mapToFeatures`, add `activeDescriptors`**
+
+In `Sources/AnglesiteCore/WorkerActivation.swift`, replace lines 57-65 (the `mapToFeatures` function and its doc comment) with:
+
+```swift
+    /// The effective active worker set as full `WorkerDescriptor`s, resolved by id against
+    /// `catalog` — what `WorkerComposition.generateWranglerToml` and
+    /// `SocialWorkerProvisionCommand.provision` need now that composition is descriptor-driven
+    /// (#708). An id present in `activeIDs` but absent from `catalog` (a stale id, or a catalog
+    /// fetch that hasn't happened yet) is silently dropped — there is no descriptor data to
+    /// compose it with. Mirrors `WorkerRouteClaims.activeClaims(catalog:activeIDs:)`'s shape.
+    public static func activeDescriptors(catalog: [WorkerDescriptor], activeIDs: Set<String>) -> [WorkerDescriptor] {
+        catalog.filter { activeIDs.contains($0.id) }
+    }
+```
+
+- [ ] **Step 9: Run the test target to confirm `WorkerActivationTests` now passes**
+
+Run: `swift test --package-path . --filter WorkerActivationTests`
+Expected: PASS (10 tests: 7 existing `effectiveActiveIDs`/`removedIDs` tests + 3 new `activeDescriptors` tests).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerActivation.swift Tests/AnglesiteCoreTests/WorkerActivationTests.swift
+git commit -m "refactor(workers): replace WorkerActivation.mapToFeatures shim with activeDescriptors (#708)"
+```
+
+- [ ] **Step 11: Update `SocialWorkerProvisionCommandTests.swift` to the target `workers:` API (will not compile yet)**
+
+In `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`, add these fixtures immediately after the `import` lines (before `@Suite("SocialWorkerProvisionCommand")`):
+
+```swift
+private func worker(_ id: String, d1: Bool, kv: Bool, r2: Bool) -> WorkerDescriptor {
+    WorkerDescriptor(
+        id: id, displayName: id, description: "test fixture", group: "test",
+        binding: .settingsActivated, resources: .init(needsD1: d1, needsKV: kv, needsR2: r2)
+    )
+}
+
+private let webmentionWorker = worker("webmention", d1: true, kv: true, r2: false)
+private let indieauthWorker = worker("indieauth", d1: true, kv: true, r2: false)
+private let micropubWorker = worker("micropub", d1: true, kv: true, r2: true)
+private let websubWorker = worker("websub", d1: true, kv: true, r2: false)
+private let v2Workers = [webmentionWorker, indieauthWorker]
+private let v3Workers = [webmentionWorker, indieauthWorker, micropubWorker, websubWorker]
+```
+
+Then apply these exact edits (every other test in the file is unaffected and stays as-is):
+
+1. `provisionsV2Worker` — the call `await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")` becomes `await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)`. (The old default value was `WorkerComposition.Feature.v2`; the new default is `[]`, so this test — which asserts D1+KV get created — must pass workers explicitly now.)
+
+2. `provisionsR2ForMicropub` — `features: WorkerComposition.Feature.v3` becomes `workers: v3Workers`.
+
+3. `missingToken` — **unchanged**. It returns before `workers` is ever read, so the default value doesn't affect its assertions.
+
+4. `reusesPersistedResources` — both occurrences of `features: WorkerComposition.Feature.v3` (the fixture-TOML `generateWranglerToml` call, and the `command.provision` call) become `workers: v3Workers`.
+
+5. `partialFailureReportsResources` — the call `await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site")` becomes `await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)` (this test exercises the D1-succeeds/KV-fails path, which needs `needsD1`/`needsKV` true — the old `.v2` default provided that implicitly).
+
+6. `deployFailureReportsResources` — same change as #5: add `workers: v2Workers` to the `command.provision` call.
+
+7. `workerNameConflictPropagates` — same change as #5: add `workers: v2Workers`.
+
+8. `migrationFailureStopsDeploy` — same change as #5: add `workers: v2Workers` (this test also needs the IndieAuth migration step to run, which requires an `indieauth`-id worker — `v2Workers` includes it).
+
+9. `resourceIDExtraction`, `persistedResourceParsing` — **unchanged**. Neither calls `provision` or `generateWranglerToml`.
+
+10. `reusesKnownResourcesOverFileScrape` — the fixture-TOML call `features: [.indieauth]` becomes `workers: [indieauthWorker]`; the `command.provision(..., features: [.indieauth, .micropub], knownResources: known)` call becomes `command.provision(..., workers: [indieauthWorker, micropubWorker], knownResources: known)`.
+
+11. `asDeployCommandResultMapsSucceeded`, `asDeployCommandResultMapsBlocked`, `asDeployCommandResultMapsWorkerNameConflict`, `asDeployCommandResultMapsFailed` — **unchanged**. None call `provision` or `generateWranglerToml`.
+
+- [ ] **Step 12: Run the test target to confirm it fails to compile**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: **build error** — `incorrect argument label in call (have 'features:', expected 'workers:')` at the still-unmigrated call sites, plus the same error surfacing from `WorkerComposition.generateWranglerToml`'s already-migrated signature.
+
+- [ ] **Step 13: Migrate `SocialWorkerProvisionCommand.swift`**
+
+In `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift`:
+
+Change the `provision` signature (originally lines 50-65) — replace:
+
+```swift
+        features: [WorkerComposition.Feature] = WorkerComposition.Feature.v2,
+```
+
+with:
+
+```swift
+        workers: [WorkerDescriptor] = [],
+```
+
+Replace every `features` reference in the `provision` body (originally lines 91, 112, 118, 139, 145, 159, 165, 172, 228, 238) as follows:
+
+- `if features.contains(where: { $0.needsD1 }) {` → `if workers.contains(where: { $0.resources.needsD1 }) {`
+- `if features.contains(where: { $0.needsKV }) {` → `if workers.contains(where: { $0.resources.needsKV }) {`
+- `if features.contains(where: { $0.needsR2 }) {` → `if workers.contains(where: { $0.resources.needsR2 }) {`
+- every `persistConfig(siteDirectory: siteDirectory, siteName: siteName, features: features, routeClaims: routeClaims, resources: resources)` call (there are 4: after the D1 block, after the KV block, after the R2 block, and the unconditional one before the IndieAuth migration step) → `persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources)`
+- `if features.contains(.indieauth) {` (guarding the `d1 migrations apply AUTH_DB` step) → `if workers.contains(where: { $0.id == "indieauth" }) {`
+
+Change `persistConfig`'s signature (originally lines 225-231) — replace:
+
+```swift
+    private func persistConfig(
+        siteDirectory: URL,
+        siteName: String,
+        features: [WorkerComposition.Feature],
+        routeClaims: [WorkerRouteClaim],
+        resources: WorkerComposition.ProvisionedResources
+    ) -> Result? {
+```
+
+with:
+
+```swift
+    private func persistConfig(
+        siteDirectory: URL,
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim],
+        resources: WorkerComposition.ProvisionedResources
+    ) -> Result? {
+```
+
+And inside `persistConfig`'s body, the `WorkerComposition.generateWranglerToml(siteName: siteName, features: features, routeClaims: routeClaims, resources: resources)` call becomes `WorkerComposition.generateWranglerToml(siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources)`.
+
+- [ ] **Step 14: Migrate `SiteScaffolder.swift:186`**
+
+In `Sources/AnglesiteCore/SiteScaffolder.swift`, change:
+
+```swift
+        let toml = try WorkerComposition.generateWranglerToml(siteName: siteName, features: [])
+```
+
+to:
+
+```swift
+        let toml = try WorkerComposition.generateWranglerToml(siteName: siteName, workers: [])
+```
+
+- [ ] **Step 15: Migrate `SiteOperations.swift`**
+
+In `Sources/AnglesiteCore/SiteOperations.swift`, in `deployWithWorkerComposition`, replace lines 75-92:
+
+```swift
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
+        let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
+
+        // Dynamic-route claims (#746): this path has no catalog fetcher wired (matching the
+        // `catalog: []` activation choice above), but the on-disk cache from a previous GUI fetch
+        // still lets active workers keep their `run_worker_first` routes — otherwise a headless
+        // deploy would silently regenerate wrangler.toml without them. Validation failures refuse
+        // the deploy before any Cloudflare call, mirroring `DeployModel.runDeploy`.
+        let cachedCatalog = WorkerCatalogFetcher.cachedCatalog()
+        if cachedCatalog.isEmpty && !effectiveActiveIDs.isEmpty {
+            // The shadowing-protection gap this leaves (an active worker's routes deploy without
+            // their run_worker_first entries) must be visible in the debug pane, not silent.
+            await LogCenter.shared.append(
+                source: "deploy:\(site.id)",
+                stream: .stderr,
+                text: "no cached worker catalog — deploying active workers (\(effectiveActiveIDs.sorted().joined(separator: ", "))) without route claims; run_worker_first will be omitted until a catalog fetch succeeds"
+            )
+        }
+```
+
+with:
+
+```swift
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
+
+        // Dynamic-route claims (#746) and resource composition (#708) both need real descriptor
+        // data, which the `catalog: []` activation call above deliberately doesn't have (matching
+        // the effectiveActiveIDs "settings-activated only" comment above). The on-disk cache from
+        // a previous GUI fetch is the only source of that data on this headless path.
+        let cachedCatalog = WorkerCatalogFetcher.cachedCatalog()
+        let workers = WorkerActivation.activeDescriptors(catalog: cachedCatalog, activeIDs: effectiveActiveIDs)
+        if cachedCatalog.isEmpty && !effectiveActiveIDs.isEmpty {
+            // The gap this leaves (an active worker deploys with no D1/KV/R2 bindings and no
+            // run_worker_first entries — there's no catalog data to resolve its active id against)
+            // must be visible in the debug pane, not silent.
+            await LogCenter.shared.append(
+                source: "deploy:\(site.id)",
+                stream: .stderr,
+                text: "no cached worker catalog — deploying active workers (\(effectiveActiveIDs.sorted().joined(separator: ", "))) with no resource bindings or route claims; wrangler.toml will be static-only until a catalog fetch succeeds"
+            )
+        }
+```
+
+Then in the same function, change the `provision` call (originally lines 111-118):
+
+```swift
+        let provisionResult = await factory.socialWorkerProvision().provision(
+            siteID: site.id,
+            siteDirectory: siteDirectory,
+            siteName: workerSiteName,
+            features: features,
+            routeClaims: routeClaims.map(\.claim),
+            knownResources: settings.provisionedWorkerResources ?? .init()
+        )
+```
+
+to:
+
+```swift
+        let provisionResult = await factory.socialWorkerProvision().provision(
+            siteID: site.id,
+            siteDirectory: siteDirectory,
+            siteName: workerSiteName,
+            workers: workers,
+            routeClaims: routeClaims.map(\.claim),
+            knownResources: settings.provisionedWorkerResources ?? .init()
+        )
+```
+
+- [ ] **Step 16: Run the full `AnglesiteCore` test target**
+
+Run: `swift test --package-path .`
+Expected: PASS — all `AnglesiteCoreTests`, `AnglesiteSiteModelTests`, `AnglesiteBridgeTests`, and (on Swift 6.4+/Xcode 27) `AnglesiteIntentsTests` suites green, no build errors.
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift Sources/AnglesiteCore/SiteScaffolder.swift Sources/AnglesiteCore/SiteOperations.swift Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+git commit -m "refactor(workers): migrate SocialWorkerProvisionCommand and its callers to WorkerDescriptor (#708)"
+```
+
+---
+
+## Task 2: AnglesiteApp — migrate `DeployModel.swift`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift:450,506`
+
+**Interfaces:**
+- Consumes: `WorkerActivation.activeDescriptors(catalog:activeIDs:) -> [WorkerDescriptor]` and `SocialWorkerProvisionCommand.provision(workers:)` from Task 1.
+- Produces: nothing new — this is the last caller of the old `mapToFeatures`/`features:` shape.
+
+- [ ] **Step 1: Migrate the two call sites**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, in `runDeploy`, change line 450:
+
+```swift
+        let features = WorkerActivation.mapToFeatures(effectiveActiveIDs)
+```
+
+to:
+
+```swift
+        let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
+```
+
+(`catalog` here is the `[WorkerDescriptor]` fetched two lines earlier at `let catalog = await workerCatalog()` — the same catalog already used for `effectiveActiveIDs` and `routeClaims`, so this needs no new fetch.)
+
+Then change the `provision` call (originally lines 502-509):
+
+```swift
+        let provisionResult = await socialCommand.provision(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            siteName: workerSiteName,
+            features: features,
+            routeClaims: routeClaims.map(\.claim),
+            knownResources: settings.provisionedWorkerResources ?? .init()
+        )
+```
+
+to:
+
+```swift
+        let provisionResult = await socialCommand.provision(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            siteName: workerSiteName,
+            workers: workers,
+            routeClaims: routeClaims.map(\.claim),
+            knownResources: settings.provisionedWorkerResources ?? .init()
+        )
+```
+
+- [ ] **Step 2: Build the app target**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`. If `Anglesite.xcodeproj` doesn't exist yet in this worktree, run `xcodegen generate` first (per this repo's worktree setup — the project file is gitignored).
+
+- [ ] **Step 3: Confirm no remaining references to the deleted API**
+
+Run: `grep -rn "WorkerComposition.Feature\|WorkerActivation.mapToFeatures" Sources/ Tests/`
+Expected: no output (empty). If anything matches, it's a missed call site — go back and migrate it before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift
+git commit -m "refactor(workers): migrate DeployModel to WorkerDescriptor-based composition (#708)"
+```
+
+---
+
+## Task 3: Full verification and PR
+
+- [ ] **Step 1: Run the complete test suite one more time from a clean state**
+
+Run: `swift test --package-path .`
+Expected: PASS, zero failures.
+
+- [ ] **Step 2: Run the full app build one more time**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Review the diff for stray debug output or leftover TODOs**
+
+Run: `git diff main --stat` and `git log main.. --oneline` to review the commit sequence, then `git diff main -- Sources/ Tests/` to eyeball the full diff.
+Expected: only the files listed in Tasks 1-2's File Structure table are touched; no `.xcodeproj` changes (it's gitignored); no stray `print`/`FIXME` left behind.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "refactor(workers): migrate WorkerComposition to WorkerDescriptor (#708)" --body "$(cat <<'EOF'
+## Summary
+- Migrates `WorkerComposition.generateWranglerToml` and `SocialWorkerProvisionCommand.provision` from the closed `WorkerComposition.Feature` enum to catalog-driven `WorkerDescriptor`, per #708's remaining prerequisites (design doc §3).
+- Deletes the `WorkerActivation.mapToFeatures` interim shim (#709 design §4/§10), replacing it with `activeDescriptors(catalog:activeIDs:)`, mirroring the existing `WorkerRouteClaims.activeClaims` pattern.
+- Fixes a documented limitation of the old shim: a catalog worker with no matching `Feature` case used to be silently dropped from composition; any catalog-known id now composes correctly.
+- First of #708's two remaining sub-tasks. The `wrangler dev --local` local-runtime sub-task is a separate follow-up PR.
+
+## Test plan
+- [x] `swift test --package-path .` — all AnglesiteCore suites pass
+- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — app target builds
+- [ ] No paired sidecar PR needed — this is app-internal composition logic, not an MCP schema change
+EOF
+)"
+```
+
+- [ ] **Step 5: Remove the in-progress claim on #708**
+
+Do NOT close #708 — the local-runtime sub-task is still open. Leave the `🛠️ In Progress` label in place until that follow-up PR opens too, or remove it now and re-add when starting the follow-up (either is fine; the PR itself is the up-to-date signal per CONTRIBUTING.md once it exists).


### PR DESCRIPTION
## Summary
- Migrates `WorkerComposition.generateWranglerToml` and `SocialWorkerProvisionCommand.provision` from the closed `WorkerComposition.Feature` enum to catalog-driven `WorkerDescriptor`, per #708's remaining prerequisites (design doc `docs/superpowers/specs/2026-07-13-workers-local-debugging-design.md` §3). This is the first of #708's two remaining sub-tasks — the `wrangler dev --local` local-runtime sub-task is a separate follow-up.
- Deletes the `WorkerActivation.mapToFeatures` interim shim, replacing it with `activeDescriptors(catalog:activeIDs:)`, mirroring the existing `WorkerRouteClaims.activeClaims` pattern.
- Fixes a documented limitation of the old shim: a catalog worker with no matching `Feature` case used to be silently dropped from composition; any catalog-known id now composes correctly.
- **Two follow-up fixes found during final verification** (not in the original plan, both test-guarded):
  - `SiteOperations.provisionSocialWorker` relied on `provision`'s old `Feature.v2` default without passing workers explicitly; the migration's new empty default silently zeroed its D1/KV/AUTH_DB provisioning. Restored via a fixed `v2StarterWorkers` constant matching the old default exactly (now with a dedicated regression test).
  - `SiteOperations.deployWithWorkerComposition` (the headless/Shortcuts deploy path) resolved worker resources only from `WorkerCatalogFetcher.cachedCatalog()`, a hardcoded disk-cache read with no test seam — empty in any environment before a GUI catalog fetch has happened, silently zeroing D1/KV/R2 bindings for an active worker where the old enum-based code worked unconditionally. Added an injectable `cachedWorkerCatalog` seam; also added the matching empty-catalog warning to the GUI deploy path (`DeployModel.runDeploy`) for symmetry with the headless path's existing one.
- **Addressed review feedback** (both rounds):
  - The empty-catalog warning on both deploy paths now fires on any *unresolved* active id (`WorkerActivation.unresolvedActiveIDs`), not just a fully-empty catalog — a partial catalog missing one active worker's entry used to warn on neither path.
  - The warning text is now generated once via `WorkerActivation.missingDescriptorWarning`, shared by both `DeployModel.swift` and `SiteOperations.swift`, so the wording can't drift between them again.
  - Added `DeployModelTests` coverage for the GUI-path warning branch (previously only the headless path had a test seam for this).
  - Added a dedicated `v2StarterWorkers` regression test in `SiteOperationsTests.swift`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

> No MCP message schema or plugin-skill changes here — this only consumes the existing `WorkerDescriptor` shape from the `@dwk/workers` catalog manifest (a third repo, not the `Anglesite/anglesite` pairing), with no new manifest fields or decoding changes.

## Test plan
- [x] `swift test --package-path .` — 2213/2213 passing (only the known, pre-existing, unrelated `GenerableTypesTests` on-device Foundation Models token-overflow flake observed, not a regression)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`
- [ ] Manual smoke (if UI-touching): not needed — no UI surface changed, only deploy-time composition logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)