### PR TITLE
fix(#775): Debug-only NetworkSharing mach-lookup exception restores sandboxed container boots on macOS 27 betas

### DIFF
--- a/Resources/Anglesite-Debug.entitlements
+++ b/Resources/Anglesite-Debug.entitlements
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<!-- The container runtime exposes preview/MCP through app-owned loopback proxies. -->
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+
+	<!-- Apple Containerization framework (#69): boot local OCI containers. -->
+	<key>com.apple.security.virtualization</key>
+	<true/>
+
+	<!-- DEBUG-ONLY WORKAROUND for #775 — do not add to Resources/Anglesite.entitlements.
+	     macOS 27 seeds 26A5378n–26A5388g deny sandboxed processes the mach bootstrap
+	     look-up of com.apple.NetworkSharing that vmnet_network_create now performs, so
+	     every sandboxed VM boot dies with VMNET_MEM_FAILURE (1002). Punching just that
+	     look-up back through restores container previews (verified 2026-07-20 on
+	     26A5388g). The real fix is Apple's — remove this when #775 closes. -->
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>com.apple.NetworkSharing</string>
+	</array>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -66,6 +66,8 @@ targets:
         PRODUCT_NAME: Anglesite
         INFOPLIST_FILE: Resources/Info.plist
         GENERATE_INFOPLIST_FILE: NO
+        # Release keeps the clean MAS entitlements; Debug adds a temporary-exception
+        # mach-lookup workaround for #775 (see Resources/Anglesite-Debug.entitlements).
         CODE_SIGN_ENTITLEMENTS: Resources/Anglesite.entitlements
         ENABLE_HARDENED_RUNTIME: YES
         MACOSX_DEPLOYMENT_TARGET: "27.0"
@@ -87,6 +89,10 @@ targets:
         Debug:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "-"
+          # #775 workaround: punch the com.apple.NetworkSharing mach look-up back
+          # through the sandbox so container boots survive macOS 27 seeds
+          # 26A5378n–26A5388g. Debug-only — never ships to MAS.
+          CODE_SIGN_ENTITLEMENTS: Resources/Anglesite-Debug.entitlements
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Apple Distribution"


### PR DESCRIPTION
## Summary

- **Debug-only workaround for #775**: macOS 27 seeds 26A5378n–26A5388g deny sandboxed processes the mach bootstrap look-up of `com.apple.NetworkSharing` that `vmnet_network_create` performs, killing every sandboxed container boot with `VMNET_MEM_FAILURE (1002)`. Adding `com.apple.security.temporary-exception.mach-lookup.global-name` → `com.apple.NetworkSharing` restores container previews.
- Debug builds now sign with new `Resources/Anglesite-Debug.entitlements` (base entitlements + the exception); **Release keeps `Resources/Anglesite.entitlements` untouched**, so nothing changes for MAS.
- #775 stays open to track the real (OS-side) fix; the exception should be deleted when it closes.

**Evidence (2026-07-20, macOS 27.0 build 26A5388g, beta 4):** A/B/A on the same machine, same site, same minutes — unmodified sandboxed Debug app fails 100% (3 boots + one #812 Restart-Networking retry, all `VMNET_MEM_FAILURE (1002)` ~330–450 ms after initfs unpack); the identical binary re-signed with only this exception added boots, brings up both loopback proxies, and serves the site (HTTP 200); the unmodified app relaunched afterwards fails again. Details in [#775's retest comment](https://github.com/Anglesite/Anglesite-app/issues/775#issuecomment-5026162932).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — not run locally: no SwiftPM target is touched (entitlements + project.yml only); relying on CI.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds; `codesign -d --entitlements` on the product shows the exception present in Debug.
- [x] Manual smoke: sandboxed app with these exact entitlements boots the QA Bakery container on 26A5388g and serves the preview (curl 200, site title rendered); without them, boots fail 100% (see #775).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
