### PR TITLE
feat(reader): Microsub reader — follow + timeline (#365)

### DIFF
--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/rss": "^4.0.0",
         "@dwk/indieauth": "0.1.0-beta.3",
         "@dwk/micropub": "0.1.0-beta.4",
+        "@dwk/microsub": "0.1.0-beta.4",
         "@dwk/webmention": "0.1.0-beta.3",
         "@dwk/websub": "0.1.0-beta.4",
         "@tgwf/co2": "^0.19.0",
@@ -288,9 +289,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -306,9 +304,6 @@
       "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -326,9 +321,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -344,9 +336,6 @@
       "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -988,9 +977,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,9 +989,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1020,9 +1003,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,9 +1015,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1422,6 +1399,44 @@
       "resolved": "https://registry.npmjs.org/@dwk/log/-/log-0.1.0-beta.4.tgz",
       "integrity": "sha512-iZorLyOil69RCudBmiXp88g5sfzT++WWIoRe7YgdnSRzBnk2SwQkkpM6HPFPyhKhdMdcSLCwBPWOyCrRBCkSLA==",
       "license": "ISC"
+    },
+    "node_modules/@dwk/microsub": {
+      "version": "0.1.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@dwk/microsub/-/microsub-0.1.0-beta.4.tgz",
+      "integrity": "sha512-MHdpSCFf9yrCANE4SmmlW7gpyfpklBYt7x9TC+ipYwCfAe8J6eXoy+p0mhio5X2HP/gODhRWeTdFnOXWSa2e5w==",
+      "license": "ISC",
+      "dependencies": {
+        "@dwk/dpop": "0.1.0-beta.3",
+        "@dwk/indieauth": "0.1.0-beta.4",
+        "@dwk/log": "0.1.0-beta.4",
+        "@dwk/mcp": "0.1.0-beta.0",
+        "@dwk/safe-fetch": "0.1.0-beta.3"
+      }
+    },
+    "node_modules/@dwk/microsub/node_modules/@dwk/indieauth": {
+      "version": "0.1.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@dwk/indieauth/-/indieauth-0.1.0-beta.4.tgz",
+      "integrity": "sha512-HaFfoFJb/3vIHXyheCh1EQFyPAVKSYcP8eVEqPxFEW5beSaXcQ5k9gti48kXIEzHYG/lytQtMLG9N0pqtFUxlA==",
+      "license": "ISC",
+      "dependencies": {
+        "@dwk/dpop": "0.1.0-beta.3",
+        "@dwk/log": "0.1.0-beta.4"
+      }
+    },
+    "node_modules/@dwk/microsub/node_modules/@dwk/log": {
+      "version": "0.1.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@dwk/log/-/log-0.1.0-beta.4.tgz",
+      "integrity": "sha512-iZorLyOil69RCudBmiXp88g5sfzT++WWIoRe7YgdnSRzBnk2SwQkkpM6HPFPyhKhdMdcSLCwBPWOyCrRBCkSLA==",
+      "license": "ISC"
+    },
+    "node_modules/@dwk/microsub/node_modules/@dwk/safe-fetch": {
+      "version": "0.1.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@dwk/safe-fetch/-/safe-fetch-0.1.0-beta.3.tgz",
+      "integrity": "sha512-mNnTbHJJatHbzW8HdA159uECkxxshFjHDQXjbfWQxu073niTVhQpwIytwn6kn1ZTXfsbmlErCekGAPqXL7i7aw==",
+      "license": "ISC",
+      "dependencies": {
+        "@dwk/log": "0.1.0-beta.4"
+      }
     },
     "node_modules/@dwk/safe-fetch": {
       "version": "0.1.0-beta.2",
@@ -2229,6 +2244,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2251,6 +2267,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2273,6 +2290,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2289,6 +2307,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2305,9 +2324,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2324,9 +2341,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2343,9 +2358,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2362,9 +2375,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2381,9 +2392,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2400,9 +2409,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2419,9 +2426,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2438,9 +2443,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2457,9 +2460,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2482,9 +2483,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2507,9 +2506,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2532,9 +2529,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2557,9 +2552,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2582,9 +2575,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2607,9 +2598,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2632,9 +2621,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2657,6 +2644,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2676,6 +2664,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2695,6 +2684,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2714,6 +2704,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4744,9 +4735,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4762,9 +4750,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4782,9 +4767,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4800,9 +4782,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4820,9 +4799,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4838,9 +4814,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8025,9 +7998,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8047,9 +8017,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -8071,9 +8038,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8093,9 +8057,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -15,6 +15,7 @@
     "@astrojs/rss": "^4.0.0",
     "@dwk/indieauth": "0.1.0-beta.3",
     "@dwk/micropub": "0.1.0-beta.4",
+    "@dwk/microsub": "0.1.0-beta.4",
     "@dwk/webmention": "0.1.0-beta.3",
     "@dwk/websub": "0.1.0-beta.4",
     "@tgwf/co2": "^0.19.0",

--- a/Resources/Template/vitest.config.ts
+++ b/Resources/Template/vitest.config.ts
@@ -8,15 +8,20 @@ export default defineConfig({
       miniflare: {
         compatibilityDate: "2026-07-15",
         compatibilityFlags: ["nodejs_compat"],
-        d1Databases: ["AUTH_DB", "WEBMENTION_INBOX", "MICROPUB_DB", "WEBSUB_DB"],
+        d1Databases: ["AUTH_DB", "WEBMENTION_INBOX", "MICROPUB_DB", "WEBSUB_DB", "MICROSUB_DB"],
         kvNamespaces: ["INBOX_KV", "SOCIAL_KV"],
         r2Buckets: ["MEDIA"],
-        queueProducers: { WEBMENTION_QUEUE: "site-webmention", WEBSUB_QUEUE: "site-websub" },
-        // site-websub is deliberately NOT registered as a consumer here: a delivered verify job
-        // would make @dwk/websub's consumer attempt a real verification GET to the test's fake
-        // subscriber callback and schedule a queue retry when it fails, which the pool tears
-        // down as an "uncaught exception" after the suite passes. The consumer dispatch itself
-        // is covered by calling worker.queue directly with a stubbed batch.
+        queueProducers: {
+          WEBMENTION_QUEUE: "site-webmention",
+          WEBSUB_QUEUE: "site-websub",
+          MICROSUB_QUEUE: "site-microsub",
+        },
+        // site-websub/site-microsub are deliberately NOT registered as consumers here: a
+        // delivered job would make the library's consumer attempt a real network fetch (a
+        // verification GET for websub, a feed fetch for microsub) that fails in the test
+        // sandbox and schedules a queue retry, which the pool tears down as an "uncaught
+        // exception" after the suite passes. The consumer dispatch itself is covered by calling
+        // worker.queue directly with a stubbed batch.
         queueConsumers: ["site-webmention"],
         bindings: {
           TOKEN_SIGNING_KEY: "test-token-signing-key-with-at-least-32-bytes",

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -892,6 +892,144 @@ test("websub queue consumer: dispatches into @dwk/websub's consumer without thro
   ).resolves.toBeUndefined();
 });
 
+// --- Microsub reader (V-4.3, #365) ----------------------------------------------------------
+// Composition of @dwk/microsub's single endpoint. These run through worker.fetch in the workerd
+// pool with MICROSUB_DB/MICROSUB_QUEUE/AUTH_DB/TOKEN_SIGNING_KEY bound (see vitest.config.ts),
+// exercising the same DPoP-authorized dispatch path production serves. Feed discovery/parsing
+// and the poller/queue-consumer's own internals are the library's own concern (covered by its
+// suite), not re-tested here — `discoverFeed` fails closed against the sandbox's blocked network,
+// so `follow` still succeeds (it persists the subscription unconditionally) but never populates
+// the timeline from a live fetch.
+
+async function createMicrosubChannel(
+  name: string,
+  token: string,
+  keyPair: CryptoKeyPair,
+): Promise<string> {
+  const url = "https://owner.example/microsub?action=channels";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: new URLSearchParams({ name }),
+  }));
+  const { uid } = await response.json() as { uid: string };
+  return uid;
+}
+
+test("microsub: an unauthorized request (no Authorization header) is rejected", async () => {
+  const response = await fetchWorker(new Request("https://owner.example/microsub?action=channels"));
+  expect(response.status).toBe(401);
+});
+
+test("microsub: a valid token creates a channel and follows a feed (200)", async () => {
+  const { token, keyPair } = await mintAccessToken("follow channels");
+  const uid = await createMicrosubChannel("Blogs", token, keyPair);
+
+  const followURL = "https://owner.example/microsub?action=follow";
+  const follow = await fetchWorker(new Request(followURL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(followURL, "POST", keyPair, token),
+    },
+    body: new URLSearchParams({ channel: uid, url: "https://feed.example/atom.xml" }),
+  }));
+  expect(follow.status).toBe(200);
+  await expect(follow.json()).resolves.toMatchObject({ type: "feed", url: "https://feed.example/atom.xml" });
+});
+
+test("microsub: the timeline for a freshly created channel is empty with no paging cursor", async () => {
+  const { token, keyPair } = await mintAccessToken("channels");
+  const uid = await createMicrosubChannel("Timeline", token, keyPair);
+
+  const timelineURL = `https://owner.example/microsub?action=timeline&channel=${uid}`;
+  const timeline = await fetchWorker(new Request(timelineURL, {
+    headers: {
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(timelineURL, "GET", keyPair, token),
+    },
+  }));
+  expect(timeline.status).toBe(200);
+  await expect(timeline.json()).resolves.toMatchObject({ items: [], paging: {} });
+});
+
+test("microsub: an unknown channel is rejected (404)", async () => {
+  const { token, keyPair } = await mintAccessToken("channels");
+  const timelineURL = "https://owner.example/microsub?action=timeline&channel=does-not-exist";
+  const response = await fetchWorker(new Request(timelineURL, {
+    headers: {
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(timelineURL, "GET", keyPair, token),
+    },
+  }));
+  expect(response.status).toBe(404);
+});
+
+test("microsub: 503 when MICROSUB_DB isn't bound", async () => {
+  const { MICROSUB_DB: _unusedDB, ...envWithoutDB } = testEnv;
+  const response = await worker.fetch(
+    new Request("https://owner.example/microsub?action=channels"),
+    envWithoutDB as WorkerEnv,
+    createExecutionContext(),
+  );
+  expect(response.status).toBe(503);
+});
+
+test("microsub: 503 when MICROSUB_QUEUE isn't bound", async () => {
+  const { MICROSUB_QUEUE: _unusedQueue, ...envWithoutQueue } = testEnv;
+  const response = await worker.fetch(
+    new Request("https://owner.example/microsub?action=channels"),
+    envWithoutQueue as WorkerEnv,
+    createExecutionContext(),
+  );
+  expect(response.status).toBe(503);
+});
+
+test("microsub queue consumer: no-ops (does not throw) when unprovisioned", async () => {
+  const { MICROSUB_DB: _unusedDB, ...envWithoutMicrosub } = testEnv;
+  const emptyBatch = { queue: "site-microsub", messages: [] } as unknown as Parameters<
+    NonNullable<typeof worker.queue>
+  >[0];
+  await expect(
+    worker.queue!(emptyBatch, envWithoutMicrosub as WorkerEnv, createExecutionContext()),
+  ).resolves.toBeUndefined();
+});
+
+test("microsub queue consumer: dispatches into @dwk/microsub's consumer without throwing when provisioned", async () => {
+  // An empty batch exercises the real provisioned path without triggering any poll-fetch job —
+  // same rationale as the WebSub queue-consumer test above.
+  const emptyBatch = { queue: "site-microsub", messages: [] } as unknown as Parameters<
+    NonNullable<typeof worker.queue>
+  >[0];
+  await expect(
+    worker.queue!(emptyBatch, testEnv, createExecutionContext()),
+  ).resolves.toBeUndefined();
+});
+
+test("microsub scheduled poller: no-ops (does not throw) when unprovisioned", async () => {
+  const { MICROSUB_DB: _unusedDB, ...envWithoutMicrosub } = testEnv;
+  const controller = { cron: "*/15 * * * *", scheduledTime: Date.now() } as unknown as Parameters<
+    NonNullable<typeof worker.scheduled>
+  >[0];
+  await expect(
+    worker.scheduled!(controller, envWithoutMicrosub as WorkerEnv, createExecutionContext()),
+  ).resolves.toBeUndefined();
+});
+
+test("microsub scheduled poller: does not throw when provisioned (no followed feeds to poll)", async () => {
+  const controller = { cron: "*/15 * * * *", scheduledTime: Date.now() } as unknown as Parameters<
+    NonNullable<typeof worker.scheduled>
+  >[0];
+  await expect(
+    worker.scheduled!(controller, testEnv, createExecutionContext()),
+  ).resolves.toBeUndefined();
+});
+
 test("queue dispatch: an unrecognized queue name is a no-op, not misrouted to the webmention consumer", async () => {
   // Locks in the fail-safe default from worker.ts's queue() dispatcher: matching is positive
   // ("-webmention" / "-websub") rather than "webmention = doesn't end in -websub", so a queue

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -21,6 +21,13 @@ import {
   type WebSubEnv,
   type WebSubJob,
 } from "@dwk/websub";
+import {
+  createMicrosub,
+  createMicrosubPoller,
+  createMicrosubQueueConsumer,
+  type MicrosubEnv,
+  type MicrosubJob,
+} from "@dwk/microsub";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -93,6 +100,18 @@ export interface WorkerEnv extends IndieAuthEnv {
    */
   WEBSUB_DB?: D1Database;
   WEBSUB_QUEUE?: Queue<WebSubJob>;
+  /**
+   * Microsub reader bindings (V-4.3, #365). Both optional: a site that hasn't provisioned
+   * Microsub has neither bound, and `/microsub` plus its scheduled poller/queue consumer degrade
+   * gracefully (503 / no-op) rather than throwing. `AUTH_DB`/`TOKEN_SIGNING_KEY` are already
+   * required by `IndieAuthEnv` above — Microsub's catalog entry `requires: ["indieauth"]`
+   * (resolved by `WorkerActivation`) guarantees both are provisioned together, so this handler
+   * still explicitly checks all four before dispatching, matching `handleMicropub`'s
+   * defense-in-depth pattern rather than trusting reachability alone. See
+   * `WorkerComposition.generateWranglerToml` (Swift) for the binding generation.
+   */
+  MICROSUB_DB?: D1Database;
+  MICROSUB_QUEUE?: Queue<MicrosubJob>;
 }
 
 const RATE_LIMIT_WINDOW_SECONDS = 3600;
@@ -363,7 +382,12 @@ function indieAuthHandler(request: Request, env: WorkerEnv) {
   const baseUrl = new URL(request.url).origin;
   return createIndieAuth({
     baseUrl,
-    scopesSupported: ["create", "update", "delete", "media"],
+    // Micropub's scopes ("create"/"update"/"delete"/"media") plus Microsub's ("follow"/
+    // "channels"/"read", V-4.3 #365) — @dwk/indieauth's constrainScopes drops any requested
+    // scope absent from this list, so a client authorizing for Microsub without "follow"/
+    // "channels" listed here would silently be granted an empty scope and then fail every
+    // Microsub action with `insufficient_scope`.
+    scopesSupported: ["create", "update", "delete", "media", "follow", "channels", "read"],
     resourceIndicatorPolicy(resource) {
       try {
         return new URL(resource).origin === baseUrl;
@@ -474,6 +498,87 @@ function handleMicropub(
     TOKEN_SIGNING_KEY: env.TOKEN_SIGNING_KEY,
   };
   return micropub(request, micropubEnv, ctx);
+}
+
+/**
+ * Microsub reader (V-4.3, #365).
+ *
+ * Composes `@dwk/microsub`'s single endpoint: channel/feed subscriptions, following (with
+ * immediate timeline population from the discovery fetch), and the normalised JF2 timeline
+ * (mark read/unread, remove, per-channel unread counts). Requires `@dwk/indieauth` to be active
+ * on the same site (catalog `requires`, resolved by `WorkerActivation`) — Microsub authorizes
+ * every request against `AUTH_DB`'s issued-token store with a DPoP-bound access token, the same
+ * as `@dwk/micropub`.
+ *
+ * Returns `503` when Microsub isn't fully provisioned (`MICROSUB_DB`/`MICROSUB_QUEUE` unbound,
+ * or IndieAuth's `AUTH_DB`/`TOKEN_SIGNING_KEY` unbound) rather than letting `@dwk/microsub` throw
+ * its own loud startup error.
+ */
+function handleMicrosub(
+  request: Request,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  if (!env.MICROSUB_DB || !env.MICROSUB_QUEUE || !env.AUTH_DB || !env.TOKEN_SIGNING_KEY) {
+    return Promise.resolve(new Response("Microsub is not configured", { status: 503 }));
+  }
+  const baseUrl = new URL(request.url).origin;
+  const microsub = createMicrosub({ baseUrl, me: `${baseUrl}/` });
+  const microsubEnv: MicrosubEnv = {
+    MICROSUB_DB: env.MICROSUB_DB,
+    MICROSUB_QUEUE: env.MICROSUB_QUEUE,
+    AUTH_DB: env.AUTH_DB,
+    TOKEN_SIGNING_KEY: env.TOKEN_SIGNING_KEY,
+  };
+  return microsub(request, microsubEnv, ctx);
+}
+
+/**
+ * Cron-triggered feed poller for Microsub (V-4.3, #365): enqueues one poll job per followed
+ * feed onto `MICROSUB_QUEUE`. Runs off the read path — `handleMicrosub`'s timeline action only
+ * ever serves stored entries. No-ops when Microsub isn't provisioned.
+ */
+function handleMicrosubScheduled(
+  controller: ScheduledController,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): Promise<void> {
+  if (!env.MICROSUB_DB || !env.MICROSUB_QUEUE || !env.AUTH_DB || !env.TOKEN_SIGNING_KEY) {
+    return Promise.resolve();
+  }
+  const baseUrl = env.SITE_URL ?? "";
+  if (!baseUrl) return Promise.resolve();
+  const poll = createMicrosubPoller({ baseUrl, me: `${baseUrl}/` });
+  const microsubEnv: MicrosubEnv = {
+    MICROSUB_DB: env.MICROSUB_DB,
+    MICROSUB_QUEUE: env.MICROSUB_QUEUE,
+    AUTH_DB: env.AUTH_DB,
+    TOKEN_SIGNING_KEY: env.TOKEN_SIGNING_KEY,
+  };
+  return poll(controller, microsubEnv, ctx);
+}
+
+/**
+ * Queue consumer for Microsub's feed-poll fan-out (V-4.3, #365): fetches + parses each polled
+ * feed and appends new entries to the following channel's timeline. Acks-without-work when
+ * Microsub isn't provisioned — same contract as `handleWebmentionQueue`/`handleWebSubQueue`.
+ */
+function handleMicrosubQueue(
+  batch: MessageBatch<MicrosubJob>,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): Promise<void> {
+  if (!env.MICROSUB_DB || !env.MICROSUB_QUEUE || !env.AUTH_DB || !env.TOKEN_SIGNING_KEY || !env.SITE_URL) {
+    return Promise.resolve();
+  }
+  const consume = createMicrosubQueueConsumer({ baseUrl: env.SITE_URL, me: `${env.SITE_URL}/` });
+  const microsubEnv: MicrosubEnv = {
+    MICROSUB_DB: env.MICROSUB_DB,
+    MICROSUB_QUEUE: env.MICROSUB_QUEUE,
+    AUTH_DB: env.AUTH_DB,
+    TOKEN_SIGNING_KEY: env.TOKEN_SIGNING_KEY,
+  };
+  return consume(batch, microsubEnv, ctx);
 }
 
 /**
@@ -746,6 +851,13 @@ export const ROUTES: readonly WorkerRoute[] = [
     methods: ["POST"],
     handler: (request, env, ctx) => handleWebSubHub(request, env, ctx),
   },
+  {
+    // Microsub reader (V-4.3, #365): action=channels|follow|unfollow|timeline|search|preview.
+    path: "/microsub",
+    match: "exact",
+    methods: ["GET", "POST"],
+    handler: (request, env, ctx) => handleMicrosub(request, env, ctx),
+  },
 ];
 
 export function matchRoute(pathname: string, routes: readonly WorkerRoute[] = ROUTES): WorkerRoute | null {
@@ -830,13 +942,14 @@ export default {
   },
 
   // Async queue work, present unconditionally; no-ops for sites without the matching feature
-  // provisioned. Two queues deliver here — Webmention verification (V-3.1, #359) and WebSub
-  // verification/distribution/delivery (V-3.3, #361) — dispatched on the queue's name:
-  // Anglesite provisions deterministic names (`<site>-webmention`, `<site>-websub`). Both
-  // matches are positive (rather than "webmention = anything that isn't -websub") so a future
-  // third queue-backed feature can't get silently misrouted into the webmention consumer.
+  // provisioned. Three queues deliver here — Webmention verification (V-3.1, #359), WebSub
+  // verification/distribution/delivery (V-3.3, #361), and Microsub feed-poll fan-out (V-4.3,
+  // #365) — dispatched on the queue's name: Anglesite provisions deterministic names
+  // (`<site>-webmention`, `<site>-websub`, `<site>-microsub`). All matches are positive (rather
+  // than "webmention = anything that isn't -websub") so a future queue-backed feature can't get
+  // silently misrouted into another's consumer.
   async queue(
-    batch: MessageBatch<WebmentionJob | WebSubJob>,
+    batch: MessageBatch<WebmentionJob | WebSubJob | MicrosubJob>,
     env: WorkerEnv,
     ctx: ExecutionContext,
   ): Promise<void> {
@@ -846,6 +959,19 @@ export default {
     if (batch.queue.endsWith("-webmention")) {
       return handleWebmentionQueue(batch as MessageBatch<WebmentionJob>, env, ctx);
     }
+    if (batch.queue.endsWith("-microsub")) {
+      return handleMicrosubQueue(batch as MessageBatch<MicrosubJob>, env, ctx);
+    }
     return Promise.resolve();
   },
-} satisfies ExportedHandler<WorkerEnv, WebmentionJob | WebSubJob>;
+
+  // Cron Trigger, present unconditionally; no-ops for a site without Microsub provisioned
+  // (V-4.3, #365) — the only feature that schedules work today.
+  async scheduled(
+    controller: ScheduledController,
+    env: WorkerEnv,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    return handleMicrosubScheduled(controller, env, ctx);
+  },
+} satisfies ExportedHandler<WorkerEnv, WebmentionJob | WebSubJob | MicrosubJob>;

--- a/Resources/Template/worker/workers-version.json
+++ b/Resources/Template/worker/workers-version.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Pinned @dwk/workers version range for this template. Read by Anglesite during scaffold and social-feature enablement. Updated when a new @dwk/workers release ships.",
-  "version": "0.1.0-beta.3",
-  "range": "0.1.0-beta.3",
-  "note": "IndieAuth, Webmention (inbound receive, V-3.1), Micropub (V-3.2), and WebSub (hub, V-3.3) are pinned to the exact published betas composed into worker.ts and verified by the template Worker integration suite; the remaining social packages remain gated on their conformance status until composed.",
+  "version": "0.1.0-beta.4",
+  "range": "0.1.0-beta.4",
+  "note": "IndieAuth, Webmention (inbound receive, V-3.1), Micropub (V-3.2), WebSub (hub, V-3.3), and Microsub (reader, V-4.3) are pinned to the exact published betas composed into worker.ts and verified by the template Worker integration suite; the remaining social packages remain gated on their conformance status until composed.",
   "packages": {
     "@dwk/indieauth": "0.1.0-beta.3",
     "@dwk/webmention": "0.1.0-beta.3",
     "@dwk/micropub": "0.1.0-beta.4",
     "@dwk/websub": "0.1.0-beta.4",
-    "@dwk/microsub": "^0.0.0",
+    "@dwk/microsub": "0.1.0-beta.4",
     "@dwk/webfinger": "^0.0.0",
     "@dwk/activitypub": "^0.0.0"
   }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -357,6 +357,9 @@
     "Apply…" : {
 
     },
+    "Approve sign-in in your browser, then copy the final URL from the address bar (it will fail to load — that's expected) and paste it here." : {
+
+    },
     "Arguments (space-separated)" : {
 
     },
@@ -516,6 +519,9 @@
     "Change Logo…" : {
 
     },
+    "Channel" : {
+
+    },
     "Chat" : {
 
     },
@@ -631,6 +637,9 @@
 
     },
     "Commit and push working-tree changes to your current branch" : {
+
+    },
+    "Complete Sign In" : {
 
     },
     "Component" : {
@@ -1063,6 +1072,12 @@
     "Flip Vertically" : {
 
     },
+    "Follow" : {
+
+    },
+    "Follow a feed or site URL…" : {
+
+    },
     "Font" : {
 
     },
@@ -1459,6 +1474,9 @@
     "No copy issues found across %lld pages — nice work." : {
 
     },
+    "No entries yet — follow a feed above to get started." : {
+
+    },
     "No issues found in the most recent scan." : {
 
     },
@@ -1612,6 +1630,9 @@
     "Paste the HTML code from another analytics provider here, such as Google Analytics, Plausible, Fathom, or a conversion tag." : {
 
     },
+    "Pasted callback URL" : {
+
+    },
     "Pause" : {
 
     },
@@ -1721,6 +1742,9 @@
 
     },
     "Re-check" : {
+
+    },
+    "Reader…" : {
 
     },
     "Reading %@ zone settings from Cloudflare…" : {
@@ -2123,6 +2147,15 @@
     "Shows the most recent pre-deploy scan results" : {
 
     },
+    "Sign In…" : {
+
+    },
+    "Sign Out" : {
+
+    },
+    "Sign in to read your feeds" : {
+
+    },
     "Signed in as %@" : {
 
     },
@@ -2283,6 +2316,9 @@
 
     },
     "That's a different site — choose the original package folder instead." : {
+
+    },
+    "The Reader follows feeds and stores your timeline on this site's own Microsub endpoint — sign in as this site's owner to use it." : {
 
     },
     "The build produced no output." : {

--- a/Sources/AnglesiteApp/MicrosubReaderModel.swift
+++ b/Sources/AnglesiteApp/MicrosubReaderModel.swift
@@ -1,0 +1,205 @@
+import AppKit
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Reader pane (Website ▸ Reader…, V-4.3 #365): sign in to the site's own deployed
+/// IndieAuth server, follow a feed, and render the resulting Microsub timeline. App glue only —
+/// protocol logic lives in `AnglesiteCore` (`SiteIndieAuthClient`, `MicrosubClient`, `DPoPKeyPair`).
+@MainActor
+@Observable
+final class MicrosubReaderModel {
+    enum SignInState: Equatable {
+        case signedOut
+        /// The authorize URL is open in the system browser; waiting on the user to paste back the
+        /// callback URL from the address bar (see `SiteIndieAuthLoopback`'s doc comment for why
+        /// there's no automatic capture).
+        case awaitingCallback
+        case signedIn(me: String)
+    }
+
+    private(set) var signInState: SignInState = .signedOut
+    private(set) var channels: [MicrosubChannel] = []
+    private(set) var selectedChannelID: String?
+    private(set) var timeline: [MicrosubTimelineEntry] = []
+    private(set) var isLoading = false
+    var errorMessage: String?
+    var followURLText = ""
+    var pastedCallbackText = ""
+
+    private var siteID: String?
+    private var siteURL: URL?
+    private let secretStore: any SecretStore
+    private let indieAuthClient: SiteIndieAuthClient
+    private var pendingAuthRequest: SiteIndieAuthRequest?
+    private var microsubClient: MicrosubClient?
+
+    init(
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        indieAuthClient: SiteIndieAuthClient = SiteIndieAuthClient()
+    ) {
+        self.secretStore = secretStore
+        self.indieAuthClient = indieAuthClient
+    }
+
+    /// Records which site this reader talks to and restores an already-signed-in session from the
+    /// Keychain, if any. No network I/O. Called once per site open from
+    /// `SiteWindowModel.loadAndStart()`, mirroring `ProjectCleanupModel.configure(site:)`.
+    func configure(site: CurrentSite) {
+        siteID = site.id
+        siteURL = DeployCoordinator.resolveSiteURL(siteDirectory: site.sourceDirectory).flatMap { URL(string: $0) }
+        restoreSession()
+    }
+
+    private func restoreSession() {
+        guard let siteID, let siteURL,
+              let token = try? secretStore.readIndieAuthAccessToken(siteID: siteID), !token.isEmpty,
+              let keyPair = try? secretStore.readIndieAuthDPoPKeyPair(siteID: siteID)
+        else { return }
+        // The exact `me` claim isn't persisted separately from the token — the site's own origin
+        // is what it always canonicalizes to for a single-owner endpoint, so it's a fine display
+        // value without a second Keychain round-trip.
+        signInState = .signedIn(me: siteURL.absoluteString)
+        microsubClient = MicrosubClient(
+            endpoint: siteURL.appendingPathComponent("microsub"), accessToken: token, dpopKeyPair: keyPair
+        )
+    }
+
+    var canStartSignIn: Bool { siteURL != nil && signInState == .signedOut }
+
+    /// Starts sign-in: builds the authorize URL against the site's own IndieAuth server and opens
+    /// it in the system browser. The server redirects the browser to a loopback URL nothing is
+    /// listening on; the user copies that final URL from the address bar into `pastedCallbackText`
+    /// and calls `completeSignIn()`.
+    func startSignIn() {
+        guard let siteURL else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        errorMessage = nil
+        Task {
+            do {
+                let request = try await indieAuthClient.makeAuthorizationRequest(
+                    siteURL: siteURL,
+                    scope: SiteIndieAuthLoopback.microsubScope,
+                    clientID: SiteIndieAuthLoopback.clientID,
+                    redirectURI: SiteIndieAuthLoopback.redirectURI
+                )
+                pendingAuthRequest = request
+                signInState = .awaitingCallback
+                NSWorkspace.shared.open(request.authorizeURL)
+            } catch {
+                errorMessage = "Couldn't start sign-in: \(error)"
+            }
+        }
+    }
+
+    /// Completes sign-in from the callback URL the user pasted into `pastedCallbackText`.
+    func completeSignIn() {
+        guard let request = pendingAuthRequest, let siteID, let siteURL else { return }
+        let trimmed = pastedCallbackText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let callbackURL = URL(string: trimmed), !trimmed.isEmpty else {
+            errorMessage = "That doesn't look like a URL."
+            return
+        }
+        errorMessage = nil
+        Task {
+            do {
+                let code = try SiteIndieAuthClient.authorizationCode(from: callbackURL, matching: request)
+                let keyPair = DPoPKeyPair()
+                let token = try await indieAuthClient.exchange(code: code, for: request, dpopKeyPair: keyPair)
+                try secretStore.writeIndieAuthAccessToken(token.accessToken, siteID: siteID)
+                try secretStore.writeIndieAuthDPoPKeyPair(keyPair, siteID: siteID)
+                pendingAuthRequest = nil
+                pastedCallbackText = ""
+                signInState = .signedIn(me: token.me)
+                microsubClient = MicrosubClient(
+                    endpoint: siteURL.appendingPathComponent("microsub"),
+                    accessToken: token.accessToken, dpopKeyPair: keyPair
+                )
+                await loadChannels()
+            } catch {
+                errorMessage = "Sign-in failed: \(error)"
+            }
+        }
+    }
+
+    func cancelSignIn() {
+        pendingAuthRequest = nil
+        pastedCallbackText = ""
+        signInState = .signedOut
+    }
+
+    func signOut() {
+        if let siteID { try? secretStore.clearIndieAuthSession(siteID: siteID) }
+        signInState = .signedOut
+        microsubClient = nil
+        channels = []
+        timeline = []
+        selectedChannelID = nil
+        pendingAuthRequest = nil
+    }
+
+    /// Loads the channel list, creating a default "Following" channel on first use (a brand-new
+    /// Microsub reader has none — a reserved `notifications` channel exists server-side but is not
+    /// meant to hold followed feeds), then loads the selected channel's timeline.
+    func loadChannels() async {
+        guard let microsubClient else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            var list = try await microsubClient.listChannels().filter { $0.uid != "notifications" }
+            if list.isEmpty {
+                let created = try await microsubClient.createChannel(name: "Following")
+                list = [created]
+            }
+            channels = list
+            if selectedChannelID == nil || !list.contains(where: { $0.id == selectedChannelID }) {
+                selectedChannelID = list.first?.id
+            }
+            await loadTimeline()
+        } catch {
+            errorMessage = "Couldn't load channels: \(error)"
+        }
+    }
+
+    func selectChannel(_ channelID: String) {
+        guard channelID != selectedChannelID else { return }
+        selectedChannelID = channelID
+        Task { await loadTimeline() }
+    }
+
+    func loadTimeline() async {
+        guard let microsubClient, let selectedChannelID else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let page = try await microsubClient.timeline(channel: selectedChannelID)
+            timeline = page.items
+        } catch {
+            errorMessage = "Couldn't load the timeline: \(error)"
+        }
+    }
+
+    /// Follows `followURLText` into the selected channel (creating a default one first if none
+    /// exists yet), then refreshes the timeline.
+    func follow() {
+        let url = followURLText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !url.isEmpty, let microsubClient else { return }
+        errorMessage = nil
+        Task {
+            if channels.isEmpty { await loadChannels() }
+            guard let channel = selectedChannelID ?? channels.first?.id else {
+                errorMessage = "No channel to follow into."
+                return
+            }
+            do {
+                try await microsubClient.follow(url: url, channel: channel)
+                followURLText = ""
+                await loadTimeline()
+            } catch {
+                errorMessage = "Couldn't follow \(url): \(error)"
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteApp/MicrosubReaderView.swift
+++ b/Sources/AnglesiteApp/MicrosubReaderView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+import AppKit
+import AnglesiteCore
+
+/// Main-pane Reader surface (Website ▸ Reader…, V-4.3 #365): sign in, follow a feed, and read the
+/// resulting timeline. Mirrors `ProjectCleanupView`'s wiring shape — a dedicated pane with its own
+/// model, no in-content pane picker (#519's toolbar/View-menu switcher stays the only navigation).
+struct MicrosubReaderView: View {
+    @Bindable var reader: MicrosubReaderModel
+
+    var body: some View {
+        Group {
+            switch reader.signInState {
+            case .signedOut, .awaitingCallback:
+                signInContent
+            case .signedIn:
+                readerContent
+            }
+        }
+        .navigationSubtitle("Reader")
+        .alert(
+            "Reader error",
+            isPresented: Binding(
+                get: { reader.errorMessage != nil },
+                set: { if !$0 { reader.errorMessage = nil } }),
+            presenting: reader.errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) { reader.errorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    @ViewBuilder
+    private var signInContent: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Sign in to read your feeds")
+                .font(.title2)
+            Text("The Reader follows feeds and stores your timeline on this site's own Microsub endpoint — sign in as this site's owner to use it.")
+                .foregroundStyle(.secondary)
+
+            if reader.signInState == .awaitingCallback {
+                Text("Approve sign-in in your browser, then copy the final URL from the address bar (it will fail to load — that's expected) and paste it here.")
+                TextField("Pasted callback URL", text: $reader.pastedCallbackText)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { reader.completeSignIn() }
+                HStack {
+                    Button("Complete Sign In") { reader.completeSignIn() }
+                        .disabled(reader.pastedCallbackText.trimmingCharacters(in: .whitespaces).isEmpty)
+                    Button("Cancel", role: .cancel) { reader.cancelSignIn() }
+                }
+            } else {
+                Button("Sign In…") { reader.startSignIn() }
+                    .disabled(!reader.canStartSignIn)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private var readerContent: some View {
+        VStack(spacing: 0) {
+            HStack {
+                TextField("Follow a feed or site URL…", text: $reader.followURLText)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { reader.follow() }
+                Button("Follow") { reader.follow() }
+                    .disabled(reader.followURLText.trimmingCharacters(in: .whitespaces).isEmpty)
+                Spacer()
+                Button("Sign Out") { reader.signOut() }
+            }
+            .padding()
+
+            if !reader.channels.isEmpty {
+                Picker("Channel", selection: channelSelection) {
+                    ForEach(reader.channels) { channel in
+                        Text(channel.unread.map { $0 > 0 ? "\(channel.name) (\($0))" : channel.name } ?? channel.name)
+                            .tag(channel.id)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .padding(.horizontal)
+            }
+
+            List {
+                if reader.timeline.isEmpty && !reader.isLoading {
+                    Text("No entries yet — follow a feed above to get started.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(reader.timeline) { entry in
+                        timelineRow(entry)
+                    }
+                }
+            }
+        }
+        .task {
+            if reader.channels.isEmpty { await reader.loadChannels() }
+        }
+    }
+
+    private var channelSelection: Binding<String> {
+        Binding(
+            get: { reader.selectedChannelID ?? reader.channels.first?.id ?? "" },
+            set: { reader.selectChannel($0) }
+        )
+    }
+
+    @ViewBuilder
+    private func timelineRow(_ entry: MicrosubTimelineEntry) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(entry.name ?? entry.summary ?? entry.content?.text ?? entry.url ?? "Untitled entry")
+                .font(.headline)
+                .lineLimit(2)
+            HStack(spacing: 8) {
+                if let author = entry.author?.name {
+                    Text(author)
+                }
+                if let published = entry.published {
+                    Text(published)
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+        .contextMenu {
+            if let urlString = entry.url, let url = URL(string: urlString) {
+                Button("Open in Browser") { NSWorkspace.shared.open(url) }
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -765,6 +765,8 @@ struct SiteWindow: View {
                 onOpen: { model.openCleanupCandidate($0) },
                 onDelete: { await model.deleteCleanupCandidate($0) }
             )
+        case .reader:
+            MicrosubReaderView(reader: model.reader)
         case .preview:
             previewPane(for: site)
         }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -11,6 +11,7 @@ enum MainPaneMode: Equatable {
     case editor(FileRef)
     case graph
     case cleanup        // Site ▸ Cleanup… (#714 moved it out of the sidebar)
+    case reader         // Website ▸ Reader… (V-4.3, #365)
 }
 
 enum ActiveEditor {
@@ -114,6 +115,9 @@ final class SiteWindowModel {
     /// `scan()` runs once automatically when `ProjectCleanupView` first appears; the manual
     /// Rescan button re-runs it on demand afterward.
     var cleanup: ProjectCleanupModel
+    /// Drives the main-pane Reader view (Website ▸ Reader…, V-4.3 #365): Microsub sign-in, follow,
+    /// and timeline.
+    var reader = MicrosubReaderModel()
     var harden = HardenModel()
     var onionRouting = OnionRoutingModel()
     var domain = DomainModel()
@@ -225,6 +229,9 @@ final class SiteWindowModel {
         // all correctly read as unselected instead of Cleanup falsely appearing as Preview (#723
         // review).
         if case .cleanup = mainPaneMode { return 3 }
+        // Same reasoning as Cleanup above: Reader has no toolbar/View-menu segment (Website ▸
+        // Reader… is the only way in).
+        if case .reader = mainPaneMode { return 4 }
         return 0
     }
 
@@ -260,6 +267,17 @@ final class SiteWindowModel {
             activeEditor = nil
             inspectorContext = nil
             mainPaneMode = .cleanup
+        }
+    }
+
+    /// Switches the main pane to Reader (Website ▸ Reader…, V-4.3 #365). Mirrors
+    /// `presentCleanup()`'s leave-current-surface-first guard.
+    func presentReader() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            inspectorContext = nil
+            mainPaneMode = .reader
         }
     }
 
@@ -1357,6 +1375,7 @@ final class SiteWindowModel {
         navigator = navModel
         graphExplorer.start(site: currentSite)
         cleanup.configure(site: currentSite)
+        reader.configure(site: currentSite)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -52,6 +52,9 @@ struct WebsiteCommands: Commands {
             Button("Cleanup…") { model?.presentCleanup() }
                 .disabled(model == nil)
 
+            Button("Reader…") { model?.presentReader() }
+                .disabled(model == nil)
+
             // Ellipsis items open a sheet for further input, per the HIG.
             Button("Harden…") { model?.harden.openSheet() }
                 .disabled(model?.canRunHarden != true)

--- a/Sources/AnglesiteCore/DPoPKeyPair.swift
+++ b/Sources/AnglesiteCore/DPoPKeyPair.swift
@@ -1,0 +1,103 @@
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+/// A DPoP (RFC 9449) proof-of-possession key pair. `@dwk/indieauth` mints access tokens bound to
+/// the public key's thumbprint (`cnf.jkt`); every subsequent resource request (`@dwk/microsub`,
+/// `@dwk/micropub`, …) must present a proof signed by the *same* key pair the token endpoint saw,
+/// so this value is generated once per site sign-in and persisted (see `SecretAccounts`) rather
+/// than regenerated per request.
+public struct DPoPKeyPair: Sendable {
+    #if canImport(CryptoKit)
+    private let privateKey: P256.Signing.PrivateKey
+    #endif
+
+    /// Generates a fresh P-256 key pair.
+    public init() {
+        #if canImport(CryptoKit)
+        self.privateKey = P256.Signing.PrivateKey()
+        #endif
+    }
+
+    /// Reconstructs a previously persisted key pair from its raw 32-byte private scalar
+    /// (`persistedRepresentation`). `nil` if `data` isn't a valid P-256 private key.
+    public init?(persistedRepresentation data: Data) {
+        #if canImport(CryptoKit)
+        guard let key = try? P256.Signing.PrivateKey(rawRepresentation: data) else { return nil }
+        self.privateKey = key
+        #else
+        return nil
+        #endif
+    }
+
+    /// The raw private-key bytes to persist (Keychain via `SecretStore`), so the same key pair
+    /// can be reconstructed for later resource requests within the sign-in's lifetime.
+    public var persistedRepresentation: Data {
+        #if canImport(CryptoKit)
+        privateKey.rawRepresentation
+        #else
+        Data()
+        #endif
+    }
+
+    #if canImport(CryptoKit)
+    /// The public key as a JWK (RFC 7518 §6.2), embedded in every proof's header so a verifier
+    /// can check the signature and compute the RFC 7638 thumbprint. Field order doesn't matter
+    /// for parsing — the verifier canonicalizes its own copy before hashing.
+    private var publicJWK: [String: String] {
+        // ANSI X9.63 uncompressed point: a leading 0x04 format byte, then X (32 bytes), then Y
+        // (32 bytes) — `.x963Representation` (not `.rawRepresentation`, whose exact byte layout
+        // isn't part of its name) is the unambiguous, explicitly-documented format for this.
+        let raw = privateKey.publicKey.x963Representation
+        let start = raw.index(after: raw.startIndex)
+        let x = raw.subdata(in: start..<(start + 32))
+        let y = raw.subdata(in: (start + 32)..<(start + 64))
+        return ["kty": "EC", "crv": "P-256", "x": Self.base64URL(x), "y": Self.base64URL(y)]
+    }
+    #endif
+
+    /// Builds and signs a DPoP proof JWT (RFC 9449 §4.2) for one HTTP request: a fresh `jti`/
+    /// `iat`, `htm`/`htu` binding it to this request, and — when `accessToken` is supplied — the
+    /// `ath` claim binding it to that specific bearer token (required on every resource request;
+    /// omit for the token-endpoint exchange, which has no token yet).
+    public func proof(htm: String, htu: String, accessToken: String? = nil) throws -> String {
+        #if canImport(CryptoKit)
+        let header: [String: Any] = ["typ": "dpop+jwt", "alg": "ES256", "jwk": publicJWK]
+        var payload: [String: Any] = [
+            "jti": UUID().uuidString,
+            "htm": htm,
+            "htu": htu,
+            "iat": Int(Date().timeIntervalSince1970),
+        ]
+        if let accessToken {
+            payload["ath"] = Self.base64URL(Data(SHA256.hash(data: Data(accessToken.utf8))))
+        }
+        let headerSegment = try Self.base64URLJSON(header)
+        let payloadSegment = try Self.base64URLJSON(payload)
+        let signingInput = Data("\(headerSegment).\(payloadSegment)".utf8)
+        let signature = try privateKey.signature(for: signingInput)
+        return "\(headerSegment).\(payloadSegment).\(Self.base64URL(signature.rawRepresentation))"
+        #else
+        // DPoP signing needs CryptoKit (Apple platforms only) — there's no sign-in UI on a
+        // platform without it either (matches CloudflareOAuthClient.codeChallenge(for:)'s posture).
+        throw DPoPError.unavailable
+        #endif
+    }
+
+    private static func base64URLJSON(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return base64URL(data)
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+public enum DPoPError: Error, Sendable {
+    case unavailable
+}

--- a/Sources/AnglesiteCore/MicrosubClient.swift
+++ b/Sources/AnglesiteCore/MicrosubClient.swift
@@ -1,0 +1,206 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// A JF2 (https://jf2.spec.indieweb.org/) timeline entry, as `@dwk/microsub` normalizes every
+/// followed feed's entries into regardless of the source's wire format (JSON Feed, Atom, RSS,
+/// h-feed). Mirrors `Jf2Entry` in the sidecar's `jf2.ts`.
+public struct MicrosubTimelineEntry: Sendable, Equatable, Decodable, Identifiable {
+    public struct Author: Sendable, Equatable, Decodable {
+        public let name: String?
+        public let url: String?
+        public let photo: String?
+    }
+
+    public struct Content: Sendable, Equatable, Decodable {
+        public let html: String?
+        public let text: String?
+    }
+
+    /// Stable per-entry identifier the store dedupes on across polls.
+    public let id: String
+    public let url: String?
+    public let published: String?
+    public let name: String?
+    public let summary: String?
+    public let content: Content?
+    public let author: Author?
+
+    enum CodingKeys: String, CodingKey {
+        case id = "_id"
+        case url, published, name, summary, content, author
+    }
+}
+
+/// A Microsub channel: a named grouping of follows with an unread count. The `notifications`
+/// channel always exists and can't be deleted/renamed (`store.ts`'s `NOTIFICATIONS_CHANNEL`).
+public struct MicrosubChannel: Sendable, Equatable, Decodable, Identifiable {
+    public let uid: String
+    public let name: String
+    public let unread: Int?
+    public var id: String { uid }
+}
+
+/// One page of a channel's timeline, with opaque before/after cursors for further paging.
+public struct MicrosubTimelinePage: Sendable, Equatable, Decodable {
+    public struct Paging: Sendable, Equatable, Decodable {
+        public let before: String?
+        public let after: String?
+    }
+
+    public let items: [MicrosubTimelineEntry]
+    public let paging: Paging
+}
+
+public enum MicrosubError: Error, Equatable, Sendable {
+    /// The endpoint returned a non-2xx status; `body` is the raw response for diagnostics.
+    case requestFailed(status: Int, body: String)
+    case decodingFailed(String)
+    /// Signing the DPoP proof needs CryptoKit (Apple platforms only).
+    case dpopUnavailable
+}
+
+/// A client for one site's deployed `@dwk/microsub` endpoint — follow/unfollow feeds, list
+/// channels, and page the normalized JF2 timeline. Every call is a DPoP-bound, bearer-authorized
+/// request (RFC 9449) built fresh per call from the injected `dpopKeyPair`/`accessToken`, mirroring
+/// `InboxKVClient`'s injectable-`Transport` shape so this stays unit-testable without real
+/// networking. `SiteIndieAuthClient` is how the caller obtains the token + key pair in the first
+/// place; this type only *presents* them.
+public struct MicrosubClient: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// The site's `/microsub` endpoint (absolute URL, no query).
+    private let endpoint: URL
+    private let accessToken: String
+    private let dpopKeyPair: DPoPKeyPair
+    private let transport: Transport
+
+    public init(
+        endpoint: URL,
+        accessToken: String,
+        dpopKeyPair: DPoPKeyPair,
+        transport: @escaping Transport = MicrosubClient.defaultTransport
+    ) {
+        self.endpoint = endpoint
+        self.accessToken = accessToken
+        self.dpopKeyPair = dpopKeyPair
+        self.transport = transport
+    }
+
+    /// Lists the site's channels with their unread counts.
+    public func listChannels() async throws -> [MicrosubChannel] {
+        struct Response: Decodable { let channels: [MicrosubChannel] }
+        let response: Response = try await get(query: [URLQueryItem(name: "action", value: "channels")])
+        return response.channels
+    }
+
+    /// Creates a new channel and returns it.
+    public func createChannel(name: String) async throws -> MicrosubChannel {
+        try await post(action: "channels", body: ["name": name])
+    }
+
+    /// Follows `url` (a feed or a page discovery finds a feed from) into `channel`. Populates the
+    /// timeline immediately from the server's discovery fetch when possible; either way the poller
+    /// picks the feed up on its next scheduled run.
+    public func follow(url: String, channel: String) async throws {
+        try await postDiscardingResponse(action: "follow", body: ["channel": channel, "url": url])
+    }
+
+    /// Unfollows `url` from `channel`.
+    public func unfollow(url: String, channel: String) async throws {
+        try await postDiscardingResponse(action: "unfollow", body: ["channel": channel, "url": url])
+    }
+
+    /// Pages `channel`'s timeline. Pass exactly one of `before`/`after` (the previous page's
+    /// matching cursor) to page; pass neither for the first page.
+    public func timeline(channel: String, before: String? = nil, after: String? = nil) async throws -> MicrosubTimelinePage {
+        var query = [URLQueryItem(name: "action", value: "timeline"), URLQueryItem(name: "channel", value: channel)]
+        if let before { query.append(URLQueryItem(name: "before", value: before)) }
+        if let after { query.append(URLQueryItem(name: "after", value: after)) }
+        return try await get(query: query)
+    }
+
+    /// Marks `entries` (entry ids) as read in `channel`.
+    public func markRead(channel: String, entries: [String]) async throws {
+        try await postDiscardingResponse(
+            action: "timeline",
+            body: ["channel": channel, "method": "mark_read", "entry": entries]
+        )
+    }
+
+    // MARK: - Request plumbing
+
+    private func get<Response: Decodable>(query: [URLQueryItem]) async throws -> Response {
+        guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+            throw MicrosubError.decodingFailed("malformed endpoint URL")
+        }
+        components.queryItems = query
+        guard let url = components.url else {
+            throw MicrosubError.decodingFailed("couldn't build request URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        try authorize(&request, method: "GET")
+        return try await send(request)
+    }
+
+    private func post<Response: Decodable>(action: String, body: [String: Any]) async throws -> Response {
+        var payload = body
+        payload["action"] = action
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        try authorize(&request, method: "POST")
+        return try await send(request)
+    }
+
+    /// For actions whose response body carries nothing the caller needs (`{}` on success).
+    private func postDiscardingResponse(action: String, body: [String: Any]) async throws {
+        struct Empty: Decodable {}
+        let _: Empty = try await post(action: action, body: body)
+    }
+
+    /// Attaches the `Authorization: DPoP <token>` and `DPoP: <proof>` headers RFC 9449 requires —
+    /// every microsub action is authorized this way, GET and POST alike (`auth.ts`'s `authorize`
+    /// always passes `accessToken` to `verifyDpopProof`, so `ath` is never optional here). The
+    /// proof's `htu` is the bare endpoint URL (no query) — matching the server's
+    /// `expectedHtu: config.microsubEndpoint`, which `verifyDpopProof`'s own `normalizeHtu` would
+    /// strip a query string from regardless.
+    private func authorize(_ request: inout URLRequest, method: String) throws {
+        request.setValue("DPoP \(accessToken)", forHTTPHeaderField: "Authorization")
+        do {
+            let proof = try dpopKeyPair.proof(htm: method, htu: endpoint.absoluteString, accessToken: accessToken)
+            request.setValue(proof, forHTTPHeaderField: "DPoP")
+        } catch is DPoPError {
+            throw MicrosubError.dpopUnavailable
+        }
+    }
+
+    private func send<Response: Decodable>(_ request: URLRequest) async throws -> Response {
+        let data: Data, http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw MicrosubError.requestFailed(status: 0, body: error.localizedDescription)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw MicrosubError.requestFailed(status: http.statusCode, body: String(data: data, encoding: .utf8) ?? "")
+        }
+        do {
+            return try JSONDecoder().decode(Response.self, from: data)
+        } catch {
+            throw MicrosubError.decodingFailed("\(error)")
+        }
+    }
+
+    /// Production transport: a plain `URLSession` request, no auth of its own (that's `authorize`'s job).
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+}

--- a/Sources/AnglesiteCore/Platform/SecretStore.swift
+++ b/Sources/AnglesiteCore/Platform/SecretStore.swift
@@ -49,6 +49,21 @@ public enum SecretAccounts {
         "posse:\(siteID):bluesky-app-password"
     }
 
+    /// The site's own IndieAuth-issued DPoP-bound access token (V-4.3, #365) — what
+    /// `MicrosubClient` presents to the site's deployed `/microsub` endpoint. Deliberately
+    /// separate from `cloudflareToken`: this credential is minted by the site itself during
+    /// `SiteIndieAuthClient` sign-in and never reaches api.cloudflare.com.
+    public static func indieAuthAccessToken(siteID: String) -> String {
+        "indieauth:\(siteID):access-token"
+    }
+
+    /// The raw private-key bytes (`DPoPKeyPair.persistedRepresentation`) bound to
+    /// `indieAuthAccessToken`'s `cnf.jkt` — every resource request must sign its DPoP proof with
+    /// this same key pair, so it's persisted alongside the token rather than regenerated per call.
+    public static func indieAuthDPoPKey(siteID: String) -> String {
+        "indieauth:\(siteID):dpop-key"
+    }
+
     /// Bearer token for a `.remote` ACP agent connection, keyed by the connection's `id` — there
     /// can be many connections, so this is a function, not a single constant like
     /// `cloudflareToken`/`gitHubToken`.
@@ -101,6 +116,40 @@ public extension SecretStore {
     /// Clear the bearer token for a `.remote` ACP agent connection.
     func clearACPAgentToken(id: UUID) throws {
         try delete(account: SecretAccounts.acpAgentToken(id: id))
+    }
+
+    /// Read the site's IndieAuth access token (V-4.3, #365).
+    func readIndieAuthAccessToken(siteID: String) throws -> String? {
+        try read(account: SecretAccounts.indieAuthAccessToken(siteID: siteID))
+    }
+
+    /// Store the site's IndieAuth access token. Empty string clears.
+    func writeIndieAuthAccessToken(_ token: String, siteID: String) throws {
+        try write(token, account: SecretAccounts.indieAuthAccessToken(siteID: siteID))
+    }
+
+    /// Read the DPoP key pair bound to the site's IndieAuth session, if any. `nil` when unset or
+    /// the stored bytes no longer decode as a P-256 private key.
+    func readIndieAuthDPoPKeyPair(siteID: String) throws -> DPoPKeyPair? {
+        guard let base64 = try read(account: SecretAccounts.indieAuthDPoPKey(siteID: siteID)),
+              let data = Data(base64Encoded: base64) else { return nil }
+        return DPoPKeyPair(persistedRepresentation: data)
+    }
+
+    /// Store the DPoP key pair bound to the site's IndieAuth session.
+    func writeIndieAuthDPoPKeyPair(_ keyPair: DPoPKeyPair, siteID: String) throws {
+        try write(
+            keyPair.persistedRepresentation.base64EncodedString(),
+            account: SecretAccounts.indieAuthDPoPKey(siteID: siteID)
+        )
+    }
+
+    /// Clear the site's IndieAuth access token and its bound DPoP key pair together — a token
+    /// without its key (or vice versa) can never produce a valid proof, so the two are always
+    /// cleared as one unit rather than leaving either behind.
+    func clearIndieAuthSession(siteID: String) throws {
+        try delete(account: SecretAccounts.indieAuthAccessToken(siteID: siteID))
+        try delete(account: SecretAccounts.indieAuthDPoPKey(siteID: siteID))
     }
 }
 

--- a/Sources/AnglesiteCore/SiteIndieAuthClient.swift
+++ b/Sources/AnglesiteCore/SiteIndieAuthClient.swift
@@ -1,0 +1,276 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+/// Loopback (RFC 8252 §7.3) client identity for signing in against a *site's own* IndieAuth
+/// server — as opposed to `CloudflareOAuthConfiguration`'s fixed, Anglesite-hosted `client_id`/
+/// `redirect_uri`. A per-site server has no pre-registered client, and `@dwk/indieauth`'s default
+/// `redirectUriPolicy` requires `redirect_uri` to share an origin with `client_id` — a loopback
+/// origin satisfies both `isHttpUrl`'s "loopback host" exception (`handler.ts`) and the
+/// same-origin check at once.
+///
+/// Nothing actually listens on `redirectPort`: after the user approves sign-in in the system
+/// browser, the site's IndieAuth server redirects the browser to `redirectURI` with `code`/
+/// `state` in the query. The connection fails to load (there's no local server), but the
+/// browser's address bar still shows that final URL — `MicrosubReaderModel`'s sign-in flow has
+/// the user copy it back into the app rather than standing up a real loopback HTTP server to
+/// capture it automatically. Neither URL is a secret (PKCE public clients have none).
+public enum SiteIndieAuthLoopback {
+    public static let redirectPort: UInt16 = 51789
+    public static let clientID = URL(string: "http://127.0.0.1:51789/")!
+    public static let redirectURI = URL(string: "http://127.0.0.1:51789/callback")!
+
+    /// The scopes `@dwk/microsub` needs: read the timeline, manage channels, follow/unfollow
+    /// feeds (`spec/packages/microsub.md`'s scope names, checked against `handler.ts`'s
+    /// `requireAuth` calls).
+    public static let microsubScope = "read channels follow"
+}
+
+/// The subset of an IndieAuth server's `.well-known/oauth-authorization-server` metadata
+/// (RFC 8414) a client needs: where to send the user and where to redeem the code.
+struct IndieAuthMetadata: Decodable, Sendable {
+    let issuer: String
+    let authorizationEndpoint: URL
+    let tokenEndpoint: URL
+
+    enum CodingKeys: String, CodingKey {
+        case issuer
+        case authorizationEndpoint = "authorization_endpoint"
+        case tokenEndpoint = "token_endpoint"
+    }
+}
+
+public enum SiteIndieAuthError: Error, Equatable, Sendable {
+    /// Discovery document couldn't be fetched or decoded.
+    case discoveryUnavailable(String)
+    /// The callback's `state` didn't match the one this request minted — possible CSRF, never
+    /// silently accepted.
+    case stateMismatch
+    /// The authorization server (or the user) denied the request, e.g. `error=access_denied`.
+    case callbackDenied(String)
+    /// The callback had a matching `state` but no `code`.
+    case missingAuthorizationCode
+    /// The token endpoint rejected the exchange or returned something undecodable.
+    case tokenExchangeFailed(String)
+    /// Signing the DPoP proof needs CryptoKit (Apple platforms only).
+    case dpopUnavailable
+}
+
+/// One authorize attempt: the URL to present plus what's needed to complete it once a callback
+/// URL comes back — pasted back by the user, not captured automatically (see
+/// `SiteIndieAuthLoopback`'s doc comment for why).
+public struct SiteIndieAuthRequest: Sendable {
+    public let authorizeURL: URL
+    let state: String
+    let codeVerifier: String
+    let clientID: URL
+    let redirectURI: URL
+    let tokenEndpoint: URL
+}
+
+/// The token response from a site's own `/token` endpoint (`@dwk/indieauth`'s DPoP-bound access
+/// token, see `token.ts`'s `signAccessToken`).
+public struct SiteIndieAuthToken: Sendable, Equatable {
+    public let accessToken: String
+    public let tokenType: String
+    public let scope: String
+    public let me: String
+    public let expiresIn: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case scope
+        case me
+        case expiresIn = "expires_in"
+    }
+}
+
+extension SiteIndieAuthToken: Decodable {}
+
+/// Authorization Code + PKCE + DPoP sign-in against a **site's own** IndieAuth server (V-4.3,
+/// #365) — the credential `MicrosubClient` presents to the site's deployed `/microsub` endpoint.
+/// Distinct from `CloudflareOAuthClient` (Anglesite's own registered Cloudflare client): here
+/// every site is its own authorization server with no pre-registered client, so this type uses
+/// the RFC 8252 loopback pattern (`SiteIndieAuthLoopback`) instead of a fixed `client_id`/
+/// `redirect_uri`.
+///
+/// This type only builds requests, parses callbacks, and exchanges codes — presenting the actual
+/// browser (`NSWorkspace.open`) and capturing the pasted-back callback URL are the caller's job
+/// (`MicrosubReaderModel`), kept out of this type so it stays fully unit-testable without
+/// networking beyond the injected `Transport`. Mirrors `CloudflareOAuthClient`'s seam.
+public struct SiteIndieAuthClient: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let transport: Transport
+
+    public init(transport: @escaping Transport = SiteIndieAuthClient.defaultTransport) {
+        self.transport = transport
+    }
+
+    /// Fetches `siteURL`'s IndieAuth metadata, mints a PKCE verifier/challenge + CSRF state, and
+    /// builds the authorize URL. The caller presents `request.authorizeURL` in the system browser
+    /// and passes the pasted-back callback URL to `authorizationCode(from:matching:)`.
+    public func makeAuthorizationRequest(
+        siteURL: URL,
+        scope: String,
+        clientID: URL,
+        redirectURI: URL
+    ) async throws -> SiteIndieAuthRequest {
+        let metadata = try await discoverMetadata(siteURL: siteURL)
+        let verifier = Self.makeCodeVerifier()
+        let state = Self.makeState()
+        guard var components = URLComponents(url: metadata.authorizationEndpoint, resolvingAgainstBaseURL: false) else {
+            throw SiteIndieAuthError.discoveryUnavailable("malformed authorization_endpoint")
+        }
+        components.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: clientID.absoluteString),
+            URLQueryItem(name: "redirect_uri", value: redirectURI.absoluteString),
+            URLQueryItem(name: "scope", value: scope),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: try Self.codeChallenge(for: verifier)),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+        ]
+        guard let url = components.url else {
+            throw SiteIndieAuthError.discoveryUnavailable("couldn't build the authorize URL")
+        }
+        return SiteIndieAuthRequest(
+            authorizeURL: url,
+            state: state,
+            codeVerifier: verifier,
+            clientID: clientID,
+            redirectURI: redirectURI,
+            tokenEndpoint: metadata.tokenEndpoint
+        )
+    }
+
+    /// Extracts and validates the authorization code from the loopback listener's captured
+    /// callback URL against the `state` minted for `request`. Pure URL parsing, mirrors
+    /// `CloudflareOAuthClient.authorizationCode(from:matching:)`.
+    public static func authorizationCode(from callbackURL: URL, matching request: SiteIndieAuthRequest) throws -> String {
+        let items = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        func value(_ name: String) -> String? { items.first { $0.name == name }?.value }
+
+        guard let state = value("state"), state == request.state else {
+            throw SiteIndieAuthError.stateMismatch
+        }
+        if let error = value("error") {
+            throw SiteIndieAuthError.callbackDenied(value("error_description") ?? error)
+        }
+        guard let code = value("code"), !code.isEmpty else {
+            throw SiteIndieAuthError.missingAuthorizationCode
+        }
+        return code
+    }
+
+    /// Exchanges `code` for a DPoP-bound access token, proving possession of `dpopKeyPair` at the
+    /// token endpoint (RFC 9449 §5) — the same key pair must sign every later resource-request
+    /// proof, since the minted token's `cnf.jkt` binds to it.
+    public func exchange(
+        code: String,
+        for request: SiteIndieAuthRequest,
+        dpopKeyPair: DPoPKeyPair
+    ) async throws -> SiteIndieAuthToken {
+        var form = URLComponents()
+        form.queryItems = [
+            URLQueryItem(name: "grant_type", value: "authorization_code"),
+            URLQueryItem(name: "code", value: code),
+            URLQueryItem(name: "client_id", value: request.clientID.absoluteString),
+            URLQueryItem(name: "redirect_uri", value: request.redirectURI.absoluteString),
+            URLQueryItem(name: "code_verifier", value: request.codeVerifier),
+        ]
+        var urlRequest = URLRequest(url: request.tokenEndpoint)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = Data((form.percentEncodedQuery ?? "").utf8)
+        do {
+            urlRequest.setValue(
+                try dpopKeyPair.proof(htm: "POST", htu: request.tokenEndpoint.absoluteString),
+                forHTTPHeaderField: "DPoP"
+            )
+        } catch is DPoPError {
+            throw SiteIndieAuthError.dpopUnavailable
+        }
+
+        let data: Data, http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(urlRequest)
+        } catch {
+            throw SiteIndieAuthError.tokenExchangeFailed(error.localizedDescription)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw SiteIndieAuthError.tokenExchangeFailed("HTTP \(http.statusCode): \(String(data: data, encoding: .utf8) ?? "")")
+        }
+        do {
+            return try JSONDecoder().decode(SiteIndieAuthToken.self, from: data)
+        } catch {
+            throw SiteIndieAuthError.tokenExchangeFailed("bad response: \(error)")
+        }
+    }
+
+    private func discoverMetadata(siteURL: URL) async throws -> IndieAuthMetadata {
+        let metadataURL = siteURL.appendingPathComponent(".well-known/oauth-authorization-server")
+        var request = URLRequest(url: metadataURL)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let data: Data, http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw SiteIndieAuthError.discoveryUnavailable(error.localizedDescription)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw SiteIndieAuthError.discoveryUnavailable("HTTP \(http.statusCode)")
+        }
+        do {
+            return try JSONDecoder().decode(IndieAuthMetadata.self, from: data)
+        } catch {
+            throw SiteIndieAuthError.discoveryUnavailable("bad response: \(error)")
+        }
+    }
+
+    /// Production transport: a plain `URLSession` POST/GET, no auth of its own.
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+
+    /// 32 random bytes, base64url-encoded (no padding) — well within RFC 7636's 43-128 char
+    /// range. Mirrors `CloudflareOAuthClient.makeCodeVerifier()`.
+    static func makeCodeVerifier() -> String {
+        var rng = SystemRandomNumberGenerator()
+        let bytes = (0..<32).map { _ in UInt8.random(in: .min ... .max, using: &rng) }
+        return base64URLEncode(Data(bytes))
+    }
+
+    static func makeState() -> String {
+        var rng = SystemRandomNumberGenerator()
+        let bytes = (0..<16).map { _ in UInt8.random(in: .min ... .max, using: &rng) }
+        return base64URLEncode(Data(bytes))
+    }
+
+    #if canImport(CryptoKit)
+    static func codeChallenge(for verifier: String) throws -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return base64URLEncode(Data(digest))
+    }
+    #else
+    static func codeChallenge(for verifier: String) throws -> String {
+        throw SiteIndieAuthError.dpopUnavailable
+    }
+    #endif
+
+    private static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -184,9 +184,11 @@ public actor SocialWorkerProvisionCommand {
 
         let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
         let hasWebSub = workers.contains(where: { $0.id == WorkerComposition.websubWorkerID })
+        let hasMicrosub = workers.contains(where: { $0.id == WorkerComposition.microsubWorkerID })
         let needsWebmentionQueue = hasWebmentionReceive && resources.queueName == nil
         let needsWebSubQueue = hasWebSub && resources.websubQueueName == nil
-        if needsWebmentionQueue || needsWebSubQueue {
+        let needsMicrosubQueue = hasMicrosub && resources.microsubQueueName == nil
+        if needsWebmentionQueue || needsWebSubQueue || needsMicrosubQueue {
             guard acknowledgesPaidPlan else {
                 return .webmentionPaidPlanConfirmationNeeded(resources: resources)
             }
@@ -226,6 +228,29 @@ public actor SocialWorkerProvisionCommand {
             switch result {
             case .success:
                 resources.websubQueueName = name
+            case .failure(let failure):
+                return failure
+            }
+            if let failure = persistConfig(
+                siteDirectory: siteDirectory, siteName: siteName, workers: workers,
+                routeClaims: routeClaims, resources: resources, siteURL: siteURL
+            ) {
+                return failure
+            }
+        }
+
+        if needsMicrosubQueue {
+            let name = "\(siteName)-microsub"
+            let result = await runWrangler(
+                siteDirectory: siteDirectory,
+                arguments: ["queues", "create", name, "--json"],
+                environment: environment,
+                source: source,
+                resources: resources
+            )
+            switch result {
+            case .success:
+                resources.microsubQueueName = name
             case .failure(let failure):
                 return failure
             }
@@ -359,19 +384,21 @@ public actor SocialWorkerProvisionCommand {
         guard let toml = try? String(contentsOf: url, encoding: .utf8) else {
             return .init()
         }
-        // Two features each own a queue; the generated names are deterministic
-        // (`<site>-webmention` / `<site>-websub`), so classify every `queue = "…"` value by its
-        // suffix rather than taking the first match (which would mis-assign whichever block
-        // happened to be emitted first). Both matches are positive (rather than "webmention =
-        // doesn't end in -websub") so a future third queue-backed feature can't get silently
-        // misclassified as webmention's queue just because it doesn't end in "-websub".
+        // Three features each own a queue; the generated names are deterministic
+        // (`<site>-webmention` / `<site>-websub` / `<site>-microsub`), so classify every
+        // `queue = "…"` value by its suffix rather than taking the first match (which would
+        // mis-assign whichever block happened to be emitted first). All matches are positive
+        // (rather than "webmention = doesn't end in -websub") so a future queue-backed feature
+        // can't get silently misclassified as another's queue just because it doesn't end in
+        // that other feature's suffix.
         let queueNames = extractAllTomlStrings(named: "queue", from: toml)
         return .init(
             d1DatabaseID: extractTomlString(named: "database_id", from: toml),
             kvNamespaceID: extractTomlString(named: "id", from: toml),
             r2BucketName: extractTomlString(named: "bucket_name", from: toml),
             queueName: queueNames.first(where: { $0.hasSuffix("-webmention") }),
-            websubQueueName: queueNames.first(where: { $0.hasSuffix("-websub") })
+            websubQueueName: queueNames.first(where: { $0.hasSuffix("-websub") }),
+            microsubQueueName: queueNames.first(where: { $0.hasSuffix("-microsub") })
         )
     }
 

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -44,6 +44,13 @@ public enum WorkerComposition {
     /// those binding names are part of `@dwk/websub`'s public composition contract.
     public static let websubWorkerID = "websub"
 
+    /// `@dwk/microsub`'s catalog id — like `webmentionWorkerID`, composition keys off this
+    /// directly for the reader's bespoke bindings (`MICROSUB_DB`, its own Queue), since those
+    /// binding names are part of `@dwk/microsub`'s public composition contract. The catalog
+    /// declares `requires: ["indieauth"]`, so `WorkerActivation` always activates `indieauth`
+    /// alongside this one — the `AUTH_DB`/`TOKEN_SIGNING_KEY` bindings below fall out for free.
+    public static let microsubWorkerID = "microsub"
+
     /// The bespoke app-side inbox-capture route (#587) — not a `@dwk/workers` catalog worker, so
     /// its claim lives here rather than in `catalog.json`. Appended automatically when
     /// `generateWranglerToml` is called with `inboxCaptureEnabled`.
@@ -72,16 +79,23 @@ public enum WorkerComposition {
         /// suffix. Optional like every other field: `nil` decodes cleanly from settings
         /// persisted before this field existed.
         public var websubQueueName: String?
+        /// The Cloudflare Queue name backing `@dwk/microsub`'s feed-poll fan-out and retries —
+        /// deterministic (`\(siteName)-microsub`), separate from `queueName`/`websubQueueName` so
+        /// the composed Worker's `queue()` handler can dispatch on the name suffix. Optional like
+        /// every other field: `nil` decodes cleanly from settings persisted before this field
+        /// existed.
+        public var microsubQueueName: String?
 
         public init(
             d1DatabaseID: String? = nil, kvNamespaceID: String? = nil, r2BucketName: String? = nil,
-            queueName: String? = nil, websubQueueName: String? = nil
+            queueName: String? = nil, websubQueueName: String? = nil, microsubQueueName: String? = nil
         ) {
             self.d1DatabaseID = d1DatabaseID
             self.kvNamespaceID = kvNamespaceID
             self.r2BucketName = r2BucketName
             self.queueName = queueName
             self.websubQueueName = websubQueueName
+            self.microsubQueueName = microsubQueueName
         }
     }
 
@@ -135,6 +149,7 @@ public enum WorkerComposition {
         let hasWebmentionReceive = workers.contains(where: { $0.id == webmentionWorkerID })
         let hasMicropub = workers.contains(where: { $0.id == micropubWorkerID })
         let hasWebSub = workers.contains(where: { $0.id == websubWorkerID })
+        let hasMicrosub = workers.contains(where: { $0.id == microsubWorkerID })
 
         var lines: [String] = []
         lines.append("name = \"\(siteName)\"")
@@ -264,6 +279,47 @@ public enum WorkerComposition {
             lines.append("max_retries = 3")
         }
 
+        // Same shared per-site D1 database, bound under MICROSUB_DB — @dwk/microsub creates its
+        // own channels/follows/timeline-item tables on first use, so no separate database or
+        // migration is needed here (matches the WEBSUB_DB comment above).
+        if hasMicrosub {
+            lines.append("")
+            lines.append("[[d1_databases]]")
+            lines.append("binding = \"MICROSUB_DB\"")
+            lines.append("database_name = \"\(siteName)-social\"")
+            if let id = resources.d1DatabaseID, !id.isEmpty {
+                lines.append("database_id = \"\(id)\"")
+            } else {
+                lines.append("database_id = \"\"  # filled by provisioning")
+            }
+        }
+
+        // Dedicated Cloudflare Queue for @dwk/microsub's feed-poll fan-out and retries.
+        // Deliberately separate from the Webmention/WebSub queues: the composed Worker's
+        // queue() handler dispatches on the queue-name suffix (`-microsub`).
+        if hasMicrosub {
+            lines.append("")
+            let microsubQueueName = resources.microsubQueueName ?? "\(siteName)-microsub"
+            lines.append("[[queues.producers]]")
+            lines.append("queue = \"\(microsubQueueName)\"")
+            lines.append("binding = \"MICROSUB_QUEUE\"")
+            lines.append("")
+            lines.append("[[queues.consumers]]")
+            lines.append("queue = \"\(microsubQueueName)\"")
+            lines.append("max_batch_size = 10")
+            lines.append("max_batch_timeout = 30")
+            lines.append("max_retries = 3")
+        }
+
+        // @dwk/microsub's poller runs off the read path on a Cron Trigger, enqueuing one poll job
+        // per followed feed (see `createMicrosubPoller` in the package README) — the read path
+        // itself only ever serves stored entries.
+        if hasMicrosub {
+            lines.append("")
+            lines.append("[triggers]")
+            lines.append("crons = [\"*/15 * * * *\"]")
+        }
+
         if workers.contains(where: { $0.resources.needsKV }) {
             lines.append("")
             lines.append("[[kv_namespaces]]")
@@ -294,9 +350,10 @@ public enum WorkerComposition {
         }
 
         // SITE_URL: the canonical origin the queue consumers key on — Webmention's verifier
-        // scopes accepted targets with it, and WebSub's consumer derives its topic URLs from it
-        // (neither has a request to derive an origin from).
-        if hasWebmentionReceive || hasWebSub, let siteURL, !siteURL.isEmpty, isSafeTomlStringValue(siteURL) {
+        // scopes accepted targets with it, WebSub's consumer derives its topic URLs from it, and
+        // Microsub's poller/queue consumer use it as their `baseUrl`/`me` (none of the three has
+        // a request to derive an origin from).
+        if hasWebmentionReceive || hasWebSub || hasMicrosub, let siteURL, !siteURL.isEmpty, isSafeTomlStringValue(siteURL) {
             lines.append("")
             lines.append("[vars]")
             lines.append("SITE_URL = \"\(siteURL)\"")

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -619,4 +619,68 @@ extension SiteWindowModelTests {
         #expect(model.mainPaneMode == .editor(fileRef))
         #expect(model.activeEditor != nil)
     }
+
+    /// Mirrors `presentCleanupSwitchesPane` for `presentReader()` (V-4.3, #365) — same
+    /// leave-current-surface-first guard, same out-of-range `paneSelection` reasoning.
+    @Test("presentReader switches the main pane to Reader, clearing any open editor/inspector")
+    func presentReaderSwitchesPane() async throws {
+        let (root, packageURL, package) = try makeSitePackage()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let model = makeModel()
+        model.site = SiteStore.Site(
+            id: "site-a", name: "Test", packageURL: packageURL,
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
+        )
+        let priorFile = FileRef(url: root.appendingPathComponent("dummy.astro"), group: .components, name: "dummy.astro")
+        model.activeEditor = .text(FileEditorModel(file: priorFile))
+        model.mainPaneMode = .editor(priorFile)
+        model.inspectorContext = .page(PageMetadataModel(file: priorFile, sourceDirectory: package.sourceURL))
+
+        model.presentReader()
+
+        while model.mainPaneMode != .reader { await Task.yield() }
+        #expect(model.activeEditor == nil)
+        #expect(model.inspectorContext == nil)
+        // Same "out of the Picker's 0–2 range" reasoning as Cleanup's 3 (#723) — Reader has no
+        // toolbar/View-menu segment of its own either.
+        #expect(model.paneSelection == 4)
+    }
+
+    /// Mirrors `presentCleanupAbortsOnEditorConflict` for `presentReader()`.
+    @Test("presentReader doesn't switch panes when leaveCurrentEditor aborts on an editor conflict")
+    func presentReaderAbortsOnEditorConflict() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let model = makeModel()
+        let editedFile = root.appendingPathComponent("conflict.txt")
+        try Data("original".utf8).write(to: editedFile)
+        let fileRef = FileRef(url: editedFile, group: .components, name: "conflict.txt")
+        let editorModel = FileEditorModel(file: fileRef)
+        await editorModel.load()
+        editorModel.text = "dirty edit"
+        try Data("changed on disk".utf8).write(to: editedFile)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(2)], ofItemAtPath: editedFile.path
+        )
+        model.mainPaneMode = .editor(fileRef)
+        model.activeEditor = .text(editorModel)
+
+        model.presentReader()
+
+        var iterations = 0
+        while editorModel.conflictDiskContents == nil, iterations < 10_000 {
+            await Task.yield()
+            iterations += 1
+        }
+        guard editorModel.conflictDiskContents != nil else {
+            Issue.record("flushBeforeLeaving never surfaced the external conflict")
+            return
+        }
+
+        #expect(model.mainPaneMode == .editor(fileRef))
+        #expect(model.activeEditor != nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/DPoPKeyPairTests.swift
+++ b/Tests/AnglesiteCoreTests/DPoPKeyPairTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+@testable import AnglesiteCore
+
+/// Tests `DPoPKeyPair`'s proof construction (RFC 9449 §4.2) and persistence round-trip — the
+/// piece `SiteIndieAuthClient`/`MicrosubClient` lean on for every DPoP-bound request.
+@Suite
+struct DPoPKeyPairTests {
+    private func base64urlDecode(_ segment: String) -> Data {
+        var base64 = segment.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 { base64 += "=" }
+        return Data(base64Encoded: base64) ?? Data()
+    }
+
+    private func jsonSegment(_ segment: String) -> [String: Any] {
+        (try? JSONSerialization.jsonObject(with: base64urlDecode(segment))) as? [String: Any] ?? [:]
+    }
+
+    @Test("persistedRepresentation round-trips through init?(persistedRepresentation:)")
+    func persistenceRoundTrips() throws {
+        let original = DPoPKeyPair()
+        let restored = DPoPKeyPair(persistedRepresentation: original.persistedRepresentation)
+        #expect(restored != nil)
+        #expect(restored?.persistedRepresentation == original.persistedRepresentation)
+    }
+
+    @Test("init?(persistedRepresentation:) rejects malformed bytes")
+    func rejectsMalformedBytes() {
+        #expect(DPoPKeyPair(persistedRepresentation: Data([0x01, 0x02, 0x03])) == nil)
+    }
+
+    #if canImport(CryptoKit)
+    @Test("proof carries a well-formed header and htm/htu/jti/iat payload, no ath by default")
+    func proofClaims() throws {
+        let keyPair = DPoPKeyPair()
+        let proof = try keyPair.proof(htm: "POST", htu: "https://owner.example/microsub")
+        let segments = proof.split(separator: ".", omittingEmptySubsequences: false)
+        #expect(segments.count == 3)
+
+        let header = jsonSegment(String(segments[0]))
+        #expect(header["typ"] as? String == "dpop+jwt")
+        #expect(header["alg"] as? String == "ES256")
+        let jwk = header["jwk"] as? [String: String]
+        #expect(jwk?["kty"] == "EC")
+        #expect(jwk?["crv"] == "P-256")
+        #expect(jwk?["x"]?.isEmpty == false)
+        #expect(jwk?["y"]?.isEmpty == false)
+
+        let payload = jsonSegment(String(segments[1]))
+        #expect(payload["htm"] as? String == "POST")
+        #expect(payload["htu"] as? String == "https://owner.example/microsub")
+        #expect((payload["jti"] as? String)?.isEmpty == false)
+        #expect(payload["iat"] as? Int != nil)
+        #expect(payload["ath"] == nil)
+    }
+
+    @Test("proof(accessToken:) carries the base64url(SHA-256(token)) ath claim")
+    func proofAccessTokenHash() throws {
+        let keyPair = DPoPKeyPair()
+        let token = "example-access-token"
+        let proof = try keyPair.proof(htm: "GET", htu: "https://owner.example/microsub", accessToken: token)
+        let segments = proof.split(separator: ".", omittingEmptySubsequences: false)
+        let payload = jsonSegment(String(segments[1]))
+
+        let expectedAth = Data(SHA256.hash(data: Data(token.utf8)))
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        #expect(payload["ath"] as? String == expectedAth)
+    }
+
+    @Test("two proofs for the same request use distinct jti values")
+    func jtiIsUnique() throws {
+        let keyPair = DPoPKeyPair()
+        let first = jsonSegment(String(try keyPair.proof(htm: "GET", htu: "https://owner.example/x").split(separator: ".")[1]))
+        let second = jsonSegment(String(try keyPair.proof(htm: "GET", htu: "https://owner.example/x").split(separator: ".")[1]))
+        #expect(first["jti"] as? String != second["jti"] as? String)
+    }
+
+    @Test("the proof's signature verifies against its own embedded public key")
+    func signatureVerifiesAgainstEmbeddedKey() throws {
+        let keyPair = DPoPKeyPair()
+        let proof = try keyPair.proof(htm: "POST", htu: "https://owner.example/microsub")
+        let segments = proof.split(separator: ".", omittingEmptySubsequences: false)
+        let header = jsonSegment(String(segments[0]))
+        let jwk = header["jwk"] as! [String: String]
+
+        let x = base64urlDecode(jwk["x"]!)
+        let y = base64urlDecode(jwk["y"]!)
+        // Matches DPoPKeyPair.publicJWK's own extraction: X9.63 uncompressed point format.
+        let publicKey = try P256.Signing.PublicKey(x963Representation: Data([0x04]) + x + y)
+
+        let signingInput = Data("\(segments[0]).\(segments[1])".utf8)
+        let signatureBytes = base64urlDecode(String(segments[2]))
+        let signature = try P256.Signing.ECDSASignature(rawRepresentation: signatureBytes)
+        #expect(publicKey.isValidSignature(signature, for: signingInput))
+    }
+    #endif
+}

--- a/Tests/AnglesiteCoreTests/MicrosubClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MicrosubClientTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests `MicrosubClient` against an injected `Transport` — request shaping (method, DPoP/
+/// Authorization headers, JSON body vs. query params) and response decoding, no real networking.
+@Suite(.serialized)
+struct MicrosubClientTests {
+    private let endpoint = URL(string: "https://owner.example/microsub")!
+
+    private func response(_ code: Int, url: URL? = nil) -> HTTPURLResponse {
+        HTTPURLResponse(url: url ?? endpoint, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    #if canImport(CryptoKit)
+    @Test("listChannels sends a GET with action=channels and decodes the channel list")
+    func listChannelsDecodesResponse() async throws {
+        var captured: URLRequest?
+        let client = MicrosubClient(
+            endpoint: endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                captured = request
+                let body = #"{"channels":[{"uid":"c1","name":"Blogs","unread":3}]}"#
+                return (Data(body.utf8), self.response(200))
+            }
+        )
+        let channels = try await client.listChannels()
+
+        #expect(channels == [MicrosubChannel(uid: "c1", name: "Blogs", unread: 3)])
+        #expect(captured?.httpMethod == "GET")
+        let items = URLComponents(url: captured!.url!, resolvingAgainstBaseURL: false)!.queryItems!
+        #expect(items.contains(URLQueryItem(name: "action", value: "channels")))
+        #expect(captured?.value(forHTTPHeaderField: "Authorization") == "DPoP tok-123")
+        #expect(captured?.value(forHTTPHeaderField: "DPoP")?.split(separator: ".").count == 3)
+    }
+
+    @Test("follow posts a JSON body with action/channel/url")
+    func followPostsJSONBody() async throws {
+        var captured: URLRequest?
+        let client = MicrosubClient(
+            endpoint: endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                captured = request
+                return (Data("{}".utf8), self.response(200))
+            }
+        )
+        try await client.follow(url: "https://feed.example/atom.xml", channel: "c1")
+
+        #expect(captured?.httpMethod == "POST")
+        #expect(captured?.url == endpoint)
+        #expect(captured?.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        let body = try JSONSerialization.jsonObject(with: captured!.httpBody!) as! [String: String]
+        #expect(body["action"] == "follow")
+        #expect(body["channel"] == "c1")
+        #expect(body["url"] == "https://feed.example/atom.xml")
+    }
+
+    @Test("markRead sends the entry ids as a JSON array")
+    func markReadSendsEntryArray() async throws {
+        var captured: URLRequest?
+        let client = MicrosubClient(
+            endpoint: endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                captured = request
+                return (Data("{}".utf8), self.response(200))
+            }
+        )
+        try await client.markRead(channel: "c1", entries: ["e1", "e2"])
+
+        let body = try JSONSerialization.jsonObject(with: captured!.httpBody!) as! [String: Any]
+        #expect(body["method"] as? String == "mark_read")
+        #expect(body["entry"] as? [String] == ["e1", "e2"])
+    }
+
+    @Test("timeline decodes items and paging cursors")
+    func timelineDecodesPage() async throws {
+        let client = MicrosubClient(
+            endpoint: endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { _ in
+                let body = """
+                {"items":[{"_id":"1","url":"https://feed.example/1","name":"Hello","content":{"text":"hi"}}],"paging":{"after":"cursor-2"}}
+                """
+                return (Data(body.utf8), self.response(200))
+            }
+        )
+        let page = try await client.timeline(channel: "c1")
+
+        #expect(page.items.count == 1)
+        #expect(page.items[0].id == "1")
+        #expect(page.items[0].name == "Hello")
+        #expect(page.items[0].content?.text == "hi")
+        #expect(page.paging.after == "cursor-2")
+        #expect(page.paging.before == nil)
+    }
+
+    @Test("a non-2xx response throws .requestFailed with the status code")
+    func nonSuccessStatusThrows() async {
+        let client = MicrosubClient(
+            endpoint: endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { _ in (Data("insufficient_scope".utf8), self.response(403)) }
+        )
+        await #expect(throws: MicrosubError.requestFailed(status: 403, body: "insufficient_scope")) {
+            _ = try await client.listChannels()
+        }
+    }
+
+    @Test("an undecodable response throws .decodingFailed")
+    func undecodableResponseThrows() async {
+        let client = MicrosubClient(
+            endpoint: endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { _ in (Data("not json".utf8), self.response(200)) }
+        )
+        await #expect(throws: MicrosubError.self) {
+            _ = try await client.listChannels()
+        }
+    }
+    #endif
+}

--- a/Tests/AnglesiteCoreTests/SiteIndieAuthClientTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteIndieAuthClientTests.swift
@@ -1,0 +1,160 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests `SiteIndieAuthClient`'s pure logic — discovery parsing, authorize-URL construction,
+/// callback validation, and DPoP-bound token exchange — all against an injected `Transport`, no
+/// real network and no browser/UI (that boundary is the whole point of the type, mirroring
+/// `CloudflareOAuthClientTests`).
+@Suite(.serialized)
+struct SiteIndieAuthClientTests {
+    private let siteURL = URL(string: "https://owner.example")!
+    private let metadataURL = URL(string: "https://owner.example/.well-known/oauth-authorization-server")!
+    private let clientID = SiteIndieAuthLoopback.clientID
+    private let redirectURI = SiteIndieAuthLoopback.redirectURI
+    private let metadataJSON = Data("""
+    {"issuer":"https://owner.example","authorization_endpoint":"https://owner.example/authorize","token_endpoint":"https://owner.example/token"}
+    """.utf8)
+
+    private func response(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: metadataURL, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    // MARK: Authorization request
+
+    @Test("makeAuthorizationRequest builds a well-formed authorize URL from site metadata")
+    func buildsAuthorizeURL() async throws {
+        let client = SiteIndieAuthClient(transport: { [metadataJSON] _ in (metadataJSON, self.response(200)) })
+        let request = try await client.makeAuthorizationRequest(
+            siteURL: siteURL, scope: SiteIndieAuthLoopback.microsubScope,
+            clientID: clientID, redirectURI: redirectURI
+        )
+
+        let items = URLComponents(url: request.authorizeURL, resolvingAgainstBaseURL: false)!.queryItems!
+        func value(_ name: String) -> String? { items.first { $0.name == name }?.value }
+
+        #expect(request.authorizeURL.host == "owner.example")
+        #expect(request.authorizeURL.path == "/authorize")
+        #expect(value("response_type") == "code")
+        #expect(value("client_id") == clientID.absoluteString)
+        #expect(value("redirect_uri") == redirectURI.absoluteString)
+        #expect(value("scope") == SiteIndieAuthLoopback.microsubScope)
+        #expect(value("state") == request.state)
+        #expect(value("code_challenge_method") == "S256")
+        #expect(value("code_challenge")?.isEmpty == false)
+    }
+
+    @Test("client_id and redirect_uri share one origin, satisfying the server's same-origin redirect policy")
+    func clientIDAndRedirectShareOrigin() {
+        #expect(clientID.scheme == redirectURI.scheme)
+        #expect(clientID.host == redirectURI.host)
+        #expect(clientID.port == redirectURI.port)
+    }
+
+    @Test("discovery HTTP failure surfaces as .discoveryUnavailable")
+    func discoveryFailureSurfaces() async {
+        let client = SiteIndieAuthClient(transport: { _ in (Data(), self.response(500)) })
+        await #expect(throws: SiteIndieAuthError.self) {
+            _ = try await client.makeAuthorizationRequest(
+                siteURL: siteURL, scope: "read", clientID: clientID, redirectURI: redirectURI
+            )
+        }
+    }
+
+    // MARK: Callback validation (pure, no network)
+
+    private func makeRequest(state: String = "abc123") -> SiteIndieAuthRequest {
+        SiteIndieAuthRequest(
+            authorizeURL: URL(string: "https://owner.example/authorize")!,
+            state: state, codeVerifier: "verifier",
+            clientID: clientID, redirectURI: redirectURI,
+            tokenEndpoint: URL(string: "https://owner.example/token")!
+        )
+    }
+
+    @Test("a matching state yields the code")
+    func callbackMatchingState() throws {
+        let request = makeRequest()
+        let callback = URL(string: "http://127.0.0.1:51789/callback?code=xyz&state=abc123")!
+        #expect(try SiteIndieAuthClient.authorizationCode(from: callback, matching: request) == "xyz")
+    }
+
+    @Test("a mismatched state throws .stateMismatch, never returns the code")
+    func callbackMismatchedState() {
+        let request = makeRequest()
+        let callback = URL(string: "http://127.0.0.1:51789/callback?code=xyz&state=WRONG")!
+        #expect(throws: SiteIndieAuthError.stateMismatch) {
+            _ = try SiteIndieAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
+    @Test("an error query param throws .callbackDenied when the state matches")
+    func callbackDenied() {
+        let request = makeRequest()
+        let callback = URL(string: "http://127.0.0.1:51789/callback?error=access_denied&state=abc123")!
+        #expect(throws: SiteIndieAuthError.callbackDenied("access_denied")) {
+            _ = try SiteIndieAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
+    @Test("a matching state but missing code throws .missingAuthorizationCode")
+    func callbackMissingCode() {
+        let request = makeRequest()
+        let callback = URL(string: "http://127.0.0.1:51789/callback?state=abc123")!
+        #expect(throws: SiteIndieAuthError.missingAuthorizationCode) {
+            _ = try SiteIndieAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
+    // MARK: Token exchange
+
+    #if canImport(CryptoKit)
+    @Test("exchange posts a DPoP proof + the PKCE verifier and decodes the token, without re-fetching discovery")
+    func exchangeParsesToken() async throws {
+        let request = makeRequest()
+        let dpopKeyPair = DPoPKeyPair()
+        var capturedBody: String?
+        var capturedDPoPHeader: String?
+        var transportCallCount = 0
+        let client = SiteIndieAuthClient(transport: { req in
+            transportCallCount += 1
+            #expect(req.url == request.tokenEndpoint)
+            #expect(req.httpMethod == "POST")
+            capturedBody = req.httpBody.flatMap { String(data: $0, encoding: .utf8) }
+            capturedDPoPHeader = req.value(forHTTPHeaderField: "DPoP")
+            let body = #"{"access_token":"tok-123","token_type":"DPoP","scope":"read","me":"https://owner.example/","expires_in":3600}"#
+            return (Data(body.utf8), self.response(200))
+        })
+        let token = try await client.exchange(code: "auth-code", for: request, dpopKeyPair: dpopKeyPair)
+
+        #expect(token.accessToken == "tok-123")
+        #expect(token.tokenType == "DPoP")
+        #expect(token.scope == "read")
+        #expect(token.me == "https://owner.example/")
+        #expect(token.expiresIn == 3600)
+        #expect(capturedBody?.contains("code_verifier=verifier") == true)
+        #expect(capturedBody?.contains("code=auth-code") == true)
+        #expect(capturedBody?.contains("grant_type=authorization_code") == true)
+        #expect(capturedDPoPHeader?.split(separator: ".").count == 3)
+        #expect(transportCallCount == 1) // no second discovery round trip
+    }
+    #endif
+
+    @Test("a non-2xx token response throws .tokenExchangeFailed")
+    func exchangeHTTPFailure() async {
+        let request = makeRequest()
+        let client = SiteIndieAuthClient(transport: { _ in (Data("bad code".utf8), self.response(400)) })
+        await #expect(throws: SiteIndieAuthError.self) {
+            _ = try await client.exchange(code: "auth-code", for: request, dpopKeyPair: DPoPKeyPair())
+        }
+    }
+
+    @Test("an undecodable token response throws .tokenExchangeFailed")
+    func exchangeBadJSON() async {
+        let request = makeRequest()
+        let client = SiteIndieAuthClient(transport: { _ in (Data("not json".utf8), self.response(200)) })
+        await #expect(throws: SiteIndieAuthError.self) {
+            _ = try await client.exchange(code: "auth-code", for: request, dpopKeyPair: DPoPKeyPair())
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -737,7 +737,93 @@ struct SocialWorkerProvisionCommandTests {
         #expect(SiteConfigFile.value(forKey: "WEBSUB_ENABLED", in: disabledConfig) == "false")
     }
 
-    @Test("readPersistedResources classifies webmention and websub queues by suffix")
+    @Test("microsub worker without paid-plan acknowledgment returns the confirmation-needed gate, no wrangler call")
+    func microsubWithoutAcknowledgmentBlocksBeforeAnyCall() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                return .init(stdout: "", stderr: "unexpected call", exitCode: 1)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let microsub = WorkerDescriptor(
+            id: "microsub", displayName: "Microsub", description: "test", group: "publishing",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [microsub], acknowledgesPaidPlan: false)
+
+        guard case .webmentionPaidPlanConfirmationNeeded = result else {
+            Issue.record("expected .webmentionPaidPlanConfirmationNeeded, got \(result)")
+            return
+        }
+        #expect(calledArguments.isEmpty, "must not call wrangler before the user acknowledges the paid-plan requirement")
+    }
+
+    @Test("microsub worker with acknowledgment creates its own queue")
+    func microsubWithAcknowledgmentCreatesQueue() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                if arguments.first == "queues" {
+                    return .init(stdout: #"{"result":{"queue_name":"my-site-microsub"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let microsub = WorkerDescriptor(
+            id: "microsub", displayName: "Microsub", description: "test", group: "publishing",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [microsub], acknowledgesPaidPlan: true)
+
+        guard case .succeeded(_, let resources, _) = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(resources.microsubQueueName == "my-site-microsub")
+        #expect(calledArguments.contains(["queues", "create", "my-site-microsub", "--json"]))
+    }
+
+    @Test("an already-provisioned microsub queue is not re-created")
+    func alreadyProvisionedMicrosubQueueSkipsCreation() async throws {
+        let site = try temporaryDirectory()
+        var calledArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" },
+            runner: { _, arguments, _, _ in
+                calledArguments.append(arguments)
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let microsub = WorkerDescriptor(
+            id: "microsub", displayName: "Microsub", description: "test", group: "publishing",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false))
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [microsub], knownResources: .init(microsubQueueName: "my-site-microsub"),
+            acknowledgesPaidPlan: true)
+
+        guard case .succeeded = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        #expect(!calledArguments.contains(where: { $0.first == "queues" }))
+    }
+
+    @Test("readPersistedResources classifies webmention, websub, and microsub queues by suffix")
     func persistedQueueClassification() throws {
         let site = try temporaryDirectory()
         let toml = """
@@ -748,6 +834,9 @@ struct SocialWorkerProvisionCommandTests {
         [[queues.producers]]
         queue = "my-site-websub"
         binding = "WEBSUB_QUEUE"
+        [[queues.producers]]
+        queue = "my-site-microsub"
+        binding = "MICROSUB_QUEUE"
         """
         try toml.write(to: site.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
 
@@ -755,6 +844,7 @@ struct SocialWorkerProvisionCommandTests {
 
         #expect(resources.queueName == "my-site-webmention")
         #expect(resources.websubQueueName == "my-site-websub")
+        #expect(resources.microsubQueueName == "my-site-microsub")
     }
 
     @Test("readPersistedResources with only a websub queue leaves the webmention queue nil")

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -14,6 +14,7 @@ private let genericD1KVWorker = worker("generic-d1kv-fixture", d1: true, kv: tru
 private let indieauthWorker = worker("indieauth", d1: true, kv: true, r2: false)
 private let micropubWorker = worker("micropub", d1: true, kv: true, r2: true)
 private let websubWorker = worker("websub", d1: true, kv: true, r2: false)
+private let microsubWorker = worker(WorkerComposition.microsubWorkerID, d1: true, kv: false, r2: false)
 private let v2Workers = [genericD1KVWorker, indieauthWorker]
 private let v3Workers = [genericD1KVWorker, indieauthWorker, micropubWorker, websubWorker]
 private let webmentionWorker = worker(WorkerComposition.webmentionWorkerID, d1: false, kv: false, r2: false)
@@ -284,6 +285,70 @@ struct WorkerCompositionTests {
         let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [webmentionWorker])
         #expect(!toml.contains("[vars]"))
         #expect(!toml.contains("SITE_URL"))
+    }
+
+    // MARK: - Microsub reader (V-4.3, #365)
+
+    @Test("microsub adds a MICROSUB_DB D1 binding on the shared database")
+    func microsubAddsStoreBinding() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: [microsubWorker],
+            resources: .init(d1DatabaseID: "d1-id")
+        )
+        #expect(toml.contains("binding = \"MICROSUB_DB\""))
+        #expect(toml.contains("database_id = \"d1-id\""))
+    }
+
+    @Test("no microsub worker means no MICROSUB_DB binding or microsub queue")
+    func noMicrosubOmitsReaderBindings() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [webmentionWorker])
+        #expect(!toml.contains("MICROSUB_DB"))
+        #expect(!toml.contains("MICROSUB_QUEUE"))
+        #expect(!toml.contains("my-site-microsub"))
+    }
+
+    @Test("microsub adds its own queue producer/consumer blocks, separate from webmention's/websub's")
+    func microsubAddsQueueBlocks() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site",
+            workers: [webmentionWorker, websubWorker, microsubWorker],
+            resources: .init(
+                queueName: "my-site-webmention", websubQueueName: "my-site-websub",
+                microsubQueueName: "my-site-microsub"
+            )
+        )
+        #expect(toml.contains("binding = \"WEBMENTION_QUEUE\""))
+        #expect(toml.contains("binding = \"WEBSUB_QUEUE\""))
+        #expect(toml.contains("binding = \"MICROSUB_QUEUE\""))
+        #expect(toml.contains("queue = \"my-site-microsub\""))
+    }
+
+    @Test("microsub queue name defaults to a deterministic placeholder before provisioning")
+    func microsubQueueDefaultsUnprovisioned() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [microsubWorker])
+        #expect(toml.contains("queue = \"my-site-microsub\""))
+    }
+
+    @Test("microsub adds a Cron Trigger for the feed poller")
+    func microsubAddsCronTrigger() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [microsubWorker])
+        #expect(toml.contains("[triggers]"))
+        #expect(toml.contains("crons = [\"*/15 * * * *\"]"))
+    }
+
+    @Test("no microsub worker means no Cron Trigger")
+    func noMicrosubMeansNoCronTrigger() throws {
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [webmentionWorker])
+        #expect(!toml.contains("[triggers]"))
+    }
+
+    @Test("microsub alone (no webmention/websub) with a known site URL emits a SITE_URL var")
+    func microsubEmitsSiteURL() throws {
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [microsubWorker], siteURL: "https://my-site.example")
+        #expect(toml.contains("[vars]"))
+        #expect(toml.contains("SITE_URL = \"https://my-site.example\""))
     }
 
     @Test("micropub adds a MICROPUB_DB D1 binding on the shared database")


