### PR TITLE
feat(#744): add .well-known inventory descriptor + collision enforcement

### DIFF
--- a/Sources/AnglesiteCore/WellKnownInventory.swift
+++ b/Sources/AnglesiteCore/WellKnownInventory.swift
@@ -293,10 +293,19 @@ public enum WellKnownInventory {
                 claimants: claimants.sorted { ($0.owner, $0.delivery.rawValue) < ($1.owner, $1.delivery.rawValue) })
         }
 
+        // The design doc's overlap rules are scoped to "another owner['s]" prefix / "different
+        // owners" — a descriptor nested inside its OWN prefix claim is self-delegation, not a
+        // collision (e.g. a runtime reporting both "I own acme-challenge/ generally" and "I've
+        // placed a token at acme-challenge/http-01 right now"). This deliberately differs from
+        // `WorkerRouteClaims.activeClaims`'s stricter same-worker rejection: that type validates
+        // one flat HTTP dispatch table, where two overlapping declared routes from one worker are
+        // a manifest bug: there's nothing to reconcile once dispatch is fixed. Here, ownership
+        // claims and materialized artifacts are different concerns even from the same owner, so
+        // only a genuine cross-owner overlap blocks.
         let sorted = all.sorted { ($0.suffix, $0.owner) < ($1.suffix, $1.owner) }
         for (index, row) in sorted.enumerated() where row.match == .prefix {
             let prefixPath = row.suffix.hasSuffix("/") ? row.suffix : row.suffix + "/"
-            for other in sorted[(index + 1)...] where other.suffix.hasPrefix(prefixPath) {
+            for other in sorted[(index + 1)...] where other.suffix.hasPrefix(prefixPath) && other.owner != row.owner {
                 throw CollisionError.overlappingClaims(
                     path: other.suffix, claimant: Claimant(owner: other.owner, delivery: other.delivery),
                     otherPath: row.suffix, other: Claimant(owner: row.owner, delivery: row.delivery))

--- a/Sources/AnglesiteCore/WellKnownInventory.swift
+++ b/Sources/AnglesiteCore/WellKnownInventory.swift
@@ -1,0 +1,395 @@
+import Foundation
+
+// See docs/superpowers/specs/2026-07-14-well-known-support-design.md — #744 owns the portable
+// `/.well-known/` endpoint descriptor, the filesystem inventory scan, and cross-owner collision
+// enforcement. It consumes #746's `WorkerRouteClaims.wellKnownClaims(_:)` for the dynamic-route
+// input and #748's `RuntimeOwnedPathClaim`/`WellKnownClaimManifest`/`WellKnownBuildSeamResult` for
+// the runtime-reservation input and the build-seam round trip; it must not re-derive either.
+
+/// A portable, attributed claim on one `/.well-known/` path — the merged view across all four
+/// delivery-owner classes the design doc defines (design doc §"Endpoint inventory and
+/// validation"). `suffix` is relative to `.well-known/` itself (no leading slash, no
+/// `.well-known/` prefix) — e.g. `"security.txt"`, `"webfinger"`, `"acme-challenge/"` — matching
+/// `WellKnownClaimManifest.Entry.path`'s convention.
+public struct WellKnownEndpointDescriptor: Sendable, Codable, Equatable, Identifiable {
+    public enum Delivery: String, Sendable, Codable, Equatable {
+        /// A committed file in `Source/public/.well-known/` with no recognized Anglesite marker.
+        case userStatic
+        /// A deterministic static file Anglesite generates from git-visible site source (e.g.
+        /// `security.txt`), identified by its first-line marker.
+        case generated
+        /// An exact or specification-approved-prefix Worker route owned by an enabled feature.
+        case dynamic
+        /// A path demonstrably controlled by the active hosting/TLS runtime (`RuntimeOwnedPathClaim`).
+        case externalRuntime
+    }
+
+    /// IANA Well-Known URI registry status, or `.custom` for anything else (including "not
+    /// registered at all" and "registration unknown to this descriptor").
+    public enum Registration: Sendable, Codable, Equatable {
+        case permanent
+        case provisional
+        case deprecated
+        case custom(String)
+
+        public init(from decoder: Decoder) throws {
+            let raw = try decoder.singleValueContainer().decode(String.self)
+            switch raw {
+            case "permanent": self = .permanent
+            case "provisional": self = .provisional
+            case "deprecated": self = .deprecated
+            default: self = .custom(raw)
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .permanent: try container.encode("permanent")
+            case .provisional: try container.encode("provisional")
+            case .deprecated: try container.encode("deprecated")
+            case .custom(let raw): try container.encode(raw)
+            }
+        }
+    }
+
+    public var id: String
+    public var suffix: String
+    public var match: WellKnownPathMatch
+    public var delivery: Delivery
+    /// Stable feature, generator, or runtime id — e.g. `"generator:security-txt"`,
+    /// `"webfinger"` (a `WorkerDescriptor.id`), or a `RuntimeOwnedPathClaim.owner`.
+    public var owner: String
+    public var registration: Registration
+    public var specificationURL: URL?
+    /// `nil` means inventory-only: Anglesite makes no conformance claim for this endpoint.
+    public var validatorID: String?
+    public var authorityBinding: Bool
+
+    public init(
+        id: String,
+        suffix: String,
+        match: WellKnownPathMatch,
+        delivery: Delivery,
+        owner: String,
+        registration: Registration,
+        specificationURL: URL? = nil,
+        validatorID: String? = nil,
+        authorityBinding: Bool = false
+    ) {
+        self.id = id
+        self.suffix = suffix
+        self.match = match
+        self.delivery = delivery
+        self.owner = owner
+        self.registration = registration
+        self.specificationURL = specificationURL
+        self.validatorID = validatorID
+        self.authorityBinding = authorityBinding
+    }
+}
+
+/// Assembles and validates the effective `/.well-known/` inventory: a filesystem scan of
+/// `Source/public/.well-known/`, Anglesite's own generators, active dynamic Worker routes, and
+/// runtime-reported reservations. Pure — no actor isolation — mirroring `WorkerRouteClaims`'s
+/// shape: the app/deploy orchestrator gathers each input first (design doc: "Worker activation
+/// lives in package `Config/`, and provider capabilities are host-side; neither is present inside
+/// the site's runtime clone").
+public enum WellKnownInventory {
+
+    /// One party attributed to a collision, for naming both remediation sources in an error.
+    public struct Claimant: Sendable, Equatable, Hashable {
+        public let owner: String
+        public let delivery: WellKnownEndpointDescriptor.Delivery
+
+        public init(owner: String, delivery: WellKnownEndpointDescriptor.Delivery) {
+            self.owner = owner
+            self.delivery = delivery
+        }
+    }
+
+    /// A non-fatal scan or build-verification finding — a rejected file, a missing expected
+    /// artifact, or an unexpected artifact. Never blocks assembly by itself; callers decide how to
+    /// surface these (e.g. as `PreDeployCheck.ScanWarning`/`ScanFailure`).
+    public struct Finding: Sendable, Equatable {
+        public var path: String?
+        public var message: String
+
+        public init(path: String? = nil, message: String) {
+            self.path = path
+            self.message = message
+        }
+    }
+
+    /// A cross-owner collision the design doc requires to stop build/deploy and name both owners.
+    /// There is no collision precedence ("static wins" or "dynamic wins") — every case names the
+    /// exact path and every claimant involved.
+    public enum CollisionError: Error, Equatable, CustomStringConvertible {
+        /// Two or more claims for the same exact path — covers exact/exact, static/generated,
+        /// static/dynamic, and active-runtime collisions alike; the claimants' `delivery` values
+        /// tell the caller which case it is.
+        case duplicateClaim(path: String, claimants: [Claimant])
+        /// An exact or prefix claim falls inside another owner's prefix claim — covers
+        /// exact/prefix and prefix/prefix collisions.
+        case overlappingClaims(path: String, claimant: Claimant, otherPath: String, other: Claimant)
+
+        public var description: String {
+            switch self {
+            case .duplicateClaim(let path, let claimants):
+                let owners = claimants.map { "\($0.owner) (\($0.delivery.rawValue))" }.joined(separator: ", ")
+                return "/.well-known/\(path) is claimed more than once: \(owners)"
+            case .overlappingClaims(let path, let claimant, let otherPath, let other):
+                return "/.well-known/\(path) (\(claimant.owner), \(claimant.delivery.rawValue)) overlaps " +
+                    "/.well-known/\(otherPath) (\(other.owner), \(other.delivery.rawValue))"
+            }
+        }
+    }
+
+    // MARK: Filesystem scan
+
+    /// Default cap on a single `.well-known` file — generous for text-based protocol documents
+    /// (JRDs, policy files) while still bounding what an unreviewed static file can commit.
+    public static let defaultMaxFileSizeBytes = 64 * 1024
+
+    /// Scans `wellKnownDirectory` (normally `<siteDirectory>/public/.well-known`) and returns one
+    /// row per file, classified `.generated` when its first line matches a known Anglesite marker
+    /// (`GeneratedEndpoints`) or `.userStatic` otherwise. A missing directory returns no rows and
+    /// no findings — a site need not have any `.well-known` content yet.
+    ///
+    /// Rejects (as a `Finding`, excluding the entry from `rows`) any symlink, any path whose
+    /// standardized location resolves outside `wellKnownDirectory`, and any file over
+    /// `maxFileSizeBytes`. A filename containing `%` is also rejected — real filesystems cannot
+    /// contain `..` or an empty segment, but a percent-encoded-looking name could still smuggle a
+    /// path-traversal segment past a later URL-facing consumer that decodes it.
+    public static func scanUserStatic(
+        wellKnownDirectory: URL,
+        maxFileSizeBytes: Int = defaultMaxFileSizeBytes,
+        ownerID: String = "user-static"
+    ) -> (rows: [WellKnownEndpointDescriptor], findings: [Finding]) {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: wellKnownDirectory.path, isDirectory: &isDir), isDir.boolValue else {
+            return ([], [])
+        }
+        let standardizedRoot = wellKnownDirectory.resolvingSymlinksInPath().standardizedFileURL.path
+
+        var rows: [WellKnownEndpointDescriptor] = []
+        var findings: [Finding] = []
+
+        func walk(_ dir: URL, prefix: [String]) {
+            guard let entries = try? fm.contentsOfDirectory(
+                at: dir, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey, .fileSizeKey], options: []
+            ) else { return }
+            for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+                let name = entry.lastPathComponent
+                let relPath = (prefix + [name]).joined(separator: "/")
+                let values = try? entry.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey, .fileSizeKey])
+
+                if values?.isSymbolicLink == true {
+                    findings.append(Finding(path: relPath, message: "symlink not allowed under .well-known/ — excluded from inventory"))
+                    continue
+                }
+                if name.contains("%") {
+                    findings.append(Finding(path: relPath, message: "percent-encoded-looking filename not allowed under .well-known/ — excluded from inventory"))
+                    continue
+                }
+                if values?.isDirectory == true {
+                    walk(entry, prefix: prefix + [name])
+                    continue
+                }
+                let standardizedEntry = entry.resolvingSymlinksInPath().standardizedFileURL.path
+                guard standardizedEntry == standardizedRoot || standardizedEntry.hasPrefix(standardizedRoot + "/") else {
+                    findings.append(Finding(path: relPath, message: "resolved path escapes .well-known/ root — excluded from inventory"))
+                    continue
+                }
+                if let size = values?.fileSize, size > maxFileSizeBytes {
+                    findings.append(Finding(path: relPath, message: "file exceeds \(maxFileSizeBytes) bytes — excluded from inventory"))
+                    continue
+                }
+                let content = try? String(contentsOf: entry, encoding: .utf8)
+                if let generator = GeneratedEndpoints.matching(content: content) {
+                    rows.append(generator.descriptor(suffix: relPath))
+                } else {
+                    rows.append(WellKnownEndpointDescriptor(
+                        id: "\(ownerID):\(relPath)",
+                        suffix: relPath,
+                        match: .exact,
+                        delivery: .userStatic,
+                        owner: ownerID,
+                        registration: .custom("unregistered")
+                    ))
+                }
+            }
+        }
+        walk(wellKnownDirectory, prefix: [])
+        return (rows, findings)
+    }
+
+    // MARK: Dynamic and runtime conversion
+
+    /// Converts already-filtered well-known dynamic route claims (the caller passes
+    /// `WorkerRouteClaims.wellKnownClaims(WorkerRouteClaims.activeClaims(...))`) into inventory
+    /// rows. A claim whose path isn't actually under `/.well-known/` is dropped defensively —
+    /// `wellKnownClaims` already filters this, but this function must not fabricate a nonsensical
+    /// suffix if a caller passes an unfiltered claim by mistake.
+    public static func dynamicRows(from claims: [WorkerRouteClaims.OwnedClaim]) -> [WellKnownEndpointDescriptor] {
+        let prefix = "/.well-known/"
+        return claims.compactMap { owned -> WellKnownEndpointDescriptor? in
+            guard owned.claim.path.hasPrefix(prefix) else { return nil }
+            let suffix = String(owned.claim.path.dropFirst(prefix.count))
+            return WellKnownEndpointDescriptor(
+                id: "\(owned.owner):\(suffix)",
+                suffix: suffix,
+                match: owned.claim.match == .prefix ? .prefix : .exact,
+                delivery: .dynamic,
+                owner: owned.owner,
+                registration: .custom("worker-declared"),
+                specificationURL: owned.claim.specificationURL,
+                validatorID: owned.claim.validatorID,
+                authorityBinding: owned.claim.authorityBinding
+            )
+        }
+    }
+
+    /// Converts runtime/provider-reported ownership claims (#748) into inventory rows. Pass an
+    /// empty array both when no runtime has been asked and when a runtime affirmatively reports no
+    /// claims — either way, no reservation should suppress a static or dynamic claim at that path.
+    public static func runtimeRows(from claims: [RuntimeOwnedPathClaim]) -> [WellKnownEndpointDescriptor] {
+        claims.map { claim in
+            WellKnownEndpointDescriptor(
+                id: claim.id,
+                suffix: claim.path,
+                match: claim.match,
+                delivery: .externalRuntime,
+                owner: claim.owner,
+                registration: .custom("runtime-reported"),
+                specificationURL: claim.specificationURL
+            )
+        }
+    }
+
+    // MARK: Merge and collision enforcement
+
+    /// Merges every delivery class into one effective, collision-checked inventory, sorted by
+    /// suffix then owner for deterministic output. Throws the first collision found, naming every
+    /// claimant involved — there is no "static wins" or "dynamic wins" recovery (design doc
+    /// §"Collision rules"). Call this both before generation (to reject a declared collision early)
+    /// and again after build against the observed artifacts via `verifyBuildArtifacts`.
+    public static func merge(
+        userStatic: [WellKnownEndpointDescriptor] = [],
+        generated: [WellKnownEndpointDescriptor] = [],
+        dynamic: [WellKnownEndpointDescriptor] = [],
+        runtime: [WellKnownEndpointDescriptor] = []
+    ) throws -> [WellKnownEndpointDescriptor] {
+        let all = userStatic + generated + dynamic + runtime
+
+        var claimantsBySuffix: [String: [Claimant]] = [:]
+        for row in all {
+            claimantsBySuffix[row.suffix, default: []].append(Claimant(owner: row.owner, delivery: row.delivery))
+        }
+        if let (suffix, claimants) = claimantsBySuffix.sorted(by: { $0.key < $1.key }).first(where: { $0.value.count > 1 }) {
+            throw CollisionError.duplicateClaim(
+                path: suffix,
+                claimants: claimants.sorted { ($0.owner, $0.delivery.rawValue) < ($1.owner, $1.delivery.rawValue) })
+        }
+
+        let sorted = all.sorted { ($0.suffix, $0.owner) < ($1.suffix, $1.owner) }
+        for (index, row) in sorted.enumerated() where row.match == .prefix {
+            let prefixPath = row.suffix.hasSuffix("/") ? row.suffix : row.suffix + "/"
+            for other in sorted[(index + 1)...] where other.suffix.hasPrefix(prefixPath) {
+                throw CollisionError.overlappingClaims(
+                    path: other.suffix, claimant: Claimant(owner: other.owner, delivery: other.delivery),
+                    otherPath: row.suffix, other: Claimant(owner: row.owner, delivery: row.delivery))
+            }
+        }
+        return sorted
+    }
+
+    // MARK: #748 build-seam derivation and verification
+
+    /// Derives the ephemeral, non-secret `WellKnownClaimManifest` (#748) a runtime's build step
+    /// receives so it can detect a fresh on-disk collision against the effective claim set.
+    public static func claimManifest(from rows: [WellKnownEndpointDescriptor]) -> WellKnownClaimManifest {
+        WellKnownClaimManifest(entries: rows.map {
+            WellKnownClaimManifest.Entry(id: $0.id, path: $0.suffix, match: $0.match, owner: $0.owner)
+        })
+    }
+
+    /// Verifies static/generated rows actually reached their exact `dist/.well-known/...` path
+    /// (design doc: "Static/generated claims are verified at their exact `dist/.well-known/...`
+    /// paths"), and folds in whatever findings the build step itself reported. Only meaningful
+    /// once a `WellKnownBuildSeamResult` actually exists — callers can only obtain one from a
+    /// `WellKnownBuildSeamOutcome.completed` case, so calling this after `.unsupported` or
+    /// `.cancelled` is structurally avoided rather than silently claiming protection that never ran.
+    public static func verifyBuildArtifacts(
+        expected: [WellKnownEndpointDescriptor],
+        result: WellKnownBuildSeamResult
+    ) -> [Finding] {
+        var findings = result.findings.map { Finding(path: $0.path, message: $0.message) }
+        let observed = Set(result.observedArtifacts)
+        let staticallyDelivered = expected.filter { $0.delivery == .userStatic || $0.delivery == .generated }
+        for row in staticallyDelivered where !observed.contains(row.suffix) {
+            findings.append(Finding(
+                path: row.suffix,
+                message: "expected .well-known/\(row.suffix) (owner: \(row.owner)) was not found in the built output"))
+        }
+        let expectedSuffixes = Set(staticallyDelivered.map(\.suffix))
+        for artifact in result.observedArtifacts where !expectedSuffixes.contains(artifact) {
+            findings.append(Finding(
+                path: artifact,
+                message: "unexpected .well-known/\(artifact) appeared in the built output with no matching inventory claim"))
+        }
+        return findings
+    }
+}
+
+/// Anglesite's own generated `.well-known` endpoints, identified by the first-line marker their
+/// generator writes (`Resources/Template/scripts/edge-artifacts.ts`). Content-marker
+/// classification means the Swift-side scan never has to re-derive the TypeScript generator's
+/// activation logic (`SECURITY_TXT_MODE`, `MTA_STS_MODE`, …) — it just recognizes what that
+/// generator already wrote, the same way `isSecurityTxtMarkerOwned`/`isMTAStsMarkerOwned` do on
+/// the TypeScript side.
+public enum GeneratedEndpoints {
+    /// Mirrors `SECURITY_TXT_MARKER` in `Resources/Template/scripts/edge-artifacts.ts` —
+    /// duplicated as a content literal (not logic) so this scan needs no JS bridge;
+    /// `WellKnownInventoryFixtureTests` guards against the two drifting apart.
+    public static let securityTxtMarker =
+        "# Generated by Anglesite — do not edit; edit SECURITY_CONTACT/.site-config instead (SECURITY_TXT_MODE=generated)"
+
+    /// Mirrors `MTA_STS_MARKER` in `Resources/Template/scripts/edge-artifacts.ts`.
+    public static let mtaStsMarker = "x-anglesite: generated"
+
+    /// One Anglesite generator's identity, for building the row a matched file becomes.
+    struct Descriptor {
+        let owner: String
+        let validatorID: String
+        let specificationURL: URL
+
+        func descriptor(suffix: String) -> WellKnownEndpointDescriptor {
+            WellKnownEndpointDescriptor(
+                id: owner, suffix: suffix, match: .exact, delivery: .generated, owner: owner,
+                registration: .permanent, specificationURL: specificationURL, validatorID: validatorID)
+        }
+    }
+
+    private static let securityTxt = Descriptor(
+        owner: "generator:security-txt", validatorID: "rfc9116",
+        specificationURL: URL(string: "https://www.rfc-editor.org/rfc/rfc9116")!)
+    private static let mtaSts = Descriptor(
+        owner: "generator:mta-sts", validatorID: "rfc8461",
+        specificationURL: URL(string: "https://www.rfc-editor.org/rfc/rfc8461")!)
+
+    /// The generator whose marker appears on `content`'s first line (`security.txt`) or anywhere
+    /// in `content` (`mta-sts.txt`, matching `isMTAStsMarkerOwned`'s own scan), or `nil` when
+    /// `content` is `nil` or matches no known marker.
+    static func matching(content: String?) -> Descriptor? {
+        guard let content else { return nil }
+        if content.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false).first == securityTxtMarker[...] {
+            return securityTxt
+        }
+        if content.split(separator: "\n").contains(where: { $0 == mtaStsMarker[...] }) {
+            return mtaSts
+        }
+        return nil
+    }
+}

