### PR TITLE
feat(#744): close the .well-known build seam end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
           cache-dependency-path: Resources/Template/package-lock.json
       - run: npm ci --no-audit --no-fund
       - run: npm run test:worker
+      # The template's node:test suites (scripts/*.test.ts) had no CI lane at all — the
+      # `.well-known` design doc calls that out explicitly. `test:worker` is vitest/workerd only.
+      - run: npm run test:scripts
       - run: npm run build
 
   help-book-links:

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -4,12 +4,14 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "prebuild": "npx tsx scripts/csp.ts && npx tsx scripts/edge-artifacts.ts",
+    "prebuild": "npx tsx scripts/well-known.ts check && npx tsx scripts/csp.ts && npx tsx scripts/edge-artifacts.ts",
     "build": "astro check && astro build && npx tsx scripts/check-microformats.ts",
+    "postbuild": "npx tsx scripts/well-known.ts verify",
     "preview": "astro preview",
     "check": "npx tsx scripts/pre-deploy-check.ts",
     "build:ci": "npm run build && npx tsx scripts/pre-deploy-check.ts --json --strict",
-    "test:worker": "vitest run --config vitest.config.ts"
+    "test:worker": "vitest run --config vitest.config.ts",
+    "test:scripts": "npx tsx --test scripts/*.test.ts"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.0",

--- a/Resources/Template/scripts/well-known.test.ts
+++ b/Resources/Template/scripts/well-known.test.ts
@@ -1,0 +1,329 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  MANIFEST_ENV_VAR,
+  MAX_FILE_SIZE_BYTES,
+  RESULT_PATH_ENV_VAR,
+  claimsCovering,
+  classifyStaticPaths,
+  mergeSeamResult,
+  parseClaimManifest,
+  readSeamResult,
+  runCheck,
+  runVerify,
+  scanWellKnown,
+  type ClaimEntry,
+} from "./well-known";
+import { MTA_STS_MARKER, SECURITY_TXT_MARKER } from "./edge-artifacts";
+
+/** A scratch site directory, removed by the caller's `t.after`. */
+function scratch(): string {
+  return mkdtempSync(join(tmpdir(), "anglesite-well-known-"));
+}
+
+function writeFile(root: string, relPath: string, contents: string): void {
+  const full = resolve(root, relPath);
+  mkdirSync(resolve(full, ".."), { recursive: true });
+  writeFileSync(full, contents, "utf-8");
+}
+
+function entry(overrides: Partial<ClaimEntry> & Pick<ClaimEntry, "path">): ClaimEntry {
+  return {
+    id: overrides.id ?? overrides.path,
+    path: overrides.path,
+    match: overrides.match ?? "exact",
+    owner: overrides.owner ?? "user-static",
+    delivery: overrides.delivery ?? "userStatic",
+  };
+}
+
+// --- parseClaimManifest ---
+
+test("parseClaimManifest: reads the manifest Swift encodes", () => {
+  const json = JSON.stringify({
+    entries: [
+      { id: "user-static:security.txt", path: "security.txt", match: "exact", owner: "user-static", delivery: "userStatic" },
+      { id: "webfinger:webfinger", path: "webfinger", match: "exact", owner: "webfinger", delivery: "dynamic" },
+    ],
+  });
+  const entries = parseClaimManifest(json);
+  assert.equal(entries.length, 2);
+  assert.deepEqual(entries[1], {
+    id: "webfinger:webfinger",
+    path: "webfinger",
+    match: "exact",
+    owner: "webfinger",
+    delivery: "dynamic",
+  });
+});
+
+test("parseClaimManifest: malformed JSON degrades to no entries instead of throwing", () => {
+  assert.deepEqual(parseClaimManifest("not json"), []);
+  assert.deepEqual(parseClaimManifest(""), []);
+  assert.deepEqual(parseClaimManifest("[1,2,3]"), []);
+  assert.deepEqual(parseClaimManifest('{"entries":"nope"}'), []);
+});
+
+test("parseClaimManifest: an entry with no delivery defaults to the non-blocking class", () => {
+  const entries = parseClaimManifest('{"entries":[{"id":"a","path":"a","match":"exact","owner":"o"}]}');
+  assert.equal(entries[0].delivery, "userStatic");
+});
+
+test("parseClaimManifest: skips entries missing required fields", () => {
+  const entries = parseClaimManifest('{"entries":[{"path":"a"},{"owner":"o"},{"path":"b","owner":"o"}]}');
+  assert.deepEqual(entries.map((e) => e.path), ["b"]);
+});
+
+// --- scanWellKnown ---
+
+test("scanWellKnown: a missing directory yields nothing and no findings", () => {
+  const { paths, findings } = scanWellKnown(join(tmpdir(), "anglesite-does-not-exist-well-known"));
+  assert.deepEqual(paths, []);
+  assert.deepEqual(findings, []);
+});
+
+test("scanWellKnown: lists nested files with POSIX-relative paths, sorted", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "security.txt", "Contact: mailto:x@example.com\n");
+  writeFile(root, "acme-challenge/token-b", "b");
+  writeFile(root, "acme-challenge/token-a", "a");
+
+  const { paths, findings } = scanWellKnown(root);
+  assert.deepEqual(paths, ["acme-challenge/token-a", "acme-challenge/token-b", "security.txt"]);
+  assert.deepEqual(findings, []);
+});
+
+test("scanWellKnown: excludes a symlink and reports it", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "real.txt", "ok");
+  symlinkSync(resolve(root, "real.txt"), resolve(root, "link.txt"));
+
+  const { paths, findings } = scanWellKnown(root);
+  assert.deepEqual(paths, ["real.txt"]);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].path, "link.txt");
+  assert.match(findings[0].message, /symlink/);
+});
+
+test("scanWellKnown: excludes a percent-encoded-looking filename", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "%2e%2e", "traversal-ish");
+
+  const { paths, findings } = scanWellKnown(root);
+  assert.deepEqual(paths, []);
+  assert.match(findings[0].message, /percent-encoded/);
+});
+
+test("scanWellKnown: excludes a file over the size cap", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "huge.json", "x".repeat(MAX_FILE_SIZE_BYTES + 1));
+  writeFile(root, "small.json", "{}");
+
+  const { paths, findings } = scanWellKnown(root);
+  assert.deepEqual(paths, ["small.json"]);
+  assert.match(findings[0].message, new RegExp(String(MAX_FILE_SIZE_BYTES)));
+});
+
+// --- claimsCovering / classifyStaticPaths ---
+
+test("claimsCovering: an exact claim matches only its own path", () => {
+  const entries = [entry({ path: "security.txt" })];
+  assert.equal(claimsCovering(entries, "security.txt").length, 1);
+  assert.equal(claimsCovering(entries, "security.txt.bak").length, 0);
+});
+
+test("claimsCovering: a prefix claim matches its children but not the bare prefix path", () => {
+  const entries = [entry({ path: "acme-challenge", match: "prefix" })];
+  assert.equal(claimsCovering(entries, "acme-challenge/token").length, 1);
+  assert.equal(claimsCovering(entries, "acme-challenge").length, 0);
+  assert.equal(claimsCovering(entries, "acme-challenges/token").length, 0);
+});
+
+test("classifyStaticPaths: a static file shadowing a dynamic route blocks and names both owners", () => {
+  const entries = [entry({ path: "webfinger", owner: "webfinger", delivery: "dynamic" })];
+  const { blocking, advisory } = classifyStaticPaths(entries, ["webfinger"]);
+  assert.deepEqual(advisory, []);
+  assert.equal(blocking.length, 1);
+  assert.match(blocking[0].message, /static file in the site source/);
+  assert.match(blocking[0].message, /webfinger \(dynamic\)/);
+});
+
+test("classifyStaticPaths: a static file inside a runtime-owned prefix blocks", () => {
+  const entries = [
+    entry({ path: "acme-challenge", match: "prefix", owner: "cloudflare-managed-tls", delivery: "externalRuntime" }),
+  ];
+  const { blocking } = classifyStaticPaths(entries, ["acme-challenge/token"]);
+  assert.equal(blocking.length, 1);
+  assert.match(blocking[0].message, /cloudflare-managed-tls \(externalRuntime\)/);
+});
+
+test("classifyStaticPaths: user-static and generated claims never block", () => {
+  const entries = [
+    entry({ path: "humans.txt" }),
+    entry({ path: "security.txt", owner: "generator:security-txt", delivery: "generated" }),
+  ];
+  const { blocking, advisory } = classifyStaticPaths(entries, ["humans.txt", "security.txt"]);
+  assert.deepEqual(blocking, []);
+  assert.deepEqual(advisory, []);
+});
+
+test("classifyStaticPaths: an unclaimed static file is advisory, not blocking", () => {
+  const { blocking, advisory } = classifyStaticPaths([], ["surprise.json"]);
+  assert.deepEqual(blocking, []);
+  assert.equal(advisory.length, 1);
+  assert.match(advisory[0].message, /no matching inventory claim/);
+});
+
+// --- result-file I/O ---
+
+test("readSeamResult: a missing or malformed file degrades to an empty result", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  assert.deepEqual(readSeamResult(join(root, "nope.json")), { observedArtifacts: [], generatedArtifacts: [], findings: [] });
+  writeFile(root, "bad.json", "{{{");
+  assert.deepEqual(readSeamResult(join(root, "bad.json")), { observedArtifacts: [], generatedArtifacts: [], findings: [] });
+});
+
+test("mergeSeamResult: keeps earlier findings and de-duplicates artifacts", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const path = join(root, "result.json");
+
+  mergeSeamResult(path, { findings: [{ path: "a", message: "first" }] });
+  const merged = mergeSeamResult(path, {
+    observedArtifacts: ["b", "a", "a"],
+    findings: [{ message: "second" }],
+  });
+
+  assert.deepEqual(merged.observedArtifacts, ["a", "b"]);
+  assert.deepEqual(merged.findings.map((f) => f.message), ["first", "second"]);
+  assert.deepEqual(JSON.parse(readFileSync(path, "utf-8")), merged);
+});
+
+// --- runCheck / runVerify ---
+
+test("runCheck: no manifest env var means no seam — succeeds and writes nothing", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "public/.well-known/webfinger", "static");
+
+  assert.equal(runCheck(root, {}), 0);
+});
+
+test("runCheck: blocks with exit 1 when a static file shadows a dynamic claim", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "public/.well-known/webfinger", "static shadow");
+  writeFile(
+    root,
+    "manifest.json",
+    JSON.stringify({ entries: [{ id: "w", path: "webfinger", match: "exact", owner: "webfinger", delivery: "dynamic" }] }),
+  );
+  const resultPath = join(root, "result.json");
+
+  const code = runCheck(root, {
+    [MANIFEST_ENV_VAR]: join(root, "manifest.json"),
+    [RESULT_PATH_ENV_VAR]: resultPath,
+  });
+
+  assert.equal(code, 1);
+  const result = readSeamResult(resultPath);
+  assert.equal(result.findings.length, 1);
+  assert.match(result.findings[0].message, /collides with/);
+});
+
+test("runCheck: passes when every static file has a compatible claim", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "public/.well-known/security.txt", "Contact: mailto:x@example.com\n");
+  writeFile(
+    root,
+    "manifest.json",
+    JSON.stringify({
+      entries: [{ id: "s", path: "security.txt", match: "exact", owner: "user-static", delivery: "userStatic" }],
+    }),
+  );
+  const resultPath = join(root, "result.json");
+
+  assert.equal(runCheck(root, { [MANIFEST_ENV_VAR]: join(root, "manifest.json"), [RESULT_PATH_ENV_VAR]: resultPath }), 0);
+  assert.deepEqual(readSeamResult(resultPath).findings, []);
+});
+
+test("runVerify: records the exact dist/.well-known artifacts the build produced", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "dist/.well-known/security.txt", "Contact: mailto:x@example.com\n");
+  writeFile(root, "dist/.well-known/nested/thing.json", "{}");
+  writeFile(root, "manifest.json", JSON.stringify({ entries: [] }));
+  const resultPath = join(root, "result.json");
+
+  assert.equal(runVerify(root, { [MANIFEST_ENV_VAR]: join(root, "manifest.json"), [RESULT_PATH_ENV_VAR]: resultPath }), 0);
+  assert.deepEqual(readSeamResult(resultPath).observedArtifacts, ["nested/thing.json", "security.txt"]);
+});
+
+test("runVerify: preserves the findings runCheck already recorded", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "public/.well-known/surprise.json", "{}");
+  writeFile(root, "dist/.well-known/surprise.json", "{}");
+  writeFile(root, "manifest.json", JSON.stringify({ entries: [] }));
+  const env = { [MANIFEST_ENV_VAR]: join(root, "manifest.json"), [RESULT_PATH_ENV_VAR]: join(root, "result.json") };
+
+  assert.equal(runCheck(root, env), 0);
+  assert.equal(runVerify(root, env), 0);
+
+  const result = readSeamResult(join(root, "result.json"));
+  assert.deepEqual(result.observedArtifacts, ["surprise.json"]);
+  assert.equal(result.findings.length, 1);
+  assert.match(result.findings[0].message, /no matching inventory claim/);
+});
+
+test("runVerify: reports a marker-owned artifact separately so the host doesn't read it as unclaimed", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "dist/.well-known/security.txt", `${SECURITY_TXT_MARKER}\nContact: mailto:x@example.com\n`);
+  writeFile(root, "dist/.well-known/mta-sts.txt", `version: STSv1\n${MTA_STS_MARKER}\n`);
+  writeFile(root, "dist/.well-known/hand-written.txt", "not generated\n");
+  writeFile(root, "manifest.json", JSON.stringify({ entries: [] }));
+  const resultPath = join(root, "result.json");
+
+  runVerify(root, { [MANIFEST_ENV_VAR]: join(root, "manifest.json"), [RESULT_PATH_ENV_VAR]: resultPath });
+
+  const result = readSeamResult(resultPath);
+  assert.deepEqual(result.observedArtifacts, ["hand-written.txt", "mta-sts.txt", "security.txt"]);
+  assert.deepEqual(result.generatedArtifacts, ["mta-sts.txt", "security.txt"]);
+});
+
+test("runCheck: a blocking collision writes only the collisions, not unrelated advisories", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "public/.well-known/webfinger", "static shadow");
+  writeFile(root, "public/.well-known/unclaimed.json", "{}");
+  writeFile(
+    root,
+    "manifest.json",
+    JSON.stringify({ entries: [{ id: "w", path: "webfinger", match: "exact", owner: "webfinger", delivery: "dynamic" }] }),
+  );
+  const resultPath = join(root, "result.json");
+
+  assert.equal(runCheck(root, { [MANIFEST_ENV_VAR]: join(root, "manifest.json"), [RESULT_PATH_ENV_VAR]: resultPath }), 1);
+  const findings = readSeamResult(resultPath).findings;
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].path, "webfinger");
+});
+
+test("runVerify: no seam configured means no result file is written", (t) => {
+  const root = scratch();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  writeFile(root, "dist/.well-known/security.txt", "x");
+
+  assert.equal(runVerify(root, {}), 0);
+  assert.deepEqual(readSeamResult(join(root, "result.json")), { observedArtifacts: [], generatedArtifacts: [], findings: [] });
+});

