### PR TITLE
feat: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: "🐛 Bug report"
+description: Report something broken in the Anglesite macOS app
+title: "[Bug]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please check [open issues](https://github.com/Anglesite/Anglesite-app/issues) first to avoid duplicates — if one already exists, add a comment there instead.
+
+        This repo is the native macOS app. If the bug is actually in the MCP sidecar server, file it in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) instead — use the "Which repo" field below if you're not sure.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong, in a sentence or two.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps from a clean state, if possible.
+      placeholder: |
+        1. Open site '...'
+        2. Click '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: repo
+    attributes:
+      label: Which repo does this affect?
+      options:
+        - Anglesite-app (this repo — SwiftUI shell, template, preview, edit overlay)
+        - anglesite (MCP sidecar server)
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      placeholder: e.g. 27.0
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: App version / build
+      description: From the app's About window, or the git commit if you built from source.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Every spawned subprocess streams stdout/stderr to the app's debug pane — paste anything relevant from there, plus any Console.app crash logs.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, related issues, anything else that helps.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: "🐛 Bug report"
 description: Report something broken in the Anglesite macOS app
 title: "[Bug]: "
-labels: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contribution guide
+    url: https://github.com/Anglesite/Anglesite-app/blob/main/CONTRIBUTING.md
+    about: Read this before claiming an issue or opening a PR.
+  - name: Roadmap / build plan
+    url: https://github.com/Anglesite/Anglesite-app/blob/main/docs/build-plan.md
+    about: Check current phase and planned work before filing a feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: "✨ Feature request"
+description: Suggest an idea or enhancement for Anglesite
+title: "[Feature]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check [`docs/build-plan.md`](https://github.com/Anglesite/Anglesite-app/blob/main/docs/build-plan.md) and [open issues](https://github.com/Anglesite/Anglesite-app/issues) first — this may already be planned or in flight.
+
+        For anything beyond a small improvement, this issue **is** the "discuss big changes first" step from `CONTRIBUTING.md` — please describe the problem and proposed approach before opening a PR.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What's missing or painful today? Who does this help?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: repo
+    attributes:
+      label: Which repo does this touch?
+      description: Changes to the MCP message schema need a paired PR — see CLAUDE.md ▸ "Two-repo coordination".
+      options:
+        - Anglesite-app only (SwiftUI shell, template, preview, edit overlay)
+        - anglesite only (MCP sidecar server)
+        - Both (paired PR)
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, related issues, prior discussion.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: "✨ Feature request"
 description: Suggest an idea or enhancement for Anglesite
 title: "[Feature]: "
-labels: []
 body:
   - type: markdown
     attributes:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/JS/edit-overlay"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,113 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at me@dwk.io. All complaints will be
+reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning, providing clarity around the
+nature of the violation and an explanation of why the behavior was
+inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary
+or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported versions
+
+Anglesite is pre-release and moving fast — only the latest release (and `main`) is supported. There are no older maintained lines to backport fixes to.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately using [GitHub Security Advisories](https://github.com/Anglesite/Anglesite-app/security/advisories/new) ("Report a vulnerability" under the Security tab) rather than filing a public issue.
+
+Include as much detail as you can: affected version/commit, reproduction steps, and impact. This is a solo-maintained project, so response times are best-effort, but reports are taken seriously and will be acknowledged as soon as possible.
+
+## Scope
+
+This repo is the native macOS app (SwiftUI shell, website template, WKWebView preview, edit overlay). It ships sandboxed for the Mac App Store and runs site builds/deploys inside a container runtime.
+
+If the vulnerability is in the MCP sidecar server instead, please report it against [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite/security/advisories/new) — see `CLAUDE.md` ▸ "Two-repo coordination" for how the two repos relate.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,8 @@
+# Support
+
+- **Bug reports and feature requests** — [open an issue](https://github.com/Anglesite/Anglesite-app/issues/new/choose) using the provided templates.
+- **Questions, ideas, and general discussion** — use [GitHub Discussions](https://github.com/Anglesite/Anglesite-app/discussions).
+- **Contributing** — read [`CONTRIBUTING.md`](CONTRIBUTING.md) first; it covers issue claiming, testing, and PR expectations.
+- **Security vulnerabilities** — do not open a public issue; see [`SECURITY.md`](SECURITY.md).
+
+This is a solo-maintained, pre-release project, so support is best-effort.


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` (GitHub issue forms) plus a `config.yml` chooser. Both ask which repo the issue affects (app vs. `anglesite` MCP sidecar), matching the two-repo/paired-PR workflow in `CLAUDE.md`. No labels are pre-assigned — the repo only has manually-applied 🎯 area labels.
- Add `SECURITY.md` — private reporting via GitHub Security Advisories, notes the paired-repo split for sidecar vulnerabilities.
- Add `SUPPORT.md` — points to GitHub Discussions (enabled on the repo as part of this PR) for Q&A, issue templates for bugs/features.
- Add `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1, enforcement contact me@dwk.io.
- Add `.github/dependabot.yml` — weekly update PRs for `github-actions`, `npm` (`JS/edit-overlay`), and `swift` (`Package.swift`).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite`.

## Test plan

- [x] Validated all YAML files (`ISSUE_TEMPLATE/*.yml`, `dependabot.yml`) parse with `python3 -c "import yaml; ..."`.
- N/A — config/docs-only change, no Swift/JS touched.