### PR TITLE
refactor(#821): extract shared SiteRuntime state-machine + teardown-reentrancy helper

### DIFF
--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -24,9 +24,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     private var fileWatcher: (any SiteFileWatching)?
     private var containerTerminationLease: SuddenTerminationController.Lease?
 
-    private var current: SiteRuntimeState = .idle
-    private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
-    private var generation = 0
+    private let stateMachine = SiteRuntimeStateMachine()
     private var activeSiteID: String?
     private var activeSiteDirectory: URL?
     private var loadedKnowledgeSiteID: String?
@@ -76,7 +74,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         self.beginActivity = beginActivity
     }
 
-    public var state: SiteRuntimeState { current }
+    public var state: SiteRuntimeState { stateMachine.state }
 
     /// The `LocalContainerControl` held by this runtime, or `nil` if no site is currently
     /// started. Callers (e.g. `PreviewModel`) read this to build a `ContainerDeployExecutor`
@@ -124,7 +122,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
               commit.unicodeScalars.allSatisfy({ Self.hexDigits.contains($0) })
         else { throw SiteRuntimePersistenceError.missingOrInvalidCommit }
 
-        let expectedGeneration = generation
+        let expectedGeneration = stateMachine.currentGeneration
         guard let siteID = activeSiteID, let siteDirectory = activeSiteDirectory else {
             throw SiteRuntimePersistenceError.runtimeNotRunning
         }
@@ -132,7 +130,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         await acquirePersistenceSlot()
         defer { releasePersistenceSlot() }
 
-        guard expectedGeneration == generation,
+        guard stateMachine.isCurrent(expectedGeneration),
               activeSiteID == siteID,
               activeSiteDirectory == siteDirectory
         else {
@@ -180,7 +178,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
                 }
             )
         } catch {
-            guard expectedGeneration == generation, activeSiteID == siteID else {
+            guard stateMachine.isCurrent(expectedGeneration), activeSiteID == siteID else {
                 throw SiteRuntimePersistenceError.runtimeNotRunning
             }
             throw SiteRuntimePersistenceError.syncFailed(error.localizedDescription)
@@ -191,7 +189,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
                 detail.isEmpty ? "git handoff exited \(result.exitCode)" : detail)
         }
 
-        guard expectedGeneration == generation,
+        guard stateMachine.isCurrent(expectedGeneration),
               activeSiteID == siteID,
               activeSiteDirectory == siteDirectory
         else {
@@ -232,30 +230,14 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     }
 
     public func observe() -> AsyncStream<SiteRuntimeState> {
-        let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
-        let id = UUID()
-        observers[id] = continuation
-        continuation.onTermination = { [weak self] _ in Task { await self?.removeObserver(id) } }
-        continuation.yield(current)
-        return stream
+        stateMachine.observe()
     }
 
     /// `siteDirectory` is the package's `Source/` directory; it becomes the `file://` repo the
     /// container clones (git is the source of truth, #72). The configured `ref` selects the commit.
     public func start(siteID: String, siteDirectory: URL) async {
         await teardown()
-        generation += 1
-        let gen = generation
-        // `setState` dedups against the current value, so re-entering `.starting(siteID:)` for the
-        // same site (Restart while already `.starting` — the "wedged boot" case this command exists
-        // for) would otherwise be silently dropped: observers never see a change, so the progress
-        // bar stays frozen on the superseded attempt. Force a transient `.idle` first only in that
-        // specific case — `.ready`/`.failed`/`.idle` already differ from the new `.starting` value
-        // and don't need it.
-        if case .starting(let existingSiteID) = current, existingSiteID == siteID {
-            setState(.idle)
-        }
-        setState(.starting(siteID: siteID))
+        let gen = stateMachine.beginStarting(siteID: siteID)
         let suddenTerminationLease = suddenTerminationController.acquire()
         // Scoped to the boot window only (unlike suddenTerminationLease, which outlives it as
         // containerTerminationLease) — released on every exit path below, including success:
@@ -301,12 +283,12 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
                 siteID: siteID, sourceRepo: siteDirectory, ref: ref,
                 onOutput: { line, stream in continuation.yield((line, stream)) })
             containerStarted = true
-            guard gen == generation else { await abandonSupersededAttempt(); return }
+            guard stateMachine.isCurrent(gen) else { await abandonSupersededAttempt(); return }
             try await connect(mcpClient, session.mcpURL)
