### PR TITLE
fix(template): bump workers-types pin for wrangler 4.113 peer (#900)

### DIFF
--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -19,7 +19,7 @@
         "@astrojs/check": "^0.9.9",
         "@astrojs/react": "^6.0.1",
         "@cloudflare/vitest-pool-workers": "0.18.5",
-        "@cloudflare/workers-types": "5.20260715.1",
+        "@cloudflare/workers-types": "5.20260723.1",
         "@keystatic/astro": "^5.0.4",
         "@keystatic/core": "^0.5.34",
         "@types/node": "^24.0.0",
@@ -1324,9 +1324,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260715.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260715.1.tgz",
-      "integrity": "sha512-saxo/nMqQJ1dKDUXp1a2y/+IjKENFVD9+QRefHg5EjJZY20OG3xcEge4PGljbqZiF3AiU4o5ZLS3Vm7cayQIxg==",
+      "version": "5.20260723.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260723.1.tgz",
+      "integrity": "sha512-+P5tDo+ZjW5nmWq/zagLVIyV8U/mSk7n8n0mLUHjn3pOdY7kdEDmURUxvhwwYqLJ/VPnyMJPAYtZjHbqAnIpDg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -23,7 +23,7 @@
     "@astrojs/check": "^0.9.9",
     "@astrojs/react": "^6.0.1",
     "@cloudflare/vitest-pool-workers": "0.18.5",
-    "@cloudflare/workers-types": "5.20260715.1",
+    "@cloudflare/workers-types": "5.20260723.1",
     "@keystatic/astro": "^5.0.4",
     "@keystatic/core": "^0.5.34",
     "@types/node": "^24.0.0",


### PR DESCRIPTION
## Summary

- #900 (Dependabot) bumped the template's `wrangler` to 4.113.0, which peer-requires `@cloudflare/workers-types ^5.20260721.1` — but the template pins workers-types at exactly `5.20260715.1`, so both `npm ci` and the `npm install` fallback fail with `ERESOLVE` during the container-image bake. **Vendoring the container image has been broken for everyone since #900 merged.**
- Bumps the pin to `5.20260723.1` and regenerates `package-lock.json`. Verified: `npm ci --dry-run` passes against the new lockfile, and `scripts/vendor-container-image.sh` completes the previously-failing baked-node_modules stage.
- CI missed it because no lane runs the template's `npm ci` the way the image bake does; found while re-running #491's GUI smoke.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 169 tests in 27 suites, all passed
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [x] `scripts/vendor-container-image.sh` — completes (previously failed at the baked-node_modules stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)