### PR TITLE
fix(#988): unbundle the guest's edit instead of cloning it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -310,7 +310,7 @@ var packageDependencies: [Package.Dependency] = []
 // pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
 // deliberately.
 packageDependencies.append(
-    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "9fa2f72762ce327980649303460cd5cfd0b92979")
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "446d4777ae4413c2faaa88425693ff29981e4b07")
 )
 
 // Component Editor slice 4 (spec §7, §4.3): STTextView-backed code panes ("Props & Data",

--- a/Sources/AnglesiteCore/InProcessEditPersistence.swift
+++ b/Sources/AnglesiteCore/InProcessEditPersistence.swift
@@ -21,23 +21,38 @@ public enum InProcessEditPersistence {
             throw SiteRuntimePersistenceError.syncFailed("canonical Source repository has uncommitted changes")
         }
         let head = try result(canonical.HEAD())
-        let temp = FileManager.default.temporaryDirectory.appendingPathComponent("anglesite-import-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: temp) }
-        let exported = try result(Repository.clone(from: bundleURL, to: temp, localClone: true))
-        let exportedCommit = try result(exported.HEAD()).oid
+        // Unpack the guest's pack straight into this repository's object database. Cloning the
+        // bundle instead — which is what this did until #988 — could never work: libgit2 has no
+        // bundle support at all, so `Repository.clone(from:)` failed here every time with "could
+        // not find repository at …/x.bundle" and nothing below it had ever executed. Reading the
+        // bundle is a fork addition (Anglesite/SwiftGit2#4).
+        //
+        // The pack is thin (exported `^parent`), so it only resolves against a repository that
+        // already has that parent — which is exactly the fast-forward-only precondition asserted
+        // below, and `unbundle` reports a missing prerequisite as such rather than as a delta
+        // failure. The guest's objects stay unreferenced afterwards; its blobs and trees dedupe
+        // against the commit made below (identical content, identical OIDs), leaving only its
+        // commit object, which `git gc --auto` reaps on the user's next git command in Source/.
+        // The same holds when a guard below rejects the edit: unpacking necessarily precedes
+        // reading the commit's parent, so a refused import leaves those objects behind too —
+        // unreferenced, so HEAD, the index, and the worktree are all untouched by it.
+        let exported = try result(canonical.unbundle(at: bundleURL))
+        guard exported.references.count == 1, let exportedCommit = exported.references.values.first else {
+            throw SiteRuntimePersistenceError.syncFailed("exported bundle did not carry exactly one ref")
+        }
         guard exportedCommit.description == commit else {
             throw SiteRuntimePersistenceError.syncFailed("exported commit did not match the requested edit")
         }
-        let guestCommit = try result(exported.commit(exportedCommit))
+        let guestCommit = try result(canonical.commit(exportedCommit))
         guard guestCommit.parents.count == 1, guestCommit.parents[0].oid == head.oid else {
             throw SiteRuntimePersistenceError.syncFailed("overlay edit conflicts with newer Source changes")
         }
 
-        let sourceTree = try result(exported.object(from: guestCommit.tree)).asTree()
+        let sourceTree = try result(canonical.object(from: guestCommit.tree)).asTree()
         let hostTree = try result(canonical.commit(head.oid))
         let hostRoot = try result(canonical.object(from: hostTree.tree)).asTree()
         var sourcePaths: Set<String> = []
-        try materialize(tree: sourceTree, from: exported, into: sourceDirectory, prefix: "", paths: &sourcePaths)
+        try materialize(tree: sourceTree, from: canonical, into: sourceDirectory, prefix: "", paths: &sourcePaths)
         try removeMissing(tree: hostRoot, from: canonical, root: sourceDirectory, prefix: "", keeping: sourcePaths)
         _ = try result(canonical.addAll())
         // Resolved through `GitIdentity`, not `defaultSignature()` directly: under App Sandbox the

--- a/Tests/AnglesiteCoreTests/InProcessEditPersistenceTests.swift
+++ b/Tests/AnglesiteCoreTests/InProcessEditPersistenceTests.swift
@@ -5,14 +5,11 @@ import Testing
 /// The container edit-sync import path: a commit made by the MCP sidecar inside the container is
 /// handed back to the host and replayed onto the canonical `Source/` repository.
 ///
-/// These drive `importBundle` with the exported commit in a **repository directory** rather than
-/// the `.bundle` file `LocalContainerSiteRuntime.persistEdit` actually writes. That is not the
-/// scenario being dodged — it is the only one reachable: libgit2 has no bundle support whatsoever
-/// (#655's root cause, in this consumer #988), so `Repository.clone(from:)` fails with "could not
-/// find repository at …/x.bundle" for both a thin and a complete bundle, and `persistEdit` cannot
-/// complete today at all. Everything past that transport boundary — the divergence guards, the
-/// tree replay, and the commit under test here — is identical either way, so these should move
-/// onto the real artifact when #988 fixes the transport.
+/// The fixture exports a **real thin git bundle** — `git bundle create … refs/heads/anglesite-persist
+/// ^parent`, byte-for-byte what `LocalContainerSiteRuntime.persistEdit`'s guest script produces.
+/// These tests originally had to substitute a repository directory, because libgit2 has no bundle
+/// support and `Repository.clone(from:)` rejected every bundle; #988 closed that with
+/// `Repository.unbundle(at:)` in the fork, so they now exercise the real artifact end to end.
 struct InProcessEditPersistenceTests {
     @Test("importBundle commits the overlay edit with the app identity when none is configured")
     func importsWithAppFallbackIdentity() async throws {
@@ -33,7 +30,7 @@ struct InProcessEditPersistenceTests {
         defer { fixture.cleanUp() }
 
         try await InProcessEditPersistence.importBundle(
-            fixture.exported, commit: fixture.guestCommit, into: fixture.host)
+            fixture.bundle, commit: fixture.guestCommit, into: fixture.host)
 
         #expect(try String(contentsOf: fixture.host.appendingPathComponent("p.astro"), encoding: .utf8) == "two\n")
         #expect(try await fixture.hostAuthor() == "Anglesite <noreply@anglesite.app>")
@@ -50,20 +47,43 @@ struct InProcessEditPersistenceTests {
         defer { fixture.cleanUp() }
 
         try await InProcessEditPersistence.importBundle(
-            fixture.exported, commit: fixture.guestCommit, into: fixture.host)
+            fixture.bundle, commit: fixture.guestCommit, into: fixture.host)
 
         #expect(try await fixture.hostAuthor() == "host <host@t.io>")
     }
+
+    @Test("importBundle refuses an overlay edit that no longer sits on the host's HEAD")
+    func refusesDivergedHost() async throws {
+        // Fast-forward only, by design: a native host-side content operation committed after the
+        // runtime was hydrated must not be silently overwritten. Worth covering now because it
+        // was unreachable before #988 — every import died at the bundle clone, so no guard past
+        // that point had ever run against a real artifact.
+        let fixture = try await EditSyncFixture.make(hostIdentity: .configured)
+        defer { fixture.cleanUp() }
+        try await fixture.commitOnHost(file: "native.astro", contents: "native edit\n")
+        let divergedHead = try await fixture.hostHead()
+
+        await #expect(throws: SiteRuntimePersistenceError.self) {
+            try await InProcessEditPersistence.importBundle(
+                fixture.bundle, commit: fixture.guestCommit, into: fixture.host)
+        }
+
+        // Refused, not half-applied: HEAD is untouched and the worktree is clean, so the next
+        // import isn't wedged by the "uncommitted changes" guard on the way in.
+        #expect(try await fixture.hostHead() == divergedHead)
+        #expect(try await fixture.hostStatus() == "")
+    }
 }
 
