### PR TITLE
feat(#71): add AnglesiteMobile iOS thin-client target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Sources/
 ├── AnglesiteIntents/    App Intents: Siri/Shortcuts/Spotlight entities and intents
 ├── AnglesiteContainer/  Apple Containerization local container runtime
 ├── AnglesiteIOS/        iOS WKWebView preview shell for the remote-only runtime path (#71)
+├── AnglesiteMobile/     iOS thin-client app target (Xcode-only, not a SwiftPM target): remote session shell over RemoteSandboxSiteRuntime
 └── AnglesiteBridge/     WKWebView script messages + JS overlay injection
 JS/
 └── edit-overlay/        TypeScript edit overlay compiled and bundled into app resources

--- a/Resources/Info-iOS.plist
+++ b/Resources/Info-iOS.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Anglesite</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Sources/AnglesiteCore/Platform/SecretStore.swift
+++ b/Sources/AnglesiteCore/Platform/SecretStore.swift
@@ -33,6 +33,11 @@ public enum SecretAccounts {
     /// REST API (#654). The app owns this credential: the old `gh auth login` flow left the
     /// token with `gh`, which the sandboxed app can neither spawn nor read.
     public static let gitHubToken = "github-token"
+    /// Bearer token for the user's deployed Sandbox Control Worker (#66/#71) — the credential
+    /// `HTTPSandboxControlClient` sends on `start`/`status`/`stop`. Distinct from
+    /// `cloudflareToken` (a Cloudflare *API* token): this one is minted for the Control Worker
+    /// during remote-runtime onboarding and never reaches api.cloudflare.com.
+    public static let sandboxControlToken = "sandbox-control-token"
 
     /// Site-scoped POSSE token slots. Account names include the stable site UUID so credentials
     /// never leak across two packages configured for different social accounts.

--- a/Sources/AnglesiteIOS/RemotePreviewWebView.swift
+++ b/Sources/AnglesiteIOS/RemotePreviewWebView.swift
@@ -16,6 +16,8 @@ public struct RemotePreviewWebView: UIViewRepresentable {
     private let url: URL
     private let scriptHandler: WKScriptMessageHandler?
     private let scriptMessageNamespace: String
+    private let makeConfiguration: (() -> WKWebViewConfiguration)?
+    private let prepareBeforeLoad: ((WKWebView) async -> Void)?
     private let configureWebView: (WKWebView) -> Void
 
     public init(
@@ -27,19 +29,54 @@ public struct RemotePreviewWebView: UIViewRepresentable {
         self.url = url
         self.scriptHandler = scriptHandler
         self.scriptMessageNamespace = scriptMessageNamespace
+        self.makeConfiguration = nil
+        self.prepareBeforeLoad = nil
+        self.configureWebView = configureWebView
+    }
+
+    /// Caller-owned configuration variant: the session shell builds the full
+    /// `WKWebViewConfiguration` itself (script handler, overlay user script) and can await
+    /// `prepareBeforeLoad` — e.g. injecting the session-token cookie so the auth-proxy sees it
+    /// on the very first request — before the preview URL is loaded.
+    public init(
+        url: URL,
+        makeConfiguration: @escaping () -> WKWebViewConfiguration,
+        prepareBeforeLoad: ((WKWebView) async -> Void)? = nil,
+        configureWebView: @escaping (WKWebView) -> Void = { _ in }
+    ) {
+        self.url = url
+        self.scriptHandler = nil
+        self.scriptMessageNamespace = Self.defaultScriptMessageNamespace
+        self.makeConfiguration = makeConfiguration
+        self.prepareBeforeLoad = prepareBeforeLoad
         self.configureWebView = configureWebView
     }
 
     public func makeUIView(context: Context) -> WKWebView {
-        let configuration = WKWebViewConfiguration()
-        if let scriptHandler {
-            configuration.userContentController.add(scriptHandler, name: scriptMessageNamespace)
+        let configuration: WKWebViewConfiguration
+        if let makeConfiguration {
+            configuration = makeConfiguration()
+        } else {
+            configuration = WKWebViewConfiguration()
+            if let scriptHandler {
+                configuration.userContentController.add(scriptHandler, name: scriptMessageNamespace)
+            }
         }
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.isInspectable = true
         configureWebView(webView)
-        webView.load(URLRequest(url: url))
         context.coordinator.loadedURL = url
+        if let prepareBeforeLoad {
+            // Await the pre-load work (async cookie-store writes) before the first request;
+            // `WKWebView` tolerates `load` arriving a beat after creation.
+            let target = url
+            Task { @MainActor in
+                await prepareBeforeLoad(webView)
+                webView.load(URLRequest(url: target))
+            }
+        } else {
+            webView.load(URLRequest(url: url))
+        }
         return webView
     }
 

--- a/Sources/AnglesiteMobile/AnglesiteMobileApp.swift
+++ b/Sources/AnglesiteMobile/AnglesiteMobileApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// iOS thin client (#71): a remote-only shell over `RemoteSandboxSiteRuntime`. No local files,
+/// no subprocesses, no local containers — the site runs in the user's Cloudflare sandbox and
+/// this app is a `WKWebView` plus MCP-over-HTTPS edits (design 2026-06-23).
+@main
+struct AnglesiteMobileApp: App {
+    @State private var model = RemoteSessionModel()
+
+    var body: some Scene {
+        WindowGroup {
+            RemoteSessionScreen(model: model)
+        }
+    }
+}

--- a/Sources/AnglesiteMobile/Localizable.xcstrings
+++ b/Sources/AnglesiteMobile/Localizable.xcstrings
@@ -1,0 +1,75 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Anglesite" : {
+
+    },
+    "Branch" : {
+
+    },
+    "Cloudflare Control Worker" : {
+
+    },
+    "Connect your Cloudflare Worker first." : {
+
+    },
+    "Connect…" : {
+
+    },
+    "Control Worker token" : {
+
+    },
+    "Couldn't Open Site" : {
+
+    },
+    "Done" : {
+
+    },
+    "From the one-time Deploy to Cloudflare setup. The token is stored in the Keychain on this device only." : {
+
+    },
+    "No Site Open" : {
+
+    },
+    "Open Site" : {
+
+    },
+    "Open your site in the remote sandbox to preview and edit it." : {
+
+    },
+    "Remote Session" : {
+
+    },
+    "Session Settings" : {
+
+    },
+    "Session Settings…" : {
+
+    },
+    "Site" : {
+
+    },
+    "Site ID" : {
+
+    },
+    "Starting %@ in the sandbox…" : {
+
+    },
+    "Stop" : {
+
+    },
+    "The sandbox clones this repository — git stays the source of truth for your site." : {
+
+    },
+    "Try Again" : {
+
+    },
+    "https://anglesite-sandbox.example.workers.dev" : {
+
+    },
+    "https://github.com/you/site.git" : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/AnglesiteMobile/RemoteSessionModel.swift
+++ b/Sources/AnglesiteMobile/RemoteSessionModel.swift
@@ -90,14 +90,19 @@ public final class RemoteSessionModel {
         return url
     }
 
-    /// Boot (or reboot) the remote session. Safe to call repeatedly — the runtime tears down
-    /// any previous session first.
+    /// Boot (or reboot) the remote session. Safe to call repeatedly — any previous runtime is
+    /// stopped (its sandbox session told to shut down) before the replacement starts, so a
+    /// retry after `.failed` can never orphan a running Cloudflare session.
     public func start() {
         guard isConfigured, let workerURL, let gitRemote else {
             state = .failed(siteID: siteID, message: String(localized: "Connect your Cloudflare Worker first."))
             return
         }
         observationTask?.cancel()
+        if let previousRuntime = runtime {
+            runtime = nil
+            Task { await previousRuntime.stop() }
+        }
 
         let token = SessionToken.mint()
         sessionToken = token

--- a/Sources/AnglesiteMobile/RemoteSessionModel.swift
+++ b/Sources/AnglesiteMobile/RemoteSessionModel.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives one remote sandbox session for the iOS thin client (#71).
+///
+/// Owns the configuration (Control Worker URL + bearer token + the site's git coordinates),
+/// the `RemoteSandboxSiteRuntime`, and a mirror of its state stream for SwiftUI. The bearer
+/// token lives in the iOS Keychain (`KeychainStore`, `kSecAttrAccessibleAfterFirstUnlock-
+/// ThisDeviceOnly` — same accessibility class as macOS); everything else is plain defaults.
+@MainActor
+@Observable
+public final class RemoteSessionModel {
+    // MARK: Configuration (persisted)
+
+    /// Base URL of the user's deployed Sandbox Control Worker (design 2026-06-23 §"Provision").
+    public var workerURLString: String {
+        didSet { defaults.set(workerURLString, forKey: Self.workerURLKey) }
+    }
+
+    /// HTTPS clone URL of the site's `Source/` repo — the sandbox hydrates from git (#72).
+    public var gitRemoteString: String {
+        didSet { defaults.set(gitRemoteString, forKey: Self.gitRemoteKey) }
+    }
+
+    public var gitRef: String {
+        didSet { defaults.set(gitRef, forKey: Self.gitRefKey) }
+    }
+
+    /// Stable per-user site identifier the Control Worker keys its sandbox Durable Object on.
+    public var siteID: String {
+        didSet { defaults.set(siteID, forKey: Self.siteIDKey) }
+    }
+
+    /// The Control Worker bearer token, Keychain-backed. Never logged, never in defaults.
+    public var controlToken: String {
+        didSet {
+            // `SecretStore.write("")` deletes the entry, so clearing the field round-trips.
+            try? secretStore.write(controlToken, account: SecretAccounts.sandboxControlToken)
+        }
+    }
+
+    // MARK: Session
+
+    public private(set) var state: SiteRuntimeState = .idle
+    /// The session token for the *current* start attempt — the preview screen injects it as the
+    /// auth-proxy cookie before the first `WKWebView` request (design 2026-06-23 §"Start session").
+    public private(set) var sessionToken: SessionToken?
+    public private(set) var mcpClient: MCPClient?
+
+    private var runtime: RemoteSandboxSiteRuntime?
+    private var observationTask: Task<Void, Never>?
+
+    private let defaults: UserDefaults
+    private let secretStore: any SecretStore
+
+    private static let workerURLKey = "remoteSession.workerURL"
+    private static let gitRemoteKey = "remoteSession.gitRemote"
+    private static let gitRefKey = "remoteSession.gitRef"
+    private static let siteIDKey = "remoteSession.siteID"
+
+    public init(
+        defaults: UserDefaults = .standard,
+        secretStore: (any SecretStore)? = nil
+    ) {
+        self.defaults = defaults
+        let store: any SecretStore = secretStore ?? KeychainStore()
+        self.secretStore = store
+        self.workerURLString = defaults.string(forKey: Self.workerURLKey) ?? ""
+        self.gitRemoteString = defaults.string(forKey: Self.gitRemoteKey) ?? ""
+        self.gitRef = defaults.string(forKey: Self.gitRefKey) ?? "main"
+        self.siteID = defaults.string(forKey: Self.siteIDKey) ?? ""
+        self.controlToken = (try? store.read(account: SecretAccounts.sandboxControlToken) ?? "") ?? ""
+    }
+
+    /// Everything the Control Worker needs before a session can start. The connect form gates
+    /// its "Open Site" button on this; `start()` also refuses (routing back to the form) so a
+    /// stale deep-link can't reach the Worker unauthenticated.
+    public var isConfigured: Bool {
+        workerURL != nil && gitRemote != nil && !controlToken.isEmpty && !siteID.isEmpty
+    }
+
+    public var workerURL: URL? {
+        guard let url = URL(string: workerURLString), url.scheme?.hasPrefix("http") == true else { return nil }
+        return url
+    }
+
+    public var gitRemote: URL? {
+        guard let url = URL(string: gitRemoteString), url.scheme != nil else { return nil }
+        return url
+    }
+
+    /// Boot (or reboot) the remote session. Safe to call repeatedly — the runtime tears down
+    /// any previous session first.
+    public func start() {
+        guard isConfigured, let workerURL, let gitRemote else {
+            state = .failed(siteID: siteID, message: String(localized: "Connect your Cloudflare Worker first."))
+            return
+        }
+        observationTask?.cancel()
+
+        let token = SessionToken.mint()
+        sessionToken = token
+        let control = HTTPSandboxControlClient(workerBaseURL: workerURL, apiToken: controlToken)
+        // iOS never spawns: the default supervisor backend is `UnavailableProcessBackend`, and
+        // this client only ever uses the HTTP transport (`connect(httpEndpoint:)`).
+        let client = MCPClient(supervisor: ProcessSupervisor())
+        mcpClient = client
+        let runtime = RemoteSandboxSiteRuntime(
+            gitRemote: gitRemote,
+            gitRef: gitRef,
+            control: control,
+            mcpClient: client,
+            mintToken: { token }
+        )
+        self.runtime = runtime
+
+        observationTask = Task { [weak self] in
+            let stream = await runtime.observe()
+            for await next in stream {
+                guard let self, !Task.isCancelled else { return }
+                self.state = next
+            }
+        }
+
+        let id = siteID
+        Task {
+            // `siteDirectory` is unused on the remote path (no local files on iOS).
+            await runtime.start(siteID: id, siteDirectory: URL(fileURLWithPath: NSTemporaryDirectory()))
+        }
+    }
+
+    public func stop() {
+        guard let runtime else { return }
+        self.runtime = nil
+        sessionToken = nil
+        mcpClient = nil
+        observationTask?.cancel()
+        observationTask = nil
+        state = .idle
+        Task { await runtime.stop() }
+    }
+}

--- a/Sources/AnglesiteMobile/RemoteSessionScreen.swift
+++ b/Sources/AnglesiteMobile/RemoteSessionScreen.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+import WebKit
+import AnglesiteCore
+import AnglesiteBridge
+import AnglesiteIOS
+
+/// Root screen of the iOS thin client: connect form until a session is configured and started,
+/// then the live sandbox preview. iPad-first, but nothing here is size-class-specific yet.
+struct RemoteSessionScreen: View {
+    @Bindable var model: RemoteSessionModel
+    @State private var showsSettings = false
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text("Anglesite"))
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            showsSettings = true
+                        } label: {
+                            Label("Session Settings", systemImage: "gearshape")
+                        }
+                    }
+                    if case .ready = model.state {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button {
+                                model.stop()
+                            } label: {
+                                Label("Stop", systemImage: "stop.circle")
+                            }
+                        }
+                    }
+                }
+                .sheet(isPresented: $showsSettings) {
+                    RemoteConnectForm(model: model)
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.state {
+        case .idle:
+            ContentUnavailableView {
+                Label("No Site Open", systemImage: "globe")
+            } description: {
+                Text("Open your site in the remote sandbox to preview and edit it.")
+            } actions: {
+                if model.isConfigured {
+                    Button("Open Site") { model.start() }
+                        .buttonStyle(.borderedProminent)
+                } else {
+                    Button("Connect…") { showsSettings = true }
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+        case .starting(let siteID):
+            VStack(spacing: 12) {
+                ProgressView()
+                Text("Starting \(siteID) in the sandbox…")
+                    .foregroundStyle(.secondary)
+            }
+        case .ready(_, let url, _):
+            RemoteSandboxPreview(url: url, model: model)
+                .ignoresSafeArea(edges: .bottom)
+        case .failed(_, let message):
+            ContentUnavailableView {
+                Label("Couldn't Open Site", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(message)
+            } actions: {
+                Button("Try Again") { model.start() }
+                    .buttonStyle(.borderedProminent)
+                Button("Session Settings…") { showsSettings = true }
+            }
+        }
+    }
+}
+
+/// The `WKWebView` leg: composes the shared bridge configuration (script handler + edit
+/// overlay user script) and injects the session-token cookie before the first request so the
+/// in-container auth-proxy accepts the preview and its HMR WebSocket (#67).
+private struct RemoteSandboxPreview: View {
+    let url: URL
+    let model: RemoteSessionModel
+
+    var body: some View {
+        let token = model.sessionToken
+        let handler = AnglesiteScriptHandler(
+            router: MCPApplyEditRouter(mcpClient: { [weak model] in await MainActor.run { model?.mcpClient } })
+        )
+        RemotePreviewWebView(
+            url: url,
+            makeConfiguration: {
+                WebViewBridge.localDevConfiguration(handler: handler)
+            },
+            prepareBeforeLoad: { webView in
+                guard let token, let host = url.host() else { return }
+                await WebViewBridge.injectSessionToken(
+                    into: webView.configuration.websiteDataStore.httpCookieStore,
+                    token: token,
+                    for: host
+                )
+            }
+        )
+    }
+}
+
+/// Connect form: the Worker URL + bearer token from the one-time Deploy-to-Cloudflare
+/// provisioning, plus the site's git coordinates. The token field writes through to the iOS
+/// Keychain (`SecretAccounts.sandboxControlToken`), never to defaults.
+private struct RemoteConnectForm: View {
+    @Bindable var model: RemoteSessionModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("https://anglesite-sandbox.example.workers.dev", text: $model.workerURLString)
+                        .keyboardType(.URL)
+                        .textContentType(.URL)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    SecureField("Control Worker token", text: $model.controlToken)
+                } header: {
+                    Text("Cloudflare Control Worker")
+                } footer: {
+                    Text("From the one-time Deploy to Cloudflare setup. The token is stored in the Keychain on this device only.")
+                }
+
+                Section {
+                    TextField("Site ID", text: $model.siteID)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    TextField("https://github.com/you/site.git", text: $model.gitRemoteString)
+                        .keyboardType(.URL)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    TextField("Branch", text: $model.gitRef)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } header: {
+                    Text("Site")
+                } footer: {
+                    Text("The sandbox clones this repository — git stays the source of truth for your site.")
+                }
+            }
+            .navigationTitle(Text("Remote Session"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/docs/qa/ios-thin-client-readiness.md
+++ b/docs/qa/ios-thin-client-readiness.md
@@ -18,13 +18,16 @@ scripts/audit-ios-thin-client-readiness.sh
 
 Expected today:
 
-- The command exits 0.
-- It lists the remote-runtime and bridge pieces already present.
-- It lists the remaining blockers, including package/project platform declarations, iOS app bundle
-  metadata, FSEvents/security-scoped/Core host runtime surfaces, and AppKit-bound intents code.
+- The command exits 0 and reports **no tracked blockers** — the seams landed with the
+  `AnglesiteMobile` target: `Package.swift` declares `.iOS`, `project.yml` has the iOS app
+  target + `Resources/Info-iOS.plist`, the host subprocess backend (`InProcessBackend`) and
+  `LocalContainerSiteRuntime` are `#if !os(iOS)`-gated out of iOS builds, and the
+  AppKit-coupled Intents surface lives in its own macOS-gated file.
 
-The `AnglesiteIOS` shell target must not depend on `AnglesiteBridge` until the bridge can be split
-away from `AnglesiteCore`; otherwise SwiftPM pulls macOS-only host runtime files into iOS builds.
+The SwiftPM `AnglesiteIOS` shell target stays dependency-free (WebKit/SwiftUI only) — the audit
+enforces this. The iOS *app* target (`AnglesiteMobile`, Xcode-only) is where `AnglesiteCore`,
+`AnglesiteBridge`, and `AnglesiteIOS` compose; those products all build with
+`--triple arm64-apple-ios27.0`.
 
 ## Readiness Gate
 

--- a/project.yml
+++ b/project.yml
@@ -3,6 +3,7 @@ options:
   bundleIdPrefix: io.dwk.anglesite
   deploymentTarget:
     macOS: "27.0"
+    iOS: "27.0"
   developmentLanguage: en
   createIntermediateGroups: true
   generateEmptyDirectories: true
@@ -116,6 +117,49 @@ targets:
       - target: AnglesiteQuickLookThumbnail
         embed: true
 
+  # iOS thin client (#71): remote-only shell over RemoteSandboxSiteRuntime. Links only the
+  # shared pieces it can use (Core's HTTP MCP client + sandbox control, the Bridge boundary,
+  # and the AnglesiteIOS WKWebView wrapper) — never AnglesiteContainer or the editor packages.
+  AnglesiteMobile:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources/AnglesiteMobile
+      - path: Resources/edit-overlay
+        type: folder
+        buildPhase: resources
+        optional: true
+    preBuildScripts:
+      - name: Build edit overlay
+        script: "\"${PROJECT_DIR}/scripts/build-overlay.sh\""
+        basedOnDependencyAnalysis: false
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite.ios
+        PRODUCT_NAME: Anglesite
+        INFOPLIST_FILE: Resources/Info-iOS.plist
+        GENERATE_INFOPLIST_FILE: NO
+        IPHONEOS_DEPLOYMENT_TARGET: "27.0"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SUPPORTS_MACCATALYST: NO
+        SWIFT_VERSION: "5.10"
+        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: "0.1.0"
+      configs:
+        Debug:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "-"
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+    dependencies:
+      - package: Anglesite
+        product: AnglesiteCore
+      - package: Anglesite
+        product: AnglesiteBridge
+      - package: Anglesite
+        product: AnglesiteIOS
+
   AnglesiteQuickLookPreview:
     type: app-extension
     platform: macOS
@@ -179,6 +223,14 @@ schemes:
     build:
       targets:
         Anglesite: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+  AnglesiteMobile:
+    build:
+      targets:
+        AnglesiteMobile: all
     run:
       config: Debug
     archive:

--- a/project.yml
+++ b/project.yml
@@ -142,6 +142,11 @@ targets:
         IPHONEOS_DEPLOYMENT_TARGET: "27.0"
         TARGETED_DEVICE_FAMILY: "1,2"
         SUPPORTS_MACCATALYST: NO
+        # String Catalog scaffolding, mirroring the macOS target (#528): Xcode IDE builds merge
+        # extracted literals into Sources/AnglesiteMobile/Localizable.xcstrings; CLI builds need
+        # the manual `xcstringstool sync` recipe from CONTRIBUTING.md.
+        SWIFT_EMIT_LOC_STRINGS: YES
+        LOCALIZATION_PREFERS_STRING_CATALOGS: YES
         SWIFT_VERSION: "5.10"
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"

--- a/scripts/check-xcodeproj-sync.sh
+++ b/scripts/check-xcodeproj-sync.sh
@@ -54,11 +54,6 @@ elif [[ "$(printf '%s\n%s\n' "$MIN_XCODEGEN" "$xcodegen_version" | sort -V | hea
   exit 1
 fi
 
-# The app target's `sources:` root in project.yml. The AnglesiteCore/Bridge/Intents trees are
-# SwiftPM package products (compiled by SwiftPM, not file-referenced in the pbxproj), so only
-# this app-target tree is verifiable against the generated project.
-sources_root="Sources/AnglesiteApp"
-
 # Regenerate the project. A spec-validation error (e.g. a path typo) exits non-zero here and
 # `set -e` aborts. --quiet suppresses the success banner but still emits warnings/errors.
 echo "Regenerating Anglesite.xcodeproj via xcodegen…"
@@ -78,19 +73,31 @@ pbx_json="$(mktemp "${TMPDIR:-/tmp}/anglesite-pbxproj.XXXXXX.json")"
 trap 'rm -f "$pbx_json"' EXIT
 plutil -convert json -o "$pbx_json" "$pbxproj"
 
-python3 - "$sources_root" "$pbx_json" <<'PY'
+python3 - "$pbx_json" <<'PY'
 import json, os, sys
 
-sources_root, pbx_json = sys.argv[1], sys.argv[2]
+pbx_json = sys.argv[1]
 
-# On-disk Swift files, as paths relative to sources_root (e.g. "Foo.swift", "Views/Bar.swift").
-on_disk = {
-    os.path.relpath(os.path.join(root, f), sources_root)
-    for root, _dirs, files in os.walk(sources_root)
-    for f in files if f.endswith(".swift")
+# Each application target's `sources:` root in project.yml. The AnglesiteCore/Bridge/Intents
+# trees are SwiftPM package products (compiled by SwiftPM, not file-referenced in the pbxproj),
+# so only these app-target trees are verifiable against the generated project. A new
+# application target must be added here or the check fails loudly below — the unmapped-target
+# error, not a silent pass, is the contract.
+SOURCES_ROOTS = {
+    "Anglesite": "Sources/AnglesiteApp",
+    "AnglesiteMobile": "Sources/AnglesiteMobile",
 }
-if not on_disk:
-    sys.exit(f"error: no .swift files found under {sources_root} — is the working tree intact?")
+
+def on_disk_swift(sources_root):
+    # On-disk Swift files, as paths relative to sources_root (e.g. "Foo.swift", "Views/Bar.swift").
+    files = {
+        os.path.relpath(os.path.join(root, f), sources_root)
+        for root, _dirs, names in os.walk(sources_root)
+        for f in names if f.endswith(".swift")
+    }
+    if not files:
+        sys.exit(f"error: no .swift files found under {sources_root} — is the working tree intact?")
+    return files
 
 with open(pbx_json) as fh:
     objects = json.load(fh)["objects"]
@@ -124,7 +131,19 @@ if not app_targets:
     sys.exit("error: no application targets found in the generated project.")
 
 failed = False
+checked = []
 for target in sorted(app_targets, key=lambda t: t["name"]):
+    name = target["name"]
+    sources_root = SOURCES_ROOTS.get(name)
+    if sources_root is None:
+        failed = True
+        print(
+            f"error: application target '{name}' has no sources root mapped in "
+            f"SOURCES_ROOTS (scripts/check-xcodeproj-sync.sh) — add it so its compile "
+            "phase is verified.", file=sys.stderr)
+        continue
+    on_disk = on_disk_swift(sources_root)
+
     compiled = set()
     for phase_id in target.get("buildPhases", []):
         phase = objects.get(phase_id, {})
@@ -140,18 +159,18 @@ for target in sorted(app_targets, key=lambda t: t["name"]):
     if missing:
         failed = True
         print(
-            f"error: target '{target['name']}' does not compile {len(missing)} file(s) that "
+            f"error: target '{name}' does not compile {len(missing)} file(s) that "
             f"exist under {sources_root}.", file=sys.stderr)
         print(
             "       project.yml's sources have drifted from disk; an xcodebuild of this target "
             "would fail with 'cannot find … in scope':", file=sys.stderr)
         for rel in missing:
             print(f"         - {sources_root}/{rel}", file=sys.stderr)
+    else:
+        checked.append(f"{name} ({len(on_disk)} file(s) under {sources_root})")
 
 if failed:
     sys.exit(1)
 
-names = ", ".join(sorted(t["name"] for t in app_targets))
-print(f"✓ Anglesite.xcodeproj is in sync: {len(on_disk)} file(s) under {sources_root} "
-      f"compiled by every app target ({names}).")
+print("✓ Anglesite.xcodeproj is in sync: " + "; ".join(checked) + ".")
 PY


### PR DESCRIPTION
## Summary

- Adds the iOS thin-client app target from the approved 2026-06-23 remote-sandbox design: `AnglesiteMobile` (`platform: iOS`, iPad-first `TARGETED_DEVICE_FAMILY 1,2`, `io.dwk.anglesite.ios`, `Resources/Info-iOS.plist`), linking only `AnglesiteCore` + `AnglesiteBridge` + `AnglesiteIOS` — never `AnglesiteContainer` or the editor packages. Stacked on #885.
- `RemoteSessionModel` drives `RemoteSandboxSiteRuntime` end to end: mints the `SessionToken`, builds `HTTPSandboxControlClient` from the stored Control Worker URL + bearer token (iOS Keychain via `KeychainStore`, `AfterFirstUnlockThisDeviceOnly` — same accessibility class as macOS, under the new `SecretAccounts.sandboxControlToken` slot), and mirrors the runtime state stream into SwiftUI (connect form → starting → preview → failed states).
- The preview composes the shared bridge boundary: `WebViewBridge.localDevConfiguration` (script handler + edit-overlay user script, edits routed through `MCPApplyEditRouter` over the authenticated MCP tunnel) and `WebViewBridge.injectSessionToken` as a new async `prepareBeforeLoad` hook on `RemotePreviewWebView`, so the auth-proxy cookie is in place before the first request (and its HMR WebSocket upgrade, #67). The SwiftPM `AnglesiteIOS` target stays dependency-free (audit-enforced).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` (full suite green)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (macOS app unaffected)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile -configuration Debug -destination 'generic/platform=iOS Simulator' build` — **BUILD SUCCEEDED**
- [x] `scripts/audit-ios-thin-client-readiness.sh --expect-ready` — exits 0, "No tracked iOS thin-client blockers remain."
- [ ] Manual smoke against a live Control Worker (needs a provisioned Cloudflare sandbox — the Deploy-to-Cloudflare onboarding flow is a tracked follow-up on #71)

## Follow-ups (tracked on #71)

- Deploy-to-Cloudflare onboarding (`ASWebAuthenticationSession`) to provision the Control Worker instead of manual URL/token entry.
- UIKit equivalent of the AppKit `AppEntityUIElement` provider (B.4) for Siri annotations on iOS.
- Site switcher / multi-site UX beyond the single-session form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)