### PR TITLE
refactor(#822): extract SiteWindowModel's four embedded subsystems; add CurrentSite

### DIFF
--- a/Sources/AnglesiteApp/AssistantSessionAssembler.swift
+++ b/Sources/AnglesiteApp/AssistantSessionAssembler.swift
@@ -1,0 +1,60 @@
+import Foundation
+import AnglesiteCore
+
+/// Assembles the per-site `SiteAssistantSession`: the MCP-client and container-control closures
+/// `PreviewModel` exposes, the theme catalog `SetupThemeTool` needs, and the call into
+/// `SiteAssistantSessionFactory.makeSession` itself.
+///
+/// Extracted from `SiteWindowModel.loadAndStart` (#822) as the fourth of its four embedded
+/// subsystems. This is pure assembly with no state of its own to own across calls — a stateless
+/// namespace, not a composed controller like `InvisiblePublishCoordinator`/
+/// `SecurityScopedGrantController` — `loadAndStart` calls it once per site open/replay and keeps
+/// only the resulting `SiteAssistantSession`.
+///
+/// Takes `preview: PreviewModel` directly (not just its `mcpClient`/`activeContainerControl`
+/// results) because both closures must stay *lazy*: `SiteAssistantSessionFactory`'s
+/// `containerControlProvider` is resolved at the moment a deploy/assistant call actually runs
+/// (#823), not at session-assembly time — capturing `preview` and calling through it on each
+/// invocation preserves that, matching what `loadAndStart` did inline before this extraction.
+@MainActor
+enum AssistantSessionAssembler {
+    static func makeSession(
+        for site: CurrentSite,
+        preview: PreviewModel,
+        contentGraph: SiteContentGraph,
+        knowledgeIndex: SiteKnowledgeIndex,
+        semanticRanker: SemanticRanker?,
+        conventionsEngine: ProjectConventionsEngine,
+        integrationService: any IntegrationOperationsService,
+        graphSnapshotProvider: @escaping SiteAssistantSessionFactory.GraphSnapshotProvider
+    ) -> SiteAssistantSession {
+        let mcpClient: @Sendable () async -> MCPClient? = { [preview] in
+            await preview.mcpClient()
+        }
+        let containerControlProvider: SiteAssistantSessionFactory.ContainerControlProvider = { [preview] in
+            await preview.activeContainerControl()
+        }
+        // Best-effort: SetupThemeTool only attaches to the chat assistant when a catalog loads
+        // successfully. A missing/unreadable template must not block opening the site — the
+        // assistant simply runs without the theme-apply tool, same as before this catalog existed.
+        let themeCatalog: ThemeCatalog? = {
+            guard let templateURL = TemplateRuntime.resolve().url else { return nil }
+            return try? ThemeCatalog.load(templateURL: templateURL)
+        }()
+        return SiteAssistantSessionFactory.makeSession(
+            siteID: site.id,
+            sourceDirectory: site.sourceDirectory,
+            configDirectory: site.configDirectory,
+            packageURL: site.packageURL,
+            mcpClient: mcpClient,
+            containerControlProvider: containerControlProvider,
+            contentGraph: contentGraph,
+            knowledgeIndex: knowledgeIndex,
+            semanticRanker: semanticRanker,
+            conventionsEngine: conventionsEngine,
+            integrationService: integrationService,
+            themeCatalog: themeCatalog,
+            graphSnapshotProvider: graphSnapshotProvider
+        )
+    }
+}

--- a/Sources/AnglesiteApp/CompletionNotificationHub.swift
+++ b/Sources/AnglesiteApp/CompletionNotificationHub.swift
@@ -1,0 +1,131 @@
+import Foundation
+import AnglesiteCore
+
+/// Wires Deploy/Backup/Audit phase transitions to the completion notifier and the Dock-tile
+/// progress bar (#526). Thin glue by design: wording lives in `CompletionNoticeBuilder` and the
+/// milestone→fraction mapping in `DeployDockProgress` (both unit-tested in `AnglesiteCore`);
+/// these closures only forward phase data.
+///
+/// Extracted from `SiteWindowModel.wireCompletionHooks`/`postNotice` (#822) as one of its four
+/// embedded subsystems. Stateless by design (a namespace, not a composed controller like
+/// `InvisiblePublishCoordinator`/`SecurityScopedGrantController`): `SiteWindowModel.init` calls
+/// `wire(deploy:backup:audit:)` exactly once and never needs to reach back into this type again.
+///
+/// Deliberately captures **nothing** from the calling `SiteWindowModel`. Closing a window does
+/// *not* stop an in-flight operation: the models' `Task { [weak self] in await self?.run…() }`
+/// retains the model strongly for the whole async call (the optional-chained receiver is kept
+/// alive across every suspension inside it), so an abandoned operation runs to a real terminal
+/// phase after the window model is gone — and must still notify, since "the window is no longer
+/// watching" is exactly the case the feature covers. The site id therefore arrives from the model
+/// per-run (so a window replayed onto a different site can't mis-attribute a still-in-flight
+/// run), and the display name is resolved fresh from `SiteStore` at post time (so a rename
+/// mid-run notifies under the current name). Dock state is likewise driven entirely by the run's
+/// own transitions — every terminal phase clears its token, so no close-time cleanup is needed
+/// (or correct: an eager clear would just be re-added by the still-running deploy's next
+/// milestone).
+@MainActor
+enum CompletionNotificationHub {
+    static func wire(deploy: DeployModel, backup: BackupModel, audit: AuditModel) {
+        deploy.onPhaseTransition = { siteID, phase in
+            let dockToken = "deploy:\(siteID)"
+            switch phase {
+            case .idle:
+                DockProgressController.shared.clear(token: dockToken)
+            case .running:
+                // Indeterminate until the first structured milestone arrives.
+                DockProgressController.shared.update(fraction: nil, for: dockToken)
+            case .succeeded(let url, let duration):
+                DockProgressController.shared.clear(token: dockToken)
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.deploy(
+                        siteName: name, siteID: siteID,
+                        outcome: .succeeded(url: url.absoluteString, duration: duration)
+                    )
+                }
+            case .failed(let reason, _):
+                // Command-produced reasons already carry the exit code where it matters
+                // ("npm run build failed (exit 1)"), so don't append it again here.
+                DockProgressController.shared.clear(token: dockToken)
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.deploy(siteName: name, siteID: siteID, outcome: .failed(reason: reason))
+                }
+            case .blocked(let failures, _):
+                DockProgressController.shared.clear(token: dockToken)
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.deploy(
+                        siteName: name, siteID: siteID, outcome: .blocked(failureCount: failures.count)
+                    )
+                }
+            case .workerNameConflict:
+                // The conflict sheet (wired separately) carries the actionable info, and the
+                // deploy is parked rather than finished — no completion notice, just stop
+                // showing progress on the Dock tile.
+                DockProgressController.shared.clear(token: dockToken)
+            }
+        }
+        deploy.onMilestone = { siteID, progress in
+            guard progress.kind == .deploy else { return }
+            DockProgressController.shared.update(
+                fraction: DeployDockProgress.fraction(forPhase: progress.phase),
+                for: "deploy:\(siteID)"
+            )
+        }
+
+        backup.onPhaseTransition = { siteID, phase in
+            switch phase {
+            case .idle, .running:
+                break
+            case .succeeded(let sha, let branch, let remote, _):
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.backup(
+                        siteName: name, siteID: siteID,
+                        outcome: .succeeded(commitSHA: sha, branch: branch, remote: remote)
+                    )
+                }
+            case .noChanges:
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.backup(siteName: name, siteID: siteID, outcome: .noChanges)
+                }
+            case .failed(let reason, _):
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.backup(siteName: name, siteID: siteID, outcome: .failed(reason: reason))
+                }
+            }
+        }
+
+        audit.onPhaseTransition = { siteID, phase in
+            switch phase {
+            case .idle, .running:
+                break
+            case .succeeded(let report, _):
+                let counts = Dictionary(grouping: report.findings, by: \.severity).mapValues(\.count)
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.audit(
+                        siteName: name, siteID: siteID,
+                        outcome: .succeeded(
+                            criticalCount: counts[.critical, default: 0],
+                            warningCount: counts[.warning, default: 0],
+                            infoCount: counts[.info, default: 0]
+                        )
+                    )
+                }
+            case .failed(let reason, _, _):
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.audit(siteName: name, siteID: siteID, outcome: .failed(reason: reason))
+                }
+            }
+        }
+    }
+
+    /// Resolve the site's *current* display name from the registry and hand the notice to the
+    /// notifier (which applies the settings toggle and the not-frontmost gate). The posting path
+    /// must not depend on the window model still existing — an operation whose window closed
+    /// mid-run finishes later and still notifies. A site removed from the registry mid-run posts
+    /// with an empty subtitle rather than not at all.
+    private static func postNotice(siteID: String, _ make: @escaping @MainActor (String) -> CompletionNotice) {
+        Task { @MainActor in
+            let name = await SiteStore.shared.find(id: siteID)?.name ?? ""
+            CompletionNotifier.shared.post(make(name))
+        }
+    }
+}

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -12,6 +12,13 @@ struct ComponentEditorContext {
     let baseURL: URL?
     let modelClient: ComponentModelClient?
     let sourceRoot: URL
+    /// The open site's identity/paths (#822's shared current-site value type), threaded in
+    /// alongside `sourceRoot` rather than replacing it — `sourceRoot` predates `CurrentSite` and
+    /// this file's draft/commit-state migration (#824) is a separate, larger in-flight change to
+    /// this same type, so this field is deliberately additive and unused beyond being available:
+    /// `nil` in tests/previews that don't construct it (matching `onOpenFile`/`duplicateComponent`
+    /// below).
+    var site: CurrentSite? = nil
     /// Routes canvas-originated edits (e.g. a style tweak from the Styles
     /// panel) to the running site's MCP server. At the production call site
     /// (`SiteWindow`) this is always `model.preview.editRouter` — the same

--- a/Sources/AnglesiteApp/ComponentEditorModel.swift
+++ b/Sources/AnglesiteApp/ComponentEditorModel.swift
@@ -13,11 +13,12 @@ struct ComponentEditorContext {
     let modelClient: ComponentModelClient?
     let sourceRoot: URL
     /// The open site's identity/paths (#822's shared current-site value type), threaded in
-    /// alongside `sourceRoot` rather than replacing it — `sourceRoot` predates `CurrentSite` and
-    /// this file's draft/commit-state migration (#824) is a separate, larger in-flight change to
-    /// this same type, so this field is deliberately additive and unused beyond being available:
-    /// `nil` in tests/previews that don't construct it (matching `onOpenFile`/`duplicateComponent`
-    /// below).
+    /// alongside `sourceRoot` rather than replacing it — `sourceRoot` predates `CurrentSite`.
+    /// #824's draft/commit-state migration (PR #846) landed a much larger restructuring of
+    /// `ComponentEditorModel` itself, but left this context struct untouched, so this field
+    /// stays deliberately additive groundwork rather than a replacement for any existing
+    /// plumbing: `nil` in tests/previews that don't construct it (matching
+    /// `onOpenFile`/`duplicateComponent` below).
     var site: CurrentSite? = nil
     /// Routes canvas-originated edits (e.g. a style tweak from the Styles
     /// panel) to the running site's MCP server. At the production call site

--- a/Sources/AnglesiteApp/CurrentSite.swift
+++ b/Sources/AnglesiteApp/CurrentSite.swift
@@ -1,0 +1,57 @@
+import Foundation
+import AnglesiteCore
+
+/// The identity and on-disk paths for a site window's currently open site (#822).
+///
+/// Before this type existed, `SiteWindowModel.loadAndStart` re-derived `id`/`sourceDirectory`/
+/// `packageURL`/`configDirectory` from `SiteStore.Site` separately at each of six child models'
+/// own call sites (`PreviewModel.open`, `SiteNavigatorModel.start`, `ProjectCleanupModel.configure`,
+/// `SiteGraphExplorerModel.start`, and — via `ComponentEditorContext` — `ComponentEditorModel`),
+/// each reading a different subset of the same three-ish fields off the same `SiteStore.Site`
+/// value. That's harmless as long as every call site reads the same local, but it's a stale-state
+/// bug waiting to happen the moment one of those calls moves to a different lifecycle point than
+/// the others (e.g. a future replay path that resolves the site twice). Threading one
+/// `CurrentSite`, constructed once per site open/replay, closes that off: every child model
+/// downstream of `loadAndStart` sees the exact same values.
+///
+/// Deliberately narrower than `SiteStore.Site` — this carries only what a child model needs to
+/// operate on a site's *files*, not the mutable registry bookkeeping (`isValid`,
+/// `missingSentinels`, `lastSeen`, `bookmarkData`, `needsReauthorization`) that only
+/// `SiteWindowModel` itself and the launcher care about.
+///
+/// Not threaded into `ChatModel`/`SiteAssistantSessionFactory`: that factory's `makeSession`
+/// intentionally takes `siteID`/`sourceDirectory`/`configDirectory`/an *optional* `packageURL`
+/// as disaggregated parameters — `packageURL` is optional on purpose (see
+/// `SiteAssistantSessionFactoryTests.missingPackageURLMeansNoFactory`, which exercises the
+/// no-design-interview-factory branch), and `CurrentSite.packageURL` is never optional for a
+/// real open site. Forcing `CurrentSite` through that boundary would either fight the factory's
+/// existing optionality contract or require a second, parallel "maybe a site" type — not worth
+/// it for a factory `SiteWindowModel` already calls through `AssistantSessionAssembler`.
+struct CurrentSite: Equatable, Sendable {
+    let id: String
+    let name: String
+    let packageURL: URL
+    let sourceDirectory: URL
+    let configDirectory: URL
+
+    init(_ site: SiteStore.Site) {
+        self.id = site.id
+        self.name = site.name
+        self.packageURL = site.packageURL
+        self.sourceDirectory = site.sourceDirectory
+        self.configDirectory = site.configDirectory
+    }
+
+    /// Fixture initializer: builds a `CurrentSite` directly from its component values, without
+    /// going through a `SiteStore.Site` (which needs a real, on-disk `.anglesite` package layout
+    /// to compute `sourceDirectory`/`configDirectory` from). For tests that construct child
+    /// models directly against a plain temp directory rather than a full package fixture.
+    /// `name`/`configDirectory` default for call sites that don't exercise them.
+    init(id: String, name: String = "", packageURL: URL, sourceDirectory: URL, configDirectory: URL? = nil) {
+        self.id = id
+        self.name = name
+        self.packageURL = packageURL
+        self.sourceDirectory = sourceDirectory
+        self.configDirectory = configDirectory ?? sourceDirectory
+    }
+}

--- a/Sources/AnglesiteApp/InvisiblePublishCoordinator.swift
+++ b/Sources/AnglesiteApp/InvisiblePublishCoordinator.swift
@@ -1,0 +1,107 @@
+import Foundation
+import AnglesiteCore
+
+/// Owns the invisible-publish (#357) background machinery for one open site window: the publish
+/// queue itself, the connectivity monitor that flips it online/offline, and the source-tree file
+/// watcher that feeds it edits.
+///
+/// Extracted from `SiteWindowModel` (#822) as one of its four embedded subsystems — composition,
+/// not inheritance, mirroring how `SiteRuntimeStateMachine` (#821) was pulled out of the
+/// `SiteRuntime` conformers. `SiteWindowModel` still owns *what a publish actually does*
+/// (`performInvisiblePublish`, which reaches into `deploy`/`backup`/`audit`/`contentGraph`/
+/// `preview` — none of which this type has any business knowing about) and hands it in as the
+/// `publisher` closure; this type only owns the queue/watcher/monitor lifecycle around that
+/// closure, plus the pure file-change relevance filter.
+@MainActor
+final class InvisiblePublishCoordinator {
+    private var queue: InvisiblePublishQueue?
+    private var watcher: (any SiteFileWatching)?
+    private var connectivityMonitor: (any ConnectivityMonitoring)?
+    private var startTask: Task<Void, Never>?
+
+    init() {}
+
+    /// (Re)starts the subsystem for `site`, tearing down any prior instance first — safe to call
+    /// again on window replay onto a different site. `watcherFactory`/`monitorFactory` are
+    /// injection seams for tests; production always uses the `Platform*.make()` defaults.
+    func start(
+        for site: CurrentSite,
+        publisher: @escaping @Sendable () async -> InvisiblePublishQueue.Result,
+        onStateChange: @escaping @MainActor (InvisiblePublishQueue.State) -> Void,
+        watcherFactory: () -> any SiteFileWatching = { PlatformFileWatcher.make() },
+        monitorFactory: () -> any ConnectivityMonitoring = { PlatformConnectivityMonitor.make() }
+    ) {
+        stop()
+
+        let queue = InvisiblePublishQueue(
+            configDirectory: site.configDirectory,
+            publisher: publisher,
+            onStateChange: { state in
+                Task { @MainActor in onStateChange(state) }
+            }
+        )
+        self.queue = queue
+
+        let monitor = monitorFactory()
+        connectivityMonitor = monitor
+        startTask = Task { [weak self, queue, monitor] in
+            await queue.start(isOnline: false)
+            guard !Task.isCancelled, self?.queue === queue else { return }
+            monitor.start { online in
+                Task { await queue.setOnline(online) }
+            }
+        }
+
+        let watcher = watcherFactory()
+        do {
+            try watcher.start(root: site.sourceDirectory) { [queue, root = site.sourceDirectory] batch in
+                guard Self.isPublishRelevant(batch, sourceDirectory: root) else { return }
+                Task { await queue.recordEdit() }
+            }
+            self.watcher = watcher
+        } catch {
+            Task {
+                await LogCenter.shared.append(
+                    source: "publish:\(site.id)", stream: .stderr,
+                    text: "invisible publish: couldn't watch source edits: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    /// Tears the subsystem down: cancels the start task, stops the watcher and connectivity
+    /// monitor, and stops the queue. Safe to call when nothing is running (window close after a
+    /// site never fully opened, or a second `stop()` in a row).
+    func stop() {
+        startTask?.cancel()
+        startTask = nil
+        watcher?.stop()
+        watcher = nil
+        connectivityMonitor?.stop()
+        connectivityMonitor = nil
+        if let queue { Task { await queue.stop() } }
+        queue = nil
+    }
+
+    /// Retries any pending publish now that the dev server is deployable — called from
+    /// `SiteWindowModel.previewStateChanged` once `preview.canDeploy` flips true. No-ops when
+    /// nothing has been started yet.
+    func retryPendingIfDeployable() {
+        guard let queue else { return }
+        Task { await queue.retryPending() }
+    }
+
+    /// Whether a batch of file-system changes under `sourceDirectory` should mark the invisible
+    /// publish queue dirty. Pure logic (no queue/watcher state), so it's unit-testable directly.
+    nonisolated static func isPublishRelevant(_ batch: FileChangeBatch, sourceDirectory: URL) -> Bool {
+        if batch.needsFullRescan { return true }
+        let root = sourceDirectory.standardizedFileURL.pathComponents
+        let ignoredTopLevel = Set([".git", ".astro", "dist", "node_modules"])
+        return batch.paths.contains { path in
+            let components = path.standardizedFileURL.pathComponents
+            guard components.starts(with: root) else { return false }
+            guard let firstRelative = components.dropFirst(root.count).first else { return true }
+            return !ignoredTopLevel.contains(firstRelative)
+        }
+    }
+}

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -173,7 +173,9 @@ final class PreviewModel {
         }
     }
 
-    func open(siteID: String, siteDirectory: URL) {
+    func open(site: CurrentSite) {
+        let siteID = site.id
+        let siteDirectory = site.sourceDirectory
         openSiteID = siteID
         openSiteDirectory = siteDirectory
         devServerStoppedByUser = false
@@ -244,7 +246,7 @@ final class PreviewModel {
     }
 
     /// Whether a site is open enough to (re)start its dev server: both fields are captured by
-    /// `open(siteID:siteDirectory:)`, so this is true from first open until `close()`.
+    /// `open(site:)`, so this is true from first open until `close()`.
     private var siteOpenForDevServer: Bool {
         openSiteID != nil && openSiteDirectory != nil
     }
@@ -278,7 +280,7 @@ final class PreviewModel {
     }
 
     /// Shared Start/Restart dispatch. The edit router stays registered across a stop, so no
-    /// re-registration is needed here (unlike `open(siteID:siteDirectory:)`).
+    /// re-registration is needed here (unlike `open(site:)`).
     private func relaunchDevServer() {
         guard let siteID = openSiteID, let siteDirectory = openSiteDirectory else { return }
         devServerStoppedByUser = false

--- a/Sources/AnglesiteApp/ProjectCleanupModel.swift
+++ b/Sources/AnglesiteApp/ProjectCleanupModel.swift
@@ -44,9 +44,9 @@ final class ProjectCleanupModel {
 
     /// Records which site this model scans. Cheap — does no I/O. Called once per site open from
     /// `SiteWindowModel.loadAndStart()`.
-    func configure(siteID: String, sourceDirectory: URL) {
-        self.siteID = siteID
-        self.sourceDirectory = sourceDirectory
+    func configure(site: CurrentSite) {
+        self.siteID = site.id
+        self.sourceDirectory = site.sourceDirectory
     }
 
     /// Runs (or re-runs) the full cleanup scan. On-demand only — never called automatically.

--- a/Sources/AnglesiteApp/SecurityScopedGrantController.swift
+++ b/Sources/AnglesiteApp/SecurityScopedGrantController.swift
@@ -1,0 +1,65 @@
+#if ANGLESITE_MAS
+import Foundation
+import AnglesiteCore
+
+/// Holds the security-scoped bookmark grant for one open site window's package, under App
+/// Sandbox / Mac App Store distribution (#242). Extracted from `SiteWindowModel.acquireGrant`
+/// (#822) as one of its four embedded subsystems.
+///
+/// One instance per `SiteWindowModel`, reused across window replay (a `WindowGroup` restoring a
+/// different site into the same view instance) — `acquireGrant` releases any prior grant before
+/// resolving the new one.
+@MainActor
+final class SecurityScopedGrantController {
+    private(set) var scopedURL: URL?
+
+    init() {}
+
+    /// Resolve the site's persisted security-scoped bookmark and hold the grant for the window's
+    /// lifetime. Must run before any subprocess spawn so direct children inherit folder access.
+    /// On a stale bookmark, re-mint and persist a fresh one (grant must be active to do so).
+    func acquireGrant(for site: SiteStore.Site, in store: SiteStore) async {
+        // Release any prior grant first (window replay into the same instance): the window now
+        // shows a different site, so keeping the old grant — even on the failure paths below — leaks.
+        if let previous = scopedURL {
+            previous.stopAccessingSecurityScopedResource()
+            scopedURL = nil
+        }
+        guard let bookmark = await store.bookmarkData(for: site.id) else {
+            await LogCenter.shared.append(
+                source: "grant:\(site.id)", stream: .stderr,
+                text: "No security-scoped bookmark for \(site.name); preview will fail until the package is re-added via Open Site…"
+            )
+            return
+        }
+        do {
+            let resolved = try SecurityScopedBookmark.resolve(bookmark)
+            guard resolved.url.startAccessingSecurityScopedResource() else {
+                await LogCenter.shared.append(
+                    source: "grant:\(site.id)", stream: .stderr,
+                    text: "startAccessingSecurityScopedResource() returned false for \(resolved.url.path)"
+                )
+                return
+            }
+            scopedURL = resolved.url
+            if resolved.isStale, let fresh = try? SecurityScopedBookmark.create(for: resolved.url) {
+                try? await store.setBookmark(fresh, for: site.id)
+            }
+        } catch {
+            await LogCenter.shared.append(
+                source: "grant:\(site.id)", stream: .stderr,
+                text: "Couldn't resolve security-scoped bookmark for \(site.name): \(error)"
+            )
+        }
+    }
+
+    /// Clears the held grant and returns the URL that was released, if any — the caller (window
+    /// close) is responsible for actually calling `stopAccessingSecurityScopedResource()` on it,
+    /// deferred until any pending editor/inspector save tasks finish (they may still need the
+    /// scope active). Mirrors `SiteWindowModel.close()`'s existing ordering.
+    func release() -> URL? {
+        defer { scopedURL = nil }
+        return scopedURL
+    }
+}
+#endif

--- a/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
+++ b/Sources/AnglesiteApp/SiteGraphExplorerModel.swift
@@ -120,7 +120,9 @@ final class SiteGraphExplorerModel {
         SiteGraphExplorerGrouping.summary(nodeCount: filteredNodes.count, edgeCount: filteredEdges.count)
     }
 
-    func start(siteID: String, sourceDirectory: URL) {
+    func start(site: CurrentSite) {
+        let siteID = site.id
+        let sourceDirectory = site.sourceDirectory
         self.siteID = siteID
         self.sourceDirectory = sourceDirectory
         observeTask?.cancel()

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -43,8 +43,10 @@ final class SiteNavigatorModel {
         self.graph = graph
     }
 
-    func start(siteID: String, siteRoot: URL, sourceDirectory: URL, websiteTitle: String) {
-        self.sourceDirectory = sourceDirectory
+    func start(site: CurrentSite, websiteTitle: String) {
+        let siteID = site.id
+        let siteRoot = site.packageURL
+        self.sourceDirectory = site.sourceDirectory
         self.websiteTitle = websiteTitle
         self.siteID = siteID
         self.siteRoot = siteRoot

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -715,6 +715,7 @@ struct SiteWindow: View {
                             await preview.mcpClient()
                         }),
                         sourceRoot: site.sourceDirectory,
+                        site: CurrentSite(site),
                         // Reuse the preview canvas's own router rather than building a second,
                         // unwired MCPApplyEditRouter: model.preview.editRouter is registered in
                         // EditRouterRegistry (Siri/App Intents) and wired to record chat-history

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -49,20 +49,21 @@ final class SiteWindowModel {
     private let contentIndexerStore: ContentIndexerStore
     private let integrationOps = IntegrationOperations.live()
     private let contentCreation: ContentCreationWorkflow
-    @ObservationIgnored private var invisiblePublishQueue: InvisiblePublishQueue?
-    @ObservationIgnored private var invisiblePublishWatcher: (any SiteFileWatching)?
-    @ObservationIgnored private var connectivityMonitor: (any ConnectivityMonitoring)?
-    @ObservationIgnored private var invisiblePublishStartTask: Task<Void, Never>?
+    /// Owns the invisible-publish (#357) queue/watcher/connectivity-monitor lifecycle — see
+    /// `InvisiblePublishCoordinator`'s own doc comment (one of #822's four extracted subsystems).
+    @ObservationIgnored private let invisiblePublish = InvisiblePublishCoordinator()
     @ObservationIgnored
     private var dismissSiteWindow: (() -> Void)?
 
     var site: SiteStore.Site?
 
     #if ANGLESITE_MAS
-    /// The security-scoped URL whose grant is held for this window's lifetime. Resolved from the
-    /// site's persisted bookmark in `loadAndStart()` before any subprocess spawns; the directly
-    /// spawned Node/Astro/wrangler children inherit folder access. Released in `close()`.
-    var scopedURL: URL?
+    /// Owns the security-scoped bookmark grant for this window's lifetime — see
+    /// `SecurityScopedGrantController`'s own doc comment (one of #822's four extracted
+    /// subsystems). Resolved from the site's persisted bookmark in `loadAndStart()` before any
+    /// subprocess spawns; the directly spawned Node/Astro/wrangler children inherit folder
+    /// access. Released in `close()`.
+    @ObservationIgnored private let grantController = SecurityScopedGrantController()
     #endif
 
     var preview: PreviewModel
@@ -207,8 +208,8 @@ final class SiteWindowModel {
         self.cleanup = ProjectCleanupModel(knowledgeIndex: knowledgeIndex, contentGraph: contentGraph)
         // Wired once here (not per-site in loadAndStart): the hooks capture nothing from self
         // and receive the run's site id from the model, so there is nothing to rebind on
-        // window replay — see wireCompletionHooks.
-        wireCompletionHooks()
+        // window replay — see CompletionNotificationHub's own doc comment.
+        CompletionNotificationHub.wire(deploy: deploy, backup: backup, audit: audit)
     }
 
     var activeEditorFile: FileRef? {
@@ -381,8 +382,8 @@ final class SiteWindowModel {
 
     func previewStateChanged(_ state: SiteRuntimeState) {
         startup.ingest(state: state)
-        guard preview.canDeploy, let invisiblePublishQueue else { return }
-        Task { await invisiblePublishQueue.retryPending() }
+        guard preview.canDeploy else { return }
+        invisiblePublish.retryPendingIfDeployable()
     }
 
     func handleSiteChanged() {
@@ -440,8 +441,7 @@ final class SiteWindowModel {
         let closeTerminationLease = suddenTerminationLease
             ?? ((editorSaveTask != nil || inspectorWasDirty) ? SuddenTerminationController.shared.acquire() : nil)
         #if ANGLESITE_MAS
-        let closingScopedURL = scopedURL
-        self.scopedURL = nil
+        let closingScopedURL = grantController.release()
         #endif
         Task { @MainActor in
             await editorSaveTask?.value
@@ -1249,11 +1249,15 @@ final class SiteWindowModel {
             return
         }
         site = resolved
+        // Constructed once and threaded into every child model below instead of each one
+        // separately re-deriving `id`/`sourceDirectory`/`packageURL`/`configDirectory` from
+        // `resolved` at its own call site (#822) — see `CurrentSite`'s own doc comment.
+        let currentSite = CurrentSite(resolved)
         AppSettings.shared.lastOpenedSiteID = resolved.id
         try? await store.touch(id: resolved.id)
 
         #if ANGLESITE_MAS
-        await acquireGrant(for: resolved, in: store)
+        await grantController.acquireGrant(for: resolved, in: store)
         #endif
 
         // Recreate the provider whenever the resolved siteID changes — SwiftUI's
@@ -1315,8 +1319,8 @@ final class SiteWindowModel {
         // value is present, so seeding order matters: seed first, or a restored override is
         // silently discarded by the runtime's fresh scan (#313).
         await styleGuide?.seedFromDisk()
-        preview.open(siteID: resolved.id, siteDirectory: resolved.sourceDirectory)
-        startInvisiblePublishing(for: resolved)
+        preview.open(site: currentSite)
+        startInvisiblePublishing(for: currentSite)
         // Warm the content graph now rather than waiting for the first create/delete (#660), so
         // `SearchContentTool`'s `isPopulated` check is already reliable by the time the chat
         // assistant is wired up below. Kicked off in the background (not awaited here) so its
@@ -1338,46 +1342,23 @@ final class SiteWindowModel {
         // this creation and stop the freshly-made navigator instead.
         navigator?.stop()
         let navModel = SiteNavigatorModel(graph: contentGraph)
-        navModel.start(
-            siteID: resolved.id,
-            siteRoot: resolved.packageURL,
-            sourceDirectory: resolved.sourceDirectory,
-            websiteTitle: resolved.name
-        )
+        navModel.start(site: currentSite, websiteTitle: currentSite.name)
         navigator = navModel
-        graphExplorer.start(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
-        cleanup.configure(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
+        graphExplorer.start(site: currentSite)
+        cleanup.configure(site: currentSite)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)
         applyPendingDesignInterviewRequest(for: resolved.id)
-        let mcpClient: @Sendable () async -> MCPClient? = { [preview] in
-            await preview.mcpClient()
-        }
-        let containerControlProvider: SiteAssistantSessionFactory.ContainerControlProvider = { [preview] in
-            await preview.activeContainerControl()
-        }
-        // Best-effort: SetupThemeTool only attaches to the chat assistant when a catalog loads
-        // successfully. A missing/unreadable template must not block opening the site — the
-        // assistant simply runs without the theme-apply tool, same as before this catalog existed.
-        let themeCatalog: ThemeCatalog? = {
-            guard let templateURL = TemplateRuntime.resolve().url else { return nil }
-            return try? ThemeCatalog.load(templateURL: templateURL)
-        }()
         await contentGraphRefresh.value
-        let assistantSession = SiteAssistantSessionFactory.makeSession(
-            siteID: resolved.id,
-            sourceDirectory: resolved.sourceDirectory,
-            configDirectory: resolved.configDirectory,
-            packageURL: resolved.packageURL,
-            mcpClient: mcpClient,
-            containerControlProvider: containerControlProvider,
+        let assistantSession = AssistantSessionAssembler.makeSession(
+            for: currentSite,
+            preview: preview,
             contentGraph: contentGraph,
             knowledgeIndex: knowledgeIndex,
             semanticRanker: semanticRanker,
             conventionsEngine: conventionsEngine,
             integrationService: integrationOps,
-            themeCatalog: themeCatalog,
             graphSnapshotProvider: { [weak self] in
                 guard let self else { return SiteGraphExplorerSnapshot(nodes: [], edges: []) }
                 return await MainActor.run { self.graphExplorer.snapshot }
@@ -1399,57 +1380,19 @@ final class SiteWindowModel {
 
     // MARK: - Invisible publishing (#357)
 
-    private func startInvisiblePublishing(for site: SiteStore.Site) {
-        stopInvisiblePublishing()
-
-        let queue = InvisiblePublishQueue(
-            configDirectory: site.configDirectory,
+    private func startInvisiblePublishing(for site: CurrentSite) {
+        invisiblePublish.start(
+            for: site,
             publisher: { [weak self] in
                 guard let self else { return .deferred(reason: "the site window closed") }
                 return await self.performInvisiblePublish(siteID: site.id)
             },
-            onStateChange: { [weak self] state in
-                Task { @MainActor in self?.invisiblePublishState = state }
-            }
+            onStateChange: { [weak self] state in self?.invisiblePublishState = state }
         )
-        invisiblePublishQueue = queue
-
-        let monitor = PlatformConnectivityMonitor.make()
-        connectivityMonitor = monitor
-        invisiblePublishStartTask = Task { [weak self, queue, monitor] in
-            await queue.start(isOnline: false)
-            guard !Task.isCancelled, self?.invisiblePublishQueue === queue else { return }
-            monitor.start { online in
-                Task { await queue.setOnline(online) }
-            }
-        }
-
-        let watcher = PlatformFileWatcher.make()
-        do {
-            try watcher.start(root: site.sourceDirectory) { [queue, root = site.sourceDirectory] batch in
-                guard Self.isPublishRelevant(batch, sourceDirectory: root) else { return }
-                Task { await queue.recordEdit() }
-            }
-            invisiblePublishWatcher = watcher
-        } catch {
-            Task {
-                await LogCenter.shared.append(
-                    source: "publish:\(site.id)", stream: .stderr,
-                    text: "invisible publish: couldn't watch source edits: \(error.localizedDescription)"
-                )
-            }
-        }
     }
 
     private func stopInvisiblePublishing() {
-        invisiblePublishStartTask?.cancel()
-        invisiblePublishStartTask = nil
-        invisiblePublishWatcher?.stop()
-        invisiblePublishWatcher = nil
-        connectivityMonitor?.stop()
-        connectivityMonitor = nil
-        if let queue = invisiblePublishQueue { Task { await queue.stop() } }
-        invisiblePublishQueue = nil
+        invisiblePublish.stop()
         invisiblePublishState = .idle
     }
 
@@ -1469,177 +1412,4 @@ final class SiteWindowModel {
             siteName: site.name
         )
     }
-
-    nonisolated private static func isPublishRelevant(_ batch: FileChangeBatch, sourceDirectory: URL) -> Bool {
-        if batch.needsFullRescan { return true }
-        let root = sourceDirectory.standardizedFileURL.pathComponents
-        let ignoredTopLevel = Set([".git", ".astro", "dist", "node_modules"])
-        return batch.paths.contains { path in
-            let components = path.standardizedFileURL.pathComponents
-            guard components.starts(with: root) else { return false }
-            guard let firstRelative = components.dropFirst(root.count).first else { return true }
-            return !ignoredTopLevel.contains(firstRelative)
-        }
-    }
-
-    /// Wire Deploy/Backup/Audit phase transitions to the completion notifier and the Dock-tile
-    /// progress bar (#526). Thin glue by design: wording lives in `CompletionNoticeBuilder` and
-    /// the milestone→fraction mapping in `DeployDockProgress` (both unit-tested in
-    /// AnglesiteCore); these closures only forward phase data.
-    ///
-    /// Deliberately captures **nothing** from `self`. Closing a window does *not* stop an
-    /// in-flight operation: the models' `Task { [weak self] in await self?.run…() }` retains the
-    /// model strongly for the whole async call (the optional-chained receiver is kept alive
-    /// across every suspension inside it), so an abandoned operation runs to a real terminal
-    /// phase after this window model is gone — and must still notify, since "the window is no
-    /// longer watching" is exactly the case the feature covers. The site id therefore arrives
-    /// from the model per-run (so a window replayed onto a different site can't mis-attribute a
-    /// still-in-flight run), and the display name is resolved fresh from `SiteStore` at post
-    /// time (so a rename mid-run notifies under the current name). Dock state is likewise
-    /// driven entirely by the run's own transitions — every terminal phase clears its token, so
-    /// no close-time cleanup is needed (or correct: an eager clear would just be re-added by
-    /// the still-running deploy's next milestone).
-    private func wireCompletionHooks() {
-        deploy.onPhaseTransition = { siteID, phase in
-            let dockToken = "deploy:\(siteID)"
-            switch phase {
-            case .idle:
-                DockProgressController.shared.clear(token: dockToken)
-            case .running:
-                // Indeterminate until the first structured milestone arrives.
-                DockProgressController.shared.update(fraction: nil, for: dockToken)
-            case .succeeded(let url, let duration):
-                DockProgressController.shared.clear(token: dockToken)
-                Self.postNotice(siteID: siteID) { name in
-                    CompletionNoticeBuilder.deploy(
-                        siteName: name, siteID: siteID,
-                        outcome: .succeeded(url: url.absoluteString, duration: duration)
-                    )
-                }
-            case .failed(let reason, _):
-                // Command-produced reasons already carry the exit code where it matters
-                // ("npm run build failed (exit 1)"), so don't append it again here.
-                DockProgressController.shared.clear(token: dockToken)
-                Self.postNotice(siteID: siteID) { name in
-                    CompletionNoticeBuilder.deploy(siteName: name, siteID: siteID, outcome: .failed(reason: reason))
-                }
-            case .blocked(let failures, _):
-                DockProgressController.shared.clear(token: dockToken)
-                Self.postNotice(siteID: siteID) { name in
-                    CompletionNoticeBuilder.deploy(
-                        siteName: name, siteID: siteID, outcome: .blocked(failureCount: failures.count)
-                    )
-                }
-            case .workerNameConflict:
-                // The conflict sheet (wired separately) carries the actionable info, and the
-                // deploy is parked rather than finished — no completion notice, just stop
-                // showing progress on the Dock tile.
-                DockProgressController.shared.clear(token: dockToken)
-            }
-        }
-        deploy.onMilestone = { siteID, progress in
-            guard progress.kind == .deploy else { return }
-            DockProgressController.shared.update(
-                fraction: DeployDockProgress.fraction(forPhase: progress.phase),
-                for: "deploy:\(siteID)"
-            )
-        }
-
-        backup.onPhaseTransition = { siteID, phase in
-            switch phase {
-            case .idle, .running:
-                break
-            case .succeeded(let sha, let branch, let remote, _):
-                Self.postNotice(siteID: siteID) { name in
-                    CompletionNoticeBuilder.backup(
-                        siteName: name, siteID: siteID,
-                        outcome: .succeeded(commitSHA: sha, branch: branch, remote: remote)
-                    )
-                }
-            case .noChanges:
-                Self.postNotice(siteID: siteID) { name in
-                    CompletionNoticeBuilder.backup(siteName: name, siteID: siteID, outcome: .noChanges)
-                }
-            case .failed(let reason, _):
-                Self.postNotice(siteID: siteID) { name in
-                    CompletionNoticeBuilder.backup(siteName: name, siteID: siteID, outcome: .failed(reason: reason))
-                }
-            }
-        }
-
-        audit.onPhaseTransition = { siteID, phase in
-            switch phase {
-            case .idle, .running:
-                break
-            case .succeeded(let report, _):
-                let counts = Dictionary(grouping: report.findings, by: \.severity).mapValues(\.count)
-                Self.postNotice(siteID: siteID) { name in
-                    CompletionNoticeBuilder.audit(
-                        siteName: name, siteID: siteID,
-                        outcome: .succeeded(
-                            criticalCount: counts[.critical, default: 0],
-                            warningCount: counts[.warning, default: 0],
-                            infoCount: counts[.info, default: 0]
-                        )
-                    )
-                }
-            case .failed(let reason, _, _):
-                Self.postNotice(siteID: siteID) { name in
-                    CompletionNoticeBuilder.audit(siteName: name, siteID: siteID, outcome: .failed(reason: reason))
-                }
-            }
-        }
-    }
-
-    /// Resolve the site's *current* display name from the registry and hand the notice to the
-    /// notifier (which applies the settings toggle and the not-frontmost gate). `static` on
-    /// purpose: the posting path must not depend on the window model still existing — an
-    /// operation whose window closed mid-run finishes later and still notifies. A site removed
-    /// from the registry mid-run posts with an empty subtitle rather than not at all.
-    private static func postNotice(siteID: String, _ make: @escaping @MainActor (String) -> CompletionNotice) {
-        Task { @MainActor in
-            let name = await SiteStore.shared.find(id: siteID)?.name ?? ""
-            CompletionNotifier.shared.post(make(name))
-        }
-    }
-
-    #if ANGLESITE_MAS
-    /// Resolve the site's persisted security-scoped bookmark and hold the grant for the window's
-    /// lifetime. Must run before any subprocess spawn so direct children inherit folder access.
-    /// On a stale bookmark, re-mint and persist a fresh one (grant must be active to do so).
-    private func acquireGrant(for site: SiteStore.Site, in store: SiteStore) async {
-        // Release any prior grant first (window replay into the same instance): the window now
-        // shows a different site, so keeping the old grant — even on the failure paths below — leaks.
-        if let previous = scopedURL {
-            previous.stopAccessingSecurityScopedResource()
-            scopedURL = nil
-        }
-        guard let bookmark = await store.bookmarkData(for: site.id) else {
-            await LogCenter.shared.append(
-                source: "grant:\(site.id)", stream: .stderr,
-                text: "No security-scoped bookmark for \(site.name); preview will fail until the package is re-added via Open Site…"
-            )
-            return
-        }
-        do {
-            let resolved = try SecurityScopedBookmark.resolve(bookmark)
-            guard resolved.url.startAccessingSecurityScopedResource() else {
-                await LogCenter.shared.append(
-                    source: "grant:\(site.id)", stream: .stderr,
-                    text: "startAccessingSecurityScopedResource() returned false for \(resolved.url.path)"
-                )
-                return
-            }
-            scopedURL = resolved.url
-            if resolved.isStale, let fresh = try? SecurityScopedBookmark.create(for: resolved.url) {
-                try? await store.setBookmark(fresh, for: site.id)
-            }
-        } catch {
-            await LogCenter.shared.append(
-                source: "grant:\(site.id)", stream: .stderr,
-                text: "Couldn't resolve security-scoped bookmark for \(site.name): \(error)"
-            )
-        }
-    }
-    #endif
 }

--- a/Sources/AnglesiteCore/InboxSubmissionSync.swift
+++ b/Sources/AnglesiteCore/InboxSubmissionSync.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Orchestrates #587's "pull staged submissions and commit them into the site's git working
 /// copy" step: list what's staged in `INBOX_KV` (`InboxKVClient`), write + commit the new ones
 /// (`InboxSubmissionCommitter`), then clear only the ones that made it into a commit. Designed to
-/// be called once per site-open (`PreviewModel.open(siteID:siteDirectory:)`).
+/// be called once per site-open (`PreviewModel.open(site:)`).
 public enum InboxSubmissionSync {
     /// Pulls every staged submission from `client`, commits the new ones into `siteDirectory`,
     /// and deletes only the ones that were actually committed — a submission that fails to write

--- a/Tests/AnglesiteAppTests/CurrentSiteTests.swift
+++ b/Tests/AnglesiteAppTests/CurrentSiteTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// `CurrentSite` (#822) bundles the identity/path fields `SiteWindowModel.loadAndStart` threads
+/// into its child models. Both initializers just copy fields, but the `SiteStore.Site`-based one
+/// must read `sourceDirectory`/`configDirectory` off the *package* layout (`Source/`/`Config/`),
+/// not off `packageURL` directly — that's the one place a typo could silently break every child
+/// model's file paths at once, so it's worth a direct assertion.
+@Suite("CurrentSite")
+struct CurrentSiteTests {
+    @Test("initializing from a SiteStore.Site derives sourceDirectory/configDirectory from the package layout")
+    func fromSiteStoreSiteDerivesPackageSubdirectories() {
+        let packageURL = URL(fileURLWithPath: "/tmp/Example.anglesite")
+        let site = SiteStore.Site(
+            id: "site-a", name: "Example", packageURL: packageURL,
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
+        )
+
+        let current = CurrentSite(site)
+
+        #expect(current.id == "site-a")
+        #expect(current.name == "Example")
+        #expect(current.packageURL == packageURL)
+        #expect(current.sourceDirectory.path == packageURL.appendingPathComponent("Source").path)
+        #expect(current.configDirectory.path == packageURL.appendingPathComponent("Config").path)
+    }
+
+    @Test("the fixture initializer defaults configDirectory to sourceDirectory when not given")
+    func fixtureInitializerDefaultsConfigDirectory() {
+        let root = URL(fileURLWithPath: "/tmp/fixture-root")
+
+        let current = CurrentSite(id: "site-b", packageURL: root, sourceDirectory: root)
+
+        #expect(current.name == "")
+        #expect(current.configDirectory == root)
+    }
+
+    @Test("the fixture initializer honors an explicit configDirectory")
+    func fixtureInitializerHonorsExplicitConfigDirectory() {
+        let sourceDirectory = URL(fileURLWithPath: "/tmp/fixture-root/Source")
+        let configDirectory = URL(fileURLWithPath: "/tmp/fixture-root/Config")
+
+        let current = CurrentSite(
+            id: "site-c", name: "Fixture", packageURL: URL(fileURLWithPath: "/tmp/fixture-root"),
+            sourceDirectory: sourceDirectory, configDirectory: configDirectory
+        )
+
+        #expect(current.sourceDirectory == sourceDirectory)
+        #expect(current.configDirectory == configDirectory)
+    }
+}

--- a/Tests/AnglesiteAppTests/InvisiblePublishCoordinatorTests.swift
+++ b/Tests/AnglesiteAppTests/InvisiblePublishCoordinatorTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// `isPublishRelevant` is the one piece of `InvisiblePublishCoordinator` (#822, extracted from
+/// `SiteWindowModel`) that's pure logic with no queue/watcher/actor state to stand up — a batch of
+/// changed paths in, a bool out — so it gets direct coverage here rather than only being exercised
+/// indirectly through a live file watcher.
+@Suite("InvisiblePublishCoordinator.isPublishRelevant")
+struct InvisiblePublishCoordinatorTests {
+    private let root = URL(fileURLWithPath: "/tmp/site-root")
+
+    @Test("a full-rescan batch is always relevant, even with no paths")
+    func fullRescanIsAlwaysRelevant() {
+        let batch = FileChangeBatch(paths: [], needsFullRescan: true)
+        #expect(InvisiblePublishCoordinator.isPublishRelevant(batch, sourceDirectory: root))
+    }
+
+    @Test("a change under an ignored top-level directory (.git) is not relevant")
+    func gitDirectoryIsIgnored() {
+        let batch = FileChangeBatch(
+            paths: [root.appendingPathComponent(".git/index")], needsFullRescan: false
+        )
+        #expect(!InvisiblePublishCoordinator.isPublishRelevant(batch, sourceDirectory: root))
+    }
+
+    @Test("a change under each other ignored top-level directory is not relevant")
+    func otherIgnoredDirectoriesAreIgnored() {
+        for ignored in [".astro", "dist", "node_modules"] {
+            let batch = FileChangeBatch(
+                paths: [root.appendingPathComponent("\(ignored)/generated.js")], needsFullRescan: false
+            )
+            #expect(
+                !InvisiblePublishCoordinator.isPublishRelevant(batch, sourceDirectory: root),
+                "expected \(ignored) to be filtered out"
+            )
+        }
+    }
+
+    @Test("a change under src/ is relevant")
+    func sourceChangeIsRelevant() {
+        let batch = FileChangeBatch(
+            paths: [root.appendingPathComponent("src/pages/about.astro")], needsFullRescan: false
+        )
+        #expect(InvisiblePublishCoordinator.isPublishRelevant(batch, sourceDirectory: root))
+    }
+
+    @Test("a batch mixing an ignored path and a relevant path is relevant")
+    func mixedBatchIsRelevantIfAnyPathQualifies() {
+        let batch = FileChangeBatch(
+            paths: [
+                root.appendingPathComponent(".git/index"),
+                root.appendingPathComponent("src/pages/about.astro"),
+            ],
+            needsFullRescan: false
+        )
+        #expect(InvisiblePublishCoordinator.isPublishRelevant(batch, sourceDirectory: root))
+    }
+
+    @Test("a change outside sourceDirectory entirely is not relevant")
+    func pathOutsideRootIsNotRelevant() {
+        let batch = FileChangeBatch(
+            paths: [URL(fileURLWithPath: "/tmp/somewhere-else/file.txt")], needsFullRescan: false
+        )
+        #expect(!InvisiblePublishCoordinator.isPublishRelevant(batch, sourceDirectory: root))
+    }
+
+    @Test("a change directly at sourceDirectory's root (no relative component) is relevant")
+    func changeAtRootIsRelevant() {
+        let batch = FileChangeBatch(paths: [root], needsFullRescan: false)
+        #expect(InvisiblePublishCoordinator.isPublishRelevant(batch, sourceDirectory: root))
+    }
+}

--- a/Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift
+++ b/Tests/AnglesiteAppTests/ProjectCleanupModelTests.swift
@@ -32,7 +32,7 @@ struct ProjectCleanupModelTests {
         let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDirectory) }
-        model.configure(siteID: "site-a", sourceDirectory: tempDirectory)
+        model.configure(site: CurrentSite(id: "site-a", packageURL: tempDirectory, sourceDirectory: tempDirectory))
 
         // `candidates` starts empty (no scan() has run), so `staleCandidate` is not in the
         // live list — delete must refuse rather than calling gitDelete.
@@ -82,7 +82,7 @@ struct ProjectCleanupModelTests {
             // of this test lacked.
             gitDelete: { _, _, _ in await gate.waitUntilOpen(); return "deadbeef" }
         )
-        model.configure(siteID: "site-a", sourceDirectory: root)
+        model.configure(site: CurrentSite(id: "site-a", packageURL: root, sourceDirectory: root))
         await model.scan()
         let candidate = try #require(model.candidates.first { $0.path == "public/images/orphan.png" })
 

--- a/Tests/AnglesiteAppTests/SiteGraphExplorerModelExplainTests.swift
+++ b/Tests/AnglesiteAppTests/SiteGraphExplorerModelExplainTests.swift
@@ -45,7 +45,7 @@ struct SiteGraphExplorerModelExplainTests {
             posts: [], images: []
         )
         let model = SiteGraphExplorerModel(graph: graph, explainer: explainer)
-        model.start(siteID: "site-1", sourceDirectory: root)
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root))
         while model.snapshot.nodes.isEmpty { await Task.yield() }
         model.selectedNodeID = model.snapshot.nodes.first?.id
         return (model, root)

--- a/Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift
@@ -25,7 +25,7 @@ struct SiteNavigatorModelTests {
             posts: [], images: []
         )
         let model = SiteNavigatorModel(graph: graph)
-        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
         while model.nodes.isEmpty { await Task.yield() }
 
         let id = try #require(flatten(model.nodes).first { $0.title == "About" }?.id)
@@ -52,7 +52,7 @@ struct SiteNavigatorModelTests {
             posts: [], images: []
         )
         let model = SiteNavigatorModel(graph: graph)
-        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
         while model.nodes.isEmpty { await Task.yield() }
 
         let id = try #require(model.nodes.first { $0.kind == .website }?.id)
@@ -84,7 +84,7 @@ struct SiteNavigatorModelTests {
             posts: [], images: []
         )
         let model = SiteNavigatorModel(graph: graph)
-        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
         while model.nodes.isEmpty { await Task.yield() }
         let id = try #require(flatten(model.nodes).first { $0.title == "About" }?.id)
 
@@ -113,7 +113,7 @@ struct SiteNavigatorModelTests {
             posts: [], images: []
         )
         let model = SiteNavigatorModel(graph: graph)
-        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
         while model.nodes.isEmpty { await Task.yield() }
         let id = try #require(flatten(model.nodes).first { $0.title == "About" }?.id)
         model.selection = id
@@ -137,7 +137,7 @@ struct SiteNavigatorModelTests {
             posts: [], images: []
         )
         let model = SiteNavigatorModel(graph: graph)
-        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
         while model.nodes.isEmpty { await Task.yield() }
         let id = try #require(model.nodes.first { $0.kind == .website }?.id)
         model.selection = id
@@ -164,8 +164,9 @@ struct SiteNavigatorModelRedirectsTests {
     private func makeModel(sourceDirectory: URL) -> SiteNavigatorModel {
         let graph = SiteContentGraph()
         let model = SiteNavigatorModel(graph: graph)
-        model.start(siteID: "site1", siteRoot: sourceDirectory,
-                     sourceDirectory: sourceDirectory, websiteTitle: "Test")
+        model.start(
+            site: CurrentSite(id: "site1", packageURL: sourceDirectory, sourceDirectory: sourceDirectory),
+            websiteTitle: "Test")
         return model
     }
 
@@ -231,7 +232,7 @@ struct SiteNavigatorModelPublishGatingTests {
         )
 
         let model = SiteNavigatorModel(graph: graph)
-        model.start(siteID: "site-1", siteRoot: root, sourceDirectory: root, websiteTitle: "Test")
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
         while model.nodes.isEmpty { await Task.yield() }
 
         #expect(model.canPublish("site-1:post:draft-note") == true)

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -117,7 +117,7 @@ extension SiteWindowModelTests {
         // would short-circuit before ever reaching the stale-candidate check this test targets —
         // exactly the trap Task 4's fix-cycle flagged. Configure it directly so execution reaches
         // the second guard.
-        model.cleanup.configure(siteID: "site-a", sourceDirectory: sourceDirectory)
+        model.cleanup.configure(site: CurrentSite(id: "site-a", packageURL: sourceDirectory, sourceDirectory: sourceDirectory))
         let candidate = DeadAssetScanner.CleanupCandidate(
             id: "public/images/ghost.png", path: "public/images/ghost.png",
             kind: .image, lastModified: Date(timeIntervalSince1970: 0), referenceCount: 0
@@ -266,7 +266,7 @@ extension SiteWindowModelTests {
             posts: [], images: []
         )
         let model = makeModel(contentGraph: contentGraph)
-        model.graphExplorer.start(siteID: "site-1", sourceDirectory: root)
+        model.graphExplorer.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root))
         while model.graphExplorer.snapshot.nodes.isEmpty { await Task.yield() }
 
         let handled = model.revealCitationInGraph("src/pages/about.astro")
@@ -306,7 +306,7 @@ extension SiteWindowModelTests {
             posts: [], images: []
         )
         let model = makeModel(contentGraph: contentGraph)
-        model.graphExplorer.start(siteID: "site-1", sourceDirectory: root)
+        model.graphExplorer.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root))
         while model.graphExplorer.snapshot.nodes.isEmpty { await Task.yield() }
 
         // A dirty editor whose file changed externally under it — `flushBeforeLeaving()`'s real
@@ -468,7 +468,7 @@ extension SiteWindowModelTests {
             isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
         )
         let navModel = SiteNavigatorModel(graph: graph)
-        navModel.start(siteID: "site-a", siteRoot: packageURL, sourceDirectory: package.sourceURL, websiteTitle: "Test")
+        navModel.start(site: CurrentSite(id: "site-a", packageURL: packageURL, sourceDirectory: package.sourceURL), websiteTitle: "Test")
         while navModel.nodes.isEmpty { await Task.yield() }
         #expect(navModel.target(for: "website") == .websiteSettings)
         model.navigator = navModel
@@ -517,7 +517,7 @@ extension SiteWindowModelTests {
         model.inspectorContext = .page(PageMetadataModel(file: priorFile, sourceDirectory: package.sourceURL))
 
         let navModel = SiteNavigatorModel(graph: graph)
-        navModel.start(siteID: "site-a", siteRoot: packageURL, sourceDirectory: package.sourceURL, websiteTitle: "Test")
+        navModel.start(site: CurrentSite(id: "site-a", packageURL: packageURL, sourceDirectory: package.sourceURL), websiteTitle: "Test")
         while navModel.nodes.count < 2 { await Task.yield() }
         let directoryID = "dir:/notes/"
         #expect(navModel.target(for: directoryID) == .directory(collection: "notes", route: "/notes/"))


### PR DESCRIPTION
## Summary

- Extracts four cleanly-separable subsystems out of `SiteWindowModel.swift` (flagged in #822 as the highest-churn file in the repo — 22 child models, 62 methods) into standalone controllers owned by composition, mirroring #821's `SiteRuntimeStateMachine` extraction:
  - `InvisiblePublishCoordinator` — the invisible-publish (#357) queue/watcher/connectivity-monitor lifecycle. Its pure relevance filter (`isPublishRelevant`) is now directly unit-tested.
  - `CompletionNotificationHub` — Deploy/Backup/Audit phase-transition wiring to the completion notifier and Dock-tile progress bar (#526). Stateless namespace, wired once from `SiteWindowModel.init`.
  - `SecurityScopedGrantController` — the MAS security-scoped bookmark grant lifecycle (#242), guarded under `ANGLESITE_MAS`.
  - `AssistantSessionAssembler` — the MCP-client/container-control closures, theme catalog resolution, and `SiteAssistantSessionFactory.makeSession` call that used to live inline in `loadAndStart`.
- Introduces `CurrentSite`, a shared current-site value type (`id`/`name`/`packageURL`/`sourceDirectory`/`configDirectory`), threaded into `loadAndStart`'s five directly-owned child-model entry points (`PreviewModel.open`, `SiteNavigatorModel.start`, `ProjectCleanupModel.configure`, `SiteGraphExplorerModel.start`, `ComponentEditorContext`) instead of each one separately re-deriving the same fields from `SiteStore.Site`.
- Net: `SiteWindowModel.swift` shrinks from 1645 to ~1415 lines.

## Scoping notes for reviewers

- **`SiteAssistantSessionFactory.makeSession` is deliberately NOT changed** to take `CurrentSite`. It intentionally keeps a disaggregated `siteID`/`sourceDirectory`/`configDirectory`/*optional* `packageURL` signature — `CurrentSite.packageURL` is never optional for a real open site, and forcing it through would break `SiteAssistantSessionFactoryTests.missingPackageURLMeansNoFactory`, which exercises the no-design-interview-factory branch on purpose. `ChatModel`'s own init (only ever constructed inside that factory) is left alone for the same reason.
- **`ComponentEditorModel.swift`'s change is intentionally minimal**: an additive, default-`nil` `site: CurrentSite?` field on `ComponentEditorContext`, wired at its one production call site (`SiteWindow.swift`). Issue #824's in-flight draft/commit-state migration (PR #846, not yet merged, not in this branch's history) is a separate, larger restructuring of this same file — this PR deliberately does not touch anything else in it, so the two diffs don't collide more than necessary. Expect #846 to need a small merge-conflict reconciliation on this one field regardless of merge order.
- `SiteWindow.swift`'s `siteUI(for:)`/`mainPane(for:)`/`previewPane(for:)` still thread `site: SiteStore.Site` explicitly even though `model.site` already holds it — noted in the original issue as a further simplification opportunity, but left out of this PR to keep the SwiftUI view-layer diff (already touched for the `ComponentEditorContext` wiring) minimal and focused.

## Stacking

This PR is stacked **fourth** in the #821 → #823 → #825 → #822 chain:
- Base: `claude/issue-825-deploy-coordinator` (#848)
- Which is based on `claude/issue-823-runtime-capability` (#847)
- Which is based on `claude/issue-821-runtime-statemachine` (#845)

None of #845/#847/#848 are merged into `main` yet. **CI will not run on this PR** (`ci.yml` only fires on PRs targeting `main` — see the stacked-PR CI gap this repo has documented). Verification below was run locally instead.

## Test plan

- [x] `swift test --package-path .` — full suite (2245 tests, 310 suites): all pass except the pre-existing, documented FoundationModels `Generable` token-overflow flake (`GenerableTypes round-trips` ▸ `ContentSummary parses numeric reading metadata`, "8194 tokens... exceeds the maximum allowed context size of 8192") — unrelated to this change, same flake #821/#823/#824/#825 called out.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED (required a fresh `xcodegen generate` after adding the five new source files, since the Xcode project's file list is generated statically and doesn't auto-pick-up new files the way SwiftPM's glob-based targets do).
- [x] New focused tests: `InvisiblePublishCoordinatorTests` (pure `isPublishRelevant` filter logic) and `CurrentSiteTests` (both initializers).
- [x] All pre-existing `SiteWindowModel`/`PreviewModel`/`SiteNavigatorModel`/`ProjectCleanupModel`/`SiteGraphExplorerModel`/`SiteAssistantSessionFactory` tests pass unmodified in behavior — only their `.start(...)`/`.configure(...)`/`.open(...)` call-site *signatures* changed (mechanical `CurrentSite(...)` construction swapped in for the old scalar args), not their assertions.
- [ ] Manual GUI smoke — not performed; this is a pure internal refactor with no observable behavior change, and the full test suite + hosted app build together cover what CI would otherwise check.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)