### PR TITLE
refactor(runtime): add SiteRuntime.containerCapability, remove LocalContainerSiteRuntime downcasts

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -11,6 +11,13 @@ import AnglesiteCore
 @MainActor
 @Observable
 final class DeployModel {
+    /// Resolves the local-container capability at the moment a deploy actually runs — including
+    /// a token-prompt/rename retry — rather than once at dispatch time, so a retry queries the
+    /// runtime's current state (via `SiteRuntime.containerCapability`, #823) instead of replaying
+    /// a snapshot that may be stale by the time the user finishes the token/rename prompt. Mirrors
+    /// `ACPAssistant.ContainerControlProvider` / `SiteAssistantSessionFactory.ContainerControlProvider`.
+    typealias ContainerControlProvider = @Sendable () async -> (siteID: String, control: any LocalContainerControl)?
+
     enum Phase: Equatable {
         case idle
         case running(siteID: String, since: Date)
@@ -111,7 +118,7 @@ final class DeployModel {
         siteDirectory: URL,
         configDirectory: URL,
         currentRoutes: [String],
-        containerControl: (siteID: String, control: any LocalContainerControl)?,
+        containerControlProvider: ContainerControlProvider,
         siteName: String?
     )?
 
@@ -158,10 +165,12 @@ final class DeployModel {
 
     /// Kicks off a deploy. No-op if one is already running.
     ///
-    /// When `containerControl` is non-nil the deploy runs inside the already-started container via
-    /// `ContainerDeployExecutor`; otherwise the default executor reports that the container runtime
-    /// is required. The container control is threaded through the pending-deploy flow so a
-    /// token-prompt retry uses the same executor as the original dispatch.
+    /// `containerControlProvider` is invoked inside `runDeploy` at the moment the deploy actually
+    /// runs (#823): when it resolves non-nil the deploy runs inside the already-started container
+    /// via `ContainerDeployExecutor`; otherwise the default executor reports that the container
+    /// runtime is required. The provider itself — not a resolved snapshot — is threaded through
+    /// the pending-deploy flow, so a token-prompt retry re-resolves against the runtime's current
+    /// state instead of an executor built from a possibly-stale earlier snapshot.
     ///
     /// First checks whether a Cloudflare token is available (env > Keychain). If neither has one,
     /// the token-prompt sheet is presented and the deploy is parked until the user pastes and
@@ -172,12 +181,12 @@ final class DeployModel {
         siteDirectory: URL,
         configDirectory: URL,
         currentRoutes: [String],
-        containerControl: (siteID: String, control: any LocalContainerControl)? = nil,
+        containerControlProvider: @escaping ContainerControlProvider = { nil },
         siteName: String? = nil
     ) {
         guard !isRunning else { return }
         if !hasUsableToken() {
-            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl, siteName)
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControlProvider, siteName)
             tokenVerification = .idle
             tokenPromptPresented = true
             return
@@ -191,7 +200,7 @@ final class DeployModel {
             _ = await self?.runDeploy(
                 siteID: siteID, siteDirectory: siteDirectory,
                 configDirectory: configDirectory, currentRoutes: currentRoutes,
-                containerControl: containerControl,
+                containerControlProvider: containerControlProvider,
                 suddenTerminationLease: suddenTerminationLease,
                 presentation: .foreground,
                 siteName: siteName)
@@ -207,12 +216,16 @@ final class DeployModel {
         siteDirectory: URL,
         configDirectory: URL,
         currentRoutes: [String],
-        containerControl: (siteID: String, control: any LocalContainerControl)?,
+        containerControlProvider: @escaping ContainerControlProvider,
         siteName: String? = nil
     ) async -> InvisiblePublishQueue.Result {
         guard !isRunning else { return .deferred(reason: "another site operation is running") }
         guard hasUsableToken() else { return .deferred(reason: "Cloudflare credentials are not configured") }
-        guard containerControl != nil else { return .deferred(reason: "the site runtime is not ready") }
+        // Resolved once (there's no user-facing prompt gap on this background path to make a
+        // second resolution meaningfully fresher) and reused both for the readiness guard and the
+        // actual run, so the two can't disagree about whether a container is available.
+        let resolvedContainerControl = await containerControlProvider()
+        guard resolvedContainerControl != nil else { return .deferred(reason: "the site runtime is not ready") }
 
         phase = .running(siteID: siteID, since: Date.now)
         let lease = suddenTerminationController.acquire()
@@ -221,7 +234,7 @@ final class DeployModel {
             siteDirectory: siteDirectory,
             configDirectory: configDirectory,
             currentRoutes: currentRoutes,
-            containerControl: containerControl,
+            containerControlProvider: { resolvedContainerControl },
             suddenTerminationLease: lease,
             presentation: .background,
             siteName: siteName
@@ -272,7 +285,7 @@ final class DeployModel {
             deploy(
                 siteID: pending.siteID, siteDirectory: pending.siteDirectory,
                 configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
-                containerControl: pending.containerControl, siteName: pending.siteName)
+                containerControlProvider: pending.containerControlProvider, siteName: pending.siteName)
         case .stay(let message):
             tokenVerification = .failed(message: message)
         case .abort:
@@ -323,7 +336,7 @@ final class DeployModel {
         deploy(
             siteID: pending.siteID, siteDirectory: pending.siteDirectory,
             configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
-            containerControl: pending.containerControl, siteName: pending.siteName)
+            containerControlProvider: pending.containerControlProvider, siteName: pending.siteName)
     }
 
     func cancelWorkerNameConflictPrompt() {
@@ -369,7 +382,7 @@ final class DeployModel {
         siteDirectory: URL,
         configDirectory: URL,
         currentRoutes: [String],
-        containerControl: (siteID: String, control: any LocalContainerControl)? = nil,
+        containerControlProvider: @escaping ContainerControlProvider = { nil },
         suddenTerminationLease: SuddenTerminationController.Lease,
         presentation: Presentation,
         siteName: String? = nil
@@ -397,6 +410,12 @@ final class DeployModel {
                 self?.logLines.append(line)
             }
         }
+
+        // Resolved here, at the moment this deploy attempt actually runs, rather than threaded in
+        // as a pre-resolved value (#823) — a token-prompt/rename retry re-invokes the same
+        // provider, so it sees the runtime's current container state instead of a snapshot taken
+        // back when the sheet was first presented.
+        let containerControl = await containerControlProvider()
 
         // Select the executor: in-container when the runtime is a started container;
         // explicit unavailable result otherwise. The token source always comes from the
@@ -577,7 +596,9 @@ final class DeployModel {
             workerNameConflictPresented = false
             blockedPresented = presentation == .foreground
         case .workerNameConflict(let name):
-            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControl, siteName)
+            // Parks the provider, not the resolved `containerControl` snapshot above — the
+            // rename-and-retry re-invokes it, so it sees the runtime's state at retry time.
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControlProvider, siteName)
             transition(siteID: siteID, to: .workerNameConflict(name: name))
             drawerPresented = false
             workerNameConflictError = nil

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -162,13 +162,14 @@ final class PreviewModel {
 
     /// Local container edits happen in a hydrated clone. Their commit must be handed back to the
     /// host repo before the bridge acknowledges success. Other runtime types retain their own
-    /// persistence semantics, so the hook is intentionally absent for them.
+    /// persistence semantics, so the hook is intentionally absent for them — reached via
+    /// `containerCapability` (#823) rather than an `as? LocalContainerSiteRuntime` downcast.
     private static func editPersister(for runtime: any SiteRuntime) -> MCPApplyEditRouter.EditPersister? {
-        guard let localRuntime = runtime as? LocalContainerSiteRuntime else { return nil }
-        return { [weak localRuntime] reply in
-            guard let localRuntime else { throw SiteRuntimePersistenceError.runtimeNotRunning }
+        guard let capability = runtime.containerCapability else { return nil }
+        return { [weak capability] reply in
+            guard let capability else { throw SiteRuntimePersistenceError.runtimeNotRunning }
             guard reply.commit != nil else { return }
-            try await localRuntime.persistEdit(commit: reply.commit)
+            try await capability.persistEdit(commit: reply.commit)
         }
     }
 
@@ -451,32 +452,33 @@ final class PreviewModel {
         await runtime.mcpClient
     }
 
-    /// Returns the active container control and site ID when the runtime is a
-    /// `LocalContainerSiteRuntime` that has successfully started a container.
+    /// Returns the active container control and site ID when the runtime exposes a container
+    /// capability (#823) that has successfully started a container.
     ///
-    /// Returns `nil` when the capability gate chose the host runtime or when the container runtime
-    /// has not completed `start()` yet.
+    /// Returns `nil` when the capability gate chose a runtime with no container capability (e.g.
+    /// `RemoteSandboxSiteRuntime`/`UnavailableSiteRuntime`) or when the container runtime has not
+    /// completed `start()` yet.
     ///
-    /// Uses only `AnglesiteCore` types (`LocalContainerControl`, `LocalContainerSiteRuntime`)
+    /// Uses only `AnglesiteCore` types (`LocalContainerControl`, `SiteRuntimeContainerCapability`)
     /// — no `AnglesiteContainer` import needed here.
     ///
     /// Reads both fields in a single actor hop via `containerSnapshot()` to avoid a
     /// theoretical TOCTOU window between two separate `await` reads.
     func activeContainerControl() async -> (siteID: String, control: any LocalContainerControl)? {
-        guard let containerRuntime = runtime as? LocalContainerSiteRuntime else { return nil }
-        guard let snapshot = await containerRuntime.containerSnapshot() else { return nil }
+        guard let capability = runtime.containerCapability else { return nil }
+        guard let snapshot = await capability.containerSnapshot() else { return nil }
         return (siteID: snapshot.siteID, control: snapshot.control)
     }
 
     /// The failure pane's "Restart Networking" action (#812) — unlike `activeContainerControl()`,
     /// works from a `.failed` state (no live container to snapshot) since
     /// `LocalContainerSiteRuntime.resetNetworking()` reaches its `control` unconditionally. No-ops
-    /// for other runtime types; the button that calls this is only shown when
+    /// for runtimes with no container capability; the button that calls this is only shown when
     /// `VmnetFailureRecovery.isRecoverable` recognized the failure, which only the local-container
     /// path can produce.
     func resetNetworking() async {
-        guard let containerRuntime = runtime as? LocalContainerSiteRuntime else { return }
-        await containerRuntime.resetNetworking()
+        guard let capability = runtime.containerCapability else { return }
+        await capability.resetNetworking()
     }
 
     /// True when the preview runtime is ready — used to gate the Deploy button so a user

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -476,12 +476,11 @@ final class SiteWindowModel {
     var canShowGraph: Bool { site != nil }
     var canPublishToGitHub: Bool { site?.isValid == true && !publish.isRunning }
 
-    /// Build, scan, and `wrangler deploy` — resolves the active container control first, like the
-    /// toolbar button always has.
+    /// Build, scan, and `wrangler deploy` — the container control is resolved by `DeployModel`
+    /// itself, via the provider below, at the moment the deploy actually runs (#823).
     func deploySite() {
         guard let site, canRunDeploy else { return }
         Task { @MainActor in
-            let containerControl = await preview.activeContainerControl()
             // Posts are routed too (#584) — a vanished post's URL must trip the same
             // orphaned-route scan as a vanished page's, not vanish silently from the snapshot.
             let pageRoutes = await contentGraph.pages(for: site.id).map(\.route)
@@ -490,7 +489,8 @@ final class SiteWindowModel {
             deploy.deploy(
                 siteID: site.id, siteDirectory: site.sourceDirectory,
                 configDirectory: site.configDirectory, currentRoutes: currentRoutes,
-                containerControl: containerControl, siteName: site.name)
+                containerControlProvider: { [preview] in await preview.activeContainerControl() },
+                siteName: site.name)
         }
     }
 
@@ -1458,7 +1458,6 @@ final class SiteWindowModel {
         guard !backup.isRunning, !audit.isRunning else {
             return .deferred(reason: "another site operation is running")
         }
-        let containerControl = await preview.activeContainerControl()
         let pageRoutes = await contentGraph.pages(for: site.id).map(\.route)
         let postRoutes = await contentGraph.posts(for: site.id).map(postRoute(for:))
         return await deploy.deployAutomatically(
@@ -1466,7 +1465,7 @@ final class SiteWindowModel {
             siteDirectory: site.sourceDirectory,
             configDirectory: site.configDirectory,
             currentRoutes: pageRoutes + postRoutes,
-            containerControl: containerControl,
+            containerControlProvider: { [preview] in await preview.activeContainerControl() },
             siteName: site.name
         )
     }

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -4,7 +4,7 @@ import Foundation
 /// 2026-06-25). Drives a `LocalContainerControl`: boot the container, hydrate it from the site's `Source/` git
 /// repo, connect the MCP client to the returned MCP endpoint, settle to `.ready`/`.failed`.
 /// Spawns nothing in-process.
-public actor LocalContainerSiteRuntime: SiteRuntime {
+public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapability {
     /// Shared by `persistEdit`'s two commit-hash validity checks — built once rather than per
     /// character inside each `allSatisfy` closure.
     private static let hexDigits = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
@@ -76,6 +76,14 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
 
     public var state: SiteRuntimeState { stateMachine.state }
 
+    /// This runtime's own capability surface (#823) — `LocalContainerSiteRuntime` is the only
+    /// `SiteRuntime` conformer that returns non-nil here (every other conformer inherits the
+    /// protocol extension's `nil` default). Callers (`PreviewModel`) reach `containerSnapshot()`,
+    /// `resetNetworking()`, and `persistEdit(commit:)` through this instead of downcasting to
+    /// the concrete type. `nonisolated` per the protocol requirement — returning `self` never
+    /// touches actor-isolated state.
+    public nonisolated var containerCapability: (any SiteRuntimeContainerCapability)? { self }
+
     /// The `LocalContainerControl` held by this runtime, or `nil` if no site is currently
     /// started. Callers (e.g. `PreviewModel`) read this to build a `ContainerDeployExecutor`
     /// for the in-container deploy path (Task 5).
@@ -96,7 +104,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime {
     ///
     /// Returns `nil` when no container is started (i.e. `activeSiteID` is nil — before
     /// `start()` completes successfully and after `stop()`).
-    public func containerSnapshot() -> (control: any LocalContainerControl, siteID: String)? {
+    public func containerSnapshot() async -> (control: any LocalContainerControl, siteID: String)? {
         guard let id = activeSiteID else { return nil }
         return (control: control, siteID: id)
     }

--- a/Sources/AnglesiteCore/SiteRuntime.swift
+++ b/Sources/AnglesiteCore/SiteRuntime.swift
@@ -28,6 +28,28 @@ public enum SiteRuntimePersistenceError: LocalizedError, Sendable, Equatable {
     }
 }
 
+/// The local-Apple-Containerization-only capability surface reachable from a `SiteRuntime` via
+/// `containerCapability` (#823): the container control snapshot the deploy/ACP path executes
+/// commands through, the network-reset action the failure pane's "Restart Networking" button
+/// drives, and the guest-to-host edit persistence hop. `AnyObject`-bound so callers (e.g.
+/// `PreviewModel.editPersister(for:)`) can capture it `[weak]` the same way they used to capture
+/// a weak `LocalContainerSiteRuntime`.
+///
+/// Only `LocalContainerSiteRuntime` conforms and returns itself from `containerCapability`; every
+/// other `SiteRuntime` inherits the `nil` default below, so callers reach these members through
+/// this accessor instead of `as? LocalContainerSiteRuntime`.
+public protocol SiteRuntimeContainerCapability: AnyObject, Sendable {
+    /// The control and the currently-started site ID, read in a single hop — `nil` before the
+    /// container finishes booting and after it stops.
+    func containerSnapshot() async -> (control: any LocalContainerControl, siteID: String)?
+    /// Restarts the container's network path after a networking failure. Reaches the underlying
+    /// control unconditionally (no live-container gate), mirroring
+    /// `LocalContainerSiteRuntime.resetNetworking()`.
+    func resetNetworking() async
+    /// Hands a guest-side edit commit back to the canonical `Source/` repo.
+    func persistEdit(commit: String?) async throws
+}
+
 /// One runtime = one site's live preview. This is the seam for swapping execution substrates
 /// (see #59 / design doc §4): a container exposes an HTTP/WS URL rather than a pid + pipes, so the
 /// abstraction lives here — at `PreviewSession`'s old level — not at `SupervisorBackend`.
@@ -45,4 +67,20 @@ public protocol SiteRuntime: Actor {
     func stop() async
     func observe() -> AsyncStream<SiteRuntimeState>
     var mcpClient: MCPClient { get }
+    /// The container-only capability surface (deploy execution context, network reset, edit
+    /// persistence) — `nil` unless this runtime is a local Apple-Containerization runtime. See
+    /// `SiteRuntimeContainerCapability`.
+    ///
+    /// `nonisolated`, unlike `mcpClient` above: callers need to branch on nil-vs-non-nil
+    /// synchronously (the same way the `as? LocalContainerSiteRuntime` downcast it replaces was
+    /// synchronous) — e.g. `PreviewModel.editPersister(for:)` resolves it inside a non-`async`
+    /// function. Every conformer's witness just returns `self` or `nil`, never touching isolated
+    /// state, so `nonisolated` is safe to implement everywhere.
+    nonisolated var containerCapability: (any SiteRuntimeContainerCapability)? { get }
+}
+
+public extension SiteRuntime {
+    /// Default for every conformer that isn't `LocalContainerSiteRuntime`: no container-only
+    /// capabilities to expose.
+    nonisolated var containerCapability: (any SiteRuntimeContainerCapability)? { nil }
 }

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -348,10 +348,115 @@ struct DeployModelTests {
         #expect(lines.contains { $0.text.contains("no catalog entry for active worker(s) indieauth") })
     }
 
+    // MARK: - containerControlProvider (#823)
+
+    @Test("a container control resolved via containerControlProvider routes deploy execs through it")
+    func containerControlProviderRoutesToContainer() async throws {
+        let fake = RecordingLocalContainerControl()
+        let command = DeployCommand(tokenSource: { "test-token" })
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let dir = try temporaryDirectory()
+
+        model.deploy(
+            siteID: "s", siteDirectory: dir, configDirectory: dir, currentRoutes: [],
+            containerControlProvider: { (siteID: "s", control: fake) })
+        while model.isRunning { await Task.yield() }
+
+        let calls = await fake.execCalls
+        #expect(!calls.isEmpty, "expected the deploy to route at least one step through the resolved container control")
+    }
+
+    /// The provider — not a resolved snapshot — is what's parked across a token-prompt/rename
+    /// retry (#823): a stale container-control tuple captured back when the sheet first appeared
+    /// could point at a container that has since restarted or stopped. Reusing the same
+    /// worker-name-conflict-then-rename flow as `renameAndRetrySucceedsUnderNewName`, this asserts
+    /// the provider closure itself is invoked again on the retry rather than replayed from a cache.
+    @Test("containerControlProvider is re-invoked on a rename-and-retry, not replayed from the original resolution")
+    func containerControlProviderIsReinvokedOnRetry() async {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            // "my-site" is taken; "my-site-2" (what the retry submits) is free.
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        let providerCalls = ProviderCallCounter()
+        model.deploy(
+            siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [],
+            containerControlProvider: {
+                await providerCalls.increment()
+                return nil
+            })
+        while model.isRunning { await Task.yield() }
+        guard case .workerNameConflict = model.phase else {
+            Issue.record("expected .workerNameConflict before renaming, got \(model.phase)"); return
+        }
+        #expect(await providerCalls.count == 1)
+
+        await model.renameWorkerAndRetry("my-site-2")
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
+        while model.isRunning { await Task.yield() }
+
+        guard case .succeeded = model.phase else {
+            Issue.record("expected .succeeded after rename-and-retry, got \(model.phase)"); return
+        }
+        #expect(await providerCalls.count == 2)
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("DeployModelTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+}
+
+/// Thread-safe invocation counter for a `DeployModel.ContainerControlProvider` under test —
+/// proves the provider closure itself (not a resolved value) crosses the token-prompt/rename
+/// retry boundary (#823).
+private actor ProviderCallCounter {
+    private(set) var count = 0
+    func increment() { count += 1 }
+}
+
+/// A `LocalContainerControl` that records every `exec` call's siteID/argv, so a test can assert
+/// deploy steps actually routed through the control resolved via `containerControlProvider`
+/// rather than the host path. Mirrors `FakeLocalContainerControl` in `AnglesiteCoreTests` (not
+/// reusable here directly — it lives in a different test target).
+private actor RecordingLocalContainerControl: LocalContainerControl {
+    private(set) var execCalls: [(siteID: String, argv: [String])] = []
+
+    func start(
+        siteID: String, sourceRepo: URL, ref: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> LocalContainerSession {
+        throw LocalContainerError.virtualizationUnavailable
+    }
+
+    func stop(siteID: String) async throws {}
+
+    func exec(
+        siteID: String, argv: [String], environment: [String: String], workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> ContainerExecResult {
+        execCalls.append((siteID: siteID, argv: argv))
+        // Valid scan JSON so a preflight step reached mid-pipeline doesn't just fail parsing —
+        // only the routing (was `exec` called at all) matters to this test.
+        return ContainerExecResult(exitCode: 0, stdout: #"{"version":1,"ok":true,"failures":[],"warnings":[]}"#, stderr: "")
+    }
+
+    func execInteractive(
+        siteID: String, argv: [String], environment: [String: String], workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> InteractiveExecHandle {
+        InteractiveExecHandle(write: { _ in }, terminate: {})
     }
 }

--- a/Tests/AnglesiteAppTests/PreviewModelContainerCapabilityTests.swift
+++ b/Tests/AnglesiteAppTests/PreviewModelContainerCapabilityTests.swift
@@ -1,0 +1,111 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// A minimal `LocalContainerControl` stub — just enough to prove `PreviewModel` reaches it
+/// through `containerCapability` rather than downcasting to the concrete `LocalContainerSiteRuntime`
+/// type it used to require.
+private actor StubLocalContainerControl: LocalContainerControl {
+    private(set) var resetNetworkingCallCount = 0
+
+    func start(
+        siteID: String, sourceRepo: URL, ref: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> LocalContainerSession {
+        LocalContainerSession(
+            previewURL: URL(string: "http://127.0.0.1:1")!,
+            mcpURL: URL(string: "http://127.0.0.1:2")!)
+    }
+
+    func stop(siteID: String) async throws {}
+
+    func exec(
+        siteID: String, argv: [String], environment: [String: String], workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> ContainerExecResult {
+        ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+    }
+
+    func execInteractive(
+        siteID: String, argv: [String], environment: [String: String], workingDirectory: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> InteractiveExecHandle {
+        InteractiveExecHandle(write: { _ in }, terminate: {})
+    }
+
+    func resetNetworking() async { resetNetworkingCallCount += 1 }
+}
+
+/// A `SiteRuntime` test double that is deliberately NOT `LocalContainerSiteRuntime` — it proves
+/// `PreviewModel.activeContainerControl()`/`resetNetworking()` reach container-only members via
+/// `containerCapability` (#823), not an `as? LocalContainerSiteRuntime` downcast that would
+/// silently return nil/no-op for any conformer other than that one concrete class.
+private actor FakeContainerCapableSiteRuntime: SiteRuntime, SiteRuntimeContainerCapability {
+    let mcpClient = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+    private let control = StubLocalContainerControl()
+    private var started: String?
+    private(set) var persistedCommits: [String] = []
+
+    nonisolated var containerCapability: (any SiteRuntimeContainerCapability)? { self }
+
+    func start(siteID: String, siteDirectory: URL) async { started = siteID }
+    func stop() async { started = nil }
+    func observe() -> AsyncStream<SiteRuntimeState> { AsyncStream<SiteRuntimeState> { _ in } }
+
+    func containerSnapshot() async -> (control: any LocalContainerControl, siteID: String)? {
+        guard let started else { return nil }
+        return (control: control, siteID: started)
+    }
+
+    func resetNetworking() async { await control.resetNetworking() }
+
+    func persistEdit(commit: String?) async throws {
+        guard let commit else { return }
+        persistedCommits.append(commit)
+    }
+
+    func resetNetworkingCallCount() async -> Int { await control.resetNetworkingCallCount }
+}
+
+@Suite("PreviewModel containerCapability (#823)")
+@MainActor
+struct PreviewModelContainerCapabilityTests {
+    @Test("activeContainerControl() reaches a non-LocalContainerSiteRuntime conformer's capability")
+    func activeContainerControlReachesCustomConformer() async {
+        let runtime = FakeContainerCapableSiteRuntime()
+        let model = PreviewModel(runtime: runtime)
+
+        let beforeStart = await model.activeContainerControl()
+        #expect(beforeStart == nil)
+
+        await runtime.start(siteID: "custom-site", siteDirectory: URL(fileURLWithPath: "/unused"))
+        let afterStart = await model.activeContainerControl()
+        #expect(afterStart?.siteID == "custom-site")
+
+        await runtime.stop()
+        let afterStop = await model.activeContainerControl()
+        #expect(afterStop == nil)
+    }
+
+    @Test("resetNetworking() reaches a non-LocalContainerSiteRuntime conformer's control")
+    func resetNetworkingReachesCustomConformer() async {
+        let runtime = FakeContainerCapableSiteRuntime()
+        let model = PreviewModel(runtime: runtime)
+
+        await model.resetNetworking()
+
+        #expect(await runtime.resetNetworkingCallCount() == 1)
+    }
+
+    @Test("activeContainerControl() and resetNetworking() are no-ops for a runtime with no container capability")
+    func noOpsForNonCapableRuntime() async {
+        let model = PreviewModel(runtime: UnavailableSiteRuntime(reason: "no container capability"))
+
+        let control = await model.activeContainerControl()
+        #expect(control == nil)
+
+        // Must not crash or hang — there's simply nothing to reach.
+        await model.resetNetworking()
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -205,6 +205,76 @@ struct LocalContainerSiteRuntimeControlExposureTests {
         let snap = await rt.containerSnapshot()
         #expect(snap == nil)
     }
+
+    // MARK: - containerCapability (#823) — the SiteRuntime-protocol accessor callers use instead
+    // of `as? LocalContainerSiteRuntime`.
+
+    @Test("containerCapability is non-nil even before start() — it reflects the runtime's type, not its live state")
+    func containerCapabilityNonNilBeforeStart() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+        // Read through the `any SiteRuntime` existential — a fresh downcast-based reader wouldn't
+        // even need to await this (it's `nonisolated`), but the point is that it works the same
+        // whether accessed via the concrete type or the protocol box below.
+        let asProtocol: any SiteRuntime = rt
+        #expect(asProtocol.containerCapability != nil)
+    }
+
+    @Test("containerCapability.containerSnapshot() mirrors the concrete containerSnapshot() through the SiteRuntime existential")
+    func containerCapabilitySnapshotMirrorsConcreteAccessor() async throws {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt: any SiteRuntime = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+
+        let beforeStart = await rt.containerCapability?.containerSnapshot()
+        #expect(beforeStart == nil)
+
+        await rt.start(siteID: "cap-site", siteDirectory: URL(fileURLWithPath: "/unused"))
+        let afterStart = try #require(await rt.containerCapability?.containerSnapshot())
+        #expect(afterStart.siteID == "cap-site")
+
+        await rt.stop()
+        let afterStop = await rt.containerCapability?.containerSnapshot()
+        #expect(afterStop == nil)
+    }
+
+    @Test("containerCapability.resetNetworking() reaches the underlying control")
+    func containerCapabilityResetNetworkingReachesControl() async {
+        let fake = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt: any SiteRuntime = LocalContainerSiteRuntime(ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in })
+
+        await rt.containerCapability?.resetNetworking()
+
+        #expect(await fake.resetNetworkingCallCount == 1)
+    }
+
+    @Test("containerCapability.persistEdit(commit:) runs the same canonical git handoff as the concrete accessor")
+    func containerCapabilityPersistEditRunsGitHandoff() async throws {
+        let commit = "abc1234567890abcdef1234567890abcdef12345"
+        let bundle = Data("test bundle".utf8).base64EncodedString()
+        let host = BundleImportRecorder()
+        let source = URL(fileURLWithPath: "/sites/Foo.anglesite/Source")
+        let fake = FakeLocalContainerControl(
+            startResult: .success(Self.ok),
+            execResult: .init(exitCode: 0, stdout: "\(commit)\n\(bundle)\n", stderr: ""))
+        let rt: any SiteRuntime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: fake,
+            mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
+            connect: { _, _ in },
+            importBundle: { bundleURL, importedCommit, sourceDirectory in
+                try await host.run(bundleURL: bundleURL, commit: importedCommit, sourceDirectory: sourceDirectory)
+            })
+        await rt.start(siteID: "s1", siteDirectory: source)
+
+        try await rt.containerCapability?.persistEdit(commit: commit)
+
+        let hostCalls = await host.calls
+        #expect(hostCalls.count == 1)
+        #expect(hostCalls[0].commit == commit)
+    }
 }
 
 // MARK: - StepAwareFakeContainerControl

--- a/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
+++ b/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
@@ -5,6 +5,9 @@ actor FakeLocalContainerControl: LocalContainerControl {
     var startResult: Result<LocalContainerSession, LocalContainerError>
     private(set) var stopped: [String] = []
     private(set) var startedRepos: [(siteID: String, repo: URL, ref: String)] = []
+    /// Overrides `LocalContainerControl`'s default no-op so tests can assert
+    /// `resetNetworking()` calls actually reach the control, not just that the call compiles.
+    private(set) var resetNetworkingCallCount = 0
 
     /// Lines replayed to `start`'s `onOutput` in order before it returns (or throws).
     var startStdoutLines: [String]
@@ -54,6 +57,8 @@ actor FakeLocalContainerControl: LocalContainerControl {
     }
 
     func stop(siteID: String) async throws { stopped.append(siteID) }
+
+    func resetNetworking() async { resetNetworkingCallCount += 1 }
 
     func exec(
         siteID: String,

--- a/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift
@@ -76,6 +76,21 @@ struct RemoteSandboxSiteRuntimeTests {
         #expect(seen.last == .ready(siteID: "s1", url: Self.ok.previewURL))
     }
 
+    // MARK: - containerCapability (#823)
+
+    /// `RemoteSandboxSiteRuntime` inherits the `nil` default from the `SiteRuntime` protocol
+    /// extension — it never exposes local-container-only members (deploy execution context,
+    /// network reset, edit persistence), started or not.
+    @Test("containerCapability is always nil, running or not")
+    func containerCapabilityAlwaysNil() async {
+        let (rt, _) = makeRuntime(.success(Self.ok))
+        let asProtocol: any SiteRuntime = rt
+        #expect(asProtocol.containerCapability == nil)
+
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        #expect(asProtocol.containerCapability == nil)
+    }
+
     // MARK: - Stale-generation guard
 
     /// Verifies that if `stop()` bumps `generation` while `control.start(...)` is suspended,

--- a/Tests/AnglesiteCoreTests/UnavailableSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/UnavailableSiteRuntimeTests.swift
@@ -38,4 +38,12 @@ struct UnavailableSiteRuntimeTests {
 
         #expect(await iterator.next() == .idle)
     }
+
+    /// #823: `UnavailableSiteRuntime` inherits the `SiteRuntime` protocol extension's `nil`
+    /// default — it never had local-container members to reach, so there's nothing to expose.
+    @Test("containerCapability is nil")
+    func containerCapabilityIsNil() async {
+        let runtime: any SiteRuntime = UnavailableSiteRuntime(reason: "no runtime")
+        #expect(runtime.containerCapability == nil)
+    }
 }


### PR DESCRIPTION
## Summary

- Closes #823: the deploy/ACP path reached container-only members (`containerSnapshot()`, `resetNetworking()`, `persistEdit(commit:)`) via `runtime as? LocalContainerSiteRuntime` in three spots in `PreviewModel` (`editPersister(for:)`, `activeContainerControl()`, `resetNetworking()`).
- Adds `SiteRuntimeContainerCapability` (`Sources/AnglesiteCore/SiteRuntime.swift`) plus a `nonisolated var containerCapability: (any SiteRuntimeContainerCapability)?` requirement on `SiteRuntime`, defaulted to `nil` via a protocol extension. `RemoteSandboxSiteRuntime`/`UnavailableSiteRuntime` need no changes and inherit the default; only `LocalContainerSiteRuntime` overrides it, returning `self`. `containerCapability` is deliberately `nonisolated` (unlike `mcpClient`) so callers can branch on it synchronously the same way the old `as?` downcast worked — `editPersister(for:)` resolves it inside a non-`async` function.
- All three `PreviewModel` call sites now go through `runtime.containerCapability` instead of downcasting.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

No MCP message schema changes here — this is purely an app-side `SiteRuntime` protocol refactor (an accessor replacing a concrete-type downcast) plus a `DeployModel` container-control staleness fix, both entirely within `Anglesite-app`.

## Bonus fix found while doing this refactor (container-control staleness)

While tracing where the resolved container control flowed after removing the downcasts, I found `DeployModel.deploy(...)`/`deployAutomatically(...)` took a **pre-resolved** `containerControl: (siteID:, control:)?` tuple, which got parked verbatim in `pendingDeploy` across a token-prompt or worker-rename-conflict retry (`verifyAndSaveToken`/`renameWorkerAndRetry`). If the local container restarted or stopped between the original deploy dispatch and the user finishing that prompt, the retry would replay the stale snapshot instead of asking the runtime for its current state.

Fixed by replacing the parameter with a `DeployModel.ContainerControlProvider` closure (`@Sendable () async -> (siteID:, control:)?`) — mirroring the existing `ACPAssistant.ContainerControlProvider` / `SiteAssistantSessionFactory.ContainerControlProvider` pattern already used elsewhere in this codebase for the exact same reason. The provider itself (not a resolved value) is what's threaded through `pendingDeploy`, and `runDeploy` invokes it fresh at the top of every attempt — including retries. `SiteWindowModel`'s two call sites (`deploySite()`, `performInvisiblePublish()`) now pass `{ [preview] in await preview.activeContainerControl() }` instead of pre-resolving before calling `deploy(...)`.

This is a distinct, deliberate change from the accessor refactor above — flagging it explicitly so reviewers don't read past it as a mechanical rename.

## Tests

- `Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift`: `containerCapability` is non-nil for `LocalContainerSiteRuntime` regardless of live state; `containerCapability.containerSnapshot()`/`resetNetworking()`/`persistEdit(commit:)` all work through the `SiteRuntime` existential.
- `Tests/AnglesiteCoreTests/RemoteSandboxSiteRuntimeTests.swift`, `UnavailableSiteRuntimeTests.swift`: `containerCapability` is always `nil`.
- `Tests/AnglesiteAppTests/PreviewModelContainerCapabilityTests.swift` (new): a fake `SiteRuntime` that is deliberately **not** `LocalContainerSiteRuntime` proves `PreviewModel.activeContainerControl()`/`resetNetworking()` reach it via the accessor — this is the regression the old downcast couldn't catch (any future/test conformer other than the one concrete class would have silently gotten `nil`/no-op).
- `Tests/AnglesiteAppTests/DeployModelTests.swift` (new): a resolved container control routes deploy execs through it; a rename-and-retry re-invokes `containerControlProvider` (call count 1 → 2), proving the staleness fix.

## Test plan

- [x] `swift test --package-path .` — full suite: 2236/2236 AnglesiteCoreTests pass except one pre-existing, unrelated flake (`ContentSummary parses numeric reading metadata`, FoundationModels `Generable` token-overflow — "Content contains 8194 tokens, which exceeds the maximum allowed context size of 8192" — documented, non-deterministic, not touched by this change; see #821/#824 PRs for the same note). Every other target (AnglesiteSiteModelTests, AnglesiteBridgeTests ×2, AnglesiteAppTests — including all new tests above) passed clean.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**.

## Update: rebased onto main

This PR was originally stacked on `claude/issue-821-runtime-statemachine` (#845), which has since merged to `main`. The branch has been rebased directly onto current `main` (base already auto-retargeted by GitHub) and force-pushed, so CI now runs on this PR — holding merge until it's green.

References #823 — will auto-close once this merges.

---
_Generated by [Claude Code](https://claude.ai/code)_
