### PR TITLE
fix(ui): stop delete dialog dismissal cancelling itself (#968)

### DIFF
--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -652,11 +652,18 @@ struct SiteWindow: View {
         } message: {
             Text("Unsaved changes in the editor and inspector will be discarded.")
         }
+        // The setter has NO side effect, and each button is solely responsible for clearing
+        // `deleteConfirmation` — the same rule (and the same reason) as `MainPaneEditorView`'s
+        // conflict alert. A clearing setter is what made every content delete a silent no-op
+        // (#968/#969): SwiftUI runs it as the dialog dismisses, which lands *after* the Delete
+        // button's synchronous action but *before* the `Task` it spawns gets to run, so
+        // `confirmDelete()`'s `guard let item = deleteConfirmation` always saw nil and returned —
+        // no delete, no commit, and no error to raise the alert below.
         .confirmationDialog(
             contentDeleteTitle,
             isPresented: Binding(
                 get: { bindableModel.deleteConfirmation != nil },
-                set: { if !$0 { model.deleteConfirmation = nil } }),
+                set: { _ in }),
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) { Task { await model.confirmDelete() } }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1260,6 +1260,10 @@ final class SiteWindowModel {
             relPath = post.filePath
             deletedRoute = postRoute(for: post)
         } else {
+            // Reachable whenever the row outlived the graph entry behind it (a page deleted
+            // outside the app, a rescan mid-dialog). Reported rather than returned silently:
+            // an unexplained no-op here is exactly what #968 was raised about.
+            contentActionError = "\(item.title) is no longer part of this site's content."
             return
         }
 


### PR DESCRIPTION
## Summary

- Fixes #968. The delete confirmation dialog's `isPresented` setter cleared `deleteConfirmation`. SwiftUI runs that setter as the dialog dismisses — **after** the Delete button's synchronous action, but **before** the `Task` it spawns runs — so `confirmDelete()`'s `guard let item = deleteConfirmation` always saw `nil` and returned. Every content delete was a silent no-op, and nothing ever set `contentActionError`, so the "Couldn't complete that action" alert had nothing to present. The alert itself was never broken.
- The setter is now side-effect-free, with the buttons solely responsible for clearing the state — the rule (and the reasoning) that `MainPaneEditorView`'s conflict alert already documents.
- `confirmDelete()` also now reports its previously-silent "row outlived its content-graph entry" path instead of returning with no feedback.

Nine lines of change; the bulk of it is the comment explaining the ordering trap so it doesn't get reintroduced.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 2690 tests. The only failures are the on-device `FoundationModelAssistant` streaming cases ("Session ended without producing a response"), which reproduce in isolation and are environmental; `Sources/AnglesiteApp` isn't a SwiftPM target, so this diff can't affect that run either way.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED** (re-run after the rebase).
- [x] `scripts/check-localization-catalog.sh`, `scripts/check-xcodeproj-sync.sh` — both clean after the rebase.
- [x] Manual GUI smoke — **re-run against the rebased branch on current `main`, all cases pass.**

### How the root cause was established

`Sources/AnglesiteApp` has no test target, so this was verified with a standalone SwiftUI harness reproducing `SiteWindow`'s modifier chain — `NavigationSplitView` + `.inspector` + `.toolbar(id:)` + 24 sibling `.sheet`s + the delete `.confirmationDialog` + the error `.alert` in the same order — driven by a real `performClick` on the dialog's Delete button:

```
# pre-fix
>> clicking Delete
>> confirmDelete entered, deleteConfirmation=nil
>> RETURNED EARLY (guard)
t=0.25  err=false  sheets=[]

# post-fix
>> clicking Delete
>> confirmDelete entered, deleteConfirmation=Optional("foo")
t=0.25  err=true   sheets=[Couldn't complete that action / No file exists at src/pages/foo.md]
```

Instrumenting the button action pins the ordering: the action closure sees `Optional("foo")`, the setter nils it, and only then does the `Task` body run.

Driving the same harness *without* a click (setting state directly) presented the error alert correctly both before and after — which is why #968 read as an alert-presentation bug. The presentation chain, its depth, and the `model`-vs-`bindableModel` inconsistency named in the issue were all tested and are not implicated.

### Manual GUI smoke

Re-run after the rebase, on a Debug (ad-hoc signed, sandboxed) build of this branch against a throwaway `smoke-968.anglesite` with a fresh site UUID, clean tree, and a repo-local git identity (holding out #983's identity defect so this fix is tested alone). The container runtime isn't provisioned in this worktree, so Preview shows "Can't preview" throughout — irrelevant to the content-ops path.

| # | Case | Result |
|---|---|---|
| 1 | Select About → Edit ▸ Delete (⌘⌫) → Delete | Row gone, "Add Redirect" offered. `src/pages/about.md` removed, `anglesite: delete src/pages/about.md` committed, tree clean. |
| 2 | Skip the redirect, then **Edit ▸ Undo (⌘Z)** | File restored, `anglesite: restore src/pages/about.md` committed, row back, inspector reopened, tree clean. |
| 3 | `rm src/pages/404.astro` outside the app, then Delete the stale "Page Not Found" row | `Couldn't complete that action` / `No file exists at src/pages/404.astro` — the issue's own repro, now surfacing. |
| 4 | Duplicate (⌘D) on a page | `fresh-bread-daily-copy.astro` created and selected, `anglesite: duplicate page /fresh-bread-daily-copy` committed. |

Cases 1, 2 and 3 were all total no-ops before this change. Case 2 specifically exercises `main`'s new ⌘Z path from #954 on top of this fix — the combination that didn't exist when the branch was first smoked.

The dialog in cases 1 and 3 showed `main`'s current copy ("You can bring it back with Edit ▸ Undo"), and the window carried the #520 toolbar search field, both confirming the build under test was the rebased one.

## Rebase note

Rebased onto `d2fb621`. The branch originally also fixed the same setter bug on the post-delete **Undo alert**; `main` has since deleted that alert entirely in #954 (feat(#675): undo/redo for structural content operations), which replaced the modal Undo offer with real Edit ▸ Undo. That half of the change is dropped as obsolete rather than resurrected, along with the follow-up commit that corrected its Esc comment. `main`'s own `confirmDelete()` still carries the identical guard bug, so the core fix applies unchanged.

## Relationship to #969

#969 ("delete silently fails on a sandboxed build") describes the same GUI symptom. PR #983 has since established, by A/B against a real sandboxed process, that `processGitDelete` fails there on git identity: sandboxed `HOME` hides `~/.gitconfig`, `git_signature_default` fails, and the delete is rolled back leaving the tree byte-identical.

These are two independent defects on the same journey, and both have to land for delete to work:

- This PR: the Delete button never reaches `deleteContent` at all, because `confirmDelete()` returns at its first guard. That is sufficient on its own to explain the observed no-op, and it explains why Duplicate worked in the same session (it takes an `id` directly and has no confirmation dialog).
- #983: once the call *is* reached, the sandboxed commit fails on identity.

I have not confirmed which of the two #969's specific traces exercised. Details in [this comment](https://github.com/Anglesite/Anglesite-app/issues/969#issuecomment-5087006340).

## Spun out

- #989 — the Edit menu shows two enabled "Delete" items when a Navigator row is selected. Noticed during this smoke, present on `main`, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
