### PR TITLE
feat(#912): sync Micropub posts into Source/ as typed content

### DIFF
--- a/Resources/Template/worker/post-type-discovery.test.ts
+++ b/Resources/Template/worker/post-type-discovery.test.ts
@@ -71,6 +71,13 @@ describe("discoverCollection", () => {
     }))).toBe("articles");
   });
 
+  test("rich-text content object with only an html key (the standard Micropub create shape, no value key) is read via html", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      name: ["My Announcement"],
+      content: [{ html: "<p>Something else entirely</p>" }],
+    }))).toBe("articles");
+  });
+
   test("absent mf2 type ([]) is treated as h-entry", () => {
     expect(discoverCollection({ type: [], properties: { content: ["hi"] } })).toBe("notes");
   });

--- a/Resources/Template/worker/post-type-discovery.test.ts
+++ b/Resources/Template/worker/post-type-discovery.test.ts
@@ -132,4 +132,20 @@ describe("generateSlug", () => {
     const slug = generateSlug(mf2("h-entry", { content: ["hi"] }), commands());
     expect(slug).toMatch(/^[0-9a-z]+-[0-9a-z]{4}$/);
   });
+
+  test("an mp-slug containing a slash is sanitized to a single path segment", () => {
+    const slug = generateSlug(mf2("h-entry", { content: ["hi"] }), commands({ slug: "notes/x" }));
+    expect(slug).not.toContain("/");
+    expect(slug).toBe("notes-x");
+  });
+
+  test("an mp-slug that sluggifies to empty falls through to the name-derived slug", () => {
+    const slug = generateSlug(mf2("h-entry", { name: ["Hello"] }), commands({ slug: "///" }));
+    expect(slug).toBe("hello");
+  });
+
+  test("an mp-slug that sluggifies to empty with no name falls through to a random slug", () => {
+    const slug = generateSlug(mf2("h-entry", { content: ["hi"] }), commands({ slug: "///" }));
+    expect(slug).toMatch(/^[0-9a-z]+-[0-9a-z]{4}$/);
+  });
 });

--- a/Resources/Template/worker/post-type-discovery.test.ts
+++ b/Resources/Template/worker/post-type-discovery.test.ts
@@ -1,0 +1,128 @@
+// Resources/Template/worker/post-type-discovery.test.ts
+import { describe, expect, test } from "vitest";
+import { discoverCollection, generateSlug } from "./post-type-discovery.ts";
+import type { Mf2Object, MicropubCommands } from "@dwk/micropub";
+
+function mf2(type: string, properties: Record<string, unknown[]> = {}): Mf2Object {
+  return { type: [type], properties };
+}
+
+function commands(overrides: Partial<MicropubCommands> = {}): MicropubCommands {
+  return { syndicateTo: [], ...overrides };
+}
+
+describe("discoverCollection", () => {
+  test("h-event maps to events", () => {
+    expect(discoverCollection(mf2("h-event", { name: ["Meetup"] }))).toBe("events");
+  });
+
+  test("h-review maps to reviews", () => {
+    expect(discoverCollection(mf2("h-review", { "item-reviewed": ["A Book"] }))).toBe("reviews");
+  });
+
+  test("an unrecognized h-* type returns null", () => {
+    expect(discoverCollection(mf2("h-card", { name: ["Jane"] }))).toBeNull();
+  });
+
+  test("bookmark-of maps to bookmarks", () => {
+    expect(discoverCollection(mf2("h-entry", { "bookmark-of": ["https://example.com"] }))).toBe("bookmarks");
+  });
+
+  test("like-of maps to likes", () => {
+    expect(discoverCollection(mf2("h-entry", { "like-of": ["https://example.com"] }))).toBe("likes");
+  });
+
+  test("in-reply-to maps to replies", () => {
+    expect(discoverCollection(mf2("h-entry", { "in-reply-to": ["https://example.com"] }))).toBe("replies");
+  });
+
+  test("exactly one photo maps to photos", () => {
+    expect(discoverCollection(mf2("h-entry", { photo: ["https://example.com/a.jpg"] }))).toBe("photos");
+  });
+
+  test("two or more photos maps to albums", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      photo: ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+    }))).toBe("albums");
+  });
+
+  test("a name whose content doesn't start with it maps to articles", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      name: ["My Big Announcement"],
+      content: ["Today I'm launching something new..."],
+    }))).toBe("articles");
+  });
+
+  test("a name that is just the start of the content (auto-derived) maps to notes", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      name: ["Hello world"],
+      content: ["Hello world"],
+    }))).toBe("notes");
+  });
+
+  test("no name at all maps to notes", () => {
+    expect(discoverCollection(mf2("h-entry", { content: ["Just a quick note"] }))).toBe("notes");
+  });
+
+  test("rich-text content object is read via its plain-text value", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      name: ["My Announcement"],
+      content: [{ html: "<p>Something else entirely</p>", value: "Something else entirely" }],
+    }))).toBe("articles");
+  });
+
+  test("absent mf2 type ([]) is treated as h-entry", () => {
+    expect(discoverCollection({ type: [], properties: { content: ["hi"] } })).toBe("notes");
+  });
+
+  test("empty content does not trigger the article check even with a name present", () => {
+    expect(discoverCollection(mf2("h-entry", { name: ["Untitled"] }))).toBe("notes");
+  });
+
+  test("repost-of returns null", () => {
+    expect(discoverCollection(mf2("h-entry", { "repost-of": ["https://example.com/post"] }))).toBeNull();
+  });
+
+  test("rsvp returns null", () => {
+    expect(discoverCollection(mf2("h-entry", { rsvp: ["yes"] }))).toBeNull();
+  });
+
+  test("an RSVP (rsvp + in-reply-to together — the standard RSVP shape) returns null, not replies", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      "in-reply-to": ["https://example.com/event"],
+      rsvp: ["yes"],
+    }))).toBeNull();
+  });
+
+  test("checkin returns null", () => {
+    expect(discoverCollection(mf2("h-entry", { checkin: [{ type: ["h-card"], properties: { name: ["Venue"] } }] }))).toBeNull();
+  });
+
+  test("video returns null", () => {
+    expect(discoverCollection(mf2("h-entry", { video: ["https://example.com/video.mp4"] }))).toBeNull();
+  });
+
+  test("a name that is a prefix of longer content (not the whole content) still maps to notes", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      name: ["Hello world"],
+      content: ["Hello world and much more than that"],
+    }))).toBe("notes");
+  });
+});
+
+describe("generateSlug", () => {
+  test("prefers an explicit mp-slug command", () => {
+    const slug = generateSlug(mf2("h-entry", { content: ["hi"] }), commands({ slug: "my-slug" }));
+    expect(slug).toBe("my-slug");
+  });
+
+  test("falls back to a slugified name", () => {
+    const slug = generateSlug(mf2("h-entry", { name: ["Hello, World!"] }), commands());
+    expect(slug).toBe("hello-world");
+  });
+
+  test("falls back to a random timestamp-based slug when there is no slug or name", () => {
+    const slug = generateSlug(mf2("h-entry", { content: ["hi"] }), commands());
+    expect(slug).toMatch(/^[0-9a-z]+-[0-9a-z]{4}$/);
+  });
+});

--- a/Resources/Template/worker/post-type-discovery.ts
+++ b/Resources/Template/worker/post-type-discovery.ts
@@ -16,12 +16,19 @@ function hasProperty(mf2: Mf2Object, name: string): boolean {
   return Array.isArray(values) && values.length > 0;
 }
 
