### PR TITLE
ci: replace dorny/paths-filter with inline git diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,40 +35,69 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # Full history. `dorny/paths-filter` diffs push events against `github.event.before`,
-          # the tip of `main` before the push — which can be more than one commit back (this
-          # repo allows merge-commit and rebase-merge, and has no branch protection stopping a
-          # direct multi-commit push), so a shallow `before`-sized depth can undershoot and fail
-          # the diff. The repo is ~9MB/474 commits, so a full clone here is still fast — cheap
+          # Full history. We diff push events against `github.event.before`, the tip of `main`
+          # before the push — which can be more than one commit back (this repo allows
+          # merge-commit and rebase-merge, and has no branch protection stopping a direct
+          # multi-commit push), so a shallow `before`-sized depth can undershoot and fail the
+          # diff. The repo is ~9MB/474 commits, so a full clone here is still fast — cheap
           # insurance against a job that gates every other job in this workflow.
           fetch-depth: 0
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - name: Detect changed paths
         id: filter
-        with:
-          # `.github/workflows/ci.yml` is in every group: a change to this file should never
-          # cause a job to go unevaluated just because we're the ones who touched the filters.
-          filters: |
-            swift:
-              - 'Package.swift'
-              - 'Package.resolved'
-              - 'project.yml'
-              - 'Sources/**'
-              - 'Tests/**'
-              - 'Resources/Template/**'
-              - 'scripts/**'
-              - '.github/workflows/ci.yml'
-            js:
-              - 'JS/edit-overlay/**'
-              - 'scripts/node-version.txt'
-              - '.github/workflows/ci.yml'
-            template:
-              - 'Resources/Template/**'
-              - 'scripts/node-version.txt'
-              - '.github/workflows/ci.yml'
-            helpBook:
-              - 'Resources/Anglesite.help/**'
-              - 'scripts/check-help-links.sh'
-              - '.github/workflows/ci.yml'
+        # Inline replacement for a third-party path-filter action: the org's Actions policy
+        # only allows GitHub-owned/Verified-Creator actions, and dorny/paths-filter (an
+        # individual's action, not an org) doesn't qualify — every run failed at startup with
+        # no job ever dispatched. This reproduces the same four filter groups with plain git
+        # + bash so the gating job has no external-action dependency at all.
+        #
+        # `.github/workflows/ci.yml` is in every group: a change to this file should never
+        # cause a job to go unevaluated just because we're the ones who touched the filters.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="$BASE_SHA"
+          else
+            base="$BEFORE_SHA"
+            # First push of a new branch (or a force-push) reports an all-zero `before` — fall
+            # back to the parent commit, and to the empty tree if there isn't one (initial
+            # commit), which conservatively treats every tracked file as changed.
+            if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$base" 2>/dev/null; then
+              base=$(git rev-parse HEAD~1 2>/dev/null || git hash-object -t tree /dev/null)
+            fi
+          fi
+
+          echo "Diffing against: $base"
+          declare -a changed=()
+          mapfile -t changed < <(git diff --name-only "$base" HEAD)
+          printf '  changed: %s\n' "${changed[@]}"
+
+          matches() {
+            local f pattern
+            for f in "${changed[@]}"; do
+              for pattern in "$@"; do
+                case "$f" in
+                  $pattern) return 0 ;;
+                esac
+              done
+            done
+            return 1
+          }
+
+          swift=false; js=false; template=false; helpBook=false
+          matches 'Package.swift' 'Package.resolved' 'project.yml' 'Sources/**' 'Tests/**' 'Resources/Template/**' 'scripts/**' '.github/workflows/ci.yml' && swift=true
+          matches 'JS/edit-overlay/**' 'scripts/node-version.txt' '.github/workflows/ci.yml' && js=true
+          matches 'Resources/Template/**' 'scripts/node-version.txt' '.github/workflows/ci.yml' && template=true
+          matches 'Resources/Anglesite.help/**' 'scripts/check-help-links.sh' '.github/workflows/ci.yml' && helpBook=true
+
+          echo "swift=$swift" >> "$GITHUB_OUTPUT"
+          echo "js=$js" >> "$GITHUB_OUTPUT"
+          echo "template=$template" >> "$GITHUB_OUTPUT"
+          echo "helpBook=$helpBook" >> "$GITHUB_OUTPUT"
 
   edit-overlay:
     name: JS edit-overlay (lint/typecheck/test)


### PR DESCRIPTION
## Summary

- The org's Actions permissions policy (`allowed_actions: "selected"`, `patterns_allowed: []`) only allows GitHub-owned and Verified-Creator actions — `dorny/paths-filter` (an individual's action) doesn't qualify, so every CI run has failed with `startup_failure` since the policy took effect earlier today (no jobs ever dispatch, no logs, "1 expected check" never reports).
- Replaces the `dorny/paths-filter` step in the `changes` job with a plain `git diff` + bash `case`-pattern implementation that reproduces the same four filter groups (`swift`, `js`, `template`, `helpBook`), removing the third-party-action dependency entirely.
- Verified the new logic locally against real commit ranges in this repo (multi-group change, empty diff, docs-only commit, and a `scripts/node-version.txt`-only change) — outputs match what the original filter definitions would produce in each case.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: N/A

## Test plan

- [ ] `swift test --package-path .` — not run; no Swift/JS source changed, workflow-file-only change
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; no Swift/JS source changed, workflow-file-only change
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses cleanly
- [x] Manual: extracted the new filter shell logic and ran it under real `bash` against several real diff ranges in this repo (see Summary) — outputs matched expectations in every case
- [ ] This PR's own CI run is the real end-to-end proof — watch it for a green `changes` job now that the blocked action is gone