### PR TITLE
feat(#71): compile Core, Bridge, Intents for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -423,7 +423,8 @@ if ProcessInfo.processInfo.environment["ANGLESITE_LINUX_SHELL"] == "1" {
 let package = Package(
     name: "Anglesite",
     platforms: [
-        .macOS("27.0")
+        .macOS("27.0"),
+        .iOS("27.0")
     ],
     products: packageProducts,
     dependencies: packageDependencies,

--- a/Sources/AnglesiteBridge/PreviewPrinting.swift
+++ b/Sources/AnglesiteBridge/PreviewPrinting.swift
@@ -1,3 +1,6 @@
+// AppKit print plumbing for the macOS File ▸ Print path; the iOS thin client (#71) has no
+// NSPrintInfo/printOperation, so the whole file compiles out there.
+#if os(macOS)
 import AppKit
 import WebKit
 import AnglesiteCore
@@ -94,3 +97,4 @@ public enum PreviewPrinting {
         view.frame = NSRect(origin: .zero, size: operation.printInfo.paperSize)
     }
 }
+#endif

--- a/Sources/AnglesiteCore/ACPAgentStore.swift
+++ b/Sources/AnglesiteCore/ACPAgentStore.swift
@@ -67,7 +67,7 @@ public final class ACPAgentStore: @unchecked Sendable {
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
-        )) ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        )) ?? fileManager.portableHomeDirectory
             .appendingPathComponent("Library/Application Support", isDirectory: true)
         return support
             .appendingPathComponent("Anglesite", isDirectory: true)

--- a/Sources/AnglesiteCore/ACPAgentStore.swift
+++ b/Sources/AnglesiteCore/ACPAgentStore.swift
@@ -67,7 +67,7 @@ public final class ACPAgentStore: @unchecked Sendable {
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
-        )) ?? fileManager.homeDirectoryForCurrentUser
+        )) ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
             .appendingPathComponent("Library/Application Support", isDirectory: true)
         return support
             .appendingPathComponent("Anglesite", isDirectory: true)

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -103,7 +103,7 @@ public final class AppSettings: @unchecked Sendable {
     /// Effective root for site discovery. Returns the override when set, otherwise `~/Sites/`.
     public var sitesRoot: URL {
         sitesRootOverride
-            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true).appendingPathComponent("Sites", isDirectory: true)
+            ?? FileManager.default.portableHomeDirectory.appendingPathComponent("Sites", isDirectory: true)
     }
 
     /// Opt-in toggle (Settings → Advanced) that surfaces the Debug pane menu item in Release

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -103,7 +103,7 @@ public final class AppSettings: @unchecked Sendable {
     /// Effective root for site discovery. Returns the override when set, otherwise `~/Sites/`.
     public var sitesRoot: URL {
         sitesRootOverride
-            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Sites", isDirectory: true)
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true).appendingPathComponent("Sites", isDirectory: true)
     }
 
     /// Opt-in toggle (Settings → Advanced) that surfaces the Debug pane menu item in Release

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -525,6 +525,10 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// the same tools a freshly-created one would.
     private func conversationTools(for context: AssistantContext, includeSpotlight: Bool) -> [any Tool] {
         var tools: [any Tool] = []
+        // The iOS *simulator* SDK doesn't vend `SpotlightSearchTool` (device and macOS SDKs do),
+        // so the append compiles out there — simulators have no Apple Intelligence session to
+        // reach the tool anyway.
+        #if !targetEnvironment(simulator)
         if includeSpotlight {
             // Default GuidanceLevel.complete injects a ~13k-token query manual that exceeds the
             // on-device 4,096-token window. .focused(.items) scopes guidance to our page/post
@@ -533,6 +537,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
                 sources: [.coreSpotlight],
                 guide: .init(level: .focused(.items), format: .compact))))
         }
