### PR TITLE
feat(#362): snapshot webmention inbox into git

### DIFF
--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -197,6 +197,11 @@ final class PreviewModel {
                 .appendingPathComponent("Config", isDirectory: true)
             _ = await InboxSubmissionSync.pullAndCommitIfConfigured(
                 siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #362: pull the webmention Worker's verified inbox from D1 and snapshot it into the
+            // git working copy. No-ops for sites without a provisioned D1 database
+            // (SiteSettings.provisionedWorkerResources.d1DatabaseID unset).
+            _ = await ReceivedInteractionSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
             clearDevServerCommandInFlight(token: token)
         }
     }

--- a/Sources/AnglesiteCore/ReceivedInteractionCommitter.swift
+++ b/Sources/AnglesiteCore/ReceivedInteractionCommitter.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Writes the Worker's D1 inbox (`WebmentionInboxD1Client`) into the site's local git working
+/// copy as `data/interactions/{id}.json` files, per the received-interaction canonicality design
+/// (`docs/specs/2026-06-29-c3-received-interaction-canonicality.md`) — the "snapshot to git" half
+/// of #362. This is the counterpart to `InboxSubmissionCommitter` (#587), but reconciles against
+/// the *full current set* every call rather than draining a staging queue: D1 stays the permanent
+/// operational store (there's nothing to delete from it after a successful commit), so a stale
+/// snapshot file — one whose interaction was later unverified or its source deleted — must be
+/// removed on the next reconcile too, per the design doc's "sender-side delete" behavior.
+public enum ReceivedInteractionCommitter {
+    /// JSON encoding for one interaction's snapshot file: sorted keys (stable, clean diffs) and
+    /// ISO 8601 dates, matching the Astro template's zod schema
+    /// (`Resources/Template/src/lib/interactions.ts`) and `ReceivedInteractionTests`'s own
+    /// round-trip fixture.
+    public static func jsonData(for interaction: ReceivedInteraction) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(interaction)
+    }
+
+    /// Reconciles `data/interactions/` under `siteDirectory` against `interactions` (the full,
+    /// current, verified set from D1) and commits the result in one commit:
+    /// - a new or changed interaction is written (or overwritten) at its `gitPath`
+    /// - an existing snapshot file whose id is absent from `interactions` is deleted
+    /// - unchanged files are left untouched, so a sync with nothing new is a true no-op — no
+    ///   empty commit, no git subprocess/libgit2 call at all
+    ///
+    /// Returns every id actually touched by the resulting commit — written (new or changed
+    /// content) or deleted (stale, no longer in `interactions`) — empty (never throws) if there
+    /// was nothing to reconcile, or if the git commit closure failed, so an interrupted or failed
+    /// sync simply re-attempts the same reconcile next time rather than losing state. An id whose
+    /// file was already up to date is not included: it wasn't part of this commit.
+    @discardableResult
+    public static func commit(
+        interactions: [ReceivedInteraction],
+        into siteDirectory: URL,
+        fileManager: FileManager = .default,
+        gitCommitBatch: @Sendable (URL, [String], String) async -> String? = InboxSubmissionCommitter.processGitCommitBatch
+    ) async -> [String] {
+        let interactionsDir = siteDirectory.appendingPathComponent("data/interactions", isDirectory: true)
+        let currentIDs = Set(interactions.map(\.id))
+
+        var relPaths: [String] = []
+        var writtenIDs: [String] = []
+        var deletedIDs: [String] = []
+
+        let existingFiles = (try? fileManager.contentsOfDirectory(at: interactionsDir, includingPropertiesForKeys: nil)) ?? []
+        for file in existingFiles where file.pathExtension == "json" {
+            let id = file.deletingPathExtension().lastPathComponent
+            guard !currentIDs.contains(id) else { continue }
+            guard (try? fileManager.removeItem(at: file)) != nil else { continue }
+            relPaths.append("data/interactions/\(id).json")
+            deletedIDs.append(id)
+        }
+
+        if !interactions.isEmpty {
+            try? fileManager.createDirectory(at: interactionsDir, withIntermediateDirectories: true)
+        }
+        for interaction in interactions {
+            guard let data = try? jsonData(for: interaction) else { continue }
+            let fileURL = interactionsDir.appendingPathComponent("\(interaction.id).json")
+            if let existing = try? Data(contentsOf: fileURL), existing == data { continue }
+            guard (try? data.write(to: fileURL, options: .atomic)) != nil else { continue }
+            relPaths.append(interaction.gitPath)
+            writtenIDs.append(interaction.id)
+        }
+
+        guard !relPaths.isEmpty else { return [] }
+
+        let message = Self.commitMessage(writtenCount: writtenIDs.count, deletedCount: deletedIDs.count)
+        guard await gitCommitBatch(siteDirectory, relPaths, message) != nil else { return [] }
+        return writtenIDs + deletedIDs
+    }
+
+    /// Describes what actually changed, since a reconcile can be a pure write, a pure delete
+    /// (every interaction from a source was unverified/removed), or both at once.
+    static func commitMessage(writtenCount: Int, deletedCount: Int) -> String {
+        switch (writtenCount, deletedCount) {
+        case (let w, 0):
+            return w == 1 ? "chore: snapshot 1 received interaction" : "chore: snapshot \(w) received interactions"
+        case (0, let d):
+            return d == 1 ? "chore: remove 1 received interaction" : "chore: remove \(d) received interactions"
+        case (let w, let d):
+            return "chore: snapshot \(w) received interaction\(w == 1 ? "" : "s"), remove \(d)"
+        }
+    }
+}

