### PR TITLE
Add Website ▸ Onion Routing… menu command (#872)

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -745,6 +745,9 @@
     "Create" : {
 
     },
+    "Create a private GitHub repo and push this site" : {
+
+    },
     "Create a website" : {
 
     },
@@ -865,6 +868,9 @@
     "Digital downloads" : {
 
     },
+    "Disable" : {
+
+    },
     "Disallow" : {
 
     },
@@ -922,7 +928,13 @@
     "Emphasis" : {
 
     },
+    "Enable" : {
+
+    },
     "Enable Onion Routing" : {
+
+    },
+    "Enable Tor Browser access for this site via Cloudflare's zone-level setting" : {
 
     },
     "Enter the domain to harden" : {
@@ -1459,6 +1471,9 @@
     "Onion Routing" : {
 
     },
+    "Onion Routing…" : {
+
+    },
     "Open" : {
 
     },
@@ -1505,6 +1520,9 @@
 
     },
     "Open the preview first to start the runtime before deploying" : {
+
+    },
+    "Open this site's GitHub repository" : {
 
     },
     "Opens %@" : {
@@ -1887,6 +1905,9 @@
 
     },
     "Save…" : {
+
+    },
+    "Saving Cloudflare zone settings…" : {
 
     },
     "Scan" : {
@@ -2533,3 +2554,4 @@
   },
   "version" : "1.0"
 }
+

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -56,6 +56,9 @@ struct WebsiteCommands: Commands {
             Button("Harden…") { model?.harden.openSheet() }
                 .disabled(model?.canRunHarden != true)
 
+            Button("Onion Routing…") { model?.onionRouting.openSheet() }
+                .disabled(model?.canRunOnionRouting != true)
+
             Button("Siri AI Readiness…") { model?.openSiriReadiness() }
                 .disabled(model?.canOpenSiriReadiness != true)
 


### PR DESCRIPTION
## Summary

- Adds a `Website ▸ Onion Routing…` menu command to `WebsiteCommands.swift`, mirroring the existing `Harden…` entry, so the feature stays reachable when its toolbar item is hidden or removed (per `docs/mac-assed-app-spec.md`: "every significant command must be discoverable from a menu, even when it also appears in a toolbar").
- Calls `model?.onionRouting.openSheet()`, exactly matching the toolbar button's action.
- Syncs `Localizable.xcstrings` with the handful of strings this adds/touches.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

## Test plan

- [x] `swift test --package-path .` — 2255 tests, 1 pre-existing failure unrelated to this change: `FoundationModelAssistant "converse trims the cached session's transcript once it exceeds the retained-turn budget (#456)"` asserts on live on-device Foundation Models generated text and is a known flake class (content-dependent expectation against a real on-device model). `SiteToolbarItemIDTests.toolbarItemIDsAreFrozen()` passes cleanly.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds.
- [x] `scripts/check-localization-catalog.sh` — passes (no missing catalog keys).
- [ ] Manual smoke (if UI-touching): not yet performed — this is a small, mechanically-verified menu addition mirroring an existing, already-smoke-tested pattern (`Harden…`).

Note: this branch was originally built against a locally-drifted worktree base (a duplicate of the Onion Routing merge under a different commit hash than what actually landed on `main`), which produced a bogus merge conflict and a wrong `openOnionRoutingSheet()` call. Rebased onto the real `origin/main`, corrected the method call to match the true `SiteWindowModel` API, and re-verified build + full test suite from scratch.

Closes #872.