### PR TITLE
fix: drop dup readConfig imports from BaseLayout injections

### DIFF
--- a/Resources/Template/src/layouts/BlogPost.astro
+++ b/Resources/Template/src/layouts/BlogPost.astro
@@ -11,6 +11,10 @@ import BaseLayout from "./BaseLayout.astro";
 import SyndicationLinks from "../components/SyndicationLinks.astro";
 import DraftBadge from "../components/DraftBadge.astro";
 import Interactions from "../components/Interactions.astro";
+// Imported unconditionally (like BaseLayout.astro) so the giscus and share
+// integrations, which both read config at this anchor, don't each need their
+// own copy — astro check rejects the resulting duplicate identifier.
+import { readConfig } from "../../scripts/config";
 
 interface Props {
   title: string;

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -91,8 +91,11 @@ public enum IntegrationCatalog {
                       when: .always),
             .copyFile(from: TemplateRef("integrations/pages/book.astro"),
                       to: "src/pages/book.astro", when: .fieldEquals(key: "style", value: "inline")),
+            // No readConfig re-import here: BaseLayout.astro already imports it unconditionally
+            // at the top of the file (added for WEBMENTION_RECEIVE_ENABLED), and astro check
+            // rejects a duplicate identifier — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "// anglesite:imports",
-                            snippet: "import BookingWidget from \"../components/BookingWidget.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            snippet: "import BookingWidget from \"../components/BookingWidget.astro\";",
                             when: .fieldEquals(key: "style", value: "floating"), style: .line),
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:body-end -->",
                             snippet: "{readConfig(\"BOOKING_STYLE\") === \"floating\" && (<BookingWidget provider={readConfig(\"BOOKING_PROVIDER\")} username={readConfig(\"BOOKING_USERNAME\")} eventSlug={readConfig(\"BOOKING_EVENT_SLUG\")} buttonText={readConfig(\"BOOKING_BUTTON_TEXT\")} style=\"floating\" />)}",
@@ -263,8 +266,11 @@ public enum IntegrationCatalog {
         operations: [
             .copyFile(from: TemplateRef("integrations/components/ConsentBanner.astro"),
                       to: "src/components/ConsentBanner.astro", when: .always),
+            // No readConfig re-import here: BaseLayout.astro already imports it unconditionally
+            // at the top of the file (added for WEBMENTION_RECEIVE_ENABLED), and astro check
+            // rejects a duplicate identifier — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "// anglesite:imports",
-                            snippet: "import ConsentBanner from \"../components/ConsentBanner.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            snippet: "import ConsentBanner from \"../components/ConsentBanner.astro\";",
                             when: .always, style: .line),
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:body-end -->",
                             snippet: "<ConsentBanner analytics={readConfig(\"CONSENT_ANALYTICS\") === \"true\"} embeds={readConfig(\"CONSENT_EMBEDS\") === \"true\"} ads={readConfig(\"CONSENT_ADS\") === \"true\"} defaultPolicy={readConfig(\"CONSENT_DEFAULT\")} version={readConfig(\"CONSENT_VERSION\")} />",
@@ -303,8 +309,11 @@ public enum IntegrationCatalog {
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:head-end -->",
                             snippet: "<link rel=\"manifest\" href=\"/manifest.webmanifest\" />\n<meta name=\"theme-color\" content={readConfig(\"PWA_THEME_COLOR\")} />",
                             when: .always, style: .html),
+            // No readConfig re-import here: BaseLayout.astro already imports it unconditionally
+            // at the top of the file (added for WEBMENTION_RECEIVE_ENABLED), and astro check
+            // rejects a duplicate identifier — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "// anglesite:imports",
-                            snippet: "import InstallPrompt from \"../components/InstallPrompt.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            snippet: "import InstallPrompt from \"../components/InstallPrompt.astro\";",
                             when: .always, style: .line),
             // The install prompt's install-prompt on/off toggle is resolved at Astro build time
             // via readConfig, the same way booking's floating-vs-button variants are — not by
