### PR TITLE
refactor(deploy): extract DeployCoordinator from DeployModel.runDeploy

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -438,37 +438,25 @@ final class DeployModel {
             containerRunner = nil
         }
 
-        // Effective active worker set (#709 design §4-5): component-tied workers via
-        // ImpactAnalysis (only when this site's content graph has actually been scanned — a
-        // headless/never-opened site contributes nothing there, matching ImpactAnalysis's own
-        // "never invents, may under-report" bias) unioned with settings-activated workers.
+        // Effective active worker set (#709 design §4-5, #825): the content-graph snapshot build
+        // and the `WorkerActivation` computation now live in `DeployCoordinator.planWorkerActivation`
+        // (AnglesiteCore) so this orchestration is unit-tested outside a hosted app-target test.
         let configStore = SiteConfigStore(configDirectory: configDirectory)
         let settings = (try? await configStore.load()) ?? SiteSettings()
         let catalog = await workerCatalog()
-        let snapshot: SiteGraphExplorerSnapshot?
-        if await contentGraph.isPopulated(siteID: siteID) {
-            snapshot = SiteGraphExplorer.build(
-                projectRoot: siteDirectory,
-                siteID: siteID,
-                pages: await contentGraph.pages(for: siteID),
-                posts: await contentGraph.posts(for: siteID),
-                images: await contentGraph.images(for: siteID)
-            )
-        } else {
-            snapshot = nil
-        }
-        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: snapshot)
-        let removedIDs = WorkerActivation.removedIDs(previous: Set(settings.lastDeployedWorkerIDs ?? []), next: effectiveActiveIDs)
-        if !removedIDs.isEmpty {
+        let activationPlan = await DeployCoordinator.planWorkerActivation(
+            siteID: siteID, siteDirectory: siteDirectory, settings: settings, catalog: catalog, contentGraph: contentGraph
+        )
+        let effectiveActiveIDs = activationPlan.effectiveActiveIDs
+        if !activationPlan.removedIDs.isEmpty {
             await logCenter.append(
                 source: "deploy:\(siteID)",
                 stream: .stdout,
-                text: "Deactivating workers: \(removedIDs.sorted().joined(separator: ", "))"
+                text: "Deactivating workers: \(activationPlan.removedIDs.sorted().joined(separator: ", "))"
             )
         }
-        let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
-        let unresolvedIDs = WorkerActivation.unresolvedActiveIDs(activeIDs: effectiveActiveIDs, resolved: workers)
-        if let warning = WorkerActivation.missingDescriptorWarning(unresolvedIDs: unresolvedIDs) {
+        let workers = activationPlan.workers
+        if let warning = WorkerActivation.missingDescriptorWarning(unresolvedIDs: activationPlan.unresolvedIDs) {
             // Mirrors SiteOperations.deployWithWorkerComposition's identical warning — shared
             // text via WorkerActivation so the two paths can't drift (#708 review feedback).
             await logCenter.append(source: "deploy:\(siteID)", stream: .stderr, text: warning)
@@ -514,16 +502,13 @@ final class DeployModel {
             }
         )
 
-        // Prefer the site's already-established Worker name (`.site-config`'s `CF_PROJECT_NAME`,
-        // set at the first successful deploy or by a worker-name-conflict rename, #740) over
-        // re-deriving one from the site's display name. Otherwise every deploy after a
-        // rename-and-retry would silently regenerate `wrangler.toml` under the original
-        // (still-taken) name basis via `persistConfig`, defeating the rename. Falls back to the
-        // derived slug only when no candidate name has been recorded yet — a genuinely first-ever
-        // deploy.
-        let existingConfig = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
-        let workerSiteName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: existingConfig)
-            ?? SiteSlug.derive(from: siteName ?? siteID)
+        // Worker-name resolution precedence (#740, #825): moved to
+        // `DeployCoordinator.resolveWorkerSiteName` — prefers the site's already-established
+        // Worker name (`.site-config`'s `CF_PROJECT_NAME`) over re-deriving one from the site's
+        // display name, so a rename-and-retry isn't silently reverted on the next deploy.
+        let workerSiteName = DeployCoordinator.resolveWorkerSiteName(
+            siteDirectory: siteDirectory, siteID: siteID, siteName: siteName
+        )
         let provisionResult = await socialCommand.provision(
             siteID: siteID,
             siteDirectory: siteDirectory,
@@ -534,10 +519,10 @@ final class DeployModel {
         )
 
         if case .succeeded(_, let resources, _) = provisionResult {
-            var updated = settings
-            updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
-            updated.provisionedWorkerResources = resources
-            try? await configStore.save(updated)
+            await DeployCoordinator.persistProvisionedResources(
+                configStore: configStore, settings: settings,
+                effectiveActiveIDs: effectiveActiveIDs, resources: resources
+            )
         }
 
         let result = provisionResult.asDeployCommandResult
@@ -550,20 +535,23 @@ final class DeployModel {
         case .succeeded(let url, let duration):
             // Astro's build above regenerates RSS/Atom/JSON feeds. Social delivery is ordered
             // after the deployed canonical pages exist, and completion is notified only after
-            // both best-effort passes finish.
-            emitPostDeployMilestone(.deployWebmentions, siteID: siteID)
-            await webmentionCommand.send(
-                siteID: siteID,
-                siteDirectory: siteDirectory,
-                configDirectory: configDirectory,
-                siteBase: url
-            )
-            emitPostDeployMilestone(.deploySyndicating, siteID: siteID)
-            await posseCommand.syndicate(
-                siteID: siteID,
-                siteDirectory: siteDirectory,
-                configDirectory: configDirectory,
-                siteBase: url
+            // both best-effort passes finish. The ordering itself is
+            // `DeployCoordinator.runPostDeploySequencing` (#825); this closure-composes it with
+            // the concrete webmention/POSSE commands and the milestone hook.
+            await DeployCoordinator.runPostDeploySequencing(
+                onMilestone: { [weak self] progress in self?.emitPostDeployMilestone(progress, siteID: siteID) },
+                sendWebmentions: { [weak self] in
+                    guard let self else { return }
+                    await self.webmentionCommand.send(
+                        siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: url
+                    )
+                },
+                syndicate: { [weak self] in
+                    guard let self else { return }
+                    await self.posseCommand.syndicate(
+                        siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: url
+                    )
+                }
             )
             currentMilestone = nil
             workerNameConflictPresented = false

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// The deploy-orchestration business logic that used to live inside `DeployModel.runDeploy` — an
+/// app-target `@MainActor` view model that can't be exercised by `swift test` on CI (only hosted
+/// `xcodebuild test` can run it, and that doesn't work on CI's older runners; see this repo's
+/// CLAUDE.md build notes). #825 pulls the pieces that are pure orchestration — no SwiftUI, no
+/// observable state — out into this plain `AnglesiteCore` namespace so they get real
+/// `AnglesiteCoreTests` coverage, mirroring how `TokenOnboarding` was extracted for the same reason.
+///
+/// `DeployModel` still owns: presenting the token/rename/blocked sheets, the log-line subscription
+/// that drives the streaming drawer, phase transitions, and the failure-summary generation —
+/// all of that is genuinely UI-state-shaped and stays app-side. The container-control threading
+/// from #823 (`ContainerControlProvider`, resolved lazily at the moment a deploy actually runs)
+/// also stays exactly where it is: this type has no opinion about how a deploy step gets executed,
+/// only about the worker-composition inputs and the deploy-adjacent effects around it.
+public enum DeployCoordinator {
+    /// The effective active worker set for a deploy, plus the diff against the last-deployed
+    /// baseline and the resolved `[WorkerDescriptor]`s `SocialWorkerProvisionCommand.provision`
+    /// takes directly now that composition is descriptor-driven (#708).
+    public struct WorkerActivationPlan: Sendable, Equatable {
+        public let effectiveActiveIDs: Set<String>
+        /// Ids present in the previous deploy's baseline but not in `effectiveActiveIDs` — the
+        /// caller decides whether/how to surface this (`DeployModel` logs it to the debug pane).
+        public let removedIDs: Set<String>
+        /// `effectiveActiveIDs` resolved against `catalog`, sorted by id — what
+        /// `WorkerComposition.generateWranglerToml` and `SocialWorkerProvisionCommand.provision`
+        /// need (#708).
+        public let workers: [WorkerDescriptor]
+        /// Active ids `workers` couldn't resolve against the catalog — the caller decides whether
+        /// to surface `WorkerActivation.missingDescriptorWarning` for this (`DeployModel` logs it
+        /// to the debug pane, mirroring `SiteOperations.deployWithWorkerComposition`).
+        public let unresolvedIDs: Set<String>
+
+        public init(
+            effectiveActiveIDs: Set<String>, removedIDs: Set<String>,
+            workers: [WorkerDescriptor], unresolvedIDs: Set<String>
+        ) {
+            self.effectiveActiveIDs = effectiveActiveIDs
+            self.removedIDs = removedIDs
+            self.workers = workers
+            self.unresolvedIDs = unresolvedIDs
+        }
+    }
+
+    /// Builds a `SiteGraphExplorerSnapshot` for `siteID` only when `contentGraph` has actually
+    /// been populated for it (a headless/never-opened site contributes nothing there, matching
+    /// `ImpactAnalysis`'s "never invents, may under-report" bias — see `WorkerActivation`'s own
+    /// doc comment), then computes the effective active worker-id set and its diff against
+    /// `settings.lastDeployedWorkerIDs` (#709 design §4-5). These two steps are combined here
+    /// because the snapshot only exists to feed `WorkerActivation.effectiveActiveIDs` — no other
+    /// caller needs it standalone.
+    public static func planWorkerActivation(
+        siteID: String,
+        siteDirectory: URL,
+        settings: SiteSettings,
+        catalog: [WorkerDescriptor],
+        contentGraph: SiteContentGraph
+    ) async -> WorkerActivationPlan {
+        let snapshot: SiteGraphExplorerSnapshot?
+        if await contentGraph.isPopulated(siteID: siteID) {
+            snapshot = SiteGraphExplorer.build(
+                projectRoot: siteDirectory,
+                siteID: siteID,
+                pages: await contentGraph.pages(for: siteID),
+                posts: await contentGraph.posts(for: siteID),
+                images: await contentGraph.images(for: siteID)
+            )
+        } else {
+            snapshot = nil
+        }
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: snapshot)
+        let removedIDs = WorkerActivation.removedIDs(previous: Set(settings.lastDeployedWorkerIDs ?? []), next: effectiveActiveIDs)
+        let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
+        let unresolvedIDs = WorkerActivation.unresolvedActiveIDs(activeIDs: effectiveActiveIDs, resolved: workers)
+        return WorkerActivationPlan(
+            effectiveActiveIDs: effectiveActiveIDs, removedIDs: removedIDs,
+            workers: workers, unresolvedIDs: unresolvedIDs
+        )
+    }
+
+    /// Worker-name resolution precedence (#740): prefer the site's already-established Worker name
+    /// (`.site-config`'s `CF_PROJECT_NAME`, set at the first successful deploy or by a
+    /// worker-name-conflict rename) over re-deriving one from the site's display name. Falling back
+    /// to re-derivation on every deploy would silently regenerate `wrangler.toml` under the
+    /// original (still-taken) name basis after a rename-and-retry, defeating the rename. Only a
+    /// genuinely first-ever deploy (no candidate name recorded yet) falls through to the derived
+    /// slug of `siteName ?? siteID`.
+    public static func resolveWorkerSiteName(siteDirectory: URL, siteID: String, siteName: String?) -> String {
+        let existingConfig = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        return SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: existingConfig)
+            ?? SiteSlug.derive(from: siteName ?? siteID)
+    }
+
+    /// Persists the newly-provisioned Cloudflare resources and advances the `lastDeployedWorkerIDs`
+    /// baseline to `effectiveActiveIDs` (#709) after a successful provision — the diff baseline
+    /// `WorkerActivation.removedIDs` compares the *next* deploy's plan against. Best-effort, like
+    /// the rest of the deploy pipeline's post-success persistence (`DeployCommand.persistSiteURL`
+    /// et al.): a settings-write failure must never turn an already-successful deploy into a
+    /// failed one, so this never throws.
+    public static func persistProvisionedResources(
+        configStore: SiteConfigStore,
+        settings: SiteSettings,
+        effectiveActiveIDs: Set<String>,
+        resources: WorkerComposition.ProvisionedResources
+    ) async {
+        var updated = settings
+        updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
+        updated.provisionedWorkerResources = resources
+        try? await configStore.save(updated)
+    }
+
+    /// Runs the post-deploy webmention-send and POSSE-syndication passes in the fixed order the
+    /// deploy pipeline has always used: Astro's build (already complete by the time this runs)
+    /// regenerates the site's RSS/Atom/JSON feeds, so webmention discovery is ordered after the
+    /// deployed canonical pages exist, and syndication is ordered after that. `onMilestone` fires
+    /// immediately before each pass so a UI caller can surface progress (`DeployModel` wires it to
+    /// the Dock-tile progress bar, #526) — the milestone always fires even if the caller-supplied
+    /// closure for that pass turns out to be a no-op (e.g. no pending webmention targets). Both
+    /// passes are awaited sequentially, never concurrently, matching the historical behavior;
+    /// neither closure is expected to throw (the real `WebmentionSendCommand`/
+    /// `POSSESyndicationCommand` calls they wrap are documented best-effort and never throw).
+    public static func runPostDeploySequencing(
+        onMilestone: (OperationProgress) -> Void,
+        sendWebmentions: () async -> Void,
+        syndicate: () async -> Void
+    ) async {
+        onMilestone(.deployWebmentions)
+        await sendWebmentions()
+        onMilestone(.deploySyndicating)
+        await syndicate()
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -1,0 +1,198 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests the deploy-orchestration business logic extracted from `DeployModel.runDeploy` (#825):
+/// worker-activation planning, worker-name resolution precedence, provisioned-resource
+/// persistence, and post-deploy webmention/POSSE sequencing — none of it previously had coverage
+/// because it was trapped inside an app-target `@MainActor` view model that only a hosted
+/// `xcodebuild test` can exercise, and that doesn't run on CI (see this repo's CLAUDE.md build
+/// notes). Mirrors `TokenOnboardingTests`'s approach of driving the extracted type directly.
+@Suite("DeployCoordinator")
+struct DeployCoordinatorTests {
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DeployCoordinatorTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func descriptor(
+        id: String, group: String = "social", binding: WorkerDescriptor.Binding
+    ) -> WorkerDescriptor {
+        WorkerDescriptor(
+            id: id, displayName: id, description: "d", group: group, binding: binding,
+            resources: .init(needsD1: false, needsKV: false, needsR2: false)
+        )
+    }
+
+    // MARK: - planWorkerActivation
+
+    @Test("a headless/unpopulated content graph contributes no component-tied workers, but settings-activated ones still apply")
+    func planWorkerActivationWithoutPopulatedGraph() async throws {
+        let catalog = [
+            descriptor(id: "webmention", binding: .componentTied(componentIDs: ["webmention-form"])),
+            descriptor(id: "indieauth", binding: .settingsActivated)
+        ]
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"])
+        let dir = try temporaryDirectory()
+        let contentGraph = SiteContentGraph()
+
+        let plan = await DeployCoordinator.planWorkerActivation(
+            siteID: "site-1", siteDirectory: dir, settings: settings, catalog: catalog, contentGraph: contentGraph
+        )
+
+        #expect(plan.effectiveActiveIDs == ["indieauth"])
+        #expect(plan.workers.map(\.id) == ["indieauth"])
+        #expect(plan.unresolvedIDs.isEmpty)
+    }
+
+    @Test("a populated content graph activates a component-tied worker whose component a page imports")
+    func planWorkerActivationWithPopulatedGraph() async throws {
+        // `SiteGraphExplorer.build` ids a discovered component file as "<siteID>:file:<relative
+        // path>" (see its `kind(for:)`/`resolveImport` — anything under `src/components/` is a
+        // `.component` node) — the catalog's componentIDs must match that scheme exactly.
+        let componentID = "site-1:file:src/components/webmention-form.astro"
+        let catalog = [descriptor(id: "webmention", binding: .componentTied(componentIDs: [componentID]))]
+        let dir = try temporaryDirectory()
+        let contentGraph = SiteContentGraph()
+        let page = SiteContentGraph.Page(
+            id: "site-1:page:/", siteID: "site-1", route: "/",
+            filePath: "src/pages/index.astro", title: "Home", lastModified: .now
+        )
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("src/pages"), withIntermediateDirectories: true)
+        try "import WebmentionForm from '../components/webmention-form.astro';\n".write(
+            to: dir.appendingPathComponent("src/pages/index.astro"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("src/components"), withIntermediateDirectories: true)
+        try "<div></div>\n".write(
+            to: dir.appendingPathComponent("src/components/webmention-form.astro"), atomically: true, encoding: .utf8)
+        await contentGraph.load(siteID: "site-1", pages: [page], posts: [], images: [])
+
+        let plan = await DeployCoordinator.planWorkerActivation(
+            siteID: "site-1", siteDirectory: dir, settings: SiteSettings(), catalog: catalog, contentGraph: contentGraph
+        )
+
+        #expect(plan.effectiveActiveIDs == ["webmention"])
+    }
+
+    @Test("an active id with no catalog entry resolves to an empty workers list and is reported as unresolved")
+    func planWorkerActivationReportsUnresolvedIDs() async throws {
+        // Empty catalog: `WorkerActivation.effectiveActiveIDs` trusts `activeWorkerIDs` verbatim
+        // in this case (no successful fetch/cache — see its doc comment), so the id is still
+        // "active" but has nothing to resolve a `WorkerDescriptor` against.
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"])
+        let dir = try temporaryDirectory()
+        let contentGraph = SiteContentGraph()
+
+        let plan = await DeployCoordinator.planWorkerActivation(
+            siteID: "site-1", siteDirectory: dir, settings: settings, catalog: [], contentGraph: contentGraph
+        )
+
+        #expect(plan.effectiveActiveIDs == ["indieauth"])
+        #expect(plan.workers.isEmpty)
+        #expect(plan.unresolvedIDs == ["indieauth"])
+    }
+
+    @Test("removedIDs reports the last-deployed baseline minus the new effective set")
+    func planWorkerActivationComputesRemovedIDs() async throws {
+        let catalog = [descriptor(id: "indieauth", binding: .settingsActivated)]
+        let settings = SiteSettings(activeWorkerIDs: [], lastDeployedWorkerIDs: ["indieauth", "websub"])
+        let dir = try temporaryDirectory()
+        let contentGraph = SiteContentGraph()
+
+        let plan = await DeployCoordinator.planWorkerActivation(
+            siteID: "site-1", siteDirectory: dir, settings: settings, catalog: catalog, contentGraph: contentGraph
+        )
+
+        #expect(plan.effectiveActiveIDs.isEmpty)
+        #expect(plan.removedIDs == ["indieauth", "websub"])
+    }
+
+    // MARK: - resolveWorkerSiteName
+
+    @Test("an established CF_PROJECT_NAME wins over the siteName/siteID derivation")
+    func resolveWorkerSiteNamePrefersEstablishedName() throws {
+        let dir = try temporaryDirectory()
+        try "CF_PROJECT_NAME=already-taken-name\n".write(
+            to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        let name = DeployCoordinator.resolveWorkerSiteName(siteDirectory: dir, siteID: "site-1", siteName: "My Cool Site")
+
+        #expect(name == "already-taken-name")
+    }
+
+    @Test("with no established name, the site's display name is derived into a slug")
+    func resolveWorkerSiteNameDerivesFromSiteName() throws {
+        let dir = try temporaryDirectory()
+
+        let name = DeployCoordinator.resolveWorkerSiteName(siteDirectory: dir, siteID: "site-1", siteName: "My Cool Site")
+
+        #expect(name == SiteSlug.derive(from: "My Cool Site"))
+    }
+
+    @Test("with no established name and no siteName, the siteID is derived into a slug")
+    func resolveWorkerSiteNameFallsBackToSiteID() throws {
+        let dir = try temporaryDirectory()
+
+        let name = DeployCoordinator.resolveWorkerSiteName(siteDirectory: dir, siteID: "site-1", siteName: nil)
+
+        #expect(name == SiteSlug.derive(from: "site-1"))
+    }
+
+    // MARK: - persistProvisionedResources
+
+    @Test("persists the sorted effective active set and the provisioned resources")
+    func persistProvisionedResourcesWritesSettings() async throws {
+        let dir = try temporaryDirectory()
+        let configStore = SiteConfigStore(configDirectory: dir)
+        let resources = WorkerComposition.ProvisionedResources(d1DatabaseID: "d1-1", kvNamespaceID: "kv-1", r2BucketName: nil)
+
+        await DeployCoordinator.persistProvisionedResources(
+            configStore: configStore,
+            settings: SiteSettings(displayName: "Keep Me"),
+            effectiveActiveIDs: ["websub", "indieauth"],
+            resources: resources
+        )
+
+        let saved = try await configStore.load()
+        #expect(saved.lastDeployedWorkerIDs == ["indieauth", "websub"])
+        #expect(saved.provisionedWorkerResources == resources)
+        // Unrelated fields on the passed-in settings are preserved, not clobbered.
+        #expect(saved.displayName == "Keep Me")
+    }
+
+    // MARK: - runPostDeploySequencing
+
+    /// Not an actor: `runPostDeploySequencing` calls `onMilestone` synchronously and awaits
+    /// `sendWebmentions`/`syndicate` in sequence on the calling task, with no concurrent access —
+    /// a plain recorder keeps the assertion a simple, unambiguous array equality instead of an
+    /// actor hop whose Task-scheduling order isn't guaranteed to match call order.
+    private final class CallRecorder: @unchecked Sendable {
+        private(set) var calls: [String] = []
+        func record(_ name: String) { calls.append(name) }
+    }
+
+    @Test("runs webmention-send fully before syndication starts, with a milestone immediately before each")
+    func postDeploySequencingRunsInOrder() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { progress in recorder.record("milestone:\(progress.phase)") },
+            sendWebmentions: { recorder.record("send") },
+            syndicate: { recorder.record("syndicate") }
+        )
+        #expect(recorder.calls == ["milestone:webmentions", "send", "milestone:syndicating", "syndicate"])
+    }
+
+    @Test("both passes still run even when the caller's onMilestone closure does nothing observable")
+    func postDeploySequencingRunsBothPassesRegardless() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { _ in },
+            sendWebmentions: { recorder.record("send") },
+            syndicate: { recorder.record("syndicate") }
+        )
+        #expect(recorder.calls == ["send", "syndicate"])
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts the pure-orchestration pieces of `DeployModel.runDeploy` (an app-target `@MainActor` view model) into a new `AnglesiteCore.DeployCoordinator`, mirroring how `TokenOnboarding` was extracted for the same reason: app-target logic can't run on CI (only `swift test` SwiftPM targets can — hosted `xcodebuild test` doesn't work on CI's older runners).
- Moved into the coordinator:
  - `planWorkerActivation` — content-graph snapshot building + `WorkerActivation.effectiveActiveIDs`/`removedIDs` computation, resolved to `[WorkerDescriptor]` via `WorkerActivation.activeDescriptors` plus the unresolved-id set for the missing-descriptor warning (see note below)
  - `resolveWorkerSiteName` — `CF_PROJECT_NAME` precedence over a derived slug (#740)
  - `persistProvisionedResources` — settings persistence of provisioned Cloudflare resources after a successful provision
  - `runPostDeploySequencing` — webmention-send → POSSE-syndicate ordering with milestone hooks, expressed as injectable closures so the *sequencing* itself is unit-testable independent of the concrete commands
- `verifyAndSaveToken`/`renameWorkerAndRetry` stay app-side per the issue — they're UI-flow-specific (token prompts, rename-and-retry sheets).
- Composes cleanly with #823's `ContainerControlProvider` closure: the coordinator has no opinion on how a deploy step executes (container vs. host executor selection stays in `DeployModel`, unchanged), only on the worker-composition inputs and deploy-adjacent effects around it.
- Adds `Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift` — real coverage for all four extracted responsibilities (worker-activation diffing with both a populated and unpopulated `SiteContentGraph` plus an unresolved-id case, worker-name resolution precedence, settings persistence, post-deploy sequencing order), none of which had any test coverage before since it was trapped inside an app-target view model.

Closes #825.

**Rebase note:** this branch was rebased onto `main` after #821 (#845), #823 (#847), and #824 (#846) merged, and after #708/#834 (`refactor(workers): migrate WorkerComposition to WorkerDescriptor`) merged from an unrelated stack. That last merge changed `SocialWorkerProvisionCommand.provision` to take `[WorkerDescriptor]` directly instead of `[WorkerComposition.Feature]`, so `DeployCoordinator.WorkerActivationPlan` was updated to carry `workers: [WorkerDescriptor]` + `unresolvedIDs: Set<String>` (resolved via `WorkerActivation.activeDescriptors`/`unresolvedActiveIDs`, mirroring `SiteOperations.deployWithWorkerComposition`) instead of the now-retired `features`/`mapToFeatures` shim. `DeployModel`'s call site and the `DeployCoordinatorTests` fixtures were updated to match — pure type/shape migration, no orchestration-logic change.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` — full suite passes (post-rebase, against the `WorkerDescriptor`-based `DeployCoordinator`). Only pre-existing failure expected: the known FoundationModels `Generable`-type token-overflow flake (`ContentSummary parses numeric reading metadata`), unrelated to this change (also called out in the #821/#823/#824 PRs).
- [x] New `DeployCoordinatorTests` suite (10 tests, including the new unresolved-id case) passes cleanly on its own and in the full run.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**, confirming the app target still links against the refactored `DeployModel` and the `WorkerDescriptor`-based coordinator.
- [x] All pre-existing `DeployModelTests` (container-control provider routing/re-invocation, worker-name-conflict rename-and-retry, sudden-termination lease bracketing, static-site and settings-activated-worker deploy paths) pass unchanged, confirming behavior parity after the extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