--- a/Tests/AnglesiteCoreTests/WellKnownInventoryTests.swift
+++ b/Tests/AnglesiteCoreTests/WellKnownInventoryTests.swift
@@ -243,6 +243,26 @@ struct WellKnownInventoryTests {
         }
     }
 
+    @Test("an exact claim inside the SAME owner's own prefix claim is self-delegation, not a collision")
+    func exactInsideOwnPrefixIsSelfDelegation() throws {
+        let runtime = [
+            row("acme-challenge/", delivery: .externalRuntime, owner: "cloudflare-managed-tls", match: .prefix),
+            row("acme-challenge/http-01", delivery: .externalRuntime, owner: "cloudflare-managed-tls"),
+        ]
+        let merged = try WellKnownInventory.merge(runtime: runtime)
+        #expect(merged.map(\.suffix) == ["acme-challenge/", "acme-challenge/http-01"])
+    }
+
+    @Test("two overlapping prefix claims from the SAME owner are self-delegation, not a collision")
+    func prefixPrefixSameOwnerIsSelfDelegation() throws {
+        let dynamic = [
+            row("oauth/", delivery: .dynamic, owner: "indieauth", match: .prefix),
+            row("oauth/callback", delivery: .dynamic, owner: "indieauth", match: .prefix),
+        ]
+        let merged = try WellKnownInventory.merge(dynamic: dynamic)
+        #expect(merged.map(\.suffix) == ["oauth/", "oauth/callback"])
+    }
+
     // MARK: #748 build-seam derivation and verification
 
     @Test("claimManifest derives one entry per row, preserving path/match/owner")

