### PR TITLE
fix(#934): thread wellKnownDynamicClaims into headless deploy

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -541,7 +541,7 @@ final class DeployModel {
             tokenSource: { [weak self] in try await self?.command.tokenSource() },
             runner: containerRunner ?? SocialWorkerProvisionCommand.defaultRunner,
             secretRunner: containerSecretRunner ?? SocialWorkerProvisionCommand.defaultSecretRunner,
-            deployer: { [weak self] _, deploySiteID, deploySiteDirectory in
+            deployer: { [weak self] _, deploySiteID, deploySiteDirectory, _ in
                 await activeCommand.deploy(
                     siteID: deploySiteID,
                     siteDirectory: deploySiteDirectory,

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -121,7 +121,12 @@ public struct SiteOperations: Sendable {
             siteName: workerSiteName,
             workers: workers,
             routeClaims: routeClaims.map(\.claim),
-            knownResources: settings.provisionedWorkerResources ?? .init()
+            knownResources: settings.provisionedWorkerResources ?? .init(),
+            // #934: this headless path (App Intents/Shortcuts/Siri) now sees the same active
+            // dynamic /.well-known/ claims the GUI Deploy button already threads via
+            // `DeployModel.runDeploy`'s custom deployer closure, so #744's collision check blocks
+            // identically regardless of trigger.
+            wellKnownDynamicClaims: WorkerRouteClaims.wellKnownClaims(routeClaims)
         )
         onProgress?(.deployFinalizing)
 

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -58,7 +58,8 @@ public actor SocialWorkerProvisionCommand {
     public typealias Deployer = @Sendable (
         _ token: String,
         _ siteID: String,
-        _ siteDirectory: URL
+        _ siteDirectory: URL,
+        _ wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim]
     ) async -> DeployCommand.Result
 
     public nonisolated let tokenSource: TokenSource
@@ -110,7 +111,14 @@ public actor SocialWorkerProvisionCommand {
         /// the Cloudflare Workers Paid plan (#359) — `DeployModel` sets this from
         /// `SiteSettings.webmentionReceivePaidPlanAcknowledged` plus the in-flight confirmation
         /// sheet's "Enable & retry" action. Ignored unless a `webmention` worker is active.
-        acknowledgesPaidPlan: Bool = false
+        acknowledgesPaidPlan: Bool = false,
+        /// Effective active dynamic `/.well-known/` route claims (#746), with owner attribution —
+        /// forwarded verbatim to `deployer` for `DeployCommand.deploy`'s pre-build #744 collision
+        /// check, the same way `DeployModel.runDeploy`'s custom deployer closure already threads
+        /// `WorkerRouteClaims.wellKnownClaims(routeClaims)` for the GUI path (#934). Distinct from
+        /// `routeClaims` above (`[WorkerRouteClaim]`, used only to compose `wrangler.toml`)
+        /// because the collision check needs the `OwnedClaim` wrapper's owner attribution.
+        wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim] = []
     ) async -> Result {
         let token: String?
         do {
@@ -345,7 +353,7 @@ public actor SocialWorkerProvisionCommand {
             }
         }
 
-        switch await deployer(token, siteID, siteDirectory) {
+        switch await deployer(token, siteID, siteDirectory, wellKnownDynamicClaims) {
         case .succeeded(let url, _):
             return .succeeded(url: url, resources: resources, duration: Date().timeIntervalSince(started))
         case .blocked(let failures, let warnings):
@@ -537,14 +545,15 @@ public actor SocialWorkerProvisionCommand {
         try ActivityPubKeyProvisioning.secrets(siteID: siteID, secretStore: PlatformSecretStore.make())
     }
 
-    // Calls `DeployCommand.deploy` with its defaults: no `configDirectory` (route-coverage
-    // scanning skipped, #530) and no `wellKnownDynamicClaims` (#744's pre-build /.well-known/
-    // collision check still runs — `scanUserStatic` and `executor.reportOwnedPathClaims()` don't
-    // need it — but with no visibility into this deploy's active dynamic Worker routes, so a
-    // static/dynamic collision on this path isn't caught pre-build). `DeployModel.runDeploy`
-    // constructs its own deployer closure specifically to thread both through.
-    public static let defaultDeployer: Deployer = { token, siteID, siteDirectory in
-        await DeployCommand(tokenSource: { token }).deploy(siteID: siteID, siteDirectory: siteDirectory)
+    // Calls `DeployCommand.deploy` with `configDirectory` still defaulted (route-coverage
+    // scanning skipped, #530), but now forwards `wellKnownDynamicClaims` through to #744's
+    // pre-build /.well-known/ collision check (#934) — `provision`'s caller supplies whatever
+    // active dynamic-route claims it computed (empty if it didn't, matching prior behavior).
+    // `DeployModel.runDeploy` still constructs its own deployer closure (for `configDirectory`/
+    // `onPreflight`/`onProgress`, which this default has no equivalent for).
+    public static let defaultDeployer: Deployer = { token, siteID, siteDirectory, wellKnownDynamicClaims in
+        await DeployCommand(tokenSource: { token }).deploy(
+            siteID: siteID, siteDirectory: siteDirectory, wellKnownDynamicClaims: wellKnownDynamicClaims)
     }
 }
 

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -366,6 +366,48 @@ struct SiteOperationsTests {
         ])
     }
 
+    @Test("headless deploy forwards active /.well-known/ route claims to the deployer (#934)")
+    func headlessDeployForwardsWellKnownDynamicClaimsToDeployer() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Blue Bottle Cafe", packageURL: package)
+        let configStore = SiteConfigStore(configDirectory: site.configDirectory)
+        try await configStore.save(SiteSettings(activeWorkerIDs: ["webfinger"]))
+
+        let webfingerRoute = WorkerRouteClaim(
+            path: "/.well-known/webfinger", match: .exact, methods: ["GET"], handler: "webfinger")
+        let webfingerWorker = WorkerDescriptor(
+            id: "webfinger", displayName: "webfinger", description: "test fixture", group: "social",
+            binding: .settingsActivated, resources: .init(needsD1: false, needsKV: false, needsR2: false),
+            routes: [webfingerRoute]
+        )
+
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(
+            factory: SocialWorkerFactory(recorder: recorder),
+            store: throwawayStore(),
+            socialWorkerAccess: { site, store, body in try await SiteAccess.withScopedAccess(to: site, in: store, body) },
+            cachedWorkerCatalog: { [webfingerWorker] }
+        )
+
+        let result = await ops.deploy(site: site)
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        // Mirrors DeployModel.runDeploy's GUI-path wiring (#744/#746): the headless deploy path
+        // (App Intents/Shortcuts/Siri, #934) must see the same active dynamic /.well-known/
+        // route claims, or a static/dynamic collision that the GUI Deploy button would block
+        // could slip through here.
+        #expect(await recorder.deployCalls == [
+            .init(
+                token: "token", siteID: "s1", siteDirectory: site.sourceDirectory,
+                wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim(owner: "webfinger", claim: webfingerRoute)]
+            ),
+        ])
+    }
+
     @Test("headless deploy with no activated workers still deploys through the plain static path")
     func headlessDeployWithNoActiveWorkers() async throws {
         let package = try temporaryPackage()
@@ -421,8 +463,13 @@ private actor SocialWorkerRecorder {
         }
     }
 
-    func deploy(token: String, siteID: String, siteDirectory: URL) -> DeployCommand.Result {
-        seenDeployCalls.append(.init(token: token, siteID: siteID, siteDirectory: siteDirectory))
+    func deploy(
+        token: String, siteID: String, siteDirectory: URL,
+        wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim]
+    ) -> DeployCommand.Result {
+        seenDeployCalls.append(.init(
+            token: token, siteID: siteID, siteDirectory: siteDirectory,
+            wellKnownDynamicClaims: wellKnownDynamicClaims))
         return .succeeded(url: URL(string: "https://blue-bottle-cafe.example.workers.dev")!, duration: 1)
     }
 }
