### PR TITLE
fix(container): resolve split-repo gitfile before guest clone (#903)

### DIFF
--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -54,9 +54,13 @@ public struct ContainerizationControl: LocalContainerControl {
         ref: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> LocalContainerSession {
-        try SourceRepoPrecondition.requireGitRepo(at: sourceRepo)
+        // Resolves the split-repo gitfile layout (#888/#903): share the directory git can
+        // actually clone (Source/ for an embedded .git, the resolved Config/repo.nosync/ gitdir
+        // for a migrated package) — a Source/-only share leaves the gitfile's target invisible
+        // to the guest and the clone below exits 128.
+        let cloneSource = try SourceRepoPrecondition.cloneSource(for: sourceRepo)
 
-        let container = try await makeBareContainer(siteID: siteID, sourceRepo: sourceRepo, onOutput: onOutput)
+        let container = try await makeBareContainer(siteID: siteID, sourceRepo: cloneSource, onOutput: onOutput)
 
         // 3. Hydrate from the repo: clone the virtio-fs-shared host repo into /workspace/site, then
         //    check out ref. Cloning from the read-only share (not in place) keeps /workspace

--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -30,11 +30,39 @@ public enum LocalContainerError: Error, Equatable {
 /// where a `Source/` without `.git` (a failed scaffold git-init, or a pre-existing site) died
 /// inside the guest with a raw `git clone ... exited 128` and no indication why.
 public enum SourceRepoPrecondition {
-    public static func requireGitRepo(at sourceRepo: URL, fileManager: FileManager = .default) throws {
-        guard fileManager.fileExists(atPath: sourceRepo.appendingPathComponent(".git").path) else {
+    /// Validates that `sourceRepo` is hydratable and returns the host directory a container
+    /// runtime must share into the guest as the clone source:
+    /// - embedded layout (`Source/.git` is a directory) → `sourceRepo` itself, unchanged.
+    /// - split layout (#888: `Source/.git` is a gitfile pointing at `Config/repo.nosync/`) → the
+    ///   resolved git directory. The gitfile's target sits outside a `Source/`-only share, so the
+    ///   guest's `git clone` cannot resolve `.git` and dies with exit 128 (#903). `git clone`
+    ///   accepts a git *directory* as its source and produces the same HEAD checkout, so the
+    ///   runtime shares the resolved git dir instead. `Config/` as a whole must never enter a
+    ///   container — only the relocated git dir is shared.
+    public static func cloneSource(for sourceRepo: URL, fileManager: FileManager = .default) throws -> URL {
+        let gitPath = sourceRepo.appendingPathComponent(".git")
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: gitPath.path, isDirectory: &isDirectory) else {
             throw LocalContainerError.cloneFailed(
                 "this site has no git repository — recreate it, or run `git init` in its Source folder")
         }
+        if isDirectory.boolValue { return sourceRepo }
+
+        let contents = (try? String(contentsOf: gitPath, encoding: .utf8)) ?? ""
+        let target = contents.split(separator: "\n").first.flatMap { line -> String? in
+            guard line.hasPrefix("gitdir:") else { return nil }
+            return line.dropFirst("gitdir:".count).trimmingCharacters(in: .whitespaces)
+        }
+        guard let target, !target.isEmpty else {
+            throw LocalContainerError.cloneFailed(
+                "this site's Source/.git isn't a git directory or a gitdir pointer — recreate it, or run `git init` in its Source folder")
+        }
+        let resolved = URL(fileURLWithPath: target, relativeTo: sourceRepo).standardizedFileURL
+        guard fileManager.fileExists(atPath: resolved.appendingPathComponent("HEAD").path) else {
+            throw LocalContainerError.cloneFailed(
+                "this site's git history (\(resolved.path)) is missing — wait for iCloud to sync it, or open the site on the Mac that has it")
+        }
+        return resolved
     }
 }
 

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -93,7 +93,8 @@ public struct PodmanContainerControl: LocalContainerControl {
         ref: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> LocalContainerSession {
-        try SourceRepoPrecondition.requireGitRepo(at: sourceRepo)
+        // Resolves the split-repo gitfile layout (#888/#903) — see SourceRepoPrecondition.
+        let cloneSource = try SourceRepoPrecondition.cloneSource(for: sourceRepo)
         let name = Self.containerName(for: siteID)
 
         // 1. Boot a bare, long-lived container (podman's equivalent of Apple Containerization's
@@ -118,7 +119,7 @@ public struct PodmanContainerControl: LocalContainerControl {
                 podmanExecutable: podmanExecutable,
                 arguments: [
                     "run", "-d", "--rm", "--name", name,
-                    "-v", "\(sourceRepo.path):\(Self.repoSharePath):ro",
+                    "-v", "\(cloneSource.path):\(Self.repoSharePath):ro",
                     "-p", "127.0.0.1::\(Self.previewPort)",
                     "-p", "127.0.0.1::\(Self.mcpPort)",
                     image, "sleep", "infinity",

--- a/Tests/AnglesiteCoreTests/SourceRepoPreconditionTests.swift
+++ b/Tests/AnglesiteCoreTests/SourceRepoPreconditionTests.swift
@@ -7,6 +7,10 @@ import XCTest
 /// `ANGLESITE_CONTAINER_TESTS=1` — which CI never sets. So the guard had no coverage CI actually
 /// runs. Extracting it into `SourceRepoPrecondition` (AnglesiteCore, always built/tested in CI)
 /// gives the check real regression coverage.
+///
+/// #903 extended the guard into `cloneSource(for:)`: it now also resolves the split-repo layout
+/// (#888, `Source/.git` is a gitfile pointing at `Config/repo.nosync/`) to the directory a
+/// container runtime must actually share and clone.
 final class SourceRepoPreconditionTests: XCTestCase {
 
     private func tmpDir() -> URL {
@@ -17,7 +21,7 @@ final class SourceRepoPreconditionTests: XCTestCase {
 
     func testThrowsCloneFailedWhenNoGitDirectory() {
         let dir = tmpDir()
-        XCTAssertThrowsError(try SourceRepoPrecondition.requireGitRepo(at: dir)) { error in
+        XCTAssertThrowsError(try SourceRepoPrecondition.cloneSource(for: dir)) { error in
             guard case LocalContainerError.cloneFailed(let message) = error else {
                 return XCTFail("expected .cloneFailed, got \(error)")
             }
@@ -25,9 +29,52 @@ final class SourceRepoPreconditionTests: XCTestCase {
         }
     }
 
-    func testSucceedsWhenGitDirectoryExists() throws {
+    func testEmbeddedGitDirectoryResolvesToSourceItself() throws {
         let dir = tmpDir()
         try FileManager.default.createDirectory(at: dir.appendingPathComponent(".git"), withIntermediateDirectories: true)
-        try SourceRepoPrecondition.requireGitRepo(at: dir)   // must not throw
+        XCTAssertEqual(try SourceRepoPrecondition.cloneSource(for: dir), dir)
+    }
+
+    func testSplitLayoutGitfileResolvesToLiveRepository() throws {
+        // Package shape from RepoRelocator (#888): Source/.git is a gitfile whose relative
+        // target is Config/repo.nosync/ — a real git dir (HEAD present) beside Source/.
+        let pkg = tmpDir()
+        let source = pkg.appendingPathComponent("Source", isDirectory: true)
+        let live = pkg.appendingPathComponent("Config/repo.nosync", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: live, withIntermediateDirectories: true)
+        try "ref: refs/heads/main\n".write(to: live.appendingPathComponent("HEAD"), atomically: true, encoding: .utf8)
+        try "gitdir: ../Config/repo.nosync\n".write(to: source.appendingPathComponent(".git"), atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            try SourceRepoPrecondition.cloneSource(for: source).standardizedFileURL.path,
+            live.standardizedFileURL.path)
+    }
+
+    func testDanglingGitfileThrowsLegibleError() throws {
+        // The #879 "fresh peer" shape: gitfile present, its target never synced to this machine.
+        let pkg = tmpDir()
+        let source = pkg.appendingPathComponent("Source", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "gitdir: ../Config/repo.nosync\n".write(to: source.appendingPathComponent(".git"), atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try SourceRepoPrecondition.cloneSource(for: source)) { error in
+            guard case LocalContainerError.cloneFailed(let message) = error else {
+                return XCTFail("expected .cloneFailed, got \(error)")
+            }
+            XCTAssertTrue(message.contains("repo.nosync"), "should name the missing gitdir: \(message)")
+        }
+    }
+
+    func testMalformedGitfileThrowsLegibleError() throws {
+        let dir = tmpDir()
+        try "not a gitdir pointer\n".write(to: dir.appendingPathComponent(".git"), atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try SourceRepoPrecondition.cloneSource(for: dir)) { error in
+            guard case LocalContainerError.cloneFailed(let message) = error else {
+                return XCTFail("expected .cloneFailed, got \(error)")
+            }
+            XCTAssertTrue(message.contains("gitdir pointer"), "unexpected message: \(message)")
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #903: since #888's heal-on-open migration, every opened package has `Source/.git` as a gitfile pointing at `Config/repo.nosync/` — but the container runtimes shared only `Source/` into the guest, so the in-guest `git clone` couldn't resolve `.git` and every local preview failed with `cloneFailed(... exited 128)`.
- `SourceRepoPrecondition.requireGitRepo` becomes `cloneSource(for:)`: embedded `.git` directory → share `Source/` (unchanged); split layout → parse the gitfile and share the resolved git directory (`git clone` accepts a git dir as its source and yields the same HEAD checkout). Dangling (#879 fresh-peer) and malformed gitfiles now fail with legible errors instead of a raw guest exit 128 — restoring #548's diagnosability, which the gitfile shape had silently defeated.
- Applied to both conformers: `ContainerizationControl` (macOS) and the Glibc-gated `PodmanContainerControl` (Linux). `Config/` as a whole still never enters the container — only the relocated git dir is shared.
- Stacked on #905/#904 (all three found blocking the same #491 smoke re-run).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 169 tests in 27 suites, all passed (includes 5 new `SourceRepoPreconditionTests` covering embedded/split/dangling/malformed layouts)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [x] Live end-to-end: the migrated `issue491-smoke.anglesite` package that reproduced the bug now boots to a rendered preview in ~30 s in the rebuilt app (same site, same container image)
- [x] `swiftc -parse` on the Glibc-gated Podman file (full type-check happens on the Linux CI leg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)