### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through a stack trace

### DIFF
--- a/Spikes/CloudflareSandboxSpike/src/index.ts
+++ b/Spikes/CloudflareSandboxSpike/src/index.ts
@@ -217,7 +217,8 @@ export default {
           return json({ error: "not found", try: "/" }, 404);
       }
     } catch (e) {
-      return json({ error: String(e), stack: e instanceof Error ? e.stack : undefined }, 500);
+      console.error("Sandbox spike request failed", e);
+      return json({ error: "internal server error" }, 500);
     }
   },
 };


### PR DESCRIPTION
## Summary

- Fixes [code scanning alert #8](https://github.com/Anglesite/Anglesite-app/security/code-scanning/8) (information exposure through a stack trace) in `Spikes/CloudflareSandboxSpike/src/index.ts`.
- The top-level request handler's `catch` block returned `{ error: String(e), stack: e instanceof Error ? e.stack : undefined }` to the client, leaking internal stack traces to callers of the spike Worker.
- Now logs the error server-side with `console.error("Sandbox spike request failed", e)` and returns a generic `{ error: "internal server error" }` with a 500 status, preserving troubleshooting via `wrangler tail` without exposing internals.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

Not applicable — this is a one-line hardening fix in the throwaway Cloudflare Sandbox spike (`Spikes/CloudflareSandboxSpike/`, #61), not an MCP message or template change.

## Test plan

- [ ] `swift test --package-path .` — not applicable, no Swift changes.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not applicable, no Swift changes.
- [x] `npx tsc --noEmit` in `Spikes/CloudflareSandboxSpike/` — passes with no errors.
- [x] All CI checks on this PR (CodeQL, `CI required checks`, `Analyze (javascript-typescript)`, `Analyze (actions)`, `Analyze (swift)`, `Detect changed paths`) are green; the rest are skipped because this PR only touches an unreferenced spike path.

Note: `npm install` in this spike currently hits a pre-existing peer-dependency conflict between `wrangler@4.114.0` and the pinned `@cloudflare/workers-types` version (unrelated to this change, needs `--legacy-peer-deps`); not addressed here since it's out of scope for this fix and this spike has no CI coverage.
