### PR TITLE
feat(worker): compose @dwk/webmention inbound receiver (#359)

### DIFF
--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.0",
         "@dwk/indieauth": "0.1.0-beta.3",
+        "@dwk/webmention": "0.1.0-beta.3",
         "astro": "^6.4.8",
         "astro-embed": "^0.13.0",
         "astro-seo-schema": "^6.0.0"
@@ -1526,6 +1527,25 @@
       "resolved": "https://registry.npmjs.org/@dwk/log/-/log-0.1.0-beta.3.tgz",
       "integrity": "sha512-gnXom/1623VbaPSm5plmr2KPpCHxoW06jTId9n/mHC9boR0dG6Plzo+5Ie4dXVbYSodRIwipeA2CkAlCbyaefA==",
       "license": "ISC"
+    },
+    "node_modules/@dwk/safe-fetch": {
+      "version": "0.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@dwk/safe-fetch/-/safe-fetch-0.1.0-beta.2.tgz",
+      "integrity": "sha512-iluM5HAqRC3TPOWBeO1ts7egsCHQAmXTHQguPaBLm0brRcwW3ZkQ1/sBnTpCVaBQUfkwsyrBofiwWVQpitMpyg==",
+      "license": "ISC",
+      "dependencies": {
+        "@dwk/log": "0.1.0-beta.3"
+      }
+    },
+    "node_modules/@dwk/webmention": {
+      "version": "0.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@dwk/webmention/-/webmention-0.1.0-beta.3.tgz",
+      "integrity": "sha512-VRl1oRz1foILXRVJ1jJqRFiSFfY/VoYdM//nbJG3Wgf3mUm/WpF1OPE9/0TyZEZy5tZu/UMQNOrByuulZ8l2lA==",
+      "license": "ISC",
+      "dependencies": {
+        "@dwk/log": "0.1.0-beta.3",
+        "@dwk/safe-fetch": "0.1.0-beta.2"
+      }
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.0",
     "@dwk/indieauth": "0.1.0-beta.3",
+    "@dwk/webmention": "0.1.0-beta.3",
     "astro": "^6.4.8",
     "astro-embed": "^0.13.0",
     "astro-seo-schema": "^6.0.0"

--- a/Resources/Template/vitest.config.ts
+++ b/Resources/Template/vitest.config.ts
@@ -8,11 +8,14 @@ export default defineConfig({
       miniflare: {
         compatibilityDate: "2026-07-15",
         compatibilityFlags: ["nodejs_compat"],
-        d1Databases: ["AUTH_DB"],
+        d1Databases: ["AUTH_DB", "WEBMENTION_INBOX"],
         kvNamespaces: ["INBOX_KV", "SOCIAL_KV"],
+        queueProducers: { WEBMENTION_QUEUE: "site-webmentions" },
+        queueConsumers: ["site-webmentions"],
         bindings: {
           TOKEN_SIGNING_KEY: "test-token-signing-key-with-at-least-32-bytes",
           INDIEAUTH_OWNER_PASSWORD: "correct horse battery staple",
+          SITE_URL: "https://test.example",
         },
       },
     }),

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -438,3 +438,71 @@ test("handleIndieAuthConsent: 429s once the per-IP login attempt limit is exceed
   const limited = await handleIndieAuthConsent(makeRequest(), testEnv);
   expect(limited.status).toBe(429);
 });