-/** Mirrors `worker.ts`'s AP fan-out `extractMf2ContentString` — same mf2 rich-text shape. */
+/**
+ * Mirrors `worker.ts`'s AP fan-out `extractMf2ContentString` — same mf2 rich-text shape. The
+ * standard Micropub JSON *create* shape for HTML content is `content: [{"html": "..."}]` with NO
+ * `value` key at all — `value` only appears in mf2 read back off a rendered page, not in what a
+ * client posts — so `html` is checked as a fallback, not just `value`.
+ */
 function plainTextContent(mf2: Mf2Object): string {
   const raw = mf2.properties.content?.[0];
   if (typeof raw === "string") return raw;
-  if (raw && typeof raw === "object" && typeof (raw as { value?: unknown }).value === "string") {
-    return (raw as { value: string }).value;
+  if (raw && typeof raw === "object") {
+    const obj = raw as { value?: unknown; html?: unknown };
+    if (typeof obj.value === "string") return obj.value;
+    if (typeof obj.html === "string") return obj.html;
   }
   return "";
 }

--- a/Resources/Template/worker/post-type-discovery.ts
+++ b/Resources/Template/worker/post-type-discovery.ts
@@ -1,0 +1,93 @@
+/**
+ * IndieWeb Post Type Discovery (https://www.w3.org/TR/post-type-discovery/), extended with a
+ * `bookmark-of` check and a count-based photo/album split, mapping an incoming Micropub mf2
+ * object to the Astro content collection it should land in once synced to git. See
+ * docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md §1.
+ *
+ * `discoverCollection` returns `null` for any type this bridge doesn't support yet (an
+ * unrecognized `h-*` type, `repost-of`, `rsvp`, `checkin`, `video`) — the caller must fall back
+ * to `@dwk/micropub`'s own default flat-URL policy rather than guessing a collection.
+ */
+
+import type { Mf2Object, MicropubCommands } from "@dwk/micropub";
+
+function hasProperty(mf2: Mf2Object, name: string): boolean {
+  const values = mf2.properties[name];
+  return Array.isArray(values) && values.length > 0;
+}
+
+/** Mirrors `worker.ts`'s AP fan-out `extractMf2ContentString` — same mf2 rich-text shape. */
+function plainTextContent(mf2: Mf2Object): string {
+  const raw = mf2.properties.content?.[0];
+  if (typeof raw === "string") return raw;
+  if (raw && typeof raw === "object" && typeof (raw as { value?: unknown }).value === "string") {
+    return (raw as { value: string }).value;
+  }
+  return "";
+}
+
+export function discoverCollection(mf2: Mf2Object): string | null {
+  const type = mf2.type[0];
+  if (type === "h-event") return "events";
+  if (type === "h-review") return "reviews";
+  if (type !== undefined && type !== "h-entry") return null;
+
+  // Unsupported post types — these should be skipped, not miscategorized as notes/articles.
+  // Check these before supported types (e.g., in-reply-to) to prevent combinations like
+  // RSVP + in-reply-to from being miscategorized.
+  if (hasProperty(mf2, "repost-of")) return null;
+  if (hasProperty(mf2, "rsvp")) return null;
+  if (hasProperty(mf2, "checkin")) return null;
+  if (hasProperty(mf2, "video")) return null;
+
+  if (hasProperty(mf2, "bookmark-of")) return "bookmarks";
+  if (hasProperty(mf2, "like-of")) return "likes";
+  if (hasProperty(mf2, "in-reply-to")) return "replies";
+
+  const photoCount = mf2.properties.photo?.length ?? 0;
+  if (photoCount === 1) return "photos";
+  if (photoCount > 1) return "albums";
+
+  const name = mf2.properties.name?.[0];
+  if (typeof name === "string" && name.trim().length > 0) {
+    const trimmedName = name.trim();
+    const content = plainTextContent(mf2).trim();
+    if (content.length > 0 && !content.startsWith(trimmedName)) return "articles";
+  }
+  return "notes";
+}
+
+/** Lowercase, dash-separated slug derived from arbitrary text (max 80 chars). */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+/** A short, collision-resistant slug: base36 timestamp plus random suffix. */
+function randomSlug(): string {
+  const time = Date.now().toString(36);
+  const rand = Math.floor(Math.random() * 36 ** 4)
+    .toString(36)
+    .padStart(4, "0");
+  return `${time}-${rand}`;
+}
+
+/**
+ * Same slug policy as `@dwk/micropub`'s own default `generatePostUrl` (`mp-slug` → a slug
+ * derived from `name` → a timestamp-based slug) — reimplemented here (not imported) because
+ * the package doesn't export its internal `slugify`/`randomSlug` helpers. Kept identical so a
+ * post's slug doesn't change depending on whether its type was recognized (see `worker.ts`'s
+ * `generatePostUrl`, which calls this once and uses the same slug for both the type-aware and
+ * flat-URL fallback branches).
+ */
+export function generateSlug(mf2: Mf2Object, commands: MicropubCommands): string {
+  const name = mf2.properties.name?.[0];
+  return (
+    commands.slug ||
+    (typeof name === "string" && name.trim() ? slugify(name) : "") ||
+    randomSlug()
+  );
+}

--- a/Resources/Template/worker/post-type-discovery.ts
+++ b/Resources/Template/worker/post-type-discovery.ts
@@ -89,12 +89,18 @@ function randomSlug(): string {
  * post's slug doesn't change depending on whether its type was recognized (see `worker.ts`'s
  * `generatePostUrl`, which calls this once and uses the same slug for both the type-aware and
  * flat-URL fallback branches).
+ *
+ * `commands.slug` (the Micropub `mp-slug` command) is client-supplied and unvalidated by
+ * `@dwk/micropub` — it must be run through `slugify()` just like the name-derived fallback, or a
+ * value containing `/` produces a multi-segment slug that either smuggles an unrecognized post
+ * into a collection (flat-URL fallback happens to look like `collection/slug`) or breaks the
+ * Swift-side `collectionAndSlug` two-segment parser for a real, recognized post. Slugifying can
+ * itself reduce a command to an empty string (e.g. `"///"`), so all three sources fall through in
+ * priority order rather than short-circuiting on a merely-present `commands.slug`.
  */
 export function generateSlug(mf2: Mf2Object, commands: MicropubCommands): string {
   const name = mf2.properties.name?.[0];
-  return (
-    commands.slug ||
-    (typeof name === "string" && name.trim() ? slugify(name) : "") ||
-    randomSlug()
-  );
+  const fromCommand = commands.slug ? slugify(commands.slug) : "";
+  const fromName = typeof name === "string" && name.trim() ? slugify(name) : "";
+  return fromCommand || fromName || randomSlug();
 }

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -1074,6 +1074,33 @@ test("micropub-to-activitypub fan-out: an mf2 rich-text content object publishes
   expect(outboxPage.orderedItems?.some((item) => item.object?.content?.includes("[object Object]"))).toBe(false);
 });
 
+test("micropub-to-activitypub fan-out: an html-only mf2 rich-text content object (the standard Micropub create shape, no value key) still publishes a non-empty Note", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const ctx = createExecutionContext();
+  const createResponse = await worker.fetch(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      // Standard Micropub JSON *create* shape for HTML content: { html } with no `value` key at
+      // all — `value` only appears in mf2 read back off a rendered page. The fan-out must fall
+      // back to `.html`, not just `.value`, or this silently skips publishing.
+      properties: { content: [{ html: "<p>Hello, html-only fediverse</p>" }] },
+    }),
+  }), testEnv, ctx);
+  expect(createResponse.status).toBe(201);
+  await waitOnExecutionContext(ctx);
+
+  const outboxPageResponse = await fetchWorker(new Request("https://owner.example/users/site/outbox?page=1"));
+  const outboxPage = await outboxPageResponse.json() as { orderedItems?: Array<{ object?: { content?: string } }> };
+  expect(outboxPage.orderedItems?.some((item) => item.object?.content?.includes("Hello, html-only fediverse"))).toBe(true);
+});
+
 test("micropub-to-activitypub fan-out: never fires when ActivityPub isn't provisioned", async () => {
   const { AP_PUBLISH_TOKEN: _unusedToken, ...envWithoutToken } = testEnv;
   const { token, keyPair } = await mintAccessToken("create");

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -656,6 +656,107 @@ test("micropub: 503 when MICROPUB_DB isn't bound", async () => {
   expect(response.status).toBe(503);
 });
 
+test("micropub: a note (plain content, no name) is created under /notes/", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: { content: ["Just a quick note"] },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  const location = response.headers.get("location");
+  expect(location).toMatch(/^https:\/\/owner\.example\/notes\/[0-9a-z-]+$/);
+});
+
+test("micropub: an article (name distinct from content) is created under /articles/", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: {
+        name: ["My Big Announcement"],
+        content: ["Today I'm launching something new..."],
+      },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  expect(response.headers.get("location")).toMatch(/^https:\/\/owner\.example\/articles\/my-big-announcement/);
+});
+
+test("micropub: a bookmark (bookmark-of) is created under /bookmarks/", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: { "bookmark-of": ["https://example.com/article"] },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  expect(response.headers.get("location")).toMatch(/^https:\/\/owner\.example\/bookmarks\//);
+});
+
+test("micropub: an h-event post is created under /events/", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-event"],
+      properties: { name: ["Meetup"], start: ["2026-08-01T18:00:00Z"] },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  expect(response.headers.get("location")).toMatch(/^https:\/\/owner\.example\/events\//);
+});
+
+test("micropub: an unrecognized type (h-card) falls back to the flat URL scheme", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-card"],
+      properties: { name: ["Jane Doe"] },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  const location = response.headers.get("location") ?? "";
+  // Flat scheme: exactly one path segment, no collection prefix.
+  expect(new URL(location).pathname.split("/").filter(Boolean).length).toBe(1);
+});
+
 // --- WebSub hub (V-3.3, #361) ---------------------------------------------------------------
 // Composition of @dwk/websub's hub. These run through worker.fetch in the workerd pool with
 // WEBSUB_DB/WEBSUB_QUEUE/SITE_URL bound (see vitest.config.ts), so they exercise the same

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -507,8 +507,13 @@ function handleWebmentionQueue(
  */
 function extractMf2ContentString(raw: unknown): string {
   if (typeof raw === "string") return raw;
-  if (raw && typeof raw === "object" && typeof (raw as { value?: unknown }).value === "string") {
-    return (raw as { value: string }).value;
+  if (raw && typeof raw === "object") {
+    const obj = raw as { value?: unknown; html?: unknown };
+    if (typeof obj.value === "string") return obj.value;
+    // Standard Micropub JSON *create* shape for HTML content: { html } with no `value` key at
+    // all — `value` only appears in mf2 read back off a rendered page, not in what a client
+    // posts — so `html` is checked as a fallback, not just `value`.
+    if (typeof obj.html === "string") return obj.html;
   }
   return "";
 }

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -14,6 +14,7 @@ import {
   createMicropub,
   type MicropubEnv,
 } from "@dwk/micropub";
+import { discoverCollection, generateSlug } from "./post-type-discovery.ts";
 import {
   createActivityPub,
   ActivityPubObject,
@@ -533,7 +534,19 @@ function handleMicropub(
     return Promise.resolve(new Response("Micropub is not configured", { status: 503 }));
   }
   const baseUrl = new URL(request.url).origin;
-  const micropub = createMicropub({ baseUrl, me: `${baseUrl}/` });
+  const micropub = createMicropub({
+    baseUrl,
+    me: `${baseUrl}/`,
+    // #912: assign a type-aware URL at create time so a synced git file (written under
+    // src/content/{collection}/, per MicropubContentSync) renders at the same URL this
+    // response's Location header already promised — see post-type-discovery.ts and
+    // docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md §1.
+    generatePostUrl: (post, commands) => {
+      const slug = generateSlug(post, commands);
+      const collection = discoverCollection(post);
+      return collection ? `${baseUrl}/${collection}/${slug}` : `${baseUrl}/${slug}`;
+    },
+  });
   const micropubEnv: MicropubEnv = {
     MEDIA: env.MEDIA,
     MICROPUB_DB: env.MICROPUB_DB,

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -202,6 +202,11 @@ final class PreviewModel {
             // (SiteSettings.provisionedWorkerResources.d1DatabaseID unset).
             _ = await ReceivedInteractionSync.pullAndCommitIfConfigured(
                 siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #912: pull Micropub-created posts from MICROPUB_DB and sync each into a typed
+            // content file under src/content/. No-ops for sites without a provisioned D1
+            // database (same gate as ReceivedInteractionSync — Micropub shares the database).
+            _ = await MicropubContentSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
             clearDevServerCommandInFlight(token: token)
         }
     }

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -273,5 +273,7 @@ public enum ContentScaffold {
         return out
     }
 
-    private static let titleLikeFieldNames: Set<String> = ["title", "name", "itemReviewed"]
+    // Not `private`: `MicropubContentSync` (#912) also reads this to fall back to a slug-derived
+    // title for a required title-like field a Micropub client didn't send.
+    static let titleLikeFieldNames: Set<String> = ["title", "name", "itemReviewed"]
 }

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -74,6 +74,23 @@ public struct ContentTypeProjections: Sendable, Equatable {
         self.microformatProperties = microformatProperties
         self.schemaType = schemaType
     }
+
+    /// The raw mf2 property name `@dwk/micropub` stores for `fieldName` — `microformatProperties`
+    /// with its mf2 prefix class (`p-`/`e-`/`u-`/`dt-`) stripped. `nil` if `fieldName` has no mf2
+    /// mapping (e.g. `draft`, which is derived from the Post Status extension's `post-status`
+    /// property rather than its own mf2 property). Used by the Micropub content-sync bridge
+    /// (#912) to read a post's raw property map — bare names, no prefix — for a given
+    /// `ContentTypeField`.
+    public func rawMf2Property(forField fieldName: String) -> String? {
+        microformatProperties[fieldName].map(Self.stripMf2Prefix)
+    }
+
+    private static func stripMf2Prefix(_ mfProperty: String) -> String {
+        for prefix in ["p-", "e-", "u-", "dt-"] where mfProperty.hasPrefix(prefix) {
+            return String(mfProperty.dropFirst(prefix.count))
+        }
+        return mfProperty
+    }
 }
 
 /// Where instances of a content type live on disk, mirroring the Astro layout `ContentScaffold`

--- a/Sources/AnglesiteCore/MicropubContentCommitter.swift
+++ b/Sources/AnglesiteCore/MicropubContentCommitter.swift
@@ -1,0 +1,143 @@
+// Sources/AnglesiteCore/MicropubContentCommitter.swift
+import Foundation
+
+/// Writes Micropub posts resolved by `MicropubContentSync` into the site's local git working
+/// copy as typed content files (`src/content/<collection>/<slug>.md`), then commits them in one
+/// commit. This is the "commit resolved posts into git" half of #912 — mirrors
+/// `ReceivedInteractionCommitter`'s full-set reconciliation, but per-collection and slug-aware:
+/// its id-keyed `data/interactions/` has no collision risk, while `src/content/<collection>/` is
+/// a directory humans hand-edit too. See
+/// docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md §4.
+public enum MicropubContentCommitter {
+    /// `Config/micropubSync.json`'s persisted shape: Micropub post URL → the `Source/`-relative
+    /// path it was written to. A flat `[String: String]` (not a wrapper struct with a
+    /// `pathsByURL` field) so the file on disk is exactly `{"<url>": "<relPath>", ...}` — simpler
+    /// to inspect/decode directly (including from tests) than a nested shape would be. Read/
+    /// written outside the git commit (it lives in `Config/`, never `Source/`) so a later
+    /// re-sync of the same post updates that exact file instead of re-resolving (and potentially
+    /// re-suffixing) its slug every time.
+    typealias SyncState = [String: String]
+
+    private static let stateFileName = "micropubSync.json"
+
+    private static func loadState(from configDirectory: URL) -> SyncState {
+        let url = configDirectory.appendingPathComponent(stateFileName)
+        guard let data = try? Data(contentsOf: url),
+              let state = try? JSONDecoder().decode(SyncState.self, from: data)
+        else { return [:] }
+        return state
+    }
+
+    private static func saveState(_ state: SyncState, to configDirectory: URL, fileManager: FileManager) {
+        let url = configDirectory.appendingPathComponent(stateFileName)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(state) else { return }
+        try? fileManager.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// Resolves the relative path a post should be written to: the path already recorded in
+    /// `state` for its URL, or (first sync) a freshly slugified path — suffixed (`-2`, `-3`, …)
+    /// until it names either a nonexistent file or one already owned by this committer (i.e.
+    /// present in `state`'s values), so a Micropub-created file never silently overwrites a
+    /// hand-authored one sharing the same slug.
+    static func resolvePath(
+        for post: MicropubContentSync.ResolvedPost,
+        state: SyncState,
+        siteDirectory: URL,
+        fileManager: FileManager
+    ) -> String {
+        if let existing = state[post.url] { return existing }
+
+        let baseSlug = MicropubContentSync.collectionAndSlug(from: post.url)?.slug ?? post.url
+        let ownedPaths = Set(state.values)
+        var candidateSlug = baseSlug
+        var attempt = 1
+        while true {
+            let relPath = ContentScaffold.postRelativePath(collection: post.collection, slug: candidateSlug)
+            let fileURL = siteDirectory.appendingPathComponent(relPath)
+            if ownedPaths.contains(relPath) || !fileManager.fileExists(atPath: fileURL.path) {
+                return relPath
+            }
+            attempt += 1
+            candidateSlug = "\(baseSlug)-\(attempt)"
+        }
+    }
+
+    /// Reconciles `src/content/<collection>/` directories under `siteDirectory` against `posts`
+    /// (the full, current, resolved set) and commits the result in one commit:
+    /// - a new or changed post is written (or overwritten) at its resolved path
+    /// - a previously-synced post (per `Config/micropubSync.json`) absent from `posts` has its
+    ///   file deleted and its state entry removed
+    /// - unchanged files are left untouched, so a sync with nothing new is a true no-op
+    ///
+    /// `micropubSync.json` is saved regardless of whether the git commit itself succeeds: the
+    /// physical file write already happened, so a later retry must see that path as already
+    /// resolved rather than re-deriving (and potentially re-suffixing) a fresh slug for the same
+    /// post — only the *count this call reports* (and thus whether a caller treats it as "synced
+    /// this round") depends on the commit having actually landed.
+    @discardableResult
+    public static func commit(
+        posts: [MicropubContentSync.ResolvedPost],
+        into siteDirectory: URL,
+        configDirectory: URL,
+        fileManager: FileManager = .default,
+        now: @Sendable () -> Date = Date.init,
+        gitCommitBatch: @Sendable (URL, [String], String) async -> String? = InboxSubmissionCommitter.processGitCommitBatch
+    ) async -> Int {
+        var state = loadState(from: configDirectory)
+        let currentURLs = Set(posts.map(\.url))
+
+        var relPaths: [String] = []
+        var writtenCount = 0
+        var deletedCount = 0
+
+        // Delete files for URLs no longer in the current resolved set before writing, so a slug
+        // freed by a deletion is immediately available to a same-round collision resolution.
+        for (url, relPath) in state where !currentURLs.contains(url) {
+            let fileURL = siteDirectory.appendingPathComponent(relPath)
+            guard (try? fileManager.removeItem(at: fileURL)) != nil else { continue }
+            relPaths.append(relPath)
+            deletedCount += 1
+            state.removeValue(forKey: url)
+        }
+
+        for post in posts {
+            let relPath = resolvePath(for: post, state: state, siteDirectory: siteDirectory, fileManager: fileManager)
+            let fileURL = siteDirectory.appendingPathComponent(relPath)
+            let existingContents = try? String(contentsOf: fileURL, encoding: .utf8)
+            let baseContents = existingContents
+                ?? ContentScaffold.renderEntry(descriptor: post.descriptor, title: nil, now: now())
+            let newContents = TypedContentEditor.write(post.values, into: baseContents, descriptor: post.descriptor)
+            state[post.url] = relPath
+            guard newContents != existingContents else { continue }
+            try? fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            guard (try? newContents.data(using: .utf8)?.write(to: fileURL, options: .atomic)) != nil else { continue }
+            relPaths.append(relPath)
+            writtenCount += 1
+        }
+
+        guard !relPaths.isEmpty else {
+            saveState(state, to: configDirectory, fileManager: fileManager)
+            return 0
+        }
+
+        let message = Self.commitMessage(writtenCount: writtenCount, deletedCount: deletedCount)
+        let committed = await gitCommitBatch(siteDirectory, relPaths, message) != nil
+        saveState(state, to: configDirectory, fileManager: fileManager)
+        return committed ? writtenCount + deletedCount : 0
+    }
+
+    static func commitMessage(writtenCount: Int, deletedCount: Int) -> String {
+        switch (writtenCount, deletedCount) {
+        case (let w, 0):
+            return w == 1 ? "micropub: sync 1 post" : "micropub: sync \(w) posts"
+        case (0, let d):
+            return d == 1 ? "micropub: remove 1 post" : "micropub: remove \(d) posts"
+        case (let w, let d):
+            return "micropub: sync \(w) post\(w == 1 ? "" : "s"), remove \(d)"
+        }
+    }
+}

--- a/Sources/AnglesiteCore/MicropubContentCommitter.swift
+++ b/Sources/AnglesiteCore/MicropubContentCommitter.swift
@@ -97,11 +97,16 @@ public enum MicropubContentCommitter {
 
         // Delete files for URLs no longer in the current resolved set before writing, so a slug
         // freed by a deletion is immediately available to a same-round collision resolution.
+        // The state entry is dropped unconditionally, even when the removal itself fails (e.g.
+        // the file was already deleted by hand outside the app) — only whether to stage/commit
+        // the removal depends on `removeItem` having actually done something; otherwise a stale
+        // entry for an already-gone file would retry (and fail) on every sync forever.
         for (url, relPath) in state where !currentURLs.contains(url) {
             let fileURL = siteDirectory.appendingPathComponent(relPath)
-            guard (try? fileManager.removeItem(at: fileURL)) != nil else { continue }
-            relPaths.append(relPath)
-            deletedCount += 1
+            if (try? fileManager.removeItem(at: fileURL)) != nil {
+                relPaths.append(relPath)
+                deletedCount += 1
+            }
             state.removeValue(forKey: url)
         }
 

--- a/Sources/AnglesiteCore/MicropubContentCommitter.swift
+++ b/Sources/AnglesiteCore/MicropubContentCommitter.swift
@@ -39,9 +39,12 @@ public enum MicropubContentCommitter {
 
     /// Resolves the relative path a post should be written to: the path already recorded in
     /// `state` for its URL, or (first sync) a freshly slugified path — suffixed (`-2`, `-3`, …)
-    /// until it names either a nonexistent file or one already owned by this committer (i.e.
-    /// present in `state`'s values), so a Micropub-created file never silently overwrites a
-    /// hand-authored one sharing the same slug.
+    /// until it names a nonexistent file, so a Micropub-created file never silently overwrites a
+    /// hand-authored one (or a DIFFERENT Micropub post's own file) sharing the same slug. By the
+    /// time this loop runs, `post.url` has no entry in `state` (the early return above already
+    /// handled that case), so the only way a candidate path can already be on disk is that some
+    /// other post — hand-authored or a different, already-synced Micropub post — owns it; a
+    /// fresh post always suffixes past it regardless of who put it there.
     static func resolvePath(
         for post: MicropubContentSync.ResolvedPost,
         state: SyncState,
@@ -51,13 +54,12 @@ public enum MicropubContentCommitter {
         if let existing = state[post.url] { return existing }
 
         let baseSlug = MicropubContentSync.collectionAndSlug(from: post.url)?.slug ?? post.url
-        let ownedPaths = Set(state.values)
         var candidateSlug = baseSlug
         var attempt = 1
         while true {
             let relPath = ContentScaffold.postRelativePath(collection: post.collection, slug: candidateSlug)
             let fileURL = siteDirectory.appendingPathComponent(relPath)
-            if ownedPaths.contains(relPath) || !fileManager.fileExists(atPath: fileURL.path) {
+            if !fileManager.fileExists(atPath: fileURL.path) {
                 return relPath
             }
             attempt += 1

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -177,12 +177,16 @@ public enum MicropubContentSync {
             }
             if field.required { return nil }
 
-            // A non-required date/url-kind field that can't be resolved must be OMITTED, not set
-            // to an empty placeholder: `TypedContentEditor.write` only touches keys present in
-            // the `Values` it's given, so omitting the key leaves the file's existing value (or
-            // leaves it simply absent for a new file) instead of emitting an invalid blank scalar
-            // that a `z.coerce.date().optional()` / `z.string().url().optional()` schema rejects.
-            if field.kind == .date || field.kind == .datetime || field.kind == .url { continue }
+            // A non-required date/url/number-kind field that can't be resolved must be OMITTED,
+            // not set to an empty placeholder: `TypedContentEditor.write` only touches keys
+            // present in the `Values` it's given, so omitting the key leaves the file's existing
+            // value (or leaves it simply absent for a new file) instead of emitting an invalid
+            // blank scalar that a `z.coerce.date().optional()` / `z.string().url().optional()` /
+            // `z.number().optional()` schema rejects (`TypedContentEditor.defaultValue(for:
+            // .number)` is `.number(nil)`, which serializes to `.string("")` the same way the
+            // date/url defaults do).
+            if field.kind == .date || field.kind == .datetime || field.kind == .url
+                || field.kind == .number { continue }
 
             out[field.name] = TypedContentEditor.defaultValue(for: field.kind)
         }

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -28,17 +28,49 @@ public enum MicropubContentSync {
         return (segments[0], segments[1])
     }
 
-    /// Extracts a plain-text string from one mf2 property value: a bare string, or a rich-text
-    /// object's `value` key (mirrors `worker.ts`'s AP fan-out `extractMf2ContentString` — same
-    /// mf2 shape, same fallback). `nil` for any other shape.
+    /// Extracts a plain-text string from one mf2 property value: a bare string, a rich-text
+    /// object's `value` key, or (the standard Micropub JSON *create* shape, as opposed to mf2
+    /// read back off a rendered page) a rich-text object's `html` key with no `value` key at all
+    /// (mirrors `worker.ts`'s AP fan-out `extractMf2ContentString` — same mf2 shape, same
+    /// fallback). Storing the raw HTML string as-is in the Markdown body is a deliberate
+    /// simplification for this slice — no HTML-to-Markdown conversion (see the design doc's §3).
+    /// `nil` for any other shape.
     static func plainText(from value: JSONValue?) -> String? {
         switch value {
         case .string(let s): return s
         case .object(let o):
             if case .string(let s)? = o["value"] { return s }
+            if case .string(let s)? = o["html"] { return s }
             return nil
         default: return nil
         }
+    }
+
+    /// Extracts the `name` of a nested h-item/h-card mf2 object (`{type: [...], properties: {name:
+    /// [...]}}`) — the conventional shape for h-review's `item` property. Narrowly scoped to
+    /// `itemReviewed` resolution, not a general mf2-object-tree walker.
+    static func nestedItemName(from value: JSONValue?) -> String? {
+        guard case .object(let o)? = value, case .object(let properties)? = o["properties"] else { return nil }
+        switch properties["name"] {
+        case .string(let s): return s
+        case .array(let values):
+            if case .string(let s)? = values.first { return s }
+            return nil
+        default: return nil
+        }
+    }
+
+    /// `title`/`name` — the two field names this registry uses purely as a post's own title (as
+    /// opposed to `itemReviewed`, which is also "title-like" for `ContentScaffold`'s placeholder-
+    /// fill purposes but names the *reviewed item*, not the post — a slug-derived fallback would
+    /// be nonsensical there).
+    private static let slugFallbackFieldNames = ContentScaffold.titleLikeFieldNames.subtracting(["itemReviewed"])
+
+    /// "my-trip-2026" → "My Trip 2026": the slug-derived title fallback for a required title-like
+    /// field (`title`/`name`) a Micropub client didn't send (e.g. a nameless multi-photo post that
+    /// Post Type Discovery still routes to `albums`, whose descriptor requires `title`).
+    static func titleFromSlug(_ slug: String) -> String {
+        slug.split(separator: "-").map { $0.capitalized }.joined(separator: " ")
     }
 
     private static let isoWithFractionalSeconds: ISO8601DateFormatter = {
@@ -57,9 +89,10 @@ public enum MicropubContentSync {
         return df.date(from: raw)
     }
 
-    /// Builds one `ContentTypeField`'s value from a post's raw mf2 properties. Returns `nil` only
-    /// when `field.required` and no usable value exists — the caller (`values(for:properties:)`)
-    /// treats that as "skip the whole post."
+    /// Builds one `ContentTypeField`'s value from a post's raw mf2 properties. Returns `nil` when
+    /// no usable value exists at all — regardless of `field.required` — leaving the
+    /// required-vs-optional decision (fail the whole post vs. fall back vs. omit the key) to the
+    /// caller, `values(for:properties:updatedAt:slug:)`.
     static func fieldValue(
         for field: ContentTypeField,
         rawProperty: String,
@@ -68,9 +101,11 @@ public enum MicropubContentSync {
         let values = properties[rawProperty] ?? []
         switch field.kind {
         case .string, .text, .url, .image, .markdown:
-            guard let text = values.first.flatMap(plainText) else {
-                return field.required ? nil : .text("")
-            }
+            let raw = values.first
+            // `itemReviewed` (h-review's `item`) is conventionally a nested h-item/h-card mf2
+            // object, not a plain string — only that field tries the nested-object fallback.
+            let text = plainText(from: raw) ?? (field.name == "itemReviewed" ? nestedItemName(from: raw) : nil)
+            guard let text else { return nil }
             return .text(text)
         // No field in the built-in registry maps a raw mf2 property to `.bool` today (`draft` is
         // special-cased in `values(for:)` below, driven by `post-status` instead) — this arm
@@ -78,29 +113,38 @@ public enum MicropubContentSync {
         case .bool:
             return .flag(false)
         case .date, .datetime:
-            guard let text = values.first.flatMap(plainText), let date = parseDate(text) else {
-                return field.required ? nil : .date(nil)
-            }
+            guard let text = values.first.flatMap(plainText), let date = parseDate(text) else { return nil }
             return .date(date)
         case .number:
-            guard let text = values.first.flatMap(plainText), let number = Double(text) else {
-                return field.required ? nil : .number(nil)
-            }
+            // A client can send `rating` as a genuine JSON number (not a string) — check that
+            // directly before falling back to the plainText-then-`Double(text)` string path.
+            if case .int(let n)? = values.first { return .number(Double(n)) }
+            if case .double(let n)? = values.first { return .number(n) }
+            guard let text = values.first.flatMap(plainText), let number = Double(text) else { return nil }
             return .number(number)
         case .stringArray:
             return .list(values.compactMap(plainText))
         case .imageArray:
             let strings = values.compactMap(plainText)
-            return (field.required && strings.isEmpty) ? nil : .list(strings)
+            return strings.isEmpty ? nil : .list(strings)
         }
     }
 
     /// Builds every field value for `descriptor` from a post's raw mf2 properties. Returns `nil`
-    /// (skip the whole post) when a required field can't be resolved — a malformed/partial post
-    /// shouldn't produce invalid frontmatter.
+    /// (skip the whole post) when a required field can't be resolved even after the fallbacks
+    /// below — a malformed/partial post shouldn't produce invalid frontmatter.
+    ///
+    /// - `updatedAt`: the D1 row's own `updated_at`, used as a `publishDate` fallback — `@dwk/
+    ///   micropub` does NOT inject a `published` timestamp on create, so the micropub.rocks
+    ///   conformance shape (no dates at all) would otherwise fail this always-required field.
+    /// - `slug`: the post URL's slug, used as a `title`/`name` fallback for a post whose required
+    ///   title-like field has no resolvable mf2 value (e.g. a nameless multi-photo post Post Type
+    ///   Discovery still routes to `albums`).
     static func values(
         for descriptor: ContentTypeDescriptor,
-        properties: [String: [JSONValue]]
+        properties: [String: [JSONValue]],
+        updatedAt: Int,
+        slug: String
     ) -> TypedContentEditor.Values? {
         var out = TypedContentEditor.Values()
         for field in descriptor.fields {
@@ -112,15 +156,35 @@ public enum MicropubContentSync {
                 out["draft"] = .flag(status == "draft")
                 continue
             }
-            guard let rawProperty = descriptor.projections.rawMf2Property(forField: field.name) else {
-                if field.required { return nil }
-                out[field.name] = TypedContentEditor.defaultValue(for: field.kind)
+
+            let resolved = descriptor.projections.rawMf2Property(forField: field.name)
+                .flatMap { fieldValue(for: field, rawProperty: $0, properties: properties) }
+            if let resolved {
+                out[field.name] = resolved
                 continue
             }
-            guard let value = fieldValue(for: field, rawProperty: rawProperty, properties: properties) else {
-                return nil
+
+            // Unresolved (no mf2 mapping at all, or a mapping with no usable value). Try the
+            // field-specific fallbacks before giving up on the field/post.
+            if field.name == "publishDate" {
+                out[field.name] = .date(Date(timeIntervalSince1970: Double(updatedAt)))
+                continue
             }
-            out[field.name] = value
+            if field.required, field.kind == .string || field.kind == .text,
+               slugFallbackFieldNames.contains(field.name) {
+                out[field.name] = .text(titleFromSlug(slug))
+                continue
+            }
+            if field.required { return nil }
+
+            // A non-required date/url-kind field that can't be resolved must be OMITTED, not set
+            // to an empty placeholder: `TypedContentEditor.write` only touches keys present in
+            // the `Values` it's given, so omitting the key leaves the file's existing value (or
+            // leaves it simply absent for a new file) instead of emitting an invalid blank scalar
+            // that a `z.coerce.date().optional()` / `z.string().url().optional()` schema rejects.
+            if field.kind == .date || field.kind == .datetime || field.kind == .url { continue }
+
+            out[field.name] = TypedContentEditor.defaultValue(for: field.kind)
         }
         return out
     }
@@ -132,9 +196,10 @@ public enum MicropubContentSync {
         post: MicropubPostD1Client.Post,
         registry: ContentTypeRegistry = .default
     ) -> ResolvedPost? {
-        guard let (collection, _) = collectionAndSlug(from: post.url),
+        guard let (collection, slug) = collectionAndSlug(from: post.url),
               let descriptor = registry.descriptor(forCollection: collection),
-              let values = values(for: descriptor, properties: post.properties)
+              let values = values(
+                for: descriptor, properties: post.properties, updatedAt: post.updatedAt, slug: slug)
         else { return nil }
         return ResolvedPost(
             url: post.url, collection: collection, descriptor: descriptor,
@@ -146,12 +211,25 @@ public enum MicropubContentSync {
     /// `MicropubContentCommitter`. Returns 0 (never throws) if the D1 query failed. Soft-deleted
     /// and unresolvable posts are simply absent from the resolved set passed to the committer — a
     /// previously-synced post whose row later became unresolvable (soft-deleted, or an edit that
-    /// broke a required field) is removed from git the same way a truly-deleted post is.
+    /// broke a required field) is removed from git the same way a truly-deleted post is. A live
+    /// post that `resolve(post:)` can't map (unknown collection, or a required field with no
+    /// resolvable value even after the fallbacks above) is logged to `LogCenter`, per the design
+    /// doc's Error Handling section, rather than silently vanishing.
     public static func pullAndCommit(
         client: MicropubPostD1Client, siteDirectory: URL, configDirectory: URL
     ) async -> Int {
         guard let posts = try? await client.listAllPosts() else { return 0 }
-        let resolved = posts.filter { !$0.deleted }.compactMap { resolve(post: $0) }
+        var resolved: [ResolvedPost] = []
+        for post in posts where !post.deleted {
+            if let resolvedPost = resolve(post: post) {
+                resolved.append(resolvedPost)
+            } else {
+                await LogCenter.shared.append(
+                    source: "MicropubContentSync", stream: .stderr,
+                    text: "Skipping unresolvable Micropub post \(post.url): unknown collection "
+                        + "or a required field with no resolvable mf2 value.")
+            }
+        }
         return await MicropubContentCommitter.commit(
             posts: resolved, into: siteDirectory, configDirectory: configDirectory)
     }

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -140,4 +140,59 @@ public enum MicropubContentSync {
             url: post.url, collection: collection, descriptor: descriptor,
             values: values, updatedAt: post.updatedAt)
     }
+
+    /// Queries `client` for every current post (live and soft-deleted), resolves each to its
+    /// content type, and reconciles the result into `siteDirectory` via
+    /// `MicropubContentCommitter`. Returns 0 (never throws) if the D1 query failed. Soft-deleted
+    /// and unresolvable posts are simply absent from the resolved set passed to the committer — a
+    /// previously-synced post whose row later became unresolvable (soft-deleted, or an edit that
+    /// broke a required field) is removed from git the same way a truly-deleted post is.
+    public static func pullAndCommit(
+        client: MicropubPostD1Client, siteDirectory: URL, configDirectory: URL
+    ) async -> Int {
+        guard let posts = try? await client.listAllPosts() else { return 0 }
+        let resolved = posts.filter { !$0.deleted }.compactMap { resolve(post: $0) }
+        return await MicropubContentCommitter.commit(
+            posts: resolved, into: siteDirectory, configDirectory: configDirectory)
+    }
+
+    /// Reads the site's `SiteSettings` and the Cloudflare API token from `secretStore`; no-ops
+    /// (returns 0, no network call) unless a D1 database has been provisioned — same gate
+    /// `ReceivedInteractionSync` uses, since Micropub shares the same D1 database.
+    /// `configDirectory` is the package's `Config/` directory (`AnglesitePackage.configURL`), a
+    /// sibling of `siteDirectory` (`AnglesitePackage.sourceURL`).
+    public static func pullAndCommitIfConfigured(
+        siteDirectory: URL,
+        configDirectory: URL,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) async -> Int {
+        guard let settings = try? SiteConfigStore.read(from: configDirectory),
+              let databaseID = settings.provisionedWorkerResources?.d1DatabaseID, !databaseID.isEmpty,
+              let token = try? secretStore.readCloudflareToken(), !token.isEmpty
+        else { return 0 }
+        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        else { return 0 }
+
+        let client = MicropubPostD1Client(
+            accountID: accountID, databaseID: databaseID, apiToken: token, baseURL: baseURL, transport: transport)
+        return await pullAndCommit(client: client, siteDirectory: siteDirectory, configDirectory: configDirectory)
+    }
+
+    private struct CFAccount: Decodable, Sendable { let id: String }
+    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
+
+    /// Resolves the token's first visible Cloudflare account id — same resolution
+    /// `ReceivedInteractionSync` uses, since a personal Anglesite deployment has exactly one
+    /// Cloudflare account per token.
+    private static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
+        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
+        else { return nil }
+        return envelope.result?.first?.id
+    }
 }

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -1,0 +1,143 @@
+// Sources/AnglesiteCore/MicropubContentSync.swift
+import Foundation
+
+/// Orchestrates #912's "pull Micropub-created posts from D1 and turn each into a typed content
+/// file" step. This file holds the pure URL-parsing and mf2-to-field mapping logic; `pullAndCommit`
+/// / `pullAndCommitIfConfigured` (Task 7) extend this enum with the D1-query + commit glue.
+/// See docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md.
+public enum MicropubContentSync {
+    /// One post resolved to its content type, ready for `MicropubContentCommitter`.
+    public struct ResolvedPost: Sendable, Equatable {
+        public let url: String
+        public let collection: String
+        public let descriptor: ContentTypeDescriptor
+        public let values: TypedContentEditor.Values
+        public let updatedAt: Int
+    }
+
+    /// Parses `{baseUrl}/{collection}/{slug}` — the shape `post-type-discovery.ts`'s
+    /// `generatePostUrl` assigns at create time for a recognized mf2 type — into its collection
+    /// and slug. Returns `nil` for any other shape: the flat `{baseUrl}/{slug}` fallback URL a
+    /// post gets when its mf2 type wasn't recognized at create time, or a malformed URL. This
+    /// bridge only ever reads the collection out of the URL — it never re-derives it from mf2
+    /// properties, so classification happens exactly once (Worker-side, at create time).
+    static func collectionAndSlug(from urlString: String) -> (collection: String, slug: String)? {
+        guard let url = URL(string: urlString) else { return nil }
+        let segments = url.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard segments.count == 2 else { return nil }
+        return (segments[0], segments[1])
+    }
+
+    /// Extracts a plain-text string from one mf2 property value: a bare string, or a rich-text
+    /// object's `value` key (mirrors `worker.ts`'s AP fan-out `extractMf2ContentString` — same
+    /// mf2 shape, same fallback). `nil` for any other shape.
+    static func plainText(from value: JSONValue?) -> String? {
+        switch value {
+        case .string(let s): return s
+        case .object(let o):
+            if case .string(let s)? = o["value"] { return s }
+            return nil
+        default: return nil
+        }
+    }
+
+    private static let isoWithFractionalSeconds: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static func parseDate(_ raw: String) -> Date? {
+        if let d = isoWithFractionalSeconds.date(from: raw) { return d }
+        if let d = ISO8601DateFormatter().date(from: raw) { return d }
+        let df = DateFormatter()
+        df.calendar = Calendar(identifier: .iso8601)
+        df.timeZone = TimeZone(identifier: "UTC")
+        df.dateFormat = "yyyy-MM-dd"
+        return df.date(from: raw)
+    }
+
+    /// Builds one `ContentTypeField`'s value from a post's raw mf2 properties. Returns `nil` only
+    /// when `field.required` and no usable value exists — the caller (`values(for:properties:)`)
+    /// treats that as "skip the whole post."
+    static func fieldValue(
+        for field: ContentTypeField,
+        rawProperty: String,
+        properties: [String: [JSONValue]]
+    ) -> TypedContentEditor.FieldValue? {
+        let values = properties[rawProperty] ?? []
+        switch field.kind {
+        case .string, .text, .url, .image, .markdown:
+            guard let text = values.first.flatMap(plainText) else {
+                return field.required ? nil : .text("")
+            }
+            return .text(text)
+        // No field in the built-in registry maps a raw mf2 property to `.bool` today (`draft` is
+        // special-cased in `values(for:)` below, driven by `post-status` instead) — this arm
+        // exists only for switch exhaustiveness / defense-in-depth against a future bool field.
+        case .bool:
+            return .flag(false)
+        case .date, .datetime:
+            guard let text = values.first.flatMap(plainText), let date = parseDate(text) else {
+                return field.required ? nil : .date(nil)
+            }
+            return .date(date)
+        case .number:
+            guard let text = values.first.flatMap(plainText), let number = Double(text) else {
+                return field.required ? nil : .number(nil)
+            }
+            return .number(number)
+        case .stringArray:
+            return .list(values.compactMap(plainText))
+        case .imageArray:
+            let strings = values.compactMap(plainText)
+            return (field.required && strings.isEmpty) ? nil : .list(strings)
+        }
+    }
+
+    /// Builds every field value for `descriptor` from a post's raw mf2 properties. Returns `nil`
+    /// (skip the whole post) when a required field can't be resolved — a malformed/partial post
+    /// shouldn't produce invalid frontmatter.
+    static func values(
+        for descriptor: ContentTypeDescriptor,
+        properties: [String: [JSONValue]]
+    ) -> TypedContentEditor.Values? {
+        var out = TypedContentEditor.Values()
+        for field in descriptor.fields {
+            // `draft` has no mf2 property of its own — it's derived from the Post Status
+            // extension's `post-status` property (`@dwk/micropub` validates this is either
+            // "draft" or "published"/absent before storing it).
+            if field.name == "draft" {
+                let status = properties["post-status"]?.first.flatMap(plainText)
+                out["draft"] = .flag(status == "draft")
+                continue
+            }
+            guard let rawProperty = descriptor.projections.rawMf2Property(forField: field.name) else {
+                if field.required { return nil }
+                out[field.name] = TypedContentEditor.defaultValue(for: field.kind)
+                continue
+            }
+            guard let value = fieldValue(for: field, rawProperty: rawProperty, properties: properties) else {
+                return nil
+            }
+            out[field.name] = value
+        }
+        return out
+    }
+
+    /// Resolves one D1 row to a `ResolvedPost`, or `nil` (skip — the caller logs this) when its
+    /// URL's collection isn't one this bridge maps to a registered content type, or a required
+    /// field can't be resolved from its mf2 properties.
+    static func resolve(
+        post: MicropubPostD1Client.Post,
+        registry: ContentTypeRegistry = .default
+    ) -> ResolvedPost? {
+        guard let (collection, _) = collectionAndSlug(from: post.url),
+              let descriptor = registry.descriptor(forCollection: collection),
+              let values = values(for: descriptor, properties: post.properties)
+        else { return nil }
+        return ResolvedPost(
+            url: post.url, collection: collection, descriptor: descriptor,
+            values: values, updatedAt: post.updatedAt)
+    }
+}

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -1,5 +1,10 @@
 // Sources/AnglesiteCore/MicropubContentSync.swift
 import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Orchestrates #912's "pull Micropub-created posts from D1 and turn each into a typed content
 /// file" step. This file holds the pure URL-parsing and mf2-to-field mapping logic; `pullAndCommit`

--- a/Sources/AnglesiteCore/MicropubPostD1Client.swift
+++ b/Sources/AnglesiteCore/MicropubPostD1Client.swift
@@ -1,0 +1,114 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Cloudflare D1 HTTP API client for `@dwk/micropub`'s `posts` table (#912). Mirrors
+/// `WebmentionInboxD1Client` exactly — same injectable-transport DI, same D1 HTTP query shape —
+/// reading the shared `{site}-social` D1 database's Micropub post store instead of the
+/// webmention inbox. See docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md §2.
+public struct MicropubPostD1Client: Sendable {
+    /// A stored Micropub post, as read from the `posts` table
+    /// (`@dwk/micropub`'s `packages/micropub/src/store.ts`).
+    public struct Post: Sendable, Equatable {
+        public let url: String
+        /// The mf2 root type, e.g. `"h-entry"`.
+        public let type: String
+        /// The raw mf2 property map — each property name maps to its ordered value list,
+        /// matching `@dwk/micropub`'s `Record<string, unknown[]>` storage shape.
+        public let properties: [String: [JSONValue]]
+        public let deleted: Bool
+        public let updatedAt: Int
+
+        public init(url: String, type: String, properties: [String: [JSONValue]], deleted: Bool, updatedAt: Int) {
+            self.url = url
+            self.type = type
+            self.properties = properties
+            self.deleted = deleted
+            self.updatedAt = updatedAt
+        }
+    }
+
+    private struct Row: Decodable {
+        let url: String
+        let type: String
+        let properties: String
+        let deleted: Int
+        let updated_at: Int
+    }
+
+    private struct QueryResult: Decodable {
+        let results: [Row]?
+        let success: Bool
+    }
+
+    private struct Envelope: Decodable {
+        let success: Bool
+        let result: [QueryResult]?
+    }
+
+    private struct QueryBody: Encodable {
+        let sql: String
+    }
+
+    /// Selects every post row — live and soft-deleted alike, newest-updated first. The sync
+    /// bridge needs soft-deleted rows too, so it can remove their git snapshot on the next
+    /// reconcile (mirrors `ReceivedInteractionSync`'s "pull the full current set" pattern).
+    private static let listAllSQL =
+        "SELECT url, type, properties, deleted, updated_at FROM posts ORDER BY updated_at DESC"
+
+    private let baseURL: String
+    private let accountID: String
+    private let databaseID: String
+    private let apiToken: String
+    private let transport: CloudflareTransport
+
+    public init(
+        accountID: String,
+        databaseID: String,
+        apiToken: String,
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.accountID = accountID
+        self.databaseID = databaseID
+        self.apiToken = apiToken
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    /// Lists every post currently in `MICROPUB_DB`, live and soft-deleted alike. A row whose
+    /// `properties` column isn't valid JSON (or isn't a JSON object of arrays) is skipped rather
+    /// than failing the whole pull — a single malformed row shouldn't block every other post.
+    public func listAllPosts() async throws -> [Post] {
+        let url = URL(string: "\(baseURL)/accounts/\(accountID)/d1/database/\(databaseID)/query")
+        guard let url else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(QueryBody(sql: Self.listAllSQL))
+
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data), envelope.success,
+              let rows = envelope.result?.first?.results
+        else { throw CloudflareError.malformedResponse }
+
+        return rows.compactMap { row in
+            guard let propertiesData = row.properties.data(using: .utf8),
+                  let raw = try? JSONSerialization.jsonObject(with: propertiesData) as? [String: [Any]]
+            else { return nil }
+            var properties: [String: [JSONValue]] = [:]
+            for (key, values) in raw {
+                properties[key] = values.compactMap(JSONValue.from)
+            }
+            return Post(
+                url: row.url, type: row.type, properties: properties,
+                deleted: row.deleted != 0, updatedAt: row.updated_at)
+        }
+    }
+}

--- a/Sources/AnglesiteCore/MicropubPostD1Client.swift
+++ b/Sources/AnglesiteCore/MicropubPostD1Client.swift
@@ -98,17 +98,25 @@ public struct MicropubPostD1Client: Sendable {
               let rows = envelope.result?.first?.results
         else { throw CloudflareError.malformedResponse }
 
-        return rows.compactMap { row in
+        var posts: [Post] = []
+        for row in rows {
             guard let propertiesData = row.properties.data(using: .utf8),
                   let raw = try? JSONSerialization.jsonObject(with: propertiesData) as? [String: [Any]]
-            else { return nil }
+            else {
+                await LogCenter.shared.append(
+                    source: "MicropubPostD1Client", stream: .stderr,
+                    text: "Skipping Micropub post \(row.url): properties column is not valid JSON. "
+                        + "It will be re-attempted on the next pull.")
+                continue
+            }
             var properties: [String: [JSONValue]] = [:]
             for (key, values) in raw {
                 properties[key] = values.compactMap(JSONValue.from)
             }
-            return Post(
+            posts.append(Post(
                 url: row.url, type: row.type, properties: properties,
-                deleted: row.deleted != 0, updatedAt: row.updated_at)
+                deleted: row.deleted != 0, updatedAt: row.updated_at))
         }
+        return posts
     }
 }

--- a/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
@@ -243,4 +243,27 @@ struct ContentTypeRegistryTests {
             }
         }
     }
+
+    // MARK: rawMf2Property reverse lookup
+
+    @Test("rawMf2Property strips the mf2 prefix class from a field's microformat mapping")
+    func rawMf2PropertyStripsPrefix() {
+        let article = ContentTypeRegistry.article
+        #expect(article.projections.rawMf2Property(forField: "body") == "content")        // e-content
+        #expect(article.projections.rawMf2Property(forField: "publishDate") == "published") // dt-published
+        #expect(article.projections.rawMf2Property(forField: "tags") == "category")        // p-category
+    }
+
+    @Test("rawMf2Property handles the u- prefix")
+    func rawMf2PropertyHandlesUPrefix() {
+        let bookmark = ContentTypeRegistry.bookmark
+        #expect(bookmark.projections.rawMf2Property(forField: "bookmarkOf") == "bookmark-of") // u-bookmark-of
+    }
+
+    @Test("rawMf2Property returns nil for a field with no mf2 mapping")
+    func rawMf2PropertyNilForUnmappedField() {
+        let article = ContentTypeRegistry.article
+        #expect(article.projections.rawMf2Property(forField: "draft") == nil)
+        #expect(article.projections.rawMf2Property(forField: "nonexistent") == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
@@ -1,0 +1,195 @@
+// Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Serialized for the same reason as ReceivedInteractionCommitterTests: real `git` subprocesses
+// via raw `Process()` in `makeThrowawayGitRepo()` trip a rare CI heap-corruption crash when run
+// concurrently with the rest of the subprocess-heavy suite.
+@Suite(.serialized)
+struct MicropubContentCommitterTests {
+    private static func post(
+        url: String, collection: String = "notes", body: String = "Hello world",
+        updatedAt: Int = 1_753_300_000
+    ) -> MicropubContentSync.ResolvedPost {
+        let descriptor = ContentTypeRegistry.default.descriptor(forCollection: collection)!
+        var values = TypedContentEditor.Values()
+        values["body"] = .text(body)
+        values["publishDate"] = .date(Date(timeIntervalSince1970: 1_753_358_400))
+        values["tags"] = .list([])
+        values["draft"] = .flag(false)
+        return MicropubContentSync.ResolvedPost(
+            url: url, collection: collection, descriptor: descriptor, values: values, updatedAt: updatedAt)
+    }
+
+    @Test("commit writes a new post to src/content/<collection>/<slug>.md and records it in micropubSync.json")
+    func commitWritesNewPost() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let count = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123")],
+            into: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 1)
+
+        let written = siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+        let contents = try String(contentsOf: written, encoding: .utf8)
+        #expect(contents.contains("Hello world"))
+
+        let stateURL = configDirectory.appendingPathComponent("micropubSync.json")
+        let stateData = try Data(contentsOf: stateURL)
+        let state = try JSONDecoder().decode([String: String].self, from: stateData)
+        #expect(state["https://me.example/notes/hello-abc123"] == "src/content/notes/hello-abc123.md")
+    }
+
+    @Test("a second sync of the same post updates the same file without re-suffixing")
+    func secondSyncUpdatesInPlace() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        _ = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123", body: "First version")],
+            into: siteDirectory, configDirectory: configDirectory)
+
+        let count = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123", body: "Edited version")],
+            into: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 1)
+
+        // Still exactly the original path — no "-2" suffix from a spurious collision.
+        let written = siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md")
+        let contents = try String(contentsOf: written, encoding: .utf8)
+        #expect(contents.contains("Edited version"))
+        #expect(!FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123-2.md").path))
+    }
+
+    @Test("a slug colliding with an existing hand-authored file is suffixed, never overwritten")
+    func collisionWithHandAuthoredFileIsSuffixed() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let notesDir = siteDirectory.appendingPathComponent("src/content/notes", isDirectory: true)
+        try FileManager.default.createDirectory(at: notesDir, withIntermediateDirectories: true)
+        try "---\nbody: \"hand-authored\"\n---\n".write(
+            to: notesDir.appendingPathComponent("hello-abc123.md"), atomically: true, encoding: .utf8)
+
+        _ = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123", body: "From Micropub")],
+            into: siteDirectory, configDirectory: configDirectory)
+
+        let original = try String(contentsOf: notesDir.appendingPathComponent("hello-abc123.md"), encoding: .utf8)
+        #expect(original.contains("hand-authored"))
+        let suffixed = try String(contentsOf: notesDir.appendingPathComponent("hello-abc123-2.md"), encoding: .utf8)
+        #expect(suffixed.contains("From Micropub"))
+    }
+
+    @Test("commit deletes the file and state entry for a post no longer in the resolved set")
+    func commitDeletesStalePost() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        _ = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123")],
+            into: siteDirectory, configDirectory: configDirectory)
+        let written = siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+
+        // The post is now absent from the resolved set (soft-deleted in D1, or fell out of scope).
+        let count = await MicropubContentCommitter.commit(
+            posts: [], into: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 1)
+        #expect(!FileManager.default.fileExists(atPath: written.path))
+
+        let stateData = try Data(contentsOf: configDirectory.appendingPathComponent("micropubSync.json"))
+        let state = try JSONDecoder().decode([String: String].self, from: stateData)
+        #expect(state.isEmpty)
+    }
+
+    @Test("commit is a no-op when nothing changed")
+    func commitNoOpWhenNothingChanged() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let posts = [Self.post(url: "https://me.example/notes/hello-abc123")]
+        _ = await MicropubContentCommitter.commit(posts: posts, into: siteDirectory, configDirectory: configDirectory)
+
+        let callCount = CallCounter()
+        let count = await MicropubContentCommitter.commit(
+            posts: posts, into: siteDirectory, configDirectory: configDirectory,
+            gitCommitBatch: { _, _, _ in
+                await callCount.increment()
+                return "should-not-be-called"
+            })
+        #expect(count == 0)
+        #expect(await callCount.value == 0)
+    }
+
+    @Test("a git-commit failure still records state, so a retry doesn't duplicate the file with a suffixed slug")
+    func gitFailureStillRecordsStateToAvoidDuplication() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let posts = [Self.post(url: "https://me.example/notes/hello-abc123")]
+        let firstCount = await MicropubContentCommitter.commit(
+            posts: posts, into: siteDirectory, configDirectory: configDirectory,
+            gitCommitBatch: { _, _, _ in nil })
+        #expect(firstCount == 0)
+
+        // The file is on disk (uncommitted) and state.json already points at it — a retry must
+        // reuse that exact path rather than treating the leftover file as a foreign collision.
+        let retryCount = await MicropubContentCommitter.commit(posts: posts, into: siteDirectory, configDirectory: configDirectory)
+        #expect(retryCount == 0) // content unchanged since the failed attempt — nothing to (re-)commit
+        #expect(!FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123-2.md").path))
+    }
+
+    @Test("commitMessage describes write-only, delete-only, and mixed reconciles")
+    func commitMessageVariants() {
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 1, deletedCount: 0) == "micropub: sync 1 post")
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 2, deletedCount: 0) == "micropub: sync 2 posts")
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 0, deletedCount: 1) == "micropub: remove 1 post")
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 0, deletedCount: 2) == "micropub: remove 2 posts")
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 1, deletedCount: 1) == "micropub: sync 1 post, remove 1")
+    }
+
+    /// A throwaway `.anglesite`-style package: `Source/` (a git repo) beside `Config/`.
+    private static func makeThrowawaySite() throws -> (siteDirectory: URL, configDirectory: URL) {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("micropub-commit-test-\(UUID().uuidString)", isDirectory: true)
+        let siteDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("Config", isDirectory: true)
+        try fm.createDirectory(at: siteDirectory, withIntermediateDirectories: true)
+        try fm.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: siteDirectory.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = siteDirectory
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return (siteDirectory, configDirectory)
+    }
+}
+
+private actor CallCounter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}