--- a/Tests/AnglesiteCoreTests/WellKnownInventoryTests.swift
+++ b/Tests/AnglesiteCoreTests/WellKnownInventoryTests.swift
@@ -1,0 +1,355 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("WellKnownInventory")
+struct WellKnownInventoryTests {
+
+    // MARK: Filesystem scan
+
+    @Test("absent .well-known directory scans to no rows, no findings")
+    func absentDirectoryScansEmpty() throws {
+        let root = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let (rows, findings) = WellKnownInventory.scanUserStatic(wellKnownDirectory: root.appendingPathComponent(".well-known"))
+        #expect(rows.isEmpty)
+        #expect(findings.isEmpty)
+    }
+
+    @Test("unknown file scans as user-static with no conformance claim")
+    func unknownFileScansAsUserStatic() throws {
+        let wellKnown = try makeWellKnownDirectory()
+        defer { try? FileManager.default.removeItem(at: wellKnown.deletingLastPathComponent()) }
+        try "hello".write(to: wellKnown.appendingPathComponent("apple-app-site-association"), atomically: true, encoding: .utf8)
+
+        let (rows, findings) = WellKnownInventory.scanUserStatic(wellKnownDirectory: wellKnown)
+        #expect(findings.isEmpty)
+        #expect(rows.count == 1)
+        #expect(rows[0].suffix == "apple-app-site-association")
+        #expect(rows[0].delivery == .userStatic)
+        #expect(rows[0].validatorID == nil)
+        #expect(rows[0].owner == "user-static")
+    }
+
+    @Test("nested directories are preserved with their relative suffix")
+    func nestedDirectoriesPreserveSuffix() throws {
+        let wellKnown = try makeWellKnownDirectory()
+        defer { try? FileManager.default.removeItem(at: wellKnown.deletingLastPathComponent()) }
+        let nested = wellKnown.appendingPathComponent("acme-challenge")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "token".write(to: nested.appendingPathComponent("abc123"), atomically: true, encoding: .utf8)
+
+        let (rows, findings) = WellKnownInventory.scanUserStatic(wellKnownDirectory: wellKnown)
+        #expect(findings.isEmpty)
+        #expect(rows.map(\.suffix) == ["acme-challenge/abc123"])
+    }
+
+    @Test("a file whose content carries the security.txt marker is classified generated")
+    func securityTxtMarkerClassifiesAsGenerated() throws {
+        let wellKnown = try makeWellKnownDirectory()
+        defer { try? FileManager.default.removeItem(at: wellKnown.deletingLastPathComponent()) }
+        let content = GeneratedEndpoints.securityTxtMarker + "\nContact: mailto:security@example.com\nExpires: 2027-01-01T00:00:00Z\n"
+        try content.write(to: wellKnown.appendingPathComponent("security.txt"), atomically: true, encoding: .utf8)
+
+        let (rows, _) = WellKnownInventory.scanUserStatic(wellKnownDirectory: wellKnown)
+        #expect(rows.count == 1)
+        #expect(rows[0].delivery == .generated)
+        #expect(rows[0].owner == "generator:security-txt")
+        #expect(rows[0].validatorID == "rfc9116")
+    }
+
+    @Test("a file whose content carries the mta-sts marker is classified generated")
+    func mtaStsMarkerClassifiesAsGenerated() throws {
+        let wellKnown = try makeWellKnownDirectory()
+        defer { try? FileManager.default.removeItem(at: wellKnown.deletingLastPathComponent()) }
+        let content = "version: STSv1\nmode: testing\nmx: mail.example.com\nmax_age: 604800\n\(GeneratedEndpoints.mtaStsMarker)\n"
+        try content.write(to: wellKnown.appendingPathComponent("mta-sts.txt"), atomically: true, encoding: .utf8)
+
+        let (rows, _) = WellKnownInventory.scanUserStatic(wellKnownDirectory: wellKnown)
+        #expect(rows.count == 1)
+        #expect(rows[0].delivery == .generated)
+        #expect(rows[0].owner == "generator:mta-sts")
+        #expect(rows[0].validatorID == "rfc8461")
+    }
+
+    @Test("a hand-authored file that merely mentions the marker text mid-body is not misclassified")
+    func markerMustBeOnRecognizedLine() throws {
+        let wellKnown = try makeWellKnownDirectory()
+        defer { try? FileManager.default.removeItem(at: wellKnown.deletingLastPathComponent()) }
+        // Marker text appears, but not as security.txt's first line — must not be classified generated.
+        let content = "hand-authored file\n" + GeneratedEndpoints.securityTxtMarker + "\n"
+        try content.write(to: wellKnown.appendingPathComponent("security.txt"), atomically: true, encoding: .utf8)
+
+        let (rows, _) = WellKnownInventory.scanUserStatic(wellKnownDirectory: wellKnown)
+        #expect(rows.count == 1)
+        #expect(rows[0].delivery == .userStatic)
+    }
+
+    @Test("a symlink is excluded from inventory with a finding")
+    func symlinkIsRejected() throws {
+        let wellKnown = try makeWellKnownDirectory()
+        defer { try? FileManager.default.removeItem(at: wellKnown.deletingLastPathComponent()) }
+        let outside = wellKnown.deletingLastPathComponent().appendingPathComponent("secret")
+        try "shh".write(to: outside, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: wellKnown.appendingPathComponent("linked"), withDestinationURL: outside)
+
+        let (rows, findings) = WellKnownInventory.scanUserStatic(wellKnownDirectory: wellKnown)
+        #expect(rows.isEmpty)
+        #expect(findings.count == 1)
+        #expect(findings[0].message.contains("symlink"))
+    }
+
+    @Test("a percent-encoded-looking filename is excluded from inventory with a finding")
+    func percentEncodedNameIsRejected() throws {
+        let wellKnown = try makeWellKnownDirectory()
+        defer { try? FileManager.default.removeItem(at: wellKnown.deletingLastPathComponent()) }
+        try "x".write(to: wellKnown.appendingPathComponent("foo%2E%2Ebar"), atomically: true, encoding: .utf8)
+
+        let (rows, findings) = WellKnownInventory.scanUserStatic(wellKnownDirectory: wellKnown)
+        #expect(rows.isEmpty)
+        #expect(findings.count == 1)
+        #expect(findings[0].message.contains("percent-encoded"))
+    }
+
+    @Test("an oversized file is excluded from inventory with a finding")
+    func oversizedFileIsRejected() throws {
+        let wellKnown = try makeWellKnownDirectory()
+        defer { try? FileManager.default.removeItem(at: wellKnown.deletingLastPathComponent()) }
+        try "0123456789".write(to: wellKnown.appendingPathComponent("big.txt"), atomically: true, encoding: .utf8)
+
+        let (rows, findings) = WellKnownInventory.scanUserStatic(wellKnownDirectory: wellKnown, maxFileSizeBytes: 4)
+        #expect(rows.isEmpty)
+        #expect(findings.count == 1)
+        #expect(findings[0].message.contains("exceeds"))
+    }
+
+    // MARK: Dynamic and runtime conversion
+
+    @Test("dynamicRows converts an owned well-known claim and drops one outside .well-known")
+    func dynamicRowsConverts() throws {
+        let webfinger = WorkerRouteClaim(
+            path: "/.well-known/webfinger", match: .exact, methods: ["GET", "HEAD"], handler: "webfinger",
+            validatorID: "rfc7033", authorityBinding: true,
+            specificationURL: URL(string: "https://www.rfc-editor.org/rfc/rfc7033"))
+        let notWellKnown = WorkerRouteClaim(path: "/inbox", match: .exact, methods: ["POST"], handler: "inbox")
+        let claims = [
+            WorkerRouteClaims.OwnedClaim(owner: "webfinger", claim: webfinger),
+            WorkerRouteClaims.OwnedClaim(owner: "inbox-capture", claim: notWellKnown),
+        ]
+        let rows = WellKnownInventory.dynamicRows(from: claims)
+        #expect(rows.count == 1)
+        #expect(rows[0].suffix == "webfinger")
+        #expect(rows[0].owner == "webfinger")
+        #expect(rows[0].delivery == .dynamic)
+        #expect(rows[0].authorityBinding == true)
+        #expect(rows[0].validatorID == "rfc7033")
+    }
+
+    @Test("runtimeRows converts RuntimeOwnedPathClaim, preserving prefix match")
+    func runtimeRowsConverts() throws {
+        let claim = RuntimeOwnedPathClaim(
+            id: "acme-managed-tls", owner: "cloudflare-managed-tls", path: "acme-challenge/", match: .prefix,
+            schemes: [.http], port: 80, capability: "RFC 8555 managed-TLS ownership")
+        let rows = WellKnownInventory.runtimeRows(from: [claim])
+        #expect(rows.count == 1)
+        #expect(rows[0].suffix == "acme-challenge/")
+        #expect(rows[0].match == .prefix)
+        #expect(rows[0].delivery == .externalRuntime)
+        #expect(rows[0].owner == "cloudflare-managed-tls")
+    }
+
+    // MARK: Merge / collision enforcement
+
+    @Test("disjoint rows from every delivery class merge without error, sorted by suffix")
+    func disjointRowsMergeCleanly() throws {
+        let userStatic = [row("apple-app-site-association", delivery: .userStatic, owner: "user-static")]
+        let generated = [row("security.txt", delivery: .generated, owner: "generator:security-txt")]
+        let dynamic = [row("webfinger", delivery: .dynamic, owner: "webfinger")]
+        let runtime = [row("acme-challenge/", delivery: .externalRuntime, owner: "cloudflare-managed-tls", match: .prefix)]
+
+        let merged = try WellKnownInventory.merge(userStatic: userStatic, generated: generated, dynamic: dynamic, runtime: runtime)
+        #expect(merged.map(\.suffix) == ["acme-challenge/", "apple-app-site-association", "security.txt", "webfinger"])
+    }
+
+    @Test("two exact claims for the same path is a duplicateClaim error")
+    func exactExactCollision() throws {
+        let userStatic = [row("webfinger", delivery: .userStatic, owner: "user-static")]
+        let dynamic = [row("webfinger", delivery: .dynamic, owner: "webfinger")]
+        #expect(throws: WellKnownInventory.CollisionError.self) {
+            try WellKnownInventory.merge(userStatic: userStatic, dynamic: dynamic)
+        }
+    }
+
+    @Test("static vs generated at the same path collides and names both owners")
+    func staticGeneratedCollision() throws {
+        let userStatic = [row("security.txt", delivery: .userStatic, owner: "user-static")]
+        let generated = [row("security.txt", delivery: .generated, owner: "generator:security-txt")]
+        do {
+            _ = try WellKnownInventory.merge(userStatic: userStatic, generated: generated)
+            Issue.record("expected a collision error")
+        } catch WellKnownInventory.CollisionError.duplicateClaim(let path, let claimants) {
+            #expect(path == "security.txt")
+            #expect(Set(claimants.map(\.owner)) == ["user-static", "generator:security-txt"])
+        }
+    }
+
+    @Test("static vs dynamic at the same path collides")
+    func staticDynamicCollision() throws {
+        let userStatic = [row("webfinger", delivery: .userStatic, owner: "user-static")]
+        let dynamic = [row("webfinger", delivery: .dynamic, owner: "webfinger")]
+        #expect(throws: WellKnownInventory.CollisionError.self) {
+            try WellKnownInventory.merge(userStatic: userStatic, dynamic: dynamic)
+        }
+    }
+
+    @Test("an active runtime reservation collides with a static claim at the same path")
+    func activeRuntimeCollision() throws {
+        let userStatic = [row("acme-challenge/mine", delivery: .userStatic, owner: "user-static")]
+        let runtime = [row("acme-challenge/mine", delivery: .externalRuntime, owner: "cloudflare-managed-tls")]
+        #expect(throws: WellKnownInventory.CollisionError.self) {
+            try WellKnownInventory.merge(userStatic: userStatic, runtime: runtime)
+        }
+    }
+
+    @Test("no runtime reservation means an exact path under a runtime's usual prefix is untouched")
+    func noRuntimeClaimMeansNoReservation() throws {
+        let userStatic = [row("acme-challenge/mine", delivery: .userStatic, owner: "user-static")]
+        let merged = try WellKnownInventory.merge(userStatic: userStatic, runtime: [])
+        #expect(merged.map(\.suffix) == ["acme-challenge/mine"])
+    }
+
+    @Test("an exact claim inside another owner's prefix is an overlappingClaims error")
+    func exactInsidePrefixCollision() throws {
+        let runtime = [row("acme-challenge/", delivery: .externalRuntime, owner: "cloudflare-managed-tls", match: .prefix)]
+        let userStatic = [row("acme-challenge/token123", delivery: .userStatic, owner: "user-static")]
+        do {
+            _ = try WellKnownInventory.merge(userStatic: userStatic, runtime: runtime)
+            Issue.record("expected an overlap error")
+        } catch WellKnownInventory.CollisionError.overlappingClaims(let path, let claimant, let otherPath, let other) {
+            #expect(path == "acme-challenge/token123")
+            #expect(claimant.owner == "user-static")
+            #expect(otherPath == "acme-challenge/")
+            #expect(other.owner == "cloudflare-managed-tls")
+        }
+    }
+
+    @Test("two overlapping prefix claims from different owners collide")
+    func prefixPrefixCollision() throws {
+        let dynamic = [row("oauth/", delivery: .dynamic, owner: "indieauth", match: .prefix)]
+        let runtime = [row("oauth/callback", delivery: .externalRuntime, owner: "some-runtime", match: .prefix)]
+        #expect(throws: WellKnownInventory.CollisionError.self) {
+            try WellKnownInventory.merge(dynamic: dynamic, runtime: runtime)
+        }
+    }
+
+    // MARK: #748 build-seam derivation and verification
+
+    @Test("claimManifest derives one entry per row, preserving path/match/owner")
+    func claimManifestDerivesEntries() throws {
+        let rows = [
+            row("security.txt", delivery: .generated, owner: "generator:security-txt"),
+            row("acme-challenge/", delivery: .externalRuntime, owner: "cloudflare-managed-tls", match: .prefix),
+        ]
+        let manifest = WellKnownInventory.claimManifest(from: rows)
+        #expect(manifest.entries.count == 2)
+        #expect(manifest.entries.contains { $0.path == "security.txt" && $0.owner == "generator:security-txt" && $0.match == .exact })
+        #expect(manifest.entries.contains { $0.path == "acme-challenge/" && $0.owner == "cloudflare-managed-tls" && $0.match == .prefix })
+    }
+
+    @Test("verifyBuildArtifacts reports a missing expected static/generated artifact")
+    func verifyReportsMissingArtifact() throws {
+        let expected = [row("security.txt", delivery: .generated, owner: "generator:security-txt")]
+        let result = WellKnownBuildSeamResult(observedArtifacts: [], findings: [])
+        let findings = WellKnownInventory.verifyBuildArtifacts(expected: expected, result: result)
+        #expect(findings.count == 1)
+        #expect(findings[0].path == "security.txt")
+        #expect(findings[0].message.contains("was not found"))
+    }
+
+    @Test("verifyBuildArtifacts reports an unexpected artifact with no matching claim")
+    func verifyReportsUnexpectedArtifact() throws {
+        let result = WellKnownBuildSeamResult(observedArtifacts: ["mystery.txt"], findings: [])
+        let findings = WellKnownInventory.verifyBuildArtifacts(expected: [], result: result)
+        #expect(findings.count == 1)
+        #expect(findings[0].path == "mystery.txt")
+        #expect(findings[0].message.contains("no matching inventory claim"))
+    }
+
+    @Test("verifyBuildArtifacts passes clean when every expected static/generated row was observed")
+    func verifyPassesWhenArtifactsMatch() throws {
+        let expected = [
+            row("security.txt", delivery: .generated, owner: "generator:security-txt"),
+            row("webfinger", delivery: .dynamic, owner: "webfinger"),
+        ]
+        // Dynamic rows never produce a dist/ artifact, so only security.txt is expected on disk.
+        let result = WellKnownBuildSeamResult(observedArtifacts: ["security.txt"], findings: [])
+        let findings = WellKnownInventory.verifyBuildArtifacts(expected: expected, result: result)
+        #expect(findings.isEmpty)
+    }
+
+    @Test("verifyBuildArtifacts folds in the build step's own findings")
+    func verifyFoldsInSeamFindings() throws {
+        let result = WellKnownBuildSeamResult(observedArtifacts: [], findings: [.init(path: "mta-sts.txt", message: "stale marker")])
+        let findings = WellKnownInventory.verifyBuildArtifacts(expected: [], result: result)
+        #expect(findings == [.init(path: "mta-sts.txt", message: "stale marker")])
+    }
+
+    // MARK: WellKnownEndpointDescriptor.Registration Codable
+
+    @Test("Registration round-trips known and custom cases through JSON")
+    func registrationRoundTrips() throws {
+        for registration in [WellKnownEndpointDescriptor.Registration.permanent, .provisional, .deprecated, .custom("worker-declared")] {
+            let descriptor = row("x", delivery: .userStatic, owner: "user-static")
+            var mutable = descriptor
+            mutable.registration = registration
+            let data = try JSONEncoder().encode(mutable)
+            let decoded = try JSONDecoder().decode(WellKnownEndpointDescriptor.self, from: data)
+            #expect(decoded.registration == registration)
+        }
+    }
+
+    // MARK: Marker drift guard
+
+    /// Reads the REAL `edge-artifacts.ts` template source and asserts Swift's duplicated marker
+    /// literals (`GeneratedEndpoints.securityTxtMarker`/`mtaStsMarker`) still appear verbatim —
+    /// catching the two drifting apart the way #742's fixture test guards the scan envelope.
+    @Test("GeneratedEndpoints markers match the real edge-artifacts.ts source")
+    func markersMatchTemplateSource() throws {
+        // Tests/AnglesiteCoreTests/WellKnownInventoryTests.swift -> repo root -> Resources/Template/scripts
+        let scriptURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/Template/scripts/edge-artifacts.ts", isDirectory: false)
+        let source = try String(contentsOf: scriptURL, encoding: .utf8)
+        #expect(source.contains(GeneratedEndpoints.securityTxtMarker))
+        #expect(source.contains(GeneratedEndpoints.mtaStsMarker))
+    }
+
+    // MARK: Test helpers
+
+    private func row(
+        _ suffix: String,
+        delivery: WellKnownEndpointDescriptor.Delivery,
+        owner: String,
+        match: WellKnownPathMatch = .exact
+    ) -> WellKnownEndpointDescriptor {
+        WellKnownEndpointDescriptor(
+            id: "\(owner):\(suffix)", suffix: suffix, match: match, delivery: delivery,
+            owner: owner, registration: .custom("test"))
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func makeWellKnownDirectory() throws -> URL {
+        let root = try makeTempDirectory()
+        let wellKnown = root.appendingPathComponent(".well-known")
+        try FileManager.default.createDirectory(at: wellKnown, withIntermediateDirectories: true)
+        return wellKnown
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `WellKnownEndpointDescriptor` and `WellKnownInventory` to `AnglesiteCore` — the portable `/.well-known/` endpoint descriptor and cross-owner collision-enforcement core from the [`.well-known` support design](docs/superpowers/specs/2026-07-14-well-known-support-design.md), closing out #744 (its own blockers — #742, #743, #746, #748 — have all landed).
- `WellKnownInventory.scanUserStatic` walks `Source/public/.well-known/` (symlink/traversal/oversized-file safe), classifying each file `.generated` when it carries an existing Anglesite marker (`security.txt`/`mta-sts.txt`, content-based — no re-derivation of the TypeScript generator's activation logic) or `.userStatic` otherwise, with unknown files always preserved and never rewritten.
- `dynamicRows(from:)`/`runtimeRows(from:)` convert #746's `WorkerRouteClaims.OwnedClaim` and #748's `RuntimeOwnedPathClaim` into the same row shape.
- `merge(...)` enforces the design's collision rules (exact/exact, exact/prefix, prefix/prefix — which structurally covers static/generated, static/dynamic, and active-runtime collisions too) and throws, naming every claimant — there's no "static wins"/"dynamic wins" recovery.
- `claimManifest(from:)`/`verifyBuildArtifacts(expected:result:)` derive #748's `WellKnownClaimManifest` and verify the build seam's observed artifacts against the expected static/generated set; `verifyBuildArtifacts` only accepts an already-obtained `WellKnownBuildSeamResult`, so a caller can't claim cross-owner protection when the seam was `.unsupported`.

**Follow-up (not in this PR):** wiring `WellKnownInventory` into `DeployCommand`'s live build/deploy sequence — assembling the inventory from Worker activation + runtime claims, calling `runBuildWithClaimManifest`, and merging findings into `PreDeployCheck.Outcome` — mirroring how #746 (`WorkerComposition`) and #748 (the build seam) each landed their own capability before a separate call site wired it in.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — `AnglesiteCoreTests` isn't in the Linux-portable target set, so I verified `WellKnownInventoryTests.swift`'s scenarios via a standalone scratch executable linked against the (portable) `AnglesiteCore` library, exercising every scan/merge/collision/verify case directly — all passed. The full portable suite (`AnglesiteSiteModelTests`, `AnglesiteQuickLookSupportTests`, `AnglesiteBridgeCoreTests`) passes with no regressions. CI's macOS lane will run `AnglesiteCoreTests` itself; I'll watch for and fix any failure there.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (no Xcode/macOS in this session's environment).
- [ ] Manual smoke: n/a — no UI surface in this PR.

Progresses #366 (WebFinger), which is blocked on #744 landing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRGRLNZ498PE5wC5Zx6YyT)_