### PR TITLE
feat(#366): WebFinger discovery for the ActivityPub actor

### DIFF
--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -13,6 +13,7 @@
         "@dwk/indieauth": "0.1.0-beta.3",
         "@dwk/micropub": "0.1.0-beta.4",
         "@dwk/microsub": "0.1.0-beta.4",
+        "@dwk/webfinger": "0.1.0-beta.4",
         "@dwk/webmention": "0.1.0-beta.3",
         "@dwk/websub": "0.1.0-beta.4",
         "@tgwf/co2": "^0.19.0",
@@ -2315,7 +2316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2338,7 +2338,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2358,7 +2357,6 @@
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
       "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2381,7 +2379,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2398,7 +2395,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2415,7 +2411,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2432,7 +2427,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2449,7 +2443,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2466,7 +2459,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2483,7 +2475,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2500,7 +2491,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2517,7 +2507,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2534,7 +2523,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2551,7 +2539,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2574,7 +2561,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2597,7 +2583,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2620,7 +2605,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2643,7 +2627,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2666,7 +2649,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2689,7 +2671,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2712,7 +2693,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2732,7 +2712,6 @@
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
       "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2752,7 +2731,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -2772,7 +2750,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2792,7 +2769,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2812,7 +2788,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -19,6 +19,7 @@
     "@dwk/webmention": "0.1.0-beta.3",
     "@dwk/activitypub": "0.1.0-beta.5",
     "@dwk/websub": "0.1.0-beta.4",
+    "@dwk/webfinger": "0.1.0-beta.4",
     "@tgwf/co2": "^0.19.0",
     "astro": "^7.1.3",
     "astro-embed": "^0.13.0",

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -1015,6 +1015,52 @@ test("websub queue consumer: dispatches into @dwk/websub's consumer without thro
   ).resolves.toBeUndefined();
 });
 
+// --- WebFinger discovery (V-4.4, #366) ------------------------------------------------------
+// Composition of @dwk/webfinger's handler, which is RFC 7033-conformant on its own (query
+// validation, CORS, JRD body, 400/404) — these tests cover only what this file supplies: the
+// resource map resolving `acct:site@<host>` to the ActivityPub actor, and the 503-when-
+// unconfigured guard every other composed handler in this file follows.
+
+test("webfinger: resolves acct:site@<host> to the ActivityPub actor", async () => {
+  const response = await fetchWorker(
+    new Request("https://owner.example/.well-known/webfinger?resource=acct:site@owner.example"),
+  );
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toContain("application/jrd+json");
+  expect(response.headers.get("access-control-allow-origin")).toBe("*");
+  const jrd = await response.json() as { subject: string; links: Array<{ rel: string; type?: string; href?: string }> };
+  expect(jrd.subject).toBe("acct:site@owner.example");
+  expect(jrd.links).toContainEqual({
+    rel: "self",
+    type: "application/activity+json",
+    href: "https://owner.example/users/site",
+  });
+});
+
+test("webfinger: 503 when ActivityPub isn't configured", async () => {
+  const { ACTOR: _unusedActor, ...envWithoutActor } = testEnv;
+  const response = await worker.fetch(
+    new Request("https://owner.example/.well-known/webfinger?resource=acct:site@owner.example"),
+    envWithoutActor as WorkerEnv,
+    createExecutionContext(),
+  );
+  expect(response.status).toBe(503);
+});
+
+test("webfinger: 400 when the resource query parameter is missing", async () => {
+  const response = await fetchWorker(new Request("https://owner.example/.well-known/webfinger"));
+  expect(response.status).toBe(400);
+  expect(response.headers.get("access-control-allow-origin")).toBe("*");
+});
+
+test("webfinger: 404 for a resource this site does not control", async () => {
+  const response = await fetchWorker(
+    new Request("https://owner.example/.well-known/webfinger?resource=acct:someone-else@owner.example"),
+  );
+  expect(response.status).toBe(404);
+  expect(response.headers.get("access-control-allow-origin")).toBe("*");
+});
+
 // --- Microsub reader (V-4.3, #365) ----------------------------------------------------------
 // Composition of @dwk/microsub's single endpoint. These run through worker.fetch in the workerd
 // pool with MICROSUB_DB/MICROSUB_QUEUE/AUTH_DB/TOKEN_SIGNING_KEY bound (see vitest.config.ts),

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -34,6 +34,7 @@ import {
   type MicrosubEnv,
   type MicrosubJob,
 } from "@dwk/microsub";
