### PR TITLE
ci: bump actions/checkout & setup-node off Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       template: ${{ steps.filter.outputs.template }}
       helpBook: ${{ steps.filter.outputs.helpBook }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history. We diff push events against `github.event.before`, the tip of `main`
           # before the push — which can be more than one commit back (this repo allows
@@ -109,8 +109,8 @@ jobs:
       run:
         working-directory: JS/edit-overlay
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Track the vendored runtime (scripts/vendor-node.sh) so CI tests on the
           # same Node major the app ships.
@@ -132,8 +132,8 @@ jobs:
       run:
         working-directory: Resources/Template
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: scripts/node-version.txt
           cache: npm
@@ -151,7 +151,7 @@ jobs:
     # Split out of edit-overlay: a Help Book-only change shouldn't pay for a full npm
     # install/lint/typecheck/test cycle just to reach this check. Plain bash+grep, no deps.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check Help Book links
         run: scripts/check-help-links.sh
 
@@ -170,7 +170,7 @@ jobs:
     container:
       image: swift:6.3.3-noble
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Show toolchain versions
         run: swift --version
@@ -208,14 +208,14 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The end-to-end tests spawn the real plugin's MCP server, so CI needs the sibling repo
       # present and `npm ci`-installed. Without these, the Swift Testing suites gated with
       # `.enabled(if:)` traits skip cleanly (ANGLESITE_PLUGIN_PATH absent); with them, the full
       # overlay → patcher → file-on-disk round-trip is exercised.
       - name: Checkout sibling Anglesite plugin
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: Anglesite/anglesite
           # Pinned to the plugin release the app currently exercises. get_component_model
@@ -225,7 +225,7 @@ jobs:
           path: anglesite-plugin
 
       - name: Set up Node (for plugin MCP server tests)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Track the vendored runtime (scripts/vendor-node.sh) so the e2e tests spawn
           # the plugin's MCP server on the same Node the app embeds.
@@ -300,7 +300,7 @@ jobs:
     # skips the sibling-plugin checkout. TSan deterministically flags data races the probabilistic
     # `concurrentDeliver*` tests would otherwise only catch by timing luck (#203).
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select latest available Xcode
         # Same toolchain rationale as build-test: CLAUDE.md mandates Xcode 27+.
@@ -356,7 +356,7 @@ jobs:
       # release (or MITM) can't substitute a different binary. Re-fetch and update on every bump.
       XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install XcodeGen (pinned)
         run: |
@@ -384,7 +384,7 @@ jobs:
     # merges new/removed keys into Localizable.xcstrings. This lane is a static heuristic
     # substitute: it needs only python3, so it runs on ubuntu-latest with no Xcode/xcodegen.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: scripts/check-localization-catalog.sh
 
   appintents-schema:
@@ -414,7 +414,7 @@ jobs:
       XCODEGEN_VERSION: 2.45.4
       XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Select latest available Xcode
         run: |


### PR DESCRIPTION
## Summary

- GitHub Actions deprecated the Node 20 action runtime, so `actions/checkout@v4.2.2` and `actions/setup-node@v4.4.0` (both `using: node20`) were being force-run on Node 24 with a deprecation warning on every `build-test` job.
- Bumped both actions' pinned SHAs to their current majors — `actions/checkout@3d3c42e` (v7.0.1) and `actions/setup-node@8207627` (v7.0.0) — which declare `using: node24` natively, across all 11 checkout and 3 setup-node call sites in `ci.yml`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] Confirmed `actions/checkout@v7.0.1` and `actions/setup-node@v7.0.0` action.yml both declare `using: node24` (checked via raw.githubusercontent.com).
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses cleanly.
- [ ] `swift test --package-path .` — not applicable, no Swift/JS source changed (CI workflow config only).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not applicable, same reason.
- [x] Manual smoke: this PR's own `build-test` and other `ci.yml` jobs running on GitHub Actions are the real-world verification that the new action versions execute cleanly.