### PR TITLE
fix(git): use app identity for container edit sync (#969)

### DIFF
--- a/Sources/AnglesiteCore/InProcessEditPersistence.swift
+++ b/Sources/AnglesiteCore/InProcessEditPersistence.swift
@@ -10,11 +10,11 @@ import SwiftGit2
 public enum InProcessEditPersistence {
     public static func importBundle(_ bundleURL: URL, commit: String, into sourceDirectory: URL) async throws {
         try await Task.detached(priority: .userInitiated) {
-            try importBundleSync(bundleURL, commit: commit, into: sourceDirectory)
+            try await performImport(bundleURL, commit: commit, into: sourceDirectory)
         }.value
     }
 
-    private static func importBundleSync(_ bundleURL: URL, commit: String, into sourceDirectory: URL) throws {
+    private static func performImport(_ bundleURL: URL, commit: String, into sourceDirectory: URL) async throws {
         SwiftGit2Bootstrap.ensureInitialized
         let canonical = try result(Repository.at(sourceDirectory))
         guard case .success(let status) = canonical.status(), status.isEmpty else {
@@ -40,7 +40,15 @@ public enum InProcessEditPersistence {
         try materialize(tree: sourceTree, from: exported, into: sourceDirectory, prefix: "", paths: &sourcePaths)
         try removeMissing(tree: hostRoot, from: canonical, root: sourceDirectory, prefix: "", keeping: sourcePaths)
         _ = try result(canonical.addAll())
-        let signature = try result(canonical.defaultSignature())
+        // Resolved through `GitIdentity`, not `defaultSignature()` directly: under App Sandbox the
+        // user's ~/.gitconfig is unreadable, so on a stock machine (no *repo-local* identity) that
+        // call fails and takes the whole import with it — after `materialize`/`removeMissing` have
+        // already written the edit into the worktree. That leaves Source/ dirty with an uncommitted
+        // edit, which then trips this function's own `status.isEmpty` guard, so every subsequent
+        // overlay edit fails too until the user commits or resets by hand (#969). The host identity
+        // is what's recorded, as before — the guest's commit carries the container image's git
+        // identity, which is no closer to the user's than the app's own.
+        let signature = await GitIdentity.signature(for: canonical)
         _ = try result(canonical.commit(message: guestCommit.message, signature: signature))
     }
 

--- a/Tests/AnglesiteCoreTests/InProcessEditPersistenceTests.swift
+++ b/Tests/AnglesiteCoreTests/InProcessEditPersistenceTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+/// The container edit-sync import path: a commit made by the MCP sidecar inside the container is
+/// handed back to the host and replayed onto the canonical `Source/` repository.
+///
+/// These drive `importBundle` with the exported commit in a **repository directory** rather than
+/// the `.bundle` file `LocalContainerSiteRuntime.persistEdit` actually writes. That is not the
+/// scenario being dodged — it is the only one reachable: libgit2 has no bundle support whatsoever
+/// (#655's root cause, in this consumer #988), so `Repository.clone(from:)` fails with "could not
+/// find repository at …/x.bundle" for both a thin and a complete bundle, and `persistEdit` cannot
+/// complete today at all. Everything past that transport boundary — the divergence guards, the
+/// tree replay, and the commit under test here — is identical either way, so these should move
+/// onto the real artifact when #988 fixes the transport.
+///
+/// `.serialized` is load-bearing, not caution: run in parallel these two abort the whole test
+/// process (SIGABRT) inside libgit2's own error buffer — `git_error_set` → `git_str_grow` →
+/// `realloc` on a pointer libmalloc says was never allocated. The vendored libgit2 is built
+/// without `GIT_THREADS`, so its "thread-local" storage is a process-global array and its mutexes
+/// are no-ops (#994). Reproducible on demand by dropping this trait; remove it when #994 lands.
+@Suite(.serialized)
+struct InProcessEditPersistenceTests {
+    @Test("importBundle commits the overlay edit with the app identity when none is configured")
+    func importsWithAppFallbackIdentity() async throws {
+        // #969: under App Sandbox `HOME` is redirected into the app's container, so libgit2 can't
+        // read the user's ~/.gitconfig and `defaultSignature()` fails unless the site repo carries
+        // a *repo-local* identity — which a stock machine's doesn't. Worse than a clean refusal:
+        // the failure lands after the guest tree has already been written into the worktree, so
+        // the edit is left uncommitted and every later import trips the "canonical Source
+        // repository has uncommitted changes" guard on the way in.
+        //
+        // An empty repo-local user.name/user.email is the deterministic way to reproduce a
+        // `defaultSignature()` failure on a dev/CI machine that has a real ambient global identity
+        // (the same trigger `NativeContentOperationsTests` uses — a merely *absent* local identity
+        // would silently fall through to it, and libgit2's config-search-path cache is
+        // process-global, so mutating HOME mid-test can't truncate the chain the way the sandbox
+        // does).
+        let fixture = try await EditSyncFixture.make(hostIdentity: .none)
+        defer { fixture.cleanUp() }
+
+        try await InProcessEditPersistence.importBundle(
+            fixture.exported, commit: fixture.guestCommit, into: fixture.host)
+
+        #expect(try String(contentsOf: fixture.host.appendingPathComponent("p.astro"), encoding: .utf8) == "two\n")
+        #expect(try await fixture.hostAuthor() == "Anglesite <noreply@anglesite.app>")
+        #expect(try await fixture.hostSubject() == "overlay edit")
+        // Replayed, not fast-forwarded: the host records its own commit over the guest's tree.
+        #expect(try await fixture.hostHead() != fixture.guestCommit)
+        // The commit really landed — a signature failure would leave the replayed tree uncommitted.
+        #expect(try await fixture.hostStatus() == "")
+    }
+
+    @Test("importBundle prefers the repository's configured identity over the app fallback")
+    func importsWithConfiguredIdentity() async throws {
+        let fixture = try await EditSyncFixture.make(hostIdentity: .configured)
+        defer { fixture.cleanUp() }
+
+        try await InProcessEditPersistence.importBundle(
+            fixture.exported, commit: fixture.guestCommit, into: fixture.host)
+
+        #expect(try await fixture.hostAuthor() == "host <host@t.io>")
+    }
+}
+
+/// A host `Source/` repo plus the guest's export: one commit on top of the host's HEAD, on the
+/// `anglesite-persist` ref `LocalContainerSiteRuntime.persistEdit`'s guest script writes.
+private struct EditSyncFixture {
+    enum HostIdentity { case none, configured }
+
+    let root: URL
+    let host: URL
+    let exported: URL
+    let guestCommit: String
+
+    /// Call from a `defer` in the test — the fixture is built and used across `await`s, so it
+    /// can't clean up inside `make`.
+    func cleanUp() { try? FileManager.default.removeItem(at: root) }
+
+    static func make(hostIdentity: HostIdentity) async throws -> EditSyncFixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edit-sync-\(UUID().uuidString)", isDirectory: true)
+        let host = root.appendingPathComponent("Source", isDirectory: true)
+        let guest = root.appendingPathComponent("guest", isDirectory: true)
+        try FileManager.default.createDirectory(at: host, withIntermediateDirectories: true)
+
+        try await git(["init"], in: host)
+        try await git(["config", "user.email", "seed@t.io"], in: host)
+        try await git(["config", "user.name", "seed"], in: host)
+        try "one\n".write(to: host.appendingPathComponent("p.astro"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: host)
+        try await git(["commit", "-m", "seed"], in: host)
+
+        // The container's clone of the host repo, committing under the image's own git identity —
+        // which is no more the user's than the app's is, hence the host-side signature.
+        try await git(["clone", host.path, guest.path], in: root)
+        try await git(["config", "user.email", "guest@t.io"], in: guest)
+        try await git(["config", "user.name", "guest"], in: guest)
+        try "two\n".write(to: guest.appendingPathComponent("p.astro"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: guest)
+        try await git(["commit", "-m", "overlay edit"], in: guest)
+        let guestCommit = try await git(["rev-parse", "HEAD"], in: guest)
+        try await git(["update-ref", "refs/heads/anglesite-persist", guestCommit], in: guest)
+
+        // Set the host identity last, so the seed commit above could still be made.
+        switch hostIdentity {
+        case .none:
+            try await git(["config", "user.email", ""], in: host)
+            try await git(["config", "user.name", ""], in: host)
+        case .configured:
+            try await git(["config", "user.email", "host@t.io"], in: host)
+            try await git(["config", "user.name", "host"], in: host)
+        }
+        return EditSyncFixture(root: root, host: host, exported: guest, guestCommit: guestCommit)
+    }
+
+    func hostHead() async throws -> String { try await Self.git(["rev-parse", "HEAD"], in: host) }
+    func hostAuthor() async throws -> String { try await Self.git(["log", "-1", "--format=%an <%ae>"], in: host) }
+    func hostSubject() async throws -> String { try await Self.git(["log", "-1", "--format=%s"], in: host) }
+    func hostStatus() async throws -> String { try await Self.git(["status", "--porcelain"], in: host) }
+
+    @discardableResult
+    private static func git(_ arguments: [String], in directory: URL) async throws -> String {
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/git"), arguments: arguments, currentDirectoryURL: directory)
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## Summary

- Picks up the one `defaultSignature()` caller #983 deliberately left out: `InProcessEditPersistence`, the container-runtime edit-sync import. It now resolves through `GitIdentity.signature(for:)` like the content-operation paths.
- The "it throws, so failures surface" rationale for excluding it doesn't survive a closer look. The throw lands *after* `materialize`/`removeMissing` have already written the guest tree into the worktree, so a missing identity leaves `Source/` dirty with an uncommitted edit — which then trips this same function's `status.isEmpty` guard on the way in, failing every subsequent overlay edit until the user commits or resets by hand. On a stock machine (no repo-local identity, `~/.gitconfig` invisible under App Sandbox) that's the default outcome.
- `GitIdentity.signature(for:)` is async, so `importBundleSync` becomes `performImport` and awaits inside the existing `Task.detached`. The host identity is still what's recorded — the guest's commit carries the container image's git identity, no closer to the user's than the app's own.
- Adds the first tests for this file.

Follows #983, which has since merged; rebased onto `main` and no longer stacked.

### This call site is unreachable today — see #988

While writing the test I found `LocalContainerSiteRuntime.persistEdit` cannot complete at all: it hands `importBundle` a `.bundle` file, and libgit2 has no bundle support whatsoever, so `Repository.clone(from:)` fails 17 lines before the signature call with `could not find repository at …/edit.bundle`. Verified directly against the vendored SwiftGit2 fork for **both** thin (`^parent`, what the guest script produces) and complete (`--all`) bundles, `localClone` true and false — all four fail identically. Same root cause as #655, second consumer, this one wired up and shipping. Filed as #988.

So this PR closes a latent bug ahead of that transport fix rather than a live one. The tests therefore hand `importBundle` the exported commit in a **repository directory**, which exercises everything past the transport boundary — divergence guards, tree replay, commit — unchanged; they should move onto the real artifact when #988 lands.

### Second finding, not addressed here — see #994

The two new tests abort the whole test process (SIGABRT) if allowed to run in parallel, inside libgit2's own error buffer: `git_error_set` → `git_str_grow` → `realloc` on a pointer libmalloc reports was never allocated. Root cause traced to source: the `Anglesite/SwiftGit2` fork's `Package.swift` sets `LIBGIT2_NO_FEATURES_H` and hand-lists the feature defines, and **`GIT_THREADS` isn't among them**. In that mode `src/util/thread.c` backs `git_tlsdata_*` with a process-global `static tlsdata_value tlsdata_values[16]` instead of real TLS — and libgit2 stores its error state there — while `git_mutex_*` degrade to no-ops. So it's not just the error path: any two concurrent SwiftGit2 calls can crash the app, and there are four unsequenced call sites today. Filed as #994. `@Suite(.serialized)` works around it here and the trait points at #994.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 2322 tests. Only failures are `FoundationModelAssistant`'s "generate streams non-empty text" and "abandoning a generate stream mid-generation drains without trapping (#201)", both `Session ended without producing a response`. Confirmed pre-existing: they fail identically on the unmodified base branch with the change stashed.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`.
- [x] Regression coverage verified to gate the fix: reverting the source line back to `defaultSignature()` fails `importsWithAppFallbackIdentity` with `Signature cannot have an empty name or email`.
- [ ] Manual smoke — not possible for this path until #988; the import cannot run end-to-end today.
