### PR TITLE
fix(git): commit with app identity when none configured (#969)

### DIFF
--- a/Sources/AnglesiteCore/GitIdentity.swift
+++ b/Sources/AnglesiteCore/GitIdentity.swift
@@ -1,0 +1,59 @@
+#if canImport(Darwin)
+import Foundation
+import SwiftGit2
+
+/// The identity app-initiated commits are made with.
+///
+/// `git_signature_default` (SwiftGit2's `defaultSignature()`) walks git's own config chain —
+/// repo, then global, then system. Under App Sandbox that chain is truncated: `HOME` is
+/// redirected into the app's container, so the user's `~/.gitconfig` is invisible to libgit2 no
+/// matter how they configured git in Terminal, and only a *repo-local* identity resolves. libgit2
+/// then fails with "config value 'user.name' was not found", and every commit path that treated
+/// that failure as fatal did nothing at all: Delete removed the file, failed to commit, rolled
+/// back, and reported nothing, so it read as "I clicked Delete and nothing happened" (#969, and
+/// #656's duplicate-commit box).
+///
+/// Confirmed by A/B against a real sandboxed process (ad-hoc-signed bundle carrying
+/// `com.apple.security.app-sandbox`, operating on a `~/Sites/*.anglesite` package with the
+/// relocated git dir): the full remove→commit sequence succeeds unsandboxed via `~/.gitconfig`
+/// and fails sandboxed with exactly that error. libgit2 itself is unaffected by the sandbox — the
+/// same sequence succeeds sandboxed as soon as an identity is reachable, so this is an identity
+/// problem, not the `/usr/bin/git`-under-sandbox problem (#640) surviving the SwiftGit2 migration.
+///
+/// So a resolvable identity is preferred and an app-owned one is the fallback, rather than the
+/// operation failing. `RepoBootstrap.commitAll` already made exactly this call for a new site's
+/// initial commit; this hoists that identity into one place so later commits match it.
+public enum GitIdentity {
+    /// The identity used when libgit2 can't resolve a configured one. Deliberately
+    /// app-attributed rather than a guessed personal identity: the app really is the author, and
+    /// synthesizing a `user@host` address the way bare `git` does would put an address the user
+    /// never chose — and can't receive mail at — into permanent, publishable history.
+    public static let appFallback = Signature(name: "Anglesite", email: "noreply@anglesite.app")
+
+    /// `repo`'s configured identity, falling back to ``appFallback``.
+    ///
+    /// The fallback is logged rather than silent: it changes what lands in the user's git history,
+    /// and it's the signal that tells them a repo-local identity would attribute these commits to
+    /// them instead.
+    public static func signature(for repo: Repository) async -> Signature {
+        if case .success(let configured) = repo.defaultSignature() { return configured }
+        await logSubstitution(appFallback)
+        return appFallback
+    }
+
+    /// Records that `substitute` stood in for a configured identity.
+    ///
+    /// Separate from ``signature(for:)`` for the one caller that can't use it:
+    /// `RepoBootstrap.ensureCommittable` takes its fallback as a parameter precisely so the
+    /// GitHub-publish path can pass none and *refuse* instead of substituting (its own tests pin
+    /// that refusal). It still needs the substitution it does make to be logged the same way, so
+    /// the logging lives here rather than inside the resolver.
+    static func logSubstitution(_ substitute: Signature) async {
+        await LogCenter.shared.append(
+            source: "git:identity", stream: .stderr,
+            text: "No git identity resolved for this site — a sandboxed app can't read ~/.gitconfig. "
+                + "Committing as \(substitute.name) <\(substitute.email)>. To attribute commits to you, "
+                + "set one in the site's Source/: `git config user.name \"You\"` and `git config user.email you@example.com`.")
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/InboxSubmissionCommitter.swift
+++ b/Sources/AnglesiteCore/InboxSubmissionCommitter.swift
@@ -125,7 +125,7 @@ public enum InboxSubmissionCommitter {
         for relPath in relPaths {
             guard case .success = repo.add(path: relPath) else { return nil }
         }
-        guard case .success(let signature) = repo.defaultSignature() else { return nil }
+        let signature = await GitIdentity.signature(for: repo)
         guard case .success(let commit) = repo.commit(message: message, signature: signature) else { return nil }
         return commit.oid.description
     }

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -497,9 +497,10 @@ public struct NativeContentOperations: ContentOperationsService {
 
     #if canImport(Darwin)
     /// Stage and commit exactly `relPath` on the current branch. Returns the new HEAD SHA, or
-    /// nil on any failure (not a repo, no configured git identity) — best-effort, mirroring the
-    /// Node sidecar's `commitFile`. Via SwiftGit2 (in-process libgit2, #640): `/usr/bin/git`
-    /// cannot execute at all under App Sandbox.
+    /// nil on any failure (not a repo) — best-effort, mirroring the Node sidecar's `commitFile`.
+    /// Via SwiftGit2 (in-process libgit2, #640): `/usr/bin/git` cannot execute at all under App
+    /// Sandbox. A missing git identity is not a failure: it resolves through `GitIdentity`, which
+    /// falls back to the app's own identity rather than dropping the commit (#969).
     ///
     /// Two behavioral differences from the subprocess-git version this replaced, both judged
     /// acceptable for this app's single-user, one-operation-at-a-time usage:
@@ -516,7 +517,7 @@ public struct NativeContentOperations: ContentOperationsService {
         SwiftGit2Bootstrap.ensureInitialized
         guard case .success(let repo) = Repository.at(projectRoot) else { return nil }
         guard case .success = repo.add(path: relPath) else { return nil }
-        guard case .success(let signature) = repo.defaultSignature() else { return nil }
+        let signature = await GitIdentity.signature(for: repo)
         guard case .success(let commit) = repo.commit(message: message, signature: signature) else { return nil }
         return commit.oid.description
     }
@@ -568,8 +569,10 @@ public struct NativeContentOperations: ContentOperationsService {
 
     #if canImport(Darwin)
     /// Stage-delete and commit exactly `relPath` on the current branch (`git rm` + `git commit`
-    /// equivalent). Returns the new HEAD SHA, or nil on any failure (not a repo, no configured
-    /// git identity, no HEAD copy) — best-effort, mirroring `processGitCommit`'s shape exactly.
+    /// equivalent). Returns the new HEAD SHA, or nil on any failure (not a repo, no HEAD copy) —
+    /// best-effort, mirroring `processGitCommit`'s shape exactly. A missing git identity is not
+    /// one of those failures: it resolves through `GitIdentity`, which falls back to the app's own
+    /// identity rather than aborting the delete (#969).
     /// Git history is the sole undo/archive mechanism for this delete; there is no separate
     /// trash/archive path. Via SwiftGit2 (in-process libgit2, #640): `/usr/bin/git` cannot
     /// execute at all under App Sandbox. Uses three fork-specific additions —
@@ -586,15 +589,12 @@ public struct NativeContentOperations: ContentOperationsService {
         guard repo.headHasEntry(atPath: relPath) else { return nil }
         guard case .success = repo.remove(path: relPath) else { return nil }
 
-        let commitResult = repo.defaultSignature().flatMap { signature in
-            repo.commit(message: message, signature: signature)
-        }
-        guard case .success(let commit) = commitResult else {
+        let signature = await GitIdentity.signature(for: repo)
+        guard case .success(let commit) = repo.commit(message: message, signature: signature) else {
             // remove(path:) already removed the file from the index and working tree before the
-            // commit failed (no identity configured, etc.) — restore both from HEAD so a failed
-            // delete never leaves the file gone without a commit. Same "never a raw
-            // non-git-recoverable delete" safety property the happy path relies on, applied to
-            // the failure path too.
+            // commit failed — restore both from HEAD so a failed delete never leaves the file gone
+            // without a commit. Same "never a raw non-git-recoverable delete" safety property the
+            // happy path relies on, applied to the failure path too.
             // This second failure (the rollback itself also failing) has no regression test: by
             // this point the `headHasEntry` guard above has already confirmed HEAD has the file,
             // so the restore failing here means something environmental went wrong between that

--- a/Sources/AnglesiteCore/RepoBootstrap.swift
+++ b/Sources/AnglesiteCore/RepoBootstrap.swift
@@ -112,6 +112,10 @@ public actor RepoBootstrap {
         if case .success(let configuredSignature) = repo.defaultSignature() {
             signature = configuredSignature
         } else if let signatureFallback {
+            // Logged, not silent — same reasoning as `GitIdentity.signature(for:)`: substituting an
+            // identity changes what lands in the user's git history, and that's just as true of a
+            // new site's very first commit as of any later one (PR #983 review).
+            await GitIdentity.logSubstitution(signatureFallback)
             signature = signatureFallback
         } else {
             throw RepoBootstrapError(reason: "No git identity configured (user.name/user.email).")
@@ -201,8 +205,7 @@ public actor RepoBootstrap {
         // Preserve the user's configured identity when libgit2 can resolve one. The app identity
         // is only a fallback: a sandboxed build cannot necessarily read ~/.gitconfig even when
         // Terminal can, and a commit-less new site cannot be cloned into the container runtime.
-        let signature = Signature(name: "Anglesite", email: "noreply@anglesite.app")
-        try await ensureCommittable(source: source, signatureFallback: signature, emit: { _ in })
+        try await ensureCommittable(source: source, signatureFallback: GitIdentity.appFallback, emit: { _ in })
         #else
         try await ensureCommittable(source: source, emit: { _ in })
         #endif

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -215,33 +215,108 @@ struct NativeContentOperationsTests {
         #expect(sha?.count == 40)
     }
 
-    @Test("processGitCommit returns nil when the configured git identity can't be resolved")
+    @Test("processGitCommit falls back to the app identity when none is configured")
     func realGitNoIdentity() async throws {
-        // Forcing "genuinely no user.name/user.email anywhere in the config chain" isn't
-        // reliably constructible here: SwiftGit2's resolution goes through libgit2's own
-        // process-global config-search-path cache (populated once, at first SwiftGit2Init()), so
-        // mutating HOME/XDG_CONFIG_HOME mid-test doesn't retroactively affect it. Making the local
-        // repo config merely unreadable doesn't work either — empirically verified: libgit2
-        // silently skips an inaccessible local config and falls through to this dev/CI machine's
-        // real ambient global config instead of failing. What *does* reliably fail is malformed
-        // config syntax: a config file libgit2 can open but not parse is a hard error, not a
-        // silently-skipped level. This is a different trigger than "no identity configured
-        // anywhere" but exercises the exact thing this test actually cares about: a
-        // `defaultSignature()` failure, for any reason, must make `processGitCommit` return nil
-        // rather than crash or silently misbehave (finding #2 in PR #649's review).
+        // #969: under App Sandbox `HOME` is redirected into the app's container, so the user's
+        // ~/.gitconfig is invisible to libgit2 no matter how they configured git in Terminal.
+        // `git_signature_default` then fails and every commit that treated that as fatal did
+        // nothing at all. The commit must still land, attributed to the app.
+        //
+        // An *empty* repo-local user.name/user.email is the deterministic way to reproduce that
+        // here: it fails `defaultSignature()` ("Signature cannot have an empty name or email")
+        // even on a dev/CI machine that has a real ambient global identity, which a merely-absent
+        // local identity would silently fall through to. (libgit2's config-search-path cache is
+        // process-global and populated at the first SwiftGit2Init(), so mutating HOME/XDG mid-test
+        // can't truncate the chain the way the sandbox does.)
+        let repo = try await makeIdentitylessRepo(seeding: "p.astro", contents: "page")
+
+        let sha = await NativeContentOperations.processGitCommit(repo, "p.astro", "anglesite: add page /p")
+        #expect(sha?.count == 40)
+        #expect(try await lastCommitAuthor(in: repo) == "Anglesite <noreply@anglesite.app>")
+    }
+
+    @Test("processGitCommit still returns nil on a corrupt repo config, rather than committing as the app")
+    func realGitMalformedConfig() async throws {
+        // The identity fallback must not swallow a *corrupt* repository. A config libgit2 can open
+        // but not parse is a different thing from "this user never configured an identity", and it
+        // shouldn't quietly land a commit attributed to Anglesite in a repo that's structurally
+        // broken.
+        //
+        // It doesn't, but not via the fallback: an unparseable config fails `Repository.at`
+        // (`git_repository_open` reads config as part of opening), so the guard at the top of
+        // `processGitCommit` returns nil before identity resolution is ever reached. This test
+        // exists to pin that ordering — it's what keeps `GitIdentity`'s "any `defaultSignature()`
+        // failure ⇒ substitute" rule from widening into "any broken repo ⇒ commit anyway"
+        // (PR #983 review). It's the surviving half of the pre-#983 `realGitNoIdentity` test, whose
+        // other assertion (a missing identity ⇒ nil) is the behavior #969 fixed.
         let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
         let git = URL(fileURLWithPath: "/usr/bin/git")
         _ = try await ProcessSupervisor.shared.run(executable: git, arguments: ["init"], currentDirectoryURL: repo)
-        // Deliberately no `git config user.email`/`user.name` this time — and the config file's
-        // contents are overwritten with unparseable garbage below, so it can't fall back to
-        // whatever `git init` itself wrote there either.
-        let configPath = repo.appendingPathComponent(".git/config")
-        try "[core\nthis is not valid git-config syntax".write(to: configPath, atomically: true, encoding: .utf8)
-
+        try "[core\nthis is not valid git-config syntax".write(
+            to: repo.appendingPathComponent(".git/config"), atomically: true, encoding: .utf8)
         try "page".write(to: repo.appendingPathComponent("p.astro"), atomically: true, encoding: .utf8)
+
         let sha = await NativeContentOperations.processGitCommit(repo, "p.astro", "anglesite: add page /p")
         #expect(sha == nil)
+    }
+
+    @Test("processGitCommit prefers a configured identity over the app fallback")
+    func realGitPrefersConfiguredIdentity() async throws {
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "t@t.io"], ["config", "user.name", "t"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        try "page".write(to: repo.appendingPathComponent("p.astro"), atomically: true, encoding: .utf8)
+
+        let sha = await NativeContentOperations.processGitCommit(repo, "p.astro", "anglesite: add page /p")
+        #expect(sha?.count == 40)
+        #expect(try await lastCommitAuthor(in: repo) == "t <t@t.io>")
+    }
+
+    @Test("processGitDelete deletes and commits when no git identity is configured")
+    func realGitDeleteNoIdentity() async throws {
+        // The #969 headline symptom: on a sandboxed build the delete removed the file, failed to
+        // commit for want of an identity, rolled back, and reported nothing — so Delete read as
+        // "I clicked it and nothing happened". It must complete instead.
+        let repo = try await makeIdentitylessRepo(seeding: "unused.astro", contents: "<div></div>", commitSeed: true)
+        let filePath = repo.appendingPathComponent("unused.astro")
+
+        let sha = await NativeContentOperations.processGitDelete(repo, "unused.astro", "Remove unused.astro")
+        #expect(sha?.count == 40)
+        #expect(!FileManager.default.fileExists(atPath: filePath.path))
+        #expect(try await lastCommitAuthor(in: repo) == "Anglesite <noreply@anglesite.app>")
+    }
+
+    /// A repo whose local `user.name`/`user.email` are set to the empty string — the deterministic
+    /// `defaultSignature()` failure described in `realGitNoIdentity`. Seeded (and optionally
+    /// committed) *before* the identity is blanked, so `HEAD` can still contain the file.
+    private func makeIdentitylessRepo(
+        seeding relPath: String, contents: String, commitSeed: Bool = false
+    ) async throws -> URL {
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "seed@t.io"], ["config", "user.name", "seed"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        try contents.write(to: repo.appendingPathComponent(relPath), atomically: true, encoding: .utf8)
+        if commitSeed {
+            _ = await NativeContentOperations.processGitCommit(repo, relPath, "add \(relPath)")
+        }
+        for args in [["config", "user.email", ""], ["config", "user.name", ""]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        return repo
+    }
+
+    private func lastCommitAuthor(in repo: URL) async throws -> String {
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/git"),
+            arguments: ["log", "-1", "--format=%an <%ae>"], currentDirectoryURL: repo)
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     @Test("processGitDelete removes and commits the file, nil outside a repo")


### PR DESCRIPTION
## Summary

- Fixes #969 — deleting a page/post did nothing on a sandboxed build (file stayed, no commit, no error). The cause is **not** the sandbox blocking libgit2; it's **git identity resolution**. `git_signature_default` walks git's config chain (repo → global → system), but under App Sandbox `HOME` is redirected into the app's container, so the user's `~/.gitconfig` is invisible however they configured git in Terminal. libgit2 fails with `config value 'user.name' was not found`, and `processGitDelete` treated that as fatal: remove the file → commit fails → roll back from HEAD → return nil, leaving the tree byte-identical. That *is* the reported "nothing happened."
- New `GitIdentity` prefers the repo's configured identity and falls back to the app's own (`Anglesite <noreply@anglesite.app>`) rather than dropping the operation, logging the fallback so it isn't silent. Applied to `processGitCommit`, `processGitDelete`, and the batched `InboxSubmissionCommitter` counterpart. `RepoBootstrap.commitAll` already made exactly this call for a new site's initial commit — its literal is hoisted into `GitIdentity` so later commits match it.
- Same root cause explains #656's "Duplicate: commit recorded" box failing while duplicate's *file write* succeeded — duplicate's commit is best-effort and its nil was ignored.

### Two corrections to the issue's framing

Both established by experiment, not by reading code:

1. **App Sandbox does not break the SwiftGit2 delete path.** #640's `/usr/bin/git`-under-sandbox problem did **not** survive the migration. A genuinely sandboxed process (ad-hoc-signed bundle carrying `com.apple.security.app-sandbox`, container-redirected `HOME`) runs the full `Repository.at` → `headHasEntry` → `remove` → `defaultSignature` → `commit` sequence successfully against a real `~/Sites/*.anglesite` package with the relocated git dir (`Source/.git` gitfile → `Config/repo.nosync`).
2. **#968 was not actually a prerequisite.** The failing step was isolatable without the alert, via an A/B on one variable:

| | unsandboxed | sandboxed |
|---|---|---|
| identity in repo-local config | ✅ commits | ✅ commits |
| identity only in `~/.gitconfig` | ✅ commits | ❌ `config value 'user.name' was not found` → rollback → silent no-op |

#968 is still a real bug worth fixing on its own — it's why this presented as "nothing happened" rather than a reportable error — but it no longer blocks this one.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 2693 tests pass (rebased onto current `main`). The only failures are `FoundationModelAssistant`'s two on-device cases ("Session ended without producing a response"); **verified pre-existing** by re-running that suite on a stashed (pristine) tree, where they fail identically.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**.
- [x] Regression tests: `processGitDelete`/`processGitCommit` now commit with the app identity when none is configured, and a configured identity still wins. The trigger is an **empty** repo-local `user.name`/`user.email` — that fails `defaultSignature()` deterministically even on a dev/CI machine with a real ambient global identity, which a merely-*absent* local identity would silently fall through to. The old malformed-config test's parse-failure half is **restored** as `realGitMalformedConfig` (review follow-up): an unparseable config fails `Repository.at` before identity resolution is reached, so a corrupt repo still returns nil rather than committing as the app — the test pins that ordering. Its other half (missing identity ⇒ nil) is the behavior being fixed.
- [x] Sandboxed end-to-end, no identity anywhere reachable, **with** the fix: file removed, delete commit recorded as `Anglesite <noreply@anglesite.app>`.

Not manually smoked in the GUI — this session had no interactive app session, so #969's original Navigator repro is still worth a pass by someone who does. The sandboxed-process harness above covers the mechanism end to end.

### Deliberately out of scope

`RepoBootstrap.publish`'s GitHub path deliberately *refuses* when no identity resolves (pinned by `publishInitializesRepoWhenNotYetOne`), so its `signatureFallback` seam is kept and only the substitution logging is unified — see the review thread. It has the same #969 exposure when publishing with a dirty tree, which deserves its own issue.

`InProcessEditPersistence.persist` has the same identity dependency, but it *throws* (surfaces) rather than failing silently, and it's the container-runtime edit-sync subsystem. Flagged for a follow-up rather than widened into this PR. `InProcessGit`'s commit shim is left as-is on purpose: it emulates the `git` CLI and already returns an actionable "set an identity" error, so mirroring git's own refusal is correct there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