--- a/Sources/AnglesiteCore/ReceivedInteractionSync.swift
+++ b/Sources/AnglesiteCore/ReceivedInteractionSync.swift
@@ -1,0 +1,96 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Orchestrates #362's "pull the Worker's verified webmention inbox and snapshot it into the
+/// site's git working copy" step: query D1 (`WebmentionInboxD1Client`), reconcile + commit
+/// (`ReceivedInteractionCommitter`). This is the counterpart to #587's `InboxSubmissionSync`, but
+/// there is no staging store to drain — D1 remains the permanent operational store, so every call
+/// reconciles against the *current full inbox*, not just what's new since last time. Designed to
+/// be called once per site-open (`PreviewModel.open(site:)`), alongside `InboxSubmissionSync`.
+public enum ReceivedInteractionSync {
+    /// Maps one D1 row to the git-canonical schema. Returns `nil` (skip, don't fail the whole
+    /// pull) when `source`/`target` aren't parseable URLs, or the id fails
+    /// `ReceivedInteraction`'s path-traversal guard — a malformed row shouldn't block every other
+    /// mention. An unrecognized/absent `interactionType` defaults to `.mention`, and an absent
+    /// `publishedAt` falls back to `verifiedAt`, mirroring `InboxStore.list()`'s own defaults on
+    /// the Worker side (`packages/webmention/src/inbox.ts`) — including rows written by
+    /// `@dwk/webmention` versions published before the mf2-enrichment columns existed.
+    static func makeInteraction(from mention: WebmentionInboxD1Client.Mention) -> ReceivedInteraction? {
+        guard let source = URL(string: mention.source), let target = URL(string: mention.target) else { return nil }
+        let interactionType = mention.interactionType.flatMap(ReceivedInteraction.InteractionType.init(rawValue:)) ?? .mention
+        let author: ReceivedInteraction.Author? =
+            (mention.authorName != nil || mention.authorURL != nil || mention.authorPhoto != nil)
+            ? .init(
+                name: mention.authorName,
+                url: mention.authorURL.flatMap(URL.init(string:)),
+                photo: mention.authorPhoto.flatMap(URL.init(string:)))
+            : nil
+        let verifiedAt = Double(mention.verifiedAt) / 1000
+        let publishedAt = Double(mention.publishedAt ?? mention.verifiedAt) / 1000
+        return try? ReceivedInteraction(
+            id: mention.id, type: .webmention, source: source, target: target,
+            interactionType: interactionType, author: author, content: mention.content,
+            published: Date(timeIntervalSince1970: publishedAt),
+            verified: Date(timeIntervalSince1970: verifiedAt), verificationStatus: .verified)
+    }
+
+    /// Queries `client` for the full current inbox, maps it to `ReceivedInteraction`, and
+    /// reconciles it into `siteDirectory`. Returns 0 (never throws) if the D1 query failed, so
+    /// callers simply re-attempt on the next site-open rather than surfacing a transient network
+    /// error. An empty inbox still reconciles (proceeds to `commit`) rather than short-circuiting,
+    /// so previously-snapshotted mentions that were later unverified/removed still get cleaned up.
+    public static func pullAndCommit(client: WebmentionInboxD1Client, siteDirectory: URL) async -> Int {
+        guard let mentions = try? await client.listVerifiedMentions() else { return 0 }
+        let interactions = mentions.compactMap(Self.makeInteraction(from:))
+        let committedIDs = await ReceivedInteractionCommitter.commit(interactions: interactions, into: siteDirectory)
+        return committedIDs.count
+    }
+
+    private struct CFAccount: Decodable, Sendable { let id: String }
+    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
+
+    /// Resolves the token's first visible Cloudflare account id — same "just take the first
+    /// account" resolution `HTTPCloudflareClient.workerScriptNames`/`CloudflareCapabilityProber`
+    /// use, since a personal Anglesite deployment has exactly one Cloudflare account per token, and
+    /// there is no separate stored account id for webmention/D1 to key off (unlike #587's
+    /// `inboxCaptureAccountID`, since the D1 database itself is already identified by
+    /// `SiteSettings.provisionedWorkerResources.d1DatabaseID`).
+    private static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
+        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
+        else { return nil }
+        return envelope.result?.first?.id
+    }
+
+    /// Reads the site's `SiteSettings` and the Cloudflare API token from `secretStore`; no-ops
+    /// (returns 0, no network call) unless a D1 database has been provisioned
+    /// (`provisionedWorkerResources.d1DatabaseID`, set once the webmention receive Worker has been
+    /// provisioned — see `SocialWorkerProvisionCommand`) and a token is available.
+    /// `configDirectory` is the package's `Config/` directory (`AnglesitePackage.configURL`), a
+    /// sibling of `siteDirectory` (`AnglesitePackage.sourceURL`).
+    public static func pullAndCommitIfConfigured(
+        siteDirectory: URL,
+        configDirectory: URL,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) async -> Int {
+        guard let settings = try? SiteConfigStore.read(from: configDirectory),
+              let databaseID = settings.provisionedWorkerResources?.d1DatabaseID, !databaseID.isEmpty,
+              let token = try? secretStore.readCloudflareToken(), !token.isEmpty
+        else { return 0 }
+        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        else { return 0 }
+
+        let client = WebmentionInboxD1Client(
+            accountID: accountID, databaseID: databaseID, apiToken: token, baseURL: baseURL, transport: transport)
+        return await pullAndCommit(client: client, siteDirectory: siteDirectory)
+    }
+}