### PR DESCRIPTION
## Summary

- Composes `@dwk/microsub` into the per-site Worker (`MICROSUB_DB` D1 binding on the shared `{site}-social` database, a dedicated `MICROSUB_QUEUE` for feed-poll fan-out, and a Cron Trigger for the poller) the same way #360/#359 composed Micropub and inbound Webmention — including a real bug fix along the way: the `[vars] SITE_URL` emission needed to gate on `hasMicrosub` too, since the poller/queue consumer use it as their `baseUrl`/`me`.
- Adds the app-side pieces neither of those precedents needed: a `DPoPKeyPair` (RFC 9449 proof-of-possession, CryptoKit/P-256), a `SiteIndieAuthClient` (Authorization Code + PKCE + DPoP against a **site's own** IndieAuth server, RFC 8252 loopback client identity since there's no pre-registered client), and a `MicrosubClient` (follow/unfollow/channels/timeline over DPoP-bound bearer requests).
- Adds the Reader pane (**Website ▸ Reader…**): sign in (opens the site's authorize page in the system browser; the loopback redirect never resolves, so the user pastes the final URL back from the address bar), follow a feed, and read the resulting JF2 timeline — fulfilling the issue's acceptance criteria.

**Maintainer override note (per #365/#338 discussion):** this issue was labeled 🚫 Blocked, gated on `@dwk/microsub`/`@dwk/activitypub` reaching Microsub conformance in `davidwkeith/workers`' `conformance/status.json`. Per explicit maintainer direction, that gate is overridden for this PR — both `Anglesite/anglesite` and `davidwkeith/workers` are active pre-release development, and building against the already-published `@dwk/microsub@0.1.0-beta.4` now may help surface conformance bugs in the sidecar package itself.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

No MCP message schema changes — `@dwk/microsub` is already published in the `davidwkeith/workers` catalog (`catalog.json`) with a decode-compatible shape, so no catalog change was needed either. This follows the same posture as #360 (Micropub) and #359 (Webmention receive).

## Test plan

- [x] `Resources/Template`: `npx vitest run --config vitest.config.ts` — 70/70 passing (11 new Microsub cases: unauthorized rejection, channel-create + follow, empty timeline + paging shape, unknown-channel 404, `MICROSUB_DB`/`MICROSUB_QUEUE` 503 degrades, queue-consumer no-op/dispatch, scheduled-poller no-op/dispatch).
- [x] `Resources/Template`: `npx tsc --noEmit -p tsconfig.json` scoped check — no new errors from `worker.ts` (pre-existing unrelated `astro:content` errors in `src/` are untouched by this change).
- [ ] `swift test --package-path .` — **could not run**: this session has no Swift toolchain available (Linux container, no `swift` binary). New/changed Swift tests are `DPoPKeyPairTests`, `SiteIndieAuthClientTests`, `MicrosubClientTests`, plus additions to `WorkerCompositionTests`, `SocialWorkerProvisionCommandTests`, and `SiteWindowModelTests` (`presentReader` mirroring `presentCleanup`'s coverage). Please run this on a macOS checkout before merging.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **could not run**, same toolchain limitation.
- [ ] Manual smoke — **not done**, no macOS/Xcode available in this session. Worth a manual pass: Website ▸ Reader… → Sign In → approve in browser → paste callback URL → follow a feed → confirm the timeline renders. The DPoP/loopback plumbing (`DPoPKeyPair`, `SiteIndieAuthClient`) is unit-tested against injected transports but never exercised against a real deployed site in this session.

**Design notes:**
- Reader pane wiring mirrors `ProjectCleanupView`/`presentCleanup()` exactly (menu-only entry point, out-of-range `paneSelection`, `.reader` case in `MainPaneMode`) — no toolbar/View-menu segment.
- Sign-in uses a fixed, symbolic loopback `client_id`/`redirect_uri` (`http://127.0.0.1:51789/…`) rather than a real local HTTP listener: nothing needs to actually accept the connection since the browser's address bar still shows the final redirect URL after the (failed) navigation, and the user copies it back. This avoids Network.framework/NWListener code that this session couldn't compile-check.
- New Keychain slots: `SecretAccounts.indieAuthAccessToken(siteID:)` / `.indieAuthDPoPKey(siteID:)`, site-scoped and separate from the Cloudflare token.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE4cw5oaBLowiB8TzHBzBA)_