### PR TITLE
fix(reader): validate callback URL against redirectURI

### DIFF
--- a/Sources/AnglesiteCore/SiteIndieAuthClient.swift
+++ b/Sources/AnglesiteCore/SiteIndieAuthClient.swift
@@ -60,6 +60,9 @@ public enum SiteIndieAuthError: Error, Equatable, Sendable {
     case tokenExchangeFailed(String)
     /// Signing the DPoP proof needs CryptoKit (Apple platforms only).
     case dpopUnavailable
+    /// The pasted-back URL's scheme/host/port/path don't match `request.redirectURI` — not the
+    /// callback URL for this sign-in attempt (e.g. pasted from a stale browser tab).
+    case redirectURIMismatch
 }
 
 /// One authorize attempt: the URL to present plus what's needed to complete it once a callback
@@ -151,10 +154,22 @@ public struct SiteIndieAuthClient: Sendable {
         )
     }
 
-    /// Extracts and validates the authorization code from the loopback listener's captured
-    /// callback URL against the `state` minted for `request`. Pure URL parsing, mirrors
-    /// `CloudflareOAuthClient.authorizationCode(from:matching:)`.
+    /// Extracts and validates the authorization code from the pasted-back callback URL against
+    /// `request`. Pure URL parsing, mirrors `CloudflareOAuthClient.authorizationCode(from:matching:)`
+    /// plus one check that type has no equivalent for: since the user manually copies this URL
+    /// from the browser address bar (there's no automatic capture — see `SiteIndieAuthLoopback`),
+    /// a stale tab or the wrong copy/paste could hand this a URL that isn't the callback at all.
+    /// Checking `redirectURI` first, before even reading `state`, turns that into a clear
+    /// `.redirectURIMismatch` instead of a confusing `.stateMismatch`.
     public static func authorizationCode(from callbackURL: URL, matching request: SiteIndieAuthRequest) throws -> String {
+        guard callbackURL.scheme == request.redirectURI.scheme,
+              callbackURL.host == request.redirectURI.host,
+              callbackURL.port == request.redirectURI.port,
+              callbackURL.path == request.redirectURI.path
+        else {
+            throw SiteIndieAuthError.redirectURIMismatch
+        }
+
         let items = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
         func value(_ name: String) -> String? { items.first { $0.name == name }?.value }
 

--- a/Tests/AnglesiteCoreTests/SiteIndieAuthClientTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteIndieAuthClientTests.swift
@@ -79,6 +79,25 @@ struct SiteIndieAuthClientTests {
         #expect(try SiteIndieAuthClient.authorizationCode(from: callback, matching: request) == "xyz")
     }
 
+    @Test("a URL that isn't the redirect URI throws .redirectURIMismatch, even with a matching state/code")
+    func callbackWrongRedirectURI() {
+        let request = makeRequest()
+        // A plausible "pasted the wrong tab" mistake: right query params, wrong origin entirely.
+        let callback = URL(string: "https://accounts.example.com/oauth/callback?code=xyz&state=abc123")!
+        #expect(throws: SiteIndieAuthError.redirectURIMismatch) {
+            _ = try SiteIndieAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
+    @Test("a URL on the right host but wrong path throws .redirectURIMismatch")
+    func callbackWrongPath() {
+        let request = makeRequest()
+        let callback = URL(string: "http://127.0.0.1:51789/not-the-callback?code=xyz&state=abc123")!
+        #expect(throws: SiteIndieAuthError.redirectURIMismatch) {
+            _ = try SiteIndieAuthClient.authorizationCode(from: callback, matching: request)
+        }
+    }
+
     @Test("a mismatched state throws .stateMismatch, never returns the code")
     func callbackMismatchedState() {
         let request = makeRequest()


### PR DESCRIPTION
## Summary

- Review follow-up on #932 (merged): `SiteIndieAuthClient.authorizationCode(from:matching:)` now checks the pasted-back callback URL's scheme/host/port/path against `request.redirectURI` *before* reading `state`/`code`, so pasting the wrong URL (e.g. from a stale browser tab) fails with a clear new `.redirectURIMismatch` error instead of a confusing `.stateMismatch`.
- Addresses @davidwkeith's inline review comment on #932 (`SiteIndieAuthClient.swift:162`): "a defense-in-depth check here would guard against a user pasting the wrong URL... and getting a confusing downstream error instead of a clear message."
- Two new test cases (`callbackWrongRedirectURI`, `callbackWrongPath`) covering a completely different origin and a same-host-wrong-path mismatch; existing callback tests are unaffected since their fixture URLs already match `SiteIndieAuthLoopback.redirectURI` exactly.

**Not addressed here, left as a possible fast-follow:** the review's other flag — no RFC 9449 §8 DPoP-nonce challenge/retry handling in `SiteIndieAuthClient`/`MicrosubClient`. Per the review's own hedge, I confirmed directly against the `@dwk/indieauth`/`@dwk/microsub` source (`handler.ts`'s token endpoint, `auth.ts`'s `authorize`) that neither ever passes `expectedNonce` to `verifyDpopProof` today, so there is no live server-side nonce challenge to handle yet. Happy to file a tracking issue if wanted.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

No MCP or catalog changes — pure client-side URL validation.

## Test plan

- [ ] `swift test --package-path .` — **could not run**: this session has no Swift toolchain available (Linux container, no `swift` binary). New tests are `SiteIndieAuthClientTests.callbackWrongRedirectURI` / `.callbackWrongPath`; existing `SiteIndieAuthClientTests` callback-validation cases are unaffected (their fixtures already match `redirectURI`).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **could not run**, same toolchain limitation. Note: #932's `build-test` CI lane (macOS, `swift test`/`xcodebuild` debug+release) passed cleanly on the code this PR is a small diff against, so the surrounding code is verified even though this specific diff isn't yet.
- [ ] Manual smoke — not done, no macOS/Xcode available in this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE4cw5oaBLowiB8TzHBzBA)_