### PR TITLE
fix(container): decouple MCP staging from plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Before handing work off, re-check the changed files against `CONTRIBUTING.md`, r
 
 The **website template** (Astro project skeleton, themes, scaffold script, pre-deploy check) lives in this repo at `Resources/Template/`. It is a committed, first-class app resource. `TemplateRuntime` resolves it from the app bundle (with a Settings override for development).
 
-The sidecar repo's Claude-plugin machinery (markdown skills, `hooks.json`, `.claude-plugin/` manifest) is retired on the app side (#466): the app no longer bundles or loads any of it — `scripts/copy-plugin.sh`, `Resources/plugin/`, and `PluginRuntime` are gone. What the app consumes from the sibling repo is only `server/` (+ its npm manifests), staged into the container image by `scripts/lib/stage-dev-image-context.sh`. Until the sidecar's converted repo drops the `.claude-plugin/plugin.json` marker, the staging scripts still use that file as an identity check — that check moves with the paired plugin-repo conversion PR.
+The sibling `Anglesite/anglesite` repo continues to publish Anglesite as a Claude Skill and standalone project. Its Claude-plugin machinery (markdown skills, `hooks.json`, `.claude-plugin/` manifest) is retired **on the app side** (#466): the app no longer bundles or loads it — `scripts/copy-plugin.sh`, `Resources/plugin/`, and `PluginRuntime` are gone. What the app consumes from that checkout is only `server/` (+ its npm manifests), staged into the container image by `scripts/lib/stage-dev-image-context.sh`. The staging scripts identify that MCP-server boundary by `server/index.mjs` and `package.json`, rather than by the plugin manifest.
 
 Cross-cutting work (e.g. extending the MCP server with new messages) still lands as paired PRs:
 
@@ -107,7 +107,7 @@ When shared-core constraints conflict with a platform convention, keep the share
 Do feature work — and **all** dispatched-agent work — in a git worktree, never directly on the main checkout. Multiple agents run in parallel here, so the main tree must stay clean. Worktrees live under `.claude/worktrees/<name>/`.
 
 - **Run `xcodegen generate` first** — `Anglesite.xcodeproj` is gitignored and regenerated from `project.yml`, so a fresh worktree has no project file until you generate it.
-- **Set `ANGLESITE_PLUGIN_SRC`** — its default (`../anglesite`) resolves wrong from inside a worktree; point it at the real sidecar checkout (`…/github.com/Anglesite/anglesite`) so the container-image scripts (`vendor-container-image.sh` / `build-podman-image.sh` / `build-container-image.sh`) can stage the MCP sidecar.
+- **Set `ANGLESITE_SIDECAR_SRC`** — its default (`../anglesite`) resolves wrong from inside a worktree; point it at the real sidecar checkout (`…/github.com/Anglesite/anglesite`) so the container-image scripts (`vendor-container-image.sh` / `build-podman-image.sh` / `build-container-image.sh`) can stage the MCP sidecar. `ANGLESITE_PLUGIN_SRC` remains a compatibility alias.
 - **Dispatched subagents must `cd` to the worktree** — give them a hard `cd <worktree>` guard before any git op, or they run against the main checkout.
 
 ## Build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Anglesite (Mac app)
 
-Thanks for your interest in contributing! This repo is the native macOS app that hosts the [Anglesite plugin](https://github.com/Anglesite/anglesite). It's pre-release and moving fast, so a quick read of this page will save you time.
+Thanks for your interest in contributing! This repo is the native macOS app that consumes the MCP server from the published [Anglesite Claude Skill](https://github.com/Anglesite/anglesite). It's pre-release and moving fast, so a quick read of this page will save you time.
 
 ## Before you start
 
@@ -39,7 +39,7 @@ Key things to know:
   ```
   Always pass `--skip-marking-strings-stale`: without it, `sync` deletes any catalog key it can't find in the given `.stringsdata` files, and unless every one of them came from the exact same complete build, that silently nukes real entries — confirmed the hard way while writing this: a from-scratch `-derivedDataPath` build's `.stringsdata` set made `sync` empty the entire 700+-key catalog. This CLI recipe is only known-good against the `DerivedData` your own machine has already accumulated from normal `xcodebuild`/Xcode use — there is no known way yet to make it work reliably from an isolated, from-scratch build (e.g. in CI); review the `.xcstrings` diff yourself and include it in the same commit. Do not blindly restore the catalog when it appears after a build. If extraction looks incomplete or unexpectedly large, run a clean build first (`xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug clean build`) and review the stabilized result before committing it. CI's `localization-catalog` lane (`scripts/check-localization-catalog.sh`, #811) is a static backstop, not a substitute: it heuristically scans `Sources/AnglesiteApp` for common SwiftUI call sites (`Text`, `Button`, `Label`, …) and `String(localized:)`/`LocalizedStringKey(...)` literals with no matching catalog key, but it doesn't type-check call sites and can't catch every extraction vector Xcode recognizes.
 - **Linux contributors welcome.** The portable SwiftPM targets build and test on Linux (Swift 6.3+, no Xcode or Node needed) — see [Developing on Linux](README.md#developing-on-linux). The cross-platform port ([#571](https://github.com/Anglesite/Anglesite-app/issues/571)) is an active track.
-- **Plugin sibling checkout (optional).** Some end-to-end tests expect the plugin repo checked out next to this one (`../anglesite`); they skip cleanly when it's absent.
+- **Plugin sibling checkout (optional).** Some end-to-end tests expect the Anglesite plugin repo checked out next to this one (`../anglesite`); they skip cleanly when it's absent.
 
 ## Testing
 
@@ -59,7 +59,7 @@ npm run lint && npm run typecheck && npm test
 Notes:
 
 - Container runtime tests are opt-in: `ANGLESITE_CONTAINER_TESTS=1` (plus `ANGLESITE_CONTAINER_E2E=1` for end-to-end cases).
-- MCP/apply-edit e2e tests run only when `ANGLESITE_PLUGIN_PATH` points at a plugin checkout; otherwise they skip.
+- MCP/apply-edit e2e tests run only when `ANGLESITE_PLUGIN_PATH` points at an Anglesite plugin checkout; otherwise they skip.
 - If you touch `Resources/Template/`, run `swift test` too — some Swift tests couple to the template markup.
 - CI runs the JS overlay checks, Linux portable-target builds, macOS `swift test` (including ThreadSanitizer lanes), an `Anglesite.xcodeproj` ↔ `project.yml` sync check, and an AppIntents schema check. All must pass.
 
@@ -69,14 +69,14 @@ Notes:
 - **Process spawning is centralized** in `AnglesiteCore/ProcessSupervisor` — never call `Process()` from a view.
 - **Logs are sacred** — every spawned subprocess streams stdout+stderr to the debug pane. Don't silently discard output.
 - **Git is the source of truth for sites** — the app must never become the only way to edit a site. A site's `Source/` repo stays clonable and editable outside the app.
-- **The app cannot bypass plugin security hooks** — `pre-deploy-check.sh` runs before every deploy; surface failures, don't add overrides.
+- **The app cannot bypass the template security gate** — `pre-deploy-check.ts` runs before every deploy; surface failures, don't add overrides.
 - **JS/TypeScript** (edit overlay) uses ES modules, vanilla APIs, and the existing oxlint/tsc/vitest toolchain.
 
 ## Commits and pull requests
 
 - **Conventional commits** — `feat(scope): …`, `fix(scope): …`, `ci: …`, etc. Reference the issue number in the subject when there is one (see `git log` for examples). Keep the whole subject line to **72 characters or fewer** (aim for ~50) — `type(scope): summary (#123)` adds up faster than it looks, and an over-length subject gets silently wrapped or split across `git log --oneline`, GitHub's commit/PR views, and `gh`'s own output. If it doesn't fit, shorten the summary and put the extra detail in the commit body, not the subject.
 - **Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) as-is.** Open the file and copy its exact section headings into the PR body — **Summary**, **Paired PR check**, and **Test plan** — even for a trivial change. Don't substitute a generic "Summary / Test plan" body from a different tool's default PR format: that shape silently drops the Paired PR check. Extra sections (Design notes, screenshots, etc.) are welcome appended after the template's own sections — never in place of them.
-- **Paired PRs.** Changes to the MCP message schema or plugin skills need a paired PR in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite): the plugin PR ships first in a tagged release, then the app PR consumes it. Template changes (`Resources/Template/`) are app-only. See `AGENTS.md` ▸ "Two-repo coordination".
+- **Paired PRs.** Changes to the MCP message schema need a paired PR in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite): the sidecar PR ships first in a tagged release, then the app PR consumes it. Template changes (`Resources/Template/`) are app-only. See `AGENTS.md` ▸ "Two-repo coordination".
 - **`@dwk/workers` catalog coordination.** The Worker catalog (`WorkerCatalog.swift` and friends) consumes `catalog.json` published by the separate [`davidwkeith/workers`](https://github.com/davidwkeith/workers) monorepo — a third repo outside the `Anglesite/anglesite` pairing above. Schema extensions there land the same way: keep the app-side decoding **backward-compatible** (new manifest fields optional, feature inert until the catalog publishes them) so the app PR can merge first, and note the pending catalog change in the PR body. Example: the #746 route-claims PR ([#829](https://github.com/Anglesite/Anglesite-app/pull/829)) shipped an optional `routes` field the catalog can adopt later.
 - Keep PRs focused; opportunistic cleanup near the code you're touching is fine, drive-by refactors of unrelated code are not.
 

--- a/Containers/anglesite-dev/Dockerfile
+++ b/Containers/anglesite-dev/Dockerfile
@@ -4,7 +4,7 @@
 #   - scripts/build-podman-image.sh (podman, native host arch — arm64 or amd64 — tagged
 #     localhost/anglesite-dev:latest for PodmanContainerControl on Linux)
 # Bakes Node + git + socat (the vsock<->TCP bridge, macOS path only) + the app's MCP sidecar
-# (the plugin's server/, npm ci'd for the build's native arch so sharp's native binary is
+# (the MCP sidecar's server/, npm ci'd for the build's native arch so sharp's native binary is
 # correct) so a fresh container needs no in-guest install.
 
 # Per-arch digest pin (reproducible; re-bump periodically for base security updates). The build
@@ -20,16 +20,16 @@ FROM ${BASE_IMAGE} AS base
 # Unused on the podman path (port-mapping replaces vsock there) but harmless to install.
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates socat \
     && rm -rf /var/lib/apt/lists/*
-# MCP sidecar: staged by the build script from the plugin's server/ dir. npm ci runs on the
+# MCP sidecar: staged by the build script from the plugin checkout's server/ dir. npm ci runs on the
 # build's native arch → pulls the matching @img/sharp-linux-{arm64,x64} native prebuilt from the
 # lockfile. --omit=dev drops devDependencies. We intentionally do NOT pass --omit=optional
 # because the sharp prebuilts are marked optional in the lockfile (platform-specific); npm's
 # platform-cpu/os filters already skip the other arch's prebuilt and macOS-only optionals like
 # fsevents.
 COPY mcp-sidecar/ /usr/local/lib/anglesite-mcp/
-# Playwright is an unused optionalDependency of the plugin. We keep `npm ci` (reproducible; lock-exact)
-# and cannot pass --omit=optional because the sharp prebuilt is also optional (platform prebuilt).
-# ENV prevents playwright's postinstall from downloading ~300 MB of browsers; rm strips the pkg dirs.
+# Playwright is an unused optionalDependency of the plugin package. We keep `npm ci`
+# (reproducible; lock-exact) and cannot pass --omit=optional because the sharp prebuilt is also
+# optional. This prevents Playwright from downloading browsers while the image builds.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 RUN cd /usr/local/lib/anglesite-mcp \
     && npm ci --omit=dev \

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Notes:
 
 ## Relationship to the sidecar repo
 
-This repo expects to live next to `Anglesite/anglesite` on disk (both checked out under the same parent directory) — or set `ANGLESITE_PLUGIN_SRC` to point elsewhere. The sibling repo supplies the **MCP sidecar** (`server/`), which the container-image scripts (`scripts/vendor-container-image.sh`, `scripts/build-podman-image.sh`) stage into the dev-server image; the MCP end-to-end tests also spawn it directly from the checkout (`ANGLESITE_PLUGIN_PATH`). Nothing from the sibling repo is bundled into the app itself anymore (#466).
+This repo expects to live next to `Anglesite/anglesite` on disk (both checked out under the same parent directory) — or set `ANGLESITE_SIDECAR_SRC` to point elsewhere (`ANGLESITE_PLUGIN_SRC` remains a compatibility alias). The sibling repo supplies the **MCP sidecar** (`server/`), which the container-image scripts (`scripts/vendor-container-image.sh`, `scripts/build-podman-image.sh`) stage into the dev-server image; the MCP end-to-end tests also spawn it directly from the checkout (`ANGLESITE_PLUGIN_PATH`). Nothing from the sibling repo is bundled into the app itself anymore (#466).
 
 ## License
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -7,7 +7,7 @@
 # is exported into Resources/container-image/ by scripts/vendor-container-image.sh.
 #
 # This Dockerfile remains for the Cloudflare Sandbox / remote-runtime pipeline:
-# the Astro dev server and the plugin's MCP server run inside this Linux
+# the Astro dev server and the MCP sidecar run inside this Linux
 # container so the remote runtime can match the local runtime's behavior.
 #
 #   • Apple Containerization (macOS) — Containers/anglesite-dev/ bundled as OCI.
@@ -35,19 +35,19 @@ ENV ANGLESITE_HOME=/opt/anglesite \
     SITE_DIR=/workspace \
     PORT=4321
 
-# ---- Plugin MCP server runtime ------------------------------------------------
-# The plugin is the source of truth for the MCP server (CLAUDE.md). Bake its
+# ---- MCP sidecar runtime ------------------------------------------------------
+# The sidecar is the source of truth for the MCP server. Bake its
 # runtime — server/*.mjs plus the production dependency closure
 # (@modelcontextprotocol/sdk, sharp, and the SDK's hoisted zod) — so the runtime
 # substrates can start it with no network install. Deps are installed against the
 # committed lockfile before the source is copied so this layer caches well.
-COPY plugin/package.json plugin/package-lock.json ${ANGLESITE_HOME}/plugin/
-RUN cd ${ANGLESITE_HOME}/plugin \
+COPY mcp-sidecar/package.json mcp-sidecar/package-lock.json ${ANGLESITE_HOME}/mcp-sidecar/
+RUN cd ${ANGLESITE_HOME}/mcp-sidecar \
  && ( npm ci --omit=dev \
-      || { echo "WARN: plugin lockfile out of sync — falling back to npm install" >&2; \
+      || { echo "WARN: sidecar lockfile out of sync — falling back to npm install" >&2; \
            npm install --omit=dev; } )
-COPY plugin/ ${ANGLESITE_HOME}/plugin/
-ENV ANGLESITE_MCP_ENTRY=${ANGLESITE_HOME}/plugin/server/index.mjs
+COPY mcp-sidecar/ ${ANGLESITE_HOME}/mcp-sidecar/
+ENV ANGLESITE_MCP_ENTRY=${ANGLESITE_HOME}/mcp-sidecar/server/index.mjs
 
 # ---- Pre-baked site toolchain (skip npm ci on cold start; design §5b) ---------
 # Install the template's full dependency closure once, at build time. This warms

--- a/container/README.md
+++ b/container/README.md
@@ -17,7 +17,7 @@ a canonical dev-server image plus the Cloudflare-specific wrapper
 `Resources/container-image/`.
 
 Original design intent: one behavior-defining OCI image, with substrate-specific
-packaging where needed. The Astro dev server and the plugin's MCP server run
+packaging where needed. The Astro dev server and the MCP sidecar run
 inside the Linux container so the dev server behaves consistently:
 
 | Substrate | Current source |
@@ -31,8 +31,8 @@ This realizes the [design doc](../docs/specs/2026-05-30-cloudflare-sandbox-dev-s
 
 - **Node**, pinned to [`scripts/node-version.txt`](../scripts/node-version.txt) (passed as `NODE_VERSION` at build).
 - **`git`** — Git is the source of truth (design §3.1 option A); the container clones the site on start, edits commit/push. No host-share, no embedded Node.
-- **The Astro / site toolchain**, pre-installed from the plugin template's lockfile (`@opt/anglesite/baked`).
-- **The plugin's MCP server runtime** — `server/*.mjs` plus its production deps, baked at `/opt/anglesite/plugin` (`ANGLESITE_MCP_ENTRY`). The plugin is the source of truth for the MCP server (`CLAUDE.md`).
+- **The Astro / site toolchain**, pre-installed from the app template's lockfile (`@opt/anglesite/baked`).
+- **The MCP sidecar runtime** — `server/*.mjs` plus its production deps, baked at `/opt/anglesite/mcp-sidecar` (`ANGLESITE_MCP_ENTRY`).
 - **`tini`** as PID 1 for signal/zombie reaping.
 
 Defaults to **`linux/arm64`** for historical/local builds. Cloudflare Sandbox is
@@ -62,9 +62,9 @@ scripts/build-container-image.sh
 scripts/build-container-image.sh --push
 ```
 
-Env overrides: `IMAGE_REPO` (default `ghcr.io/anglesite/anglesite-devserver`), `IMAGE_TAG` (default `dev`), `ANGLESITE_PLUGIN_SRC` (default `../anglesite`, same as `copy-plugin.sh`).
+Env overrides: `IMAGE_REPO` (default `ghcr.io/anglesite/anglesite-devserver`), `IMAGE_TAG` (default `dev`), and `ANGLESITE_SIDECAR_SRC` (default `../anglesite`; `ANGLESITE_PLUGIN_SRC` remains a compatibility alias).
 
-The script stages a clean build context (plugin runtime + template manifests + helper scripts), so the `Dockerfile` is **not** buildable on its own — build through the script.
+The script stages a clean build context (MCP sidecar + template manifests + helper scripts), so the `Dockerfile` is **not** buildable on its own — build through the script.
 
 ## Runtime contract
 
@@ -78,7 +78,7 @@ The default `ENTRYPOINT` ([`entrypoint.sh`](entrypoint.sh)) hydrates then execs 
 | `PORT` | Astro dev port (default `4321`) |
 | `ANGLESITE_MCP_ENTRY` | path to the baked MCP server entry |
 
-The default CMD ([`start-dev-server.sh`](start-dev-server.sh)) runs `astro dev` bound to `0.0.0.0`. The **network-reachable MCP server** starts here too once the plugin's HTTP/SSE transport (#63) and `MCPClient`'s HTTP transport (#64) land; until then the MCP runtime is baked in and started over stdio by the runtime layer.
+The default CMD ([`start-dev-server.sh`](start-dev-server.sh)) runs `astro dev` bound to `0.0.0.0`. The sidecar's Streamable HTTP transport exposes the MCP server on the runtime-managed port, while stdio remains available for direct local use.
 
 ## Distribution decision (Q-D)
 
@@ -88,4 +88,4 @@ The default CMD ([`start-dev-server.sh`](start-dev-server.sh)) runs `astro dev` 
 - **Apple Containerization** no longer consumes this lowercase path in the app. It uses the vendored OCI layout produced from `../Containers/anglesite-dev/`.
 - **Cloudflare Sandbox** can't run the base image entirely unmodified: the Sandbox SDK needs its standalone init binary in the image. [`Dockerfile.cloudflare`](Dockerfile.cloudflare) `FROM`s the base image (by digest) and adds **only** that binary. Cloudflare builds/pushes this thin wrapper to its own registry at `wrangler deploy`; the exact init source pin is finalized by the Cloudflare spike (#61).
 
-This keeps the *behavior-defining* layers (Node, git, Astro toolchain, plugin MCP runtime, baked deps) reusable for the remote substrate while keeping the active macOS image source unambiguous.
+This keeps the *behavior-defining* layers (Node, git, Astro toolchain, MCP sidecar, baked deps) reusable for the remote substrate while keeping the active macOS image source unambiguous.

--- a/container/README.md
+++ b/container/README.md
@@ -78,7 +78,7 @@ The default `ENTRYPOINT` ([`entrypoint.sh`](entrypoint.sh)) hydrates then execs 
 | `PORT` | Astro dev port (default `4321`) |
 | `ANGLESITE_MCP_ENTRY` | path to the baked MCP server entry |
 
-The default CMD ([`start-dev-server.sh`](start-dev-server.sh)) runs `astro dev` bound to `0.0.0.0`. The sidecar's Streamable HTTP transport exposes the MCP server on the runtime-managed port, while stdio remains available for direct local use.
+The default CMD ([`start-dev-server.sh`](start-dev-server.sh)) runs `astro dev` bound to `0.0.0.0`. The network-reachable MCP server starts here once the sidecar grows an HTTP/SSE transport and the remote runtime wires its matching HTTP transport; until then the MCP runtime is baked in and started over stdio by the runtime layer.
 
 ## Distribution decision (Q-D)
 

--- a/container/start-dev-server.sh
+++ b/container/start-dev-server.sh
@@ -4,7 +4,7 @@
 # can reach it (local container IP, or a Cloudflare exposed port). HMR rides the
 # same connection (design §2).
 #
-# The network-reachable MCP server starts here too once the plugin grows an
+# The network-reachable MCP server starts here too once the sidecar grows an
 # HTTP/SSE transport (#63) and MCPClient grows the matching HTTP transport (#64).
 # Until then the MCP runtime is baked in (ANGLESITE_MCP_ENTRY) and started by the
 # runtime layer over stdio. See container/README.md.

--- a/scripts/build-container-image.sh
+++ b/scripts/build-container-image.sh
@@ -8,7 +8,7 @@
 #
 # This path remains for the Cloudflare Sandbox / remote-runtime image pipeline.
 # Node is pinned to scripts/node-version.txt; git, the Astro/site toolchain, and
-# the plugin's MCP server runtime are baked in; the template's dependency closure
+# the MCP sidecar runtime is baked in; the template's dependency closure
 # is pre-installed so cold starts skip npm ci (design §5b).
 #
 # Usage:
@@ -21,7 +21,8 @@
 #   PLATFORM             build arch   (default: linux/arm64). Set linux/amd64 for the
 #                        Cloudflare substrate (CF Containers are amd64-only), or a
 #                        comma list "linux/amd64,linux/arm64" for a multi-arch manifest.
-#   ANGLESITE_PLUGIN_SRC plugin checkout (default: ../anglesite sibling, like stage-dev-image-context.sh)
+#   ANGLESITE_SIDECAR_SRC sidecar checkout (default: ../anglesite sibling)
+#   ANGLESITE_PLUGIN_SRC  legacy alias for ANGLESITE_SIDECAR_SRC
 #
 # Distribution (decision Q-D): the Cloudflare/shared image is pushed to a registry
 # BY DIGEST. Cloudflare Containers run amd64 (remote); the substrate layers its
@@ -58,11 +59,12 @@ fi
 NODE_VERSION=$(tr -d '[:space:]' < "$VERSION_FILE")
 [[ -n "$NODE_VERSION" ]] || { echo "$VERSION_FILE is empty" >&2; exit 1; }
 
-# Resolve the plugin source the same way scripts/lib/stage-dev-image-context.sh does.
+# Resolve the sidecar source the same way scripts/lib/stage-dev-image-context.sh does.
 DEFAULT_SRC=$(cd "$REPO_ROOT/.." && pwd)/anglesite
-SRC="${ANGLESITE_PLUGIN_SRC:-$DEFAULT_SRC}"
-[[ -d "$SRC" ]] || { echo "plugin source not found at $SRC (set ANGLESITE_PLUGIN_SRC)" >&2; exit 1; }
-[[ -f "$SRC/.claude-plugin/plugin.json" ]] || { echo "$SRC is not the Anglesite plugin (no .claude-plugin/plugin.json)" >&2; exit 1; }
+SIDECAR_SRC="${ANGLESITE_SIDECAR_SRC:-${ANGLESITE_PLUGIN_SRC:-$DEFAULT_SRC}}"
+[[ -d "$SIDECAR_SRC" ]] || { echo "MCP sidecar source not found at $SIDECAR_SRC (set ANGLESITE_SIDECAR_SRC)" >&2; exit 1; }
+[[ -f "$SIDECAR_SRC/server/index.mjs" && -f "$SIDECAR_SRC/package.json" ]] \
+    || { echo "$SIDECAR_SRC is not an Anglesite MCP sidecar (need server/index.mjs and package.json)" >&2; exit 1; }
 TEMPLATE_DIR="$REPO_ROOT/Resources/Template"
 [[ -f "$TEMPLATE_DIR/package.json" ]] \
     || { echo "template manifests missing under $TEMPLATE_DIR" >&2; exit 1; }
@@ -84,17 +86,13 @@ echo "==> Staging build context"
 cp "$CONTAINER_DIR/Dockerfile" "$CONTAINER_DIR/.dockerignore" "$CTX/"
 cp "$CONTAINER_DIR/entrypoint.sh" "$CONTAINER_DIR/hydrate.sh" "$CONTAINER_DIR/start-dev-server.sh" "$CTX/"
 
-# Plugin runtime: server + manifests + lockfile. node_modules/.git and other
-# heavy/private dirs are excluded — production deps are installed inside the image.
-mkdir -p "$CTX/plugin"
+# MCP sidecar runtime: server + manifests + lockfile. Production dependencies
+# are installed inside the image.
+mkdir -p "$CTX/mcp-sidecar"
 rsync -a \
-    --exclude='node_modules/' --exclude='.git/' --exclude='.github/' \
-    --exclude='.worktrees/' --exclude='.serena/' --exclude='.playwright-mcp/' \
-    --exclude='.claude/' --exclude='dist/' --exclude='build/' \
-    --exclude='tests/' --exclude='test/' --exclude='docs/' \
-    --exclude='*.log' --exclude='.DS_Store' \
-    --exclude='template/' \
-    "$SRC/" "$CTX/plugin/"
+    --exclude='node_modules/' --exclude='.git/' \
+    "$SIDECAR_SRC/server/" "$CTX/mcp-sidecar/server/"
+cp "$SIDECAR_SRC/package.json" "$SIDECAR_SRC/package-lock.json" "$CTX/mcp-sidecar/"
 
 # Template: manifests only. We bake the template's dependency closure, not its source.
 mkdir -p "$CTX/template"

--- a/scripts/lib/stage-dev-image-context.sh
+++ b/scripts/lib/stage-dev-image-context.sh
@@ -2,7 +2,7 @@
 # Shared staging step for scripts that build Containers/anglesite-dev/Dockerfile (the app's
 # local dev-server image), whichever tool builds it (Apple `container` CLI or podman).
 #
-# Stages the MCP sidecar (from the sibling plugin repo) and the website template's dependency
+# Stages the MCP sidecar (from the sibling Anglesite plugin repo) and the website template's dependency
 # manifests into the build context, and registers a cleanup trap so the staged, gitignored
 # copies don't linger after the build. Source this file, then call stage_dev_image_context "$CTX".
 #
@@ -16,34 +16,35 @@ stage_dev_image_context() {
     local root
     root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-    # Honor $ANGLESITE_PLUGIN_SRC, default to
-    # ../anglesite (sibling under the same parent dir as this repo — wrong from inside a
-    # worktree, so set ANGLESITE_PLUGIN_SRC there).
-    local default_plugin_src="$(cd "$root/.." && pwd)/anglesite"
-    local plugin_src="${ANGLESITE_PLUGIN_SRC:-$default_plugin_src}"
+    # Honor $ANGLESITE_SIDECAR_SRC for the MCP-server source boundary. The sibling
+    # checkout remains the published Anglesite plugin; ANGLESITE_PLUGIN_SRC remains
+    # a compatibility alias for existing local development environments.
+    local default_sidecar_src="$(cd "$root/.." && pwd)/anglesite"
+    local sidecar_src="${ANGLESITE_SIDECAR_SRC:-${ANGLESITE_PLUGIN_SRC:-$default_sidecar_src}}"
 
-    if [[ ! -d "$plugin_src" ]]; then
-        echo "ERROR: plugin source not found at $plugin_src" >&2
-        echo "       Set ANGLESITE_PLUGIN_SRC or clone github.com/Anglesite/anglesite as a sibling." >&2
+    if [[ ! -d "$sidecar_src" ]]; then
+        echo "ERROR: MCP sidecar source not found at $sidecar_src" >&2
+        echo "       Set ANGLESITE_SIDECAR_SRC or clone github.com/Anglesite/anglesite as a sibling." >&2
         exit 1
     fi
-    if [[ ! -f "$plugin_src/.claude-plugin/plugin.json" ]]; then
-        echo "ERROR: $plugin_src does not look like the Anglesite plugin (no .claude-plugin/plugin.json)" >&2
+    if [[ ! -f "$sidecar_src/server/index.mjs" || ! -f "$sidecar_src/package.json" ]]; then
+        echo "ERROR: $sidecar_src does not look like an Anglesite MCP sidecar" >&2
+        echo "       Expected server/index.mjs and package.json." >&2
         exit 1
     fi
 
     local sidecar_stage="$ctx/mcp-sidecar"
-    echo "Staging MCP sidecar from $plugin_src → $sidecar_stage"
+    echo "Staging MCP sidecar from $sidecar_src → $sidecar_stage"
     rm -rf "$sidecar_stage"
     mkdir -p "$sidecar_stage"
 
-    # Copy the plugin's server/ directory + package manifests (no node_modules, no .git).
+    # Copy the sidecar's server/ directory + package manifests (no node_modules, no .git).
     rsync -a --delete \
         --exclude='node_modules/' \
         --exclude='.git/' \
-        "$plugin_src/server/" "$sidecar_stage/server/"
-    cp "$plugin_src/package.json" "$sidecar_stage/"
-    cp "$plugin_src/package-lock.json" "$sidecar_stage/"
+        "$sidecar_src/server/" "$sidecar_stage/server/"
+    cp "$sidecar_src/package.json" "$sidecar_stage/"
+    cp "$sidecar_src/package-lock.json" "$sidecar_stage/"
 
     echo "Sidecar staged: $(ls "$sidecar_stage")"
 

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -74,9 +74,9 @@ setup_macos() {
     fi
 
     if [[ -d "$REPO_ROOT/../anglesite" ]]; then
-        ok "sibling plugin checkout found (../anglesite) — MCP e2e tests can run (ANGLESITE_PLUGIN_PATH)"
+        ok "sibling Anglesite plugin checkout found (../anglesite) — MCP e2e tests can run (ANGLESITE_PLUGIN_PATH)"
     else
-        note "sibling plugin repo not found at ../anglesite — MCP e2e tests will skip cleanly (optional)"
+        note "sibling Anglesite plugin repo not found at ../anglesite — MCP e2e tests will skip cleanly (optional)"
     fi
 
     echo


### PR DESCRIPTION
## Summary

- Stage only Anglesite’s MCP `server/` and npm manifests into the app container image, identifying that boundary by `server/index.mjs` rather than `.claude-plugin/plugin.json`.
- Keep the published Anglesite Claude Skill, its plugin metadata, skills, and standalone template outside the app’s build boundary.
- Introduce `ANGLESITE_SIDECAR_SRC` with the existing plugin-source variable as a compatibility alias, and retain the package’s Playwright-install safeguard.

Closes #466.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Staged the MCP server from the published Anglesite plugin checkout, verifying its plugin manifest remains present and the app context contains only the server and package manifests.
- [x] Shell syntax check for changed staging scripts.