+import { createWebfinger } from "@dwk/webfinger";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -624,8 +625,9 @@ async function fanOutMicropubCreateToActivityPub(
 /**
  * Fixed identity for this app's single-actor-per-site model (V-4.1, #363) — no per-site
  * Settings field for a custom handle; see the design doc §"Actor identity source". WebFinger
- * (`.well-known/webfinger`, so `@site@domain` search resolves) is a separate feature (#364);
- * Mastodon can still follow this actor by pasting its URL directly into search.
+ * (`.well-known/webfinger`, so `@site@domain` search resolves) is composed by
+ * `handleWebFinger` below (V-4.4, #366); Mastodon can still follow this actor by pasting its
+ * URL directly into search even where WebFinger isn't active.
  */
 const ACTIVITYPUB_USERNAME = "site";
 
@@ -672,6 +674,42 @@ function handleActivityPub(
   }
   const activitypub = createActivityPub(config);
   return activitypub(request, env as unknown as ActivityPubEnv, ctx);
+}
+
+/**
+ * WebFinger discovery (V-4.4, #366): resolves `acct:<username>@<host>` to this site's
+ * ActivityPub actor, so `@site@domain` search works in Mastodon and other fediverse clients.
+ * `@dwk/webfinger`'s handler is RFC 7033-conformant on its own (query validation, CORS, JRD
+ * body, 400/404); this function only supplies the resource map. The actor is WebFinger's only
+ * controlled resource today, so — like every other composed handler in this file — this
+ * returns 503 when ActivityPub isn't provisioned rather than constructing an always-empty
+ * endpoint.
+ */
+function handleWebFinger(
+  request: Request,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const config = activityPubConfig(request, env);
+  if (!config) {
+    return Promise.resolve(new Response("WebFinger is not configured", { status: 503 }));
+  }
+  const baseUrl = new URL(request.url).origin;
+  const host = new URL(baseUrl).hostname;
+  const webfinger = createWebfinger({
+    resources: {
+      [`acct:${config.actor.username}@${host}`]: {
+        links: [
+          {
+            rel: "self",
+            type: "application/activity+json",
+            href: `${baseUrl}/users/${config.actor.username}`,
+          },
+        ],
+      },
+    },
+  });
+  return webfinger(request, {}, ctx);
 }
 
 /**
@@ -1054,6 +1092,13 @@ export const ROUTES: readonly WorkerRoute[] = [
     match: "exact",
     methods: ["GET", "POST"],
     handler: (request, env, ctx) => handleMicrosub(request, env, ctx),
+  },
+  {
+    // WebFinger discovery (V-4.4, #366): resolve acct:site@<host> to the ActivityPub actor.
+    path: "/.well-known/webfinger",
+    match: "exact",
+    methods: ["GET", "HEAD"],
+    handler: (request, env, ctx) => handleWebFinger(request, env, ctx),
   },
 ];
 


### PR DESCRIPTION
## Summary

- Compose `@dwk/webfinger` in the template's Worker (`Resources/Template/worker/worker.ts`) so `/.well-known/webfinger` resolves `acct:site@<host>` to the ActivityPub actor's `self` link, letting `@site@domain` search work in Mastodon and other fediverse clients.
- RFC 7033 conformance (query validation, CORS, JRD body, 400/404) lives entirely inside `@dwk/webfinger`'s own handler; this PR only supplies the resource map and returns 503 when ActivityPub isn't configured, matching every other composed handler in this file.
- Fixed a stale `#364` comment reference near `ACTIVITYPUB_USERNAME` (should have been `#366`).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`. The `@dwk/workers` monorepo's `catalog.json` already publishes the `webfinger` route claim (`id: "webfinger"`, `/.well-known/webfinger`, `authorityBound: true`) on `main` — no sidecar change needed. `@dwk/webfinger@0.1.0-beta.4` is already published to npm and is now a direct dependency of the template.
- [ ] This change needs a paired PR in `Anglesite/anglesite` — N/A.

## Test plan

- [x] `npm run test:worker` (vitest, `Resources/Template/`) — added 4 new tests (200/JRD/CORS success, 503 unconfigured, 400 missing resource, 404 unknown resource), all pass; full suite (82 tests) passes with no regressions.
- [x] `npx tsc --noEmit` in `Resources/Template/` — clean.
- [x] `swift test --package-path .` (targeted: `WorkerCatalogTests`, `WorkerCompositionTests`, `WellKnownInventoryTests`, `SocialWorkerProvisionCommandTests`, `DependencySyncApplierTests`, `DependencySyncCheckerTests`) — all pass; these are the suites that read `package.json`/route-claim fixtures.
- [x] `swift test --package-path .` (full suite) — passes except a **pre-existing, unrelated** flake in `FoundationModelAssistant` (on-device streaming generation), confirmed unrelated by re-running `AnglesiteCoreTests` in isolation (clean). No Swift files were touched by this PR.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; this PR touches only `Resources/Template/`, no Swift/Xcode sources.
- Manual smoke: not applicable — this is a server-side Worker route with no UI surface; covered by the vitest suite exercising the real composed `worker.fetch` dispatch path.

Closes #366.