### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Anglesite/Anglesite-app/security/code-scanning/7](https://github.com/Anglesite/Anglesite-app/security/code-scanning/7)

Add an explicit `permissions` block to the workflow so all jobs (including `ci`) inherit restricted token scopes.  
Best single fix without changing functionality: add root-level:

- `permissions:`
  - `contents: read`

This is sufficient for checkout/read operations and keeps token rights minimal.  
Edit location: `.github/workflows/ci.yml`, directly after the `on:` trigger block (before `concurrency:` is a clean, conventional placement).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