--- a/Resources/Template/scripts/well-known.ts
+++ b/Resources/Template/scripts/well-known.ts
@@ -1,0 +1,368 @@
+#!/usr/bin/env npx tsx
+/**
+ * Template side of the `/.well-known/` build seam (#744, transport from #748).
+ *
+ * The app/deploy orchestrator — not this script — assembles the *complete* effective claim
+ * inventory, because Worker activation lives in the package's `Config/` and provider capabilities
+ * are host-side; neither is present inside the site's runtime clone. Before the build it hands
+ * this script an ephemeral, non-secret `WellKnownClaimManifest` and asks for two things back
+ * (docs/superpowers/specs/2026-07-14-well-known-support-design.md §"Delivery rules", steps 2 and 6):
+ *
+ *   `check`  — run at **prebuild, before any generator writes**. Rescans the actual runtime clone's
+ *              `public/.well-known/` and rejects a static file that shadows a `dynamic` or
+ *              `externalRuntime` claim. The host scanned its own working tree; the guest holds a
+ *              clone of git `HEAD`, so a collision can exist here that the host never saw. Exits
+ *              non-zero on such a collision, which stops the build before generation.
+ *   `verify` — run at **postbuild**. Reports the exact `dist/.well-known/...` artifacts the build
+ *              actually produced, so the orchestrator can verify every static/generated claim
+ *              landed and flag any artifact with no matching claim.
+ *
+ * Both modes are a **no-op unless the seam env vars are set**, so an ordinary `npm run build`
+ * (dev, CI, `npm run build:ci`) is completely unaffected.
+ *
+ * Contract notes:
+ * - `ANGLESITE_WELLKNOWN_CLAIM_MANIFEST` holds a path to the manifest JSON; absent means "no
+ *   orchestrator on the other end" and every mode returns immediately.
+ * - `ANGLESITE_WELLKNOWN_RESULT_PATH` holds the path to write the result JSON to. Both modes
+ *   merge into whatever is already there, so `check`'s findings survive `verify`'s rewrite.
+ * - This script must never print the runtime's result marker itself — the runtime shell emits it
+ *   exactly once after the build exits (see `ContainerDeployExecutor.wellKnownResultMarker`).
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isMTAStsMarkerOwned, isSecurityTxtMarkerOwned } from "./edge-artifacts";
+
+/** Mirrors `WellKnownClaimManifest.environmentVariableName`. */
+export const MANIFEST_ENV_VAR = "ANGLESITE_WELLKNOWN_CLAIM_MANIFEST";
+/** Mirrors `WellKnownClaimManifest.resultPathEnvironmentVariable`. */
+export const RESULT_PATH_ENV_VAR = "ANGLESITE_WELLKNOWN_RESULT_PATH";
+
+/**
+ * Mirrors `WellKnownInventory.defaultMaxFileSizeBytes`. Generous for text-based protocol documents
+ * while still bounding what an unreviewed static file can commit to the origin's namespace.
+ */
+export const MAX_FILE_SIZE_BYTES = 64 * 1024;
+
+/** One entry of the ephemeral manifest — mirrors `WellKnownClaimManifest.Entry`. */
+export interface ClaimEntry {
+  id: string;
+  /** Relative to `.well-known/` itself: no leading slash, no `.well-known/` prefix. */
+  path: string;
+  match: "exact" | "prefix";
+  owner: string;
+  /** Raw value of `WellKnownEndpointDescriptor.Delivery`. */
+  delivery: "userStatic" | "generated" | "dynamic" | "externalRuntime";
+}
+
+/** Mirrors `WellKnownBuildSeamResult.Finding`. */
+export interface Finding {
+  path?: string;
+  message: string;
+}
+
+/** Mirrors `WellKnownBuildSeamResult`. */
+export interface SeamResult {
+  observedArtifacts: string[];
+  /** The subset of `observedArtifacts` carrying an Anglesite generator's content marker. */
+  generatedArtifacts: string[];
+  findings: Finding[];
+}
+
+/**
+ * Parses a manifest JSON blob. Never throws: a malformed or unexpectedly shaped blob yields no
+ * entries rather than failing the build, matching #748's "malformed results degrade" contract on
+ * the other direction of this same seam. Entries missing `delivery` default to `userStatic`, which
+ * is the non-blocking classification — this script must not invent a collision out of a field an
+ * older orchestrator never sent.
+ */
+export function parseClaimManifest(json: string): ClaimEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (typeof parsed !== "object" || parsed === null) return [];
+  const entries = (parsed as { entries?: unknown }).entries;
+  if (!Array.isArray(entries)) return [];
+  const out: ClaimEntry[] = [];
+  for (const raw of entries) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const entry = raw as Record<string, unknown>;
+    if (typeof entry.path !== "string" || typeof entry.owner !== "string") continue;
+    out.push({
+      id: typeof entry.id === "string" ? entry.id : entry.path,
+      path: entry.path,
+      match: entry.match === "prefix" ? "prefix" : "exact",
+      owner: entry.owner,
+      delivery:
+        entry.delivery === "generated" || entry.delivery === "dynamic" || entry.delivery === "externalRuntime"
+          ? entry.delivery
+          : "userStatic",
+    });
+  }
+  return out;
+}
+
+/**
+ * Recursively lists files under `dir`, returning paths relative to `dir` (POSIX separators, no
+ * leading slash) plus findings for anything excluded. A missing directory yields nothing — a site
+ * need not have any `.well-known` content.
+ *
+ * Exclusions mirror `WellKnownInventory.scanUserStatic` exactly, so the guest's view of what
+ * counts as an inventoried file matches the host's: symlinks, percent-encoded-looking names (a
+ * real filesystem can't hold `..` or an empty segment, but such a name could still smuggle a
+ * traversal segment past a later URL-facing consumer that decodes it), paths that resolve outside
+ * the root, and files over `maxFileSizeBytes`.
+ */
+export function scanWellKnown(
+  dir: string,
+  maxFileSizeBytes: number = MAX_FILE_SIZE_BYTES,
+): { paths: string[]; findings: Finding[] } {
+  const paths: string[] = [];
+  const findings: Finding[] = [];
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return { paths, findings };
+  const root = resolvedPath(dir);
+
+  const walk = (current: string, prefix: string[]): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(current).sort();
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      const relPath = [...prefix, name].join("/");
+      const full = resolve(current, name);
+      const stats = lstatSync(full);
+      if (stats.isSymbolicLink()) {
+        findings.push({ path: relPath, message: "symlink not allowed under .well-known/ — excluded from inventory" });
+        continue;
+      }
+      if (name.includes("%")) {
+        findings.push({
+          path: relPath,
+          message: "percent-encoded-looking filename not allowed under .well-known/ — excluded from inventory",
+        });
+        continue;
+      }
+      if (stats.isDirectory()) {
+        walk(full, [...prefix, name]);
+        continue;
+      }
+      // Compare *resolved* paths on both sides, mirroring Swift's `resolvingSymlinksInPath()`:
+      // the scan root itself often lives under a symlinked ancestor (macOS `/var` → `/private/var`
+      // is the everyday case), so comparing a raw join against a resolved root would reject every
+      // real file. Direct symlinks are already excluded above, so this only catches a genuine
+      // escape through a resolved ancestor.
+      const resolvedFull = resolvedPath(full);
+      if (!(resolvedFull === root || resolvedFull.startsWith(root + "/"))) {
+        findings.push({ path: relPath, message: "resolved path escapes .well-known/ root — excluded from inventory" });
+        continue;
+      }
+      if (stats.size > maxFileSizeBytes) {
+        findings.push({ path: relPath, message: `file exceeds ${maxFileSizeBytes} bytes — excluded from inventory` });
+        continue;
+      }
+      paths.push(relPath);
+    }
+  };
+  walk(dir, []);
+  return { paths, findings };
+}
+
+function resolvedPath(dir: string): string {
+  try {
+    return realpathSync(dir);
+  } catch {
+    return resolve(dir);
+  }
+}
+
+/** The manifest entries that cover `path`: an exact match, or a prefix claim containing it. */
+export function claimsCovering(entries: ClaimEntry[], path: string): ClaimEntry[] {
+  return entries.filter((entry) => {
+    if (entry.match === "exact") return entry.path === path;
+    const prefix = entry.path.endsWith("/") ? entry.path : entry.path + "/";
+    return path.startsWith(prefix);
+  });
+}
+
+/**
+ * Classifies each static file the runtime clone actually holds against the effective claim set.
+ *
+ * `blocking` findings are the design doc's "a dynamic route and same-path static output conflict
+ * even if the current host would choose one" rule, caught at the one moment the host cannot: after
+ * the clone materializes and before any generator writes. There is no precedence recovery — the
+ * finding names both owners and the caller stops the build.
+ *
+ * `advisory` findings cover a static file with no claim at all, which is drift between the host's
+ * working tree (what the orchestrator scanned) and the clone's git `HEAD` — worth surfacing, never
+ * worth blocking a deploy over.
+ */
+export function classifyStaticPaths(
+  entries: ClaimEntry[],
+  staticPaths: string[],
+): { blocking: Finding[]; advisory: Finding[] } {
+  const blocking: Finding[] = [];
+  const advisory: Finding[] = [];
+  for (const path of staticPaths) {
+    const covering = claimsCovering(entries, path);
+    if (covering.length === 0) {
+      advisory.push({
+        path,
+        message:
+          `.well-known/${path} exists in the built source but has no matching inventory claim ` +
+          "— the deploying working tree and the committed source may have drifted",
+      });
+      continue;
+    }
+    for (const claim of covering) {
+      if (claim.delivery !== "dynamic" && claim.delivery !== "externalRuntime") continue;
+      blocking.push({
+        path,
+        message:
+          `.well-known/${path} (static file in the site source) collides with ` +
+          `/.well-known/${claim.path} claimed by ${claim.owner} (${claim.delivery})`,
+      });
+    }
+  }
+  return { blocking, advisory };
+}
+
+// --- result-file I/O ---
+
+/** A fresh empty result — a function, not a shared const, so no caller can mutate the arrays. */
+const emptyResult = (): SeamResult => ({ observedArtifacts: [], generatedArtifacts: [], findings: [] });
+
+/** Reads whatever result JSON already exists at `path`, degrading to an empty result. */
+export function readSeamResult(path: string): SeamResult {
+  if (!existsSync(path)) return emptyResult();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return emptyResult();
+  }
+  const record = (typeof parsed === "object" && parsed !== null ? parsed : {}) as Record<string, unknown>;
+  const stringArray = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+  return {
+    observedArtifacts: stringArray(record.observedArtifacts),
+    generatedArtifacts: stringArray(record.generatedArtifacts),
+    findings: Array.isArray(record.findings)
+      ? (record.findings as unknown[]).flatMap((value) => {
+          if (typeof value !== "object" || value === null) return [];
+          const finding = value as Record<string, unknown>;
+          if (typeof finding.message !== "string") return [];
+          return [{ path: typeof finding.path === "string" ? finding.path : undefined, message: finding.message }];
+        })
+      : [],
+  };
+}
+
+/** Merges `addition` into whatever is already at `path` and writes the result back. */
+export function mergeSeamResult(path: string, addition: Partial<SeamResult>): SeamResult {
+  const existing = readSeamResult(path);
+  const merged: SeamResult = {
+    observedArtifacts: [...new Set([...existing.observedArtifacts, ...(addition.observedArtifacts ?? [])])].sort(),
+    generatedArtifacts: [...new Set([...existing.generatedArtifacts, ...(addition.generatedArtifacts ?? [])])].sort(),
+    findings: [...existing.findings, ...(addition.findings ?? [])],
+  };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(merged), "utf-8");
+  return merged;
+}
+
+// --- modes ---
+
+/**
+ * Prebuild mode. Returns the process exit code: 1 when the clone holds a static file that shadows
+ * a dynamic or runtime-owned claim, 0 otherwise (including "no seam configured").
+ *
+ * On a blocking collision the result file carries **only** the blocking findings, so the
+ * orchestrator's rule stays unambiguous: a non-zero build exit plus a non-empty finding list means
+ * "these are the collisions that stopped the build," never a mix of collisions and advisories.
+ */
+export function runCheck(cwd: string, env: NodeJS.ProcessEnv): number {
+  const manifestPath = env[MANIFEST_ENV_VAR];
+  const resultPath = env[RESULT_PATH_ENV_VAR];
+  if (!manifestPath || !existsSync(manifestPath)) return 0;
+
+  const entries = parseClaimManifest(readFileSync(manifestPath, "utf-8"));
+  const scan = scanWellKnown(resolve(cwd, "public/.well-known"));
+  const { blocking, advisory } = classifyStaticPaths(entries, scan.paths);
+
+  if (resultPath) {
+    mergeSeamResult(resultPath, { findings: blocking.length > 0 ? blocking : [...scan.findings, ...advisory] });
+  }
+  for (const finding of blocking) console.error(`well-known collision: ${finding.message}`);
+  return blocking.length > 0 ? 1 : 0;
+}
+
+/**
+ * Postbuild mode. Records the exact `dist/.well-known/...` artifacts the build produced so the
+ * orchestrator can verify each static/generated claim landed. Always succeeds — deciding what a
+ * missing or unexpected artifact means is the orchestrator's job
+ * (`WellKnownInventory.verifyBuildArtifacts`), not this script's.
+ *
+ * Artifacts carrying an Anglesite generator's marker are reported separately: those files are
+ * written by `edge-artifacts.ts` during *this* prebuild, so the host-side inventory could not have
+ * seen them and must not read them as unclaimed.
+ */
+export function runVerify(cwd: string, env: NodeJS.ProcessEnv): number {
+  const manifestPath = env[MANIFEST_ENV_VAR];
+  const resultPath = env[RESULT_PATH_ENV_VAR];
+  if (!manifestPath || !resultPath) return 0;
+
+  const distWellKnown = resolve(cwd, "dist/.well-known");
+  const scan = scanWellKnown(distWellKnown);
+  const generated = scan.paths.filter((path) => isGeneratedArtifact(resolve(distWellKnown, path)));
+  mergeSeamResult(resultPath, {
+    observedArtifacts: scan.paths,
+    generatedArtifacts: generated,
+    findings: scan.findings,
+  });
+  return 0;
+}
+
+/**
+ * True when the file at `fullPath` carries one of Anglesite's generator content markers — the same
+ * marker predicates `edge-artifacts.ts` uses to decide it owns an existing file, and that
+ * `GeneratedEndpoints` mirrors on the Swift side.
+ */
+function isGeneratedArtifact(fullPath: string): boolean {
+  let content: string;
+  try {
+    content = readFileSync(fullPath, "utf-8");
+  } catch {
+    return false;
+  }
+  return isSecurityTxtMarkerOwned(content) || isMTAStsMarkerOwned(content);
+}
+
+function main(argv: string[]): void {
+  const mode = argv[2];
+  if (mode !== "check" && mode !== "verify") {
+    console.error("usage: npx tsx scripts/well-known.ts <check|verify>");
+    process.exit(2);
+  }
+  const code = mode === "check" ? runCheck(process.cwd(), process.env) : runVerify(process.cwd(), process.env);
+  if (code !== 0) process.exit(code);
+}
+
+// Run only when invoked directly (e.g. `npx tsx scripts/well-known.ts check`), never on import.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main(process.argv);
+}

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -6,7 +6,10 @@ import Foundation
 /// each run through the injected `DeployExecutor` seam. Container runtimes run the steps in a
 /// guest; the default process-backed executor fails explicitly after embedded Node retirement.
 ///   1. Resolve / read the Cloudflare API token (pre-spawn; no token → `.failed`).