--- a/Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
@@ -85,6 +85,43 @@ struct MicropubContentCommitterTests {
         #expect(suffixed.contains("From Micropub"))
     }
 
+    @Test("a second, unrelated post whose natural slug matches an earlier post's suffixed path gets its own file")
+    func distinctPostsWithCollidingNaturalSlugsGetDistinctFiles() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        // A hand-authored file already occupies the slug "hello" — post A (slug "hello") collides
+        // with it and gets suffixed to "hello-2.md".
+        let notesDir = siteDirectory.appendingPathComponent("src/content/notes", isDirectory: true)
+        try FileManager.default.createDirectory(at: notesDir, withIntermediateDirectories: true)
+        try "---\nbody: \"hand-authored\"\n---\n".write(
+            to: notesDir.appendingPathComponent("hello.md"), atomically: true, encoding: .utf8)
+        let postA = Self.post(url: "https://me.example/notes/hello", body: "Post A")
+
+        // Post B is a completely distinct, later-created URL (e.g. an explicit `mp-slug=hello-2`)
+        // whose OWN natural slug happens to be "hello-2" — the exact path A was just suffixed
+        // onto. `@dwk/micropub`'s URL-uniqueness check is per-URL, not per-eventual-filename, so
+        // this is a legitimate, distinct post. Before the fix, `ownedPaths.contains(relPath)`
+        // treated A's own suffixed path as "free real estate" for any post, so B silently
+        // collapsed onto A's file instead of suffixing past it.
+        let postB = Self.post(url: "https://me.example/notes/hello-2", body: "Post B")
+
+        _ = await MicropubContentCommitter.commit(
+            posts: [postA, postB], into: siteDirectory, configDirectory: configDirectory)
+
+        let stateData = try Data(contentsOf: configDirectory.appendingPathComponent("micropubSync.json"))
+        let state = try JSONDecoder().decode([String: String].self, from: stateData)
+        let pathA = try #require(state["https://me.example/notes/hello"])
+        let pathB = try #require(state["https://me.example/notes/hello-2"])
+        #expect(pathA == "src/content/notes/hello-2.md")
+        #expect(pathA != pathB, "distinct Micropub posts must never collapse onto the same file")
+
+        let contentsA = try String(contentsOf: siteDirectory.appendingPathComponent(pathA), encoding: .utf8)
+        let contentsB = try String(contentsOf: siteDirectory.appendingPathComponent(pathB), encoding: .utf8)
+        #expect(contentsA.contains("Post A"))
+        #expect(contentsB.contains("Post B"))
+    }
+
     @Test("commit deletes the file and state entry for a post no longer in the resolved set")
     func commitDeletesStalePost() async throws {
         let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()

--- a/Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
@@ -144,6 +144,29 @@ struct MicropubContentCommitterTests {
         #expect(state.isEmpty)
     }
 
+    @Test("a stale state entry for an already hand-deleted file is still dropped, not retried forever")
+    func staleStateEntryForAlreadyDeletedFileIsDropped() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        _ = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123")],
+            into: siteDirectory, configDirectory: configDirectory)
+        let written = siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md")
+
+        // Simulate the file having already been removed by hand, outside the app, before the
+        // post falls out of the resolved set.
+        try FileManager.default.removeItem(at: written)
+
+        let count = await MicropubContentCommitter.commit(
+            posts: [], into: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 0)  // nothing was actually removed by this call — it was already gone
+
+        let stateData = try Data(contentsOf: configDirectory.appendingPathComponent("micropubSync.json"))
+        let state = try JSONDecoder().decode([String: String].self, from: stateData)
+        #expect(state.isEmpty, "the stale entry must be dropped even though removeItem had nothing to remove")
+    }
+
     @Test("commit is a no-op when nothing changed")
     func commitNoOpWhenNothingChanged() async throws {
         let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()

--- a/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
@@ -23,6 +23,11 @@ struct MicropubContentSyncTests {
         #expect(MicropubContentSync.collectionAndSlug(from: "not a url") == nil)
     }
 
+    @Test("collectionAndSlug returns nil for a three-segment URL (a real, supported post's own path must never smuggle an extra segment past this guard)")
+    func collectionAndSlugNilForThreeSegments() {
+        #expect(MicropubContentSync.collectionAndSlug(from: "https://me.example/notes/a/b") == nil)
+    }
+
     // MARK: - plainText
 
     @Test("plainText reads a bare string value")

--- a/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
@@ -1,0 +1,137 @@
+// Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct MicropubContentSyncTests {
+    // MARK: - collectionAndSlug
+
+    @Test("collectionAndSlug parses a two-segment collection URL")
+    func collectionAndSlugParsesTwoSegments() {
+        let result = MicropubContentSync.collectionAndSlug(from: "https://me.example/notes/hello-abc123")
+        #expect(result?.collection == "notes")
+        #expect(result?.slug == "hello-abc123")
+    }
+
+    @Test("collectionAndSlug returns nil for the flat one-segment fallback URL")
+    func collectionAndSlugNilForFlatURL() {
+        #expect(MicropubContentSync.collectionAndSlug(from: "https://me.example/hello-abc123") == nil)
+    }
+
+    @Test("collectionAndSlug returns nil for a malformed URL")
+    func collectionAndSlugNilForMalformedURL() {
+        #expect(MicropubContentSync.collectionAndSlug(from: "not a url") == nil)
+    }
+
+    // MARK: - plainText
+
+    @Test("plainText reads a bare string value")
+    func plainTextReadsBareString() {
+        #expect(MicropubContentSync.plainText(from: .string("hello")) == "hello")
+    }
+
+    @Test("plainText reads a rich-text object's value key")
+    func plainTextReadsRichTextValue() {
+        let value = JSONValue.object(["html": .string("<p>hi</p>"), "value": .string("hi")])
+        #expect(MicropubContentSync.plainText(from: value) == "hi")
+    }
+
+    @Test("plainText returns nil for an unsupported shape")
+    func plainTextNilForUnsupportedShape() {
+        #expect(MicropubContentSync.plainText(from: .bool(true)) == nil)
+        #expect(MicropubContentSync.plainText(from: nil) == nil)
+    }
+
+    // MARK: - values(for:properties:)
+
+    @Test("values builds a note's fields from raw mf2 properties")
+    func valuesBuildsNoteFields() throws {
+        let note = ContentTypeRegistry.note
+        let properties: [String: [JSONValue]] = [
+            "content": [.string("Hello world")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+            "category": [.string("indieweb"), .string("test")],
+        ]
+        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        #expect(values["body"] == .text("Hello world"))
+        #expect(values["tags"] == .list(["indieweb", "test"]))
+        guard case .date(let date) = values["publishDate"] else {
+            Issue.record("expected publishDate to decode as a date")
+            return
+        }
+        #expect(date?.timeIntervalSince1970 == 1_784_894_400)
+    }
+
+    @Test("values derives draft from the post-status extension property, not a raw field")
+    func valuesDerivesDraftFromPostStatus() throws {
+        let note = ContentTypeRegistry.note
+        let properties: [String: [JSONValue]] = [
+            "content": [.string("Hello")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+            "post-status": [.string("draft")],
+        ]
+        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        #expect(values["draft"] == .flag(true))
+    }
+
+    @Test("values defaults draft to false when post-status is absent (published)")
+    func valuesDefaultsDraftToFalse() throws {
+        let note = ContentTypeRegistry.note
+        let properties: [String: [JSONValue]] = [
+            "content": [.string("Hello")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+        ]
+        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        #expect(values["draft"] == .flag(false))
+    }
+
+    @Test("values returns nil when a required field has no matching mf2 property")
+    func valuesNilWhenRequiredFieldMissing() {
+        let note = ContentTypeRegistry.note
+        // "body" (e-content, required) is missing.
+        let properties: [String: [JSONValue]] = ["published": [.string("2026-07-24T12:00:00Z")]]
+        #expect(MicropubContentSync.values(for: note, properties: properties) == nil)
+    }
+
+    @Test("values requires all photo values to resolve album's imageArray, or fails")
+    func valuesRequiresAlbumImages() {
+        let album = ContentTypeRegistry.album
+        let properties: [String: [JSONValue]] = [
+            "name": [.string("Trip")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+        ]
+        // "images" (u-photo, required imageArray) has no matching values at all.
+        #expect(MicropubContentSync.values(for: album, properties: properties) == nil)
+    }
+
+    // MARK: - resolve
+
+    @Test("resolve maps a post to its descriptor via the URL's collection segment")
+    func resolveMapsPostToDescriptor() throws {
+        let post = MicropubPostD1Client.Post(
+            url: "https://me.example/notes/hello-abc123", type: "h-entry",
+            properties: ["content": [.string("Hello")], "published": [.string("2026-07-24T12:00:00Z")]],
+            deleted: false, updatedAt: 1_753_300_000)
+        let resolved = try #require(MicropubContentSync.resolve(post: post))
+        #expect(resolved.collection == "notes")
+        #expect(resolved.descriptor.id == "note")
+        #expect(resolved.url == post.url)
+        #expect(resolved.updatedAt == 1_753_300_000)
+    }
+
+    @Test("resolve returns nil for the flat fallback URL (no collection segment)")
+    func resolveNilForFlatURL() {
+        let post = MicropubPostD1Client.Post(
+            url: "https://me.example/hello-abc123", type: "h-card",
+            properties: ["name": [.string("Jane")]], deleted: false, updatedAt: 1_753_300_000)
+        #expect(MicropubContentSync.resolve(post: post) == nil)
+    }
+
+    @Test("resolve returns nil when the URL's collection has no registered content type")
+    func resolveNilForUnknownCollection() {
+        let post = MicropubPostD1Client.Post(
+            url: "https://me.example/mystery/abc123", type: "h-entry",
+            properties: ["content": [.string("hi")]], deleted: false, updatedAt: 1_753_300_000)
+        #expect(MicropubContentSync.resolve(post: post) == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
@@ -42,7 +42,9 @@ struct MicropubContentSyncTests {
         #expect(MicropubContentSync.plainText(from: nil) == nil)
     }
 
-    // MARK: - values(for:properties:)
+    // MARK: - values(for:properties:updatedAt:slug:)
+
+    private static let anUpdatedAt = 1_753_300_000
 
     @Test("values builds a note's fields from raw mf2 properties")
     func valuesBuildsNoteFields() throws {
@@ -52,7 +54,8 @@ struct MicropubContentSyncTests {
             "published": [.string("2026-07-24T12:00:00Z")],
             "category": [.string("indieweb"), .string("test")],
         ]
-        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        let values = try #require(MicropubContentSync.values(
+            for: note, properties: properties, updatedAt: Self.anUpdatedAt, slug: "hello"))
         #expect(values["body"] == .text("Hello world"))
         #expect(values["tags"] == .list(["indieweb", "test"]))
         guard case .date(let date) = values["publishDate"] else {
@@ -70,7 +73,8 @@ struct MicropubContentSyncTests {
             "published": [.string("2026-07-24T12:00:00Z")],
             "post-status": [.string("draft")],
         ]
-        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        let values = try #require(MicropubContentSync.values(
+            for: note, properties: properties, updatedAt: Self.anUpdatedAt, slug: "hello"))
         #expect(values["draft"] == .flag(true))
     }
 
@@ -81,7 +85,8 @@ struct MicropubContentSyncTests {
             "content": [.string("Hello")],
             "published": [.string("2026-07-24T12:00:00Z")],
         ]
-        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        let values = try #require(MicropubContentSync.values(
+            for: note, properties: properties, updatedAt: Self.anUpdatedAt, slug: "hello"))
         #expect(values["draft"] == .flag(false))
     }
 