@@ -431,6 +478,7 @@ private struct DeployCall: Sendable, Equatable {
     let token: String
     let siteID: String
     let siteDirectory: URL
+    let wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim]
 }
 
 private struct TestAccessError: LocalizedError, Sendable {
@@ -454,7 +502,11 @@ private struct SocialWorkerFactory: CommandFactory {
         SocialWorkerProvisionCommand(
             tokenSource: { "token" },
             runner: { _, arguments, _, _ in await recorder.run(arguments: arguments) },
-            deployer: { token, siteID, siteDirectory in await recorder.deploy(token: token, siteID: siteID, siteDirectory: siteDirectory) }
+            deployer: { token, siteID, siteDirectory, wellKnownDynamicClaims in
+                await recorder.deploy(
+                    token: token, siteID: siteID, siteDirectory: siteDirectory,
+                    wellKnownDynamicClaims: wellKnownDynamicClaims)
+            }
         )
     }
 }

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -51,13 +51,43 @@ struct SocialWorkerProvisionCommandTests {
             ["d1", "migrations", "apply", "AUTH_DB", "--remote"],
         ])
         #expect(await recorder.environments.allSatisfy { $0["CLOUDFLARE_API_TOKEN"] == "token" })
-        #expect(await deployer.calls == [.init(token: "token", siteID: "site-1", siteDirectory: site)])
+        #expect(await deployer.calls == [
+            .init(token: "token", siteID: "site-1", siteDirectory: site, wellKnownDynamicClaims: []),
+        ])
 
         let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
         #expect(toml.contains("main = \"worker/worker.ts\""))
         #expect(toml.contains("database_id = \"d1-id\""))
         #expect(toml.contains("id = \"kv-id\""))
         #expect(!toml.contains("[[r2_buckets]]"))