-/// A host `Source/` repo plus the guest's export: one commit on top of the host's HEAD, on the
-/// `anglesite-persist` ref `LocalContainerSiteRuntime.persistEdit`'s guest script writes.
+/// A host `Source/` repo plus the guest's export: one commit on top of the host's HEAD, bundled
+/// exactly the way `LocalContainerSiteRuntime.persistEdit`'s guest script bundles it — onto a
+/// `refs/heads/anglesite-persist` ref, thin against the parent.
 private struct EditSyncFixture {
     enum HostIdentity { case none, configured }
 
     let root: URL
     let host: URL
-    let exported: URL
+    let bundle: URL
     let guestCommit: String
 
     /// Call from a `defer` in the test — the fixture is built and used across `await`s, so it
@@ -93,7 +113,12 @@ private struct EditSyncFixture {
         try await git(["add", "-A"], in: guest)
         try await git(["commit", "-m", "overlay edit"], in: guest)
         let guestCommit = try await git(["rev-parse", "HEAD"], in: guest)
+        let parent = try await git(["rev-parse", "HEAD^"], in: guest)
         try await git(["update-ref", "refs/heads/anglesite-persist", guestCommit], in: guest)
+        // Thin, against the parent — the same `git bundle create "$ref" "^$parent"` the guest
+        // script runs, so the fixture stands or falls on the real transport.
+        let bundle = root.appendingPathComponent("edit.bundle")
+        try await git(["bundle", "create", bundle.path, "refs/heads/anglesite-persist", "^\(parent)"], in: guest)
 
         // Set the host identity last, so the seed commit above could still be made.
         switch hostIdentity {
@@ -104,7 +129,17 @@ private struct EditSyncFixture {
             try await git(["config", "user.email", "host@t.io"], in: host)
             try await git(["config", "user.name", "host"], in: host)
         }
-        return EditSyncFixture(root: root, host: host, exported: guest, guestCommit: guestCommit)
+        return EditSyncFixture(root: root, host: host, bundle: bundle, guestCommit: guestCommit)
+    }
+
+    /// A native host-side commit landing after the guest's bundle was exported.
+    func commitOnHost(file: String, contents: String) async throws {
+        try contents.write(to: host.appendingPathComponent(file), atomically: true, encoding: .utf8)
+        try await Self.git(["add", "-A"], in: host)
+        // -c rather than config: the `.none` fixture blanks the repo identity, and this commit
+        // stands in for the user's own work, not the app's.
+        try await Self.git(
+            ["-c", "user.email=native@t.io", "-c", "user.name=native", "commit", "-m", "native"], in: host)
     }
 
     func hostHead() async throws -> String { try await Self.git(["rev-parse", "HEAD"], in: host) }


### PR DESCRIPTION
## Summary

- Fixes #988: container edit sync has never persisted anything. `persistEdit` exports the guest's commit as a git bundle and hands the file to `InProcessEditPersistence`, which **cloned** it — but libgit2 has no bundle support at all, so `Repository.clone(from:)` failed on every bundle, thin or complete, with `could not find repository at …/x.bundle`. The import died there and nothing past that line had ever executed, including the git-identity fix from #990.
- Bumps the SwiftGit2 pin `9fa2f727` → `446d4777` for [Anglesite/SwiftGit2#4](https://github.com/Anglesite/SwiftGit2/pull/4), which adds `Repository.unbundle(at:)`: it parses the bundle's plain-text header itself and hands the pack to `git_odb_write_pack`. A bundle's pack is ordinary, and libgit2's indexer resolves thin-pack bases out of the receiving repository's ODB — which for a `^parent`-thin export is exactly the fast-forward-only precondition this code already asserts.
- The import gets *simpler*: the temp directory and the clone disappear, and `exported` collapses into `canonical`.

Chose this over the two workarounds the issue listed (a writable scratch mount, or dropping git objects from the transport) because it's the only one that also serves #655, whose single-opaque-file-in-iCloud constraint neither of those can satisfy. Design discussion is on the issue.

### Things a reviewer should push on

- **Objects land in `Source/`'s ODB and stay unreferenced.** Blobs and trees dedupe against the host's own commit (identical content, identical OIDs), so the residue per edit is the guest's commit object plus a small `.idx` — reaped by `git gc --auto` on the user's next git command in `Source/`. The alternative (a throwaway repo with `Source/objects` as a disk alternate) keeps the canonical repo pristine at the cost of a second fork API and putting the temp directory back; I took the simpler one deliberately.
- **Unpacking necessarily precedes the divergence check**, since reading the commit's parent requires the commit. So a *refused* import also leaves those objects behind. They're unreferenced, so HEAD, index, and worktree are untouched — the new `refusesDivergedHost` test asserts exactly that.
- **v3 bundles are refused upstream rather than parsed optimistically.** We never emit them; their capability lines can change how the pack must be read.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Not the sidecar pairing. The dependency half is [Anglesite/SwiftGit2#4](https://github.com/Anglesite/SwiftGit2/pull/4), already merged to `anglesite/main`; this moves the pin.

## Test plan

- [x] `swift test --package-path .` — 2728 tests. Only failures are `FoundationModelAssistant`'s two FM-session tests, pre-existing on `main` and unrelated (their message even varies run to run — `Session ended without producing a response` vs a context-size error — which is the FM environment, not git code).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`.
- [x] `InProcessEditPersistenceTests` now drives a **real thin bundle** from `git bundle create … refs/heads/anglesite-persist ^parent` — byte-for-byte what the guest script produces — instead of the repository-directory substitute it needed while the transport was broken. That substitution going away is #988's acceptance criterion.
- [x] New `refusesDivergedHost` covers the fast-forward-only guard, which was unreachable before this change and so had never run against a real artifact.
- [x] Upstream: 152 tests in 86 suites, with 6 new bundle cases driven from real `git bundle create` output.
- [ ] Manual smoke: an end-to-end overlay edit through a booted local container is worth doing before this is trusted in anger — it's the first time this path can complete at all. Not run here.