--- a/Sources/AnglesiteCore/WebmentionInboxD1Client.swift
+++ b/Sources/AnglesiteCore/WebmentionInboxD1Client.swift
@@ -1,0 +1,122 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Cloudflare D1 HTTP API client for `@dwk/webmention`'s inbox table (#362). The per-site Worker
+/// (`Resources/Template/worker/worker.ts`) binds a shared per-site D1 database under
+/// `WEBMENTION_INBOX`; `createD1Inbox` (in the sibling `davidwkeith/workers` monorepo) creates its
+/// own `webmentions` table inside it on first use. This is the app-side reader — the counterpart
+/// to `InboxKVClient` for #587's `INBOX_KV`, same injectable-transport DI pattern, no Keychain
+/// coupling, token passed in at init.
+///
+/// The row shape is queried, not decoded from the npm package's TypeScript types, so this client
+/// tolerates the enrichment columns (`interaction_type`, `author_*`, `content`, `published_at`)
+/// being entirely `NULL` — the shape written by `@dwk/webmention` versions published before the
+/// mf2-enrichment pass (issue #417 upstream) landed. Once a site redeploys against a version that
+/// populates them, the same query returns richer rows with no app-side change needed.
+public struct WebmentionInboxD1Client: Sendable {
+    /// A verified mention row as read from the `webmentions` D1 table — field names mirror
+    /// `@dwk/webmention`'s `VerifiedMention` (`packages/webmention/src/inbox.ts`), flattened
+    /// (`author.name` -> `authorName`, etc.) since this is a SQL projection, not a JSON decode of
+    /// that type. Dates are epoch milliseconds, matching the column types.
+    public struct Mention: Sendable, Equatable {
+        public let id: String
+        public let source: String
+        public let target: String
+        public let verifiedAt: Int
+        public let interactionType: String?
+        public let authorName: String?
+        public let authorURL: String?
+        public let authorPhoto: String?
+        public let content: String?
+        public let publishedAt: Int?
+    }
+
+    private struct Row: Decodable {
+        let id: String?
+        let source: String
+        let target: String
+        let verified_at: Int
+        let interaction_type: String?
+        let author_name: String?
+        let author_url: String?
+        let author_photo: String?
+        let content: String?
+        let published_at: Int?
+    }
+
+    private struct QueryResult: Decodable {
+        let results: [Row]?
+        let success: Bool
+    }
+
+    private struct Envelope: Decodable {
+        let success: Bool
+        let result: [QueryResult]?
+    }
+
+    private struct QueryBody: Encodable {
+        let sql: String
+    }
+
+    /// Selects every row, newest-verified first, mirroring `InboxStore.list()`'s own ordering
+    /// (`packages/webmention/src/inbox.ts`) with no `target` filter — the snapshot step wants the
+    /// whole inbox, not one post's mentions.
+    private static let listVerifiedSQL = """
+    SELECT id, source, target, verified_at, interaction_type, author_name, author_url, \
+    author_photo, content, published_at FROM webmentions ORDER BY verified_at DESC
+    """
+
+    private let baseURL: String
+    private let accountID: String
+    private let databaseID: String
+    private let apiToken: String
+    private let transport: CloudflareTransport
+
+    public init(
+        accountID: String,
+        databaseID: String,
+        apiToken: String,
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.accountID = accountID
+        self.databaseID = databaseID
+        self.apiToken = apiToken
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    /// Lists every verified mention currently in the inbox. A row with no `id` (written before
+    /// the `id` column existed, per the upstream package's migration notes) is skipped rather than
+    /// re-deriving the id — that would require reimplementing `@dwk/mf2`'s FNV-1a hash in Swift
+    /// for a case that can't occur on an inbox created by the current package version.
+    public func listVerifiedMentions() async throws -> [Mention] {
+        let url = URL(string: "\(baseURL)/accounts/\(accountID)/d1/database/\(databaseID)/query")
+        guard let url else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(QueryBody(sql: Self.listVerifiedSQL))
+
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data), envelope.success,
+              let rows = envelope.result?.first?.results
+        else { throw CloudflareError.malformedResponse }
+
+        return rows.compactMap { row in
+            guard let id = row.id else { return nil }
+            return Mention(
+                id: id, source: row.source, target: row.target, verifiedAt: row.verified_at,
+                interactionType: row.interaction_type, authorName: row.author_name,
+                authorURL: row.author_url, authorPhoto: row.author_photo, content: row.content,
+                publishedAt: row.published_at)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/ReceivedInteractionCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/ReceivedInteractionCommitterTests.swift
@@ -1,0 +1,163 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Serialized for the same reason as InboxSubmissionCommitterTests: real `git` subprocesses via
+// raw `Process()` in `makeThrowawayGitRepo()` trip a rare CI heap-corruption crash when run
+// concurrently with the rest of the subprocess-heavy suite.
+@Suite(.serialized)
+struct ReceivedInteractionCommitterTests {
+    private static func interaction(id: String, content: String = "Great post!") -> ReceivedInteraction {
+        try! ReceivedInteraction(
+            id: id, type: .webmention,
+            source: URL(string: "https://alice.example/post")!,
+            target: URL(string: "https://me.example/blog/hi")!,
+            interactionType: .reply,
+            author: .init(name: "Alice", url: URL(string: "https://alice.example"), photo: nil),
+            content: content,
+            published: Date(timeIntervalSince1970: 1_753_299_000),
+            verified: Date(timeIntervalSince1970: 1_753_300_000),
+            verificationStatus: .verified)
+    }
+
+    @Test("commit writes each interaction to data/interactions/{id}.json and returns their ids")
+    func commitWritesAndReturnsIDs() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let ids = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "wm-abc123")], into: siteDirectory)
+        #expect(ids == ["wm-abc123"])
+
+        let written = siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+    }
+
+    @Test("commit returns empty for an empty interaction list with no existing files, without touching git")
+    func commitEmptyIsNoOp() async {
+        let ids = await ReceivedInteractionCommitter.commit(
+            interactions: [], into: URL(fileURLWithPath: "/nonexistent"))
+        #expect(ids.isEmpty)
+    }
+
+    @Test("commit deletes interaction files whose id is no longer present in the current set")
+    func commitDeletesStaleFiles() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        _ = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "wm-abc123"), Self.interaction(id: "wm-def456")],
+            into: siteDirectory)
+        let staleFile = siteDirectory.appendingPathComponent("data/interactions/wm-def456.json")
+        #expect(FileManager.default.fileExists(atPath: staleFile.path))
+
+        // wm-def456 dropped out of the current set (sender-side delete re-verify, per the
+        // canonicality spec) - the next reconcile should remove its snapshot file. wm-abc123's
+        // content is unchanged, so it isn't rewritten - only the deletion shows up in the commit.
+        let ids = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "wm-abc123")], into: siteDirectory)
+        #expect(ids == ["wm-def456"])
+        #expect(!FileManager.default.fileExists(atPath: staleFile.path))
+    }
+
+    @Test("commit is a no-op when every interaction already matches what's on disk and nothing needs deleting")
+    func commitNoOpWhenNothingChanged() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let interactions = [Self.interaction(id: "wm-abc123")]
+        let firstIDs = await ReceivedInteractionCommitter.commit(interactions: interactions, into: siteDirectory)
+        #expect(firstIDs == ["wm-abc123"])
+
+        let callCount = CallCounter()
+        let secondIDs = await ReceivedInteractionCommitter.commit(
+            interactions: interactions, into: siteDirectory,
+            gitCommitBatch: { _, _, _ in
+                await callCount.increment()
+                return "should-not-be-called"
+            })
+        #expect(secondIDs.isEmpty)
+        #expect(await callCount.value == 0)
+    }
+
+    @Test("commit re-writes an interaction file whose content changed since the last snapshot")
+    func commitRewritesChangedContent() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        _ = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "wm-abc123", content: "Great post!")], into: siteDirectory)
+
+        let ids = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "wm-abc123", content: "Edited: even better post!")],
+            into: siteDirectory)
+        #expect(ids == ["wm-abc123"])
+
+        let written = siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json")
+        let data = try Data(contentsOf: written)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("Edited: even better post!"))
+    }
+
+    @Test("commit returns empty (not throw) when the git commit closure fails")
+    func commitReturnsEmptyOnGitCommitFailure() async throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(
+            "interactions-commit-fail-test-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let ids = await ReceivedInteractionCommitter.commit(
+            interactions: [Self.interaction(id: "wm-abc123")], into: dir,
+            gitCommitBatch: { _, _, _ in nil })
+        #expect(ids.isEmpty)
+    }
+
+    @Test("jsonData serializes with sorted keys and ISO 8601 dates")
+    func jsonDataFormat() throws {
+        let data = try ReceivedInteractionCommitter.jsonData(for: Self.interaction(id: "wm-abc123"))
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("\"id\" : \"wm-abc123\""))
+        #expect(text.contains("\"verificationStatus\" : \"verified\""))
+        // ISO 8601, not epoch seconds/millis - the Astro template's zod schema (`z.string().datetime()`)
+        // expects this shape.
+        #expect(text.range(of: #""published" : "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z""#, options: .regularExpression) != nil)
+    }
+
+    /// Mirrors `InboxSubmissionCommitterTests.makeThrowawayGitRepo`.
+    private static func makeThrowawayGitRepo() throws -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(
+            "interactions-commit-test-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = dir
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return dir
+    }
+}
+
+private actor CallCounter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}