-///   2. `executor.run(step: .build, …)` so `dist/` is fresh.
+///   2. `executor.runBuildWithClaimManifest(…)` so `dist/` is fresh — the build carries the derived
+///      `/.well-known/` claim manifest (#744/#748) so the runtime can reject a collision in its own
+///      clone and report the artifacts it produced. An executor without the seam falls back to
+///      `executor.run(step: .build, …)` and gets no post-build well-known verification.
 ///   3. `executor.run(step: .preflight, …)` — the bundled plugin's pre-deploy scan; its captured
 ///      stdout is parsed into a `PreDeployCheck.Outcome`. `.blocked` short-circuits with no
 ///      override (per CLAUDE.md, the app cannot bypass plugin security hooks).
@@ -146,8 +149,9 @@ public actor DeployCommand {
             wellKnownDirectory: siteDirectory.appendingPathComponent("public/.well-known", isDirectory: true))
         let wellKnownRuntimeRows = WellKnownInventory.runtimeRows(from: await executor.reportOwnedPathClaims())
         let wellKnownDynamicRows = WellKnownInventory.dynamicRows(from: wellKnownDynamicClaims)
+        let wellKnownInventory: [WellKnownEndpointDescriptor]
         do {
-            _ = try WellKnownInventory.merge(
+            wellKnownInventory = try WellKnownInventory.merge(
                 userStatic: wellKnownScan.rows.filter { $0.delivery == .userStatic },
                 generated: wellKnownScan.rows.filter { $0.delivery == .generated },
                 dynamic: wellKnownDynamicRows,
@@ -169,13 +173,57 @@ public actor DeployCommand {
         }
 
         // Build dist/ before the scan needs it. Streams to LogCenter via the executor.
+        //
+        // #744/#748 build seam: when the executor implements it, the build runs with the derived
+        // claim manifest so the runtime can (a) rescan its OWN clone before any generator writes —
+        // catching a collision the host's working-tree scan above could not see — and (b) report
+        // the exact `dist/.well-known/...` artifacts it produced. An executor that returns
+        // `.unsupported` falls back to the plain build step and gets NO post-build verification;
+        // we must not claim protection that never ran.
         onProgress?(.deployBuilding)
-        let buildResult = await executor.run(
-            step: .build,
+        var wellKnownArtifactWarnings: [PreDeployCheck.ScanWarning] = []
+        let buildResult: DeployStepResult
+        switch await executor.runBuildWithClaimManifest(
             siteDirectory: siteDirectory,
             environment: baseEnvironment,
-            source: "deploy:\(siteID):build"
-        )
+            source: "deploy:\(siteID):build",
+            claimManifest: WellKnownInventory.claimManifest(from: wellKnownInventory)
+        ) {
+        case .unsupported:
+            buildResult = await executor.run(
+                step: .build,
+                siteDirectory: siteDirectory,
+                environment: baseEnvironment,
+                source: "deploy:\(siteID):build"
+            )
+        case .cancelled:
+            return .failed(reason: "build was terminated", exitCode: nil)
+        case .completed(let stepResult, let seamResult):
+            buildResult = stepResult
+            // A failed build that still reported findings is the runtime's own collision rejection
+            // (`scripts/well-known.ts check` writes ONLY the blocking findings before exiting
+            // non-zero). Surface it as a `.blocked` security outcome with both owners named, not as
+            // an opaque "npm run build failed (exit 1)".
+            if stepResult.exitCode != 0, !seamResult.findings.isEmpty {
+                let failures = seamResult.findings.map {
+                    PreDeployCheck.ScanFailure(
+                        category: .wellKnownCollision,
+                        message: $0.message,
+                        file: $0.path.map { "public/.well-known/\($0)" },
+                        remediation: "Resolve the /.well-known/ ownership conflict named above (rename or remove one of the claims), then redeploy.")
+                }
+                let outcome = PreDeployCheck.Outcome.blocked(failures: failures, warnings: [])
+                onPreflight?(outcome)
+                return .blocked(failures: failures, warnings: [])
+            }
+            wellKnownArtifactWarnings = WellKnownInventory.verifyBuildArtifacts(
+                expected: wellKnownInventory, result: seamResult
+            ).map {
+                PreDeployCheck.ScanWarning(
+                    category: .wellKnownArtifact, message: $0.message,
+                    file: $0.path.map { "dist/.well-known/\($0)" })
+            }
+        }
         guard buildResult.exitCode == 0 else {
             if let code = buildResult.exitCode {
                 return .failed(reason: "npm run build failed (exit \(code))", exitCode: code)
@@ -203,7 +251,7 @@ public actor DeployCommand {
         var preflightOutcome = Self.parseScanReport(output: preflightResult.output, exitCode: preflightResult.exitCode)
         // Swift-computed warnings, not emitted by the JS scan script — merged into the outcome
         // the same way `RouteCoverageScanner`'s `.orphanedRoute` findings always have been.
-        var extraWarnings = wellKnownScanWarnings
+        var extraWarnings = wellKnownScanWarnings + wellKnownArtifactWarnings
         if let configDirectory {
             let previousRoutes = DeployedRoutesSnapshot.load(from: configDirectory)
             let redirects = (try? RedirectsStore(sourceDirectory: siteDirectory).load()) ?? []

--- a/Sources/AnglesiteCore/WellKnownClaimManifest.swift
+++ b/Sources/AnglesiteCore/WellKnownClaimManifest.swift
@@ -66,12 +66,30 @@ public struct WellKnownClaimManifest: Sendable, Codable, Equatable {
         public var path: String
         public var match: WellKnownPathMatch
         public var owner: String
+        /// The claim's delivery class, as the raw value of
+        /// `WellKnownEndpointDescriptor.Delivery` (`AnglesiteCore` owns that enum; this contract
+        /// stays a plain string so the seam's JSON has no dependency direction). The build step
+        /// needs it to tell a fresh static file that merely *is* a user-static claim from one that
+        /// **shadows** a `dynamic`/`externalRuntime` claim — the latter is a collision it must
+        /// reject before generation. Decodes as `"userStatic"` when absent so an older producer's
+        /// manifest still parses.
+        public var delivery: String
 
-        public init(id: String, path: String, match: WellKnownPathMatch, owner: String) {
+        public init(id: String, path: String, match: WellKnownPathMatch, owner: String, delivery: String = "userStatic") {
             self.id = id
             self.path = path
             self.match = match
             self.owner = owner
+            self.delivery = delivery
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            path = try container.decode(String.self, forKey: .path)
+            match = try container.decode(WellKnownPathMatch.self, forKey: .match)
+            owner = try container.decode(String.self, forKey: .owner)
+            delivery = try container.decodeIfPresent(String.self, forKey: .delivery) ?? "userStatic"
         }
     }
 
@@ -105,11 +123,25 @@ public struct WellKnownBuildSeamResult: Sendable, Codable, Equatable {
 
     /// Relative `dist/.well-known/...` paths the build actually produced.
     public var observedArtifacts: [String]
+    /// The subset of `observedArtifacts` the build recognized as its own generator's output (by
+    /// the generator's content marker). Anglesite's generators run *inside* the runtime clone
+    /// during prebuild, so the host-assembled inventory legitimately cannot know about a file that
+    /// did not exist when it scanned — without this, every generated `security.txt`/`mta-sts.txt`
+    /// would read as an unclaimed artifact on a first deploy.
+    public var generatedArtifacts: [String]
     public var findings: [Finding]
 
-    public init(observedArtifacts: [String] = [], findings: [Finding] = []) {
+    public init(observedArtifacts: [String] = [], generatedArtifacts: [String] = [], findings: [Finding] = []) {
         self.observedArtifacts = observedArtifacts
+        self.generatedArtifacts = generatedArtifacts
         self.findings = findings
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        observedArtifacts = try container.decodeIfPresent([String].self, forKey: .observedArtifacts) ?? []
+        generatedArtifacts = try container.decodeIfPresent([String].self, forKey: .generatedArtifacts) ?? []
+        findings = try container.decodeIfPresent([Finding].self, forKey: .findings) ?? []
     }
 
     /// Parses the JSON blob a build step returns after the result marker. Never throws — an

--- a/Sources/AnglesiteCore/WellKnownInventory.swift
+++ b/Sources/AnglesiteCore/WellKnownInventory.swift
@@ -320,7 +320,8 @@ public enum WellKnownInventory {
     /// receives so it can detect a fresh on-disk collision against the effective claim set.
     public static func claimManifest(from rows: [WellKnownEndpointDescriptor]) -> WellKnownClaimManifest {
         WellKnownClaimManifest(entries: rows.map {
-            WellKnownClaimManifest.Entry(id: $0.id, path: $0.suffix, match: $0.match, owner: $0.owner)
+            WellKnownClaimManifest.Entry(
+                id: $0.id, path: $0.suffix, match: $0.match, owner: $0.owner, delivery: $0.delivery.rawValue)
         })
     }
 
@@ -342,7 +343,12 @@ public enum WellKnownInventory {
                 path: row.suffix,
                 message: "expected .well-known/\(row.suffix) (owner: \(row.owner)) was not found in the built output"))
         }
-        let expectedSuffixes = Set(staticallyDelivered.map(\.suffix))
+        // A build-generated artifact counts as claimed even though the host-side inventory couldn't
+        // have seen it: Anglesite's generators run inside the runtime clone at prebuild, so a
+        // first-deploy `security.txt` exists only after the host finished scanning. The build step
+        // identifies these by the generator's own content marker, exactly as `GeneratedEndpoints`
+        // does host-side — so this stays "recognized generator output," never "anything new."
+        let expectedSuffixes = Set(staticallyDelivered.map(\.suffix)).union(result.generatedArtifacts)
         for artifact in result.observedArtifacts where !expectedSuffixes.contains(artifact) {
             findings.append(Finding(
                 path: artifact,

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -233,6 +233,165 @@ struct DeployCommandTests {
         }
     }
 
+    // MARK: #744/#748 build-seam wiring
+
+    /// A `DeployExecutor` that implements the well-known build seam, records the manifest it was
+    /// handed, and returns a canned outcome. Everything else delegates to the plain fake.
+    private final class SeamExecutor: DeployExecutor, @unchecked Sendable {
+        private let inner = FakeExecutor()
+        private let lock = NSLock()
+        private var outcome: WellKnownBuildSeamOutcome = .unsupported
+        private(set) var receivedManifest: WellKnownClaimManifest?
+
+        @discardableResult
+        func returning(_ outcome: WellKnownBuildSeamOutcome) -> SeamExecutor {
+            lock.lock(); self.outcome = outcome; lock.unlock()
+            return self
+        }
+
+        @discardableResult
+        func set(_ step: DeployStep, exitCode: Int32?, output: String) -> SeamExecutor {
+            inner.set(step, exitCode: exitCode, output: output)
+            return self
+        }
+
+        func ran(_ step: DeployStep) -> Bool { inner.ran(step) }
+
+        func run(step: DeployStep, siteDirectory: URL, environment: [String: String], source: String) async -> DeployStepResult {
+            await inner.run(step: step, siteDirectory: siteDirectory, environment: environment, source: source)
+        }
+
+        func runBuildWithClaimManifest(
+            siteDirectory: URL, environment: [String: String], source: String, claimManifest: WellKnownClaimManifest
+        ) async -> WellKnownBuildSeamOutcome {
+            lock.lock(); receivedManifest = claimManifest; let outcome = self.outcome; lock.unlock()
+            return outcome
+        }
+    }
+
+    /// The whole point of the seam: the orchestrator owns the complete inventory (Worker activation
+    /// lives in `Config/`, provider capabilities are host-side), so the runtime can only rescan its
+    /// clone against what it is handed.
+    @Test("the derived claim manifest carries every effective claim with its delivery class")
+    func seamManifestCarriesEffectiveClaims() async throws {
+        let siteDirectory = try makeWellKnownSiteDirectory(wellKnownFiles: ["humans.txt": "hi"])
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = SeamExecutor()
+            .returning(.completed(DeployStepResult(exitCode: 0, output: ""), WellKnownBuildSeamResult(
+                observedArtifacts: ["humans.txt"])))
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let claim = WorkerRouteClaims.OwnedClaim(
+            owner: "webfinger",
+            claim: WorkerRouteClaim(path: "/.well-known/webfinger", match: .exact, methods: ["GET"], handler: "h"))
+
+        _ = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+            .deploy(siteID: "s", siteDirectory: siteDirectory, wellKnownDynamicClaims: [claim])
+
+        let entries = try #require(exec.receivedManifest?.entries)
+        #expect(entries.contains { $0.path == "humans.txt" && $0.delivery == "userStatic" })
+        #expect(entries.contains { $0.path == "webfinger" && $0.delivery == "dynamic" && $0.owner == "webfinger" })
+        #expect(!exec.ran(.build), "the seam replaces the plain build step, it doesn't run alongside it")
+    }
+
+    @Test("an executor without the seam falls back to the plain build step")
+    func seamUnsupportedFallsBackToPlainBuild() async throws {
+        let siteDirectory = try makeWellKnownSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = SeamExecutor()
+            .returning(.unsupported)
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+
+        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+            .deploy(siteID: "s", siteDirectory: siteDirectory)
+
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        #expect(exec.ran(.build))
+    }
+
+    @Test("a collision the runtime found in its own clone blocks the deploy with both owners named")
+    func seamRuntimeCollisionBlocks() async throws {
+        let siteDirectory = try makeWellKnownSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = SeamExecutor()
+            .returning(.completed(
+                DeployStepResult(exitCode: 1, output: "build failed"),
+                WellKnownBuildSeamResult(findings: [.init(
+                    path: "webfinger",
+                    message: ".well-known/webfinger (static file in the site source) collides with /.well-known/webfinger claimed by webfinger (dynamic)")])))
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+
+        var observedOutcome: PreDeployCheck.Outcome?
+        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+            .deploy(siteID: "s", siteDirectory: siteDirectory, onPreflight: { observedOutcome = $0 })
+
+        guard case .blocked(let failures, _) = result else {
+            Issue.record("expected .blocked, got \(result)"); return
+        }
+        #expect(failures.count == 1)
+        #expect(failures.first?.category == .wellKnownCollision)
+        #expect(failures.first?.file == "public/.well-known/webfinger")
+        #expect(failures.first?.message.contains("claimed by webfinger (dynamic)") == true)
+        if case .blocked = observedOutcome {} else {
+            Issue.record("expected the preflight observer to see .blocked, got \(String(describing: observedOutcome))")
+        }
+        #expect(!exec.ran(.preflight), "a collision stops the deploy before the security scan runs")
+    }
+
+    /// An ordinary build failure carries no findings; it must stay a plain `.failed`, not get
+    /// dressed up as a security block.
+    @Test("a build failure with no seam findings stays a plain failure")
+    func seamBuildFailureWithoutFindingsIsNotBlocked() async throws {
+        let siteDirectory = try makeWellKnownSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = SeamExecutor()
+            .returning(.completed(DeployStepResult(exitCode: 2, output: "syntax error"), WellKnownBuildSeamResult()))
+
+        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+            .deploy(siteID: "s", siteDirectory: siteDirectory)
+
+        guard case .failed(_, let exitCode) = result else {
+            Issue.record("expected .failed, got \(result)"); return
+        }
+        #expect(exitCode == 2)
+    }
+
+    @Test("a static claim missing from the built output becomes an advisory warning")
+    func seamMissingArtifactBecomesWarning() async throws {
+        let siteDirectory = try makeWellKnownSiteDirectory(wellKnownFiles: ["humans.txt": "hi"])
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = SeamExecutor()
+            .returning(.completed(DeployStepResult(exitCode: 0, output: ""), WellKnownBuildSeamResult()))
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+
+        var observedOutcome: PreDeployCheck.Outcome?
+        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+            .deploy(siteID: "s", siteDirectory: siteDirectory, onPreflight: { observedOutcome = $0 })
+
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+        guard case .passed(let warnings) = observedOutcome else {
+            Issue.record("expected .passed with warnings, got \(String(describing: observedOutcome))"); return
+        }
+        #expect(warnings.contains {
+            $0.category == .wellKnownArtifact && $0.file == "dist/.well-known/humans.txt"
+        })
+    }
+
+    @Test("a cancelled seam build reports termination rather than a spurious failure reason")
+    func seamCancelledBuildTerminates() async throws {
+        let siteDirectory = try makeWellKnownSiteDirectory()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let exec = SeamExecutor().returning(.cancelled)
+
+        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+            .deploy(siteID: "s", siteDirectory: siteDirectory)
+
+        #expect(result == .failed(reason: "build was terminated", exitCode: nil))
+    }
+
     // MARK: Host environment curation
 
     @Test("hostDeployEnvironment retains PATH, HOME, and CI")

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -98,7 +98,12 @@ struct DeployExecutorSelectionTests {
         let calls = await stepAware.calls
         let argvs = calls.map(\.argv)
         #expect(argvs.count == 3)
-        #expect(argvs[0] == ["npm", "run", "build"])
+        // The build step goes through the #744/#748 well-known claim-manifest seam, which
+        // `ContainerDeployExecutor` implements — so it's a wrapper shell around `npm run build`
+        // rather than the bare argv. The manifest itself is a positional parameter, never spliced
+        // into the script text (`wellKnownSeamArgv`).
+        #expect(argvs[0].first == "sh")
+        #expect(argvs[0].contains { $0.contains("npm run build") })
         #expect(argvs[1] == ["npx", "tsx", "scripts/pre-deploy-check.ts", "--json"])
         #expect(argvs[2] == ["npx", "wrangler", "deploy"])
     }

--- a/Tests/AnglesiteCoreTests/WellKnownInventoryTests.swift
+++ b/Tests/AnglesiteCoreTests/WellKnownInventoryTests.swift
@@ -277,6 +277,27 @@ struct WellKnownInventoryTests {
         #expect(manifest.entries.contains { $0.path == "acme-challenge/" && $0.owner == "cloudflare-managed-tls" && $0.match == .prefix })
     }
 
+    /// The build step needs the delivery class to tell a static file that merely *is* a user-static
+    /// claim from one that shadows a dynamic/runtime claim — the collision it must reject.
+    @Test("claimManifest carries each row's delivery class")
+    func claimManifestCarriesDelivery() throws {
+        let rows = [
+            row("humans.txt", delivery: .userStatic, owner: "user-static"),
+            row("security.txt", delivery: .generated, owner: "generator:security-txt"),
+            row("webfinger", delivery: .dynamic, owner: "webfinger"),
+            row("acme-challenge/", delivery: .externalRuntime, owner: "cloudflare-managed-tls", match: .prefix),
+        ]
+        let manifest = WellKnownInventory.claimManifest(from: rows)
+        #expect(manifest.entries.map(\.delivery) == ["userStatic", "generated", "dynamic", "externalRuntime"])
+    }
+
+    @Test("a manifest entry with no delivery decodes as the non-blocking class")
+    func manifestEntryDeliveryDefaults() throws {
+        let json = #"{"entries":[{"id":"a","path":"a","match":"exact","owner":"o"}]}"#
+        let manifest = try JSONDecoder().decode(WellKnownClaimManifest.self, from: Data(json.utf8))
+        #expect(manifest.entries.first?.delivery == "userStatic")
+    }
+
     @Test("verifyBuildArtifacts reports a missing expected static/generated artifact")
     func verifyReportsMissingArtifact() throws {
         let expected = [row("security.txt", delivery: .generated, owner: "generator:security-txt")]
@@ -294,6 +315,17 @@ struct WellKnownInventoryTests {
         #expect(findings.count == 1)
         #expect(findings[0].path == "mystery.txt")
         #expect(findings[0].message.contains("no matching inventory claim"))
+    }
+
+    /// Anglesite's generators run inside the runtime clone at prebuild, so a first deploy's
+    /// `security.txt` cannot appear in the host-assembled inventory. Without this, every such
+    /// deploy would warn about its own generated output.
+    @Test("verifyBuildArtifacts accepts an artifact the build reported as its own generator output")
+    func verifyAcceptsBuildGeneratedArtifact() throws {
+        let result = WellKnownBuildSeamResult(
+            observedArtifacts: ["security.txt", "mystery.txt"], generatedArtifacts: ["security.txt"])
+        let findings = WellKnownInventory.verifyBuildArtifacts(expected: [], result: result)
+        #expect(findings.map(\.path) == ["mystery.txt"])
     }
 
     @Test("verifyBuildArtifacts passes clean when every expected static/generated row was observed")
@@ -345,6 +377,30 @@ struct WellKnownInventoryTests {
         let source = try String(contentsOf: scriptURL, encoding: .utf8)
         #expect(source.contains(GeneratedEndpoints.securityTxtMarker))
         #expect(source.contains(GeneratedEndpoints.mtaStsMarker))
+    }
+
+    /// The build seam is a *string* contract across two languages: rename an env var on either side
+    /// and the runtime silently stops receiving the manifest — a security gate that fails open.
+    /// This asserts the real `well-known.ts` still names both variables, and that the template's
+    /// build lifecycle actually invokes both of its modes.
+    @Test("the template build seam still uses the env var names Swift sends")
+    func buildSeamContractMatchesTemplateSource() throws {
+        let templateRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/Template", isDirectory: true)
+        let script = try String(
+            contentsOf: templateRoot.appendingPathComponent("scripts/well-known.ts"), encoding: .utf8)
+        #expect(script.contains(WellKnownClaimManifest.environmentVariableName))
+        #expect(script.contains(WellKnownClaimManifest.resultPathEnvironmentVariable))
+        // The runtime shell emits the result marker itself, exactly once; the script must not.
+        #expect(!script.contains(ContainerDeployExecutor.wellKnownResultMarker))
+
+        let packageJSON = try String(
+            contentsOf: templateRoot.appendingPathComponent("package.json"), encoding: .utf8)
+        #expect(packageJSON.contains("well-known.ts check"))
+        #expect(packageJSON.contains("well-known.ts verify"))
     }
 
     // MARK: Test helpers

--- a/docs/superpowers/specs/2026-07-14-well-known-support-design.md
+++ b/docs/superpowers/specs/2026-07-14-well-known-support-design.md
@@ -376,8 +376,10 @@ Swift/TypeScript.
 - Astro build smoke proving hidden files reach `dist/.well-known/...` byte-for-byte; and
 - exact `_headers` generation that survives a CSP rebuild.
 
-Template Node tests are not currently a direct CI lane. Add a hermetic Swift asset test or a
-dedicated template Node lane so these tests actually execute in CI.
+Template Node tests originally had no direct CI lane. #744 added both halves: `npm run
+test:scripts` runs `Resources/Template/scripts/*.test.ts` in the existing `template-worker` job,
+and `WellKnownInventoryTests` carries hermetic Swift asset tests that read the real template source
+to catch the cross-language marker and build-seam contracts drifting apart.
 
 ### HTTP behavior
 


### PR DESCRIPTION
## Summary

- Adds `Resources/Template/scripts/well-known.ts`, the template-side producer the #744 build seam has been missing since #930: `check` (prebuild) rescans the runtime clone's `public/.well-known/` against the claim manifest and exits non-zero when a static file shadows a `dynamic`/`externalRuntime` claim; `verify` (postbuild) reports the exact `dist/.well-known/...` artifacts the build produced. Both are no-ops unless the seam env vars are set, so ordinary `npm run build` / `build:ci` are unaffected.
- Wires `DeployCommand.deploy` through `runBuildWithClaimManifest` + `verifyBuildArtifacts`, falling back to the plain `.build` step (and no post-build verification) when an executor reports `.unsupported`. A collision the runtime finds in its own clone now surfaces as `.blocked` with both owners named, instead of an opaque "npm run build failed (exit 1)".
- Two absent-tolerant contract fields make that possible: `WellKnownClaimManifest.Entry.delivery` (so the build step can tell a user-static file from one shadowing a Worker route) and `WellKnownBuildSeamResult.generatedArtifacts` (so a marker-owned `security.txt` generated *inside* the clone isn't flagged as unclaimed on every first deploy — the false-positive that kept this piece out of #933).
- Gives the template's `node:test` suites a CI lane (`npm run test:scripts`) in the existing `template-worker` job; the design doc called this gap out explicitly, and without it none of the new template tests would run in CI.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

No MCP schema change — the seam is an ephemeral host↔build-step contract, and `Resources/Template/` is app-only.

## Test plan

- [x] `swift test --package-path .` — 107 tests across the touched suites pass; full run is green apart from two pre-existing `FoundationModelAssistantTests` failures ("Session ended without producing a response") that are environmental and untouched by this change.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**.
- [x] `npm run test:scripts` (183 pass, 2 skipped) and `npm run test:worker` (115 pass) in `Resources/Template`; `npx tsc --noEmit` clean.
- [x] Real end-to-end seam exercise against an actual template build, not just unit fakes:
  - manifest claiming two static files → build exits 0, result JSON reports both under `observedArtifacts`.
  - manifest claiming `webfinger` as a `dynamic` Worker route with a static `public/.well-known/webfinger` present → build exits **1** at prebuild, before `edge-artifacts.ts` writes anything, and the result JSON carries exactly the one collision finding.
  - no env vars set → `npm run build` completes normally with no result file written.
- [ ] Manual smoke: not UI-touching. The `.blocked` path renders through the existing no-override pre-deploy sheet.

## Notes

`DeployExecutorSelectionTests` needed one assertion update: the build step's guest argv is now the seam's wrapper shell around `npm run build` rather than the bare `["npm", "run", "build"]`. The manifest still crosses as a positional shell parameter, never spliced into script text.

With this, #744's remaining acceptance bullets are met — every collision class (including the runtime-clone rescan) blocks a real deploy, and static/generated claims are verified at their exact `dist/.well-known/...` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
