### PR TITLE
feat(#744): wire WellKnownInventory into DeployCommand's pre-build gate

### DIFF
--- a/Sources/AnglesiteApp/BlockedDeploySheetView.swift
+++ b/Sources/AnglesiteApp/BlockedDeploySheetView.swift
@@ -102,6 +102,7 @@ private struct FailureCard: View {
         case .thirdPartyScript: return "network"
         case .keystaticRoute: return "lock.shield"
         case .cspMisconfigured: return "shield.slash"
+        case .wellKnownCollision: return "exclamationmark.lock"
         case .other: return "exclamationmark.triangle"
         }
     }
@@ -115,6 +116,7 @@ private struct FailureCard: View {
         case .thirdPartyScript: return "Third-party script"
         case .keystaticRoute: return "Keystatic admin route"
         case .cspMisconfigured: return "CSP misconfigured"
+        case .wellKnownCollision: return "/.well-known/ collision"
         case .other: return "Other"
         }
     }
@@ -159,6 +161,7 @@ private struct WarningCard: View {
         case .securityTxtIssue: return "security.txt issue"
         case .mtaStsIssue: return "MTA-STS issue"
         case .thirdPartyScript: return "Third-party script"
+        case .wellKnownArtifact: return "/.well-known/ file excluded"
         case .other: return "Other"
         }
     }

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -542,6 +542,9 @@ final class DeployModel {
                     siteDirectory: deploySiteDirectory,
                     configDirectory: configDirectory,
                     currentRoutes: currentRoutes,
+                    // #744: feeds the same already-validated active route claims (#746, computed
+                    // above) into DeployCommand's pre-build /.well-known/ collision check.
+                    wellKnownDynamicClaims: WorkerRouteClaims.wellKnownClaims(routeClaims),
                     onPreflight: { [weak self] outcome in
                         Task { @MainActor in self?.onScanComplete?(outcome) }
                     },

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -98,6 +98,12 @@ public actor DeployCommand {
         /// The site's currently published route set (from `SiteContentGraph`), used only when
         /// `configDirectory` is non-nil.
         currentRoutes: [String] = [],
+        /// Effective active dynamic `/.well-known/` route claims (#746), already validated via
+        /// `WorkerRouteClaims.activeClaims` and filtered with `WorkerRouteClaims.wellKnownClaims`.
+        /// Empty means "no active dynamic well-known routes," not "skip the #744 collision check"
+        /// — the check always runs, using whatever this array and `executor.reportOwnedPathClaims()`
+        /// report.
+        wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim] = [],
         onPreflight: PreflightObserver? = nil,
         onProgress: ProgressHandler? = nil
     ) async -> Result {
@@ -123,6 +129,44 @@ public actor DeployCommand {
         // stripping unrelated secrets the developer's shell may carry. The token is added only
         // for the wrangler step below.
         let baseEnvironment = Self.hostDeployEnvironment()
+
+        // #744: validate the effective /.well-known/ inventory before spending time on a build.
+        // Static/generated rows come from whatever's already on disk in Source/public/.well-known/
+        // (which mirrors the guest's clone — see ContainerDeployExecutor's HOST-path doc comment,
+        // and note `scanUserStatic` classifies a previously-generated file like security.txt by its
+        // own marker, so a redeploy sees it correctly without this re-deriving the TS generator's
+        // activation logic); dynamic rows from the caller's already-validated active route claims;
+        // runtime rows from whatever this executor can affirmatively prove it owns (empty when
+        // unsupported or when the runtime reports no claims — either way, no reservation). A
+        // collision blocks the deploy immediately with no override, matching the design doc's "no
+        // collision precedence" (docs/superpowers/specs/2026-07-14-well-known-support-design.md).
+        // Non-fatal scan findings (a rejected symlink/oversized/percent-encoded file) are folded
+        // into the preflight outcome's warnings below rather than blocking.
+        let wellKnownScan = WellKnownInventory.scanUserStatic(
+            wellKnownDirectory: siteDirectory.appendingPathComponent("public/.well-known", isDirectory: true))
+        let wellKnownRuntimeRows = WellKnownInventory.runtimeRows(from: await executor.reportOwnedPathClaims())
+        let wellKnownDynamicRows = WellKnownInventory.dynamicRows(from: wellKnownDynamicClaims)
+        do {
+            _ = try WellKnownInventory.merge(
+                userStatic: wellKnownScan.rows.filter { $0.delivery == .userStatic },
+                generated: wellKnownScan.rows.filter { $0.delivery == .generated },
+                dynamic: wellKnownDynamicRows,
+                runtime: wellKnownRuntimeRows)
+        } catch {
+            let failure = PreDeployCheck.ScanFailure(
+                category: .wellKnownCollision,
+                message: "\(error)",
+                remediation: "Resolve the /.well-known/ ownership conflict named above (rename or remove one of the claims), then redeploy."
+            )
+            let outcome = PreDeployCheck.Outcome.blocked(failures: [failure], warnings: [])
+            onPreflight?(outcome)
+            return .blocked(failures: [failure], warnings: [])
+        }
+        let wellKnownScanWarnings = wellKnownScan.findings.map {
+            PreDeployCheck.ScanWarning(
+                category: .wellKnownArtifact, message: $0.message,
+                file: $0.path.map { "public/.well-known/\($0)" })
+        }
 
         // Build dist/ before the scan needs it. Streams to LogCenter via the executor.
         onProgress?(.deployBuilding)
@@ -157,23 +201,26 @@ public actor DeployCommand {
             source: "deploy:\(siteID):preflight"
         )
         var preflightOutcome = Self.parseScanReport(output: preflightResult.output, exitCode: preflightResult.exitCode)
+        // Swift-computed warnings, not emitted by the JS scan script — merged into the outcome
+        // the same way `RouteCoverageScanner`'s `.orphanedRoute` findings always have been.
+        var extraWarnings = wellKnownScanWarnings
         if let configDirectory {
             let previousRoutes = DeployedRoutesSnapshot.load(from: configDirectory)
             let redirects = (try? RedirectsStore(sourceDirectory: siteDirectory).load()) ?? []
-            let coverageWarnings = RouteCoverageScanner.scan(
+            extraWarnings += RouteCoverageScanner.scan(
                 currentRoutes: currentRoutes,
                 previousRoutes: previousRoutes,
                 redirectSources: Set(redirects.map(\.source))
             )
-            if !coverageWarnings.isEmpty {
-                switch preflightOutcome {
-                case .passed(let warnings):
-                    preflightOutcome = .passed(warnings: warnings + coverageWarnings)
-                case .blocked(let failures, let warnings):
-                    preflightOutcome = .blocked(failures: failures, warnings: warnings + coverageWarnings)
-                case .error:
-                    break
-                }
+        }
+        if !extraWarnings.isEmpty {
+            switch preflightOutcome {
+            case .passed(let warnings):
+                preflightOutcome = .passed(warnings: warnings + extraWarnings)
+            case .blocked(let failures, let warnings):
+                preflightOutcome = .blocked(failures: failures, warnings: warnings + extraWarnings)
+            case .error:
+                break
             }
         }
         onPreflight?(preflightOutcome)

--- a/Sources/AnglesiteCore/PreDeployCheck.swift
+++ b/Sources/AnglesiteCore/PreDeployCheck.swift
@@ -32,6 +32,11 @@ public actor PreDeployCheck {
             case thirdPartyScript = "third-party-script"
             case keystaticRoute = "keystatic-route"
             case cspMisconfigured = "csp-misconfigured"
+            /// Two or more owners claim the same effective `/.well-known/` path (or an
+            /// exact/prefix pair overlaps) — `WellKnownInventory.merge` (#744) computed this
+            /// Swift-side before build, the same way `RouteCoverageScanner`'s `.orphanedRoute`
+            /// is computed Swift-side rather than emitted by the TS scan script.
+            case wellKnownCollision = "well-known-collision"
             /// Any category code this build doesn't recognize yet — decoding falls back here
             /// instead of throwing, so a future/typo'd category can't crash the whole scan (#742).
             case other = "other"
@@ -85,6 +90,11 @@ public actor PreDeployCheck {
             /// An RFC 8461 MTA-STS configuration or generated-policy defect.
             case mtaStsIssue = "mta-sts-issue"
             case thirdPartyScript = "third-party-script"
+            /// A `/.well-known/` file `WellKnownInventory.scanUserStatic` (#744) excluded from
+            /// the inventory — a symlink, a percent-encoded-looking name, an oversized file, or a
+            /// path that resolves outside the scanned root. Advisory: the file is simply left out
+            /// of the effective inventory, not itself a collision.
+            case wellKnownArtifact = "well-known-artifact"
             /// Any category code this build doesn't recognize yet — decoding falls back here
             /// instead of throwing, so a future/typo'd category can't crash the whole scan (#742).
             case other = "other"

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -435,6 +435,12 @@ public actor SocialWorkerProvisionCommand {
         return ProcessSupervisor.RunResult(stdout: reason, stderr: "", exitCode: 127)
     }
 
+    // Calls `DeployCommand.deploy` with its defaults: no `configDirectory` (route-coverage
+    // scanning skipped, #530) and no `wellKnownDynamicClaims` (#744's pre-build /.well-known/
+    // collision check still runs — `scanUserStatic` and `executor.reportOwnedPathClaims()` don't
+    // need it — but with no visibility into this deploy's active dynamic Worker routes, so a
+    // static/dynamic collision on this path isn't caught pre-build). `DeployModel.runDeploy`
+    // constructs its own deployer closure specifically to thread both through.
     public static let defaultDeployer: Deployer = { token, siteID, siteDirectory in
         await DeployCommand(tokenSource: { token }).deploy(siteID: siteID, siteDirectory: siteDirectory)
     }

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -136,7 +136,7 @@ struct DeployCommandTests {
 
     /// A fresh temp site directory (unlike the shared `tmpDir`, isolated per test) with the given
     /// `public/.well-known/<relative path>: content` files written.
-    private func makeSiteDirectory(wellKnownFiles: [String: String] = [:]) throws -> URL {
+    private func makeWellKnownSiteDirectory(wellKnownFiles: [String: String] = [:]) throws -> URL {
         let siteDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("DeployCommandTests-\(UUID().uuidString)", isDirectory: true)
         let wellKnownDir = siteDirectory.appendingPathComponent("public/.well-known", isDirectory: true)
@@ -151,7 +151,7 @@ struct DeployCommandTests {
 
     @Test("a committed static file colliding with a runtime-reported claim blocks before build runs")
     func wellKnownCollisionBlocksBeforeBuild() async throws {
-        let siteDirectory = try makeSiteDirectory(wellKnownFiles: ["acme-challenge/mine": "token"])
+        let siteDirectory = try makeWellKnownSiteDirectory(wellKnownFiles: ["acme-challenge/mine": "token"])
         defer { try? FileManager.default.removeItem(at: siteDirectory) }
         let exec = FakeExecutor()
             .withRuntimeClaims([RuntimeOwnedPathClaim(
@@ -171,7 +171,7 @@ struct DeployCommandTests {
 
     @Test("an active dynamic route claim colliding with a runtime reservation blocks before build")
     func wellKnownDynamicRuntimeCollisionBlocks() async throws {
-        let siteDirectory = try makeSiteDirectory()
+        let siteDirectory = try makeWellKnownSiteDirectory()
         defer { try? FileManager.default.removeItem(at: siteDirectory) }
         let exec = FakeExecutor()
             .withRuntimeClaims([RuntimeOwnedPathClaim(
@@ -191,7 +191,7 @@ struct DeployCommandTests {
 
     @Test("a rejected well-known file (symlink) becomes an advisory warning, not a blocker")
     func wellKnownScanFindingBecomesWarning() async throws {
-        let siteDirectory = try makeSiteDirectory()
+        let siteDirectory = try makeWellKnownSiteDirectory()
         defer { try? FileManager.default.removeItem(at: siteDirectory) }
         let wellKnownDir = siteDirectory.appendingPathComponent("public/.well-known", isDirectory: true)
         let outside = siteDirectory.appendingPathComponent("secret")
@@ -220,7 +220,7 @@ struct DeployCommandTests {
 
     @Test("no well-known content and no claims deploys unaffected")
     func wellKnownCheckIsNoOpWhenEmpty() async throws {
-        let siteDirectory = try makeSiteDirectory()
+        let siteDirectory = try makeWellKnownSiteDirectory()
         defer { try? FileManager.default.removeItem(at: siteDirectory) }
         let exec = FakeExecutor()
             .set(.build, exitCode: 0, output: "")

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -21,8 +21,21 @@ struct DeployCommandTests {
         /// Optional hook fired (inside `run`) when a given step runs — used to assert a step is
         /// NOT reached (the parallel to the old `confirmation(expectedCount: 0)` resolver guards).
         private var onRun: [String: @Sendable () -> Void] = [:]
+        /// Fed back by `reportOwnedPathClaims()` — #744's pre-build well-known collision check.
+        private var runtimeClaims: [RuntimeOwnedPathClaim] = []
 
         init() {}
+
+        @discardableResult
+        func withRuntimeClaims(_ claims: [RuntimeOwnedPathClaim]) -> FakeExecutor {
+            lock.lock(); runtimeClaims = claims; lock.unlock()
+            return self
+        }
+
+        func reportOwnedPathClaims() async -> [RuntimeOwnedPathClaim] {
+            lock.lock(); defer { lock.unlock() }
+            return runtimeClaims
+        }
 
         private func key(_ step: DeployStep) -> String {
             switch step {
@@ -117,6 +130,107 @@ struct DeployCommandTests {
         #expect(exec.environment(for: .build)?["CLOUDFLARE_API_TOKEN"] == nil)
         #expect(exec.environment(for: .preflight)?["CLOUDFLARE_API_TOKEN"] == nil)
         #expect(exec.environment(for: .wrangler)?["CLOUDFLARE_API_TOKEN"] == "secret-tok")
+    }
+
+    // MARK: #744 well-known collision check
+
+    /// A fresh temp site directory (unlike the shared `tmpDir`, isolated per test) with the given
+    /// `public/.well-known/<relative path>: content` files written.
+    private func makeSiteDirectory(wellKnownFiles: [String: String] = [:]) throws -> URL {
+        let siteDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DeployCommandTests-\(UUID().uuidString)", isDirectory: true)
+        let wellKnownDir = siteDirectory.appendingPathComponent("public/.well-known", isDirectory: true)
+        try FileManager.default.createDirectory(at: wellKnownDir, withIntermediateDirectories: true)
+        for (relativePath, content) in wellKnownFiles {
+            let fileURL = wellKnownDir.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        return siteDirectory
+    }
+
+    @Test("a committed static file colliding with a runtime-reported claim blocks before build runs")
+    func wellKnownCollisionBlocksBeforeBuild() async throws {
+        let siteDirectory = try makeSiteDirectory(wellKnownFiles: ["acme-challenge/mine": "token"])
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = FakeExecutor()
+            .withRuntimeClaims([RuntimeOwnedPathClaim(
+                id: "acme", owner: "cloudflare-managed-tls", path: "acme-challenge/", match: .prefix,
+                capability: "RFC 8555 managed-TLS ownership")])
+            .set(.build, exitCode: 0, output: "should not run")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDirectory)
+        guard case .blocked(let failures, _) = result else {
+            Issue.record("expected .blocked, got \(result)"); return
+        }
+        #expect(failures.count == 1)
+        #expect(failures.first?.category == .wellKnownCollision)
+        #expect(failures.first?.message.contains("acme-challenge/mine") == true)
+        #expect(!exec.ran(.build), "a declared collision must block before spending time on a build")
+    }
+
+    @Test("an active dynamic route claim colliding with a runtime reservation blocks before build")
+    func wellKnownDynamicRuntimeCollisionBlocks() async throws {
+        let siteDirectory = try makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = FakeExecutor()
+            .withRuntimeClaims([RuntimeOwnedPathClaim(
+                id: "acme", owner: "cloudflare-managed-tls", path: "acme-challenge/", match: .prefix,
+                capability: "RFC 8555 managed-TLS ownership")])
+            .set(.build, exitCode: 0, output: "should not run")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let claim = WorkerRouteClaims.OwnedClaim(
+            owner: "some-worker",
+            claim: WorkerRouteClaim(path: "/.well-known/acme-challenge/http-01", match: .exact, methods: ["GET"], handler: "h"))
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDirectory, wellKnownDynamicClaims: [claim])
+        guard case .blocked = result else {
+            Issue.record("expected .blocked, got \(result)"); return
+        }
+        #expect(!exec.ran(.build))
+    }
+
+    @Test("a rejected well-known file (symlink) becomes an advisory warning, not a blocker")
+    func wellKnownScanFindingBecomesWarning() async throws {
+        let siteDirectory = try makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let wellKnownDir = siteDirectory.appendingPathComponent("public/.well-known", isDirectory: true)
+        let outside = siteDirectory.appendingPathComponent("secret")
+        try "shh".write(to: outside, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: wellKnownDir.appendingPathComponent("linked"), withDestinationURL: outside)
+
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        var observedOutcome: PreDeployCheck.Outcome?
+        let result = await cmd.deploy(
+            siteID: "s", siteDirectory: siteDirectory,
+            onPreflight: { observedOutcome = $0 })
+        guard case .succeeded = result else {
+            Issue.record("expected .succeeded (a rejected file is advisory, not blocking), got \(result)"); return
+        }
+        guard case .passed(let warnings) = observedOutcome else {
+            Issue.record("expected .passed with warnings, got \(String(describing: observedOutcome))"); return
+        }
+        #expect(warnings.contains { $0.category == .wellKnownArtifact })
+        #expect(exec.ran(.build) && exec.ran(.preflight) && exec.ran(.wrangler))
+    }
+
+    @Test("no well-known content and no claims deploys unaffected")
+    func wellKnownCheckIsNoOpWhenEmpty() async throws {
+        let siteDirectory = try makeSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDirectory)
+        guard case .succeeded = result else {
+            Issue.record("expected .succeeded, got \(result)"); return
+        }
     }
 
     // MARK: Host environment curation


### PR DESCRIPTION
## Summary

- Follow-up to #930 (merged): wires `WellKnownInventory` (the portable `/.well-known/` descriptor + collision core) into `DeployCommand.deploy`'s actual sequence, per the follow-up called out in that PR's description.
- `DeployCommand.deploy` now runs a `WellKnownInventory.merge` collision check right before the build step: static/generated rows from a scan of `Source/public/.well-known/`, dynamic rows from the caller's already-validated active route claims (new `wellKnownDynamicClaims` param), and runtime rows from `executor.reportOwnedPathClaims()` (#748). A collision blocks the deploy immediately — no build spent — via a new `ScanFailure.Category.wellKnownCollision`. Non-fatal scan findings (a rejected symlink/oversized/percent-encoded file) fold into the preflight outcome as a new `ScanWarning.Category.wellKnownArtifact`, the same way `RouteCoverageScanner`'s `.orphanedRoute` findings already do.
- `DeployModel.runDeploy` threads its already-computed `WorkerRouteClaims.OwnedClaim`s through via `WorkerRouteClaims.wellKnownClaims`.
- The secondary headless path (`SocialWorkerProvisionCommand.defaultDeployer` / `SiteOperations.deployWithWorkerComposition`) still runs the static/runtime half of the check but has no dynamic-claim visibility — documented in a comment mirroring the existing `configDirectory` gap already accepted for that same path (#530).

**Deliberately not in scope here:** calling `executor.runBuildWithClaimManifest` and verifying observed build artifacts against the expected static/generated set (`WellKnownInventory.verifyBuildArtifacts`). There's no template-side script yet that reads the claim manifest and reports findings back (the design doc's `scripts/well-known.ts`), so `WellKnownBuildSeamResult` would always come back empty — wiring the post-build verification now would false-flag "missing artifact" on every single deploy that has any `.well-known` content (i.e. almost every site, since `security.txt` is the baseline generator). That's separate follow-up work gated on the template producer existing. Leaving #744 open for that piece.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — `AnglesiteCoreTests` isn't in the Linux-portable target set (same constraint as #930), so I verified the new `DeployCommandTests.swift` scenarios (collision blocks before build, dynamic/runtime collision blocks, a rejected file becomes an advisory warning not a blocker, no-op when there's no `.well-known` content) via a standalone scratch executable linked against the portable `AnglesiteCore` library — all passed. The full portable suite (`AnglesiteSiteModelTests`, `AnglesiteQuickLookSupportTests`, `AnglesiteBridgeCoreTests`) passes with no regressions.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (no Xcode/macOS in this session's environment). `DeployModel.swift` (`AnglesiteApp` target) couldn't be locally type-checked for the same reason; reviewed by hand against `DeployCommand`'s new signature.
- [ ] Manual smoke: n/a — no UI surface change in this PR.

Progresses #744 (`.well-known` inventory) and, transitively, #366 (WebFinger).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRGRLNZ498PE5wC5Zx6YyT)_