### PR TITLE
fix(ci): disable C++ CodeQL analysis — repo has no C++ sources

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,5 @@
+# CodeQL configuration: analyze only languages present in this repo.
+# Swift + TypeScript/JavaScript; disable C/C++ (no source files).
+languages:
+  - javascript-typescript
+  - swift


### PR DESCRIPTION
## Summary

- CodeQL's default language autodetection picks up `Sources/CWebKitGTK/shim.h` and treats the repo as containing C/C++, but there's no C/C++ build system for the autobuilder to extract from, so that lane fails with "Extraction failed: No source files found."
- Add `.github/codeql-config.yml` scoping analysis to `swift` and `javascript-typescript`, matching the repo's actual languages.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.

## Test plan

- [x] Verified via this PR's own CodeQL check run: `Analyze (swift)` / `Analyze (javascript-typescript)` / `Analyze (actions)` ran, no `Analyze (cpp)` job, top-level `CodeQL` check passed (neutral).
- N/A `swift test` / `xcodebuild build` — CI-config-only change, no Swift/JS source touched.