### PR TITLE
fix(deps): bump SwiftGit2 for libgit2 GIT_THREADS (#994)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -310,7 +310,7 @@ var packageDependencies: [Package.Dependency] = []
 // pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
 // deliberately.
 packageDependencies.append(
-    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "65a16e39b09c16770a684ca29f3d5b242b9d0313")
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "9fa2f72762ce327980649303460cd5cfd0b92979")
 )
 
 // Component Editor slice 4 (spec §7, §4.3): STTextView-backed code panes ("Props & Data",

--- a/Tests/AnglesiteCoreTests/InProcessEditPersistenceTests.swift
+++ b/Tests/AnglesiteCoreTests/InProcessEditPersistenceTests.swift
@@ -13,13 +13,6 @@ import Testing
 /// complete today at all. Everything past that transport boundary — the divergence guards, the
 /// tree replay, and the commit under test here — is identical either way, so these should move
 /// onto the real artifact when #988 fixes the transport.
-///
-/// `.serialized` is load-bearing, not caution: run in parallel these two abort the whole test
-/// process (SIGABRT) inside libgit2's own error buffer — `git_error_set` → `git_str_grow` →
-/// `realloc` on a pointer libmalloc says was never allocated. The vendored libgit2 is built
-/// without `GIT_THREADS`, so its "thread-local" storage is a process-global array and its mutexes
-/// are no-ops (#994). Reproducible on demand by dropping this trait; remove it when #994 lands.
-@Suite(.serialized)
 struct InProcessEditPersistenceTests {
     @Test("importBundle commits the overlay edit with the app identity when none is configured")
     func importsWithAppFallbackIdentity() async throws {


### PR DESCRIPTION
## Summary

- Bumps the SwiftGit2 pin `65a16e39` → `9fa2f727` to pick up [Anglesite/SwiftGit2#3](https://github.com/Anglesite/SwiftGit2/pull/3), which adds `.define("GIT_THREADS", to: "1")` to the `Clibgit2` target. Closes #994.
- Removes the `@Suite(.serialized)` workaround from `InProcessEditPersistenceTests` — which doubles as the app-side proof the bump works: those two tests took the whole test process down with SIGABRT when run in parallel, and now pass.

#990 has merged; rebased onto `main` and no longer stacked.

### Why

The fork builds libgit2 with `LIBGIT2_NO_FEATURES_H`, so nothing is inferred from the platform — a feature exists only if the define list says so, and `GIT_THREADS` was absent even though libgit2's own CMake build defaults it on. That selected the single-threaded build: `git_tlsdata_*` backed by a process-wide `static tlsdata_value tlsdata_values[16]` instead of real TLS, and `git_mutex_*` compiled to no-ops. libgit2 keeps its error state in that storage, so two threads calling in at once grew one shared `git_str` and aborted in `realloc`.

Not just a test artifact: `NativeContentOperations`, `InboxSubmissionCommitter`, `InProcessEditPersistence`, and `RepoBootstrap` all call libgit2 with nothing sequencing them against each other, so any two overlapping git operations could crash the app.

Upstream carries the regression test (`AnglesiteThreadSafetySpec`): it crashes 3 runs out of 3 without the define and passes 5 out of 5 with it, and the full fork suite is green at 146 tests.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Not the sidecar pairing, but this does consume a separate repo: the dependency half is [Anglesite/SwiftGit2#3](https://github.com/Anglesite/SwiftGit2/pull/3), already merged to `anglesite/main` — this PR only moves the pin.

## Test plan

- [x] `swift test --package-path .` — 2727 tests. Only failures are `FoundationModelAssistant`'s two FM-session tests (`Session ended without producing a response`), confirmed pre-existing on an unmodified base earlier in this branch's history.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`.
- [x] `InProcessEditPersistenceTests` with the `.serialized` trait removed: passes 3 runs out of 3, where before the bump it SIGABRT'd every time.
- [ ] Manual smoke — n/a, no UI change.
