### PR TITLE
feat(#362): render received interactions at build time

### DIFF
--- a/Resources/Template/src/components/Interactions.astro
+++ b/Resources/Template/src/components/Interactions.astro
@@ -23,9 +23,6 @@ function initial(i: ReceivedInteraction): string {
 function human(iso: string): string {
   return new Date(iso).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" });
 }
-function names(items: ReceivedInteraction[]): string {
-  return items.map((i) => i.author?.name ?? new URL(i.source).hostname).join(", ");
-}
 ---
 
 {

--- a/Resources/Template/src/components/Interactions.astro
+++ b/Resources/Template/src/components/Interactions.astro
@@ -1,0 +1,189 @@
+---
+// Interactions.astro — renders received-interaction snapshots (webmention/ActivityPub
+// replies, likes, reposts) for the entry whose canonical URL is passed in. The snapshots
+// are JSON files in `data/interactions/` (root-level, per ReceivedInteraction.gitPath);
+// this is the render half of V-3.4 — static, updated on rebuild.
+//
+// Sanitisation contract (ReceivedInteraction.swift): interaction `content` is rendered as
+// text via Astro's default escaping — never `set:html`.
+import { parseInteractions, interactionsFor, type ReceivedInteraction } from "../lib/interactions.ts";
+
+interface Props {
+  canonical: string;
+}
+
+const mods = import.meta.glob("../../data/interactions/*.json", { eager: true });
+const g = interactionsFor(Astro.props.canonical, parseInteractions(mods as Record<string, unknown>));
+
+function initial(i: ReceivedInteraction): string {
+  const name = i.author?.name ?? new URL(i.source).hostname;
+  return name.trim().charAt(0).toUpperCase() || "?";
+}
+// Pin locale + UTC so static output is deterministic (same convention as the layouts).
+function human(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" });
+}
+function names(items: ReceivedInteraction[]): string {
+  return items.map((i) => i.author?.name ?? new URL(i.source).hostname).join(", ");
+}
+---
+
+{
+  g.total > 0 && (
+    <section class="interactions">
+      {(g.facepile.likes.length > 0 || g.facepile.reposts.length > 0) && (
+        <div class="facepiles">
+          {[
+            { label: "like", items: g.facepile.likes },
+            { label: "repost", items: g.facepile.reposts },
+          ]
+            .filter(({ items }) => items.length > 0)
+            .map(({ label, items }) => (
+              <p class="facepile">
+                <span class="facepile-count">{`${items.length} ${label}${items.length === 1 ? "" : "s"}`}</span>
+                {items.map((i) => (
+                  <a
+                    class="h-cite avatar-link"
+                    href={i.author?.url ?? i.source}
+                    rel="nofollow ugc"
+                    title={i.author?.name ?? new URL(i.source).hostname}
+                  >
+                    {i.author?.photo ? (
+                      <img
+                        class="avatar u-photo"
+                        src={i.author.photo}
+                        alt={i.author?.name ?? ""}
+                        loading="lazy"
+                        referrerpolicy="no-referrer"
+                      />
+                    ) : (
+                      <span class="avatar avatar-fallback">{initial(i)}</span>
+                    )}
+                  </a>
+                ))}
+              </p>
+            ))}
+        </div>
+      )}
+      {g.comments.length > 0 && (
+        <div class="comments">
+          <h2>Replies</h2>
+          <ol>
+            {g.comments.map((c) => (
+              <li class="p-comment h-cite">
+                {c.author?.photo ? (
+                  <img
+                    class="avatar u-photo"
+                    src={c.author.photo}
+                    alt=""
+                    loading="lazy"
+                    referrerpolicy="no-referrer"
+                  />
+                ) : (
+                  <span class="avatar avatar-fallback">{initial(c)}</span>
+                )}
+                <div class="comment-body">
+                  <p class="comment-meta">
+                    {c.author?.url ? (
+                      <a class="u-author h-card" href={c.author.url} rel="nofollow ugc">
+                        {c.author?.name ?? new URL(c.author.url).hostname}
+                      </a>
+                    ) : (
+                      <span class="u-author h-card">{c.author?.name ?? new URL(c.source).hostname}</span>
+                    )}
+                    <a class="u-url" href={c.source} rel="nofollow ugc">
+                      <time class="dt-published" datetime={c.published}>
+                        {human(c.published)}
+                      </time>
+                    </a>
+                  </p>
+                  {c.content && <p class="p-content">{c.content}</p>}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+      {g.mentions.length > 0 && (
+        <p class="mentions">
+          Mentioned by{" "}
+          {g.mentions.map((m, index) => (
+            <>
+              <a class="h-cite" href={m.source} rel="nofollow ugc">
+                {m.author?.name ?? new URL(m.source).hostname}
+              </a>
+              {index < g.mentions.length - 1 ? ", " : ""}
+            </>
+          ))}
+        </p>
+      )}
+    </section>
+  )
+}
+
+<style>
+  .interactions {
+    margin-top: 2rem;
+    border-top: 1px solid var(--color-surface, #f8fafc);
+    padding-top: 1rem;
+  }
+  .facepile {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+  }
+  .facepile-count {
+    color: var(--color-text-muted, #64748b);
+    margin-right: 0.5rem;
+    font-size: 0.9rem;
+  }
+  .avatar {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    object-fit: cover;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .avatar-fallback {
+    background: var(--color-surface, #f8fafc);
+    color: var(--color-text-muted, #64748b);
+    font-family: var(--font-heading, system-ui);
+    font-size: 0.9rem;
+  }
+  .comments h2 {
+    font-size: 1.25rem;
+  }
+  .comments ol {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .p-comment {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+  .comment-body {
+    min-width: 0;
+  }
+  .comment-meta {
+    margin: 0 0 0.25rem;
+    font-size: 0.9rem;
+  }
+  .comment-meta .u-url {
+    color: var(--color-text-muted, #64748b);
+    margin-left: 0.5rem;
+  }
+  .p-content {
+    margin: 0;
+    overflow-wrap: break-word;
+  }
+  .mentions {
+    color: var(--color-text-muted, #64748b);
+    font-size: 0.9rem;
+  }
+</style>

--- a/Resources/Template/src/layouts/BlogPost.astro
+++ b/Resources/Template/src/layouts/BlogPost.astro
@@ -10,6 +10,7 @@ import { ownerName } from "../lib/profile.ts";
 import BaseLayout from "./BaseLayout.astro";
 import SyndicationLinks from "../components/SyndicationLinks.astro";
 import DraftBadge from "../components/DraftBadge.astro";
+import Interactions from "../components/Interactions.astro";
 
 interface Props {
   title: string;
@@ -47,6 +48,7 @@ const jsonLd = blogPostingSchema(
     <div class="e-content"><slot /></div>
     <SyndicationLinks urls={syndication} />
     <!-- anglesite:share -->
+    <Interactions canonical={canonical} />
     <!-- anglesite:comments -->
   </article>
 </BaseLayout>

--- a/Resources/Template/src/layouts/Hentry.astro
+++ b/Resources/Template/src/layouts/Hentry.astro
@@ -7,6 +7,7 @@ import { ownerName } from "../lib/profile.ts";
 import BaseLayout from "./BaseLayout.astro";
 import SyndicationLinks from "../components/SyndicationLinks.astro";
 import DraftBadge from "../components/DraftBadge.astro";
+import Interactions from "../components/Interactions.astro";
 
 interface Props {
   entry: CollectionEntry<HentryCollection>;
@@ -71,5 +72,6 @@ const jsonLd = entrySchema(entry.collection, entry.data as HentryData, {
       </ul>
     )}
     <SyndicationLinks urls={d.syndication} />
+    <Interactions canonical={canonical} />
   </article>
 </BaseLayout>

--- a/Resources/Template/src/layouts/Hevent.astro
+++ b/Resources/Template/src/layouts/Hevent.astro
@@ -4,6 +4,7 @@ import { Schema } from "astro-seo-schema";
 import { entrySchema } from "../lib/schema.ts";
 import BaseLayout from "./BaseLayout.astro";
 import SyndicationLinks from "../components/SyndicationLinks.astro";
+import Interactions from "../components/Interactions.astro";
 
 interface Props {
   entry: CollectionEntry<"events">;
@@ -34,5 +35,6 @@ const endHuman = endDate?.toLocaleString("en-US");
     {d.location && <p class="p-location">{d.location}</p>}
     <div class="e-content"><slot /></div>
     <SyndicationLinks urls={d.syndication} />
+    <Interactions canonical={canonical} />
   </article>
 </BaseLayout>

--- a/Resources/Template/src/layouts/Hreview.astro
+++ b/Resources/Template/src/layouts/Hreview.astro
@@ -4,6 +4,7 @@ import { Schema } from "astro-seo-schema";
 import { entrySchema } from "../lib/schema.ts";
 import BaseLayout from "./BaseLayout.astro";
 import SyndicationLinks from "../components/SyndicationLinks.astro";
+import Interactions from "../components/Interactions.astro";
 
 interface Props {
   entry: CollectionEntry<"reviews">;
@@ -35,5 +36,6 @@ const jsonLd = entrySchema("reviews", entry.data, { url: canonical, site: Astro.
       {iso && <time class="dt-published" datetime={iso}>{human}</time>}
     </a>
     <SyndicationLinks urls={d.syndication} />
+    <Interactions canonical={canonical} />
   </article>
 </BaseLayout>

--- a/Resources/Template/src/lib/interactions.test.ts
+++ b/Resources/Template/src/lib/interactions.test.ts
@@ -1,0 +1,128 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseInteractions, interactionsFor, type ReceivedInteraction } from "./interactions.ts";
+
+const TARGET = "https://example.com/blog/hello-world/";
+
+function raw(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "wm-abc123",
+    type: "webmention",
+    source: "https://other.example/post/42",
+    target: TARGET,
+    interactionType: "reply",
+    author: { name: "Jane Doe", url: "https://other.example", photo: "https://other.example/photo.jpg" },
+    content: "Great post!",
+    published: "2026-06-28T14:30:00Z",
+    verified: "2026-06-28T14:35:12Z",
+    verificationStatus: "verified",
+    ...overrides,
+  };
+}
+
+/** Build a glob-shaped module map (JSON eager glob wraps each file in `{ default }`). */
+function mods(...files: Record<string, unknown>[]): Record<string, unknown> {
+  return Object.fromEntries(files.map((f, i) => [`../../data/interactions/f${i}.json`, { default: f }]));
+}
+
+test("parses a valid interaction from a glob module map", () => {
+  const all = parseInteractions(mods(raw()));
+  assert.equal(all.length, 1);
+  assert.equal(all[0].id, "wm-abc123");
+  assert.equal(all[0].author?.name, "Jane Doe");
+});
+
+test("accepts a bare (non-default-wrapped) module value", () => {
+  const all = parseInteractions({ "../../data/interactions/x.json": raw() });
+  assert.equal(all.length, 1);
+});
+
+test("skips malformed files with a warning instead of throwing", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+  try {
+    const all = parseInteractions(
+      mods(
+        raw(),
+        raw({ id: "../evil" }), // fails the [A-Za-z0-9_-]+ id rule
+        raw({ target: undefined }), // missing required field
+        raw({ interactionType: "poke" }), // unknown enum value
+      ),
+    );
+    assert.equal(all.length, 1);
+    assert.equal(warnings.length, 3);
+    assert.match(warnings[0], /interactions/);
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+test("skips non-verified interactions", () => {
+  const all = parseInteractions(
+    mods(raw(), raw({ id: "wm-2", verificationStatus: "pending" }), raw({ id: "wm-3", verificationStatus: "failed" })),
+  );
+  assert.deepEqual(
+    all.map((i) => i.id),
+    ["wm-abc123"],
+  );
+});
+
+test("author and content are optional", () => {
+  const all = parseInteractions(mods(raw({ author: undefined, content: undefined })));
+  assert.equal(all.length, 1);
+  assert.equal(all[0].author, undefined);
+  assert.equal(all[0].content, undefined);
+});
+
+test("interactionsFor matches targets regardless of trailing slash", () => {
+  const all = parseInteractions(
+    mods(
+      raw({ id: "a", target: "https://example.com/blog/hello-world" }),
+      raw({ id: "b", target: "https://example.com/blog/hello-world/" }),
+      raw({ id: "c", target: "https://example.com/blog/other/" }),
+    ),
+  );
+  const grouped = interactionsFor("https://example.com/blog/hello-world/", all);
+  assert.deepEqual(grouped.comments.map((i: ReceivedInteraction) => i.id).sort(), ["a", "b"]);
+  const groupedNoSlash = interactionsFor("https://example.com/blog/hello-world", all);
+  assert.equal(groupedNoSlash.comments.length, 2);
+});
+
+test("interactionsFor groups by interaction type and sorts comments by published", () => {
+  const all = parseInteractions(
+    mods(
+      raw({ id: "later", published: "2026-07-02T00:00:00Z" }),
+      raw({ id: "earlier", published: "2026-07-01T00:00:00Z" }),
+      raw({ id: "like1", interactionType: "like" }),
+      raw({ id: "repost1", interactionType: "repost" }),
+      raw({ id: "mention1", interactionType: "mention" }),
+      raw({ id: "bookmark1", interactionType: "bookmark" }),
+    ),
+  );
+  const g = interactionsFor(TARGET, all);
+  assert.deepEqual(
+    g.comments.map((i) => i.id),
+    ["earlier", "later"],
+  );
+  assert.deepEqual(
+    g.facepile.likes.map((i) => i.id),
+    ["like1"],
+  );
+  assert.deepEqual(
+    g.facepile.reposts.map((i) => i.id),
+    ["repost1"],
+  );
+  assert.deepEqual(g.mentions.map((i) => i.id).sort(), ["bookmark1", "mention1"]);
+  assert.equal(g.total, 6);
+});
+
+test("empty input yields empty groups", () => {
+  assert.deepEqual(parseInteractions({}), []);
+  const g = interactionsFor(TARGET, []);
+  assert.equal(g.total, 0);
+  assert.equal(g.comments.length, 0);
+  assert.equal(g.facepile.likes.length, 0);
+  assert.equal(g.facepile.reposts.length, 0);
+  assert.equal(g.mentions.length, 0);
+});

--- a/Resources/Template/src/lib/interactions.test.ts
+++ b/Resources/Template/src/lib/interactions.test.ts
@@ -68,6 +68,26 @@ test("skips non-verified interactions", () => {
   );
 });
 
+test("rejects non-http(s) URL schemes on source/target/author fields", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+  try {
+    const all = parseInteractions(
+      mods(
+        raw({ id: "a", source: "javascript:alert(document.cookie)" }),
+        raw({ id: "b", target: "javascript:alert(1)" }),
+        raw({ id: "c", author: { name: "Evil", url: "javascript:alert(1)" } }),
+        raw({ id: "d", author: { name: "Evil", photo: "javascript:alert(1)" } }),
+      ),
+    );
+    assert.equal(all.length, 0);
+    assert.equal(warnings.length, 4);
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
 test("author and content are optional", () => {
   const all = parseInteractions(mods(raw({ author: undefined, content: undefined })));
   assert.equal(all.length, 1);

--- a/Resources/Template/src/lib/interactions.ts
+++ b/Resources/Template/src/lib/interactions.ts
@@ -14,18 +14,35 @@ import { z } from "astro/zod";
 
 const isoDate = z.string().refine((s) => !Number.isNaN(Date.parse(s)), { message: "not an ISO 8601 date" });
 
+/**
+ * `z.string().url()` accepts any scheme `new URL()` can parse, including `javascript:`.
+ * These fields are attacker-controlled (any anonymous webmention/ActivityPub sender) and
+ * flow straight into `href`/`src` in Interactions.astro, so scheme must be restricted to
+ * http(s) to close the stored-XSS vector.
+ */
+const httpUrl = z.string().url().refine(
+  (s) => {
+    try {
+      return ["http:", "https:"].includes(new URL(s).protocol);
+    } catch {
+      return false;
+    }
+  },
+  { message: "must be an http(s) URL" },
+);
+
 const interactionSchema = z.object({
   /// Path-traversal guard: same rule as ReceivedInteraction.swift's init.
   id: z.string().regex(/^[A-Za-z0-9_-]+$/),
   type: z.enum(["webmention", "activitypub", "micropub"]),
-  source: z.string().url(),
-  target: z.string().url(),
+  source: httpUrl,
+  target: httpUrl,
   interactionType: z.enum(["reply", "like", "repost", "bookmark", "mention"]),
   author: z
     .object({
       name: z.string().optional(),
-      url: z.string().url().optional(),
-      photo: z.string().url().optional(),
+      url: httpUrl.optional(),
+      photo: httpUrl.optional(),
     })
     .optional(),
   content: z.string().optional(),

--- a/Resources/Template/src/lib/interactions.ts
+++ b/Resources/Template/src/lib/interactions.ts
@@ -1,0 +1,95 @@
+/**
+ * Received-interaction snapshots (`data/interactions/{id}.json`) — the render half of
+ * V-3.4. The schema mirrors `ReceivedInteraction.swift` (the authoritative contract, see
+ * `docs/specs/2026-06-29-c3-received-interaction-canonicality.md`): one file per verified
+ * interaction, snapshotted from the Worker's inbox into the site's git repo.
+ *
+ * Pure logic only — the `import.meta.glob` call lives in `Interactions.astro` (the
+ * `feeds.ts` pattern) so these functions stay testable under `npx tsx --test`.
+ *
+ * These files are third-party-derived and user-editable (moderation = delete the file),
+ * so a malformed one is skipped with a warning, never a build failure.
+ */
+import { z } from "astro/zod";
+
+const isoDate = z.string().refine((s) => !Number.isNaN(Date.parse(s)), { message: "not an ISO 8601 date" });
+
+const interactionSchema = z.object({
+  /// Path-traversal guard: same rule as ReceivedInteraction.swift's init.
+  id: z.string().regex(/^[A-Za-z0-9_-]+$/),
+  type: z.enum(["webmention", "activitypub", "micropub"]),
+  source: z.string().url(),
+  target: z.string().url(),
+  interactionType: z.enum(["reply", "like", "repost", "bookmark", "mention"]),
+  author: z
+    .object({
+      name: z.string().optional(),
+      url: z.string().url().optional(),
+      photo: z.string().url().optional(),
+    })
+    .optional(),
+  content: z.string().optional(),
+  published: isoDate,
+  verified: isoDate,
+  verificationStatus: z.enum(["verified", "pending", "failed"]),
+});
+
+export type ReceivedInteraction = z.infer<typeof interactionSchema>;
+
+export interface GroupedInteractions {
+  /** Replies, sorted by `published` ascending — the threaded comment section. */
+  comments: ReceivedInteraction[];
+  /** Likes and reposts — rendered as avatar facepiles. */
+  facepile: { likes: ReceivedInteraction[]; reposts: ReceivedInteraction[] };
+  /** Mentions and bookmarks — the "mentioned by" line. */
+  mentions: ReceivedInteraction[];
+  total: number;
+}
+
+/**
+ * Validates a glob module map (path → JSON module) into verified interactions.
+ * Eager JSON globs wrap each file in `{ default }`; bare values are accepted too.
+ * Invalid files are skipped with a `console.warn` naming the file.
+ */
+export function parseInteractions(mods: Record<string, unknown>): ReceivedInteraction[] {
+  const out: ReceivedInteraction[] = [];
+  for (const [path, mod] of Object.entries(mods)) {
+    const value = mod && typeof mod === "object" && "default" in mod ? (mod as { default: unknown }).default : mod;
+    const parsed = interactionSchema.safeParse(value);
+    if (!parsed.success) {
+      console.warn(`[interactions] skipping invalid snapshot ${path}: ${parsed.error.issues[0]?.message ?? "invalid"}`);
+      continue;
+    }
+    if (parsed.data.verificationStatus !== "verified") continue;
+    out.push(parsed.data);
+  }
+  return out;
+}
+
+/** Trailing-slash-insensitive URL comparison key (origin lowercased, query/hash ignored). */
+function urlKey(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.origin.toLowerCase() + u.pathname.replace(/\/+$/, "");
+  } catch {
+    return url.replace(/\/+$/, "");
+  }
+}
+
+/** Groups the interactions whose `target` is `canonicalUrl` for rendering. */
+export function interactionsFor(canonicalUrl: string, all: ReceivedInteraction[]): GroupedInteractions {
+  const key = urlKey(canonicalUrl);
+  const matching = all.filter((i) => urlKey(i.target) === key);
+  const comments = matching
+    .filter((i) => i.interactionType === "reply")
+    .sort((a, b) => Date.parse(a.published) - Date.parse(b.published));
+  return {
+    comments,
+    facepile: {
+      likes: matching.filter((i) => i.interactionType === "like"),
+      reposts: matching.filter((i) => i.interactionType === "repost"),
+    },
+    mentions: matching.filter((i) => i.interactionType === "mention" || i.interactionType === "bookmark"),
+    total: matching.length,
+  };
+}

--- a/Tests/AnglesiteCoreTests/InteractionsRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/InteractionsRenderSmokeTests.swift
@@ -1,0 +1,84 @@
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+/// Render half of V-3.4 (#362): a `ReceivedInteraction` snapshot written to its `gitPath`
+/// renders under the target post at build time, and non-verified snapshots do not.
+/// Round-trips the actual Swift contract — `ReceivedInteraction` → JSONEncoder → the
+/// template's zod loader — so a schema drift on either side fails here.
+@Suite("Interactions render smoke")
+struct InteractionsRenderSmokeTests {
+
+    /// Repo-root-relative path to the committed template. `swift test` runs with CWD = package root.
+    static var templateDir: URL { get throws { try templateRoot() } }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool { ((try? templateDir).map { E2EPrerequisites.astroBuildable(templateDir: $0) }) ?? false }
+
+    private static func fixture(
+        id: String,
+        interactionType: ReceivedInteraction.InteractionType,
+        content: String?,
+        verificationStatus: ReceivedInteraction.VerificationStatus
+    ) throws -> ReceivedInteraction {
+        try ReceivedInteraction(
+            id: id,
+            type: .webmention,
+            source: URL(string: "https://other.example/post/42")!,
+            target: URL(string: "https://example.com/blog/welcome-to-your-blog/")!,
+            interactionType: interactionType,
+            author: .init(name: "Jane Doe", url: URL(string: "https://other.example"), photo: nil),
+            content: content,
+            published: Date(timeIntervalSince1970: 1_782_000_000),
+            verified: Date(timeIntervalSince1970: 1_782_000_300),
+            verificationStatus: verificationStatus)
+    }
+
+    @Test("a verified reply snapshot renders under the target post; non-verified does not",
+          .enabled(if: InteractionsRenderSmokeTests.buildable))
+    func rendersVerifiedReply() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let templateDir = try Self.templateDir
+        let dist = templateDir.appendingPathComponent("dist", isDirectory: true)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let verified = try Self.fixture(
+            id: "wm-swiftsmoke-reply", interactionType: .reply,
+            content: "A verified reply from the Swift smoke test.", verificationStatus: .verified)
+        let pending = try Self.fixture(
+            id: "wm-swiftsmoke-pending", interactionType: .reply,
+            content: "A pending reply that must not render.", verificationStatus: .pending)
+        let fixtureURLs = try [verified, pending].map { interaction -> URL in
+            let url = templateDir.appendingPathComponent(interaction.gitPath)
+            try encoder.encode(interaction).write(to: url)
+            return url
+        }
+
+        // Hold the shared template-build lock across the build *and* the assertions — sibling
+        // render-smoke suites rebuild the same template tree (see PersonalTypeRenderSmokeTests).
+        try await TemplateBuildSerializer.shared.serialize {
+            try? FileManager.default.removeItem(at: dist)
+            defer {
+                try? FileManager.default.removeItem(at: dist)
+                for url in fixtureURLs { try? FileManager.default.removeItem(at: url) }
+            }
+
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
+                currentDirectoryURL: templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+            let postHTML = try String(
+                contentsOf: dist.appendingPathComponent("blog/welcome-to-your-blog/index.html"),
+                encoding: .utf8)
+            #expect(postHTML.contains("p-comment h-cite"))
+            #expect(postHTML.contains("A verified reply from the Swift smoke test."))
+            #expect(postHTML.contains("Jane Doe"))
+            #expect(!postHTML.contains("A pending reply that must not render."))
+        }
+    }
+}

--- a/docs/superpowers/specs/2026-07-22-interactions-render-design.md
+++ b/docs/superpowers/specs/2026-07-22-interactions-render-design.md
@@ -1,0 +1,98 @@
+# Interactions Render (V-3.4 #362, render half) — Design
+
+**Date:** 2026-07-22
+**Status:** Approved (DWK, 2026-07-22)
+**Part of:** #362 (V-3.4), #337 (V-3), #334 (pivot epic)
+**Builds on:** `docs/specs/2026-06-29-c3-received-interaction-canonicality.md` (C.3, Decided)
+
+## Scope
+
+Pulled forward ahead of the `@dwk/workers` conformance gate: the **Astro render half** of
+V-3.4 only. The template reads received-interaction snapshots from `data/interactions/*.json`
+in a site's `Source/` at build time and renders them under the matching content entry.
+
+**Out of scope** (remains gated under #362): the Worker snapshot step (D1 → JSON → git
+commit → push), real-time display, moderation UI (V-5.3). The render half consumes whatever
+files exist in git — today that means fixtures or hand-authored files; after the gate, the
+Worker's snapshots.
+
+## Data contract
+
+`Sources/AnglesiteCore/ReceivedInteraction.swift` is authoritative (C.3 spec §schema):
+one JSON file per interaction at `data/interactions/{id}.json`, **root-level `data/`**
+(sibling of `src/`), matching `ReceivedInteraction.gitPath`. This intentionally diverges
+from the `src/data/profile.json` convention — the Swift contract shipped first.
+
+The template ships an empty `data/interactions/` (`.gitkeep`) so scaffolded sites have the
+landing spot and the glob resolves.
+
+## Components
+
+### 1. `src/lib/interactions.ts` — pure logic (the `feeds.ts` pattern)
+
+No `import.meta.glob` in the lib (template `.test.ts` files run under
+`npx tsx --test`, where Vite globs don't exist). The glob lives in the component; the lib
+exports pure, unit-testable functions:
+
+- `parseInteractions(mods: Record<string, unknown>): ReceivedInteraction[]` — takes the
+  glob result, validates each file with zod (`astro/zod`) `safeParse`, mirroring the Swift
+  schema: required `id` (`^[A-Za-z0-9_-]+$`), `type`, `source`, `target`,
+  `interactionType`, `published`, `verified`, `verificationStatus`; optional `author`
+  (`name`/`url`/`photo`), `content`. **Invalid files are skipped with a `console.warn`
+  naming the file — never a build failure.** These are third-party-derived,
+  user-editable files; a malformed one must not brick `astro build`.
+- Only `verificationStatus === "verified"` interactions pass (defense-in-depth; the
+  Worker's snapshot step already writes verified-only).
+- `interactionsFor(canonicalUrl: string, all: ReceivedInteraction[]): GroupedInteractions`
+  — matches `target` against the entry's canonical URL with trailing-slash-insensitive
+  comparison, then groups: `comments` (reply, sorted by `published` ascending),
+  `facepile.likes` / `facepile.reposts`, `mentions` (mention + bookmark). Mirrors the
+  Swift `isComment` / `isFacepile` helpers.
+
+### 2. `src/components/Interactions.astro`
+
+- Owns the glob: `import.meta.glob("../../data/interactions/*.json", { eager: true })`
+  (resolves to root-level `data/` from `src/components/`; returns `{}` when empty).
+- Props: `{ canonical: string }`.
+- Renders nothing at all when the page has no interactions.
+- Markup (standard IndieWeb mf2): replies as `<li class="p-comment h-cite">` with
+  `u-author h-card` (name, `u-url`, `u-photo`), `p-content`, `dt-published`; likes and
+  reposts as avatar facepiles with counts; mentions/bookmarks as a short "mentioned by"
+  line.
+- **Sanitisation contract honored:** `content` renders as text only (Astro's default
+  escaping / `set:text`) — never `set:html` — per the `ReceivedInteraction.swift` header.
+- Avatars: `loading="lazy"`, `referrerpolicy="no-referrer"`, initials fallback when
+  `author.photo` is absent.
+- Scoped `<style>` using global CSS custom properties with fallbacks
+  (`var(--color-text-muted, …)` etc.), matching template convention.
+
+### 3. Layout wiring (additive only)
+
+Mounted with the `canonical` URL each layout already computes, after `e-content`:
+
+- `BlogPost.astro` — before the `<!-- anglesite:comments -->` anchor, so build-time
+  interactions precede any injected giscus widget.
+- `Hentry.astro`, `Hevent.astro`, `Hreview.astro` — after `SyndicationLinks`.
+
+No existing classes or anchors change (several Swift suites string-match them).
+
+## Testing
+
+- `src/lib/interactions.test.ts` (node:test + `assert/strict`, run via
+  `npx tsx --test`): valid parse round-trip, malformed file skipped with warning,
+  unverified/pending skipped, target matching incl. trailing-slash variants and
+  non-matching targets, grouping and comment sort order, empty input.
+- Swift render smoke test (`PersonalTypeRenderSmokeTests` style): scaffold a site, write a
+  fixture reply JSON targeting a post, build, assert the built post HTML contains the
+  `h-cite` markup and the reply content — #362's render acceptance ("a received reply
+  renders under the post") minus the git-commit half.
+- Full required suites before PR: template `npm run test:worker` + `npm run build`,
+  `swift test` (template-markup coupling), JS overlay untouched.
+
+## Known interactions
+
+- **Pre-deploy PII scanner:** rendered third-party comments can contain emails/phones and
+  will flag in `pre-deploy-check.ts`. Working as designed — the gate surfaces it;
+  moderation is deleting the snapshot file. No gate changes.
+- **CMS loader:** interactions are not CMS content; they deliberately bypass
+  `collectionLoader()` / `CMS_CONTENT_API_URL` and always come from local files.


### PR DESCRIPTION
## Summary

- Part of #362 (V-3.4): the **render half**, pulled forward ahead of the `@dwk/workers` conformance gate — the template now reads verified received-interaction snapshots from `data/interactions/*.json` (the `ReceivedInteraction` contract, C.3 spec) and renders them under the matching entry at build time: replies as an mf2 `h-cite` comment thread, likes/reposts as avatar facepiles, mentions/bookmarks as a "mentioned by" line.
- Loader is skip-and-warn (`src/lib/interactions.ts`, zod `safeParse`): a malformed third-party snapshot never breaks `astro build`; only `verificationStatus: "verified"` renders. Interaction content renders text-only per the sanitisation contract in `ReceivedInteraction.swift`.
- Mounted in `BlogPost` / `Hentry` / `Hevent` / `Hreview` (additive; existing mf2 classes and injection anchors untouched). The Worker snapshot step (D1 → JSON → git) remains gated under #362. Design spec: `docs/superpowers/specs/2026-07-22-interactions-render-design.md`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Template changes are app-only (`Resources/Template/`).

## Test plan

- [x] `swift test --package-path .` — new `InteractionsRenderSmokeTests` (round-trips `ReceivedInteraction` → JSONEncoder → `astro build` → rendered HTML, and asserts a pending snapshot does *not* render) passes; all template-markup-coupled suites pass. Two pre-existing `FoundationModelAssistant` streaming tests fail on this machine ("Session ended without producing a response") — on-device FM flakiness, no `Sources/` changes in this PR, and they fail identically in isolation on an untouched checkout.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Template suites: `npx tsx --test src/lib/interactions.test.ts` (8 tests: parse/skip/verified-only/target-matching/grouping), `npm run test:worker` (37), `npm run build` (astro check + microformats validation) — all green.
- [ ] Manual smoke (if UI-touching): n/a — template-only rendering; verified via built HTML assertions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