@@ -374,8 +383,12 @@ public enum IntegrationCatalog {
         operations: [
             .copyFile(from: TemplateRef("integrations/components/TrackingScript.astro"),
                       to: "src/components/TrackingScript.astro", when: .always),
+            // readConfig itself isn't re-imported here: BaseLayout.astro already imports it
+            // unconditionally at the top of the file (added for WEBMENTION_RECEIVE_ENABLED), and
+            // astro check rejects a duplicate identifier — see the co2Badge fix (#686).
+            // asTrackingProvider is unique to this integration and still needs importing.
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "// anglesite:imports",
-                            snippet: "import TrackingScript from \"../components/TrackingScript.astro\";\nimport { readConfig, asTrackingProvider } from \"../../scripts/config\";",
+                            snippet: "import TrackingScript from \"../components/TrackingScript.astro\";\nimport { asTrackingProvider } from \"../../scripts/config\";",
                             when: .always, style: .line),
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:head-end -->",
                             snippet: "{!!readConfig(\"TRACKING_PROVIDER\") && (<TrackingScript provider={asTrackingProvider(readConfig(\"TRACKING_PROVIDER\"))} domain={readConfig(\"TRACKING_DOMAIN\")} siteId={readConfig(\"TRACKING_SITE_ID\")} measurementId={readConfig(\"TRACKING_MEASUREMENT_ID\")} />)}",
@@ -461,9 +474,9 @@ public enum IntegrationCatalog {
                   help: "Usually your domain, e.g. example.com — enables webmention/pingback discovery via webmention.io."),
         ],
         operations: [
-            .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "// anglesite:imports",
-                            snippet: "import { readConfig } from \"../../scripts/config\";",
-                            when: .always, style: .line),
+            // No imports-anchor injection needed: this integration adds no component, and
+            // BaseLayout.astro already imports readConfig unconditionally at the top of the file
+            // (added for WEBMENTION_RECEIVE_ENABLED) — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:head-end -->",
                             snippet: "{!!readConfig(\"INDIEWEB_REL_ME_1\") && (<link rel=\"me\" href={readConfig(\"INDIEWEB_REL_ME_1\")} />)}\n{!!readConfig(\"INDIEWEB_REL_ME_2\") && (<link rel=\"me\" href={readConfig(\"INDIEWEB_REL_ME_2\")} />)}\n{!!readConfig(\"INDIEWEB_REL_ME_3\") && (<link rel=\"me\" href={readConfig(\"INDIEWEB_REL_ME_3\")} />)}\n{!!readConfig(\"INDIEWEB_WEBMENTION_USERNAME\") && (<link rel=\"webmention\" href={`https://webmention.io/${readConfig(\"INDIEWEB_WEBMENTION_USERNAME\")}/webmention`} />)}\n{!!readConfig(\"INDIEWEB_WEBMENTION_USERNAME\") && (<link rel=\"pingback\" href={`https://webmention.io/${readConfig(\"INDIEWEB_WEBMENTION_USERNAME\")}/xmlrpc`} />)}",
                             when: .always, style: .html),
@@ -494,8 +507,11 @@ public enum IntegrationCatalog {
         operations: [
             .copyFile(from: TemplateRef("integrations/components/Nav.astro"),
                       to: "src/components/Nav.astro", when: .always),
+            // No readConfig re-import here: BaseLayout.astro already imports it unconditionally
+            // at the top of the file (added for WEBMENTION_RECEIVE_ENABLED), and astro check
+            // rejects a duplicate identifier — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "// anglesite:imports",
-                            snippet: "import Nav from \"../components/Nav.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            snippet: "import Nav from \"../components/Nav.astro\";",
                             when: .always, style: .line),
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:nav -->",
                             snippet: "<Nav item1Label={readConfig(\"MENU_ITEM_1_LABEL\")} item1Path={readConfig(\"MENU_ITEM_1_PATH\")} item2Label={readConfig(\"MENU_ITEM_2_LABEL\")} item2Path={readConfig(\"MENU_ITEM_2_PATH\")} item3Label={readConfig(\"MENU_ITEM_3_LABEL\")} item3Path={readConfig(\"MENU_ITEM_3_PATH\")} item4Label={readConfig(\"MENU_ITEM_4_LABEL\")} item4Path={readConfig(\"MENU_ITEM_4_PATH\")} />",
@@ -606,9 +622,9 @@ public enum IntegrationCatalog {
                       to: "src/components/SnipcartButton.astro", when: .always),
             .copyFile(from: TemplateRef("integrations/pages/store.astro"),
                       to: "src/pages/store.astro", when: .always),
-            .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "// anglesite:imports",
-                            snippet: "import { readConfig } from \"../../scripts/config\";",
-                            when: .always, style: .line),
+            // No imports-anchor injection needed: this integration adds no component, and
+            // BaseLayout.astro already imports readConfig unconditionally at the top of the file
+            // (added for WEBMENTION_RECEIVE_ENABLED) — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:body-end -->",
                             snippet: "{!!readConfig(\"SNIPCART_API_KEY\") && (<div hidden id=\"snipcart\" data-api-key={readConfig(\"SNIPCART_API_KEY\")} data-config-modal-style=\"side\"></div>)}\n{!!readConfig(\"SNIPCART_API_KEY\") && (<script async src=\"https://cdn.snipcart.com/themes/v3.7.3/default/snipcart.js\"></script>)}",
                             when: .always, style: .html),
