### PR TITLE
feat(workers): local wrangler-dev runtime for local-container previews (#708)

### DIFF
--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -28,7 +28,8 @@
         "schema-dts": "^1.1.5",
         "tsx": "^4.0.0",
         "typescript": "^5.9.3",
-        "vitest": "4.1.10"
+        "vitest": "4.1.10",
+        "wrangler": "4.112.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -1342,6 +1343,42 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "4.111.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.111.0.tgz",
+      "integrity": "sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260710.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260710.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260710.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -1556,6 +1593,7 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
       "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2230,6 +2268,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2252,6 +2291,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2274,6 +2314,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2290,6 +2331,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2306,6 +2348,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2322,6 +2365,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2338,6 +2382,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2354,6 +2399,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2370,6 +2416,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2386,6 +2433,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2402,6 +2450,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2418,6 +2467,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2434,6 +2484,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2456,6 +2507,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2478,6 +2530,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2500,6 +2553,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2522,6 +2576,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2544,6 +2599,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2566,6 +2622,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2588,6 +2645,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2610,6 +2668,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2629,6 +2688,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2648,6 +2708,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2667,6 +2728,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10818,7 +10880,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -10847,6 +10909,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10863,6 +10926,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10879,6 +10943,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10895,6 +10960,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10911,6 +10977,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10927,6 +10994,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10943,6 +11011,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10959,6 +11028,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10975,6 +11045,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10991,6 +11062,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11007,6 +11079,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11023,6 +11096,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11039,6 +11113,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11055,6 +11130,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11071,6 +11147,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11087,6 +11164,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11103,6 +11181,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11119,6 +11198,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11135,6 +11215,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11151,6 +11232,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11167,6 +11249,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11183,6 +11266,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11199,6 +11283,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11215,6 +11300,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11231,6 +11317,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11247,6 +11334,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11771,6 +11859,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11787,6 +11876,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11803,6 +11893,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11819,6 +11910,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11835,6 +11927,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11851,6 +11944,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11867,6 +11961,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11883,6 +11978,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11899,6 +11995,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11915,6 +12012,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11931,6 +12029,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11947,6 +12046,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11963,6 +12063,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11979,6 +12080,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11995,6 +12097,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12011,6 +12114,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12027,6 +12131,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12043,6 +12148,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12059,6 +12165,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12075,6 +12182,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12091,6 +12199,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12107,6 +12216,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12123,6 +12233,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12139,6 +12250,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12155,6 +12267,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12171,6 +12284,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12699,9 +12813,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.111.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.111.0.tgz",
-      "integrity": "sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ==",
+      "version": "4.112.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.112.0.tgz",
+      "integrity": "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -12709,10 +12823,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260710.0",
+        "miniflare": "4.20260714.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260710.1"
+        "workerd": "1.20260714.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -12726,12 +12840,97 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260710.1"
+        "@cloudflare/workers-types": "^5.20260714.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260714.1.tgz",
+      "integrity": "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260714.1.tgz",
+      "integrity": "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260714.1.tgz",
+      "integrity": "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260714.1.tgz",
+      "integrity": "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260714.1.tgz",
+      "integrity": "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
@@ -13216,6 +13415,48 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "4.20260714.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260714.0.tgz",
+      "integrity": "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260714.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260714.1.tgz",
+      "integrity": "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260714.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260714.1",
+        "@cloudflare/workerd-linux-64": "1.20260714.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260714.1",
+        "@cloudflare/workerd-windows-64": "1.20260714.1"
       }
     },
     "node_modules/wrap-ansi": {

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -24,6 +24,7 @@
     "@cloudflare/vitest-pool-workers": "0.18.5",
     "@cloudflare/workers-types": "5.20260715.1",
     "@keystatic/astro": "^5.0.4",
+    "wrangler": "4.112.0",
     "@keystatic/core": "^0.5.34",
     "@types/node": "^24.0.0",
     "microformats-parser": "^2.0.4",

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -24,7 +24,6 @@
     "@cloudflare/vitest-pool-workers": "0.18.5",
     "@cloudflare/workers-types": "5.20260715.1",
     "@keystatic/astro": "^5.0.4",
-    "wrangler": "4.112.0",
     "@keystatic/core": "^0.5.34",
     "@types/node": "^24.0.0",
     "microformats-parser": "^2.0.4",
@@ -33,6 +32,7 @@
     "schema-dts": "^1.1.5",
     "tsx": "^4.0.0",
     "typescript": "^5.9.3",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "wrangler": "4.112.0"
   }
 }

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -314,6 +314,15 @@ final class PreviewModel {
         return nil
     }
 