+
+// --- Inbound Webmention receive (V-3.1, #359) ----------------------------------------------
+// Composition of @dwk/webmention's receiver. These run through worker.fetch in the workerd pool
+// with WEBMENTION_QUEUE/WEBMENTION_INBOX/SITE_URL bound (see vitest.config.ts), so they exercise
+// the same synchronous validate-then-enqueue path production serves. Async link-verification is
+// the library's own concern (covered by its suite + webmention.rocks), not re-tested here.
+
+function webmentionForm(fields: Record<string, string>): Request {
+  return new Request("https://owner.example/webmention", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(fields).toString(),
+  });
+}
+
+test("webmention receive: a valid source/target under this origin is accepted (202)", async () => {
+  const response = await fetchWorker(
+    webmentionForm({ source: "https://commenter.example/reply", target: "https://owner.example/blog/hello/" }),
+  );
+  expect(response.status).toBe(202);
+});
+
+test("webmention receive: a missing field is rejected (400)", async () => {
+  const noTarget = await fetchWorker(webmentionForm({ source: "https://commenter.example/reply" }));
+  expect(noTarget.status).toBe(400);
+  const noSource = await fetchWorker(webmentionForm({ target: "https://owner.example/blog/hello/" }));
+  expect(noSource.status).toBe(400);
+});
+
+test("webmention receive: source equal to target is rejected (400)", async () => {
+  const response = await fetchWorker(
+    webmentionForm({ source: "https://owner.example/x/", target: "https://owner.example/x/" }),
+  );
+  expect(response.status).toBe(400);
+});
+
+test("webmention receive: a target on a foreign host is rejected (400)", async () => {
+  const response = await fetchWorker(
+    webmentionForm({ source: "https://commenter.example/reply", target: "https://elsewhere.example/post/" }),
+  );
+  expect(response.status).toBe(400);
+});
+
+test("webmention receive: a non-POST method gets 405 with Allow: POST", async () => {
+  const response = await fetchWorker(new Request("https://owner.example/webmention", { method: "GET" }));
+  expect(response.status).toBe(405);
+  expect(response.headers.get("allow")).toBe("POST");
+});
+
+test("webmention receive: 503 when inbound Webmention isn't provisioned (no queue binding)", async () => {
+  const { WEBMENTION_QUEUE: _unusedQueue, ...envWithoutQueue } = testEnv;
+  const response = await worker.fetch(
+    webmentionForm({ source: "https://commenter.example/reply", target: "https://owner.example/blog/hello/" }),
+    envWithoutQueue as WorkerEnv,
+    createExecutionContext(),
+  );
+  expect(response.status).toBe(503);
+});
+
+test("webmention queue consumer: no-ops (does not throw) when the inbox/site origin is unprovisioned", async () => {
+  const { WEBMENTION_INBOX: _unusedInbox, SITE_URL: _unusedSiteURL, ...envWithoutInbox } = testEnv;
+  const emptyBatch = { queue: "site-webmentions", messages: [] } as unknown as Parameters<
+    NonNullable<typeof worker.queue>
+  >[0];
+  await expect(
+    worker.queue!(emptyBatch, envWithoutInbox as WorkerEnv, createExecutionContext()),
+  ).resolves.toBeUndefined();
+});

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -3,6 +3,13 @@ import {
   type AuthorizationRequest,
   type IndieAuthEnv,
 } from "@dwk/indieauth";
+import {
+  createWebmention,
+  createWebmentionQueueConsumer,
+  createD1Inbox,
+  type WebmentionEnv,
+  type WebmentionJob,
+} from "@dwk/webmention";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -39,6 +46,17 @@ export interface WorkerEnv extends IndieAuthEnv {
   INBOX_KV?: InboxKV;
   SOCIAL_KV?: InboxKV;
   INDIEAUTH_OWNER_PASSWORD: string;
+  /**
+   * Inbound-Webmention bindings (V-3.1, #359). All optional: a site that hasn't provisioned
+   * inbound Webmention has none of them bound, and the `/webmention` route + `queue` consumer
+   * degrade gracefully (503 / ack-without-work) rather than throwing. Provisioning wires them —
+   * a Cloudflare Queue for async verification, a D1 database for the verified-mention inbox, and
+   * the site's canonical origin (the `queue` consumer has no request to derive it from).
+   * See `WorkerComposition.generateWranglerToml` (Swift) for the binding generation.
+   */
+  WEBMENTION_QUEUE?: Queue<WebmentionJob>;
+  WEBMENTION_INBOX?: D1Database;
+  SITE_URL?: string;
 }
 
 const RATE_LIMIT_WINDOW_SECONDS = 3600;
@@ -331,6 +349,66 @@ function indieAuthHandler(request: Request, env: WorkerEnv) {
   });
 }
 