+    }
+
+    @Test("forwards wellKnownDynamicClaims to the deployer so #744's collision check sees them (#934)")
+    func forwardsWellKnownDynamicClaimsToDeployer() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
+            ["kv", "namespace", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"id":"kv-id"}}"#, stderr: "", exitCode: 0),
+            ["queues", "create", "my-site-webmention", "--json"]: .init(stdout: #"{"result":{"queue_name":"my-site-webmention"}}"#, stderr: "", exitCode: 0),
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
+        ])
+        let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
+        let claims = [
+            WorkerRouteClaims.OwnedClaim(
+                owner: "webfinger",
+                claim: WorkerRouteClaim(path: "/.well-known/webfinger", match: .exact, methods: ["GET"], handler: "webfinger")
+            ),
+        ]
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: v2Workers,
+            acknowledgesPaidPlan: true, wellKnownDynamicClaims: claims
+        )
+
+        #expect(await deployer.calls == [
+            .init(token: "token", siteID: "site-1", siteDirectory: site, wellKnownDynamicClaims: claims),
+        ])
     }
 
     @Test("provisions R2 only when a selected feature needs media")
@@ -552,7 +582,7 @@ struct SocialWorkerProvisionCommandTests {
                 calledArguments.append(arguments)
                 return .init(stdout: "", stderr: "unexpected call", exitCode: 1)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let webmention = WorkerDescriptor(
             id: "webmention", displayName: "Webmentions", description: "test", group: "social",
@@ -582,7 +612,7 @@ struct SocialWorkerProvisionCommandTests {
                 }
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let webmention = WorkerDescriptor(
             id: "webmention", displayName: "Webmentions", description: "test", group: "social",
@@ -610,7 +640,7 @@ struct SocialWorkerProvisionCommandTests {
                 calledArguments.append(arguments)
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let webmention = WorkerDescriptor(
             id: "webmention", displayName: "Webmentions", description: "test", group: "social",
@@ -639,7 +669,7 @@ struct SocialWorkerProvisionCommandTests {
                 }
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let webmention = WorkerDescriptor(
             id: "webmention", displayName: "Webmentions", description: "test", group: "social",
@@ -664,7 +694,7 @@ struct SocialWorkerProvisionCommandTests {
                 }
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let webmention = WorkerDescriptor(
             id: "webmention", displayName: "Webmentions", description: "test", group: "social",
@@ -697,7 +727,7 @@ struct SocialWorkerProvisionCommandTests {
                 }
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         // needsD1: true so the D1 block's persistConfig call runs (and reconciles the flag to
         // "false") before the code reaches the paid-plan gate below it — mirrors production,
@@ -728,7 +758,7 @@ struct SocialWorkerProvisionCommandTests {
                 calledArguments.append(arguments)
                 return .init(stdout: "", stderr: "unexpected call", exitCode: 1)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let websub = WorkerDescriptor(
             id: "websub", displayName: "WebSub", description: "test", group: "social",
@@ -758,7 +788,7 @@ struct SocialWorkerProvisionCommandTests {
                 }
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let websub = WorkerDescriptor(
             id: "websub", displayName: "WebSub", description: "test", group: "social",
@@ -794,7 +824,7 @@ struct SocialWorkerProvisionCommandTests {
                 }
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let plain = { (id: String) in
             WorkerDescriptor(
@@ -824,7 +854,7 @@ struct SocialWorkerProvisionCommandTests {
                 calledArguments.append(arguments)
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let websub = WorkerDescriptor(
             id: "websub", displayName: "WebSub", description: "test", group: "social",
@@ -853,7 +883,7 @@ struct SocialWorkerProvisionCommandTests {
                 }
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let websub = WorkerDescriptor(
             id: "websub", displayName: "WebSub", description: "test", group: "social",
@@ -884,7 +914,7 @@ struct SocialWorkerProvisionCommandTests {
                 calledArguments.append(arguments)
                 return .init(stdout: "", stderr: "unexpected call", exitCode: 1)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let microsub = WorkerDescriptor(
             id: "microsub", displayName: "Microsub", description: "test", group: "publishing",
@@ -914,7 +944,7 @@ struct SocialWorkerProvisionCommandTests {
                 }
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let microsub = WorkerDescriptor(
             id: "microsub", displayName: "Microsub", description: "test", group: "publishing",
@@ -942,7 +972,7 @@ struct SocialWorkerProvisionCommandTests {
                 calledArguments.append(arguments)
                 return .init(stdout: "", stderr: "", exitCode: 0)
             },
-            deployer: { _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
         )
         let microsub = WorkerDescriptor(
             id: "microsub", displayName: "Microsub", description: "test", group: "publishing",
@@ -1013,6 +1043,7 @@ private struct DeployCall: Sendable, Equatable {
     let token: String
     let siteID: String
     let siteDirectory: URL
+    let wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim]
 }
 
 private actor DeployRecorder {
@@ -1026,13 +1057,20 @@ private actor DeployRecorder {
     var calls: [DeployCall] { seenCalls }
 
     nonisolated var deployer: SocialWorkerProvisionCommand.Deployer {
-        { token, siteID, siteDirectory in
-            await self.deploy(token: token, siteID: siteID, siteDirectory: siteDirectory)
+        { token, siteID, siteDirectory, wellKnownDynamicClaims in
+            await self.deploy(
+                token: token, siteID: siteID, siteDirectory: siteDirectory,
+                wellKnownDynamicClaims: wellKnownDynamicClaims)
         }
     }
 
-    private func deploy(token: String, siteID: String, siteDirectory: URL) -> DeployCommand.Result {
-        seenCalls.append(DeployCall(token: token, siteID: siteID, siteDirectory: siteDirectory))
+    private func deploy(
+        token: String, siteID: String, siteDirectory: URL,
+        wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim]
+    ) -> DeployCommand.Result {
+        seenCalls.append(DeployCall(
+            token: token, siteID: siteID, siteDirectory: siteDirectory,
+            wellKnownDynamicClaims: wellKnownDynamicClaims))
         return result
     }
 }


### PR DESCRIPTION
## Summary

- `SocialWorkerProvisionCommand.Deployer` now accepts and forwards `wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim]`, and `SocialWorkerProvisionCommand.provision` threads a new `wellKnownDynamicClaims` param through to it (defaulting to `[]`, so existing callers are unaffected unless they opt in).
- `SiteOperations.deployWithWorkerComposition` (the headless deploy path used by `DeploySiteIntent`/Siri/Shortcuts/App Intents) now passes `WorkerRouteClaims.wellKnownClaims(routeClaims)` — the same active dynamic-route claims it already computes for `routeClaims` — into that new parameter, so #744's pre-build `/.well-known/` collision check sees them there too.
- `DeployModel.runDeploy`'s custom deployer closure (used by the GUI Deploy button) is updated only for the new closure arity; its own well-known-claims computation is unchanged, so GUI behavior is identical to before.

Closes #934.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` — passes, except 7 pre-existing failures in `BusinessTypeRenderSmokeTests`/`JsonLdRenderSmokeTests`/`SiteIdentityRenderSmokeTests` (and similar render-smoke suites) unrelated to this change: `astro build` fails with `Cannot find module '@tgwf/co2'` in `Resources/Template/node_modules`, an environment/dependency issue in this worktree, not touched by this PR.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds (required an `xcodegen generate` first; the checked-out `.xcodeproj` was stale relative to `project.yml`/new files, unrelated to this change).
- [ ] Manual smoke (if UI-touching): not UI-touching — added two unit tests (`SocialWorkerProvisionCommandTests.forwardsWellKnownDynamicClaimsToDeployer`, `SiteOperationsTests.headlessDeployForwardsWellKnownDynamicClaimsToDeployer`) that assert the claim actually reaches the deployer closure end-to-end.