+    /// The local `wrangler dev --local` endpoint, if the session is `.ready` and the site has an
+    /// active worker (#708). `nil` for a static-only site — no debug-panel consumer exists yet
+    /// (no Workers tab, #700c), so this is currently unread outside tests, but the accessor
+    /// mirrors `readyURL`'s exact pattern so a future consumer needs no runtime changes.
+    var workersDevURL: URL? {
+        if case .ready(_, _, let workersDevURL) = state { return workersDevURL }
+        return nil
+    }
+
     /// Show `route` in the preview. Safe to call before the runtime is `.ready` — `displayURL`
     /// derives the target lazily once a base URL exists (the cold-open Siri case).
     func navigate(toRoute route: String) { activeRoute = route }

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -310,7 +310,7 @@ final class PreviewModel {
 
     /// The ready preview URL, if the session is currently `.ready`.
     var readyURL: URL? {
-        if case .ready(_, let url) = state { return url }
+        if case .ready(_, let url, _) = state { return url }
         return nil
     }
 

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -751,7 +751,7 @@ struct SiteWindow: View {
     @ViewBuilder
     private func previewPane(for site: SiteStore.Site) -> some View {
         switch model.preview.state {
-        case .ready(_, let url):
+        case .ready(_, let url, _):
             PreviewView(
                 url: model.preview.displayURL ?? url,
                 router: model.preview.editRouter,

--- a/Sources/AnglesiteApp/StartupProgressModel.swift
+++ b/Sources/AnglesiteApp/StartupProgressModel.swift
@@ -39,7 +39,7 @@ final class StartupProgressModel {
         switch state {
         case .starting(let id):
             begin(siteID: id)
-        case .ready(let id, _):
+        case .ready(let id, _, _):
             estimator.ingest(runtimeState: state, at: clock())
             if let profile = estimator.completedProfile {
                 timingStore.record(profile, for: id)

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -243,9 +243,21 @@ public struct ContainerizationControl: LocalContainerControl {
         // pattern above: wrangler-dev only ever binds a plain TCP socket, and
         // container.dialVsock(port:) dials an AF_VSOCK listener — without this bridge the proxy
         // below has nothing to connect to at the vsock layer, and every dial fails.
+        //
+        // Uses execInteractive (not runDetached) specifically so a later failure in this same
+        // call (the proxy-start catch below) can terminate this one process — unlike astro/mcp's
+        // bridges, which only ever need to live until a full container teardown, this bridge can
+        // be started and torn down many times across a single container's life (every
+        // startWorkersDev call, including future toggle-restarts via updateActiveWorkers), so an
+        // orphaned bridge from a failed attempt would accumulate rather than being reaped once.
+        let bridgeHandle: InteractiveExecHandle
         do {
-            try await runDetached(container, id: "bridge-workers-dev", label: "bridge-workers-dev", onOutput: onOutput,
-                ["/usr/bin/socat", "VSOCK-LISTEN:\(Self.workersPort),reuseaddr,fork", "TCP:127.0.0.1:\(Self.workersPort)"])
+            bridgeHandle = try await execInteractive(
+                siteID: siteID,
+                argv: ["/usr/bin/socat", "VSOCK-LISTEN:\(Self.workersPort),reuseaddr,fork", "TCP:127.0.0.1:\(Self.workersPort)"],
+                environment: [:],
+                workingDirectory: "/",
+                onOutput: { line, stream in onOutput("[bridge-workers-dev] \(line)", stream) })
         } catch {
             await supervisor.stop()
             throw LocalContainerError.bootFailed("workers-dev vsock bridge failed to start: \(error)")
@@ -270,10 +282,11 @@ public struct ContainerizationControl: LocalContainerControl {
             url = try await proxy.start()
         } catch {
             await supervisor.stop()
+            await bridgeHandle.terminate()
             throw LocalContainerError.bootFailed("workers-dev proxy start failed: \(error)")
         }
 
-        await live.storeWorkersDev(siteID: siteID, supervisor: supervisor, proxy: proxy)
+        await live.storeWorkersDev(siteID: siteID, supervisor: supervisor, bridge: bridgeHandle, proxy: proxy)
         return url
     }
 
@@ -1119,10 +1132,16 @@ actor LiveContainers {
     private var proxies: [String: [VsockTCPProxy]] = [:]
     /// Per-site ext4 files (rootfs + initfs) to delete on teardown so disk doesn't grow per start/stop.
     private var ext4Artifacts: [String: [URL]] = [:]
-    /// The workers-dev supervisor + its own proxy, present only while `startWorkersDev` has an
-    /// active session for that site — absent entirely for a static-only site.
+    /// The workers-dev supervisor + its own proxy + its own vsock bridge, present only while
+    /// `startWorkersDev` has an active session for that site — absent entirely for a static-only
+    /// site. Unlike astro/mcp's bridges (which only ever need reaping once, at full container
+    /// teardown), this bridge can be started and torn down many times across one container's
+    /// life — every `startWorkersDev` call, including a future toggle-restart via
+    /// `updateActiveWorkers` — so it's tracked here and explicitly terminated in
+    /// `teardownWorkersDev`, not left for `LinuxContainer.stop()` to reap.
     private var workersDevSupervisors: [String: GuestProcessSupervisor] = [:]
     private var workersDevProxies: [String: VsockTCPProxy] = [:]
+    private var workersDevBridges: [String: InteractiveExecHandle] = [:]
 
     func container(for siteID: String) -> LinuxContainer? { containers[siteID] }
 
@@ -1132,19 +1151,24 @@ actor LiveContainers {
         ext4Artifacts[siteID] = artifacts
     }
 
-    func storeWorkersDev(siteID: String, supervisor: GuestProcessSupervisor, proxy: VsockTCPProxy) {
+    func storeWorkersDev(
+        siteID: String, supervisor: GuestProcessSupervisor, bridge: InteractiveExecHandle, proxy: VsockTCPProxy
+    ) {
         workersDevSupervisors[siteID] = supervisor
+        workersDevBridges[siteID] = bridge
         workersDevProxies[siteID] = proxy
     }
 
     func workersDevSupervisor(for siteID: String) -> GuestProcessSupervisor? { workersDevSupervisors[siteID] }
 
-    /// Stops just the workers-dev process + its proxy for `siteID`, leaving astro/mcp/the
-    /// container itself untouched — used both for an explicit `stopWorkersDev` call and as the
-    /// first step of a full `teardown`.
+    /// Stops just the workers-dev process + its bridge + its proxy for `siteID`, leaving
+    /// astro/mcp/the container itself untouched — used both for an explicit `stopWorkersDev` call
+    /// and as the first step of a full `teardown`.
     func teardownWorkersDev(siteID: String) async {
         if let supervisor = workersDevSupervisors[siteID] { await supervisor.stop() }
         workersDevSupervisors[siteID] = nil
+        if let bridge = workersDevBridges[siteID] { await bridge.terminate() }
+        workersDevBridges[siteID] = nil
         if let proxy = workersDevProxies[siteID] { await proxy.stop() }
         workersDevProxies[siteID] = nil
     }

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -38,6 +38,8 @@ public struct ContainerizationControl: LocalContainerControl {
     // Guest-side ports the dev server + MCP sidecar listen on (also the vsock ports the bridge maps to).
     private static let previewPort: UInt32 = 4321
     private static let mcpPort: UInt32 = 4399
+    /// Wrangler's own conventional local-dev port.
+    private static let workersPort: UInt32 = 8787
 
     /// Guest mountpoint for the read-only virtio-fs share of the host `Source/` repo (see `start()` step 3).
     private static let repoSharePath = "/run/anglesite-source"
@@ -200,17 +202,64 @@ public struct ContainerizationControl: LocalContainerControl {
         await network.reset()
     }
 
+    /// See `LocalContainerControl.startWorkersDev` for the full contract.
     public func startWorkersDev(
         siteID: String,
         workers: [WorkerDescriptor],
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> URL {
-        // Stub implementation — real behavior lands in Task 4.
-        URL(string: "http://127.0.0.1:51003")!
+        guard let container = await live.container(for: siteID) else {
+            throw LocalContainerError.bootFailed("startWorkersDev: no live container for siteID '\(siteID)'")
+        }
+
+        // Any previously-running workers-dev session for this site is torn down first — this
+        // method also serves as the "restart with a new active set" entry point once a future
+        // Workers tab calls `LocalContainerSiteRuntime.updateActiveWorkers(_:)` (#708 design §2:
+        // this PR builds that capability even though `start()` is its only caller today).
+        await live.teardownWorkersDev(siteID: siteID)
+
+        // Ephemeral, git-ignore-free local config: lives outside /workspace/site entirely, so a
+        // transient local-dev session can never dirty the site's real, git-tracked wrangler.toml
+        // (#708 design §4). No real resource ids — Miniflare creates local-persisted D1/KV/R2
+        // stores automatically for declared bindings in --local mode.
+        let toml = try WorkerComposition.generateWranglerToml(siteName: siteID, workers: workers)
+        let configDir = "/tmp/anglesite-workers-dev/\(siteID)"
+        let configPath = "\(configDir)/wrangler.toml"
+        try await runToCompletion(container, id: "workers-dev-mkdir", onOutput: onOutput,
+            ["mkdir", "-p", configDir])
+        try await writeGuestFile(container, path: configPath, contents: toml, onOutput: onOutput)
+
+        let launcher = LinuxContainerProcessLauncher(container: container)
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher,
+            id: "workers-dev",
+            argv: ["sh", "-lc",
+                "cd /workspace/site && npx wrangler dev --local --config \(configPath) --port \(Self.workersPort)"],
+            restartPolicy: .onCrash(maxAttempts: 3, baseBackoff: 0.5),
+            onOutput: { line, stream in onOutput("[workers-dev] \(line)", stream) })
+        try await supervisor.start()
+
+        let dial: VsockDialer = { port in try await container.dialVsock(port: port) }
+        let proxy = VsockTCPProxy(
+            guestPort: Self.workersPort,
+            dial: dial,
+            onDialError: { error in onOutput("[proxy:workers-dev] dialVsock(\(Self.workersPort)) failed: \(error)", .stderr) },
+            onEvent: { event in onOutput("[proxy:workers-dev] \(event)", .stdout) })
+        let url: URL
+        do {
+            url = try await proxy.start()
+        } catch {
+            await supervisor.stop()
+            throw LocalContainerError.bootFailed("workers-dev proxy start failed: \(error)")
+        }
+
+        await live.storeWorkersDev(siteID: siteID, supervisor: supervisor, proxy: proxy)
+        return url
     }
 
+    /// See `LocalContainerControl.stopWorkersDev` for the full contract.
     public func stopWorkersDev(siteID: String) async throws {
-        // Stub implementation — real behavior lands in Task 4.
+        await live.teardownWorkersDev(siteID: siteID)
     }
 
     /// Phases 0–2 of `start()`: resolve bundled artifacts, unpack rootfs/initfs, boot the VM.
@@ -887,6 +936,20 @@ public struct ContainerizationControl: LocalContainerControl {
         }
     }
 
+    /// Writes `contents` to `path` inside the guest via a one-shot `sh -c 'cat > path'` fed the
+    /// text as a heredoc-safe base64 payload (avoiding any shell-quoting/escaping surface for
+    /// `contents`, which is a generated wrangler.toml — untrusted only in the sense that it embeds
+    /// a site name, already validated by `WorkerComposition.isValidSiteName`).
+    private func writeGuestFile(
+        _ container: LinuxContainer, path: String, contents: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws {
+        let encoded = Data(contents.utf8).base64EncodedString()
+        try await runToCompletion(container, id: "write-\(path.replacingOccurrences(of: "/", with: "-"))",
+            onOutput: onOutput,
+            ["sh", "-c", "echo \(encoded) | base64 -d > \(path)"])
+    }
+
     /// Start a guest process detached (no `wait`), e.g. a long-running dev server. Its stdout/stderr
     /// stream to `onOutput` live via `LineStreamingWriter`, each line prefixed `[label]` so a single
     /// stream can distinguish astro/mcp/bridge output — this is the only visibility into the guest
@@ -1036,6 +1099,10 @@ actor LiveContainers {
     private var proxies: [String: [VsockTCPProxy]] = [:]
     /// Per-site ext4 files (rootfs + initfs) to delete on teardown so disk doesn't grow per start/stop.
     private var ext4Artifacts: [String: [URL]] = [:]
+    /// The workers-dev supervisor + its own proxy, present only while `startWorkersDev` has an
+    /// active session for that site — absent entirely for a static-only site.
+    private var workersDevSupervisors: [String: GuestProcessSupervisor] = [:]
+    private var workersDevProxies: [String: VsockTCPProxy] = [:]
 
     func container(for siteID: String) -> LinuxContainer? { containers[siteID] }
 
@@ -1045,7 +1112,25 @@ actor LiveContainers {
         ext4Artifacts[siteID] = artifacts
     }
 
+    func storeWorkersDev(siteID: String, supervisor: GuestProcessSupervisor, proxy: VsockTCPProxy) {
+        workersDevSupervisors[siteID] = supervisor
+        workersDevProxies[siteID] = proxy
+    }
+
+    func workersDevSupervisor(for siteID: String) -> GuestProcessSupervisor? { workersDevSupervisors[siteID] }
+
+    /// Stops just the workers-dev process + its proxy for `siteID`, leaving astro/mcp/the
+    /// container itself untouched — used both for an explicit `stopWorkersDev` call and as the
+    /// first step of a full `teardown`.
+    func teardownWorkersDev(siteID: String) async {
+        if let supervisor = workersDevSupervisors[siteID] { await supervisor.stop() }
+        workersDevSupervisors[siteID] = nil
+        if let proxy = workersDevProxies[siteID] { await proxy.stop() }
+        workersDevProxies[siteID] = nil
+    }
+
     func teardown(siteID: String) async {
+        await teardownWorkersDev(siteID: siteID)
         for p in proxies[siteID] ?? [] { await p.stop() }
         proxies[siteID] = nil
         // Stop the VM first (releases the file handles), then remove the backing ext4 images.

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -236,15 +236,35 @@ public struct ContainerizationControl: LocalContainerControl {
             argv: ["sh", "-lc",
                 "cd /workspace/site && npx wrangler dev --local --config \(configPath) --port \(Self.workersPort)"],
             restartPolicy: .onCrash(maxAttempts: 3, baseBackoff: 0.5),
-            onOutput: { line, stream in onOutput("[workers-dev] \(line)", stream) })
+            onOutput: onOutput)
         try await supervisor.start()
 
+        // Vsock<->TCP bridge for the workers-dev port, matching the bridge-preview/bridge-mcp
+        // pattern above: wrangler-dev only ever binds a plain TCP socket, and
+        // container.dialVsock(port:) dials an AF_VSOCK listener — without this bridge the proxy
+        // below has nothing to connect to at the vsock layer, and every dial fails.
+        do {
+            try await runDetached(container, id: "bridge-workers-dev", label: "bridge-workers-dev", onOutput: onOutput,
+                ["/usr/bin/socat", "VSOCK-LISTEN:\(Self.workersPort),reuseaddr,fork", "TCP:127.0.0.1:\(Self.workersPort)"])
+        } catch {
+            await supervisor.stop()
+            throw LocalContainerError.bootFailed("workers-dev vsock bridge failed to start: \(error)")
+        }
+
+        // Rate-limited the same way previewProxy/mcpProxy are (see their construction above): a
+        // persistently-failing dial can otherwise emit enough identical events to evict one-time
+        // boot lines out of LogCenter's bounded ring buffer. Scoped to this call rather than
+        // shared with the boot-time limiter, since a workers-dev session's lifecycle is
+        // independent of the container's boot.
+        let workersDevEventLimiter = EventRateLimiter()
         let dial: VsockDialer = { port in try await container.dialVsock(port: port) }
         let proxy = VsockTCPProxy(
             guestPort: Self.workersPort,
             dial: dial,
-            onDialError: { error in onOutput("[proxy:workers-dev] dialVsock(\(Self.workersPort)) failed: \(error)", .stderr) },
-            onEvent: { event in onOutput("[proxy:workers-dev] \(event)", .stdout) })
+            onDialError: { error in
+                workersDevEventLimiter.log("[proxy:workers-dev] dialVsock(\(Self.workersPort)) failed: \(error)", onOutput: onOutput)
+            },
+            onEvent: { event in workersDevEventLimiter.log("[proxy:workers-dev] \(event)", onOutput: onOutput) })
         let url: URL
         do {
             url = try await proxy.start()
@@ -936,8 +956,8 @@ public struct ContainerizationControl: LocalContainerControl {
         }
     }
 
-    /// Writes `contents` to `path` inside the guest via a one-shot `sh -c 'cat > path'` fed the
-    /// text as a heredoc-safe base64 payload (avoiding any shell-quoting/escaping surface for
+    /// Writes `contents` to `path` inside the guest via a one-shot `sh -c "echo <b64> | base64 -d
+    /// > path"`, base64-encoding the text first (avoiding any shell-quoting/escaping surface for
     /// `contents`, which is a generated wrangler.toml — untrusted only in the sense that it embeds
     /// a site name, already validated by `WorkerComposition.isValidSiteName`).
     private func writeGuestFile(

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -200,6 +200,19 @@ public struct ContainerizationControl: LocalContainerControl {
         await network.reset()
     }
 
+    public func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        // Stub implementation — real behavior lands in Task 4.
+        URL(string: "http://127.0.0.1:51003")!
+    }
+
+    public func stopWorkersDev(siteID: String) async throws {
+        // Stub implementation — real behavior lands in Task 4.
+    }
+
     /// Phases 0–2 of `start()`: resolve bundled artifacts, unpack rootfs/initfs, boot the VM.
     /// `sourceRepo: nil` boots a bare container (no virtio-fs share) — used by the vsock e2e test.
     /// Does NOT register the container in `live` — the caller owns its lifecycle (either `start()`'s

--- a/Sources/AnglesiteContainer/GuestProcessSupervisor.swift
+++ b/Sources/AnglesiteContainer/GuestProcessSupervisor.swift
@@ -165,6 +165,14 @@ actor GuestProcessSupervisor {
             let exitCode = try? await handle.wait()
             try? await handle.delete()
             guard gen == generation, !isStopping else { return }
+            // A clean exit (code 0) is never a crash — it stops regardless of restart policy,
+            // mirroring RestartPolicy's own documented contract ("clean exit code 0 always
+            // stops", SupervisorBackend.swift:14) that InProcessBackend.superviseLoop already
+            // honors but this loop didn't.
+            if exitCode == 0 {
+                setState(.stopped)
+                return
+            }
             switch restartPolicy {
             case .never:
                 setState(.failed(reason: "exited with code \(exitCode.map(String.init) ?? "unknown")"))

--- a/Sources/AnglesiteContainer/GuestProcessSupervisor.swift
+++ b/Sources/AnglesiteContainer/GuestProcessSupervisor.swift
@@ -165,7 +165,8 @@ actor GuestProcessSupervisor {
             let exitCode = try? await handle.wait()
             try? await handle.delete()
             guard gen == generation, !isStopping else { return }
-            // A clean exit (code 0) is never a crash — it stops regardless of restart policy,
+            // A clean exit (code 0) is never a crash — it stops regardless of restart policy
+            // (.never included: a deliberate exit isn't the same as giving up after failures),
             // mirroring RestartPolicy's own documented contract ("clean exit code 0 always
             // stops", SupervisorBackend.swift:14) that InProcessBackend.superviseLoop already
             // honors but this loop didn't.

--- a/Sources/AnglesiteContainer/GuestProcessSupervisor.swift
+++ b/Sources/AnglesiteContainer/GuestProcessSupervisor.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Containerization
+import AnglesiteCore
+
+/// Abstraction over "launch one guest process and get back a live handle" — the seam
+/// `GuestProcessSupervisor` tests against with a fake launcher, since a real launch needs a live
+/// `LinuxContainer` inside a booted VM. `LinuxContainerProcessLauncher` (below) is the real
+/// conformer, wrapping `LinuxContainer.exec`.
+protocol GuestProcessLauncher: Sendable {
+    func launch(
+        id: String,
+        argv: [String],
+        environment: [String: String],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> any GuestProcessHandle
+}
+
+/// One launched guest process: start it, wait for it to exit, or kill it early.
+protocol GuestProcessHandle: Sendable {
+    func start() async throws
+    /// Suspends until the process exits (normally or via `kill()`), returning its exit code.
+    func wait() async throws -> Int32
+    func kill() async throws
+    func delete() async throws
+}
+
+/// The real `GuestProcessLauncher`, wrapping `LinuxContainer.exec` — one instance per
+/// `LinuxContainer`, constructed by `ContainerizationControl.startWorkersDev` alongside the
+/// container itself.
+struct LinuxContainerProcessLauncher: GuestProcessLauncher {
+    let container: LinuxContainer
+
+    func launch(
+        id: String,
+        argv: [String],
+        environment: [String: String],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> any GuestProcessHandle {
+        let stdoutSink = LineStreamingWriter(stream: .stdout, onLine: onOutput)
+        let stderrSink = LineStreamingWriter(stream: .stderr, onLine: onOutput)
+        let proc = try await container.exec(id) { config in
+            config.arguments = argv
+            config.environmentVariables =
+                ["PATH=\(LinuxProcessConfiguration.defaultPath)"]
+                + environment.map { "\($0.key)=\($0.value)" }
+            config.stdout = stdoutSink
+            config.stderr = stderrSink
+        }
+        return LinuxProcessHandle(process: proc, stdoutSink: stdoutSink, stderrSink: stderrSink)
+    }
+}
+
+private struct LinuxProcessHandle: GuestProcessHandle {
+    let process: LinuxProcess
+    let stdoutSink: LineStreamingWriter
+    let stderrSink: LineStreamingWriter
+
+    func start() async throws { try await process.start() }
+
+    func wait() async throws -> Int32 {
+        let status = try await process.wait()
+        stdoutSink.flush()
+        stderrSink.flush()
+        return status.exitCode
+    }
+
+    func kill() async throws { try await process.kill(.term) }
+    func delete() async throws { try await process.delete() }
+}
+
+/// Supervises one long-lived guest process with crash-restart, mirroring
+/// `InProcessBackend.superviseLoop`'s host-process restart-policy shape but driving a guest
+/// process via `GuestProcessLauncher` instead of a host `Process`. Generic — not specific to
+/// wrangler-dev — so a future PR could retrofit `astro`/`mcp` onto the same mechanism without a
+/// redesign, though only wrangler-dev uses it today; `astro`/`mcp` stay on the existing
+/// fire-and-forget `runDetached` path (#708 design decision — out of scope to touch them here).
+actor GuestProcessSupervisor {
+    enum State: Sendable, Equatable {
+        case running
+        case restarting(attempt: Int)
+        case stopped
+        case failed(reason: String)
+    }
+
+    private let launcher: any GuestProcessLauncher
+    private let id: String
+    private let argv: [String]
+    private let environment: [String: String]
+    private let restartPolicy: RestartPolicy
+    private let onOutput: @Sendable (String, LogCenter.Stream) -> Void
+
+    private var current: (any GuestProcessHandle)?
+    private var state: State = .stopped
+    private var observers: [UUID: AsyncStream<State>.Continuation] = [:]
+    private var isStopping = false
+    private var superviseTask: Task<Void, Never>?
+    private var generation = 0
+
+    init(
+        launcher: any GuestProcessLauncher,
+        id: String,
+        argv: [String],
+        environment: [String: String] = [:],
+        restartPolicy: RestartPolicy,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) {
+        self.launcher = launcher
+        self.id = id
+        self.argv = argv
+        self.environment = environment
+        self.restartPolicy = restartPolicy
+        self.onOutput = onOutput
+    }
+
+    func observe() -> AsyncStream<State> {
+        AsyncStream { continuation in
+            let token = UUID()
+            observers[token] = continuation
+            continuation.yield(state)
+            continuation.onTermination = { @Sendable [weak self] _ in
+                Task { await self?.removeObserver(token) }
+            }
+        }
+    }
+
+    private func removeObserver(_ token: UUID) { observers[token] = nil }
+
+    private func setState(_ new: State) {
+        state = new
+        for continuation in observers.values { continuation.yield(new) }
+    }
+
+    /// Launches the process and begins supervising it. Throws only if the *first* launch fails —
+    /// once running, crashes are handled by the restart loop internally, never by throwing back
+    /// to this call's caller.
+    func start() async throws {
+        generation += 1
+        let gen = generation
+        let handle = try await launcher.launch(id: id, argv: argv, environment: environment, onOutput: onOutput)
+        try await handle.start()
+        current = handle
+        isStopping = false
+        setState(.running)
+        superviseTask = Task { [weak self] in await self?.superviseLoop(handle: handle, generation: gen) }
+    }
+
+    /// Intentional stop — suppresses the next restart attempt. Idempotent.
+    func stop() async {
+        isStopping = true
+        generation += 1
+        if let current {
+            try? await current.kill()
+            try? await current.delete()
+        }
+        current = nil
+        superviseTask?.cancel()
+        superviseTask = nil
+        setState(.stopped)
+    }
+
+    private func superviseLoop(handle initialHandle: any GuestProcessHandle, generation gen: Int) async {
+        var handle = initialHandle
+        var attempt = 0
+        while true {
+            let exitCode = try? await handle.wait()
+            try? await handle.delete()
+            guard gen == generation, !isStopping else { return }
+            switch restartPolicy {
+            case .never:
+                setState(.failed(reason: "exited with code \(exitCode.map(String.init) ?? "unknown")"))
+                return
+            case .onCrash(let maxAttempts, let baseBackoff):
+                attempt += 1
+                guard attempt <= maxAttempts else {
+                    onOutput("[\(id)] gave up restarting after \(attempt - 1) attempt(s)", .stderr)
+                    setState(.failed(reason: "retries exhausted after \(attempt - 1) attempt(s), last exit code \(exitCode.map(String.init) ?? "unknown")"))
+                    return
+                }
+                onOutput("[\(id)] crashed (exit \(exitCode.map(String.init) ?? "unknown")), restarting (attempt \(attempt)/\(maxAttempts))", .stderr)
+                setState(.restarting(attempt: attempt))
+                let backoffSeconds = baseBackoff * pow(2.0, Double(attempt - 1))
+                try? await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
+                guard gen == generation, !isStopping else { return }
+                do {
+                    let newHandle = try await launcher.launch(id: id, argv: argv, environment: environment, onOutput: onOutput)
+                    try await newHandle.start()
+                    current = newHandle
+                    handle = newHandle
+                    setState(.running)
+                } catch {
+                    setState(.failed(reason: "relaunch failed: \(error)"))
+                    return
+                }
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteContainer/GuestProcessSupervisor.swift
+++ b/Sources/AnglesiteContainer/GuestProcessSupervisor.swift
@@ -36,8 +36,15 @@ struct LinuxContainerProcessLauncher: GuestProcessLauncher {
         environment: [String: String],
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> any GuestProcessHandle {
-        let stdoutSink = LineStreamingWriter(stream: .stdout, onLine: onOutput)
-        let stderrSink = LineStreamingWriter(stream: .stderr, onLine: onOutput)
+        // Tag raw process output with [id], mirroring runDetached's own tagging convention
+        // (ContainerizationControl.swift) — GuestProcessSupervisor's own status messages
+        // (crash/restart/give-up) already self-prefix with the same id, so this keeps every
+        // line this component ever emits consistently single-tagged.
+        let tag: @Sendable (String, LogCenter.Stream) -> Void = { line, stream in
+            onOutput("[\(id)] \(line)", stream)
+        }
+        let stdoutSink = LineStreamingWriter(stream: .stdout, onLine: tag)
+        let stderrSink = LineStreamingWriter(stream: .stderr, onLine: tag)
         let proc = try await container.exec(id) { config in
             config.arguments = argv
             config.environmentVariables =

--- a/Sources/AnglesiteContainerProbe/main.swift
+++ b/Sources/AnglesiteContainerProbe/main.swift
@@ -19,13 +19,16 @@ import Containerization
 //           host dialVsock round-trip. THE decision gate for Task 4b.
 //   boot  — mirrors ContainerizationControlTests.bootsAndServes: full start() against a
 //           throwaway Astro repo, polling the preview URL for a live HTTP response. Task 5's gate.
+//   workers-dev — mirrors ContainerizationControlTests.startsWorkersDevForActiveWorker: boot a
+//           container, start local wrangler-dev for one active (fixture) worker, poll its URL
+//           for a live HTTP response. The #708 local-runtime feature's own decision gate.
 
 @main
 struct AnglesiteContainerProbe {
     static func main() async {
         let args = CommandLine.arguments.dropFirst()
         guard let subcommand = args.first else {
-            FileHandle.standardError.write(Data("usage: anglesite-container-probe <echo|boot>\n".utf8))
+            FileHandle.standardError.write(Data("usage: anglesite-container-probe <echo|boot|workers-dev>\n".utf8))
             exit(2)
         }
 
@@ -35,8 +38,11 @@ struct AnglesiteContainerProbe {
             exitCode = await runEcho()
         case "boot":
             exitCode = await runBoot()
+        case "workers-dev":
+            exitCode = await runWorkersDev()
         default:
-            FileHandle.standardError.write(Data("unknown subcommand '\(subcommand)' (expected echo|boot)\n".utf8))
+            FileHandle.standardError.write(
+                Data("unknown subcommand '\(subcommand)' (expected echo|boot|workers-dev)\n".utf8))
             exitCode = 2
         }
         exit(exitCode)
@@ -172,6 +178,55 @@ struct AnglesiteContainerProbe {
         }
 
         print("BOOT: PASS (boot wall-clock: \(elapsed))")
+        return 0
+    }
+
+    // MARK: - workers-dev
+
+    /// Mirrors `ContainerizationControlTests.startsWorkersDevForActiveWorker`: boot a container,
+    /// start local wrangler-dev for one active (fixture) worker, poll its URL for a live HTTP
+    /// response. The #708 local-runtime feature's own decision gate.
+    private static func runWorkersDev() async -> Int32 {
+        let siteID = "workers-dev-probe"
+        let control = ContainerizationControl()
+
+        let repo: URL
+        do {
+            repo = try makeThrowawayAstroRepo()
+        } catch {
+            print("WORKERS-DEV: FAIL — could not create throwaway Astro repo: \(error)")
+            return 1
+        }
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        do {
+            _ = try await control.start(siteID: siteID, sourceRepo: repo, ref: "HEAD", onOutput: logLine)
+        } catch {
+            print("WORKERS-DEV: FAIL — control.start threw: \(error)")
+            return 1
+        }
+
+        let workers = [WorkerDescriptor(
+            id: "indieauth", displayName: "IndieAuth", description: "probe fixture", group: "identity",
+            binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))]
+        let workersDevURL: URL
+        do {
+            workersDevURL = try await control.startWorkersDev(siteID: siteID, workers: workers, onOutput: logLine)
+        } catch {
+            print("WORKERS-DEV: FAIL — control.startWorkersDev threw: \(error)")
+            try? await control.stop(siteID: siteID)
+            return 1
+        }
+
+        let ok = await pollForHTTPResponse(workersDevURL, timeout: .seconds(60))
+        try? await control.stop(siteID: siteID)
+
+        guard ok else {
+            print("WORKERS-DEV: FAIL — \(workersDevURL) never answered within the timeout")
+            return 1
+        }
+
+        print("WORKERS-DEV: PASS")
         return 0
     }
 

--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -5,9 +5,14 @@ import Foundation
 public struct LocalContainerSession: Sendable, Equatable {
     public let previewURL: URL
     public let mcpURL: URL
-    public init(previewURL: URL, mcpURL: URL) {
+    /// The local `wrangler dev --local` endpoint, populated only when `startWorkersDev` has been
+    /// called for this session (#708) — not part of the initial `start()` payload, since the
+    /// workers-dev process is started conditionally, after boot, not during it.
+    public let workersDevURL: URL?
+    public init(previewURL: URL, mcpURL: URL, workersDevURL: URL? = nil) {
         self.previewURL = previewURL
         self.mcpURL = mcpURL
+        self.workersDevURL = workersDevURL
     }
 }
 
@@ -124,6 +129,24 @@ public protocol LocalContainerControl: Sendable {
         workingDirectory: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> InteractiveExecHandle
+
+    /// Starts a local `wrangler dev --local` (Miniflare-backed, no real Cloudflare account calls)
+    /// guest process for the given site's currently-active workers, as a fourth guest process
+    /// sibling to astro/mcp/bridges — called only after `start()` has already succeeded, and only
+    /// when `workers` is non-empty (#708 design §7 "started on demand, not unconditionally").
+    /// Crash-restart-capable (via `GuestProcessSupervisor`) — a wrangler-dev crash after this
+    /// returns does not throw back to any caller; it's handled internally.
+    /// - Returns: The host-proxied URL wrangler-dev is reachable at.
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL
+
+    /// Stops the workers-dev process (and its supervisor) for `siteID`, independent of astro/mcp —
+    /// used both when the effective active set becomes empty and as part of a full container
+    /// teardown (`LiveContainers.teardown` already calls this before `container.stop()`).
+    func stopWorkersDev(siteID: String) async throws
 
     /// Explicit, scoped network-layer recovery (#812): discards whatever shared network state this
     /// control's boot path caches, so the *next* boot attempt builds fresh state instead of reusing

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -161,18 +161,21 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
     /// capability a future Workers tab (#700c) calls on toggle. Not called anywhere in this PR
     /// besides `start()`'s own initial computation (which goes through `startWorkersDevIfActive`
     /// directly, not through this method) — built and left as public API now so #700c needs no
-    /// further runtime-side work. Guards on `gen == generation` and `activeSiteID == siteID` after
-    /// EVERY `await` in this method, not just before the final `setState` — the mutating calls
-    /// (`control.stopWorkersDev`/`startWorkersDevIfActive`) are exactly as siteID-keyed-not-
-    /// container-keyed as the bug `start()`'s own post-assignment guard fixes (#708 review), so a
-    /// stale attempt here could stop or restart a brand-new container a later `start()` already
-    /// booted under the same siteID if it ran unguarded. Currently unreachable (no caller yet),
-    /// but shipping it unguarded would just be a latent repeat of that exact bug.
+    /// further runtime-side work. Guards on `stateMachine.isCurrent(gen)` and `activeSiteID ==
+    /// siteID` after EVERY `await` in this method, not just before the final `settle` — the
+    /// mutating calls (`control.stopWorkersDev`/`startWorkersDevIfActive`) are exactly as
+    /// siteID-keyed-not-container-keyed as the bug `start()`'s own post-assignment guard fixes
+    /// (#708 review), so a stale attempt here could stop or restart a brand-new container a later
+    /// `start()` already booted under the same siteID if it ran unguarded. Currently unreachable
+    /// (no caller yet), but shipping it unguarded would just be a latent repeat of that exact bug.
+    /// `gen` here is a snapshot via `currentGeneration` (not a new attempt via `beginAttempt()`)
+    /// since this method doesn't start a new lifecycle attempt, it supplements an already-running
+    /// one — mirroring `persistEdit`'s identical use of `currentGeneration` for the same reason.
     public func updateActiveWorkers(_ settings: SiteSettings) async {
         guard let siteID = activeSiteID, let siteDirectory = activeSiteDirectory else { return }
-        let gen = generation
+        let gen = stateMachine.currentGeneration
         let catalog = await workerCatalog()
-        guard gen == generation, activeSiteID == siteID else { return }
+        guard stateMachine.isCurrent(gen), activeSiteID == siteID else { return }
         let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
         let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
         let workersDevURL: URL?
@@ -182,9 +185,9 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
         } else {
             workersDevURL = await startWorkersDevIfActive(siteID: siteID, siteDirectory: siteDirectory)
         }
-        guard gen == generation, activeSiteID == siteID else { return }
-        if case .ready(let readySiteID, let url, _) = current, readySiteID == siteID {
-            setState(.ready(siteID: readySiteID, url: url, workersDevURL: workersDevURL))
+        guard stateMachine.isCurrent(gen), activeSiteID == siteID else { return }
+        if case .ready(let readySiteID, let url, _) = stateMachine.state, readySiteID == siteID {
+            stateMachine.settle(gen: gen, to: .ready(siteID: readySiteID, url: url, workersDevURL: workersDevURL))
         }
     }
 

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -21,6 +21,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
     private let importBundle: @Sendable (URL, String, URL) async throws -> Void
     private let suddenTerminationController: SuddenTerminationController
     private let beginActivity: @Sendable (String) -> ActivityAssertion.Lease
+    private let workerCatalog: @Sendable () async -> [WorkerDescriptor]
     private var fileWatcher: (any SiteFileWatching)?
     private var containerTerminationLease: SuddenTerminationController.Lease?
 
@@ -58,7 +59,10 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
             #endif
         },
         suddenTerminationController: SuddenTerminationController = .shared,
-        beginActivity: @escaping @Sendable (String) -> ActivityAssertion.Lease = ActivityAssertion.begin
+        beginActivity: @escaping @Sendable (String) -> ActivityAssertion.Lease = ActivityAssertion.begin,
+        workerCatalog: @escaping @Sendable () async -> [WorkerDescriptor] = {
+            await WorkerCatalogFetcher(catalogURL: WorkerCatalogFetcher.productionCatalogURL).catalog()
+        }
     ) {
         self.ref = ref
         self.control = control
@@ -72,6 +76,7 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
         self.importBundle = importBundle
         self.suddenTerminationController = suddenTerminationController
         self.beginActivity = beginActivity
+        self.workerCatalog = workerCatalog
     }
 
     public var state: SiteRuntimeState { stateMachine.state }
@@ -115,6 +120,68 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
     /// the most recent boot failed.
     public func resetNetworking() async {
         await control.resetNetworking()
+    }
+
+    /// Computes the site's effective active-worker set (mirroring `DeployModel.runDeploy`'s own
+    /// pipeline) and starts local `wrangler dev` if it's non-empty. Returns `nil` on any failure —
+    /// logged, never thrown — or when there are no active workers. #708 design §7/§6: a settings-
+    /// activated worker reliably resolves here; a component-tied worker may not, if this site's
+    /// `SiteGraphExplorerSnapshot` hasn't been populated yet (accepted thin-slice limitation, not
+    /// solved by this PR — see the design doc §6).
+    ///
+    /// `logCenter`/`source` are captured locally (not read from `self` inside `onOutput`) so late-
+    /// arriving wrangler-dev output — it's a long-lived guest process, crash-restart-supervised, and
+    /// can keep emitting long after this call returns — is always attributed to the `siteID` this
+    /// call started it for, even if this runtime has since been reused for a different site (its
+    /// `activeSiteID` would otherwise have moved on by the time a late line arrives).
+    private func startWorkersDevIfActive(siteID: String, siteDirectory: URL) async -> URL? {
+        let configDirectory = AnglesitePackage(url: AnglesitePackage.packageRoot(fromSourceURL: siteDirectory)).configURL
+        let settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+        let catalog = await workerCatalog()
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
+        guard !workers.isEmpty else { return nil }
+        let logCenter = self.logCenter
+        let source = "container:\(siteID)"
+        do {
+            return try await control.startWorkersDev(
+                siteID: siteID, workers: workers,
+                onOutput: { line, stream in
+                    Task { await logCenter.append(source: source, stream: stream, text: line) }
+                })
+        } catch {
+            await logCenter.append(
+                source: source, stream: .stderr,
+                text: "local wrangler-dev failed to start: \(error) — active workers will have no local dev endpoint this session")
+            return nil
+        }
+    }
+
+    /// Recomputes the effective active-worker set and restarts local wrangler-dev to match — the
+    /// capability a future Workers tab (#700c) calls on toggle. Not called anywhere in this PR
+    /// besides `start()`'s own initial computation (which goes through `startWorkersDevIfActive`
+    /// directly, not through this method) — built and left as public API now so #700c needs no
+    /// further runtime-side work. Guards on `gen == generation` and `activeSiteID == siteID` after
+    /// its own await, matching `start()`'s discipline, even though nothing exercises that race yet:
+    /// a future caller inherits the same actor-reentrancy hazard `start()` has, and shipping this
+    /// unguarded now would just be latent.
+    public func updateActiveWorkers(_ settings: SiteSettings) async {
+        guard let siteID = activeSiteID, let siteDirectory = activeSiteDirectory else { return }
+        let gen = generation
+        let catalog = await workerCatalog()
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
+        let workersDevURL: URL?
+        if workers.isEmpty {
+            try? await control.stopWorkersDev(siteID: siteID)
+            workersDevURL = nil
+        } else {
+            workersDevURL = await startWorkersDevIfActive(siteID: siteID, siteDirectory: siteDirectory)
+        }
+        guard gen == generation, activeSiteID == siteID else { return }
+        if case .ready(let readySiteID, let url, _) = current, readySiteID == siteID {
+            setState(.ready(siteID: readySiteID, url: url, workersDevURL: workersDevURL))
+        }
     }
 
     /// Copies one commit produced by the MCP sidecar in `/workspace/site` back into the host's
@@ -318,7 +385,23 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
             activeSiteDirectory = siteDirectory
             containerTerminationLease = suddenTerminationLease
             activityLease.release()
-            stateMachine.settle(gen: gen, to: .ready(siteID: siteID, url: session.previewURL))
+            // Local wrangler-dev (#708): computed once here, not wired to a live Settings
+            // toggle yet (no Workers tab exists to trigger one — #700c). A start failure here
+            // degrades to `workersDevURL: nil` rather than failing the whole runtime — wrangler-
+            // dev is an add-on capability, unlike the MCP connection above.
+            let workersDevURL = await self.startWorkersDevIfActive(siteID: siteID, siteDirectory: siteDirectory)
+            // Unlike every earlier `stateMachine.isCurrent(gen)` guard in this method,
+            // `activeSiteID`/`activeSiteDirectory`/`containerTerminationLease` are already assigned
+            // above by the time this await returns — a superseding stop()/start() during it
+            // discovers this attempt's container via the ordinary activeSiteID-based teardown()
+            // path and already tears it down (or, in a rapid stop→restart, replaces it) correctly.
+            // `settle` itself already no-ops when superseded (gen != generation internally), which
+            // is exactly the "just bail" behavior this needs — no explicit guard or
+            // `abandonSupersededAttempt()` call required (that helper's own `control.stop(siteID:)`
+            // is keyed by siteID, not container instance, so re-issuing it here could stop a BRAND
+            // NEW container a later start() has since booted and settled to `.ready` under the same
+            // siteID — a real, if narrow, race an unconditional cleanup call here would reintroduce).
+            stateMachine.settle(gen: gen, to: .ready(siteID: siteID, url: session.previewURL, workersDevURL: workersDevURL))
         } catch {
             // Finish this attempt's own (locally-captured) boot log stream immediately rather than
             // leaving it for the next start()/stop() call to clean up via teardown() — control.start()

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -162,13 +162,17 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
     /// besides `start()`'s own initial computation (which goes through `startWorkersDevIfActive`
     /// directly, not through this method) — built and left as public API now so #700c needs no
     /// further runtime-side work. Guards on `gen == generation` and `activeSiteID == siteID` after
-    /// its own await, matching `start()`'s discipline, even though nothing exercises that race yet:
-    /// a future caller inherits the same actor-reentrancy hazard `start()` has, and shipping this
-    /// unguarded now would just be latent.
+    /// EVERY `await` in this method, not just before the final `setState` — the mutating calls
+    /// (`control.stopWorkersDev`/`startWorkersDevIfActive`) are exactly as siteID-keyed-not-
+    /// container-keyed as the bug `start()`'s own post-assignment guard fixes (#708 review), so a
+    /// stale attempt here could stop or restart a brand-new container a later `start()` already
+    /// booted under the same siteID if it ran unguarded. Currently unreachable (no caller yet),
+    /// but shipping it unguarded would just be a latent repeat of that exact bug.
     public func updateActiveWorkers(_ settings: SiteSettings) async {
         guard let siteID = activeSiteID, let siteDirectory = activeSiteDirectory else { return }
         let gen = generation
         let catalog = await workerCatalog()
+        guard gen == generation, activeSiteID == siteID else { return }
         let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
         let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
         let workersDevURL: URL?

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -233,6 +233,23 @@ public struct PodmanContainerControl: LocalContainerControl {
         }
     }
 
+    /// Local wrangler-dev (#708) is designed and implemented against `ContainerizationControl`'s
+    /// vsock-bridged guest only — the cross-platform Linux port (#571) hasn't reached this guest
+    /// process yet. Throwing a clear, dedicated error here (rather than silently no-op'ing or
+    /// pretending success) keeps `LocalContainerSiteRuntime.startWorkersDevIfActive` honest: it
+    /// already degrades any `startWorkersDev` failure to `workersDevURL: nil` rather than failing
+    /// the whole preview, so this surfaces as "no workers-dev URL" on Linux instead of a crash.
+    public func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        throw LocalContainerError.bootFailed(
+            "workers-dev is not yet supported on the Linux/podman runtime (#571 tracks the port)")
+    }
+
+    public func stopWorkersDev(siteID: String) async throws {}
+
     public func exec(
         siteID: String,
         argv: [String],

--- a/Sources/AnglesiteCore/SiteRuntime.swift
+++ b/Sources/AnglesiteCore/SiteRuntime.swift
@@ -4,7 +4,12 @@ import Foundation
 public enum SiteRuntimeState: Sendable, Equatable {
     case idle
     case starting(siteID: String)
-    case ready(siteID: String, url: URL)
+    /// `workersDevURL` is the local `wrangler dev --local` endpoint, present only when the site's
+    /// effective active-worker set was non-empty at start time (#708) — `nil` for a static-only
+    /// site, and always `nil` for `RemoteSandboxSiteRuntime`/`UnavailableSiteRuntime` (a
+    /// local-container-only capability for v1). Defaulted so every existing `.ready(siteID:url:)`
+    /// construction site keeps compiling unchanged.
+    case ready(siteID: String, url: URL, workersDevURL: URL? = nil)
     /// Couldn't preview this site (deps not installed, dev server crashed, etc.). `message` is
     /// shown to the owner; the Debug pane has the full subprocess output.
     case failed(siteID: String, message: String)

--- a/Sources/AnglesiteLinux/AnglesiteLinuxApp.swift
+++ b/Sources/AnglesiteLinux/AnglesiteLinuxApp.swift
@@ -108,7 +108,7 @@ struct AnglesiteLinuxApp: App {
                 .title("Starting \(name)…")
                 .description("Booting the site container and dev server. First boot clones the site and installs dependencies.")
                 .child { Spinner() }
-        case .ready(_, let url):
+        case .ready(_, let url, _):
             PreviewWebView(
                 url: url,
                 router: router ?? MCPApplyEditRouter(mcpClient: { nil }),
@@ -166,7 +166,7 @@ struct AnglesiteLinuxApp: App {
                         break
                     case .starting:
                         status = .starting(name: site.displayName)
-                    case .ready(_, let url):
+                    case .ready(_, let url, _):
                         status = .ready(name: site.displayName, url: url.absoluteString)
                     case .failed(_, let message):
                         status = .failed(name: site.displayName, message: message)

--- a/Sources/AnglesiteSiteModel/AnglesitePackage.swift
+++ b/Sources/AnglesiteSiteModel/AnglesitePackage.swift
@@ -49,6 +49,13 @@ public struct AnglesitePackage: Sendable, Equatable {
         configURL.appendingPathComponent("quicklook-thumbnail.png", isDirectory: false)
     }
 
+    /// The inverse of `sourceURL`: reconstructs a package's root `url` from its `Source/`
+    /// directory. For callers (like `LocalContainerSiteRuntime`) that are only ever handed the
+    /// `Source/` path, not the package root itself.
+    public static func packageRoot(fromSourceURL sourceURL: URL) -> URL {
+        sourceURL.deletingLastPathComponent()
+    }
+
     // MARK: - Marker
 
     /// The `Info.plist` marker: stable identity + format version + provenance. Encoded with

--- a/Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift
@@ -66,6 +66,54 @@ struct ContainerizationControlTests {
         try? await control.stop(siteID: "e2e-interactive")
     }
 
+    @Test("startWorkersDev boots a reachable local wrangler-dev endpoint for an active worker")
+    func startsWorkersDevForActiveWorker() async throws {
+        try #require(enabled, "set ANGLESITE_CONTAINER_E2E=1 on an entitled Apple-Silicon Mac")
+
+        let siteID = "workers-dev-e2e"
+        let control = ContainerizationControl()
+        let repo = try makeThrowawayAstroRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        _ = try await control.start(siteID: siteID, sourceRepo: repo, ref: "HEAD", onOutput: { _, _ in })
+        // Safety net: fires on any exit path (incl. a thrown #expect below) so a failed
+        // assertion doesn't leave the VM running. stop() is idempotent, so the awaited
+        // happy-path stop below is harmless after this.
+        defer { Task { try? await control.stop(siteID: siteID) } }
+
+        let workers = [WorkerDescriptor(
+            id: "indieauth", displayName: "IndieAuth", description: "d", group: "identity",
+            binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))]
+        let workersDevURL = try await control.startWorkersDev(siteID: siteID, workers: workers, onOutput: { _, _ in })
+
+        let ok = await pollForHTTPResponse(workersDevURL, timeout: .seconds(60))
+        #expect(ok, "wrangler dev --local never answered within the timeout")
+
+        try? await control.stop(siteID: siteID)
+    }
+
+    /// Polls `url` for any HTTP response (any status code is a pass — we only care that
+    /// wrangler-dev is accepting connections and speaking HTTP), bounded by `timeout`. There is no
+    /// internal readiness wait for `startWorkersDev` equivalent to `start()`'s `waitUntilServing`
+    /// (wrangler-dev can take a few seconds to bind its port after the call returns), so this test
+    /// needs its own retry loop. Mirrors `AnglesiteContainerProbe.pollForHTTPResponse` in
+    /// `Sources/AnglesiteContainerProbe/main.swift` — kept as a small, self-contained duplicate
+    /// here rather than sharing code across the test target/executable boundary (SwiftPM test
+    /// targets aren't importable from an executable target).
+    private func pollForHTTPResponse(_ url: URL, timeout: Duration) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            do {
+                let (_, response) = try await URLSession.shared.data(from: url)
+                if response is HTTPURLResponse { return true }
+            } catch {
+                // Not ready yet — wrangler-dev may still be starting up inside the guest.
+            }
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+        return false
+    }
+
     /// Create a throwaway on-disk git repo containing a minimal Astro site and an initial commit.
     /// Returns the repo directory URL (a `file://` path the driver clones into the guest).
     private func makeThrowawayAstroRepo() throws -> URL {

--- a/Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift
@@ -128,6 +128,28 @@ struct GuestProcessSupervisorTests {
         #expect(await launcher.launchCalls.count == 3)
     }
 
+    @Test("a clean exit (code 0) under .onCrash stops without restarting — clean exit is never a crash")
+    func cleanExitUnderOnCrashStopsWithoutRestarting() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"],
+            restartPolicy: .onCrash(maxAttempts: 3, baseBackoff: 0.01), onOutput: { _, _ in })
+        try await supervisor.start()
+        let stream = await supervisor.observe()
+        var iterator = stream.makeAsyncIterator()
+        while await iterator.next() != .running {}
+
+        await launcher.handles[0].exit(code: 0)
+        var final: GuestProcessSupervisor.State?
+        while let s = await iterator.next() {
+            final = s
+            if s == .stopped { break }
+        }
+        #expect(final == .stopped)
+        // No relaunch happened — a clean exit isn't a crash.
+        #expect(await launcher.launchCalls.count == 1)
+    }
+
     @Test("stop() suppresses the next restart — an intentional stop never relaunches")
     func stopSuppressesRestart() async throws {
         let launcher = FakeGuestProcessLauncher()

--- a/Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteContainer
+
+private actor FakeGuestProcessHandle: GuestProcessHandle {
+    private var waitContinuation: CheckedContinuation<Int32, Error>?
+    private var pendingExitCode: Int32?
+    private(set) var started = false
+    private(set) var killed = false
+    private(set) var deleted = false
+
+    func start() async throws { started = true }
+
+    func wait() async throws -> Int32 {
+        if let code = pendingExitCode { pendingExitCode = nil; return code }
+        return try await withCheckedThrowingContinuation { waitContinuation = $0 }
+    }
+
+    func kill() async throws { killed = true }
+    func delete() async throws { deleted = true }
+
+    /// Test control: makes the next (or currently-parked) `wait()` return `code`.
+    func exit(code: Int32) {
+        if let cont = waitContinuation {
+            waitContinuation = nil
+            cont.resume(returning: code)
+        } else {
+            pendingExitCode = code
+        }
+    }
+}
+
+private actor FakeGuestProcessLauncher: GuestProcessLauncher {
+    private(set) var launchCalls: [(id: String, argv: [String])] = []
+    /// One handle per launch, in call order — the test drives each one's `exit(code:)` directly.
+    private(set) var handles: [FakeGuestProcessHandle] = []
+
+    func launch(
+        id: String,
+        argv: [String],
+        environment: [String: String],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> any GuestProcessHandle {
+        launchCalls.append((id: id, argv: argv))
+        let handle = FakeGuestProcessHandle()
+        handles.append(handle)
+        return handle
+    }
+}
+
+@Suite("GuestProcessSupervisor")
+struct GuestProcessSupervisorTests {
+    @Test("start() launches and reaches .running")
+    func startReachesRunning() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"], restartPolicy: .never, onOutput: { _, _ in })
+        try await supervisor.start()
+        var seen: [GuestProcessSupervisor.State] = []
+        for await s in await supervisor.observe() { seen.append(s); if s == .running { break } }
+        #expect(seen.last == .running)
+        #expect(await launcher.launchCalls.count == 1)
+    }
+
+    @Test("a clean exit under .never gives up without restarting")
+    func neverPolicyGivesUpOnExit() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"], restartPolicy: .never, onOutput: { _, _ in })
+        try await supervisor.start()
+        let stream = await supervisor.observe()
+        var iterator = stream.makeAsyncIterator()
+        while await iterator.next() != .running {}
+        await launcher.handles[0].exit(code: 1)
+        var final: GuestProcessSupervisor.State?
+        while let s = await iterator.next() {
+            final = s
+            if case .failed = s { break }
+        }
+        guard case .failed = final else {
+            Issue.record("expected .failed, got \(String(describing: final))")
+            return
+        }
+        #expect(await launcher.launchCalls.count == 1)
+    }
+
+    @Test("a crash under .onCrash relaunches, up to maxAttempts, then gives up")
+    func onCrashPolicyRestartsThenGivesUp() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"],
+            restartPolicy: .onCrash(maxAttempts: 2, baseBackoff: 0.01), onOutput: { _, _ in })
+        try await supervisor.start()
+        let stream = await supervisor.observe()
+        var iterator = stream.makeAsyncIterator()
+        while await iterator.next() != .running {}
+
+        // Crash 1 → restarting(1) → running (relaunch #2)
+        await launcher.handles[0].exit(code: 1)
+        var sawRestarting1 = false
+        while let s = await iterator.next() {
+            if s == .restarting(attempt: 1) { sawRestarting1 = true }
+            if s == .running, sawRestarting1 { break }
+        }
+        #expect(await launcher.launchCalls.count == 2)
+
+        // Crash 2 → restarting(2) → running (relaunch #3)
+        await launcher.handles[1].exit(code: 1)
+        var sawRestarting2 = false
+        while let s = await iterator.next() {
+            if s == .restarting(attempt: 2) { sawRestarting2 = true }
+            if s == .running, sawRestarting2 { break }
+        }
+        #expect(await launcher.launchCalls.count == 3)
+
+        // Crash 3 → attempt 3 exceeds maxAttempts(2) → .failed, no further relaunch.
+        await launcher.handles[2].exit(code: 1)
+        var final: GuestProcessSupervisor.State?
+        while let s = await iterator.next() {
+            final = s
+            if case .failed = s { break }
+        }
+        guard case .failed = final else {
+            Issue.record("expected .failed after exhausting retries, got \(String(describing: final))")
+            return
+        }
+        #expect(await launcher.launchCalls.count == 3)
+    }
+
+    @Test("stop() suppresses the next restart — an intentional stop never relaunches")
+    func stopSuppressesRestart() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"],
+            restartPolicy: .onCrash(maxAttempts: 5, baseBackoff: 0.01), onOutput: { _, _ in })
+        try await supervisor.start()
+        let stream = await supervisor.observe()
+        var iterator = stream.makeAsyncIterator()
+        while await iterator.next() != .running {}
+
+        await supervisor.stop()
+        #expect(await iterator.next() == .stopped)
+        #expect(await launcher.handles[0].killed)
+
+        // Give the (now-cancelled) supervise loop a beat to prove it does NOT relaunch.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await launcher.launchCalls.count == 1)
+    }
+}

--- a/Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift
@@ -63,8 +63,8 @@ struct GuestProcessSupervisorTests {
         #expect(await launcher.launchCalls.count == 1)
     }
 
-    @Test("a clean exit under .never gives up without restarting")
-    func neverPolicyGivesUpOnExit() async throws {
+    @Test("a non-zero exit under .never gives up without restarting")
+    func neverPolicyGivesUpOnNonZeroExit() async throws {
         let launcher = FakeGuestProcessLauncher()
         let supervisor = GuestProcessSupervisor(
             launcher: launcher, id: "test", argv: ["true"], restartPolicy: .never, onOutput: { _, _ in })
@@ -82,6 +82,25 @@ struct GuestProcessSupervisorTests {
             Issue.record("expected .failed, got \(String(describing: final))")
             return
         }
+        #expect(await launcher.launchCalls.count == 1)
+    }
+
+    @Test("a clean exit (code 0) under .never stops, not fails — clean exit is never a crash regardless of policy")
+    func cleanExitUnderNeverStopsNotFails() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"], restartPolicy: .never, onOutput: { _, _ in })
+        try await supervisor.start()
+        let stream = await supervisor.observe()
+        var iterator = stream.makeAsyncIterator()
+        while await iterator.next() != .running {}
+        await launcher.handles[0].exit(code: 0)
+        var final: GuestProcessSupervisor.State?
+        while let s = await iterator.next() {
+            final = s
+            if s == .stopped { break }
+        }
+        #expect(final == .stopped)
         #expect(await launcher.launchCalls.count == 1)
     }
 

--- a/Tests/AnglesiteCoreTests/ContainerCommandRunnerTests.swift
+++ b/Tests/AnglesiteCoreTests/ContainerCommandRunnerTests.swift
@@ -128,4 +128,14 @@ private actor ThrowingFakeLocalContainerControl: LocalContainerControl {
     ) async throws -> InteractiveExecHandle {
         throw ExecError.boom
     }
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        throw ExecError.boom
+    }
+    func stopWorkersDev(siteID: String) async throws {
+        throw ExecError.boom
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
@@ -521,6 +521,16 @@ private actor ThrowingFakeLocalContainerControl: LocalContainerControl {
     ) async throws -> InteractiveExecHandle {
         throw ExecError.boom
     }
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        throw ExecError.boom
+    }
+    func stopWorkersDev(siteID: String) async throws {
+        throw ExecError.boom
+    }
 }
 
 // MARK: - CancelParkingFakeContainerControl
@@ -568,6 +578,16 @@ private actor CancelParkingFakeContainerControl: LocalContainerControl {
     ) async throws -> InteractiveExecHandle {
         InteractiveExecHandle(write: { _ in }, terminate: {})
     }
+
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        URL(string: "http://127.0.0.1:51003")!
+    }
+
+    func stopWorkersDev(siteID: String) async throws {}
 
     private func signalParked() {
         parkedContinuation?.resume()

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -327,4 +327,14 @@ private actor StepAwareFakeContainerControl: LocalContainerControl {
     ) async throws -> InteractiveExecHandle {
         InteractiveExecHandle(write: { _ in }, terminate: {})
     }
+
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        URL(string: "http://127.0.0.1:51003")!
+    }
+
+    func stopWorkersDev(siteID: String) async throws {}
 }

--- a/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
+++ b/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
@@ -31,6 +31,15 @@ actor FakeLocalContainerControl: LocalContainerControl {
     /// Whether the most recently returned handle's `terminate()` was called.
     private(set) var execInteractiveTerminated = false
 
+    /// Canned result returned by `startWorkersDev`. Defaults to a successful fixed URL.
+    var startWorkersDevResult: Result<URL, LocalContainerError> = .success(URL(string: "http://127.0.0.1:51003")!)
+    /// Lines replayed to `startWorkersDev`'s `onOutput` in order before it returns.
+    var startWorkersDevStdoutLines: [String] = []
+    /// All `startWorkersDev` invocations recorded for assertion.
+    private(set) var startWorkersDevCalls: [(siteID: String, workers: [WorkerDescriptor])] = []
+    /// All `stopWorkersDev` invocations recorded for assertion.
+    private(set) var stopWorkersDevCalls: [String] = []
+
     init(
         startResult: Result<LocalContainerSession, LocalContainerError>,
         startStdoutLines: [String] = [],
@@ -59,6 +68,20 @@ actor FakeLocalContainerControl: LocalContainerControl {
     func stop(siteID: String) async throws { stopped.append(siteID) }
 
     func resetNetworking() async { resetNetworkingCallCount += 1 }
+
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        startWorkersDevCalls.append((siteID: siteID, workers: workers))
+        for line in startWorkersDevStdoutLines { onOutput(line, .stdout) }
+        return try startWorkersDevResult.get()
+    }
+
+    func stopWorkersDev(siteID: String) async throws {
+        stopWorkersDevCalls.append(siteID)
+    }
 
     func exec(
         siteID: String,
@@ -144,6 +167,16 @@ actor PersistenceGatedFakeLocalContainerControl: LocalContainerControl {
 
     func stop(siteID: String) async throws {}
 
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        URL(string: "http://127.0.0.1:51003")!
+    }
+
+    func stopWorkersDev(siteID: String) async throws {}
+
     func exec(
         siteID: String,
         argv: [String],
@@ -220,6 +253,16 @@ actor StopGatedFakeLocalContainerControl: LocalContainerControl {
         }
     }
 
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        URL(string: "http://127.0.0.1:51003")!
+    }
+
+    func stopWorkersDev(siteID: String) async throws {}
+
     func exec(
         siteID: String,
         argv: [String],
@@ -268,6 +311,16 @@ actor GatedFakeLocalContainerControl: LocalContainerControl {
         return try result.get()
     }
     func stop(siteID: String) async throws { stopped.append(siteID) }
+
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        URL(string: "http://127.0.0.1:51003")!
+    }
+
+    func stopWorkersDev(siteID: String) async throws {}
 
     func exec(
         siteID: String,

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -16,7 +16,8 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: mcp,
             connect: connect,
-            importBundle: importBundle)
+            importBundle: importBundle,
+            workerCatalog: { [] })
         return (rt, fake)
     }
 
@@ -33,7 +34,8 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
             connect: { _, _ in },
-            suddenTerminationController: controller
+            suddenTerminationController: controller,
+            workerCatalog: { [] }
         )
 
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
@@ -51,7 +53,8 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
             connect: { _, _ in },
-            suddenTerminationController: controller
+            suddenTerminationController: controller,
+            workerCatalog: { [] }
         )
 
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
@@ -84,7 +87,8 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
             connect: { _, _ in },
-            beginActivity: counter.beginActivity
+            beginActivity: counter.beginActivity,
+            workerCatalog: { [] }
         )
 
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
@@ -101,7 +105,8 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
             connect: { _, _ in },
-            beginActivity: counter.beginActivity
+            beginActivity: counter.beginActivity,
+            workerCatalog: { [] }
         )
 
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
@@ -121,7 +126,8 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter()),
             connect: { _, _ in },
-            beginActivity: counter.beginActivity
+            beginActivity: counter.beginActivity,
+            workerCatalog: { [] }
         )
 
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
@@ -215,7 +221,8 @@ struct LocalContainerSiteRuntimeTests {
             connect: { _, _ in },
             importBundle: { bundleURL, importedCommit, sourceDirectory in
                 try await host.run(bundleURL: bundleURL, commit: importedCommit, sourceDirectory: sourceDirectory)
-            }
+            },
+            workerCatalog: { [] }
         )
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
 
@@ -245,7 +252,8 @@ struct LocalContainerSiteRuntimeTests {
             connect: { _, _ in },
             importBundle: { bundleURL, importedCommit, sourceDirectory in
                 try await host.run(bundleURL: bundleURL, commit: importedCommit, sourceDirectory: sourceDirectory)
-            }
+            },
+            workerCatalog: { [] }
         )
         await runtime.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/sites/One/Source"))
 
@@ -287,7 +295,8 @@ struct LocalContainerSiteRuntimeTests {
         let subscription = await logCenter.subscribe()
         let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
         let rt = LocalContainerSiteRuntime(
-            ref: "HEAD", control: fake, mcpClient: mcp, logCenter: logCenter, connect: { _, _ in })
+            ref: "HEAD", control: fake, mcpClient: mcp, logCenter: logCenter, connect: { _, _ in },
+            workerCatalog: { [] })
 
         await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
 
@@ -322,7 +331,8 @@ struct LocalContainerSiteRuntimeTests {
             control: fake,
             mcpClient: mcp,
             logCenter: logCenter,
-            connect: { _, _ in })
+            connect: { _, _ in },
+            workerCatalog: { [] })
 
         await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
 
@@ -353,7 +363,8 @@ struct LocalContainerSiteRuntimeTests {
         let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
         let rt = LocalContainerSiteRuntime(
             ref: "HEAD",
-            control: gated, mcpClient: mcp, connect: { _, _ in })
+            control: gated, mcpClient: mcp, connect: { _, _ in },
+            workerCatalog: { [] })
         let startTask = Task { await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused")) }
         await gated.waitUntilParked()
         await rt.stop()
@@ -376,7 +387,8 @@ struct LocalContainerSiteRuntimeTests {
         let control = StopGatedFakeLocalContainerControl(result: .success(Self.ok))
         let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
         let rt = LocalContainerSiteRuntime(
-            ref: "HEAD", control: control, mcpClient: mcp, connect: { _, _ in })
+            ref: "HEAD", control: control, mcpClient: mcp, connect: { _, _ in },
+            workerCatalog: { [] })
         let dir = URL(fileURLWithPath: "/unused")
         await rt.start(siteID: "s1", siteDirectory: dir)
 
@@ -441,13 +453,95 @@ struct LocalContainerSiteRuntimeTests {
 
     /// Attaches the observer BEFORE start() runs, then drives start() through a suspending control
     /// client so `.starting` is delivered to a live observer (not drained from a buffer after the fact).
+    // MARK: - Workers-dev worker-awareness (#708)
+
+    private func temporaryPackage() throws -> URL {
+        let package = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalContainerSiteRuntimeTests-\(UUID().uuidString).anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: AnglesitePackage(url: package).sourceURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: AnglesitePackage(url: package).configURL, withIntermediateDirectories: true)
+        return package
+    }
+
+    @Test("workers-dev starts when the effective active set is non-empty")
+    func startsWorkersDevWhenActiveSetNonEmpty() async throws {
+        let control = FakeLocalContainerControl(startResult: .success(Self.ok))
+        // FakeLocalContainerControl.startWorkersDevResult already defaults to a `.success` of this
+        // same URL — it's an actor-isolated `var`, so it can't be assigned from outside via a bare
+        // `await control.startWorkersDevResult = ...` (the brief's original test code did that; it
+        // doesn't compile — mutating actor-isolated stored state needs an isolated method, not just
+        // `await` at the call site). The default already matches what this test expects.
+        let package = try temporaryPackage()
+        let configStore = SiteConfigStore(configDirectory: AnglesitePackage(url: package).configURL)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+        let rt = LocalContainerSiteRuntime(
+            ref: "HEAD", control: control, mcpClient: MCPClient(supervisor: .shared),
+            connect: { _, _ in },
+            workerCatalog: { [WorkerDescriptor(
+                id: "indieauth", displayName: "IndieAuth", description: "d", group: "identity",
+                binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))] })
+
+        await rt.start(siteID: "s1", siteDirectory: AnglesitePackage(url: package).sourceURL)
+
+        guard case .ready(_, _, let workersDevURL) = await rt.state else {
+            Issue.record("expected .ready, got \(await rt.state)")
+            return
+        }
+        #expect(workersDevURL == URL(string: "http://127.0.0.1:51003")!)
+        #expect(await control.startWorkersDevCalls.map(\.siteID) == ["s1"])
+    }
+
+    @Test("workers-dev does not start when the effective active set is empty")
+    func doesNotStartWorkersDevWhenActiveSetEmpty() async throws {
+        let control = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let package = try temporaryPackage()
+        let rt = LocalContainerSiteRuntime(
+            ref: "HEAD", control: control, mcpClient: MCPClient(supervisor: .shared),
+            connect: { _, _ in },
+            workerCatalog: { [] })
+
+        await rt.start(siteID: "s1", siteDirectory: AnglesitePackage(url: package).sourceURL)
+
+        guard case .ready(_, _, let workersDevURL) = await rt.state else {
+            Issue.record("expected .ready, got \(await rt.state)")
+            return
+        }
+        #expect(workersDevURL == nil)
+        #expect(await control.startWorkersDevCalls.isEmpty)
+    }
+
+    @Test("teardown stops workers-dev via the ordinary control.stop(siteID:) path")
+    func teardownStopsWorkersDev() async throws {
+        let control = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let package = try temporaryPackage()
+        let configStore = SiteConfigStore(configDirectory: AnglesitePackage(url: package).configURL)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+        let rt = LocalContainerSiteRuntime(
+            ref: "HEAD", control: control, mcpClient: MCPClient(supervisor: .shared),
+            connect: { _, _ in },
+            workerCatalog: { [WorkerDescriptor(
+                id: "indieauth", displayName: "IndieAuth", description: "d", group: "identity",
+                binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))] })
+
+        await rt.start(siteID: "s1", siteDirectory: AnglesitePackage(url: package).sourceURL)
+        await rt.stop()
+
+        // stopWorkersDev is not called directly — teardown relies on the same control.stop(siteID:)
+        // call it already makes, which (per Task 4) tears down workers-dev too. This test documents
+        // that expectation against the fake, which only records `stop`, not `stopWorkersDev`.
+        #expect(await control.stopped == ["s1"])
+    }
+
     @Test("observe delivers .starting to a live observer while runtime is mid-start")
     func observeDeliversStartingToLiveObserver() async throws {
         let gated = GatedFakeLocalContainerControl(result: .success(Self.ok))
         let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
         let rt = LocalContainerSiteRuntime(
             ref: "HEAD",
-            control: gated, mcpClient: mcp, connect: { _, _ in })
+            control: gated, mcpClient: mcp, connect: { _, _ in },
+            workerCatalog: { [] })
 
         // Attach the observer BEFORE start().
         let stream = await rt.observe()

--- a/Tests/AnglesiteSiteModelTests/AnglesitePackageTests.swift
+++ b/Tests/AnglesiteSiteModelTests/AnglesitePackageTests.swift
@@ -23,6 +23,13 @@ struct AnglesitePackageTests {
         #expect(pkg.sourceURL.deletingLastPathComponent().path == pkgURL.path)
     }
 
+    @Test("packageRoot(fromSourceURL:) is the inverse of sourceURL")
+    func packageRootFromSourceURLRoundTrips() {
+        let root = URL(fileURLWithPath: "/tmp/my-site.anglesite", isDirectory: true)
+        let pkg = AnglesitePackage(url: root)
+        #expect(AnglesitePackage.packageRoot(fromSourceURL: pkg.sourceURL) == root)
+    }
+
     @Test("quickLookThumbnailURL resolves under Config/")
     func quickLookThumbnailURLResolves() throws {
         let pkgURL = URL(fileURLWithPath: "/tmp/Acme.anglesite", isDirectory: true)

--- a/docs/superpowers/plans/2026-07-20-local-wrangler-dev-runtime.md
+++ b/docs/superpowers/plans/2026-07-20-local-wrangler-dev-runtime.md
@@ -1,0 +1,1420 @@
+# Local `wrangler dev` Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a local `wrangler dev --local` guest process to `LocalContainerSiteRuntime`, started only when a site's effective active-worker set is non-empty, crash-restart-capable via a new generic guest-process supervisor, and reachable through the runtime's existing state/session payloads — the last of #708's three prerequisites.
+
+**Architecture:** Two additive type extensions (`LocalContainerSession`, `SiteRuntimeState.ready` both gain an optional `workersDevURL`) plus two new `LocalContainerControl` protocol methods (`startWorkersDev`/`stopWorkersDev`) let `LocalContainerSiteRuntime` start/stop a fourth guest process alongside astro/mcp/bridges, without changing `SiteRuntime`'s three-method protocol surface. A new, generic `GuestProcessSupervisor` (mirroring `InProcessBackend`'s host-process `RestartPolicy` shape, but driving a guest process via a new `GuestProcessLauncher` seam) gives wrangler-dev real crash-restart — the first guest process in this codebase to get that. The effective active-worker set is computed once, inside `LocalContainerSiteRuntime.start()`, using the same `WorkerActivation`/`SiteConfigStore` pipeline `DeployModel` already uses.
+
+**Tech Stack:** Swift 6.4, Apple's Containerization framework (`LinuxContainer`/`LinuxProcess`), Swift Testing, SwiftPM (`AnglesiteCore`, `AnglesiteContainer`, `AnglesiteContainerLocalTests` — the last gated behind `ANGLESITE_CONTAINER_TESTS=1`), Xcode/`xcodebuild` for `AnglesiteApp`.
+
+## Global Constraints
+
+- Governing spec: `docs/superpowers/specs/2026-07-13-workers-local-debugging-design.md` §7. This plan's own design doc: `docs/superpowers/specs/2026-07-20-local-wrangler-dev-runtime-design.md`.
+- No `SiteRuntime` protocol change — `start`/`stop`/`observe`/`mcpClient` stay exactly as they are. All new capability is additive to `SiteRuntimeState`/`LocalContainerSession`/`LocalContainerControl`.
+- Out of scope (per the design doc, do not build): a live-toggle-restart UI caller (the Workers tab, #700c, doesn't exist yet — build `updateActiveWorkers(_:)` and test it directly, but `start()` is its only caller); retrofitting `astro`/`mcp` onto `GuestProcessSupervisor`; any new SwiftUI status indicator for supervisor state.
+- `wrangler` becomes a new `Resources/Template/package.json` devDependency — no Dockerfile change, no paired sidecar PR (template changes are app-only per CLAUDE.md).
+- The ephemeral `wrangler.toml` for local dev lives at a path outside `/workspace/site` entirely (`/tmp/anglesite-workers-dev/<siteID>/wrangler.toml` inside the guest) — refining the design doc's "git-ignored path under `Source/`" sketch to something that needs no `.gitignore` entry at all, since it's outside the cloned repo.
+- Every `AnglesiteCoreTests`/`AnglesiteContainerLocalTests` suite touched must pass. `AnglesiteContainerLocalTests` requires `ANGLESITE_CONTAINER_TESTS=1` in the build environment; its live-VM cases additionally require `ANGLESITE_CONTAINER_E2E=1` at runtime and can only really run via `scripts/run-container-probe.sh`, never bare `swift test` (`swiftpm-testing-helper` cannot carry the virtualization entitlement).
+- `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` must succeed.
+- If you touch `Resources/Template/`, run `swift test` too (CONTRIBUTING.md) — some Swift tests couple to template markup.
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `Sources/AnglesiteCore/SiteRuntime.swift` | `SiteRuntimeState.ready` gains `workersDevURL: URL? = nil` |
+| `Sources/AnglesiteCore/LocalContainerControl.swift` | `LocalContainerSession` gains `workersDevURL: URL? = nil`; protocol gains `startWorkersDev`/`stopWorkersDev` |
+| `Sources/AnglesiteSiteModel/AnglesitePackage.swift` | New static helper: package root from a `Source/` URL |
+| `Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift` | All four `LocalContainerControl` conformers gain the two new methods |
+| `Resources/Template/package.json` | Add `wrangler` devDependency |
+| `Sources/AnglesiteContainer/GuestProcessSupervisor.swift` | New file: `GuestProcessLauncher`/`GuestProcessHandle` protocols, `LinuxContainerProcessLauncher` real conformer, `GuestProcessSupervisor` actor |
+| `Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift` | New file: restart-policy state-machine tests against a fake launcher |
+| `Sources/AnglesiteContainer/ContainerizationControl.swift` | `startWorkersDev`/`stopWorkersDev`, `LiveContainers` gains a supervisors dict, `Self.workersPort` |
+| `Sources/AnglesiteCore/LocalContainerSiteRuntime.swift` | Worker-awareness: compute effective active set, call `startWorkersDev`, `updateActiveWorkers(_:)` |
+| `Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift` | New cases for the above |
+| `Sources/AnglesiteApp/PreviewModel.swift`, `SiteWindow.swift`, `StartupProgressModel.swift` | Fix the 3 real `.ready(...)` pattern-match sites; add `PreviewModel.workersDevURL` |
+| `Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift` | New e2e case (boot with an active worker, assert workers-dev URL answers HTTP) |
+| `Sources/AnglesiteContainerProbe/main.swift`, `scripts/run-container-probe.sh` | New `workers-dev` subcommand |
+
+---
+
+## Task 1: AnglesiteCore — additive type/protocol surface
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteRuntime.swift:7`
+- Modify: `Sources/AnglesiteCore/LocalContainerControl.swift`
+- Modify: `Sources/AnglesiteSiteModel/AnglesitePackage.swift`
+- Modify: `Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift`
+- Test: `Tests/AnglesiteSiteModelTests/AnglesitePackageTests.swift` (or wherever existing `AnglesitePackage` tests live — locate via `grep -rl "AnglesitePackage(" Tests/AnglesiteSiteModelTests/`)
+
+**Interfaces:**
+- Produces: `SiteRuntimeState.ready(siteID:url:workersDevURL:)`; `LocalContainerSession.workersDevURL`; `LocalContainerControl.startWorkersDev(siteID:workers:onOutput:) -> URL` / `.stopWorkersDev(siteID:)`; `AnglesitePackage.packageRoot(fromSourceURL:) -> URL`. Task 5 (`LocalContainerSiteRuntime`) and Task 6 (`AnglesiteApp`) consume all four.
+
+- [ ] **Step 1: Add `workersDevURL` to `SiteRuntimeState.ready`**
+
+In `Sources/AnglesiteCore/SiteRuntime.swift`, replace:
+
+```swift
+    case ready(siteID: String, url: URL)
+```
+
+with:
+
+```swift
+    /// `workersDevURL` is the local `wrangler dev --local` endpoint, present only when the site's
+    /// effective active-worker set was non-empty at start time (#708) — `nil` for a static-only
+    /// site, and always `nil` for `RemoteSandboxSiteRuntime`/`UnavailableSiteRuntime` (a
+    /// local-container-only capability for v1). Defaulted so every existing `.ready(siteID:url:)`
+    /// construction site keeps compiling unchanged.
+    case ready(siteID: String, url: URL, workersDevURL: URL? = nil)
+```
+
+- [ ] **Step 2: Add `workersDevURL` to `LocalContainerSession` and the two new protocol methods**
+
+In `Sources/AnglesiteCore/LocalContainerControl.swift`, replace:
+
+```swift
+public struct LocalContainerSession: Sendable, Equatable {
+    public let previewURL: URL
+    public let mcpURL: URL
+    public init(previewURL: URL, mcpURL: URL) {
+        self.previewURL = previewURL
+        self.mcpURL = mcpURL
+    }
+}
+```
+
+with:
+
+```swift
+public struct LocalContainerSession: Sendable, Equatable {
+    public let previewURL: URL
+    public let mcpURL: URL
+    /// The local `wrangler dev --local` endpoint, populated only when `startWorkersDev` has been
+    /// called for this session (#708) — not part of the initial `start()` payload, since the
+    /// workers-dev process is started conditionally, after boot, not during it.
+    public let workersDevURL: URL?
+    public init(previewURL: URL, mcpURL: URL, workersDevURL: URL? = nil) {
+        self.previewURL = previewURL
+        self.mcpURL = mcpURL
+        self.workersDevURL = workersDevURL
+    }
+}
+```
+
+Then add the two new protocol methods. Find the `LocalContainerControl` protocol's method list (ends with `resetNetworking()`'s default extension) and add, on the protocol itself:
+
+```swift
+    /// Starts a local `wrangler dev --local` (Miniflare-backed, no real Cloudflare account calls)
+    /// guest process for the given site's currently-active workers, as a fourth guest process
+    /// sibling to astro/mcp/bridges — called only after `start()` has already succeeded, and only
+    /// when `workers` is non-empty (#708 design §7 "started on demand, not unconditionally").
+    /// Crash-restart-capable (via `GuestProcessSupervisor`) — a wrangler-dev crash after this
+    /// returns does not throw back to any caller; it's handled internally.
+    /// - Returns: The host-proxied URL wrangler-dev is reachable at.
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL
+
+    /// Stops the workers-dev process (and its supervisor) for `siteID`, independent of astro/mcp —
+    /// used both when the effective active set becomes empty and as part of a full container
+    /// teardown (`LiveContainers.teardown` already calls this before `container.stop()`).
+    func stopWorkersDev(siteID: String) async throws
+```
+
+- [ ] **Step 3: Add the reverse package-root derivation to `AnglesitePackage`**
+
+In `Sources/AnglesiteSiteModel/AnglesitePackage.swift`, after the existing `sourceURL`/`configURL` computed properties (near line 28-29), add:
+
+```swift
+    /// The inverse of `sourceURL`: reconstructs a package's root `url` from its `Source/`
+    /// directory. For callers (like `LocalContainerSiteRuntime`) that are only ever handed the
+    /// `Source/` path, not the package root itself.
+    public static func packageRoot(fromSourceURL sourceURL: URL) -> URL {
+        sourceURL.deletingLastPathComponent()
+    }
+```
+
+- [ ] **Step 4: Add a round-trip test for the new `AnglesitePackage` helper**
+
+Find the existing `AnglesitePackage` test file (`grep -rl "AnglesitePackage(" Tests/AnglesiteSiteModelTests/`) and add:
+
+```swift
+    @Test("packageRoot(fromSourceURL:) is the inverse of sourceURL")
+    func packageRootFromSourceURLRoundTrips() {
+        let root = URL(fileURLWithPath: "/tmp/my-site.anglesite", isDirectory: true)
+        let pkg = AnglesitePackage(url: root)
+        #expect(AnglesitePackage.packageRoot(fromSourceURL: pkg.sourceURL) == root)
+    }
+```
+
+- [ ] **Step 5: Run the test target to confirm it fails to compile (expected — the four `LocalContainerControl` test conformers don't implement the two new protocol methods yet)**
+
+Run: `swift test --package-path . --filter AnglesiteSiteModelTests`
+Expected: PASS (Step 3/4 alone compile and pass — this step is really about confirming the *next* build step's failure mode, so run this instead: `swift build --package-path . --target AnglesiteCoreTests` or just `swift test --package-path . --filter LocalContainerSiteRuntimeTests`)
+Expected: **build error** — `type 'FakeLocalContainerControl' does not conform to protocol 'LocalContainerControl'` (missing `startWorkersDev`/`stopWorkersDev`), same for the other three conformers in that file.
+
+- [ ] **Step 6: Add the two new methods to all four test conformers in `Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift`**
+
+To `FakeLocalContainerControl` (the main one, used by richer tests — Task 5 extends this further), add stored state and the two methods:
+
+```swift
+    /// Canned result returned by `startWorkersDev`. Defaults to a successful fixed URL.
+    var startWorkersDevResult: Result<URL, LocalContainerError> = .success(URL(string: "http://127.0.0.1:51003")!)
+    /// Lines replayed to `startWorkersDev`'s `onOutput` in order before it returns.
+    var startWorkersDevStdoutLines: [String] = []
+    /// All `startWorkersDev` invocations recorded for assertion.
+    private(set) var startWorkersDevCalls: [(siteID: String, workers: [WorkerDescriptor])] = []
+    /// All `stopWorkersDev` invocations recorded for assertion.
+    private(set) var stopWorkersDevCalls: [String] = []
+```
+
+and the two methods, alongside the existing `stop(siteID:)`:
+
+```swift
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        startWorkersDevCalls.append((siteID: siteID, workers: workers))
+        for line in startWorkersDevStdoutLines { onOutput(line, .stdout) }
+        return try startWorkersDevResult.get()
+    }
+
+    func stopWorkersDev(siteID: String) async throws {
+        stopWorkersDevCalls.append(siteID)
+    }
+```
+
+To each of `PersistenceGatedFakeLocalContainerControl`, `StopGatedFakeLocalContainerControl`, and `GatedFakeLocalContainerControl` (none of which exercise the new methods — mirror their existing trivial `execInteractive` no-op pattern), add:
+
+```swift
+    func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        URL(string: "http://127.0.0.1:51003")!
+    }
+
+    func stopWorkersDev(siteID: String) async throws {}
+```
+
+- [ ] **Step 7: Run the full AnglesiteCore test target**
+
+Run: `swift test --package-path .`
+Expected: PASS — everything compiles (the four conformers satisfy the protocol again) and every existing test still passes unchanged (all four new methods are additive; no existing test calls them yet).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteRuntime.swift Sources/AnglesiteCore/LocalContainerControl.swift Sources/AnglesiteSiteModel/AnglesitePackage.swift Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift Tests/AnglesiteSiteModelTests/*.swift
+git commit -m "feat(workers): additive type/protocol surface for local wrangler-dev runtime (#708)"
+```
+
+---
+
+## Task 2: Template — make `wrangler` available inside the container
+
+**Files:**
+- Modify: `Resources/Template/package.json`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `wrangler` resolvable via `npx wrangler` (or directly, once installed) inside any site's `node_modules`, hydrated by the existing `anglesite-hydrate` pre-baked-tarball path — no code depends on this directly; Task 4's guest `argv` is the first real consumer.
+
+- [ ] **Step 1: Add the devDependency**
+
+In `Resources/Template/package.json`, in the `"devDependencies"` object, add (alphabetically, next to the other Cloudflare-adjacent deps):
+
+```json
+    "@cloudflare/vitest-pool-workers": "0.18.5",
+    "@cloudflare/workers-types": "5.20260715.1",
+```
+
+becomes:
+
+```json
+    "@cloudflare/vitest-pool-workers": "0.18.5",
+    "@cloudflare/workers-types": "5.20260715.1",
+    "wrangler": "^4.0.0",
+```
+
+(pin the exact version by checking what's current at implementation time — `npm view wrangler version` — rather than assuming `^4.0.0` is still accurate; update this step's exact string before running `npm install`.)
+
+- [ ] **Step 2: Regenerate the lockfile**
+
+Run: `cd Resources/Template && npm install && cd ../..`
+Expected: `Resources/Template/package-lock.json` updates to include `wrangler` and its transitive dependencies. Review the diff — this is a large lockfile change, expected and fine.
+
+- [ ] **Step 3: Run the template-coupled Swift test suite**
+
+Per CONTRIBUTING.md, touching `Resources/Template/` needs a `swift test` pass (some Swift tests couple to template markup/manifest contents — find them via `grep -rl "Resources/Template/package.json\|ProjectValidator" Tests/`).
+
+Run: `swift test --package-path .`
+Expected: PASS — a devDependency addition doesn't change any sentinel file `ProjectValidator` checks for, so no test should react to this change. If something does fail, read why before assuming it's unrelated — per [`project_projectvalidator_sentinel_drift`], this exact class of drift has bitten this repo before.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Resources/Template/package.json Resources/Template/package-lock.json
+git commit -m "feat(workers): add wrangler as a template devDependency for local dev (#708)"
+```
+
+---
+
+## Task 3: `GuestProcessSupervisor` — the generic guest-process crash-restart component
+
+**Files:**
+- Create: `Sources/AnglesiteContainer/GuestProcessSupervisor.swift`
+- Test: `Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift`
+
+**Interfaces:**
+- Consumes: `RestartPolicy`/`ProcessExitReason` from `Sources/AnglesiteCore/SupervisorBackend.swift` (reused, not redefined); `LogCenter.Stream` from `AnglesiteCore`.
+- Produces: `GuestProcessLauncher` protocol, `GuestProcessHandle` protocol, `LinuxContainerProcessLauncher` (real conformer, consumed by Task 4), `GuestProcessSupervisor` actor with `start()`/`stop()`/`observe() -> AsyncStream<State>`. Task 4 (`ContainerizationControl.startWorkersDev`) is the first real caller.
+
+- [ ] **Step 1: Write the failing tests first — the restart-policy state machine against a fake launcher**
+
+Create `Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift`:
+
+```swift
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteContainer
+
+private actor FakeGuestProcessHandle: GuestProcessHandle {
+    private var waitContinuation: CheckedContinuation<Int32, Error>?
+    private var pendingExitCode: Int32?
+    private(set) var started = false
+    private(set) var killed = false
+    private(set) var deleted = false
+
+    func start() async throws { started = true }
+
+    func wait() async throws -> Int32 {
+        if let code = pendingExitCode { pendingExitCode = nil; return code }
+        return try await withCheckedThrowingContinuation { waitContinuation = $0 }
+    }
+
+    func kill() async throws { killed = true }
+    func delete() async throws { deleted = true }
+
+    /// Test control: makes the next (or currently-parked) `wait()` return `code`.
+    func exit(code: Int32) {
+        if let cont = waitContinuation {
+            waitContinuation = nil
+            cont.resume(returning: code)
+        } else {
+            pendingExitCode = code
+        }
+    }
+}
+
+private actor FakeGuestProcessLauncher: GuestProcessLauncher {
+    private(set) var launchCalls: [(id: String, argv: [String])] = []
+    /// One handle per launch, in call order — the test drives each one's `exit(code:)` directly.
+    private(set) var handles: [FakeGuestProcessHandle] = []
+
+    func launch(
+        id: String,
+        argv: [String],
+        environment: [String: String],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> any GuestProcessHandle {
+        launchCalls.append((id: id, argv: argv))
+        let handle = FakeGuestProcessHandle()
+        handles.append(handle)
+        return handle
+    }
+}
+
+@Suite("GuestProcessSupervisor")
+struct GuestProcessSupervisorTests {
+    @Test("start() launches and reaches .running")
+    func startReachesRunning() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"], restartPolicy: .never, onOutput: { _, _ in })
+        try await supervisor.start()
+        var seen: [GuestProcessSupervisor.State] = []
+        for await s in await supervisor.observe() { seen.append(s); if s == .running { break } }
+        #expect(seen.last == .running)
+        #expect(await launcher.launchCalls.count == 1)
+    }
+
+    @Test("a clean exit under .never gives up without restarting")
+    func neverPolicyGivesUpOnExit() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"], restartPolicy: .never, onOutput: { _, _ in })
+        try await supervisor.start()
+        let stream = await supervisor.observe()
+        var iterator = stream.makeAsyncIterator()
+        while await iterator.next() != .running {}
+        await launcher.handles[0].exit(code: 1)
+        var final: GuestProcessSupervisor.State?
+        while let s = await iterator.next() {
+            final = s
+            if case .failed = s { break }
+        }
+        guard case .failed = final else {
+            Issue.record("expected .failed, got \(String(describing: final))")
+            return
+        }
+        #expect(await launcher.launchCalls.count == 1)
+    }
+
+    @Test("a crash under .onCrash relaunches, up to maxAttempts, then gives up")
+    func onCrashPolicyRestartsThenGivesUp() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"],
+            restartPolicy: .onCrash(maxAttempts: 2, baseBackoff: 0.01), onOutput: { _, _ in })
+        try await supervisor.start()
+        let stream = await supervisor.observe()
+        var iterator = stream.makeAsyncIterator()
+        while await iterator.next() != .running {}
+
+        // Crash 1 → restarting(1) → running (relaunch #2)
+        await launcher.handles[0].exit(code: 1)
+        var sawRestarting1 = false
+        while let s = await iterator.next() {
+            if s == .restarting(attempt: 1) { sawRestarting1 = true }
+            if s == .running, sawRestarting1 { break }
+        }
+        #expect(await launcher.launchCalls.count == 2)
+
+        // Crash 2 → restarting(2) → running (relaunch #3)
+        await launcher.handles[1].exit(code: 1)
+        var sawRestarting2 = false
+        while let s = await iterator.next() {
+            if s == .restarting(attempt: 2) { sawRestarting2 = true }
+            if s == .running, sawRestarting2 { break }
+        }
+        #expect(await launcher.launchCalls.count == 3)
+
+        // Crash 3 → attempt 3 exceeds maxAttempts(2) → .failed, no further relaunch.
+        await launcher.handles[2].exit(code: 1)
+        var final: GuestProcessSupervisor.State?
+        while let s = await iterator.next() {
+            final = s
+            if case .failed = s { break }
+        }
+        guard case .failed = final else {
+            Issue.record("expected .failed after exhausting retries, got \(String(describing: final))")
+            return
+        }
+        #expect(await launcher.launchCalls.count == 3)
+    }
+
+    @Test("stop() suppresses the next restart — an intentional stop never relaunches")
+    func stopSuppressesRestart() async throws {
+        let launcher = FakeGuestProcessLauncher()
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher, id: "test", argv: ["true"],
+            restartPolicy: .onCrash(maxAttempts: 5, baseBackoff: 0.01), onOutput: { _, _ in })
+        try await supervisor.start()
+        let stream = await supervisor.observe()
+        var iterator = stream.makeAsyncIterator()
+        while await iterator.next() != .running {}
+
+        await supervisor.stop()
+        #expect(await iterator.next() == .stopped)
+        #expect(await launcher.handles[0].killed)
+
+        // Give the (now-cancelled) supervise loop a beat to prove it does NOT relaunch.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await launcher.launchCalls.count == 1)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test target to confirm it fails to compile**
+
+Run: `ANGLESITE_CONTAINER_TESTS=1 swift test --package-path . --filter GuestProcessSupervisorTests`
+Expected: **build error** — `no such module 'AnglesiteContainer'` findable types (`GuestProcessLauncher`, `GuestProcessHandle`, `GuestProcessSupervisor` don't exist yet).
+
+- [ ] **Step 3: Implement `GuestProcessSupervisor.swift`**
+
+Create `Sources/AnglesiteContainer/GuestProcessSupervisor.swift`:
+
+```swift
+import Foundation
+import Containerization
+import AnglesiteCore
+
+/// Abstraction over "launch one guest process and get back a live handle" — the seam
+/// `GuestProcessSupervisor` tests against with a fake launcher, since a real launch needs a live
+/// `LinuxContainer` inside a booted VM. `LinuxContainerProcessLauncher` (below) is the real
+/// conformer, wrapping `LinuxContainer.exec`.
+protocol GuestProcessLauncher: Sendable {
+    func launch(
+        id: String,
+        argv: [String],
+        environment: [String: String],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> any GuestProcessHandle
+}
+
+/// One launched guest process: start it, wait for it to exit, or kill it early.
+protocol GuestProcessHandle: Sendable {
+    func start() async throws
+    /// Suspends until the process exits (normally or via `kill()`), returning its exit code.
+    func wait() async throws -> Int32
+    func kill() async throws
+    func delete() async throws
+}
+
+/// The real `GuestProcessLauncher`, wrapping `LinuxContainer.exec` — one instance per
+/// `LinuxContainer`, constructed by `ContainerizationControl.startWorkersDev` alongside the
+/// container itself.
+struct LinuxContainerProcessLauncher: GuestProcessLauncher {
+    let container: LinuxContainer
+
+    func launch(
+        id: String,
+        argv: [String],
+        environment: [String: String],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> any GuestProcessHandle {
+        let stdoutSink = LineStreamingWriter(stream: .stdout, onLine: onOutput)
+        let stderrSink = LineStreamingWriter(stream: .stderr, onLine: onOutput)
+        let proc = try await container.exec(id) { config in
+            config.arguments = argv
+            config.environmentVariables =
+                ["PATH=\(LinuxProcessConfiguration.defaultPath)"]
+                + environment.map { "\($0.key)=\($0.value)" }
+            config.stdout = stdoutSink
+            config.stderr = stderrSink
+        }
+        return LinuxProcessHandle(process: proc, stdoutSink: stdoutSink, stderrSink: stderrSink)
+    }
+}
+
+private struct LinuxProcessHandle: GuestProcessHandle {
+    let process: LinuxProcess
+    let stdoutSink: LineStreamingWriter
+    let stderrSink: LineStreamingWriter
+
+    func start() async throws { try await process.start() }
+
+    func wait() async throws -> Int32 {
+        let status = try await process.wait()
+        stdoutSink.flush()
+        stderrSink.flush()
+        return status.exitCode
+    }
+
+    func kill() async throws { try await process.kill(.term) }
+    func delete() async throws { try await process.delete() }
+}
+
+/// Supervises one long-lived guest process with crash-restart, mirroring
+/// `InProcessBackend.superviseLoop`'s host-process restart-policy shape but driving a guest
+/// process via `GuestProcessLauncher` instead of a host `Process`. Generic — not specific to
+/// wrangler-dev — so a future PR could retrofit `astro`/`mcp` onto the same mechanism without a
+/// redesign, though only wrangler-dev uses it today; `astro`/`mcp` stay on the existing
+/// fire-and-forget `runDetached` path (#708 design decision — out of scope to touch them here).
+actor GuestProcessSupervisor {
+    enum State: Sendable, Equatable {
+        case running
+        case restarting(attempt: Int)
+        case stopped
+        case failed(reason: String)
+    }
+
+    private let launcher: any GuestProcessLauncher
+    private let id: String
+    private let argv: [String]
+    private let environment: [String: String]
+    private let restartPolicy: RestartPolicy
+    private let onOutput: @Sendable (String, LogCenter.Stream) -> Void
+
+    private var current: (any GuestProcessHandle)?
+    private var state: State = .stopped
+    private var observers: [UUID: AsyncStream<State>.Continuation] = [:]
+    private var isStopping = false
+    private var superviseTask: Task<Void, Never>?
+    private var generation = 0
+
+    init(
+        launcher: any GuestProcessLauncher,
+        id: String,
+        argv: [String],
+        environment: [String: String] = [:],
+        restartPolicy: RestartPolicy,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) {
+        self.launcher = launcher
+        self.id = id
+        self.argv = argv
+        self.environment = environment
+        self.restartPolicy = restartPolicy
+        self.onOutput = onOutput
+    }
+
+    func observe() -> AsyncStream<State> {
+        AsyncStream { continuation in
+            let token = UUID()
+            observers[token] = continuation
+            continuation.yield(state)
+            continuation.onTermination = { @Sendable [weak self] _ in
+                Task { await self?.removeObserver(token) }
+            }
+        }
+    }
+
+    private func removeObserver(_ token: UUID) { observers[token] = nil }
+
+    private func setState(_ new: State) {
+        state = new
+        for continuation in observers.values { continuation.yield(new) }
+    }
+
+    /// Launches the process and begins supervising it. Throws only if the *first* launch fails —
+    /// once running, crashes are handled by the restart loop internally, never by throwing back
+    /// to this call's caller.
+    func start() async throws {
+        generation += 1
+        let gen = generation
+        let handle = try await launcher.launch(id: id, argv: argv, environment: environment, onOutput: onOutput)
+        try await handle.start()
+        current = handle
+        isStopping = false
+        setState(.running)
+        superviseTask = Task { [weak self] in await self?.superviseLoop(handle: handle, generation: gen) }
+    }
+
+    /// Intentional stop — suppresses the next restart attempt. Idempotent.
+    func stop() async {
+        isStopping = true
+        generation += 1
+        if let current {
+            try? await current.kill()
+            try? await current.delete()
+        }
+        current = nil
+        superviseTask?.cancel()
+        superviseTask = nil
+        setState(.stopped)
+    }
+
+    private func superviseLoop(handle initialHandle: any GuestProcessHandle, generation gen: Int) async {
+        var handle = initialHandle
+        var attempt = 0
+        while true {
+            let exitCode = try? await handle.wait()
+            try? await handle.delete()
+            guard gen == generation, !isStopping else { return }
+            switch restartPolicy {
+            case .never:
+                setState(.failed(reason: "exited with code \(exitCode.map(String.init) ?? "unknown")"))
+                return
+            case .onCrash(let maxAttempts, let baseBackoff):
+                attempt += 1
+                guard attempt <= maxAttempts else {
+                    onOutput("[\(id)] gave up restarting after \(attempt - 1) attempt(s)", .stderr)
+                    setState(.failed(reason: "retries exhausted after \(attempt - 1) attempt(s), last exit code \(exitCode.map(String.init) ?? "unknown")"))
+                    return
+                }
+                onOutput("[\(id)] crashed (exit \(exitCode.map(String.init) ?? "unknown")), restarting (attempt \(attempt)/\(maxAttempts))", .stderr)
+                setState(.restarting(attempt: attempt))
+                let backoffSeconds = baseBackoff * pow(2.0, Double(attempt - 1))
+                try? await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
+                guard gen == generation, !isStopping else { return }
+                do {
+                    let newHandle = try await launcher.launch(id: id, argv: argv, environment: environment, onOutput: onOutput)
+                    try await newHandle.start()
+                    current = newHandle
+                    handle = newHandle
+                    setState(.running)
+                } catch {
+                    setState(.failed(reason: "relaunch failed: \(error)"))
+                    return
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test target to confirm it passes**
+
+Run: `ANGLESITE_CONTAINER_TESTS=1 swift test --package-path . --filter GuestProcessSupervisorTests`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteContainer/GuestProcessSupervisor.swift Tests/AnglesiteContainerLocalTests/GuestProcessSupervisorTests.swift
+git commit -m "feat(workers): add GuestProcessSupervisor — generic guest-process crash-restart (#708)"
+```
+
+---
+
+## Task 4: `ContainerizationControl` — real `startWorkersDev`/`stopWorkersDev`
+
+**Files:**
+- Modify: `Sources/AnglesiteContainer/ContainerizationControl.swift`
+
+**Interfaces:**
+- Consumes: `GuestProcessSupervisor`/`LinuxContainerProcessLauncher` (Task 3); `WorkerComposition.generateWranglerToml(workers:)` (existing, from PR #834); `VsockTCPProxy` (existing).
+- Produces: `ContainerizationControl.startWorkersDev(siteID:workers:onOutput:) -> URL` / `.stopWorkersDev(siteID:)` — the real conformances of Task 1's protocol methods. Task 5 (`LocalContainerSiteRuntime`) is the first real caller.
+
+This task has no separate unit-test step of its own — `ContainerizationControl` can only be exercised against a live VM (`ANGLESITE_CONTAINER_TESTS=1 ANGLESITE_CONTAINER_E2E=1`, via the probe script), which is Task 7. Verify this task by confirming the package still builds (`swift build --package-path .`) and by code review against Task 3's already-tested `GuestProcessSupervisor` contract.
+
+- [ ] **Step 1: Add the guest port constant**
+
+In `Sources/AnglesiteContainer/ContainerizationControl.swift`, near the existing port constants:
+
+```swift
+    private static let previewPort: UInt32 = 4321
+    private static let mcpPort: UInt32 = 4399
+```
+
+add:
+
+```swift
+    /// Wrangler's own conventional local-dev port.
+    private static let workersPort: UInt32 = 8787
+```
+
+- [ ] **Step 2: Extend `LiveContainers` with a supervisors dict and workers-dev proxy tracking**
+
+Replace:
+
+```swift
+actor LiveContainers {
+    private var containers: [String: LinuxContainer] = [:]
+    private var proxies: [String: [VsockTCPProxy]] = [:]
+    /// Per-site ext4 files (rootfs + initfs) to delete on teardown so disk doesn't grow per start/stop.
+    private var ext4Artifacts: [String: [URL]] = [:]
+
+    func container(for siteID: String) -> LinuxContainer? { containers[siteID] }
+
+    func store(siteID: String, container: LinuxContainer, proxies ps: [VsockTCPProxy], ext4Artifacts artifacts: [URL]) {
+        containers[siteID] = container
+        proxies[siteID] = ps
+        ext4Artifacts[siteID] = artifacts
+    }
+
+    func teardown(siteID: String) async {
+        for p in proxies[siteID] ?? [] { await p.stop() }
+        proxies[siteID] = nil
+        // Stop the VM first (releases the file handles), then remove the backing ext4 images.
+        if let c = containers[siteID] { try? await c.stop() }
+        containers[siteID] = nil
+        for url in ext4Artifacts[siteID] ?? [] {
+            try? FileManager.default.removeItem(at: url)
+        }
+        ext4Artifacts[siteID] = nil
+    }
+}
+```
+
+with:
+
+```swift
+actor LiveContainers {
+    private var containers: [String: LinuxContainer] = [:]
+    private var proxies: [String: [VsockTCPProxy]] = [:]
+    /// Per-site ext4 files (rootfs + initfs) to delete on teardown so disk doesn't grow per start/stop.
+    private var ext4Artifacts: [String: [URL]] = [:]
+    /// The workers-dev supervisor + its own proxy, present only while `startWorkersDev` has an
+    /// active session for that site — absent entirely for a static-only site.
+    private var workersDevSupervisors: [String: GuestProcessSupervisor] = [:]
+    private var workersDevProxies: [String: VsockTCPProxy] = [:]
+
+    func container(for siteID: String) -> LinuxContainer? { containers[siteID] }
+
+    func store(siteID: String, container: LinuxContainer, proxies ps: [VsockTCPProxy], ext4Artifacts artifacts: [URL]) {
+        containers[siteID] = container
+        proxies[siteID] = ps
+        ext4Artifacts[siteID] = artifacts
+    }
+
+    func storeWorkersDev(siteID: String, supervisor: GuestProcessSupervisor, proxy: VsockTCPProxy) {
+        workersDevSupervisors[siteID] = supervisor
+        workersDevProxies[siteID] = proxy
+    }
+
+    func workersDevSupervisor(for siteID: String) -> GuestProcessSupervisor? { workersDevSupervisors[siteID] }
+
+    /// Stops just the workers-dev process + its proxy for `siteID`, leaving astro/mcp/the
+    /// container itself untouched — used both for an explicit `stopWorkersDev` call and as the
+    /// first step of a full `teardown`.
+    func teardownWorkersDev(siteID: String) async {
+        if let supervisor = workersDevSupervisors[siteID] { await supervisor.stop() }
+        workersDevSupervisors[siteID] = nil
+        if let proxy = workersDevProxies[siteID] { await proxy.stop() }
+        workersDevProxies[siteID] = nil
+    }
+
+    func teardown(siteID: String) async {
+        await teardownWorkersDev(siteID: siteID)
+        for p in proxies[siteID] ?? [] { await p.stop() }
+        proxies[siteID] = nil
+        // Stop the VM first (releases the file handles), then remove the backing ext4 images.
+        if let c = containers[siteID] { try? await c.stop() }
+        containers[siteID] = nil
+        for url in ext4Artifacts[siteID] ?? [] {
+            try? FileManager.default.removeItem(at: url)
+        }
+        ext4Artifacts[siteID] = nil
+    }
+}
+```
+
+- [ ] **Step 3: Implement `startWorkersDev`/`stopWorkersDev` on `ContainerizationControl`**
+
+Add these two methods to `ContainerizationControl` (near `stop(siteID:)`):
+
+```swift
+    /// See `LocalContainerControl.startWorkersDev` for the full contract.
+    public func startWorkersDev(
+        siteID: String,
+        workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        guard let container = await live.container(for: siteID) else {
+            throw LocalContainerError.bootFailed("startWorkersDev: no live container for siteID '\(siteID)'")
+        }
+
+        // Any previously-running workers-dev session for this site is torn down first — this
+        // method also serves as the "restart with a new active set" entry point once a future
+        // Workers tab calls `LocalContainerSiteRuntime.updateActiveWorkers(_:)` (#708 design §2:
+        // this PR builds that capability even though `start()` is its only caller today).
+        await live.teardownWorkersDev(siteID: siteID)
+
+        // Ephemeral, git-ignore-free local config: lives outside /workspace/site entirely, so a
+        // transient local-dev session can never dirty the site's real, git-tracked wrangler.toml
+        // (#708 design §4). No real resource ids — Miniflare creates local-persisted D1/KV/R2
+        // stores automatically for declared bindings in --local mode.
+        let toml = try WorkerComposition.generateWranglerToml(siteName: siteID, workers: workers)
+        let configDir = "/tmp/anglesite-workers-dev/\(siteID)"
+        let configPath = "\(configDir)/wrangler.toml"
+        try await runToCompletion(container, id: "workers-dev-mkdir", onOutput: onOutput,
+            ["mkdir", "-p", configDir])
+        try await writeGuestFile(container, path: configPath, contents: toml, onOutput: onOutput)
+
+        let launcher = LinuxContainerProcessLauncher(container: container)
+        let supervisor = GuestProcessSupervisor(
+            launcher: launcher,
+            id: "workers-dev",
+            argv: ["sh", "-lc",
+                "cd /workspace/site && npx wrangler dev --local --config \(configPath) --port \(Self.workersPort)"],
+            restartPolicy: .onCrash(maxAttempts: 3, baseBackoff: 0.5),
+            onOutput: { line, stream in onOutput("[workers-dev] \(line)", stream) })
+        try await supervisor.start()
+
+        let dial: VsockDialer = { port in try await container.dialVsock(port: port) }
+        let proxy = VsockTCPProxy(
+            guestPort: Self.workersPort,
+            dial: dial,
+            onDialError: { error in onOutput("[proxy:workers-dev] dialVsock(\(Self.workersPort)) failed: \(error)", .stderr) },
+            onEvent: { event in onOutput("[proxy:workers-dev] \(event)", .stdout) })
+        let url: URL
+        do {
+            url = try await proxy.start()
+        } catch {
+            await supervisor.stop()
+            throw LocalContainerError.bootFailed("workers-dev proxy start failed: \(error)")
+        }
+
+        await live.storeWorkersDev(siteID: siteID, supervisor: supervisor, proxy: proxy)
+        return url
+    }
+
+    /// See `LocalContainerControl.stopWorkersDev` for the full contract.
+    public func stopWorkersDev(siteID: String) async throws {
+        await live.teardownWorkersDev(siteID: siteID)
+    }
+```
+
+- [ ] **Step 4: Add the small `writeGuestFile` helper this uses**
+
+`runToCompletion` (the existing `git clone`/`checkout` helper) only runs argv commands, no built-in way to write file contents from the host. Add a small helper near `runToCompletion`:
+
+```swift
+    /// Writes `contents` to `path` inside the guest via a one-shot `sh -c 'cat > path'` fed the
+    /// text as a heredoc-safe base64 payload (avoiding any shell-quoting/escaping surface for
+    /// `contents`, which is a generated wrangler.toml — untrusted only in the sense that it embeds
+    /// a site name, already validated by `WorkerComposition.isValidSiteName`).
+    private func writeGuestFile(
+        _ container: LinuxContainer, path: String, contents: String,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws {
+        let encoded = Data(contents.utf8).base64EncodedString()
+        try await runToCompletion(container, id: "write-\(path.replacingOccurrences(of: "/", with: "-"))",
+            onOutput: onOutput,
+            ["sh", "-c", "echo \(encoded) | base64 -d > \(path)"])
+    }
+```
+
+- [ ] **Step 5: Build the package to confirm it compiles**
+
+Run: `swift build --package-path .`
+Expected: `Build complete!` — no errors. (This target can't be unit-tested without a live VM; Task 7 is the real verification.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteContainer/ContainerizationControl.swift
+git commit -m "feat(workers): ContainerizationControl.startWorkersDev/stopWorkersDev (#708)"
+```
+
+---
+
+## Task 5: `LocalContainerSiteRuntime` — worker-awareness
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/LocalContainerSiteRuntime.swift`
+- Test: `Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerActivation.effectiveActiveIDs`/`activeDescriptors` (existing, PR #834); `SiteConfigStore`/`SiteSettings` (existing); `WorkerCatalogFetcher` (existing); `AnglesitePackage.packageRoot(fromSourceURL:)` (Task 1); `LocalContainerControl.startWorkersDev` (Task 1's protocol addition, Task 4's real implementation, Task 1's fake).
+- Produces: `LocalContainerSiteRuntime.updateActiveWorkers(_:)` (built and tested, `start()` is its only caller in this plan); `.ready(siteID:url:workersDevURL:)` populated when applicable.
+
+- [ ] **Step 1: Write the failing tests first**
+
+In `Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift`, add (adjust the exact helper names — `makeRuntime`/similar — to match this file's actual existing construction helper, found via reading the file's `start`-family tests):
+
+```swift
+    @Test("workers-dev starts when the effective active set is non-empty")
+    func startsWorkersDevWhenActiveSetNonEmpty() async throws {
+        let control = FakeLocalContainerControl(startResult: .success(Self.ok))
+        await control.startWorkersDevResult = .success(URL(string: "http://127.0.0.1:51003")!)
+        let package = try temporaryPackage()  // see Step 2 for this helper if it doesn't exist yet
+        let configStore = SiteConfigStore(configDirectory: AnglesitePackage(url: package).configURL)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+        let rt = LocalContainerSiteRuntime(
+            ref: "HEAD", control: control, mcpClient: MCPClient(supervisor: .shared),
+            workerCatalog: { [WorkerDescriptor(
+                id: "indieauth", displayName: "IndieAuth", description: "d", group: "identity",
+                binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))] })
+
+        await rt.start(siteID: "s1", siteDirectory: AnglesitePackage(url: package).sourceURL)
+
+        guard case .ready(_, _, let workersDevURL) = await rt.state else {
+            Issue.record("expected .ready, got \(await rt.state)")
+            return
+        }
+        #expect(workersDevURL == URL(string: "http://127.0.0.1:51003")!)
+        #expect(await control.startWorkersDevCalls.map(\.siteID) == ["s1"])
+    }
+
+    @Test("workers-dev does not start when the effective active set is empty")
+    func doesNotStartWorkersDevWhenActiveSetEmpty() async throws {
+        let control = FakeLocalContainerControl(startResult: .success(Self.ok))
+        let package = try temporaryPackage()
+        let rt = LocalContainerSiteRuntime(
+            ref: "HEAD", control: control, mcpClient: MCPClient(supervisor: .shared),
+            workerCatalog: { [] })
+
+        await rt.start(siteID: "s1", siteDirectory: AnglesitePackage(url: package).sourceURL)
+
+        guard case .ready(_, _, let workersDevURL) = await rt.state else {
+            Issue.record("expected .ready, got \(await rt.state)")
+            return
+        }
+        #expect(workersDevURL == nil)
+        #expect(await control.startWorkersDevCalls.isEmpty)
+    }
+
+    @Test("teardown stops workers-dev via the ordinary control.stop(siteID:) path")
+    func teardownStopsWorkersDev() async throws {
+        let control = FakeLocalContainerControl(startResult: .success(Self.ok))
+        await control.startWorkersDevResult = .success(URL(string: "http://127.0.0.1:51003")!)
+        let package = try temporaryPackage()
+        let configStore = SiteConfigStore(configDirectory: AnglesitePackage(url: package).configURL)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["indieauth"]))
+        let rt = LocalContainerSiteRuntime(
+            ref: "HEAD", control: control, mcpClient: MCPClient(supervisor: .shared),
+            workerCatalog: { [WorkerDescriptor(
+                id: "indieauth", displayName: "IndieAuth", description: "d", group: "identity",
+                binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))] })
+
+        await rt.start(siteID: "s1", siteDirectory: AnglesitePackage(url: package).sourceURL)
+        await rt.stop()
+
+        // stopWorkersDev is not called directly — teardown relies on the same control.stop(siteID:)
+        // call it already makes, which (per Task 4) tears down workers-dev too. This test documents
+        // that expectation against the fake, which only records `stop`, not `stopWorkersDev`.
+        #expect(await control.stopped == ["s1"])
+    }
+```
+
+- [ ] **Step 2: Confirm/add the `temporaryPackage()` helper if this test file doesn't already have one**
+
+Check `Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift` for an existing `temporaryPackage()`/similar helper (other test files in this plan's earlier task, e.g. `SiteOperationsTests.swift`, already have one — mirror it exactly if this file needs its own):
+
+```swift
+    private func temporaryPackage() throws -> URL {
+        let package = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalContainerSiteRuntimeTests-\(UUID().uuidString).anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: AnglesitePackage(url: package).sourceURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: AnglesitePackage(url: package).configURL, withIntermediateDirectories: true)
+        return package
+    }
+```
+
+- [ ] **Step 3: Run the test target to confirm it fails to compile**
+
+Run: `swift test --package-path . --filter LocalContainerSiteRuntimeTests`
+Expected: **build error** — `extra argument 'workerCatalog' in call` (the initializer doesn't accept it yet) and `.ready` pattern-match arity errors in the new tests.
+
+- [ ] **Step 4: Add worker-awareness to `LocalContainerSiteRuntime`**
+
+Add the new init parameter. Replace:
+
+```swift
+        suddenTerminationController: SuddenTerminationController = .shared,
+        beginActivity: @escaping @Sendable (String) -> ActivityAssertion.Lease = ActivityAssertion.begin
+    ) {
+        self.ref = ref
+        self.control = control
+        self.mcpClient = mcpClient
+        self.knowledgeIndex = knowledgeIndex
+        self.semanticRanker = semanticRanker
+        self.conventionsEngine = conventionsEngine
+        self.logCenter = logCenter
+        self.connect = connect
+        self.makeFileWatcher = makeFileWatcher
+        self.importBundle = importBundle
+        self.suddenTerminationController = suddenTerminationController
+        self.beginActivity = beginActivity
+    }
+```
+
+with:
+
+```swift
+        suddenTerminationController: SuddenTerminationController = .shared,
+        beginActivity: @escaping @Sendable (String) -> ActivityAssertion.Lease = ActivityAssertion.begin,
+        workerCatalog: @escaping @Sendable () async -> [WorkerDescriptor] = {
+            await WorkerCatalogFetcher(catalogURL: WorkerCatalogFetcher.productionCatalogURL).catalog()
+        }
+    ) {
+        self.ref = ref
+        self.control = control
+        self.mcpClient = mcpClient
+        self.knowledgeIndex = knowledgeIndex
+        self.semanticRanker = semanticRanker
+        self.conventionsEngine = conventionsEngine
+        self.logCenter = logCenter
+        self.connect = connect
+        self.makeFileWatcher = makeFileWatcher
+        self.importBundle = importBundle
+        self.suddenTerminationController = suddenTerminationController
+        self.beginActivity = beginActivity
+        self.workerCatalog = workerCatalog
+    }
+```
+
+and add the stored property alongside the other `private let` closures near the top of the actor:
+
+```swift
+    private let workerCatalog: @Sendable () async -> [WorkerDescriptor]
+```
+
+Now wire it into `start()`. Replace:
+
+```swift
+            loadedKnowledgeSiteID = siteID
+            startFileWatcher(siteID: siteID, projectRoot: siteDirectory, generation: gen)
+            activeSiteID = siteID
+            activeSiteDirectory = siteDirectory
+            containerTerminationLease = suddenTerminationLease
+            activityLease.release()
+            setState(.ready(siteID: siteID, url: session.previewURL))
+```
+
+with:
+
+```swift
+            loadedKnowledgeSiteID = siteID
+            startFileWatcher(siteID: siteID, projectRoot: siteDirectory, generation: gen)
+            activeSiteID = siteID
+            activeSiteDirectory = siteDirectory
+            containerTerminationLease = suddenTerminationLease
+            activityLease.release()
+
+            // Local wrangler-dev (#708): computed once here, not wired to a live Settings
+            // toggle yet (no Workers tab exists to trigger one — #700c). A start failure here
+            // degrades to `workersDevURL: nil` rather than failing the whole runtime — wrangler-
+            // dev is an add-on capability, unlike the MCP connection above.
+            let workersDevURL = await self.startWorkersDevIfActive(siteID: siteID, siteDirectory: siteDirectory)
+            guard gen == generation else { await abandonSupersededAttempt(); return }
+            setState(.ready(siteID: siteID, url: session.previewURL, workersDevURL: workersDevURL))
+```
+
+Add the new private helper and the public `updateActiveWorkers(_:)` (built per the design doc's §2 scope decision — tested directly, `start()` is its only caller) near `resetNetworking()`:
+
+```swift
+    /// Computes the site's effective active-worker set (mirroring `DeployModel.runDeploy`'s own
+    /// pipeline) and starts local `wrangler dev` if it's non-empty. Returns `nil` on any failure —
+    /// logged, never thrown — or when there are no active workers. #708 design §7/§6: a settings-
+    /// activated worker reliably resolves here; a component-tied worker may not, if this site's
+    /// `SiteGraphExplorerSnapshot` hasn't been populated yet (accepted thin-slice limitation, not
+    /// solved by this PR — see the design doc §6).
+    private func startWorkersDevIfActive(siteID: String, siteDirectory: URL) async -> URL? {
+        let configDirectory = AnglesitePackage(url: AnglesitePackage.packageRoot(fromSourceURL: siteDirectory)).configURL
+        let settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+        let catalog = await workerCatalog()
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
+        guard !workers.isEmpty else { return nil }
+        do {
+            return try await control.startWorkersDev(
+                siteID: siteID, workers: workers,
+                onOutput: { [weak self] line, stream in
+                    Task { await self?.appendBootLog(line, stream) }
+                })
+        } catch {
+            await logCenter.append(
+                source: "container:\(siteID)", stream: .stderr,
+                text: "local wrangler-dev failed to start: \(error) — active workers will have no local dev endpoint this session")
+            return nil
+        }
+    }
+
+    /// `startWorkersDevIfActive`'s `onOutput` needs an actor-isolated sink for lines that may
+    /// arrive after `start()` itself has returned (wrangler-dev keeps running for the session's
+    /// lifetime) — appends directly to `logCenter` rather than routing through the boot-log
+    /// stream/continuation, which is intentionally finished once `start()` settles.
+    private func appendBootLog(_ line: String, _ stream: LogCenter.Stream) async {
+        guard let siteID = activeSiteID else { return }
+        await logCenter.append(source: "container:\(siteID)", stream: stream, text: line)
+    }
+
+    /// Recomputes the effective active-worker set and restarts local wrangler-dev to match — the
+    /// capability a future Workers tab (#700c) calls on toggle. Not called anywhere in this PR
+    /// besides `start()`'s own initial computation (#708 design §2) — built and tested now so
+    /// #700c needs no further runtime-side work.
+    public func updateActiveWorkers(_ settings: SiteSettings) async {
+        guard let siteID = activeSiteID, let siteDirectory = activeSiteDirectory else { return }
+        let catalog = await workerCatalog()
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: nil)
+        let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
+        let workersDevURL: URL?
+        if workers.isEmpty {
+            try? await control.stopWorkersDev(siteID: siteID)
+            workersDevURL = nil
+        } else {
+            workersDevURL = await startWorkersDevIfActive(siteID: siteID, siteDirectory: siteDirectory)
+        }
+        if case .ready(let readySiteID, let url, _) = current, readySiteID == siteID {
+            setState(.ready(siteID: readySiteID, url: url, workersDevURL: workersDevURL))
+        }
+    }
+```
+
+Note: `startWorkersDevIfActive` re-derives the effective set from disk rather than accepting it as a parameter, so `updateActiveWorkers(_:)` can call it too without duplicating the settings→descriptors pipeline — the `settings` parameter to `updateActiveWorkers` is accepted for a future caller's convenience (a Workers tab that just saved new settings and wants to push them immediately) but this method still re-reads the catalog itself; only `graph: nil` is a shared simplification with `start()`, consistent with the design doc's accepted component-tied limitation.
+
+- [ ] **Step 5: Run the test target**
+
+Run: `swift test --package-path . --filter LocalContainerSiteRuntimeTests`
+Expected: PASS — all pre-existing tests unaffected (the new `workerCatalog` param defaults to a real fetch only reachable in production, but existing tests never inspect `workersDevURL` and default-construct without it, so `.ready(siteID:url:)`-shaped `#expect` comparisons still compile and pass against a `.ready(...)` value whose `workersDevURL` is `nil` on both sides — unless a pre-existing test's `workerCatalog` default triggers a real network call. Check this specifically: if any pre-existing test doesn't inject `workerCatalog: { [] }` explicitly, its `start()` call will invoke the REAL `WorkerCatalogFetcher` default, doing a live network fetch in a unit test — unacceptable. If so, this step must add `workerCatalog: { [] }` to every pre-existing `LocalContainerSiteRuntime(...)` test construction as part of this step, not skip it.)
+
+Run: `grep -n "LocalContainerSiteRuntime(" Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift` and add `workerCatalog: { [] }` to every construction this step's grep finds that doesn't already specify one, before considering this step done.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LocalContainerSiteRuntime.swift Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+git commit -m "feat(workers): LocalContainerSiteRuntime starts local wrangler-dev when workers are active (#708)"
+```
+
+---
+
+## Task 6: AnglesiteApp — fix pattern-match sites, expose `workersDevURL`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/PreviewModel.swift:312`
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:754`
+- Modify: `Sources/AnglesiteApp/StartupProgressModel.swift:42`
+
+**Interfaces:**
+- Consumes: `SiteRuntimeState.ready(siteID:url:workersDevURL:)` (Task 1).
+- Produces: `PreviewModel.workersDevURL: URL?` — no consumer yet in this plan (no Workers tab/debug UI to show it), but the accessor exists so one doesn't need retrofitting later, mirroring `readyURL`'s exact pattern.
+
+- [ ] **Step 1: Fix the three pattern-match sites (mechanical — none of these three need the new value, they only need to keep compiling)**
+
+In `Sources/AnglesiteApp/StartupProgressModel.swift`, replace:
+```swift
+        case .ready(let id, _):
+```
+with:
+```swift
+        case .ready(let id, _, _):
+```
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, replace:
+```swift
+        case .ready(_, let url):
+```
+with:
+```swift
+        case .ready(_, let url, _):
+```
+
+- [ ] **Step 2: Add `PreviewModel.workersDevURL`, updating the one site that should extract the new value**
+
+In `Sources/AnglesiteApp/PreviewModel.swift`, replace:
+
+```swift
+    /// The ready preview URL, if the session is currently `.ready`.
+    var readyURL: URL? {
+        if case .ready(_, let url) = state { return url }
+        return nil
+    }
+```
+
+with:
+
+```swift
+    /// The ready preview URL, if the session is currently `.ready`.
+    var readyURL: URL? {
+        if case .ready(_, let url, _) = state { return url }
+        return nil
+    }
+
+    /// The local `wrangler dev --local` endpoint, if the session is `.ready` and the site has an
+    /// active worker (#708). `nil` for a static-only site — no debug-panel consumer exists yet
+    /// (no Workers tab, #700c), so this is currently unread outside tests, but the accessor
+    /// mirrors `readyURL`'s exact pattern so a future consumer needs no runtime changes.
+    var workersDevURL: URL? {
+        if case .ready(_, _, let workersDevURL) = state { return workersDevURL }
+        return nil
+    }
+```
+
+- [ ] **Step 3: Build the app target**
+
+Run: `xcodegen generate` (if `Anglesite.xcodeproj` doesn't exist in this worktree yet), then:
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PreviewModel.swift Sources/AnglesiteApp/SiteWindow.swift Sources/AnglesiteApp/StartupProgressModel.swift
+git commit -m "feat(workers): thread workersDevURL through AnglesiteApp's runtime-state consumers (#708)"
+```
+
+---
+
+## Task 7: End-to-end verification
+
+**Files:**
+- Modify: `Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift`
+- Modify: `Sources/AnglesiteContainerProbe/main.swift`
+- Modify: `scripts/run-container-probe.sh`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-6.
+- Produces: a real, live-VM-backed proof that a booted container with an active worker serves a reachable `wrangler dev --local` endpoint — the human-run verification gate this whole feature needs, since neither CI nor a bare `swift test` can carry the virtualization entitlement.
+
+- [ ] **Step 1: Add the e2e test case to `ContainerizationControlTests.swift`**
+
+Read the existing `bootsAndServes` test in this file first (it's this suite's closest sibling — same throwaway-repo/HTTP-poll shape) and add a new case following its exact structure:
+
+```swift
+    @Test("startWorkersDev boots a reachable local wrangler-dev endpoint for an active worker")
+    func startsWorkersDevForActiveWorker() async throws {
+        try #require(enabled)  // this file's existing ANGLESITE_CONTAINER_E2E runtime gate
+        let siteID = "workers-dev-e2e"
+        let control = ContainerizationControl()
+        let repo = try makeThrowawayAstroRepo()  // this file's existing helper
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let session = try await control.start(siteID: siteID, sourceRepo: repo, ref: "HEAD", onOutput: { _, _ in })
+        defer { Task { try? await control.stop(siteID: siteID) } }
+
+        let workers = [WorkerDescriptor(
+            id: "indieauth", displayName: "IndieAuth", description: "d", group: "identity",
+            binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))]
+        let workersDevURL = try await control.startWorkersDev(siteID: siteID, workers: workers, onOutput: { _, _ in })
+
+        let ok = await pollForHTTPResponse(workersDevURL, timeout: .seconds(60))  // this file's existing helper
+        #expect(ok, "wrangler dev --local never answered within the timeout")
+    }
+```
+
+(`enabled`/`makeThrowawayAstroRepo`/`pollForHTTPResponse` — confirm the exact existing helper names in this file at implementation time and reuse them verbatim; do not reintroduce duplicates.)
+
+- [ ] **Step 2: Add the `workers-dev` subcommand to the probe**
+
+In `Sources/AnglesiteContainerProbe/main.swift`, replace:
+
+```swift
+        switch subcommand {
+        case "echo":
+            exitCode = await runEcho()
+        case "boot":
+            exitCode = await runBoot()
+        default:
+            FileHandle.standardError.write(Data("unknown subcommand '\(subcommand)' (expected echo|boot)\n".utf8))
+            exitCode = 2
+        }
+```
+
+with:
+
+```swift
+        switch subcommand {
+        case "echo":
+            exitCode = await runEcho()
+        case "boot":
+            exitCode = await runBoot()
+        case "workers-dev":
+            exitCode = await runWorkersDev()
+        default:
+            FileHandle.standardError.write(Data("unknown subcommand '\(subcommand)' (expected echo|boot|workers-dev)\n".utf8))
+            exitCode = 2
+        }
+```
+
+and add a new method mirroring `runBoot()`'s exact shape:
+
+```swift
+    // MARK: - workers-dev
+
+    /// Mirrors `ContainerizationControlTests.startsWorkersDevForActiveWorker`: boot a container,
+    /// start local wrangler-dev for one active (fixture) worker, poll its URL for a live HTTP
+    /// response. The #708 local-runtime feature's own decision gate.
+    private static func runWorkersDev() async -> Int32 {
+        let siteID = "workers-dev-probe"
+        let control = ContainerizationControl()
+
+        let repo: URL
+        do {
+            repo = try makeThrowawayAstroRepo()
+        } catch {
+            print("WORKERS-DEV: FAIL — could not create throwaway Astro repo: \(error)")
+            return 1
+        }
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        do {
+            _ = try await control.start(siteID: siteID, sourceRepo: repo, ref: "HEAD", onOutput: logLine)
+        } catch {
+            print("WORKERS-DEV: FAIL — control.start threw: \(error)")
+            return 1
+        }
+
+        let workers = [WorkerDescriptor(
+            id: "indieauth", displayName: "IndieAuth", description: "probe fixture", group: "identity",
+            binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))]
+        let workersDevURL: URL
+        do {
+            workersDevURL = try await control.startWorkersDev(siteID: siteID, workers: workers, onOutput: logLine)
+        } catch {
+            print("WORKERS-DEV: FAIL — control.startWorkersDev threw: \(error)")
+            try? await control.stop(siteID: siteID)
+            return 1
+        }
+
+        let ok = await pollForHTTPResponse(workersDevURL, timeout: .seconds(60))
+        try? await control.stop(siteID: siteID)
+
+        guard ok else {
+            print("WORKERS-DEV: FAIL — \(workersDevURL) never answered within the timeout")
+            return 1
+        }
+
+        print("WORKERS-DEV: PASS")
+        return 0
+    }
+```
+
+- [ ] **Step 3: Update `scripts/run-container-probe.sh`'s subcommand list**
+
+Replace:
+
+```sh
+SUBCOMMAND="${1:-}"
+case "${SUBCOMMAND}" in
+    echo|boot) ;;
+    *)
+        echo "usage: $(basename "$0") <echo|boot>" >&2
+        exit 2
+        ;;
+esac
+```
+
+with:
+
+```sh
+SUBCOMMAND="${1:-}"
+case "${SUBCOMMAND}" in
+    echo|boot|workers-dev) ;;
+    *)
+        echo "usage: $(basename "$0") <echo|boot|workers-dev>" >&2
+        exit 2
+        ;;
+esac
+```
+
+and update the script's own header comment (the `Usage:` block near the top) to list `workers-dev` alongside `echo`/`boot`.
+
+- [ ] **Step 4: Attempt the probe run**
+
+Run: `scripts/run-container-probe.sh workers-dev`
+Expected: `WORKERS-DEV: PASS`. **If this sandboxed execution environment cannot boot a real VM** (nested virtualization is frequently unavailable inside a CI/agent sandbox, unlike a real entitled Mac), this step will fail for reasons unrelated to the code — report that explicitly rather than treating a sandbox limitation as a code bug, and flag to the user that they need to run this command themselves on a real Mac before merging, per CLAUDE.md's "the app cannot bypass" spirit applied to this verification gate.
+
+- [ ] **Step 5: Full verification**
+
+Run: `swift test --package-path .` (expect PASS, modulo the known unrelated `GenerableTypesTests` FM flake)
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (expect `** BUILD SUCCEEDED **`)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift Sources/AnglesiteContainerProbe/main.swift scripts/run-container-probe.sh
+git commit -m "test(workers): e2e coverage + probe subcommand for local wrangler-dev (#708)"
+```
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(workers): local wrangler-dev runtime in LocalContainerSiteRuntime (#708)" --body "$(cat <<'EOF'
+## Summary
+- Adds a local `wrangler dev --local` guest process to `LocalContainerSiteRuntime`, started only when a site's effective active-worker set is non-empty — the last of #708's three prerequisites.
+- New generic `GuestProcessSupervisor` (`Sources/AnglesiteContainer/GuestProcessSupervisor.swift`) gives it real crash-restart, the first guest process in this codebase to have that — mirrors `InProcessBackend`'s host-process `RestartPolicy` shape.
+- Additive-only surface: `SiteRuntimeState.ready`/`LocalContainerSession` both gain an optional `workersDevURL`; `LocalContainerControl` gains `startWorkersDev`/`stopWorkersDev`. No `SiteRuntime` protocol change.
+- `wrangler` becomes a template devDependency (no Dockerfile change, no paired sidecar PR).
+- Design doc: `docs/superpowers/specs/2026-07-20-local-wrangler-dev-runtime-design.md`.
+
+**Known, accepted thin-slice limitations** (see design doc §2/§6):
+- No live-toggle-restart caller yet — `updateActiveWorkers(_:)` is built and tested, but only `start()` calls it; the Workers tab (#700c) becomes its second caller later.
+- Component-tied worker detection needs a populated `SiteGraphExplorerSnapshot`, likely not yet scanned when a site window first opens — a settings-activated worker reliably starts; a component-tied one may not, this session.
+- `astro`/`mcp` are not retrofitted onto `GuestProcessSupervisor` — they stay on the existing `runDetached` path.
+
+## Paired PR check
+- [x] This change is **self-contained** to `Anglesite-app`.
+- [ ] This change **needs a paired PR** in `Anglesite/anglesite`.
+
+> No MCP schema change — only consumes existing `WorkerDescriptor`/`WorkerComposition` from PR #834.
+
+## Test plan
+- [x] `swift test --package-path .`
+- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+- [ ] `scripts/run-container-probe.sh workers-dev` — **requires a real entitled Mac**, not this sandboxed environment; run before merging.
+EOF
+)"
+```
+
+- [ ] **Step 8: Close out #708**
+
+Once this PR merges, close #708 (all three prerequisites done) and remove the `🛠️ In Progress` label if still present.

--- a/docs/superpowers/specs/2026-07-20-local-wrangler-dev-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-20-local-wrangler-dev-runtime-design.md
@@ -1,0 +1,85 @@
+# Local `wrangler dev` runtime — design
+
+**Issue:** [#708](https://github.com/Anglesite/Anglesite-app/issues/708) (last of its three prerequisites — the other two shipped in PR #834)
+**Governing spec:** [`docs/superpowers/specs/2026-07-13-workers-local-debugging-design.md`](2026-07-13-workers-local-debugging-design.md) §7 ("Local runtime (700a)")
+**Date:** 2026-07-20
+**Status:** Approved
+
+## 1. Problem
+
+A site's Cloudflare Worker composes `@dwk/workers` packages (webmention, indieauth, micropub, etc.) behind the site's static assets. Today the only way to see that Worker run at all is a real Cloudflare deploy — there is no local dev/debug path. This design adds a local `wrangler dev --local` (Miniflare-backed, no real Cloudflare account calls) process inside `LocalContainerSiteRuntime`, as a third guest process alongside the existing `astro dev` + MCP sidecar, so a site's active workers can be exercised entirely offline before ever deploying.
+
+## 2. Scope
+
+**In scope:** starting/stopping a local `wrangler dev` process tied to a site's currently-active worker set, computed once when a site's preview session opens; a real, generic, crash-restart-capable guest-process supervisor (not a one-off for this feature); the proxied URL reaching `LocalContainerSiteRuntime`'s public state.
+
+**Out of scope (explicitly deferred, not silently missing):**
+- **Live restart on toggle.** The design doc's "toggling a worker in the Workers tab restarts the local session" requirement has no real caller yet — the Workers tab (#700c) doesn't exist. This slice builds the underlying `updateActiveWorkers(_:)` capability and tests it directly, but `start()` is its only caller. #700c becomes the second caller later with no further runtime-side work needed.
+- **Retrofitting `astro`/`mcp` onto the new crash-restart supervisor.** They stay on the existing `runDetached` fire-and-forget path. The supervisor's API is designed generically so a future PR *can* retrofit them, but doing so here would be an unrelated drive-by change (CONTRIBUTING.md: focused PRs).
+- **A UI status indicator for wrangler-dev's running/restarting/failed state.** There's no Workers tab to show it in yet. The state is still exposed as an `AsyncStream` (see §5) so a future UI doesn't need retrofitting, but nothing consumes it in this PR beyond driving restart decisions and debug-pane log lines.
+- **Component-tied worker detection at session-open time** — see the accepted limitation in §6.
+
+## 3. Making `wrangler` available inside the container
+
+`wrangler` is not a dependency anywhere in `Resources/Template/package.json` today, and the container image's Dockerfile has no explicit `npm install -g wrangler` either — but the image already bakes a full `npm ci` (not `--omit=dev`) of whatever the template's `package.json`/`package-lock.json` declare, via the same pre-baked-`node_modules`-tarball path `astro`/`tsx`/etc. already ride. So: **add `wrangler` as a new `devDependency` in `Resources/Template/package.json`.** No Dockerfile change, no paired sidecar PR (template changes are app-only per CLAUDE.md). The existing `anglesite-hydrate` step picks it up automatically the next time the vendored image is rebuilt.
+
+## 4. Local-only `wrangler.toml`
+
+`wrangler dev --local` needs a `wrangler.toml`, but the site's real one lives in the git-tracked `Source/wrangler.toml` — a transient local-dev session must never dirty that file, and per explicit product decision, **local dev must work fully before the user has ever deployed**, reflecting whatever worker toggles are active *right now*, not whatever was last deployed.
+
+Resolution: generate an ephemeral, git-ignored `wrangler.toml` variant inside the guest on every wrangler-dev (re)start, via the existing `WorkerComposition.generateWranglerToml(workers:)` — with no real resource IDs, since Miniflare creates local-persisted D1/KV/R2 stores automatically for declared bindings in `--local` mode. `wrangler dev --local --config <ephemeral-path> --port 8787` points at it. The exact ephemeral path (e.g. a location under `/workspace/site/.anglesite-local/`) and its `.gitignore` entry are plan-level detail, not a design fork.
+
+## 5. Type and protocol surface
+
+Three additive changes, chosen to avoid breaking any existing conformer or call site:
+
+- **`LocalContainerSession`** gains `workersDevURL: URL? = nil`. Every existing construction in tests/production uses keyword args, so this is fully source-compatible.
+- **`SiteRuntimeState.ready`** gains the same `workersDevURL: URL? = nil` as a new associated value — additive per the governing spec's own architecture note ("extending `SiteRuntimeState` rather than changing the `SiteRuntime` protocol's shape"). This *does* touch every `case .ready(let siteID, let url)`-shaped pattern match across the app and test suites (Swift requires updating the pattern itself, not just construction sites) — the exact enumeration of those call sites is plan-level work, not a design decision, since there's no ambiguity in what needs to happen at each one (add the new binding or ignore it).
+- **`LocalContainerControl` protocol** gains two new methods, called only *after* the main `start()` has already succeeded — a second, independent lifecycle nested inside the container's own, not part of boot:
+  ```swift
+  func startWorkersDev(siteID: String, workers: [WorkerDescriptor], onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void) async throws -> URL
+  func stopWorkersDev(siteID: String) async throws
+  ```
+  `startWorkersDev` writes the ephemeral `wrangler.toml` (§4), launches `wrangler dev --local` as a *supervised* guest process (§6), wires a fourth `VsockTCPProxy` the same way `previewProxy`/`mcpProxy` already work, and returns the proxied host URL. `stopWorkersDev` tears down that one process + its proxy, independent of astro/mcp.
+
+Since these two methods live on the public `LocalContainerControl` protocol (not the internal `runDetached`/`exec` helpers), only `ContainerizationControl` (the real conformer) and `FakeLocalContainerControl` (the test double) need them — no existing test that never calls them is affected.
+
+## 6. Guest-process supervisor (`GuestProcessSupervisor`)
+
+Lives in `Sources/AnglesiteContainer/` (needs Apple's Containerization types — `LinuxContainer`/`LinuxProcess` — which the Linux-portable `AnglesiteCore` target can't import). Reuses `RestartPolicy`/`ProcessExitReason` from `AnglesiteCore/SupervisorBackend.swift` directly rather than redefining them — same enum, same semantics as the existing host-process supervisor (`InProcessBackend`), just driving a guest `LinuxProcess` instead of a host `Process`.
+
+**Mechanics**, mirroring `InProcessBackend.superviseLoop`'s existing shape:
+1. `start()` execs and starts the guest process, then spawns a detached background `Task` that loops on `proc.wait()`.
+2. When `wait()` returns: if the exit was an intentional `stop()` (a flag set before killing it), the loop exits cleanly, no restart. Otherwise, `RestartPolicy` is consulted exactly like the host-side version — `.onCrash(maxAttempts:baseBackoff:)` backs off, re-execs a fresh process, and gives up (logging a stderr line into the debug pane — "logs are sacred") once attempts are exhausted. Default policy mirrors `AstroDevServer`'s own restart-on-crash default (`maxAttempts: 3, baseBackoff: 0.5`) for consistency between the two dev-process kinds sharing a container.
+3. **State is exposed as an `AsyncStream`, mirroring `SiteRuntime.observe()`'s pattern** (`running` / `restarting(attempt:)` / `stopped` / `failed(reason:)`), even though nothing consumes it in this PR — so a future debug-panel status indicator doesn't need the supervisor retrofitted later.
+
+**Ownership:** `ContainerizationControl.startWorkersDev(...)` constructs one supervisor per site, stored in `LiveContainers` alongside the existing `containers`/`proxies` dictionaries. `LiveContainers.teardown(siteID:)` calls the supervisor's `stop()` *before* `container.stop()`, so its background loop can't try to relaunch a process into a container that's already going down.
+
+**Designed generically now, used narrowly:** the API doesn't assume anything wrangler-dev-specific (argv, environment, restart policy are all parameters) — a future PR *could* retrofit `astro`/`mcp` onto it, but that retrofit is explicitly out of scope here (§2).
+
+## 7. Activation wiring
+
+`LocalContainerSiteRuntime.start()` computes the effective active-worker set *internally* — no `SiteRuntime` protocol change. It loads `SiteConfigStore` from the site's `Config/` directory (derived from the package layout the same way other call sites already do), does a live catalog fetch with cache-fallback (matching `DeployModel`'s GUI-path precedent — a live fetch, not the headless path's cached-only read, since this is a GUI session opening and freshest data is available), and runs it through the same `WorkerActivation.effectiveActiveIDs` / `activeDescriptors` pipeline `DeployModel` already uses. If the resulting set is non-empty, `startWorkersDev` is called after the container is otherwise ready; if empty, nothing starts (matching the governing spec's "started on demand, not unconditionally" requirement).
+
+The runtime also gains a `updateActiveWorkers(_:)` method with the same start/stop/restart logic, built and tested directly — but `start()` is its only caller in this PR (§2).
+
+**Known, accepted limitation:** component-tied worker detection needs a populated `SiteGraphExplorerSnapshot`, which likely isn't scanned yet the moment a site window first opens (it's populated lazily elsewhere, e.g. by the Graph Explorer tab). A **settings-activated** worker (toggled on in Settings) reliably starts its local wrangler-dev at session open; a **component-tied** worker might not, if the graph hasn't populated in time — and, combined with no live-toggle-restart wiring yet, might not start at all during that session. This mirrors the existing accepted "never invents, may under-report" bias `WorkerActivation.effectiveActiveIDs` already documents for headless deploys, surfacing in a new place. Explicitly accepted as a thin-slice tradeoff, not something this PR solves (e.g. by triggering a graph scan as part of `start()`).
+
+## 8. Container-side details
+
+Guest port: wrangler's own conventional local-dev port, `8787`. Proxied via a fourth `VsockTCPProxy`, exactly like the existing preview/mcp proxies (`LiveContainers.teardown` already iterates its `proxies` array generically — no teardown-path change needed for a third entry). Output streams into the same `LogCenter` source the container's other processes already use, with its own line-label prefix so it's visually distinguishable in the debug pane, matching the existing `[astro]`/`[mcp]` convention.
+
+## 9. Testing
+
+- **Unit:** `FakeLocalContainerControl` gains the two new methods (mirroring its existing `exec`-call-recording shape) for `LocalContainerSiteRuntimeTests` to drive — new cases: wrangler-dev starts when the effective set is non-empty, doesn't start when empty, `.ready`'s `workersDevURL` populates once available, teardown calls `stopWorkersDev`.
+- **`GuestProcessSupervisor`:** its own dedicated unit-test suite covering the restart-policy state machine (crash → restart → give-up, intentional stop suppresses restart), against a fake/injectable process-launch seam — exact shape is plan-level detail, following this container target's existing test-double conventions.
+- **End-to-end:** a new case in the existing `ANGLESITE_CONTAINER_TESTS=1 ANGLESITE_CONTAINER_E2E=1`-gated `ContainerizationControlTests` suite — boot with an active worker, assert the workers-dev URL answers HTTP. Per the governing spec's own §9 testing note.
+- **Human-run verification gate:** `scripts/run-container-probe.sh` gains a third subcommand (`workers-dev`), mirroring the existing `boot` subcommand's HTTP-poll pattern — this is how a human, not CI, verifies the new guest process actually boots and is reachable (CI can never carry the virtualization entitlement `swift test` would need).
+
+## 10. Open items carried into the implementation plan (not design forks — mechanical detail)
+
+- Exact ephemeral `wrangler.toml` path and its `.gitignore` entry.
+- Every `.ready(siteID:url:)` pattern-match call site that needs updating for the new associated value.
+- The exact existing log-line-prefixing mechanism (`runDetached`'s `label:` param vs. elsewhere) to mirror for wrangler-dev's own prefix.
+- `LocalContainerSiteRuntime`'s exact derivation of a site's `Config/` directory from its package layout (reuse an existing `AnglesiteSiteModel` helper rather than hand-rolling path arithmetic).
+- The `GuestProcessSupervisor` test seam over `LinuxContainer.exec`.

--- a/scripts/run-container-probe.sh
+++ b/scripts/run-container-probe.sh
@@ -11,8 +11,9 @@
 # process that really is entitled.
 #
 # Usage:
-#   scripts/run-container-probe.sh echo   # THE Task 4b decision gate (vsock round-trip)
-#   scripts/run-container-probe.sh boot    # Task 5's gate (full boot + preview HTTP poll)
+#   scripts/run-container-probe.sh echo         # THE Task 4b decision gate (vsock round-trip)
+#   scripts/run-container-probe.sh boot         # Task 5's gate (full boot + preview HTTP poll)
+#   scripts/run-container-probe.sh workers-dev  # #708's gate (boot + local wrangler-dev HTTP poll)
 #
 # The boot probe is also the #715 concurrent-vmnet regression gate. Before running it, use
 # `container network create anglesite-715-regression` to hold a second vmnet shared-mode network;
@@ -31,9 +32,9 @@ cd "${ROOT_DIR}"
 
 SUBCOMMAND="${1:-}"
 case "${SUBCOMMAND}" in
-    echo|boot) ;;
+    echo|boot|workers-dev) ;;
     *)
-        echo "usage: $(basename "$0") <echo|boot>" >&2
+        echo "usage: $(basename "$0") <echo|boot|workers-dev>" >&2
         exit 2
         ;;
 esac


### PR DESCRIPTION
## Summary

Stacked on #834 (this PR's base branch) — adds the last of #708's three prerequisites: a local `wrangler dev --local` guest process inside `LocalContainerSiteRuntime`, started only when a site's effective active-worker set is non-empty.

- Design doc: `docs/superpowers/specs/2026-07-20-local-wrangler-dev-runtime-design.md`
- Implementation plan: `docs/superpowers/plans/2026-07-20-local-wrangler-dev-runtime.md`

**What shipped:**
- Additive-only type/protocol surface: `SiteRuntimeState.ready`/`LocalContainerSession` both gain an optional `workersDevURL`; `LocalContainerControl` gains `startWorkersDev`/`stopWorkersDev`. No `SiteRuntime` protocol change.
- `wrangler` added as a `Resources/Template/package.json` devDependency (no Dockerfile change, no paired sidecar PR — the existing hydrate/pre-baked-`node_modules` path picks it up the same way `astro`/`tsx` already are).
- New `GuestProcessSupervisor` (`Sources/AnglesiteContainer/GuestProcessSupervisor.swift`) — a generic, reusable crash-restart component for guest processes, mirroring `InProcessBackend`'s host-process `RestartPolicy` shape but driving a guest `LinuxProcess`. The first guest process in this codebase to get real crash-restart (`astro`/`mcp` remain fire-and-forget, unchanged, per the design's explicit scope decision).
- Real `ContainerizationControl.startWorkersDev`/`stopWorkersDev`: writes an ephemeral, git-ignore-free `wrangler.toml` outside `/workspace/site` (so local dev works fully before a site has ever been deployed), launches wrangler-dev as a supervised guest process, exposes it through a fourth `VsockTCPProxy`.
- `LocalContainerSiteRuntime` worker-awareness: computes the effective active-worker set once at `start()` (mirroring `DeployModel`'s existing `WorkerActivation`/`SiteConfigStore` pipeline), starts local wrangler-dev if non-empty. `updateActiveWorkers(_:)` is built and tested for a future Workers tab (#700c) to call — `start()` is its only caller in this PR.
- `PreviewModel.workersDevURL` — no UI consumer yet (no Workers tab), but the accessor exists so one doesn't need retrofitting later.
- E2E test (`ContainerizationControlTests.startsWorkersDevForActiveWorker`, gated behind `ANGLESITE_CONTAINER_TESTS=1 ANGLESITE_CONTAINER_E2E=1`) and a new `scripts/run-container-probe.sh workers-dev` subcommand for the human-run verification gate.

**Known, accepted thin-slice limitations** (see design doc §2/§6, unchanged from what was proposed and approved before implementation):
- No live-toggle-restart caller yet — the Workers tab (#700c) becomes `updateActiveWorkers(_:)`'s second caller later.
- Component-tied worker detection needs a populated `SiteGraphExplorerSnapshot`, likely not yet scanned when a site window first opens — a settings-activated worker reliably starts; a component-tied one may not, this session.
- `astro`/`mcp` are not retrofitted onto `GuestProcessSupervisor` — they stay on the existing `runDetached` path.

**Bugs caught and fixed during implementation** (all self-caught by implementers or found in task review, all closed before this PR — flagging for visibility since several were genuine, not cosmetic):
- A clean exit (code 0) under `GuestProcessSupervisor`'s `.onCrash` policy was being treated as a crash requiring restart, contradicting `RestartPolicy`'s own documented contract ("clean exit code 0 always stops") that the sibling `InProcessBackend` already honors. Fixed, with regression tests for both `.onCrash` and `.never` policies.
- **Critical**: the first `ContainerizationControl.startWorkersDev` implementation never started the guest-side `socat` vsock↔TCP bridge process the existing `bridge-preview`/`bridge-mcp` pattern requires — the returned URL would have been unreachable end-to-end on a live VM despite compiling cleanly. Caught in task review, fixed, plus rate-limited proxy logging (matching `previewProxy`/`mcpProxy`) and consistent guest-process output tagging.
- A genuine actor-reentrancy race in `LocalContainerSiteRuntime.start()`'s new wiring: inserting an `await` *after* `activeSiteID` is already assigned meant a superseded attempt calling the existing `abandonSupersededAttempt()` helper could stop a brand-new container a later `start()` had already booted under the same siteID (`control.stop(siteID:)` is keyed by siteID string, not container instance). Self-caught by the implementer, independently traced and confirmed against `LiveContainers`' actual dictionary-keyed teardown during review. The same unguarded-mutation shape was then found and fixed in the not-yet-called `updateActiveWorkers(_:)` too.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

> No MCP message schema change — this is app-internal container-runtime plumbing plus a template devDependency addition.

## Test plan
- [x] `swift test --package-path .` — 2222/2222 passing (only the known, pre-existing, unrelated `GenerableTypesTests`/`FoundationModelAssistantTests` on-device Foundation Models token-overflow flake observed across runs, not a regression)
- [x] `ANGLESITE_CONTAINER_TESTS=1 swift build --build-tests` — clean (the new `GuestProcessSupervisorTests`/`ContainerizationControlTests` additions compile)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **blocked on this machine** by an unrelated, pre-existing environment issue: Homebrew's `node@22` is linked against `libsimdutf.33.dylib`, which no longer exists after an unrelated `simdutf` upgrade to a version shipping only `libsimdutf.34.dylib`. Confirmed via `dyld` error output that this is a system Homebrew/Node linkage problem, not caused by any file in this diff (neither Swift compilation nor the two touched files are part of the JS edit-overlay phase that fails). Needs `brew reinstall node@22` (or equivalent) on this machine; Swift compilation itself was independently confirmed clean via `swift build`.
- [ ] `scripts/run-container-probe.sh workers-dev` — **requires a real entitled Mac with a working `container` CLI system service**, not this sandboxed environment: the run failed with `imageUnavailable("imageLayoutNotProvisioned")`, traced to Apple's `container` CLI backing service not being registered with launchd (`container system status` confirms `apiserver is not running`) — a virtualization-substrate-level sandbox limitation, not anything wrangler-specific. **Please run this before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)