+/**
+ * Inbound-Webmention receive endpoint (V-3.1, #359).
+ *
+ * Composes `@dwk/webmention`'s receiver: a form-encoded `POST` of `source` + `target` is
+ * validated synchronously (both `http(s)` URLs, distinct, `target` under this origin) and, on
+ * success, enqueued to `WEBMENTION_QUEUE` for asynchronous link-verification before a `202`.
+ * The heavy work — fetching the source through an SSRF-safe wrapper and confirming it links to
+ * the target — happens in the `queue` consumer, keeping the request path cheap and spam-resistant.
+ *
+ * Returns `503` when inbound Webmention isn't provisioned for this site (no `WEBMENTION_QUEUE`),
+ * so a stray request to an un-provisioned site gets a clean "not configured" rather than the
+ * library's loud throw. The `/webmention` route is only advertised (`<link rel="webmention">`)
+ * once provisioning is on — that discovery wiring is the paired template/Swift follow-up.
+ */
+function handleWebmentionReceive(
+  request: Request,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  if (!env.WEBMENTION_QUEUE) {
+    return Promise.resolve(new Response("Webmention receiving is not configured", { status: 503 }));
+  }
+  const baseUrl = new URL(request.url).origin;
+  const receiver = createWebmention({ baseUrl });
+  const webmentionEnv: WebmentionEnv = {
+    WEBMENTION_QUEUE: env.WEBMENTION_QUEUE,
+    WEBMENTION_INBOX: env.WEBMENTION_INBOX,
+  };
+  return receiver(request, webmentionEnv, ctx);
+}
+
+/**
+ * Queue consumer for asynchronous Webmention verification (V-3.1, #359).
+ *
+ * For each queued `(source, target)` job, `@dwk/webmention` fetches the source through its
+ * SSRF-safe wrapper and upserts a verified mention into the D1 inbox — or removes it when the
+ * source no longer links. Acks-without-work (rather than throwing) when the inbox or the site
+ * origin isn't provisioned, so an un-provisioned site's stray queue delivery can't wedge the
+ * consumer. `SITE_URL` scopes which targets verification accepts; the consumer has no request to
+ * derive the origin from, so provisioning supplies it as a plain var.
+ */
+function handleWebmentionQueue(
+  batch: MessageBatch<WebmentionJob>,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): Promise<void> {
+  if (!env.WEBMENTION_QUEUE || !env.WEBMENTION_INBOX || !env.SITE_URL) {
+    return Promise.resolve();
+  }
+  const consumer = createWebmentionQueueConsumer({
+    baseUrl: env.SITE_URL,
+    inbox: createD1Inbox(env.WEBMENTION_INBOX),
+  });
+  const webmentionEnv: WebmentionEnv = {
+    WEBMENTION_QUEUE: env.WEBMENTION_QUEUE,
+    WEBMENTION_INBOX: env.WEBMENTION_INBOX,
+  };
+  return consumer(batch, webmentionEnv, ctx);
+}
+
 export interface InboxFields {
   subject: string;
   from: string;
@@ -475,6 +553,13 @@ export const ROUTES: readonly WorkerRoute[] = [
     methods: ["POST"],
     handler: (request, env) => handleInbox(request, env),
   },
+  {
+    // Inbound Webmention receiver (V-3.1, #359): POST source+target, validate, enqueue, 202.
+    path: "/webmention",
+    match: "exact",
+    methods: ["POST"],
+    handler: (request, env, ctx) => handleWebmentionReceive(request, env, ctx),
+  },
 ];
 
 export function matchRoute(pathname: string, routes: readonly WorkerRoute[] = ROUTES): WorkerRoute | null {
@@ -557,4 +642,10 @@ export default {
     }
     return assets.fetch(request);
   },
-} satisfies ExportedHandler<WorkerEnv>;
+
+  // Async Webmention verification (V-3.1, #359). Present unconditionally; no-ops for sites
+  // without inbound Webmention provisioned (see `handleWebmentionQueue`).
+  async queue(batch: MessageBatch<WebmentionJob>, env: WorkerEnv, ctx: ExecutionContext): Promise<void> {
+    return handleWebmentionQueue(batch, env, ctx);
+  },
+} satisfies ExportedHandler<WorkerEnv, WebmentionJob>;

