### PR TITLE
feat(#881): iCloud sync P5 — app wiring, conflict UX, manual QA doc

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -983,6 +983,12 @@
     "Disallow" : {
 
     },
+    "Discard" : {
+
+    },
+    "Discard %@" : {
+
+    },
     "Dismiss" : {
 
     },
@@ -1076,6 +1082,9 @@
     "Error" : {
 
     },
+    "Error: %@" : {
+
+    },
     "Explain" : {
 
     },
@@ -1125,6 +1134,12 @@
 
     },
     "File modified outside Anglesite" : {
+
+    },
+    "Files edited on both Macs" : {
+
+    },
+    "Files iCloud saved as separate conflict copies. Their content already exists in this site's history; you can discard them." : {
 
     },
     "Filter retrieval by content type" : {
@@ -1292,6 +1307,9 @@
     "Hide related pages" : {
 
     },
+    "Hide this banner — the site stays fully editable; reopen it from the sync status icon" : {
+
+    },
     "Highlight" : {
 
     },
@@ -1377,6 +1395,12 @@
 
     },
     "Keep My Changes" : {
+
+    },
+    "Keep which version" : {
+
+    },
+    "Keep which version of %@" : {
 
     },
     "Kind" : {
@@ -1658,6 +1682,9 @@
     "Open %@ in its own window" : {
 
     },
+    "Open Both…" : {
+
+    },
     "Open Cloudflare API tokens" : {
 
     },
@@ -1712,10 +1739,16 @@
     "Opens %@ in the default editor" : {
 
     },
+    "Opens both versions of %@ in Finder to compare before choosing" : {
+
+    },
     "Opens the live log of the running dev server and dependency installation." : {
 
     },
     "Opens the log of the failed dev server launch." : {
+
+    },
+    "Opens the sync conflict resolution sheet" : {
 
     },
     "Optional" : {
@@ -1725,6 +1758,9 @@
 
     },
     "Ordered" : {
+
+    },
+    "Other Mac" : {
 
     },
     "Overview of the whole graph — click to jump to a node" : {
@@ -1883,6 +1919,9 @@
     "Publish…" : {
 
     },
+    "Quarantined copies" : {
+
+    },
     "Re-check" : {
 
     },
@@ -2034,7 +2073,13 @@
     "Resolve" : {
 
     },
+    "Resolve Sync Conflict" : {
+
+    },
     "Resolve this annotation" : {
+
+    },
+    "Resolve…" : {
 
     },
     "Resolving zone and reading current state…" : {
@@ -2063,6 +2108,12 @@
       }
     },
     "Retry" : {
+
+    },
+    "Reveal" : {
+
+    },
+    "Reveal %@ in Finder" : {
 
     },
     "Reveal in Finder" : {
@@ -2314,6 +2365,9 @@
     "Shows the most recent pre-deploy scan results" : {
 
     },
+    "Shows this site's iCloud sync status" : {
+
+    },
     "Sign In…" : {
 
     },
@@ -2515,6 +2569,9 @@
     "Thinking…" : {
 
     },
+    "This Mac" : {
+
+    },
     "This can't be undone." : {
 
     },
@@ -2522,6 +2579,9 @@
 
     },
     "This component changed outside Anglesite — your edit wasn't applied, reloaded the latest version." : {
+
+    },
+    "This copy's content already exists in this site's git history" : {
 
     },
     "This file appears unused and will be permanently removed." : {
@@ -2811,6 +2871,12 @@
 
     },
     "https://agent.example.com/acp" : {
+
+    },
+    "iCloud Sync" : {
+
+    },
+    "iCloud sync status" : {
 
     },
     "low confidence" : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -205,6 +205,16 @@ struct SiteWindow: View {
         } detail: {
             ZStack(alignment: .bottom) {
                 VStack(spacing: 0) {
+                    // Non-blocking conflict banner (#881): docked above the content, never a
+                    // sheet/alert, so the site stays fully editable while it's showing.
+                    if model.sync.bannerPresented {
+                        SyncConflictBannerView(
+                            fileCount: (model.sync.conflict?.conflictedPaths.count ?? 0) + model.sync.quarantinedFiles.count,
+                            onResolve: { model.sync.openResolutionSheet() },
+                            onDismiss: { model.sync.dismissBanner() }
+                        )
+                        .transition(reduceMotion ? .opacity : .move(edge: .top).combined(with: .opacity))
+                    }
                     HStack(spacing: 0) {
                         mainPane(for: site)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -303,6 +313,13 @@ struct SiteWindow: View {
                     Label("Site Graph", systemImage: "point.3.connected.trianglepath.dotted")
                 }
                 .help("Explore pages, layouts, components, collections, and assets")
+            }
+
+            // iCloud sync status (#881): renders nothing for a package that isn't in iCloud
+            // Drive (`SyncStatusView` is an `EmptyView` when `!model.sync.isEligible`), so this
+            // item never widens a local-only site's toolbar.
+            ToolbarItem(id: SiteToolbarItemID.sync.rawValue, placement: .primaryAction) {
+                SyncStatusView(model: model.sync)
             }
 
             ToolbarItem(id: SiteToolbarItemID.backup.rawValue, placement: .primaryAction) {
@@ -544,6 +561,9 @@ struct SiteWindow: View {
                 siteName: site.name,
                 onRunAgain: { model.audit.audit(siteID: site.id, siteDirectory: site.sourceDirectory) }
             )
+        }
+        .sheet(isPresented: $bindableModel.sync.resolutionSheetPresented) {
+            SyncConflictResolutionSheetView(model: model.sync, siteName: site.name)
         }
         .sheet(isPresented: $bindableModel.harden.sheetPresented) {
             HardenSheetView(model: model.harden)

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -3,6 +3,7 @@ import Foundation
 import Observation
 import AnglesiteCore
 import AnglesiteIntents
+import AnglesiteSiteModel
 
 /// Which content the main pane shows: the live preview, or the inline text editor
 /// for a specific file. Driven by navigator selection (`applyNavigatorSelection`).
@@ -80,6 +81,10 @@ final class SiteWindowModel {
     var publish = PublishModel()
     var backup = BackupModel()
     var audit = AuditModel()
+    /// Drives this site's iCloud git sync (#881): status surface, `NSMetadataQuery` bundle-change
+    /// observation, and the conflict banner/resolution sheet. No-ops entirely for a package that
+    /// doesn't live in iCloud Drive — see `SyncModel.start(package:)`.
+    var sync = SyncModel()
     // Chat is now on both targets and backed by the on-device `FoundationModelAssistant`;
     // the panel UI is target-agnostic.
     var chat: ChatModel?
@@ -229,6 +234,22 @@ final class SiteWindowModel {
         // and receive the run's site id from the model, so there is nothing to rebind on
         // window replay — see CompletionNotificationHub's own doc comment.
         CompletionNotificationHub.wire(deploy: deploy, backup: backup, audit: audit)
+        // Layered on top of (not inside) CompletionNotificationHub, which deliberately captures
+        // nothing from this model: a successful backup or deploy is one of #881's three debounced
+        // push triggers (design doc §2's "App wiring" paragraph). `[weak self]` mirrors the same
+        // "an abandoned window doesn't block the operation's own terminal notification" contract —
+        // if the window is already gone by the time this fires, there's no sync status surface
+        // left to update either, and the site's next open runs `siteOpened()` regardless.
+        let backupHook = backup.onPhaseTransition
+        backup.onPhaseTransition = { [weak self] siteID, phase in
+            backupHook?(siteID, phase)
+            if case .succeeded = phase { self?.sync.backupCompleted() }
+        }
+        let deployHook = deploy.onPhaseTransition
+        deploy.onPhaseTransition = { [weak self] siteID, phase in
+            deployHook?(siteID, phase)
+            if case .succeeded = phase { self?.sync.deployCompleted() }
+        }
     }
 
     var activeEditorFile: FileRef? {
@@ -451,6 +472,7 @@ final class SiteWindowModel {
 
     func close(suddenTerminationLease: SuddenTerminationController.Lease? = nil) {
         stopInvisiblePublishing()
+        sync.stop()
         preview.close()
         startup.stop()
         // Note: an in-flight Deploy/Backup/Audit is intentionally NOT cancelled or cleaned up
@@ -1411,6 +1433,9 @@ final class SiteWindowModel {
         let currentSite = CurrentSite(resolved)
         AppSettings.shared.lastOpenedSiteID = resolved.id
         try? await store.touch(id: resolved.id)
+        // #881: pull on site open. `SyncModel.start` no-ops entirely for a package that isn't in
+        // iCloud Drive, so a plain local site sees zero sync activity here.
+        sync.start(package: AnglesitePackage(url: resolved.packageURL))
 
         #if ANGLESITE_MAS
         await grantController.acquireGrant(for: resolved, in: store)

--- a/Sources/AnglesiteApp/SyncConflictBannerView.swift
+++ b/Sources/AnglesiteApp/SyncConflictBannerView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Non-blocking "this site was edited on two Macs" banner (#881, design doc §3's "Conflict UX"
+/// paragraph). Docked at the top of the detail pane — never a sheet or alert, so it never
+/// interrupts editing (#881 acceptance criteria: "conflict banner never blocks editing"). A single
+/// "Resolve…" action opens `SyncConflictResolutionSheetView`.
+struct SyncConflictBannerView: View {
+    let fileCount: Int
+    let onResolve: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.icloud.fill")
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
+            Text(message)
+                .font(.callout)
+            Spacer(minLength: 12)
+            Button("Resolve…", action: onResolve)
+                .controlSize(.small)
+                .buttonStyle(.borderedProminent)
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.plain)
+            .controlSize(.small)
+            .accessibilityLabel("Dismiss")
+            .help("Hide this banner — the site stays fully editable; reopen it from the sync status icon")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(.orange.opacity(0.12), in: Rectangle())
+        .overlay(alignment: .bottom) { Divider() }
+    }
+
+    private var message: String {
+        "This site was edited on two Macs — \(fileCount) file\(fileCount == 1 ? "" : "s") need attention."
+    }
+}

--- a/Sources/AnglesiteApp/SyncConflictResolutionSheetView.swift
+++ b/Sources/AnglesiteApp/SyncConflictResolutionSheetView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Per-file sync conflict resolution sheet (#881, design doc §3): keep this Mac's / keep the
+/// other's / open both, for every path `SyncModel.conflictedFiles` lists, plus the quarantined
+/// `Config/conflicts/` working-tree copies in the same sheet. "Apply" is disabled until every
+/// conflicted path has a choice — a partial resolution can't produce a valid merge commit
+/// (`SyncConflictResolver.resolve` itself refuses one).
+///
+/// Mac-assed-app-spec compliance: standard sheet chrome (Cancel/Apply in the standard toolbar
+/// placements — Esc and ⌘. both dismiss via Cancel, ⌘Return activates Apply), VoiceOver labels on
+/// every control, and no state is silently discarded — Cancel leaves the conflict exactly as it
+/// was; nothing here writes to the repo until Apply succeeds.
+struct SyncConflictResolutionSheetView: View {
+    @Bindable var model: SyncModel
+    let siteName: String
+
+    @State private var choices: [String: SyncConflictResolver.Choice] = [:]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if !model.conflictedFiles.isEmpty {
+                    Section("Files edited on both Macs") {
+                        ForEach(model.conflictedFiles) { file in
+                            conflictedFileRow(file)
+                        }
+                    }
+                }
+                if !model.quarantinedFiles.isEmpty {
+                    Section("Quarantined copies") {
+                        ForEach(model.quarantinedFiles, id: \.self) { url in
+                            quarantinedFileRow(url)
+                        }
+                    }
+                    .accessibilityLabel("Files iCloud saved as separate conflict copies. Their content already exists in this site's history; you can discard them.")
+                }
+                if let error = model.resolutionError {
+                    Section {
+                        Label(error, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                            .accessibilityLabel("Error: \(error)")
+                    }
+                }
+            }
+            .navigationTitle("Resolve Sync Conflict")
+            .navigationSubtitle(siteName)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { model.dismissResolutionSheet() }
+                        .keyboardShortcut(.cancelAction)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        model.resolve(choices: choices)
+                    } label: {
+                        if model.isResolving {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Text("Apply")
+                        }
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!isEveryConflictedFileResolved || model.isResolving)
+                }
+            }
+        }
+        .frame(minWidth: 520, minHeight: 360)
+        // Esc's default sheet-dismiss behavior is exactly Cancel here — resolving nothing is
+        // always safe (the site stays editable, per the design doc; only pushing this branch
+        // stays paused), so no `.interactiveDismissDisabled()` is needed.
+    }
+
+    private var isEveryConflictedFileResolved: Bool {
+        !model.conflictedFiles.isEmpty && model.conflictedFiles.allSatisfy { choices[$0.path] != nil }
+    }
+
+    @ViewBuilder
+    private func conflictedFileRow(_ file: SyncConflictResolver.ConflictedFile) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(file.path)
+                .font(.callout.monospaced())
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Picker("Keep which version", selection: Binding<SyncConflictResolver.Choice?>(
+                get: { choices[file.path] },
+                set: { choices[file.path] = $0 }
+            )) {
+                Text("This Mac").tag(Optional(SyncConflictResolver.Choice.keepMine))
+                Text("Other Mac").tag(Optional(SyncConflictResolver.Choice.keepTheirs))
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityLabel("Keep which version of \(file.path)")
+
+            Button("Open Both…") {
+                model.openBothVersions(for: file)
+            }
+            .buttonStyle(.link)
+            .font(.caption)
+            .disabled(file.oursText == nil && file.theirsText == nil)
+            .accessibilityHint("Opens both versions of \(file.path) in Finder to compare before choosing")
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func quarantinedFileRow(_ url: URL) -> some View {
+        HStack {
+            Image(systemName: "doc.on.doc")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(url.lastPathComponent)
+                .font(.callout.monospaced())
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            Button("Reveal") { model.revealQuarantinedFile(url) }
+                .buttonStyle(.link)
+                .font(.caption)
+                .accessibilityLabel("Reveal \(url.lastPathComponent) in Finder")
+            Button("Discard", role: .destructive) { model.deleteQuarantinedFile(url) }
+                .buttonStyle(.link)
+                .font(.caption)
+                .accessibilityLabel("Discard \(url.lastPathComponent)")
+                .accessibilityHint("This copy's content already exists in this site's git history")
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SyncModel.swift
+++ b/Sources/AnglesiteApp/SyncModel.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+import AppKit
+import AnglesiteCore
+import AnglesiteSiteModel
+
+/// SwiftUI-facing wrapper around one site's `SyncScheduler`/`SyncEngine`/`SyncConflictResolver`
+/// (#881). One per open site window, matching `SyncEngine`'s single-caller-per-package invariant
+/// (`SiteWindowModel` owns exactly one `SyncModel`, same as `deploy`/`backup`).
+///
+/// **Thin by design.** Every debounce/coalescing/trigger decision lives in `SyncScheduler`
+/// (AnglesiteCore, unit-tested in `SyncSchedulerTests`) — this type only renders its status and
+/// forwards events the scheduler has no business knowing about: `NSMetadataQuery` bundle-change
+/// observation, `NSApplication.didResignActiveNotification` for backgrounding, and the
+/// backup/deploy completion hooks wired in `SiteWindowModel.init`.
+///
+/// **Eligibility gate.** `start(package:)` only stands up an engine/scheduler/query when
+/// `ICloudSyncEligibility.isEligible(package:)` is true. A plain local package never gets any of
+/// that — `status` stays `.idle` forever and nothing here ever touches the filesystem beyond that
+/// one check, satisfying #881's "no sync activity for idle [local] sites".
+@MainActor
+@Observable
+final class SyncModel {
+    /// Mirrors `SyncScheduler.Status`. The scheduler is an actor SwiftUI can't observe directly,
+    /// so this is kept in sync via the scheduler's `onStatusChange` callback.
+    private(set) var status: SyncScheduler.Status = .idle
+    /// `true` once this site's package was confirmed to live in iCloud Drive. `SiteWindow` uses
+    /// this to hide the sync status affordance entirely for a local-only site, rather than
+    /// showing a permanently-idle indicator that implies a feature which isn't active.
+    private(set) var isEligible = false
+
+    var resolutionSheetPresented = false
+    private(set) var conflictedFiles: [SyncConflictResolver.ConflictedFile] = []
+    /// Files iCloud dropped as `name 2.ext`-style conflict copies of plain `Source/` files
+    /// (design doc §3, "Working-tree conflict copies"), quarantined by `SyncEngine.pull()` into
+    /// `Config/conflicts/` — listed here so the resolution sheet can surface them too (#881 scope).
+    private(set) var quarantinedFiles: [URL] = []
+    var resolutionError: String?
+    private(set) var isResolving = false
+
+    private var package: AnglesitePackage?
+    private var engine: SyncEngine?
+    private var scheduler: SyncScheduler?
+    private let resolver = SyncConflictResolver()
+    private var metadataQuery: NSMetadataQuery?
+    private var metadataObserver: (any NSObjectProtocol)?
+    private var backgroundObserver: (any NSObjectProtocol)?
+
+    /// Set by the banner's dismiss (✕) button — hides the banner without resolving anything;
+    /// the sync status toolbar icon reopens the resolution sheet at any time. Reset automatically
+    /// once the conflict is actually resolved, so a *future* conflict shows its own banner rather
+    /// than staying silently suppressed by an old dismissal.
+    private var bannerDismissed = false
+
+    /// `true` while the non-blocking conflict banner should show — never gates editing (#881
+    /// acceptance criteria: "conflict banner never blocks editing").
+    var bannerPresented: Bool {
+        guard case .needsAttention = status else { return false }
+        return !bannerDismissed
+    }
+
+    func dismissBanner() {
+        bannerDismissed = true
+    }
+
+    var conflict: SyncEngine.SyncConflict? {
+        if case .needsAttention(let conflict) = status { return conflict }
+        return nil
+    }
+
+    var statusLabel: String {
+        switch status {
+        case .idle: return isEligible ? "Not yet synced" : "Not synced with iCloud"
+        case .syncing: return "Syncing…"
+        case .synced: return "Synced"
+        case .waitingForICloud: return "Waiting for iCloud…"
+        case .needsAttention(let conflict):
+            let count = conflict.conflictedPaths.count + quarantinedFiles.count
+            return "\(count) file\(count == 1 ? "" : "s") need attention"
+        case .failed(let reason): return "Sync problem: \(reason)"
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Called once per site open (`SiteWindowModel.loadAndStart`). Safe to call again on window
+    /// replay — tears down any previous wiring first.
+    func start(package: AnglesitePackage) {
+        stop()
+        self.package = package
+        guard ICloudSyncEligibility.isEligible(package: package) else {
+            isEligible = false
+            status = .idle
+            return
+        }
+        isEligible = true
+
+        let engine = SyncEngine()
+        self.engine = engine
+        let scheduler = SyncScheduler(package: package, engine: engine) { [weak self] newStatus in
+            Task { @MainActor in self?.apply(newStatus, for: package) }
+        }
+        self.scheduler = scheduler
+
+        observeBundleChanges(package: package)
+        observeAppBackground()
+        refreshQuarantinedFiles()
+        Task { await scheduler.siteOpened() }
+    }
+
+    /// Tears down this site's sync wiring — called from `SiteWindowModel.close()`. An in-flight
+    /// push is left to finish (mirrors `close()`'s own treatment of Deploy/Backup/Audit): only the
+    /// debounce timer and the observers are cancelled.
+    func stop() {
+        metadataQuery?.stop()
+        metadataQuery = nil
+        if let metadataObserver { NotificationCenter.default.removeObserver(metadataObserver) }
+        metadataObserver = nil
+        if let backgroundObserver { NotificationCenter.default.removeObserver(backgroundObserver) }
+        backgroundObserver = nil
+        if let scheduler {
+            Task { await scheduler.stop() }
+        }
+        scheduler = nil
+        engine = nil
+        package = nil
+        status = .idle
+        isEligible = false
+        resolutionSheetPresented = false
+        conflictedFiles = []
+        quarantinedFiles = []
+        resolutionError = nil
+        bannerDismissed = false
+    }
+
+    // MARK: - Push triggers (forwarded from BackupCommand/DeployModel completion + app background)
+
+    func backupCompleted() {
+        guard let scheduler else { return }
+        Task { await scheduler.backupCompleted() }
+    }
+
+    func deployCompleted() {
+        guard let scheduler else { return }
+        Task { await scheduler.deployCompleted() }
+    }
+
+    // MARK: - Conflict resolution sheet
+
+    /// Opens the resolution sheet: loads both sides' text for every conflicted path, and refreshes
+    /// the quarantined-file listing so both surface together.
+    func openResolutionSheet() {
+        guard let package, let conflict else { return }
+        resolutionError = nil
+        refreshQuarantinedFiles()
+        resolutionSheetPresented = true
+        let resolver = resolver
+        Task { @MainActor [weak self] in
+            let files = await resolver.loadConflictedFiles(package: package, conflict: conflict)
+            self?.conflictedFiles = files
+        }
+    }
+
+    func dismissResolutionSheet() {
+        resolutionSheetPresented = false
+        resolutionError = nil
+    }
+
+    /// Commits `choices` (one `SyncConflictResolver.Choice` per conflicted path) as the merge
+    /// resolution, acknowledges it with the engine so pushing resumes, and re-syncs. Leaves the
+    /// sheet open with `resolutionError` set on failure so the user can adjust and retry.
+    func resolve(choices: [String: SyncConflictResolver.Choice]) {
+        guard let package, let conflict, let engine, let scheduler else { return }
+        resolutionError = nil
+        isResolving = true
+        Task { @MainActor [weak self] in
+            let outcome = await self?.resolver.resolve(package: package, conflict: conflict, choices: choices)
+            self?.isResolving = false
+            switch outcome {
+            case .success:
+                await engine.acknowledgeConflictResolved(package: package)
+                self?.resolutionSheetPresented = false
+                self?.conflictedFiles = []
+                _ = await scheduler.conflictResolved()
+            case .failure(let error):
+                self?.resolutionError = error.description
+            case .none:
+                break
+            }
+        }
+    }
+
+    /// "Open both" (#881 scope): materializes both sides' content to a temp location and reveals
+    /// them in Finder so the user can compare before choosing keep-mine/keep-theirs. Doesn't itself
+    /// resolve anything — the user still picks a side afterward.
+    func openBothVersions(for file: SyncConflictResolver.ConflictedFile) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AnglesiteSyncConflict-\(UUID().uuidString)", isDirectory: true)
+        guard (try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)) != nil else { return }
+        let stem = (file.path as NSString).lastPathComponent
+        let mineURL = directory.appendingPathComponent("This Mac — \(stem)")
+        let theirsURL = directory.appendingPathComponent("Other Mac — \(stem)")
+        var revealed: [URL] = []
+        if let oursText = file.oursText, (try? oursText.write(to: mineURL, atomically: true, encoding: .utf8)) != nil {
+            revealed.append(mineURL)
+        }
+        if let theirsText = file.theirsText, (try? theirsText.write(to: theirsURL, atomically: true, encoding: .utf8)) != nil {
+            revealed.append(theirsURL)
+        }
+        guard !revealed.isEmpty else { return }
+        NSWorkspace.shared.activateFileViewerSelecting(revealed)
+    }
+
+    // MARK: - Quarantined working-tree conflict copies
+
+    private func refreshQuarantinedFiles() {
+        guard let package else { quarantinedFiles = []; return }
+        let directory = package.conflictsDirectoryURL
+        let items = (try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)) ?? []
+        quarantinedFiles = items.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    func revealQuarantinedFile(_ url: URL) {
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    /// Discards a quarantined conflict-copy permanently. Safe: the design doc's rationale for
+    /// quarantining rather than deleting outright is that the real content already lives in git
+    /// history by the time `SyncEngine.pull()` swept it here — this is cleanup of a redundant
+    /// working-tree artifact, not the user's only copy of anything.
+    func deleteQuarantinedFile(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        refreshQuarantinedFiles()
+    }
+
+    // MARK: - Status bridging
+
+    private func apply(_ newStatus: SyncScheduler.Status, for package: AnglesitePackage) {
+        // Guard against a stale callback firing after `stop()`/`start()` moved on to a different
+        // package (window replay) — `Task { @MainActor in ... }` in `start(package:)` can resume
+        // after a subsequent `stop()`.
+        guard self.package?.url == package.url else { return }
+        status = newStatus
+        if case .needsAttention = newStatus {
+            refreshQuarantinedFiles()
+        } else {
+            bannerDismissed = false
+        }
+    }
+
+    // MARK: - Observation wiring
+
+    /// Watches `source.bundle` for changes via `NSMetadataQuery` while this site's window is open
+    /// (design doc's "App wiring" paragraph). Scoped to this package's sync directory by path
+    /// prefix in addition to filename — `NSMetadataItemPathKey` is only populated once iCloud has
+    /// resolved the item's location, so an item this Mac has never seen download at all won't
+    /// match until its first `NSMetadataQueryDidUpdate`; that's fine here because `siteOpened()`
+    /// already ran an unconditional `pull()` when the window opened.
+    private func observeBundleChanges(package: AnglesitePackage) {
+        let query = NSMetadataQuery()
+        query.searchScopes = [NSMetadataQueryUbiquitousDataScope]
+        query.predicate = NSPredicate(
+            format: "%K == %@ AND %K BEGINSWITH %@",
+            NSMetadataItemFSNameKey, package.syncBundleURL.lastPathComponent,
+            NSMetadataItemPathKey, package.syncDirectoryURL.path
+        )
+        metadataObserver = NotificationCenter.default.addObserver(
+            forName: .NSMetadataQueryDidUpdate, object: query, queue: .main
+        ) { [weak self] _ in
+            guard let scheduler = self?.scheduler else { return }
+            Task { await scheduler.bundleChanged() }
+        }
+        metadataQuery = query
+        query.start()
+    }
+
+    /// #881: "debounced push()… on app background." `NSApplication.didResignActiveNotification`
+    /// is the standard macOS "the app is no longer frontmost" signal — the closest equivalent to
+    /// an iOS background transition for a Mac app that otherwise just keeps running.
+    private func observeAppBackground() {
+        backgroundObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let scheduler = self?.scheduler else { return }
+            Task { await scheduler.appDidBackground() }
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SyncStatusView.swift
+++ b/Sources/AnglesiteApp/SyncStatusView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import AnglesiteCore
+
+/// iCloud sync status badge (#881), rendered as a palette `ToolbarItem` (`SiteToolbarItemID.sync`)
+/// — mirrors `HealthBadgeView`'s small dot-indicator + popover shape. Hidden entirely (an
+/// `EmptyView`) for a package that doesn't live in iCloud Drive, so a local-only site's toolbar
+/// never implies a feature that isn't active for it.
+struct SyncStatusView: View {
+    @Bindable var model: SyncModel
+
+    @State private var popoverPresented = false
+    @Environment(\.accessibilityDifferentiateWithoutColor) private var differentiateWithoutColor
+    @ScaledMetric(relativeTo: .body) private var badgeDimension = 18
+    @ScaledMetric(relativeTo: .body) private var glyphSize = 11
+
+    var body: some View {
+        if model.isEligible {
+            Button {
+                if model.bannerPresented {
+                    model.openResolutionSheet()
+                } else {
+                    popoverPresented.toggle()
+                }
+            } label: {
+                indicator
+            }
+            .buttonStyle(.plain)
+            .controlSize(.small)
+            .help(model.statusLabel)
+            .accessibilityLabel("iCloud sync status")
+            .accessibilityValue(model.statusLabel)
+            .accessibilityHint(model.bannerPresented
+                ? "Opens the sync conflict resolution sheet"
+                : "Shows this site's iCloud sync status")
+            .popover(isPresented: $popoverPresented, arrowEdge: .top) {
+                popoverContent
+                    .padding(14)
+                    .frame(width: 280)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var indicator: some View {
+        ZStack {
+            if differentiateWithoutColor {
+                Image(systemName: stateSymbol)
+                    .font(.system(size: glyphSize, weight: .bold))
+                    .foregroundStyle(color)
+            } else {
+                Circle()
+                    .fill(color)
+                    .frame(width: 10, height: 10)
+            }
+            if isSyncing {
+                Circle()
+                    .strokeBorder(Color.secondary.opacity(0.5), lineWidth: 1)
+                    .frame(width: 14, height: 14)
+            }
+        }
+        .frame(width: badgeDimension, height: badgeDimension, alignment: .center)
+        .contentShape(Rectangle())
+    }
+
+    private var isSyncing: Bool {
+        if case .syncing = model.status { return true }
+        return false
+    }
+
+    private var stateSymbol: String {
+        switch model.status {
+        case .idle: return "icloud"
+        case .syncing: return "arrow.triangle.2.circlepath.icloud"
+        case .synced: return "checkmark.icloud"
+        case .waitingForICloud: return "icloud.and.arrow.down"
+        case .needsAttention: return "exclamationmark.icloud"
+        case .failed: return "xmark.icloud"
+        }
+    }
+
+    private var color: Color {
+        switch model.status {
+        case .idle, .syncing: return .secondary.opacity(0.6)
+        case .synced: return .green
+        case .waitingForICloud: return .yellow
+        case .needsAttention: return .orange
+        case .failed: return .red
+        }
+    }
+
+    @ViewBuilder
+    private var popoverContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "icloud").foregroundStyle(.secondary)
+                Text("iCloud Sync").font(.headline)
+            }
+            Text(model.statusLabel).font(.callout).foregroundStyle(.secondary)
+            if model.bannerPresented {
+                Button("Resolve…") {
+                    popoverPresented = false
+                    model.openResolutionSheet()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteCore/ICloudSyncEligibility.swift
+++ b/Sources/AnglesiteCore/ICloudSyncEligibility.swift
@@ -1,0 +1,21 @@
+#if canImport(Darwin)
+import Foundation
+import AnglesiteSiteModel
+
+/// Whether a `.anglesite` package should ever get a `SyncScheduler`/`SyncEngine` at all (#881,
+/// design doc §5): only a package that actually lives in iCloud Drive. A plain local package (the
+/// default save location, `~/Sites/`, or anywhere outside an iCloud container) has no
+/// `source.bundle` peer to sync with, and — per #881's acceptance criteria — must see **zero**
+/// sync activity, not merely a quiet one. The app layer checks this once per site open/relocate
+/// and only constructs sync machinery when it's `true`; `SyncScheduler` itself has no idea this
+/// check exists.
+public enum ICloudSyncEligibility {
+    /// `true` when `package.url` is inside a ubiquity container (`FileManager.isUbiquitousItem`).
+    /// A package that hasn't finished being indexed by iCloud yet (freshly moved into Drive) can
+    /// transiently answer `false`; callers re-check on the next site open rather than caching this
+    /// for a window's whole lifetime.
+    public static func isEligible(package: AnglesitePackage, fileManager: FileManager = .default) -> Bool {
+        fileManager.isUbiquitousItem(at: package.url)
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/SiteToolbarItemID.swift
+++ b/Sources/AnglesiteCore/SiteToolbarItemID.swift
@@ -26,4 +26,6 @@ public enum SiteToolbarItemID: String, CaseIterable, Sendable {
     case chat
     case inspector
     case styleGuide
+    /// iCloud sync status badge (#881) — synced/syncing/waiting-for-iCloud/needs-attention.
+    case sync
 }

--- a/Sources/AnglesiteCore/SyncConflictResolver.swift
+++ b/Sources/AnglesiteCore/SyncConflictResolver.swift
@@ -1,0 +1,244 @@
+#if canImport(Darwin)
+import Foundation
+import Clibgit2
+import SwiftGit2
+import AnglesiteSiteModel
+
+/// Commits a user's per-file resolution of a `SyncEngine.SyncConflict` (#881, design doc §3's
+/// "Conflict UX" paragraph): reads both tips' versions of each conflicted path so the resolution
+/// sheet can show them side by side, then — once every path has a `Choice` — replays the same
+/// `git_merge_commits` three-way merge `SyncEngine.threeWayMerge` ran (deterministically
+/// reproducing the same textual conflicts), resolves each conflicted index entry to the user's
+/// chosen side, and commits the result with `[ourOID, theirOID]` as parents. That commit *is* the
+/// merge `SyncEngine`'s own automatic three-way merge would have produced had the edits not
+/// overlapped — nothing here rewrites history, it only supplies the missing human judgment call.
+///
+/// This module doesn't decide the pause is lifted: the caller commits a resolution via `resolve`,
+/// then calls `SyncEngine.acknowledgeConflictResolved(package:)` itself — the two-step split
+/// keeps this type from needing a `SyncEngine` reference at all (it operates purely via
+/// `Repository`/libgit2 against `package.sourceURL`, the same live repo `SyncEngine` uses).
+public actor SyncConflictResolver {
+    /// Which side's content to keep for one conflicted path.
+    public enum Choice: Sendable, Equatable {
+        case keepMine
+        case keepTheirs
+    }
+
+    /// Both tips' content for one conflicted path, for the resolution sheet's side-by-side view.
+    /// `nil` text means that side deleted the path, or the blob is binary/too large to preview
+    /// (200 KB cap — plenty for template source files, not for images).
+    public struct ConflictedFile: Sendable, Equatable, Identifiable {
+        public var id: String { path }
+        public let path: String
+        public let oursText: String?
+        public let theirsText: String?
+    }
+
+    public enum ResolveError: Error, Equatable, CustomStringConvertible {
+        case repositoryUnavailable
+        case invalidConflict
+        case missingChoices(paths: [String])
+        case stillConflicted
+        case libgit2(String)
+
+        public var description: String {
+            switch self {
+            case .repositoryUnavailable: return "this site's git repository couldn't be opened."
+            case .invalidConflict: return "the recorded conflict is missing its commit tips."
+            case .missingChoices(let paths): return "no choice was made for: \(paths.joined(separator: ", "))"
+            case .stillConflicted: return "some paths are still conflicted after applying the chosen resolutions."
+            case .libgit2(let message): return message
+            }
+        }
+    }
+
+    public init() {}
+
+    /// Reads both sides' content for every path in `conflict.conflictedPaths`, for display in the
+    /// resolution sheet. Best-effort per file: a path this can't read on either side just gets
+    /// `nil` text for that side rather than failing the whole read.
+    public func loadConflictedFiles(package: AnglesitePackage, conflict: SyncEngine.SyncConflict) -> [ConflictedFile] {
+        SwiftGit2Bootstrap.ensureInitialized
+        guard case .success(let repo) = Repository.at(package.sourceURL),
+              let ourOID = OID(string: conflict.ourOID), let theirOID = OID(string: conflict.theirOID)
+        else { return [] }
+
+        return conflict.conflictedPaths.map { path in
+            ConflictedFile(
+                path: path,
+                oursText: Self.blobText(repo: repo, commitOID: ourOID, path: path),
+                theirsText: Self.blobText(repo: repo, commitOID: theirOID, path: path)
+            )
+        }
+    }
+
+    /// Commits `choices` as a merge resolving `conflict`. Every path in
+    /// `conflict.conflictedPaths` must have a `Choice` — a partial resolution can't produce a
+    /// valid tree, so this fails loudly (`.missingChoices`) rather than guessing or silently
+    /// dropping a path. On success, `Source/` is checked out to the merge commit and the caller
+    /// should call `SyncEngine.acknowledgeConflictResolved(package:)` to lift the push pause.
+    public func resolve(
+        package: AnglesitePackage,
+        conflict: SyncEngine.SyncConflict,
+        choices: [String: Choice]
+    ) async -> Result<Void, ResolveError> {
+        SwiftGit2Bootstrap.ensureInitialized
+        let missing = conflict.conflictedPaths.filter { choices[$0] == nil }
+        guard missing.isEmpty else { return .failure(.missingChoices(paths: missing)) }
+        guard case .success(let repo) = Repository.at(package.sourceURL) else {
+            return .failure(.repositoryUnavailable)
+        }
+        guard let ourOID = OID(string: conflict.ourOID), let theirOID = OID(string: conflict.theirOID) else {
+            return .failure(.invalidConflict)
+        }
+
+        var oursGitOID = ourOID.oid
+        var oursRaw: OpaquePointer?
+        guard git_commit_lookup(&oursRaw, repo.pointer, &oursGitOID) == GIT_OK.rawValue, let oursRaw else {
+            return .failure(.libgit2("couldn't look up this Mac's commit: \(Self.lastErrorMessage())"))
+        }
+        defer { git_commit_free(oursRaw) }
+
+        var theirsGitOID = theirOID.oid
+        var theirsRaw: OpaquePointer?
+        guard git_commit_lookup(&theirsRaw, repo.pointer, &theirsGitOID) == GIT_OK.rawValue, let theirsRaw else {
+            return .failure(.libgit2("couldn't look up the synced commit: \(Self.lastErrorMessage())"))
+        }
+        defer { git_commit_free(theirsRaw) }
+
+        var mergeOptions = git_merge_options()
+        guard git_merge_options_init(&mergeOptions, UInt32(GIT_MERGE_OPTIONS_VERSION)) == GIT_OK.rawValue else {
+            return .failure(.libgit2("git_merge_options_init failed: \(Self.lastErrorMessage())"))
+        }
+        var index: OpaquePointer?
+        guard git_merge_commits(&index, repo.pointer, oursRaw, theirsRaw, &mergeOptions) == GIT_OK.rawValue, let index else {
+            return .failure(.libgit2("git_merge_commits failed: \(Self.lastErrorMessage())"))
+        }
+        defer { git_index_free(index) }
+
+        for path in conflict.conflictedPaths {
+            guard let choice = choices[path] else { continue }
+            if case .failure(let error) = Self.resolveConflictEntry(index: index, path: path, choice: choice) {
+                return .failure(error)
+            }
+        }
+        guard git_index_has_conflicts(index) == 0 else {
+            return .failure(.stillConflicted)
+        }
+
+        var mergedTreeOID = git_oid()
+        guard git_index_write_tree_to(&mergedTreeOID, index, repo.pointer) == GIT_OK.rawValue else {
+            return .failure(.libgit2("git_index_write_tree_to failed: \(Self.lastErrorMessage())"))
+        }
+        guard case .success(let oursCommit) = repo.commit(ourOID), case .success(let theirsCommit) = repo.commit(theirOID) else {
+            return .failure(.libgit2("couldn't re-read this conflict's parent commits."))
+        }
+        let signature = await GitIdentity.signature(for: repo)
+        let message = "Merge synced history into \(conflict.branch) (resolved conflict)"
+        switch repo.commit(tree: OID(mergedTreeOID), parents: [oursCommit, theirsCommit], message: message, signature: signature) {
+        case .failure(let error):
+            return .failure(.libgit2(error.localizedDescription))
+        case .success:
+            break
+        }
+
+        guard case .success = repo.checkout(strategy: [.force, .recreateMissing]) else {
+            return .failure(.libgit2("checkout failed after committing the resolution."))
+        }
+        return .success(())
+    }
+
+    // MARK: - Index conflict resolution
+
+    private static func resolveConflictEntry(index: OpaquePointer, path: String, choice: Choice) -> Result<Void, ResolveError> {
+        var ancestor: UnsafePointer<git_index_entry>?
+        var ours: UnsafePointer<git_index_entry>?
+        var theirs: UnsafePointer<git_index_entry>?
+        let getResult = path.withCString { cPath in
+            git_index_conflict_get(&ancestor, &ours, &theirs, index, cPath)
+        }
+        guard getResult == GIT_OK.rawValue else {
+            // Not actually conflicted in this replayed merge (e.g. the same content on both
+            // sides) — nothing to resolve for this path.
+            return .success(())
+        }
+
+        // Snapshot the chosen side's scalar fields (id/mode/etc.) now — `chosen` points into
+        // memory `git_index_conflict_remove` below owns and frees (including the entry's own
+        // `path` C string), so nothing here can still read through that pointer afterward.
+        let chosenEntrySnapshot: git_index_entry? = ((choice == .keepMine) ? ours : theirs)?.pointee
+
+        let removeResult = path.withCString { cPath in git_index_conflict_remove(index, cPath) }
+        guard removeResult == GIT_OK.rawValue else {
+            return .failure(.libgit2("couldn't clear conflict markers for \(path): \(lastErrorMessage())"))
+        }
+
+        if var chosenEntry = chosenEntrySnapshot {
+            // Clear the conflict stage bits (and any other flags) so this re-lands as a normal
+            // stage-0 entry — the same normalization `git checkout --ours/--theirs` performs.
+            chosenEntry.flags = 0
+            chosenEntry.flags_extended = 0
+            let addResult = path.withCString { cPath -> Int32 in
+                // Repoint `path` at a C string that's alive for exactly this call — the one
+                // copied from `chosen.pointee` above no longer is. `git_index_add` copies the
+                // string into its own storage before returning, so it doesn't need to outlive
+                // this closure.
+                chosenEntry.path = cPath
+                return git_index_add(index, &chosenEntry)
+            }
+            guard addResult == GIT_OK.rawValue else {
+                return .failure(.libgit2("couldn't stage the chosen version of \(path): \(lastErrorMessage())"))
+            }
+        } else {
+            // The chosen side deleted this path.
+            let removePathResult = path.withCString { cPath in git_index_remove_bypath(index, cPath) }
+            guard removePathResult == GIT_OK.rawValue else {
+                return .failure(.libgit2("couldn't remove \(path): \(lastErrorMessage())"))
+            }
+        }
+        return .success(())
+    }
+
+    // MARK: - Blob preview
+
+    private static func blobText(repo: Repository, commitOID: OID, path: String) -> String? {
+        var oid = commitOID.oid
+        var commitObject: OpaquePointer?
+        guard git_object_lookup(&commitObject, repo.pointer, &oid, GIT_OBJECT_COMMIT) == GIT_OK.rawValue, let commitObject else {
+            return nil
+        }
+        defer { git_object_free(commitObject) }
+        guard let treeOIDPointer = git_commit_tree_id(commitObject) else { return nil }
+        var treeOID = treeOIDPointer.pointee
+        var tree: OpaquePointer?
+        guard git_tree_lookup(&tree, repo.pointer, &treeOID) == GIT_OK.rawValue, let tree else { return nil }
+        defer { git_object_free(tree) }
+
+        var entry: OpaquePointer?
+        let entryResult = path.withCString { cPath in git_tree_entry_bypath(&entry, tree, cPath) }
+        guard entryResult == GIT_OK.rawValue, let entry else { return nil }
+        defer { git_tree_entry_free(entry) }
+        guard git_tree_entry_type(entry) == GIT_OBJECT_BLOB, let blobOIDPointer = git_tree_entry_id(entry) else {
+            return nil
+        }
+
+        var blobOID = blobOIDPointer.pointee
+        var blob: OpaquePointer?
+        guard git_blob_lookup(&blob, repo.pointer, &blobOID) == GIT_OK.rawValue, let blob else { return nil }
+        defer { git_blob_free(blob) }
+        guard git_blob_is_binary(blob) == 0 else { return nil }
+
+        let size = git_blob_rawsize(blob)
+        guard size <= 200_000, let raw = git_blob_rawcontent(blob) else { return nil }
+        let data = Data(bytes: raw, count: Int(size))
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func lastErrorMessage() -> String {
+        if let error = git_error_last() {
+            return String(cString: error.pointee.message)
+        }
+        return "unknown libgit2 error"
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/SyncEngine.swift
+++ b/Sources/AnglesiteCore/SyncEngine.swift
@@ -684,7 +684,7 @@ public actor SyncEngine {
         }
         guard !quarantined.isEmpty else { return }
 
-        let quarantineDirectory = package.configURL.appendingPathComponent("conflicts", isDirectory: true)
+        let quarantineDirectory = package.conflictsDirectoryURL
         try? fileManager.createDirectory(at: quarantineDirectory, withIntermediateDirectories: true)
         for url in quarantined {
             let destination = quarantineDirectory.appendingPathComponent("\(UUID().uuidString)-\(url.lastPathComponent)")

--- a/Sources/AnglesiteCore/SyncScheduler.swift
+++ b/Sources/AnglesiteCore/SyncScheduler.swift
@@ -1,0 +1,208 @@
+#if canImport(Darwin)
+import Foundation
+import AnglesiteSiteModel
+
+/// Narrow seam `SyncScheduler` depends on instead of the concrete `SyncEngine` actor, so this
+/// file's debounce/coalescing/trigger policy can be unit-tested against a fake — no real git
+/// repository, libgit2 call, or iCloud round-trip needed (#881's "keep the app layer thin, push
+/// the testable logic into AnglesiteCore" instruction, mirroring how `TokenOnboarding` was
+/// extracted from `DeployModel`).
+public protocol SyncEngineProtocol: Sendable {
+    func pull(package: AnglesitePackage) async -> SyncEngine.PullResult
+    func push(package: AnglesitePackage) async -> SyncEngine.PushResult
+    func pendingConflict(package: AnglesitePackage) -> SyncEngine.SyncConflict?
+    func acknowledgeConflictResolved(package: AnglesitePackage) async
+}
+
+extension SyncEngine: SyncEngineProtocol {}
+
+/// Owns *when* a `.anglesite` package's `SyncEngine` runs, for one open site window (design doc
+/// `2026-07-21-icloud-git-sync-design.md`'s "App wiring" paragraph, #881): pull on site open and
+/// on every observed `source.bundle` change, and a single debounced/coalesced push after each
+/// trigger that can produce new local history — a successful `BackupCommand` auto-commit, a
+/// deploy, or the app going to the background.
+///
+/// **Idle = zero activity.** This actor does nothing on its own: no timer, no polling loop. Every
+/// pull or push happens because a caller invoked one of the `…Occurred`/`…Changed` methods below.
+/// A site that never changes and is never reopened never touches its `SyncEngine` again after the
+/// first `siteOpened()` — matching #881's acceptance criteria ("no sync activity for idle sites").
+/// Callers (the app layer) are responsible for only constructing a scheduler for a package that
+/// actually lives in iCloud Drive (`ICloudSyncEligibility`) — a plain local package should never
+/// get one at all, which is the only way to guarantee it sees zero sync activity, ever.
+///
+/// **One scheduler per open site window**, matching `SyncEngine`'s own single-caller invariant:
+/// nothing here re-enters `engine.pull`/`engine.push` concurrently for the same package.
+public actor SyncScheduler {
+    /// Coarse status for `SiteWindow`'s toolbar/menu surface (#881: "synced / syncing / waiting
+    /// for iCloud / needs attention"). `.idle` is the initial state before the first `siteOpened()`
+    /// — a package this scheduler has never touched, including one that was never eligible.
+    public enum Status: Sendable, Equatable {
+        case idle
+        case syncing
+        case synced(Date)
+        case waitingForICloud
+        case needsAttention(SyncEngine.SyncConflict)
+        case failed(reason: String)
+    }
+
+    public typealias StatusObserver = @Sendable (Status) -> Void
+    /// Debounce timer seam — mirrors `InvisiblePublishQueue.Sleep`: production always sleeps for
+    /// real, tests substitute a manually-released gate so debounce assertions don't race a live
+    /// timer against actor scheduling under CI load (#762's lesson, reapplied here).
+    public typealias Sleep = @Sendable (Duration) async throws -> Void
+
+    private let package: AnglesitePackage
+    private let engine: any SyncEngineProtocol
+    private let pushDebounce: Duration
+    private let onStatusChange: StatusObserver?
+    private let now: @Sendable () -> Date
+    private let sleep: Sleep
+
+    private(set) var status: Status = .idle
+    /// Set whenever a push-worthy trigger fires; cleared only once a push actually runs for it.
+    /// Lets a trigger that lands *while* a push is already in flight schedule a fresh debounce for
+    /// the newer state, instead of being silently dropped (same shape as
+    /// `InvisiblePublishQueue.isPending`/`finish`).
+    private var pushPending = false
+    private var pushDebounceTask: Task<Void, Never>?
+    private var pushTask: Task<Void, Never>?
+
+    public init(
+        package: AnglesitePackage,
+        engine: any SyncEngineProtocol,
+        pushDebounce: Duration = .seconds(5),
+        onStatusChange: StatusObserver? = nil,
+        now: @escaping @Sendable () -> Date = { Date.now },
+        sleep: @escaping Sleep = { try await Task.sleep(for: $0) }
+    ) {
+        self.package = package
+        self.engine = engine
+        self.pushDebounce = pushDebounce
+        self.onStatusChange = onStatusChange
+        self.now = now
+        self.sleep = sleep
+    }
+
+    public func currentStatus() -> Status { status }
+
+    // MARK: - Pull triggers
+
+    /// Runs immediately (no debounce — a user just opened the window and is waiting on it).
+    @discardableResult
+    public func siteOpened() async -> Status { await runPull() }
+
+    /// Runs immediately: an `NSMetadataQuery`/file-presenter observed `source.bundle` change
+    /// while this site's window is open. Also undebounced — the whole point is showing the
+    /// incoming edit promptly; `SyncEngine.pull()` itself is already a cheap no-op
+    /// (`.upToDate`) on the overwhelmingly common case where the change was this Mac's own push.
+    @discardableResult
+    public func bundleChanged() async -> Status { await runPull() }
+
+    // MARK: - Push triggers (all debounced + coalesced into a single push)
+
+    /// A `BackupCommand` auto-commit succeeded — there may be new local history to mirror.
+    public func backupCompleted() { schedulePush() }
+
+    /// A deploy completed — same reasoning as `backupCompleted()`.
+    public func deployCompleted() { schedulePush() }
+
+    /// The app is going to the background (`NSApplication.didResignActiveNotification`). Still a
+    /// debounced push (#881's wording), but with no delay: the window may not get another chance
+    /// to run before the user switches away for a while, so don't make it wait out the normal
+    /// quiescence window first. Still coalesces with any push already in flight or already
+    /// scheduled, so backgrounding immediately after a backup doesn't double-push.
+    public func appDidBackground() { schedulePush(immediate: true) }
+
+    /// Cancels any pending debounce. An in-flight push (already past the debounce, actually
+    /// running) is deliberately left alone — same reasoning as `SiteWindowModel.close()` leaving
+    /// an in-flight Deploy/Backup running: its Task retains everything it needs and should reach a
+    /// real terminal result rather than being cut off mid-write.
+    public func stop() {
+        pushDebounceTask?.cancel()
+        pushDebounceTask = nil
+    }
+
+    // MARK: - Conflict resolution hookup
+
+    /// Re-checks `engine.pendingConflict(package:)` and re-pulls/pushes once the caller has
+    /// committed a resolution and called `engine.acknowledgeConflictResolved(package:)` — the
+    /// scheduler's status was pinned at `.needsAttention` until this runs.
+    @discardableResult
+    public func conflictResolved() async -> Status { await runPull() }
+
+    // MARK: - Pull
+
+    private func runPull() async -> Status {
+        transition(.syncing)
+        let result = await engine.pull(package: package)
+        switch result {
+        case .upToDate, .fastForwarded, .bootstrapped, .merged, .localAhead:
+            transition(.synced(now()))
+        case .conflicted(let conflict):
+            transition(.needsAttention(conflict))
+        case .waitingForICloud:
+            transition(.waitingForICloud)
+        case .failed(let reason):
+            transition(.failed(reason: reason))
+        }
+        return status
+    }
+
+    // MARK: - Push (debounced + coalesced)
+
+    private func schedulePush(immediate: Bool = false) {
+        pushPending = true
+        pushDebounceTask?.cancel()
+        let delay = immediate ? Duration.zero : pushDebounce
+        pushDebounceTask = Task { [weak self, sleep] in
+            do {
+                try await sleep(delay)
+            } catch {
+                return
+            }
+            await self?.beginPush()
+        }
+    }
+
+    private func beginPush() {
+        guard pushPending, pushTask == nil else { return }
+        pushDebounceTask = nil
+        pushPending = false
+        transition(.syncing)
+        pushTask = Task { [self, engine, package] in
+            let result = await engine.push(package: package)
+            await finishPush(result)
+        }
+    }
+
+    private func finishPush(_ result: SyncEngine.PushResult) {
+        pushTask = nil
+        switch result {
+        case .unchanged, .pushed:
+            transition(.synced(now()))
+        case .pausedForConflict(let branch):
+            // Reflect the pause even for a push-only trigger that never itself ran a pull: check
+            // the engine's own persisted marker so the UI's "needs attention" state doesn't
+            // depend on which trigger happened to fire first.
+            if let conflict = engine.pendingConflict(package: package), conflict.branch == branch {
+                transition(.needsAttention(conflict))
+            } else {
+                transition(.failed(reason: "push paused for an unresolved conflict on \(branch)"))
+            }
+        case .failed(let reason):
+            transition(.failed(reason: reason))
+        }
+        // A trigger landed while this push was in flight — cover the newer state with a fresh
+        // (still debounced) push rather than dropping it.
+        if pushPending {
+            schedulePush()
+        }
+    }
+
+    private func transition(_ newStatus: Status) {
+        guard status != newStatus else { return }
+        status = newStatus
+        onStatusChange?(newStatus)
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/SyncScheduler.swift
+++ b/Sources/AnglesiteCore/SyncScheduler.swift
@@ -154,15 +154,15 @@ public actor SyncScheduler {
         pushPending = true
         pushDebounceTask?.cancel()
         pushDebounceTask = nil
-        guard !immediate else {
-            // Deliberately bypasses the Task+`sleep` debounce machinery below rather than
-            // routing through it with a zero delay: creating a `Task` that immediately awaits
-            // `sleep(.zero)` in the same beat as cancelling the *previous* debounce `Task`
-            // reproducibly crashed the Swift concurrency runtime's task-local allocator on
-            // macOS 26 CI runners ("freed pointer was not the last allocation" — the same crash
-            // class documented for PR #644/#646, which forced those lanes off macOS 15).
-            // `beginPush()` still spawns the one `Task` actually needed, for `engine.push()`
-            // itself — only the artificial zero-duration sleep is removed.
+        guard !immediate, pushDebounce > .zero else {
+            // Deliberately bypasses the Task+`sleep` debounce machinery below for both the
+            // immediate path and a non-positive debounce: a `Task` that awaits
+            // `Task.sleep(for: .zero)` reproducibly crashes the Swift concurrency runtime's
+            // task-local allocator on macOS 26 CI runners ("freed pointer was not the last
+            // allocation" — the same crash class documented for PR #644/#646, which forced
+            // those lanes off macOS 15), regardless of whether another debounce Task was just
+            // cancelled. `beginPush()` still spawns the one `Task` actually needed, for
+            // `engine.push()` itself — only the zero-duration sleep is removed.
             beginPush()
             return
         }

--- a/Sources/AnglesiteCore/SyncScheduler.swift
+++ b/Sources/AnglesiteCore/SyncScheduler.swift
@@ -106,11 +106,11 @@ public actor SyncScheduler {
     /// A deploy completed — same reasoning as `backupCompleted()`.
     public func deployCompleted() { schedulePush() }
 
-    /// The app is going to the background (`NSApplication.didResignActiveNotification`). Still a
-    /// debounced push (#881's wording), but with no delay: the window may not get another chance
-    /// to run before the user switches away for a while, so don't make it wait out the normal
-    /// quiescence window first. Still coalesces with any push already in flight or already
-    /// scheduled, so backgrounding immediately after a backup doesn't double-push.
+    /// The app is going to the background (`NSApplication.didResignActiveNotification`). Pushed
+    /// with no delay: the window may not get another chance to run before the user switches away
+    /// for a while, so don't make it wait out the normal quiescence window first. Still coalesces
+    /// with any push already in flight or already scheduled, so backgrounding immediately after a
+    /// backup doesn't double-push.
     public func appDidBackground() { schedulePush(immediate: true) }
 
     /// Cancels any pending debounce. An in-flight push (already past the debounce, actually
@@ -153,10 +153,22 @@ public actor SyncScheduler {
     private func schedulePush(immediate: Bool = false) {
         pushPending = true
         pushDebounceTask?.cancel()
-        let delay = immediate ? Duration.zero : pushDebounce
-        pushDebounceTask = Task { [weak self, sleep] in
+        pushDebounceTask = nil
+        guard !immediate else {
+            // Deliberately bypasses the Task+`sleep` debounce machinery below rather than
+            // routing through it with a zero delay: creating a `Task` that immediately awaits
+            // `sleep(.zero)` in the same beat as cancelling the *previous* debounce `Task`
+            // reproducibly crashed the Swift concurrency runtime's task-local allocator on
+            // macOS 26 CI runners ("freed pointer was not the last allocation" — the same crash
+            // class documented for PR #644/#646, which forced those lanes off macOS 15).
+            // `beginPush()` still spawns the one `Task` actually needed, for `engine.push()`
+            // itself — only the artificial zero-duration sleep is removed.
+            beginPush()
+            return
+        }
+        pushDebounceTask = Task { [weak self, sleep, pushDebounce] in
             do {
-                try await sleep(delay)
+                try await sleep(pushDebounce)
             } catch {
                 return
             }

--- a/Sources/AnglesiteSiteModel/AnglesitePackage.swift
+++ b/Sources/AnglesiteSiteModel/AnglesitePackage.swift
@@ -49,6 +49,12 @@ public struct AnglesitePackage: Sendable, Equatable {
     /// local repo — the bundle acts as an iCloud-mediated remote.
     public var syncBundleURL: URL { syncDirectoryURL.appendingPathComponent("source.bundle", isDirectory: false) }
 
+    /// Quarantine directory for files iCloud dropped as conflict-copies of `Source/`'s own
+    /// working tree (design doc §3, "Working-tree conflict copies") — swept there by
+    /// `SyncEngine.pull()` rather than left in place or silently deleted, and surfaced in the
+    /// sync conflict resolution sheet (#881) alongside the git-level `SyncConflict`.
+    public var conflictsDirectoryURL: URL { configURL.appendingPathComponent("conflicts", isDirectory: true) }
+
     /// Cached home-page thumbnail (nice-to-have, #621). Nothing writes this file yet — a future
     /// feature (e.g. captured on deploy) will populate it. The Quick Look preview and thumbnail
     /// extensions (`AnglesiteQuickLookPreview` / `AnglesiteQuickLookThumbnail`) read it if present

--- a/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
@@ -24,6 +24,7 @@ struct SiteToolbarItemIDTests {
             "chat",
             "inspector",
             "styleGuide",
+            "sync",
         ])
     }
 }

--- a/Tests/AnglesiteCoreTests/SyncConflictResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/SyncConflictResolverTests.swift
@@ -1,0 +1,195 @@
+#if canImport(Darwin)
+import Testing
+import Foundation
+import AnglesiteSiteModel
+import AnglesiteTestSupport
+import SwiftGit2
+@testable import AnglesiteCore
+
+/// `SyncConflictResolver` (#881) commits the user's per-file keep-mine/keep-theirs choice as a
+/// merge resolving a `SyncEngine.SyncConflict`. Fixtures mirror `SyncEngineTests`' own (real
+/// repos, subprocess git, a fake iCloud transport via file copy) so a genuine textual conflict —
+/// the same shape `SyncEngineTests.divergedPullReportsOverlappingConflict` produces — is available
+/// to resolve against.
+///
+/// .serialized: libgit2 isn't safe for uncoordinated concurrent use in this codebase.
+@Suite("SyncConflictResolver", .serialized) struct SyncConflictResolverTests {
+
+    // MARK: - Fixtures (mirrors SyncEngineTests)
+
+    @discardableResult
+    private func git(_ arguments: [String], in dir: URL) async throws -> ProcessSupervisor.RunResult {
+        let result = try await ProcessSupervisor.shared.run(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: ["git"] + arguments,
+            currentDirectoryURL: dir
+        )
+        #expect(result.exitCode == 0, "fixture git \(arguments.joined(separator: " ")) exited \(result.exitCode): \(result.stderr)")
+        return result
+    }
+
+    private func makeGitPackage(name: String, commits: Int = 1) async throws -> AnglesitePackage {
+        let root = try makeTempDir(prefix: "sync-conflict-resolver")
+        let pkgURL = root.appendingPathComponent("\(name).anglesite", isDirectory: true)
+        let (pkg, _) = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: name)
+        try await git(["init", "-b", "main"], in: pkg.sourceURL)
+        try await git(["config", "user.email", "t@t.io"], in: pkg.sourceURL)
+        try await git(["config", "user.name", "t"], in: pkg.sourceURL)
+        for i in 0..<max(commits, 1) {
+            try "content \(i)".write(to: pkg.sourceURL.appendingPathComponent("file\(i).txt"), atomically: true, encoding: .utf8)
+            try await git(["add", "-A"], in: pkg.sourceURL)
+            try await git(["commit", "-m", "commit \(i)"], in: pkg.sourceURL)
+        }
+        return pkg
+    }
+
+    private func copyArtifact(from source: AnglesitePackage, to destination: AnglesitePackage) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: destination.syncDirectoryURL, withIntermediateDirectories: true)
+        if fm.fileExists(atPath: destination.syncBundleURL.path) {
+            try fm.removeItem(at: destination.syncBundleURL)
+        }
+        try fm.copyItem(at: source.syncBundleURL, to: destination.syncBundleURL)
+    }
+
+    private func makeFreshPeerPackage(mirroring source: AnglesitePackage, name: String) throws -> AnglesitePackage {
+        let fm = FileManager.default
+        let root = try makeTempDir(prefix: "sync-conflict-resolver-peer")
+        let pkgURL = root.appendingPathComponent("\(name).anglesite", isDirectory: true)
+        let (pkg, _) = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: name)
+        for item in try fm.contentsOfDirectory(at: source.sourceURL, includingPropertiesForKeys: nil)
+        where item.lastPathComponent != ".git" {
+            try fm.copyItem(at: item, to: pkg.sourceURL.appendingPathComponent(item.lastPathComponent))
+        }
+        try "gitdir: ../Config/repo.nosync\n".write(
+            to: pkg.sourceURL.appendingPathComponent(".git"), atomically: true, encoding: .utf8)
+        try copyArtifact(from: source, to: pkg)
+        return pkg
+    }
+
+    /// Produces a genuine `SyncConflict` on `b`, mirroring
+    /// `SyncEngineTests.divergedPullReportsOverlappingConflict`: `a` and `b` both edit the same
+    /// file from the same base, `a` pushes first, and `b`'s `pull()` hits the textual conflict.
+    private func makeConflict(fileName: String = "file0.txt") async throws -> (a: AnglesitePackage, b: AnglesitePackage, conflict: SyncEngine.SyncConflict) {
+        let a = try await makeGitPackage(name: "A", commits: 1)
+        let engineA = SyncEngine()
+        guard case .pushed = await engineA.push(package: a) else {
+            throw TestFailure("fixture push failed")
+        }
+        let b = try makeFreshPeerPackage(mirroring: a, name: "B")
+        let engineB = SyncEngine()
+        guard case .bootstrapped = await engineB.pull(package: b) else {
+            throw TestFailure("fixture bootstrap failed")
+        }
+
+        try "a-version".write(to: a.sourceURL.appendingPathComponent(fileName), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: a.sourceURL)
+        try await git(["commit", "-m", "a's conflicting edit"], in: a.sourceURL)
+        guard case .pushed = await engineA.push(package: a) else {
+            throw TestFailure("fixture A push failed")
+        }
+        try copyArtifact(from: a, to: b)
+
+        try "b-version".write(to: b.sourceURL.appendingPathComponent(fileName), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: b.sourceURL)
+        try await git(["commit", "-m", "b's conflicting edit"], in: b.sourceURL)
+
+        let result = await engineB.pull(package: b)
+        guard case .conflicted(let conflict) = result else {
+            throw TestFailure("expected .conflicted, got \(result)")
+        }
+        return (a, b, conflict)
+    }
+
+    private struct TestFailure: Error, CustomStringConvertible {
+        let message: String
+        init(_ message: String) { self.message = message }
+        var description: String { message }
+    }
+
+    // MARK: - Tests
+
+    @Test("loadConflictedFiles reads both sides' text content")
+    func loadsBothSides() async throws {
+        let (_, b, conflict) = try await makeConflict()
+        let resolver = SyncConflictResolver()
+
+        let files = await resolver.loadConflictedFiles(package: b, conflict: conflict)
+        #expect(files.count == 1)
+        #expect(files.first?.path == "file0.txt")
+        #expect(files.first?.oursText == "b-version")
+        #expect(files.first?.theirsText == "a-version")
+    }
+
+    @Test("resolve() with keepMine commits this Mac's content and clears the conflict")
+    func resolveKeepMine() async throws {
+        let (_, b, conflict) = try await makeConflict()
+        let resolver = SyncConflictResolver()
+
+        let outcome = await resolver.resolve(package: b, conflict: conflict, choices: ["file0.txt": .keepMine])
+        guard case .success = outcome else {
+            Issue.record("expected success, got \(outcome)"); return
+        }
+        let content = try String(contentsOf: b.sourceURL.appendingPathComponent("file0.txt"), encoding: .utf8)
+        #expect(content == "b-version")
+
+        SwiftGit2Bootstrap.ensureInitialized
+        guard case .success(let repo) = Repository.at(b.sourceURL), case .success(let head) = repo.HEAD(),
+              let branch = head as? Branch else {
+            Issue.record("couldn't read HEAD after resolving"); return
+        }
+        guard case .success(let commit) = repo.commit(branch.oid) else {
+            Issue.record("couldn't read the resolution commit"); return
+        }
+        #expect(commit.parents.count == 2)
+    }
+
+    @Test("resolve() with keepTheirs commits the other Mac's content")
+    func resolveKeepTheirs() async throws {
+        let (_, b, conflict) = try await makeConflict()
+        let resolver = SyncConflictResolver()
+
+        let outcome = await resolver.resolve(package: b, conflict: conflict, choices: ["file0.txt": .keepTheirs])
+        guard case .success = outcome else {
+            Issue.record("expected success, got \(outcome)"); return
+        }
+        let content = try String(contentsOf: b.sourceURL.appendingPathComponent("file0.txt"), encoding: .utf8)
+        #expect(content == "a-version")
+    }
+
+    @Test("resolve() fails with missingChoices when a conflicted path has no choice")
+    func resolveRequiresEveryPath() async throws {
+        let (_, b, conflict) = try await makeConflict()
+        let resolver = SyncConflictResolver()
+
+        let outcome = await resolver.resolve(package: b, conflict: conflict, choices: [:])
+        guard case .failure(.missingChoices(let paths)) = outcome else {
+            Issue.record("expected .missingChoices, got \(outcome)"); return
+        }
+        #expect(paths == ["file0.txt"])
+    }
+
+    @Test("resolving lets the engine acknowledge the conflict and resume pushing")
+    func resolutionUnblocksEnginePush() async throws {
+        let (_, b, conflict) = try await makeConflict()
+        let resolver = SyncConflictResolver()
+        let engine = SyncEngine()
+
+        // Before resolving, push() is paused.
+        guard case .pausedForConflict = await engine.push(package: b) else {
+            Issue.record("expected the pending conflict to pause push() before resolution"); return
+        }
+
+        let outcome = await resolver.resolve(package: b, conflict: conflict, choices: ["file0.txt": .keepMine])
+        guard case .success = outcome else {
+            Issue.record("expected success, got \(outcome)"); return
+        }
+        await engine.acknowledgeConflictResolved(package: b)
+
+        let pushResult = await engine.push(package: b)
+        guard case .pushed = pushResult else {
+            Issue.record("expected push to succeed after acknowledging resolution, got \(pushResult)"); return
+        }
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/SyncSchedulerTests.swift
+++ b/Tests/AnglesiteCoreTests/SyncSchedulerTests.swift
@@ -1,0 +1,257 @@
+#if canImport(Darwin)
+import Testing
+import Foundation
+import AnglesiteSiteModel
+@testable import AnglesiteCore
+
+/// `SyncScheduler` (#881) owns *when* a site's `SyncEngine` runs: pull on open/bundle-change,
+/// debounced+coalesced push after backup/deploy/backgrounding. These tests drive it against a
+/// fake `SyncEngineProtocol` so the trigger/debounce/coalescing policy is verified without any
+/// real git repository or iCloud round-trip — see `SyncEngineTests` for the engine's own
+/// integration coverage against real repos.
+@Suite("SyncScheduler", .serialized) struct SyncSchedulerTests {
+
+    // MARK: - Fakes
+
+    private actor FakeEngine: SyncEngineProtocol {
+        var pullResult: SyncEngine.PullResult = .upToDate
+        var pushResult: SyncEngine.PushResult = .unchanged
+        var conflict: SyncEngine.SyncConflict?
+        private(set) var pullCount = 0
+        private(set) var pushCount = 0
+        private(set) var acknowledgedCount = 0
+
+        func pull(package: AnglesitePackage) async -> SyncEngine.PullResult {
+            pullCount += 1
+            return pullResult
+        }
+
+        func push(package: AnglesitePackage) async -> SyncEngine.PushResult {
+            pushCount += 1
+            return pushResult
+        }
+
+        nonisolated func pendingConflict(package: AnglesitePackage) -> SyncEngine.SyncConflict? {
+            // `nonisolated` per the protocol, so this can't touch actor-isolated `conflict`
+            // directly; tests that need it exercised set `pushResult` instead of relying on this.
+            nil
+        }
+
+        func acknowledgeConflictResolved(package: AnglesitePackage) async {
+            acknowledgedCount += 1
+        }
+
+        func set(pullResult: SyncEngine.PullResult) { self.pullResult = pullResult }
+        func set(pushResult: SyncEngine.PushResult) { self.pushResult = pushResult }
+    }
+
+    /// A manually-triggered stand-in for `SyncScheduler`'s debounce timer — mirrors
+    /// `InvisiblePublishQueueTests.ManualDebounceGate` (#762's lesson: don't race a real timer
+    /// against actor scheduling under CI load).
+    private actor ManualDebounceGate {
+        private var continuations: [CheckedContinuation<Void, Never>] = []
+        func sleep() async { await withCheckedContinuation { continuations.append($0) } }
+        func armedCount() -> Int { continuations.count }
+        func release() {
+            let pending = continuations
+            continuations.removeAll()
+            pending.forEach { $0.resume() }
+        }
+    }
+
+    private func makePackage(name: String = "Test") throws -> AnglesitePackage {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SyncSchedulerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let pkgURL = root.appendingPathComponent("\(name).anglesite", isDirectory: true)
+        let (pkg, _) = try AnglesitePackage.createSkeleton(at: pkgURL, displayName: name)
+        return pkg
+    }
+
+    // MARK: - Pull triggers
+
+    @Test("siteOpened() pulls immediately and reports synced on upToDate")
+    func siteOpenedPullsImmediately() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        let scheduler = SyncScheduler(package: package, engine: engine)
+
+        let status = await scheduler.siteOpened()
+        #expect(await engine.pullCount == 1)
+        if case .synced = status {} else {
+            Issue.record("expected .synced, got \(status)")
+        }
+    }
+
+    @Test("bundleChanged() pulls again")
+    func bundleChangedPulls() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        let scheduler = SyncScheduler(package: package, engine: engine)
+
+        _ = await scheduler.siteOpened()
+        _ = await scheduler.bundleChanged()
+        #expect(await engine.pullCount == 2)
+    }
+
+    @Test("a conflicted pull surfaces needsAttention with the typed conflict")
+    func conflictedPullSurfacesNeedsAttention() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        let conflict = SyncEngine.SyncConflict(
+            branch: "main", conflictedPaths: ["file.txt"], ourOID: "aaa", theirOID: "bbb", theirSource: "icloud")
+        await engine.set(pullResult: .conflicted(conflict))
+        let scheduler = SyncScheduler(package: package, engine: engine)
+
+        let status = await scheduler.siteOpened()
+        #expect(status == .needsAttention(conflict))
+    }
+
+    @Test("waitingForICloud and failed pulls surface as their own statuses")
+    func pullFailureStatuses() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        await engine.set(pullResult: .waitingForICloud)
+        let scheduler = SyncScheduler(package: package, engine: engine)
+        #expect(await scheduler.siteOpened() == .waitingForICloud)
+
+        let engine2 = FakeEngine()
+        await engine2.set(pullResult: .failed(reason: "boom"))
+        let scheduler2 = SyncScheduler(package: package, engine: engine2)
+        #expect(await scheduler2.siteOpened() == .failed(reason: "boom"))
+    }
+
+    // MARK: - Idle = zero activity
+
+    @Test("a scheduler that's never triggered never touches the engine")
+    func idleSchedulerTouchesNothing() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        _ = SyncScheduler(package: package, engine: engine)
+        // No trigger called — give any errant background activity a chance to happen, then assert none did.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await engine.pullCount == 0)
+        #expect(await engine.pushCount == 0)
+    }
+
+    // MARK: - Debounced + coalesced push
+
+    @Test("backup/deploy/background triggers debounce into a single push")
+    func pushTriggersCoalesce() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        let gate = ManualDebounceGate()
+        let scheduler = SyncScheduler(
+            package: package, engine: engine, pushDebounce: .milliseconds(250),
+            sleep: { _ in await gate.sleep() })
+
+        await scheduler.backupCompleted()
+        await scheduler.deployCompleted()
+        // `ManualDebounceGate` doesn't model cancellation (like `InvisiblePublishQueueTests`'
+        // own gate of the same name): `pushDebounceTask?.cancel()` in `schedulePush()` cancels
+        // the *Task*, but our fake `sleep` isn't cancellation-aware the way the production
+        // `Task.sleep(for:)` seam is, so the first trigger's debounce still arms a (now-stale)
+        // gate continuation alongside the second's. Both triggers land before either "elapses",
+        // so exactly 2 continuations arm here regardless of scheduling order; release both and
+        // assert the actual push still only fires once — `beginPush()`'s `pushTask == nil` guard
+        // is what does the real coalescing, not the cancellation.
+        try await waitUntil { await gate.armedCount() == 2 }
+        await gate.release()
+
+        try await waitUntil { await engine.pushCount == 1 }
+        #expect(await engine.pushCount == 1)
+    }
+
+    @Test("appDidBackground pushes with zero delay")
+    func backgroundPushIsImmediate() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        let scheduler = SyncScheduler(package: package, engine: engine, pushDebounce: .seconds(999))
+
+        await scheduler.appDidBackground()
+        try await waitUntil { await engine.pushCount == 1 }
+        #expect(await engine.pushCount == 1)
+    }
+
+    @Test("a trigger that lands mid-push schedules a fresh debounced push instead of being dropped")
+    func triggerDuringPushSchedulesAnother() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        let gate = ManualDebounceGate()
+        let scheduler = SyncScheduler(
+            package: package, engine: engine, pushDebounce: .milliseconds(10),
+            sleep: { _ in await gate.sleep() })
+
+        await scheduler.backupCompleted()
+        try await waitUntil { await gate.armedCount() == 1 }
+        await gate.release()
+        try await waitUntil { await engine.pushCount == 1 }
+
+        // A second trigger after the first push already completed schedules its own debounce.
+        await scheduler.deployCompleted()
+        try await waitUntil { await gate.armedCount() == 1 }
+        await gate.release()
+        try await waitUntil { await engine.pushCount == 2 }
+        #expect(await engine.pushCount == 2)
+    }
+
+    @Test("push result unchanged/pushed both report synced")
+    func pushResultsReportSynced() async throws {
+        let package = try makePackage()
+        let engine = FakeEngine()
+        await engine.set(pushResult: .unchanged)
+        let scheduler = SyncScheduler(package: package, engine: engine, pushDebounce: .zero)
+
+        await scheduler.backupCompleted()
+        try await waitUntil { await engine.pushCount == 1 }
+        try await waitUntil {
+            if case .synced = await scheduler.currentStatus() { return true }
+            return false
+        }
+    }
+
+    @Test("a paused-for-conflict push result surfaces needsAttention when the engine has a pending conflict")
+    func pausedPushSurfacesConflict() async throws {
+        let package = try makePackage()
+        let conflict = SyncEngine.SyncConflict(
+            branch: "main", conflictedPaths: ["file.txt"], ourOID: "aaa", theirOID: "bbb", theirSource: "icloud")
+        let engine = ConflictAwareFakeEngine(conflict: conflict)
+        let scheduler = SyncScheduler(package: package, engine: engine, pushDebounce: .zero)
+
+        await scheduler.backupCompleted()
+        try await waitUntil {
+            if case .needsAttention(let c) = await scheduler.currentStatus() { return c == conflict }
+            return false
+        }
+    }
+
+    /// `FakeEngine.pendingConflict` is deliberately `nil` (it's `nonisolated`, so it can't read
+    /// actor state) — this variant hardcodes the conflict outside actor isolation to exercise
+    /// `SyncScheduler`'s `.pausedForConflict` branch.
+    private final class ConflictAwareFakeEngine: SyncEngineProtocol, @unchecked Sendable {
+        private let conflict: SyncEngine.SyncConflict
+        init(conflict: SyncEngine.SyncConflict) { self.conflict = conflict }
+        func pull(package: AnglesitePackage) async -> SyncEngine.PullResult { .upToDate }
+        func push(package: AnglesitePackage) async -> SyncEngine.PushResult { .pausedForConflict(branch: conflict.branch) }
+        func pendingConflict(package: AnglesitePackage) -> SyncEngine.SyncConflict? { conflict }
+        func acknowledgeConflictResolved(package: AnglesitePackage) async {}
+    }
+
+    // MARK: - Helpers
+
+    private func waitUntil(
+        timeout: Duration = .seconds(10),
+        condition: @escaping @Sendable () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !(await condition()) {
+            guard clock.now < deadline else {
+                Issue.record("timed out waiting for sync scheduler state")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+#endif

--- a/docs/qa/2026-07-27-icloud-sync-manual-qa.md
+++ b/docs/qa/2026-07-27-icloud-sync-manual-qa.md
@@ -1,0 +1,150 @@
+# iCloud Git Sync Manual QA Checklist
+
+**Issue:** [#881](https://github.com/Anglesite/Anglesite-app/issues/881) — iCloud sync P5: app wiring, conflict UX, manual QA doc
+**Epic:** [#876](https://github.com/Anglesite/Anglesite-app/issues/876)
+**Design:** [`docs/superpowers/specs/2026-07-21-icloud-git-sync-design.md`](../superpowers/specs/2026-07-21-icloud-git-sync-design.md)
+**Status:** **NOT YET RUN.** CI and `swift test` exercise `SyncEngine`, `SyncScheduler`, and
+`SyncConflictResolver` against local fixtures and a faked `VersionStore` (real `NSFileVersion`
+conflict versions can't be manufactured in CI). This checklist is the only coverage of the real
+multi-Mac iCloud path and must be run by hand on real hardware before this feature is considered
+release-ready.
+
+## Purpose
+
+Verify that a `.anglesite` package kept in iCloud Drive:
+
+- Syncs its git history between two Macs on the same iCloud account via the single-file
+  `Config/sync/source.bundle` artifact (never the live `.git`, which is excluded via `.nosync`).
+- Reconciles true concurrent edits (not just sequential handoff) through the automatic merge path,
+  and surfaces genuine textual conflicts through the non-blocking banner + resolution sheet rather
+  than silently corrupting or losing anything.
+- Recovers cleanly from offline edits, eviction ("Optimize Mac Storage"), and app backgrounding.
+- Produces **zero** sync activity for a package that isn't in iCloud Drive at all.
+
+## Preconditions
+
+- Two Macs signed into the **same iCloud account**, both with iCloud Drive enabled and this app's
+  container included in "Documents & Data" for iCloud Drive (Settings ▸ Apple ID ▸ iCloud ▸ iCloud
+  Drive ▸ Apps Using iCloud Drive — enable this app if the toggle is available; MAS apps use their
+  own iCloud container automatically once entitled).
+- Both Macs running a build of this branch (or a release that includes #881), signed consistently
+  enough that both can open the same `.anglesite` package.
+- A test `.anglesite` package created in the default iCloud Drive save location, so
+  `ICloudSyncEligibility.isEligible(package:)` is `true` on both Macs. Confirm eligibility
+  indirectly: the sync status icon appears in the site window's toolbar at all (it renders nothing
+  for a non-iCloud package).
+- A stable network connection on at least the Mac performing each write, for the "offline edit"
+  case use macOS's own airplane-mode-equivalent (Wi-Fi off) rather than pulling the physical cable,
+  so iCloud's own resync behavior is exercised realistically.
+- Patience: iCloud Drive propagation between two Macs is typically seconds but can occasionally
+  take minutes; do not treat a slow-but-eventual sync as a failure unless noted otherwise below.
+
+## How to observe sync state during this checklist
+
+- **Toolbar icon** (`SiteToolbarItemID.sync`, `SyncStatusView`): a small cloud glyph in the site
+  window's toolbar. Hover/click for the current status (`Not yet synced`, `Syncing…`, `Synced`,
+  `Waiting for iCloud…`, `N files need attention`, or a failure reason).
+- **Conflict banner**: a non-blocking orange bar at the top of the site window's content area,
+  shown only while a `SyncConflict` is pending. It never blocks editing — you should be able to
+  keep clicking around the site with the banner showing.
+- **Debug pane** (⌥⌘D, or View ▸ Show Debug Pane if enabled): `sync:push`, `sync:pull`,
+  `sync:bootstrap` log lines record every push/pull/bootstrap/merge this app performs, including
+  the specific commit range and merged-tip sources — the fastest way to confirm *what actually
+  happened* without guessing from UI state alone.
+- **Finder**: `Foo.anglesite/Config/sync/source.bundle` is the single synced artifact; its iCloud
+  status (cloud/checkmark/download badge in Finder, or "Right-click ▸ Get Info") reflects whether
+  it's fully downloaded on this Mac. `Foo.anglesite/Config/repo.nosync/` never uploads — Finder
+  should never show a cloud badge on it. `Foo.anglesite/Config/conflicts/` holds quarantined
+  working-tree conflict copies, if any.
+
+---
+
+## 1. Sequential handoff
+
+Baseline case: edit on Mac A, close, edit on Mac B — no true concurrency.
+
+| Step | Action | Expected outcome |
+|---|---|---|
+| 1.1 | On Mac A, create a new site (or open an existing iCloud-hosted one) and make a content edit. | Toolbar sync icon shows `Syncing…` shortly after the edit auto-commits (via `BackupCommand`), then `Synced`. |
+| 1.2 | Quit Anglesite on Mac A (or just close the site window). | No error; `source.bundle` exists in `Config/sync/` and has a recent modification time. |
+| 1.3 | On Mac B, open the same site (via File ▸ Open Recent, or Finder double-click once the package has synced down). | The site opens with Mac A's edit already present — no manual pull step needed. Sync icon reads `Synced` (or briefly `Syncing…` → `Synced`) shortly after open. |
+| 1.4 | Make a different content edit on Mac B, then reopen the site on Mac A (without touching it in between). | Mac A picks up Mac B's edit on open. No conflict banner — this is a clean fast-forward, not a merge. |
+
+**Pass criteria:** every edit round-trips exactly once, no conflict ever appears, and Debug Pane
+`sync:pull` lines show `fastForwarded`, never `merged` or `conflicted`, for this whole section.
+
+## 2. Simultaneous edit (true concurrency)
+
+The core scenario #881 is required to handle: both Macs editing *while online* at close to the same
+time.
+
+| Step | Action | Expected outcome |
+|---|---|---|
+| 2.1 | With the same site open in windows on **both** Macs simultaneously, edit **different pages** on each Mac within the same ~1 minute window. | Both Macs' edits auto-commit (`BackupCommand`) and push (debounced) independently. |
+| 2.2 | Wait ~30s–2min for iCloud to propagate both writes, watching the sync icon on both Macs. | Both Macs eventually show `Synced` with **both** edits present — Debug Pane `sync:pull` shows a `merged` line (non-overlapping edits three-way-merge cleanly), never `conflicted`. No banner appears. |
+| 2.3 | Now edit **the same page, same content region** on both Macs within the same window (a genuine textual collision — e.g. both retype the same paragraph differently). | Both writes push. On whichever Mac's `pull()` runs against the *other's* now-diverged history, the toolbar icon turns to `N files need attention` and the orange banner appears: "This site was edited on two Macs — N files need attention." |
+| 2.4 | Confirm the banner does **not** block editing: keep navigating/editing other pages while it's showing. | All other editing works normally; only pushing *this branch* is paused (Debug Pane may show `sync:push` logging a pause, or simply no new `pushed` lines for this branch until resolved). |
+| 2.5 | Click "Resolve…" on the banner (or the toolbar icon's popover). | The resolution sheet opens, listing the conflicted file(s) with a segmented "This Mac / Other Mac" picker per file and an "Open Both…" link. |
+| 2.6 | Use "Open Both…" for the conflicted file. | Finder opens showing two files ("This Mac — …" / "Other Mac — …") with each side's actual content, for comparison. |
+| 2.7 | Choose a side (This Mac or Other Mac) for every conflicted file, then click Apply. | The sheet closes with no error; the toolbar icon returns to `Syncing…` then `Synced`. Debug Pane shows a resolution merge commit and a subsequent successful push. |
+| 2.8 | Open the site on the *other* Mac and pull (open the window, or wait for the next automatic pull). | The other Mac converges to the same resolved content — no repeat conflict, no banner. |
+
+**Pass criteria:** the conflict is detected, never silently auto-resolved or rewound (both Macs'
+edits are individually recoverable from git history even before resolving — spot check with
+`git log --all --oneline` inside `Source/` if you have shell access to the live repo via a VS Code
+window, since `/usr/bin/git` doesn't run inside the sandboxed app itself), and after resolving,
+both Macs converge to the identical chosen content.
+
+## 3. Offline edit + reconnect
+
+| Step | Action | Expected outcome |
+|---|---|---|
+| 3.1 | On Mac A, turn off Wi-Fi (or otherwise fully disconnect from the network). | App keeps working normally — editing is fully local. |
+| 3.2 | Make several edits while offline. Confirm auto-commits still happen (`BackupCommand` operates on the local repo, no network needed). | Sync icon shows `Syncing…` → (no network) it should settle on either `Synced` (if a prior push already reflected current state and there's nothing new to push, unlikely) or a failure/waiting state — note exactly what it shows; expected is that a push attempt either times out gracefully or the icon reflects "couldn't sync" without crashing or hanging the UI. |
+| 3.3 | Meanwhile, edit the **same site** from Mac B (online) — a few different edits, ideally not overlapping Mac A's paths for this step (overlap is covered in §2). | Mac B syncs normally. |
+| 3.4 | Reconnect Mac A's Wi-Fi. | Within a short window, the debounced push (background/backup/deploy trigger, or the next site-open pull) resumes. Sync icon transitions through `Syncing…` to `Synced`, having merged Mac B's edits made while Mac A was offline. |
+| 3.5 | Verify both Macs' offline-period edits are present on both Macs afterward. | No edits lost; a `merged` line appears in Debug Pane rather than a silent drop. |
+
+**Pass criteria:** no edits made while offline are lost, and reconnecting doesn't require any
+manual action from the user (no explicit "sync now" button exists by design — reconnection alone
+should be enough, though opening/reopening the site window is an acceptable manual nudge to note
+if automatic reconnection sync doesn't fire promptly).
+
+## 4. Eviction ("Optimize Mac Storage")
+
+Exercises `VersionStore.materialize`'s eviction-handling path (`waitingForICloud`) against a real,
+not faked, ubiquitous item.
+
+| Step | Action | Expected outcome |
+|---|---|---|
+| 4.1 | On Mac B (not currently editing this site), enable "Optimize Mac Storage" for iCloud Drive (System Settings ▸ Apple ID ▸ iCloud ▸ iCloud Drive), or manually evict the file: Finder ▸ right-click `source.bundle` ▸ "Remove Download". | The Finder badge on `source.bundle` shows the cloud-download (not-yet-downloaded) icon. |
+| 4.2 | On Mac A, make an edit and let it push. | Push succeeds normally (push doesn't require the *local* copy to be materialized before overwriting it — confirm no crash/hang). |
+| 4.3 | On Mac B, open the site (forcing a pull against the evicted local artifact). | Toolbar icon shows `Waiting for iCloud…` briefly while `startDownloadingUbiquitousItem` materializes the file, then proceeds to pull normally and shows `Synced` with Mac A's edit present. If materialization takes unusually long, confirm the UI stays responsive (not blocked) and eventually settles rather than hanging indefinitely. |
+| 4.4 | Repeat with a large-ish site history (many commits) if practical, to see whether the timeout (`SyncEngine`'s default `materializeTimeout`, 15s) is ever hit on a slow connection. | If it times out, the UI should show a clear "waiting for iCloud" state rather than a confusing generic failure — note whether the copy is legible and actionable. |
+
+**Pass criteria:** eviction never crashes, hangs indefinitely, or silently fails; the user always
+sees either progress or an explicit "waiting for iCloud" state, per the mac-assed-app-spec's
+requirement that a blocking operation always show a clear operation/status.
+
+## 5. Non-iCloud site: zero activity (sanity check)
+
+| Step | Action | Expected outcome |
+|---|---|---|
+| 5.1 | Create or open a `.anglesite` package **outside** iCloud Drive (e.g. on an external volume, or with iCloud Drive Desktop & Documents folders off and the package saved elsewhere). | The sync status toolbar icon does not appear at all (not even as a disabled/idle state) — `SyncStatusView` renders nothing when `SyncModel.isEligible` is `false`. |
+| 5.2 | Watch the Debug Pane while using this site normally (editing, backing up, deploying). | No `sync:push`/`sync:pull`/`sync:bootstrap` log lines ever appear for this site. |
+| 5.3 | Confirm `Config/sync/` is never created for this package. | No `Config/sync/source.bundle` file exists on disk for a site that was never in iCloud. |
+
+**Pass criteria:** a local-only site shows zero sync-related UI, zero sync-related log activity,
+and zero sync-related files on disk — matching #881's acceptance criteria verbatim.
+
+---
+
+## Recording results
+
+When this checklist is run, replace **Status: NOT YET RUN** above with the date, the two Macs'
+macOS/Xcode/app build identifiers, and a pass/fail per section (1–5) with notes on any deviation
+from the expected outcomes — particularly exact timings observed for iCloud propagation (§1–2),
+offline reconnect latency (§3), and eviction/materialization latency (§4), since these are the
+dimensions most likely to need tuning (`SyncScheduler`'s push debounce interval,
+`SyncEngine`'s `materializeTimeout`) once exercised against real iCloud rather than the faked
+`VersionStore` the automated test suite uses.


### PR DESCRIPTION
## Summary

- Adds `SyncScheduler` (AnglesiteCore actor) owning the pull-on-open/bundle-change and debounced+coalesced push-after-backup/deploy/background trigger policy, unit-tested end to end against a fake `SyncEngineProtocol` — zero sync activity when never triggered.
- Adds `SyncConflictResolver` (AnglesiteCore actor) that reads both tips of a `SyncEngine.SyncConflict` and commits the user's per-file keep-mine/keep-theirs resolution as a real merge commit (parents `[ourOID, theirOID]`), tested against real git fixtures.
- Adds `ICloudSyncEligibility` and `AnglesitePackage.conflictsDirectoryURL`; `SyncEngine` now reads the quarantine path from the latter instead of an inline literal.
- Wires it all into the app: `SyncModel` (`Sources/AnglesiteApp`) drives one open site window's scheduler — pull on site open, `NSMetadataQuery` observation of `source.bundle` while the window is open, debounced push on `BackupCommand`/deploy success and `NSApplication.didResignActiveNotification`. No-ops entirely for a package that isn't in iCloud Drive.
- `SiteWindow` gains a toolbar sync-status badge (`SyncStatusView`), a non-blocking conflict banner (`SyncConflictBannerView`) that never blocks editing, and a per-file resolution sheet (`SyncConflictResolutionSheetView`: keep this Mac's / keep the other's / open both, plus the quarantined `Config/conflicts/` copies) with standard sheet chrome (Cancel/Apply, Esc/Return, VoiceOver labels) per `docs/mac-assed-app-spec.md`.
- Adds `docs/qa/2026-07-27-icloud-sync-manual-qa.md`: the two-Mac manual QA checklist (sequential handoff, simultaneous edit, offline edit + reconnect, eviction, non-iCloud-site zero-activity sanity check) — **marked NOT YET RUN**.

**Stacked PR** — fourth in the iCloud-sync stack. This PR's base is `feat/880-nsfileversion-reconciliation`, which is itself based on `feat/879-syncengine-core` (#998), based on `feat/878-syncartifact-bundle-v2` (#997). Please merge bottom-up: #997 → #998 → #1001 (P3, this stack's direct base) → this PR. The diff shown here will shrink to just this phase's commits once the earlier PRs merge.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite green except the two documented, pre-existing `FoundationModelAssistant` flaky failures ("Session ended without producing a response", #FM known-flaky signature, reproduced identically across two consecutive full runs — unrelated to this change).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds.
- [x] `scripts/check-localization-catalog.sh` — passes; `Localizable.xcstrings` synced via the CONTRIBUTING CLI recipe and reviewed (pure additions for the new sync/conflict-sheet strings, no existing keys touched, trailing newline preserved).
- [ ] Manual smoke (UI-touching): **pending** — see `docs/qa/2026-07-27-icloud-sync-manual-qa.md`. This feature requires two real Macs on the same iCloud account and cannot be exercised in this environment; the checklist is written and ready to run but has not yet been executed on real hardware. Per #881's acceptance criteria, full two-Mac QA pass is required before this is release-ready — flagging that explicitly rather than checking this box.

Closes #881. Part of epic #876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)