+        #endif
         if let editBridge, let contentGraph {
             tools.append(ApplyEditTool(
                 bridge: editBridge,

--- a/Sources/AnglesiteCore/InProcessBackend.swift
+++ b/Sources/AnglesiteCore/InProcessBackend.swift
@@ -1,3 +1,6 @@
+// `Foundation.Process` exists on every supported platform except iOS (the iOS thin client is
+// remote-only, #71); the whole host-spawn backend compiles out there.
+#if !os(iOS)
 import Foundation
 #if canImport(Darwin)
 import Darwin
@@ -471,3 +474,4 @@ public actor InProcessBackend: SupervisorBackend {
         }
     }
 }
+#endif

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -1,3 +1,7 @@
+// The iOS thin client is remote-only (#71): it must never link the local container runtime, so
+// the whole file compiles out there. macOS (Apple Containerization) and Linux (Podman control)
+// both keep it.
+#if !os(iOS)
 import Foundation
 
 /// `SiteRuntime` over a local Apple-Containerization VM (macOS 26+/Apple Silicon; see design
@@ -580,3 +584,4 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
         }
     }
 }
+#endif

--- a/Sources/AnglesiteCore/Platform/DarwinSecurityScopedBookmark.swift
+++ b/Sources/AnglesiteCore/Platform/DarwinSecurityScopedBookmark.swift
@@ -1,6 +1,7 @@
 // Darwin implementation of the SecurityScopedBookmark seam. The whole file compiles out on
-// platforms without Darwin's security-scoped bookmark APIs.
-#if canImport(Darwin)
+// platforms without the App Sandbox's `.withSecurityScope` bookmark APIs (macOS-only —
+// iOS Foundation has no `.withSecurityScope`, so iOS takes the Unavailable path).
+#if os(macOS)
 import Foundation
 
 /// MAS-only at runtime: the sandboxed app persists one bookmark per site (on

--- a/Sources/AnglesiteCore/Platform/FSEventsFileWatcher.swift
+++ b/Sources/AnglesiteCore/Platform/FSEventsFileWatcher.swift
@@ -1,6 +1,7 @@
 // Darwin implementation of the SiteFileWatching seam. The whole file compiles out on
-// platforms without the CoreServices framework.
-#if canImport(CoreServices)
+// platforms without the FSEvents API (macOS-only — iOS ships a CoreServices module, but
+// without `FSEventStream*`).
+#if os(macOS)
 import Foundation
 import CoreServices
 

--- a/Sources/AnglesiteCore/Platform/PortableHomeDirectory.swift
+++ b/Sources/AnglesiteCore/Platform/PortableHomeDirectory.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension FileManager {
+    /// Portable spelling of `homeDirectoryForCurrentUser`, which is compile-time unavailable on
+    /// iOS. On iOS this resolves the app's sandboxed container home via `NSHomeDirectory()`
+    /// (bypassing the receiver — no injected-`FileManager` test exercises the iOS leg); every
+    /// other platform keeps the instance property so the DI seam callers rely on stays intact.
+    public var portableHomeDirectory: URL {
+        #if os(iOS)
+        URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        #else
+        homeDirectoryForCurrentUser
+        #endif
+    }
+}

