### PR TITLE
fix(#363): normalize catalog prefix-route trailing slash

### DIFF
--- a/Sources/AnglesiteCore/WorkerCatalog.swift
+++ b/Sources/AnglesiteCore/WorkerCatalog.swift
@@ -174,7 +174,9 @@ public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
 
     /// Absolute origin path, e.g. `"/.well-known/webfinger"`. Validated by
     /// `WorkerRouteClaims.validate` (leading slash, no traversal/encoding/query, no root or bare
-    /// `/.well-known` claims).
+    /// `/.well-known` claims). A `prefix` claim's trailing slash — the `davidwkeith/workers`
+    /// catalog's published convention (`spec/catalog.md`: "a prefix path ends with `/`") — is
+    /// stripped on construction so this always holds the app's own slash-less canonical form.
     public let path: String
     public let match: Match
     /// Uppercase HTTP methods the handler serves. `HEAD` must be declared explicitly to be
@@ -205,7 +207,7 @@ public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
         authorityBinding: Bool = false,
         specificationURL: URL? = nil
     ) {
-        self.path = path
+        self.path = Self.normalizedPrefixPath(path, match: match)
         self.match = match
         self.methods = methods
         self.handler = handler
@@ -220,13 +222,25 @@ public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        path = try container.decode(String.self, forKey: .path)
-        match = try container.decode(Match.self, forKey: .match)
+        let decodedPath = try container.decode(String.self, forKey: .path)
+        let decodedMatch = try container.decode(Match.self, forKey: .match)
+        path = Self.normalizedPrefixPath(decodedPath, match: decodedMatch)
+        match = decodedMatch
         methods = try container.decode([String].self, forKey: .methods)
         handler = try container.decode(String.self, forKey: .handler)
         validatorID = try container.decodeIfPresent(String.self, forKey: .validatorID)
         authorityBinding = try container.decodeIfPresent(Bool.self, forKey: .authorityBinding) ?? false
         specificationURL = try container.decodeIfPresent(URL.self, forKey: .specificationURL)
+    }
+
+    /// Strips a single trailing slash from a `prefix` claim's path — the `davidwkeith/workers`
+    /// catalog declares prefix paths with a trailing slash (`spec/catalog.md`), while
+    /// `WorkerRouteClaims.validate` and `runWorkerFirstPatterns` expect the slash-less form and
+    /// append their own `/*` glob. `exact` claims and the bare root are left untouched so a
+    /// genuinely malformed exact-match trailing slash still fails validation.
+    private static func normalizedPrefixPath(_ path: String, match: Match) -> String {
+        guard match == .prefix, path.count > 1, path.hasSuffix("/") else { return path }
+        return String(path.dropLast())
     }
 }
 

--- a/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCatalogTests.swift
@@ -306,6 +306,38 @@ struct WorkerCatalogReaderTests {
         #expect(decoded == original)
     }
 
