### PR TITLE
fix(tests): conform test LocalContainerControl stubs to workers-dev methods

### DIFF
--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -443,6 +443,15 @@ private actor RecordingLocalContainerControl: LocalContainerControl {
 
     func stop(siteID: String) async throws {}
 
+    func startWorkersDev(
+        siteID: String, workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        URL(string: "http://127.0.0.1:3")!
+    }
+
+    func stopWorkersDev(siteID: String) async throws {}
+
     func exec(
         siteID: String, argv: [String], environment: [String: String], workingDirectory: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void

--- a/Tests/AnglesiteAppTests/PreviewModelContainerCapabilityTests.swift
+++ b/Tests/AnglesiteAppTests/PreviewModelContainerCapabilityTests.swift
@@ -20,6 +20,15 @@ private actor StubLocalContainerControl: LocalContainerControl {
 
     func stop(siteID: String) async throws {}
 
+    func startWorkersDev(
+        siteID: String, workers: [WorkerDescriptor],
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> URL {
+        URL(string: "http://127.0.0.1:3")!
+    }
+
+    func stopWorkersDev(siteID: String) async throws {}
+
     func exec(
         siteID: String, argv: [String], environment: [String: String], workingDirectory: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void


### PR DESCRIPTION
## Summary
- `startWorkersDev(siteID:workers:onOutput:)` and `stopWorkersDev(siteID:)` were added to `LocalContainerControl` in 7e9299f (#708/#850), but two pre-existing test-double conformers were never updated: `StubLocalContainerControl` (`Tests/AnglesiteAppTests/PreviewModelContainerCapabilityTests.swift`, added in #847) and `RecordingLocalContainerControl` (`Tests/AnglesiteAppTests/DeployModelTests.swift`).
- This broke compilation of the `AnglesiteAppTests` target — `swift test --package-path .` fails with "type does not conform to protocol 'LocalContainerControl'" for both types before any test can run.
- Fixed by adding trivial stub implementations (matching `PodmanContainerControl`'s no-op pattern and the other test-double conformers already updated in #850, e.g. `FakeLocalContainerControl`).

## Why CI didn't catch this
CI's `build-test` job currently runs on whatever Xcode is "latest available" on the `macos-26` runner image that isn't the broken 26.3 build — right now that's Xcode 26.6, Swift 6.3.3. `Package.swift` gates the `AnglesiteAppCore`/`AnglesiteAppTests`/`AnglesiteIntentsTests` targets behind `#if compiler(>=6.4) && canImport(Darwin)` (Swift 6.4 is only available in Xcode 27+, per `CLAUDE.md`'s toolchain requirement). Since 6.3.3 < 6.4, those targets are silently excluded from the SwiftPM package graph `swift test` builds in CI — confirmed by the compile log for the #850 CI run (29802310434) and this fix's own baseline run (29803301401): neither shows a single `Compiling AnglesiteApp*` line, and both otherwise-affected `swift test` steps reported success in well under 90 seconds.

No other CI job fills the gap: `appintents-schema` only builds the `AnglesiteIntents` library scheme (not `AnglesiteApp`/`AnglesiteAppTests`), and only once a Xcode 27 runner is detected (currently always skips, per its own comment). So `AnglesiteAppTests` (and `AnglesiteAppCore`, `AnglesiteIntentsTests`) currently has **no CI coverage at all** until a hosted runner ships Xcode 27/Swift 6.4 — this bug (and any future one scoped to those targets) is only catchable by running `swift test` locally with `DEVELOPER_DIR` pointed at Xcode 27, or via `xcodebuild -scheme Anglesite build`.

I'm not proposing a CI change here — that needs its own discussion (self-hosted Xcode-27 runner vs. relaxing the compiler gate vs. accepting the gap until GitHub ships Xcode 27 images) — but wanted the mechanism on record. Happy to file a tracked issue for it if that's the right next step.

## Test plan
- [x] `swift test --package-path . --filter PreviewModelContainerCapabilityTests` passes (DEVELOPER_DIR=Xcode 27 beta)
- [x] Full `swift test --package-path .` — `AnglesiteAppTests` (157 tests) passes in full
- [x] Confirmed no other `LocalContainerControl` conformer in the tree is missing these methods (repo-wide sweep)
- Note: full-suite run also surfaced a pre-existing, unrelated failure in `AnglesiteCoreTests`/`FoundationModelAssistantTests` ("Session ended without producing a response") — reproduces on a clean retry of just that suite, touches on-device Apple Intelligence streaming, and is untouched by this diff. Likely an on-device-model-availability environmental issue in this sandbox, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)