--- a/Sources/AnglesiteCore/Platform/SecurityScopedBookmark.swift
+++ b/Sources/AnglesiteCore/Platform/SecurityScopedBookmark.swift
@@ -67,7 +67,7 @@ public struct UnavailableSecurityScopedBookmark: SecurityScopedBookmarking {
 /// production default; tests inject fakes directly.
 public enum PlatformSecurityScopedBookmark {
     public static func make() -> any SecurityScopedBookmarking {
-        #if canImport(Darwin)
+        #if os(macOS)
         DarwinSecurityScopedBookmark()
         #else
         UnavailableSecurityScopedBookmark()

--- a/Sources/AnglesiteCore/Platform/SiteFileWatching.swift
+++ b/Sources/AnglesiteCore/Platform/SiteFileWatching.swift
@@ -50,7 +50,7 @@ public struct UnavailableFileWatcher: SiteFileWatching {
 /// inject fakes (e.g. `ControllableWatcher`) directly.
 public enum PlatformFileWatcher {
     public static func make() -> any SiteFileWatching {
-        #if canImport(CoreServices)
+        #if os(macOS)
         FSEventsFileWatcher()
         #elseif canImport(Glibc)
         InotifyFileWatcher()

--- a/Sources/AnglesiteCore/ProcessSupervisor.swift
+++ b/Sources/AnglesiteCore/ProcessSupervisor.swift
@@ -60,10 +60,17 @@ public actor ProcessSupervisor {
 
     /// Convenience for the app and tests: the default in-process backend. The app is sandboxed and
     /// still uses subprocesses for non-Node helper tools, holding a per-`SiteWindow`
-    /// security-scoped grant so spawned children inherit folder access.
+    /// security-scoped grant so spawned children inherit folder access. iOS has no
+    /// `Foundation.Process`, so `InProcessBackend` compiles out there (#71) and the remote-only
+    /// client gets `UnavailableProcessBackend` — every spawn fails capability-flagged; the iOS
+    /// runtime selection never reaches this backend in normal operation.
     public init(suddenTerminationController: SuddenTerminationController = .shared) {
         _ = Self.ignoreSIGPIPE
+        #if os(iOS)
+        self.backend = UnavailableProcessBackend()
+        #else
         self.backend = InProcessBackend()
+        #endif
         self.defaultEnvironment = { nil }
         self.suddenTerminationController = suddenTerminationController
     }

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -395,7 +395,7 @@ public actor SiteStore {
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
-        )) ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        )) ?? fileManager.portableHomeDirectory
             .appendingPathComponent("Library/Application Support", isDirectory: true)
         return support
             .appendingPathComponent("Anglesite", isDirectory: true)

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -395,7 +395,7 @@ public actor SiteStore {
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
-        )) ?? fileManager.homeDirectoryForCurrentUser
+        )) ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
             .appendingPathComponent("Library/Application Support", isDirectory: true)
         return support
             .appendingPathComponent("Anglesite", isDirectory: true)

--- a/Sources/AnglesiteCore/SupervisorBackend.swift
+++ b/Sources/AnglesiteCore/SupervisorBackend.swift
@@ -75,3 +75,41 @@ public protocol SupervisorBackend: Sendable {
     /// live file descriptor across the boundary returns `nil` and exposes `writeStdin` instead.
     func stdinHandle(_ handle: SpawnedProcessHandle) async -> FileHandle?
 }
+
+/// Placeholder backend for platforms without `Foundation.Process` (iOS, #71): every spawn fails
+/// with `spawnFailed`, mirroring the `UnavailableFileWatcher`/`UnavailableSecurityScopedBookmark`
+/// seam pattern — features degrade capability-flagged, never by pretending a subprocess ran. The
+/// iOS thin client is remote-only and selects `RemoteSandboxSiteRuntime`, so nothing reaches this
+/// in normal operation.
+public struct UnavailableProcessBackend: SupervisorBackend {
+    public init() {}
+
+    private static let message = "Subprocess spawning is unavailable on this platform."
+
+    public func runOneShot(_ spec: SpawnSpec) async throws -> ProcessResult {
+        throw SupervisorBackendError.spawnFailed(Self.message)
+    }
+
+    public func launch(
+        _ spec: SpawnSpec,
+        restartPolicy: RestartPolicy,
+        onRespawn: RespawnHandler?,
+        logCenter: LogCenter
+    ) async throws -> SpawnedProcessHandle {
+        throw SupervisorBackendError.spawnFailed(Self.message)
+    }
+
+    public func waitForExit(_ handle: SpawnedProcessHandle) async -> ProcessExitReason { .terminated }
+
+    public func isRunning(_ handle: SpawnedProcessHandle) async -> Bool { false }
+
+    public func terminate(_ handle: SpawnedProcessHandle, timeout: TimeInterval) async {}
+
+    public func shutdownAll(timeout: TimeInterval) async {}
+
+    public func writeStdin(_ handle: SpawnedProcessHandle, _ bytes: Data) async throws {
+        throw SupervisorBackendError.spawnFailed(Self.message)
+    }
+
+    public func stdinHandle(_ handle: SpawnedProcessHandle) async -> FileHandle? { nil }
+}

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -122,7 +122,7 @@ public actor WorkerCatalogFetcher {
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
-        )) ?? fileManager.homeDirectoryForCurrentUser
+        )) ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
             .appendingPathComponent("Library/Application Support", isDirectory: true)
         return support
             .appendingPathComponent("Anglesite", isDirectory: true)

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -122,7 +122,7 @@ public actor WorkerCatalogFetcher {
             in: .userDomainMask,
             appropriateFor: nil,
             create: true
-        )) ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        )) ?? fileManager.portableHomeDirectory
             .appendingPathComponent("Library/Application Support", isDirectory: true)
         return support
             .appendingPathComponent("Anglesite", isDirectory: true)

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -1,15 +1,11 @@
 import AppIntents
-import AppKit
 import AnglesiteCore
 import CoreGraphics
 import Foundation
 