-            guard gen == generation else { await abandonSupersededAttempt(); return }
+            guard stateMachine.isCurrent(gen) else { await abandonSupersededAttempt(); return }
             await knowledgeIndex?.rebuild(siteID: siteID, projectRoot: siteDirectory)
             await conventionsEngine?.rebuild(siteID: siteID, projectRoot: siteDirectory)
-            guard gen == generation else {
+            guard stateMachine.isCurrent(gen) else {
                 await knowledgeIndex?.unload(siteID: siteID)
                 await conventionsEngine?.unload(siteID: siteID)
                 await abandonSupersededAttempt()
@@ -315,7 +297,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             if let documents = await knowledgeIndex?.documents(siteID: siteID) {
                 await semanticRanker?.sync(siteID: siteID, documents: documents)
             }
-            guard gen == generation else {
+            guard stateMachine.isCurrent(gen) else {
                 await knowledgeIndex?.unload(siteID: siteID)
                 await semanticRanker?.unload(siteID: siteID)
                 await conventionsEngine?.unload(siteID: siteID)
@@ -328,7 +310,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             activeSiteDirectory = siteDirectory
             containerTerminationLease = suddenTerminationLease
             activityLease.release()
-            setState(.ready(siteID: siteID, url: session.previewURL))
+            stateMachine.settle(gen: gen, to: .ready(siteID: siteID, url: session.previewURL))
         } catch {
             // Finish this attempt's own (locally-captured) boot log stream immediately rather than
             // leaving it for the next start()/stop() call to clean up via teardown() — control.start()
@@ -344,10 +326,10 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             }
             suddenTerminationLease.release()
             activityLease.release()
-            guard gen == generation else { return }
+            guard stateMachine.isCurrent(gen) else { return }
             bootLogContinuation = nil
             bootLogDrainTask = nil
-            setState(.failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
+            stateMachine.settle(gen: gen, to: .failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
         }
     }
 
@@ -355,15 +337,13 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     /// callsite: queued `readabilityHandler`s on the vsock proxy may still fire after teardown but
     /// are idempotent; in-flight bytes are not drained by design.
     public func stop() async {
-        generation += 1
-        let gen = generation
+        let gen = stateMachine.beginAttempt()
         await teardown()
         // Actors are reentrant, so a start()/stop() issued while teardown() was suspended has
         // superseded this stop and owns the state now — emitting `.idle` here would clobber its
         // `.starting`/`.ready` (the rapid Stop → Restart race, PR #542 review): the UI would show
         // the boot spinner forever while the dev server is actually running.
-        guard gen == generation else { return }
-        setState(.idle)
+        stateMachine.settle(gen: gen, to: .idle)
     }
 
     // MARK: Internals
@@ -445,7 +425,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     }
 
     private func applyFileChanges(_ batch: FileChangeBatch, siteID: String, projectRoot: URL, generation gen: Int) async {
-        guard gen == generation else { return }
+        guard stateMachine.isCurrent(gen) else { return }
         if let knowledgeIndex {
             await KnowledgeReindex.apply(batch, to: knowledgeIndex, ranker: semanticRanker, siteID: siteID, projectRoot: projectRoot)
         }
@@ -455,7 +435,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
         // A stop()/site-switch may have superseded us during the apply above; if so, drop anything
         // we re-added for a site this runtime no longer owns — mirroring populateSharedIndexes'
         // post-await unload discipline.
-        guard gen == generation else {
+        guard stateMachine.isCurrent(gen) else {
             await knowledgeIndex?.unload(siteID: siteID)
             await semanticRanker?.unload(siteID: siteID)
             await conventionsEngine?.unload(siteID: siteID)
@@ -486,14 +466,6 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
             }
         }
     }
-
-    private func setState(_ s: SiteRuntimeState) {
-        guard s != current else { return }
-        current = s
-        for c in observers.values { c.yield(s) }
-    }
-
-    private func removeObserver(_ id: UUID) { observers[id] = nil }
 
     static func friendlyMessage(for error: Error) -> String {
         switch error {

--- a/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
+++ b/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
@@ -11,9 +11,7 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
     private let mintToken: @Sendable () -> SessionToken
     private let connect: @Sendable (MCPClient, URL, SessionToken) async throws -> Void
 
-    private var current: SiteRuntimeState = .idle
-    private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
-    private var generation = 0
+    private let stateMachine = SiteRuntimeStateMachine()
     private var activeSiteID: String?
 
     public init(
@@ -34,33 +32,17 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
         self.connect = connect
     }
 
-    public var state: SiteRuntimeState { current }
+    public var state: SiteRuntimeState { stateMachine.state }
 
     public func observe() -> AsyncStream<SiteRuntimeState> {
-        let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
-        let id = UUID()
-        observers[id] = continuation
-        continuation.onTermination = { [weak self] _ in Task { await self?.removeObserver(id) } }
-        continuation.yield(current)
-        return stream
+        stateMachine.observe()
     }
 
     /// `siteDirectory` is unused on the remote path (no local files on iOS); the git remote + ref
     /// come from `init`. Tears down any previous session, then settles to `.ready`/`.failed`.
     public func start(siteID: String, siteDirectory: URL) async {
         await teardown()
-        generation += 1
-        let gen = generation
-        // `setState` dedups against the current value, so re-entering `.starting(siteID:)` for the
-        // same site (Restart while already `.starting` — the "wedged boot" case this command exists
-        // for) would otherwise be silently dropped: observers never see a change, so the progress
-        // bar stays frozen on the superseded attempt. Force a transient `.idle` first only in that
-        // specific case — `.ready`/`.failed`/`.idle` already differ from the new `.starting` value
-        // and don't need it.
-        if case .starting(let existingSiteID) = current, existingSiteID == siteID {
-            setState(.idle)
-        }
-        setState(.starting(siteID: siteID))
+        let gen = stateMachine.beginStarting(siteID: siteID)
         do {
             let token = mintToken()
             let session = try await control.start(
@@ -69,27 +51,24 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
             // suspended above — before `activeSiteID` was assigned, so that teardown() had nothing
             // of ours to stop. If we've been superseded, this attempt alone knows about the session
             // it just created, so it alone is responsible for tearing it down.
-            guard gen == generation else { try? await control.stop(siteID: siteID); return }
+            guard stateMachine.isCurrent(gen) else { try? await control.stop(siteID: siteID); return }
             try await connect(mcpClient, session.mcpURL, token)
-            guard gen == generation else { try? await control.stop(siteID: siteID); return }
+            guard stateMachine.isCurrent(gen) else { try? await control.stop(siteID: siteID); return }
             activeSiteID = siteID
-            setState(.ready(siteID: siteID, url: session.previewURL))
+            stateMachine.settle(gen: gen, to: .ready(siteID: siteID, url: session.previewURL))
         } catch {
-            guard gen == generation else { return }
-            setState(.failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
+            stateMachine.settle(gen: gen, to: .failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
         }
     }
 
     public func stop() async {
-        generation += 1
-        let gen = generation
+        let gen = stateMachine.beginAttempt()
         await teardown()
         // Actors are reentrant, so a start()/stop() issued while teardown() was suspended has
         // superseded this stop and owns the state now — emitting `.idle` here would clobber its
         // `.starting`/`.ready` (the rapid Stop → Restart race, PR #542 review): the UI would show
         // the boot spinner forever while the dev server is actually running.
-        guard gen == generation else { return }
-        setState(.idle)
+        stateMachine.settle(gen: gen, to: .idle)
     }
 
     // MARK: Internals
@@ -107,14 +86,6 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
             try? await control.stop(siteID: id)
         }
     }
-
-    private func setState(_ s: SiteRuntimeState) {
-        guard s != current else { return }
-        current = s
-        for c in observers.values { c.yield(s) }
-    }
-
-    private func removeObserver(_ id: UUID) { observers[id] = nil }
 
     static func friendlyMessage(for error: Error) -> String {
         switch error {

--- a/Sources/AnglesiteCore/SiteRuntimeStateMachine.swift
+++ b/Sources/AnglesiteCore/SiteRuntimeStateMachine.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Shared observer / state-transition / generation-guard plumbing for `SiteRuntime` conformers.
+///
+/// Every `SiteRuntime` actor (`LocalContainerSiteRuntime`, `RemoteSandboxSiteRuntime`,
+/// `UnavailableSiteRuntime`) owns one of these **by composition**, not inheritance: this type has no
+/// opinion about what's being started or stopped (a container, a sandbox, nothing at all) — only the
+/// mechanics every conformer needs, so the same protocol lives in exactly one place instead of three
+/// drifting copies.
+///
+/// ## Why this isn't itself an actor
+///
+/// `SiteRuntime.observe()` is a non-`async` protocol requirement — callers shouldn't need to hop
+/// actor isolation just to subscribe — and Swift does not allow an `async` function to witness a
+/// non-`async` protocol requirement. So a conformer's `observe()` implementation cannot itself
+/// `await` into a separate `actor` state machine. Instead this type is a plain, lock-protected
+/// class: safe because every mutating call happens either (a) from within the owning `SiteRuntime`
+/// actor's isolated methods — already mutually exclusive with each other by actor semantics, since an
+/// actor runs at most one synchronous stretch of its own code at a time — or (b) from
+/// `AsyncStream`'s `onTermination` callback, the one path that genuinely runs off any actor's
+/// isolation (fired by the stream's own machinery when a consumer stops iterating). The lock
+/// reconciles (b) with (a) without requiring conformers to hop back onto their own actor just to
+/// remove a defunct observer.
+///
+/// ## The generation guard
+///
+/// `start()`/`stop()` are `async`, and every conformer is an actor — reentrant at each `await` — so a
+/// second `start()`/`stop()` call can run to completion (including its own teardown) while an earlier
+/// one is still suspended (e.g. inside a container/sandbox control call). `beginAttempt()` /
+/// `beginStarting(siteID:)` hand the caller a generation number — its ticket for checking, via
+/// `isCurrent(_:)` or `settle(gen:to:)`, whether it has since been superseded. A superseded caller
+/// must tear down whatever *it* created, because the superseding call's own teardown ran before this
+/// attempt's bookkeeping (e.g. `activeSiteID`) existed for it to find.
+public final class SiteRuntimeStateMachine: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: SiteRuntimeState = .idle
+    private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
+    private var generation = 0
+
+    public init() {}
+
+    /// The current lifecycle state.
+    public var state: SiteRuntimeState {
+        lock.lock(); defer { lock.unlock() }
+        return current
+    }
+
+    /// The current generation, without bumping it — for callers (e.g.
+    /// `LocalContainerSiteRuntime.persistEdit`) that need to snapshot "which attempt is this" up
+    /// front and later confirm, via `isCurrent(_:)`, that nothing superseded it in between.
+    public var currentGeneration: Int {
+        lock.lock(); defer { lock.unlock() }
+        return generation
+    }
+
+    /// The number of currently-registered observers. Test-only diagnostic (no production caller
+    /// needs this), used to verify that a cancelled/finished consumer's observer is actually
+    /// unregistered rather than leaking.
+    public var observerCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return observers.count
+    }
+
+    /// Registers a new observer, replaying the current state immediately (every conformer's prior
+    /// behavior). The returned stream removes its observer automatically when its consumer stops
+    /// iterating (cancellation, `break`, deinit).
+    public func observe() -> AsyncStream<SiteRuntimeState> {
+        let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
+        let id = UUID()
+        lock.lock()
+        observers[id] = continuation
+        let snapshot = current
+        lock.unlock()
+        continuation.onTermination = { [weak self] _ in self?.removeObserver(id) }
+        continuation.yield(snapshot)
+        return stream
+    }
+
+    /// Bumps and returns the new generation — the caller's ticket for `isCurrent`/`settle`.
+    @discardableResult
+    public func beginAttempt() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        generation += 1
+        return generation
+    }
+
+    /// `beginAttempt()` plus the `.starting(siteID:)` transition. `setState` dedups against the
+    /// current value, so re-entering `.starting(siteID:)` for the same site (Restart while already
+    /// `.starting` — the "wedged boot" case that command exists for) would otherwise be silently
+    /// dropped: observers never see a change, so the progress bar stays frozen on the superseded
+    /// attempt. This forces a transient `.idle` first, but only in that specific case — `.ready`,
+    /// `.failed`, and `.idle` already differ from the new `.starting` value and don't need it.
+    @discardableResult
+    public func beginStarting(siteID: String) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        generation += 1
+        if case .starting(let existingSiteID) = current, existingSiteID == siteID {
+            applyLocked(.idle)
+        }
+        applyLocked(.starting(siteID: siteID))
+        return generation
+    }
+
+    /// Whether `gen` is still the current attempt — i.e. no later `start()`/`stop()` has bumped the
+    /// generation since. Callers check this after every suspension point to detect supersession.
+    public func isCurrent(_ gen: Int) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return gen == generation
+    }
+
+    /// Applies `state` only if `gen` is still current; a superseded caller's result is dropped
+    /// instead of clobbering whatever the superseding call already settled to.
+    public func settle(gen: Int, to state: SiteRuntimeState) {
+        lock.lock(); defer { lock.unlock() }
+        guard gen == generation else { return }
+        applyLocked(state)
+    }
+
+    /// Unconditional state transition (still dedup'd against `current`), for conformers whose
+    /// `start()`/`stop()` never race (e.g. `UnavailableSiteRuntime`, which settles synchronously)
+    /// and so need no generation guard.
+    public func setState(_ state: SiteRuntimeState) {
+        lock.lock(); defer { lock.unlock() }
+        applyLocked(state)
+    }
+
+    // MARK: - Internals (caller must hold `lock`)
+
+    private func applyLocked(_ state: SiteRuntimeState) {
+        guard state != current else { return }
+        current = state
+        for continuation in observers.values { continuation.yield(state) }
+    }
+
+    private func removeObserver(_ id: UUID) {
+        lock.lock(); defer { lock.unlock() }
+        observers[id] = nil
+    }
+}

--- a/Sources/AnglesiteCore/UnavailableSiteRuntime.swift
+++ b/Sources/AnglesiteCore/UnavailableSiteRuntime.swift
@@ -6,8 +6,7 @@ import Foundation
 public actor UnavailableSiteRuntime: SiteRuntime {
     private let reason: String
     public let mcpClient: MCPClient
-    private var current: SiteRuntimeState = .idle
-    private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
+    private let stateMachine = SiteRuntimeStateMachine()
 
     public init(reason: String, mcpClient: MCPClient = MCPClient(supervisor: .shared)) {
         self.reason = reason
@@ -15,30 +14,15 @@ public actor UnavailableSiteRuntime: SiteRuntime {
     }
 
     public func start(siteID: String, siteDirectory: URL) async {
-        setState(.failed(siteID: siteID, message: reason))
+        stateMachine.setState(.failed(siteID: siteID, message: reason))
     }
 
     public func stop() async {
         await mcpClient.stop()
-        setState(.idle)
+        stateMachine.setState(.idle)
     }
 
     public func observe() -> AsyncStream<SiteRuntimeState> {
-        let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream(bufferingPolicy: .unbounded)
-        let id = UUID()
-        observers[id] = continuation
-        continuation.onTermination = { [weak self] _ in Task { await self?.removeObserver(id) } }
-        continuation.yield(current)
-        return stream
-    }
-
-    private func setState(_ state: SiteRuntimeState) {
-        guard state != current else { return }
-        current = state
-        for continuation in observers.values { continuation.yield(state) }
-    }
-
-    private func removeObserver(_ id: UUID) {
-        observers[id] = nil
+        stateMachine.observe()
     }
 }

--- a/Tests/AnglesiteCoreTests/SiteRuntimeStateMachineTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteRuntimeStateMachineTests.swift
@@ -1,0 +1,238 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Focused spec for the shared `SiteRuntimeStateMachine` plumbing extracted from the three
+/// `SiteRuntime` conformers (#821). These cases mirror the observer/dedup/generation-guard tests
+/// that used to live redundantly in `LocalContainerSiteRuntimeTests` and
+/// `RemoteSandboxSiteRuntimeTests` — this is now the one place that behavior is specified.
+struct SiteRuntimeStateMachineTests {
+    // MARK: - Initial state / observe
+
+    @Test("starts at .idle")
+    func startsIdle() {
+        let machine = SiteRuntimeStateMachine()
+        #expect(machine.state == .idle)
+    }
+
+    @Test("observe replays the current state immediately")
+    func observeReplaysCurrentState() async {
+        let machine = SiteRuntimeStateMachine()
+        machine.setState(.failed(siteID: "s1", message: "boom"))
+
+        var iterator = machine.observe().makeAsyncIterator()
+        #expect(await iterator.next() == .failed(siteID: "s1", message: "boom"))
+    }
+
+    @Test("a live observer sees every transition in order")
+    func liveObserverSeesTransitionsInOrder() async {
+        let machine = SiteRuntimeStateMachine()
+        var iterator = machine.observe().makeAsyncIterator()
+        #expect(await iterator.next() == .idle)
+
+        machine.setState(.starting(siteID: "s1"))
+        #expect(await iterator.next() == .starting(siteID: "s1"))
+
+        let url = URL(string: "http://127.0.0.1:1")!
+        machine.setState(.ready(siteID: "s1", url: url))
+        #expect(await iterator.next() == .ready(siteID: "s1", url: url))
+    }
+
+    @Test("fan-out: every registered observer receives the same transitions")
+    func fanOutToMultipleObservers() async {
+        let machine = SiteRuntimeStateMachine()
+        var first = machine.observe().makeAsyncIterator()
+        var second = machine.observe().makeAsyncIterator()
+        #expect(await first.next() == .idle)
+        #expect(await second.next() == .idle)
+
+        machine.setState(.starting(siteID: "s1"))
+        #expect(await first.next() == .starting(siteID: "s1"))
+        #expect(await second.next() == .starting(siteID: "s1"))
+    }
+
+    // MARK: - setState dedup
+
+    @Test("setState dedups against the current value")
+    func setStateDedupsAgainstCurrentValue() async {
+        let machine = SiteRuntimeStateMachine()
+        let stream = machine.observe()
+        let collector = StateMachineCollector()
+
+        let drainTask = Task {
+            var count = 0
+            for await s in stream {
+                await collector.append(s)
+                count += 1
+                if count >= 2 { break }
+            }
+        }
+
+        // Redundant .idle must be swallowed — the only delivery is observe()'s initial replay.
+        machine.setState(.idle)
+
+        drainTask.cancel()
+        _ = await drainTask.result
+        #expect(await collector.states == [.idle])
+    }
+
+    // MARK: - Observer removal
+
+    @Test("removeObserver: cancelling the consumer's task unregisters it")
+    func observerRemovedWhenConsumerCancels() async {
+        let machine = SiteRuntimeStateMachine()
+        let stream = machine.observe()
+        #expect(machine.observerCount == 1)
+
+        let drainTask = Task {
+            for await _ in stream { }
+        }
+        drainTask.cancel()
+        _ = await drainTask.result
+
+        var count = machine.observerCount
+        for _ in 0..<20 where count > 0 {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+            count = machine.observerCount
+        }
+        #expect(count == 0)
+    }
+
+    // MARK: - Generation guard
+
+    @Test("beginAttempt returns strictly increasing generations")
+    func beginAttemptIncreasesGeneration() {
+        let machine = SiteRuntimeStateMachine()
+        let first = machine.beginAttempt()
+        let second = machine.beginAttempt()
+        #expect(second == first + 1)
+    }
+
+    @Test("currentGeneration reads without bumping")
+    func currentGenerationDoesNotBump() {
+        let machine = SiteRuntimeStateMachine()
+        let gen = machine.beginAttempt()
+        #expect(machine.currentGeneration == gen)
+        #expect(machine.currentGeneration == gen)
+    }
+
+    @Test("isCurrent is true only for the latest generation")
+    func isCurrentReflectsOnlyLatestGeneration() {
+        let machine = SiteRuntimeStateMachine()
+        let stale = machine.beginAttempt()
+        let latest = machine.beginAttempt()
+        #expect(!machine.isCurrent(stale))
+        #expect(machine.isCurrent(latest))
+    }
+
+    @Test("settle applies the state when gen is current")
+    func settleAppliesWhenCurrent() {
+        let machine = SiteRuntimeStateMachine()
+        let gen = machine.beginAttempt()
+        machine.settle(gen: gen, to: .idle)
+        #expect(machine.state == .idle)
+
+        let gen2 = machine.beginAttempt()
+        machine.settle(gen: gen2, to: .failed(siteID: "s1", message: "x"))
+        #expect(machine.state == .failed(siteID: "s1", message: "x"))
+    }
+
+    @Test("settle drops a stale result instead of clobbering the current state")
+    func settleDropsStaleResult() {
+        let machine = SiteRuntimeStateMachine()
+        let stale = machine.beginAttempt()
+        let latest = machine.beginAttempt()
+        machine.settle(gen: latest, to: .starting(siteID: "s2"))
+
+        // The stale attempt's settle must be a no-op: it must not clobber the newer attempt's state.
+        machine.settle(gen: stale, to: .idle)
+        #expect(machine.state == .starting(siteID: "s2"))
+    }
+
+    // MARK: - beginStarting (the "wedged boot" dedup-defeat)
+
+    @Test("beginStarting from .idle transitions directly to .starting")
+    func beginStartingFromIdle() async {
+        let machine = SiteRuntimeStateMachine()
+        let stream = machine.observe()
+        let collector = StateMachineCollector()
+        let drainTask = Task {
+            for await s in stream {
+                await collector.append(s)
+                if case .starting = s { break }
+            }
+        }
+
+        _ = machine.beginStarting(siteID: "s1")
+        await drainTask.value
+
+        // Only the initial .idle replay, then a single .starting — no forced transient .idle when
+        // there was nothing to "un-stick".
+        #expect(await collector.states == [.idle, .starting(siteID: "s1")])
+    }
+
+    @Test("beginStarting re-entering .starting for the SAME site forces a transient .idle first")
+    func beginStartingSameSiteForcesTransientIdle() async {
+        let machine = SiteRuntimeStateMachine()
+        _ = machine.beginStarting(siteID: "s1")
+
+        let stream = machine.observe()
+        let collector = StateMachineCollector()
+        let drainTask = Task {
+            var count = 0
+            for await s in stream {
+                await collector.append(s)
+                count += 1
+                if count >= 3 { break }
+            }
+        }
+
+        // Re-entering .starting(siteID: "s1") while already .starting(siteID: "s1") would otherwise
+        // be silently swallowed by setState's dedup — the wedged-boot Restart case (#542-adjacent).
+        _ = machine.beginStarting(siteID: "s1")
+
+        drainTask.cancel()
+        _ = await drainTask.result
+        #expect(await collector.states == [.starting(siteID: "s1"), .idle, .starting(siteID: "s1")])
+    }
+
+    @Test("beginStarting for a DIFFERENT site does not force a transient .idle")
+    func beginStartingDifferentSiteSkipsTransientIdle() async {
+        let machine = SiteRuntimeStateMachine()
+        _ = machine.beginStarting(siteID: "s1")
+
+        let stream = machine.observe()
+        let collector = StateMachineCollector()
+        let drainTask = Task {
+            var count = 0
+            for await s in stream {
+                await collector.append(s)
+                count += 1
+                if count >= 2 { break }
+            }
+        }
+
+        _ = machine.beginStarting(siteID: "s2")
+
+        drainTask.cancel()
+        _ = await drainTask.result
+        #expect(await collector.states == [.starting(siteID: "s1"), .starting(siteID: "s2")])
+    }
+
+    @Test("beginStarting bumps the generation")
+    func beginStartingBumpsGeneration() {
+        let machine = SiteRuntimeStateMachine()
+        let before = machine.beginAttempt()
+        let started = machine.beginStarting(siteID: "s1")
+        #expect(started == before + 1)
+        #expect(machine.isCurrent(started))
+        #expect(!machine.isCurrent(before))
+    }
+}
+
+/// Test-only collector for `SiteRuntimeState` sequences (avoids Sendable warnings across the
+/// drain `Task`), mirroring `StateCollector` in `RemoteSandboxSiteRuntimeTests`.
+actor StateMachineCollector {
+    private(set) var states: [SiteRuntimeState] = []
+    func append(_ s: SiteRuntimeState) { states.append(s) }
+}


### PR DESCRIPTION
## Summary

Closes #821.

The observer/state-machine boilerplate and the generation-guard +
teardown-reentrancy protocol were copy-pasted (including multi-paragraph
explanatory comments) across all three `SiteRuntime` conformers in
`Sources/AnglesiteCore/`: `LocalContainerSiteRuntime`,
`RemoteSandboxSiteRuntime`, and `UnavailableSiteRuntime`.

This PR extracts a shared `SiteRuntimeStateMachine` (new file:
`Sources/AnglesiteCore/SiteRuntimeStateMachine.swift`) using
**composition, not inheritance**:

- Each conformer now stores a `private let stateMachine =
  SiteRuntimeStateMachine()` and delegates to it for
  `observe()`/`setState(_:)`/`beginAttempt()`/`beginStarting(siteID:)`/
  `isCurrent(_:)`/`settle(gen:to:)` instead of re-implementing the
  observer dictionary, dedup'd state transitions, and the
  generation-guard supersession check.
- `SiteRuntimeStateMachine` is a plain, lock-protected (`NSLock`)
  `final class`, **not** an `actor` — `SiteRuntime.observe()` is a
  non-`async` protocol requirement, and Swift does not allow an `async`
  function to witness a non-`async` requirement, so a separate `actor`
  couldn't be called into from a conformer's `observe()` at all. The
  lock protects the one path that genuinely runs off any actor's
  isolation: `AsyncStream`'s `onTermination` callback when a consumer
  stops iterating.
- `beginStarting(siteID:)` centralizes the "wedged boot" fix (forcing a
  transient `.idle` before re-entering `.starting` for the same site,
  so a Restart during an already-`.starting` boot doesn't get silently
  swallowed by `setState`'s dedup).

**What stayed conformer-specific (not moved):**

- `LocalContainerSiteRuntime`: file watcher, knowledge-index /
  conventions-engine rebuild + reindex plumbing, `persistEdit`'s
  git-bundle handoff, activity/sudden-termination lease bookkeeping,
  boot-log draining. These aren't state-machine concerns — they're the
  container-specific teardown/boot steps the issue called out to leave
  alone.
- `RemoteSandboxSiteRuntime`: its own `teardown()` (session token /
  sandbox control stop) and `friendlyMessage(for:)` error mapping.
- `UnavailableSiteRuntime`: trivial synchronous `start()`/`stop()` —
  doesn't need the generation guard at all, so it just calls
  `stateMachine.setState(_:)` directly.
- `friendlyMessage(for:)` stayed a parallel switch in each conformer
  (per the issue's guidance) — each maps a genuinely different error
  enum (`LocalContainerError` vs. `SandboxControlError`), so unifying
  them would need a shared error type that doesn't otherwise exist.

**Net effect:** ~106 lines removed from the three conformers (33
re-added as thin delegation calls), replaced by one ~140-line, single-
tested implementation (`Sources/AnglesiteCore/SiteRuntimeStateMachine.swift`)
instead of three drifting copies.

## Testing

- New suite `Tests/AnglesiteCoreTests/SiteRuntimeStateMachineTests.swift`
  (15 tests): observer replay/fan-out, `setState` dedup, generation-guard
  semantics (`beginAttempt`/`isCurrent`/`settle`), observer removal on
  consumer cancellation, and the `beginStarting` wedged-boot transient-
  `.idle` behavior (same-site vs. different-site cases) — this is now
  the one place that behavior is specified, mirroring what used to be
  tested redundantly per-conformer.
- All pre-existing per-conformer tests
  (`LocalContainerSiteRuntimeTests`, `LocalContainerSiteRuntimeReindexTests`,
  `RemoteSandboxSiteRuntimeTests`, `UnavailableSiteRuntimeTests`) still
  pass unmodified against the refactored implementation.
- `swift test --package-path .` — confirmed green for all 5
  runtime/state-machine suites, both filtered and as part of the full
  `AnglesiteCoreTests` target run.
- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite
  -configuration Debug build` — **BUILD SUCCEEDED**.

### Note on an unrelated flake observed during verification

The full, unfiltered `AnglesiteCoreTests` run hit one `swift-testing`
worker crash (`exited with unexpected signal code 5`), with **no**
attributable failed assertion — the crash notice was interleaved
mid-line into an unrelated `InProcessGit` test's log output, a
byte-level splice consistent with a concurrently-crashing parallel
worker under heavy test-suite load, not a specific test's fault. All
five runtime/state-machine suites touched by this PR explicitly report
`passed` in that same run. This matches the project's documented
pre-existing Swift-concurrency-runtime crash flakes (see
`project_ci_macos15_task_allocator_crash` in memory) rather than a
regression from this change — flagging it here so reviewers aren't
surprised if they see it too, not something this PR introduced or
needs to fix.

## Test plan

- [x] `swift test --package-path .` (runtime/state-machine suites green)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] New `SiteRuntimeStateMachineTests` suite covers observer add/remove,
      state-transition + generation-guard semantics, and the
      teardown-reentrancy protocol
- [x] Existing per-conformer tests unmodified and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)