### PR TITLE
feat(#361): WebSub hub (subscriber notify on publish)

### DIFF
--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -12,6 +12,7 @@
         "@dwk/indieauth": "0.1.0-beta.3",
         "@dwk/micropub": "0.1.0-beta.4",
         "@dwk/webmention": "0.1.0-beta.3",
+        "@dwk/websub": "0.1.0-beta.4",
         "astro": "^7.1.3",
         "astro-embed": "^0.13.0",
         "astro-seo-schema": "^7.0.0"
@@ -1438,6 +1439,31 @@
       "dependencies": {
         "@dwk/log": "0.1.0-beta.3",
         "@dwk/safe-fetch": "0.1.0-beta.2"
+      }
+    },
+    "node_modules/@dwk/websub": {
+      "version": "0.1.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@dwk/websub/-/websub-0.1.0-beta.4.tgz",
+      "integrity": "sha512-Helw2IC/l15AsLNLYB1qXdAaNSaETTSsOb45C6v825mWytCxEa+GzbU8XlUp+3v5wvHzTyyN5H+SCjeg0TN3Cg==",
+      "license": "ISC",
+      "dependencies": {
+        "@dwk/log": "0.1.0-beta.4",
+        "@dwk/safe-fetch": "0.1.0-beta.3"
+      }
+    },
+    "node_modules/@dwk/websub/node_modules/@dwk/log": {
+      "version": "0.1.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@dwk/log/-/log-0.1.0-beta.4.tgz",
+      "integrity": "sha512-iZorLyOil69RCudBmiXp88g5sfzT++WWIoRe7YgdnSRzBnk2SwQkkpM6HPFPyhKhdMdcSLCwBPWOyCrRBCkSLA==",
+      "license": "ISC"
+    },
+    "node_modules/@dwk/websub/node_modules/@dwk/safe-fetch": {
+      "version": "0.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@dwk/safe-fetch/-/safe-fetch-0.1.0-beta.3.tgz",
+      "integrity": "sha512-mNnTbHJJatHbzW8HdA159uECkxxshFjHDQXjbfWQxu073niTVhQpwIytwn6kn1ZTXfsbmlErCekGAPqXL7i7aw==",
+      "license": "ISC",
+      "dependencies": {
+        "@dwk/log": "0.1.0-beta.4"
       }
     },
     "node_modules/@emmetio/abbreviation": {

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -16,6 +16,7 @@
     "@dwk/indieauth": "0.1.0-beta.3",
     "@dwk/micropub": "0.1.0-beta.4",
     "@dwk/webmention": "0.1.0-beta.3",
+    "@dwk/websub": "0.1.0-beta.4",
     "astro": "^7.1.3",
     "astro-embed": "^0.13.0",
     "astro-seo-schema": "^7.0.0"

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -8,6 +8,7 @@ import {
   renderRss,
   renderAtom,
   renderJsonFeed,
+  websubHub,
   type FeedEntry,
 } from "./feeds.ts";
 
@@ -106,4 +107,65 @@ test("renderJsonFeed produces valid JSON Feed 1.1", async () => {
   assert.equal(feed.version, "https://jsonfeed.org/version/1.1");
   assert.equal(feed.feed_url, `${SITE}/feed.json`);
   assert.equal(feed.items[0].url, `${SITE}/blog/a/`);
+});
+
+// --- WebSub discovery (V-3.3, #361) ---------------------------------------------------------
+
+test("websubHub returns hub + self URLs when enabled, undefined when not", () => {
+  assert.deepEqual(websubHub(SITE, "/rss.xml", true), {
+    hubUrl: "https://example.com/websub",
+    selfUrl: "https://example.com/rss.xml",
+  });
+  assert.equal(websubHub(SITE, "/rss.xml", false), undefined);
+});
+
+test("renderRss advertises the hub via atom:link rel=hub and rel=self when enabled", async () => {
+  const hub = websubHub(SITE, "/rss.xml", true)!;
+  const res = await renderRss({
+    title: "All",
+    description: "Everything",
+    site: SITE,
+    items: [],
+    hub,
+  });
+  const xml = await res.text();
+  assert.match(xml, /xmlns:atom="http:\/\/www\.w3\.org\/2005\/Atom"/);
+  assert.match(xml, /<atom:link rel="hub" href="https:\/\/example\.com\/websub"\/>/);
+  assert.match(xml, /<atom:link rel="self" type="application\/rss\+xml" href="https:\/\/example\.com\/rss\.xml"\/>/);
+});
+
+test("renderRss emits no hub advertisement when the hub is not provisioned", async () => {
+  const res = await renderRss({ title: "All", description: "Everything", site: SITE, items: [] });
+  const xml = await res.text();
+  assert.doesNotMatch(xml, /rel="hub"/);
+});
+
+test("renderAtom emits a rel=hub link only when a hub URL is given", async () => {
+  const withHub = renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [],
+    hubUrl: `${SITE}/websub`,
+  });
+  assert.match(await withHub.text(), /<link rel="hub" href="https:\/\/example\.com\/websub"\/>/);
+
+  const withoutHub = renderAtom({ title: "All", site: SITE, feedUrl: `${SITE}/atom.xml`, items: [] });
+  assert.doesNotMatch(await withoutHub.text(), /rel="hub"/);
+});
+
+test("renderJsonFeed emits a WebSub hubs array only when a hub URL is given", async () => {
+  const withHub = renderJsonFeed({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/feed.json`,
+    items: [],
+    hubUrl: `${SITE}/websub`,
+  });
+  assert.deepEqual(JSON.parse(await withHub.text()).hubs, [
+    { type: "WebSub", url: `${SITE}/websub` },
+  ]);
+
+  const withoutHub = renderJsonFeed({ title: "All", site: SITE, feedUrl: `${SITE}/feed.json`, items: [] });
+  assert.equal(JSON.parse(await withoutHub.text()).hubs, undefined);
 });

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -74,6 +74,33 @@ export function siteFrom(context: { site?: URL }): string {
   return context.site.href;
 }
 
+/** WebSub discovery advertisement for one feed: the hub plus the feed's own canonical URL. */
+export interface WebSubHubAdvertisement {
+  /** Absolute URL of the site's WebSub hub endpoint (`/websub`). */
+  hubUrl: string;
+  /** Absolute canonical URL of this feed — the topic a subscriber passes as `hub.topic`. */
+  selfUrl: string;
+}
+
+/**
+ * The WebSub advertisement for the feed at `selfPath`, or `undefined` when the hub isn't
+ * provisioned (`WEBSUB_ENABLED` in `.site-config`, written by Anglesite's worker provisioning).
+ * WebSub discovery requires the topic to advertise both `rel="hub"` and `rel="self"`, and the
+ * URLs must match the hub's allowed-topic list (worker/worker.ts `WEBSUB_TOPIC_PATHS`) — both
+ * derive from the same canonical site origin, so they agree by construction.
+ */
+export function websubHub(
+  site: string,
+  selfPath: string,
+  enabled: boolean,
+): WebSubHubAdvertisement | undefined {
+  if (!enabled) return undefined;
+  return {
+    hubUrl: new URL("/websub", site).href,
+    selfUrl: new URL(selfPath, site).href,
+  };
+}
+
 export function toFeedItem(collection: string, entry: FeedEntry, site: string): FeedItem {
   const cfg = FEED_COLLECTIONS[collection];
   if (!cfg) throw new Error(`No feed config for collection "${collection}"`);
@@ -103,11 +130,21 @@ export function renderRss(o: {
   description: string;
   site: string;
   items: FeedItem[];
+  hub?: WebSubHubAdvertisement;
 }): Promise<Response> {
+  // RSS 2.0 has no native link relations; WebSub discovery in RSS uses Atom link elements
+  // inside <channel> (the convention websub.rocks and every major reader check).
+  const hubData = o.hub
+    ? `<atom:link rel="hub" href="${escapeXml(o.hub.hubUrl)}"/>` +
+      `<atom:link rel="self" type="application/rss+xml" href="${escapeXml(o.hub.selfUrl)}"/>`
+    : undefined;
   return rss({
     title: o.title,
     description: o.description,
     site: o.site,
+    ...(hubData
+      ? { xmlns: { atom: "http://www.w3.org/2005/Atom" }, customData: hubData }
+      : {}),
     items: o.items.map((i) => ({
       title: i.title,
       link: i.link,
@@ -131,6 +168,8 @@ export function renderAtom(o: {
   site: string;
   feedUrl: string;
   items: FeedItem[];
+  /** WebSub hub URL; emits a `rel="hub"` link when set (`rel="self"` is always present). */
+  hubUrl?: string;
 }): Response {
   const updated = o.items[0]?.date ?? new Date(0);
   const entries = o.items
@@ -153,7 +192,7 @@ export function renderAtom(o: {
   <id>${escapeXml(o.site)}</id>
   <link href="${escapeXml(o.site)}"/>
   <link rel="self" href="${escapeXml(o.feedUrl)}"/>
-  <updated>${updated.toISOString()}</updated>
+${o.hubUrl ? `  <link rel="hub" href="${escapeXml(o.hubUrl)}"/>\n` : ""}  <updated>${updated.toISOString()}</updated>
 ${entries}
 </feed>
 `;
@@ -167,12 +206,15 @@ export function renderJsonFeed(o: {
   site: string;
   feedUrl: string;
   items: FeedItem[];
+  /** WebSub hub URL; emits the JSON Feed `hubs` array when set. */
+  hubUrl?: string;
 }): Response {
   const feed = {
     version: "https://jsonfeed.org/version/1.1",
     title: o.title,
     home_page_url: o.site,
     feed_url: o.feedUrl,
+    ...(o.hubUrl ? { hubs: [{ type: "WebSub", url: o.hubUrl }] } : {}),
     items: o.items.map((i) => ({
       id: i.link,
       url: i.link,

--- a/Resources/Template/src/pages/atom.xml.ts
+++ b/Resources/Template/src/pages/atom.xml.ts
@@ -1,6 +1,7 @@
 import type { APIContext } from "astro";
+import { readConfig } from "../../scripts/config";
 import { getCombinedItems } from "../lib/feed-data.ts";
-import { renderAtom, siteFrom } from "../lib/feeds.ts";
+import { renderAtom, siteFrom, websubHub } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
   const site = siteFrom(context);
@@ -9,5 +10,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL("/atom.xml", site).href,
     items: await getCombinedItems(site),
+    hubUrl: websubHub(site, "/atom.xml", readConfig("WEBSUB_ENABLED") === "true")?.hubUrl,
   });
 }

--- a/Resources/Template/src/pages/feed.json.ts
+++ b/Resources/Template/src/pages/feed.json.ts
@@ -1,6 +1,7 @@
 import type { APIContext } from "astro";
+import { readConfig } from "../../scripts/config";
 import { getCombinedItems } from "../lib/feed-data.ts";
-import { renderJsonFeed, siteFrom } from "../lib/feeds.ts";
+import { renderJsonFeed, siteFrom, websubHub } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
   const site = siteFrom(context);
@@ -9,5 +10,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL("/feed.json", site).href,
     items: await getCombinedItems(site),
+    hubUrl: websubHub(site, "/feed.json", readConfig("WEBSUB_ENABLED") === "true")?.hubUrl,
   });
 }

--- a/Resources/Template/src/pages/rss.xml.ts
+++ b/Resources/Template/src/pages/rss.xml.ts
@@ -1,6 +1,7 @@
 import type { APIContext } from "astro";
+import { readConfig } from "../../scripts/config";
 import { getCombinedItems } from "../lib/feed-data.ts";
-import { renderRss, siteFrom } from "../lib/feeds.ts";
+import { renderRss, siteFrom, websubHub } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
   const site = siteFrom(context);
@@ -9,5 +10,6 @@ export async function GET(context: APIContext) {
     description: "Everything published on this site.",
     site,
     items: await getCombinedItems(site),
+    hub: websubHub(site, "/rss.xml", readConfig("WEBSUB_ENABLED") === "true"),
   });
 }

--- a/Resources/Template/vitest.config.ts
+++ b/Resources/Template/vitest.config.ts
@@ -8,11 +8,16 @@ export default defineConfig({
       miniflare: {
         compatibilityDate: "2026-07-15",
         compatibilityFlags: ["nodejs_compat"],
-        d1Databases: ["AUTH_DB", "WEBMENTION_INBOX", "MICROPUB_DB"],
+        d1Databases: ["AUTH_DB", "WEBMENTION_INBOX", "MICROPUB_DB", "WEBSUB_DB"],
         kvNamespaces: ["INBOX_KV", "SOCIAL_KV"],
         r2Buckets: ["MEDIA"],
-        queueProducers: { WEBMENTION_QUEUE: "site-webmentions" },
-        queueConsumers: ["site-webmentions"],
+        queueProducers: { WEBMENTION_QUEUE: "site-webmention", WEBSUB_QUEUE: "site-websub" },
+        // site-websub is deliberately NOT registered as a consumer here: a delivered verify job
+        // would make @dwk/websub's consumer attempt a real verification GET to the test's fake
+        // subscriber callback and schedule a queue retry when it fails, which the pool tears
+        // down as an "uncaught exception" after the suite passes. The consumer dispatch itself
+        // is covered by calling worker.queue directly with a stubbed batch.
+        queueConsumers: ["site-webmention"],
         bindings: {
           TOKEN_SIGNING_KEY: "test-token-signing-key-with-at-least-32-bytes",
           INDIEAUTH_OWNER_PASSWORD: "correct horse battery staple",

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -595,7 +595,7 @@ test("webmention receive: 503 when inbound Webmention isn't provisioned (no queu
 
 test("webmention queue consumer: no-ops (does not throw) when the inbox/site origin is unprovisioned", async () => {
   const { WEBMENTION_INBOX: _unusedInbox, SITE_URL: _unusedSiteURL, ...envWithoutInbox } = testEnv;
-  const emptyBatch = { queue: "site-webmentions", messages: [] } as unknown as Parameters<
+  const emptyBatch = { queue: "site-webmention", messages: [] } as unknown as Parameters<
     NonNullable<typeof worker.queue>
   >[0];
   await expect(
@@ -651,6 +651,105 @@ test("micropub: 503 when MICROPUB_DB isn't bound", async () => {
   const response = await worker.fetch(
     new Request("https://owner.example/micropub?q=config"),
     envWithoutDB as WorkerEnv,
+    createExecutionContext(),
+  );
+  expect(response.status).toBe(503);
+});
+
+// --- WebSub hub (V-3.3, #361) ---------------------------------------------------------------
+// Composition of @dwk/websub's hub. These run through worker.fetch in the workerd pool with
+// WEBSUB_DB/WEBSUB_QUEUE/SITE_URL bound (see vitest.config.ts), so they exercise the same
+// synchronous validate-then-enqueue path production serves. Intent verification, fan-out, and
+// HMAC delivery signing are the library's own concern (covered by its suite + websub.rocks),
+// not re-tested here. SITE_URL (https://test.example) is the canonical topic origin — requests
+// arrive on a different origin below precisely to pin down that topics are keyed on SITE_URL,
+// not on whatever host the request happened to hit.
+
+function websubForm(fields: Record<string, string>): Request {
+  return new Request("https://owner.example/websub", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(fields).toString(),
+  });
+}
+
+test("websub hub: a subscribe for a canonical feed topic is accepted (202)", async () => {
+  const response = await fetchWorker(
+    websubForm({
+      "hub.mode": "subscribe",
+      "hub.callback": "https://subscriber.example/callback",
+      "hub.topic": "https://test.example/rss.xml",
+    }),
+  );
+  expect(response.status).toBe(202);
+});
+
+test("websub hub: every root feed is a subscribable topic", async () => {
+  for (const path of ["/rss.xml", "/atom.xml", "/feed.json"]) {
+    const response = await fetchWorker(
+      websubForm({
+        "hub.mode": "subscribe",
+        "hub.callback": "https://subscriber.example/callback",
+        "hub.topic": `https://test.example${path}`,
+      }),
+    );
+    expect(response.status).toBe(202);
+  }
+});
+
+test("websub hub: a subscribe for a non-feed topic is rejected (400)", async () => {
+  const response = await fetchWorker(
+    websubForm({
+      "hub.mode": "subscribe",
+      "hub.callback": "https://subscriber.example/callback",
+      "hub.topic": "https://test.example/blog/hello/",
+    }),
+  );
+  expect(response.status).toBe(400);
+});
+
+test("websub hub: topics are keyed on SITE_URL, not the request origin", async () => {
+  // The request arrives on owner.example, but the canonical origin is SITE_URL
+  // (test.example) — a feed path on the request origin is not a topic this hub serves.
+  const response = await fetchWorker(
+    websubForm({
+      "hub.mode": "subscribe",
+      "hub.callback": "https://subscriber.example/callback",
+      "hub.topic": "https://owner.example/rss.xml",
+    }),
+  );
+  expect(response.status).toBe(400);
+});
+
+test("websub hub: a publish ping for a canonical feed topic is accepted (202)", async () => {
+  const response = await fetchWorker(
+    websubForm({ "hub.mode": "publish", "hub.url": "https://test.example/atom.xml" }),
+  );
+  expect(response.status).toBe(202);
+});
+
+test("websub hub: a publish ping for a foreign topic is rejected (400)", async () => {
+  const response = await fetchWorker(
+    websubForm({ "hub.mode": "publish", "hub.url": "https://elsewhere.example/rss.xml" }),
+  );
+  expect(response.status).toBe(400);
+});
+
+test("websub hub: a non-POST method gets 405 with Allow: POST", async () => {
+  const response = await fetchWorker(new Request("https://owner.example/websub", { method: "GET" }));
+  expect(response.status).toBe(405);
+  expect(response.headers.get("allow")).toBe("POST");
+});
+
+test("websub hub: 503 when the hub isn't provisioned (no queue/store binding)", async () => {
+  const { WEBSUB_QUEUE: _unusedQueue, WEBSUB_DB: _unusedDB, ...envWithoutHub } = testEnv;
+  const response = await worker.fetch(
+    websubForm({
+      "hub.mode": "subscribe",
+      "hub.callback": "https://subscriber.example/callback",
+      "hub.topic": "https://test.example/rss.xml",
+    }),
+    envWithoutHub as WorkerEnv,
     createExecutionContext(),
   );
   expect(response.status).toBe(503);
@@ -767,4 +866,40 @@ test("routing: /media/ prefix dispatches to the Micropub handler directly (not y
   // rather than `.text()` (which would warn about a non-text content-type on a body that, in
   // fact, is text).
   expect(new TextDecoder().decode(await response.arrayBuffer())).toBe("dispatch probe");
+});
+
+test("websub queue consumer: no-ops (does not throw) when the hub is unprovisioned", async () => {
+  const { WEBSUB_DB: _unusedDB, SITE_URL: _unusedSiteURL, ...envWithoutHub } = testEnv;
+  const emptyBatch = { queue: "site-websub", messages: [] } as unknown as Parameters<
+    NonNullable<typeof worker.queue>
+  >[0];
+  await expect(
+    worker.queue!(emptyBatch, envWithoutHub as WorkerEnv, createExecutionContext()),
+  ).resolves.toBeUndefined();
+});
+
+test("websub queue consumer: dispatches into @dwk/websub's consumer without throwing when provisioned", async () => {
+  // An empty batch exercises the real provisioned path — env validated, websubOrigin resolved,
+  // createWebSubQueueConsumer instantiated, consumer(batch, ...) invoked — without triggering any
+  // verify/distribute/deliver job (there are none), so it's safe to run against the real
+  // `@dwk/websub` consumer rather than a stub, unlike a populated batch (see vitest.config.ts's
+  // comment on why site-websub isn't a registered queue consumer in this suite).
+  const emptyBatch = { queue: "site-websub", messages: [] } as unknown as Parameters<
+    NonNullable<typeof worker.queue>
+  >[0];
+  await expect(
+    worker.queue!(emptyBatch, testEnv, createExecutionContext()),
+  ).resolves.toBeUndefined();
+});
+
+test("queue dispatch: an unrecognized queue name is a no-op, not misrouted to the webmention consumer", async () => {
+  // Locks in the fail-safe default from worker.ts's queue() dispatcher: matching is positive
+  // ("-webmention" / "-websub") rather than "webmention = doesn't end in -websub", so a queue
+  // name belonging to neither feature is dropped rather than silently handled as webmention.
+  const emptyBatch = { queue: "site-some-future-feature", messages: [] } as unknown as Parameters<
+    NonNullable<typeof worker.queue>
+  >[0];
+  await expect(
+    worker.queue!(emptyBatch, testEnv, createExecutionContext()),
+  ).resolves.toBeUndefined();
 });

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -14,6 +14,13 @@ import {
   createMicropub,
   type MicropubEnv,
 } from "@dwk/micropub";
+import {
+  createWebSub,
+  createWebSubQueueConsumer,
+  type WebSubConfig,
+  type WebSubEnv,
+  type WebSubJob,
+} from "@dwk/websub";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -73,6 +80,19 @@ export interface WorkerEnv extends IndieAuthEnv {
    */
   MICROPUB_DB?: D1Database;
   MEDIA?: R2Bucket;
+  /**
+   * WebSub hub bindings (V-3.3, #361). Optional like the Webmention set above: a site that
+   * hasn't provisioned the hub has none of them bound, and the `/websub` route + queue
+   * consumer degrade gracefully (503 / ack-without-work). Provisioning wires a D1 database
+   * for the strongly-consistent subscription store and a dedicated Cloudflare Queue for
+   * intent verification + per-subscriber delivery fan-out. `WEBSUB_CONTENT` (R2 staging for
+   * snapshots too large to inline in a queue message) is deliberately not provisioned yet —
+   * a feed that outgrows the ~64 KB inline limit fails the fan-out loudly rather than
+   * truncating, and wiring the staging bucket (with its lifecycle expiration rule) is the
+   * documented follow-up.
+   */
+  WEBSUB_DB?: D1Database;
+  WEBSUB_QUEUE?: Queue<WebSubJob>;
 }
 
 const RATE_LIMIT_WINDOW_SECONDS = 3600;
@@ -456,6 +476,91 @@ function handleMicropub(
   return micropub(request, micropubEnv, ctx);
 }
 
+/**
+ * The site's feed paths — the only topics the WebSub hub serves. These are the template's
+ * static root feeds (src/pages/{rss.xml,atom.xml,feed.json}.ts); they cover everything the
+ * site publishes, so a subscriber to any of them sees every update. The same list drives the
+ * `rel="hub"` advertisement in the generated feeds (src/lib/feeds.ts) and Anglesite's
+ * publish ping after a deploy — all three must agree or a discoverable topic would 400 on
+ * subscribe or never receive a push.
+ */
+export const WEBSUB_TOPIC_PATHS = ["/rss.xml", "/atom.xml", "/feed.json"] as const;
+
+/**
+ * WebSub hub configuration for a given canonical site origin. Topics are the root feeds on
+ * that origin; the hub endpoint itself is `/websub` on the same origin.
+ */
+function websubConfig(origin: string): WebSubConfig {
+  return {
+    baseUrl: origin,
+    hubUrl: `${origin}/websub`,
+    allowedTopics: WEBSUB_TOPIC_PATHS.map((path) => `${origin}${path}`),
+  };
+}
+
+/**
+ * The canonical origin WebSub topics are keyed on, or `null` when `SITE_URL` isn't provisioned
+ * or isn't a valid URL. Both the hub route and the queue consumer require this — subscriptions
+ * are keyed on exact topic URLs, and a hub that fell back to the request's origin could accept
+ * a subscription the queue consumer (which has no request to derive an origin from, and always
+ * requires `SITE_URL`) would then silently never fan out to. Failing the hub route closed here
+ * keeps both sides of the same feature agreeing on what "provisioned" means.
+ */
+function websubOrigin(env: WorkerEnv): string | null {
+  if (!env.SITE_URL) return null;
+  try {
+    return new URL(env.SITE_URL).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * WebSub hub endpoint (V-3.3, #361).
+ *
+ * Composes `@dwk/websub`'s hub: a form-encoded `POST` of `hub.mode=subscribe|unsubscribe`
+ * is validated synchronously and a verification-of-intent job enqueued (202);
+ * `hub.mode=publish` for one of this site's feeds enqueues a distribution job (202) — the
+ * consumer fetches the feed once and POSTs it to every verified subscriber, HMAC-signing
+ * the body (`X-Hub-Signature`) for subscribers that registered a secret. Returns 503 when
+ * the hub isn't provisioned for this site (no queue/store binding, or no canonical `SITE_URL`
+ * — see `websubOrigin`), mirroring `handleWebmentionReceive`'s degrade-gracefully contract.
+ */
+function handleWebSubHub(request: Request, env: WorkerEnv, ctx: ExecutionContext): Promise<Response> {
+  const origin = websubOrigin(env);
+  if (!env.WEBSUB_QUEUE || !env.WEBSUB_DB || !origin) {
+    return Promise.resolve(new Response("WebSub hub is not configured", { status: 503 }));
+  }
+  const hub = createWebSub(websubConfig(origin));
+  const websubEnv: WebSubEnv = {
+    WEBSUB_DB: env.WEBSUB_DB,
+    WEBSUB_QUEUE: env.WEBSUB_QUEUE,
+  };
+  return hub(request, websubEnv, ctx);
+}
+
+/**
+ * Queue consumer for WebSub verification + distribution + per-subscriber delivery (V-3.3,
+ * #361). Acks-without-work when the hub or the canonical site origin isn't provisioned —
+ * same contract as `handleWebmentionQueue`.
+ */
+function handleWebSubQueue(
+  batch: MessageBatch<WebSubJob>,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): Promise<void> {
+  const origin = websubOrigin(env);
+  if (!env.WEBSUB_QUEUE || !env.WEBSUB_DB || !origin) {
+    return Promise.resolve();
+  }
+  const consumer = createWebSubQueueConsumer(websubConfig(origin));
+  const websubEnv: WebSubEnv = {
+    WEBSUB_DB: env.WEBSUB_DB,
+    WEBSUB_QUEUE: env.WEBSUB_QUEUE,
+  };
+  return consumer(batch, websubEnv, ctx);
+}
+
 export interface InboxFields {
   subject: string;
   from: string;
@@ -634,6 +739,13 @@ export const ROUTES: readonly WorkerRoute[] = [
     methods: ["GET", "HEAD"],
     handler: (request, env, ctx) => handleMicropub(request, env, ctx),
   },
+  {
+    // WebSub hub (V-3.3, #361): POST hub.mode=subscribe|unsubscribe|publish, validate, enqueue, 202.
+    path: "/websub",
+    match: "exact",
+    methods: ["POST"],
+    handler: (request, env, ctx) => handleWebSubHub(request, env, ctx),
+  },
 ];
 
 export function matchRoute(pathname: string, routes: readonly WorkerRoute[] = ROUTES): WorkerRoute | null {
@@ -717,9 +829,23 @@ export default {
     return assets.fetch(request);
   },
 
-  // Async Webmention verification (V-3.1, #359). Present unconditionally; no-ops for sites
-  // without inbound Webmention provisioned (see `handleWebmentionQueue`).
-  async queue(batch: MessageBatch<WebmentionJob>, env: WorkerEnv, ctx: ExecutionContext): Promise<void> {
-    return handleWebmentionQueue(batch, env, ctx);
+  // Async queue work, present unconditionally; no-ops for sites without the matching feature
+  // provisioned. Two queues deliver here — Webmention verification (V-3.1, #359) and WebSub
+  // verification/distribution/delivery (V-3.3, #361) — dispatched on the queue's name:
+  // Anglesite provisions deterministic names (`<site>-webmention`, `<site>-websub`). Both
+  // matches are positive (rather than "webmention = anything that isn't -websub") so a future
+  // third queue-backed feature can't get silently misrouted into the webmention consumer.
+  async queue(
+    batch: MessageBatch<WebmentionJob | WebSubJob>,
+    env: WorkerEnv,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    if (batch.queue.endsWith("-websub")) {
+      return handleWebSubQueue(batch as MessageBatch<WebSubJob>, env, ctx);
+    }
+    if (batch.queue.endsWith("-webmention")) {
+      return handleWebmentionQueue(batch as MessageBatch<WebmentionJob>, env, ctx);
+    }
+    return Promise.resolve();
   },
-} satisfies ExportedHandler<WorkerEnv, WebmentionJob>;
+} satisfies ExportedHandler<WorkerEnv, WebmentionJob | WebSubJob>;

--- a/Resources/Template/worker/workers-version.json
+++ b/Resources/Template/worker/workers-version.json
@@ -3,12 +3,12 @@
   "description": "Pinned @dwk/workers version range for this template. Read by Anglesite during scaffold and social-feature enablement. Updated when a new @dwk/workers release ships.",
   "version": "0.1.0-beta.3",
   "range": "0.1.0-beta.3",
-  "note": "IndieAuth, Webmention (inbound receive, V-3.1), and Micropub (V-3.2) are pinned to the exact published betas composed into worker.ts and verified by the template Worker integration suite; the remaining social packages remain gated on their conformance status until composed.",
+  "note": "IndieAuth, Webmention (inbound receive, V-3.1), Micropub (V-3.2), and WebSub (hub, V-3.3) are pinned to the exact published betas composed into worker.ts and verified by the template Worker integration suite; the remaining social packages remain gated on their conformance status until composed.",
   "packages": {
     "@dwk/indieauth": "0.1.0-beta.3",
     "@dwk/webmention": "0.1.0-beta.3",
     "@dwk/micropub": "0.1.0-beta.4",
-    "@dwk/websub": "^0.0.0",
+    "@dwk/websub": "0.1.0-beta.4",
     "@dwk/microsub": "^0.0.0",
     "@dwk/webfinger": "^0.0.0",
     "@dwk/activitypub": "^0.0.0"

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -97,6 +97,7 @@ final class DeployModel {
     private let command: DeployCommand
     private let webmentionCommand: WebmentionSendCommand
     private let posseCommand: POSSESyndicationCommand
+    private let websubPing: WebSubPublishPing
     private let logCenter: LogCenter
     private let keychain: KeychainStore
     private let onboarding: TokenOnboarding
@@ -137,6 +138,7 @@ final class DeployModel {
         command: DeployCommand = DeployCommand(),
         webmentionCommand: WebmentionSendCommand = WebmentionSendCommand(),
         posseCommand: POSSESyndicationCommand = POSSESyndicationCommand(),
+        websubPing: WebSubPublishPing = WebSubPublishPing(),
         logCenter: LogCenter = .shared,
         keychain: KeychainStore = KeychainStore(),
         verifier: TokenVerifying = CloudflareAPITokenVerifier(),
@@ -149,6 +151,7 @@ final class DeployModel {
         self.command = command
         self.webmentionCommand = webmentionCommand
         self.posseCommand = posseCommand
+        self.websubPing = websubPing
         self.logCenter = logCenter
         self.keychain = keychain
         self.onboarding = TokenOnboarding(verifier: verifier)
@@ -582,15 +585,24 @@ final class DeployModel {
             drawerPresented = false
             webmentionPaidPlanConfirmationPresented = presentation == .foreground
             return .failed(
-                reason: "Inbound Webmention requires the Cloudflare Workers Paid plan — confirm to continue",
+                reason: "Inbound Webmention and WebSub require the Cloudflare Workers Paid plan — confirm to continue",
                 exitCode: nil)
         }
 
+        // Whether the WebSub hub is actually live after this provision (worker active AND its
+        // Queue exists) — the gate for the post-deploy publish pings below. Computed from the
+        // provision result's resources, not settings, so a hub provisioned in this very run
+        // pings on its first deploy.
+        let websubProvisioned: Bool
         if case .succeeded(_, let resources, _) = provisionResult {
             await DeployCoordinator.persistProvisionedResources(
                 configStore: configStore, settings: settings,
                 effectiveActiveIDs: effectiveActiveIDs, resources: resources
             )
+            websubProvisioned = workers.contains(where: { $0.id == WorkerComposition.websubWorkerID })
+                && resources.websubQueueName != nil
+        } else {
+            websubProvisioned = false
         }
 
         let result = provisionResult.asDeployCommandResult
@@ -618,6 +630,17 @@ final class DeployModel {
                     guard let self else { return }
                     await self.posseCommand.syndicate(
                         siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: url
+                    )
+                },
+                notifySubscribers: { [weak self] in
+                    // WebSub publish pings (#361): only when the hub is live for this site. The
+                    // canonical site URL is preferred — the hub's allowed topics derive from the
+                    // Worker's SITE_URL var, which resolveSiteURL also sourced — falling back to
+                    // the deployed URL (whose request origin the un-var'd hub falls back to).
+                    guard let self, websubProvisioned else { return }
+                    _ = await self.websubPing.notify(
+                        siteURL: siteURL ?? url.absoluteString,
+                        source: "websub:\(siteID)"
                     )
                 }
             )

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1222,6 +1222,9 @@
     "Inactive — not used" : {
 
     },
+    "Inbound Webmention and WebSub require the Workers Paid plan" : {
+
+    },
     "Inbound Webmention requires the Workers Paid plan" : {
 
     },
@@ -1721,6 +1724,9 @@
 
     },
     "Reading %@ zone settings from Cloudflare…" : {
+
+    },
+    "Receiving webmentions and pushing feed updates to subscribers both work asynchronously using Cloudflare Queues, which aren't available on the Workers Free plan. Continuing will create the Queues these features need on your connected Cloudflare account." : {
 
     },
     "Receiving webmentions verifies each one asynchronously using a Cloudflare Queue, which isn't available on the Workers Free plan. Continuing will create a Queue on your connected Cloudflare account." : {

--- a/Sources/AnglesiteApp/WebmentionPaidPlanConfirmationSheetView.swift
+++ b/Sources/AnglesiteApp/WebmentionPaidPlanConfirmationSheetView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 import AnglesiteCore
 
-/// Sheet shown when a deploy needs to provision the Cloudflare Queue that inbound Webmention's
-/// async verification step relies on — Queues require the Workers **Paid** plan, so the app
-/// asks for an explicit one-time acknowledgment before ever calling `wrangler queues create`
-/// (#359). Mirrors `WorkerNameConflictSheetView`'s park-and-retry shape.
+/// Sheet shown when a deploy needs to provision a Cloudflare Queue for a queue-backed social
+/// feature — inbound Webmention's async verification (#359) or the WebSub hub's delivery
+/// fan-out (#361). Queues require the Workers **Paid** plan, so the app asks for an explicit
+/// one-time acknowledgment before ever calling `wrangler queues create`. Mirrors
+/// `WorkerNameConflictSheetView`'s park-and-retry shape.
 struct WebmentionPaidPlanConfirmationSheetView: View {
     let model: DeployModel
     let onCancel: () -> Void
@@ -12,9 +13,9 @@ struct WebmentionPaidPlanConfirmationSheetView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Inbound Webmention requires the Workers Paid plan")
+                Text("Inbound Webmention and WebSub require the Workers Paid plan")
                     .font(.headline)
-                Text("Receiving webmentions verifies each one asynchronously using a Cloudflare Queue, which isn't available on the Workers Free plan. Continuing will create a Queue on your connected Cloudflare account.")
+                Text("Receiving webmentions and pushing feed updates to subscribers both work asynchronously using Cloudflare Queues, which aren't available on the Workers Free plan. Continuing will create the Queues these features need on your connected Cloudflare account.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -138,11 +138,18 @@ public enum DeployCoordinator {
     public static func runPostDeploySequencing(
         onMilestone: (OperationProgress) -> Void,
         sendWebmentions: () async -> Void,
-        syndicate: () async -> Void
+        syndicate: () async -> Void,
+        /// WebSub publish pings (#361): tells the site's own hub the feeds changed so it fans
+        /// the update out to subscribers. Ordered last — the deployed feeds must exist before
+        /// the hub fetches them, and (like the other two passes) it's best-effort and never
+        /// throws. Callers without the hub provisioned pass a no-op.
+        notifySubscribers: () async -> Void = {}
     ) async {
         onMilestone(.deployWebmentions)
         await sendWebmentions()
         onMilestone(.deploySyndicating)
         await syndicate()
+        onMilestone(.deployNotifyingSubscribers)
+        await notifySubscribers()
     }
 }

--- a/Sources/AnglesiteCore/OperationProgress.swift
+++ b/Sources/AnglesiteCore/OperationProgress.swift
@@ -41,6 +41,7 @@ public extension OperationProgress {
     static let deployFinalizing = OperationProgress(kind: .deploy, phase: "finalizing", label: "Finishing up…")
     static let deployWebmentions = OperationProgress(kind: .deploy, phase: "webmentions", label: "Sending webmentions…")
     static let deploySyndicating = OperationProgress(kind: .deploy, phase: "syndicating", label: "Syndicating posts…")
+    static let deployNotifyingSubscribers = OperationProgress(kind: .deploy, phase: "websubPing", label: "Notifying feed subscribers…")
 
     static let backupStaging = OperationProgress(kind: .backup, phase: "staging", label: "Staging changes…")
     static let backupCommitting = OperationProgress(kind: .backup, phase: "committing", label: "Committing…")

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -244,7 +244,7 @@ public struct SiteOperations: Sendable {
         case .workerNameConflict(let name, let resources):
             return "Social Worker provisioning blocked: the Worker name \"\(name)\" is already in use on your Cloudflare account. Rename the site's Worker in Anglesite and try again.\(resourceSuffix(resources))"
         case .webmentionPaidPlanConfirmationNeeded(let resources):
-            return "Social Worker provisioning paused: inbound Webmention requires the Cloudflare Workers Paid plan. Confirm this in Anglesite's deploy sheet and try again.\(resourceSuffix(resources))"
+            return "Social Worker provisioning paused: inbound Webmention and WebSub require the Cloudflare Workers Paid plan. Confirm this in Anglesite's deploy sheet and try again.\(resourceSuffix(resources))"
         case .failed(let reason, _, let resources):
             return "Social Worker provisioning failed: \(reason).\(resourceSuffix(resources))"
         }

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -17,12 +17,15 @@ public actor SocialWorkerProvisionCommand {
         /// this site has never deployed before — mirrors `DeployCommand.Result.workerNameConflict`
         /// rather than collapsing it, so callers can drive the same rename-and-retry UX (#740).
         case workerNameConflict(name: String, resources: WorkerComposition.ProvisionedResources)
-        /// Webmention receive is active but the site hasn't explicitly acknowledged that
-        /// Cloudflare Queues require the Workers Paid plan (#359). Returned *before any wrangler
-        /// call for the Queue* — earlier D1/KV/R2 wrangler calls (and their `persistConfig`
-        /// writes) may already have run in this same `provision()` invocation before this gate
-        /// is reached. `DeployModel` parks the deploy and presents a confirmation sheet;
-        /// retrying with `acknowledgesPaidPlan: true` proceeds to create the Queue.
+        /// A Queue-backed worker (inbound Webmention #359, or the WebSub hub #361) is active but
+        /// the site hasn't explicitly acknowledged that Cloudflare Queues require the Workers
+        /// Paid plan. Returned *before any wrangler call for a Queue* — earlier D1/KV/R2
+        /// wrangler calls (and their `persistConfig` writes) may already have run in this same
+        /// `provision()` invocation before this gate is reached. `DeployModel` parks the deploy
+        /// and presents a confirmation sheet; retrying with `acknowledgesPaidPlan: true`
+        /// proceeds to create the Queue(s). (The case keeps its original Webmention-era name;
+        /// one acknowledgment covers every Queue-backed feature — it's the same account-level
+        /// plan fact.)
         case webmentionPaidPlanConfirmationNeeded(resources: WorkerComposition.ProvisionedResources)
         case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
     }
@@ -180,10 +183,15 @@ public actor SocialWorkerProvisionCommand {
         }
 
         let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
-        if hasWebmentionReceive, resources.queueName == nil {
+        let hasWebSub = workers.contains(where: { $0.id == WorkerComposition.websubWorkerID })
+        let needsWebmentionQueue = hasWebmentionReceive && resources.queueName == nil
+        let needsWebSubQueue = hasWebSub && resources.websubQueueName == nil
+        if needsWebmentionQueue || needsWebSubQueue {
             guard acknowledgesPaidPlan else {
                 return .webmentionPaidPlanConfirmationNeeded(resources: resources)
             }
+        }
+        if needsWebmentionQueue {
             let name = "\(siteName)-webmention"
             let result = await runWrangler(
                 siteDirectory: siteDirectory,
@@ -195,6 +203,29 @@ public actor SocialWorkerProvisionCommand {
             switch result {
             case .success:
                 resources.queueName = name
+            case .failure(let failure):
+                return failure
+            }
+            if let failure = persistConfig(
+                siteDirectory: siteDirectory, siteName: siteName, workers: workers,
+                routeClaims: routeClaims, resources: resources, siteURL: siteURL
+            ) {
+                return failure
+            }
+        }
+
+        if needsWebSubQueue {
+            let name = "\(siteName)-websub"
+            let result = await runWrangler(
+                siteDirectory: siteDirectory,
+                arguments: ["queues", "create", name, "--json"],
+                environment: environment,
+                source: source,
+                resources: resources
+            )
+            switch result {
+            case .success:
+                resources.websubQueueName = name
             case .failure(let failure):
                 return failure
             }
@@ -301,10 +332,18 @@ public actor SocialWorkerProvisionCommand {
             // `<link rel="webmention">` at an endpoint the Worker no longer serves.
             let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
             let webmentionReceiveEnabled = hasWebmentionReceive && resources.queueName != nil
+            // Same "actually live" contract for the WebSub hub: the flag gates the feeds'
+            // rel="hub" advertisement (src/lib/feeds.ts), which must never point at an endpoint
+            // the Worker doesn't serve or a hub whose Queue doesn't exist.
+            let hasWebSub = workers.contains(where: { $0.id == WorkerComposition.websubWorkerID })
+            let websubEnabled = hasWebSub && resources.websubQueueName != nil
             let configURL = siteDirectory.appendingPathComponent(".site-config")
             let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
             let updated = SiteConfigFile.upsert(
-                [("WEBMENTION_RECEIVE_ENABLED", webmentionReceiveEnabled ? "true" : "false")], into: existing
+                [
+                    ("WEBMENTION_RECEIVE_ENABLED", webmentionReceiveEnabled ? "true" : "false"),
+                    ("WEBSUB_ENABLED", websubEnabled ? "true" : "false"),
+                ], into: existing
             )
             if updated != existing {
                 try updated.write(to: configURL, atomically: true, encoding: .utf8)
@@ -320,11 +359,19 @@ public actor SocialWorkerProvisionCommand {
         guard let toml = try? String(contentsOf: url, encoding: .utf8) else {
             return .init()
         }
+        // Two features each own a queue; the generated names are deterministic
+        // (`<site>-webmention` / `<site>-websub`), so classify every `queue = "…"` value by its
+        // suffix rather than taking the first match (which would mis-assign whichever block
+        // happened to be emitted first). Both matches are positive (rather than "webmention =
+        // doesn't end in -websub") so a future third queue-backed feature can't get silently
+        // misclassified as webmention's queue just because it doesn't end in "-websub".
+        let queueNames = extractAllTomlStrings(named: "queue", from: toml)
         return .init(
             d1DatabaseID: extractTomlString(named: "database_id", from: toml),
             kvNamespaceID: extractTomlString(named: "id", from: toml),
             r2BucketName: extractTomlString(named: "bucket_name", from: toml),
-            queueName: extractTomlString(named: "queue", from: toml)
+            queueName: queueNames.first(where: { $0.hasSuffix("-webmention") }),
+            websubQueueName: queueNames.first(where: { $0.hasSuffix("-websub") })
         )
     }
 
@@ -345,16 +392,18 @@ public actor SocialWorkerProvisionCommand {
     }
 
     private static func extractTomlString(named key: String, from toml: String) -> String? {
+        extractAllTomlStrings(named: key, from: toml).first
+    }
+
+    private static func extractAllTomlStrings(named key: String, from toml: String) -> [String] {
         let escaped = NSRegularExpression.escapedPattern(for: key)
         let pattern = #"(?m)^\s*#(KEY)\s*=\s*"([^"]+)""#.replacingOccurrences(of: "#(KEY)", with: escaped)
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: toml, range: NSRange(toml.startIndex..., in: toml)),
-              match.numberOfRanges > 1,
-              let range = Range(match.range(at: 1), in: toml) else {
-            return nil
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        return regex.matches(in: toml, range: NSRange(toml.startIndex..., in: toml)).compactMap { match in
+            guard match.numberOfRanges > 1, let range = Range(match.range(at: 1), in: toml) else { return nil }
+            let value = String(toml[range])
+            return value.isEmpty ? nil : value
         }
-        let value = String(toml[range])
-        return value.isEmpty ? nil : value
     }
 
     private static func findID(in value: Any) -> String? {
@@ -409,7 +458,7 @@ extension SocialWorkerProvisionCommand.Result {
             // convenience mapping (rather than reading `SocialWorkerProvisionCommand.Result`
             // directly) see this as a plain failure until the confirmation-sheet wiring lands.
             return .failed(
-                reason: "Inbound Webmention requires the Cloudflare Workers Paid plan — confirm in Settings before deploying",
+                reason: "Inbound Webmention and WebSub require the Cloudflare Workers Paid plan — confirm in Settings before deploying",
                 exitCode: nil
             )
         case .failed(let reason, let exitCode, _):

--- a/Sources/AnglesiteCore/WebSubPublishPing.swift
+++ b/Sources/AnglesiteCore/WebSubPublishPing.swift
@@ -1,0 +1,137 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Pings the site's own WebSub hub after a successful deploy so subscribers get pushed the
+/// updated feeds (V-3.3, #361).
+///
+/// The hub (`@dwk/websub`, composed into the per-site Worker at `/websub`) treats a
+/// `hub.mode=publish` POST for one of the site's feed topics as "this topic changed": it fetches
+/// the feed once and delivers the snapshot to every verified subscriber, HMAC-signing the body
+/// (`X-Hub-Signature`) for subscribers that registered a secret. A deploy regenerates every
+/// feed, so the app pings all of them — WebSub publish pings are deliberately unauthenticated
+/// (a spoofed ping only makes the hub re-fetch content it already serves).
+///
+/// Best-effort by contract: a failed ping must never turn an already-successful deploy into a
+/// failure, so `notify` reports outcomes (and logs them) instead of throwing — the same posture
+/// as the webmention-send and POSSE passes it runs alongside in
+/// `DeployCoordinator.runPostDeploySequencing`.
+public struct WebSubPublishPing: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// The feed paths the hub serves as topics. Must mirror the template's
+    /// `worker/worker.ts` `WEBSUB_TOPIC_PATHS` — a ping for any other path is a 400.
+    public static let topicPaths = ["/rss.xml", "/atom.xml", "/feed.json"]
+
+    public struct Outcome: Equatable, Sendable {
+        public let topic: String
+        public let accepted: Bool
+        public let detail: String?
+
+        public init(topic: String, accepted: Bool, detail: String? = nil) {
+            self.topic = topic
+            self.accepted = accepted
+            self.detail = detail
+        }
+    }
+
+    private let transport: Transport
+
+    public init(transport: @escaping Transport = WebSubPublishPing.defaultTransport) {
+        self.transport = transport
+    }
+
+    /// POSTs one `hub.mode=publish` ping per feed topic to `<origin>/websub` and returns the
+    /// per-topic outcomes. `siteURL` is the site's canonical URL
+    /// (`DeployCoordinator.resolveSiteURL`); an unparseable value yields no pings. Outcomes are
+    /// also appended to the debug log under `source`.
+    public func notify(siteURL: String, source: String = "websub-ping") async -> [Outcome] {
+        guard let origin = Self.origin(from: siteURL) else {
+            await LogCenter.shared.append(
+                source: source, stream: .stderr,
+                text: "skipping WebSub publish pings — no canonical site URL"
+            )
+            return []
+        }
+        guard let hubURL = URL(string: "\(origin)/websub") else { return [] }
+
+        var outcomes: [Outcome] = []
+        for path in Self.topicPaths {
+            let topic = "\(origin)\(path)"
+            var request = URLRequest(url: hubURL)
+            request.httpMethod = "POST"
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            request.httpBody = Self.formEncode([("hub.mode", "publish"), ("hub.url", topic)])
+
+            let outcome: Outcome
+            do {
+                let (data, http) = try await transport(request)
+                if (200..<300).contains(http.statusCode) {
+                    outcome = Outcome(topic: topic, accepted: true)
+                } else {
+                    let body = String(data: data, encoding: .utf8) ?? ""
+                    outcome = Outcome(
+                        topic: topic, accepted: false,
+                        detail: "HTTP \(http.statusCode)\(body.isEmpty ? "" : ": \(body)")"
+                    )
+                }
+            } catch {
+                outcome = Outcome(topic: topic, accepted: false, detail: "\(error)")
+            }
+            outcomes.append(outcome)
+            await LogCenter.shared.append(
+                source: source,
+                stream: outcome.accepted ? .stdout : .stderr,
+                text: outcome.accepted
+                    ? "notified hub: \(topic)"
+                    : "hub ping failed for \(topic): \(outcome.detail ?? "unknown error")"
+            )
+        }
+        return outcomes
+    }
+
+    /// The canonical origin (`scheme://host[:port]`) of `siteURL`, or `nil` when it has no
+    /// usable scheme/host. Topic URLs must match the hub's allowed-topic list exactly, and that
+    /// list derives from the same origin (worker.ts `websubConfig`), so both sides agree by
+    /// construction.
+    static func origin(from siteURL: String) -> String? {
+        guard let url = URL(string: siteURL.trimmingCharacters(in: .whitespacesAndNewlines)),
+              let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https",
+              let host = url.host, !host.isEmpty
+        else { return nil }
+        let port = url.port.map { ":\($0)" } ?? ""
+        return "\(scheme)://\(host)\(port)"
+    }
+
+    /// application/x-www-form-urlencoded body. Values here are URLs (no spaces), so plain
+    /// percent-encoding of everything outside the unreserved set is sufficient and unambiguous.
+    static func formEncode(_ fields: [(String, String)]) -> Data {
+        let unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+        let encoded = fields.map { key, value in
+            let k = key.addingPercentEncoding(withAllowedCharacters: unreserved) ?? key
+            let v = value.addingPercentEncoding(withAllowedCharacters: unreserved) ?? value
+            return "\(k)=\(v)"
+        }
+        return Data(encoded.joined(separator: "&").utf8)
+    }
+
+    /// Bounded well below `URLSession.shared`'s ~60s default: three sequential pings on
+    /// `URLSession.shared` could add up to ~3 minutes to a deploy before this best-effort pass
+    /// gives up on an unreachable hub. The hub is the site's own just-deployed Worker, so a
+    /// healthy response is near-instant — 10s per ping is generous headroom, not a tight budget.
+    /// Internal (not private) so tests can confirm it's actually wired into `defaultSession`.
+    static let requestTimeoutSeconds: TimeInterval = 10
+
+    static let defaultSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = requestTimeoutSeconds
+        return URLSession(configuration: config)
+    }()
+
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await defaultSession.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+}

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -39,6 +39,11 @@ public enum WorkerComposition {
     /// out for free once `WorkerDescriptor.Resources` decodes that entry correctly.
     public static let micropubWorkerID = "micropub"
 
+    /// `@dwk/websub`'s catalog id — like `webmentionWorkerID`, composition keys off this
+    /// directly for the hub's bespoke bindings (`WEBSUB_DB`, its own Queue, `SITE_URL`), since
+    /// those binding names are part of `@dwk/websub`'s public composition contract.
+    public static let websubWorkerID = "websub"
+
     /// The bespoke app-side inbox-capture route (#587) — not a `@dwk/workers` catalog worker, so
     /// its claim lives here rather than in `catalog.json`. Appended automatically when
     /// `generateWranglerToml` is called with `inboxCaptureEnabled`.
@@ -61,15 +66,22 @@ public enum WorkerComposition {
         /// `r2BucketName`, this is a deterministic name (`\(siteName)-webmention`), not an id —
         /// wrangler.toml's `[[queues.*]]` blocks reference queues by name.
         public var queueName: String?
+        /// The Cloudflare Queue name backing `@dwk/websub`'s intent verification and
+        /// per-subscriber delivery fan-out — deterministic (`\(siteName)-websub`), separate from
+        /// `queueName` so the composed Worker's `queue()` handler can dispatch on the name
+        /// suffix. Optional like every other field: `nil` decodes cleanly from settings
+        /// persisted before this field existed.
+        public var websubQueueName: String?
 
         public init(
             d1DatabaseID: String? = nil, kvNamespaceID: String? = nil, r2BucketName: String? = nil,
-            queueName: String? = nil
+            queueName: String? = nil, websubQueueName: String? = nil
         ) {
             self.d1DatabaseID = d1DatabaseID
             self.kvNamespaceID = kvNamespaceID
             self.r2BucketName = r2BucketName
             self.queueName = queueName
+            self.websubQueueName = websubQueueName
         }
     }
 
@@ -122,6 +134,7 @@ public enum WorkerComposition {
         let hasIndieauth = workers.contains(where: { $0.id == indieauthWorkerID })
         let hasWebmentionReceive = workers.contains(where: { $0.id == webmentionWorkerID })
         let hasMicropub = workers.contains(where: { $0.id == micropubWorkerID })
+        let hasWebSub = workers.contains(where: { $0.id == websubWorkerID })
 
         var lines: [String] = []
         lines.append("name = \"\(siteName)\"")
@@ -218,6 +231,39 @@ public enum WorkerComposition {
             lines.append("max_retries = 3")
         }
 
+        // Same shared per-site D1 database, bound under WEBSUB_DB — @dwk/websub's
+        // createD1SubscriptionStore creates its own `websub_subscriptions` table on first use,
+        // so no separate database or migration is needed here.
+        if hasWebSub {
+            lines.append("")
+            lines.append("[[d1_databases]]")
+            lines.append("binding = \"WEBSUB_DB\"")
+            lines.append("database_name = \"\(siteName)-social\"")
+            if let id = resources.d1DatabaseID, !id.isEmpty {
+                lines.append("database_id = \"\(id)\"")
+            } else {
+                lines.append("database_id = \"\"  # filled by provisioning")
+            }
+        }
+
+        // Dedicated Cloudflare Queue for @dwk/websub's intent verification and per-subscriber
+        // delivery fan-out. Deliberately separate from the Webmention queue: the composed
+        // Worker's queue() handler dispatches on the queue-name suffix (`-websub`), and each
+        // feature's retry traffic stays isolated from the other's.
+        if hasWebSub {
+            lines.append("")
+            let websubQueueName = resources.websubQueueName ?? "\(siteName)-websub"
+            lines.append("[[queues.producers]]")
+            lines.append("queue = \"\(websubQueueName)\"")
+            lines.append("binding = \"WEBSUB_QUEUE\"")
+            lines.append("")
+            lines.append("[[queues.consumers]]")
+            lines.append("queue = \"\(websubQueueName)\"")
+            lines.append("max_batch_size = 10")
+            lines.append("max_batch_timeout = 30")
+            lines.append("max_retries = 3")
+        }
+
         if workers.contains(where: { $0.resources.needsKV }) {
             lines.append("")
             lines.append("[[kv_namespaces]]")
@@ -247,7 +293,10 @@ public enum WorkerComposition {
             }
         }
 
-        if hasWebmentionReceive, let siteURL, !siteURL.isEmpty, isSafeTomlStringValue(siteURL) {
+        // SITE_URL: the canonical origin the queue consumers key on — Webmention's verifier
+        // scopes accepted targets with it, and WebSub's consumer derives its topic URLs from it
+        // (neither has a request to derive an origin from).
+        if hasWebmentionReceive || hasWebSub, let siteURL, !siteURL.isEmpty, isSafeTomlStringValue(siteURL) {
             lines.append("")
             lines.append("[vars]")
             lines.append("SITE_URL = \"\(siteURL)\"")

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -201,25 +201,46 @@ struct DeployCoordinatorTests {
         func record(_ name: String) { calls.append(name) }
     }
 
-    @Test("runs webmention-send fully before syndication starts, with a milestone immediately before each")
+    @Test("runs webmention-send, syndication, then subscriber notify in order, with a milestone immediately before each")
     func postDeploySequencingRunsInOrder() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { progress in recorder.record("milestone:\(progress.phase)") },
+            sendWebmentions: { recorder.record("send") },
+            syndicate: { recorder.record("syndicate") },
+            notifySubscribers: { recorder.record("notify") }
+        )
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+        ])
+    }
+
+    @Test("all passes still run even when the caller's onMilestone closure does nothing observable")
+    func postDeploySequencingRunsBothPassesRegardless() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { _ in },
+            sendWebmentions: { recorder.record("send") },
+            syndicate: { recorder.record("syndicate") },
+            notifySubscribers: { recorder.record("notify") }
+        )
+        #expect(recorder.calls == ["send", "syndicate", "notify"])
+    }
+
+    @Test("notifySubscribers defaults to a no-op so callers without a hub change nothing")
+    func postDeploySequencingDefaultsNotifyToNoOp() async {
         let recorder = CallRecorder()
         await DeployCoordinator.runPostDeploySequencing(
             onMilestone: { progress in recorder.record("milestone:\(progress.phase)") },
             sendWebmentions: { recorder.record("send") },
             syndicate: { recorder.record("syndicate") }
         )
-        #expect(recorder.calls == ["milestone:webmentions", "send", "milestone:syndicating", "syndicate"])
-    }
-
-    @Test("both passes still run even when the caller's onMilestone closure does nothing observable")
-    func postDeploySequencingRunsBothPassesRegardless() async {
-        let recorder = CallRecorder()
-        await DeployCoordinator.runPostDeploySequencing(
-            onMilestone: { _ in },
-            sendWebmentions: { recorder.record("send") },
-            syndicate: { recorder.record("syndicate") }
-        )
-        #expect(recorder.calls == ["send", "syndicate"])
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing",
+        ])
     }
 }

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -68,6 +68,7 @@ struct SocialWorkerProvisionCommandTests {
             ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"id":"kv-id"}"#, stderr: "", exitCode: 0),
             ["r2", "bucket", "create", "my-site-media"]: .init(stdout: "Created bucket my-site-media", stderr: "", exitCode: 0),
             ["queues", "create", "my-site-webmention", "--json"]: .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0),
+            ["queues", "create", "my-site-websub", "--json"]: .init(stdout: #"{"result":{"queue_name":"my-site-websub"}}"#, stderr: "", exitCode: 0),
             ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
         ])
         let command = SocialWorkerProvisionCommand(
@@ -578,6 +579,199 @@ struct SocialWorkerProvisionCommandTests {
         }
         let config = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(SiteConfigFile.value(forKey: "WEBMENTION_RECEIVE_ENABLED", in: config) == "false")
+    }
+
+    @Test("websub worker without paid-plan acknowledgment returns the confirmation-needed gate, no wrangler call")
+    func websubWithoutAcknowledgmentBlocksBeforeAnyCall() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                return .init(stdout: "", stderr: "unexpected call", exitCode: 1)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let websub = WorkerDescriptor(
+            id: "websub", displayName: "WebSub", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [websub], acknowledgesPaidPlan: false)
+
+        guard case .webmentionPaidPlanConfirmationNeeded = result else {
+            Issue.record("expected .webmentionPaidPlanConfirmationNeeded, got \(result)")
+            return
+        }
+        #expect(calledArguments.isEmpty, "must not call wrangler before the user acknowledges the paid-plan requirement")
+    }
+
+    @Test("websub worker with acknowledgment creates its own queue")
+    func websubWithAcknowledgmentCreatesQueue() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                if arguments.first == "queues" {
+                    return .init(stdout: #"{"result":{"queue_name":"my-site-websub"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let websub = WorkerDescriptor(
+            id: "websub", displayName: "WebSub", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [websub], acknowledgesPaidPlan: true)
+
+        guard case .succeeded(_, let resources, _) = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(resources.websubQueueName == "my-site-websub")
+        #expect(resources.queueName == nil, "no webmention worker, so no webmention queue")
+        #expect(calledArguments.contains(["queues", "create", "my-site-websub", "--json"]))
+        #expect(!calledArguments.contains(["queues", "create", "my-site-webmention", "--json"]))
+    }
+
+    @Test("webmention and websub active together create both queues under one acknowledgment")
+    func webmentionAndWebsubCreateBothQueues() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                if arguments == ["queues", "create", "my-site-webmention", "--json"] {
+                    return .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0)
+                }
+                if arguments == ["queues", "create", "my-site-websub", "--json"] {
+                    return .init(stdout: #"{"result":{"queue_name":"my-site-websub"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let plain = { (id: String) in
+            WorkerDescriptor(
+                id: id, displayName: id, description: "test", group: "social",
+                binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+        }
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [plain("webmention"), plain("websub")], acknowledgesPaidPlan: true)
+
+        guard case .succeeded(_, let resources, _) = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(resources.queueName == "my-site-webmention")
+        #expect(resources.websubQueueName == "my-site-websub")
+    }
+
+    @Test("an already-provisioned websub queue is not re-created")
+    func alreadyProvisionedWebsubQueueSkipsCreation() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let websub = WorkerDescriptor(
+            id: "websub", displayName: "WebSub", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [websub], knownResources: .init(websubQueueName: "my-site-websub"),
+            acknowledgesPaidPlan: true)
+
+        guard case .succeeded = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(!calledArguments.contains(where: { $0.first == "queues" }))
+    }
+
+    @Test("websub writes WEBSUB_ENABLED into .site-config, and deactivation reconciles it to false")
+    func websubWritesEnabledFlagAndReconciles() async throws {
+        let siteDirectory = try temporaryDirectory()
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                if arguments.first == "queues" {
+                    return .init(stdout: #"{"result":{"queue_name":"my-site-websub"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let websub = WorkerDescriptor(
+            id: "websub", displayName: "WebSub", description: "test", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [websub], acknowledgesPaidPlan: true)
+
+        let enabledConfig = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "WEBSUB_ENABLED", in: enabledConfig) == "true")
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [], acknowledgesPaidPlan: true)
+
+        let disabledConfig = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "WEBSUB_ENABLED", in: disabledConfig) == "false")
+    }
+
+    @Test("readPersistedResources classifies webmention and websub queues by suffix")
+    func persistedQueueClassification() throws {
+        let site = try temporaryDirectory()
+        let toml = """
+        name = "my-site"
+        [[queues.producers]]
+        queue = "my-site-webmention"
+        binding = "WEBMENTION_QUEUE"
+        [[queues.producers]]
+        queue = "my-site-websub"
+        binding = "WEBSUB_QUEUE"
+        """
+        try toml.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+
+        let resources = SocialWorkerProvisionCommand.readPersistedResources(from: site)
+
+        #expect(resources.queueName == "my-site-webmention")
+        #expect(resources.websubQueueName == "my-site-websub")
+    }
+
+    @Test("readPersistedResources with only a websub queue leaves the webmention queue nil")
+    func persistedWebsubOnlyQueue() throws {
+        let site = try temporaryDirectory()
+        let toml = """
+        name = "my-site"
+        [[queues.producers]]
+        queue = "my-site-websub"
+        binding = "WEBSUB_QUEUE"
+        """
+        try toml.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+
+        let resources = SocialWorkerProvisionCommand.readPersistedResources(from: site)
+
+        #expect(resources.queueName == nil)
+        #expect(resources.websubQueueName == "my-site-websub")
     }
 
     private func temporaryDirectory() throws -> URL {

--- a/Tests/AnglesiteCoreTests/WebSubPublishPingTests.swift
+++ b/Tests/AnglesiteCoreTests/WebSubPublishPingTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+/// `WebSubPublishPing` (V-3.3, #361): the post-deploy publish pings that tell the site's own
+/// WebSub hub its feeds changed. Transport is a closure (the `GreenHostChecker` pattern), so
+/// these run without any network.
+@Suite("WebSubPublishPing")
+struct WebSubPublishPingTests {
+
+    private final class RequestRecorder: @unchecked Sendable {
+        private(set) var requests: [URLRequest] = []
+        private let lock = NSLock()
+        func record(_ request: URLRequest) {
+            lock.lock()
+            defer { lock.unlock() }
+            requests.append(request)
+        }
+    }
+
+    private static func transport(
+        recording recorder: RequestRecorder, status: Int = 202
+    ) -> WebSubPublishPing.Transport {
+        { request in
+            recorder.record(request)
+            let http = HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil
+            )!
+            return (Data(), http)
+        }
+    }
+
+    @Test("POSTs one form-encoded publish ping per feed topic to the site's hub")
+    func pingsEveryFeedTopic() async {
+        let recorder = RequestRecorder()
+        let ping = WebSubPublishPing(transport: Self.transport(recording: recorder))
+
+        let outcomes = await ping.notify(siteURL: "https://example.com")
+
+        #expect(outcomes.count == 3)
+        #expect(outcomes.allSatisfy { $0.accepted })
+        #expect(recorder.requests.count == 3)
+        for request in recorder.requests {
+            #expect(request.url?.absoluteString == "https://example.com/websub")
+            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+        }
+        let bodies = recorder.requests.compactMap { $0.httpBody.flatMap { String(data: $0, encoding: .utf8) } }
+        #expect(bodies == [
+            "hub.mode=publish&hub.url=https%3A%2F%2Fexample.com%2Frss.xml",
+            "hub.mode=publish&hub.url=https%3A%2F%2Fexample.com%2Fatom.xml",
+            "hub.mode=publish&hub.url=https%3A%2F%2Fexample.com%2Ffeed.json",
+        ])
+    }
+
+    @Test("a non-2xx hub response is reported as a failed outcome, not thrown")
+    func non2xxReportsFailure() async {
+        let recorder = RequestRecorder()
+        let ping = WebSubPublishPing(transport: Self.transport(recording: recorder, status: 503))
+
+        let outcomes = await ping.notify(siteURL: "https://example.com")
+
+        #expect(outcomes.count == 3)
+        #expect(outcomes.allSatisfy { !$0.accepted })
+        #expect(outcomes.allSatisfy { $0.detail?.contains("HTTP 503") == true })
+    }
+
+    @Test("a transport error is reported as a failed outcome, not thrown")
+    func transportErrorReportsFailure() async {
+        let ping = WebSubPublishPing(transport: { _ in throw URLError(.notConnectedToInternet) })
+
+        let outcomes = await ping.notify(siteURL: "https://example.com")
+
+        #expect(outcomes.count == 3)
+        #expect(outcomes.allSatisfy { !$0.accepted })
+    }
+
+    @Test("an unparseable site URL yields no pings")
+    func unparseableSiteURLSkips() async {
+        let recorder = RequestRecorder()
+        let ping = WebSubPublishPing(transport: Self.transport(recording: recorder))
+
+        #expect(await ping.notify(siteURL: "not a url").isEmpty)
+        #expect(await ping.notify(siteURL: "ftp://example.com").isEmpty)
+        #expect(recorder.requests.isEmpty)
+    }
+
+    @Test("origin folds a path or trailing slash away but keeps an explicit port")
+    func originDerivation() {
+        #expect(WebSubPublishPing.origin(from: "https://example.com") == "https://example.com")
+        #expect(WebSubPublishPing.origin(from: "https://example.com/") == "https://example.com")
+        #expect(WebSubPublishPing.origin(from: "https://example.com/some/page") == "https://example.com")
+        #expect(WebSubPublishPing.origin(from: "http://localhost:4321") == "http://localhost:4321")
+        #expect(WebSubPublishPing.origin(from: " https://example.com ") == "https://example.com")
+        #expect(WebSubPublishPing.origin(from: "example.com") == nil)
+        #expect(WebSubPublishPing.origin(from: "") == nil)
+    }
+
+    @Test("topic paths mirror the template's WebSub topic list")
+    func topicPathsMatchTemplate() {
+        #expect(WebSubPublishPing.topicPaths == ["/rss.xml", "/atom.xml", "/feed.json"])
+    }
+
+    @Test("the default transport's session enforces a bounded per-request timeout, not URLSession.shared's ~60s default")
+    func defaultTransportHasABoundedTimeout() {
+        #expect(WebSubPublishPing.requestTimeoutSeconds > 0)
+        #expect(WebSubPublishPing.requestTimeoutSeconds < 60)
+        #expect(WebSubPublishPing.defaultSession.configuration.timeoutIntervalForRequest == WebSubPublishPing.requestTimeoutSeconds)
+    }
+}

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -225,6 +225,52 @@ struct WorkerCompositionTests {
         #expect(toml.contains("queue = \"my-site-webmention\""))
     }
 
+    @Test("websub adds a WEBSUB_DB D1 binding on the shared database")
+    func websubAddsStoreBinding() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: [websubWorker],
+            resources: .init(d1DatabaseID: "d1-id")
+        )
+        #expect(toml.contains("binding = \"WEBSUB_DB\""))
+        #expect(toml.contains("database_id = \"d1-id\""))
+    }
+
+    @Test("no websub worker means no WEBSUB_DB binding or websub queue")
+    func noWebsubOmitsHubBindings() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [webmentionWorker])
+        #expect(!toml.contains("WEBSUB_DB"))
+        #expect(!toml.contains("WEBSUB_QUEUE"))
+        #expect(!toml.contains("my-site-websub"))
+    }
+
+    @Test("websub adds its own queue producer/consumer blocks, separate from webmention's")
+    func websubAddsQueueBlocks() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: [webmentionWorker, websubWorker],
+            resources: .init(queueName: "my-site-webmention", websubQueueName: "my-site-websub")
+        )
+        #expect(toml.contains("binding = \"WEBMENTION_QUEUE\""))
+        #expect(toml.contains("queue = \"my-site-webmention\""))
+        #expect(toml.contains("binding = \"WEBSUB_QUEUE\""))
+        #expect(toml.contains("queue = \"my-site-websub\""))
+    }
+
+    @Test("websub queue name defaults to a deterministic placeholder before provisioning")
+    func websubQueueDefaultsUnprovisioned() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [websubWorker])
+        #expect(toml.contains("queue = \"my-site-websub\""))
+    }
+
+    @Test("websub alone (no webmention) with a known site URL emits a SITE_URL var")
+    func websubEmitsSiteURL() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [websubWorker], siteURL: "https://my-site.example")
+        #expect(toml.contains("[vars]"))
+        #expect(toml.contains("SITE_URL = \"https://my-site.example\""))
+    }
+
     @Test("webmention receive with a known site URL emits a SITE_URL var")
     func webmentionEmitsSiteURL() throws {
         let toml = try WorkerComposition.generateWranglerToml(


### PR DESCRIPTION
## Summary

- **Composes `@dwk/websub@0.1.0-beta.4` into the template's per-site Worker** (V-3.3, #361, the #887 pattern): a `POST /websub` hub route (subscribe/unsubscribe/publish → validate → enqueue → 202, 503 when unprovisioned) plus the queue consumer for intent verification and per-subscriber HMAC-signed delivery (`X-Hub-Signature`). Two queues now feed the one `queue()` handler, dispatched on the deterministic queue-name suffix (`<site>-webmention` / `<site>-websub`). Topics are the three root feeds (`/rss.xml`, `/atom.xml`, `/feed.json`), keyed on the canonical `SITE_URL` origin.
- **App-side provisioning + discovery** (the #896 pattern): `WorkerComposition` gains `websubWorkerID`, a `WEBSUB_DB` binding on the shared per-site D1 database, a dedicated `<site>-websub` queue (producer + consumer blocks), `SITE_URL` emission when websub is active, and `ProvisionedResources.websubQueueName`; `SocialWorkerProvisionCommand` creates the queue behind the same one-time Workers-Paid-plan acknowledgment as Webmention (sheet copy generalized to name both features) and reconciles a `WEBSUB_ENABLED` flag into `.site-config`. Feeds advertise the hub only when that flag is true — `atom:link rel="hub"/"self"` in RSS, `<link rel="hub">` in Atom, `hubs: []` in JSON Feed.
- **Publish pings on deploy**: a new best-effort `WebSubPublishPing` (injectable-transport, GreenHostChecker pattern) POSTs `hub.mode=publish` per feed topic to the site's own hub as a third `runPostDeploySequencing` pass ("Notifying feed subscribers…" milestone), gated on the hub actually being provisioned.

Closes #361. Acceptance ("subscribers receive HMAC-signed pings on publish") is met to the same standard as #359: the end-to-end path is composed, provisioned, advertised, and pinged; HMAC signing/delivery is `@dwk/websub`'s own tested behavior, and the websub.rocks live hub check — like webmention.rocks receiver conformance — needs an interactive session against a deployed site, so it remains a manual post-provision verification.

Known limitation (documented in `worker.ts`): the optional `WEBSUB_CONTENT` R2 staging bucket is not provisioned yet — a feed snapshot over the ~64 KB inline queue-message limit fails the fan-out loudly rather than truncating; wiring the staging bucket (with an R2 lifecycle expiration rule) is the follow-up.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Template + app-side only; no MCP schema change. The `@dwk/workers` side is already published (`@dwk/websub@0.1.0-beta.4` on npm; `catalog.json` already lists the `websub` worker with its D1/queue resources and the `POST /websub` route claim), so no catalog coordination is pending either.

## Test plan

- [x] `swift test --package-path .` — full suite, including new `WebSubPublishPingTests`, websub cases in `WorkerCompositionTests`/`SocialWorkerProvisionCommandTests`, and the extended `runPostDeploySequencing` ordering tests
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (+ `xcstringstool sync` for the generalized paid-plan sheet copy; `scripts/check-localization-catalog.sh` passes)
- [x] Template: `npm run test:worker` (46 tests — hub 202/400/405/503, SITE_URL-keyed topics, queue-consumer no-op) and `npx tsx --test src/lib/feeds.test.ts` (hub advertisement in all three feed renderers), `npx tsc --noEmit`, `npm run build` (astro check + build + microformats)
- [ ] Manual smoke (post-provision, real site): subscribe via websub.rocks and verify a signed push arrives after a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
