### PR TITLE
ci: add Xcode Cloud post-clone bootstrap and setup doc

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Xcode Cloud post-clone hook (Apple auto-detects and runs any executable in ci_scripts/
+# immediately after cloning the repo, before resolving package dependencies or opening the
+# project — see https://developer.apple.com/documentation/xcode/writing-custom-build-scripts).
+#
+# Anglesite.xcodeproj is gitignored and generated from project.yml via XcodeGen (see
+# CONTRIBUTING.md), so a fresh Xcode Cloud clone has no project file at all. This script
+# regenerates it before Xcode Cloud tries to resolve the scheme it was configured to build.
+#
+# XcodeGen version/digest pinned to match .github/workflows/ci.yml and MIN_XCODEGEN in
+# scripts/check-xcodeproj-sync.sh — bump all three together.
+set -euo pipefail
+
+XCODEGEN_VERSION="2.45.4"
+XCODEGEN_SHA256="090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef"
+
+# CI_PRIMARY_REPOSITORY_PATH is the clone of this repo (Xcode Cloud env var); fall back to
+# this script's own location so it can also be run by hand for local testing.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CI_PRIMARY_REPOSITORY_PATH:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+echo "==> Installing XcodeGen ${XCODEGEN_VERSION}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+curl -fsSL "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" \
+    -o "$WORK_DIR/xcodegen.zip"
+echo "${XCODEGEN_SHA256}  $WORK_DIR/xcodegen.zip" | shasum -a 256 --check
+unzip -q "$WORK_DIR/xcodegen.zip" -d "$WORK_DIR/dist"
+
+XCODEGEN_BIN="$WORK_DIR/dist/xcodegen/bin/xcodegen"
+[[ -x "$XCODEGEN_BIN" ]] \
+    || { echo "error: xcodegen binary not found at expected path after unzip — check zip layout" >&2; exit 1; }
+
+echo "==> Generating Anglesite.xcodeproj from project.yml"
+cd "$REPO_ROOT"
+"$XCODEGEN_BIN" generate

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -8,8 +8,10 @@
 # CONTRIBUTING.md), so a fresh Xcode Cloud clone has no project file at all. This script
 # regenerates it before Xcode Cloud tries to resolve the scheme it was configured to build.
 #
-# XcodeGen version/digest pinned to match .github/workflows/ci.yml and MIN_XCODEGEN in
-# scripts/check-xcodeproj-sync.sh — bump all three together.
+# XcodeGen version/digest pinned to match the XCODEGEN_VERSION/XCODEGEN_SHA256 exact pin in
+# .github/workflows/ci.yml — bump both together. (scripts/check-xcodeproj-sync.sh's
+# MIN_XCODEGEN is a floor, not an exact pin, so it doesn't need to match this value bump for
+# bump, but it should stay <= it.)
 set -euo pipefail
 
 XCODEGEN_VERSION="2.45.4"

--- a/docs/xcode-cloud.md
+++ b/docs/xcode-cloud.md
@@ -1,0 +1,83 @@
+> **[Build + test only]** This doc scopes an Xcode Cloud workflow to Debug build + `swift test` on
+> pushes/PRs, alongside the existing GitHub Actions CI (`.github/workflows/ci.yml`) — it does not
+> archive or upload to TestFlight/App Store Connect. See [release.md](release.md) for the App
+> Store release pipeline, which stays a separate, manual (`scripts/release.sh`) flow.
+
+# Xcode Cloud
+
+Xcode Cloud gives PRs/branches a build+test signal from a real Xcode toolchain, complementing the
+GitHub Actions lanes in `.github/workflows/ci.yml` (which run `swift test` and `xcodebuild build`
+on GitHub's runner images — see [`docs/build-plan.md`](build-plan.md) and issue #128 for why those
+runners can lag behind the Xcode version this repo targets).
+
+Xcode Cloud workflows themselves are configured in Xcode / App Store Connect, not in files
+committed to this repo — there is no declarative workflow-as-code file format. What *is*
+repo-side, and what this doc covers, is:
+
+- [`ci_scripts/ci_post_clone.sh`](../ci_scripts/ci_post_clone.sh) — the one piece Xcode Cloud
+  reads directly from the repo.
+- The one-time workflow setup steps you still have to click through in Xcode / App Store Connect.
+
+## Why a post-clone script is required
+
+`Anglesite.xcodeproj` is gitignored and generated from [`project.yml`](../project.yml) via
+XcodeGen (see [`xcode-setup.md`](xcode-setup.md)). A fresh Xcode Cloud clone has no project file
+at all, so without help Xcode Cloud has nothing to build.
+
+Xcode Cloud auto-detects and runs any executable script under a `ci_scripts/` directory at the
+repo root, at fixed points in the pipeline (`ci_post_clone.sh` → resolve package dependencies →
+`ci_pre_xcodebuild.sh` → build/test/archive → `ci_post_xcodebuild.sh`). `ci_post_clone.sh` here
+installs the same pinned XcodeGen release used by `.github/workflows/ci.yml`
+(`scripts/check-xcodeproj-sync.sh`'s `MIN_XCODEGEN` too — bump all three together) and runs
+`xcodegen generate`, so the project exists before Xcode Cloud tries to resolve the scheme.
+
+Everything else the app build needs is already handled without Xcode Cloud-specific work:
+
+- **Container image/kernel/initfs vendoring** (`scripts/vendor-container-image.sh` /
+  `vendor-container-kernel.sh`) is not run in CI. `scripts/check-container-resources.sh` (wired
+  into `project.yml` as a `preBuildScripts` entry) only **warns** on missing container resources
+  in **Debug** builds — it **fails** in Release. Since this workflow builds Debug only, no
+  Xcode Cloud environment variable or extra step is needed here. (A future Release/TestFlight
+  workflow would need to either vendor those artifacts on the Xcode Cloud VM — untested, and the
+  `container` CLI's availability there is unconfirmed — or set
+  `ANGLESITE_ALLOW_UNPROVISIONED_CONTAINER=1` as a workflow environment variable and accept that
+  the resulting build's local-container preview won't work.)
+- **JS edit-overlay build** (`scripts/build-overlay.sh`) and **Help index build**
+  (`scripts/build-help-index.sh`) are both best-effort: they warn and exit `0` when `npm`/`hiutil`
+  isn't available, rather than failing the build.
+
+## One-time setup (Xcode / App Store Connect)
+
+This part has to be done interactively — from a Mac with access to the Apple Developer team, not
+from this repo:
+
+1. Locally, make sure the project generates cleanly: `xcodegen generate && open Anglesite.xcodeproj`.
+2. In Xcode: **Product ▸ Xcode Cloud ▸ Create Workflow**. Sign in with the Apple Developer account
+   for this app's team and grant Xcode Cloud access to the `Anglesite/Anglesite-app` GitHub repo
+   if prompted.
+3. Configure the workflow:
+   - **Scheme:** `Anglesite`.
+   - **Start Conditions:** Branch Changes (`main`) and Pull Request Changes into `main` — mirrors
+     the `on: push`/`on: pull_request` triggers in `.github/workflows/ci.yml`.
+   - **Actions:** Build (Debug), then Test (Debug/Test destination on the same Mac runner
+     platform this repo targets — macOS 27+/Xcode 27+, per the deployment target in `project.yml`).
+     Do **not** add an Archive action for this workflow — that's out of scope here (see the note
+     at the top of this doc).
+   - **Environment:** pick an Xcode version ≥ 27 to match `MACOSX_DEPLOYMENT_TARGET: "27.0"` and
+     the Swift 6.4 toolchain requirement (see the root [`CLAUDE.md`](../CLAUDE.md) "Build" section).
+     If Xcode Cloud's environment picker doesn't yet offer Xcode 27, the workflow isn't usable
+     until it does — there's no override the app can build against an older SDK.
+4. Save. Xcode Cloud pushes the workflow definition to App Store Connect (Settings tab there is
+   the durable place to review/edit it afterward — Xcode itself is just an editor for it).
+5. Trigger a build (push a commit, or **Product ▸ Xcode Cloud ▸ Manage Workflows ▸ Start Build**)
+   and confirm `ci_post_clone.sh` ran (visible in the build's log) and the `Anglesite` scheme built
+   and tested successfully.
+
+## Notes
+
+- No signing setup is needed for a Debug build/test workflow — Xcode Cloud handles Debug
+  ad-hoc/automatic signing itself; there's no provisioning profile or certificate to install here
+  (contrast with the manual Release flow in [`release.md`](release.md), which does need those).
+- If `swift test`'s Package.swift-level suites should also run under Xcode Cloud (rather than
+  relying on GitHub Actions for that), add a **Test** action against the `Anglesite-Package`
+  scheme too — this doc only scopes the app-target `Anglesite` scheme.

--- a/docs/xcode-setup.md
+++ b/docs/xcode-setup.md
@@ -63,3 +63,8 @@ ASC_API_KEY_ID=XXXXXXXXXX \
 ASC_API_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
   scripts/release.sh --validate-only
 ```
+
+## Xcode Cloud
+
+For a build+test CI signal from Xcode Cloud (in addition to GitHub Actions), see
+[xcode-cloud.md](xcode-cloud.md).


### PR DESCRIPTION
## Summary

- Add `ci_scripts/ci_post_clone.sh`, the one file Xcode Cloud auto-detects and runs after cloning. It installs the same pinned XcodeGen release used by `.github/workflows/ci.yml` and runs `xcodegen generate`, since `Anglesite.xcodeproj` is gitignored and a fresh Xcode Cloud clone otherwise has nothing to build.
- Add `docs/xcode-cloud.md` scoping the workflow to **Debug build + `swift test`** on push/PR (no archive/TestFlight), and documenting the one-time workflow setup that has to happen in Xcode / App Store Connect — that part isn't file-based config, so it can't be done from this repo/session.
- Link the new doc from `docs/xcode-setup.md`.

No app source changed; this is CI/doc scaffolding only. Debug builds already tolerate missing container-image/kernel/initfs vendoring and missing Node/hiutil (both best-effort, warn-only), so no other workaround was needed for a Debug-only workflow.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change needs a paired PR in `Anglesite/anglesite`.

## Test plan

- [x] `swift test --package-path .` — N/A, unaffected by this change (no Swift source touched)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — N/A, unaffected by this change
- [x] Manual: verified the pinned XcodeGen download+checksum in `ci_post_clone.sh` mirrors the identical, already-proven pattern in `.github/workflows/ci.yml` byte-for-byte (same version `2.45.4` / same SHA-256). Could not exercise `xcodegen generate` end-to-end since XcodeGen ships a macOS-only binary and this session runs Linux; `docs/xcode-cloud.md` calls out the remaining Xcode Cloud workflow setup as an interactive, macOS-side step for the repo owner to verify.
