### PR TITLE
test(#977): stop asserting on a global LogCenter count

### DIFF
--- a/Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubPostD1ClientTests.swift
@@ -75,24 +75,29 @@ struct MicropubPostD1ClientTests {
 
     @Test("skips a row whose properties column isn't valid JSON, and logs the skip")
     func skipsMalformedPropertiesRow() async throws {
+        // Unique to this test, so the filter below can't pick up another test's entry —
+        // `LogCenter.shared` is process-global and Swift Testing runs suites in parallel, so
+        // asserting on its total count or its `.last` entry is a race (#977).
+        let url = "https://me.example/notes/bad-properties-\(UUID().uuidString)"
         let body = Self.d1Body("""
-        {"url": "https://me.example/notes/bad", "type": "h-entry",
+        {"url": "\(url)", "type": "h-entry",
          "properties": "not json", "deleted": 0, "updated_at": 1753300000}
         """)
         let client = MicropubPostD1Client(
             accountID: "acct1", databaseID: "db1", apiToken: "token",
             transport: { _ in (body, Self.response(200)) })
 
-        let beforeCount = await LogCenter.shared.snapshot().count
         let posts = try await client.listAllPosts()
         #expect(posts.isEmpty)
 
-        let logged = await LogCenter.shared.snapshot()
-        #expect(logged.count == beforeCount + 1)
+        // Filter to the entries this call caused, then assert on those — the pattern
+        // `BackupCommandInProcessTests` already uses against the same shared log. Filtering on
+        // the marker alone (not the source) keeps the source assertion below meaningful.
+        let logged = await LogCenter.shared.snapshot().filter { $0.text.contains(url) }
+        #expect(logged.count == 1)
         let entry = try #require(logged.last)
         #expect(entry.source == "MicropubPostD1Client")
         #expect(entry.stream == .stderr)
-        #expect(entry.text.contains("https://me.example/notes/bad"))
     }
 
     @Test("throws unauthorized on 401")


### PR DESCRIPTION
## Summary

- `MicropubPostD1ClientTests` ▸ "skips a row whose properties column isn't valid JSON" snapshotted the process-global `LogCenter.shared` before and after the call, asserted an exact count delta, and read `logged.last`. Swift Testing runs suites in parallel, so any concurrently-logging test broke both assertions.
- It fails on `main` today: it took down the `build-test` lane of [#976](https://github.com/Anglesite/Anglesite-app/pull/976), a template-only PR that touches no Swift, after picking up a `container:s1:persist` entry from #912's own feature tests (`(logged.count → 27) == (beforeCount + 1 → 22)`).
- The fixture URL now carries a `UUID`, and the assertions filter the snapshot to entries containing that marker before checking count, source, and stream — the pattern [`BackupCommandInProcessTests.swift:66`](Tests/AnglesiteCoreTests/BackupCommandInProcessTests.swift:66) already uses against the same shared log. Filtering on the marker rather than the source keeps the `source` assertion meaningful rather than folding it into the filter.

`LogCenter.shared.snapshot()` has only these two call sites in `Tests/`, so this was the single outlier.

Closes #977.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — full suite; `MicropubPostD1Client` passes both in isolation (7 tests) and in the full parallel run, where the interfering loggers actually exist. The two `FoundationModelAssistantTests` failures are pre-existing and reproduce on an unmodified `main` (on-device model issue on this machine), unrelated to this change.
- [x] Test-only change; no production code touched, so no app build or manual smoke applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)