-// `AppEntityUIElement` and `AppEntityUIElementsContext` are defined by the
-// `_AppIntents_AppKit` cross-import overlay, which auto-loads when both `AppIntents` and
-// `AppKit` are imported explicitly in the consuming file. Swift's `MemberImportVisibility`
-// upcoming-feature (enabled by the macOS 27 SDK module flags) requires both base modules
-// here — transitive imports through other frameworks aren't enough, and the compile error
-// blames the type rather than the missing import.
+// The AppKit-coupled `AppEntityUIElement` surface (the `_AppIntents_AppKit` cross-import
+// overlay) lives in `PreviewAnnotationProviderUIElements.swift`, macOS-gated, so this file —
+// and the provider itself — stays platform-neutral for the iOS thin client (#71).
 
 /// Per-WKWebView state holding the latest `VisibleElementReport` and mapping each element to
 /// an `AppEntity`. AppKit's `appEntityUIElementProvider` (B.4 / #148) reads from this when
@@ -84,63 +80,6 @@ public final class PreviewAnnotationProvider: ElementEntityProviding, Sendable {
     public func annotations() -> [(rect: CGRect, entity: any AppEntity)] {
         annotated
     }
-
-    // `AppEntityUIElement` and `AppEntityUIElementsContext` are macOS 26+ symbols (Xcode 27 /
-    // Swift 6.4 SDK). CI's `macos-15` runner currently ships Xcode 26.3 / Swift 6.3 and doesn't
-    // have these types, so the methods that reference them are gated. Local Xcode 27 builds get
-    // the full surface; CI compiles the library without it. Same pattern as `Package.swift`'s
-    // `#if compiler(>=6.4)` gate around `AnglesiteIntentsTests`. Tracked for removal in #128
-    // when GH's runner ships Xcode 27.
-    #if compiler(>=6.4)
-    /// Shape annotations into `[AppEntityUIElement]` for `NSView.appEntityUIElementProvider`
-    /// (B.4 / #148). The system asks for either `.visible(rect:)` — return everything whose
-    /// stored rect intersects `rect` — or `.selected`. We don't track an in-page selection
-    /// model (the overlay's hover/click states are transient), so `.selected` yields `[]`.
-    public func uiElements(for context: AppEntityUIElementsContext) -> [AppEntityUIElement] {
-        uiElements(forRequests: context.requests)
-    }
-
-    /// Inner helper taking the raw request set so tests can drive it directly —
-    /// `AppEntityUIElementsContext` has no public initializer.
-    public func uiElements(
-        forRequests requests: Set<AppEntityUIElementsContext.ElementsRequest>
-    ) -> [AppEntityUIElement] {
-        var out: [AppEntityUIElement] = []
-        for request in requests {
-            switch request {
-            case .visible(let rect):
-                for (annoRect, entity) in annotated where annoRect.intersects(rect) {
-                    out.append(makeUIElement(entity: entity, bounds: annoRect))
-                }
-            case .selected:
-                continue
-            @unknown default:
-                continue
-            }
-        }
-        return out
-    }
-
-    /// Existential-opening helper. `AppEntityUIElement.init<E: AppEntity>(_ entity:, bounds:)` is
-    /// generic over a concrete entity type; each of the four concrete types we map to gets a
-    /// dedicated branch so the compiler can specialize. The trailing fallback exists only to
-    /// satisfy the type checker — the four cases above are exhaustive given `resolve`'s rules.
-    /// If a fifth entity type is ever returned by `resolve` without updating this switch, the
-    /// `assertionFailure` makes the regression loud in debug builds; release builds fall through
-    /// to the placeholder so production keeps working.
-    private func makeUIElement(entity: any AppEntity, bounds: CGRect) -> AppEntityUIElement {
-        if let e = entity as? PageEntity { return AppEntityUIElement(e, bounds: bounds) }
-        if let e = entity as? PostEntity { return AppEntityUIElement(e, bounds: bounds) }
-        if let e = entity as? ImageEntity { return AppEntityUIElement(e, bounds: bounds) }
-        if let e = entity as? ElementEntity { return AppEntityUIElement(e, bounds: bounds) }
-        assertionFailure("makeUIElement: unhandled entity type \(type(of: entity)) — extend the switch in PreviewAnnotationProvider")
-        let placeholder = ElementEntity(
-            id: "unknown", displayName: "unknown", siteID: siteID,
-            selector: "{}", pagePath: "/"
-        )
-        return AppEntityUIElement(placeholder, bounds: bounds)
-    }
-    #endif
 
     // MARK: ElementEntityProviding
 

--- a/Sources/AnglesiteIntents/PreviewAnnotationProviderUIElements.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProviderUIElements.swift
@@ -1,0 +1,76 @@
+// AppKit-only half of `PreviewAnnotationProvider` (B.4 / #148): the
+// `NSView.appEntityUIElementProvider` surface comes from the `_AppIntents_AppKit`
+// cross-import overlay, so this file is macOS-only. The iOS thin client (#71) compiles the
+// provider without it; a UIKit equivalent (`_AppIntents_UIKit`) is future work tracked on #71.
+#if os(macOS)
+import AppIntents
+import AppKit
+import CoreGraphics
+import Foundation
+
+// `AppEntityUIElement` and `AppEntityUIElementsContext` are defined by the
+// `_AppIntents_AppKit` cross-import overlay, which auto-loads when both `AppIntents` and
+// `AppKit` are imported explicitly in the consuming file. Swift's `MemberImportVisibility`
+// upcoming-feature (enabled by the macOS 27 SDK module flags) requires both base modules
+// here — transitive imports through other frameworks aren't enough, and the compile error
+// blames the type rather than the missing import.
+
+// `AppEntityUIElement` and `AppEntityUIElementsContext` are macOS 26+ symbols (Xcode 27 /
+// Swift 6.4 SDK). CI's `macos-15` runner currently ships Xcode 26.3 / Swift 6.3 and doesn't
+// have these types, so the methods that reference them are gated. Local Xcode 27 builds get
+// the full surface; CI compiles the library without it. Same pattern as `Package.swift`'s
+// `#if compiler(>=6.4)` gate around `AnglesiteIntentsTests`. Tracked for removal in #128
+// when GH's runner ships Xcode 27.
+#if compiler(>=6.4)
+extension PreviewAnnotationProvider {
+    /// Shape annotations into `[AppEntityUIElement]` for `NSView.appEntityUIElementProvider`
+    /// (B.4 / #148). The system asks for either `.visible(rect:)` — return everything whose
+    /// stored rect intersects `rect` — or `.selected`. We don't track an in-page selection
+    /// model (the overlay's hover/click states are transient), so `.selected` yields `[]`.
+    public func uiElements(for context: AppEntityUIElementsContext) -> [AppEntityUIElement] {
+        uiElements(forRequests: context.requests)
+    }
+
+    /// Inner helper taking the raw request set so tests can drive it directly —
+    /// `AppEntityUIElementsContext` has no public initializer.
+    public func uiElements(
+        forRequests requests: Set<AppEntityUIElementsContext.ElementsRequest>
+    ) -> [AppEntityUIElement] {
+        var out: [AppEntityUIElement] = []
+        for request in requests {
+            switch request {
+            case .visible(let rect):
+                for (annoRect, entity) in annotations() where annoRect.intersects(rect) {
+                    out.append(makeUIElement(entity: entity, bounds: annoRect))
+                }
+            case .selected:
+                continue
+            @unknown default:
+                continue
+            }
+        }
+        return out
+    }
+
+    /// Existential-opening helper. `AppEntityUIElement.init<E: AppEntity>(_ entity:, bounds:)` is
+    /// generic over a concrete entity type; each of the four concrete types we map to gets a
+    /// dedicated branch so the compiler can specialize. The trailing fallback exists only to
+    /// satisfy the type checker — the four cases above are exhaustive given `resolve`'s rules.
+    /// If a fifth entity type is ever returned by `resolve` without updating this switch, the
+    /// `assertionFailure` makes the regression loud in debug builds; release builds fall through
+    /// to the placeholder so production keeps working.
+    private func makeUIElement(entity: any AppEntity, bounds: CGRect) -> AppEntityUIElement {
+        if let e = entity as? PageEntity { return AppEntityUIElement(e, bounds: bounds) }
+        if let e = entity as? PostEntity { return AppEntityUIElement(e, bounds: bounds) }
+        if let e = entity as? ImageEntity { return AppEntityUIElement(e, bounds: bounds) }
+        if let e = entity as? ElementEntity { return AppEntityUIElement(e, bounds: bounds) }
+        assertionFailure("makeUIElement: unhandled entity type \(type(of: entity)) — extend the switch in PreviewAnnotationProvider")
+        let placeholder = ElementEntity(
+            id: "unknown", displayName: "unknown", siteID: siteID,
+            selector: "{}", pagePath: "/"
+        )
+        return AppEntityUIElement(placeholder, bounds: bounds)
+    }
+}
+#endif
+#endif

--- a/Tests/AnglesiteCoreTests/UnavailableProcessBackendTests.swift
+++ b/Tests/AnglesiteCoreTests/UnavailableProcessBackendTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+/// `UnavailableProcessBackend` is the iOS fallback for `ProcessSupervisor`'s convenience init
+/// (#71): every spawn must fail loudly with `spawnFailed`, and the passive queries must read as
+/// "nothing running" — never pretend a subprocess exists.
+struct UnavailableProcessBackendTests {
+    private let backend = UnavailableProcessBackend()
+    private let spec = SpawnSpec(
+        executable: URL(fileURLWithPath: "/usr/bin/true"),
+        arguments: [],
+        logSource: "test"
+    )
+
+    @Test func runOneShotThrowsSpawnFailed() async {
+        await #expect(throws: SupervisorBackendError.self) {
+            _ = try await backend.runOneShot(spec)
+        }
+    }
+
+    @Test func launchThrowsSpawnFailed() async {
+        await #expect(throws: SupervisorBackendError.self) {
+            _ = try await backend.launch(spec, restartPolicy: .never, onRespawn: nil, logCenter: LogCenter())
+        }
+    }
+
+    @Test func writeStdinThrowsSpawnFailed() async {
+        await #expect(throws: SupervisorBackendError.self) {
+            try await backend.writeStdin(SpawnedProcessHandle(id: UUID(), pid: -1), Data("x".utf8))
+        }
+    }
+
+    @Test func passiveQueriesReportNothingRunning() async {
+        let handle = SpawnedProcessHandle(id: UUID(), pid: -1)
+        #expect(await backend.isRunning(handle) == false)
+        #expect(await backend.waitForExit(handle) == .terminated)
+        #expect(await backend.stdinHandle(handle) == nil)
+        // Termination paths are no-ops, not traps.
+        await backend.terminate(handle, timeout: 0)
+        await backend.shutdownAll(timeout: 0)
+    }
+}