+    @Test("decoding a prefix route strips the published trailing slash (davidwkeith/workers spec/catalog.md convention)")
+    func decodingPrefixRouteStripsTrailingSlash() throws {
+        let json = Data("""
+        {
+          "workers": [
+            {
+              "id": "activitypub",
+              "package": "@dwk/activitypub",
+              "displayName": "Fediverse",
+              "description": "ActivityPub actor",
+              "group": "social",
+              "binding": { "kind": "settingsActivated" },
+              "resources": { "needsD1": false, "needsKV": false, "needsR2": false },
+              "routes": [
+                {
+                  "path": "/users/",
+                  "match": "prefix",
+                  "methods": ["GET"],
+                  "handler": "createActivityPub",
+                  "specificationURL": "https://www.w3.org/TR/activitypub/"
+                }
+              ]
+            }
+          ]
+        }
+        """.utf8)
+
+        let workers = try WorkerCatalogReader.parse(json)
+        let route = try #require(workers.first?.routes?.first)
+        #expect(route.path == "/users")
+    }
+
     @Test("route claims round-trip through JSONEncoder/JSONDecoder")
     func routeClaimRoundTrip() throws {
         let claim = WorkerRouteClaim(

--- a/Tests/AnglesiteCoreTests/WorkerRouteClaimsTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerRouteClaimsTests.swift
@@ -119,6 +119,25 @@ struct WorkerRouteClaimsTests {
         #expect(claims.count == 1)
     }
 
+    @Test("normalizes a published prefix claim's trailing slash (davidwkeith/workers catalog convention)")
+    func normalizesPrefixTrailingSlash() throws {
+        let claims = try WorkerRouteClaims.activeClaims(
+            catalog: [descriptor(id: "activitypub", routes: [
+                claim("/users/", match: .prefix, specificationURL: spec)
+            ])],
+            activeIDs: ["activitypub"])
+        #expect(claims.map(\.claim.path) == ["/users"])
+    }
+
+    @Test("an exact claim's trailing slash is still rejected — normalization is prefix-only")
+    func exactClaimTrailingSlashStillRejected() {
+        #expect(throws: WorkerRouteClaims.ValidationError.self) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [descriptor(id: "w", routes: [claim("/users/", match: .exact)])],
+                activeIDs: ["w"])
+        }
+    }
+
     // MARK: Overlap rejection
 
     @Test("rejects two exact claims for the same path, naming both owners")
@@ -227,6 +246,14 @@ struct WorkerRouteClaimsTests {
     @Test("no claims yields no patterns")
     func emptyPatterns() {
         #expect(WorkerRouteClaims.runWorkerFirstPatterns([]).isEmpty)
+    }
+
+    @Test("a catalog-style prefix claim with a trailing slash yields a clean glob, not a doubled slash")
+    func runWorkerFirstPatternsNormalizesCatalogPrefix() {
+        let patterns = WorkerRouteClaims.runWorkerFirstPatterns([
+            claim("/users/", match: .prefix, specificationURL: spec)
+        ])
+        #expect(patterns == ["/users", "/users/*"])
     }
 
     // MARK: #744 seam


### PR DESCRIPTION
## Summary

- davidwkeith/workers' published catalog.json declares every match: "prefix" route with a trailing slash (spec/catalog.md: "a prefix path ends with /"; enforced by that repo's own scripts/catalog-gate.mjs), but WorkerRouteClaims.validate unconditionally rejected any trailing slash - so every deploy activating a prefix-route worker was refused with .invalidPath. This wasn't unique to activitypub (flagged in #931's PR body): it also blocks micropub (/media/), mastodon-api (/api/v1/, /api/v2/), solid-pod (/pod/), webdav (/dav/), remotestorage (/storage/), and atproto-pds (/xrpc/).
- Fix: strip a single trailing slash from match: .prefix claims at WorkerRouteClaim construction (both the JSON-decoding initializer and the memberwise one), landing on the app's existing slash-less canonical form that WorkerRouteClaims.validate and runWorkerFirstPatterns already assume. match: .exact claims are untouched, so a genuinely malformed exact-match trailing slash still fails.
- This closes #363 - the app-side ActivityPub actor work (#931) was already merged; this was the one thing standing between it and an actual deploy.

## Paired PR check

- [x] This change is self-contained to Anglesite-app.
- [ ] This change needs a paired PR in Anglesite/anglesite (MCP sidecar server).

No MCP schema change, and no change to the davidwkeith/workers catalog either - the fix normalizes the already-published, spec-documented, gate-enforced catalog shape on the app side rather than asking a third repo to change its own also internally-consistent contract.

## Test plan

- [x] swift test --package-path . - new tests added in WorkerCatalogTests.swift (decode-time normalization) and WorkerRouteClaimsTests.swift (validation + runWorkerFirstPatterns glob generation), watched RED before the fix, GREEN after. Full AnglesiteCoreTests target: 2477 tests passing, no regressions.
- [x] xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build - BUILD SUCCEEDED.
- [ ] Manual smoke: not performed (no UI surface - this is a pure data-normalization fix in the catalog decode/validation path).

Closes #363
