### PR TITLE
build(signing): let local Debug signing survive xcodegen regen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ Resources/Anglesite.help/**/*.helpindex
 # Playwright MCP browser-session artifacts
 .playwright-mcp/
 build-smoke/
+
+# Personal signing override (see xcconfig/Signing-Debug.xcconfig) — machine-specific
+# Apple Developer Team, never shared.
+xcconfig/Signing-Debug.local.xcconfig

--- a/project.yml
+++ b/project.yml
@@ -61,6 +61,12 @@ targets:
       - name: Build Help index
         script: "\"${PROJECT_DIR}/scripts/build-help-index.sh\""
         basedOnDependencyAnalysis: false
+    # Debug signing (CODE_SIGN_STYLE/IDENTITY/TEAM) comes from xcconfig/Signing-Debug.xcconfig
+    # instead of inline settings below, so a personal Team set via Xcode's Signing &
+    # Capabilities tab can persist across `xcodegen generate` — see that file for how to
+    # override it locally without editing this tracked config.
+    configFiles:
+      Debug: xcconfig/Signing-Debug.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite
@@ -88,8 +94,6 @@ targets:
         OTHER_LDFLAGS: "$(inherited) -weak_framework FoundationModels"
       configs:
         Debug:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "-"
           # #775 workaround: punch the com.apple.NetworkSharing mach look-up back
           # through the sandbox so container boots survive macOS 27 seeds
           # 26A5378n–26A5388g. Debug-only — never ships to MAS.
@@ -133,6 +137,9 @@ targets:
       - name: Build edit overlay
         script: "\"${PROJECT_DIR}/scripts/build-overlay.sh\""
         basedOnDependencyAnalysis: false
+    # See the Anglesite target's matching comment on configFiles above.
+    configFiles:
+      Debug: xcconfig/Signing-Debug.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite.ios
@@ -151,9 +158,6 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"
       configs:
-        Debug:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "-"
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Apple Distribution"
@@ -170,6 +174,10 @@ targets:
     platform: macOS
     sources:
       - path: Sources/AnglesiteQuickLookPreview
+    # See the Anglesite target's matching comment on configFiles above. Extensions embedded
+    # in the host app need matching signing style/team for automatic signing to resolve.
+    configFiles:
+      Debug: xcconfig/Signing-Debug.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite.QuickLookPreview
@@ -184,9 +192,6 @@ targets:
         MARKETING_VERSION: "0.1.0"
         SKIP_INSTALL: YES
       configs:
-        Debug:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "-"
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Apple Distribution"
@@ -199,6 +204,10 @@ targets:
     platform: macOS
     sources:
       - path: Sources/AnglesiteQuickLookThumbnail
+    # See the Anglesite target's matching comment on configFiles above. Extensions embedded
+    # in the host app need matching signing style/team for automatic signing to resolve.
+    configFiles:
+      Debug: xcconfig/Signing-Debug.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite.QuickLookThumbnail
@@ -213,9 +222,6 @@ targets:
         MARKETING_VERSION: "0.1.0"
         SKIP_INSTALL: YES
       configs:
-        Debug:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "-"
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Apple Distribution"

--- a/xcconfig/Signing-Debug.local.xcconfig.example
+++ b/xcconfig/Signing-Debug.local.xcconfig.example
@@ -1,0 +1,7 @@
+// Copy this file to Signing-Debug.local.xcconfig (same directory) to pin your own
+// Apple Developer Team for local Debug builds. That filename is gitignored, so it
+// survives `xcodegen generate` without affecting CI or other contributors.
+//
+// Find your Team ID in Xcode: Settings > Accounts > (your Apple ID) > (team) > Team ID.
+CODE_SIGN_STYLE = Automatic
+DEVELOPMENT_TEAM = YOUR_TEAM_ID

--- a/xcconfig/Signing-Debug.xcconfig
+++ b/xcconfig/Signing-Debug.xcconfig
@@ -1,0 +1,13 @@
+// Shared Debug-config code-signing defaults, wired in via each target's `configFiles`
+// entry in project.yml. Tracked — keep these values CI-safe (ad-hoc, no team) so a
+// fresh clone or CI runner can build Debug without owning an Apple Developer Team.
+//
+// To run locally with your own Team (e.g. so "Automatically manage signing" in Xcode's
+// Signing & Capabilities tab survives `xcodegen generate` instead of being silently
+// reverted), copy Signing-Debug.local.xcconfig.example to Signing-Debug.local.xcconfig
+// (gitignored) next to this file and fill in your Team ID.
+CODE_SIGN_STYLE = Manual
+CODE_SIGN_IDENTITY = -
+DEVELOPMENT_TEAM =
+
+#include? "Signing-Debug.local.xcconfig"


### PR DESCRIPTION
## Summary

- `Anglesite.xcodeproj` is gitignored and fully regenerated from `project.yml` on every `xcodegen generate`, but `project.yml` pinned `CODE_SIGN_STYLE: Manual` for every target — so checking "Automatically manage signing" (and picking a personal Team) in Xcode's Signing & Capabilities tab wrote straight into the disposable `.pbxproj` and got silently reverted on the next regen.
- Debug signing for `Anglesite`, `AnglesiteMobile`, `AnglesiteQuickLookPreview`, and `AnglesiteQuickLookThumbnail` now comes from a tracked `xcconfig/Signing-Debug.xcconfig` (CI-safe defaults: ad-hoc, no team) that optionally `#include?`s a gitignored `xcconfig/Signing-Debug.local.xcconfig` — so a contributor's personal Team persists across every `xcodegen generate` without editing a shared, tracked file. A `.example` template documents the format.
- Release configs are untouched — still pinned to `Manual` / `Apple Distribution` for MAS submission, as before.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [x] `xcodegen generate` then `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds, with a local `Signing-Debug.local.xcconfig` present, `xcodebuild -showBuildSettings` confirms Debug resolves `CODE_SIGN_STYLE = Automatic` / `DEVELOPMENT_TEAM` from the local override, while `-configuration Release -showBuildSettings` confirms Release still resolves `Manual` / `Apple Distribution` with no team.
- [ ] `swift test --package-path .` — not run; this change touches only `project.yml`/Xcode signing config, no Swift or JS sources.