### PR TITLE
feat(#890): CloudflareOAuthClient PKCE authorization flow

### DIFF
--- a/Sources/AnglesiteCore/CloudflareOAuthClient.swift
+++ b/Sources/AnglesiteCore/CloudflareOAuthClient.swift
@@ -1,0 +1,240 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+/// Cloudflare's registered OAuth client for the iOS onboarding flow (#889-#891). The client ID is
+/// not a secret — PKCE public clients (`token_endpoint_auth_method: none`) have none — so it's
+/// safe to commit. The redirect URI is the callback Worker from #891, reached via Apple Associated
+/// Domains rather than a custom URL scheme: Cloudflare's OAuth-client registration form only
+/// accepts `http(s)` redirect URIs.
+public enum CloudflareOAuthConfiguration {
+    public static let clientID = "e6705eb5f46254ecae0641b2e4da0ee2"
+    public static let redirectURI = URL(string: "https://auth.anglesite.dwk.io/oauth-callback")!
+    public static let discoveryURL = URL(string: "https://dash.cloudflare.com/.well-known/openid-configuration")!
+}
+
+/// The two endpoints a Cloudflare OAuth client needs, fetched from the OIDC discovery document
+/// rather than hardcoded — standard OIDC practice, and survives Cloudflare relocating them.
+struct OAuthDiscoveryDocument: Decodable, Sendable {
+    let authorizationEndpoint: URL
+    let tokenEndpoint: URL
+
+    enum CodingKeys: String, CodingKey {
+        case authorizationEndpoint = "authorization_endpoint"
+        case tokenEndpoint = "token_endpoint"
+    }
+}
+
+/// The token response from Cloudflare's token endpoint.
+public struct OAuthToken: Decodable, Sendable, Equatable {
+    public let accessToken: String
+    public let tokenType: String
+    public let expiresIn: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+    }
+}
+
+public enum CloudflareOAuthError: Error, Equatable, Sendable {
+    /// Discovery document couldn't be fetched or decoded.
+    case discoveryUnavailable(String)
+    /// The callback's `state` didn't match the one this request minted — possible CSRF, never
+    /// silently accepted.
+    case stateMismatch
+    /// The authorization server (or the user) denied the request, e.g. `error=access_denied`.
+    case callbackDenied(String)
+    /// The callback had a matching `state` but no `code`.
+    case missingAuthorizationCode
+    /// The token endpoint rejected the exchange or returned something undecodable.
+    case tokenExchangeFailed(String)
+}
+
+/// One authorize attempt: the URL to present plus what's needed to complete it once a callback
+/// URL comes back. `codeVerifier` never leaves this type except via `CloudflareOAuthClient.exchange`.
+public struct CloudflareOAuthRequest: Sendable {
+    public let authorizeURL: URL
+    let state: String
+    let codeVerifier: String
+}
+
+/// Cloudflare's self-managed OAuth (opened to all developers 2026-06-03): Authorization Code +
+/// PKCE for public/native clients. This type only builds requests, parses callbacks, and exchanges
+/// codes — presenting the actual browser sheet (`ASWebAuthenticationSession`) is the caller's job,
+/// kept out of this type entirely so it stays fully unit-testable without `AuthenticationServices`
+/// or any UI, the same separation `TokenOnboarding` keeps from SwiftUI. Mirrors
+/// `CloudflareAPITokenVerifier`'s injected-`Transport` seam for the same reason.
+public struct CloudflareOAuthClient: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let clientID: String
+    private let redirectURI: URL
+    private let scope: String
+    private let discoveryURL: URL
+    private let transport: Transport
+
+    /// - scope: a Cloudflare OAuth scope name (== an API token permission-group name, e.g. the
+    ///   dashboard's "User Details" Read). No default — the exact literal must come from the
+    ///   registered client's available scopes (design doc §5's open item), not a guess baked in here.
+    public init(
+        clientID: String = CloudflareOAuthConfiguration.clientID,
+        redirectURI: URL = CloudflareOAuthConfiguration.redirectURI,
+        scope: String,
+        discoveryURL: URL = CloudflareOAuthConfiguration.discoveryURL,
+        transport: @escaping Transport = CloudflareOAuthClient.defaultTransport
+    ) {
+        self.clientID = clientID
+        self.redirectURI = redirectURI
+        self.scope = scope
+        self.discoveryURL = discoveryURL
+        self.transport = transport
+    }
+
+    /// Fetches discovery, mints a PKCE verifier/challenge + CSRF state, and builds the authorize
+    /// URL. The caller presents `request.authorizeURL` (e.g. via `ASWebAuthenticationSession`) and
+    /// passes whatever callback URL comes back to `authorizationCode(from:matching:)`.
+    public func makeAuthorizationRequest() async throws -> CloudflareOAuthRequest {
+        let discovery = try await discover()
+        let verifier = Self.makeCodeVerifier()
+        let state = Self.makeState()
+        guard var components = URLComponents(url: discovery.authorizationEndpoint, resolvingAgainstBaseURL: false) else {
+            throw CloudflareOAuthError.discoveryUnavailable("malformed authorization_endpoint")
+        }
+        components.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI.absoluteString),
+            URLQueryItem(name: "scope", value: scope),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: try Self.codeChallenge(for: verifier)),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+        ]
+        guard let url = components.url else {
+            throw CloudflareOAuthError.discoveryUnavailable("couldn't build the authorize URL")
+        }
+        return CloudflareOAuthRequest(authorizeURL: url, state: state, codeVerifier: verifier)
+    }
+
+    /// Extracts and validates the authorization code from a completed browser session's callback
+    /// URL against the `state` minted for `request`. Static and side-effect-free: this is pure URL
+    /// parsing, not a network call.
+    public static func authorizationCode(from callbackURL: URL, matching request: CloudflareOAuthRequest) throws -> String {
+        let items = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        func value(_ name: String) -> String? { items.first { $0.name == name }?.value }
+
+        if let error = value("error") {
+            throw CloudflareOAuthError.callbackDenied(value("error_description") ?? error)
+        }
+        guard let state = value("state"), state == request.state else {
+            throw CloudflareOAuthError.stateMismatch
+        }
+        guard let code = value("code"), !code.isEmpty else {
+            throw CloudflareOAuthError.missingAuthorizationCode
+        }
+        return code
+    }
+
+    /// Exchanges `code` (from `authorizationCode(from:matching:)`) + the matching request's PKCE
+    /// verifier for an access token.
+    public func exchange(code: String, for request: CloudflareOAuthRequest) async throws -> OAuthToken {
+        let discovery = try await discover()
+        var form = URLComponents()
+        form.queryItems = [
+            URLQueryItem(name: "grant_type", value: "authorization_code"),
+            URLQueryItem(name: "code", value: code),
+            URLQueryItem(name: "redirect_uri", value: redirectURI.absoluteString),
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "code_verifier", value: request.codeVerifier),
+        ]
+        var urlRequest = URLRequest(url: discovery.tokenEndpoint)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = Data((form.percentEncodedQuery ?? "").utf8)
+
+        let data: Data, http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(urlRequest)
+        } catch {
+            throw CloudflareOAuthError.tokenExchangeFailed(error.localizedDescription)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CloudflareOAuthError.tokenExchangeFailed("HTTP \(http.statusCode): \(String(data: data, encoding: .utf8) ?? "")")
+        }
+        do {
+            return try JSONDecoder().decode(OAuthToken.self, from: data)
+        } catch {
+            throw CloudflareOAuthError.tokenExchangeFailed("bad response: \(error)")
+        }
+    }
+
+    private func discover() async throws -> OAuthDiscoveryDocument {
+        var request = URLRequest(url: discoveryURL)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let data: Data, http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw CloudflareOAuthError.discoveryUnavailable(error.localizedDescription)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CloudflareOAuthError.discoveryUnavailable("HTTP \(http.statusCode)")
+        }
+        do {
+            return try JSONDecoder().decode(OAuthDiscoveryDocument.self, from: data)
+        } catch {
+            throw CloudflareOAuthError.discoveryUnavailable("bad response: \(error)")
+        }
+    }
+
+    /// Production transport: a plain `URLSession` POST/GET, no auth of its own.
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+
+    /// 32 random bytes, base64url-encoded (no padding) — well within RFC 7636's 43-128 char range.
+    /// `SystemRandomNumberGenerator` is cryptographically secure on every supported platform
+    /// (arc4random_buf on Darwin, getrandom(2) on Linux) — same reasoning `SessionToken.mint()` uses.
+    static func makeCodeVerifier() -> String {
+        var rng = SystemRandomNumberGenerator()
+        let bytes = (0..<32).map { _ in UInt8.random(in: .min ... .max, using: &rng) }
+        return base64URLEncode(Data(bytes))
+    }
+
+    static func makeState() -> String {
+        var rng = SystemRandomNumberGenerator()
+        let bytes = (0..<16).map { _ in UInt8.random(in: .min ... .max, using: &rng) }
+        return base64URLEncode(Data(bytes))
+    }
+
+    #if canImport(CryptoKit)
+    static func codeChallenge(for verifier: String) throws -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return base64URLEncode(Data(digest))
+    }
+    #else
+    static func codeChallenge(for verifier: String) throws -> String {
+        // OAuth login only ever happens from the iOS UI layer (`ASWebAuthenticationSession`),
+        // which doesn't exist on Linux either — there's no path that reaches this on that platform
+        // today. Throwing rather than hand-rolling SHA-256 keeps that honest instead of silently
+        // producing a wrong challenge.
+        throw CloudflareOAuthError.discoveryUnavailable("PKCE S256 challenge needs CryptoKit (Apple platforms only)")
+    }
+    #endif
+
+    private static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Sources/AnglesiteCore/CloudflareOAuthClient.swift
+++ b/Sources/AnglesiteCore/CloudflareOAuthClient.swift
@@ -64,6 +64,9 @@ public struct CloudflareOAuthRequest: Sendable {
     public let authorizeURL: URL
     let state: String
     let codeVerifier: String
+    /// Resolved from the same discovery fetch that built `authorizeURL`, so `exchange(code:for:)`
+    /// doesn't need a second round trip to `.well-known/openid-configuration` for the same login.
+    let tokenEndpoint: URL
 }
 
 /// Cloudflare's self-managed OAuth (opened to all developers 2026-06-03): Authorization Code +