--- a/Resources/Template/worker/workers-version.json
+++ b/Resources/Template/worker/workers-version.json
@@ -3,10 +3,10 @@
   "description": "Pinned @dwk/workers version range for this template. Read by Anglesite during scaffold and social-feature enablement. Updated when a new @dwk/workers release ships.",
   "version": "0.1.0-beta.3",
   "range": "0.1.0-beta.3",
-  "note": "IndieAuth is pinned to the exact published beta verified by the template Worker integration suite; later social packages remain gated on their conformance status.",
+  "note": "IndieAuth and Webmention (inbound receive, V-3.1) are pinned to the exact published betas composed into worker.ts and verified by the template Worker integration suite; the remaining social packages remain gated on their conformance status until composed.",
   "packages": {
     "@dwk/indieauth": "0.1.0-beta.3",
-    "@dwk/webmention": "^0.0.0",
+    "@dwk/webmention": "0.1.0-beta.3",
     "@dwk/micropub": "^0.0.0",
     "@dwk/websub": "^0.0.0",
     "@dwk/microsub": "^0.0.0",


### PR DESCRIPTION
## Summary

- **V-3.1 (inbound social) first slice** — the per-site Worker now composes `@dwk/webmention`'s receiver, unblocked by the `0.1.0-beta.3` release landing. Adds a `/webmention` route (synchronous validate → enqueue → `202`) and a `queue` consumer that verifies each job through the library's SSRF-safe fetch and upserts/removes the mention in a D1 inbox.
- **Degrades gracefully:** all new bindings (`WEBMENTION_QUEUE`, `WEBMENTION_INBOX`, `SITE_URL`) are optional. An un-provisioned site returns `503` from `/webmention` (instead of the library's loud throw) and the consumer acks-without-work, so existing sites are unaffected until provisioning wires them.
- Pins `@dwk/webmention` to `0.1.0-beta.3` (dependency + `workers-version.json`) and adds the matching miniflare test bindings.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`. It consumes the already-published `@dwk/webmention@0.1.0-beta.3` from npm (backward-compatible — the endpoint is inert until provisioned) and touches only `Resources/Template/`, which is app-only.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite` (MCP sidecar server).

## Test plan

- [x] `npm run test:worker` (Resources/Template) — 37 tests pass (7 new covering receive `202`/`400`/`405`/`503` and the consumer no-op guard), run in the `@cloudflare/vitest-pool-workers` workerd pool. This is the CI `template-worker` lane.
- [x] `npm run build` (Resources/Template) — `astro check` + `astro build` + microformats validation all pass; the new dependency doesn't affect the Astro graph.
- [x] `npx tsc --noEmit` — `worker.ts` type-checks clean (remaining errors are the pre-existing `astro sync` ones in `src/`).
- [ ] `swift test` / `xcodebuild` — **not run**: no Swift toolchain in this environment. This PR deliberately contains **no Swift changes** (see below), so the Swift/xcodebuild CI lanes are the gate for the untouched app target.

## Scope & deferred follow-ups

Kept to the TypeScript worker composition so every change is locally verifiable (no Swift toolchain here to test app-target code). The remaining #359/#362 work, to be sequenced next:

- **Swift — binding generation & provisioning:** the Queue + `WEBMENTION_INBOX` (D1) bindings and `SITE_URL` var in `WorkerComposition.generateWranglerToml`, plus Queue creation in `SocialWorkerProvisionCommand`. **Note:** the `@dwk/webmention` receiver requires a Cloudflare **Queue**, which needs the Workers **Paid** plan — a product decision to surface at provisioning time (it cuts against the "free-tier default"), not a silent requirement.
- **Swift — canonicality snapshot:** app-side D1→git sync into `Source/data/interactions/` as `ReceivedInteraction` JSON (per the decided C.3 schema, `docs/specs/2026-06-29-c3-received-interaction-canonicality.md`). The library's stored `VerifiedMention` is minimal (`source`/`target`/`verifiedAt`/`rsvp?`); enriching with author/content (mf2) is part of the render slice.
- **Discovery + render:** `<link rel="webmention">` advertisement (provisioning-gated) and rendering received replies/likes on the page (#362).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu3dLxdiZ7n6qu3EQqMebq)_