### PR TITLE
feat(#880): NSFileVersion reconciliation + three-way merge

### DIFF
--- a/Sources/AnglesiteCore/SyncEngine.swift
+++ b/Sources/AnglesiteCore/SyncEngine.swift
@@ -9,12 +9,14 @@ import AnglesiteSiteModel
 /// unshippable `BundleSync` (#283), which shelled out to `/usr/bin/git` and can't run under the
 /// MAS App Sandbox (#640). Every git operation here goes through SwiftGit2/libgit2 in-process.
 ///
-/// **Scope of this phase (#879).** `pull()` is fast-forward only: a diverged branch is *reported*
-/// via `.diverged`, never merged — P4 (design doc §3) adds the three-way-merge reconciliation
-/// exactly on top of that case (fetch the artifact's history into `refs/remotes/icloud/<branch>`
-/// already happened by the time `.diverged` is returned, so P4's merge step has everything it
-/// needs without re-fetching). `push()` never merges either; it just mirrors the local repo's
-/// current heads into the artifact.
+/// **Divergence reconciliation (#880, design doc §3).** When local history and the artifact
+/// diverge, `pull()` doesn't just report it: it snapshots local changes, fetches every
+/// NSFileVersion conflict version of the artifact alongside the current one, and folds each tip
+/// into the local branch — fast-forwarding when possible, three-way-merging (auto-committed) on a
+/// clean divergence. A textual conflict stops the line and surfaces as a typed `SyncConflict`,
+/// never auto-resolved or rewound; full convergence checks the merged history out and pushes it
+/// back. `push()` never merges; it just mirrors the local repo's current heads into the artifact,
+/// pausing while a conflict from an earlier `pull()` is unacknowledged.
 ///
 /// **Concurrency.** Like `BundleArtifact`/`InProcessGit`, every libgit2 call here assumes the
 /// caller serializes access — wrapping the engine's public methods in an `actor` provides that
@@ -40,6 +42,12 @@ public actor SyncEngine {
         /// The artifact already reflected the repo's heads — nothing written, no iCloud churn.
         case unchanged
         case pushed(refs: [SyncArtifactRef])
+        /// A prior `pull()` hit a textual merge conflict on this branch (`SyncConflict`) that
+        /// hasn't been acknowledged resolved yet (`acknowledgeConflictResolved(package:)`) —
+        /// design doc §3: "pushes of that branch pause" while the local copy stays editable and
+        /// incoming bundles keep fetching. Not an error: the caller should surface the pending
+        /// conflict (`pendingConflict(package:)`) rather than retry.
+        case pausedForConflict(branch: String)
         case failed(reason: String)
     }
 
@@ -48,10 +56,19 @@ public actor SyncEngine {
         case fastForwarded(branch: String, from: String, to: String)
         /// This Mac's branch is ahead of the artifact — nothing to pull; call `push()`.
         case localAhead(branch: String)
-        /// Local and artifact history have diverged. **Not merged in this phase** — this is the
-        /// hook point P4's three-way merge replaces. The fetched history is already sitting at
-        /// `refs/remotes/icloud/<branch>` in the repo by the time this is returned.
-        case diverged(branch: String)
+        /// Local and artifact history diverged, and every fetched tip (the current artifact plus
+        /// every NSFileVersion conflict version) merged or fast-forwarded cleanly — the merged
+        /// history is checked out into `Source/` and already pushed back to the artifact (design
+        /// doc §3 steps 3–4). `mergedTips` lists the sources folded in, in the order they were
+        /// applied: `"icloud"` for the current artifact, `"peer-<n>"` for the nth conflict
+        /// version.
+        case merged(branch: String, mergedTips: [String])
+        /// A three-way merge against `theirSource`'s tip hit textual conflicts — never
+        /// auto-resolved, never rewound (design doc §3 step 3). Local HEAD is exactly where it
+        /// was before this merge attempt; any earlier tip in this same pull that merged cleanly
+        /// stays merged. `push()` on this branch pauses until the conflict is acknowledged
+        /// resolved.
+        case conflicted(SyncConflict)
         /// `Source/` had a dangling gitfile, or its live repo failed to open — rebuilt from the
         /// artifact (fresh peer, or the integrity-check repair path). Any working-tree edits newer
         /// than the artifact's history landed as a snapshot commit on top, never clobbered.
@@ -59,6 +76,26 @@ public actor SyncEngine {
         /// The artifact is evicted and iCloud didn't finish downloading it within the timeout.
         case waitingForICloud
         case failed(reason: String)
+    }
+
+    /// A three-way merge (design doc §3 step 3) that hit textual conflicts and was left
+    /// unresolved — both tips stay fully intact in git history (`ourOID`/`theirOID`), nothing is
+    /// rewound or guessed at. P5 builds the resolution UI on top of this; this module's job ends
+    /// at detecting, persisting, and reporting it (`pendingConflict(package:)`), and clearing the
+    /// pause once the caller says it's resolved (`acknowledgeConflictResolved(package:)`).
+    public struct SyncConflict: Sendable, Equatable, Codable {
+        public let branch: String
+        /// Paths git flagged with textual conflicts in the failed three-way merge.
+        public let conflictedPaths: [String]
+        /// This Mac's tip going into the failed merge attempt.
+        public let ourOID: String
+        /// The tip that conflicted — the other Mac's edit, still fully reachable from its own
+        /// history (`refs/remotes/<theirSource>/<branch>`).
+        public let theirOID: String
+        /// Which fetched tip this came from: `"icloud"` for the current artifact, `"peer-<n>"`
+        /// for the nth NSFileVersion conflict version — so the UI can say which Mac's edit
+        /// collided.
+        public let theirSource: String
     }
 
     // MARK: - Configuration
@@ -87,11 +124,23 @@ public actor SyncEngine {
     /// otherwise a sibling-temp write, a verify pass, then a coordinated swap into place.
     public func push(package: AnglesitePackage) async -> PushResult {
         SwiftGit2Bootstrap.ensureInitialized
+        let repo: Repository
         switch await prepareRepository(package: package) {
         case .failure(let reason):
             return .failed(reason: reason.message)
-        case .success:
-            break // Either shape is fine for push — we only need a healthy repo, not its bootstrap branch.
+        case .success(.bootstrapped(let bootstrapped, _)):
+            repo = bootstrapped
+        case .success(.existing(let existing)):
+            repo = existing
+        }
+
+        // A pending conflict on the currently checked-out branch pauses its pushes (design doc
+        // §3: "local branch stays editable; pushes of that branch pause") until the caller
+        // acknowledges it resolved — never auto-lifted, since only the caller (P5's resolution
+        // UI, or whatever committed a fix) knows the conflict is actually settled.
+        if let conflict = pendingConflict(package: package),
+           case .success(let head) = repo.HEAD(), let branch = head as? Branch, branch.name == conflict.branch {
+            return .pausedForConflict(branch: conflict.branch)
         }
 
         let fileManager = FileManager.default
@@ -153,6 +202,11 @@ public actor SyncEngine {
     /// A dangling gitfile or an unopenable live repo is rebuilt from the artifact first (fresh
     /// peer / integrity-check repair) — that already performs the equivalent of a pull, so this
     /// returns `.bootstrapped` without a separate fetch.
+    ///
+    /// On genuine divergence, hands off to ``reconcileDivergence(repo:package:branchName:branchRefName:localOID:icloudOID:)``
+    /// (#880, design doc §3) for full reconciliation — fast-forward/merge every NSFileVersion
+    /// conflict version of the artifact alongside the current one, rather than just reporting the
+    /// divergence.
     public func pull(package: AnglesitePackage) async -> PullResult {
         SwiftGit2Bootstrap.ensureInitialized
         let repo: Repository
@@ -170,6 +224,27 @@ public actor SyncEngine {
         }
         if case .timedOut = await versionStore.materialize(at: package.syncBundleURL, timeout: materializeTimeout) {
             return .waitingForICloud
+        }
+
+        // Working-tree conflict-copy sweep (design doc §3): `Source/`'s own files sync as plain
+        // files independently of git, so iCloud can drop `name (conflicted copy …).ext`/`name
+        // 2.ext`-style copies there. Both sides' real content already lives in git history by the
+        // time this runs, so these are redundant — quarantined rather than left to pollute the
+        // snapshot commit below or be mistaken for resolved history.
+        Self.quarantineConflictCopies(package: package)
+
+        // Detached HEAD is checked before the snapshot below, so a snapshot commit is never
+        // created only to be stranded off any branch.
+        guard case .success(let headBeforeSnapshot) = repo.HEAD(), (headBeforeSnapshot as? Branch)?.isLocal == true else {
+            return .failed(reason: "the repo is in a detached-HEAD state — check out a branch before syncing.")
+        }
+
+        // Snapshot local changes before any history moves (design doc §3 step 1) — the same
+        // addAll + GitIdentity + commit machinery `bootstrapFromArtifact` uses for its own
+        // snapshot, mirroring the deterministic add→commit shape `BackupCommand` established for
+        // user-triggered backups.
+        if case .failure(let reason) = await Self.snapshotIfDirty(repo: repo, message: "Snapshot: local edits before syncing") {
+            return .failed(reason: "couldn't snapshot local changes before syncing: \(reason.message)")
         }
 
         guard case .success(let head) = repo.HEAD(), let currentBranch = head as? Branch, currentBranch.isLocal else {
@@ -216,8 +291,111 @@ public actor SyncEngine {
         case (let ahead, 0) where ahead > 0:
             return .localAhead(branch: branchName)
         default:
-            return .diverged(branch: branchName)
+            return await reconcileDivergence(
+                repo: repo, package: package, branchName: branchName, branchRefName: currentBranch.longName,
+                localOID: localOID, icloudOID: remoteOID)
         }
+    }
+
+    // MARK: - Divergence reconciliation (#880, design doc §3)
+
+    /// Folds every fetched tip — the current artifact plus each NSFileVersion conflict version —
+    /// into the local branch, one at a time: fast-forward when a tip is strictly ahead, a libgit2
+    /// three-way merge (auto-committed) when it diverges cleanly. The first tip whose merge hits a
+    /// textual conflict stops the line: nothing merged so far in this call is rewound, but no
+    /// further tips are attempted and the branch's next push pauses until the conflict is
+    /// acknowledged resolved. Only entered once the caller has already established that the
+    /// current artifact itself diverges from local history.
+    private func reconcileDivergence(
+        repo: Repository, package: AnglesitePackage, branchName: String, branchRefName: String,
+        localOID: OID, icloudOID: OID
+    ) async -> PullResult {
+        var tips: [(source: String, oid: OID)] = [(Self.namespace, icloudOID)]
+        var handlesBySource: [String: ConflictVersionHandle] = [:]
+
+        for (index, handle) in await versionStore.conflictVersions(of: package.syncBundleURL).enumerated() {
+            let source = "peer-\(index)"
+            handlesBySource[source] = handle
+            do {
+                let landedPeer = try artifact.fetch(into: package.sourceURL, namespace: source, from: handle.contentURL)
+                guard let peerRef = landedPeer.first(where: { $0.name == "refs/remotes/\(source)/\(branchName)" }),
+                      let peerOID = OID(string: peerRef.oid) else {
+                    continue // this conflict version doesn't carry the branch we're syncing — skip it
+                }
+                tips.append((source, peerOID))
+            } catch {
+                return .failed(reason: "couldn't fetch a conflicting version of the synced history: \(error.localizedDescription)")
+            }
+        }
+
+        var currentOID = localOID
+        var mergedTips: [String] = []
+
+        for (source, tipOID) in tips {
+            guard case .success(let counts) = repo.aheadBehind(local: currentOID, upstream: tipOID) else {
+                return .failed(reason: "couldn't compare local history to \(source).")
+            }
+            if counts.behind == 0 {
+                continue // nothing from this tip we don't already have
+            }
+
+            if counts.ahead == 0 {
+                guard case .success = Self.fastForward(repo: repo, branchRefName: branchRefName, to: tipOID) else {
+                    return .failed(reason: "couldn't fast-forward \(branchName) to \(source).")
+                }
+                currentOID = tipOID
+                mergedTips.append(source)
+                continue
+            }
+
+            switch await Self.threeWayMerge(repo: repo, ours: currentOID, theirs: tipOID, branchName: branchName) {
+            case .failure(let reason):
+                return .failed(reason: "couldn't merge \(source) into \(branchName): \(reason)")
+            case .success(.conflicted(let paths)):
+                let conflict = SyncConflict(
+                    branch: branchName, conflictedPaths: paths,
+                    ourOID: currentOID.description, theirOID: tipOID.description, theirSource: source)
+                Self.persistConflict(conflict, package: package)
+                await LogCenter.shared.append(
+                    source: "sync:pull", stream: .stderr,
+                    text: "merge conflict syncing \(branchName) against \(source) — "
+                        + "\(paths.count) file\(paths.count == 1 ? "" : "s") need attention: \(paths.joined(separator: ", "))")
+                return .conflicted(conflict)
+            case .success(.merged(let mergeCommit)):
+                guard case .success = repo.checkout(strategy: [.force, .recreateMissing]) else {
+                    return .failed(reason: "checkout failed after merging \(source) into \(branchName)")
+                }
+                currentOID = mergeCommit.oid
+                mergedTips.append(source)
+            }
+        }
+
+        guard !mergedTips.isEmpty else {
+            // Unreachable in practice: this function only runs once the caller already found the
+            // *icloud* tip diverged, and icloud is always the first tip processed above — but
+            // fail loudly rather than silently reporting an inaccurate result if that invariant
+            // is ever violated.
+            return .failed(reason: "internal error: reconciliation found no changes despite a detected divergence")
+        }
+
+        // Full convergence: every fetched tip merged or fast-forwarded cleanly. Resolve the
+        // folded-in conflict versions, clear any stale conflict marker, and push the result back
+        // (design doc §3 step 4).
+        for source in mergedTips where source != Self.namespace {
+            handlesBySource[source]?.markResolved()
+        }
+        Self.clearPersistedConflict(package: package)
+
+        await LogCenter.shared.append(
+            source: "sync:pull", stream: .stdout,
+            text: "merged \(mergedTips.joined(separator: ", ")) into \(branchName) "
+                + "(\(localOID.description.prefix(7)) → \(currentOID.description.prefix(7)))")
+
+        if case .failed(let reason) = await push(package: package) {
+            return .failed(reason: "merged \(branchName) locally but couldn't push the result: \(reason)")
+        }
+
+        return .merged(branch: branchName, mergedTips: mergedTips)
     }
 
     // MARK: - Repository preparation (migration, dangling-gitfile / corrupted-repo repair)
@@ -321,21 +499,218 @@ public actor SyncEngine {
         // Snapshot: whatever's actually on disk in Source/ that differs from the bootstrapped
         // history lands as a commit on top — never clobbered by a checkout, since bootstrap never
         // touches the working directory.
-        if case .success(let status) = repo.status(options: [.includeUntracked, .recurseUntrackedDirs]), !status.isEmpty {
-            _ = repo.addAll()
-            let signature = await GitIdentity.signature(for: repo)
-            if case .failure(let error) = repo.commit(
-                message: "Snapshot: local edits synced ahead of this Mac's git history",
-                signature: signature
-            ) {
-                return .failure("couldn't snapshot local edits: \(error.localizedDescription)")
-            }
+        if case .failure(let reason) = await Self.snapshotIfDirty(
+            repo: repo, message: "Snapshot: local edits synced ahead of this Mac's git history"
+        ) {
+            return .failure("couldn't snapshot local edits: \(reason.message)")
         }
 
         await LogCenter.shared.append(
             source: "sync:bootstrap", stream: .stdout,
             text: "rebuilt \(package.liveRepositoryURL.lastPathComponent) from the synced history (\(branch))")
         return .success((repo, branch))
+    }
+
+    // MARK: - Snapshot commit (shared by pull()'s pre-reconciliation step and bootstrap)
+
+    /// Auto-commits any dirty `Source/` working-tree state — the same addAll + `GitIdentity` +
+    /// commit machinery the fresh-peer bootstrap path uses for its own snapshot, mirroring the
+    /// deterministic add→commit shape `BackupCommand` established for user-triggered backups. A
+    /// no-op on a clean tree.
+    private static func snapshotIfDirty(repo: Repository, message: String) async -> Result<Void, EngineError> {
+        guard case .success(let status) = repo.status(options: [.includeUntracked, .recurseUntrackedDirs]) else {
+            return .failure("couldn't read working-tree status.")
+        }
+        guard !status.isEmpty else { return .success(()) }
+
+        guard case .success = repo.addAll() else {
+            return .failure("couldn't stage local changes for the pre-sync snapshot.")
+        }
+        let signature = await GitIdentity.signature(for: repo)
+        guard case .success = repo.commit(message: message, signature: signature) else {
+            return .failure("couldn't create the pre-sync snapshot commit.")
+        }
+        return .success(())
+    }
+
+    // MARK: - Three-way merge (#880, design doc §3 step 3)
+
+    private enum MergeOutcome {
+        case merged(Commit)
+        case conflicted([String])
+    }
+
+    /// Three-way-merges `theirs` into `ours` via libgit2's `git_merge_commits` (computes the
+    /// merge base itself; touches no working-directory or index state of its own — the caller
+    /// checks out the result explicitly). A clean result creates a merge commit (parents `ours`,
+    /// `theirs`) via `Repository.commit(tree:parents:message:signature:)`, whose own
+    /// `update_ref: "HEAD"` moves the current branch to it — valid here because every caller only
+    /// ever passes the *actual* current branch tip as `ours`. A conflicted result touches
+    /// nothing: no commit, no ref move — so the caller can report it without rewinding anything
+    /// already merged earlier in the same reconciliation.
+    private static func threeWayMerge(
+        repo: Repository, ours oursOID: OID, theirs theirsOID: OID, branchName: String
+    ) async -> Result<MergeOutcome, EngineError> {
+        var oursGitOID = oursOID.oid
+        var oursRaw: OpaquePointer?
+        guard git_commit_lookup(&oursRaw, repo.pointer, &oursGitOID) == GIT_OK.rawValue, let oursRaw else {
+            return .failure("couldn't look up this Mac's commit: \(lastErrorMessage())")
+        }
+        defer { git_commit_free(oursRaw) }
+
+        var theirsGitOID = theirsOID.oid
+        var theirsRaw: OpaquePointer?
+        guard git_commit_lookup(&theirsRaw, repo.pointer, &theirsGitOID) == GIT_OK.rawValue, let theirsRaw else {
+            return .failure("couldn't look up the synced commit: \(lastErrorMessage())")
+        }
+        defer { git_commit_free(theirsRaw) }
+
+        var mergeOptions = git_merge_options()
+        guard git_merge_options_init(&mergeOptions, UInt32(GIT_MERGE_OPTIONS_VERSION)) == GIT_OK.rawValue else {
+            return .failure("git_merge_options_init failed: \(lastErrorMessage())")
+        }
+
+        var index: OpaquePointer?
+        guard git_merge_commits(&index, repo.pointer, oursRaw, theirsRaw, &mergeOptions) == GIT_OK.rawValue, let index else {
+            return .failure("git_merge_commits failed: \(lastErrorMessage())")
+        }
+        defer { git_index_free(index) }
+
+        if git_index_has_conflicts(index) != 0 {
+            return .success(.conflicted(Self.conflictedPaths(in: index)))
+        }
+
+        var mergedTreeOID = git_oid()
+        guard git_index_write_tree_to(&mergedTreeOID, index, repo.pointer) == GIT_OK.rawValue else {
+            return .failure("git_index_write_tree_to failed: \(lastErrorMessage())")
+        }
+
+        guard case .success(let oursCommit) = repo.commit(oursOID),
+              case .success(let theirsCommit) = repo.commit(theirsOID) else {
+            return .failure("couldn't re-read this merge's parent commits.")
+        }
+        let signature = await GitIdentity.signature(for: repo)
+        let message = "Merge synced history into \(branchName) (\(oursOID.description.prefix(7)) + \(theirsOID.description.prefix(7)))"
+        switch repo.commit(tree: OID(mergedTreeOID), parents: [oursCommit, theirsCommit], message: message, signature: signature) {
+        case .success(let mergeCommit):
+            return .success(.merged(mergeCommit))
+        case .failure(let error):
+            return .failure(EngineError(error.localizedDescription))
+        }
+    }
+
+    /// The paths flagged with textual conflicts in a merged `git_index` — from whichever of the
+    /// conflict's ancestor/ours/theirs entries is present (a pure add/add or add/delete conflict
+    /// may not carry an ancestor entry at all).
+    private static func conflictedPaths(in index: OpaquePointer) -> [String] {
+        var iterator: OpaquePointer?
+        guard git_index_conflict_iterator_new(&iterator, index) == GIT_OK.rawValue, let iterator else { return [] }
+        defer { git_index_conflict_iterator_free(iterator) }
+
+        var paths: Set<String> = []
+        while true {
+            var ancestor: UnsafePointer<git_index_entry>?
+            var ours: UnsafePointer<git_index_entry>?
+            var theirs: UnsafePointer<git_index_entry>?
+            let result = git_index_conflict_next(&ancestor, &ours, &theirs, iterator)
+            if result == GIT_ITEROVER.rawValue { break }
+            guard result == GIT_OK.rawValue else { break }
+            if let path = ancestor?.pointee.path ?? ours?.pointee.path ?? theirs?.pointee.path {
+                paths.insert(String(cString: path))
+            }
+        }
+        return paths.sorted()
+    }
+
+    // MARK: - Conflicted-state persistence (#880, design doc §3)
+
+    private static func conflictMarkerURL(for package: AnglesitePackage) -> URL {
+        package.syncDirectoryURL.appendingPathComponent("conflict.json", isDirectory: false)
+    }
+
+    private static func persistConflict(_ conflict: SyncConflict, package: AnglesitePackage) {
+        do {
+            try FileManager.default.createDirectory(at: package.syncDirectoryURL, withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(conflict)
+            try data.write(to: conflictMarkerURL(for: package), options: .atomic)
+        } catch {
+            // Best-effort: a failure to persist only means push()'s pause-while-conflicted check
+            // won't fire on this Mac — the SyncConflict itself is still returned to this pull()
+            // call's own caller, so nothing here is silently lost.
+        }
+    }
+
+    private static func clearPersistedConflict(package: AnglesitePackage) {
+        try? FileManager.default.removeItem(at: conflictMarkerURL(for: package))
+    }
+
+    /// The unresolved `SyncConflict` recorded against `package`, if any — for callers (P5's
+    /// conflict banner) that want to check without going through a `push()`/`pull()` call.
+    /// `nonisolated`: a plain file read with no actor state to protect.
+    public nonisolated func pendingConflict(package: AnglesitePackage) -> SyncConflict? {
+        guard let data = try? Data(contentsOf: Self.conflictMarkerURL(for: package)) else { return nil }
+        return try? JSONDecoder().decode(SyncConflict.self, from: data)
+    }
+
+    /// Clears the pause `push()` applies while `package` has a pending conflict. This module
+    /// doesn't drive conflict resolution itself (out of scope for #880 — P5 builds the resolution
+    /// UI on top of the typed `SyncConflict` `pull()` returns); it only owns lifting the pause
+    /// once the caller says the branch is ready to sync again — e.g. after committing a chosen
+    /// resolution (stage the chosen content, commit with both tips as parents; or a "keep this
+    /// Mac's"/"keep the other's" choice) on top of `conflictedPaths`.
+    public func acknowledgeConflictResolved(package: AnglesitePackage) {
+        Self.clearPersistedConflict(package: package)
+    }
+
+    // MARK: - Working-tree conflict-copy quarantine (#880, design doc §3)
+
+    private static let numberedDuplicatePattern = try! NSRegularExpression(pattern: #"^(.+) (\d+)(\.[^./]+)?$"#)
+
+    /// Sweeps `Source/` for files matching iCloud's conflict-copy naming and moves them into
+    /// `Config/conflicts/` — quarantined, never silently deleted. Best-effort: a failure to
+    /// enumerate or move a file just leaves it where it was, it's never lost either way.
+    private static func quarantineConflictCopies(package: AnglesitePackage) {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: package.sourceURL, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
+        ) else { return }
+
+        var quarantined: [URL] = []
+        for case let url as URL in enumerator {
+            guard !url.lastPathComponent.hasPrefix(".") else { continue }
+            guard let isDirectory = try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory, isDirectory != true else { continue }
+            guard Self.isConflictCopyName(url.lastPathComponent, in: url.deletingLastPathComponent(), fileManager: fileManager) else { continue }
+            quarantined.append(url)
+        }
+        guard !quarantined.isEmpty else { return }
+
+        let quarantineDirectory = package.configURL.appendingPathComponent("conflicts", isDirectory: true)
+        try? fileManager.createDirectory(at: quarantineDirectory, withIntermediateDirectories: true)
+        for url in quarantined {
+            let destination = quarantineDirectory.appendingPathComponent("\(UUID().uuidString)-\(url.lastPathComponent)")
+            try? fileManager.moveItem(at: url, to: destination)
+        }
+    }
+
+    /// `true` for a filename iCloud would have generated as a conflict copy: either its classic
+    /// verbose "conflicted copy" naming, or the numbered-duplicate form (`"name 2.ext"`) *and* a
+    /// sibling without the number suffix exists alongside it — requiring the sibling is what
+    /// distinguishes a real iCloud conflict copy from an ordinary, legitimately numbered filename.
+    private static func isConflictCopyName(_ filename: String, in directory: URL, fileManager: FileManager) -> Bool {
+        if filename.range(of: "conflicted copy", options: [.caseInsensitive]) != nil { return true }
+
+        let fullRange = NSRange(filename.startIndex..., in: filename)
+        guard let match = numberedDuplicatePattern.firstMatch(in: filename, range: fullRange),
+              let stemRange = Range(match.range(at: 1), in: filename) else { return false }
+
+        let ext: String
+        if match.range(at: 3).location != NSNotFound, let extRange = Range(match.range(at: 3), in: filename) {
+            ext = String(filename[extRange])
+        } else {
+            ext = ""
+        }
+        let baseName = String(filename[stemRange]) + ext
+        return fileManager.fileExists(atPath: directory.appendingPathComponent(baseName).path)
     }
 
     // MARK: - libgit2 helpers

--- a/Sources/AnglesiteCore/VersionStore.swift
+++ b/Sources/AnglesiteCore/VersionStore.swift
@@ -14,21 +14,61 @@ public enum VersionMaterialization: Sendable, Equatable {
     case timedOut
 }
 
+/// One `NSFileVersion` conflict copy of a synced item, still pending resolution — a peer Mac's
+/// write that iCloud kept as a conflict version rather than folding into the "current" version
+/// (design doc `2026-07-21-icloud-git-sync-design.md` §3 step 2). `SyncEngine.pull()` reads
+/// `contentURL` the same way it reads the current artifact's own URL — passed straight to
+/// `SyncArtifact.fetch(into:namespace:from:)` — and calls `markResolved()` once the history it
+/// carries has been folded into a fully-converged merge (§3 step 4).
+///
+/// `@unchecked Sendable`: `NSFileVersion` itself isn't concurrency-checked by Foundation, but
+/// `SyncEngine` (an actor) is the only thing that ever touches a handle, and only within the
+/// single `pull()` call that requested it — the same single-threaded discipline this module
+/// already leans on for libgit2.
+public final class ConflictVersionHandle: @unchecked Sendable, Equatable {
+    /// Identity for logging and for naming the synthetic `refs/remotes/peer-<id>` namespace this
+    /// version is fetched into — not used to re-locate the underlying `NSFileVersion` (the
+    /// wrapped `markResolved` closure already pins that).
+    public let id: String
+    /// Where this conflict version's content can be read from directly.
+    public let contentURL: URL
+    private let markResolvedAction: @Sendable () -> Void
+
+    public init(id: String, contentURL: URL, markResolved: @escaping @Sendable () -> Void) {
+        self.id = id
+        self.contentURL = contentURL
+        self.markResolvedAction = markResolved
+    }
+
+    /// Marks this conflict version resolved — production removes it from iCloud's conflict list
+    /// (`NSFileVersion.isResolved`); called only once the reconciliation that folded its history
+    /// in has fully converged, never on a partial or conflicted result.
+    public func markResolved() { markResolvedAction() }
+
+    public static func == (lhs: ConflictVersionHandle, rhs: ConflictVersionHandle) -> Bool {
+        lhs.id == rhs.id && lhs.contentURL == rhs.contentURL
+    }
+}
+
 /// Seam over iCloud materialization that `SyncEngine.pull()` (and `push()`'s no-op comparison)
 /// use to make sure the sync artifact is actually present on disk with real content before
 /// reading it — an evicted item needs `startDownloadingUbiquitousItem` and a wait, not an
 /// immediate read.
 ///
-/// **Scope of this phase (#879).** A `VersionStore` only answers "is the *current* version of
-/// this file materialized" — single-version behavior, no conflict-version enumeration. P4
-/// (concurrent-edit reconciliation, design doc §3) extends this seam with a method that lists the
-/// other `NSFileVersion`s iCloud is holding as conflict copies of the same file, for fetching
-/// every peer's history rather than just the current one; that's a new, additive method next to
-/// this one; it doesn't change `materialize(at:timeout:)`'s contract, so P3 callers (this file)
-/// keep working unmodified. Real conflict versions can't be manufactured in CI, so both phases
-/// fake this seam in tests instead of exercising real iCloud.
+/// **Scope.** `materialize(at:timeout:)` (#879) answers "is the *current* version of this file
+/// materialized" — single-version behavior. `conflictVersions(of:)` (#880, design doc §3 step 2)
+/// is a new, additive method that lists the other `NSFileVersion`s iCloud is holding as conflict
+/// copies of the same file, for fetching every peer's history rather than just the current one;
+/// it doesn't change `materialize(at:timeout:)`'s contract, so P3 callers keep working unmodified.
+/// Real conflict versions can't be manufactured in CI, so both phases fake this seam in tests
+/// instead of exercising real iCloud.
 public protocol VersionStore: Sendable {
     func materialize(at url: URL, timeout: TimeInterval) async -> VersionMaterialization
+
+    /// Enumerates `url`'s unresolved NSFileVersion conflict versions — the peer writes iCloud
+    /// kept when two Macs wrote the artifact concurrently. Empty when there's no conflict (the
+    /// overwhelmingly common case).
+    func conflictVersions(of url: URL) async -> [ConflictVersionHandle]
 }
 
 /// Production `VersionStore`: polls `URLResourceValues.ubiquitousItemDownloadingStatus`, kicking
@@ -59,6 +99,15 @@ public struct UbiquitousVersionStore: VersionStore {
 
     private static func downloadingStatus(of url: URL) -> URLUbiquitousItemDownloadingStatus? {
         try? url.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]).ubiquitousItemDownloadingStatus
+    }
+
+    public func conflictVersions(of url: URL) async -> [ConflictVersionHandle] {
+        guard let versions = NSFileVersion.unresolvedConflictVersionsOfItem(at: url) else { return [] }
+        return versions.enumerated().map { index, version in
+            ConflictVersionHandle(id: "peer-\(index)", contentURL: version.url) {
+                version.isResolved = true
+            }
+        }
     }
 }
 #endif

--- a/Tests/AnglesiteCoreTests/SyncEngineTests.swift
+++ b/Tests/AnglesiteCoreTests/SyncEngineTests.swift
@@ -7,11 +7,11 @@ import SwiftGit2
 @testable import AnglesiteCore
 
 /// `SyncEngine` pushes/pulls a `.anglesite` package's git history through its single-file iCloud
-/// sync artifact (#879, design doc `2026-07-21-icloud-git-sync-design.md` §2/§4). Fixtures build
-/// real repos with subprocess git (tests run unsandboxed, matching `BundleArtifactTests`'/
+/// sync artifact (#879, #880; design doc `2026-07-21-icloud-git-sync-design.md` §2–§3). Fixtures
+/// build real repos with subprocess git (tests run unsandboxed, matching `BundleArtifactTests`'/
 /// `RepoRelocatorTests`' convention); "iCloud" is faked by literally copying the bundle file
-/// between two package trees, and `VersionStore` is faked so no real iCloud materialization is
-/// exercised.
+/// between two package trees, and `VersionStore` is faked so no real iCloud materialization or
+/// `NSFileVersion` conflict-version enumeration is exercised.
 ///
 /// .serialized: libgit2 isn't safe for uncoordinated concurrent use in this codebase.
 @Suite("SyncEngine", .serialized) struct SyncEngineTests {
@@ -26,9 +26,25 @@ import SwiftGit2
         var outcome: VersionMaterialization = .alreadyLocal
         private(set) var materializedURLs: [URL] = []
 
+        /// Manufactured "iCloud conflict versions" — bundle URLs to hand back as
+        /// `ConflictVersionHandle`s. Real `NSFileVersion` conflicts can't be created in CI, so
+        /// tests populate this directly with sibling package bundles standing in for a peer Mac's
+        /// concurrent write.
+        var conflictArtifactURLs: [URL] = []
+        private(set) var resolvedIDs: [String] = []
+
         func materialize(at url: URL, timeout: TimeInterval) async -> VersionMaterialization {
             materializedURLs.append(url)
             return outcome
+        }
+
+        func conflictVersions(of url: URL) async -> [ConflictVersionHandle] {
+            conflictArtifactURLs.enumerated().map { index, artifactURL in
+                let id = "peer-\(index)"
+                return ConflictVersionHandle(id: id, contentURL: artifactURL) { [weak self] in
+                    self?.resolvedIDs.append(id)
+                }
+            }
         }
     }
 
@@ -94,6 +110,34 @@ import SwiftGit2
             to: pkg.sourceURL.appendingPathComponent(".git"), atomically: true, encoding: .utf8)
         try copyArtifact(from: source, to: pkg)
         return pkg
+    }
+
+    private struct FixtureFailure: Error, CustomStringConvertible {
+        let message: String
+        var description: String { message }
+    }
+
+    /// Builds a standalone package that bootstraps from `base`'s already-pushed history, applies
+    /// `edit`, commits, and pushes — returning its own sync-artifact file to hand a
+    /// `FakeVersionStore` as a manufactured NSFileVersion conflict version. Real conflict versions
+    /// can't be created in CI (#880 scope note); this stands in for "a peer Mac wrote
+    /// concurrently" the same way `makeFreshPeerPackage`/`copyArtifact` stand in for iCloud
+    /// transport elsewhere in this file.
+    private func makeConflictVersionBundle(
+        from base: AnglesitePackage, name: String, edit: @escaping (URL) throws -> Void
+    ) async throws -> URL {
+        let peer = try makeFreshPeerPackage(mirroring: base, name: name)
+        let engine = SyncEngine()
+        guard case .bootstrapped = await engine.pull(package: peer) else {
+            throw FixtureFailure(message: "bootstrap of conflict-version peer \(name) failed")
+        }
+        try edit(peer.sourceURL)
+        try await git(["add", "-A"], in: peer.sourceURL)
+        try await git(["commit", "-m", "conflict-version edit"], in: peer.sourceURL)
+        guard case .pushed = await engine.push(package: peer) else {
+            throw FixtureFailure(message: "push of conflict-version peer \(name) failed")
+        }
+        return peer.syncBundleURL
     }
 
     // MARK: - push(): no-op
@@ -215,8 +259,10 @@ import SwiftGit2
         #expect(branch == "main")
     }
 
-    @Test("pull reports diverged, without merging, when local and artifact history disagree")
-    func divergedPullIsReportedNotMerged() async throws {
+    // MARK: - pull(): divergence reconciliation (#880)
+
+    @Test("pull auto-merges non-overlapping divergent history and pushes the result")
+    func divergedPullMergesNonOverlappingEdits() async throws {
         let a = try await makeGitPackage(name: "A4", commits: 1)
         let engineA = SyncEngine()
         guard case .pushed = await engineA.push(package: a) else {
@@ -228,9 +274,8 @@ import SwiftGit2
         guard case .bootstrapped = await engineB.pull(package: b) else {
             Issue.record("fixture bootstrap failed"); return
         }
-        let commonAncestor = try await headOID(in: b.sourceURL)
 
-        // A and B each commit independently from the same base.
+        // A and B each commit independently from the same base, touching different files.
         try "a-edit".write(to: a.sourceURL.appendingPathComponent("a-only.txt"), atomically: true, encoding: .utf8)
         try await git(["add", "-A"], in: a.sourceURL)
         try await git(["commit", "-m", "a's work"], in: a.sourceURL)
@@ -242,23 +287,263 @@ import SwiftGit2
         try "b-edit".write(to: b.sourceURL.appendingPathComponent("b-only.txt"), atomically: true, encoding: .utf8)
         try await git(["add", "-A"], in: b.sourceURL)
         try await git(["commit", "-m", "b's work"], in: b.sourceURL)
+
+        let result = await engineB.pull(package: b)
+        guard case .merged(let branch, let mergedTips) = result else {
+            Issue.record("expected .merged, got \(result)"); return
+        }
+        #expect(branch == "main")
+        #expect(mergedTips == ["icloud"])
+
+        // Both sides' edits survived — nothing lost.
+        #expect(FileManager.default.fileExists(atPath: b.sourceURL.appendingPathComponent("a-only.txt").path))
+        #expect(FileManager.default.fileExists(atPath: b.sourceURL.appendingPathComponent("b-only.txt").path))
+
+        // Full convergence pushed the merged bundle back — a peer bootstrapping fresh now sees
+        // both edits.
+        SwiftGit2Bootstrap.ensureInitialized
+        guard case .success(let repo) = Repository.at(b.sourceURL), case .success(let head) = repo.HEAD(),
+              let headCommit = try? repo.commit(head.oid).get() else {
+            Issue.record("couldn't read B's merged HEAD"); return
+        }
+        #expect(headCommit.parents.count == 2)
+    }
+
+    @Test("pull surfaces overlapping edits as a typed SyncConflict, rewinding nothing")
+    func divergedPullReportsOverlappingConflict() async throws {
+        let a = try await makeGitPackage(name: "A9", commits: 1)
+        let engineA = SyncEngine()
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture push failed"); return
+        }
+
+        let b = try makeFreshPeerPackage(mirroring: a, name: "B9")
+        let engineB = SyncEngine()
+        guard case .bootstrapped = await engineB.pull(package: b) else {
+            Issue.record("fixture bootstrap failed"); return
+        }
+
+        // A and B both edit the SAME file from the same base — a genuine textual conflict.
+        try "a-version".write(to: a.sourceURL.appendingPathComponent("file0.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: a.sourceURL)
+        try await git(["commit", "-m", "a's conflicting edit"], in: a.sourceURL)
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture A push failed"); return
+        }
+        try copyArtifact(from: a, to: b)
+        let aHead = try await headOID(in: a.sourceURL)
+
+        try "b-version".write(to: b.sourceURL.appendingPathComponent("file0.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: b.sourceURL)
+        try await git(["commit", "-m", "b's conflicting edit"], in: b.sourceURL)
         let bHeadBeforePull = try await headOID(in: b.sourceURL)
 
         let result = await engineB.pull(package: b)
-        guard case .diverged(let branch) = result else {
-            Issue.record("expected .diverged, got \(result)"); return
+        guard case .conflicted(let conflict) = result else {
+            Issue.record("expected .conflicted, got \(result)"); return
         }
-        #expect(branch == "main")
-        // Not merged: B's checked-out HEAD is untouched by the diverged pull.
+        #expect(conflict.branch == "main")
+        #expect(conflict.conflictedPaths == ["file0.txt"])
+        #expect(conflict.ourOID == bHeadBeforePull)
+        #expect(conflict.theirOID == aHead)
+        #expect(conflict.theirSource == "icloud")
+
+        // Never auto-resolved, never rewound: B's local HEAD is exactly where it was.
         #expect(try await headOID(in: b.sourceURL) == bHeadBeforePull)
-        // But the fetch happened — A's history is sitting in the namespaced remote ref, ready for
-        // P4's three-way merge to pick up without re-fetching.
+        // Both tips intact: A's edit is still fully reachable from the namespaced remote ref.
         SwiftGit2Bootstrap.ensureInitialized
         guard case .success(let repo) = Repository.at(b.sourceURL),
               case .success(let icloudMain) = repo.reference(named: "refs/remotes/icloud/main") else {
-            Issue.record("expected refs/remotes/icloud/main to exist after a diverged pull"); return
+            Issue.record("expected refs/remotes/icloud/main to exist after a conflicted pull"); return
         }
-        #expect(icloudMain.oid.description != commonAncestor)
+        #expect(icloudMain.oid.description == aHead)
+    }
+
+    @Test("pull folds in multiple NSFileVersion conflict versions, fetching each into its own peer namespace")
+    func pullFetchesMultipleConflictVersions() async throws {
+        let a = try await makeGitPackage(name: "A10", commits: 1)
+        let engineA = SyncEngine()
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture push failed"); return
+        }
+        let peerBundle = try await makeConflictVersionBundle(from: a, name: "Peer10") { sourceURL in
+            try "peer-edit".write(to: sourceURL.appendingPathComponent("peer-only.txt"), atomically: true, encoding: .utf8)
+        }
+
+        let b = try makeFreshPeerPackage(mirroring: a, name: "B10")
+        let engineB = SyncEngine()
+        guard case .bootstrapped = await engineB.pull(package: b) else {
+            Issue.record("fixture bootstrap failed"); return
+        }
+
+        // A advances the icloud tip so B's own local edit below genuinely diverges from it
+        // (rather than merely being ahead) — the manufactured conflict version is folded in
+        // alongside that divergence.
+        try "a-edit".write(to: a.sourceURL.appendingPathComponent("a-only.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: a.sourceURL)
+        try await git(["commit", "-m", "a's work"], in: a.sourceURL)
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture A push failed"); return
+        }
+        try copyArtifact(from: a, to: b)
+
+        try "b-edit".write(to: b.sourceURL.appendingPathComponent("b-only.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: b.sourceURL)
+        try await git(["commit", "-m", "b's work"], in: b.sourceURL)
+
+        let versionStore = FakeVersionStore()
+        versionStore.conflictArtifactURLs = [peerBundle]
+        let engine = SyncEngine(versionStore: versionStore)
+        let result = await engine.pull(package: b)
+        guard case .merged(let branch, let mergedTips) = result else {
+            Issue.record("expected .merged, got \(result)"); return
+        }
+        #expect(branch == "main")
+        #expect(mergedTips == ["icloud", "peer-0"])
+        #expect(versionStore.resolvedIDs == ["peer-0"])
+
+        #expect(FileManager.default.fileExists(atPath: b.sourceURL.appendingPathComponent("a-only.txt").path))
+        #expect(FileManager.default.fileExists(atPath: b.sourceURL.appendingPathComponent("b-only.txt").path))
+        #expect(FileManager.default.fileExists(atPath: b.sourceURL.appendingPathComponent("peer-only.txt").path))
+
+        SwiftGit2Bootstrap.ensureInitialized
+        guard case .success(let repo) = Repository.at(b.sourceURL) else {
+            Issue.record("Repository.at failed after reconciliation"); return
+        }
+        #expect((try? repo.reference(named: "refs/remotes/peer-0/main").get()) != nil)
+    }
+
+    @Test("both peers converge to the same history after independently running reconciliation")
+    func bothPeersConverge() async throws {
+        let a = try await makeGitPackage(name: "A11", commits: 1)
+        let engineA = SyncEngine()
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture push failed"); return
+        }
+
+        let b = try makeFreshPeerPackage(mirroring: a, name: "B11")
+        let engineB = SyncEngine()
+        guard case .bootstrapped = await engineB.pull(package: b) else {
+            Issue.record("fixture bootstrap failed"); return
+        }
+
+        // A and B diverge with non-overlapping edits.
+        try "a-edit".write(to: a.sourceURL.appendingPathComponent("a-only.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: a.sourceURL)
+        try await git(["commit", "-m", "a's work"], in: a.sourceURL)
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture A push failed"); return
+        }
+        try copyArtifact(from: a, to: b)
+
+        try "b-edit".write(to: b.sourceURL.appendingPathComponent("b-only.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: b.sourceURL)
+        try await git(["commit", "-m", "b's work"], in: b.sourceURL)
+
+        // B reconciles and pushes the merge first.
+        guard case .merged = await engineB.pull(package: b) else {
+            Issue.record("expected B to merge cleanly"); return
+        }
+        let bHead = try await headOID(in: b.sourceURL)
+
+        // A pulls next: its own commit is already an ancestor of B's merge, so this is a plain
+        // fast-forward — both Macs run the same procedure and land on the same history without
+        // an arbiter.
+        try copyArtifact(from: b, to: a)
+        let result = await engineA.pull(package: a)
+        guard case .fastForwarded(_, _, let to) = result else {
+            Issue.record("expected A to fast-forward onto B's merge, got \(result)"); return
+        }
+        #expect(to == bHead)
+        #expect(try await headOID(in: a.sourceURL) == bHead)
+        #expect(FileManager.default.fileExists(atPath: a.sourceURL.appendingPathComponent("a-only.txt").path))
+        #expect(FileManager.default.fileExists(atPath: a.sourceURL.appendingPathComponent("b-only.txt").path))
+    }
+
+    // MARK: - Conflicted state: pause + resolution acknowledgement
+
+    @Test("push pauses while a conflict is pending, then proceeds once acknowledged")
+    func pushPausesWhileConflicted() async throws {
+        let a = try await makeGitPackage(name: "A12", commits: 1)
+        let engineA = SyncEngine()
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture push failed"); return
+        }
+
+        let b = try makeFreshPeerPackage(mirroring: a, name: "B12")
+        let engineB = SyncEngine()
+        guard case .bootstrapped = await engineB.pull(package: b) else {
+            Issue.record("fixture bootstrap failed"); return
+        }
+
+        try "a-version".write(to: a.sourceURL.appendingPathComponent("file0.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: a.sourceURL)
+        try await git(["commit", "-m", "a's conflicting edit"], in: a.sourceURL)
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture A push failed"); return
+        }
+        try copyArtifact(from: a, to: b)
+
+        try "b-version".write(to: b.sourceURL.appendingPathComponent("file0.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: b.sourceURL)
+        try await git(["commit", "-m", "b's conflicting edit"], in: b.sourceURL)
+
+        guard case .conflicted = await engineB.pull(package: b) else {
+            Issue.record("expected fixture pull to conflict"); return
+        }
+        #expect(await engineB.pendingConflict(package: b) != nil)
+
+        let pausedPush = await engineB.push(package: b)
+        guard case .pausedForConflict(let branch) = pausedPush else {
+            Issue.record("expected .pausedForConflict, got \(pausedPush)"); return
+        }
+        #expect(branch == "main")
+
+        await engineB.acknowledgeConflictResolved(package: b)
+        #expect(await engineB.pendingConflict(package: b) == nil)
+
+        // No longer paused — an ordinary push attempt proceeds (whatever its outcome).
+        let pushAfterAcknowledge = await engineB.push(package: b)
+        if case .pausedForConflict = pushAfterAcknowledge {
+            Issue.record("push should no longer be paused after acknowledging the conflict")
+        }
+    }
+
+    // MARK: - Working-tree conflict-copy quarantine
+
+    @Test("pull quarantines iCloud conflict-copy-named files in Source/ into Config/conflicts/")
+    func pullQuarantinesConflictCopies() async throws {
+        let pkg = try await makeGitPackage(name: "A13", commits: 1)
+        let engine = SyncEngine()
+        guard case .pushed = await engine.push(package: pkg) else {
+            Issue.record("fixture push failed"); return
+        }
+
+        let numberedDuplicateName = "file0 2.txt" // sibling "file0.txt" already exists from the fixture
+        let verboseConflictName = "notes (Some Mac's conflicted copy 2026-07-21).txt"
+        try "dup".write(to: pkg.sourceURL.appendingPathComponent(numberedDuplicateName), atomically: true, encoding: .utf8)
+        try "verbose-dup".write(to: pkg.sourceURL.appendingPathComponent(verboseConflictName), atomically: true, encoding: .utf8)
+        // Not a conflict copy: no sibling "season.txt" exists, so this must survive the sweep.
+        try "not-a-conflict".write(to: pkg.sourceURL.appendingPathComponent("season 2.txt"), atomically: true, encoding: .utf8)
+
+        // The quarantined files were never committed, so removing them leaves no trace — but the
+        // deliberately-surviving "season 2.txt" is still untracked afterward, so the snapshot step
+        // commits it, putting local ahead of the (unchanged) artifact.
+        let result = await engine.pull(package: pkg)
+        guard case .localAhead(let branch) = result else {
+            Issue.record("expected .localAhead, got \(result)"); return
+        }
+        #expect(branch == "main")
+
+        let fm = FileManager.default
+        #expect(!fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent(numberedDuplicateName).path))
+        #expect(!fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent(verboseConflictName).path))
+        #expect(fm.fileExists(atPath: pkg.sourceURL.appendingPathComponent("season 2.txt").path))
+
+        let quarantineDirectory = pkg.configURL.appendingPathComponent("conflicts", isDirectory: true)
+        let quarantined = (try? fm.contentsOfDirectory(at: quarantineDirectory, includingPropertiesForKeys: nil)) ?? []
+        #expect(quarantined.contains { $0.lastPathComponent.hasSuffix(numberedDuplicateName) })
+        #expect(quarantined.contains { $0.lastPathComponent.hasSuffix(verboseConflictName) })
     }
 
     // MARK: - Fresh peer / dangling-gitfile repair / corrupted-repo rebuild


### PR DESCRIPTION
## Summary

- `SyncEngine.pull()` now fully reconciles divergence (design doc `2026-07-21-icloud-git-sync-design.md` §3) instead of just reporting it: snapshot local changes, fetch every NSFileVersion conflict version of the sync bundle alongside the current artifact, then fold each fetched tip into the local branch — fast-forward when possible, an auto-committed libgit2 three-way merge on clean divergence. A textual conflict stops the line and surfaces as a typed `SyncConflict` (never auto-resolved, never rewound); `push()` pauses on that branch until `acknowledgeConflictResolved()` is called. Full convergence checks the merged HEAD out into `Source/` and pushes it back.
- Working-tree conflict-copy files iCloud drops into `Source/` (`"name (conflicted copy …).ext"`, `"name 2.ext"` with a sibling) are quarantined into `Config/conflicts/` on every `pull()` — never silently deleted.
- `VersionStore` gains one new, additive method, `conflictVersions(of:)`, returning `ConflictVersionHandle`s — `materialize(at:timeout:)`'s contract is unchanged, so P3 callers keep compiling unmodified.

This is **stacked on #998** (`feat/879-syncengine-core`), which is itself stacked on #997 (`feat/878-syncartifact-bundle-v2`). Please merge bottom-up: #997 → #998 → this PR. References #880, epic #876.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

## Test plan

- [x] `swift test --package-path .` — full suite green except the 2 known pre-existing `FoundationModelAssistant` flaky failures ("Session ended without producing a response" on `generate streams non-empty text` and `abandoning a generate stream mid-generation drains without trapping (#201)`), reproduced identically on a second run of that suite alone and unrelated to this change (no `SyncEngine`/`VersionStore` involvement). All 16 `SyncEngineTests` (5 new + 11 existing, migrated where P3 behavior changed) pass, including new coverage for multi-version fetch, clean-merge convergence (both peers), conflict surfacing, pause-while-conflicted, and the conflict-copy quarantine sweep.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; this is pure SwiftPM work in `AnglesiteCore`/`AnglesiteCoreTests`, no `Sources/AnglesiteApp` files touched, and a worktree has no generated `.xcodeproj` (per repo convention, xcodegen isn't needed for this change).
- [ ] Manual smoke (if UI-touching): N/A — no UI in this phase; P5 wires the conflict banner/resolution UI on top of the API this PR exposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)