--- a/Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/ReceivedInteractionSyncTests.swift
@@ -1,0 +1,238 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Serialized for the same reason as InboxSubmissionSyncTests: real `git` subprocesses via raw
+// `Process()` in `makeThrowawayGitRepo()` trip a rare CI heap-corruption crash when run
+// concurrently with the rest of the subprocess-heavy suite.
+@Suite(.serialized)
+struct ReceivedInteractionSyncTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func d1Body(_ rowsJSON: String) -> Data {
+        Data("""
+        {"success": true, "result": [{"success": true, "results": [\(rowsJSON)]}]}
+        """.utf8)
+    }
+
+    // MARK: - makeInteraction mapping
+
+    @Test("makeInteraction maps a fully-enriched mention")
+    func makeInteractionMapsFullMention() throws {
+        let mention = WebmentionInboxD1Client.Mention(
+            id: "wm-abc123", source: "https://alice.example/post", target: "https://me.example/blog/hi",
+            verifiedAt: 1_753_300_000_000, interactionType: "reply", authorName: "Alice",
+            authorURL: "https://alice.example", authorPhoto: "https://alice.example/photo.jpg",
+            content: "Great post!", publishedAt: 1_753_299_000_000)
+
+        let interaction = try #require(ReceivedInteractionSync.makeInteraction(from: mention))
+        #expect(interaction.id == "wm-abc123")
+        #expect(interaction.type == .webmention)
+        #expect(interaction.interactionType == .reply)
+        #expect(interaction.author?.name == "Alice")
+        #expect(interaction.author?.url?.absoluteString == "https://alice.example")
+        #expect(interaction.content == "Great post!")
+        #expect(interaction.verificationStatus == .verified)
+        #expect(interaction.published.timeIntervalSince1970 == 1_753_299_000)
+        #expect(interaction.verified.timeIntervalSince1970 == 1_753_300_000)
+    }
+
+    @Test("makeInteraction defaults a legacy (pre-enrichment) mention to a plain mention with no author/content")
+    func makeInteractionDefaultsLegacyMention() throws {
+        let mention = WebmentionInboxD1Client.Mention(
+            id: "wm-def456", source: "https://bob.example/post", target: "https://me.example/blog/hi",
+            verifiedAt: 1_753_300_000_000, interactionType: nil, authorName: nil,
+            authorURL: nil, authorPhoto: nil, content: nil, publishedAt: nil)
+
+        let interaction = try #require(ReceivedInteractionSync.makeInteraction(from: mention))
+        #expect(interaction.interactionType == .mention)
+        #expect(interaction.author == nil)
+        #expect(interaction.content == nil)
+        // publishedAt falls back to verifiedAt, matching the Worker's own list() fallback.
+        #expect(interaction.published == interaction.verified)
+    }
+
+    @Test("makeInteraction returns nil for an unparseable source URL")
+    func makeInteractionSkipsInvalidSourceURL() {
+        let mention = WebmentionInboxD1Client.Mention(
+            id: "wm-bad", source: "", target: "https://me.example/blog/hi",
+            verifiedAt: 1_753_300_000_000, interactionType: nil, authorName: nil,
+            authorURL: nil, authorPhoto: nil, content: nil, publishedAt: nil)
+        #expect(ReceivedInteractionSync.makeInteraction(from: mention) == nil)
+    }
+
+    // MARK: - pullAndCommit
+
+    @Test("pulls verified mentions from D1 and commits them")
+    func pullsAndCommits() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let body = Self.d1Body("""
+        {"id": "wm-abc123", "source": "https://alice.example/post", "target": "https://me.example/blog/hi",
+         "verified_at": 1753300000000, "interaction_type": "reply", "author_name": "Alice",
+         "author_url": null, "author_photo": null, "content": "Great post!", "published_at": 1753299000000}
+        """)
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (body, Self.response(200)) })
+
+        let count = await ReceivedInteractionSync.pullAndCommit(client: client, siteDirectory: siteDirectory)
+        #expect(count == 1)
+        let written = siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+    }
+
+    @Test("returns 0 without touching git when D1 has nothing and no local snapshot files exist")
+    func emptyInboxIsNoOp() async throws {
+        let body = Self.d1Body("")
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (body, Self.response(200)) })
+
+        let count = await ReceivedInteractionSync.pullAndCommit(
+            client: client, siteDirectory: URL(fileURLWithPath: "/nonexistent"))
+        #expect(count == 0)
+    }
+
+    @Test("reconciles away stale local snapshot files when D1 no longer has that mention")
+    func reconcilesAwayStaleFiles() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let interactionsDir = siteDirectory.appendingPathComponent("data/interactions", isDirectory: true)
+        try FileManager.default.createDirectory(at: interactionsDir, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: interactionsDir.appendingPathComponent("wm-stale.json"))
+
+        let body = Self.d1Body("")
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (body, Self.response(200)) })
+
+        let count = await ReceivedInteractionSync.pullAndCommit(client: client, siteDirectory: siteDirectory)
+        #expect(count == 1)
+        #expect(!FileManager.default.fileExists(
+            atPath: interactionsDir.appendingPathComponent("wm-stale.json").path))
+    }
+
+    @Test("returns 0 without touching git when the D1 query fails")
+    func d1FailureIsNoOp() async throws {
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (Data(), Self.response(500)) })
+
+        let count = await ReceivedInteractionSync.pullAndCommit(
+            client: client, siteDirectory: URL(fileURLWithPath: "/nonexistent"))
+        #expect(count == 0)
+    }
+
+    // MARK: - pullAndCommitIfConfigured
+
+    @Test("pullAndCommitIfConfigured no-ops when the site has no provisioned D1 database")
+    func noOpsWithoutD1Database() async {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("interactions-sync-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+
+        let count = await ReceivedInteractionSync.pullAndCommitIfConfigured(
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "unused"),
+            transport: { _ in
+                Issue.record("transport must not be called with no provisioned D1 database")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommitIfConfigured no-ops (with no network call) when a D1 database is provisioned but no token is stored")
+    func noOpsWithNoToken() async throws {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("interactions-sync-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(d1DatabaseID: "db1")))
+
+        let count = await ReceivedInteractionSync.pullAndCommitIfConfigured(
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: nil),
+            transport: { _ in
+                Issue.record("transport must not be called when no Cloudflare token is available")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommitIfConfigured resolves the account id, queries D1, and commits")
+    func resolvesAccountAndCommits() async throws {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("interactions-sync-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(d1DatabaseID: "db1")))
+
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let accountsBody = Data("""
+        {"success": true, "result": [{"id": "acct1"}]}
+        """.utf8)
+        let d1Body = Self.d1Body("""
+        {"id": "wm-abc123", "source": "https://alice.example/post", "target": "https://me.example/blog/hi",
+         "verified_at": 1753300000000, "interaction_type": "reply", "author_name": "Alice",
+         "author_url": null, "author_photo": null, "content": "Great post!", "published_at": 1753299000000}
+        """)
+
+        let count = await ReceivedInteractionSync.pullAndCommitIfConfigured(
+            siteDirectory: siteDirectory,
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "token"),
+            transport: { request in
+                if request.url!.path.hasSuffix("/accounts") { return (accountsBody, Self.response(200)) }
+                if request.url!.path.contains("/d1/database/db1/query") { return (d1Body, Self.response(200)) }
+                return (Data(), Self.response(404))
+            })
+        #expect(count == 1)
+        let written = siteDirectory.appendingPathComponent("data/interactions/wm-abc123.json")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+    }
+
+    private static func makeThrowawayGitRepo() throws -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("interactions-sync-repo-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = dir
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return dir
+    }
+}
+
+private struct FakeSecretStore: SecretStore {
+    let token: String?
+    func read(account: String) throws -> String? { account == SecretAccounts.cloudflareToken ? token : nil }
+    func write(_ value: String, account: String) throws {}
+    func delete(account: String) throws {}
+}

--- a/Tests/AnglesiteCoreTests/WebmentionInboxD1ClientTests.swift
+++ b/Tests/AnglesiteCoreTests/WebmentionInboxD1ClientTests.swift
@@ -1,0 +1,130 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct WebmentionInboxD1ClientTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    @Test("lists verified mentions with full enrichment fields")
+    func listsVerifiedMentionsWithEnrichment() async throws {
+        let body = Data("""
+        {"success": true, "result": [{"success": true, "results": [
+            {"id": "wm-abc123", "source": "https://alice.example/post", "target": "https://me.example/blog/hi",
+             "verified_at": 1753300000000, "interaction_type": "reply", "author_name": "Alice",
+             "author_url": "https://alice.example", "author_photo": "https://alice.example/photo.jpg",
+             "content": "Great post!", "published_at": 1753299000000}
+        ]}]}
+        """.utf8)
+
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let mentions = try await client.listVerifiedMentions()
+        #expect(mentions.count == 1)
+        let mention = try #require(mentions.first)
+        #expect(mention.id == "wm-abc123")
+        #expect(mention.source == "https://alice.example/post")
+        #expect(mention.target == "https://me.example/blog/hi")
+        #expect(mention.verifiedAt == 1_753_300_000_000)
+        #expect(mention.interactionType == "reply")
+        #expect(mention.authorName == "Alice")
+        #expect(mention.authorURL == "https://alice.example")
+        #expect(mention.authorPhoto == "https://alice.example/photo.jpg")
+        #expect(mention.content == "Great post!")
+        #expect(mention.publishedAt == 1_753_299_000_000)
+    }
+
+    @Test("decodes rows from a pre-enrichment inbox where the new columns are all null")
+    func decodesLegacyRowsWithNullEnrichmentColumns() async throws {
+        let body = Data("""
+        {"success": true, "result": [{"success": true, "results": [
+            {"id": "wm-def456", "source": "https://bob.example/post", "target": "https://me.example/blog/hi",
+             "verified_at": 1753300000000, "interaction_type": null, "author_name": null,
+             "author_url": null, "author_photo": null, "content": null, "published_at": null}
+        ]}]}
+        """.utf8)
+
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let mentions = try await client.listVerifiedMentions()
+        let mention = try #require(mentions.first)
+        #expect(mention.id == "wm-def456")
+        #expect(mention.interactionType == nil)
+        #expect(mention.authorName == nil)
+        #expect(mention.content == nil)
+        #expect(mention.publishedAt == nil)
+    }
+
+    @Test("skips a row with no id and no way to derive one")
+    func skipsRowMissingID() async throws {
+        let body = Data("""
+        {"success": true, "result": [{"success": true, "results": [
+            {"id": null, "source": "https://carol.example/post", "target": "https://me.example/blog/hi",
+             "verified_at": 1753300000000, "interaction_type": null, "author_name": null,
+             "author_url": null, "author_photo": null, "content": null, "published_at": null}
+        ]}]}
+        """.utf8)
+
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let mentions = try await client.listVerifiedMentions()
+        #expect(mentions.isEmpty)
+    }
+
+    @Test("throws unauthorized on 401")
+    func throwsUnauthorizedOn401() async throws {
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "bad-token",
+            transport: { _ in (Data(), Self.response(401)) })
+
+        await #expect(throws: CloudflareError.unauthorized) {
+            _ = try await client.listVerifiedMentions()
+        }
+    }
+
+    @Test("throws http error on a non-2xx, non-auth status")
+    func throwsHTTPErrorOnFailureStatus() async throws {
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+
+        await #expect(throws: CloudflareError.http(status: 500)) {
+            _ = try await client.listVerifiedMentions()
+        }
+    }
+
+    @Test("sends the query as a POST to the D1 query endpoint for the given account and database")
+    func sendsPostToD1QueryEndpoint() async throws {
+        let capturedRequest = ActorBox<URLRequest?>(nil)
+        let client = WebmentionInboxD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { request in
+                await capturedRequest.set(request)
+                let body = Data("""
+                {"success": true, "result": [{"success": true, "results": []}]}
+                """.utf8)
+                return (body, Self.response(200))
+            })
+
+        _ = try await client.listVerifiedMentions()
+        let request = await capturedRequest.get()
+        #expect(request?.httpMethod == "POST")
+        #expect(request?.url?.absoluteString == "https://api.cloudflare.com/client/v4/accounts/acct1/d1/database/db1/query")
+        #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+    }
+}
+
+private actor ActorBox<Value: Sendable> {
+    private var value: Value
+    init(_ value: Value) { self.value = value }
+    func set(_ newValue: Value) { value = newValue }
+    func get() -> Value { value }
+}

--- a/docs/specs/2026-06-29-c3-received-interaction-canonicality.md
+++ b/docs/specs/2026-06-29-c3-received-interaction-canonicality.md
@@ -1,9 +1,19 @@
 # C.3: Received-Interaction Data Canonicality
 
 **Date:** 2026-06-29
-**Status:** Decided
+**Status:** Decided; snapshot step implemented (#362, 2026-07-24)
 **Part of:** #340 (cross-cutting decisions), #334 (pivot epic)
 **Prerequisite for:** V-3.4 (#362, render + snapshot received interactions)
+
+**Note on the mf2-enrichment gap:** `@dwk/webmention`'s D1 rows only carry
+`interactionType`/`author`/`content`/`publishedAt` once its inbox is enriched
+via `@dwk/mf2` — that enrichment pass merged to the sibling `davidwkeith/workers`
+monorepo's `main` on 2026-07-24 but was not yet published to npm when #362
+shipped. `WebmentionInboxD1Client` reads those columns as fully optional, so a
+site running the older published package still snapshots (as plain
+`"mention"`-typed interactions, no author/content) rather than breaking; the
+richer data appears automatically once the site redeploys against a released
+version that populates them — no further app-side change needed.
 
 ---
 
@@ -104,24 +114,39 @@ External site → Webmention/AP → Worker inbox (D1)
    live-updated — if the sender changes their name/photo, the old values persist
    in the snapshot. This is standard IndieWeb practice.
 
-### How the snapshot enters git
+### How the snapshot enters git (implemented, V-3.4 / #362)
 
-The Worker's snapshot step (V-3.4, #362):
-1. Queries D1 for interactions verified since the last snapshot timestamp
-2. Serializes each to `Source/data/interactions/{id}.json`
-3. Commits: `chore: snapshot {n} received interactions`
-4. Pushes to the site's repo
+As built, the pull runs app-side rather than Worker-side — the Worker never
+gains git credentials or push access; it stays a read-only D1 store, matching
+every other `Source/`-writing path in this app (#72: the app's local working
+copy is hydrated from the repo and pushed back to it, not the container). This
+mirrors #587's `InboxSubmissionSync`/`InboxKVClient` precedent exactly, swapping
+KV for D1:
 
-The app can trigger this on-demand (from the UI or via an App Intent), or the
-Worker can run it on a cron schedule. The commit is a normal git commit — the
-user can inspect, revert, or cherry-pick interaction snapshots like any other
-content change.
+1. `WebmentionInboxD1Client` queries the Worker's shared per-site D1 database
+   (`SiteSettings.provisionedWorkerResources.d1DatabaseID`) directly over
+   Cloudflare's D1 HTTP API — `SELECT … FROM webmentions ORDER BY verified_at
+   DESC`, the *full current inbox*, not just what's new since last time.
+2. `ReceivedInteractionSync.makeInteraction` maps each row to `ReceivedInteraction`.
+3. `ReceivedInteractionCommitter` reconciles `Source/data/interactions/` against
+   that set: writes new/changed files, deletes files whose interaction is no
+   longer present, and is a true no-op (no git call at all) when nothing
+   changed — full-set reconciliation is what makes deletion (see below) work
+   without a separate "since last snapshot" cursor.
+4. Commits in one batch: `chore: snapshot {n} received interactions` (or
+   `chore: remove {n} received interactions` for a deletion-only reconcile).
+
+Triggered once per site-open (`PreviewModel.open(site:)`), alongside
+`InboxSubmissionSync` — not a cron job, not yet exposed as an on-demand UI/App
+Intent action (both remain open follow-ups if a longer gap between opens turns
+out to matter in practice).
 
 ### What about deletion?
 
 If a sender deletes their webmention (sends a 410/404 on re-verification), the
-Worker marks the interaction as deleted in D1, and the next snapshot removes the
-file from git. This is a normal file deletion + commit.
+Worker's `InboxStore.remove` drops the D1 row, and the next reconcile removes
+the corresponding file from git (full-set reconciliation, not a soft-delete
+marker: the file's id simply stops appearing in the queried set).
 
 If the site *owner* wants to hide an interaction (moderation), they delete the
 JSON file from their repo. The Worker's D1 record is unaffected (it's operational


### PR DESCRIPTION
## Summary

- Adds the D1→git snapshot half of received-interaction canonicality (the render half already shipped in #901): `WebmentionInboxD1Client` reads the site's shared D1 database over Cloudflare's REST API, `ReceivedInteractionSync` maps rows to `ReceivedInteraction`, and `ReceivedInteractionCommitter` reconciles `Source/data/interactions/` (write/update, delete stale files, single batched commit, true no-op when nothing changed).
- Wired into `PreviewModel.open(site:)` alongside #587's `InboxSubmissionSync`, gated on `SiteSettings.provisionedWorkerResources.d1DatabaseID` (set once webmention receive is provisioned) and a stored Cloudflare token — no new Settings surface needed.
- Updates `docs/specs/2026-06-29-c3-received-interaction-canonicality.md` to describe the as-built app-side pull (mirrors #587's precedent) instead of the original "Worker pushes to git" sketch, since the Worker never gains git credentials in this app's architecture.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

**Third-repo note (not the sidecar pairing above):** `@dwk/webmention` (in `davidwkeith/workers`, published as `0.1.0-beta.4`) doesn't yet populate `interaction_type`/`author_*`/`content`/`published_at` on its D1 rows — an mf2-enrichment pass for that landed on that repo's `main` today (2026-07-24) but hasn't been published to npm yet. `WebmentionInboxD1Client` decodes those columns as fully optional, so this snapshots correctly today (as plain `"mention"`-typed interactions with no author/content) and the richer data appears automatically once a site redeploys against a released version — no further app-side change needed then.

## Test plan

- [x] `swift test --package-path .` (2502 tests, full suite, including 23 new tests across the three new files)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke: not run — needs a deployed site with webmention receive provisioned and at least one verified inbound mention, which isn't available in this environment.