### PR TITLE
fix(edit-overlay-test): deflake image-drop FileReader wait

### DIFF
--- a/JS/edit-overlay/test/overlay.test.ts
+++ b/JS/edit-overlay/test/overlay.test.ts
@@ -194,10 +194,23 @@ describe("image drop", () => {
     return event;
   }
 
-  /** jsdom's FileReader fires its onload callback after two macrotask ticks. */
+  /** jsdom's FileReader resolves its read via two chained `setImmediate` calls internally
+   *  (see node_modules/jsdom/lib/jsdom/living/file-api/FileReader-impl.js). A fixed count of
+   *  `setTimeout(fn, 0)` ticks is NOT a reliable way to wait for that: Node only guarantees
+   *  `setImmediate` runs before a same-tick `setTimeout(fn, 0)` when both are scheduled from
+   *  inside an I/O callback — here they're scheduled from the test body instead, so their
+   *  relative order across the timers vs. check phases is unspecified and can flip under load
+   *  (confirmed empirically: ~0.1% of trials one way in a tight loop, more when the event loop
+   *  is busier, e.g. CI). That let the "flush" resolve before the reader's onload ran (dropping
+   *  `sent` to 0) or let a *previous* test's still-pending onload fire during the *next* test
+   *  (bumping `sent` to 2) — matching both observed CI failure shapes. Poll for the actual
+   *  effect (a new `sent` entry) instead of guessing tick counts.
+   */
   async function flushFileReader(): Promise<void> {
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const before = sent.length;
+    await vi.waitFor(() => {
+      if (sent.length <= before) throw new Error("FileReader has not completed yet");
+    });
   }
 
   it("highlights every replaceable image while a Finder file is dragged over the page", () => {


### PR DESCRIPTION
## Summary

- `flushFileReader()` in `JS/edit-overlay/test/overlay.test.ts` waited a fixed 2 `setTimeout(fn, 0)` ticks for jsdom's `FileReader`, which internally resolves via 2 chained `setImmediate` calls (`node_modules/jsdom/lib/jsdom/living/file-api/FileReader-impl.js`).
- Node doesn't guarantee relative ordering between the timers phase (`setTimeout`) and the check phase (`setImmediate`) when both are scheduled from the test body rather than from inside an I/O callback — confirmed empirically with a standalone repro (~0.1%+ of trials flip order in a tight loop, worse under load). This let the flush resolve too early (dropping `sent` to 0 instead of 1) or leave a previous test's still-pending `onload` to fire during the next test (bumping `sent` to 2 instead of 1) — matching both CI failure shapes observed on the same commit while getting #859 merge-ready.
- Replaced the tick-counting wait with `vi.waitFor()` polling for the actual observable effect (a new `sent` entry), which removes the race entirely instead of just narrowing it.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` (from `JS/edit-overlay/`) — 72/72 passing.
- [x] `npx vitest run` looped 20x sequentially — all clean.
- [x] `npx vitest run test/overlay.test.ts` x8 concurrently under artificial CPU-contention noise (simulating CI's busier scheduler) — all clean, 22/22 each.
- [ ] `swift test --package-path .` — not applicable, no Swift files touched.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not applicable, JS-only change.