@@ -120,21 +123,26 @@ public struct CloudflareOAuthClient: Sendable {
         guard let url = components.url else {
             throw CloudflareOAuthError.discoveryUnavailable("couldn't build the authorize URL")
         }
-        return CloudflareOAuthRequest(authorizeURL: url, state: state, codeVerifier: verifier)
+        return CloudflareOAuthRequest(
+            authorizeURL: url, state: state, codeVerifier: verifier, tokenEndpoint: discovery.tokenEndpoint)
     }
 
     /// Extracts and validates the authorization code from a completed browser session's callback
     /// URL against the `state` minted for `request`. Static and side-effect-free: this is pure URL
     /// parsing, not a network call.
+    ///
+    /// `state` is checked before `error` — an `error` param only "belongs" to this request once
+    /// it's bound by a matching `state`, so a forged/unbound error callback reads as a state
+    /// mismatch rather than a denial.
     public static func authorizationCode(from callbackURL: URL, matching request: CloudflareOAuthRequest) throws -> String {
         let items = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
         func value(_ name: String) -> String? { items.first { $0.name == name }?.value }
 
-        if let error = value("error") {
-            throw CloudflareOAuthError.callbackDenied(value("error_description") ?? error)
-        }
         guard let state = value("state"), state == request.state else {
             throw CloudflareOAuthError.stateMismatch
+        }
+        if let error = value("error") {
+            throw CloudflareOAuthError.callbackDenied(value("error_description") ?? error)
         }
         guard let code = value("code"), !code.isEmpty else {
             throw CloudflareOAuthError.missingAuthorizationCode
@@ -143,9 +151,9 @@ public struct CloudflareOAuthClient: Sendable {
     }
 
     /// Exchanges `code` (from `authorizationCode(from:matching:)`) + the matching request's PKCE
-    /// verifier for an access token.
+    /// verifier for an access token. Uses `request.tokenEndpoint` rather than re-fetching
+    /// discovery — already resolved once, by `makeAuthorizationRequest()`, for this same login.
     public func exchange(code: String, for request: CloudflareOAuthRequest) async throws -> OAuthToken {
-        let discovery = try await discover()
         var form = URLComponents()
         form.queryItems = [
             URLQueryItem(name: "grant_type", value: "authorization_code"),
@@ -154,7 +162,7 @@ public struct CloudflareOAuthClient: Sendable {
             URLQueryItem(name: "client_id", value: clientID),
             URLQueryItem(name: "code_verifier", value: request.codeVerifier),
         ]
-        var urlRequest = URLRequest(url: discovery.tokenEndpoint)
+        var urlRequest = URLRequest(url: request.tokenEndpoint)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         urlRequest.httpBody = Data((form.percentEncodedQuery ?? "").utf8)

--- a/Tests/AnglesiteCoreTests/CloudflareOAuthClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareOAuthClientTests.swift
@@ -1,0 +1,169 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests `CloudflareOAuthClient`'s pure logic — PKCE generation, discovery parsing, authorize-URL
+/// construction, callback validation, and token exchange — all against an injected `Transport`, no
+/// real network and no `AuthenticationServices`/UI (that boundary is the whole point of the type).
+@Suite(.serialized)
+struct CloudflareOAuthClientTests {
+    private let discoveryURL = URL(string: "https://dash.cloudflare.com/.well-known/openid-configuration")!
+    private let redirectURI = URL(string: "https://auth.anglesite.dwk.io/oauth-callback")!
+    private let discoveryJSON = Data("""
+    {"authorization_endpoint":"https://dash.cloudflare.com/oauth2/auth","token_endpoint":"https://dash.cloudflare.com/oauth2/token"}
+    """.utf8)
+
+    private func response(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: discoveryURL, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    // MARK: PKCE
+
+    @Test("code_challenge matches RFC 7636 Appendix B's test vector")
+    func rfc7636Vector() throws {
+        // https://www.rfc-editor.org/rfc/rfc7636#appendix-B
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        #expect(try CloudflareOAuthClient.codeChallenge(for: verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    @Test("makeCodeVerifier produces a base64url string with no padding/plus/slash")
+    func verifierIsBase64URL() {
+        let verifier = CloudflareOAuthClient.makeCodeVerifier()
+        #expect(!verifier.contains("+"))
+        #expect(!verifier.contains("/"))
+        #expect(!verifier.contains("="))
+        #expect(verifier.count >= 43) // RFC 7636's floor
+    }
+
+    @Test("makeState produces distinct values across calls")
+    func stateIsRandom() {
+        #expect(CloudflareOAuthClient.makeState() != CloudflareOAuthClient.makeState())
+    }
+
+    // MARK: Authorization request
+
+    @Test("makeAuthorizationRequest builds a well-formed authorize URL")
+    func buildsAuthorizeURL() async throws {
+        let client = CloudflareOAuthClient(
+            redirectURI: redirectURI, scope: "user.read", discoveryURL: discoveryURL,
+            transport: { [discoveryJSON] _ in (discoveryJSON, self.response(200)) })
+        let request = try await client.makeAuthorizationRequest()
+
+        let items = URLComponents(url: request.authorizeURL, resolvingAgainstBaseURL: false)!.queryItems!
+        func value(_ name: String) -> String? { items.first { $0.name == name }?.value }
+
+        #expect(request.authorizeURL.host == "dash.cloudflare.com")
+        #expect(request.authorizeURL.path == "/oauth2/auth")
+        #expect(value("response_type") == "code")
+        #expect(value("redirect_uri") == redirectURI.absoluteString)
+        #expect(value("scope") == "user.read")
+        #expect(value("state") == request.state)
+        #expect(value("code_challenge_method") == "S256")
+        #expect(value("code_challenge")?.isEmpty == false)
+    }
+
+    @Test("discovery HTTP failure surfaces as .discoveryUnavailable")
+    func discoveryFailureSurfaces() async {
+        let client = CloudflareOAuthClient(
+            redirectURI: redirectURI, scope: "user.read", discoveryURL: discoveryURL,
+            transport: { _ in (Data(), self.response(500)) })
+        await #expect(throws: CloudflareOAuthError.self) {
+            _ = try await client.makeAuthorizationRequest()
+        }
+    }
+
+    // MARK: Callback validation (pure, no network)
+
+    private func makeRequest(state: String = "abc123") -> CloudflareOAuthRequest {
+        CloudflareOAuthRequest(
+            authorizeURL: URL(string: "https://dash.cloudflare.com/oauth2/auth")!,
+            state: state, codeVerifier: "verifier")
+    }
+
+    @Test("a matching state yields the code")
+    func callbackMatchingState() throws {
+        let request = makeRequest()
+        let callback = URL(string: "https://auth.anglesite.dwk.io/oauth-callback?code=xyz&state=abc123")!
+        #expect(try CloudflareOAuthClient.authorizationCode(from: callback, matching: request) == "xyz")
+    }
+
+    @Test("a mismatched state throws .stateMismatch, never returns the code")
+    func callbackMismatchedState() {
+        let request = makeRequest()
+        let callback = URL(string: "https://auth.anglesite.dwk.io/oauth-callback?code=xyz&state=WRONG")!
+        #expect(throws: CloudflareOAuthError.stateMismatch) {
+            _ = try CloudflareOAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
+    @Test("an error query param throws .callbackDenied even with a matching state")
+    func callbackDenied() {
+        let request = makeRequest()
+        let callback = URL(string: "https://auth.anglesite.dwk.io/oauth-callback?error=access_denied&state=abc123")!
+        #expect(throws: CloudflareOAuthError.callbackDenied("access_denied")) {
+            _ = try CloudflareOAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
+    @Test("a matching state but missing code throws .missingAuthorizationCode")
+    func callbackMissingCode() {
+        let request = makeRequest()
+        let callback = URL(string: "https://auth.anglesite.dwk.io/oauth-callback?state=abc123")!
+        #expect(throws: CloudflareOAuthError.missingAuthorizationCode) {
+            _ = try CloudflareOAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
+    // MARK: Token exchange
+
+    @Test("exchange posts the PKCE verifier and decodes the token")
+    func exchangeParsesToken() async throws {
+        let request = makeRequest()
+        var capturedBody: String?
+        let client = CloudflareOAuthClient(
+            redirectURI: redirectURI, scope: "user.read", discoveryURL: discoveryURL,
+            transport: { [discoveryJSON] req in
+                if req.url == self.discoveryURL { return (discoveryJSON, self.response(200)) }
+                #expect(req.httpMethod == "POST")
+                capturedBody = req.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+                let body = #"{"access_token":"tok-123","token_type":"bearer","expires_in":3600}"#
+                return (Data(body.utf8), self.response(200))
+            })
+        let token = try await client.exchange(code: "auth-code", for: request)
+
+        #expect(token.accessToken == "tok-123")
+        #expect(token.tokenType == "bearer")
+        #expect(token.expiresIn == 3600)
+        #expect(capturedBody?.contains("code_verifier=verifier") == true)
+        #expect(capturedBody?.contains("code=auth-code") == true)
+        #expect(capturedBody?.contains("grant_type=authorization_code") == true)
+    }
+
+    @Test("a non-2xx token response throws .tokenExchangeFailed")
+    func exchangeHTTPFailure() async {
+        let request = makeRequest()
+        let client = CloudflareOAuthClient(
+            redirectURI: redirectURI, scope: "user.read", discoveryURL: discoveryURL,
+            transport: { [discoveryJSON] req in
+                if req.url == self.discoveryURL { return (discoveryJSON, self.response(200)) }
+                return (Data("bad code".utf8), self.response(400))
+            })
+        await #expect(throws: CloudflareOAuthError.self) {
+            _ = try await client.exchange(code: "auth-code", for: request)
+        }
+    }
+
+    @Test("an undecodable token response throws .tokenExchangeFailed")
+    func exchangeBadJSON() async {
+        let request = makeRequest()
+        let client = CloudflareOAuthClient(
+            redirectURI: redirectURI, scope: "user.read", discoveryURL: discoveryURL,
+            transport: { [discoveryJSON] req in
+                if req.url == self.discoveryURL { return (discoveryJSON, self.response(200)) }
+                return (Data("not json".utf8), self.response(200))
+            })
+        await #expect(throws: CloudflareOAuthError.self) {
+            _ = try await client.exchange(code: "auth-code", for: request)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareOAuthClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareOAuthClientTests.swift
@@ -77,7 +77,8 @@ struct CloudflareOAuthClientTests {
     private func makeRequest(state: String = "abc123") -> CloudflareOAuthRequest {
         CloudflareOAuthRequest(
             authorizeURL: URL(string: "https://dash.cloudflare.com/oauth2/auth")!,
-            state: state, codeVerifier: "verifier")
+            state: state, codeVerifier: "verifier",
+            tokenEndpoint: URL(string: "https://dash.cloudflare.com/oauth2/token")!)
     }
 
     @Test("a matching state yields the code")
@@ -96,11 +97,20 @@ struct CloudflareOAuthClientTests {
         }
     }
 
-    @Test("an error query param throws .callbackDenied even with a matching state")
+    @Test("an error query param throws .callbackDenied when the state matches")
     func callbackDenied() {
         let request = makeRequest()
         let callback = URL(string: "https://auth.anglesite.dwk.io/oauth-callback?error=access_denied&state=abc123")!
         #expect(throws: CloudflareOAuthError.callbackDenied("access_denied")) {
+            _ = try CloudflareOAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
+    @Test("an error query param with a non-matching state throws .stateMismatch, not .callbackDenied")
+    func callbackErrorWithMismatchedStateIsStateMismatch() {
+        let request = makeRequest()
+        let callback = URL(string: "https://auth.anglesite.dwk.io/oauth-callback?error=access_denied&state=WRONG")!
+        #expect(throws: CloudflareOAuthError.stateMismatch) {
             _ = try CloudflareOAuthClient.authorizationCode(from: callback, matching: request)
         }
     }
@@ -116,14 +126,16 @@ struct CloudflareOAuthClientTests {
 
     // MARK: Token exchange
 
-    @Test("exchange posts the PKCE verifier and decodes the token")
+    @Test("exchange posts the PKCE verifier and decodes the token, without re-fetching discovery")
     func exchangeParsesToken() async throws {
         let request = makeRequest()
         var capturedBody: String?
+        var transportCallCount = 0
         let client = CloudflareOAuthClient(
             redirectURI: redirectURI, scope: "user.read", discoveryURL: discoveryURL,
-            transport: { [discoveryJSON] req in
-                if req.url == self.discoveryURL { return (discoveryJSON, self.response(200)) }
+            transport: { req in
+                transportCallCount += 1
+                #expect(req.url == request.tokenEndpoint)
                 #expect(req.httpMethod == "POST")
                 capturedBody = req.httpBody.flatMap { String(data: $0, encoding: .utf8) }
                 let body = #"{"access_token":"tok-123","token_type":"bearer","expires_in":3600}"#
@@ -137,6 +149,7 @@ struct CloudflareOAuthClientTests {
         #expect(capturedBody?.contains("code_verifier=verifier") == true)
         #expect(capturedBody?.contains("code=auth-code") == true)
         #expect(capturedBody?.contains("grant_type=authorization_code") == true)
+        #expect(transportCallCount == 1) // no second discovery round trip
     }
 
     @Test("a non-2xx token response throws .tokenExchangeFailed")
@@ -144,10 +157,7 @@ struct CloudflareOAuthClientTests {
         let request = makeRequest()
         let client = CloudflareOAuthClient(
             redirectURI: redirectURI, scope: "user.read", discoveryURL: discoveryURL,
-            transport: { [discoveryJSON] req in
-                if req.url == self.discoveryURL { return (discoveryJSON, self.response(200)) }
-                return (Data("bad code".utf8), self.response(400))
-            })
+            transport: { _ in (Data("bad code".utf8), self.response(400)) })
         await #expect(throws: CloudflareOAuthError.self) {
             _ = try await client.exchange(code: "auth-code", for: request)
         }
@@ -158,10 +168,7 @@ struct CloudflareOAuthClientTests {
         let request = makeRequest()
         let client = CloudflareOAuthClient(
             redirectURI: redirectURI, scope: "user.read", discoveryURL: discoveryURL,
-            transport: { [discoveryJSON] req in
-                if req.url == self.discoveryURL { return (discoveryJSON, self.response(200)) }
-                return (Data("not json".utf8), self.response(200))
-            })
+            transport: { _ in (Data("not json".utf8), self.response(200)) })
         await #expect(throws: CloudflareOAuthError.self) {
             _ = try await client.exchange(code: "auth-code", for: request)
         }


### PR DESCRIPTION
## Summary

- Adds `CloudflareOAuthClient` (AnglesiteCore): Cloudflare's self-managed OAuth (public client, Authorization Code + PKCE, `token_endpoint_auth_method: none`), following the [design doc](docs/superpowers/specs/2026-07-21-ios-cloudflare-onboarding-design.md) §5 — discovery-doc lookup (not hardcoded endpoints), authorize-URL construction, callback `state`/`code` validation, and token exchange.
- Presenting the browser (`ASWebAuthenticationSession`) is deliberately *not* in this type — it's injected by the UI layer (#891) — so this stays fully unit-testable without `AuthenticationServices`, mirroring how `TokenOnboarding` stays out of SwiftUI.
- Adds `CloudflareOAuthConfiguration` with the registered public client ID (`e6705eb5f46254ecae0641b2e4da0ee2` — not a secret, PKCE public clients don't get one) and the redirect URI (`https://auth.anglesite.dwk.io/oauth-callback`, hosted by #891's callback Worker).
- Requested OAuth scope stays a required (no-default) parameter — resolved to **User Details (Read)** per the design doc's updated open item, to be wired in by whichever of #889/#891 actually instantiates the client.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path . --filter CloudflareOAuthClientTests` — 12/12 pass, including Cloudflare's PKCE challenge computation verified against RFC 7636 Appendix B's published test vector.
- [x] `swift test --package-path .` (full suite) — one pre-existing, unrelated failure in `FoundationModelAssistantTests` (on-device model context-size/session flake, confirmed present before this change and untouched by it); everything else passes.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run this pass (no app-target files touched); will run before #891 wires this into the UI.