### PR TITLE
feat(#878): SyncArtifact bundle-v2 codec on libgit2

### DIFF
--- a/Sources/AnglesiteCore/BundleArtifact.swift
+++ b/Sources/AnglesiteCore/BundleArtifact.swift
@@ -1,0 +1,462 @@
+#if canImport(Darwin)
+import Foundation
+import Clibgit2
+import SwiftGit2
+
+/// Git bundle v2 codec for `SyncArtifact` (#878): a text header of refs (branches + tags + HEAD,
+/// the #283 ref policy — `--branches --tags HEAD`) followed by a packfile.
+///
+/// **Why libgit2's raw C API, not a reimplemented packfile writer.** libgit2 has no *bundle*
+/// support (`git_clone`/fetch against a `.bundle` file fails outright — #655/#988) but it does
+/// expose the two primitives a bundle's packfile needs: `git_packbuilder` (write) and
+/// `git_indexer` (read). Neither is wrapped by the `SwiftGit2` Swift API this module otherwise
+/// uses, so this file imports `Clibgit2` directly — its module turns out to be importable from
+/// AnglesiteCore despite the fork's `Package.swift` only declaring the `SwiftGit2` product
+/// (verified empirically before writing this; SwiftPM makes a C target's module available to
+/// anything that transitively builds against it), so no fork change was needed. This is
+/// preferable to hand-rolling packfile delta compression and object serialization in Swift: the
+/// resulting file is byte-for-byte a real packfile, so `git bundle verify`, `git clone
+/// <bundle>`, and `git bundle create` interoperate directly (the acceptance bar for #878).
+///
+/// **Header/pack split.** The header is plain text (`renderHeader`/`parseHeader`); everything
+/// after its terminating blank line is passed straight through to/from libgit2 as opaque bytes —
+/// this codec never re-derives object hashes or re-encodes object content itself, so there's no
+/// risk of it silently diverging from git's own canonical object encoding.
+///
+/// **Concurrency.** Like `InProcessGit`, libgit2 calls here are synchronous and assume the caller
+/// serializes access — this codebase's libgit2 use isn't safe under uncoordinated concurrency
+/// (see `InProcessGit`'s doc comment and this module's `.serialized` test suites). Each call opens
+/// its own `Repository`/`git_indexer`/`git_packbuilder` handles and shares no state across calls.
+public struct BundleArtifact: SyncArtifact {
+    public init() {}
+
+    private static let signatureLine = "# v2 git bundle"
+
+    // MARK: - SyncArtifact
+
+    @discardableResult
+    public func write(from sourceDirectory: URL, to artifactURL: URL) throws -> [SyncArtifactRef] {
+        SwiftGit2Bootstrap.ensureInitialized
+        let repo = try Self.open(sourceDirectory)
+        let (refs, packData) = try Self.buildPack(repo: repo)
+        try Self.atomicWrite(header: Self.renderHeader(refs: refs), pack: packData, to: artifactURL)
+        return refs
+    }
+
+    public func refs(of artifactURL: URL) throws -> [SyncArtifactRef] {
+        try Self.parseHeader(Self.readData(artifactURL)).refs
+    }
+
+    public func verify(artifactURL: URL) throws {
+        SwiftGit2Bootstrap.ensureInitialized
+        let data = try Self.readData(artifactURL)
+        let header = try Self.parseHeader(data)
+        try Self.checkPackSignature(data, from: header.packOffset)
+        // Index into a scratch, throwaway repo so this exercises the real libgit2
+        // checksum/delta-resolution path without touching any real repository.
+        let scratch = try Self.makeScratchRepository()
+        defer { try? FileManager.default.removeItem(at: scratch.root) }
+        let stats = try Self.importPack(data: data, from: header.packOffset, into: scratch.repo)
+        guard stats.indexedObjects > 0 else { throw SyncArtifactError.emptyPack }
+    }
+
+    @discardableResult
+    public func fetch(into sourceDirectory: URL, namespace: String, from artifactURL: URL) throws -> [SyncArtifactRef] {
+        SwiftGit2Bootstrap.ensureInitialized
+        let data = try Self.readData(artifactURL)
+        let header = try Self.parseHeader(data)
+        try Self.checkPackSignature(data, from: header.packOffset)
+        let repo = try Self.open(sourceDirectory)
+        let stats = try Self.importPack(data: data, from: header.packOffset, into: repo)
+        guard stats.indexedObjects > 0 else { throw SyncArtifactError.emptyPack }
+        return try Self.landRefs(header.refs, namespace: namespace, into: repo)
+    }
+
+    // MARK: - Opening the repository
+
+    private static func open(_ sourceDirectory: URL) throws -> Repository {
+        switch Repository.at(sourceDirectory) {
+        case .success(let repo): return repo
+        case .failure(let error): throw SyncArtifactError.libgit2(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Header format
+
+    private struct ParsedHeader {
+        let refs: [SyncArtifactRef]
+        let prerequisites: [String]
+        /// Byte offset in the artifact's `Data` where the packfile begins.
+        let packOffset: Int
+    }
+
+    /// Reads one `\n`-terminated line starting at `offset`. Returns `nil` if no `\n` is found
+    /// before EOF (an unterminated/truncated line).
+    private static func readLine(_ data: Data, from offset: Int) -> (line: String, next: Int)? {
+        guard offset <= data.count else { return nil }
+        guard let newline = data[offset...].firstIndex(of: 0x0A) else { return nil }
+        let line = String(decoding: data[offset..<newline], as: UTF8.self)
+        return (line, newline + 1)
+    }
+
+    private static func parseHeader(_ data: Data) throws -> ParsedHeader {
+        guard let (first, afterFirst) = readLine(data, from: 0) else {
+            throw SyncArtifactError.truncatedHeader
+        }
+        guard first == signatureLine else {
+            if first.hasPrefix("# v") && first.hasSuffix(" git bundle") {
+                throw SyncArtifactError.unsupportedFormat(first)
+            }
+            throw SyncArtifactError.invalidSignature(first)
+        }
+
+        var offset = afterFirst
+        var refs: [SyncArtifactRef] = []
+        var prerequisites: [String] = []
+        while true {
+            guard let (line, next) = readLine(data, from: offset) else {
+                throw SyncArtifactError.truncatedHeader
+            }
+            offset = next
+            if line.isEmpty { break } // the blank line that ends the header
+            if line.hasPrefix("-") {
+                let oid = String(line.dropFirst().prefix(40))
+                guard oid.count == 40, oid.allSatisfy(\.isHexDigit) else {
+                    throw SyncArtifactError.malformedRefLine(line)
+                }
+                prerequisites.append(oid)
+            } else {
+                let parts = line.split(separator: " ", maxSplits: 1)
+                guard parts.count == 2, parts[0].count == 40, parts[0].allSatisfy(\.isHexDigit), !parts[1].isEmpty else {
+                    throw SyncArtifactError.malformedRefLine(line)
+                }
+                refs.append(SyncArtifactRef(oid: String(parts[0]), name: String(parts[1])))
+            }
+        }
+        return ParsedHeader(refs: refs, prerequisites: prerequisites, packOffset: offset)
+    }
+
+    private static func renderHeader(refs: [SyncArtifactRef]) -> Data {
+        var text = signatureLine + "\n"
+        for ref in refs {
+            text += "\(ref.oid) \(ref.name)\n"
+        }
+        text += "\n"
+        return Data(text.utf8)
+    }
+
+    private static func checkPackSignature(_ data: Data, from offset: Int) throws {
+        guard offset < data.count else { throw SyncArtifactError.emptyPack }
+        let packBytes = data[offset...]
+        guard packBytes.count >= 12 else { throw SyncArtifactError.corruptPack("packfile is too short to be valid") }
+        guard packBytes.prefix(4).elementsEqual("PACK".utf8) else {
+            throw SyncArtifactError.corruptPack("missing the packfile's \"PACK\" signature")
+        }
+    }
+
+    // MARK: - I/O
+
+    private static func readData(_ artifactURL: URL) throws -> Data {
+        guard FileManager.default.fileExists(atPath: artifactURL.path) else {
+            throw SyncArtifactError.notFound(artifactURL)
+        }
+        do {
+            return try Data(contentsOf: artifactURL)
+        } catch {
+            throw SyncArtifactError.io(error.localizedDescription)
+        }
+    }
+
+    /// Writes `header + pack` to a sibling temp file, then swaps it into place — so a reader
+    /// never observes a half-written artifact. (The caller, `SyncEngine`, layers its own
+    /// `NSFileCoordinator` swap on top when the destination is an iCloud item; this is
+    /// self-contained atomicity for direct callers and tests.)
+    private static func atomicWrite(header: Data, pack: Data, to artifactURL: URL) throws {
+        let directory = artifactURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            throw SyncArtifactError.io(error.localizedDescription)
+        }
+        let tmpURL = directory.appendingPathComponent(".\(artifactURL.lastPathComponent).tmp-\(UUID().uuidString)")
+        var combined = header
+        combined.append(pack)
+        do {
+            try combined.write(to: tmpURL, options: .atomic)
+        } catch {
+            try? FileManager.default.removeItem(at: tmpURL)
+            throw SyncArtifactError.io(error.localizedDescription)
+        }
+        do {
+            _ = try FileManager.default.replaceItemAt(artifactURL, withItemAt: tmpURL)
+        } catch {
+            try? FileManager.default.removeItem(at: tmpURL)
+            throw SyncArtifactError.io(error.localizedDescription)
+        }
+    }
+
+    // MARK: - libgit2 error plumbing
+
+    private static func lastErrorMessage() -> String {
+        if let error = git_error_last() {
+            return String(cString: error.pointee.message)
+        }
+        return "unknown libgit2 error"
+    }
+
+    private static func checkOK(_ code: Int32, _ context: String) throws {
+        guard code == GIT_OK.rawValue else {
+            throw SyncArtifactError.libgit2("\(context) failed (\(code)): \(lastErrorMessage())")
+        }
+    }
+
+    // MARK: - Write: packbuilder
+
+    /// Walks branches + tags + HEAD, inserting every reachable commit/tree/blob (and, for
+    /// annotated tags, the tag object itself) into a `git_packbuilder`, then writes the result to
+    /// an in-memory buffer. Objects are inserted in *recency* order — branch tips first, via a
+    /// single shared `git_revwalk` — matching libgit2's own guidance for pack locality.
+    private static func buildPack(repo: Repository) throws -> (refs: [SyncArtifactRef], packData: Data) {
+        var refs: [SyncArtifactRef] = []
+        var pushedAnyRoot = false
+
+        var walk: OpaquePointer?
+        try checkOK(git_revwalk_new(&walk, repo.pointer), "git_revwalk_new")
+        guard let walk else { throw SyncArtifactError.libgit2("git_revwalk_new returned no walk") }
+        defer { git_revwalk_free(walk) }
+
+        var packbuilder: OpaquePointer?
+        try checkOK(git_packbuilder_new(&packbuilder, repo.pointer), "git_packbuilder_new")
+        guard let packbuilder else { throw SyncArtifactError.libgit2("git_packbuilder_new returned no builder") }
+        defer { git_packbuilder_free(packbuilder) }
+
+        func pushWalk(_ oid: git_oid) throws {
+            var oid = oid
+            try checkOK(git_revwalk_push(walk, &oid), "git_revwalk_push")
+            pushedAnyRoot = true
+        }
+        func insert(_ oid: git_oid, name: String?) throws {
+            var oid = oid
+            try checkOK(git_packbuilder_insert(packbuilder, &oid, name), "git_packbuilder_insert")
+            pushedAnyRoot = true
+        }
+        func insertRecur(_ oid: git_oid, name: String?) throws {
+            var oid = oid
+            try checkOK(git_packbuilder_insert_recur(packbuilder, &oid, name), "git_packbuilder_insert_recur")
+            pushedAnyRoot = true
+        }
+        /// Peels `object` toward `targetType`, returning its oid on success or `nil` if it can't
+        /// be peeled that far (e.g. peeling a tag-to-a-blob toward `GIT_OBJECT_COMMIT`).
+        func peel(_ object: OpaquePointer, to targetType: git_object_t) -> git_oid? {
+            var peeled: OpaquePointer?
+            guard git_object_peel(&peeled, object, targetType) == GIT_OK.rawValue, let peeled else { return nil }
+            defer { git_object_free(peeled) }
+            return git_object_id(peeled)?.pointee
+        }
+
+        // Local branches (refs/heads/*).
+        var branchIterator: OpaquePointer?
+        try checkOK(git_branch_iterator_new(&branchIterator, repo.pointer, GIT_BRANCH_LOCAL), "git_branch_iterator_new")
+        guard let branchIterator else { throw SyncArtifactError.libgit2("git_branch_iterator_new returned no iterator") }
+        defer { git_branch_iterator_free(branchIterator) }
+        while true {
+            var refPointer: OpaquePointer?
+            var branchType = GIT_BRANCH_LOCAL
+            let result = git_branch_next(&refPointer, &branchType, branchIterator)
+            if result == GIT_ITEROVER.rawValue { break }
+            try checkOK(result, "git_branch_next")
+            guard let refPointer else { break }
+            defer { git_reference_free(refPointer) }
+            guard let targetPointer = git_reference_target(refPointer) else { continue } // symbolic; skip
+            let name = String(cString: git_reference_name(refPointer))
+            let oid = targetPointer.pointee
+            refs.append(SyncArtifactRef(oid: OID(oid).description, name: name))
+            try pushWalk(oid)
+        }
+
+        // Tags (refs/tags/*). The header records each ref's *direct* target — the tag object's
+        // own oid for an annotated tag, matching `git show-ref`/stock bundle output — while the
+        // packbuilder also needs the tag object itself (a revwalk never visits it) and, peeled,
+        // whatever it ultimately points at.
+        var tagNames = git_strarray()
+        try checkOK(git_tag_list(&tagNames, repo.pointer), "git_tag_list")
+        defer { git_strarray_free(&tagNames) }
+        for index in 0..<tagNames.count {
+            guard let cName = tagNames.strings[index] else { continue }
+            let shortName = String(cString: cName)
+            let refName = "refs/tags/\(shortName)"
+
+            var tagRefPointer: OpaquePointer?
+            try checkOK(git_reference_lookup(&tagRefPointer, repo.pointer, refName), "git_reference_lookup")
+            guard let tagRefPointer else { continue }
+            defer { git_reference_free(tagRefPointer) }
+            guard let targetPointer = git_reference_target(tagRefPointer) else { continue }
+            let targetOID = targetPointer.pointee
+            refs.append(SyncArtifactRef(oid: OID(targetOID).description, name: refName))
+
+            var object: OpaquePointer?
+            var lookupOID = targetOID
+            try checkOK(git_object_lookup(&object, repo.pointer, &lookupOID, GIT_OBJECT_ANY), "git_object_lookup")
+            guard let object else { continue }
+            defer { git_object_free(object) }
+
+            switch git_object_type(object) {
+            case GIT_OBJECT_TAG:
+                try insert(targetOID, name: shortName) // the tag object itself
+                if let commitOID = peel(object, to: GIT_OBJECT_COMMIT) {
+                    try pushWalk(commitOID)
+                } else if let treeOID = peel(object, to: GIT_OBJECT_TREE) {
+                    try insertRecur(treeOID, name: nil)
+                } else if let blobOID = peel(object, to: GIT_OBJECT_BLOB) {
+                    try insert(blobOID, name: nil)
+                }
+            case GIT_OBJECT_COMMIT:
+                try pushWalk(targetOID)
+            default: // lightweight tag pointing straight at a tree or blob
+                try insertRecur(targetOID, name: shortName)
+            }
+        }
+
+        // HEAD — informational (which branch is "default"); GIT_EUNBORNBRANCH on a brand-new
+        // repo with no commits yet is expected, not an error.
+        var headRefPointer: OpaquePointer?
+        let headResult = git_repository_head(&headRefPointer, repo.pointer)
+        if headResult == GIT_OK.rawValue, let headRefPointer {
+            defer { git_reference_free(headRefPointer) }
+            if let targetPointer = git_reference_target(headRefPointer) {
+                let oid = targetPointer.pointee
+                refs.append(SyncArtifactRef(oid: OID(oid).description, name: "HEAD"))
+                try pushWalk(oid)
+            }
+        } else if headResult != GIT_EUNBORNBRANCH.rawValue && headResult != GIT_ENOTFOUND.rawValue {
+            try checkOK(headResult, "git_repository_head")
+        }
+
+        guard pushedAnyRoot else { throw SyncArtifactError.noRefsToWrite }
+
+        try checkOK(git_packbuilder_insert_walk(packbuilder, walk), "git_packbuilder_insert_walk")
+
+        var buf = git_buf(ptr: nil, reserved: 0, size: 0)
+        try checkOK(git_packbuilder_write_buf(&buf, packbuilder), "git_packbuilder_write_buf")
+        defer { git_buf_dispose(&buf) }
+        let packData = Data(bytes: buf.ptr, count: buf.size)
+
+        return (refs, packData)
+    }
+
+    // MARK: - Read: indexer
+
+    private struct IndexStats {
+        let indexedObjects: UInt32
+    }
+
+    /// Feeds `data[offset...]` through `git_indexer` into `repo`'s object database. Passing the
+    /// repo's own odb lets the indexer resolve a *thin* pack (one whose deltas reference objects
+    /// the sender assumed the receiver already has) against locally-available bases; a full,
+    /// non-thin pack (what `write(from:to:)` always produces) ignores it. `git_odb_refresh`
+    /// afterward makes the newly-written pack visible to a `Repository` that was already open
+    /// when it landed.
+    private static func importPack(data: Data, from offset: Int, into repo: Repository) throws -> IndexStats {
+        var odb: OpaquePointer?
+        try checkOK(git_repository_odb(&odb, repo.pointer), "git_repository_odb")
+        guard let odb else { throw SyncArtifactError.libgit2("git_repository_odb returned no odb") }
+        defer { git_odb_free(odb) }
+
+        guard let gitDirCString = git_repository_path(repo.pointer) else {
+            throw SyncArtifactError.libgit2("git_repository_path returned no path")
+        }
+        let packDirectory = URL(fileURLWithPath: String(cString: gitDirCString))
+            .appendingPathComponent("objects", isDirectory: true)
+            .appendingPathComponent("pack", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: packDirectory, withIntermediateDirectories: true)
+        } catch {
+            throw SyncArtifactError.io(error.localizedDescription)
+        }
+
+        var options = git_indexer_options()
+        try checkOK(git_indexer_options_init(&options, UInt32(GIT_INDEXER_OPTIONS_VERSION)), "git_indexer_options_init")
+        options.verify = 1
+
+        var indexer: OpaquePointer?
+        let newResult = packDirectory.withUnsafeFileSystemRepresentation { path in
+            git_indexer_new(&indexer, path, 0, odb, &options)
+        }
+        try checkOK(newResult, "git_indexer_new")
+        guard let indexer else { throw SyncArtifactError.libgit2("git_indexer_new returned no indexer") }
+        defer { git_indexer_free(indexer) }
+
+        var stats = git_indexer_progress()
+        let packBytes = data[offset...]
+        let appendResult: Int32 = packBytes.withUnsafeBytes { raw in
+            git_indexer_append(indexer, raw.baseAddress, raw.count, &stats)
+        }
+        guard appendResult == GIT_OK.rawValue else {
+            throw SyncArtifactError.corruptPack(lastErrorMessage())
+        }
+        guard git_indexer_commit(indexer, &stats) == GIT_OK.rawValue else {
+            throw SyncArtifactError.corruptPack(lastErrorMessage())
+        }
+        try checkOK(git_odb_refresh(odb), "git_odb_refresh")
+
+        return IndexStats(indexedObjects: stats.indexed_objects)
+    }
+
+    // MARK: - Read: landing refs
+
+    /// Creates `refs/remotes/<namespace>/<name>` for every header branch and
+    /// `refs/remotes/<namespace>/tags/<name>` for every header tag. `HEAD` is metadata only — no
+    /// ref is created for it, matching `BundleSync`'s own synthetic-remote convention (its
+    /// `defaultBranch` was likewise derived, never persisted as a ref).
+    private static func landRefs(_ headerRefs: [SyncArtifactRef], namespace: String, into repo: Repository) throws -> [SyncArtifactRef] {
+        var landed: [SyncArtifactRef] = []
+        for ref in headerRefs {
+            let mappedName: String
+            if ref.name.hasPrefix("refs/heads/") {
+                mappedName = "refs/remotes/\(namespace)/\(ref.name.dropFirst("refs/heads/".count))"
+            } else if ref.name.hasPrefix("refs/tags/") {
+                mappedName = "refs/remotes/\(namespace)/tags/\(ref.name.dropFirst("refs/tags/".count))"
+            } else {
+                continue // "HEAD" (or anything else a foreign bundle might carry) — informational only
+            }
+
+            guard let parsedOID = OID(string: ref.oid) else {
+                throw SyncArtifactError.malformedRefLine("\(ref.oid) \(ref.name)")
+            }
+            var oid = parsedOID.oid
+            var createdRef: OpaquePointer?
+            let result = mappedName.withCString { cName in
+                git_reference_create(&createdRef, repo.pointer, cName, &oid, 1, nil)
+            }
+            try checkOK(result, "git_reference_create")
+            if let createdRef { git_reference_free(createdRef) }
+
+            landed.append(SyncArtifactRef(oid: ref.oid, name: mappedName))
+        }
+        return landed
+    }
+
+    // MARK: - Verify: scratch repository
+
+    private struct ScratchRepository {
+        let root: URL
+        let repo: Repository
+    }
+
+    private static func makeScratchRepository() throws -> ScratchRepository {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("anglesite-bundle-verify-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        } catch {
+            throw SyncArtifactError.io(error.localizedDescription)
+        }
+        switch Repository.create(at: root) {
+        case .success(let repo): return ScratchRepository(root: root, repo: repo)
+        case .failure(let error):
+            try? FileManager.default.removeItem(at: root)
+            throw SyncArtifactError.libgit2(error.localizedDescription)
+        }
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/SyncArtifact.swift
+++ b/Sources/AnglesiteCore/SyncArtifact.swift
@@ -1,0 +1,110 @@
+#if canImport(Darwin)
+import Foundation
+
+/// A single ref recorded in a sync artifact: `oid` is the ref's direct target (a 40-hex SHA-1),
+/// `name` is its full name (`refs/heads/<n>`, `refs/tags/<n>`, or the literal `HEAD`) — the same
+/// shape `git show-ref`/`git bundle list-heads` produce. For an annotated tag, `oid` is the tag
+/// object's own id, not the peeled commit — matching stock git's own bundle/show-ref convention.
+public struct SyncArtifactRef: Sendable, Equatable, Hashable, Codable {
+    public let oid: String
+    public let name: String
+
+    public init(oid: String, name: String) {
+        self.oid = oid
+        self.name = name
+    }
+}
+
+/// Errors a `SyncArtifact` codec can raise. Cases distinguish "this isn't our problem to fix"
+/// (malformed/corrupt input — the caller should treat the artifact as untrustworthy) from
+/// ordinary I/O and libgit2 failures.
+public enum SyncArtifactError: Error, Equatable, Sendable, LocalizedError {
+    /// No file exists at the given artifact URL.
+    case notFound(URL)
+    /// The first line isn't a recognized bundle signature at all.
+    case invalidSignature(String)
+    /// The signature names a bundle format version this codec doesn't implement (only v2 is
+    /// supported).
+    case unsupportedFormat(String)
+    /// The header never reached its terminating blank line before EOF.
+    case truncatedHeader
+    /// A header line (prerequisite or ref) doesn't match `<40-hex> <rest>`.
+    case malformedRefLine(String)
+    /// The header parsed, but there's no packfile data after it.
+    case emptyPack
+    /// The packfile is present but fails libgit2's own indexing/checksum validation (e.g. a torn
+    /// pack cut off mid-object or before its trailer).
+    case corruptPack(String)
+    /// `write(from:to:)` was asked to capture a repository with no commits and no refs — there's
+    /// nothing to bundle yet.
+    case noRefsToWrite
+    /// A libgit2 call failed for a reason unrelated to malformed input (e.g. the source directory
+    /// isn't a repository at all).
+    case libgit2(String)
+    /// A filesystem operation (read/write/temp-file swap) failed.
+    case io(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notFound(let url):
+            return "no sync artifact found at \(url.path)."
+        case .invalidSignature(let line):
+            return "not a git bundle (expected \"# v2 git bundle\", found \"\(line)\")."
+        case .unsupportedFormat(let line):
+            return "unsupported bundle format: \"\(line)\" — only v2 bundles are supported."
+        case .truncatedHeader:
+            return "the artifact's header is truncated (missing the blank line that ends it)."
+        case .malformedRefLine(let line):
+            return "malformed bundle header line: \"\(line)\"."
+        case .emptyPack:
+            return "the artifact has no packfile data."
+        case .corruptPack(let reason):
+            return "the artifact's packfile is corrupt: \(reason)"
+        case .noRefsToWrite:
+            return "this repository has no commits yet — nothing to write."
+        case .libgit2(let reason):
+            return "git operation failed: \(reason)"
+        case .io(let reason):
+            return "couldn't read or write the sync artifact: \(reason)"
+        }
+    }
+}
+
+/// A codec that captures a git repository's history into (and restores it from) a single-file
+/// artifact — the transport unit `SyncEngine` (#879) moves through iCloud (design doc
+/// `2026-07-21-icloud-git-sync-design.md` §2). Swappable behind this seam: the primary
+/// implementation is `BundleArtifact` (git bundle v2 on libgit2); the design names a
+/// compressed-bare-repo-archive fallback if bundle v2 ever proves unworkable, without either
+/// `SyncEngine` or this protocol needing to change.
+///
+/// Every method here does real, potentially slow file/git I/O — conforming types are expected to
+/// be cheap value types with no shared mutable state (see `BundleArtifact`), and callers are
+/// responsible for keeping libgit2 access serialized the same way the rest of this module's
+/// git-touching code does (libgit2 is not safe for uncoordinated concurrent use here).
+public protocol SyncArtifact: Sendable {
+    /// Writes an artifact at `artifactURL` capturing every object reachable from
+    /// `sourceDirectory`'s local branches, tags, and HEAD (the #283 ref policy: `--branches
+    /// --tags HEAD`). Returns the refs written. Throws `SyncArtifactError.noRefsToWrite` if the
+    /// repository has no commits yet.
+    @discardableResult
+    func write(from sourceDirectory: URL, to artifactURL: URL) throws -> [SyncArtifactRef]
+
+    /// Reads the refs recorded in the artifact at `artifactURL`'s header, without touching any
+    /// repository or importing any objects.
+    func refs(of artifactURL: URL) throws -> [SyncArtifactRef]
+
+    /// Imports the artifact's objects into `sourceDirectory`'s repository and lands its refs
+    /// under a synthetic `refs/remotes/<namespace>/...` namespace (branches at
+    /// `refs/remotes/<namespace>/<name>`, tags at `refs/remotes/<namespace>/tags/<name>`) — never
+    /// the repository's real `refs/heads/*`/`refs/tags/*`, mirroring how `BundleSync` fetched
+    /// into its own `icloud` remote namespace. The caller (`SyncEngine`) reconciles from there.
+    /// Returns the namespaced refs actually created.
+    @discardableResult
+    func fetch(into sourceDirectory: URL, namespace: String, from artifactURL: URL) throws -> [SyncArtifactRef]
+
+    /// Validates that the artifact at `artifactURL` is well-formed — header parses, packfile
+    /// checksum and object graph are intact — without importing it into any repository. Throws on
+    /// any defect; returns normally when valid.
+    func verify(artifactURL: URL) throws
+}
+#endif

--- a/Tests/AnglesiteCoreTests/BundleArtifactInteropTests.swift
+++ b/Tests/AnglesiteCoreTests/BundleArtifactInteropTests.swift
@@ -1,0 +1,95 @@
+#if canImport(Darwin)
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+/// Proves `BundleArtifact` interoperates with real git in both directions — the acceptance bar
+/// from issue #878: "stock `git clone our.bundle` succeeds; we can read a bundle produced by
+/// stock `git bundle create`." `.enabled(if:)` skips cleanly wherever system git is unavailable
+/// (matching `RepoRelocatorInteropTests`), so this still runs in CI where git is present.
+///
+/// .serialized: libgit2 isn't safe for uncoordinated concurrent use in this codebase.
+@Suite("BundleArtifact system-git interop", .serialized) struct BundleArtifactInteropTests {
+    static var gitAvailable: Bool { FileManager.default.isExecutableFile(atPath: "/usr/bin/git") }
+
+    @discardableResult
+    private func git(_ arguments: [String], in dir: URL) async throws -> String {
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: dir
+        )
+        guard result.exitCode == 0 else {
+            Issue.record("fixture git \(arguments.joined(separator: " ")) exited \(result.exitCode): \(result.stderr)")
+            throw FixtureError.gitFailed
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private enum FixtureError: Error { case gitFailed }
+
+    private func makeRepo() async throws -> URL {
+        let dir = try makeTempDir(prefix: "bundleartifact-interop-work")
+        try await git(["init", "-b", "main"], in: dir)
+        try await git(["config", "user.name", "Test"], in: dir)
+        try await git(["config", "user.email", "test@example.com"], in: dir)
+        try "hello".write(to: dir.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: dir)
+        try await git(["commit", "-m", "first"], in: dir)
+        try "world".write(to: dir.appendingPathComponent("world.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: dir)
+        try await git(["commit", "-m", "second"], in: dir)
+        try await git(["tag", "-a", "v1", "-m", "release"], in: dir)
+        return dir
+    }
+
+    @Test(
+        "stock `git clone` succeeds against a bundle BundleArtifact wrote",
+        .enabled(if: BundleArtifactInteropTests.gitAvailable, "requires /usr/bin/git")
+    )
+    func stockGitClonesOurBundle() async throws {
+        let source = try await makeRepo()
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-interop-out").appendingPathComponent("source.bundle")
+        try BundleArtifact().write(from: source, to: bundleURL)
+
+        let cloneDest = try makeTempDir(prefix: "bundleartifact-interop-clone").appendingPathComponent("clone")
+        let clone = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git", "clone", bundleURL.path, cloneDest.path],
+            currentDirectoryURL: bundleURL.deletingLastPathComponent()
+        )
+        #expect(clone.exitCode == 0)
+        #expect(FileManager.default.fileExists(atPath: cloneDest.appendingPathComponent("world.txt").path))
+        let log = try await git(["log", "--oneline"], in: cloneDest)
+        #expect(log.contains("second"))
+        let expectedHead = try await git(["rev-parse", "HEAD"], in: source)
+        let clonedHead = try await git(["rev-parse", "HEAD"], in: cloneDest)
+        #expect(clonedHead == expectedHead)
+    }
+
+    @Test(
+        "BundleArtifact reads a bundle produced by stock `git bundle create`",
+        .enabled(if: BundleArtifactInteropTests.gitAvailable, "requires /usr/bin/git")
+    )
+    func readsStockGitBundle() async throws {
+        let source = try await makeRepo()
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-interop-stock").appendingPathComponent("stock.bundle")
+        try await git(["bundle", "create", bundleURL.path, "--branches", "--tags", "HEAD"], in: source)
+
+        let artifact = BundleArtifact()
+        let refs = try artifact.refs(of: bundleURL)
+        let expectedHead = try await git(["rev-parse", "HEAD"], in: source)
+        #expect(refs.first { $0.name == "refs/heads/main" }?.oid == expectedHead)
+        #expect(refs.first { $0.name == "HEAD" }?.oid == expectedHead)
+
+        let target = try makeTempDir(prefix: "bundleartifact-interop-stock-target")
+        try await git(["init", "-b", "placeholder"], in: target)
+        let landed = try artifact.fetch(into: target, namespace: "icloud", from: bundleURL)
+        #expect(landed.first { $0.name == "refs/remotes/icloud/main" }?.oid == expectedHead)
+
+        let show = try await git(["show", "\(expectedHead):world.txt"], in: target)
+        #expect(show == "world")
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/BundleArtifactTests.swift
+++ b/Tests/AnglesiteCoreTests/BundleArtifactTests.swift
@@ -1,0 +1,228 @@
+#if canImport(Darwin)
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+/// `BundleArtifact` implements `SyncArtifact` as a git bundle v2 (#878): a text header of refs
+/// followed by a packfile, written via `git_packbuilder` and read via `git_indexer` — libgit2 has
+/// no native bundle support (#655/#988), so this codec owns the file format itself.
+///
+/// Fixtures are built with subprocess git (tests are unsandboxed), matching `InProcessGitTests`'
+/// convention of cross-checking the in-process implementation against real git semantics rather
+/// than the implementation against itself.
+///
+/// .serialized: libgit2 isn't safe for uncoordinated concurrent use in this codebase.
+@Suite("BundleArtifact", .serialized) struct BundleArtifactTests {
+
+    // MARK: - Fixtures
+
+    @discardableResult
+    private func git(_ arguments: [String], in dir: URL) async throws -> String {
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: dir
+        )
+        guard result.exitCode == 0 else {
+            Issue.record("fixture git \(arguments.joined(separator: " ")) exited \(result.exitCode): \(result.stderr)")
+            throw FixtureError.gitFailed
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private enum FixtureError: Error { case gitFailed }
+
+    /// A repo on branch `main` with two commits, a second branch `feature`, an annotated tag
+    /// `v1` on `main`, and a lightweight tag `light` on `feature` — enough shape to exercise
+    /// every ref kind the #283 policy captures.
+    private func makeRichRepo() async throws -> URL {
+        let dir = try makeTempDir(prefix: "bundleartifact-work")
+        try await git(["init", "-b", "main"], in: dir)
+        try await git(["config", "user.name", "Test"], in: dir)
+        try await git(["config", "user.email", "test@example.com"], in: dir)
+        // A host with `tag.gpgsign = true` in its global config would otherwise force
+        // implicit annotation (and a GPG-signing prompt) on the lightweight `light` tag below —
+        // fixtures must not depend on the host's git config.
+        try await git(["config", "tag.gpgsign", "false"], in: dir)
+        try "one".write(to: dir.appendingPathComponent("one.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: dir)
+        try await git(["commit", "-m", "first"], in: dir)
+        try await git(["tag", "-a", "v1", "-m", "release 1"], in: dir)
+
+        try await git(["checkout", "-b", "feature"], in: dir)
+        try "two".write(to: dir.appendingPathComponent("two.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: dir)
+        try await git(["commit", "-m", "second"], in: dir)
+        try await git(["tag", "light"], in: dir)
+
+        try await git(["checkout", "main"], in: dir)
+        return dir
+    }
+
+    private func headOID(_ ref: String, in dir: URL) async throws -> String {
+        try await git(["rev-parse", ref], in: dir)
+    }
+
+    // MARK: - Round trip
+
+    @Test("write then fetch reproduces every branch, tag, and HEAD oid exactly")
+    func roundTripReproducesRefs() async throws {
+        let source = try await makeRichRepo()
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-out").appendingPathComponent("source.bundle")
+
+        let artifact = BundleArtifact()
+        let written = try artifact.write(from: source, to: bundleURL)
+        #expect(!written.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: bundleURL.path))
+
+        let mainOID = try await headOID("main", in: source)
+        let featureOID = try await headOID("feature", in: source)
+        let v1OID = try await headOID("v1^{}", in: source) // peeled — compare against the writer's own record below
+        let v1TagOID = try await git(["rev-parse", "v1"], in: source) // the tag object itself
+        let lightOID = try await headOID("light", in: source)
+
+        func ref(_ name: String) -> String? { written.first { $0.name == name }?.oid }
+        #expect(ref("refs/heads/main") == mainOID)
+        #expect(ref("refs/heads/feature") == featureOID)
+        #expect(ref("refs/tags/v1") == v1TagOID) // annotated tag: the tag object's own oid, not peeled
+        #expect(ref("refs/tags/light") == lightOID)
+        #expect(ref("HEAD") == mainOID)
+        _ = v1OID
+
+        // Fetch into a fresh, empty repo under a synthetic namespace.
+        let target = try makeTempDir(prefix: "bundleartifact-target")
+        try await git(["init", "-b", "placeholder"], in: target)
+        try await git(["config", "user.name", "Test"], in: target)
+        try await git(["config", "user.email", "test@example.com"], in: target)
+
+        let landed = try artifact.fetch(into: target, namespace: "icloud", from: bundleURL)
+        #expect(!landed.isEmpty)
+
+        func landedRef(_ name: String) -> String? { landed.first { $0.name == name }?.oid }
+        #expect(landedRef("refs/remotes/icloud/main") == mainOID)
+        #expect(landedRef("refs/remotes/icloud/feature") == featureOID)
+        #expect(landedRef("refs/remotes/icloud/tags/v1") == v1TagOID)
+        #expect(landedRef("refs/remotes/icloud/tags/light") == lightOID)
+        // HEAD is informational only — no `refs/remotes/icloud/HEAD` is created.
+        #expect(landed.allSatisfy { $0.name != "refs/remotes/icloud/HEAD" })
+
+        // Objects genuinely landed, not just refs pointing at nothing: content is readable.
+        let show = try await git(["show", "\(mainOID):one.txt"], in: target)
+        #expect(show == "one")
+        let showFeature = try await git(["show", "\(featureOID):two.txt"], in: target)
+        #expect(showFeature == "two")
+        let tagBody = try await git(["cat-file", "-p", v1TagOID], in: target)
+        #expect(tagBody.contains("release 1"))
+    }
+
+    @Test("refs(of:) reads the header without importing anything")
+    func refsWithoutImport() async throws {
+        let source = try await makeRichRepo()
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-out2").appendingPathComponent("source.bundle")
+        let artifact = BundleArtifact()
+        let written = try artifact.write(from: source, to: bundleURL)
+
+        let read = try artifact.refs(of: bundleURL)
+        #expect(Set(read) == Set(written))
+    }
+
+    @Test("verify accepts a bundle this codec just wrote")
+    func verifyAcceptsOwnOutput() async throws {
+        let source = try await makeRichRepo()
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-out3").appendingPathComponent("source.bundle")
+        let artifact = BundleArtifact()
+        try artifact.write(from: source, to: bundleURL)
+        try artifact.verify(artifactURL: bundleURL) // must not throw
+    }
+
+    @Test("write on a repo with no commits throws noRefsToWrite")
+    func writeOnEmptyRepoThrows() async throws {
+        let dir = try makeTempDir(prefix: "bundleartifact-empty")
+        try await git(["init", "-b", "main"], in: dir)
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-empty-out").appendingPathComponent("source.bundle")
+        let artifact = BundleArtifact()
+        #expect(throws: SyncArtifactError.noRefsToWrite) {
+            try artifact.write(from: dir, to: bundleURL)
+        }
+    }
+
+    // MARK: - Malformed input
+
+    @Test("a header with no terminating blank line before EOF is rejected as truncated")
+    func truncatedHeaderRejected() throws {
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-truncated").appendingPathComponent("source.bundle")
+        try Data("# v2 git bundle\n".utf8).write(to: bundleURL)
+
+        let artifact = BundleArtifact()
+        #expect(throws: SyncArtifactError.truncatedHeader) {
+            try artifact.refs(of: bundleURL)
+        }
+        #expect(throws: SyncArtifactError.truncatedHeader) {
+            try artifact.verify(artifactURL: bundleURL)
+        }
+        let target = try makeTempDir(prefix: "bundleartifact-truncated-target")
+        #expect(throws: SyncArtifactError.truncatedHeader) {
+            try artifact.fetch(into: target, namespace: "icloud", from: bundleURL)
+        }
+    }
+
+    @Test("a file that isn't a bundle at all is rejected, not silently accepted")
+    func nonBundleRejected() throws {
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-notabundle").appendingPathComponent("source.bundle")
+        try Data("hello, this is not a bundle\n".utf8).write(to: bundleURL)
+
+        let artifact = BundleArtifact()
+        #expect(throws: (any Error).self) {
+            try artifact.refs(of: bundleURL)
+        }
+    }
+
+    @Test("an unsupported bundle version is rejected with a descriptive error")
+    func unsupportedVersionRejected() throws {
+        let bundleURL = try makeTempDir(prefix: "bundleartifact-v3").appendingPathComponent("source.bundle")
+        try Data("# v3 git bundle\n\n".utf8).write(to: bundleURL)
+
+        let artifact = BundleArtifact()
+        #expect(throws: SyncArtifactError.unsupportedFormat("# v3 git bundle")) {
+            try artifact.refs(of: bundleURL)
+        }
+    }
+
+    @Test("a torn pack (truncated mid-object) fails verify and fetch, not silently succeeds")
+    func tornPackRejected() async throws {
+        let source = try await makeRichRepo()
+        let goodBundle = try makeTempDir(prefix: "bundleartifact-torn-src").appendingPathComponent("source.bundle")
+        let artifact = BundleArtifact()
+        try artifact.write(from: source, to: goodBundle)
+
+        let fullData = try Data(contentsOf: goodBundle)
+        // Cut the file well into the packfile, leaving a structurally-plausible but incomplete
+        // pack (no trailer, likely a deflate stream cut mid-object).
+        let tornLength = fullData.count - max(20, fullData.count / 4)
+        let tornData = fullData.prefix(tornLength)
+        let tornBundle = try makeTempDir(prefix: "bundleartifact-torn-out").appendingPathComponent("source.bundle")
+        try Data(tornData).write(to: tornBundle)
+
+        #expect(throws: (any Error).self) {
+            try artifact.verify(artifactURL: tornBundle)
+        }
+        let target = try makeTempDir(prefix: "bundleartifact-torn-target")
+        try await git(["init", "-b", "placeholder"], in: target)
+        #expect(throws: (any Error).self) {
+            try artifact.fetch(into: target, namespace: "icloud", from: tornBundle)
+        }
+    }
+
+    @Test("fetching against a missing artifact throws notFound")
+    func missingArtifactThrowsNotFound() async throws {
+        let target = try makeTempDir(prefix: "bundleartifact-missing-target")
+        try await git(["init", "-b", "placeholder"], in: target)
+        let missingURL = try makeTempDir(prefix: "bundleartifact-missing").appendingPathComponent("nope.bundle")
+        let artifact = BundleArtifact()
+        #expect(throws: SyncArtifactError.notFound(missingURL)) {
+            try artifact.refs(of: missingURL)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- Adds `SyncArtifact` (AnglesiteCore protocol: `write(from:to:)`, `refs(of:)`, `fetch(into:namespace:from:)`, `verify(artifactURL:)`) and `BundleArtifact`, its git bundle v2 implementation on libgit2 — the artifact codec named in the iCloud git-sync design (`docs/superpowers/specs/2026-07-21-icloud-git-sync-design.md` §2).
- `write` captures every object reachable from a repo's local branches, tags, and HEAD (the #283 ref policy) via `git_packbuilder`; `fetch`/`verify` read the packfile back via `git_indexer`, landing refs under a synthetic `refs/remotes/<namespace>/...` namespace (mirroring `BundleSync`'s old `icloud` remote) for `SyncEngine` (#879) to reconcile from.
- Decision gate (issue #878, "if bundle v2 on libgit2 proves gnarly, fall back to `ArchiveArtifact`"): **kept bundle v2, no fallback needed.** The concern going in was that `Clibgit2` (the fork's raw libgit2 headers) isn't declared as an SPM product of `Anglesite/SwiftGit2` — only the `SwiftGit2` Swift wrapper is — so `import Clibgit2` from `AnglesiteCore` looked like it might need a fork change. Verified empirically (temporary probe file + `swift build`) that SwiftPM makes a C target's module importable to anything that transitively builds against the product depending on it, even when that C target isn't itself a declared product. So `git_packbuilder`/`git_indexer`/`git_revwalk`/etc. are reachable directly from `AnglesiteCore` with **zero changes to the SwiftGit2 fork**.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

No MCP message schema is touched — this is a pure `AnglesiteCore` git-codec addition, no sidecar involvement.

## Test plan

- [x] `swift test --package-path .` — 2736 tests, 354 suites; all pass except 2 pre-existing-flaky `FoundationModelAssistant` tests ("Session ended without producing a response" — live on-device model calls, unrelated to this change; reran the suite alone and they failed the same way both times, consistent with the known FM flakiness noted in project memory, not caused by anything here).
- [x] New unit suite `BundleArtifactTests` (`.serialized`, 9 tests): round-trip (branches, an annotated tag, a lightweight tag, HEAD, all reproduced exactly including object content), `refs(of:)` without importing, `verify` on valid input, `write` on an empty repo throws `noRefsToWrite`, and malformed-input rejection — truncated header, non-bundle file, unsupported version, torn/truncated pack, missing artifact.
- [x] New interop suite `BundleArtifactInteropTests` (`.enabled(if:)`-gated on `/usr/bin/git`, 2 tests): stock `git clone` succeeds against a bundle this codec wrote; this codec correctly reads a bundle produced by stock `git bundle create --branches --tags HEAD`.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (pure SwiftPM change, no app-target code touched; CONTRIBUTING.md worktree guidance for this kind of change is `swift build`/`swift test` only, no xcodegen/xcodebuild needed).
- [ ] Manual smoke (if UI-touching): not applicable — no UI surface in this change.

## Design notes

- `SyncArtifactRef` records each ref's *direct* target — the tag object's own oid for an annotated tag, not the peeled commit — matching `git show-ref`/stock bundle output, so re-imported annotated tags land as real tag objects rather than being silently flattened to their target commit.
- `fetch` passes the target repo's own `git_odb` into `git_indexer`, so a *thin* pack (e.g. from an incremental `git bundle create --since=...`) resolves against locally-available bases; `write` always produces a full, non-thin pack.
- For P3 (#879, `SyncEngine`): `BundleArtifact()` is a stateless value type, safe to construct per call. `fetch`'s returned refs are already namespaced (`refs/remotes/<namespace>/<name>`, `refs/remotes/<namespace>/tags/<name>`); `HEAD` is informational only in both `write`'s and `fetch`'s ref lists — no `refs/remotes/<namespace>/HEAD` is ever created. All I/O is synchronous/blocking (matches `InProcessGit`'s pattern) and not thread-safe against concurrent libgit2 use — callers must serialize, same as the rest of this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)