### PR TITLE
test(#950): pin processGitCommitBatch's deletion-staging behavior

### DIFF
--- a/Tests/AnglesiteCoreTests/InboxSubmissionCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/InboxSubmissionCommitterTests.swift
@@ -135,6 +135,84 @@ struct InboxSubmissionCommitterTests {
         #expect(ids.isEmpty)
     }
 
+    @Test("processGitCommitBatch stages a path's deletion, not just its earlier addition")
+    func processGitCommitBatchStagesDeletion() async throws {
+        let dir = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("src/content/inbox", isDirectory: true),
+            withIntermediateDirectories: true)
+        let relPath = "src/content/inbox/stale.txt"
+        let fileURL = dir.appendingPathComponent(relPath)
+        try "stale content\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        #expect(await InboxSubmissionCommitter.processGitCommitBatch(dir, [relPath], "add stale.txt") != nil)
+
+        try FileManager.default.removeItem(at: fileURL)
+        let deleteSHA = try #require(
+            await InboxSubmissionCommitter.processGitCommitBatch(dir, [relPath], "remove stale.txt"))
+
+        // Assert against the actual commit contents, not filesystem state (removeItem above
+        // already made the file disappear from disk regardless of whether git staged anything) —
+        // a fresh checkout of `deleteSHA` must not resurrect the file. `Repository.add(path:)`
+        // wraps `git_index_add_all` with a literal (non-wildcard) single-path pathspec, which
+        // libgit2 special-cases to match plain `git add <path>` CLI semantics for a path that's
+        // gone missing from the working tree: it stages the removal, unlike the broader-pathspec
+        // case `addAll()`'s own doc comment warns about (`git_index_add_all` over a wildcard/
+        // directory pathspec only walks files that still exist on disk, so it can't discover
+        // already-gone ones — that's what `git_index_update_all` is for). Confirmed empirically:
+        // this and `processGitCommitBatchStagesMixedDeletionAndWrite` below both pass.
+        let tree = try Self.gitOutput(["ls-tree", "-r", "--name-only", deleteSHA], in: dir)
+        #expect(!tree.contains("stale.txt"))
+    }
+
+    @Test("processGitCommitBatch stages a deletion mixed with a write in the same call")
+    func processGitCommitBatchStagesMixedDeletionAndWrite() async throws {
+        let dir = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let keepURL = dir.appendingPathComponent("keep.txt")
+        let deleteURL = dir.appendingPathComponent("delete-me.txt")
+        try "keep\n".write(to: keepURL, atomically: true, encoding: .utf8)
+        try "gone\n".write(to: deleteURL, atomically: true, encoding: .utf8)
+        let setupSHA = await InboxSubmissionCommitter.processGitCommitBatch(
+            dir, ["keep.txt", "delete-me.txt"], "seed")
+        #expect(setupSHA != nil)
+
+        try FileManager.default.removeItem(at: deleteURL)
+        try "new\n".write(to: dir.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        let mixedSHA = try #require(
+            await InboxSubmissionCommitter.processGitCommitBatch(
+                dir, ["delete-me.txt", "new.txt"], "reconcile: 1 write, 1 delete"))
+
+        // Mirrors how ReceivedInteractionCommitter/MicropubContentCommitter actually call this:
+        // one relPaths array covering both a deletion and a write in the same commit.
+        let tree = try Self.gitOutput(["ls-tree", "-r", "--name-only", mixedSHA], in: dir)
+        #expect(!tree.contains("delete-me.txt"))
+        #expect(tree.contains("new.txt"))
+        #expect(tree.contains("keep.txt"))
+    }
+
+    /// Runs a read-only `git` subprocess against `dir` and returns its captured stdout — used to
+    /// inspect actual commit contents (not just filesystem state) independent of the SwiftGit2
+    /// path the code under test exercises on Darwin.
+    private static func gitOutput(_ args: [String], in dir: URL) throws -> String {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        p.arguments = args
+        p.currentDirectoryURL = dir
+        let pipe = Pipe()
+        p.standardOutput = pipe
+        try p.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        p.waitUntilExit()
+        guard p.terminationStatus == 0 else {
+            struct GitFailed: Error {}
+            throw GitFailed()
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
     /// Mirrors `AnglesiteContainerProbe.makeThrowawayAstroRepo` — a minimal on-disk git repo with
     /// one initial commit, so `git add`/`git commit` in the code under test have somewhere to work.
     private static func makeThrowawayGitRepo() throws -> URL {


### PR DESCRIPTION
## Summary

- Review of #912 flagged a suspected bug: `InboxSubmissionCommitter.processGitCommitBatch` (the shared batched-commit helper reused by `InboxSubmissionCommitter` #587, `ReceivedInteractionCommitter` #362, and `MicropubContentCommitter` #912) might not stage file *deletions* on Darwin, since `Repository.add(path:)` wraps `git_index_add_all`, and the neighboring `addAll()` method's own doc comment warns that `add(path:)` alone "leaves entries for deleted files in the index."
- Investigation (closes #950) shows this does **not** reproduce for any real caller: `add(path:)` is only ever invoked with a literal, non-wildcard, single-file relative path (one call per path, in a loop), and libgit2 special-cases that exact shape — mirroring plain `git add <path>` CLI semantics for a path that's gone missing from disk — by staging the removal. The `addAll()` doc comment's caveat is specifically about the *broad/wildcard* pathspec case (matching a whole directory or the entire repo), which never occurs in any of the three callers.
- No production code change. Adds two regression tests to `InboxSubmissionCommitterTests.swift` that assert against the actual resulting commit's tree (`git ls-tree`) rather than filesystem state — closing the coverage gap the review correctly identified, even though the underlying behavior turned out to already be correct.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — full `AnglesiteCoreTests` suite passes except 2 pre-existing, unrelated failures in `FoundationModelAssistantTests` ("Session ended without producing a response" — on-device model session flakiness, reproduces identically on `origin/main` with an isolated `--filter FoundationModelAssistant` run, unrelated to this change).
- [x] `swift test --filter InboxSubmissionCommitterTests` — all 12 tests pass, including the 2 new ones.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (test-only change to a SwiftPM target, no app-target code touched).
- [ ] Manual smoke: not applicable (no UI change).