### PR TITLE
fix(scripts): accept nested OCI index from container CLI 1.1 save

### DIFF
--- a/scripts/vendor-container-kernel.sh
+++ b/scripts/vendor-container-kernel.sh
@@ -222,11 +222,23 @@ if missing="$(missing_initfs_entry)"; then
 fi
 
 # The locally saved OCI layout may reformat/repackage index.json relative to what the registry
-# served, so don't hash the file directly — confirm the pinned manifest digest is referenced
-# somewhere in the layout's own index instead (a plain sha256 hex string is unique enough that a
-# textual search is a reliable, layout-shape-agnostic check).
-if ! grep -q "${VMINIT_ARM64_DIGEST#sha256:}" "$INITFS_OUT/index.json"; then
-    echo "ERROR: locally saved OCI layout ($INITFS_OUT/index.json) does not reference the verified manifest digest $VMINIT_ARM64_DIGEST — 'container image save' may have produced something unexpected." >&2
+# served, so don't hash the file directly — confirm the pinned manifest digest is reachable from
+# the layout's own index instead (a plain sha256 hex string is unique enough that a
+# textual search is a reliable, layout-shape-agnostic check). container CLI ≥1.1.0 writes a
+# nested layout whose top-level index references the multi-arch index blob rather than the
+# platform manifest directly, so also accept the lock-verified chain
+# index.json → index blob (VMINIT_INDEX_DIGEST) → manifest (VMINIT_ARM64_DIGEST).
+initfs_references_pinned_manifest() {
+    local manifest_hex="${VMINIT_ARM64_DIGEST#sha256:}"
+    local index_hex="${VMINIT_INDEX_DIGEST#sha256:}"
+    local index_blob="$INITFS_OUT/blobs/sha256/$index_hex"
+    grep -q "$manifest_hex" "$INITFS_OUT/index.json" && return 0
+    grep -q "$index_hex" "$INITFS_OUT/index.json" \
+        && [[ -f "$index_blob" ]] \
+        && grep -q "$manifest_hex" "$index_blob"
+}
+if ! initfs_references_pinned_manifest; then
+    echo "ERROR: locally saved OCI layout ($INITFS_OUT/index.json) does not reference the verified manifest digest $VMINIT_ARM64_DIGEST (directly or via the verified index blob $VMINIT_INDEX_DIGEST) — 'container image save' may have produced something unexpected." >&2
     exit 1
 fi
 echo "Local OCI layout references the verified manifest digest."


### PR DESCRIPTION
## Summary

- `container` CLI 1.1.0 changed `container image save`'s OCI layout shape: the top-level `index.json` now references the **multi-arch index blob** rather than the platform manifest directly. `vendor-container-kernel.sh`'s verification grepped only `index.json` for the pinned arm64 manifest digest, so a fully valid, hash-verified layout failed vendoring with "does not reference the verified manifest digest".
- The check now also accepts the lock-verified chain: `index.json` → index blob (`VMINIT_INDEX_DIGEST`, content-addressed so its filename is its hash) → arm64 manifest (`VMINIT_ARM64_DIGEST`). Strictly tighter than a generic blob search — an unverified blob referencing the manifest doesn't satisfy it. The direct-match fast path is kept for pre-1.1.0 layouts.
- Was stacked on #904 (both found blocking the same #491 smoke re-run); #904 has now merged, so this is rebased directly onto `main` as a single-commit change.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `bash -n scripts/vendor-container-kernel.sh` — syntax OK
- [x] `scripts/vendor-container-kernel.sh` end-to-end with container CLI 1.1.0 — kernel + initfs vendored, nested-layout verification passes, `Resources/container-{kernel,initfs}` populated (previously hard-failed)
- [x] Built app bundle carries all three container resources (519M image / 64M initfs / 14M kernel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)