--- a/scripts/audit-ios-thin-client-readiness.sh
+++ b/scripts/audit-ios-thin-client-readiness.sh
@@ -98,6 +98,31 @@ writing_tools_assignment_is_mac_gated() {
     ' "$path"
 }
 
+# A file is "compiled out of iOS builds" when its first non-comment, non-blank line opens an
+# `#if !os(iOS)` block and the file's last non-blank line closes it. This is how the host
+# subprocess backend and the local container runtime stay in shared Core for macOS/Linux while
+# never reaching the iOS thin client (#71) — same recognize-the-gate approach as the
+# writing-tools check above (PR #451).
+file_is_ios_gated() {
+    local path="$1"
+    [[ -e "$path" ]] || return 1
+    awk '
+        BEGIN { opened = 0; closed = 0 }
+        {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            if (line == "") { next }
+            if (line ~ /^\/\//) { next }
+            if (opened == 0) {
+                if (line ~ /^#if[[:space:]]+!os\(iOS\)/) { opened = 1; next }
+                exit 1
+            }
+            if (line ~ /^#endif/) { closed = 1 } else { closed = 0 }
+        }
+        END { exit (opened == 1 && closed == 1) ? 0 : 1 }
+    ' "$path"
+}
+
 ios_shell_target_is_safe() {
     path_exists "Sources/AnglesiteIOS" || return 1
     awk '
@@ -163,10 +188,11 @@ else
     ready "Security-scoped bookmark code is platform-gated or split out of iOS Core"
 fi
 
-if pattern_exists "Sources/AnglesiteCore/InProcessBackend.swift" "Process\\("; then
+if pattern_exists "Sources/AnglesiteCore/InProcessBackend.swift" "Process\\(" \
+    && ! file_is_ios_gated "Sources/AnglesiteCore/InProcessBackend.swift"; then
     blocker "Host subprocess backend remains in shared Core" "Sources/AnglesiteCore/InProcessBackend.swift"
 else
-    ready "Shared Core has no direct host Process backend"
+    ready "Host subprocess backend compiles out of iOS builds"
 fi
 
 if pattern_exists "Sources/AnglesiteCore/LocalSiteRuntime.swift" "LocalSiteRuntime|ProcessSupervisor|NodeRuntime"; then
@@ -175,10 +201,11 @@ else
     ready "Shared Core has no local host runtime dependency"
 fi
 
-if pattern_exists "Sources/AnglesiteCore/LocalContainerSiteRuntime.swift" "LocalContainerSiteRuntime|FSEventsFileWatcher"; then
+if pattern_exists "Sources/AnglesiteCore/LocalContainerSiteRuntime.swift" "LocalContainerSiteRuntime|FSEventsFileWatcher" \
+    && ! file_is_ios_gated "Sources/AnglesiteCore/LocalContainerSiteRuntime.swift"; then
     blocker "Local container runtime is still visible from shared Core" "Sources/AnglesiteCore/LocalContainerSiteRuntime.swift"
 else
-    ready "Local container runtime is split away from iOS Core"
+    ready "Local container runtime compiles out of iOS builds"
 fi
 
 if pattern_exists "Sources/AnglesiteIntents/PreviewAnnotationProvider.swift" "import AppKit"; then


### PR DESCRIPTION
## Summary

- Makes the shared SwiftPM products the iOS thin client needs — `AnglesiteCore` (MCP client, `RemoteSandboxSiteRuntime`, sandbox control), `AnglesiteBridge`, and `AnglesiteIntents` — build for the iOS triple (`arm64-apple-ios27.0`), clearing four of the six remaining #71 readiness-audit blockers.
- `InProcessBackend` (the only real `Process()` user in Core) and `LocalContainerSiteRuntime` compile out of iOS builds via whole-file `#if !os(iOS)` gates; `ProcessSupervisor`'s convenience init falls back to a new `UnavailableProcessBackend` (the existing `Unavailable*` seam pattern) so `.shared` call sites compile unchanged and any accidental spawn fails capability-flagged instead of pretending.
- The AppKit-coupled pieces move behind honest seams: `PreviewPrinting` (Bridge) is macOS-gated, and the `_AppIntents_AppKit` `AppEntityUIElement` surface moves to a macOS-only file so `PreviewAnnotationProvider.swift` itself is platform-neutral. `scripts/audit-ios-thin-client-readiness.sh` learns to recognize the whole-file gates (`file_is_ios_gated`), the same recognize-the-gate approach PR #451 used for Writing Tools.
- Four files' Application Support/home-dir fallbacks used `FileManager.homeDirectoryForCurrentUser`, which is compile-time unavailable on iOS. Per review, they now route through a new `FileManager.portableHomeDirectory` (`Platform/PortableHomeDirectory.swift`): the injected-`FileManager` seam is preserved on every platform that has the instance property, and the `NSHomeDirectory()` spelling is confined to an `#if os(iOS)` leg. `UnavailableProcessBackend` also gained direct unit tests.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` (full suite green on this branch's tree)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] `swift build --product AnglesiteCore|AnglesiteBridge|AnglesiteIntents --triple arm64-apple-ios27.0 --sdk "$(xcrun --sdk iphoneos --show-sdk-path)"` — all three products build for iOS (verified `arm64-apple-ios.swiftmodule` artifacts, not a silent macOS fallback)
- [x] `scripts/audit-ios-thin-client-readiness.sh` — the four Core/Bridge/Intents blockers read resolved; the two iOS-app-target blockers remain for the stacked follow-up PR

## Design notes

- Gate condition is `#if !os(iOS)` (not `os(macOS) || os(Linux)`) because `Foundation.Process` exists on every platform this project targets except iOS — including the future Windows port (#571) — so the negative condition is the future-proof one.
- `FSEventsFileWatcher`/`DarwinSecurityScopedBookmark` tighten from `canImport` gates to `os(macOS)`: iOS ships the CoreServices module and `canImport(Darwin)` is true there, but the `FSEventStream*` / `.withSecurityScope` APIs don't exist, so the `canImport` conditions were the wrong shape for iOS.
- `SpotlightSearchTool` is gated `!targetEnvironment(simulator)`: the iOS device SDK vends it, the simulator SDK does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