@@ -90,7 +95,8 @@ struct MicropubContentSyncTests {
         let note = ContentTypeRegistry.note
         // "body" (e-content, required) is missing.
         let properties: [String: [JSONValue]] = ["published": [.string("2026-07-24T12:00:00Z")]]
-        #expect(MicropubContentSync.values(for: note, properties: properties) == nil)
+        #expect(MicropubContentSync.values(
+            for: note, properties: properties, updatedAt: Self.anUpdatedAt, slug: "hello") == nil)
     }
 
     @Test("values requires all photo values to resolve album's imageArray, or fails")
@@ -101,7 +107,155 @@ struct MicropubContentSyncTests {
             "published": [.string("2026-07-24T12:00:00Z")],
         ]
         // "images" (u-photo, required imageArray) has no matching values at all.
-        #expect(MicropubContentSync.values(for: album, properties: properties) == nil)
+        #expect(MicropubContentSync.values(
+            for: album, properties: properties, updatedAt: Self.anUpdatedAt, slug: "trip") == nil)
+    }
+
+    // MARK: - values: Fix 1 — `published` fallback to `updatedAt`
+
+    @Test("values falls back to updatedAt for publishDate when the client sends no published property at all")
+    func valuesFallsBackToUpdatedAtForPublishDate() throws {
+        let note = ContentTypeRegistry.note
+        // The micropub.rocks conformance shape: h=entry&content=... with no dates whatsoever.
+        let properties: [String: [JSONValue]] = ["content": [.string("Hello world")]]
+        let values = try #require(MicropubContentSync.values(
+            for: note, properties: properties, updatedAt: 1_753_300_000, slug: "hello"))
+        #expect(values["body"] == .text("Hello world"))
+        guard case .date(let date) = values["publishDate"] else {
+            Issue.record("expected publishDate to fall back to a decoded date")
+            return
+        }
+        #expect(date?.timeIntervalSince1970 == 1_753_300_000)
+    }
+
+    // MARK: - values: Fix 2 — `{html: "..."}` rich-text objects with no `value` key
+
+    @Test("values reads body from a rich-text content object with only an html key (no value key)")
+    func valuesReadsBodyFromHTMLOnlyContentObject() throws {
+        let note = ContentTypeRegistry.note
+        let properties: [String: [JSONValue]] = [
+            "content": [.object(["html": .string("<p>Hello</p>")])],
+            "published": [.string("2026-07-24T12:00:00Z")],
+        ]
+        let values = try #require(MicropubContentSync.values(
+            for: note, properties: properties, updatedAt: Self.anUpdatedAt, slug: "hello"))
+        #expect(values["body"] == .text("<p>Hello</p>"))
+    }
+
+    // MARK: - values: Fix 5 — numeric mf2 properties and h-review's nested `item`
+
+    @Test("values resolves rating when sent as a genuine JSON number, not a string")
+    func valuesResolvesNumericRating() throws {
+        let review = ContentTypeRegistry.review
+        let properties: [String: [JSONValue]] = [
+            "item": [.string("A Book")],
+            "rating": [.int(4)],
+            "published": [.string("2026-07-24T12:00:00Z")],
+        ]
+        let values = try #require(MicropubContentSync.values(
+            for: review, properties: properties, updatedAt: Self.anUpdatedAt, slug: "a-book-review"))
+        #expect(values["rating"] == .number(4))
+    }
+
+    @Test("values resolves itemReviewed from a nested h-item mf2 object")
+    func valuesResolvesNestedItemReviewed() throws {
+        let review = ContentTypeRegistry.review
+        let nestedItem = JSONValue.object([
+            "type": .array([.string("h-item")]),
+            "properties": .object(["name": .array([.string("A Book")])]),
+        ])
+        let properties: [String: [JSONValue]] = [
+            "item": [nestedItem],
+            "rating": [.string("4")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+        ]
+        let values = try #require(MicropubContentSync.values(
+            for: review, properties: properties, updatedAt: Self.anUpdatedAt, slug: "a-book-review"))
+        #expect(values["itemReviewed"] == .text("A Book"))
+    }
+
+    // MARK: - values: Fix 6 — slug-derived title fallback for a title-like required field
+
+    @Test("values falls back to a slug-derived title for an album with no name property")
+    func valuesFallsBackToSlugDerivedTitleForAlbum() throws {
+        let album = ContentTypeRegistry.album
+        let properties: [String: [JSONValue]] = [
+            "photo": [.string("https://example.com/a.jpg"), .string("https://example.com/b.jpg")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+        ]
+        let values = try #require(MicropubContentSync.values(
+            for: album, properties: properties, updatedAt: Self.anUpdatedAt, slug: "my-trip-2026"))
+        #expect(values["title"] == .text("My Trip 2026"))
+        #expect(values["images"] == .list(["https://example.com/a.jpg", "https://example.com/b.jpg"]))
+    }
+
+    // MARK: - values: Fix 7 — an unresolvable optional date/url field is omitted, not blanked
+
+    @Test("values omits an unresolved optional datetime field instead of writing an invalid blank scalar")
+    func valuesOmitsUnresolvedOptionalDatetime() throws {
+        let article = ContentTypeRegistry.article
+        let properties: [String: [JSONValue]] = [
+            "name": [.string("My Announcement")],
+            "content": [.string("Today I'm launching something new")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+            // No "updated" property at all — `updated` (optional dt-updated) can't resolve.
+        ]
+        let values = try #require(MicropubContentSync.values(
+            for: article, properties: properties, updatedAt: Self.anUpdatedAt, slug: "my-announcement"))
+        #expect(values["updated"] == nil)
+        // A cleared optional stringArray (tags) is fine to default to an empty list, unlike date/url.
+        #expect(values["tags"] == .list([]))
+    }
+
+    // MARK: - values: Fix 8 — every built-in collection type resolves end-to-end
+
+    @Test("values resolves a realistic payload for every built-in collection type", arguments: [
+        "note", "article", "photo", "album", "bookmark", "reply", "like", "event", "review",
+    ])
+    func valuesResolvesEveryCollectionType(id: String) throws {
+        let descriptor = try #require(ContentTypeRegistry.default.descriptor(id: id))
+        let properties = Self.samplePayload(for: id)
+        let values = try #require(MicropubContentSync.values(
+            for: descriptor, properties: properties, updatedAt: Self.anUpdatedAt, slug: "sample-slug"))
+        for field in descriptor.fields where field.required {
+            #expect(values[field.name] != nil, "expected \(id)'s required field \(field.name) to resolve")
+        }
+    }
+
+    /// A plausible, complete mf2 properties payload for one built-in collection type, keyed by
+    /// each field's raw (prefix-stripped) mf2 property name.
+    private static func samplePayload(for id: String) -> [String: [JSONValue]] {
+        let published: [JSONValue] = [.string("2026-07-24T12:00:00Z")]
+        switch id {
+        case "note":
+            return ["content": [.string("Hello world")], "published": published]
+        case "article":
+            return [
+                "name": [.string("My Announcement")],
+                "content": [.string("Today I'm launching something new")],
+                "published": published,
+            ]
+        case "photo":
+            return ["photo": [.string("https://example.com/a.jpg")], "published": published]
+        case "album":
+            return [
+                "name": [.string("Trip")],
+                "photo": [.string("https://example.com/a.jpg"), .string("https://example.com/b.jpg")],
+                "published": published,
+            ]
+        case "bookmark":
+            return ["bookmark-of": [.string("https://example.com/article")], "published": published]
+        case "reply":
+            return ["in-reply-to": [.string("https://example.com/post")], "content": [.string("Agreed!")], "published": published]
+        case "like":
+            return ["like-of": [.string("https://example.com/post")], "published": published]
+        case "event":
+            return ["name": [.string("Meetup")], "start": published]
+        case "review":
+            return ["item": [.string("A Book")], "rating": [.int(5)], "published": published]
+        default:
+            return [:]
+        }
     }
 
     // MARK: - resolve

--- a/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
@@ -135,3 +135,144 @@ struct MicropubContentSyncTests {
         #expect(MicropubContentSync.resolve(post: post) == nil)
     }
 }