@@ -731,8 +747,11 @@ public enum IntegrationCatalog {
         operations: [
             .copyFile(from: TemplateRef("integrations/components/GreenHostBadge.astro"),
                       to: "src/components/GreenHostBadge.astro", when: .always),
+            // No readConfig re-import here: BaseLayout.astro already imports it unconditionally
+            // at the top of the file (added for WEBMENTION_RECEIVE_ENABLED), and astro check
+            // rejects a duplicate identifier — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "// anglesite:imports",
-                            snippet: "import GreenHostBadge from \"../components/GreenHostBadge.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            snippet: "import GreenHostBadge from \"../components/GreenHostBadge.astro\";",
                             when: .always, style: .line),
             .injectAtAnchor(file: "src/layouts/BaseLayout.astro", anchor: "<!-- anglesite:body-end -->",
                             snippet: "{readConfig(\"GREEN_HOST_VERIFIED\") === \"true\" && (<GreenHostBadge hostname={readConfig(\"GREEN_HOST_NAME\")} checkedAt={readConfig(\"GREEN_HOST_CHECKED_AT\")} />)}",

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -195,8 +195,11 @@ public enum IntegrationCatalog {
         operations: [
             .copyFile(from: TemplateRef("integrations/components/Comments.astro"),
                       to: "src/components/Comments.astro", when: .always),
+            // No readConfig re-import here: BlogPost.astro already imports it unconditionally at
+            // the top of the file (so giscus and share can share it without colliding), and astro
+            // check rejects a duplicate identifier — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BlogPost.astro", anchor: "// anglesite:imports",
-                            snippet: "import Comments from \"../components/Comments.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            snippet: "import Comments from \"../components/Comments.astro\";",
                             when: .always, style: .line),
             .injectAtAnchor(file: "src/layouts/BlogPost.astro", anchor: "<!-- anglesite:comments -->",
                             snippet: "{!!readConfig(\"GISCUS_REPO\") && (<Comments repo={readConfig(\"GISCUS_REPO\")} repoId={readConfig(\"GISCUS_REPO_ID\")} category={readConfig(\"GISCUS_CATEGORY\")} categoryId={readConfig(\"GISCUS_CATEGORY_ID\")} mapping={readConfig(\"GISCUS_MAPPING\")} />)}",
@@ -417,8 +420,11 @@ public enum IntegrationCatalog {
         operations: [
             .copyFile(from: TemplateRef("integrations/components/ShareButtons.astro"),
                       to: "src/components/ShareButtons.astro", when: .always),
+            // No readConfig re-import here: BlogPost.astro already imports it unconditionally at
+            // the top of the file (so giscus and share can share it without colliding), and astro
+            // check rejects a duplicate identifier — see the co2Badge fix (#686).
             .injectAtAnchor(file: "src/layouts/BlogPost.astro", anchor: "// anglesite:imports",
-                            snippet: "import ShareButtons from \"../components/ShareButtons.astro\";\nimport { readConfig } from \"../../scripts/config\";",
+                            snippet: "import ShareButtons from \"../components/ShareButtons.astro\";",
                             when: .always, style: .line),
             .injectAtAnchor(file: "src/layouts/BlogPost.astro", anchor: "<!-- anglesite:share -->",
                             snippet: "<ShareButtons title={title} twitter={readConfig(\"SHARE_TWITTER\") === \"true\"} mastodon={readConfig(\"SHARE_MASTODON\") === \"true\"} linkedin={readConfig(\"SHARE_LINKEDIN\") === \"true\"} copyLink={readConfig(\"SHARE_COPY_LINK\") === \"true\"} />",

--- a/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -102,6 +102,22 @@ import Testing
         }
     }
 
+    /// BaseLayout.astro imports `readConfig` unconditionally at the top of the file (added for
+    /// WEBMENTION_RECEIVE_ENABLED) — a descriptor whose "// anglesite:imports" snippet re-imports
+    /// it produces a duplicate identifier that `astro check` rejects, breaking `npm run build` for
+    /// any real site with that integration installed (the template's own `astro check` never runs
+    /// against a scaffolded copy, so this is invisible until someone builds an actual site). See
+    /// the co2Badge fix (#686) for the reference case this guards against regressing on again.
+    @Test(arguments: IntegrationCatalog.all)
+    func noDescriptorReimportsReadConfigIntoBaseLayout(_ descriptor: IntegrationDescriptor) {
+        let pattern = #/import\s*\{[^}]*\breadConfig\b[^}]*\}\s*from\s*"\.\./\.\./scripts/config"/#
+        for case .injectAtAnchor(let file, let anchor, let snippet, _, _) in descriptor.operations
+        where file.raw == "src/layouts/BaseLayout.astro" && anchor == "// anglesite:imports" {
+            #expect(snippet.raw.firstMatch(of: pattern) == nil,
+                "\(descriptor.id) re-imports readConfig into BaseLayout.astro, which already provides it: \(snippet.raw)")
+        }
+    }
+
     @Test func bookingWritesEventSlugAndButtonText() {
         let keys = writtenConfigKeys(for: IntegrationCatalog.descriptor(for: .booking))
         #expect(keys.isSuperset(of: ["BOOKING_PROVIDER", "BOOKING_USERNAME", "BOOKING_STYLE", "BOOKING_EVENT_SLUG", "BOOKING_BUTTON_TEXT"]))

--- a/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -102,19 +102,22 @@ import Testing
         }
     }
 
-    /// BaseLayout.astro imports `readConfig` unconditionally at the top of the file (added for
-    /// WEBMENTION_RECEIVE_ENABLED) — a descriptor whose "// anglesite:imports" snippet re-imports
-    /// it produces a duplicate identifier that `astro check` rejects, breaking `npm run build` for
-    /// any real site with that integration installed (the template's own `astro check` never runs
-    /// against a scaffolded copy, so this is invisible until someone builds an actual site). See
-    /// the co2Badge fix (#686) for the reference case this guards against regressing on again.
+    /// BaseLayout.astro and BlogPost.astro both import `readConfig` unconditionally at the top of
+    /// the file — a descriptor whose "// anglesite:imports" snippet re-imports it into either of
+    /// them produces a duplicate identifier that `astro check` rejects, breaking `npm run build`
+    /// for any real site with that integration installed (the template's own `astro check` never
+    /// runs against a scaffolded copy, so this is invisible until someone builds an actual site).
+    /// See the co2Badge fix (#686) for the reference case this guards against regressing on again.
     @Test(arguments: IntegrationCatalog.all)
-    func noDescriptorReimportsReadConfigIntoBaseLayout(_ descriptor: IntegrationDescriptor) {
+    func noDescriptorReimportsReadConfigIntoALayoutThatAlreadyProvidesIt(_ descriptor: IntegrationDescriptor) {
+        let layoutsWithUnconditionalReadConfig: Set<String> = [
+            "src/layouts/BaseLayout.astro", "src/layouts/BlogPost.astro",
+        ]
         let pattern = #/import\s*\{[^}]*\breadConfig\b[^}]*\}\s*from\s*"\.\./\.\./scripts/config"/#
         for case .injectAtAnchor(let file, let anchor, let snippet, _, _) in descriptor.operations
-        where file.raw == "src/layouts/BaseLayout.astro" && anchor == "// anglesite:imports" {
+        where layoutsWithUnconditionalReadConfig.contains(file.raw) && anchor == "// anglesite:imports" {
             #expect(snippet.raw.firstMatch(of: pattern) == nil,
-                "\(descriptor.id) re-imports readConfig into BaseLayout.astro, which already provides it: \(snippet.raw)")
+                "\(descriptor.id) re-imports readConfig into \(file.raw), which already provides it: \(snippet.raw)")
         }
     }
 


### PR DESCRIPTION
## Summary

- BaseLayout.astro and BlogPost.astro both import `readConfig` unconditionally at the top of the file (BaseLayout since the webmention work landed; BlogPost added here to close the same gap). Ten `IntegrationDescriptor`s still re-imported it inside their own `// anglesite:imports` snippet: booking, consent, pwa, tracking, indieweb, menu, snipcart, greenHostCheck (BaseLayout.astro), plus giscus and share (BlogPost.astro, found during review — see thread below).
- `astro check` rejects the resulting duplicate `readConfig` identifier (`ts(2300)`), which breaks `npm run build` for any real scaffolded site with one of these integrations installed — invisible in this repo since the template's own `astro check` never runs against a scaffolded copy of these layouts.
- Mirrors the existing co2Badge fix (#686): drop the redundant `readConfig` import from each snippet (keeping `asTrackingProvider` for `tracking`); for `indieweb`/`snipcart`, whose imports-anchor injection existed only to carry that now-redundant import, the whole no-op injection is removed. For `giscus`/`share`, since `BlogPost.astro` had no top-level `readConfig` import to lean on, one was added there too, mirroring `BaseLayout.astro`'s pattern, so the fix doesn't depend on install order between the two integrations.
- Added a regression test (`noDescriptorReimportsReadConfigIntoALayoutThatAlreadyProvidesIt`), parameterized over every catalog descriptor and covering both layout files, that fails if any future descriptor re-introduces this duplicate import.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

## Test plan

- [x] `swift test --package-path .`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Manual smoke: reproduced the pre-fix `booking`/`tracking` snippets in a scratch copy of `Resources/Template` and confirmed `astro check` raised `ts(2300): Duplicate identifier 'readConfig'`; confirmed the fixed snippets build clean. Repeated the same check for `giscus`+`share` installed together against `BlogPost.astro` after the fast-follow fix — clean too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)