### PR TITLE
fix(ci): remove inert codeql-config.yml again

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,5 +1,0 @@
-# CodeQL configuration: analyze only languages present in this repo.
-# Swift + TypeScript/JavaScript; disable C/C++ (no source files).
-languages:
-  - javascript-typescript
-  - swift


### PR DESCRIPTION
## Summary

- `.github/codeql-config.yml` was deliberately removed in #943 because this repo uses GitHub's Default Setup for code scanning, which never reads this file.
- It was accidentally reintroduced by #952: a stray local commit (`a642a222`, "fix(ci): disable C++ CodeQL analysis") was sitting on the main checkout's HEAD and got swept into that PR's branch.
- This PR removes it again, restoring #943's outcome.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: N/A — CI hygiene only, no MCP schema change.

## Test plan

- [x] `swift test --package-path .` — N/A, no Swift code touched (CI config only)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — N/A, no app code touched
- [x] Manual smoke: N/A, deletes an inert config file consumed by nothing