+
+// MARK: - pullAndCommit / pullAndCommitIfConfigured
+// Serialized for the same reason as ReceivedInteractionSyncTests: real `git` subprocesses trip a
+// rare CI heap-corruption crash when run concurrently with the rest of the subprocess-heavy suite.
+extension MicropubContentSyncTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func d1Body(_ rowsJSON: String) -> Data {
+        Data("""
+        {"success": true, "result": [{"success": true, "results": [\(rowsJSON)]}]}
+        """.utf8)
+    }
+
+    @Test("pullAndCommit resolves and commits every recognized live post")
+    func pullAndCommitResolvesAndCommits() async throws {
+        let (siteDirectory, _) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+        let configDirectory = siteDirectory.deletingLastPathComponent().appendingPathComponent("Config")
+
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/hello-abc123", "type": "h-entry",
+         "properties": "{\\"content\\":[\\"Hello\\"],\\"published\\":[\\"2026-07-24T12:00:00Z\\"]}",
+         "deleted": 0, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (body, Self.response(200)) })
+
+        let count = await MicropubContentSync.pullAndCommit(
+            client: client, siteDirectory: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 1)
+        #expect(FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md").path))
+    }
+
+    @Test("pullAndCommit returns 0 without touching git when the D1 query fails")
+    func pullAndCommitD1FailureIsNoOp() async {
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (Data(), Self.response(500)) })
+        let count = await MicropubContentSync.pullAndCommit(
+            client: client, siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: URL(fileURLWithPath: "/nonexistent"))
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommitIfConfigured no-ops when the site has no provisioned D1 database")
+    func noOpsWithoutD1Database() async {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("micropub-sync-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+
+        let count = await MicropubContentSync.pullAndCommitIfConfigured(
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "unused"),
+            transport: { _ in
+                Issue.record("transport must not be called with no provisioned D1 database")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommitIfConfigured resolves the account id, queries D1, and commits")
+    func resolvesAccountAndCommits() async throws {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("micropub-sync-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(d1DatabaseID: "db1")))
+
+        let (siteDirectory, _) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let accountsBody = Data("""
+        {"success": true, "result": [{"id": "acct1"}]}
+        """.utf8)
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/hello-abc123", "type": "h-entry",
+         "properties": "{\\"content\\":[\\"Hello\\"],\\"published\\":[\\"2026-07-24T12:00:00Z\\"]}",
+         "deleted": 0, "updated_at": 1753300000}
+        """)
+
+        let count = await MicropubContentSync.pullAndCommitIfConfigured(
+            siteDirectory: siteDirectory,
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "token"),
+            transport: { request in
+                if request.url!.path.hasSuffix("/accounts") { return (accountsBody, Self.response(200)) }
+                if request.url!.path.contains("/d1/database/db1/query") { return (body, Self.response(200)) }
+                return (Data(), Self.response(404))
+            })
+        #expect(count == 1)
+        #expect(FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md").path))
+    }
+
+    /// A throwaway `.anglesite`-style package: `Source/` (a git repo) beside `Config/`. Mirrors
+    /// `MicropubContentCommitterTests.makeThrowawaySite`.
+    private static func makeThrowawaySite() throws -> (siteDirectory: URL, configDirectory: URL) {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("micropub-sync-test-\(UUID().uuidString)", isDirectory: true)
+        let siteDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("Config", isDirectory: true)
+        try fm.createDirectory(at: siteDirectory, withIntermediateDirectories: true)
+        try fm.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: siteDirectory.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = siteDirectory
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return (siteDirectory, configDirectory)
+    }
+}
+
+private struct FakeSecretStore: SecretStore {
+    let token: String?
+    func read(account: String) throws -> String? { account == SecretAccounts.cloudflareToken ? token : nil }
+    func write(_ value: String, account: String) throws {}
+    func delete(account: String) throws {}
+}

--- a/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
@@ -212,6 +212,32 @@ struct MicropubContentSyncTests {
         #expect(values["tags"] == .list([]))
     }
 
+    // No built-in content type currently has an optional `.number` field (only `review.rating`,
+    // which is required), so this is defensive/latent rather than reachable through the real
+    // registry — exercise it against a synthetic descriptor instead of `ContentTypeRegistry`.
+    @Test("values omits an unresolved optional number field instead of writing an invalid blank scalar")
+    func valuesOmitsUnresolvedOptionalNumber() throws {
+        let descriptor = ContentTypeDescriptor(
+            id: "syntheticScore",
+            displayName: "Synthetic Score",
+            storage: .collection("scores"),
+            fields: [
+                ContentTypeField("title", .string, required: true),
+                ContentTypeField("score", .number, required: false),
+            ],
+            projections: ContentTypeProjections(
+                microformat: "h-entry",
+                microformatProperties: ["title": "p-name"],
+                schemaType: nil))
+        let properties: [String: [JSONValue]] = [
+            "name": [.string("Synthetic Post")],
+            // No "score" property at all — the optional `.number` field can't resolve.
+        ]
+        let values = try #require(MicropubContentSync.values(
+            for: descriptor, properties: properties, updatedAt: Self.anUpdatedAt, slug: "synthetic-post"))
+        #expect(values["score"] == nil)
+    }
+
     // MARK: - values: Fix 8 — every built-in collection type resolves end-to-end
 
     @Test("values resolves a realistic payload for every built-in collection type", arguments: [

--- a/Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
@@ -73,7 +73,7 @@ struct MicropubPostD1ClientTests {
         #expect(post.deleted == true)
     }
 
-    @Test("skips a row whose properties column isn't valid JSON")
+    @Test("skips a row whose properties column isn't valid JSON, and logs the skip")
     func skipsMalformedPropertiesRow() async throws {
         let body = Self.d1Body("""
         {"url": "https://me.example/notes/bad", "type": "h-entry",
@@ -83,8 +83,16 @@ struct MicropubPostD1ClientTests {
             accountID: "acct1", databaseID: "db1", apiToken: "token",
             transport: { _ in (body, Self.response(200)) })
 
+        let beforeCount = await LogCenter.shared.snapshot().count
         let posts = try await client.listAllPosts()
         #expect(posts.isEmpty)
+
+        let logged = await LogCenter.shared.snapshot()
+        #expect(logged.count == beforeCount + 1)
+        let entry = try #require(logged.last)
+        #expect(entry.source == "MicropubPostD1Client")
+        #expect(entry.stream == .stderr)
+        #expect(entry.text.contains("https://me.example/notes/bad"))
     }
 
     @Test("throws unauthorized on 401")

--- a/Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
@@ -1,0 +1,135 @@
+// Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct MicropubPostD1ClientTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func d1Body(_ rowsJSON: String) -> Data {
+        Data("""
+        {"success": true, "result": [{"success": true, "results": [\(rowsJSON)]}]}
+        """.utf8)
+    }
+
+    @Test("lists a live post and decodes its mf2 properties")
+    func listsLivePost() async throws {
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/abc123", "type": "h-entry",
+         "properties": "{\\"content\\":[\\"Hello world\\"],\\"published\\":[\\"2026-07-24T12:00:00Z\\"]}",
+         "deleted": 0, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let posts = try await client.listAllPosts()
+        let post = try #require(posts.first)
+        #expect(post.url == "https://me.example/notes/abc123")
+        #expect(post.type == "h-entry")
+        #expect(post.deleted == false)
+        #expect(post.updatedAt == 1_753_300_000)
+        #expect(post.properties["content"] == [.string("Hello world")])
+        #expect(post.properties["published"] == [.string("2026-07-24T12:00:00Z")])
+    }
+
+    @Test("decodes a nested rich-text content value")
+    func decodesRichTextContent() async throws {
+        let body = Self.d1Body("""
+        {"url": "https://me.example/articles/hi", "type": "h-entry",
+         "properties": "{\\"content\\":[{\\"html\\":\\"<p>Hi</p>\\",\\"value\\":\\"Hi\\"}]}",
+         "deleted": 0, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let posts = try await client.listAllPosts()
+        let post = try #require(posts.first)
+        let contentValues = try #require(post.properties["content"])
+        #expect(contentValues.count == 1)
+        guard case .object(let obj) = contentValues[0] else {
+            Issue.record("expected content[0] to decode as a JSONValue.object")
+            return
+        }
+        #expect(obj["value"] == .string("Hi"))
+    }
+
+    @Test("includes soft-deleted rows so the sync bridge can remove their git snapshot")
+    func includesSoftDeletedRows() async throws {
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/gone", "type": "h-entry",
+         "properties": "{\\"content\\":[\\"bye\\"]}", "deleted": 1, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let posts = try await client.listAllPosts()
+        let post = try #require(posts.first)
+        #expect(post.deleted == true)
+    }
+
+    @Test("skips a row whose properties column isn't valid JSON")
+    func skipsMalformedPropertiesRow() async throws {
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/bad", "type": "h-entry",
+         "properties": "not json", "deleted": 0, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let posts = try await client.listAllPosts()
+        #expect(posts.isEmpty)
+    }
+
+    @Test("throws unauthorized on 401")
+    func throwsUnauthorizedOn401() async throws {
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "bad-token",
+            transport: { _ in (Data(), Self.response(401)) })
+
+        await #expect(throws: CloudflareError.unauthorized) {
+            _ = try await client.listAllPosts()
+        }
+    }
+
+    @Test("throws http error on a non-2xx, non-auth status")
+    func throwsHTTPErrorOnFailureStatus() async throws {
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+
+        await #expect(throws: CloudflareError.http(status: 500)) {
+            _ = try await client.listAllPosts()
+        }
+    }
+
+    @Test("sends the query as a POST to the D1 query endpoint for the given account and database")
+    func sendsPostToD1QueryEndpoint() async throws {
+        let capturedRequest = ActorBox<URLRequest?>(nil)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { request in
+                await capturedRequest.set(request)
+                return (Self.d1Body(""), Self.response(200))
+            })
+
+        _ = try await client.listAllPosts()
+        let request = await capturedRequest.get()
+        #expect(request?.httpMethod == "POST")
+        #expect(request?.url?.absoluteString == "https://api.cloudflare.com/client/v4/accounts/acct1/d1/database/db1/query")
+        #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+    }
+}
+
+private actor ActorBox<Value: Sendable> {
+    private var value: Value
+    init(_ value: Value) { self.value = value }
+    func set(_ newValue: Value) { value = newValue }
+    func get() -> Value { value }
+}

--- a/docs/superpowers/plans/2026-07-24-micropub-content-sync.md
+++ b/docs/superpowers/plans/2026-07-24-micropub-content-sync.md
@@ -858,7 +858,7 @@ struct MicropubContentSyncTests {
             Issue.record("expected publishDate to decode as a date")
             return
         }
-        #expect(date?.timeIntervalSince1970 == 1_753_358_400)
+        #expect(date?.timeIntervalSince1970 == 1_784_894_400)
     }
 
     @Test("values derives draft from the post-status extension property, not a raw field")

--- a/docs/superpowers/plans/2026-07-24-micropub-content-sync.md
+++ b/docs/superpowers/plans/2026-07-24-micropub-content-sync.md
@@ -100,8 +100,8 @@ describe("discoverCollection", () => {
 
   test("rich-text content object is read via its plain-text value", () => {
     expect(discoverCollection(mf2("h-entry", {
-      name: ["Title Here"],
-      content: [{ html: "<p>Title Here and more</p>", value: "Title Here and more" }],
+      name: ["My Announcement"],
+      content: [{ html: "<p>Something else entirely</p>", value: "Something else entirely" }],
     }))).toBe("articles");
   });
 

--- a/docs/superpowers/plans/2026-07-24-micropub-content-sync.md
+++ b/docs/superpowers/plans/2026-07-24-micropub-content-sync.md
@@ -1,0 +1,1778 @@
+# Micropub Content Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A Micropub-created post (note/article/photo/album/bookmark/reply/like/event/review) becomes a typed content file under `Source/`, rendering at the same URL the Micropub client's `Location` header promised, per `docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md`.
+
+**Architecture:** Two halves. (1) `Resources/Template/worker/post-type-discovery.ts`, wired into the Micropub Worker composition via a custom `generatePostUrl`, classifies each incoming post once at creation time and encodes the target collection into its assigned URL (`{baseUrl}/{collection}/{slug}`). (2) A third app-side D1-to-git sync bridge — `MicropubPostD1Client` → `MicropubContentSync` → `MicropubContentCommitter`, mirroring the already-shipped `WebmentionInboxD1Client` → `ReceivedInteractionSync` → `ReceivedInteractionCommitter` (#362) — reads `MICROPUB_DB`, parses the collection back out of each post's URL (no re-classification needed), maps mf2 properties to frontmatter via the registry's existing `ContentTypeProjections`, and reconciles `src/content/<collection>/` on every site-open.
+
+**Tech Stack:** TypeScript (Cloudflare Worker, vitest + `@cloudflare/vitest-pool-workers`), Swift 6.4 (AnglesiteCore, Swift Testing).
+
+## Global Constraints
+
+- Conventional commit subjects, ≤72 characters, referencing #912 (`docs/superpowers/spec` reads `#912 (V-3.2 follow-up)`).
+- New Swift files go in `Sources/AnglesiteCore/` / `Tests/AnglesiteCoreTests/` — both are glob-included by `Package.swift`'s existing `AnglesiteCore`/`AnglesiteCoreTests` targets; no `Package.swift` edit needed.
+- New Swift test suites use **Swift Testing** (`import Testing`, `@Test`, `#expect`/`#require`), matching every other `AnglesiteCoreTests` file touched by this plan — not XCTest.
+- Swift test commands: `swift test --package-path . --filter <SuiteName>` (this environment's `xcode-select` already points at Xcode-beta.app; no `DEVELOPER_DIR` override needed). `--filter` only restricts what *runs*, not what compiles — a full package build still happens per invocation.
+- TS test command (from `Resources/Template/`): `npm run test:worker` (equivalently `npx vitest run --config vitest.config.ts <path>` to scope to one file).
+- No `Package.swift`, `project.yml`, or `SiteSettings` field changes — this plan reuses `SiteSettings.provisionedWorkerResources.d1DatabaseID` exactly as `ReceivedInteractionSync` already does (Micropub shares the same `{site}-social` D1 database).
+
+---
+
+### Task 1: Worker-side Post Type Discovery module
+
+**Files:**
+- Create: `Resources/Template/worker/post-type-discovery.ts`
+- Test: `Resources/Template/worker/post-type-discovery.test.ts`
+
+**Interfaces:**
+- Consumes: `Mf2Object`, `MicropubCommands` types, exported from `@dwk/micropub` (`packages/micropub/src/mf2.ts` → re-exported by `index.ts`).
+- Produces: `discoverCollection(mf2: Mf2Object): string | null` and `generateSlug(mf2: Mf2Object, commands: MicropubCommands): string` — both consumed by Task 2's `worker.ts` change.
+
+- [ ] **Step 1: Write the failing test file**
+
+```typescript
+// Resources/Template/worker/post-type-discovery.test.ts
+import { describe, expect, test } from "vitest";
+import { discoverCollection, generateSlug } from "./post-type-discovery.ts";
+import type { Mf2Object, MicropubCommands } from "@dwk/micropub";
+
+function mf2(type: string, properties: Record<string, unknown[]> = {}): Mf2Object {
+  return { type: [type], properties };
+}
+
+function commands(overrides: Partial<MicropubCommands> = {}): MicropubCommands {
+  return { syndicateTo: [], ...overrides };
+}
+
+describe("discoverCollection", () => {
+  test("h-event maps to events", () => {
+    expect(discoverCollection(mf2("h-event", { name: ["Meetup"] }))).toBe("events");
+  });
+
+  test("h-review maps to reviews", () => {
+    expect(discoverCollection(mf2("h-review", { "item-reviewed": ["A Book"] }))).toBe("reviews");
+  });
+
+  test("an unrecognized h-* type returns null", () => {
+    expect(discoverCollection(mf2("h-card", { name: ["Jane"] }))).toBeNull();
+  });
+
+  test("bookmark-of maps to bookmarks", () => {
+    expect(discoverCollection(mf2("h-entry", { "bookmark-of": ["https://example.com"] }))).toBe("bookmarks");
+  });
+
+  test("like-of maps to likes", () => {
+    expect(discoverCollection(mf2("h-entry", { "like-of": ["https://example.com"] }))).toBe("likes");
+  });
+
+  test("in-reply-to maps to replies", () => {
+    expect(discoverCollection(mf2("h-entry", { "in-reply-to": ["https://example.com"] }))).toBe("replies");
+  });
+
+  test("exactly one photo maps to photos", () => {
+    expect(discoverCollection(mf2("h-entry", { photo: ["https://example.com/a.jpg"] }))).toBe("photos");
+  });
+
+  test("two or more photos maps to albums", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      photo: ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+    }))).toBe("albums");
+  });
+
+  test("a name whose content doesn't start with it maps to articles", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      name: ["My Big Announcement"],
+      content: ["Today I'm launching something new..."],
+    }))).toBe("articles");
+  });
+
+  test("a name that is just the start of the content (auto-derived) maps to notes", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      name: ["Hello world"],
+      content: ["Hello world"],
+    }))).toBe("notes");
+  });
+
+  test("no name at all maps to notes", () => {
+    expect(discoverCollection(mf2("h-entry", { content: ["Just a quick note"] }))).toBe("notes");
+  });
+
+  test("rich-text content object is read via its plain-text value", () => {
+    expect(discoverCollection(mf2("h-entry", {
+      name: ["Title Here"],
+      content: [{ html: "<p>Title Here and more</p>", value: "Title Here and more" }],
+    }))).toBe("articles");
+  });
+
+  test("absent mf2 type ([]) is treated as h-entry", () => {
+    expect(discoverCollection({ type: [], properties: { content: ["hi"] } })).toBe("notes");
+  });
+
+  test("empty content does not trigger the article check even with a name present", () => {
+    expect(discoverCollection(mf2("h-entry", { name: ["Untitled"] }))).toBe("notes");
+  });
+});
+
+describe("generateSlug", () => {
+  test("prefers an explicit mp-slug command", () => {
+    const slug = generateSlug(mf2("h-entry", { content: ["hi"] }), commands({ slug: "my-slug" }));
+    expect(slug).toBe("my-slug");
+  });
+
+  test("falls back to a slugified name", () => {
+    const slug = generateSlug(mf2("h-entry", { name: ["Hello, World!"] }), commands());
+    expect(slug).toBe("hello-world");
+  });
+
+  test("falls back to a random timestamp-based slug when there is no slug or name", () => {
+    const slug = generateSlug(mf2("h-entry", { content: ["hi"] }), commands());
+    expect(slug).toMatch(/^[0-9a-z]+-[0-9a-z]{4}$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from `Resources/Template/`): `npx vitest run --config vitest.config.ts worker/post-type-discovery.test.ts`
+Expected: FAIL — `Cannot find module './post-type-discovery.ts'` (or similar resolution error), since the module doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// Resources/Template/worker/post-type-discovery.ts
+/**
+ * IndieWeb Post Type Discovery (https://www.w3.org/TR/post-type-discovery/), extended with a
+ * `bookmark-of` check and a count-based photo/album split, mapping an incoming Micropub mf2
+ * object to the Astro content collection it should land in once synced to git. See
+ * docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md §1.
+ *
+ * `discoverCollection` returns `null` for any type this bridge doesn't support yet (an
+ * unrecognized `h-*` type, `repost-of`, `rsvp`, `checkin`, `video`) — the caller must fall back
+ * to `@dwk/micropub`'s own default flat-URL policy rather than guessing a collection.
+ */
+
+import type { Mf2Object, MicropubCommands } from "@dwk/micropub";
+
+function hasProperty(mf2: Mf2Object, name: string): boolean {
+  const values = mf2.properties[name];
+  return Array.isArray(values) && values.length > 0;
+}
+
+/** Mirrors `worker.ts`'s AP fan-out `extractMf2ContentString` — same mf2 rich-text shape. */
+function plainTextContent(mf2: Mf2Object): string {
+  const raw = mf2.properties.content?.[0];
+  if (typeof raw === "string") return raw;
+  if (raw && typeof raw === "object" && typeof (raw as { value?: unknown }).value === "string") {
+    return (raw as { value: string }).value;
+  }
+  return "";
+}
+
+export function discoverCollection(mf2: Mf2Object): string | null {
+  const type = mf2.type[0];
+  if (type === "h-event") return "events";
+  if (type === "h-review") return "reviews";
+  if (type !== undefined && type !== "h-entry") return null;
+
+  if (hasProperty(mf2, "bookmark-of")) return "bookmarks";
+  if (hasProperty(mf2, "like-of")) return "likes";
+  if (hasProperty(mf2, "in-reply-to")) return "replies";
+
+  const photoCount = mf2.properties.photo?.length ?? 0;
+  if (photoCount === 1) return "photos";
+  if (photoCount > 1) return "albums";
+
+  const name = mf2.properties.name?.[0];
+  if (typeof name === "string" && name.trim().length > 0) {
+    const trimmedName = name.trim();
+    const content = plainTextContent(mf2).trim();
+    if (content.length > 0 && !content.startsWith(trimmedName)) return "articles";
+  }
+  return "notes";
+}
+
+/** Lowercase, dash-separated slug derived from arbitrary text (max 80 chars). */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+/** A short, collision-resistant slug: base36 timestamp plus random suffix. */
+function randomSlug(): string {
+  const time = Date.now().toString(36);
+  const rand = Math.floor(Math.random() * 36 ** 4)
+    .toString(36)
+    .padStart(4, "0");
+  return `${time}-${rand}`;
+}
+
+/**
+ * Same slug policy as `@dwk/micropub`'s own default `generatePostUrl` (`mp-slug` → a slug
+ * derived from `name` → a timestamp-based slug) — reimplemented here (not imported) because
+ * the package doesn't export its internal `slugify`/`randomSlug` helpers. Kept identical so a
+ * post's slug doesn't change depending on whether its type was recognized (see `worker.ts`'s
+ * `generatePostUrl`, which calls this once and uses the same slug for both the type-aware and
+ * flat-URL fallback branches).
+ */
+export function generateSlug(mf2: Mf2Object, commands: MicropubCommands): string {
+  const name = mf2.properties.name?.[0];
+  return (
+    commands.slug ||
+    (typeof name === "string" && name.trim() ? slugify(name) : "") ||
+    randomSlug()
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run --config vitest.config.ts worker/post-type-discovery.test.ts`
+Expected: PASS (17 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Resources/Template/worker/post-type-discovery.ts Resources/Template/worker/post-type-discovery.test.ts
+git commit -m "feat(#912): add Micropub post-type discovery for content sync"
+```
+
+---
+
+### Task 2: Wire type-aware `generatePostUrl` into the Micropub Worker composition
+
+**Files:**
+- Modify: `Resources/Template/worker/worker.ts:527-540` (the `handleMicropub` function's `createMicropub({...})` call)
+- Modify: `Resources/Template/worker/worker.test.ts` (append new Micropub URL-routing tests after the existing Micropub section, around line 657)
+
+**Interfaces:**
+- Consumes: `discoverCollection`, `generateSlug` from Task 1 (`./post-type-discovery.ts`).
+- Produces: every Micropub `POST /micropub` create response's `Location` header now reads `{baseUrl}/{collection}/{slug}` for a recognized type, or `{baseUrl}/{slug}` (unchanged flat fallback) otherwise — this is the URL shape Task 5 (`MicropubContentSync.collectionAndSlug`) parses.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Resources/Template/worker/worker.test.ts`, immediately after the existing `test("micropub: 503 when MICROPUB_DB isn't bound", ...)` block (around line 657):
+
+```typescript
+test("micropub: a note (plain content, no name) is created under /notes/", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: { content: ["Just a quick note"] },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  const location = response.headers.get("location");
+  expect(location).toMatch(/^https:\/\/owner\.example\/notes\/[0-9a-z-]+$/);
+});
+
+test("micropub: an article (name distinct from content) is created under /articles/", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: {
+        name: ["My Big Announcement"],
+        content: ["Today I'm launching something new..."],
+      },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  expect(response.headers.get("location")).toMatch(/^https:\/\/owner\.example\/articles\/my-big-announcement/);
+});
+
+test("micropub: a bookmark (bookmark-of) is created under /bookmarks/", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: { "bookmark-of": ["https://example.com/article"] },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  expect(response.headers.get("location")).toMatch(/^https:\/\/owner\.example\/bookmarks\//);
+});
+
+test("micropub: an h-event post is created under /events/", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-event"],
+      properties: { name: ["Meetup"], start: ["2026-08-01T18:00:00Z"] },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  expect(response.headers.get("location")).toMatch(/^https:\/\/owner\.example\/events\//);
+});
+
+test("micropub: an unrecognized type (h-card) falls back to the flat URL scheme", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const response = await fetchWorker(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-card"],
+      properties: { name: ["Jane Doe"] },
+    }),
+  }));
+  expect(response.status).toBe(201);
+  const location = response.headers.get("location") ?? "";
+  // Flat scheme: exactly one path segment, no collection prefix.
+  expect(new URL(location).pathname.split("/").filter(Boolean).length).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run --config vitest.config.ts worker/worker.test.ts -t "micropub:"`
+Expected: FAIL — the note/article/bookmark/event `Location` assertions fail because every create currently lands at the flat `{baseUrl}/{slug}` URL (no `/notes/`, `/articles/`, etc. prefix).
+
+- [ ] **Step 3: Wire `generatePostUrl` into `handleMicropub`**
+
+In `Resources/Template/worker/worker.ts`, add the import near the top with the other `@dwk/micropub` import (around line 14):
+
+```typescript
+import {
+  createMicropub,
+  type MicropubEnv,
+} from "@dwk/micropub";
+import { discoverCollection, generateSlug } from "./post-type-discovery.ts";
+```
+
+Then change the `createMicropub` call inside `handleMicropub` (around line 536) from:
+
+```typescript
+  const micropub = createMicropub({ baseUrl, me: `${baseUrl}/` });
+```
+
+to:
+
+```typescript
+  const micropub = createMicropub({
+    baseUrl,
+    me: `${baseUrl}/`,
+    // #912: assign a type-aware URL at create time so a synced git file (written under
+    // src/content/{collection}/, per MicropubContentSync) renders at the same URL this
+    // response's Location header already promised — see post-type-discovery.ts and
+    // docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md §1.
+    generatePostUrl: (post, commands) => {
+      const slug = generateSlug(post, commands);
+      const collection = discoverCollection(post);
+      return collection ? `${baseUrl}/${collection}/${slug}` : `${baseUrl}/${slug}`;
+    },
+  });
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run --config vitest.config.ts worker/worker.test.ts`
+Expected: PASS — every existing Micropub/fan-out test in the file still passes (the fan-out reads `location` generically and never asserted its exact shape), plus the 5 new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Resources/Template/worker/worker.ts Resources/Template/worker/worker.test.ts
+git commit -m "feat(#912): assign type-aware Micropub post URLs"
+```
+
+---
+
+### Task 3: `MicropubPostD1Client` — read `MICROPUB_DB`'s `posts` table
+
+**Files:**
+- Create: `Sources/AnglesiteCore/MicropubPostD1Client.swift`
+- Test: `Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift`
+
+**Interfaces:**
+- Consumes: `CloudflareTransport`, `CloudflareError`, `HTTPCloudflareClient.defaultTransport` (`Sources/AnglesiteCore/CloudflareReading.swift`, `HTTPCloudflareClient.swift`); `JSONValue` (`Sources/AnglesiteCore/MCPClient.swift`).
+- Produces: `MicropubPostD1Client.Post { url: String, type: String, properties: [String: [JSONValue]], deleted: Bool, updatedAt: Int }` and `MicropubPostD1Client.listAllPosts() async throws -> [Post]` — consumed by Task 5/7's `MicropubContentSync`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct MicropubPostD1ClientTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func d1Body(_ rowsJSON: String) -> Data {
+        Data("""
+        {"success": true, "result": [{"success": true, "results": [\(rowsJSON)]}]}
+        """.utf8)
+    }
+
+    @Test("lists a live post and decodes its mf2 properties")
+    func listsLivePost() async throws {
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/abc123", "type": "h-entry",
+         "properties": "{\\"content\\":[\\"Hello world\\"],\\"published\\":[\\"2026-07-24T12:00:00Z\\"]}",
+         "deleted": 0, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let posts = try await client.listAllPosts()
+        let post = try #require(posts.first)
+        #expect(post.url == "https://me.example/notes/abc123")
+        #expect(post.type == "h-entry")
+        #expect(post.deleted == false)
+        #expect(post.updatedAt == 1_753_300_000)
+        #expect(post.properties["content"] == [.string("Hello world")])
+        #expect(post.properties["published"] == [.string("2026-07-24T12:00:00Z")])
+    }
+
+    @Test("decodes a nested rich-text content value")
+    func decodesRichTextContent() async throws {
+        let body = Self.d1Body("""
+        {"url": "https://me.example/articles/hi", "type": "h-entry",
+         "properties": "{\\"content\\":[{\\"html\\":\\"<p>Hi</p>\\",\\"value\\":\\"Hi\\"}]}",
+         "deleted": 0, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let posts = try await client.listAllPosts()
+        let post = try #require(posts.first)
+        let contentValues = try #require(post.properties["content"])
+        #expect(contentValues.count == 1)
+        guard case .object(let obj) = contentValues[0] else {
+            Issue.record("expected content[0] to decode as a JSONValue.object")
+            return
+        }
+        #expect(obj["value"] == .string("Hi"))
+    }
+
+    @Test("includes soft-deleted rows so the sync bridge can remove their git snapshot")
+    func includesSoftDeletedRows() async throws {
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/gone", "type": "h-entry",
+         "properties": "{\\"content\\":[\\"bye\\"]}", "deleted": 1, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let posts = try await client.listAllPosts()
+        let post = try #require(posts.first)
+        #expect(post.deleted == true)
+    }
+
+    @Test("skips a row whose properties column isn't valid JSON")
+    func skipsMalformedPropertiesRow() async throws {
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/bad", "type": "h-entry",
+         "properties": "not json", "deleted": 0, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (body, Self.response(200)) })
+
+        let posts = try await client.listAllPosts()
+        #expect(posts.isEmpty)
+    }
+
+    @Test("throws unauthorized on 401")
+    func throwsUnauthorizedOn401() async throws {
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "bad-token",
+            transport: { _ in (Data(), Self.response(401)) })
+
+        await #expect(throws: CloudflareError.unauthorized) {
+            _ = try await client.listAllPosts()
+        }
+    }
+
+    @Test("throws http error on a non-2xx, non-auth status")
+    func throwsHTTPErrorOnFailureStatus() async throws {
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { _ in (Data(), Self.response(500)) })
+
+        await #expect(throws: CloudflareError.http(status: 500)) {
+            _ = try await client.listAllPosts()
+        }
+    }
+
+    @Test("sends the query as a POST to the D1 query endpoint for the given account and database")
+    func sendsPostToD1QueryEndpoint() async throws {
+        let capturedRequest = ActorBox<URLRequest?>(nil)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token",
+            transport: { request in
+                await capturedRequest.set(request)
+                return (Self.d1Body(""), Self.response(200))
+            })
+
+        _ = try await client.listAllPosts()
+        let request = await capturedRequest.get()
+        #expect(request?.httpMethod == "POST")
+        #expect(request?.url?.absoluteString == "https://api.cloudflare.com/client/v4/accounts/acct1/d1/database/db1/query")
+        #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+    }
+}
+
+private actor ActorBox<Value: Sendable> {
+    private var value: Value
+    init(_ value: Value) { self.value = value }
+    func set(_ newValue: Value) { value = newValue }
+    func get() -> Value { value }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter MicropubPostD1ClientTests`
+Expected: FAIL to build — `MicropubPostD1Client` doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/MicropubPostD1Client.swift
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Cloudflare D1 HTTP API client for `@dwk/micropub`'s `posts` table (#912). Mirrors
+/// `WebmentionInboxD1Client` exactly — same injectable-transport DI, same D1 HTTP query shape —
+/// reading the shared `{site}-social` D1 database's Micropub post store instead of the
+/// webmention inbox. See docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md §2.
+public struct MicropubPostD1Client: Sendable {
+    /// A stored Micropub post, as read from the `posts` table
+    /// (`@dwk/micropub`'s `packages/micropub/src/store.ts`).
+    public struct Post: Sendable, Equatable {
+        public let url: String
+        /// The mf2 root type, e.g. `"h-entry"`.
+        public let type: String
+        /// The raw mf2 property map — each property name maps to its ordered value list,
+        /// matching `@dwk/micropub`'s `Record<string, unknown[]>` storage shape.
+        public let properties: [String: [JSONValue]]
+        public let deleted: Bool
+        public let updatedAt: Int
+
+        public init(url: String, type: String, properties: [String: [JSONValue]], deleted: Bool, updatedAt: Int) {
+            self.url = url
+            self.type = type
+            self.properties = properties
+            self.deleted = deleted
+            self.updatedAt = updatedAt
+        }
+    }
+
+    private struct Row: Decodable {
+        let url: String
+        let type: String
+        let properties: String
+        let deleted: Int
+        let updated_at: Int
+    }
+
+    private struct QueryResult: Decodable {
+        let results: [Row]?
+        let success: Bool
+    }
+
+    private struct Envelope: Decodable {
+        let success: Bool
+        let result: [QueryResult]?
+    }
+
+    private struct QueryBody: Encodable {
+        let sql: String
+    }
+
+    /// Selects every post row — live and soft-deleted alike, newest-updated first. The sync
+    /// bridge needs soft-deleted rows too, so it can remove their git snapshot on the next
+    /// reconcile (mirrors `ReceivedInteractionSync`'s "pull the full current set" pattern).
+    private static let listAllSQL =
+        "SELECT url, type, properties, deleted, updated_at FROM posts ORDER BY updated_at DESC"
+
+    private let baseURL: String
+    private let accountID: String
+    private let databaseID: String
+    private let apiToken: String
+    private let transport: CloudflareTransport
+
+    public init(
+        accountID: String,
+        databaseID: String,
+        apiToken: String,
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.accountID = accountID
+        self.databaseID = databaseID
+        self.apiToken = apiToken
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    /// Lists every post currently in `MICROPUB_DB`, live and soft-deleted alike. A row whose
+    /// `properties` column isn't valid JSON (or isn't a JSON object of arrays) is skipped rather
+    /// than failing the whole pull — a single malformed row shouldn't block every other post.
+    public func listAllPosts() async throws -> [Post] {
+        let url = URL(string: "\(baseURL)/accounts/\(accountID)/d1/database/\(databaseID)/query")
+        guard let url else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(QueryBody(sql: Self.listAllSQL))
+
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        guard let envelope = try? JSONDecoder().decode(Envelope.self, from: data), envelope.success,
+              let rows = envelope.result?.first?.results
+        else { throw CloudflareError.malformedResponse }
+
+        return rows.compactMap { row in
+            guard let propertiesData = row.properties.data(using: .utf8),
+                  let raw = try? JSONSerialization.jsonObject(with: propertiesData) as? [String: [Any]]
+            else { return nil }
+            var properties: [String: [JSONValue]] = [:]
+            for (key, values) in raw {
+                properties[key] = values.compactMap(JSONValue.from)
+            }
+            return Post(
+                url: row.url, type: row.type, properties: properties,
+                deleted: row.deleted != 0, updatedAt: row.updated_at)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter MicropubPostD1ClientTests`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/MicropubPostD1Client.swift Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
+git commit -m "feat(#912): add MicropubPostD1Client to read MICROPUB_DB"
+```
+
+---
+
+### Task 4: `ContentTypeProjections.rawMf2Property(forField:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentTypeRegistry.swift` (inside `ContentTypeProjections`, after the `schemaType` property, around line 66)
+- Modify: `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift` (append new test cases)
+
+**Interfaces:**
+- Consumes: `ContentTypeProjections.microformatProperties: [String: String]` (already exists).
+- Produces: `ContentTypeProjections.rawMf2Property(forField fieldName: String) -> String?` — consumed by Task 5's `MicropubContentSync.values(for:properties:)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift` (create the file with this content if it doesn't already exist; otherwise add these as new `@Test` functions inside the existing suite type):
+
+```swift
+@Test("rawMf2Property strips the mf2 prefix class from a field's microformat mapping")
+func rawMf2PropertyStripsPrefix() {
+    let article = ContentTypeRegistry.article
+    #expect(article.projections.rawMf2Property(forField: "body") == "content")        // e-content
+    #expect(article.projections.rawMf2Property(forField: "publishDate") == "published") // dt-published
+    #expect(article.projections.rawMf2Property(forField: "tags") == "category")        // p-category
+}
+
+@Test("rawMf2Property handles the u- prefix")
+func rawMf2PropertyHandlesUPrefix() {
+    let bookmark = ContentTypeRegistry.bookmark
+    #expect(bookmark.projections.rawMf2Property(forField: "bookmarkOf") == "bookmark-of") // u-bookmark-of
+}
+
+@Test("rawMf2Property returns nil for a field with no mf2 mapping")
+func rawMf2PropertyNilForUnmappedField() {
+    let article = ContentTypeRegistry.article
+    #expect(article.projections.rawMf2Property(forField: "draft") == nil)
+    #expect(article.projections.rawMf2Property(forField: "nonexistent") == nil)
+}
+```
+
+*(If the test file doesn't exist yet, wrap these three in `import Testing`, `@testable import AnglesiteCore`, and `struct ContentTypeRegistryTests { ... }`.)*
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter ContentTypeRegistryTests`
+Expected: FAIL to build — `rawMf2Property(forField:)` doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/ContentTypeRegistry.swift`, add to `ContentTypeProjections` (immediately after the `public init(...)` block that follows `schemaType`, i.e. right after line 77's closing brace):
+
+```swift
+    /// The raw mf2 property name `@dwk/micropub` stores for `fieldName` — `microformatProperties`
+    /// with its mf2 prefix class (`p-`/`e-`/`u-`/`dt-`) stripped. `nil` if `fieldName` has no mf2
+    /// mapping (e.g. `draft`, which is derived from the Post Status extension's `post-status`
+    /// property rather than its own mf2 property). Used by the Micropub content-sync bridge
+    /// (#912) to read a post's raw property map — bare names, no prefix — for a given
+    /// `ContentTypeField`.
+    public func rawMf2Property(forField fieldName: String) -> String? {
+        microformatProperties[fieldName].map(Self.stripMf2Prefix)
+    }
+
+    private static func stripMf2Prefix(_ mfProperty: String) -> String {
+        for prefix in ["p-", "e-", "u-", "dt-"] where mfProperty.hasPrefix(prefix) {
+            return String(mfProperty.dropFirst(prefix.count))
+        }
+        return mfProperty
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter ContentTypeRegistryTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentTypeRegistry.swift Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+git commit -m "feat(#912): add reverse mf2-property lookup to ContentTypeProjections"
+```
+
+---
+
+### Task 5: `MicropubContentSync` core — URL parsing + mf2-to-field mapping
+
+**Files:**
+- Create: `Sources/AnglesiteCore/MicropubContentSync.swift`
+- Test: `Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift`
+
+**Interfaces:**
+- Consumes: `MicropubPostD1Client.Post` (Task 3), `ContentTypeProjections.rawMf2Property(forField:)` (Task 4), `ContentTypeRegistry.descriptor(forCollection:)`/`.default` (existing), `TypedContentEditor.Values`/`FieldValue`/`defaultValue(for:)` (existing), `JSONValue` (existing).
+- Produces: `MicropubContentSync.ResolvedPost { url, collection, descriptor, values, updatedAt }`, `MicropubContentSync.resolve(post:registry:) -> ResolvedPost?`, and the internal helpers `collectionAndSlug(from:)` / `plainText(from:)` — all consumed by Task 6 (`MicropubContentCommitter`) and Task 7 (this file's own `pullAndCommit`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct MicropubContentSyncTests {
+    // MARK: - collectionAndSlug
+
+    @Test("collectionAndSlug parses a two-segment collection URL")
+    func collectionAndSlugParsesTwoSegments() {
+        let result = MicropubContentSync.collectionAndSlug(from: "https://me.example/notes/hello-abc123")
+        #expect(result?.collection == "notes")
+        #expect(result?.slug == "hello-abc123")
+    }
+
+    @Test("collectionAndSlug returns nil for the flat one-segment fallback URL")
+    func collectionAndSlugNilForFlatURL() {
+        #expect(MicropubContentSync.collectionAndSlug(from: "https://me.example/hello-abc123") == nil)
+    }
+
+    @Test("collectionAndSlug returns nil for a malformed URL")
+    func collectionAndSlugNilForMalformedURL() {
+        #expect(MicropubContentSync.collectionAndSlug(from: "not a url") == nil)
+    }
+
+    // MARK: - plainText
+
+    @Test("plainText reads a bare string value")
+    func plainTextReadsBareString() {
+        #expect(MicropubContentSync.plainText(from: .string("hello")) == "hello")
+    }
+
+    @Test("plainText reads a rich-text object's value key")
+    func plainTextReadsRichTextValue() {
+        let value = JSONValue.object(["html": .string("<p>hi</p>"), "value": .string("hi")])
+        #expect(MicropubContentSync.plainText(from: value) == "hi")
+    }
+
+    @Test("plainText returns nil for an unsupported shape")
+    func plainTextNilForUnsupportedShape() {
+        #expect(MicropubContentSync.plainText(from: .bool(true)) == nil)
+        #expect(MicropubContentSync.plainText(from: nil) == nil)
+    }
+
+    // MARK: - values(for:properties:)
+
+    @Test("values builds a note's fields from raw mf2 properties")
+    func valuesBuildsNoteFields() throws {
+        let note = ContentTypeRegistry.note
+        let properties: [String: [JSONValue]] = [
+            "content": [.string("Hello world")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+            "category": [.string("indieweb"), .string("test")],
+        ]
+        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        #expect(values["body"] == .text("Hello world"))
+        #expect(values["tags"] == .list(["indieweb", "test"]))
+        guard case .date(let date) = values["publishDate"] else {
+            Issue.record("expected publishDate to decode as a date")
+            return
+        }
+        #expect(date?.timeIntervalSince1970 == 1_753_358_400)
+    }
+
+    @Test("values derives draft from the post-status extension property, not a raw field")
+    func valuesDerivesDraftFromPostStatus() throws {
+        let note = ContentTypeRegistry.note
+        let properties: [String: [JSONValue]] = [
+            "content": [.string("Hello")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+            "post-status": [.string("draft")],
+        ]
+        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        #expect(values["draft"] == .flag(true))
+    }
+
+    @Test("values defaults draft to false when post-status is absent (published)")
+    func valuesDefaultsDraftToFalse() throws {
+        let note = ContentTypeRegistry.note
+        let properties: [String: [JSONValue]] = [
+            "content": [.string("Hello")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+        ]
+        let values = try #require(MicropubContentSync.values(for: note, properties: properties))
+        #expect(values["draft"] == .flag(false))
+    }
+
+    @Test("values returns nil when a required field has no matching mf2 property")
+    func valuesNilWhenRequiredFieldMissing() {
+        let note = ContentTypeRegistry.note
+        // "body" (e-content, required) is missing.
+        let properties: [String: [JSONValue]] = ["published": [.string("2026-07-24T12:00:00Z")]]
+        #expect(MicropubContentSync.values(for: note, properties: properties) == nil)
+    }
+
+    @Test("values requires all photo values to resolve album's imageArray, or fails")
+    func valuesRequiresAlbumImages() {
+        let album = ContentTypeRegistry.album
+        let properties: [String: [JSONValue]] = [
+            "name": [.string("Trip")],
+            "published": [.string("2026-07-24T12:00:00Z")],
+        ]
+        // "images" (u-photo, required imageArray) has no matching values at all.
+        #expect(MicropubContentSync.values(for: album, properties: properties) == nil)
+    }
+
+    // MARK: - resolve
+
+    @Test("resolve maps a post to its descriptor via the URL's collection segment")
+    func resolveMapsPostToDescriptor() throws {
+        let post = MicropubPostD1Client.Post(
+            url: "https://me.example/notes/hello-abc123", type: "h-entry",
+            properties: ["content": [.string("Hello")], "published": [.string("2026-07-24T12:00:00Z")]],
+            deleted: false, updatedAt: 1_753_300_000)
+        let resolved = try #require(MicropubContentSync.resolve(post: post))
+        #expect(resolved.collection == "notes")
+        #expect(resolved.descriptor.id == "note")
+        #expect(resolved.url == post.url)
+        #expect(resolved.updatedAt == 1_753_300_000)
+    }
+
+    @Test("resolve returns nil for the flat fallback URL (no collection segment)")
+    func resolveNilForFlatURL() {
+        let post = MicropubPostD1Client.Post(
+            url: "https://me.example/hello-abc123", type: "h-card",
+            properties: ["name": [.string("Jane")]], deleted: false, updatedAt: 1_753_300_000)
+        #expect(MicropubContentSync.resolve(post: post) == nil)
+    }
+
+    @Test("resolve returns nil when the URL's collection has no registered content type")
+    func resolveNilForUnknownCollection() {
+        let post = MicropubPostD1Client.Post(
+            url: "https://me.example/mystery/abc123", type: "h-entry",
+            properties: ["content": [.string("hi")]], deleted: false, updatedAt: 1_753_300_000)
+        #expect(MicropubContentSync.resolve(post: post) == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter MicropubContentSyncTests`
+Expected: FAIL to build — `MicropubContentSync` doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/MicropubContentSync.swift
+import Foundation
+
+/// Orchestrates #912's "pull Micropub-created posts from D1 and turn each into a typed content
+/// file" step. This file holds the pure URL-parsing and mf2-to-field mapping logic; `pullAndCommit`
+/// / `pullAndCommitIfConfigured` (Task 7) extend this enum with the D1-query + commit glue.
+/// See docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md.
+public enum MicropubContentSync {
+    /// One post resolved to its content type, ready for `MicropubContentCommitter`.
+    public struct ResolvedPost: Sendable, Equatable {
+        public let url: String
+        public let collection: String
+        public let descriptor: ContentTypeDescriptor
+        public let values: TypedContentEditor.Values
+        public let updatedAt: Int
+    }
+
+    /// Parses `{baseUrl}/{collection}/{slug}` — the shape `post-type-discovery.ts`'s
+    /// `generatePostUrl` assigns at create time for a recognized mf2 type — into its collection
+    /// and slug. Returns `nil` for any other shape: the flat `{baseUrl}/{slug}` fallback URL a
+    /// post gets when its mf2 type wasn't recognized at create time, or a malformed URL. This
+    /// bridge only ever reads the collection out of the URL — it never re-derives it from mf2
+    /// properties, so classification happens exactly once (Worker-side, at create time).
+    static func collectionAndSlug(from urlString: String) -> (collection: String, slug: String)? {
+        guard let url = URL(string: urlString) else { return nil }
+        let segments = url.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard segments.count == 2 else { return nil }
+        return (segments[0], segments[1])
+    }
+
+    /// Extracts a plain-text string from one mf2 property value: a bare string, or a rich-text
+    /// object's `value` key (mirrors `worker.ts`'s AP fan-out `extractMf2ContentString` — same
+    /// mf2 shape, same fallback). `nil` for any other shape.
+    static func plainText(from value: JSONValue?) -> String? {
+        switch value {
+        case .string(let s): return s
+        case .object(let o):
+            if case .string(let s)? = o["value"] { return s }
+            return nil
+        default: return nil
+        }
+    }
+
+    private static let isoWithFractionalSeconds: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static func parseDate(_ raw: String) -> Date? {
+        if let d = isoWithFractionalSeconds.date(from: raw) { return d }
+        if let d = ISO8601DateFormatter().date(from: raw) { return d }
+        let df = DateFormatter()
+        df.calendar = Calendar(identifier: .iso8601)
+        df.timeZone = TimeZone(identifier: "UTC")
+        df.dateFormat = "yyyy-MM-dd"
+        return df.date(from: raw)
+    }
+
+    /// Builds one `ContentTypeField`'s value from a post's raw mf2 properties. Returns `nil` only
+    /// when `field.required` and no usable value exists — the caller (`values(for:properties:)`)
+    /// treats that as "skip the whole post."
+    static func fieldValue(
+        for field: ContentTypeField,
+        rawProperty: String,
+        properties: [String: [JSONValue]]
+    ) -> TypedContentEditor.FieldValue? {
+        let values = properties[rawProperty] ?? []
+        switch field.kind {
+        case .string, .text, .url, .image, .markdown:
+            guard let text = values.first.flatMap(plainText) else {
+                return field.required ? nil : .text("")
+            }
+            return .text(text)
+        // No field in the built-in registry maps a raw mf2 property to `.bool` today (`draft` is
+        // special-cased in `values(for:)` below, driven by `post-status` instead) — this arm
+        // exists only for switch exhaustiveness / defense-in-depth against a future bool field.
+        case .bool:
+            return .flag(false)
+        case .date, .datetime:
+            guard let text = values.first.flatMap(plainText), let date = parseDate(text) else {
+                return field.required ? nil : .date(nil)
+            }
+            return .date(date)
+        case .number:
+            guard let text = values.first.flatMap(plainText), let number = Double(text) else {
+                return field.required ? nil : .number(nil)
+            }
+            return .number(number)
+        case .stringArray:
+            return .list(values.compactMap(plainText))
+        case .imageArray:
+            let strings = values.compactMap(plainText)
+            return (field.required && strings.isEmpty) ? nil : .list(strings)
+        }
+    }
+
+    /// Builds every field value for `descriptor` from a post's raw mf2 properties. Returns `nil`
+    /// (skip the whole post) when a required field can't be resolved — a malformed/partial post
+    /// shouldn't produce invalid frontmatter.
+    static func values(
+        for descriptor: ContentTypeDescriptor,
+        properties: [String: [JSONValue]]
+    ) -> TypedContentEditor.Values? {
+        var out = TypedContentEditor.Values()
+        for field in descriptor.fields {
+            // `draft` has no mf2 property of its own — it's derived from the Post Status
+            // extension's `post-status` property (`@dwk/micropub` validates this is either
+            // "draft" or "published"/absent before storing it).
+            if field.name == "draft" {
+                let status = properties["post-status"]?.first.flatMap(plainText)
+                out["draft"] = .flag(status == "draft")
+                continue
+            }
+            guard let rawProperty = descriptor.projections.rawMf2Property(forField: field.name) else {
+                if field.required { return nil }
+                out[field.name] = TypedContentEditor.defaultValue(for: field.kind)
+                continue
+            }
+            guard let value = fieldValue(for: field, rawProperty: rawProperty, properties: properties) else {
+                return nil
+            }
+            out[field.name] = value
+        }
+        return out
+    }
+
+    /// Resolves one D1 row to a `ResolvedPost`, or `nil` (skip — the caller logs this) when its
+    /// URL's collection isn't one this bridge maps to a registered content type, or a required
+    /// field can't be resolved from its mf2 properties.
+    static func resolve(
+        post: MicropubPostD1Client.Post,
+        registry: ContentTypeRegistry = .default
+    ) -> ResolvedPost? {
+        guard let (collection, _) = collectionAndSlug(from: post.url),
+              let descriptor = registry.descriptor(forCollection: collection),
+              let values = values(for: descriptor, properties: post.properties)
+        else { return nil }
+        return ResolvedPost(
+            url: post.url, collection: collection, descriptor: descriptor,
+            values: values, updatedAt: post.updatedAt)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter MicropubContentSyncTests`
+Expected: PASS (13 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/MicropubContentSync.swift Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+git commit -m "feat(#912): map Micropub mf2 properties to typed content fields"
+```
+
+---
+
+### Task 6: `MicropubContentCommitter` — reconcile + commit with slug-collision state
+
+**Files:**
+- Create: `Sources/AnglesiteCore/MicropubContentCommitter.swift`
+- Test: `Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift`
+
+**Interfaces:**
+- Consumes: `MicropubContentSync.ResolvedPost` / `collectionAndSlug(from:)` (Task 5); `ContentScaffold.renderEntry(descriptor:title:now:)`, `ContentScaffold.postRelativePath(collection:slug:)` (existing); `TypedContentEditor.write(_:into:descriptor:)` (existing); `InboxSubmissionCommitter.processGitCommitBatch` (existing).
+- Produces: `MicropubContentCommitter.commit(posts:into:configDirectory:fileManager:now:gitCommitBatch:) async -> Int` — consumed by Task 7's `MicropubContentSync.pullAndCommit`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Serialized for the same reason as ReceivedInteractionCommitterTests: real `git` subprocesses
+// via raw `Process()` in `makeThrowawayGitRepo()` trip a rare CI heap-corruption crash when run
+// concurrently with the rest of the subprocess-heavy suite.
+@Suite(.serialized)
+struct MicropubContentCommitterTests {
+    private static func post(
+        url: String, collection: String = "notes", body: String = "Hello world",
+        updatedAt: Int = 1_753_300_000
+    ) -> MicropubContentSync.ResolvedPost {
+        let descriptor = ContentTypeRegistry.default.descriptor(forCollection: collection)!
+        var values = TypedContentEditor.Values()
+        values["body"] = .text(body)
+        values["publishDate"] = .date(Date(timeIntervalSince1970: 1_753_358_400))
+        values["tags"] = .list([])
+        values["draft"] = .flag(false)
+        return MicropubContentSync.ResolvedPost(
+            url: url, collection: collection, descriptor: descriptor, values: values, updatedAt: updatedAt)
+    }
+
+    @Test("commit writes a new post to src/content/<collection>/<slug>.md and records it in micropubSync.json")
+    func commitWritesNewPost() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let count = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123")],
+            into: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 1)
+
+        let written = siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+        let contents = try String(contentsOf: written, encoding: .utf8)
+        #expect(contents.contains("Hello world"))
+
+        let stateURL = configDirectory.appendingPathComponent("micropubSync.json")
+        let stateData = try Data(contentsOf: stateURL)
+        let state = try JSONDecoder().decode([String: String].self, from: stateData)
+        #expect(state["https://me.example/notes/hello-abc123"] == "src/content/notes/hello-abc123.md")
+    }
+
+    @Test("a second sync of the same post updates the same file without re-suffixing")
+    func secondSyncUpdatesInPlace() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        _ = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123", body: "First version")],
+            into: siteDirectory, configDirectory: configDirectory)
+
+        let count = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123", body: "Edited version")],
+            into: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 1)
+
+        // Still exactly the original path — no "-2" suffix from a spurious collision.
+        let written = siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md")
+        let contents = try String(contentsOf: written, encoding: .utf8)
+        #expect(contents.contains("Edited version"))
+        #expect(!FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123-2.md").path))
+    }
+
+    @Test("a slug colliding with an existing hand-authored file is suffixed, never overwritten")
+    func collisionWithHandAuthoredFileIsSuffixed() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let notesDir = siteDirectory.appendingPathComponent("src/content/notes", isDirectory: true)
+        try FileManager.default.createDirectory(at: notesDir, withIntermediateDirectories: true)
+        try "---\nbody: \"hand-authored\"\n---\n".write(
+            to: notesDir.appendingPathComponent("hello-abc123.md"), atomically: true, encoding: .utf8)
+
+        _ = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123", body: "From Micropub")],
+            into: siteDirectory, configDirectory: configDirectory)
+
+        let original = try String(contentsOf: notesDir.appendingPathComponent("hello-abc123.md"), encoding: .utf8)
+        #expect(original.contains("hand-authored"))
+        let suffixed = try String(contentsOf: notesDir.appendingPathComponent("hello-abc123-2.md"), encoding: .utf8)
+        #expect(suffixed.contains("From Micropub"))
+    }
+
+    @Test("commit deletes the file and state entry for a post no longer in the resolved set")
+    func commitDeletesStalePost() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        _ = await MicropubContentCommitter.commit(
+            posts: [Self.post(url: "https://me.example/notes/hello-abc123")],
+            into: siteDirectory, configDirectory: configDirectory)
+        let written = siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+
+        // The post is now absent from the resolved set (soft-deleted in D1, or fell out of scope).
+        let count = await MicropubContentCommitter.commit(
+            posts: [], into: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 1)
+        #expect(!FileManager.default.fileExists(atPath: written.path))
+
+        let stateData = try Data(contentsOf: configDirectory.appendingPathComponent("micropubSync.json"))
+        let state = try JSONDecoder().decode([String: String].self, from: stateData)
+        #expect(state.isEmpty)
+    }
+
+    @Test("commit is a no-op when nothing changed")
+    func commitNoOpWhenNothingChanged() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let posts = [Self.post(url: "https://me.example/notes/hello-abc123")]
+        _ = await MicropubContentCommitter.commit(posts: posts, into: siteDirectory, configDirectory: configDirectory)
+
+        let callCount = CallCounter()
+        let count = await MicropubContentCommitter.commit(
+            posts: posts, into: siteDirectory, configDirectory: configDirectory,
+            gitCommitBatch: { _, _, _ in
+                await callCount.increment()
+                return "should-not-be-called"
+            })
+        #expect(count == 0)
+        #expect(await callCount.value == 0)
+    }
+
+    @Test("a git-commit failure still records state, so a retry doesn't duplicate the file with a suffixed slug")
+    func gitFailureStillRecordsStateToAvoidDuplication() async throws {
+        let (siteDirectory, configDirectory) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let posts = [Self.post(url: "https://me.example/notes/hello-abc123")]
+        let firstCount = await MicropubContentCommitter.commit(
+            posts: posts, into: siteDirectory, configDirectory: configDirectory,
+            gitCommitBatch: { _, _, _ in nil })
+        #expect(firstCount == 0)
+
+        // The file is on disk (uncommitted) and state.json already points at it — a retry must
+        // reuse that exact path rather than treating the leftover file as a foreign collision.
+        let retryCount = await MicropubContentCommitter.commit(posts: posts, into: siteDirectory, configDirectory: configDirectory)
+        #expect(retryCount == 0) // content unchanged since the failed attempt — nothing to (re-)commit
+        #expect(!FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123-2.md").path))
+    }
+
+    @Test("commitMessage describes write-only, delete-only, and mixed reconciles")
+    func commitMessageVariants() {
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 1, deletedCount: 0) == "micropub: sync 1 post")
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 2, deletedCount: 0) == "micropub: sync 2 posts")
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 0, deletedCount: 1) == "micropub: remove 1 post")
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 0, deletedCount: 2) == "micropub: remove 2 posts")
+        #expect(MicropubContentCommitter.commitMessage(writtenCount: 1, deletedCount: 1) == "micropub: sync 1 post, remove 1")
+    }
+
+    /// A throwaway `.anglesite`-style package: `Source/` (a git repo) beside `Config/`.
+    private static func makeThrowawaySite() throws -> (siteDirectory: URL, configDirectory: URL) {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("micropub-commit-test-\(UUID().uuidString)", isDirectory: true)
+        let siteDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("Config", isDirectory: true)
+        try fm.createDirectory(at: siteDirectory, withIntermediateDirectories: true)
+        try fm.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: siteDirectory.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = siteDirectory
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return (siteDirectory, configDirectory)
+    }
+}
+
+private actor CallCounter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter MicropubContentCommitterTests`
+Expected: FAIL to build — `MicropubContentCommitter` doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Sources/AnglesiteCore/MicropubContentCommitter.swift
+import Foundation
+
+/// Writes Micropub posts resolved by `MicropubContentSync` into the site's local git working
+/// copy as typed content files (`src/content/<collection>/<slug>.md`), then commits them in one
+/// commit. This is the "commit resolved posts into git" half of #912 — mirrors
+/// `ReceivedInteractionCommitter`'s full-set reconciliation, but per-collection and slug-aware:
+/// its id-keyed `data/interactions/` has no collision risk, while `src/content/<collection>/` is
+/// a directory humans hand-edit too. See
+/// docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md §4.
+public enum MicropubContentCommitter {
+    /// `Config/micropubSync.json`'s persisted shape: Micropub post URL → the `Source/`-relative
+    /// path it was written to. A flat `[String: String]` (not a wrapper struct with a
+    /// `pathsByURL` field) so the file on disk is exactly `{"<url>": "<relPath>", ...}` — simpler
+    /// to inspect/decode directly (including from tests) than a nested shape would be. Read/
+    /// written outside the git commit (it lives in `Config/`, never `Source/`) so a later
+    /// re-sync of the same post updates that exact file instead of re-resolving (and potentially
+    /// re-suffixing) its slug every time.
+    typealias SyncState = [String: String]
+
+    private static let stateFileName = "micropubSync.json"
+
+    private static func loadState(from configDirectory: URL) -> SyncState {
+        let url = configDirectory.appendingPathComponent(stateFileName)
+        guard let data = try? Data(contentsOf: url),
+              let state = try? JSONDecoder().decode(SyncState.self, from: data)
+        else { return [:] }
+        return state
+    }
+
+    private static func saveState(_ state: SyncState, to configDirectory: URL, fileManager: FileManager) {
+        let url = configDirectory.appendingPathComponent(stateFileName)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(state) else { return }
+        try? fileManager.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// Resolves the relative path a post should be written to: the path already recorded in
+    /// `state` for its URL, or (first sync) a freshly slugified path — suffixed (`-2`, `-3`, …)
+    /// until it names either a nonexistent file or one already owned by this committer (i.e.
+    /// present in `state`'s values), so a Micropub-created file never silently overwrites a
+    /// hand-authored one sharing the same slug.
+    static func resolvePath(
+        for post: MicropubContentSync.ResolvedPost,
+        state: SyncState,
+        siteDirectory: URL,
+        fileManager: FileManager
+    ) -> String {
+        if let existing = state[post.url] { return existing }
+
+        let baseSlug = MicropubContentSync.collectionAndSlug(from: post.url)?.slug ?? post.url
+        let ownedPaths = Set(state.values)
+        var candidateSlug = baseSlug
+        var attempt = 1
+        while true {
+            let relPath = ContentScaffold.postRelativePath(collection: post.collection, slug: candidateSlug)
+            let fileURL = siteDirectory.appendingPathComponent(relPath)
+            if ownedPaths.contains(relPath) || !fileManager.fileExists(atPath: fileURL.path) {
+                return relPath
+            }
+            attempt += 1
+            candidateSlug = "\(baseSlug)-\(attempt)"
+        }
+    }
+
+    /// Reconciles `src/content/<collection>/` directories under `siteDirectory` against `posts`
+    /// (the full, current, resolved set) and commits the result in one commit:
+    /// - a new or changed post is written (or overwritten) at its resolved path
+    /// - a previously-synced post (per `Config/micropubSync.json`) absent from `posts` has its
+    ///   file deleted and its state entry removed
+    /// - unchanged files are left untouched, so a sync with nothing new is a true no-op
+    ///
+    /// `micropubSync.json` is saved regardless of whether the git commit itself succeeds: the
+    /// physical file write already happened, so a later retry must see that path as already
+    /// resolved rather than re-deriving (and potentially re-suffixing) a fresh slug for the same
+    /// post — only the *count this call reports* (and thus whether a caller treats it as "synced
+    /// this round") depends on the commit having actually landed.
+    @discardableResult
+    public static func commit(
+        posts: [MicropubContentSync.ResolvedPost],
+        into siteDirectory: URL,
+        configDirectory: URL,
+        fileManager: FileManager = .default,
+        now: @Sendable () -> Date = Date.init,
+        gitCommitBatch: @Sendable (URL, [String], String) async -> String? = InboxSubmissionCommitter.processGitCommitBatch
+    ) async -> Int {
+        var state = loadState(from: configDirectory)
+        let currentURLs = Set(posts.map(\.url))
+
+        var relPaths: [String] = []
+        var writtenCount = 0
+        var deletedCount = 0
+
+        // Delete files for URLs no longer in the current resolved set before writing, so a slug
+        // freed by a deletion is immediately available to a same-round collision resolution.
+        for (url, relPath) in state where !currentURLs.contains(url) {
+            let fileURL = siteDirectory.appendingPathComponent(relPath)
+            guard (try? fileManager.removeItem(at: fileURL)) != nil else { continue }
+            relPaths.append(relPath)
+            deletedCount += 1
+            state.removeValue(forKey: url)
+        }
+
+        for post in posts {
+            let relPath = resolvePath(for: post, state: state, siteDirectory: siteDirectory, fileManager: fileManager)
+            let fileURL = siteDirectory.appendingPathComponent(relPath)
+            let existingContents = try? String(contentsOf: fileURL, encoding: .utf8)
+            let baseContents = existingContents
+                ?? ContentScaffold.renderEntry(descriptor: post.descriptor, title: nil, now: now())
+            let newContents = TypedContentEditor.write(post.values, into: baseContents, descriptor: post.descriptor)
+            state[post.url] = relPath
+            guard newContents != existingContents else { continue }
+            try? fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            guard (try? newContents.data(using: .utf8)?.write(to: fileURL, options: .atomic)) != nil else { continue }
+            relPaths.append(relPath)
+            writtenCount += 1
+        }
+
+        guard !relPaths.isEmpty else {
+            saveState(state, to: configDirectory, fileManager: fileManager)
+            return 0
+        }
+
+        let message = Self.commitMessage(writtenCount: writtenCount, deletedCount: deletedCount)
+        let committed = await gitCommitBatch(siteDirectory, relPaths, message) != nil
+        saveState(state, to: configDirectory, fileManager: fileManager)
+        return committed ? writtenCount + deletedCount : 0
+    }
+
+    static func commitMessage(writtenCount: Int, deletedCount: Int) -> String {
+        switch (writtenCount, deletedCount) {
+        case (let w, 0):
+            return w == 1 ? "micropub: sync 1 post" : "micropub: sync \(w) posts"
+        case (0, let d):
+            return d == 1 ? "micropub: remove 1 post" : "micropub: remove \(d) posts"
+        case (let w, let d):
+            return "micropub: sync \(w) post\(w == 1 ? "" : "s"), remove \(d)"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter MicropubContentCommitterTests`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/MicropubContentCommitter.swift Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
+git commit -m "feat(#912): add MicropubContentCommitter with collision-safe sync state"
+```
+
+---
+
+### Task 7: `MicropubContentSync.pullAndCommit` / `pullAndCommitIfConfigured`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/MicropubContentSync.swift` (append to the existing `enum MicropubContentSync`)
+- Modify: `Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift` (append new test cases)
+
+**Interfaces:**
+- Consumes: `MicropubPostD1Client` (Task 3), `MicropubContentCommitter.commit` (Task 6), `SiteConfigStore.read(from:)`, `SecretStore.readCloudflareToken()`, `PlatformSecretStore.make()`, `HTTPCloudflareClient.defaultTransport` (existing).
+- Produces: `MicropubContentSync.pullAndCommit(client:siteDirectory:configDirectory:) async -> Int` and `MicropubContentSync.pullAndCommitIfConfigured(siteDirectory:configDirectory:secretStore:baseURL:transport:) async -> Int` — consumed by Task 8's `PreviewModel.open(site:)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift`:
+
+```swift
+// MARK: - pullAndCommit / pullAndCommitIfConfigured
+// Serialized for the same reason as ReceivedInteractionSyncTests: real `git` subprocesses trip a
+// rare CI heap-corruption crash when run concurrently with the rest of the subprocess-heavy suite.
+extension MicropubContentSyncTests {
+    private static func response(_ status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: "https://api.cloudflare.com/")!, statusCode: status,
+                         httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func d1Body(_ rowsJSON: String) -> Data {
+        Data("""
+        {"success": true, "result": [{"success": true, "results": [\(rowsJSON)]}]}
+        """.utf8)
+    }
+
+    @Test("pullAndCommit resolves and commits every recognized live post")
+    func pullAndCommitResolvesAndCommits() async throws {
+        let (siteDirectory, _) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+        let configDirectory = siteDirectory.deletingLastPathComponent().appendingPathComponent("Config")
+
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/hello-abc123", "type": "h-entry",
+         "properties": "{\\"content\\":[\\"Hello\\"],\\"published\\":[\\"2026-07-24T12:00:00Z\\"]}",
+         "deleted": 0, "updated_at": 1753300000}
+        """)
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (body, Self.response(200)) })
+
+        let count = await MicropubContentSync.pullAndCommit(
+            client: client, siteDirectory: siteDirectory, configDirectory: configDirectory)
+        #expect(count == 1)
+        #expect(FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md").path))
+    }
+
+    @Test("pullAndCommit returns 0 without touching git when the D1 query fails")
+    func pullAndCommitD1FailureIsNoOp() async {
+        let client = MicropubPostD1Client(
+            accountID: "acct1", databaseID: "db1", apiToken: "token", transport: { _ in (Data(), Self.response(500)) })
+        let count = await MicropubContentSync.pullAndCommit(
+            client: client, siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: URL(fileURLWithPath: "/nonexistent"))
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommitIfConfigured no-ops when the site has no provisioned D1 database")
+    func noOpsWithoutD1Database() async {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("micropub-sync-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+
+        let count = await MicropubContentSync.pullAndCommitIfConfigured(
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "unused"),
+            transport: { _ in
+                Issue.record("transport must not be called with no provisioned D1 database")
+                struct UnexpectedNetworkCall: Error {}
+                throw UnexpectedNetworkCall()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommitIfConfigured resolves the account id, queries D1, and commits")
+    func resolvesAccountAndCommits() async throws {
+        let fm = FileManager.default
+        let configDir = fm.temporaryDirectory.appendingPathComponent("micropub-sync-config-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: configDir) }
+        try await SiteConfigStore(configDirectory: configDir).save(
+            SiteSettings(provisionedWorkerResources: .init(d1DatabaseID: "db1")))
+
+        let (siteDirectory, _) = try Self.makeThrowawaySite()
+        defer { try? FileManager.default.removeItem(at: siteDirectory.deletingLastPathComponent()) }
+
+        let accountsBody = Data("""
+        {"success": true, "result": [{"id": "acct1"}]}
+        """.utf8)
+        let body = Self.d1Body("""
+        {"url": "https://me.example/notes/hello-abc123", "type": "h-entry",
+         "properties": "{\\"content\\":[\\"Hello\\"],\\"published\\":[\\"2026-07-24T12:00:00Z\\"]}",
+         "deleted": 0, "updated_at": 1753300000}
+        """)
+
+        let count = await MicropubContentSync.pullAndCommitIfConfigured(
+            siteDirectory: siteDirectory,
+            configDirectory: configDir,
+            secretStore: FakeSecretStore(token: "token"),
+            transport: { request in
+                if request.url!.path.hasSuffix("/accounts") { return (accountsBody, Self.response(200)) }
+                if request.url!.path.contains("/d1/database/db1/query") { return (body, Self.response(200)) }
+                return (Data(), Self.response(404))
+            })
+        #expect(count == 1)
+        #expect(FileManager.default.fileExists(
+            atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123.md").path))
+    }
+
+    /// A throwaway `.anglesite`-style package: `Source/` (a git repo) beside `Config/`. Mirrors
+    /// `MicropubContentCommitterTests.makeThrowawaySite`.
+    private static func makeThrowawaySite() throws -> (siteDirectory: URL, configDirectory: URL) {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("micropub-sync-test-\(UUID().uuidString)", isDirectory: true)
+        let siteDirectory = root.appendingPathComponent("Source", isDirectory: true)
+        let configDirectory = root.appendingPathComponent("Config", isDirectory: true)
+        try fm.createDirectory(at: siteDirectory, withIntermediateDirectories: true)
+        try fm.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: siteDirectory.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = siteDirectory
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return (siteDirectory, configDirectory)
+    }
+}
+
+private struct FakeSecretStore: SecretStore {
+    let token: String?
+    func read(account: String) throws -> String? { account == SecretAccounts.cloudflareToken ? token : nil }
+    func write(_ value: String, account: String) throws {}
+    func delete(account: String) throws {}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter MicropubContentSyncTests`
+Expected: FAIL to build — `pullAndCommit`/`pullAndCommitIfConfigured` don't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `Sources/AnglesiteCore/MicropubContentSync.swift`, inside the existing `public enum MicropubContentSync { ... }` (after `resolve`, before the closing `}`):
+
+```swift
+    /// Queries `client` for every current post (live and soft-deleted), resolves each to its
+    /// content type, and reconciles the result into `siteDirectory` via
+    /// `MicropubContentCommitter`. Returns 0 (never throws) if the D1 query failed. Soft-deleted
+    /// and unresolvable posts are simply absent from the resolved set passed to the committer — a
+    /// previously-synced post whose row later became unresolvable (soft-deleted, or an edit that
+    /// broke a required field) is removed from git the same way a truly-deleted post is.
+    public static func pullAndCommit(
+        client: MicropubPostD1Client, siteDirectory: URL, configDirectory: URL
+    ) async -> Int {
+        guard let posts = try? await client.listAllPosts() else { return 0 }
+        let resolved = posts.filter { !$0.deleted }.compactMap { resolve(post: $0) }
+        return await MicropubContentCommitter.commit(
+            posts: resolved, into: siteDirectory, configDirectory: configDirectory)
+    }
+
+    /// Reads the site's `SiteSettings` and the Cloudflare API token from `secretStore`; no-ops
+    /// (returns 0, no network call) unless a D1 database has been provisioned — same gate
+    /// `ReceivedInteractionSync` uses, since Micropub shares the same D1 database.
+    /// `configDirectory` is the package's `Config/` directory (`AnglesitePackage.configURL`), a
+    /// sibling of `siteDirectory` (`AnglesitePackage.sourceURL`).
+    public static func pullAndCommitIfConfigured(
+        siteDirectory: URL,
+        configDirectory: URL,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        baseURL: String = "https://api.cloudflare.com/client/v4",
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) async -> Int {
+        guard let settings = try? SiteConfigStore.read(from: configDirectory),
+              let databaseID = settings.provisionedWorkerResources?.d1DatabaseID, !databaseID.isEmpty,
+              let token = try? secretStore.readCloudflareToken(), !token.isEmpty
+        else { return 0 }
+        guard let accountID = await Self.resolveAccountID(apiToken: token, baseURL: baseURL, transport: transport)
+        else { return 0 }
+
+        let client = MicropubPostD1Client(
+            accountID: accountID, databaseID: databaseID, apiToken: token, baseURL: baseURL, transport: transport)
+        return await pullAndCommit(client: client, siteDirectory: siteDirectory, configDirectory: configDirectory)
+    }
+
+    private struct CFAccount: Decodable, Sendable { let id: String }
+    private struct CFEnvelope: Decodable, Sendable { let success: Bool; let result: [CFAccount]? }
+
+    /// Resolves the token's first visible Cloudflare account id — same resolution
+    /// `ReceivedInteractionSync` uses, since a personal Anglesite deployment has exactly one
+    /// Cloudflare account per token.
+    private static func resolveAccountID(apiToken: String, baseURL: String, transport: CloudflareTransport) async -> String? {
+        guard let url = URL(string: "\(baseURL)/accounts?per_page=1") else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        guard let (data, http) = try? await transport(request), (200..<300).contains(http.statusCode),
+              let envelope = try? JSONDecoder().decode(CFEnvelope.self, from: data), envelope.success
+        else { return nil }
+        return envelope.result?.first?.id
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter MicropubContentSyncTests`
+Expected: PASS (17 tests total: 13 from Task 5 + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/MicropubContentSync.swift Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+git commit -m "feat(#912): wire MicropubContentSync to MICROPUB_DB and the committer"
+```
+
+---
+
+### Task 8: Wire into `PreviewModel.open(site:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/PreviewModel.swift:187-206` (the `Task { ... }` block inside `open(site:)`)
+
+**Interfaces:**
+- Consumes: `MicropubContentSync.pullAndCommitIfConfigured(siteDirectory:configDirectory:)` (Task 7).
+- Produces: nothing new consumed elsewhere — this is the final integration point.
+
+- [ ] **Step 1: Make the change**
+
+In `Sources/AnglesiteApp/PreviewModel.swift`, inside `open(site:)`'s `Task { ... }` block, change:
+
+```swift
+            _ = await ReceivedInteractionSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
+            clearDevServerCommandInFlight(token: token)
+```
+
+to:
+
+```swift
+            _ = await ReceivedInteractionSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #912: pull Micropub-created posts from MICROPUB_DB and sync each into a typed
+            // content file under src/content/. No-ops for sites without a provisioned D1
+            // database (same gate as ReceivedInteractionSync — Micropub shares the database).
+            _ = await MicropubContentSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
+            clearDevServerCommandInFlight(token: token)
+```
+
+- [ ] **Step 2: Build the app target to verify it compiles**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED. (If `Anglesite.xcodeproj` is stale relative to `project.yml` — unlikely here since no new targets/files were added outside existing globbed directories — run `xcodegen generate` first and rebuild.)
+
+- [ ] **Step 3: Run the full Swift test suite once, to catch any cross-file regression**
+
+Run: `swift test --package-path .`
+Expected: PASS — every suite, including all of Tasks 3–7's new tests and the pre-existing `AnglesiteCoreTests`/`AnglesiteBridgeTests`/`AnglesiteSiteModelTests`/`AnglesiteIntentsTests` suites.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PreviewModel.swift
+git commit -m "feat(#912): sync Micropub posts into git on site-open"
+```
+
+---
+
+## Final verification (after all 8 tasks)
+
+- [ ] Run the full test matrix once more from a clean state:
+  - `swift test --package-path .` (Swift)
+  - `npm run test:worker` from `Resources/Template/` (Worker TS)
+  - `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (app target)
+- [ ] Re-read `CONTRIBUTING.md` ▸ "Commits and pull requests" before opening the PR — use `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings (Summary, Paired PR check, Test plan), not a generic Summary/Test-plan shape. This is an app-only change (template's `worker.ts`/`Resources/Template` + `Sources/AnglesiteCore`/`AnglesiteApp`) — no MCP message schema changed, so the **Paired PR check** section should say so explicitly rather than being silently omitted.
+- [ ] Remove the `🛠️ In Progress` label from #912 once the PR is open: `gh issue edit 912 --remove-label "🛠️ In Progress"`.

--- a/docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md
+++ b/docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md
@@ -129,7 +129,7 @@ public struct MicropubPostD1Client: Sendable {
         public let deleted: Bool
         public let updatedAt: Int
     }
-    public func listLivePosts() async throws -> [Post]   // SELECT ... FROM posts ORDER BY updated_at DESC
+    public func listAllPosts() async throws -> [Post]   // SELECT ... FROM posts ORDER BY updated_at DESC
 }
 ```
 
@@ -244,7 +244,7 @@ Micropub client → POST /micropub (h-entry/h-event/h-review, Bearer token)
 
 
 Next site-open (PreviewModel.open(site:)):
-     MicropubPostD1Client.listLivePosts() → full current `posts` table
+     MicropubPostD1Client.listAllPosts() → full current `posts` table
                        │
                        ▼
      MicropubContentSync: for each row, parse {collection} from url,
@@ -262,7 +262,7 @@ Next site-open (PreviewModel.open(site:)):
 
 ## Error handling
 
-- D1 query failure → `listLivePosts()` throws, caught by
+- D1 query failure → `listAllPosts()` throws, caught by
   `pullAndCommitIfConfigured` → returns 0; the next site-open re-attempts (matches both
   precedents — never surfaces a transient network error to the caller).
 - A post whose collection can't be resolved (`discoverCollection` returned `null` at create
@@ -272,10 +272,12 @@ Next site-open (PreviewModel.open(site:)):
   placeholder value that would fail the collection's Zod schema at build time anyway.
 - Filesystem collision with a non-Micropub file → suffixed per the flow in §4, never
   overwritten.
-- Commit failure (git subprocess/libgit2 error) → the whole reconcile for this sync pass
-  returns without updating `micropubSync.json` for any newly-resolved mapping, so an
-  interrupted sync re-attempts cleanly next time rather than leaving `micropubSync.json` and
-  git out of sync with each other.
+- Commit failure (git subprocess/libgit2 error) → `micropubSync.json` is still saved
+  unconditionally — the physical file writes already happened on disk, so a retry must see those
+  paths as already resolved rather than re-deriving (and potentially re-suffixing) a fresh slug
+  for the same post. Only the *count this call reports* (and thus whether a caller treats it as
+  "synced this round") depends on the commit having actually landed; a subsequent successful sync
+  reuses the recorded mapping and simply re-attempts the commit.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md
+++ b/docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md
@@ -1,0 +1,314 @@
+# Micropub Content Sync: D1 → `Source/` Bridge
+
+**Date:** 2026-07-24
+**Status:** Proposed
+**Part of:** #912 (V-3.2 follow-up), #360 (V-3.2 Micropub server), #337 (V-3 tracking), #334 (pivot epic)
+**Precedent:** #587 (`InboxSubmissionSync`), #362 (`ReceivedInteractionSync`) — same D1-to-git
+shape, third instance
+
+---
+
+## Goal
+
+A Micropub client (a blog editor app, `micropub.rocks`, an iOS posting client) creates a post
+through the site's `/micropub` endpoint. Today that post lives only as an mf2 row in
+`MICROPUB_DB` (D1) — it is not in `Source/` git, does not render on the built site, and is lost
+if the site ever migrates off this Worker's D1 database. This design closes that gap: "app-edit
+and Micropub-post are one operation on the repo," the acceptance bar #360 originally set and
+explicitly deferred to this follow-up.
+
+Concretely: a Micropub-created Note/Article/Photo/Album/Bookmark/Reply/Like/Event/Review becomes
+a typed content file under `Source/src/content/<collection>/`, indistinguishable from one created
+through the app's own editors, and renders at the URL the Micropub client was told about.
+
+## Background
+
+### The established sync pattern (read before implementing)
+
+Two prior bridges already solve "D1 is the operational store, git is canonical, reconcile
+on site-open" for this app:
+
+- `InboxSubmissionSync` / `InboxSubmissionCommitter` (#587) — `INBOX_KV` staging →
+  `src/content/inbox/`.
+- `ReceivedInteractionSync` / `ReceivedInteractionCommitter` (#362) — `WEBMENTION_INBOX` D1 →
+  `data/interactions/`.
+
+Both share: an app-side D1/KV client (injectable-transport DI, no Keychain coupling, token
+passed at init), a `Sync` orchestrator with a `pullAndCommitIfConfigured` entry point that no-ops
+(returns 0, no network call) until the relevant `SiteSettings`/`provisionedWorkerResources` field
+is set, a `Committer` that reconciles the *full current set* against a directory (write
+changed, delete stale, true no-op — no git call at all — when nothing changed), one batched
+commit via `processGitCommitBatch` (SwiftGit2 on Darwin, subprocess git off-Darwin), and a call
+site in `PreviewModel.open(site:)` alongside the others. This design is a third instance of that
+exact shape, reading `@dwk/micropub`'s `posts` table instead.
+
+### What's different this time: the URL has to be right, not just present
+
+The two precedents write into app-owned directories (`data/interactions/`, `src/content/inbox/`)
+that nothing else writes to, and their target filename is an opaque id — no collision, no
+routing concern. This bridge writes into `src/content/<collection>/`, a directory humans also
+hand-edit, and the resulting page must render at the **same URL** the Micropub client's `Location`
+header already promised. Two consequences drive the design below:
+
+1. `@dwk/micropub`'s shipped default `generatePostUrl` assigns a flat `{baseUrl}/<slug>` URL,
+   but Astro serves collection entries at `/<collection>/<slug>/`
+   (`Resources/Template/src/pages/[collection]/[...slug].astro`). Left alone, a Micropub post's
+   announced URL never matches where it will actually render. **Decision:** fix this at the
+   source — configure a custom `generatePostUrl` in `worker.ts`'s Micropub composition that picks
+   the collection at create time and returns `{baseUrl}/<collection>/<slug>`. The sync bridge
+   then parses the collection straight out of the stored `url` column; it never needs to
+   re-run type classification for the h-entry family at all, only for the top-level mf2 type.
+2. A Micropub `mp-slug` (or name-derived slug) can collide with an existing, hand-authored file
+   in the same collection — `@dwk/micropub`'s own URL-uniqueness check only guards its D1 table,
+   not git filenames. **Decision:** the sync bridge checks the filesystem too and suffixes on
+   collision, and remembers that resolution in a small per-site state file
+   (`Config/micropubSync.json`, url → relative path) so a later re-sync of the *same* post updates
+   the file it already wrote rather than re-resolving (and potentially re-suffixing) the slug
+   every time.
+
+### Content-type scope
+
+The registry's personal h-entry family (`note`, `article`, `photo`, `album`, `bookmark`,
+`reply`, `like`) plus two business types that Micropub clients can post directly via the JSON
+`type` field: `event` (h-event) and `review` (h-review). `repost` (`u-repost-of`) has no
+`ContentTypeDescriptor` today — out of scope for this slice, same posture as h-event/h-review
+were for #360: a real, logged gap rather than a forced mapping. Any other/unrecognized mf2 type
+is skipped (logged, left D1-only) by the sync — it never guesses.
+
+---
+
+## Design
+
+### 1. Worker-side: type-aware URL generation (`worker.ts`)
+
+A new pure module, `Resources/Template/worker/post-type-discovery.ts`, exports
+`discoverCollection(mf2: { type: readonly string[]; properties: Record<string, unknown[]> }): string | null`:
+
+- `type[0] === "h-event"` → `"events"`.
+- `type[0] === "h-review"` → `"reviews"`.
+- `type[0] === "h-entry"` (or absent, matching `@dwk/micropub`'s own default) → run IndieWeb
+  [Post Type Discovery](https://www.w3.org/TR/post-type-discovery/), extended with a
+  `bookmark-of` check (present in practice, not in the original algorithm text) and the
+  count-based photo/album split:
+  1. `bookmark-of` present → `"bookmarks"`
+  2. `like-of` present → `"likes"`
+  3. `in-reply-to` present → `"replies"`
+  4. `photo` present, exactly one value → `"photos"`
+  5. `photo` present, 2+ values → `"albums"`
+  6. `name` present and the plain-text `content` doesn't start with `name` → `"articles"`
+  7. else → `"notes"`
+- Anything else (unrecognized `h-*`, `repost-of`, `rsvp`, `checkin`, `video`) → `null`.
+
+`generatePostUrl` (passed into `createMicropub({ baseUrl, me, generatePostUrl })` in `worker.ts`):
+calls `discoverCollection`; if `null`, falls back to `@dwk/micropub`'s own default flat-URL
+policy (post stays creatable, just outside this bridge's scope, exactly like today). Otherwise:
+slug = `mp-slug` (commands.slug) → `name`-derived slug → timestamp-based slug (same fallback
+order and `slugify`/`randomSlug` `@dwk/micropub` already uses internally — this module doesn't
+reimplement collision-retry, since `publishPost`'s existing loop already retries the whole
+returned URL on a D1 conflict), and the function returns
+`{baseUrl}/{collection}/{slug}`. Tested in `worker.test.ts`: one case per collection dispatch
+rule, the unrecognized-type fallback, and the photo/album count split.
+
+### 2. Swift app-side: `MicropubPostD1Client`
+
+Mirrors `WebmentionInboxD1Client` exactly (same `CloudflareTransport` DI, same D1 HTTP query
+shape) — a new file, `Sources/AnglesiteCore/MicropubPostD1Client.swift`:
+
+```swift
+public struct MicropubPostD1Client: Sendable {
+    public struct Post: Sendable, Equatable {
+        public let url: String
+        public let type: String                    // mf2 root type, e.g. "h-entry"
+        public let properties: [String: [JSONValue]] // raw mf2 property map, decoded generically
+        public let deleted: Bool
+        public let updatedAt: Int
+    }
+    public func listLivePosts() async throws -> [Post]   // SELECT ... FROM posts ORDER BY updated_at DESC
+}
+```
+
+`properties` is `TEXT` (a JSON blob) in D1, not flat columns — the query decodes the row's
+`properties` column as JSON per-row (unlike `WebmentionInboxD1Client`'s flat SQL projection,
+this one JSON-decodes a nested blob). A small `JSONValue` enum (or reuse of an existing
+any-JSON decode helper if one exists in `AnglesiteCore`) represents mf2 property values, since a
+property's array elements can be plain strings or nested objects (rich-text `content`, form
+sub-keys). Queries `SELECT url, type, properties, deleted, updated_at FROM posts ORDER BY
+updated_at DESC` — no `WHERE deleted = 0` filter, matching `ReceivedInteractionSync`'s "pull the
+full current set, let the committer's reconciliation decide what's live" pattern: a soft-deleted
+row still needs to reach the committer so it can delete the corresponding file.
+
+Reuses `ReceivedInteractionSync`'s account-id resolution and the same
+`SiteSettings.provisionedWorkerResources.d1DatabaseID` (Micropub shares the same `{site}-social`
+D1 database) — `MicropubContentSync.pullAndCommitIfConfigured` needs no new `SiteSettings` field.
+
+### 3. Swift app-side: field mapping via the registry's existing projections
+
+No new mapping table. `ContentTypeProjections.microformatProperties` already maps
+`fieldName → mf2Property` (e.g. `"body": "e-content"`) for every registered type. Add one
+small, pure reverse helper (`ContentTypeProjections.rawMf2PropertyName(for field:)` or a
+computed `reverseMicroformatProperties: [String: String]`) that strips the mf2 prefix class
+(`p-`/`e-`/`u-`/`dt-`) to get the raw property key `@dwk/micropub` actually stores (`"e-content"`
+→ `"content"`), keyed by field name. `MicropubContentSync` then, for a given post's resolved
+`ContentTypeDescriptor` (looked up via `ContentTypeRegistry.descriptor(id:)` using the collection
+parsed from the post's URL — `descriptor(forCollection:)` — not by re-running Post Type
+Discovery app-side):
+
+- For each `ContentTypeField` on the descriptor, reads `properties[rawMf2PropertyName]`.
+- Converts by `Kind`: `.string`/`.text`/`.markdown`/`.url` take `values[0]` (markdown/body
+  additionally unwraps mf2 rich-text — a string as-is, or an object's `.value` string, mirroring
+  `extractMf2ContentString` in `worker.ts`'s AP fan-out; no HTML-to-Markdown conversion in this
+  slice — an explicit, stated simplification, same posture #362's design doc took on
+  interaction-content truncation); `.datetime`/`.date` parse `values[0]` as ISO 8601;
+  `.stringArray` takes the whole array as strings; `.image` takes `values[0]` as a URL string
+  (the R2 media URL a prior `/media` upload returned); `.imageArray` (album only) takes every
+  value; `.bool` (`draft`) is derived from `properties["post-status"] == ["draft"]`, not a direct
+  field — matches the Post Status extension`@dwk/micropub` already validates on write.
+- A required field with no matching property → the post is skipped (logged), not written with a
+  placeholder — a malformed/partial post shouldn't produce invalid frontmatter.
+
+### 4. Swift app-side: `MicropubContentCommitter` + sync-state file
+
+New `Sources/AnglesiteCore/MicropubContentCommitter.swift`, structurally close to
+`ReceivedInteractionCommitter` but per-collection and slug-aware rather than id-keyed:
+
+- Reads/writes `Config/micropubSync.json` (`AnglesitePackage.configURL`-relative — app-owned
+  state, never in git, same split every other per-site state already uses): a
+  `[url: String]` → `relPath: String` map.
+- For each live (non-deleted) post with a resolved collection + descriptor:
+  - If `url` is already in the map, use its recorded `relPath` directly (no re-slugging, no
+    collision check — this is what makes a second sync of the same post update-in-place).
+  - Otherwise, derive the slug (from the URL's last path segment — the same slug the Worker
+    already chose, so no independent slug logic app-side either), check
+    `src/content/<collection>/<slug>.md` for an existing file; if present and its content wasn't
+    written by this committer (no entry pointing at it in the map), suffix
+    (`<slug>-2`, `<slug>-3`, …) until free, then record the mapping.
+- For each mapped `relPath` no longer present in the live set (post soft-deleted, or its type
+  fell out of scope on an edit — see below), delete the file and its map entry.
+- Renders frontmatter (YAML, sorted keys for stable diffs) + body per the field mapping above,
+  matching each collection's exact `.strict()` Zod schema in `content.config.ts` — no extra
+  keys, or Astro's build fails closed on that collection.
+- Writes/deletes are batched into one commit via the existing
+  `InboxSubmissionCommitter.processGitCommitBatch`, message
+  `"micropub: sync {n} post(s), remove {m}"` (mirroring
+  `ReceivedInteractionCommitter.commitMessage`'s write/delete/both cases) — true no-op (no git
+  call) when nothing changed. `Config/micropubSync.json` itself is written outside the git
+  commit (it's in `Config/`, not `Source/`).
+
+**Update semantics:** `@dwk/micropub`'s `updateProperties` overwrites a live post's `properties`
+wholesale server-side already (no separate patch/merge needed app-side) — every sync simply
+re-renders the file from the row's current `properties` and overwrites if content differs,
+identical to how `ReceivedInteractionCommitter` handles a changed interaction. If an update
+changes properties enough that `discoverCollection`-equivalent classification would now differ
+(e.g. a note edited to add `bookmark-of`) — the *URL's* collection segment does not change (URLs
+are permanent once assigned, matching IndieWeb norms and `worker.ts`'s existing
+collision-retry-only-at-create behavior), so the file simply stays in its original collection
+with updated content. This is a deliberate simplification: post identity (URL, and therefore
+collection) is fixed at creation, never re-derived on update.
+
+### 5. Wiring
+
+`PreviewModel.open(site:)` gains a third call alongside the existing two:
+
+```swift
+_ = await MicropubContentSync.pullAndCommitIfConfigured(
+    siteDirectory: siteDirectory, configDirectory: configDirectory)
+```
+
+No-ops (returns 0, no network call) until `provisionedWorkerResources.d1DatabaseID` is set —
+same gate `ReceivedInteractionSync` already uses, since Micropub provisions the same shared D1
+database.
+
+---
+
+## Data flow
+
+```
+Micropub client → POST /micropub (h-entry/h-event/h-review, Bearer token)
+                       │
+                       ▼
+     @dwk/micropub validates + generatePostUrl (worker.ts, new):
+     discoverCollection(mf2) → "notes"/"articles"/.../null
+                       │
+                       ▼
+     writes mf2 row to MICROPUB_DB, url = {baseUrl}/{collection}/{slug}
+     (or the untouched flat-URL fallback when discoverCollection → null)
+                       │
+                       ▼
+              201 Created + Location: {baseUrl}/{collection}/{slug}
+
+
+Next site-open (PreviewModel.open(site:)):
+     MicropubPostD1Client.listLivePosts() → full current `posts` table
+                       │
+                       ▼
+     MicropubContentSync: for each row, parse {collection} from url,
+     descriptor(forCollection:) → ContentTypeDescriptor (skip if none)
+                       │
+                       ▼
+     MicropubContentCommitter: resolve/create slug mapping (micropubSync.json),
+     reverse-project mf2 properties → frontmatter via the field's own
+     ContentTypeProjections, reconcile src/content/{collection}/, one commit
+                       │
+                       ▼
+     Next Astro build: page renders at /{collection}/{slug}/ — the same
+     URL the Micropub client's Location already promised
+```
+
+## Error handling
+
+- D1 query failure → `listLivePosts()` throws, caught by
+  `pullAndCommitIfConfigured` → returns 0; the next site-open re-attempts (matches both
+  precedents — never surfaces a transient network error to the caller).
+- A post whose collection can't be resolved (`discoverCollection` returned `null` at create
+  time, or its mf2 `type` isn't one this bridge recognizes) → skipped, logged, left D1-only —
+  visible in the debug pane (`LogCenter`), not a silent gap.
+- A post missing a required field's mf2 property → skipped, logged — never written with a
+  placeholder value that would fail the collection's Zod schema at build time anyway.
+- Filesystem collision with a non-Micropub file → suffixed per the flow in §4, never
+  overwritten.
+- Commit failure (git subprocess/libgit2 error) → the whole reconcile for this sync pass
+  returns without updating `micropubSync.json` for any newly-resolved mapping, so an
+  interrupted sync re-attempts cleanly next time rather than leaving `micropubSync.json` and
+  git out of sync with each other.
+
+## Testing
+
+- `Resources/Template/worker/post-type-discovery.test.ts` — one case per `discoverCollection`
+  dispatch rule (each h-entry sub-type, h-event, h-review, unrecognized type → `null`, the
+  photo/album count split, `bookmark-of` alongside `like-of`/`in-reply-to` precedence).
+- `Resources/Template/worker/worker.test.ts` — `generatePostUrl` end-to-end: a create request
+  for each supported type lands at the expected `/{collection}/{slug}` URL; an unsupported type
+  falls back to the existing flat URL.
+- `Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift` — row decoding (including a
+  `properties` blob with nested rich-text `content`), unauthorized/malformed-response handling
+  (mirrors `WebmentionInboxD1ClientTests`).
+- `Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift` — collection resolution from a
+  post's `url`, descriptor lookup, skip-and-log for an unresolvable collection/missing required
+  field.
+- `Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift` — write/update/delete
+  reconciliation, `micropubSync.json` round-trip (first-sync slug resolution + suffix-on-
+  collision, second-sync reuses the recorded path with no re-suffix), no-op-when-unchanged,
+  frontmatter matches each collection's exact Zod schema (no extra/missing keys), commit-message
+  variants.
+
+## Files touched
+
+- `Resources/Template/worker/post-type-discovery.ts` (new), `.test.ts`
+- `Resources/Template/worker/worker.ts` (`generatePostUrl` wiring), `worker.test.ts`
+- `Sources/AnglesiteCore/MicropubPostD1Client.swift` (new)
+- `Sources/AnglesiteCore/MicropubContentSync.swift` (new)
+- `Sources/AnglesiteCore/MicropubContentCommitter.swift` (new)
+- `Sources/AnglesiteApp/PreviewModel.swift` (third sync call in `open(site:)`)
+- Matching files under `Tests/AnglesiteCoreTests/`
+
+## Self-review
+
+- **Placeholders:** none — every section describes concrete behavior.
+- **Internal consistency:** the URL-generation rule in §1 and the collection-parsing rule in §2
+  are the same classification, run once (Worker, create time) and read once (app, sync time) —
+  not two independent implementations of Post Type Discovery that could drift.
+- **Scope:** the h-entry family + event + review, per the confirmed decision; `repost` explicitly
+  named out of scope (no registry type exists for it yet) rather than left ambiguous.
+- **Ambiguity resolved:** URL/routing mismatch, photo-vs-album dispatch, and hand-authored-file
+  collision safety were all open questions in the originating issue; each has one stated answer
+  above, not a menu of options.

--- a/docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md
+++ b/docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md
@@ -161,16 +161,24 @@ Discovery app-side):
 
 - For each `ContentTypeField` on the descriptor, reads `properties[rawMf2PropertyName]`.
 - Converts by `Kind`: `.string`/`.text`/`.markdown`/`.url` take `values[0]` (markdown/body
-  additionally unwraps mf2 rich-text — a string as-is, or an object's `.value` string, mirroring
-  `extractMf2ContentString` in `worker.ts`'s AP fan-out; no HTML-to-Markdown conversion in this
-  slice — an explicit, stated simplification, same posture #362's design doc took on
-  interaction-content truncation); `.datetime`/`.date` parse `values[0]` as ISO 8601;
-  `.stringArray` takes the whole array as strings; `.image` takes `values[0]` as a URL string
-  (the R2 media URL a prior `/media` upload returned); `.imageArray` (album only) takes every
-  value; `.bool` (`draft`) is derived from `properties["post-status"] == ["draft"]`, not a direct
-  field — matches the Post Status extension`@dwk/micropub` already validates on write.
-- A required field with no matching property → the post is skipped (logged), not written with a
-  placeholder — a malformed/partial post shouldn't produce invalid frontmatter.
+  additionally unwraps mf2 rich-text — a string as-is, an object's `.value` string, or (the
+  standard Micropub JSON *create* shape, which has no `value` key at all) an object's `.html`
+  string as a fallback, mirroring `extractMf2ContentString` in `worker.ts`'s AP fan-out; no
+  HTML-to-Markdown conversion in this slice — an explicit, stated simplification, same posture
+  #362's design doc took on interaction-content truncation); `.datetime`/`.date` parse `values[0]`
+  as ISO 8601; `.stringArray` takes the whole array as strings; `.image` takes `values[0]` as a
+  URL string (the R2 media URL a prior `/media` upload returned); `.imageArray` (album only) takes
+  every value; `.bool` (`draft`) is derived from `properties["post-status"] == ["draft"]`, not a
+  direct field — matches the Post Status extension`@dwk/micropub` already validates on write.
+- Most required fields with no matching/resolvable property → the post is skipped (logged), not
+  written with a placeholder — a malformed/partial post shouldn't produce invalid frontmatter. Two
+  exceptions have dedicated fallbacks instead of skipping, because both have a reasonable
+  synthesized value and skipping them would drop the most common real-world Micropub create shapes:
+  `publishDate` falls back to the post's D1 `updated_at` timestamp (`@dwk/micropub` doesn't inject
+  a `published` timestamp on create, so the micropub.rocks conformance shape — no dates at all —
+  would otherwise always fail this always-required field), and a required title-like field
+  (`title`/`name`) falls back to a slug-derived title (`"my-trip-2026"` → `"My Trip 2026"`), for a
+  nameless post such as a multi-photo album.
 
 ### 4. Swift app-side: `MicropubContentCommitter` + sync-state file
 
@@ -185,9 +193,15 @@ New `Sources/AnglesiteCore/MicropubContentCommitter.swift`, structurally close t
     collision check — this is what makes a second sync of the same post update-in-place).
   - Otherwise, derive the slug (from the URL's last path segment — the same slug the Worker
     already chose, so no independent slug logic app-side either), check
-    `src/content/<collection>/<slug>.md` for an existing file; if present and its content wasn't
-    written by this committer (no entry pointing at it in the map), suffix
-    (`<slug>-2`, `<slug>-3`, …) until free, then record the mapping.
+    `src/content/<collection>/<slug>.md` for an existing file; if present, suffix (`<slug>-2`,
+    `<slug>-3`, …) until a candidate path names no file on disk, then record the mapping. File
+    existence is the only signal — there is no "owned by this committer" check (an earlier design
+    had one, but it was a bug: it let two distinct posts collapse onto the same file whenever one
+    candidate path was already claimed by a *different* URL's own state entry). The fast path
+    above already handles a post's own previously-recorded path, so by the time this loop runs the
+    only way a candidate can already exist on disk is that some other post — hand-authored or a
+    different Micropub post — owns it, and a fresh post always suffixes past it regardless of who
+    put it there.
 - For each mapped `relPath` no longer present in the live set (post soft-deleted, or its type
   fell out of scope on an edit — see below), delete the file and its map entry.
 - Renders frontmatter (YAML, sorted keys for stable diffs) + body per the field mapping above,
@@ -269,7 +283,11 @@ Next site-open (PreviewModel.open(site:)):
   time, or its mf2 `type` isn't one this bridge recognizes) → skipped, logged, left D1-only —
   visible in the debug pane (`LogCenter`), not a silent gap.
 - A post missing a required field's mf2 property → skipped, logged — never written with a
-  placeholder value that would fail the collection's Zod schema at build time anyway.
+  placeholder value that would fail the collection's Zod schema at build time anyway. Two fields
+  are exceptions with dedicated fallbacks rather than skip-on-missing (see §3): `publishDate`
+  (falls back to the post's D1 `updated_at`) and a title-like field (`title`/`name`, falls back to
+  a slug-derived title) — both have a reasonable synthesized value, and skipping them would drop
+  the most common real-world Micropub create shapes.
 - Filesystem collision with a non-Micropub file → suffixed per the flow in §4, never
   overwritten.
 - Commit failure (git subprocess/libgit2 error) → `micropubSync.json` is still saved

--- a/docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md
+++ b/docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md
@@ -86,8 +86,15 @@ A new pure module, `Resources/Template/worker/post-type-discovery.ts`, exports
 
 - `type[0] === "h-event"` → `"events"`.
 - `type[0] === "h-review"` → `"reviews"`.
-- `type[0] === "h-entry"` (or absent, matching `@dwk/micropub`'s own default) → run IndieWeb
-  [Post Type Discovery](https://www.w3.org/TR/post-type-discovery/), extended with a
+- Any other recognized `h-*` type → `null` (unsupported).
+- `type[0] === "h-entry"` (or absent, matching `@dwk/micropub`'s own default) → **first** check for
+  an unsupported post shape — `repost-of`, `rsvp`, `checkin`, or `video` present → `null`. This
+  precedes every check below, not just the terminal `"notes"` fallback: a real post can combine an
+  unsupported property with a supported one (an RSVP conventionally carries both `rsvp` and
+  `in-reply-to` — see [indieweb.org/rsvp](https://indieweb.org/rsvp)), and the unsupported shape
+  must win that combination, or it silently miscategorizes instead of skipping. Only once none of
+  those four are present does IndieWeb
+  [Post Type Discovery](https://www.w3.org/TR/post-type-discovery/) run, extended with a
   `bookmark-of` check (present in practice, not in the original algorithm text) and the
   count-based photo/album split:
   1. `bookmark-of` present → `"bookmarks"`
@@ -97,7 +104,6 @@ A new pure module, `Resources/Template/worker/post-type-discovery.ts`, exports
   5. `photo` present, 2+ values → `"albums"`
   6. `name` present and the plain-text `content` doesn't start with `name` → `"articles"`
   7. else → `"notes"`
-- Anything else (unrecognized `h-*`, `repost-of`, `rsvp`, `checkin`, `video`) → `null`.
 
 `generatePostUrl` (passed into `createMicropub({ baseUrl, me, generatePostUrl })` in `worker.ts`):
 calls `discoverCollection`; if `null`, falls back to `@dwk/micropub`'s own default flat-URL


### PR DESCRIPTION
## Summary

- A Micropub-created post (note/article/photo/album/bookmark/reply/like/event/review) now becomes a typed content file under `Source/src/content/<collection>/`, rendering at the same URL the Micropub client's `Location` header promised — closing #360's original "app-edit and Micropub-post are one operation on the repo" acceptance bar.
- Worker-side: a new `post-type-discovery.ts` module classifies each incoming mf2 post once, at create time, and `worker.ts`'s `generatePostUrl` uses that to assign a type-aware URL (`{baseUrl}/{collection}/{slug}`) instead of the default flat scheme.
- App-side: a third D1-to-git sync bridge (mirroring the shipped `InboxSubmissionSync`/#587 and `ReceivedInteractionSync`/#362) — `MicropubPostD1Client` → `MicropubContentSync` → `MicropubContentCommitter` — parses the collection back out of each post's URL, maps its mf2 properties to typed frontmatter via the existing `ContentTypeRegistry`, and reconciles `src/content/<collection>/` on every site-open, tracking a url→filepath mapping in `Config/micropubSync.json` so a slug collision with a hand-authored file only ever gets suffixed once.

Full design rationale: [`docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md`](docs/superpowers/specs/2026-07-24-micropub-content-sync-design.md). Implementation plan: [`docs/superpowers/plans/2026-07-24-micropub-content-sync.md`](docs/superpowers/plans/2026-07-24-micropub-content-sync.md).

Built and reviewed task-by-task (8 tasks, fresh implementer + independent reviewer per task), followed by two full whole-branch review rounds that caught and fixed several real gaps: a missing `publishDate` fallback for the common no-`published` create shape, unreadable HTML-only rich-text content, an `mp-slug` sanitization gap that could misroute posts across collection boundaries, a slug-collision bug that could collapse two distinct posts onto one file, missing skip-logging, and thin per-collection test coverage. See the plan/spec docs' own text for the final, corrected behavior.

One finding was filed as a separate out-of-scope follow-up rather than fixed here: `InboxSubmissionCommitter.processGitCommitBatch`'s Darwin branch (SwiftGit2) may not correctly stage file deletions into git commits — this affects two other already-shipped features (#587, #362) that share this helper, not just this PR, so it deserves its own dedicated PR.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: N/A — no MCP message schema changed; this consumes the already-published `@dwk/micropub` Worker composition (#360/#922) and the app's own Astro template.

## Test plan

- [x] `swift test --package-path .` — 2604/2606 passing. The 2 failures (`FoundationModelAssistantTests`, live on-device Foundation Models generation) are pre-existing, environment-dependent, and unrelated to this branch — confirmed by reproducing them in isolation with no code in this change touching that path.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [x] `npm run test:worker` (from `Resources/Template/`) — `post-type-discovery.test.ts` + `worker.test.ts`, all passing.
- [ ] Manual smoke (if UI-touching): N/A — no UI surface in this change; the acceptance path (a live `micropub.rocks` conformance run against a deployed, provisioned site) is a manual verification step for a follow-up, same posture as V-3.1/V-3.2's own conformance runs.