### PR TITLE
fix(ci): remove inert codeql-config.yml

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,5 +1,0 @@
-# CodeQL configuration: analyze only languages present in this repo.
-# Swift + TypeScript/JavaScript; disable C/C++ (no source files).
-languages:
-  - javascript-typescript
-  - swift


### PR DESCRIPTION
## Summary

- Removes `.github/codeql-config.yml`, added in #898 to exclude C/C++ from CodeQL analysis.
- That file has no effect: this repo runs CodeQL via GitHub's **Default Setup**, which never reads `.github/codeql-config.yml` — only "Advanced setup" (a committed workflow using `github/codeql-action/init` with `config-file:`) consults it.
- C/C++ is already excluded today via Default Setup's own language selection (Security tab → CodeQL → Edit), configured separately from this file and unaffected by removing it. Verified via `gh api repos/Anglesite/Anglesite-app/code-scanning/default-setup`: configured languages are `actions, javascript, javascript-typescript, swift, typescript` — no `cpp` — and recent/current CodeQL job matrices confirm no c-cpp job runs.
- Net effect of this PR: no behavior change, just removes a dead/misleading file that implied the exclusion was version-controlled when it wasn't.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] N/A — CI-config-only change, no Swift/JS code touched. Confirmed no remaining references to `codeql-config.yml` anywhere in the repo.