### PR TITLE
fix(catalog): decode published resources array shape (#914)

### DIFF
--- a/Sources/AnglesiteCore/WorkerCatalog.swift
+++ b/Sources/AnglesiteCore/WorkerCatalog.swift
@@ -81,6 +81,14 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
     /// Manifest-driven equivalent of the `needsD1`/`needsKV`/`needsR2` flags the old
     /// `WorkerComposition.Feature` enum used to hand-maintain as switch statements (removed by
     /// #708's descriptor migration).
+    ///
+    /// Decodes both published shapes (#914): the original object form (`{"needsD1": true, …}`)
+    /// used by this app's own fixtures and any pre-drift cache, and the array-of-typed-bindings
+    /// form the catalog has actually published since its first commit
+    /// (`[{"type": "d1", "binding": "AUTH_DB"}, …]` — davidwkeith/workers spec/catalog.md).
+    /// `d1`/`kv`/`r2` entry types map to the flags; other types (`secret`, `queue`, `cron`) have
+    /// no provisioning flag yet and are ignored here — adopting their fidelity is future work,
+    /// not silently claimed. Encoding always emits the object form.
     public struct Resources: Sendable, Equatable, Codable {
         public let needsD1: Bool
         public let needsKV: Bool
@@ -90,6 +98,37 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
             self.needsD1 = needsD1
             self.needsKV = needsKV
             self.needsR2 = needsR2
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case needsD1, needsKV, needsR2
+        }
+
+        /// One entry of the published array form. Only `type` matters to the flags; `binding`
+        /// and any other keys are ignored.
+        private struct BindingEntry: Decodable {
+            let type: String
+        }
+
+        public init(from decoder: Decoder) throws {
+            if var entries = try? decoder.unkeyedContainer() {
+                var d1 = false, kv = false, r2 = false
+                while !entries.isAtEnd {
+                    switch try entries.decode(BindingEntry.self).type.lowercased() {
+                    case "d1": d1 = true
+                    case "kv": kv = true
+                    case "r2": r2 = true
+                    default: break
+                    }
+                }
+                self.init(needsD1: d1, needsKV: kv, needsR2: r2)
+                return
+            }
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.init(
+                needsD1: try container.decode(Bool.self, forKey: .needsD1),
+                needsKV: try container.decode(Bool.self, forKey: .needsKV),
+                needsR2: try container.decode(Bool.self, forKey: .needsR2))
         }
     }
 }

--- a/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
@@ -158,6 +158,55 @@ struct WorkerCatalogReaderTests {
         #expect(webmention.specificationURL == nil)
     }
 
+    @Test("parse accepts the published array resources shape (davidwkeith/workers spec/catalog.md)")
+    func parseAcceptsPublishedResourcesArrayShape() throws {
+        let json = Data("""
+        {
+          "workers": [
+            {
+              "id": "indieauth",
+              "package": "@dwk/indieauth",
+              "displayName": "IndieAuth",
+              "description": "Sign in with your own domain",
+              "group": "identity",
+              "binding": { "kind": "settingsActivated" },
+              "requires": [],
+              "resources": [
+                { "type": "d1", "binding": "AUTH_DB" },
+                { "type": "secret", "binding": "TOKEN_SIGNING_KEY" }
+              ]
+            },
+            {
+              "id": "solid-pod",
+              "displayName": "Solid Pod",
+              "description": "Personal data store",
+              "group": "storage",
+              "binding": { "kind": "settingsActivated" },
+              "resources": [
+                { "type": "kv", "binding": "POD_KV" },
+                { "type": "r2", "binding": "POD_BLOBS" }
+              ]
+            }
+          ]
+        }
+        """.utf8)
+
+        let workers = try WorkerCatalogReader.parse(json)
+
+        let indieauth = try #require(workers.first { $0.id == "indieauth" })
+        #expect(indieauth.resources == WorkerDescriptor.Resources(needsD1: true, needsKV: false, needsR2: false))
+        let solidPod = try #require(workers.first { $0.id == "solid-pod" })
+        #expect(solidPod.resources == WorkerDescriptor.Resources(needsD1: false, needsKV: true, needsR2: true))
+    }
+
+    @Test("Resources round-trips through its encoded object shape")
+    func resourcesEncodedObjectShapeRoundTrips() throws {
+        let original = WorkerDescriptor.Resources(needsD1: true, needsKV: false, needsR2: true)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(WorkerDescriptor.Resources.self, from: data)
+        #expect(decoded == original)
+    }
+
     @Test("route claims round-trip through JSONEncoder/JSONDecoder")
     func routeClaimRoundTrip() throws {
         let claim = WorkerRouteClaim(


### PR DESCRIPTION
## Summary

- Fixes #914: `WorkerDescriptor.Resources` now decodes the `resources` shape the `@dwk/workers` catalog has actually published since its first commit — an **array** of typed binding entries (`[{"type":"d1","binding":"AUTH_DB"},…]`, davidwkeith/workers spec/catalog.md) — alongside the original object flag shape the app and its fixtures were written against.
- Without this, every live `catalog.json` fetch threw in `WorkerCatalogReader.parse` and `WorkerCatalogFetcher` degraded to an empty catalog (the cache only stores successfully parsed bytes, so it was never populated), silently starving the shipped #708/#709 consumers: local wrangler-dev startup, deploy composition, and route claims.
- `d1`/`kv`/`r2` entry types map to the `needsD1`/`needsKV`/`needsR2` flags; `secret`/`queue`/`cron` entries have no provisioning flag yet and are deliberately ignored rather than silently claimed. Encoding still emits the object form (pinned by a round-trip test).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> No MCP schema change. This is `@dwk/workers` catalog coordination (davidwkeith/workers, the third repo): the app adapts to the published `catalog.json` shape per CONTRIBUTING's backward-compatible-decoding rule — no catalog-side change needed.

## Test plan

- [x] `swift test --package-path .` — `WorkerCatalogReaderTests`/`WorkerDescriptorTests`/`WorkerCatalogFetcherTests`/`WorkerCompositionTests`/`WorkerActivationTests` (63 tests) pass locally; new fixture is copied from the live catalog's first entry. Full suite runs in CI.
- [x] `xcodebuild` build unaffected (decoder-only change in AnglesiteCore); verified via the SwiftPM build of the same target.
- [ ] Manual smoke (if UI-touching): not UI-touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)