### PR TITLE
feat(template): bake @astroanimate/core into the template (#1006)

### DIFF
--- a/Resources/Template/integrations/animations-demos/AnimatedButton.html
+++ b/Resources/Template/integrations/animations-demos/AnimatedButton.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Animated button</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  .button-content {
+    position: relative;
+    z-index: 10;
+  }
+
+  /* --- BASE STYLES --- */
+  .animated-button {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    cursor: pointer;
+    text-decoration: none;
+    border: 1px solid #ccc;
+    background: white;
+    color: #111;
+    font: inherit;
+    transition: all 0.3s ease;
+    z-index: 0;
+    padding: 1rem 1rem;
+    border-radius: 0.5em;
+  }
+
+  .animated-button:hover {
+    border-color: #999;
+  }
+
+  .animated-button:focus-visible {
+    outline: 2px solid #667eea;
+    outline-offset: 2px;
+  }
+
+  .animated-button.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .animated-button.disabled:hover {
+    border-color: #ccc;
+  }
+
+  /* --- SHIMMER VARIANT --- */
+  .button-shimmer {
+    background: #111;
+    color: white;
+    border-color: #111;
+  }
+
+  .shimmer-effect {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--shimmer-color, rgba(255, 255, 255, 0.4)),
+      transparent
+    );
+    transform: translateX(-100%);
+    pointer-events: none;
+  }
+
+  /* ✅ CRITERION 7: CSS-First (Hover triggered by CSS) */
+  .button-shimmer:not(.disabled):hover .shimmer-effect {
+    animation: shimmer 1.5s infinite;
+  }
+
+  @keyframes shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
+  }
+
+  /* --- FILL VARIANT --- */
+  .button-fill {
+    border: 1px solid currentColor;
+    color: #111;
+    background: transparent;
+  }
+
+  .fill-effect {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background: currentColor;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.4s cubic-bezier(0.19, 1, 0.22, 1);
+  }
+
+  /* ✅ CRITERION 7: CSS-First */
+  .button-fill:not(.disabled):hover .fill-effect {
+    transform: scaleX(1);
+  }
+
+  .button-fill:not(.disabled):hover .button-content {
+    color: white; /* Basic inversion for visibility */
+    mix-blend-mode: difference;
+    transition: color 0.4s ease;
+  }
+
+  /* --- BORDER VARIANT --- */
+  .button-border {
+    padding: 0.5rem 1rem;
+    color: white;
+    background: #111;
+  }
+
+  .border-line {
+    position: absolute;
+    background: white;
+    z-index: 5;
+    transition: transform 0.3s ease;
+  }
+
+  .border-line-top {
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    transform: scaleX(0);
+    transform-origin: left;
+  }
+
+  .border-line-right {
+    top: 0;
+    right: 0;
+    width: 2px;
+    height: 100%;
+    transform: scaleY(0);
+    transform-origin: top;
+    transition-delay: 0.05s;
+  }
+
+  .border-line-bottom {
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 2px;
+    transform: scaleX(0);
+    transform-origin: right;
+    transition-delay: 0.1s;
+  }
+
+  .border-line-left {
+    bottom: 0;
+    left: 0;
+    width: 2px;
+    height: 100%;
+    transform: scaleY(0);
+    transform-origin: bottom;
+    transition-delay: 0.15s;
+  }
+
+  /* ✅ CRITERION 7: CSS-First */
+  .button-border:not(.disabled):hover .border-line-top {
+    transform: scaleX(1);
+  }
+  .button-border:not(.disabled):hover .border-line-right {
+    transform: scaleY(1);
+  }
+  .button-border:not(.disabled):hover .border-line-bottom {
+    transform: scaleX(1);
+  }
+  .button-border:not(.disabled):hover .border-line-left {
+    transform: scaleY(1);
+  }
+
+  /* ✅ CRITERION 6: Reduced Motion Respected */
+  /* ALL animations and transitions wrapped or overridden */
+  @media (prefers-reduced-motion: reduce) {
+    .animated-button,
+    .shimmer-effect,
+    .fill-effect,
+    .border-line,
+    .button-content {
+      transition: none !important;
+      animation: none !important;
+      transform: none !important;
+    }
+
+    /* Fallback states for reduced motion visibility */
+    .button-fill:hover {
+      background: #111;
+      color: white;
+    }
+  }
+</style>
+</head><body>
+<!-- ✅ CRITERION 1: Visible Without JS --><!-- Meaningful HTML content exists and is visible at baseline --><button type="button" data-astro-animated-button="true" data-variant="none" style data-astro-cid-zpixjtb2="true" class="animated-button"><span class="button-content" data-astro-cid-zpixjtb2>Animated button demo</span></button>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/AnimatedCard.html
+++ b/Resources/Template/integrations/animations-demos/AnimatedCard.html
@@ -1,0 +1,519 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Animated card</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /* ✅ CRITERION 7: CSS-FIRST architecture with themeable custom properties */
+  [data-animated-card],
+  [data-animated-card] * {
+    box-sizing: border-box;
+  }
+
+  [data-animated-card] {
+    --animated-card-radius: 1.5rem;
+    --animated-card-padding: 1.5rem;
+    --animated-card-shadow:
+      0 14px 30px rgba(2, 6, 23, 0.24),
+      0 2px 10px rgba(2, 6, 23, 0.2);
+    --animated-card-shadow-active:
+      0 28px 52px rgba(2, 6, 23, 0.42),
+      0 0 0 1px rgba(255, 255, 255, 0.03);
+    --animated-card-title-size: 1.25rem;
+    --animated-card-icon-size: 3.5rem;
+
+    position: relative;
+    isolation: isolate;
+    display: flex;
+    min-height: var(--animated-card-min-height, 18rem);
+    border-radius: var(--animated-card-radius);
+    background: var(--animated-card-bg, var(--animated-card-surface));
+    border: 1px solid var(--animated-card-border);
+    box-shadow: var(--animated-card-shadow);
+    overflow: hidden;
+    color: #ffffff;
+  }
+
+  [data-animated-card][data-clickable="true"] {
+    text-decoration: none;
+  }
+
+  .animated-card__surface {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-height: inherit;
+    padding: var(--animated-card-padding);
+    gap: 0.95rem;
+    z-index: 1;
+  }
+
+  .animated-card__ambient,
+  .animated-card__grid,
+  .animated-card__shine-overlay,
+  .animated-card__inner-glow,
+  .animated-card__indicator {
+    pointer-events: none;
+    position: absolute;
+  }
+
+  .animated-card__ambient {
+    inset: auto -15% -35% auto;
+    width: 12rem;
+    height: 12rem;
+    border-radius: 999px;
+    background: radial-gradient(circle, var(--animated-card-aura), transparent 70%);
+    opacity: 0.7;
+    transition:
+      opacity 260ms ease,
+      transform 260ms ease,
+      filter 260ms ease;
+    z-index: 0;
+  }
+
+  .animated-card__grid {
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255, 255, 255, 0.045) 1px, transparent 1px);
+    background-size: 28px 28px;
+    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.4), transparent 90%);
+    opacity: 0.16;
+    z-index: 0;
+  }
+
+  .animated-card__shine-overlay {
+    inset: -35% auto -35% -120%;
+    width: 68%;
+    background: linear-gradient(
+      115deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.04) 25%,
+      rgba(255, 255, 255, 0.2) 50%,
+      rgba(255, 255, 255, 0.04) 75%,
+      transparent 100%
+    );
+    transform: skewX(-22deg) translateX(0);
+    opacity: 0;
+    transition:
+      transform 600ms cubic-bezier(0.22, 1, 0.36, 1),
+      opacity 220ms ease;
+    z-index: 1;
+  }
+
+  .animated-card__inner-glow {
+    inset: 0;
+    border-radius: inherit;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    opacity: 1;
+    transition:
+      box-shadow 280ms ease,
+      opacity 280ms ease;
+    z-index: 0;
+  }
+
+  .animated-card__indicator {
+    left: 1.25rem;
+    right: 1.25rem;
+    bottom: 0;
+    height: 0.2rem;
+    border-radius: 999px 999px 0 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--animated-card-accent),
+      transparent
+    );
+    transform: scaleX(0.18);
+    transform-origin: center;
+    opacity: 0;
+    transition:
+      transform 280ms ease,
+      opacity 280ms ease;
+    z-index: 2;
+  }
+
+  .animated-card__topline {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .animated-card__icon-shell {
+    width: var(--animated-card-icon-size);
+    height: var(--animated-card-icon-size);
+    border-radius: 1rem;
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.06),
+      var(--animated-card-soft)
+    );
+    border: 1px solid var(--animated-card-border);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--animated-card-accent-text);
+    flex-shrink: 0;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    transition:
+      transform 280ms ease,
+      background 280ms ease,
+      border-color 280ms ease;
+  }
+
+  .animated-card__icon-fallback {
+    font-size: 1.75rem;
+    line-height: 1;
+  }
+
+  .animated-card__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: flex-start;
+    padding: 0.4rem 0.72rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--animated-card-accent-text);
+    background: color-mix(in srgb, var(--animated-card-accent) 18%, transparent);
+    border: 1px solid color-mix(in srgb, var(--animated-card-accent) 32%, transparent);
+    backdrop-filter: blur(8px);
+  }
+
+  .animated-card__title {
+    margin: 0;
+    font-size: var(--animated-card-title-size);
+    line-height: 1.2;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+  }
+
+  .animated-card__description,
+  .animated-card__back-description,
+  .animated-card__hint {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.78);
+    line-height: 1.65;
+    font-size: 0.95rem;
+  }
+
+  .animated-card__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    position: relative;
+    z-index: 2;
+    flex: 1;
+  }
+
+  .animated-card__meta {
+    margin-top: auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    color: rgba(255, 255, 255, 0.68);
+    font-size: 0.82rem;
+  }
+
+  .animated-card__meta-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 999px;
+    background: var(--animated-card-accent);
+    box-shadow: 0 0 0 0.3rem color-mix(in srgb, var(--animated-card-accent) 18%, transparent);
+  }
+
+  [data-animated-card]:focus-visible,
+  .animated-card__toggle:focus-visible + .animated-card__flip-scene {
+    outline: 2px solid color-mix(in srgb, var(--animated-card-accent) 55%, white);
+    outline-offset: 4px;
+  }
+
+  [data-animated-card][data-selected="true"]:not([data-selected-on-scroll="true"]) .animated-card__indicator,
+  [data-animated-card][data-indicator-visible="true"] .animated-card__indicator,
+  [data-animated-card]:is(:hover, :focus-visible) .animated-card__indicator {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+
+  /* ✅ CRITERION 1: Meaningful card content visible server-side without JS */
+  .animated-card--lift,
+  .animated-card--scale,
+  .animated-card--shine {
+    transition:
+      transform 280ms cubic-bezier(0.22, 1, 0.36, 1),
+      box-shadow 280ms cubic-bezier(0.22, 1, 0.36, 1),
+      border-color 280ms ease,
+      filter 280ms ease;
+  }
+
+  .animated-card--lift:is(:hover, :focus-visible) {
+    transform: translateY(-0.55rem);
+    box-shadow:
+      0 28px 54px rgba(2, 6, 23, 0.42),
+      0 0 3rem color-mix(in srgb, var(--animated-card-accent) 18%, transparent);
+    border-color: color-mix(in srgb, var(--animated-card-accent) 40%, transparent);
+  }
+
+  .animated-card--lift:is(:hover, :focus-visible) .animated-card__ambient {
+    opacity: 1;
+    transform: translate3d(-0.5rem, -0.6rem, 0) scale(1.04);
+    filter: blur(2px);
+  }
+
+  .animated-card--lift:is(:hover, :focus-visible) .animated-card__icon-shell {
+    transform: translateY(-0.25rem);
+  }
+
+  .animated-card--scale:is(:hover, :focus-visible) {
+    transform: scale(1.04);
+    box-shadow:
+      0 24px 44px rgba(2, 6, 23, 0.36),
+      0 0 0 1px color-mix(in srgb, var(--animated-card-accent) 22%, transparent);
+  }
+
+  .animated-card--scale:is(:hover, :focus-visible) .animated-card__inner-glow {
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--animated-card-accent) 30%, transparent),
+      inset 0 0 2.25rem var(--animated-card-inset);
+  }
+
+  .animated-card--scale:is(:hover, :focus-visible) .animated-card__icon-shell {
+    transform: scale(1.08);
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.1),
+      color-mix(in srgb, var(--animated-card-accent) 18%, transparent)
+    );
+  }
+
+  .animated-card--shine:is(:hover, :focus-visible) {
+    box-shadow:
+      0 20px 42px rgba(2, 6, 23, 0.34),
+      0 0 0 1px rgba(255, 255, 255, 0.04);
+    border-color: color-mix(in srgb, var(--animated-card-accent) 32%, transparent);
+  }
+
+  .animated-card--shine:is(:hover, :focus-visible) .animated-card__shine-overlay {
+    opacity: 1;
+    transform: skewX(-22deg) translateX(430%);
+  }
+
+  .animated-card--shine:is(:hover, :focus-visible) .animated-card__ambient {
+    opacity: 0.92;
+    transform: scale(1.08);
+  }
+
+  .animated-card--shine:is(:hover, :focus-visible) .animated-card__icon-shell {
+    border-color: color-mix(in srgb, var(--animated-card-accent) 42%, transparent);
+  }
+
+  /* Flip variant */
+  .animated-card--flip {
+    padding: 0;
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  .animated-card__toggle {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .animated-card__flip-scene {
+    position: relative;
+    width: 100%;
+    min-height: var(--animated-card-min-height, 18rem);
+    perspective: 1200px;
+  }
+
+  .animated-card__flip-inner {
+    position: relative;
+    width: 100%;
+    min-height: inherit;
+    transform-style: preserve-3d;
+    transition: transform 600ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .animated-card__toggle:checked + .animated-card__flip-scene .animated-card__flip-inner {
+    transform: rotateY(180deg);
+  }
+
+  .animated-card__face {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    min-height: inherit;
+    border-radius: var(--animated-card-radius);
+    overflow: hidden;
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+    box-shadow: var(--animated-card-shadow);
+  }
+
+  .animated-card__face--front,
+  .animated-card__face--back {
+    background: var(--animated-card-bg, var(--animated-card-surface));
+    border: 1px solid var(--animated-card-border);
+  }
+
+  .animated-card__face--front {
+    cursor: pointer;
+  }
+
+  .animated-card__face--back {
+    background: var(--animated-card-back-surface);
+    transform: rotateY(180deg);
+  }
+
+  .animated-card__face--front .animated-card__surface,
+  .animated-card__face--back .animated-card__surface {
+    min-height: var(--animated-card-min-height, 18rem);
+  }
+
+  .animated-card__back-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 0.95rem;
+    width: 100%;
+  }
+
+  .animated-card__back-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: flex-start;
+    margin-top: 0.2rem;
+    padding: 0.8rem 1rem;
+    border-radius: 0.9rem;
+    cursor: pointer;
+    color: #fff;
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--animated-card-accent) 88%, white 6%),
+      var(--animated-card-accent)
+    );
+    border: 1px solid color-mix(in srgb, var(--animated-card-accent) 62%, transparent);
+    font-size: 0.9rem;
+    font-weight: 700;
+    box-shadow:
+      0 10px 24px color-mix(in srgb, var(--animated-card-accent) 26%, transparent),
+      inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  }
+
+  .animated-card__flip-instruction {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    margin-top: auto;
+    color: rgba(255, 255, 255, 0.68);
+    font-size: 0.82rem;
+  }
+
+  .animated-card__flip-instruction::before {
+    content: "";
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--animated-card-accent) 46%, transparent);
+    background: color-mix(in srgb, var(--animated-card-accent) 18%, transparent);
+  }
+
+  .animated-card__toggle:focus-visible + .animated-card__flip-scene .animated-card__face--front,
+  .animated-card__face--front:hover {
+    border-color: color-mix(in srgb, var(--animated-card-accent) 42%, transparent);
+    box-shadow:
+      0 28px 54px rgba(2, 6, 23, 0.42),
+      0 0 3rem color-mix(in srgb, var(--animated-card-accent) 18%, transparent);
+  }
+
+  .animated-card__face--front:hover .animated-card__icon-shell,
+  .animated-card__toggle:focus-visible
+    + .animated-card__flip-scene
+    .animated-card__face--front
+    .animated-card__icon-shell {
+    transform: translateY(-0.22rem);
+  }
+
+  /* ✅ CRITERION 6: Reduced motion disables transforms and sweep animations */
+  @media (prefers-reduced-motion: reduce) {
+    [data-animated-card],
+    [data-animated-card] * {
+      animation: none !important;
+      transition: none !important;
+      scroll-behavior: auto !important;
+    }
+
+    .animated-card--lift:is(:hover, :focus-visible),
+    .animated-card--scale:is(:hover, :focus-visible) {
+      transform: none !important;
+    }
+
+    .animated-card--shine .animated-card__shine-overlay {
+      opacity: 0 !important;
+      transform: none !important;
+    }
+
+    .animated-card__flip-inner {
+      transform: none !important;
+    }
+
+    .animated-card__toggle:checked + .animated-card__flip-scene .animated-card__face--front {
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    .animated-card__toggle:checked + .animated-card__flip-scene .animated-card__face--back {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .animated-card__face--front {
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .animated-card__face--back {
+      opacity: 0;
+      visibility: hidden;
+      transform: none !important;
+    }
+  }
+
+  @media (max-width: 640px) {
+    [data-animated-card] {
+      --animated-card-padding: 1.25rem;
+      --animated-card-radius: 1.25rem;
+    }
+
+    .animated-card__title {
+      font-size: 1.12rem;
+    }
+
+    .animated-card__description,
+    .animated-card__back-description,
+    .animated-card__hint {
+      font-size: 0.92rem;
+    }
+  }
+</style>
+</head><body>
+<article data-animated-card="true" data-color="rose" data-variant="lift" data-selected="false" data-selected-on-scroll="false" data-clickable="false" style="--animated-card-accent: #f43f5e; --animated-card-accent-text: #fb7185; --animated-card-border: rgba(244, 63, 94, 0.28); --animated-card-soft: rgba(244, 63, 94, 0.12); --animated-card-aura: rgba(244, 63, 94, 0.2); --animated-card-surface: linear-gradient(180deg, rgba(30, 41, 59, 0.96), rgba(15, 23, 42, 1)); --animated-card-back-surface: linear-gradient(180deg, rgba(38, 18, 31, 0.98), rgba(20, 11, 21, 1)); --animated-card-inset: rgba(251, 113, 133, 0.22); --animated-card-min-height: 18rem" aria-label="Feature" data-astro-cid-4aenmv2w="true" class="animated-card--lift animated-card--lift"><span class="animated-card__ambient" aria-hidden="true" data-astro-cid-4aenmv2w></span><span class="animated-card__grid" aria-hidden="true" data-astro-cid-4aenmv2w></span><span class="animated-card__shine-overlay" aria-hidden="true" data-astro-cid-4aenmv2w></span><span class="animated-card__inner-glow" aria-hidden="true" data-astro-cid-4aenmv2w></span><span class="animated-card__indicator" aria-hidden="true" data-astro-cid-4aenmv2w></span><div class="animated-card__surface" data-astro-cid-4aenmv2w><div class="animated-card__topline" data-astro-cid-4aenmv2w><div class="animated-card__icon-shell" data-astro-cid-4aenmv2w><span class="animated-card__icon-fallback" aria-hidden="true" data-astro-cid-4aenmv2w>✦</span></div></div><div class="animated-card__content" data-astro-cid-4aenmv2w><h3 class="animated-card__title" data-astro-cid-4aenmv2w>Feature</h3><p class="animated-card__description" data-astro-cid-4aenmv2w>A short description of the feature.</p></div><div class="animated-card__meta" aria-hidden="true" data-astro-cid-4aenmv2w><span class="animated-card__meta-dot" data-astro-cid-4aenmv2w></span><span data-astro-cid-4aenmv2w>lift interaction</span></div></div></article>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/ArrowCTAButton.html
+++ b/Resources/Template/integrations/animations-demos/ArrowCTAButton.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Arrow CTA button</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /* ✅ CRITERION 7: CSS-FIRST */
+
+  [data-acta] {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+
+  border: none;
+  background: transparent;
+
+  cursor: pointer;
+  text-decoration: none;
+  color: black;
+
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Arial,
+    sans-serif;
+}
+
+  .label {
+    position: relative;
+
+    padding-bottom: 0.5rem;
+    padding-right: 0.9375rem;
+
+    font-size: 0.875rem;
+    letter-spacing: 0.25rem;
+    text-transform: uppercase;
+  }
+
+  /* Underline */
+  .label::after {
+    content: "";
+
+    position: absolute;
+    left: 0;
+    bottom: 0;
+
+    width: 100%;
+    height: 2px;
+
+    background: currentColor;
+
+    transform: scaleX(0);
+    transform-origin: bottom right;
+
+    transition: transform 250ms ease-out;
+  }
+
+  [data-acta]:hover .label::after {
+    transform: scaleX(1);
+    transform-origin: bottom left;
+  }
+
+  .arrow {
+    width: 1.875rem;
+    height: 0.625rem;
+
+    transform: translateX(-0.5rem);
+
+    transition: transform 300ms ease;
+  }
+
+  [data-acta]:hover .arrow {
+    transform: translateX(0);
+  }
+
+  [data-acta]:active .arrow {
+    transform: scale(0.9);
+  }
+
+  /* Accessibility */
+  [data-acta]:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 4px;
+  }
+
+  /* ✅ CRITERION 6: REDUCED MOTION */
+  @media (prefers-reduced-motion: reduce) {
+    [data-acta],
+    [data-acta] * {
+      transition: none !important;
+      transform: none !important;
+    }
+  }
+</style>
+</head><body>
+<button data-acta type="button" class aria-label="Learn more" data-astro-cid-m7kebhko><span class="label" data-astro-cid-m7kebhko>Learn more</span><svg class="arrow" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46 16" fill="none" data-astro-cid-m7kebhko><path d="M8,0,6.545,1.455l5.506,5.506H-30V9.039H12.052L6.545,14.545,8,16l8-8Z" transform="translate(30)" fill="currentColor" data-astro-cid-m7kebhko></path></svg></button>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/ArticleCard.html
+++ b/Resources/Template/integrations/animations-demos/ArticleCard.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Article card</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /* ✅ CRITERION 7: CSS-FIRST */
+
+  [data-ac] {
+    width: min(20rem, 100%);
+
+    overflow: hidden;
+
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+
+    background: white;
+
+    font-family:
+      Inter,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      Arial,
+      sans-serif;
+
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+
+    box-shadow:
+      0 1px 2px rgba(0,0,0,0.05);
+
+    transition:
+      transform 250ms ease,
+      box-shadow 250ms ease;
+  }
+
+  [data-ac]:hover {
+    transform: translateY(-4px);
+
+    box-shadow:
+      0 12px 24px rgba(0,0,0,0.08);
+  }
+
+  .media {
+    width: 100%;
+    height: 150px;
+
+    background:
+      linear-gradient(
+        135deg,
+        rgb(239,205,255),
+        rgb(220,180,255)
+      );
+
+    overflow: hidden;
+  }
+
+  .media img {
+    width: 100%;
+    height: 100%;
+
+    object-fit: cover;
+
+    display: block;
+  }
+
+  .content {
+    padding: 1.1rem;
+  }
+
+  .title-link {
+    text-decoration: none;
+  }
+
+  .title {
+    color: #111827;
+
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+    font-weight: 600;
+
+    letter-spacing: -0.03em;
+  }
+
+  .description {
+    margin-top: 0.65rem;
+
+    color: #6b7280;
+
+    font-size: 0.92rem;
+    line-height: 1.65;
+  }
+
+  .action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+
+    margin-top: 1rem;
+    padding: 0.45rem 0.75rem;
+
+    border-radius: 0.45rem;
+
+    background: #2563eb;
+    color: white;
+
+    font-size: 0.875rem;
+    font-weight: 500;
+
+    text-decoration: none;
+
+    transition:
+      background-color 200ms ease,
+      transform 200ms ease;
+  }
+
+  .action:hover,
+  .action:focus-visible {
+    background: #1d4ed8;
+  }
+
+  .arrow {
+    transition: transform 300ms ease;
+  }
+
+  .action:hover .arrow,
+  .action:focus-visible .arrow {
+    transform: translateX(4px);
+  }
+
+  /* Accessibility */
+  .title-link:focus-visible,
+  .action:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 4px;
+  }
+
+  /* ✅ CRITERION 6: REDUCED MOTION */
+  @media (prefers-reduced-motion: reduce) {
+    [data-ac],
+    [data-ac] * {
+      transition: none !important;
+      transform: none !important;
+    }
+  }
+</style>
+</head><body>
+<article data-ac class data-astro-cid-hxvelkko><div class="media" data-astro-cid-hxvelkko></div><div class="content" data-astro-cid-hxvelkko><a href="#" class="title-link" data-astro-cid-hxvelkko><span class="title" data-astro-cid-hxvelkko>Article title</span></a><p class="description" data-astro-cid-hxvelkko>A short summary of the article.</p><a class="action" href="#" data-astro-cid-hxvelkko>Find out more<span class="arrow" aria-hidden="true" data-astro-cid-hxvelkko>→</span></a></div></article>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/CardStack.html
+++ b/Resources/Template/integrations/animations-demos/CardStack.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Card stack</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /**
+   * ✅ CRITERION 7: CSS-First
+   * Stack layout is defined in CSS using nth-last-child.
+   */
+  .astro-card-stack-container {
+    position: relative;
+    width: 100%;
+    max-width: 400px;
+    height: 320px;
+    margin: 4rem auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    perspective: 1000px;
+  }
+
+  .stack-card {
+    position: absolute;
+    width: 100%;
+    height: 260px;
+    padding: 1.5rem 2rem;
+    background: #ffffff;
+    color: #1a1a1a;
+    border-radius: 32px;
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.05),
+      0 10px 30px -10px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    cursor: grab;
+    transform-origin: center bottom;
+    will-change: transform, opacity;
+    user-select: none;
+    touch-action: none;
+    transition:
+      transform 0.6s cubic-bezier(0.23, 1, 0.32, 1),
+      opacity 0.6s ease;
+  }
+
+  /**
+   * ✅ CRITERION 6: Reduced Motion Respected
+   */
+  @media (prefers-reduced-motion: reduce) {
+    .stack-card {
+      transition: none !important;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .stack-card {
+      border-color: rgba(255, 255, 255, 0.08);
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+    }
+  }
+
+  .stack-card:nth-last-child(1) {
+    z-index: 3;
+    transform: translate3d(0, 0, 0);
+  }
+  .stack-card:nth-last-child(2) {
+    z-index: 2;
+    transform: translate3d(0, 15px, -30px) scale(0.94);
+    opacity: 0.8;
+  }
+  .stack-card:nth-last-child(3) {
+    z-index: 1;
+    transform: translate3d(0, 30px, -60px) scale(0.88);
+    opacity: 0.4;
+  }
+  .stack-card:nth-last-child(n + 4) {
+    opacity: 0;
+    transform: translate3d(0, 45px, -90px) scale(0.82);
+  }
+
+  .stack-card.dragging {
+    cursor: grabbing;
+    transition: none;
+    z-index: 50;
+  }
+
+  .quote-icon {
+    width: 32px;
+    opacity: 0.1;
+    margin-bottom: 1.5rem;
+    color: #6366f1;
+  }
+
+  .card-title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+    color: inherit;
+  }
+
+  .quote {
+    font-size: 1rem;
+    line-height: 1.6;
+    font-weight: 400;
+    color: inherit;
+    overflow-y: auto;
+    max-height: 80px;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  .quote::-webkit-scrollbar {
+    display: none;
+  }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding-top: 1.5rem;
+    margin-top: auto;
+    border-top: 1px solid rgba(0, 0, 0, 0.05);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .card-footer {
+      border-top-color: rgba(255, 255, 255, 0.05);
+    }
+  }
+
+  .avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+  }
+
+  .avatar-img {
+    object-fit: cover;
+  }
+
+  .info {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .name {
+    font-weight: 700;
+    font-size: 1rem;
+  }
+
+  .role {
+    font-size: 0.8rem;
+    opacity: 0.5;
+  }
+</style>
+</head><body>
+<div class="astro-card-stack-container" data-astro-card-stack data-enhance="false" data-stack-size="3" data-threshold="120" data-rotation="20" data-duration="500" data-astro-cid-xhgh37dk><div class="stack-card" data-id="2" style="background-color: #ffffff; color: #1a1a1a;" data-astro-cid-xhgh37dk><div class="card-content" data-astro-cid-xhgh37dk><div class="quote-icon" data-astro-cid-xhgh37dk><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-astro-cid-xhgh37dk><path d="M10 3H4V11C4 15.4183 7.58172 19 12 19V15C9.79086 15 8 13.2091 8 11V9H10V3ZM20 3H14V11C14 15.4183 17.5817 19 22 19V15C19.7909 15 18 13.2091 18 11V9H20V3Z" fill="currentColor" data-astro-cid-xhgh37dk></path></svg></div><h3 class="card-title" data-astro-cid-xhgh37dk>Priya</h3><p class="quote" data-astro-cid-xhgh37dk>Support was fast and friendly.</p></div><div class="card-footer" data-astro-cid-xhgh37dk><div class="avatar" style="background: #6366f1" data-astro-cid-xhgh37dk></div><div class="info" data-astro-cid-xhgh37dk><span class="name" data-astro-cid-xhgh37dk>Anonymous</span><span class="role" data-astro-cid-xhgh37dk></span></div></div></div><div class="stack-card" data-id="1" style="background-color: #ffffff; color: #1a1a1a;" data-astro-cid-xhgh37dk><div class="card-content" data-astro-cid-xhgh37dk><div class="quote-icon" data-astro-cid-xhgh37dk><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-astro-cid-xhgh37dk><path d="M10 3H4V11C4 15.4183 7.58172 19 12 19V15C9.79086 15 8 13.2091 8 11V9H10V3ZM20 3H14V11C14 15.4183 17.5817 19 22 19V15C19.7909 15 18 13.2091 18 11V9H20V3Z" fill="currentColor" data-astro-cid-xhgh37dk></path></svg></div><h3 class="card-title" data-astro-cid-xhgh37dk>Sam</h3><p class="quote" data-astro-cid-xhgh37dk>Setup took five minutes.</p></div><div class="card-footer" data-astro-cid-xhgh37dk><div class="avatar" style="background: #6366f1" data-astro-cid-xhgh37dk></div><div class="info" data-astro-cid-xhgh37dk><span class="name" data-astro-cid-xhgh37dk>Anonymous</span><span class="role" data-astro-cid-xhgh37dk></span></div></div></div><div class="stack-card" data-id="0" style="background-color: #ffffff; color: #1a1a1a;" data-astro-cid-xhgh37dk><div class="card-content" data-astro-cid-xhgh37dk><div class="quote-icon" data-astro-cid-xhgh37dk><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" data-astro-cid-xhgh37dk><path d="M10 3H4V11C4 15.4183 7.58172 19 12 19V15C9.79086 15 8 13.2091 8 11V9H10V3ZM20 3H14V11C14 15.4183 17.5817 19 22 19V15C19.7909 15 18 13.2091 18 11V9H20V3Z" fill="currentColor" data-astro-cid-xhgh37dk></path></svg></div><h3 class="card-title" data-astro-cid-xhgh37dk>Alex</h3><p class="quote" data-astro-cid-xhgh37dk>Loved the onboarding flow.</p></div><div class="card-footer" data-astro-cid-xhgh37dk><div class="avatar" style="background: #6366f1" data-astro-cid-xhgh37dk></div><div class="info" data-astro-cid-xhgh37dk><span class="name" data-astro-cid-xhgh37dk>Anonymous</span><span class="role" data-astro-cid-xhgh37dk></span></div></div></div></div><!-- ✅ CRITERION 8: JS Only Enhances -->
+</body></html>

--- a/Resources/Template/integrations/animations-demos/FadeInText.html
+++ b/Resources/Template/integrations/animations-demos/FadeInText.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Fade-in text</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /*
+   * Separate CSS paths for enhance=false vs enhance=true.
+   *
+   * CSS animation ONLY fires on data-enhance="false" elements.
+   * enhance=true elements start statically hidden — JS owns their animation.
+   * A 2s CSS fallback animation on enhance=true ensures content is never
+   * permanently invisible if JS fails to load.
+   */
+
+  /* ✅ C1 + C7: CSS-only path for enhance=false.
+     Plays automatically on every page load and page refresh.
+     fill-mode "both": element starts in "from" state during delay,
+     and stays in "to" state permanently after the animation ends. */
+  [data-astro-fade-in-text][data-enhance="false"]:not([data-ready]) {
+    animation: fadeInText var(--fit-duration) var(--fit-easing) var(--fit-delay) both;
+  }
+
+  /* ✅ C1: Static hidden state for enhance=true, before JS runs.
+     CSS animation is intentionally suppressed here — JS will control it.
+     The 2s fallback animation is a safety net: if JS fails or is blocked,
+     content becomes visible after 2s instead of staying hidden forever. */
+  [data-astro-fade-in-text][data-enhance="true"]:not([data-ready]) {
+    opacity: 0;
+    filter: blur(var(--fit-blur));
+    transform: translateY(var(--fit-y-offset));
+    animation: fadeInText var(--fit-duration) var(--fit-easing) 2s both;
+  }
+
+  @keyframes fadeInText {
+    from {
+      opacity: 0;
+      filter: blur(var(--fit-blur));
+      transform: translateY(var(--fit-y-offset));
+    }
+    to {
+      opacity: 1;
+      filter: blur(0px);
+      transform: translateY(0);
+    }
+  }
+
+  /* ── JS-enhanced states ─────────────────────────────────────────────────
+     Activated once JS sets data-ready="true". All visual changes are
+     driven purely by data-state attribute — JS never writes element.style.
+     ──────────────────────────────────────────────────────────────────────── */
+
+  /* ✅ C7: Waiting for viewport entry */
+  [data-astro-fade-in-text][data-ready="true"][data-state="hidden"] {
+    opacity: 0;
+    filter: blur(var(--fit-blur));
+    transform: translateY(var(--fit-y-offset));
+  }
+
+  /* ✅ C7: Element is in viewport — CSS transition to fully visible */
+  [data-astro-fade-in-text][data-ready="true"][data-state="animate"] {
+    opacity: 1;
+    filter: blur(0px);
+    transform: translateY(0);
+    transition:
+      opacity   var(--fit-duration) var(--fit-easing) var(--fit-delay),
+      filter    var(--fit-duration) var(--fit-easing) var(--fit-delay),
+      transform var(--fit-duration) var(--fit-easing) var(--fit-delay);
+  }
+
+  /* ✅ C6: ALL CSS motion neutralised for prefers-reduced-motion.
+     Covers both the CSS-only path and the JS-enhanced path.
+     Content is shown immediately regardless of animation state. */
+  @media (prefers-reduced-motion: reduce) {
+    [data-astro-fade-in-text]:not([data-ready]) {
+      animation: none !important;
+      opacity: 1 !important;
+      filter: none !important;
+      transform: none !important;
+    }
+    [data-astro-fade-in-text][data-ready="true"] {
+      opacity: 1 !important;
+      filter: none !important;
+      transform: none !important;
+      transition: none !important;
+    }
+  }
+</style>
+</head><body>
+<!-- ✅ C1: Slot content always present in HTML — meaningful without JS.
+     ✅ C4: No import.meta.env.DEV — identical in dev, build, and preview.
+     ✅ C5: No astro:* events. Standard data attributes only.
+     {...rest} forwards id, aria-label, role, tabindex, data-*, etc.
+     Style is a single inline string — no stray newlines in HTML output. --><div data-astro-fade-in-text="true" data-enhance="false" data-once="true" data-margin="-50px" style="--fit-duration:0.6s;--fit-delay:0s;--fit-easing:cubic-bezier(0.4, 0, 0.2, 1);--fit-blur:6px;--fit-y-offset:20px" data-astro-cid-6l634ln7="true" class="astro-fade-in-text">Fade-in text demo</div><!-- ✅ C2: Script emitted ONLY when enhance=true. No unconditional scripts.
+     is:inline is required — Astro does NOT bundle <script> tags sourced
+     from node_modules. is:inline embeds the script verbatim in HTML output,
+     guaranteeing it ships regardless of the consumer's build configuration. -->
+</body></html>

--- a/Resources/Template/integrations/animations-demos/FillHoverButton.html
+++ b/Resources/Template/integrations/animations-demos/FillHoverButton.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Fill hover button</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /* ✅ CRITERION 7: CSS-FIRST */
+
+  [data-fhb] {
+    position: relative;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    padding: 1em 1.5em;
+
+    border: none;
+    background: transparent;
+
+    color: #ffc506;
+
+    font-size: 1.0625rem;
+    text-transform: uppercase;
+    text-decoration: none;
+
+    cursor: pointer;
+
+    overflow: hidden;
+    isolation: isolate;
+
+    transition: color 500ms ease;
+  }
+
+  /* Underline */
+  [data-fhb]::before {
+    content: "";
+
+    position: absolute;
+    left: 0;
+    bottom: 0;
+
+    width: 0;
+    height: 2px;
+
+    background: #ffc506;
+
+    transition: width 500ms ease;
+  }
+
+  /* Fill layer */
+  [data-fhb]::after {
+    content: "";
+
+    position: absolute;
+    inset: auto 0 0 0;
+
+    width: 100%;
+    height: 0;
+
+    background: #ffc506;
+
+    z-index: -1;
+
+    transition: height 400ms ease;
+  }
+
+  [data-fhb]:hover {
+    color: #1e1e2b;
+    transition-delay: 500ms;
+  }
+
+  [data-fhb]:hover::before {
+    width: 100%;
+  }
+
+  [data-fhb]:hover::after {
+    height: 100%;
+    transition-delay: 400ms;
+  }
+
+  /* Accessibility */
+  [data-fhb]:focus-visible {
+    outline: 2px solid #ffc506;
+    outline-offset: 4px;
+  }
+
+  /* ✅ CRITERION 6: REDUCED MOTION */
+  @media (prefers-reduced-motion: reduce) {
+    [data-fhb],
+    [data-fhb]::before,
+    [data-fhb]::after {
+      transition: none !important;
+    }
+  }
+</style>
+</head><body>
+<button data-fhb type="button" class data-astro-cid-rtehwjtf>Fill hover button demo</button>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/GridDotsBackground.html
+++ b/Resources/Template/integrations/animations-demos/GridDotsBackground.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Grid dots background</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  .background-container {
+    position: relative;
+    width: 100%;
+    height: var(--gb-height, 300px);
+    overflow: hidden;
+    background-color: var(--gb-bg, #0f0f0f);
+  }
+
+  .pattern-wrapper {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  [data-mask="true"] .pattern-wrapper {
+    -webkit-mask-image: radial-gradient(
+      circle at center,
+      black 40%,
+      transparent 100%
+    );
+    mask-image: radial-gradient(circle at center, black 40%, transparent 100%);
+  }
+
+  /* ✅ CRITERION 7: Layout/visibility in CSS only */
+  .pattern-layer {
+    position: absolute;
+    width: calc(100% + var(--gap));
+    height: calc(100% + var(--gap));
+    top: 0;
+    left: 0;
+  }
+
+  /* DOT VARIANT */
+  [data-variant="dots"] .pattern-layer {
+    background-image: radial-gradient(
+      circle,
+      var(--dot-color) var(--dot-size),
+      transparent var(--dot-size)
+    );
+    background-size: var(--gap) var(--gap);
+  }
+
+  /* GRID VARIANT */
+  [data-variant="grid"] .pattern-layer {
+    background-image:
+      linear-gradient(
+        to right,
+        var(--dot-color) var(--dot-size),
+        transparent var(--dot-size)
+      ),
+      linear-gradient(
+        to bottom,
+        var(--dot-color) var(--dot-size),
+        transparent var(--dot-size)
+      );
+    background-size: var(--gap) var(--gap);
+  }
+
+  /* ✅ CRITERION 6: Subtle ambient animation */
+  [data-animate="true"] .pattern-layer {
+    animation: drift 20s linear infinite;
+  }
+
+  @keyframes drift {
+    0% {
+      transform: translate(0, 0);
+    }
+    100% {
+      transform: translate(calc(var(--gap) * -1), calc(var(--gap) * -1));
+    }
+  }
+
+  /* ✅ CRITERION 6: Reduced Motion Respected */
+  @media (prefers-reduced-motion: reduce) {
+    .pattern-layer {
+      animation: none !important;
+      transform: none !important;
+    }
+
+    [data-animate="true"] .pattern-layer {
+      animation: none !important;
+    }
+  }
+</style>
+</head><body>
+<div class="background-container" data-variant="dots" data-mask="false" data-animate="false" style="--dot-color:rgba(255,255,255,0.25);--dot-size:2px;--gap:32px;--gb-height:300px;--gb-bg:#0f0f0f" data-astro-cid-6m4dgeme><!-- ✅ CRITERION 1: Meaningful visual content visible without JS --><div class="pattern-wrapper" data-astro-cid-6m4dgeme><div class="pattern-layer" data-astro-cid-6m4dgeme></div></div>Grid dots background demo</div>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/HighlightText.html
+++ b/Resources/Template/integrations/animations-demos/HighlightText.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Highlight text</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+    .highlight-root {
+        display: inline;
+        position: relative;
+        text-decoration: none;
+        font-size: var(--fontSize, inherit);
+        padding: var(--padding);
+        border-radius: 0.15em;
+        -webkit-box-decoration-break: clone;
+        box-decoration-break: clone;
+        background-image: linear-gradient(var(--color), var(--color));
+        background-repeat: no-repeat;
+        background-position: var(--bgPosition);
+        background-size: var(--bgSizeAtStart);
+    }
+
+    /* All motion declarations wrapped in no-preference media query */
+    @media (prefers-reduced-motion: no-preference) {
+        .highlight-root {
+            transition: background-size var(--duration) ease-out var(--delay);
+        }
+
+        .trigger-load {
+            animation: highlight-reveal var(--duration) ease-out var(--delay)
+                forwards;
+        }
+
+        .trigger-hover:hover {
+            background-size: var(--bgSizeAtEnd);
+        }
+
+        @keyframes highlight-reveal {
+            from {
+                background-size: var(--bgSizeAtStart);
+            }
+            to {
+                background-size: var(--bgSizeAtEnd);
+            }
+        }
+    }
+
+    /* Reduced motion: instant reveal, no animation */
+    @media (prefers-reduced-motion: reduce) {
+        .highlight-root {
+            background-size: var(--bgSizeAtEnd);
+        }
+    }
+</style>
+</head><body>
+<span class="highlight-root trigger-load" data-highlight-text style="--fontSize:inherit;--color: #FFD700;--duration: 600ms;--delay: 0ms;--bgPosition: 0 0;--bgSizeAtStart: 0% 100%;--bgSizeAtEnd: 100% 100%;--padding: 0.2em;" data-astro-cid-yd3ywicu>Highlight text demo</span><!-- ✅ CRITERION 2: Zero Hydration (No script block, no hydrate directives) -->
+</body></html>

--- a/Resources/Template/integrations/animations-demos/InfiniteMarquee.html
+++ b/Resources/Template/integrations/animations-demos/InfiniteMarquee.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Infinite marquee</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+    .marquee-container {
+        position: relative;
+        display: flex;
+        overflow: hidden;
+        user-select: none;
+        width: 100%;
+        background: transparent;
+    }
+
+    /* Horizontal layouts */
+    .marquee-left,
+    .marquee-right {
+        flex-direction: row;
+    }
+
+    /* Vertical layouts */
+    .marquee-up,
+    .marquee-down {
+        flex-direction: column;
+        height: 400px; /* Constrain height so it clips properly and doesn't reveal empty space */
+        max-height: 100vh;
+        width: fit-content;
+    }
+
+    .marquee-track {
+        display: flex;
+        flex-shrink: 0;
+        gap: var(--gap);
+        width: max-content;
+    }
+
+    .marquee-up .marquee-track,
+    .marquee-down .marquee-track {
+        flex-direction: column;
+        width: max-content; /* Changed from 100% so track only spans the width of the cards */
+        height: max-content;
+    }
+
+    .marquee-content {
+        flex-shrink: 0;
+        display: flex;
+        gap: var(--gap);
+        padding: 10px 0; /* Only top/bottom padding to not affect horizontal scroll width */
+    }
+
+    .marquee-up .marquee-content,
+    .marquee-down .marquee-content {
+        flex-direction: column;
+        min-width: auto;
+        padding: 0 10px; /* Only left/right padding to not affect vertical scroll height */
+    }
+
+    /* Horizontal Animations applied to individual content blocks */
+    .marquee-left .marquee-content {
+        animation: scroll-left var(--speed) linear infinite;
+    }
+
+    .marquee-right .marquee-content {
+        animation: scroll-right var(--speed) linear infinite;
+    }
+
+    /* Vertical Animations applied to individual content blocks */
+    .marquee-up .marquee-content {
+        animation: scroll-up var(--speed) linear infinite;
+    }
+
+    .marquee-down .marquee-content {
+        animation: scroll-down var(--speed) linear infinite;
+    }
+
+    /* Only pause when hovering the actual track (items), not the empty space in the container */
+    .pause-hover .marquee-track:hover .marquee-content {
+        animation-play-state: paused;
+    }
+
+    @keyframes scroll-left {
+        to {
+            transform: translateX(calc(-100% - var(--gap)));
+        }
+    }
+
+    @keyframes scroll-right {
+        from {
+            transform: translateX(calc(-100% - var(--gap)));
+        }
+        to {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes scroll-up {
+        to {
+            transform: translateY(calc(-100% - var(--gap)));
+        }
+    }
+
+    @keyframes scroll-down {
+        from {
+            transform: translateY(calc(-100% - var(--gap)));
+        }
+        to {
+            transform: translateY(0);
+        }
+    }
+
+    /* Edge Fading */
+    .fade-mask.marquee-left,
+    .fade-mask.marquee-right {
+        mask-image: linear-gradient(
+            to right,
+            transparent,
+            black 10%,
+            black 90%,
+            transparent
+        );
+    }
+
+    .fade-mask.marquee-up,
+    .fade-mask.marquee-down {
+        mask-image: linear-gradient(
+            to bottom,
+            transparent,
+            black 10%,
+            black 90%,
+            transparent
+        );
+    }
+
+    /* Premium item styles (can be overridden by slots) */
+    :global(.marquee-item) {
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 12px;
+        padding: 1rem 2rem;
+        backdrop-filter: blur(10px);
+        transition: all 0.3s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        white-space: nowrap;
+        color: rgba(255, 255, 255, 0.8);
+    }
+
+    :global(.marquee-item:hover) {
+        background: rgba(255, 255, 255, 0.1);
+        border-color: rgba(255, 255, 255, 0.2);
+        color: #fff;
+        transform: translateY(-2px);
+        box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.5);
+    }
+
+    /* Card Styles */
+    .marquee-card {
+        flex-shrink: 0;
+        width: var(--card-width);
+        background: var(--card-bg);
+        border: 1px solid var(--card-border-color);
+        border-radius: var(--card-radius);
+        padding: var(--card-padding);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    }
+
+    .marquee-card-header {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .marquee-card-avatar {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: #e5e5e5;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        overflow: hidden;
+    }
+
+    .marquee-card-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .marquee-card-info {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .marquee-card-name {
+        font-weight: 600;
+        font-size: 0.95rem;
+        color: var(--name-color);
+        margin: 0;
+    }
+
+    .marquee-card-handle {
+        font-size: 0.85rem;
+        color: var(--handle-color);
+        margin: 0;
+    }
+
+    .marquee-card-content {
+        font-size: 0.9rem;
+        line-height: 1.5;
+        color: var(--text-color);
+        margin: 0;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .marquee-track, .marquee-content {
+            animation: none !important;
+            transform: none !important;
+        }
+    }
+</style>
+</head><body>
+<div class="marquee-container marquee-left pause-hover fade-mask" style="
+        --speed: 30s; 
+        --gap: 2rem;
+        --card-width: 320px;
+        --card-bg: white;
+        --card-border-color: #e5e5e5;
+        --card-radius: 16px;
+        --card-padding: 1.5rem;
+        --text-color: #333;
+        --name-color: #111;
+        --handle-color: #666;
+    " data-astro-cid-i4rc6qvh><div class="marquee-track" data-astro-cid-i4rc6qvh><div class="marquee-content" data-marquee-part="1" data-astro-cid-i4rc6qvh>Infinite marquee demo</div><div class="marquee-content" data-marquee-part="2" aria-hidden="true" data-astro-cid-i4rc6qvh>Infinite marquee demo</div><div class="marquee-content" data-marquee-part="3" aria-hidden="true" data-astro-cid-i4rc6qvh>Infinite marquee demo</div><div class="marquee-content" data-marquee-part="4" aria-hidden="true" data-astro-cid-i4rc6qvh>Infinite marquee demo</div><div class="marquee-content" data-marquee-part="5" aria-hidden="true" data-astro-cid-i4rc6qvh>Infinite marquee demo</div><div class="marquee-content" data-marquee-part="6" aria-hidden="true" data-astro-cid-i4rc6qvh>Infinite marquee demo</div></div></div>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/Loader.html
+++ b/Resources/Template/integrations/animations-demos/Loader.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Loader</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+    .loader-wrapper {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--loader-color);
+    }
+
+    /* SPINNER */
+    .loader-spinner {
+        width: var(--loader-size);
+        height: var(--loader-size);
+        animation: rotate var(--loader-speed) linear infinite;
+    }
+    .loader-spinner .path {
+        stroke: currentColor;
+        stroke-linecap: round;
+        animation: dash 1.5s ease-in-out infinite;
+    }
+
+    @keyframes rotate {
+        100% {
+            transform: rotate(360deg);
+        }
+    }
+    @keyframes dash {
+        0% {
+            stroke-dasharray: 1, 150;
+            stroke-dashoffset: 0;
+        }
+        50% {
+            stroke-dasharray: 90, 150;
+            stroke-dashoffset: -35;
+        }
+        100% {
+            stroke-dasharray: 90, 150;
+            stroke-dashoffset: -124;
+        }
+    }
+
+    /* DOTS */
+    .loader-dots {
+        display: flex;
+        gap: calc(var(--loader-size) * 0.2);
+    }
+    .dot {
+        width: calc(var(--loader-size) * 0.25);
+        height: calc(var(--loader-size) * 0.25);
+        background-color: currentColor;
+        border-radius: 50%;
+        animation: bounce 1.4s infinite ease-in-out both;
+    }
+    .dot:nth-child(1) {
+        animation-delay: -0.32s;
+    }
+    .dot:nth-child(2) {
+        animation-delay: -0.16s;
+    }
+
+    @keyframes bounce {
+        0%,
+        80%,
+        100% {
+            transform: scale(0);
+        }
+        40% {
+            transform: scale(1);
+        }
+    }
+
+    /* PULSE */
+    .loader-pulse {
+        width: var(--loader-size);
+        height: var(--loader-size);
+        background-color: currentColor;
+        border-radius: 50%;
+        opacity: 0.6;
+        animation: pulse 2s infinite ease-in-out;
+    }
+
+    @keyframes pulse {
+        0% {
+            transform: scale(0);
+            opacity: 0.8;
+        }
+        100% {
+            transform: scale(1);
+            opacity: 0;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .loader-spinner,
+        .loader-spinner .path,
+        .dot,
+        .loader-pulse {
+            animation: none !important;
+        }
+    }
+</style>
+</head><body>
+<div class="loader-wrapper" style="--loader-size: 40px; --loader-color: #3b82f6; --loader-speed: 1s;" aria-label="Loading" role="status" data-astro-cid-scuvc57w><svg class="loader-spinner" viewBox="0 0 50 50" data-astro-cid-scuvc57w><circle class="path" cx="25" cy="25" r="20" fill="none" stroke-width="4" data-astro-cid-scuvc57w></circle></svg></div>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/ProgressBar.html
+++ b/Resources/Template/integrations/animations-demos/ProgressBar.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Progress bar</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  .progress-root {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+  }
+
+  .progress-label {
+    font-size: var(--label-size, 14px);
+    font-weight: 500;
+    color: #374151;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .progress-label {
+      color: #000;
+      font-family: sans-serif;
+    }
+  }
+
+  .progress-track {
+    width: 100%;
+    height: var(--track-height, 8px);
+    background: var(--track-color, #e5e7eb);
+    border-radius: 9999px;
+    overflow: hidden;
+  }
+
+  .progress-fill {
+    height: 100%;
+    width: var(--progress, 0%);
+    background: var(--fill-color, #3b82f6);
+    border-radius: 9999px;
+    transition: width 300ms ease-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .progress-fill {
+      transition: none;
+    }
+  }
+</style>
+</head><body>
+<div class="progress-root" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="
+    --progress: 60%;
+    --track-height: 8px;
+    --label-size: 14px;
+    --fill-color: #3b82f6;
+  " data-astro-cid-ii6bfh6j><div class="progress-track" style="background: #e5e7eb;" data-astro-cid-ii6bfh6j><div class="progress-fill" data-astro-cid-ii6bfh6j></div></div></div>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/RevealImage.html
+++ b/Resources/Template/integrations/animations-demos/RevealImage.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Reveal image</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  .reveal-image-item {
+    position: relative;
+    padding: 32px 0;
+    overflow: visible;
+  }
+
+  .reveal-image-item-text {
+    font-size: 72px;
+    font-weight: 900;
+    color: #000;
+    transition: opacity 0.5s ease;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .reveal-image-item-text {
+      color: #000;
+    }
+  }
+
+  .reveal-image-item:hover .reveal-image-item-text {
+    opacity: 0.4;
+  }
+
+  .reveal-image-container {
+    position: absolute;
+    right: 32px;
+    top: -4px;
+    z-index: 40;
+    height: 80px;
+    width: 64px;
+  }
+
+  .reveal-image-effect {
+    position: relative;
+    duration: 500ms;
+    delay: 100ms;
+    scale: 0;
+    opacity: 0;
+    width: 64px;
+    height: 64px;
+    overflow: hidden;
+    border-radius: 6px;
+    transition: all 0.5s ease 0.1s;
+  }
+
+  .reveal-image-item:hover .reveal-image-effect {
+    scale: 1;
+    opacity: 1;
+    width: 100%;
+    height: 100%;
+    box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  }
+
+  .reveal-image-effect img {
+    width: 300px;
+    height: 300px;
+    object-fit: cover;
+  }
+
+  .reveal-image-container-rotated {
+    position: absolute;
+    right: 32px;
+    top: -4px;
+    z-index: 40;
+    height: 80px;
+    width: 64px;
+    transition: all 0.5s ease 0.15s;
+  }
+
+  .reveal-image-item:hover .reveal-image-container-rotated {
+    transform: translateX(24px) translateY(24px) rotate(12deg);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .reveal-image-item-text,
+    .reveal-image-effect,
+    .reveal-image-container-rotated {
+      transition: none;
+    }
+
+    .reveal-image-item:hover .reveal-image-item-text {
+      opacity: 1;
+    }
+
+    .reveal-image-item:hover .reveal-image-effect {
+      scale: 1;
+      opacity: 1;
+      width: 64px;
+      height: 64px;
+    }
+
+    .reveal-image-item:hover .reveal-image-container-rotated {
+      transform: none;
+    }
+  }
+</style>
+</head><body>
+<div class="reveal-image-item" data-astro-cid-2ryk6nie><h1 class="reveal-image-item-text" data-astro-cid-2ryk6nie>REVEAL</h1><div class="reveal-image-container" data-astro-cid-2ryk6nie><div class="reveal-image-effect" data-astro-cid-2ryk6nie><img alt src="/images/after.jpg" loading="lazy" data-astro-cid-2ryk6nie></div></div><div class="reveal-image-container-rotated" data-astro-cid-2ryk6nie><div class="reveal-image-effect" style="transition-duration: 0.2s;" data-astro-cid-2ryk6nie><img alt src="/images/before.jpg" loading="lazy" data-astro-cid-2ryk6nie></div></div></div>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/ScaleIn.html
+++ b/Resources/Template/integrations/animations-demos/ScaleIn.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Scale in</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /**
+   * ✅ CRITERION 1: Visible Without JS
+   * The default state is fully visible with no transform.
+   */
+  [data-astro-scale-in] {
+    opacity: 1;
+    transform: scale(1);
+    will-change: transform, opacity;
+  }
+
+  /**
+   * ✅ CRITERION 7: CSS-First (States)
+   * Hidden state only applies if JS has marked the component as 'ready'.
+   */
+  [data-astro-scale-in][data-ready="true"][data-state="hidden"] {
+    opacity: 0;
+    transform: scale(var(--initial-scale));
+  }
+
+  /**
+   * ✅ CRITERION 7: Visible state handles the transition.
+   */
+  [data-astro-scale-in][data-ready="true"][data-state="visible"] {
+    opacity: 1;
+    transform: scale(1);
+    transition: 
+      opacity var(--duration) var(--easing) var(--delay),
+      transform var(--duration) var(--easing) var(--delay);
+  }
+
+  /**
+   * ✅ CRITERION 6: Reduced Motion Respected
+   * All animations disabled if the user prefers reduced motion.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    [data-astro-scale-in] {
+      opacity: 1 !important;
+      transform: scale(1) !important;
+      transition: none !important;
+    }
+  }
+</style>
+</head><body>
+<!-- ✅ CRITERION 1: Meaningful HTML content exists --><div data-astro-scale-in="true" data-enhance="false" data-once="true" data-margin="0px 0px -10% 0px" style="
+  --duration: 600ms;
+  --delay: 0ms;
+  --easing: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --initial-scale: 0.9;
+" data-astro-cid-juuuxy5z="true" class="astro-scale-in">Scale in demo</div><!-- ✅ CRITERION 2: Zero Hydration (Vanilla script) -->
+</body></html>

--- a/Resources/Template/integrations/animations-demos/SlidingOverlayButton.html
+++ b/Resources/Template/integrations/animations-demos/SlidingOverlayButton.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Sliding overlay button</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /* ✅ CRITERION 7: CSS-FIRST (all visuals handled in CSS) */
+  [data-sob] {
+    position: relative;
+    font-family: inherit;
+    font-weight: 500;
+    font-size: 18px;
+    letter-spacing: 0.05em;
+    border-radius: 0.8em;
+    cursor: pointer;
+    border: none;
+    background: linear-gradient(to right, #8e2de2, #4a00e0);
+    color: ghostwhite;
+    overflow: hidden;
+    display: inline-block;
+    text-decoration: none;
+  }
+
+  /* Inner content */
+  [data-sob] > span {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.8em 1.2em 0.8em 1.05em;
+
+    /* Animation */
+    transition: color 0.4s;
+  }
+
+  /* Icon sizing (optional content) */
+  [data-sob] svg {
+    width: 1.2em;
+    height: 1.2em;
+    margin-right: 0.5em;
+  }
+
+  /* Overlay layers */
+  [data-sob]::before,
+  [data-sob]::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+
+  /* Sliding overlay */
+  [data-sob]::before {
+    background: #000;
+    width: 120%;
+    left: -10%;
+    transform: skew(30deg);
+
+    /* Animation */
+    transition: transform 0.4s cubic-bezier(0.3, 1, 0.8, 1);
+  }
+
+  /* Hover effect */
+  [data-sob]:hover::before {
+    transform: translate3d(100%, 0, 0);
+  }
+
+  /* Active press */
+  [data-sob]:active {
+    transform: scale(0.95);
+  }
+
+  /* Focus accessibility */
+  [data-sob]:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 4px;
+  }
+
+  /* Box sizing */
+  [data-sob],
+  [data-sob]::before,
+  [data-sob]::after {
+    box-sizing: border-box;
+  }
+
+  /* ✅ CRITERION 6: REDUCED MOTION (disable ALL motion) */
+  @media (prefers-reduced-motion: reduce) {
+    [data-sob],
+    [data-sob] * {
+      transition: none !important;
+      transform: none !important;
+    }
+
+    [data-sob]::before {
+      transform: none !important;
+    }
+  }
+</style>
+</head><body>
+<!-- ✅ CRITERION 1: Meaningful HTML without JS --><button data-sob type="button" class data-astro-cid-p3abr2fs><span data-astro-cid-p3abr2fs>Sliding overlay button demo</span></button>
+</body></html>

--- a/Resources/Template/integrations/animations-demos/TypewriterText.html
+++ b/Resources/Template/integrations/animations-demos/TypewriterText.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Typewriter text</title>
+<style>body{margin:0;display:grid;place-items:center;min-height:100vh;
+font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>
+<style>
+  /* ✅ CRITERION 7: All layout and visual state is CSS — JS only sets data-ready */
+
+  [data-typewriter] {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.05em;
+  }
+
+  /* ──────────────────────────────────────────────────────────────────────────
+   * ✅ CRITERION 1: Static display — visible before JS runs.
+   * The display span shows the first text. .typewriter-static is visible.
+   * .typewriter-dynamic is hidden until data-ready is set.
+   * ────────────────────────────────────────────────────────────────────────── */
+
+  /* Static fallback content — shown when JS has not run */
+  .typewriter-static {
+    display: inline;
+  }
+
+  /* Dynamic display span — hidden by default, shown when JS activates */
+  .typewriter-dynamic {
+    display: none;
+  }
+
+  /* When JS activates: swap static → dynamic */
+  [data-typewriter][data-ready="true"] .typewriter-static {
+    display: none;
+  }
+
+  [data-typewriter][data-ready="true"] .typewriter-dynamic {
+    display: inline;
+  }
+
+  /* ──────────────────────────────────────────────────────────────────────────
+   * Cursor element — CSS-driven, no JS required
+   * ────────────────────────────────────────────────────────────────────────── */
+
+  .typewriter-cursor {
+    display: inline-block;
+    margin-left: 0.05em;
+    /* ✅ CRITERION 6: cursor-blink animation ONLY runs under no-preference */
+    /* Without this media query, cursor is a static character */
+    opacity: 1;
+    color: inherit;
+    font-weight: inherit;
+  }
+
+  /* ✅ CRITERION 6: ALL CSS animations wrapped in @media (prefers-reduced-motion: no-preference) */
+  @media (prefers-reduced-motion: no-preference) {
+    .typewriter-cursor {
+      animation: cursor-blink 0.8s step-end infinite;
+    }
+
+    @keyframes cursor-blink {
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0;
+      }
+    }
+  }
+
+  /* ✅ CRITERION 6: Under reduced motion — cursor is static, no blink */
+  @media (prefers-reduced-motion: reduce) {
+    .typewriter-cursor {
+      animation: none !important;
+      opacity: 1;
+    }
+  }
+</style>
+</head><body>
+<!-- ✅ CRITERION 1: Meaningful HTML visible without JS — static fallback is rendered here --><!-- ✅ CRITERION 3: No hard-coded IDs — all queries use data-attribute selectors --><span class="typewriter-root" data-typewriter data-enhance="false" data-texts="[&quot;Design.&quot;,&quot;Build.&quot;,&quot;Ship.&quot;]" data-type-speed="70" data-erase-speed="40" data-pause-after="1800" data-pause-empty="500" data-loop="true" data-erase="true" aria-label="Design." aria-live="polite" aria-atomic="true" data-astro-cid-w33kngei><!-- ✅ CRITERION 1: First word visible without JS via .typewriter-static --><span class="typewriter-static" aria-hidden="true" data-astro-cid-w33kngei>Design.</span><!-- Dynamic output — JS writes here; hidden until data-ready="true" --><span class="typewriter-dynamic" data-typewriter-display aria-hidden="true" data-astro-cid-w33kngei></span><!-- ✅ CRITERION 1 & 7: Cursor is CSS-only — visible and blinks without JS --><span class="typewriter-cursor" aria-hidden="true" data-astro-cid-w33kngei>|</span></span><!-- 🔑 JS inlined so it runs when component is consumed from node_modules (scripts there are not bundled) -->
+</body></html>

--- a/Resources/Template/integrations/animations.json
+++ b/Resources/Template/integrations/animations.json
@@ -1,0 +1,234 @@
+{
+  "version": 1,
+  "components": [
+    {
+      "component": "FadeInText",
+      "title": "Fade-in text",
+      "ownerDescription": "Text that fades in with a soft blur when the page loads.",
+      "category": "text",
+      "keyProps": {
+        "duration": "seconds (default 0.6)",
+        "delay": "seconds (default 0)",
+        "as": "wrapper tag, e.g. \"h1\""
+      },
+      "props": {},
+      "snippet": "---\nimport FadeInText from \"@astroanimate/core/FadeInText\";\n---\n<FadeInText as=\"h1\">Welcome</FadeInText>"
+    },
+    {
+      "component": "ScaleIn",
+      "title": "Scale in",
+      "ownerDescription": "Text or content that grows into place from a slightly smaller size.",
+      "category": "text",
+      "keyProps": {
+        "initialScale": "starting scale (default 0.9)",
+        "duration": "milliseconds (default 600)",
+        "as": "wrapper tag, e.g. \"h2\""
+      },
+      "props": {},
+      "snippet": "---\nimport ScaleIn from \"@astroanimate/core/ScaleIn\";\n---\n<ScaleIn as=\"h2\">Grows into place</ScaleIn>"
+    },
+    {
+      "component": "RevealImage",
+      "title": "Reveal image",
+      "ownerDescription": "A headline where the letters reveal a background image as you scroll past.",
+      "category": "text",
+      "keyProps": {
+        "text": "overlay text (required)",
+        "image1": "first image URL (required)",
+        "image2": "second image URL (required)"
+      },
+      "props": {
+        "text": "REVEAL",
+        "image1": "/images/before.jpg",
+        "image2": "/images/after.jpg"
+      },
+      "snippet": "---\nimport RevealImage from \"@astroanimate/core/RevealImage\";\n---\n<RevealImage text=\"REVEAL\" image1=\"/images/before.jpg\" image2=\"/images/after.jpg\" />"
+    },
+    {
+      "component": "HighlightText",
+      "title": "Highlight text",
+      "ownerDescription": "A highlighter-style underline or background sweep behind a phrase.",
+      "category": "text",
+      "keyProps": {
+        "variant": "\"underline\" | \"background\" (default \"background\")",
+        "color": "highlight color (default \"#FFD700\")",
+        "trigger": "\"load\" | \"hover\" (default \"load\")"
+      },
+      "props": {},
+      "snippet": "---\nimport HighlightText from \"@astroanimate/core/HighlightText\";\n---\n<p>This is <HighlightText>important</HighlightText> text.</p>"
+    },
+    {
+      "component": "TypewriterText",
+      "title": "Typewriter text",
+      "ownerDescription": "A line of text that types itself out, one character at a time.",
+      "category": "text",
+      "keyProps": {
+        "texts": "array of strings to cycle through (required)",
+        "showCursor": "boolean (default true)",
+        "cursor": "cursor character (default \"|\")"
+      },
+      "props": {
+        "texts": ["Design.", "Build.", "Ship."]
+      },
+      "snippet": "---\nimport TypewriterText from \"@astroanimate/core/TypewriterText\";\n---\n<TypewriterText texts={[\"Design.\", \"Build.\", \"Ship.\"]} />"
+    },
+    {
+      "component": "AnimatedCard",
+      "title": "Animated card",
+      "ownerDescription": "A card that lifts, scales, or shines on hover.",
+      "category": "cards",
+      "keyProps": {
+        "title": "card title (required)",
+        "description": "card description (required)",
+        "variant": "\"lift\" | \"scale\" | \"flip\" | \"shine\" (default \"lift\")"
+      },
+      "props": {
+        "title": "Feature",
+        "description": "A short description of the feature."
+      },
+      "snippet": "---\nimport AnimatedCard from \"@astroanimate/core/AnimatedCard\";\n---\n<AnimatedCard title=\"Feature\" description=\"A short description of the feature.\" />"
+    },
+    {
+      "component": "CardStack",
+      "title": "Card stack",
+      "ownerDescription": "A stack of testimonial or feature cards, one in front of the other.",
+      "category": "cards",
+      "keyProps": {
+        "cards": "array of { title, content } cards (required)",
+        "stackSize": "visible cards (default 3)",
+        "enhance": "keep false — CSS-only mode (site CSP blocks enhance=true)"
+      },
+      "props": {
+        "enhance": false,
+        "cards": [
+          { "title": "Alex", "content": "Loved the onboarding flow." },
+          { "title": "Sam", "content": "Setup took five minutes." },
+          { "title": "Priya", "content": "Support was fast and friendly." }
+        ]
+      },
+      "snippet": "---\nimport CardStack from \"@astroanimate/core/CardStack\";\n---\n<CardStack\n  enhance={false}\n  cards={[\n    { title: \"Alex\", content: \"Loved the onboarding flow.\" },\n    { title: \"Sam\", content: \"Setup took five minutes.\" },\n  ]}\n/>"
+    },
+    {
+      "component": "ArticleCard",
+      "title": "Article card",
+      "ownerDescription": "A blog-post or article preview card with a title, summary, and link.",
+      "category": "cards",
+      "keyProps": {
+        "title": "article title (required)",
+        "description": "summary text (required)",
+        "href": "link target (default \"#\")"
+      },
+      "props": {
+        "title": "Article title",
+        "description": "A short summary of the article."
+      },
+      "snippet": "---\nimport ArticleCard from \"@astroanimate/core/ArticleCard\";\n---\n<ArticleCard title=\"Article title\" description=\"A short summary of the article.\" href=\"/blog/post\" />"
+    },
+    {
+      "component": "AnimatedButton",
+      "title": "Animated button",
+      "ownerDescription": "A button with a shimmer, fill, or border sweep on hover.",
+      "category": "buttons",
+      "keyProps": {
+        "variant": "\"shimmer\" | \"fill\" | \"border\" | \"none\" (default \"none\")",
+        "href": "renders as a link when set",
+        "disabled": "boolean (default false)"
+      },
+      "props": {},
+      "snippet": "---\nimport AnimatedButton from \"@astroanimate/core/AnimatedButton\";\n---\n<AnimatedButton variant=\"shimmer\">Get started</AnimatedButton>"
+    },
+    {
+      "component": "FillHoverButton",
+      "title": "Fill hover button",
+      "ownerDescription": "A button whose background fills in from one edge on hover.",
+      "category": "buttons",
+      "keyProps": {
+        "as": "\"button\" | \"a\" (default \"button\")",
+        "href": "link target when as=\"a\""
+      },
+      "props": {},
+      "snippet": "---\nimport FillHoverButton from \"@astroanimate/core/FillHoverButton\";\n---\n<FillHoverButton>Subscribe</FillHoverButton>"
+    },
+    {
+      "component": "ArrowCTAButton",
+      "title": "Arrow CTA button",
+      "ownerDescription": "A call-to-action link whose arrow slides forward on hover.",
+      "category": "buttons",
+      "keyProps": {
+        "label": "button text (required)",
+        "as": "\"button\" | \"a\" (default \"button\")",
+        "href": "link target when as=\"a\""
+      },
+      "props": {
+        "label": "Learn more"
+      },
+      "snippet": "---\nimport ArrowCTAButton from \"@astroanimate/core/ArrowCTAButton\";\n---\n<ArrowCTAButton label=\"Learn more\" href=\"/about\" as=\"a\" />"
+    },
+    {
+      "component": "SlidingOverlayButton",
+      "title": "Sliding overlay button",
+      "ownerDescription": "A button with a color overlay that slides in on hover.",
+      "category": "buttons",
+      "keyProps": {
+        "as": "\"button\" | \"a\" (default \"button\")",
+        "href": "link target when as=\"a\""
+      },
+      "props": {},
+      "snippet": "---\nimport SlidingOverlayButton from \"@astroanimate/core/SlidingOverlayButton\";\n---\n<SlidingOverlayButton>Contact us</SlidingOverlayButton>"
+    },
+    {
+      "component": "GridDotsBackground",
+      "title": "Grid dots background",
+      "ownerDescription": "A subtle dot-grid or line-grid backdrop for a section.",
+      "category": "backgrounds",
+      "keyProps": {
+        "variant": "\"dots\" | \"grid\" (default \"dots\")",
+        "dotColor": "CSS color (default \"rgba(255,255,255,0.25)\")",
+        "height": "CSS height (default \"300px\")"
+      },
+      "props": {},
+      "snippet": "---\nimport GridDotsBackground from \"@astroanimate/core/GridDotsBackground\";\n---\n<GridDotsBackground variant=\"grid\" height=\"200px\" />"
+    },
+    {
+      "component": "InfiniteMarquee",
+      "title": "Infinite marquee",
+      "ownerDescription": "A row of logos, text, or cards that scrolls continuously and loops.",
+      "category": "backgrounds",
+      "keyProps": {
+        "direction": "\"left\" | \"right\" | \"up\" | \"down\" (default \"left\")",
+        "speed": "CSS duration (default \"30s\")",
+        "pauseOnHover": "boolean (default true)"
+      },
+      "props": {},
+      "snippet": "---\nimport InfiniteMarquee from \"@astroanimate/core/InfiniteMarquee\";\n---\n<InfiniteMarquee>\n  <span>Trusted by teams everywhere</span>\n</InfiniteMarquee>"
+    },
+    {
+      "component": "Loader",
+      "title": "Loader",
+      "ownerDescription": "A spinning, dotted, or pulsing loading indicator.",
+      "category": "navigation",
+      "keyProps": {
+        "type": "\"spinner\" | \"dots\" | \"pulse\" (default \"spinner\")",
+        "size": "pixels (default 40)",
+        "color": "CSS color (default \"#3b82f6\")"
+      },
+      "props": {},
+      "snippet": "---\nimport Loader from \"@astroanimate/core/Loader\";\n---\n<Loader type=\"dots\" />"
+    },
+    {
+      "component": "ProgressBar",
+      "title": "Progress bar",
+      "ownerDescription": "A labeled progress bar that fills to a given value.",
+      "category": "navigation",
+      "keyProps": {
+        "value": "current value 0-max (required)",
+        "max": "maximum value (default 100)",
+        "label": "optional label text"
+      },
+      "props": {
+        "value": 60
+      },
+      "snippet": "---\nimport ProgressBar from \"@astroanimate/core/ProgressBar\";\n---\n<ProgressBar value={60} label=\"Upload progress\" />"
+    }
+  ]
+}

--- a/Resources/Template/integrations/docs/animations.md
+++ b/Resources/Template/integrations/docs/animations.md
@@ -1,0 +1,325 @@
+# Animations
+
+This site template ships [`@astroanimate/core`](https://www.astroanimate.com) `0.1.2` as a
+default dependency (`Resources/Template/package.json`) — every new site has it installed with no
+extra step. It is a CSS-first, Astro-native animated component library: components render
+meaningful content with zero client JS by default, and respect
+`prefers-reduced-motion` automatically.
+
+## CSS-only policy
+
+Every component below supports an `enhance` prop that opts into an IntersectionObserver-based
+JS enhancement path. **Never set `enhance={true}` (or `enhance="true"`) on a component in this
+site.** The library's `enhance` mode emits inline `<script>` tags, and this site's Content
+Security Policy has no `'unsafe-inline'` and no script hashes — an inline script from
+`enhance={true}` is blocked in production and will silently do nothing. CSS-only usage
+(`enhance` left unset, which defaults to `false` on every component below except
+`CardStack`, where it must be passed explicitly as `enhance={false}`) is the supported and
+tested mode.
+
+## Import style
+
+Import each component from its own export path, not the package root:
+
+```astro
+---
+import FadeInText from "@astroanimate/core/FadeInText";
+---
+```
+
+## Curated components
+
+Only the components listed below have been vetted for this site: each renders under Astro 7,
+respects `prefers-reduced-motion`, has meaningful content without JS, and emits zero
+`<script>` tags with the props shown here. The full `@astroanimate/core` package has more
+components than this — the rest are not curated for this site and are not guaranteed to be
+CSP-safe.
+
+**Text**
+
+## FadeInText
+
+Text that fades in with a soft blur when the page loads.
+
+| Prop | Notes |
+| --- | --- |
+| `duration` | seconds (default 0.6) |
+| `delay` | seconds (default 0) |
+| `as` | wrapper tag, e.g. "h1" |
+
+```astro
+---
+import FadeInText from "@astroanimate/core/FadeInText";
+---
+<FadeInText as="h1">Welcome</FadeInText>
+```
+
+## ScaleIn
+
+Text or content that grows into place from a slightly smaller size.
+
+| Prop | Notes |
+| --- | --- |
+| `initialScale` | starting scale (default 0.9) |
+| `duration` | milliseconds (default 600) |
+| `as` | wrapper tag, e.g. "h2" |
+
+```astro
+---
+import ScaleIn from "@astroanimate/core/ScaleIn";
+---
+<ScaleIn as="h2">Grows into place</ScaleIn>
+```
+
+## RevealImage
+
+A headline where the letters reveal a background image as you scroll past.
+
+| Prop | Notes |
+| --- | --- |
+| `text` | overlay text (required) |
+| `image1` | first image URL (required) |
+| `image2` | second image URL (required) |
+
+```astro
+---
+import RevealImage from "@astroanimate/core/RevealImage";
+---
+<RevealImage text="REVEAL" image1="/images/before.jpg" image2="/images/after.jpg" />
+```
+
+## HighlightText
+
+A highlighter-style underline or background sweep behind a phrase.
+
+| Prop | Notes |
+| --- | --- |
+| `variant` | "underline" | "background" (default "background") |
+| `color` | highlight color (default "#FFD700") |
+| `trigger` | "load" | "hover" (default "load") |
+
+```astro
+---
+import HighlightText from "@astroanimate/core/HighlightText";
+---
+<p>This is <HighlightText>important</HighlightText> text.</p>
+```
+
+## TypewriterText
+
+A line of text that types itself out, one character at a time.
+
+| Prop | Notes |
+| --- | --- |
+| `texts` | array of strings to cycle through (required) |
+| `showCursor` | boolean (default true) |
+| `cursor` | cursor character (default "|") |
+
+```astro
+---
+import TypewriterText from "@astroanimate/core/TypewriterText";
+---
+<TypewriterText texts={["Design.", "Build.", "Ship."]} />
+```
+
+**Cards**
+
+## AnimatedCard
+
+A card that lifts, scales, or shines on hover.
+
+| Prop | Notes |
+| --- | --- |
+| `title` | card title (required) |
+| `description` | card description (required) |
+| `variant` | "lift" | "scale" | "flip" | "shine" (default "lift") |
+
+```astro
+---
+import AnimatedCard from "@astroanimate/core/AnimatedCard";
+---
+<AnimatedCard title="Feature" description="A short description of the feature." />
+```
+
+## CardStack
+
+A stack of testimonial or feature cards, one in front of the other.
+
+| Prop | Notes |
+| --- | --- |
+| `cards` | array of { title, content } cards (required) |
+| `stackSize` | visible cards (default 3) |
+| `enhance` | keep false — CSS-only mode (site CSP blocks enhance=true) |
+
+```astro
+---
+import CardStack from "@astroanimate/core/CardStack";
+---
+<CardStack
+  enhance={false}
+  cards={[
+    { title: "Alex", content: "Loved the onboarding flow." },
+    { title: "Sam", content: "Setup took five minutes." },
+  ]}
+/>
+```
+
+## ArticleCard
+
+A blog-post or article preview card with a title, summary, and link.
+
+| Prop | Notes |
+| --- | --- |
+| `title` | article title (required) |
+| `description` | summary text (required) |
+| `href` | link target (default "#") |
+
+```astro
+---
+import ArticleCard from "@astroanimate/core/ArticleCard";
+---
+<ArticleCard title="Article title" description="A short summary of the article." href="/blog/post" />
+```
+
+**Buttons**
+
+## AnimatedButton
+
+A button with a shimmer, fill, or border sweep on hover.
+
+| Prop | Notes |
+| --- | --- |
+| `variant` | "shimmer" | "fill" | "border" | "none" (default "none") |
+| `href` | renders as a link when set |
+| `disabled` | boolean (default false) |
+
+```astro
+---
+import AnimatedButton from "@astroanimate/core/AnimatedButton";
+---
+<AnimatedButton variant="shimmer">Get started</AnimatedButton>
+```
+
+## FillHoverButton
+
+A button whose background fills in from one edge on hover.
+
+| Prop | Notes |
+| --- | --- |
+| `as` | "button" | "a" (default "button") |
+| `href` | link target when as="a" |
+
+```astro
+---
+import FillHoverButton from "@astroanimate/core/FillHoverButton";
+---
+<FillHoverButton>Subscribe</FillHoverButton>
+```
+
+## ArrowCTAButton
+
+A call-to-action link whose arrow slides forward on hover.
+
+| Prop | Notes |
+| --- | --- |
+| `label` | button text (required) |
+| `as` | "button" | "a" (default "button") |
+| `href` | link target when as="a" |
+
+```astro
+---
+import ArrowCTAButton from "@astroanimate/core/ArrowCTAButton";
+---
+<ArrowCTAButton label="Learn more" href="/about" as="a" />
+```
+
+## SlidingOverlayButton
+
+A button with a color overlay that slides in on hover.
+
+| Prop | Notes |
+| --- | --- |
+| `as` | "button" | "a" (default "button") |
+| `href` | link target when as="a" |
+
+```astro
+---
+import SlidingOverlayButton from "@astroanimate/core/SlidingOverlayButton";
+---
+<SlidingOverlayButton>Contact us</SlidingOverlayButton>
+```
+
+**Backgrounds**
+
+## GridDotsBackground
+
+A subtle dot-grid or line-grid backdrop for a section.
+
+| Prop | Notes |
+| --- | --- |
+| `variant` | "dots" | "grid" (default "dots") |
+| `dotColor` | CSS color (default "rgba(255,255,255,0.25)") |
+| `height` | CSS height (default "300px") |
+
+```astro
+---
+import GridDotsBackground from "@astroanimate/core/GridDotsBackground";
+---
+<GridDotsBackground variant="grid" height="200px" />
+```
+
+## InfiniteMarquee
+
+A row of logos, text, or cards that scrolls continuously and loops.
+
+| Prop | Notes |
+| --- | --- |
+| `direction` | "left" | "right" | "up" | "down" (default "left") |
+| `speed` | CSS duration (default "30s") |
+| `pauseOnHover` | boolean (default true) |
+
+```astro
+---
+import InfiniteMarquee from "@astroanimate/core/InfiniteMarquee";
+---
+<InfiniteMarquee>
+  <span>Trusted by teams everywhere</span>
+</InfiniteMarquee>
+```
+
+**Navigation**
+
+## Loader
+
+A spinning, dotted, or pulsing loading indicator.
+
+| Prop | Notes |
+| --- | --- |
+| `type` | "spinner" | "dots" | "pulse" (default "spinner") |
+| `size` | pixels (default 40) |
+| `color` | CSS color (default "#3b82f6") |
+
+```astro
+---
+import Loader from "@astroanimate/core/Loader";
+---
+<Loader type="dots" />
+```
+
+## ProgressBar
+
+A labeled progress bar that fills to a given value.
+
+| Prop | Notes |
+| --- | --- |
+| `value` | current value 0-max (required) |
+| `max` | maximum value (default 100) |
+| `label` | optional label text |
+
+```astro
+---
+import ProgressBar from "@astroanimate/core/ProgressBar";
+---
+<ProgressBar value={60} label="Upload progress" />
+```
+

--- a/Resources/Template/package-lock.json
+++ b/Resources/Template/package-lock.json
@@ -8,6 +8,7 @@
       "name": "anglesite-site",
       "version": "0.0.1",
       "dependencies": {
+        "@astroanimate/core": "0.1.2",
         "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/rss": "^4.0.0",
         "@dwk/activitypub": "0.1.0-beta.5",
@@ -100,6 +101,15 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astroanimate/core": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@astroanimate/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-cu1ytAp8ZPelcxnZlRavNfNrLn60DoQSUBqUzWLJr9b5n5gP/prNNb5MuH7LWK+Y5i2SZF31ptjfJroTy6il/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "astro": "^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@astrojs/check": {

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/rss": "^4.0.0",
+    "@astroanimate/core": "0.1.2",
     "@dwk/activitypub": "0.1.0-beta.5",
     "@dwk/indieauth": "0.1.0-beta.3",
     "@dwk/micropub": "0.1.0-beta.4",
@@ -46,5 +47,10 @@
     "typescript": "^5.9.3",
     "vitest": "4.1.10",
     "wrangler": "4.114.0"
+  },
+  "overrides": {
+    "@astroanimate/core": {
+      "astro": "$astro"
+    }
   }
 }

--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -11,9 +11,10 @@
     "check": "npx tsx scripts/pre-deploy-check.ts",
     "embed": "tsx scripts/embed-snapshot.ts",
     "build:ci": "npm run build && npx tsx scripts/pre-deploy-check.ts --json --strict",
-    "test": "tsx --test \"scripts/**/*.test.ts\" \"src/**/*.test.ts\"",
+    "test": "tsx --test \"scripts/**/*.test.ts\" \"src/**/*.test.ts\" && npm run test:astro",
     "test:worker": "vitest run --config vitest.config.ts",
-    "test:scripts": "npx tsx --test scripts/*.test.ts scripts/embeds/*.test.ts src/lib/*.test.ts"
+    "test:scripts": "npx tsx --test scripts/*.test.ts scripts/embeds/*.test.ts src/lib/*.test.ts",
+    "test:astro": "vitest run --config vitest.astro.config.ts"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",

--- a/Resources/Template/scripts/animations-catalog.ts
+++ b/Resources/Template/scripts/animations-catalog.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface AnimationCatalogEntry {
+  component: string;
+  title: string;
+  ownerDescription: string;
+  category: "text" | "cards" | "buttons" | "backgrounds" | "navigation";
+  keyProps: Record<string, string>;
+  props: Record<string, unknown>;
+  snippet: string;
+}
+
+export interface AnimationsCatalog {
+  version: number;
+  components: AnimationCatalogEntry[];
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function catalogPath(): string {
+  return resolve(HERE, "../integrations/animations.json");
+}
+
+export function loadAnimationsCatalog(): AnimationsCatalog {
+  return JSON.parse(readFileSync(catalogPath(), "utf8")) as AnimationsCatalog;
+}

--- a/Resources/Template/src/lib/animations-catalog.spec.ts
+++ b/Resources/Template/src/lib/animations-catalog.spec.ts
@@ -43,6 +43,54 @@ describe("animations catalog", () => {
         );
         expect(source).toContain("prefers-reduced-motion");
       });
+
+      it("demo snapshot is fresh", async () => {
+        const container = await AstroContainer.create();
+        const mod = await import(
+          /* @vite-ignore */ `@astroanimate/core/${entry.component}`
+        );
+        const inner = await container.renderToString(mod.default, {
+          props: entry.props,
+          slots: { default: `${entry.title} demo` },
+        });
+        // AstroContainer#renderToString only returns the component's own
+        // markup (plus any define:vars inline styles) — it does not bundle
+        // the component's scoped <style> block, since that extraction is
+        // normally a Vite/build-time asset step the container API doesn't
+        // run. Pull the component's real CSS straight from its source so
+        // the demo actually animates offline, in a WKWebView, with no dev
+        // server: every curated component's selectors are plain classes or
+        // data-attributes (not Astro's :scope hash), so inlining the raw
+        // rule set is safe for a page containing exactly one instance.
+        const componentSource = readFileSync(
+          `node_modules/@astroanimate/core/dist/components/${entry.component}/${entry.component}.astro`,
+          "utf8",
+        );
+        const componentCss = [...componentSource.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)]
+          .map((match) => match[1])
+          .join("\n");
+        const page = [
+          "<!doctype html>",
+          `<html lang="en"><head><meta charset="utf-8"><title>${entry.title}</title>`,
+          "<style>body{margin:0;display:grid;place-items:center;min-height:100vh;",
+          "font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>",
+          `<style>${componentCss}</style>`,
+          "</head><body>",
+          inner,
+          "</body></html>",
+          "",
+        ].join("\n");
+        await expect(page).toMatchFileSnapshot(
+          `../../integrations/animations-demos/${entry.component}.html`,
+        );
+      });
     });
   }
+
+  it("every curated component is documented", () => {
+    const docs = readFileSync("integrations/docs/animations.md", "utf8");
+    for (const entry of catalog.components) {
+      expect(docs, entry.component).toContain(`## ${entry.component}`);
+    }
+  });
 });

--- a/Resources/Template/src/lib/animations-catalog.spec.ts
+++ b/Resources/Template/src/lib/animations-catalog.spec.ts
@@ -34,8 +34,14 @@ describe("animations catalog", () => {
         // and several components' comments describe their conditional
         // <script> paths (e.g. "Script emitted ONLY when enhance=true") —
         // strip comments first so the check targets real <script> elements,
-        // not comment prose that happens to mention the tag.
-        const htmlWithoutComments = html.replace(/<!--[\s\S]*?-->/g, "");
+        // not comment prose that happens to mention the tag. Stripping loops
+        // until stable so nested/overlapping "<!--" remnants can't survive a
+        // single pass (CodeQL js/incomplete-multi-character-sanitization).
+        let htmlWithoutComments = html;
+        for (let previous = ""; previous !== htmlWithoutComments; ) {
+          previous = htmlWithoutComments;
+          htmlWithoutComments = htmlWithoutComments.replace(/<!--[\s\S]*?-->/g, "");
+        }
         expect(htmlWithoutComments).not.toContain("<script");
         const source = readFileSync(
           `node_modules/@astroanimate/core/dist/components/${entry.component}/${entry.component}.astro`,
@@ -69,6 +75,11 @@ describe("animations catalog", () => {
         const componentCss = [...componentSource.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)]
           .map((match) => match[1])
           .join("\n");
+        // Some upstream component sources (e.g. ArticleCard) carry CRLF line
+        // endings, which this pipeline would otherwise copy verbatim into the
+        // page. Git's `eol=lf` normalization strips the CRs from the committed
+        // snapshot blob, so a CI checkout could never match a fresh render —
+        // normalize here so the snapshot is byte-stable on every platform.
         const page = [
           "<!doctype html>",
           `<html lang="en"><head><meta charset="utf-8"><title>${entry.title}</title>`,
@@ -79,7 +90,7 @@ describe("animations catalog", () => {
           inner,
           "</body></html>",
           "",
-        ].join("\n");
+        ].join("\n").replace(/\r\n/g, "\n");
         await expect(page).toMatchFileSnapshot(
           `../../integrations/animations-demos/${entry.component}.html`,
         );

--- a/Resources/Template/src/lib/animations-catalog.spec.ts
+++ b/Resources/Template/src/lib/animations-catalog.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { loadAnimationsCatalog } from "../../scripts/animations-catalog";
+
+const catalog = loadAnimationsCatalog();
+
+describe("animations catalog", () => {
+  it("has at least one curated component", () => {
+    expect(catalog.components.length).toBeGreaterThan(0);
+  });
+
+  it("never catalogs enhance=true (CSP: no inline scripts)", () => {
+    for (const entry of catalog.components) {
+      expect(entry.props["enhance"], entry.component).not.toBe(true);
+      expect(entry.snippet).not.toContain("enhance={true}");
+      expect(entry.snippet).not.toContain('enhance="true"');
+    }
+  });
+
+  for (const entry of catalog.components) {
+    describe(entry.component, () => {
+      it("renders, is script-free, and guards reduced motion", async () => {
+        const container = await AstroContainer.create();
+        const mod = await import(
+          /* @vite-ignore */ `@astroanimate/core/${entry.component}`
+        );
+        const html = await container.renderToString(mod.default, {
+          props: entry.props,
+          slots: { default: "Sample content" },
+        });
+        expect(html.length).toBeGreaterThan(0);
+        // Astro preserves top-level template comments in the compiled output,
+        // and several components' comments describe their conditional
+        // <script> paths (e.g. "Script emitted ONLY when enhance=true") —
+        // strip comments first so the check targets real <script> elements,
+        // not comment prose that happens to mention the tag.
+        const htmlWithoutComments = html.replace(/<!--[\s\S]*?-->/g, "");
+        expect(htmlWithoutComments).not.toContain("<script");
+        const source = readFileSync(
+          `node_modules/@astroanimate/core/dist/components/${entry.component}/${entry.component}.astro`,
+          "utf8",
+        );
+        expect(source).toContain("prefers-reduced-motion");
+      });
+    });
+  }
+});

--- a/Resources/Template/vitest.astro.config.ts
+++ b/Resources/Template/vitest.astro.config.ts
@@ -1,0 +1,7 @@
+import { getViteConfig } from "astro/config";
+
+export default getViteConfig({
+  test: {
+    include: ["src/lib/animations-catalog.spec.ts"],
+  },
+});

--- a/docs/superpowers/plans/2026-07-27-astro-animate.md
+++ b/docs/superpowers/plans/2026-07-27-astro-animate.md
@@ -299,22 +299,26 @@ git commit -m "feat(template): animation demos + owner docs (#<ISSUE_A>)"
 **Files:**
 - No new files; verification + PR.
 
-- [ ] **Step 1: Run the template-coupled Swift guards** (repo root; xcodegen not needed for SwiftPM tests):
+- [x] **Step 1: Run the template-coupled Swift guards** (repo root; xcodegen not needed for SwiftPM tests):
 
 Run: `swift test --filter IntegrationTemplateAssetsTests && swift test --filter ProjectValidator`
 Expected: PASS. If a guard hard-codes template file lists, extend it to cover `integrations/animations.json` rather than deleting assertions.
 
-- [ ] **Step 2: Full SwiftPM suite** (template changes can couple to Swift tests; capture full output to a file, never tail):
+  Both suites passed (10/10 and 6/6 tests). Neither guard enumerates `Resources/Template/` generically or hardcodes a template file inventory that would need extending for the new `integrations/animations.json`/`animations-demos/`/`docs/animations.md` files — `IntegrationTemplateAssetsTests` targets a specific, named subset of on-demand integration assets, and `ProjectValidator`'s sentinel set doesn't reference the animations catalog.
+
+- [x] **Step 2: Full SwiftPM suite** (template changes can couple to Swift tests; capture full output to a file, never tail):
 
 Run: `swift test --package-path . > /tmp/swift-test-astroanimate.log 2>&1; tail -5 /tmp/swift-test-astroanimate.log && grep -c " passed" /tmp/swift-test-astroanimate.log`
 Expected: suite passes (known flakes: AstroDevServerTests port/ready-URL — rerun once before debugging; FM "tokens exceeds 8192" is a live-model flake).
 
-- [ ] **Step 3: Re-vendor the container image** (it bakes template `node_modules`):
+- [x] **Step 3: Re-vendor the container image** (it bakes template `node_modules`):
 
 Run: `ANGLESITE_SIDECAR_SRC=$HOME/Developer/github.com/Anglesite/anglesite scripts/vendor-container-image.sh`
 Expected: exits 0. If the environment can't build images, say so in the PR's Test plan rather than skipping silently.
 
-- [ ] **Step 4: Push branch, open PR A** targeting `main`, body built from `.github/PULL_REQUEST_TEMPLATE.md` headings (**Summary**, **Paired PR check** — note: template-only, app-only, no MCP schema change; sidecar PR is coordinated but independent — and **Test plan** listing the commands above). Then `gh issue edit <ISSUE_A> --remove-label "🛠️ In Progress"`.
+  Exited 0. The `container` CLI (1.1.0) was available; the build staged the sidecar + template context, ran `npm ci` against the template's `package.json`/`package-lock.json` (786 packages, including `@astroanimate/core`), and exported the OCI layout to `Resources/container-image/` (gitignored — nothing to commit here).
+
+- [x] **Step 4: Push branch, open PR A** targeting `main`, body built from `.github/PULL_REQUEST_TEMPLATE.md` headings (**Summary**, **Paired PR check** — note: template-only, app-only, no MCP schema change; sidecar PR is coordinated but independent — and **Test plan** listing the commands above). Then `gh issue edit <ISSUE_A> --remove-label "🛠️ In Progress"`.
 
 ---
 
@@ -413,7 +417,7 @@ import Foundation
 **Files:**
 - Modify: `docs/decisions/0008-no-third-party-javascript.md` (sidecar checkout `~/Developer/github.com/Anglesite/anglesite`, in a fresh worktree/branch)
 
-- [ ] **Step 1: Append to the "Creative coding libraries (not third-party)" section:**
+- [x] **Step 1: Append to the "Creative coding libraries (not third-party)" section:** *(done in Anglesite/anglesite#427)*
 
 ```markdown
 The same reasoning covers npm-installed **animation component libraries**. The
@@ -426,7 +430,7 @@ first-party under `script-src 'self'`. One constraint applies: the library's
 `integrations/docs/animations.md`.
 ```
 
-- [ ] **Step 2: Commit** — `docs(adr): cover animation component libraries in ADR-0008 (#<ISSUE_C>)`.
+- [x] **Step 2: Commit** — `docs(adr): cover animation component libraries in ADR-0008 (#<ISSUE_C>)`. *(done in Anglesite/anglesite#427)*
 
 ### Task 8: `/animate` skill escalation section
 
@@ -434,7 +438,7 @@ first-party under `script-src 'self'`. One constraint applies: the library's
 - Modify: `skills/animate/SKILL.md`
 - Modify: `agent-skills/animate/…` — inspect this directory first; if it duplicates the same rule text, apply the same edit there.
 
-- [ ] **Step 1: Replace the absolute prohibition.** The current text: "**Never use JavaScript for animation.**" and the ADR list entry "no JavaScript animation libraries" stay, but gain the escalation carve-out. After the "Your CSS toolkit" section, add:
+- [x] **Step 1: Replace the absolute prohibition.** *(done in Anglesite/anglesite#427)* The current text: "**Never use JavaScript for animation.**" and the ADR list entry "no JavaScript animation libraries" stay, but gain the escalation carve-out. After the "Your CSS toolkit" section, add:
 
 ```markdown
 ## Escalation: the baked-in component library
@@ -455,8 +459,8 @@ typewriter/staggered text, card-stack effects, loaders — and then:
   `.astro` components).
 ```
 
-- [ ] **Step 2: Reconcile the ADR reference list** in the same file: change "no JavaScript animation libraries" to "no JavaScript animation *runtimes*; the baked-in CSS-first component library is the recorded exception (ADR-0008)".
-- [ ] **Step 3: Commit + PR C** in the sidecar repo — `feat(animate): escalate to baked-in @astroanimate components (#<ISSUE_C>)`. The sidecar has no PR template; use Summary / Test plan and link the app-repo spec. Note ordering: merge after app PR A.
+- [x] **Step 2: Reconcile the ADR reference list** in the same file: change "no JavaScript animation libraries" to "no JavaScript animation *runtimes*; the baked-in CSS-first component library is the recorded exception (ADR-0008)".
+- [x] **Step 3: Commit + PR C** in the sidecar repo *(Anglesite/anglesite#427)* — `feat(animate): escalate to baked-in @astroanimate components (#<ISSUE_C>)`. The sidecar has no PR template; use Summary / Test plan and link the app-repo spec. Note ordering: merge after app PR A.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-27-astro-animate.md
+++ b/docs/superpowers/plans/2026-07-27-astro-animate.md
@@ -32,7 +32,7 @@
 **Interfaces:**
 - Produces: `node_modules/@astroanimate/core` present in the template; export-map imports `@astroanimate/core/<Name>` resolve.
 
-- [ ] **Step 1: Edit `package.json`.** In `dependencies` (alphabetical, after `"@astrojs/rss"`): add `"@astroanimate/core": "0.1.2",`. At top level (after `"devDependencies"`), add:
+- [x] **Step 1: Edit `package.json`.** In `dependencies` (alphabetical, after `"@astrojs/rss"`): add `"@astroanimate/core": "0.1.2",`. At top level (after `"devDependencies"`), add:
 
 ```json
 "overrides": {
@@ -42,17 +42,17 @@
 }
 ```
 
-- [ ] **Step 2: Install and verify resolution.**
+- [x] **Step 2: Install and verify resolution.**
 
 Run: `cd Resources/Template && npm install`
 Expected: exits 0, **no** `ERESOLVE` peer-dependency error; `ls node_modules/@astroanimate/core/dist/components | wc -l` prints ≥30.
 
-- [ ] **Step 3: Confirm existing template suites still pass.**
+- [x] **Step 3: Confirm existing template suites still pass.**
 
 Run (from `Resources/Template/`): `npm run test:scripts`
 Expected: PASS (no new failures).
 
-- [ ] **Step 4: Commit** (`package.json` + `package-lock.json` only):
+- [x] **Step 4: Commit** (`package.json` + `package-lock.json` only):
 
 ```bash
 git add Resources/Template/package.json Resources/Template/package-lock.json
@@ -90,7 +90,7 @@ git commit -m "feat(template): add @astroanimate/core 0.1.2 (#<ISSUE_A>)"
   `props` is the exact prop object used for rendering in tests and demos (usually `{}` = defaults; MUST NOT contain `enhance: true`). `category` ∈ `text | cards | buttons | backgrounds | navigation`.
 - Produces: `loadAnimationsCatalog(): AnimationsCatalog` from `scripts/animations-catalog.ts`.
 
-- [ ] **Step 1: Write the loader** `Resources/Template/scripts/animations-catalog.ts`:
+- [x] **Step 1: Write the loader** `Resources/Template/scripts/animations-catalog.ts`:
 
 ```ts
 import { readFileSync } from "node:fs";
@@ -123,7 +123,7 @@ export function loadAnimationsCatalog(): AnimationsCatalog {
 }
 ```
 
-- [ ] **Step 2: Write `vitest.astro.config.ts`** (Astro's Vite pipeline so `.astro` imports compile):
+- [x] **Step 2: Write `vitest.astro.config.ts`** (Astro's Vite pipeline so `.astro` imports compile):
 
 ```ts
 import { getViteConfig } from "astro/config";
@@ -135,7 +135,7 @@ export default getViteConfig({
 });
 ```
 
-- [ ] **Step 3: Write the failing rendering test** `Resources/Template/src/lib/animations-catalog.spec.ts`:
+- [x] **Step 3: Write the failing rendering test** `Resources/Template/src/lib/animations-catalog.spec.ts`:
 
 ```ts
 import { describe, it, expect } from "vitest";
@@ -182,21 +182,25 @@ describe("animations catalog", () => {
 });
 ```
 
-- [ ] **Step 4: Run it to make sure it fails** (no manifest yet).
+- [x] **Step 4: Run it to make sure it fails** (no manifest yet).
 
 Run (from `Resources/Template/`): `npx vitest run --config vitest.astro.config.ts`
 Expected: FAIL — `ENOENT … integrations/animations.json`.
 
-- [ ] **Step 5: Write `integrations/animations.json`.** Start from this candidate list and **let the test decide membership** — drop any component that emits `<script>` with default props or lacks a reduced-motion guard; keep the survivors: `FadeInText`, `ScaleIn`, `RevealImage`, `HighlightText`, `TypewriterText` (category `text`); `AnimatedCard`, `GlassCard`, `CardStack`, `ArticleCard` (category `cards`); `AnimatedButton`, `FillHoverButton`, `ArrowCTAButton`, `SlidingOverlayButton` (category `buttons`); `GridDotsBackground`, `InfiniteMarquee` (category `backgrounds`); `Loader`, `ProgressBar` (category `navigation`). Every entry follows the schema in **Interfaces** above, `props: {}` unless a prop is required to render, and a `snippet` in the exact import style shown there.
+- [x] **Step 5: Write `integrations/animations.json`.** Start from this candidate list and **let the test decide membership** — drop any component that emits `<script>` with default props or lacks a reduced-motion guard; keep the survivors: `FadeInText`, `ScaleIn`, `RevealImage`, `HighlightText`, `TypewriterText` (category `text`); `AnimatedCard`, `GlassCard`, `CardStack`, `ArticleCard` (category `cards`); `AnimatedButton`, `FillHoverButton`, `ArrowCTAButton`, `SlidingOverlayButton` (category `buttons`); `GridDotsBackground`, `InfiniteMarquee` (category `backgrounds`); `Loader`, `ProgressBar` (category `navigation`). Every entry follows the schema in **Interfaces** above, `props: {}` unless a prop is required to render, and a `snippet` in the exact import style shown there.
 
-- [ ] **Step 6: Run tests until green; prune failures.**
+  **Dropped: `GlassCard`.** Static inspection of `dist/components/GlassCard/GlassCard.astro` showed an unconditional `<script is:inline define:vars={{ cardId }}>` (tilt/glare JS) with no `enhance` gate at all — it always emits a script regardless of props, which fails the CSP zero-`<script>` rule. Excluded before writing the manifest rather than added-then-pruned. `CardStack` defaults `enhance` to `true` (unlike the other enhance-gated components); catalogued with `props: { enhance: false, ... }` and the snippet shows `enhance={false}` explicitly so copy-paste usage stays CSS-only. All other 15 candidates passed the rendering/script/reduced-motion test as originally proposed — final curated list is 16 components.
+
+- [x] **Step 6: Run tests until green; prune failures.**
 
 Run: `npx vitest run --config vitest.astro.config.ts`
 Expected: PASS with the final curated list (document dropped components in the commit body).
 
-- [ ] **Step 7: Wire the script into `package.json`** — add `"test:astro": "vitest run --config vitest.astro.config.ts"` to template scripts and extend the existing `"test"` script with ` && npm run test:astro`.
+  One test bug found and fixed along the way: the literal `expect(html).not.toContain("<script")` check false-failed on `FadeInText` — not because it emits a real `<script>` element, but because Astro preserves top-level template comments in compiled output, and `FadeInText`'s own comment ("Script emitted ONLY when enhance=true... Astro does NOT bundle `<script>` tags...") contains the literal substring `<script` inside an HTML comment. Fixed by stripping HTML comments (`html.replace(/<!--[\s\S]*?-->/g, "")`) before the containment check, so the assertion targets real `<script>` elements. All 16 curated components pass; no component was dropped by the render/script/reduced-motion assertion itself (only `GlassCard`, excluded up front per Step 5).
 
-- [ ] **Step 8: Commit:**
+- [x] **Step 7: Wire the script into `package.json`** — add `"test:astro": "vitest run --config vitest.astro.config.ts"` to template scripts and extend the existing `"test"` script with ` && npm run test:astro`.
+
+- [x] **Step 8: Commit:**
 
 ```bash
 git add Resources/Template/integrations/animations.json Resources/Template/scripts/animations-catalog.ts \

--- a/docs/superpowers/plans/2026-07-27-astro-animate.md
+++ b/docs/superpowers/plans/2026-07-27-astro-animate.md
@@ -219,7 +219,19 @@ git commit -m "feat(template): curated Astro Animate catalog + smoke tests (#<IS
 **Interfaces:**
 - Produces: `integrations/animations-demos/<Component>.html` — self-contained (inline `<style>` only) demo pages, loaded by the WS2 gallery's WKWebView via file URL.
 
-- [ ] **Step 1: Add demo-snapshot and docs tests** to `animations-catalog.spec.ts` (inside the per-entry `describe`):
+- [x] **Step 1: Add demo-snapshot and docs tests** to `animations-catalog.spec.ts` (inside the per-entry `describe`):
+
+  Deviation from the plan's literal test body: `AstroContainer#renderToString` does not bundle a
+  component's scoped `<style>` block (that extraction is normally a Vite/build-time asset step
+  the container API doesn't run), so the demo page as originally specified rendered with zero
+  CSS — no `@keyframes`, nothing — which would contradict the spec's "prerendered demos animate
+  for real" goal. Fixed by reading the component's raw source and inlining its `<style>` block
+  content (via `[...source.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)]`) into the demo page's
+  `<head>`. Verified safe: every curated component's CSS selectors are plain classes or
+  `[data-*]` attributes (not Astro's `:scope` hash), and each demo page renders exactly one
+  instance, so there's no scoping collision. Visually verified in the browser: `FadeInText.html`
+  renders the fade-in text visible after its animation completes, and `InfiniteMarquee.html`
+  shows the marquee track actually scrolling with edge fade.
 
 ```ts
       it("demo snapshot is fresh", async () => {
@@ -258,19 +270,23 @@ git commit -m "feat(template): curated Astro Animate catalog + smoke tests (#<IS
   });
 ```
 
-- [ ] **Step 2: Generate snapshots.**
+- [x] **Step 2: Generate snapshots.**
 
 Run: `npx vitest run --config vitest.astro.config.ts -u`
 Expected: PASS; one `.html` per curated component appears under `integrations/animations-demos/`. Open one in a browser and confirm the animation plays.
 
-- [ ] **Step 3: Write `integrations/docs/animations.md`.** Header explaining: baked-in `@astroanimate/core@0.1.2`, CSS-only policy (never `enhance={true}` — the site CSP blocks inline scripts), import style, and then one `## <Component>` section per curated entry containing the `ownerDescription`, key props table, and the manifest `snippet` in a fenced code block. The docs test from Step 1 enforces coverage.
+  Confirmed in the Browser pane: `FadeInText.html` and `InfiniteMarquee.html` both animate.
 
-- [ ] **Step 4: Run the full template test script.**
+- [x] **Step 3: Write `integrations/docs/animations.md`.** Header explaining: baked-in `@astroanimate/core@0.1.2`, CSS-only policy (never `enhance={true}` — the site CSP blocks inline scripts), import style, and then one `## <Component>` section per curated entry containing the `ownerDescription`, key props table, and the manifest `snippet` in a fenced code block. The docs test from Step 1 enforces coverage.
+
+- [x] **Step 4: Run the full template test script.**
 
 Run (from `Resources/Template/`): `npm test`
 Expected: PASS (tsx suites + worker vitest + astro vitest).
 
-- [ ] **Step 5: Commit:**
+  `npm test` (tsx suites, 452 passed/2 skipped, + astro vitest, 35 passed) and `npm run test:worker` (115 passed) both ran green; `npm test` as wired doesn't itself invoke `test:worker` (see CI's `template-worker` job, which runs `npm test` and `npm run test:worker` as two separate steps) — ran it separately for full coverage since this task touches template files under test.
+
+- [x] **Step 5: Commit:**
 
 ```bash
 git add Resources/Template/integrations/animations-demos Resources/Template/integrations/docs/animations.md \

--- a/docs/superpowers/plans/2026-07-27-astro-animate.md
+++ b/docs/superpowers/plans/2026-07-27-astro-animate.md
@@ -1,0 +1,447 @@
+# Astro Animate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bake `@astroanimate/core` into the Anglesite website template with a curated, CSP-safe component catalog, an app-side Animations gallery, and a sidecar skill/ADR update.
+
+**Architecture:** Three workstreams matching three GitHub issues. WS1 (app repo) adds the pinned dependency, curation manifest `integrations/animations.json`, docs, prerendered demo snapshots, and template tests. WS2 (app repo, stacked on WS1) adds an `AnimationCatalog` model in AnglesiteCore and a gallery sheet in the app. WS3 (sidecar repo) extends ADR-0008's npm carve-out and adds an escalation section to the `/animate` skill. Spec: `docs/superpowers/specs/2026-07-27-astro-animate-design.md`.
+
+**Tech Stack:** npm/Astro 7 (template), Vitest + Astro Container API (component rendering in tests), Swift 6.4 / SwiftUI / WKWebView (app), Markdown (sidecar).
+
+## Global Constraints
+
+- Dependency is `"@astroanimate/core": "0.1.2"` — **exact pin, no caret** — with npm override `"@astroanimate/core": { "astro": "$astro" }`.
+- Curated components MUST emit **zero `<script>` tags** with their cataloged props (template CSP has no `'unsafe-inline'`/hashes; `enhance` must stay `false`) and MUST include a `prefers-reduced-motion` guard in their CSS.
+- Import paths use the package export map: `import FadeInText from "@astroanimate/core/FadeInText";`.
+- App repo work happens in a git worktree; run `xcodegen generate` before any Xcode build; `cd` to the worktree before every git command.
+- Template edits require running the Swift guard suites: `swift test --filter IntegrationTemplateAssetsTests` and `swift test --filter ProjectValidator`.
+- Conventional commits, subject ≤72 chars, issue number in subject. PR bodies use `.github/PULL_REQUEST_TEMPLATE.md` headings verbatim (Summary / Paired PR check / Test plan).
+- Container image re-vendor needs `ANGLESITE_SIDECAR_SRC=$HOME/Developer/github.com/Anglesite/anglesite`.
+- New user-visible strings in the app require the `xcrun xcstringstool sync … --skip-marking-strings-stale` recipe from CONTRIBUTING.md (scoped to this worktree's DerivedData) and committing the `.xcstrings` diff.
+
+---
+
+## Workstream 1 — Template capability (app repo, Issue A)
+
+### Task 1: Add the pinned dependency with Astro-7 override
+
+**Files:**
+- Modify: `Resources/Template/package.json`
+- Modify: `Resources/Template/package-lock.json` (regenerated)
+
+**Interfaces:**
+- Produces: `node_modules/@astroanimate/core` present in the template; export-map imports `@astroanimate/core/<Name>` resolve.
+
+- [ ] **Step 1: Edit `package.json`.** In `dependencies` (alphabetical, after `"@astrojs/rss"`): add `"@astroanimate/core": "0.1.2",`. At top level (after `"devDependencies"`), add:
+
+```json
+"overrides": {
+  "@astroanimate/core": {
+    "astro": "$astro"
+  }
+}
+```
+
+- [ ] **Step 2: Install and verify resolution.**
+
+Run: `cd Resources/Template && npm install`
+Expected: exits 0, **no** `ERESOLVE` peer-dependency error; `ls node_modules/@astroanimate/core/dist/components | wc -l` prints ≥30.
+
+- [ ] **Step 3: Confirm existing template suites still pass.**
+
+Run (from `Resources/Template/`): `npm run test:scripts`
+Expected: PASS (no new failures).
+
+- [ ] **Step 4: Commit** (`package.json` + `package-lock.json` only):
+
+```bash
+git add Resources/Template/package.json Resources/Template/package-lock.json
+git commit -m "feat(template): add @astroanimate/core 0.1.2 (#<ISSUE_A>)"
+```
+
+### Task 2: Curation manifest + rendering smoke tests (Vitest + Astro Container)
+
+**Files:**
+- Create: `Resources/Template/integrations/animations.json`
+- Create: `Resources/Template/scripts/animations-catalog.ts` (manifest loader + types)
+- Create: `Resources/Template/src/lib/animations-catalog.spec.ts` (Vitest; rendering tests)
+- Modify: `Resources/Template/vitest.config.ts` — this config uses `@cloudflare/vitest-pool-workers` for `worker/` tests; do NOT touch it. Instead Create: `Resources/Template/vitest.astro.config.ts` and add script `"test:astro": "vitest run --config vitest.astro.config.ts"` to `Resources/Template/package.json`, and append `&& npm run test:astro` to the template `test` script.
+
+**Interfaces:**
+- Produces: `animations.json` schema (consumed by Task 3 docs test, Task 5 Swift decoding, Task 6 gallery):
+
+```json
+{
+  "version": 1,
+  "components": [
+    {
+      "component": "FadeInText",
+      "title": "Fade-in text",
+      "ownerDescription": "Text that fades in with a soft blur when the page loads.",
+      "category": "text",
+      "keyProps": { "duration": "seconds (default 0.6)", "delay": "seconds", "as": "wrapper tag, e.g. \"h1\"" },
+      "props": {},
+      "snippet": "---\nimport FadeInText from \"@astroanimate/core/FadeInText\";\n---\n<FadeInText as=\"h1\">Welcome</FadeInText>"
+    }
+  ]
+}
+```
+
+  `props` is the exact prop object used for rendering in tests and demos (usually `{}` = defaults; MUST NOT contain `enhance: true`). `category` ∈ `text | cards | buttons | backgrounds | navigation`.
+- Produces: `loadAnimationsCatalog(): AnimationsCatalog` from `scripts/animations-catalog.ts`.
+
+- [ ] **Step 1: Write the loader** `Resources/Template/scripts/animations-catalog.ts`:
+
+```ts
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface AnimationCatalogEntry {
+  component: string;
+  title: string;
+  ownerDescription: string;
+  category: "text" | "cards" | "buttons" | "backgrounds" | "navigation";
+  keyProps: Record<string, string>;
+  props: Record<string, unknown>;
+  snippet: string;
+}
+
+export interface AnimationsCatalog {
+  version: number;
+  components: AnimationCatalogEntry[];
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function catalogPath(): string {
+  return resolve(HERE, "../integrations/animations.json");
+}
+
+export function loadAnimationsCatalog(): AnimationsCatalog {
+  return JSON.parse(readFileSync(catalogPath(), "utf8")) as AnimationsCatalog;
+}
+```
+
+- [ ] **Step 2: Write `vitest.astro.config.ts`** (Astro's Vite pipeline so `.astro` imports compile):
+
+```ts
+import { getViteConfig } from "astro/config";
+
+export default getViteConfig({
+  test: {
+    include: ["src/lib/animations-catalog.spec.ts"],
+  },
+});
+```
+
+- [ ] **Step 3: Write the failing rendering test** `Resources/Template/src/lib/animations-catalog.spec.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { loadAnimationsCatalog } from "../../scripts/animations-catalog";
+
+const catalog = loadAnimationsCatalog();
+
+describe("animations catalog", () => {
+  it("has at least one curated component", () => {
+    expect(catalog.components.length).toBeGreaterThan(0);
+  });
+
+  it("never catalogs enhance=true (CSP: no inline scripts)", () => {
+    for (const entry of catalog.components) {
+      expect(entry.props["enhance"], entry.component).not.toBe(true);
+      expect(entry.snippet).not.toContain("enhance={true}");
+      expect(entry.snippet).not.toContain('enhance="true"');
+    }
+  });
+
+  for (const entry of catalog.components) {
+    describe(entry.component, () => {
+      it("renders, is script-free, and guards reduced motion", async () => {
+        const container = await AstroContainer.create();
+        const mod = await import(
+          /* @vite-ignore */ `@astroanimate/core/${entry.component}`
+        );
+        const html = await container.renderToString(mod.default, {
+          props: entry.props,
+          slots: { default: "Sample content" },
+        });
+        expect(html.length).toBeGreaterThan(0);
+        expect(html).not.toContain("<script");
+        const source = readFileSync(
+          `node_modules/@astroanimate/core/dist/components/${entry.component}/${entry.component}.astro`,
+          "utf8",
+        );
+        expect(source).toContain("prefers-reduced-motion");
+      });
+    });
+  }
+});
+```
+
+- [ ] **Step 4: Run it to make sure it fails** (no manifest yet).
+
+Run (from `Resources/Template/`): `npx vitest run --config vitest.astro.config.ts`
+Expected: FAIL — `ENOENT … integrations/animations.json`.
+
+- [ ] **Step 5: Write `integrations/animations.json`.** Start from this candidate list and **let the test decide membership** — drop any component that emits `<script>` with default props or lacks a reduced-motion guard; keep the survivors: `FadeInText`, `ScaleIn`, `RevealImage`, `HighlightText`, `TypewriterText` (category `text`); `AnimatedCard`, `GlassCard`, `CardStack`, `ArticleCard` (category `cards`); `AnimatedButton`, `FillHoverButton`, `ArrowCTAButton`, `SlidingOverlayButton` (category `buttons`); `GridDotsBackground`, `InfiniteMarquee` (category `backgrounds`); `Loader`, `ProgressBar` (category `navigation`). Every entry follows the schema in **Interfaces** above, `props: {}` unless a prop is required to render, and a `snippet` in the exact import style shown there.
+
+- [ ] **Step 6: Run tests until green; prune failures.**
+
+Run: `npx vitest run --config vitest.astro.config.ts`
+Expected: PASS with the final curated list (document dropped components in the commit body).
+
+- [ ] **Step 7: Wire the script into `package.json`** — add `"test:astro": "vitest run --config vitest.astro.config.ts"` to template scripts and extend the existing `"test"` script with ` && npm run test:astro`.
+
+- [ ] **Step 8: Commit:**
+
+```bash
+git add Resources/Template/integrations/animations.json Resources/Template/scripts/animations-catalog.ts \
+  Resources/Template/src/lib/animations-catalog.spec.ts Resources/Template/vitest.astro.config.ts \
+  Resources/Template/package.json
+git commit -m "feat(template): curated Astro Animate catalog + smoke tests (#<ISSUE_A>)"
+```
+
+### Task 3: Prerendered demo snapshots + owner docs
+
+**Files:**
+- Create: `Resources/Template/integrations/animations-demos/<Component>.html` (one per curated component, via file snapshots)
+- Create: `Resources/Template/integrations/docs/animations.md`
+- Modify: `Resources/Template/src/lib/animations-catalog.spec.ts` (add demo + docs tests)
+
+**Interfaces:**
+- Produces: `integrations/animations-demos/<Component>.html` — self-contained (inline `<style>` only) demo pages, loaded by the WS2 gallery's WKWebView via file URL.
+
+- [ ] **Step 1: Add demo-snapshot and docs tests** to `animations-catalog.spec.ts` (inside the per-entry `describe`):
+
+```ts
+      it("demo snapshot is fresh", async () => {
+        const container = await AstroContainer.create();
+        const mod = await import(
+          /* @vite-ignore */ `@astroanimate/core/${entry.component}`
+        );
+        const inner = await container.renderToString(mod.default, {
+          props: entry.props,
+          slots: { default: `${entry.title} demo` },
+        });
+        const page = [
+          "<!doctype html>",
+          `<html lang="en"><head><meta charset="utf-8"><title>${entry.title}</title>`,
+          "<style>body{margin:0;display:grid;place-items:center;min-height:100vh;",
+          "font-family:-apple-system,system-ui,sans-serif;background:Canvas;color:CanvasText;color-scheme:light dark}</style>",
+          "</head><body>",
+          inner,
+          "</body></html>",
+          "",
+        ].join("\n");
+        await expect(page).toMatchFileSnapshot(
+          `../../integrations/animations-demos/${entry.component}.html`,
+        );
+      });
+```
+
+  And once, outside the loop:
+
+```ts
+  it("every curated component is documented", () => {
+    const docs = readFileSync("integrations/docs/animations.md", "utf8");
+    for (const entry of catalog.components) {
+      expect(docs, entry.component).toContain(`## ${entry.component}`);
+    }
+  });
+```
+
+- [ ] **Step 2: Generate snapshots.**
+
+Run: `npx vitest run --config vitest.astro.config.ts -u`
+Expected: PASS; one `.html` per curated component appears under `integrations/animations-demos/`. Open one in a browser and confirm the animation plays.
+
+- [ ] **Step 3: Write `integrations/docs/animations.md`.** Header explaining: baked-in `@astroanimate/core@0.1.2`, CSS-only policy (never `enhance={true}` — the site CSP blocks inline scripts), import style, and then one `## <Component>` section per curated entry containing the `ownerDescription`, key props table, and the manifest `snippet` in a fenced code block. The docs test from Step 1 enforces coverage.
+
+- [ ] **Step 4: Run the full template test script.**
+
+Run (from `Resources/Template/`): `npm test`
+Expected: PASS (tsx suites + worker vitest + astro vitest).
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add Resources/Template/integrations/animations-demos Resources/Template/integrations/docs/animations.md \
+  Resources/Template/src/lib/animations-catalog.spec.ts
+git commit -m "feat(template): animation demos + owner docs (#<ISSUE_A>)"
+```
+
+### Task 4: Swift guards, container re-vendor, PR
+
+**Files:**
+- No new files; verification + PR.
+
+- [ ] **Step 1: Run the template-coupled Swift guards** (repo root; xcodegen not needed for SwiftPM tests):
+
+Run: `swift test --filter IntegrationTemplateAssetsTests && swift test --filter ProjectValidator`
+Expected: PASS. If a guard hard-codes template file lists, extend it to cover `integrations/animations.json` rather than deleting assertions.
+
+- [ ] **Step 2: Full SwiftPM suite** (template changes can couple to Swift tests; capture full output to a file, never tail):
+
+Run: `swift test --package-path . > /tmp/swift-test-astroanimate.log 2>&1; tail -5 /tmp/swift-test-astroanimate.log && grep -c " passed" /tmp/swift-test-astroanimate.log`
+Expected: suite passes (known flakes: AstroDevServerTests port/ready-URL — rerun once before debugging; FM "tokens exceeds 8192" is a live-model flake).
+
+- [ ] **Step 3: Re-vendor the container image** (it bakes template `node_modules`):
+
+Run: `ANGLESITE_SIDECAR_SRC=$HOME/Developer/github.com/Anglesite/anglesite scripts/vendor-container-image.sh`
+Expected: exits 0. If the environment can't build images, say so in the PR's Test plan rather than skipping silently.
+
+- [ ] **Step 4: Push branch, open PR A** targeting `main`, body built from `.github/PULL_REQUEST_TEMPLATE.md` headings (**Summary**, **Paired PR check** — note: template-only, app-only, no MCP schema change; sidecar PR is coordinated but independent — and **Test plan** listing the commands above). Then `gh issue edit <ISSUE_A> --remove-label "🛠️ In Progress"`.
+
+---
+
+## Workstream 2 — App gallery (app repo, Issue B; stacked on WS1)
+
+### Task 5: `AnimationCatalog` model in AnglesiteCore (TDD)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/AnimationCatalog.swift`
+- Create: `Tests/AnglesiteCoreTests/AnimationCatalogTests.swift`
+
+**Interfaces:**
+- Consumes: `integrations/animations.json` schema from Task 2.
+- Produces (used by Task 6):
+
+```swift
+public struct AnimationCatalogEntry: Sendable, Codable, Identifiable, Hashable {
+    public var id: String { component }
+    public let component: String
+    public let title: String
+    public let ownerDescription: String
+    public let category: AnimationCategory
+    public let keyProps: [String: String]
+    public let snippet: String
+}
+public enum AnimationCategory: String, Sendable, Codable, CaseIterable, Hashable {
+    case text, cards, buttons, backgrounds, navigation
+}
+public struct AnimationCatalog: Sendable {
+    public let entries: [AnimationCatalogEntry]
+    public static func load(templateDirectory: URL) throws -> AnimationCatalog
+    public func entries(in category: AnimationCategory) -> [AnimationCatalogEntry]
+    /// integrations/animations-demos/<component>.html under the same template root.
+    public static func demoURL(templateDirectory: URL, component: String) -> URL
+}
+```
+
+  Keep it Foundation-only (the Linux CI lane builds AnglesiteCore — no Darwin-only APIs).
+
+- [ ] **Step 1: Write the failing tests** `Tests/AnglesiteCoreTests/AnimationCatalogTests.swift` (Swift Testing, resolve the real template via `AnglesiteTestSupport.templateRoot()` like `IntegrationTemplateAssetsTests`):
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct AnimationCatalogTests {
+    @Test func loadsRealTemplateCatalog() throws {
+        let catalog = try AnimationCatalog.load(templateDirectory: try templateRoot())
+        #expect(!catalog.entries.isEmpty)
+        for entry in catalog.entries {
+            #expect(!entry.snippet.contains("enhance={true}"))
+            let demo = AnimationCatalog.demoURL(
+                templateDirectory: try templateRoot(), component: entry.component)
+            #expect(FileManager.default.fileExists(atPath: demo.path), "\(entry.component)")
+        }
+    }
+
+    @Test func groupsByCategory() throws {
+        let catalog = try AnimationCatalog.load(templateDirectory: try templateRoot())
+        let grouped = AnimationCategory.allCases.flatMap { catalog.entries(in: $0) }
+        #expect(grouped.count == catalog.entries.count)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.** `swift test --filter AnimationCatalogTests` → FAIL (type not defined).
+- [ ] **Step 3: Implement `AnimationCatalog.swift`** — decode a private `ManifestFile { version: Int; components: [AnimationCatalogEntry] }` from `templateDirectory/integrations/animations.json`; `demoURL` appends `integrations/animations-demos/\(component).html`.
+- [ ] **Step 4: Run to verify pass.** `swift test --filter AnimationCatalogTests` → PASS.
+- [ ] **Step 5: Commit** — `feat(core): AnimationCatalog model for template catalog (#<ISSUE_B>)`.
+
+### Task 6: Gallery sheet + Website menu item
+
+**Files:**
+- Create: `Sources/AnglesiteApp/AnimationsGalleryView.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift` (add `animationsPresented` state + `presentAnimations()` + `canOpenAnimations`, following the `presentReader()` pattern near line 289)
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift` (add `.sheet(isPresented: $bindableModel.animationsPresented)` beside the existing sheets ~line 541)
+- Modify: `Sources/AnglesiteApp/WebsiteCommands.swift` (add `Button("Animations…") { model?.presentAnimations() }` next to `"Add Integration…"`, line ~76)
+
+**Interfaces:**
+- Consumes: `AnimationCatalog.load(templateDirectory:)`, `entries(in:)`, `demoURL(templateDirectory:component:)`, `TemplateRuntime` (existing) for resolving the bundled template root.
+
+- [ ] **Step 1: Implement `AnimationsGalleryView`** — `NavigationSplitView` (sidebar: sections per `AnimationCategory` with entry titles; detail: `ownerDescription`, key-props table, `WKWebView` via `NSViewRepresentable` loading `demoURL` with `loadFileURL(_:allowingReadAccessTo: templateRoot)`, and a **Copy Snippet** button writing `entry.snippet` to `NSPasteboard.general`). Model state (selected entry, catalog load-or-error) in a small `@Observable AnimationsGalleryModel` in the same file; catalog load errors render as a plain error view, never a crash.
+- [ ] **Step 2: Wire model + sheet + menu** per the Files list; the menu button is `.disabled` when no site window is active (`canOpenAnimations`, same shape as `canOpenSocialPlan`).
+- [ ] **Step 3: Build the app** — `xcodegen generate && xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` → succeeds.
+- [ ] **Step 4: Sync the String Catalog** (new user-visible strings) with the CONTRIBUTING.md recipe, scoped to this worktree's DerivedData (match `WorkspacePath`); review + include the `.xcstrings` diff.
+- [ ] **Step 5: Verify in the running app** — launch the built app, open a site, Website ▸ Animations…, confirm a demo animates and Copy Snippet fills the pasteboard (beware duplicate installed-copy instances per repo memory).
+- [ ] **Step 6: Full test + commit + PR B** — `swift test --package-path .`; commit `feat(app): Animations gallery for template components (#<ISSUE_B>)`; open PR B **based on the WS1 branch** (stacked; note in body: retarget to `main` after PR A merges — a bare retarget doesn't trigger CI, push a real commit or rebase+force-push per repo memory). PR body from the template's exact headings; note "Add with assistant" follow-up. Remove the In Progress label from Issue B.
+
+---
+
+## Workstream 3 — Sidecar skill + ADR (sidecar repo, Issue C)
+
+### Task 7: Extend ADR-0008's npm carve-out
+
+**Files:**
+- Modify: `docs/decisions/0008-no-third-party-javascript.md` (sidecar checkout `~/Developer/github.com/Anglesite/anglesite`, in a fresh worktree/branch)
+
+- [ ] **Step 1: Append to the "Creative coding libraries (not third-party)" section:**
+
+```markdown
+The same reasoning covers npm-installed **animation component libraries**. The
+Anglesite site template ships `@astroanimate/core` (exact-pinned) as a default
+dependency: its components are CSS-first, rendered at build time, and served
+first-party under `script-src 'self'`. One constraint applies: the library's
+`enhance` prop emits inline `<script>` tags, which the template CSP blocks
+(no `'unsafe-inline'`, no hashes) — so only CSS-only usage (`enhance` unset or
+`false`) is supported. The curated list lives in the site's
+`integrations/docs/animations.md`.
+```
+
+- [ ] **Step 2: Commit** — `docs(adr): cover animation component libraries in ADR-0008 (#<ISSUE_C>)`.
+
+### Task 8: `/animate` skill escalation section
+
+**Files:**
+- Modify: `skills/animate/SKILL.md`
+- Modify: `agent-skills/animate/…` — inspect this directory first; if it duplicates the same rule text, apply the same edit there.
+
+- [ ] **Step 1: Replace the absolute prohibition.** The current text: "**Never use JavaScript for animation.**" and the ADR list entry "no JavaScript animation libraries" stay, but gain the escalation carve-out. After the "Your CSS toolkit" section, add:
+
+```markdown
+## Escalation: the baked-in component library
+
+The site template ships `@astroanimate/core` (see `integrations/docs/animations.md`
+in the site for the curated list). Vanilla CSS remains your default craft. Reach for
+a library component only when it beats hand-written CSS for the request — marquees,
+typewriter/staggered text, card-stack effects, loaders — and then:
+
+- Use only components listed in `integrations/docs/animations.md`, with the exact
+  import style shown there (`import X from "@astroanimate/core/X"`).
+- **Never set `enhance={true}`** — it emits inline scripts the site's CSP blocks in
+  production. CSS-only mode is the supported mode.
+- The reduced-motion rule still applies: library components carry their own
+  `prefers-reduced-motion` guard; your surrounding CSS keeps its own.
+- Preview-before-apply still applies. For library components, preview on a draft
+  page via the dev server (the static `_animation-preview.html` flow can't render
+  `.astro` components).
+```
+
+- [ ] **Step 2: Reconcile the ADR reference list** in the same file: change "no JavaScript animation libraries" to "no JavaScript animation *runtimes*; the baked-in CSS-first component library is the recorded exception (ADR-0008)".
+- [ ] **Step 3: Commit + PR C** in the sidecar repo — `feat(animate): escalate to baked-in @astroanimate components (#<ISSUE_C>)`. The sidecar has no PR template; use Summary / Test plan and link the app-repo spec. Note ordering: merge after app PR A.
+
+---
+
+## Self-review notes
+
+- Spec coverage: dependency+override (T1), manifest+curation gate (T2), demos+docs (T3), guards+re-vendor (T4), Swift model (T5), gallery+menu (T6), ADR (T7), skill (T8). "Add with assistant" is spec-deferred (follow-up in Issue B). Sub-package adoption is a spec non-goal.
+- The Astro Container API import of catalog entries uses the package export map verified against the published tarball (0.1.2).
+- Type names consistent: `AnimationCatalog`, `AnimationCatalogEntry`, `AnimationCategory` across T5/T6.

--- a/docs/superpowers/specs/2026-07-27-astro-animate-design.md
+++ b/docs/superpowers/specs/2026-07-27-astro-animate-design.md
@@ -1,0 +1,153 @@
+# Astro Animate in Anglesite — design
+
+**Date:** 2026-07-27
+**Status:** Approved (brainstorm 2026-07-27)
+**Repos:** `Anglesite/Anglesite-app` (template + app gallery), `Anglesite/anglesite` (skill + ADR amendment)
+
+## Context
+
+[Astro Animate](https://www.astroanimate.com) is an MIT-licensed, Astro-native animated
+component library. As of 2026-07-27 only **`@astroanimate/core@0.1.2`** is published on
+npm — the `@astroanimate/aos`, `@astroanimate/gsap`, and `@astroanimate/motion` packages
+advertised on the website do not exist yet. Core is a ~32-component animated UI kit
+(FadeInText, CountUp, InfiniteMarquee, GlassCard, Dock, TypewriterText, …) built
+CSS-first: components render meaningful content with zero client JS by default, opt into
+an IntersectionObserver path via an `enhance` prop, and respect
+`prefers-reduced-motion`. Its peer dependency range is `astro ^4 || ^5 || ^6`; the
+Anglesite template runs Astro `^7.1.3`, so installing it requires an npm `overrides`
+pin. Inspection of the shipped components shows no version-specific Astro APIs — the
+peer range is conservative, not a known incompatibility.
+
+Anglesite today has two animation-adjacent lanes:
+
+- The sidecar's conversational **`/animate` skill** — a "motion designer" that
+  hand-writes vanilla CSS, bound by ADR-0004 (vanilla CSS custom properties) and
+  ADR-0008 (no third-party JavaScript).
+- The app's deterministic **Integration Wizard**
+  (`Sources/AnglesiteCore/IntegrationCatalog.swift` + `Resources/Template/integrations/`)
+  for capabilities needing configuration.
+
+## Decisions (from the brainstorm)
+
+1. **Bake into the template.** `@astroanimate/core` ships as a default template
+   dependency; every new site has it with no install step. The wizard is not the
+   vehicle — this capability needs no keys or configuration.
+2. **npm dependency, not vendored.** Track upstream via the package (exact-pinned),
+   accepting the peer-override cost. If upstream dies, the MIT license lets us vendor
+   the curated components later without breaking sites.
+3. **Adopt future sub-packages deliberately.** `aos`/`gsap`/`motion` are adopted in a
+   follow-up decision if/when they actually publish — not designed for now.
+4. **Skill stance: CSS-first, library as escalation.** The `/animate` skill keeps
+   vanilla CSS as its default craft and reaches for Astro Animate components when CSS
+   can't deliver well (spring-like physics, orchestrated sequences, counters,
+   marquees).
+5. **Full product surface.** Curated manifest + docs + smoke tests + an app-side
+   gallery UI (approach C).
+
+## Goals
+
+- A website owner can browse real, animating previews of the curated components in the
+  app and get one into a page via copy-paste or the assistant.
+- The `/animate` skill escalates to real component names and props instead of
+  hallucinating an API.
+- Breakage from the Astro-7 peer override or upstream churn is caught by CI, not by
+  owners.
+
+## Non-goals
+
+- No deterministic "insert component into page X at position Y" machinery — placement
+  stays conversational.
+- No adoption of unpublished sub-packages; no GSAP runtime.
+- No exposure of all 32 components — only the vetted subset.
+
+## Architecture
+
+### 1. Template capability (`Resources/Template/`, app repo)
+
+- `package.json`: add `"@astroanimate/core": "0.1.2"` (exact pin, no caret) to
+  `dependencies`, plus:
+
+  ```json
+  "overrides": { "@astroanimate/core": { "astro": "$astro" } }
+  ```
+
+  so npm resolves the peer dependency to the template's Astro without `ERESOLVE`
+  failures. Regenerate `package-lock.json`.
+- **Curation manifest** — `integrations/animations.json`, the single source of truth
+  consumed by both the docs and the app gallery. Per entry:
+  `component`, `title`, `ownerDescription` (owner-language, e.g. "a number that counts
+  up when it scrolls into view"), `category` (`text` | `cards` | `buttons` |
+  `backgrounds` | `navigation`), `keyProps`, `snippet` (import + usage). Only
+  components that pass a curation pass are listed: renders under Astro 7, respects
+  `prefers-reduced-motion`, slot content meaningful without JS.
+- **Docs** — `integrations/docs/animations.md` beside the existing setup docs: the
+  human/agent-readable catalog (kept in sync with the manifest; a template test
+  cross-checks the two).
+- **Container image** — the image bakes the template's full `node_modules`, so this
+  change re-vendors the image (both vendor scripts + rebuild).
+
+### 2. App gallery (app repo)
+
+**Website ▸ Animations…** menu item opening a gallery:
+
+- **Preview without the dev server.** A template script (built on the existing
+  `component-harness`) prerenders each curated component demo into self-contained
+  static HTML (the components are scoped CSS + optional inline scripts, so prerendered
+  demos animate for real). The demo files are **generated and committed** under
+  `Resources/Template/integrations/` — a template test regenerates and diffs them so
+  stale demos fail CI — and the app bundles them as resources. The gallery is a
+  SwiftUI list (categories from `animations.json`) with a `WKWebView` rendering the
+  selected demo — works offline, before any site container boots, and nothing can leak
+  preview pages into a deployed site.
+- **Actions:** *Copy snippet* (from the manifest) and *Add with assistant* (pre-fills
+  the chat, e.g. "Add a CountUp animation to …"), keeping placement conversational.
+- Gallery model code lives in `AnglesiteCore` (manifest decoding, snippet provision) so
+  it's testable without the app host; the SwiftUI shell stays thin.
+
+### 3. Sidecar changes (`Anglesite/anglesite`, separate PR)
+
+- **ADR-0008 amended** (recorded, not silently violated): "no third-party JavaScript"
+  becomes "no third-party *runtime* JS except capabilities vetted and baked into the
+  template (currently `@astroanimate/core`); external CDN scripts remain forbidden."
+  ADR-0004 gains a cross-reference note.
+- **`/animate` skill** gains an escalation section: vanilla CSS by default; for effects
+  CSS can't do well, consult the site's `integrations/docs/animations.md` and use the
+  cataloged components by name with their real props. The preview-before-apply and
+  reduced-motion rules apply unchanged.
+
+Ordering: app PR lands first (capability exists in sites), sidecar PR follows. This is
+not an MCP schema change, so no paired-PR requirement.
+
+## Testing
+
+- **Template suite** (`npm test` in `Resources/Template/`): a harness smoke test
+  renders every curated component, asserting its marker attribute and reduced-motion
+  CSS are emitted; a consistency test asserts every `animations.json` entry resolves to
+  a real component in the installed package and appears in `animations.md`. This is the
+  tripwire that turns "peer override silently breaks on a future Astro major" into red
+  CI.
+- **Swift suite:** tests for manifest decoding, category grouping, and snippet
+  provision; run the template-coupled guards (`IntegrationTemplateAssetsTests`,
+  `ProjectValidator` suites) since template files change.
+- **Container:** re-vendor, rebuild, and verify site preview boots.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Upstream is 0.1.x, single maintainer | Exact pin; MIT fallback to vendoring the curated subset |
+| Peer override masks a real future incompatibility | Harness smoke test over every curated component |
+| Advertised sub-packages never ship | Core-only design; sub-packages are an explicit later decision |
+| A11y regressions from library components | Curation gate requires reduced-motion + no-JS fallback per component |
+| Bundle bloat | CSS-first (~0.5 KB/component, JS only with `enhance`); no CSP/external domains |
+
+## Rollout / process
+
+1. Open a tracking issue proposing the `@astroanimate/core` template dependency
+   (CONTRIBUTING requires explicit dependency approval in an issue) and claim it with
+   the `🛠️ In Progress` label.
+2. App PR: template dependency + manifest + docs + harness tests + gallery + container
+   re-vendor. Template changes are app-only.
+3. Sidecar PR: ADR amendment + `/animate` escalation section.
+4. Follow-up (untracked until relevant): revisit when upstream publishes Astro 7
+   support or the `aos`/`gsap`/`motion` packages.

--- a/docs/superpowers/specs/2026-07-27-astro-animate-design.md
+++ b/docs/superpowers/specs/2026-07-27-astro-animate-design.md
@@ -79,7 +79,12 @@ Anglesite today has two animation-adjacent lanes:
   up when it scrolls into view"), `category` (`text` | `cards` | `buttons` |
   `backgrounds` | `navigation`), `keyProps`, `snippet` (import + usage). Only
   components that pass a curation pass are listed: renders under Astro 7, respects
-  `prefers-reduced-motion`, slot content meaningful without JS.
+  `prefers-reduced-motion`, slot content meaningful without JS, **and emits zero
+  `<script>` tags under the cataloged props**. The last rule is load-bearing: the
+  template CSP is `script-src 'self' 'wasm-unsafe-eval' …` with no `'unsafe-inline'`
+  and no hashes, and the library's `enhance=true` mode emits `is:inline` scripts that
+  the CSP would block in production. v1 catalogs CSS-only usage (`enhance` stays
+  `false`); JS-requiring components are excluded.
 - **Docs** — `integrations/docs/animations.md` beside the existing setup docs: the
   human/agent-readable catalog (kept in sync with the manifest; a template test
   cross-checks the two).
@@ -99,17 +104,21 @@ Anglesite today has two animation-adjacent lanes:
   SwiftUI list (categories from `animations.json`) with a `WKWebView` rendering the
   selected demo — works offline, before any site container boots, and nothing can leak
   preview pages into a deployed site.
-- **Actions:** *Copy snippet* (from the manifest) and *Add with assistant* (pre-fills
-  the chat, e.g. "Add a CountUp animation to …"), keeping placement conversational.
+- **Actions:** *Copy snippet* (from the manifest) in v1. An *Add with assistant*
+  action (pre-filling the chat) is deferred: the app currently has no chat-prefill
+  API, and inventing one is out of scope here — tracked as a follow-up in the gallery
+  issue.
 - Gallery model code lives in `AnglesiteCore` (manifest decoding, snippet provision) so
   it's testable without the app host; the SwiftUI shell stays thin.
 
 ### 3. Sidecar changes (`Anglesite/anglesite`, separate PR)
 
-- **ADR-0008 amended** (recorded, not silently violated): "no third-party JavaScript"
-  becomes "no third-party *runtime* JS except capabilities vetted and baked into the
-  template (currently `@astroanimate/core`); external CDN scripts remain forbidden."
-  ADR-0004 gains a cross-reference note.
+- **ADR-0008 extended, not reversed.** The ADR already carves out npm-installed,
+  Astro-bundled libraries (p5.js, Three.js, GSAP, …) as *first-party* under
+  `script-src 'self'` ("Creative coding libraries (not third-party)"). The change is a
+  one-paragraph extension naming animation component libraries (`@astroanimate/core`)
+  under the same carve-out, plus a note that its `enhance` mode emits inline scripts
+  the template CSP blocks — CSS-only usage is the supported mode.
 - **`/animate` skill** gains an escalation section: vanilla CSS by default; for effects
   CSS can't do well, consult the site's `integrations/docs/animations.md` and use the
   cataloged components by name with their real props. The preview-before-apply and
@@ -140,6 +149,7 @@ not an MCP schema change, so no paired-PR requirement.
 | Advertised sub-packages never ship | Core-only design; sub-packages are an explicit later decision |
 | A11y regressions from library components | Curation gate requires reduced-motion + no-JS fallback per component |
 | Bundle bloat | CSS-first (~0.5 KB/component, JS only with `enhance`); no CSP/external domains |
+| `enhance=true` inline scripts blocked by strict CSP | Curation gate: catalog only zero-`<script>` usage; smoke test enforces |
 
 ## Rollout / process
 


### PR DESCRIPTION
## Summary

- Adds `@astroanimate/core@0.1.2` as a template dependency — exact pin, with an npm `overrides` entry resolving its conservative `astro ^4||^5||^6` peer range to the template's Astro 7 (closes #1006, the dependency-approval issue).
- Curates 16 of the package's 33 components into `integrations/animations.json` + owner docs `integrations/docs/animations.md`, with prerendered self-contained demo snapshots under `integrations/animations-demos/` for the upcoming app gallery (#1007). `GlassCard` was the one candidate rejected: it emits an unconditional `<script>` tag, failing the CSP gate below.
- New Vitest + Astro Container suite (`npm run test:astro`, wired into the template `test` script) enforces the curation invariants: every cataloged component renders under Astro 7, emits **zero `<script>` tags** with its cataloged props (the template CSP has no `'unsafe-inline'`/hashes, so the library's `enhance=true` inline scripts would be blocked in production — CSS-only usage is the supported mode), carries a `prefers-reduced-motion` guard, has a fresh demo snapshot, and is documented.
- Includes the design spec + implementation plan (`docs/superpowers/`).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

Template-only change, no MCP schema change. The sidecar PR Anglesite/anglesite#427 (ADR-0008 extension + `/animate` skill escalation, issue Anglesite/anglesite#426) is coordinated but independent; it should merge after this PR.

## Test plan

- [x] `swift test --package-path .` — full suite green (2739 tests / 355 suites in the main run group; all run groups passed, exit 0). Includes the template-coupled guards (`IntegrationTemplateAssetsTests`, `ProjectValidator`).
- [x] Template suites: `npm run test:scripts` and `npm run test:astro` (35/35 — curation invariants above) from `Resources/Template/`.
- [x] `scripts/vendor-container-image.sh` re-vendored (image bakes template `node_modules`), exit 0.
- [ ] `xcodebuild … build` — not run for this PR (no Swift/app-target changes; template + docs only). The app build is exercised in the stacked gallery PR for #1007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)