### PR TITLE
feat(#520): toolbar search field over the site content index

### DIFF
--- a/Sources/AnglesiteApp/EditMenuSkeletonCommands.swift
+++ b/Sources/AnglesiteApp/EditMenuSkeletonCommands.swift
@@ -2,11 +2,12 @@ import SwiftUI
 
 /// Edit-menu skeleton items (menu-bar spec §2.3): selection walkers and annotations after
 /// the pasteboard block, Find ▸ in the text-editing block. The Find items are live against
-/// the focused Markdown editor (#797/#517) via `MarkdownEditorFocusRegistry`; the rest are
-/// editor/subsystem-gated PlannedItems. NavigatorEditCommands owns the live Delete/Duplicate
-/// next to them.
+/// the focused Markdown editor (#797/#517) via `MarkdownEditorFocusRegistry`, and Search Site…
+/// against the focused window's toolbar search field (#520); the rest are editor/subsystem-gated
+/// PlannedItems. NavigatorEditCommands owns the live Delete/Duplicate next to them.
 struct EditMenuSkeletonCommands: Commands {
     private let registry = MarkdownEditorFocusRegistry.shared
+    @FocusedValue(\.siteSearchActions) private var searchActions
 
     var body: some Commands {
         CommandGroup(after: .pasteboard) {
@@ -37,8 +38,12 @@ struct EditMenuSkeletonCommands: Commands {
 
                 Divider()
 
-                // Shares the #520 site-search backend when it lands.
-                PlannedItem("Search Site…")
+                // ⇧⌘F, not one of the standard find keys: ⌘F/⌘G/⇧⌘G/⌥⌘F all belong to the
+                // in-editor find bar above (#797/#517). ⇧⌘F is Xcode's Find-in-Project key, and
+                // this is the same relationship — document find vs. whole-project find.
+                Button("Search Site…") { searchActions?.focusSearchField() }
+                    .keyboardShortcut("f", modifiers: [.command, .shift])
+                    .disabled(searchActions == nil)
             }
         }
     }

--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -6,6 +6,7 @@ import AnglesiteIntents
 private struct FocusedSiteIDKey: FocusedValueKey { typealias Value = String }
 private struct FocusedNewContentActionsKey: FocusedValueKey { typealias Value = NewContentActions }
 private struct FocusedNavigatorSelectionActionsKey: FocusedValueKey { typealias Value = NavigatorSelectionActions }
+private struct FocusedSiteSearchActionsKey: FocusedValueKey { typealias Value = SiteSearchActions }
 
 struct NewContentActions {
     let newPage: @MainActor () -> Void
@@ -25,7 +26,19 @@ struct NavigatorSelectionActions {
     let unpublish: (@MainActor () -> Void)?
 }
 
+/// Edit ▸ Find ▸ Search Site… acting on the focused window's toolbar search field (#520).
+/// The menu item can't reach `.searchFocused` itself — focus state is scene-local — so the
+/// window publishes the closure that flips it.
+struct SiteSearchActions {
+    let focusSearchField: @MainActor () -> Void
+}
+
 extension FocusedValues {
+    var siteSearchActions: SiteSearchActions? {
+        get { self[FocusedSiteSearchActionsKey.self] }
+        set { self[FocusedSiteSearchActionsKey.self] = newValue }
+    }
+
     var siteID: String? {
         get { self[FocusedSiteIDKey.self] }
         set { self[FocusedSiteIDKey.self] = newValue }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1513,6 +1513,9 @@
     "No matches" : {
 
     },
+    "No matching content" : {
+
+    },
     "No matching graph nodes" : {
 
     },
@@ -1642,6 +1645,9 @@
     "Page" : {
 
     },
+    "Pages" : {
+
+    },
     "Pages using this worker's components" : {
 
     },
@@ -1691,6 +1697,9 @@
 
     },
     "Post" : {
+
+    },
+    "Posts" : {
 
     },
     "Posts a notification when a Deploy, Backup, or Audit finishes while Anglesite is in the background — success or failure. Clicking the notification brings the site's window to the front. Delivery starts quietly; promote or silence Anglesite in System Settings › Notifications." : {
@@ -2058,6 +2067,9 @@
 
     },
     "Search ${site} for ${query}" : {
+
+    },
+    "Search Site" : {
 
     },
     "Search Site…" : {

--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -12,6 +12,10 @@ final class SiteNavigatorModel {
     private(set) var nodes: [URLTreeNode] = []
     /// Flattened id → node lookup, rebuilt with `nodes` (selection, targets, titles).
     private var nodesByID: [String: URLTreeNode] = [:]
+    /// Route → node id for the rows actually on screen, rebuilt with `nodes`. Lets site search
+    /// (#520) resolve a hit's computed route to a real sidebar row — and only to a row that
+    /// exists, since `ContentRouteResolver`'s route is a convention-based guess.
+    private(set) var routeIDs: [String: String] = [:]
     var selection: String?
 
     // Inline re-titling (Finder-style). `editingItemID` non-nil → that row shows a TextField.
@@ -266,6 +270,7 @@ final class SiteNavigatorModel {
             websiteTitle: websiteTitle, pages: pages, posts: posts, feedCollections: feeds)
         nodes = tree
         nodesByID = Self.index(tree)
+        routeIDs = Self.indexRoutes(nodesByID)
     }
 
     private static func index(_ nodes: [URLTreeNode]) -> [String: URLTreeNode] {
@@ -275,6 +280,18 @@ final class SiteNavigatorModel {
             node.children?.forEach(walk)
         }
         nodes.forEach(walk)
+        return map
+    }
+
+    /// Only `.route` targets: a directory row previews its index page rather than the document a
+    /// search hit names, and the website-settings row opens `Info.plist` — neither is where
+    /// activating a content hit should land.
+    private static func indexRoutes(_ nodesByID: [String: URLTreeNode]) -> [String: String] {
+        var map: [String: String] = [:]
+        for node in nodesByID.values {
+            guard case .route(let route) = node.target else { continue }
+            map[route] = node.id
+        }
         return map
     }
 

--- a/Sources/AnglesiteApp/SiteSearchField.swift
+++ b/Sources/AnglesiteApp/SiteSearchField.swift
@@ -33,9 +33,11 @@ struct SiteSearchFieldModifier: ViewModifier {
             }
             .searchSuggestions {
                 if model.hits.isEmpty {
-                    // Only once a search has actually settled — otherwise every first keystroke
-                    // flashes "no matches" during the debounce of a query that will match.
-                    if !model.isSearching {
+                    // Only for a query the user actually typed, and only once its search has
+                    // settled: an untouched field would otherwise greet ⇧⌘F with "no matches",
+                    // and every first keystroke would flash it during the debounce of a query
+                    // that will match.
+                    if model.hasQuery && !model.isSearching {
                         Text("No matching content")
                             .foregroundStyle(.secondary)
                     }

--- a/Sources/AnglesiteApp/SiteSearchField.swift
+++ b/Sources/AnglesiteApp/SiteSearchField.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The site window's toolbar search field, scope bar, and suggestions list (#520).
+///
+/// A `ViewModifier` rather than modifiers inlined into `SiteWindow.siteUI(for:)` for the reason
+/// documented on `SiteWindow.focusedValues(for:)`: that function is already at Swift's
+/// type-check-in-reasonable-time budget, and a `.searchable` + `.searchScopes` +
+/// `.searchSuggestions` chain solved as part of the same expression pushes it over.
+///
+/// Owning `@FocusState` here also keeps the Edit ▸ Find ▸ Search Site… plumbing local: focus
+/// state is scene-local and unreachable from a `Commands` tree, so the menu item reaches it
+/// through the `siteSearchActions` focused value this modifier publishes.
+struct SiteSearchFieldModifier: ViewModifier {
+    @Bindable var model: SiteSearchModel
+    let siteID: String?
+    let activate: (SiteSearchIndex.Hit) -> Void
+
+    @FocusState private var searchFieldFocused: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .searchable(
+                text: $model.query,
+                placement: .toolbar,
+                prompt: Text("Search Site")
+            )
+            .searchFocused($searchFieldFocused)
+            .searchScopes($model.scope) {
+                ForEach(SiteSearchScope.allCases) { scope in
+                    Text(scope.title).tag(scope)
+                }
+            }
+            .searchSuggestions {
+                if model.hits.isEmpty {
+                    // Only once a search has actually settled — otherwise every first keystroke
+                    // flashes "no matches" during the debounce of a query that will match.
+                    if !model.isSearching {
+                        Text("No matching content")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ForEach(model.hits) { hit in
+                        Button { activate(hit) } label: {
+                            SiteSearchSuggestionRow(hit: hit)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            // `.task(id:)` over the query+scope pair: SwiftUI cancels the in-flight search on
+            // every change, which is what implements both the debounce and the staleness guard
+            // inside `SiteSearchModel.search`.
+            .task(id: model.request) { await model.search(siteID: siteID) }
+            .focusedSceneValue(\.siteSearchActions, SiteSearchActions(
+                focusSearchField: { searchFieldFocused = true }
+            ))
+    }
+}
+
+/// One row in the search suggestions list: what it is, what it's called, where it lives, and why
+/// it matched.
+struct SiteSearchSuggestionRow: View {
+    let hit: SiteSearchIndex.Hit
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: hit.kind.symbolName)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(displayTitle)
+                        .lineLimit(1)
+                    // The route is the more meaningful locator when there is one — it's what the
+                    // user typed into a browser — so the file path only stands in for the
+                    // components, styles, and config that have no route.
+                    Text(hit.route ?? hit.path)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                if !hit.matchContext.isEmpty {
+                    Text(hit.matchContext)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
+
+    /// Components, styles, and config files carry no front-matter title; the filename is what the
+    /// user knows them by.
+    private var displayTitle: String {
+        if let title = hit.title, !title.isEmpty { return title }
+        return (hit.path as NSString).lastPathComponent
+    }
+}
+
+extension SiteSearchScope {
+    /// Localized in the app target, not alongside `kinds` in AnglesiteCore: only
+    /// `Sources/AnglesiteApp` feeds the String Catalog extractor (and CI's
+    /// `check-localization-catalog.sh`).
+    var title: LocalizedStringKey {
+        switch self {
+        case .all: LocalizedStringKey("All")
+        case .pages: LocalizedStringKey("Pages")
+        case .posts: LocalizedStringKey("Posts")
+        case .components: LocalizedStringKey("Components")
+        case .styles: LocalizedStringKey("Styles")
+        }
+    }
+}
+
+extension SiteKnowledgeIndex.Document.Kind {
+    /// Mirrors the Site Graph Explorer's visual vocabulary so the same thing looks the same in
+    /// both surfaces.
+    var symbolName: String {
+        switch self {
+        case .page: "doc.richtext"
+        case .post, .content: "text.alignleft"
+        case .component: "puzzlepiece.extension"
+        case .layout: "square.stack"
+        case .style: "paintbrush"
+        case .config: "gearshape"
+        case .script: "curlybraces"
+        case .other: "doc"
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteSearchField.swift
+++ b/Sources/AnglesiteApp/SiteSearchField.swift
@@ -41,12 +41,22 @@ struct SiteSearchFieldModifier: ViewModifier {
                     }
                 } else {
                     ForEach(model.hits) { hit in
-                        Button { activate(hit) } label: {
-                            SiteSearchSuggestionRow(hit: hit)
-                        }
-                        .buttonStyle(.plain)
+                        // `.searchCompletion`, not a `Button`: it's the mechanism that makes a
+                        // suggestion row selectable by both click and arrow-keys-then-Return,
+                        // and a bare Button here is unreliable anyway — since macOS 26 an
+                        // NSGlassContainerView swallows mouse events for interactive SwiftUI
+                        // views layered over the title-bar/toolbar area, which is exactly where
+                        // this popover sits. Selecting a row puts the completion in the field
+                        // and submits, which `onSubmit(of: .search)` below turns back into a hit.
+                        SiteSearchSuggestionRow(hit: hit)
+                            .searchCompletion(hit.path)
                     }
                 }
+            }
+            // Fires both for a selected suggestion (the completion above) and for a bare Return
+            // in the field; `SiteSearchModel.submit` distinguishes them.
+            .onSubmit(of: .search) {
+                if let hit = model.submit() { activate(hit) }
             }
             // `.task(id:)` over the query+scope pair: SwiftUI cancels the in-flight search on
             // every change, which is what implements both the debounce and the staleness guard

--- a/Sources/AnglesiteApp/SiteSearchModel.swift
+++ b/Sources/AnglesiteApp/SiteSearchModel.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the site window's toolbar search field (#520) over the `SiteSearchIndex` backend
+/// (#765). App glue only: the scope→kinds mapping and the hit→destination decision live in
+/// AnglesiteCore (`SiteSearchScope`, `SiteSearchDestination`) where CI can test them.
+///
+/// Holds no index state of its own — `SiteSearchIndex` reads the live `SiteKnowledgeIndex` on
+/// every call, so results always reflect whatever the file-watcher pipeline has most recently
+/// applied.
+@MainActor
+@Observable
+final class SiteSearchModel {
+    /// The text field's contents. Bound directly by `.searchable`.
+    var query: String = ""
+    /// The scope bar's selection. Bound directly by `.searchScopes`.
+    var scope: SiteSearchScope = .all
+
+    private(set) var hits: [SiteSearchIndex.Hit] = []
+    /// True from the moment a non-empty query is pending until its results land. The suggestions
+    /// list reads this to avoid flashing "no matches" during the debounce of a query that will
+    /// match.
+    private(set) var isSearching = false
+
+    /// Matches `SiteSearchIndex.search`'s own default. Eight rows is about what a search-field
+    /// dropdown shows without scrolling; deeper archive search is the reader-facing surface.
+    private static let resultLimit = 8
+
+    /// Long enough that typing a word doesn't fan out a query per keystroke, short enough to
+    /// feel immediate.
+    private static let debounce = Duration.milliseconds(150)
+
+    private let index: SiteKnowledgeIndex
+
+    init(index: SiteKnowledgeIndex) {
+        self.index = index
+    }
+
+    /// The identity `SiteWindow`'s `.task(id:)` keys on, so SwiftUI cancels an in-flight search
+    /// whenever the query or scope changes. That cancellation is what implements both the
+    /// debounce and the staleness guard — a superseded search stops at its next suspension point
+    /// instead of racing the newer one to `hits`.
+    struct Request: Equatable {
+        let query: String
+        let scope: SiteSearchScope
+    }
+
+    var request: Request { Request(query: query, scope: scope) }
+
+    /// Runs the current `request` against `siteID` after the debounce. Cancellation-aware, so it
+    /// is safe to call from `.task(id:)`; returns without touching `hits` when superseded.
+    func search(siteID: String?) async {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let siteID, !trimmed.isEmpty else {
+            hits = []
+            isSearching = false
+            return
+        }
+
+        isSearching = true
+        // A cancelled sleep throws, which is exactly the debounce: the superseded call leaves
+        // `isSearching` set and returns, and the newer one owns the flag from here.
+        do { try await Task.sleep(for: Self.debounce) } catch { return }
+
+        let results = await SiteSearchIndex.search(
+            index, siteID: siteID, query: trimmed,
+            limit: Self.resultLimit, kinds: scope.kinds)
+        guard !Task.isCancelled else { return }
+
+        hits = results
+        isSearching = false
+    }
+
+    /// Dismisses the suggestions list after the user picks a hit. Clearing the query is what
+    /// closes the dropdown; the field itself keeps focus per macOS convention.
+    func clear() {
+        query = ""
+        hits = []
+        isSearching = false
+    }
+}

--- a/Sources/AnglesiteApp/SiteSearchModel.swift
+++ b/Sources/AnglesiteApp/SiteSearchModel.swift
@@ -72,6 +72,13 @@ final class SiteSearchModel {
         isSearching = false
     }
 
+    /// Whether the field holds something worth searching for. Drives the empty-state row: an
+    /// untouched field has no hits and isn't searching, which would otherwise render "no matches"
+    /// at the moment the user opens search and before they've typed anything.
+    var hasQuery: Bool {
+        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     /// The hit to activate for the current field contents — a selected suggestion (whose
     /// completion put its path in the field) or, for typed text committed with Return, the
     /// top-ranked hit. `nil` when nothing matched.

--- a/Sources/AnglesiteApp/SiteSearchModel.swift
+++ b/Sources/AnglesiteApp/SiteSearchModel.swift
@@ -72,6 +72,13 @@ final class SiteSearchModel {
         isSearching = false
     }
 
+    /// The hit to activate for the current field contents — a selected suggestion (whose
+    /// completion put its path in the field) or, for typed text committed with Return, the
+    /// top-ranked hit. `nil` when nothing matched.
+    func submit() -> SiteSearchIndex.Hit? {
+        SiteSearchIndex.hit(forSubmittedQuery: query, in: hits)
+    }
+
     /// Dismisses the suggestions list after the user picks a hit. Clearing the query is what
     /// closes the dropdown; the field itself keeps focus per macOS convention.
     func clear() {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -501,6 +501,14 @@ struct SiteWindow: View {
                 .help("Show or hide the page inspector")
             }
         }
+        // Trailing search field (#520). Not a `.toolbar(id:)` item: `.searchable` mints its own
+        // toolbar item id, so it stays out of the frozen `SiteToolbarItemID` set and out of
+        // users' saved customizations.
+        .modifier(SiteSearchFieldModifier(
+            model: model.search,
+            siteID: site.id,
+            activate: { hit in model.openSearchHit(hit) }
+        ))
         .sheet(isPresented: $bindableModel.deploy.blockedPresented) {
             if case .blocked(let failures, let warnings) = model.deploy.phase {
                 BlockedDeploySheetView(failures: failures, warnings: warnings) {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -126,6 +126,11 @@ struct SiteWindow: View {
     /// function (rather than inlined into one long modifier chain) so the type checker solves it
     /// as an independent unit — `navigatorSelectionActions(for:)` pushed the combined `body`
     /// expression over Swift's type-check-in-reasonable-time budget once added inline (#516).
+    ///
+    /// One exception to "every focused value is published here": `siteSearchActions` is published
+    /// by `SiteSearchFieldModifier` (`SiteSearchField.swift`, #520), because it hands out a
+    /// closure over that modifier's own `@FocusState` — scene-local state this function has no
+    /// access to. Look there too when auditing the full set.
     @ViewBuilder
     private func focusedValues<Content: View>(for content: Content) -> some View {
         content

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1485,6 +1485,23 @@ final class SiteWindowModel {
         let contentGraphRefresh = Task {
             await refreshContentGraph(siteID: resolved.id, sourceDirectory: resolved.sourceDirectory)
         }
+        // Warm the knowledge index here for the same reason, and on the same terms (#980): it is
+        // a filesystem scan of Source/ that needs no container, no MCP, and no dev server. Until
+        // this, the only thing that populated it on the open path was the runtime — *after*
+        // `control.start` and `connect(...)` in `LocalContainerSiteRuntime` — so every index
+        // consumer (toolbar search #520, assistant retrieval, Related Pages) silently returned
+        // nothing for as long as the container took to boot, and forever on a machine where the
+        // runtime can't start at all. Searching a page by its own name and getting "No matching
+        // content" is indistinguishable from a real miss, which is what made it worth fixing here
+        // rather than leaving search to inherit it.
+        //
+        // The runtime still rebuilds when it comes up; `SiteKnowledgeIndex` is an actor and
+        // rebuild is idempotent, so the two serialize and the later one simply refreshes from the
+        // hydrated repo. Not awaited — nothing below needs it, and the assistant's tools read the
+        // index lazily at call time.
+        Task { [knowledgeIndex] in
+            await knowledgeIndex.rebuild(siteID: resolved.id, projectRoot: resolved.sourceDirectory)
+        }
         // Scan from the package ROOT (not Source/): SiteFileTree's adaptive layout detects the
         // `.anglesite` package here and resolves Source/ for Components/Styles plus the sibling
         // Config/ + Info.plist for the Metadata group. Handing it Source/ would hide Metadata.

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -127,6 +127,8 @@ final class SiteWindowModel {
     }
     var relatedPages: RelatedPagesModel
     var relatedPagesPresented = false
+    /// Drives the toolbar search field and its suggestions (#520).
+    var search: SiteSearchModel
     /// Drives the main-pane Cleanup view (Site ▸ Cleanup…, #714 moved it out of the sidebar).
     /// `scan()` runs once automatically when `ProjectCleanupView` first appears; the manual
     /// Rescan button re-runs it on demand afterward.
@@ -221,6 +223,7 @@ final class SiteWindowModel {
         )
         self.graphExplorer = SiteGraphExplorerModel(graph: contentGraph)
         self.relatedPages = RelatedPagesModel(index: knowledgeIndex, ranker: semanticRanker)
+        self.search = SiteSearchModel(index: knowledgeIndex)
         self.cleanup = ProjectCleanupModel(knowledgeIndex: knowledgeIndex, contentGraph: contentGraph)
         // Wired once here (not per-site in loadAndStart): the hooks capture nothing from self
         // and receive the run's site id from the model, so there is nothing to rebind on
@@ -815,6 +818,32 @@ final class SiteWindowModel {
                 mainPaneMode = .preview
                 preview.navigate(toRoute: route)
             }
+        }
+    }
+
+    /// Routes an activated toolbar-search hit (#520). A hit whose route matches a live navigator
+    /// row goes through `applyNavigatorSelection` so the sidebar selection, preview, inspector,
+    /// and Related Pages panel all land where a sidebar click would have put them; everything
+    /// else opens its file. `SiteSearchDestination` owns that decision (and is tested in
+    /// AnglesiteCore) — this method only executes it.
+    @MainActor
+    func openSearchHit(_ hit: SiteSearchIndex.Hit) {
+        guard let site else { return }
+        let destination = SiteSearchDestination.resolve(
+            hit: hit, navigatorRouteIDs: navigator?.routeIDs ?? [:])
+        // Dismiss the suggestions list first: both branches below can suspend, and leaving the
+        // dropdown up over the destination reads as the navigation not having happened.
+        search.clear()
+
+        switch destination {
+        case .navigator(let id):
+            navigator?.selection = id
+            applyNavigatorSelection(id)
+        case .file(let path, let group):
+            let url = site.sourceDirectory.appendingPathComponent(path)
+            openFile(FileRef(
+                url: url, group: group,
+                name: hit.title ?? url.lastPathComponent))
         }
     }
 

--- a/Sources/AnglesiteCore/SiteSearchDestination.swift
+++ b/Sources/AnglesiteCore/SiteSearchDestination.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Where activating a search hit should take the user (#520). Pure and stateless — no I/O, no
+/// dependency on the navigator or the window model — so it's testable directly against
+/// arbitrary (kind, route, path) inputs, the same shape and reasoning as `ContentRouteResolver`.
+///
+/// Kept in AnglesiteCore rather than the app target because CI runs no hosted app tests
+/// (CLAUDE.md "Build"): the branch worth testing lives here, and `SiteWindowModel` only executes
+/// the result.
+public enum SiteSearchDestination: Equatable, Sendable {
+    /// Select this row in the Site Navigator. Routes the window through the same path a sidebar
+    /// click takes, so the preview, inspector, and Related Pages panel all stay in sync.
+    case navigator(id: String)
+    /// Open this file (path relative to the site's `Source/`) in the editor.
+    case file(path: String, group: FileGroup)
+
+    /// - Parameter navigatorRouteIDs: route → navigator node id for the rows currently on
+    ///   screen. Empty while a window's tree is still loading, which resolves everything to
+    ///   `.file` — a usable destination rather than a dropped hit.
+    public static func resolve(
+        kind: SiteKnowledgeIndex.Document.Kind,
+        route: String?,
+        path: String,
+        navigatorRouteIDs: [String: String]
+    ) -> SiteSearchDestination {
+        // A non-nil route is only a convention-based guess that some route serves this document
+        // (see `ContentRouteResolver`'s note) — matching a row the navigator actually shows is
+        // what makes it safe to navigate. Anything else opens the file, which always exists.
+        if let route, let id = navigatorRouteIDs[route] {
+            return .navigator(id: id)
+        }
+        return .file(path: path, group: group(for: kind))
+    }
+
+    public static func resolve(
+        hit: SiteSearchIndex.Hit,
+        navigatorRouteIDs: [String: String]
+    ) -> SiteSearchDestination {
+        resolve(kind: hit.kind, route: hit.route, path: hit.path,
+                navigatorRouteIDs: navigatorRouteIDs)
+    }
+
+    /// `FileGroup` drives `EditorKind.resolve`, so this maps by which editor suits the file —
+    /// not by where the file sits on disk.
+    private static func group(for kind: SiteKnowledgeIndex.Document.Kind) -> FileGroup {
+        switch kind {
+        case .page: .pages
+        case .post, .content: .posts
+        case .component, .layout: .components
+        case .style: .styles
+        case .config: .metadata
+        // Scripts and unclassified files are plain text; `.components` is the group whose
+        // editor handles them (`EditorKind.resolve` picks the component editor only for
+        // `.astro`, and the text editor otherwise).
+        case .script, .other: .components
+        }
+    }
+}

--- a/Sources/AnglesiteCore/SiteSearchIndex.swift
+++ b/Sources/AnglesiteCore/SiteSearchIndex.swift
@@ -68,6 +68,18 @@ public enum SiteSearchIndex {
         public let score: Double
     }
 
+    /// The hit a submitted search query refers to, or `nil` when the query is blank or nothing
+    /// matched.
+    ///
+    /// Selecting a suggestion row sets the field to that hit's `path` and submits, so an exact
+    /// path match means the user picked that row. Anything else is typed text committed with
+    /// Return, which activates the top-ranked hit — the only sensible destination when there is
+    /// no results pane behind the field.
+    public static func hit(forSubmittedQuery query: String, in hits: [Hit]) -> Hit? {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return hits.first { $0.path == query } ?? hits.first
+    }
+
     /// Searches the index for documents matching the query.
     /// - Parameter limit: Maximum number of results to return. Clamped to a minimum of 1 by
     ///   the underlying `SiteKnowledgeIndex.SearchOptions`, so `limit: 0` still returns one hit.

--- a/Sources/AnglesiteCore/SiteSearchScope.swift
+++ b/Sources/AnglesiteCore/SiteSearchScope.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// The kind filter behind the site window's search-field scope bar (#520) — the user-facing
+/// vocabulary ("Posts") over `SiteKnowledgeIndex.Document.Kind`'s storage vocabulary
+/// (`.post` + `.content`), fed straight to `SiteSearchIndex.search(kinds:)`.
+///
+/// Lives in AnglesiteCore, not the app target, so CI's SwiftPM suites can enforce the mappings —
+/// hosted app-target tests don't run there (see CLAUDE.md "Build"). Localized titles stay in the
+/// app target, where the String Catalog extractor can see them.
+///
+/// Raw values are persisted with the window's scene state, so they're API in the same sense
+/// `SiteToolbarItemID`'s are: renaming one silently resets every user's chosen scope.
+public enum SiteSearchScope: String, CaseIterable, Sendable, Identifiable {
+    case all
+    case pages
+    case posts
+    case components
+    case styles
+
+    public var id: String { rawValue }
+
+    /// The document kinds this scope searches, or `nil` for no filter.
+    ///
+    /// `all` is deliberately `nil` rather than the union of the other cases' kinds: the index
+    /// also holds `.config`, `.script`, and `.other` documents, which no narrowing scope names,
+    /// so an explicit union would make "All" quietly search less than all.
+    public var kinds: Set<SiteKnowledgeIndex.Document.Kind>? {
+        switch self {
+        case .all: nil
+        case .pages: [.page]
+        // `.content` is the kind for a collection entry outside the post-shaped collections;
+        // both read as "a piece of writing" to someone scanning the scope bar.
+        case .posts: [.post, .content]
+        // Layouts are components as far as the editor and the user's mental model go — the
+        // navigator's Components group already holds both.
+        case .components: [.component, .layout]
+        case .styles: [.style]
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteSearchDestinationTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteSearchDestinationTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+@Suite("SiteSearchDestination")
+struct SiteSearchDestinationTests {
+
+    private let navigatorRouteIDs = [
+        "/about": "page-about",
+        "/blog/hello-world": "post-hello",
+    ]
+
+    @Test("a hit whose route is in the navigator resolves to that row")
+    func routedHitResolvesToNavigatorRow() {
+        let destination = SiteSearchDestination.resolve(
+            kind: .page, route: "/about", path: "src/pages/about.astro",
+            navigatorRouteIDs: navigatorRouteIDs)
+        #expect(destination == .navigator(id: "page-about"))
+    }
+
+    @Test("collection entries resolve to their navigator row too")
+    func contentEntryResolvesToNavigatorRow() {
+        let destination = SiteSearchDestination.resolve(
+            kind: .post, route: "/blog/hello-world",
+            path: "src/content/blog/hello-world.md",
+            navigatorRouteIDs: navigatorRouteIDs)
+        #expect(destination == .navigator(id: "post-hello"))
+    }
+
+    /// `ContentRouteResolver` documents that a computed route is a convention-based guess and
+    /// isn't guaranteed to be served — an unrouted collection produces exactly this case. The
+    /// file is the destination that always exists, so fall back to it rather than navigating
+    /// the preview to a route that may 404.
+    @Test("a route the navigator doesn't show falls back to the file")
+    func unknownRouteFallsBackToFile() {
+        let destination = SiteSearchDestination.resolve(
+            kind: .post, route: "/notes/orphan", path: "src/content/notes/orphan.md",
+            navigatorRouteIDs: navigatorRouteIDs)
+        #expect(destination == .file(path: "src/content/notes/orphan.md", group: .posts))
+    }
+
+    @Test("routeless kinds resolve to the file, grouped by editor kind")
+    func routelessKindsResolveToFile() {
+        let cases: [(SiteKnowledgeIndex.Document.Kind, String, FileGroup)] = [
+            (.component, "src/components/Card.astro", .components),
+            (.layout, "src/layouts/BaseLayout.astro", .components),
+            (.style, "src/styles/global.css", .styles),
+            (.config, "astro.config.ts", .metadata),
+            (.script, "scripts/csp.ts", .components),
+            (.other, "README.md", .components),
+        ]
+        for (kind, path, expected) in cases {
+            let destination = SiteSearchDestination.resolve(
+                kind: kind, route: nil, path: path, navigatorRouteIDs: navigatorRouteIDs)
+            #expect(destination == .file(path: path, group: expected), "\(kind) grouped wrong")
+        }
+    }
+
+    @Test("pages and posts group to their own file groups when unrouted")
+    func contentKindsGroupToContentGroups() {
+        #expect(
+            SiteSearchDestination.resolve(
+                kind: .page, route: nil, path: "src/pages/[slug].astro",
+                navigatorRouteIDs: navigatorRouteIDs)
+                == .file(path: "src/pages/[slug].astro", group: .pages))
+        #expect(
+            SiteSearchDestination.resolve(
+                kind: .content, route: nil, path: "src/content/data/spec.md",
+                navigatorRouteIDs: navigatorRouteIDs)
+                == .file(path: "src/content/data/spec.md", group: .posts))
+    }
+
+    /// An empty navigator (site still loading, or a window whose tree hasn't refreshed) must
+    /// still produce a usable destination rather than dropping the hit on the floor.
+    @Test("an empty navigator map always falls back to the file")
+    func emptyNavigatorMapFallsBackToFile() {
+        let destination = SiteSearchDestination.resolve(
+            kind: .page, route: "/about", path: "src/pages/about.astro",
+            navigatorRouteIDs: [:])
+        #expect(destination == .file(path: "src/pages/about.astro", group: .pages))
+    }
+
+    @Test("the Hit convenience resolves the same way as the field-wise call")
+    func hitConvenienceMatchesFieldwise() async throws {
+        let root = try writeSiteTree(prefix: "searchdest", [
+            "src/pages/about.astro": "---\ntitle: About\n---\n# About\nAbout the studio.",
+        ])
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "s", projectRoot: root)
+        let hit = try #require(
+            await SiteSearchIndex.search(index, siteID: "s", query: "about", limit: 5).first)
+
+        #expect(
+            SiteSearchDestination.resolve(hit: hit, navigatorRouteIDs: navigatorRouteIDs)
+                == SiteSearchDestination.resolve(
+                    kind: hit.kind, route: hit.route, path: hit.path,
+                    navigatorRouteIDs: navigatorRouteIDs))
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteSearchIndexTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteSearchIndexTests.swift
@@ -3,6 +3,58 @@ import Testing
 import AnglesiteTestSupport
 @testable import AnglesiteCore
 
+@Suite("SiteSearchIndex submitted query")
+struct SiteSearchSubmissionTests {
+
+    private func hits(_ root: URL) async -> [SiteSearchIndex.Hit] {
+        let index = SiteKnowledgeIndex()
+        await index.rebuild(siteID: "s", projectRoot: root)
+        return await SiteSearchIndex.search(index, siteID: "s", query: "about", limit: 10)
+    }
+
+    private func fixture() throws -> URL {
+        try writeSiteTree(prefix: "sitesearchsubmit", [
+            "src/pages/about.astro": "---\ntitle: About\n---\n# About\nAbout the studio.",
+            "src/components/Card.astro": "<div>A card, about nothing in particular.</div>",
+        ])
+    }
+
+    /// Selecting a suggestion puts that hit's path in the field and submits — so an exact path
+    /// match means "the user picked this row", not "the user typed a path".
+    @Test("an exact path match resolves to that hit")
+    func exactPathMatchResolves() async throws {
+        let all = await hits(try fixture())
+        let target = try #require(all.first { $0.path == "src/components/Card.astro" })
+
+        let resolved = SiteSearchIndex.hit(forSubmittedQuery: target.path, in: all)
+        #expect(resolved?.path == target.path)
+    }
+
+    /// Return on typed text commits the search, and the top-ranked hit is the only sensible
+    /// destination when there's no results pane to fall back to (Spotlight's behavior).
+    @Test("free text resolves to the top-ranked hit")
+    func freeTextResolvesToTopHit() async throws {
+        let all = await hits(try fixture())
+        let resolved = SiteSearchIndex.hit(forSubmittedQuery: "about", in: all)
+        #expect(resolved?.path == all.first?.path)
+    }
+
+    @Test("no hits resolves to nothing")
+    func noHitsResolvesToNil() {
+        #expect(SiteSearchIndex.hit(forSubmittedQuery: "about", in: []) == nil)
+    }
+
+    /// Whitespace-only submissions (Return in an empty field) must not activate the top hit —
+    /// the user never typed a query.
+    @Test("a blank query resolves to nothing even with hits present")
+    func blankQueryResolvesToNil() async throws {
+        let all = await hits(try fixture())
+        #expect(!all.isEmpty)
+        #expect(SiteSearchIndex.hit(forSubmittedQuery: "   ", in: all) == nil)
+        #expect(SiteSearchIndex.hit(forSubmittedQuery: "", in: all) == nil)
+    }
+}
+
 @Suite("SiteSearchIndex")
 struct SiteSearchIndexTests {
 

--- a/Tests/AnglesiteCoreTests/SiteSearchScopeTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteSearchScopeTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SiteSearchScope")
+struct SiteSearchScopeTests {
+
+    /// The case list is the toolbar search field's scope bar (#520). Freezing it here keeps a
+    /// new case from silently shipping without a `kinds` mapping and a localized title.
+    @Test("case set is frozen")
+    func caseSetIsFrozen() {
+        #expect(SiteSearchScope.allCases == [.all, .pages, .posts, .components, .styles])
+    }
+
+    /// `nil`, not the union of every kind: an explicit set would silently exclude the
+    /// `.config`/`.script`/`.other` documents the index also holds, so "All" would quietly
+    /// search less than all.
+    @Test("all applies no kind filter")
+    func allAppliesNoFilter() {
+        #expect(SiteSearchScope.all.kinds == nil)
+    }
+
+    @Test("each narrowing scope maps to its document kinds")
+    func narrowingScopesMapToKinds() {
+        #expect(SiteSearchScope.pages.kinds == [.page])
+        #expect(SiteSearchScope.posts.kinds == [.post, .content])
+        #expect(SiteSearchScope.components.kinds == [.component, .layout])
+        #expect(SiteSearchScope.styles.kinds == [.style])
+    }
+
+    @Test("narrowing scopes never map to an empty set")
+    func narrowingScopesAreNonEmpty() {
+        for scope in SiteSearchScope.allCases where scope != .all {
+            #expect(scope.kinds?.isEmpty == false, "\(scope) would match nothing")
+        }
+    }
+
+    /// Raw values are persisted with the window's scene state, so they're API in the same sense
+    /// `SiteToolbarItemID`'s are — renaming one silently resets a user's chosen scope.
+    @Test("raw values are stable")
+    func rawValuesAreStable() {
+        #expect(SiteSearchScope.allCases.map(\.rawValue)
+            == ["all", "pages", "posts", "components", "styles"])
+    }
+}

--- a/docs/superpowers/specs/2026-07-26-site-search-surfaces-design.md
+++ b/docs/superpowers/specs/2026-07-26-site-search-surfaces-design.md
@@ -1,0 +1,177 @@
+# Site search surfaces — design (#520)
+
+Date: 2026-07-26
+Issue: [#520](https://github.com/Anglesite/Anglesite-app/issues/520) (toolbar search field), part of [#518](https://github.com/Anglesite/Anglesite-app/issues/518)
+Backend: [#765](https://github.com/Anglesite/Anglesite-app/issues/765), landed as `Sources/AnglesiteCore/SiteSearchIndex.swift` (PR #952)
+
+## Problem
+
+`SiteSearchIndex` shipped with zero consumers. Two search surfaces are still missing:
+
+1. **In-app** — the site window has no `.searchable`, so there is no way to find content by
+   name or text. The Apple-native trailing toolbar search slot is empty, and
+   `Edit ▸ Find ▸ Search Site…` is still a disabled `PlannedItem`
+   (`Sources/AnglesiteApp/EditMenuSkeletonCommands.swift:41`).
+2. **Reader-facing** — a published site offers visitors no search at all. For a long-running
+   blog (the kottke.org persona exercise on #520: tens of thousands of posts across decades),
+   archive search is a daily workflow for both the author and their readers.
+
+## Scope
+
+Two independent deliverables, landing as two focused PRs (CONTRIBUTING ▸ "Keep PRs focused").
+They share no code: one is Swift app UI, the other is an Astro template feature with an npm
+dependency, a build step, and a CSP change.
+
+- **PR 1 — app-side site search.** Closes #520.
+- **PR 2 — Pagefind reader search.** Template-only; filed as its own issue from #520's comment.
+
+Non-goals: in-editor find (#517, already live for Markdown via #797), a full in-app search
+*results pane*, and semantic/RAG reranking of results — `SiteSearchIndex` deliberately wraps
+`SiteKnowledgeIndex.search()` lexically, because a toolbar field wants fast literal matching.
+
+## PR 1 — app-side site search
+
+### Architecture
+
+CI does not run hosted app-target tests (CLAUDE.md ▸ "Build"), so every decision worth testing
+lives in `AnglesiteCore` as a pure type, and the app target holds only SwiftUI glue. This is the
+`TokenOnboarding` precedent.
+
+#### `AnglesiteCore/SiteSearchScope`
+
+The user-facing kind filter behind `.searchScopes`:
+
+| Case | `SiteKnowledgeIndex.Document.Kind` set passed to `SiteSearchIndex.search(kinds:)` |
+|---|---|
+| `all` | `nil` (no filter) |
+| `pages` | `[.page]` |
+| `posts` | `[.post, .content]` |
+| `components` | `[.component, .layout]` |
+| `styles` | `[.style]` |
+
+A test freezes the case list and each mapping. `all` maps to `nil`, not to the union of every
+kind: an explicit set would silently exclude `.config`/`.script`/`.other` documents that the
+index does hold.
+
+#### `AnglesiteCore/SiteSearchDestination`
+
+The activation decision, as a pure function:
+
+```swift
+public enum SiteSearchDestination: Equatable {
+    case navigator(id: String)
+    case file(path: String, group: FileGroup)
+
+    public static func resolve(
+        hit: SiteSearchIndex.Hit,
+        navigatorRouteIDs: [String: String]   // route → navigator node id
+    ) -> SiteSearchDestination
+}
+```
+
+A hit whose `route` matches a live navigator row resolves to `.navigator` so the sidebar,
+preview, inspector, and Related Pages panel all stay in sync with what the user picked.
+Everything else resolves to `.file`, mapping kind → `FileGroup`:
+
+| Kind | `FileGroup` |
+|---|---|
+| `.page` | `.pages` |
+| `.post`, `.content` | `.posts` |
+| `.component`, `.layout` | `.components` |
+| `.style` | `.styles` |
+| `.config` | `.metadata` |
+| `.script`, `.other` | `.components` |
+
+`.script`/`.other` fall to `.components` because `EditorKind.resolve` reads the group only to
+choose an editor, and those files are plain text the component/text editor already handles.
+
+A hit with a non-`nil` route that matches no navigator row still resolves to `.file` — that is
+the documented `ContentRouteResolver` caveat (a convention-derived route is not a guarantee the
+route is served), so the file is the reliable destination.
+
+### App glue
+
+**`SiteSearchModel`** (`@MainActor @Observable`), shaped after `RelatedPagesModel`:
+
+- Holds `query`, `scope`, `private(set) hits`, `private(set) isSearching`.
+- `search(siteID:)` debounces ~150 ms in a single cancellable `Task` (a new keystroke cancels
+  the pending one), then calls `SiteSearchIndex.search(index, siteID:query:limit:8, kinds:)`.
+- Captures `query` and `scope` before the await and discards the result if either changed
+  during it — the generation guard `RelatedPagesModel` spells as its `currentPath` check.
+- A blank or whitespace-only query clears `hits` and issues no search.
+- Holds no index state: `SiteSearchIndex` reads the live index every call, so results always
+  reflect the latest `KnowledgeReindex` pass.
+
+**`SiteWindow`** gains, on the `NavigationSplitView`:
+
+- `.searchable(text:placement: .toolbar, prompt: "Search Site")` — the standard trailing slot.
+- `.searchScopes` bound to `SiteSearchScope`.
+- `.searchSuggestions` — one row per hit: kind icon, title (falling back to the last path
+  component), route or path as the subtitle, and the `matchContext` excerpt. An empty result
+  set renders a single disabled "No matching content" row rather than an empty dropdown.
+- `.searchFocused($searchFieldFocused)` so the menu command can focus the field.
+
+No `SiteToolbarItemID` change: `.searchable` mints its own toolbar item id, so no saved user
+customization is disturbed and the frozen id set stays as-is.
+
+**`SiteWindowModel.openSearchHit(_:)`** runs `SiteSearchDestination.resolve` against
+`navigator.routeIDs` and then either sets `navigator.selection` + calls
+`applyNavigatorSelection(id)`, or builds a `FileRef` under `site.sourceDirectory` and calls
+`openFile(_:)`. Both paths already handle leaving the current editor/inspector safely. The
+query is cleared afterward so the dropdown dismisses.
+
+**`SiteNavigatorModel`** gains `var routeIDs: [String: String]`, rebuilt alongside `nodesByID`
+in `refresh` — the same shape as the existing `postIDs`/`postsByID` sidecar maps, assigned in
+the same place so it can never drift from the tree on screen.
+
+**`EditMenuSkeletonCommands`** replaces `PlannedItem("Search Site…")` with a live `Button` on
+**⇧⌘F**, disabled when no site window is focused. ⌘F / ⌘G / ⇧⌘G / ⌥⌘F stay with the Markdown
+find bar (#797), so this is the #517 interplay the issue asked to coordinate; ⇧⌘F is Xcode's
+Find-in-Project key and is otherwise unused in this app. The action arrives through a new
+`SiteSearchActions` focused value carrying a `focus: @MainActor () -> Void` closure, published
+by `SiteWindow` next to `NavigatorSelectionActions` and consumed with `@FocusedValue` — the
+established pattern for menu items that act on the focused window.
+
+### Error handling
+
+`SiteKnowledgeIndex.search` neither throws nor fails; it returns an empty array. The three ways
+a user sees nothing are therefore indistinguishable at the API and share one message ("No
+matching content"): no match, an index that has not finished its first `KnowledgeReindex` pass,
+and a site with no indexable content. This is deliberate — a toolbar dropdown is the wrong
+place to explain indexing state, and the index populates within moments of a site opening.
+
+A hit whose file has been deleted since the last index pass resolves to `.file` and fails in
+`openFile`'s existing error path; no new handling.
+
+### Testing
+
+- `swift test` — `SiteSearchScopeTests` (case freeze + kind mappings), `SiteSearchDestinationTests`
+  (navigator match, no match, every kind→group mapping, nil-route hits).
+- `xcodebuild -scheme Anglesite -configuration Debug build`.
+- New user-visible strings mean an `xcstringstool sync` pass on `Localizable.xcstrings`,
+  committed alongside (CONTRIBUTING ▸ Development setup).
+- Manual GUI check (the navigator-command precedent, #586): field appears in the trailing
+  toolbar slot, scopes filter, ⇧⌘F focuses it, a page hit selects its navigator row and
+  previews, a component hit opens the editor.
+
+## PR 2 — Pagefind reader search
+
+Filed as its own issue, referencing #520's kottke.org comment. Sketch:
+
+- `pagefind` as a template `devDependency` and a `postbuild` step indexing `dist/`. **New
+  dependency** — approved in the #520 design conversation on 2026-07-26; to be recorded in the
+  new issue and the PR body per CONTRIBUTING ▸ "Discuss big changes first".
+- `src/pages/search.astro` using the self-hosted Pagefind UI bundle, with a `<noscript>` note.
+- One CSP baseline change in `scripts/csp.ts`: `'wasm-unsafe-eval'` in `script-src`, because
+  Pagefind compiles a WASM index reader. Everything else it loads is same-origin, which the
+  existing `'self'` baseline already covers. `csp.ts`'s test updates with it.
+- A nav link in `BaseLayout.astro`.
+
+Template-only, so no paired sidecar PR (CLAUDE.md ▸ "Two-repo coordination").
+
+## Follow-ups not taken
+
+An in-app **full results pane** (a main-pane mode beside Graph/Cleanup, with grouping and
+excerpts). `.searchable`'s dropdown shows the top ~8 hits, which serves navigation but not
+archive spelunking; PR 2's reader page covers the archive case for the author too. Worth
+filing only if the dropdown proves too thin in use.

--- a/docs/superpowers/specs/2026-07-26-site-search-surfaces-design.md
+++ b/docs/superpowers/specs/2026-07-26-site-search-surfaces-design.md
@@ -109,6 +109,18 @@ route is served), so the file is the reliable destination.
 - `.searchSuggestions` — one row per hit: kind icon, title (falling back to the last path
   component), route or path as the subtitle, and the `matchContext` excerpt. An empty result
   set renders a single disabled "No matching content" row rather than an empty dropdown.
+
+  Rows are made selectable with `.searchCompletion(hit.path)`, **not** by wrapping each in a
+  `Button`. Two reasons: `.searchCompletion` is the mechanism that makes a suggestion row
+  respond to both a click and arrow-keys-then-Return (it wraps its content in a button itself,
+  which is why Apple's guidance is to apply it to non-interactive views), and since macOS 26 an
+  `NSGlassContainerView` intercepts mouse events for interactive SwiftUI views layered over the
+  title-bar/toolbar area — exactly where this popover sits — so a bare `Button` is unreliable
+  there. Selecting a row therefore puts the hit's path in the field and submits;
+  `onSubmit(of: .search)` turns that back into a hit via
+  `SiteSearchIndex.hit(forSubmittedQuery:in:)`, which resolves an exact path match to that row
+  and any other typed text to the top-ranked hit (Spotlight's Return behavior). The path is
+  visible in the field only for the instant before activation clears it.
 - `.searchFocused($searchFieldFocused)` so the menu command can focus the field.
 
 No `SiteToolbarItemID` change: `.searchable` mints its own toolbar item id, so no saved user
@@ -146,7 +158,8 @@ A hit whose file has been deleted since the last index pass resolves to `.file` 
 ### Testing
 
 - `swift test` — `SiteSearchScopeTests` (case freeze + kind mappings), `SiteSearchDestinationTests`
-  (navigator match, no match, every kind→group mapping, nil-route hits).
+  (navigator match, no match, every kind→group mapping, nil-route hits), and
+  `SiteSearchSubmissionTests` (exact-path vs. free-text vs. blank submissions).
 - `xcodebuild -scheme Anglesite -configuration Debug build`.
 - New user-visible strings mean an `xcstringstool sync` pass on `Localizable.xcstrings`,
   committed alongside (CONTRIBUTING ▸ Development setup).


### PR DESCRIPTION
## Summary

- Gives the site window the Apple-native trailing search field, backed by the `SiteSearchIndex` that landed in #765 with zero consumers, and makes `Edit ▸ Find ▸ Search Site…` live on ⇧⌘F (⌘F/⌘G/⇧⌘G/⌥⌘F stay with the Markdown find bar from #797 — the interplay #517 asked to coordinate).
- Picking a suggestion navigates: a hit whose route matches a live navigator row goes through `applyNavigatorSelection`, so the sidebar selection, preview, inspector, and Related Pages panel land where a sidebar click would put them; everything else opens its file in the editor.
- The decisions worth testing live in `AnglesiteCore`, since CI runs no hosted app-target tests — `SiteSearchScope` (scope bar → document kinds), `SiteSearchDestination` (hit → navigator row or file), and `SiteSearchIndex.hit(forSubmittedQuery:in:)`. The app target holds only SwiftUI glue and a debounced search model.

`.searchable` mints its own toolbar item id, so the frozen `SiteToolbarItemID` set and users' saved toolbar customizations are untouched.

Design: [`docs/superpowers/specs/2026-07-26-site-search-surfaces-design.md`](docs/superpowers/specs/2026-07-26-site-search-surfaces-design.md).

Closes #520.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 20 site-search tests pass across 4 suites. Two pre-existing failures in `FoundationModelAssistantTests` ("Session ended without producing a response") reproduce identically on an unmodified checkout of `main`; they are an on-device model issue on this machine, unrelated to this change.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds, no new warnings.
- [x] `scripts/check-localization-catalog.sh` — passes. `Localizable.xcstrings` synced per CONTRIBUTING; the diff is only this PR's four new keys (two stale entries the `.stringsdata` sync pulled in from an earlier revision of #675 were removed by hand).
- [ ] **Manual smoke — not run, needs a human.** Screen-control access was declined in the authoring session, so the GUI pass is outstanding: confirm the field appears in the trailing toolbar slot, the scope bar filters, ⇧⌘F focuses the field, a page hit selects its navigator row and previews, and a component hit opens the editor.

### Design notes

Suggestion rows use `.searchCompletion(hit.path)` rather than a `Button` per row. `.searchCompletion` is what makes a row respond to both a click and arrow-keys-then-Return, and since macOS 26 an `NSGlassContainerView` intercepts mouse events for interactive SwiftUI views layered over the title-bar/toolbar area — exactly where the suggestions popover sits — so a bare `Button` there is unreliable. Selecting a row puts the hit's path in the field and submits; `onSubmit(of: .search)` resolves that back to a hit (exact path match → that row, any other typed text → top-ranked hit, matching Spotlight).

The reader-facing counterpart from this issue's kottke.org comment (a Pagefind search page in `Resources/Template/`) is deliberately **not** here — it's a separate deliverable in a different language with its own npm dependency, build step, and CSP change. It follows as its own issue and PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)