### PR TITLE
fix(#916): collect required .url values before writing an entry

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1061,6 +1061,9 @@
     "Enter a valid mail domain and at least one MX host to prepare the DNS records." : {
 
     },
+    "Enter an absolute URL, e.g. https://example.com/post" : {
+
+    },
     "Enter the domain to harden" : {
 
     },

--- a/Sources/AnglesiteApp/NewContentSheets.swift
+++ b/Sources/AnglesiteApp/NewContentSheets.swift
@@ -155,18 +155,22 @@ struct NewPageSheet: View {
 
 struct NewCollectionEntrySheet: View {
     let descriptors: [ContentTypeDescriptor]
-    let onCreate: (String, String?, ContentTypeDescriptor) async -> ContentCreateResult
+    let onCreate: (String, String?, ContentTypeDescriptor, [String: String]) async -> ContentCreateResult
 
     @Environment(\.dismiss) private var dismiss
     @State private var title = ""
     @State private var slug = ""
     @State private var selectedID: String
+    /// Values for the selected type's required `.url` fields, keyed by field name. A bookmark,
+    /// reply, or like is schema-invalid without one, so these are collected before the write rather
+    /// than scaffolded empty (#916).
+    @State private var urlValues: [String: String] = [:]
     @State private var isCreating = false
     @State private var errorMessage: String?
 
     init(
         descriptors: [ContentTypeDescriptor],
-        onCreate: @escaping (String, String?, ContentTypeDescriptor) async -> ContentCreateResult
+        onCreate: @escaping (String, String?, ContentTypeDescriptor, [String: String]) async -> ContentCreateResult
     ) {
         self.descriptors = descriptors
         self.onCreate = onCreate
@@ -189,9 +193,26 @@ struct NewCollectionEntrySheet: View {
                                 Text(descriptor.displayName).tag(descriptor.id)
                             }
                         }
-                        TextField("Title", text: $title)
+                        // A reply or like has no title field — it is identified by its target URL,
+                        // so asking for a title would collect a value the entry never stores (#916).
+                        if selectedDescriptor?.titleField != nil {
+                            TextField("Title", text: $title)
+                        }
+                        // Field names match the inspector's labels in `TypedEntryForm`.
+                        ForEach(requiredURLFields, id: \.name) { field in
+                            TextField(
+                                field.name,
+                                text: urlBinding(field.name),
+                                prompt: Text(verbatim: "https://example.com/post"))
+                        }
                         TextField("Slug", text: $slug, prompt: Text("optional"))
+                        if hasMalformedURL {
+                            Text("Enter an absolute URL, e.g. https://example.com/post")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
                     }
+                    .onChange(of: selectedID) { urlValues = [:] }
                     if let selectedCollection {
                         Section("Destination") {
                             LabeledContent("Collection", value: selectedCollection)
@@ -216,7 +237,7 @@ struct NewCollectionEntrySheet: View {
                     Button(isCreating ? "Creating…" : "Create") {
                         create()
                     }
-                    .disabled(isCreating || selectedCollection == nil || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .disabled(isCreating || selectedCollection == nil || !titleIsSatisfied || !urlFieldsAreValid)
                 }
             }
         }
@@ -230,14 +251,50 @@ struct NewCollectionEntrySheet: View {
         selectedDescriptor?.collection
     }
 
+    private var requiredURLFields: [ContentTypeField] {
+        selectedDescriptor?.requiredURLFields ?? []
+    }
+
+    private func urlBinding(_ name: String) -> Binding<String> {
+        Binding(get: { urlValues[name] ?? "" }, set: { urlValues[name] = $0 })
+    }
+
+    private func trimmedURL(_ name: String) -> String {
+        (urlValues[name] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Every required `.url` field holds a value the write boundary will accept.
+    private var urlFieldsAreValid: Bool {
+        requiredURLFields.allSatisfy { ContentFieldValidation.isAbsoluteURL(trimmedURL($0.name)) }
+    }
+
+    /// A field the user has started typing into that isn't a valid URL yet — drives the hint below
+    /// the fields. Empty fields don't nag; they just leave Create disabled.
+    private var hasMalformedURL: Bool {
+        requiredURLFields.contains {
+            let value = trimmedURL($0.name)
+            return !value.isEmpty && !ContentFieldValidation.isAbsoluteURL(value)
+        }
+    }
+
+    /// Types without a title field impose no title requirement.
+    private var titleIsSatisfied: Bool {
+        selectedDescriptor?.titleField == nil
+            || !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     private func create() {
         guard let descriptor = selectedDescriptor, selectedCollection != nil else { return }
         let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let cleanSlug = slug.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanURLs = requiredURLFields.reduce(into: [String: String]()) { values, field in
+            values[field.name] = trimmedURL(field.name)
+        }
         isCreating = true
         errorMessage = nil
         Task {
-            let result = await onCreate(cleanTitle, cleanSlug.isEmpty ? nil : cleanSlug, descriptor)
+            let result = await onCreate(
+                cleanTitle, cleanSlug.isEmpty ? nil : cleanSlug, descriptor, cleanURLs)
             await MainActor.run {
                 isCreating = false
                 switch result {

--- a/Sources/AnglesiteApp/NewContentSheets.swift
+++ b/Sources/AnglesiteApp/NewContentSheets.swift
@@ -212,7 +212,16 @@ struct NewCollectionEntrySheet: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    .onChange(of: selectedID) { urlValues = [:] }
+                    // Switching type changes which fields exist, so per-type input must not survive
+                    // the switch. `title` in particular becomes invisible after a switch to a
+                    // titleless type yet still wins slug precedence in NativeContentOperations — so
+                    // it has to be cleared here, not just hidden. `slug` is an explicit user override
+                    // and stays meaningful across types, so it is left alone.
+                    .onChange(of: selectedID) {
+                        title = ""
+                        urlValues = [:]
+                        errorMessage = nil
+                    }
                     if let selectedCollection {
                         Section("Destination") {
                             LabeledContent("Collection", value: selectedCollection)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -701,8 +701,9 @@ struct SiteWindow: View {
         .sheet(isPresented: $bindableModel.newCollectionPresented) {
             NewCollectionEntrySheet(
                 descriptors: contentTypeRegistry.all.filter { $0.collection != nil }
-            ) { title, slug, descriptor in
-                await model.createCollectionEntry(title: title, slug: slug, descriptor: descriptor)
+            ) { title, slug, descriptor, fieldValues in
+                await model.createCollectionEntry(
+                    title: title, slug: slug, descriptor: descriptor, fieldValues: fieldValues)
             }
         }
         .sheet(isPresented: $bindableModel.newPostPresented) {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1049,14 +1049,16 @@ final class SiteWindowModel {
     func createCollectionEntry(
         title: String,
         slug: String?,
-        descriptor: ContentTypeDescriptor
+        descriptor: ContentTypeDescriptor,
+        fieldValues: [String: String] = [:]
     ) async -> ContentCreateResult {
         guard let site else { return .siteNotFound }
         let result = await contentCreation.createTyped(
             siteID: site.id,
             typeID: descriptor.id,
             title: title,
-            slug: slug
+            slug: slug,
+            fieldValues: fieldValues
         )
         if case .created(let filePath, _) = result {
             await navigator?.refreshNow()

--- a/Sources/AnglesiteCore/ContentCreationWorkflow.swift
+++ b/Sources/AnglesiteCore/ContentCreationWorkflow.swift
@@ -20,6 +20,7 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         _ typeID: String,
         _ title: String,
         _ slug: String?,
+        _ fieldValues: [String: String],
         _ onProgress: ProgressHandler?
     ) async -> ContentCreateResult
     public typealias ContentDeleter = @Sendable (_ siteID: String, _ relativePath: String) async -> ContentDeleteResult
@@ -102,12 +103,13 @@ public struct ContentCreationWorkflow: ContentOperationsService {
                     onProgress: onProgress
                 )
             },
-            typedSlugCreator: { siteID, typeID, title, slug, onProgress in
+            typedSlugCreator: { siteID, typeID, title, slug, fieldValues, onProgress in
                 await native.createTyped(
                     siteID: siteID,
                     typeID: typeID,
                     title: title,
                     slug: slug,
+                    fieldValues: fieldValues,
                     onProgress: onProgress
                 )
             },
@@ -210,16 +212,20 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         return result
     }
 
+    /// `fieldValues` carries values collected before the write (required `.url` fields — #916). It
+    /// reaches `NativeContentOperations` only through `typedSlugCreator`; the `operations` fallback
+    /// is the title-only `ContentOperationsService` witness and necessarily drops them.
     public func createTyped(
         siteID: String,
         typeID: String,
         title: String,
         slug: String?,
+        fieldValues: [String: String] = [:],
         onProgress: ProgressHandler? = nil
     ) async -> ContentCreateResult {
         let result: ContentCreateResult
         if let typedSlugCreator {
-            result = await typedSlugCreator(siteID, typeID, title, slug, onProgress)
+            result = await typedSlugCreator(siteID, typeID, title, slug, fieldValues, onProgress)
         } else {
             result = await operations.createTyped(
                 siteID: siteID,

--- a/Sources/AnglesiteCore/ContentFieldValidation.swift
+++ b/Sources/AnglesiteCore/ContentFieldValidation.swift
@@ -1,0 +1,27 @@
+// Sources/AnglesiteCore/ContentFieldValidation.swift
+import Foundation
+
+/// Value checks for `ContentTypeField` values, applied before a content entry is written to disk.
+///
+/// Scaffolding renders; this validates. Kept separate from `ContentScaffold` so the create path can
+/// reject a bad value *before* asking for a render, and so the rules are testable on their own.
+public enum ContentFieldValidation {
+    /// Whether `value` is an absolute URL with a scheme **and** a non-empty host.
+    ///
+    /// Deliberately stricter than the template's `z.string().url()`, which accepts anything
+    /// `new URL()` parses — including `mailto:` and other host-less schemes. A `.url` field feeds a
+    /// `u-*` microformat property (`u-bookmark-of`, `u-in-reply-to`, `u-like-of`), which needs a
+    /// dereferenceable target, so requiring a host is the useful rule. Anything accepted here is
+    /// accepted by `z.string().url()`, so a value that passes never fails `astro check`.
+    ///
+    /// Mirrors the same host-not-just-scheme rule `IntegrationPlanner` applies to its `.url` fields.
+    public static func isAbsoluteURL(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let components = URLComponents(string: trimmed),
+              let scheme = components.scheme, !scheme.isEmpty,
+              let host = components.host, !host.isEmpty
+        else { return false }
+        return true
+    }
+}

--- a/Sources/AnglesiteCore/ContentFieldValidation.swift
+++ b/Sources/AnglesiteCore/ContentFieldValidation.swift
@@ -12,7 +12,8 @@ public enum ContentFieldValidation {
     /// `new URL()` parses — including `mailto:` and other host-less schemes. A `.url` field feeds a
     /// `u-*` microformat property (`u-bookmark-of`, `u-in-reply-to`, `u-like-of`), which needs a
     /// dereferenceable target, so requiring a host is the useful rule. Anything accepted here is
-    /// accepted by `z.string().url()`, so a value that passes never fails `astro check`.
+    /// accepted by `z.string().url()` — including the port range, see below — so a value that
+    /// passes never fails `astro check`.
     ///
     /// Mirrors the same host-not-just-scheme rule `IntegrationPlanner` applies to its `.url` fields.
     public static func isAbsoluteURL(_ value: String) -> Bool {
@@ -20,7 +21,11 @@ public enum ContentFieldValidation {
         guard !trimmed.isEmpty,
               let components = URLComponents(string: trimmed),
               let scheme = components.scheme, !scheme.isEmpty,
-              let host = components.host, !host.isEmpty
+              let host = components.host, !host.isEmpty,
+              // `URLComponents` parses ports above 65535 (e.g. `:99999`) without complaint, but the
+              // WHATWG URL parser behind `z.string().url()` rejects anything outside 0...65535 — so
+              // this bound has to be enforced here to keep the two parsers' accept sets in sync.
+              components.port.map { (0...65_535).contains($0) } ?? true
         else { return false }
         return true
     }

--- a/Sources/AnglesiteCore/ContentFieldValidation.swift
+++ b/Sources/AnglesiteCore/ContentFieldValidation.swift
@@ -19,6 +19,14 @@ public enum ContentFieldValidation {
     public static func isAbsoluteURL(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
+              // `URLComponents` rejects an interior space but happily parses an interior or
+              // trailing newline (unlike `new URL()`/WHATWG, which reject both) — and
+              // `ContentScaffold.escapeYAML` only escapes `\` and `"`, not newlines. A value with a
+              // raw newline would therefore pass this check but split the YAML frontmatter line it's
+              // written into (e.g. `bookmarkOf: "https://example.com/post\nevil: true"` becomes two
+              // YAML lines). No legitimate absolute URL contains raw whitespace, so reject any that
+              // does, after trimming, rather than relying on the parser to catch it.
+              trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
               let components = URLComponents(string: trimmed),
               let scheme = components.scheme, !scheme.isEmpty,
               let host = components.host, !host.isEmpty,

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -50,6 +50,36 @@ public enum ContentScaffold {
         "src/content/\(collection)/\(slug).md"
     }
 
+    /// Derive a slug from a target URL, for content types with no title field to slugify — `reply`
+    /// and `like` are identified by what they point at, not by a name (#916).
+    ///
+    /// `yyyy-MM-dd` (UTC, same clock and formatter family `renderEntry` uses) + the host with a
+    /// leading `www.` dropped + the last non-empty path component, all through `slugify`. Query and
+    /// fragment are ignored. The date prefix keeps entries chronologically sortable and makes
+    /// collisions practically impossible — two replies to the same URL on the same day — while
+    /// keeping the permalink descriptive; it matches the IndieWeb convention for replies and likes.
+    ///
+    /// Returns `""` when `value` has no host, so callers fall back to their own default rather than
+    /// producing a date-only slug that says nothing about the entry.
+    public static func slugFromURL(_ value: String, now: Date) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let components = URLComponents(string: trimmed),
+              let host = components.host, !host.isEmpty
+        else { return "" }
+
+        let bareHost = host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+        let lastSegment = components.path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .last
+            .map(String.init) ?? ""
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let day = String(formatter.string(from: now).prefix(10))
+
+        return slugify([day, bareHost, lastSegment].filter { !$0.isEmpty }.joined(separator: "-"))
+    }
+
     public static func singletonRelativePath(slot: String) -> String {
         "src/data/\(slot).json"
     }

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -137,7 +137,15 @@ public enum ContentScaffold {
     /// Render a new content entry's file contents from its descriptor: a YAML frontmatter block
     /// (one line per non-markdown field, in declaration order) followed by a placeholder body for
     /// the type's `markdown` field, if any. Pure; mirrors `renderPost`'s ISO8601 date format.
-    public static func renderEntry(descriptor: ContentTypeDescriptor, title: String?, now: Date) -> String {
+    /// `fieldValues` supplies caller-collected values by field name for the scalar-string kinds
+    /// (`.string`, `.text`, `.url`, `.image`); an absent key falls back to the title-like/empty
+    /// default. Still pure — an empty `fieldValues` renders exactly what it rendered before (#916).
+    public static func renderEntry(
+        descriptor: ContentTypeDescriptor,
+        title: String?,
+        now: Date,
+        fieldValues: [String: String] = [:]
+    ) -> String {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let dateTime = formatter.string(from: now)
@@ -165,16 +173,19 @@ public enum ContentScaffold {
             case .stringArray, .imageArray:
                 lines.append("\(field.name): []")
             case .string, .text, .image:
-                let value = ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
-                lines.append("\(field.name): \"\(escapeYAML(value))\"")
-            // Optional `.url` fields scaffold commented-out: an emitted `""` is not a valid URL
-            // under `z.string().url()`, unlike `.string`/`.text`/`.image`'s bare `z.string()`,
-            // which accepts an empty string. Mirrors the `.datetime`/`.date` comment-out rationale
-            // above. Required ones (bookmarkOf, inReplyTo, likeOf) stay live — those entries are
-            // already incomplete without them, same as every other required field.
+                lines.append("\(field.name): \"\(escapeYAML(scalarValue(field, title: title, fieldValues: fieldValues)))\"")
+            // A `.url` line is commented out only when the field is optional *and* nothing was
+            // supplied: an emitted `""` is not a valid URL under `z.string().url()`, unlike
+            // `.string`/`.text`/`.image`'s bare `z.string()`, which accepts an empty string.
+            // Mirrors the `.datetime`/`.date` comment-out rationale above (#913). A supplied value
+            // always renders live — that is how the create path pre-fills the required
+            // `bookmarkOf`/`inReplyTo`/`likeOf` so a new entry is schema-valid on first write
+            // (#916). Required fields with nothing supplied still render an empty live line; the
+            // create path refuses to write that, keeping this function a pure formatter.
             case .url:
-                let value = ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
-                lines.append("\(field.required ? "" : "# ")\(field.name): \"\(escapeYAML(value))\"")
+                let value = scalarValue(field, title: title, fieldValues: fieldValues)
+                let isLive = field.required || !value.isEmpty
+                lines.append("\(isLive ? "" : "# ")\(field.name): \"\(escapeYAML(value))\"")
             }
         }
         lines.append("---")
@@ -184,6 +195,17 @@ public enum ContentScaffold {
             output += "\n\(bodyPlaceholder)\n"
         }
         return output
+    }
+
+    /// The value for a scalar-string field: the caller's supplied value if there is one, otherwise
+    /// the entry title for a title-like field, otherwise empty.
+    private static func scalarValue(
+        _ field: ContentTypeField,
+        title: String?,
+        fieldValues: [String: String]
+    ) -> String {
+        if let supplied = fieldValues[field.name] { return supplied }
+        return ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
     }
 
     /// Render a per-site singleton (e.g. the representative h-card) as a JSON data module:

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -229,12 +229,22 @@ public enum ContentScaffold {
 
     /// The value for a scalar-string field: the caller's supplied value if there is one, otherwise
     /// the entry title for a title-like field, otherwise empty.
+    ///
+    /// The title fallback is deliberately skipped for `.url` fields: `titleLikeFieldNames` (`title`,
+    /// `name`, `itemReviewed`) is a name-based heuristic that assumes those names carry a
+    /// human-facing label, but a custom descriptor (via `ContentTypeRegistry.register(_:)`) could
+    /// declare an *optional* `.url` field named e.g. `name`. Falling back to the title there would
+    /// render a non-URL string into a `z.string().url()` slot as a *live* line — the field's
+    /// `isLive` rule in `renderEntry` treats any non-empty value as supplied — which is exactly the
+    /// kind of schema-invalid write this file exists to prevent. A caller-supplied `fieldValues`
+    /// entry still wins for `.url` fields; only the title fallback is suppressed.
     private static func scalarValue(
         _ field: ContentTypeField,
         title: String?,
         fieldValues: [String: String]
     ) -> String {
         if let supplied = fieldValues[field.name] { return supplied }
+        guard field.kind != .url else { return "" }
         return ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
     }
 

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -165,7 +165,7 @@ public enum ContentScaffold {
             case .stringArray, .imageArray:
                 lines.append("\(field.name): []")
             case .string, .text, .image:
-                let value = titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
+                let value = ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
                 lines.append("\(field.name): \"\(escapeYAML(value))\"")
             // Optional `.url` fields scaffold commented-out: an emitted `""` is not a valid URL
             // under `z.string().url()`, unlike `.string`/`.text`/`.image`'s bare `z.string()`,
@@ -173,7 +173,7 @@ public enum ContentScaffold {
             // above. Required ones (bookmarkOf, inReplyTo, likeOf) stay live — those entries are
             // already incomplete without them, same as every other required field.
             case .url:
-                let value = titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
+                let value = ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
                 lines.append("\(field.required ? "" : "# ")\(field.name): \"\(escapeYAML(value))\"")
             }
         }
@@ -204,7 +204,7 @@ public enum ContentScaffold {
             case .stringArray, .imageArray:
                 value = "[]"
             case .string, .text, .url, .image, .date, .datetime:
-                let filled = titleLikeFieldNames.contains(field.name) ? (name ?? "") : ""
+                let filled = ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (name ?? "") : ""
                 value = "\"\(escapeJSON(filled))\""
             }
             entries.append("\"\(field.name)\": \(value)")
@@ -272,8 +272,4 @@ public enum ContentScaffold {
         }
         return out
     }
-
-    // Not `private`: `MicropubContentSync` (#912) also reads this to fall back to a slug-derived
-    // title for a required title-like field a Micropub client didn't send.
-    static let titleLikeFieldNames: Set<String> = ["title", "name", "itemReviewed"]
 }

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -141,6 +141,25 @@ public struct ContentTypeDescriptor: Sendable, Equatable, Identifiable {
         if case let .singleton(name) = storage { return name }
         return nil
     }
+
+    /// Field names treated as a type's human-facing title, in no particular order. A descriptor
+    /// declares at most one of these; `ContentScaffold` fills whichever it declares from the
+    /// caller-supplied title (#386).
+    static let titleLikeFieldNames: Set<String> = ["title", "name", "itemReviewed"]
+
+    /// The field carrying this type's human-facing title, or `nil` when it has none. `reply` and
+    /// `like` have none — they are identified by their target URL, not by a name — so the create
+    /// UI hides the Title row for them and derives a slug from that URL instead (#916).
+    public var titleField: ContentTypeField? {
+        fields.first { Self.titleLikeFieldNames.contains($0.name) }
+    }
+
+    /// Required `.url` fields, in declaration order. The template schemas these project to are
+    /// `z.string().url()`, which rejects an empty string, so the create path must collect a value
+    /// for each one before writing rather than scaffolding a placeholder (#916).
+    public var requiredURLFields: [ContentTypeField] {
+        fields.filter { $0.kind == .url && $0.required }
+    }
 }
 
 /// An ordered, lookup-by-id catalog of content types. Value type so it composes cleanly into the

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -69,7 +69,7 @@ public enum MicropubContentSync {
     /// opposed to `itemReviewed`, which is also "title-like" for `ContentScaffold`'s placeholder-
     /// fill purposes but names the *reviewed item*, not the post — a slug-derived fallback would
     /// be nonsensical there).
-    private static let slugFallbackFieldNames = ContentScaffold.titleLikeFieldNames.subtracting(["itemReviewed"])
+    private static let slugFallbackFieldNames = ContentTypeDescriptor.titleLikeFieldNames.subtracting(["itemReviewed"])
 
     /// "my-trip-2026" → "My Trip 2026": the slug-derived title fallback for a required title-like
     /// field (`title`/`name`) a Micropub client didn't send (e.g. a nameless multi-photo post that

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -164,8 +164,18 @@ public struct NativeContentOperations: ContentOperationsService {
             return .failed(reason: "\(typeID) is not a collection type; use createTypedSingleton")
         }
 
+        // Trimmed copy of `fieldValues`, built alongside the validation loop below: `.url` values
+        // are trimmed here for both the guard and everything downstream, so the value that gets
+        // validated is exactly the value that gets rendered and slugged — not the raw, untrimmed
+        // input. Without this, a value like `"https://example.com/post\n"` passes validation (via
+        // its trimmed copy) but the untrimmed original — which `ContentScaffold.escapeYAML` doesn't
+        // clean up — is what reaches the file, splitting the YAML frontmatter (#916 follow-up).
+        var trimmedFieldValues = fieldValues
         for field in descriptor.fields where field.kind == .url {
             let supplied = fieldValues[field.name]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let supplied {
+                trimmedFieldValues[field.name] = supplied
+            }
             if field.required {
                 guard let supplied, ContentFieldValidation.isAbsoluteURL(supplied) else {
                     return .failed(reason:
@@ -178,6 +188,9 @@ public struct NativeContentOperations: ContentOperationsService {
             }
         }
 
+        // Single-sourced so the slug date and `publishDate` can never disagree across a UTC
+        // midnight boundary between the two `now()` calls this used to be.
+        let createdAt = now()
         let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let cleanSlug = (slug ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         // Slug precedence: explicit → title → target URL → type id. The URL step is what gives
@@ -185,8 +198,8 @@ public struct NativeContentOperations: ContentOperationsService {
         // (#916); it uses the first required `.url` field in declaration order, which is the only
         // one each of bookmark/reply/like declares.
         let urlSlug = descriptor.requiredURLFields.first
-            .flatMap { fieldValues[$0.name] }
-            .map { ContentScaffold.slugFromURL($0, now: now()) } ?? ""
+            .flatMap { trimmedFieldValues[$0.name] }
+            .map { ContentScaffold.slugFromURL($0, now: createdAt) } ?? ""
         let slugSource = [cleanSlug, cleanTitle, urlSlug].first { !$0.isEmpty } ?? descriptor.id
         let finalSlug = ContentScaffold.slugify(slugSource)
         guard !finalSlug.isEmpty else { return .failed(reason: "createTyped could not derive a slug") }
@@ -200,8 +213,8 @@ public struct NativeContentOperations: ContentOperationsService {
         // No `.createCallingPlugin` here: this is a native Swift write with no plugin involved.
         // `.createFinalizing` (below) covers the write + commit milestone honestly.
         let contents = ContentScaffold.renderEntry(
-            descriptor: descriptor, title: cleanTitle.isEmpty ? nil : cleanTitle, now: now(),
-            fieldValues: fieldValues)
+            descriptor: descriptor, title: cleanTitle.isEmpty ? nil : cleanTitle, now: createdAt,
+            fieldValues: trimmedFieldValues)
         do { try write(contents, to: abs) }
         catch { return .failed(reason: "\(error)") }
 

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -132,16 +132,26 @@ public struct NativeContentOperations: ContentOperationsService {
     }
 
     /// Create a typed content entry (V-1.2). Looks the type up in `registry`, derives a slug from
-    /// `slug ?? title`, renders frontmatter via `ContentScaffold.renderEntry`, writes it, and commits —
-    /// the same write/commit path as `createPost`. Collection-stored types only; singleton-stored types
-    /// (e.g. the `profile` identity) go through `createTypedSingleton`. The explicit-`slug` overload
-    /// is the native path's superset over the MCP witness (SiteWindow's per-type editor passes a
-    /// caller-chosen slug).
+    /// `slug ?? title ?? <target URL>`, renders frontmatter via `ContentScaffold.renderEntry`, writes
+    /// it, and commits — the same write/commit path as `createPost`. Collection-stored types only;
+    /// singleton-stored types (e.g. the `profile` identity) go through `createTypedSingleton`. The
+    /// explicit-`slug` overload is the native path's superset over the MCP witness (SiteWindow's
+    /// per-type editor passes a caller-chosen slug).
+    ///
+    /// `fieldValues` carries values collected before the write (the New Collection sheet's URL
+    /// rows). Every required `.url` field must have one that passes
+    /// `ContentFieldValidation.isAbsoluteURL`, and any supplied optional `.url` must too — this is
+    /// the boundary that makes a schema-invalid entry unwritable by *any* caller, not just the
+    /// sheet (#916). Note the `ContentOperationsService` protocol witness above is title-only, so a
+    /// non-native runtime cannot carry field values; unreachable today, and widening the protocol
+    /// would ripple into `RemoteSandboxSiteRuntime` (#66) / `LocalContainerSiteRuntime` (#69) for no
+    /// present benefit — same reasoning as the `createTypedSingleton` TODO below.
     public func createTyped(
         siteID: String,
         typeID: String,
         title: String,
         slug: String?,
+        fieldValues: [String: String] = [:],
         registry: ContentTypeRegistry = ContentTypeRegistry(),
         onProgress: ProgressHandler? = nil
     ) async -> ContentCreateResult {
@@ -154,9 +164,31 @@ public struct NativeContentOperations: ContentOperationsService {
             return .failed(reason: "\(typeID) is not a collection type; use createTypedSingleton")
         }
 
+        for field in descriptor.fields where field.kind == .url {
+            let supplied = fieldValues[field.name]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if field.required {
+                guard let supplied, ContentFieldValidation.isAbsoluteURL(supplied) else {
+                    return .failed(reason:
+                        "\(descriptor.displayName) needs an absolute URL for \(field.name), "
+                        + "e.g. https://example.com/post")
+                }
+            } else if let supplied, !supplied.isEmpty, !ContentFieldValidation.isAbsoluteURL(supplied) {
+                return .failed(reason:
+                    "\(field.name) must be an absolute URL, e.g. https://example.com/post")
+            }
+        }
+
         let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let cleanSlug = (slug ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let finalSlug = ContentScaffold.slugify(cleanSlug.isEmpty ? (cleanTitle.isEmpty ? descriptor.id : cleanTitle) : cleanSlug)
+        // Slug precedence: explicit → title → target URL → type id. The URL step is what gives
+        // `reply`/`like` a meaningful permalink now that they no longer ask for a throwaway title
+        // (#916); it uses the first required `.url` field in declaration order, which is the only
+        // one each of bookmark/reply/like declares.
+        let urlSlug = descriptor.requiredURLFields.first
+            .flatMap { fieldValues[$0.name] }
+            .map { ContentScaffold.slugFromURL($0, now: now()) } ?? ""
+        let slugSource = [cleanSlug, cleanTitle, urlSlug].first { !$0.isEmpty } ?? descriptor.id
+        let finalSlug = ContentScaffold.slugify(slugSource)
         guard !finalSlug.isEmpty else { return .failed(reason: "createTyped could not derive a slug") }
 
         let relPath = ContentScaffold.postRelativePath(collection: collection, slug: finalSlug)
@@ -168,7 +200,8 @@ public struct NativeContentOperations: ContentOperationsService {
         // No `.createCallingPlugin` here: this is a native Swift write with no plugin involved.
         // `.createFinalizing` (below) covers the write + commit milestone honestly.
         let contents = ContentScaffold.renderEntry(
-            descriptor: descriptor, title: cleanTitle.isEmpty ? nil : cleanTitle, now: now())
+            descriptor: descriptor, title: cleanTitle.isEmpty ? nil : cleanTitle, now: now(),
+            fieldValues: fieldValues)
         do { try write(contents, to: abs) }
         catch { return .failed(reason: "\(error)") }
 

--- a/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
@@ -159,7 +159,7 @@ struct ContentCreationWorkflowTests {
             contentGraph: graph,
             knowledgeIndex: knowledgeIndex,
             siteDirectory: { _ in root },
-            typedSlugCreator: { siteID, typeID, title, slug, _ in
+            typedSlugCreator: { siteID, typeID, title, slug, _, _ in
                 await operations.createTyped(siteID: siteID, typeID: typeID, title: title, slug: slug)
             }
         )
@@ -424,6 +424,39 @@ struct ContentCreationWorkflowTests {
 
         guard case .failed = result else { Issue.record("expected .failed, got \(result)"); return }
     }
+
+    @Test("createTyped forwards fieldValues to the typed slug creator")
+    func createTypedForwardsFieldValues() async throws {
+        let root = try makeTempDir(prefix: "content-workflow")
+        let seen = SeenFieldValues()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: nil,
+            siteDirectory: { _ in root },
+            typedSlugCreator: { _, _, _, _, fieldValues, _ in
+                await seen.record(fieldValues)
+                return .created(filePath: "src/content/likes/x.md", identifier: "x")
+            }
+        )
+
+        _ = await workflow.createTyped(
+            siteID: Self.siteID, typeID: "like", title: "", slug: nil,
+            fieldValues: ["likeOf": "https://example.com/post"])
+
+        #expect(await seen.values == ["likeOf": "https://example.com/post"])
+    }
+}
+
+private actor SeenFieldValues {
+    private(set) var values: [String: String] = [:]
+    func record(_ v: [String: String]) { values = v }
 }
 
 private struct FakeCreateOperations: ContentOperationsService {

--- a/Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
@@ -1,0 +1,26 @@
+// Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContentFieldValidation")
+struct ContentFieldValidationTests {
+    @Test("isAbsoluteURL accepts http(s) URLs with a host")
+    func acceptsAbsoluteURLs() {
+        #expect(ContentFieldValidation.isAbsoluteURL("https://example.com"))
+        #expect(ContentFieldValidation.isAbsoluteURL("https://example.com/blog/hello-world"))
+        #expect(ContentFieldValidation.isAbsoluteURL("http://a.b/c?d=e#f"))
+    }
+
+    @Test("isAbsoluteURL rejects anything without a scheme and host")
+    func rejectsNonAbsoluteURLs() {
+        #expect(!ContentFieldValidation.isAbsoluteURL(""))
+        #expect(!ContentFieldValidation.isAbsoluteURL("   "))
+        #expect(!ContentFieldValidation.isAbsoluteURL("not a url"))
+        #expect(!ContentFieldValidation.isAbsoluteURL("example.com"))
+        #expect(!ContentFieldValidation.isAbsoluteURL("/relative/path"))
+        #expect(!ContentFieldValidation.isAbsoluteURL("https:"))
+        // A scheme with no host: parses, but yields no usable u-* microformat value.
+        #expect(!ContentFieldValidation.isAbsoluteURL("mailto:a@b.c"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
@@ -34,4 +34,23 @@ struct ContentFieldValidationTests {
         #expect(!ContentFieldValidation.isAbsoluteURL("http://example.com:65536"))
         #expect(!ContentFieldValidation.isAbsoluteURL("http://example.com:99999"))
     }
+
+    @Test("isAbsoluteURL rejects an interior newline or space URLComponents would otherwise let through")
+    func rejectsInteriorWhitespaceAndNewlines() {
+        // `URLComponents` parses an interior newline without complaint (unlike an interior space,
+        // which it already rejects on its own), but a raw newline would split the YAML frontmatter
+        // line it's written into (escapeYAML doesn't escape newlines) — so this has to be caught
+        // explicitly rather than left to the parser.
+        #expect(!ContentFieldValidation.isAbsoluteURL("https://example.com/post\nevil: true"))
+        #expect(!ContentFieldValidation.isAbsoluteURL("https://exa mple.com"))
+    }
+
+    @Test("isAbsoluteURL accepts a value with only leading/trailing whitespace, trimming it away")
+    func acceptsSurroundingWhitespace() {
+        // A trailing/leading newline or space is not an *interior* character once trimmed, so it's
+        // approved here — the caller (NativeContentOperations.createTyped) is responsible for
+        // persisting the same trimmed value it validated, not the raw one (#916 follow-up).
+        #expect(ContentFieldValidation.isAbsoluteURL("https://example.com/post\n"))
+        #expect(ContentFieldValidation.isAbsoluteURL("  https://example.com/post  "))
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
@@ -23,4 +23,15 @@ struct ContentFieldValidationTests {
         // A scheme with no host: parses, but yields no usable u-* microformat value.
         #expect(!ContentFieldValidation.isAbsoluteURL("mailto:a@b.c"))
     }
+
+    @Test("isAbsoluteURL enforces the WHATWG/Zod port range")
+    func enforcesPortRange() {
+        // 0 and 65535 are the boundaries WHATWG's URL parser (and z.string().url()) accepts.
+        #expect(ContentFieldValidation.isAbsoluteURL("http://example.com:65535"))
+        #expect(ContentFieldValidation.isAbsoluteURL("http://example.com:0"))
+        // Anything above 65535 parses via URLComponents but is rejected by z.string().url(),
+        // so it must fail here too or the invariant with astro check breaks.
+        #expect(!ContentFieldValidation.isAbsoluteURL("http://example.com:65536"))
+        #expect(!ContentFieldValidation.isAbsoluteURL("http://example.com:99999"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -224,4 +224,62 @@ struct ContentScaffoldTests {
         #expect(obj?["type"] as? String == "personalProfile")
         #expect(obj?["name"] as? String == tricky) // round-trips losslessly
     }
+
+    @Test("renderEntry renders a supplied required .url value live and valid")
+    func renderEntrySuppliedRequiredURL() throws {
+        let like = try #require(ContentTypeRegistry().descriptor(id: "like"))
+        let out = ContentScaffold.renderEntry(
+            descriptor: like,
+            title: nil,
+            now: Date(timeIntervalSince1970: 1_750_000_000),
+            fieldValues: ["likeOf": "https://example.com/post"])
+        #expect(out.contains("likeOf: \"https://example.com/post\""))
+        #expect(!out.contains("likeOf: \"\""))
+    }
+
+    @Test("a supplied optional .url value renders live instead of commented out")
+    func renderEntrySuppliedOptionalURL() throws {
+        let note = try #require(ContentTypeRegistry().descriptor(id: "note"))
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+        let withValue = ContentScaffold.renderEntry(
+            descriptor: note, title: nil, now: now,
+            fieldValues: ["audience": "https://example.com/friends"])
+        #expect(withValue.contains("\naudience: \"https://example.com/friends\""))
+        #expect(!withValue.contains("# audience:"))
+
+        // An explicitly empty value is treated the same as no value: commented out (#913).
+        let withEmpty = ContentScaffold.renderEntry(
+            descriptor: note, title: nil, now: now, fieldValues: ["audience": ""])
+        #expect(withEmpty.contains("# audience: \"\""))
+    }
+
+    @Test("renderEntry escapes a supplied value and ignores unknown field names")
+    func renderEntrySuppliedValueEscaping() throws {
+        let bookmark = try #require(ContentTypeRegistry().descriptor(id: "bookmark"))
+        let out = ContentScaffold.renderEntry(
+            descriptor: bookmark,
+            title: "Title",
+            now: Date(timeIntervalSince1970: 1_750_000_000),
+            fieldValues: ["bookmarkOf": "https://example.com/a\"b", "notAField": "ignored"])
+        #expect(out.contains("bookmarkOf: \"https://example.com/a\\\"b\""))
+        #expect(!out.contains("notAField"))
+    }
+
+    @Test("an empty fieldValues reproduces the pre-#916 output for every collection type")
+    func renderEntryEmptyFieldValuesIsUnchanged() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        for descriptor in ContentTypeRegistry.builtIns where descriptor.collection != nil {
+            let withDefault = ContentScaffold.renderEntry(descriptor: descriptor, title: "Title", now: now)
+            let withEmpty = ContentScaffold.renderEntry(
+                descriptor: descriptor, title: "Title", now: now, fieldValues: [:])
+            #expect(withDefault == withEmpty, "\(descriptor.id)")
+            // Required .url fields still scaffold as an empty live line when nothing is supplied —
+            // the create path (NativeContentOperations) is what refuses to write that, not the
+            // renderer, which stays a pure formatter.
+            for field in descriptor.requiredURLFields {
+                #expect(withDefault.contains("\(field.name): \"\""), "\(descriptor.id).\(field.name)")
+            }
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -266,14 +266,35 @@ struct ContentScaffoldTests {
         #expect(!out.contains("notAField"))
     }
 
-    @Test("an empty fieldValues reproduces the pre-#916 output for every collection type")
+    @Test("a title-like optional .url field never falls back to the title, only to empty")
+    func optionalURLFieldNamedLikeTitleDoesNotLeakTitle() {
+        // `titleLikeFieldNames` ("title", "name", "itemReviewed") is a name-based heuristic meant
+        // for .string fields; a custom descriptor (via ContentTypeRegistry.register(_:)) could
+        // declare an *optional* .url field with one of those names. Falling back to the title would
+        // render a non-URL string into a z.string().url() slot as a live line — exactly the
+        // schema-invalid write this file exists to prevent (#916 follow-up).
+        let descriptor = ContentTypeDescriptor(
+            id: "syntheticURLTitle",
+            displayName: "Synthetic URL Title",
+            storage: .collection("synthetics"),
+            fields: [
+                ContentTypeField("name", .url),
+            ],
+            projections: ContentTypeProjections(
+                microformat: "h-entry", microformatProperties: [:], schemaType: nil))
+
+        let out = ContentScaffold.renderEntry(
+            descriptor: descriptor, title: "Some Title",
+            now: Date(timeIntervalSince1970: 1_750_000_000))
+        #expect(out.contains("# name: \"\""))
+        #expect(!out.contains("\nname: \"Some Title\""))
+    }
+
+    @Test("required .url fields scaffold as an empty live line when nothing is supplied")
     func renderEntryEmptyFieldValuesIsUnchanged() {
         let now = Date(timeIntervalSince1970: 1_750_000_000)
         for descriptor in ContentTypeRegistry.builtIns where descriptor.collection != nil {
             let withDefault = ContentScaffold.renderEntry(descriptor: descriptor, title: "Title", now: now)
-            let withEmpty = ContentScaffold.renderEntry(
-                descriptor: descriptor, title: "Title", now: now, fieldValues: [:])
-            #expect(withDefault == withEmpty, "\(descriptor.id)")
             // Required .url fields still scaffold as an empty live line when nothing is supplied —
             // the create path (NativeContentOperations) is what refuses to write that, not the
             // renderer, which stays a pure formatter.

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -282,4 +282,30 @@ struct ContentScaffoldTests {
             }
         }
     }
+
+    @Test("slugFromURL combines the UTC date, host, and last path segment")
+    func slugFromURLShape() {
+        // 1_750_000_000 == 2025-06-15T15:06:40Z
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        #expect(ContentScaffold.slugFromURL("https://example.com/blog/hello-world", now: now)
+                == "2025-06-15-example-com-hello-world")
+        #expect(ContentScaffold.slugFromURL("https://www.example.com/a/b/", now: now)
+                == "2025-06-15-example-com-b")
+        #expect(ContentScaffold.slugFromURL("https://example.com/", now: now)
+                == "2025-06-15-example-com")
+        #expect(ContentScaffold.slugFromURL("https://example.com", now: now)
+                == "2025-06-15-example-com")
+        // Query and fragment are not part of the slug.
+        #expect(ContentScaffold.slugFromURL("https://example.com/post?utm=x#frag", now: now)
+                == "2025-06-15-example-com-post")
+    }
+
+    @Test("slugFromURL returns empty for a value with no host, so callers can fall back")
+    func slugFromURLNoHost() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        #expect(ContentScaffold.slugFromURL("", now: now).isEmpty)
+        #expect(ContentScaffold.slugFromURL("not a url", now: now).isEmpty)
+        #expect(ContentScaffold.slugFromURL("/relative/path", now: now).isEmpty)
+        #expect(ContentScaffold.slugFromURL("mailto:a@b.c", now: now).isEmpty)
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
@@ -266,4 +266,36 @@ struct ContentTypeRegistryTests {
         #expect(article.projections.rawMf2Property(forField: "draft") == nil)
         #expect(article.projections.rawMf2Property(forField: "nonexistent") == nil)
     }
+
+    @Test("titleField finds the type's human-facing title field, or nil")
+    func titleFieldPerType() throws {
+        let registry = ContentTypeRegistry()
+        let bookmark = try #require(registry.descriptor(id: "bookmark"))
+        let event = try #require(registry.descriptor(id: "event"))
+        let review = try #require(registry.descriptor(id: "review"))
+        let reply = try #require(registry.descriptor(id: "reply"))
+        let like = try #require(registry.descriptor(id: "like"))
+
+        #expect(bookmark.titleField?.name == "title")
+        #expect(event.titleField?.name == "name")
+        #expect(review.titleField?.name == "itemReviewed")
+        // reply and like are identified by their target URL, not by a name (#916).
+        #expect(reply.titleField == nil)
+        #expect(like.titleField == nil)
+    }
+
+    @Test("requiredURLFields lists required .url fields in declaration order")
+    func requiredURLFieldsPerType() throws {
+        let registry = ContentTypeRegistry()
+        let bookmark = try #require(registry.descriptor(id: "bookmark"))
+        let reply = try #require(registry.descriptor(id: "reply"))
+        let like = try #require(registry.descriptor(id: "like"))
+        let note = try #require(registry.descriptor(id: "note"))
+
+        #expect(bookmark.requiredURLFields.map(\.name) == ["bookmarkOf"])
+        #expect(reply.requiredURLFields.map(\.name) == ["inReplyTo"])
+        #expect(like.requiredURLFields.map(\.name) == ["likeOf"])
+        // `audience` is an optional .url, so it must not appear here.
+        #expect(note.requiredURLFields.isEmpty)
+    }
 }

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -212,6 +212,22 @@ struct NativeContentOperationsTests {
         #expect(written.contains("title: \"Cool post\""))
     }
 
+    @Test("createTyped persists a required URL trimmed, not the raw supplied value")
+    func createTypedPersistsTrimmedRequiredURL() async throws {
+        let (ops, root, _) = makeOps()
+        // Surrounding whitespace (including a trailing newline) passes ContentFieldValidation's
+        // trimmed check, but the raw value must never reach disk: escapeYAML doesn't escape
+        // newlines, so persisting the untrimmed original would split the frontmatter (#916
+        // follow-up). The written line must be exactly the clean, trimmed URL.
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "bookmark", title: "Cool post", slug: nil,
+            fieldValues: ["bookmarkOf": "  https://example.com/post\n"])
+        #expect(result == .created(filePath: "src/content/bookmarks/cool-post.md", identifier: "cool-post"))
+        let written = try String(
+            contentsOf: root.appendingPathComponent("src/content/bookmarks/cool-post.md"), encoding: .utf8)
+        #expect(written.contains("bookmarkOf: \"https://example.com/post\"\n"))
+    }
+
     @Test("a titleless type with no title derives its slug from the target URL")
     func createTypedDerivesSlugFromURL() async {
         let (ops, _, spy) = makeOps()   // now == 2025-06-15T15:06:40Z

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -136,11 +136,13 @@ struct NativeContentOperationsTests {
     @Test("createTyped writes a like to its collection and commits")
     func createTypedLike() async throws {
         let (ops, root, spy) = makeOps()
-        let result = await ops.createTyped(siteID: "s1", typeID: "like", title: "Cool post")
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "like", title: "Cool post", slug: nil,
+            fieldValues: ["likeOf": "https://example.com/post"])
         #expect(result == .created(filePath: "src/content/likes/cool-post.md", identifier: "cool-post"))
         let written = try String(
             contentsOf: root.appendingPathComponent("src/content/likes/cool-post.md"), encoding: .utf8)
-        #expect(written.contains("likeOf: \"\""))
+        #expect(written.contains("likeOf: \"https://example.com/post\""))
         #expect(written.contains("publishDate:"))
         let calls = await spy.calls
         #expect(calls.count == 1)
@@ -160,6 +162,76 @@ struct NativeContentOperationsTests {
         let (ops, _, _) = makeOps()
         let result = await ops.createTyped(siteID: "s1", typeID: "businessProfile", title: "x")
         #expect(result == .failed(reason: "businessProfile is not a collection type; use createTypedSingleton"))
+    }
+
+    @Test("createTyped refuses to write an entry missing a required .url value")
+    func createTypedRejectsMissingRequiredURL() async {
+        let (ops, root, spy) = makeOps()
+        // The #916 regression guard: this is what the New Collection sheet used to do.
+        let result = await ops.createTyped(siteID: "s1", typeID: "like", title: "Cool post", slug: nil)
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("likeOf"))
+        #expect(!FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("src/content/likes/cool-post.md").path))
+        let calls = await spy.calls
+        #expect(calls.isEmpty)
+    }
+
+    @Test("createTyped refuses a required .url value that isn't an absolute URL")
+    func createTypedRejectsMalformedRequiredURL() async {
+        let (ops, root, _) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "bookmark", title: "Cool post", slug: nil,
+            fieldValues: ["bookmarkOf": "example.com/post"])
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("bookmarkOf"))
+        #expect(!FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("src/content/bookmarks/cool-post.md").path))
+    }
+
+    @Test("createTyped refuses a supplied optional .url value that isn't an absolute URL")
+    func createTypedRejectsMalformedOptionalURL() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "note", title: "Hello", slug: nil,
+            fieldValues: ["audience": "nope"])
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("audience"))
+    }
+
+    @Test("createTyped writes a bookmark with its target URL live in the frontmatter")
+    func createTypedBookmarkWritesURL() async throws {
+        let (ops, root, _) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "bookmark", title: "Cool post", slug: nil,
+            fieldValues: ["bookmarkOf": "https://example.com/blog/hello-world"])
+        #expect(result == .created(filePath: "src/content/bookmarks/cool-post.md", identifier: "cool-post"))
+        let written = try String(
+            contentsOf: root.appendingPathComponent("src/content/bookmarks/cool-post.md"), encoding: .utf8)
+        #expect(written.contains("bookmarkOf: \"https://example.com/blog/hello-world\""))
+        #expect(written.contains("title: \"Cool post\""))
+    }
+
+    @Test("a titleless type with no title derives its slug from the target URL")
+    func createTypedDerivesSlugFromURL() async {
+        let (ops, _, spy) = makeOps()   // now == 2025-06-15T15:06:40Z
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "reply", title: "", slug: nil,
+            fieldValues: ["inReplyTo": "https://example.com/blog/hello-world"])
+        #expect(result == .created(
+            filePath: "src/content/replies/2025-06-15-example-com-hello-world.md",
+            identifier: "2025-06-15-example-com-hello-world"))
+        let calls = await spy.calls
+        #expect(calls.first?.2 == "anglesite: add replies 2025-06-15-example-com-hello-world")
+    }
+
+    @Test("an explicit slug still beats both the title and the URL")
+    func createTypedExplicitSlugWins() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "reply", title: "", slug: "my-reply",
+            fieldValues: ["inReplyTo": "https://example.com/blog/hello-world"])
+        #expect(result == .created(filePath: "src/content/replies/my-reply.md", identifier: "my-reply"))
     }
 
     @Test("createTypedSingleton writes the slot data file and commits")

--- a/docs/superpowers/plans/2026-07-27-required-url-scaffold.md
+++ b/docs/superpowers/plans/2026-07-27-required-url-scaffold.md
@@ -1,0 +1,1326 @@
+# Required `.url` fields collected at creation — Implementation Plan (#916)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop Anglesite committing a schema-invalid bookmark/reply/like by collecting each type's required `.url` value in the New Collection sheet and validating it before the file is written.
+
+**Architecture:** `ContentScaffold.renderEntry` gains a pure `fieldValues:` input; `NativeContentOperations.createTyped` validates required `.url` values at the write boundary and derives a dated slug from the URL for types with no title field; `NewCollectionEntrySheet` collects those URLs and drops the throwaway Title row for `reply`/`like`.
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27+), Swift Testing (`import Testing`, `@Suite`/`@Test`/`#expect`), SwiftPM for the `AnglesiteCore` targets, XcodeGen + `xcodebuild` for the app target.
+
+**Spec:** [`docs/superpowers/specs/2026-07-27-required-url-scaffold-design.md`](../specs/2026-07-27-required-url-scaffold-design.md)
+
+## Global Constraints
+
+- **No new dependencies.** Apple frameworks only; new third-party deps need approval in an issue first (`CONTRIBUTING.md` ▸ Code guidelines).
+- **Conventional commits, subject ≤ 72 characters**, referencing `(#916)`. Extra detail goes in the body, never the subject.
+- **Work happens in this worktree only.** `cd` to the worktree before any git operation. Never touch the main checkout.
+- **`Anglesite.xcodeproj` is gitignored and generated** from `project.yml` by `xcodegen generate`. Never edit or commit the project file.
+- **Never `git add -A` / `git add .`** — the worktree contains gitignored generated resources. Stage the exact paths each step lists.
+- **`renderEntry` stays pure** — no I/O, no `Date()` calls inside it; time always arrives via the `now` parameter.
+- **Template `Resources/Template/src/content.config.ts` is NOT modified.** This is an app-only change; no paired sidecar PR.
+- **Byte-compatibility:** with an empty `fieldValues`, `ContentScaffold.renderEntry` output must be byte-identical to today's. `MicropubContentCommitter` (`Sources/AnglesiteCore/MicropubContentCommitter.swift:118`) calls it with no field values and must be unaffected.
+- **Existing tests are contracts.** Two of them are expected to change and are called out explicitly (Task 5 Step 1, Task 6 Step 3). Do not silence any other failing test — if one breaks, the implementation is wrong.
+
+## File Structure
+
+| Path | Responsibility | Task |
+|---|---|---|
+| `Sources/AnglesiteCore/ContentFieldValidation.swift` | **New.** Sole owner of "is this an absolute URL" for content fields. | 1 |
+| `Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift` | **New.** Tests for the above. | 1 |
+| `Sources/AnglesiteCore/ContentTypeRegistry.swift` | Adds `titleField` / `requiredURLFields` to `ContentTypeDescriptor` and owns `titleLikeFieldNames`. | 2 |
+| `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift` | Tests for the two new computed properties. | 2 |
+| `Sources/AnglesiteCore/ContentScaffold.swift` | `renderEntry(fieldValues:)` + `slugFromURL`. Rendering only — no validation. | 3, 4 |
+| `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift` | Tests for both. | 3, 4 |
+| `Sources/AnglesiteCore/NativeContentOperations.swift` | The write boundary: validates and picks the slug. | 5 |
+| `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` | Tests for validation + slug precedence. | 5 |
+| `Sources/AnglesiteCore/ContentCreationWorkflow.swift` | Threads `fieldValues` from the app down to the write boundary. | 6 |
+| `Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift` | Forwarding test + arity fix. | 6 |
+| `Sources/AnglesiteApp/SiteWindowModel.swift` | App-side pass-through. | 7 |
+| `Sources/AnglesiteApp/NewContentSheets.swift` | The sheet UI: URL rows, conditional Title row, Create enablement. | 7 |
+| `Sources/AnglesiteApp/Localizable.xcstrings` | Generated catalog for the sheet's new string. | 8 |
+
+Tasks 1–6 are `AnglesiteCore` (`swift test`-verifiable, Linux-portable). Task 7 is the app target (`xcodebuild` only — the app target has no CI-runnable hosted tests; see `CLAUDE.md` ▸ Build).
+
+---
+
+### Task 1: `ContentFieldValidation`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ContentFieldValidation.swift`
+- Test: `Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public enum ContentFieldValidation { public static func isAbsoluteURL(_ value: String) -> Bool }` — used by Tasks 5 and 7.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift`:
+
+```swift
+// Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContentFieldValidation")
+struct ContentFieldValidationTests {
+    @Test("isAbsoluteURL accepts http(s) URLs with a host")
+    func acceptsAbsoluteURLs() {
+        #expect(ContentFieldValidation.isAbsoluteURL("https://example.com"))
+        #expect(ContentFieldValidation.isAbsoluteURL("https://example.com/blog/hello-world"))
+        #expect(ContentFieldValidation.isAbsoluteURL("http://a.b/c?d=e#f"))
+    }
+
+    @Test("isAbsoluteURL rejects anything without a scheme and host")
+    func rejectsNonAbsoluteURLs() {
+        #expect(!ContentFieldValidation.isAbsoluteURL(""))
+        #expect(!ContentFieldValidation.isAbsoluteURL("   "))
+        #expect(!ContentFieldValidation.isAbsoluteURL("not a url"))
+        #expect(!ContentFieldValidation.isAbsoluteURL("example.com"))
+        #expect(!ContentFieldValidation.isAbsoluteURL("/relative/path"))
+        #expect(!ContentFieldValidation.isAbsoluteURL("https:"))
+        // A scheme with no host: parses, but yields no usable u-* microformat value.
+        #expect(!ContentFieldValidation.isAbsoluteURL("mailto:a@b.c"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+swift test --package-path . --filter ContentFieldValidation
+```
+
+Expected: FAIL to **compile**, with `cannot find 'ContentFieldValidation' in scope`. (A compile failure is the correct red state here — the type doesn't exist yet.)
+
+Note: `--filter` restricts what *runs*, not what *compiles*; the whole package still builds. If the build hangs with no output, a stale SwiftPM process is holding the `.build` lock — check `pgrep -fl swift-test` and kill the orphan.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/ContentFieldValidation.swift`:
+
+```swift
+// Sources/AnglesiteCore/ContentFieldValidation.swift
+import Foundation
+
+/// Value checks for `ContentTypeField` values, applied before a content entry is written to disk.
+///
+/// Scaffolding renders; this validates. Kept separate from `ContentScaffold` so the create path can
+/// reject a bad value *before* asking for a render, and so the rules are testable on their own.
+public enum ContentFieldValidation {
+    /// Whether `value` is an absolute URL with a scheme **and** a non-empty host.
+    ///
+    /// Deliberately stricter than the template's `z.string().url()`, which accepts anything
+    /// `new URL()` parses — including `mailto:` and other host-less schemes. A `.url` field feeds a
+    /// `u-*` microformat property (`u-bookmark-of`, `u-in-reply-to`, `u-like-of`), which needs a
+    /// dereferenceable target, so requiring a host is the useful rule. Anything accepted here is
+    /// accepted by `z.string().url()`, so a value that passes never fails `astro check`.
+    ///
+    /// Mirrors the same host-not-just-scheme rule `IntegrationPlanner` applies to its `.url` fields.
+    public static func isAbsoluteURL(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let components = URLComponents(string: trimmed),
+              let scheme = components.scheme, !scheme.isEmpty,
+              let host = components.host, !host.isEmpty
+        else { return false }
+        return true
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+swift test --package-path . --filter ContentFieldValidation
+```
+
+Expected: PASS, 2 tests.
+
+If `"not a url"` unexpectedly passes, `URLComponents(string:)` accepted the space on this Foundation version — add an explicit `trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil` guard and re-run. Do not weaken the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentFieldValidation.swift Tests/AnglesiteCoreTests/ContentFieldValidationTests.swift
+git commit -m "feat(core): add absolute-URL validation for content fields (#916)"
+```
+
+---
+
+### Task 2: Descriptor helpers
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentTypeRegistry.swift` (add to `ContentTypeDescriptor`)
+- Modify: `Sources/AnglesiteCore/ContentScaffold.swift` (delete the private `titleLikeFieldNames`, point its two uses at the new home)
+- Test: `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `ContentTypeDescriptor.titleField: ContentTypeField?`
+  - `ContentTypeDescriptor.requiredURLFields: [ContentTypeField]`
+  - `ContentTypeDescriptor.titleLikeFieldNames: Set<String>` (internal, module-scoped — `ContentScaffold` reads it)
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing `struct ContentTypeRegistryTests` in `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift`:
+
+```swift
+    @Test("titleField finds the type's human-facing title field, or nil")
+    func titleFieldPerType() throws {
+        let registry = ContentTypeRegistry()
+        let bookmark = try #require(registry.descriptor(id: "bookmark"))
+        let event = try #require(registry.descriptor(id: "event"))
+        let review = try #require(registry.descriptor(id: "review"))
+        let reply = try #require(registry.descriptor(id: "reply"))
+        let like = try #require(registry.descriptor(id: "like"))
+
+        #expect(bookmark.titleField?.name == "title")
+        #expect(event.titleField?.name == "name")
+        #expect(review.titleField?.name == "itemReviewed")
+        // reply and like are identified by their target URL, not by a name (#916).
+        #expect(reply.titleField == nil)
+        #expect(like.titleField == nil)
+    }
+
+    @Test("requiredURLFields lists required .url fields in declaration order")
+    func requiredURLFieldsPerType() throws {
+        let registry = ContentTypeRegistry()
+        let bookmark = try #require(registry.descriptor(id: "bookmark"))
+        let reply = try #require(registry.descriptor(id: "reply"))
+        let like = try #require(registry.descriptor(id: "like"))
+        let note = try #require(registry.descriptor(id: "note"))
+
+        #expect(bookmark.requiredURLFields.map(\.name) == ["bookmarkOf"])
+        #expect(reply.requiredURLFields.map(\.name) == ["inReplyTo"])
+        #expect(like.requiredURLFields.map(\.name) == ["likeOf"])
+        // `audience` is an optional .url, so it must not appear here.
+        #expect(note.requiredURLFields.isEmpty)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+swift test --package-path . --filter ContentTypeRegistry
+```
+
+Expected: FAIL to compile — `value of type 'ContentTypeDescriptor' has no member 'titleField'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/ContentTypeRegistry.swift`, add to `ContentTypeDescriptor` immediately after the existing `singletonSlot` computed property:
+
+```swift
+    /// Field names treated as a type's human-facing title, in no particular order. A descriptor
+    /// declares at most one of these; `ContentScaffold` fills whichever it declares from the
+    /// caller-supplied title (#386).
+    static let titleLikeFieldNames: Set<String> = ["title", "name", "itemReviewed"]
+
+    /// The field carrying this type's human-facing title, or `nil` when it has none. `reply` and
+    /// `like` have none — they are identified by their target URL, not by a name — so the create
+    /// UI hides the Title row for them and derives a slug from that URL instead (#916).
+    public var titleField: ContentTypeField? {
+        fields.first { Self.titleLikeFieldNames.contains($0.name) }
+    }
+
+    /// Required `.url` fields, in declaration order. The template schemas these project to are
+    /// `z.string().url()`, which rejects an empty string, so the create path must collect a value
+    /// for each one before writing rather than scaffolding a placeholder (#916).
+    public var requiredURLFields: [ContentTypeField] {
+        fields.filter { $0.kind == .url && $0.required }
+    }
+```
+
+In `Sources/AnglesiteCore/ContentScaffold.swift`, delete the last line of the enum:
+
+```swift
+    private static let titleLikeFieldNames: Set<String> = ["title", "name", "itemReviewed"]
+```
+
+and update its two remaining uses — one in `renderEntry`, one in `renderSingleton` — replacing each
+
+```swift
+            titleLikeFieldNames.contains(field.name)
+```
+
+with
+
+```swift
+            ContentTypeDescriptor.titleLikeFieldNames.contains(field.name)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+swift test --package-path . --filter 'ContentTypeRegistry|ContentScaffold'
+```
+
+Expected: PASS. The existing `ContentScaffold` suite must be green and unchanged — this step moves a constant, it does not change any rendered output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentTypeRegistry.swift Sources/AnglesiteCore/ContentScaffold.swift Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+git commit -m "refactor(core): add titleField/requiredURLFields to descriptors (#916)"
+```
+
+---
+
+### Task 3: `renderEntry(fieldValues:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentScaffold.swift` (`renderEntry`)
+- Test: `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeDescriptor.titleLikeFieldNames` (Task 2).
+- Produces: `ContentScaffold.renderEntry(descriptor:title:now:fieldValues:) -> String`, where `fieldValues` defaults to `[:]`. Used by Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing `struct ContentScaffoldTests` in `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift`:
+
+```swift
+    @Test("renderEntry renders a supplied required .url value live and valid")
+    func renderEntrySuppliedRequiredURL() throws {
+        let like = try #require(ContentTypeRegistry().descriptor(id: "like"))
+        let out = ContentScaffold.renderEntry(
+            descriptor: like,
+            title: nil,
+            now: Date(timeIntervalSince1970: 1_750_000_000),
+            fieldValues: ["likeOf": "https://example.com/post"])
+        #expect(out.contains("likeOf: \"https://example.com/post\""))
+        #expect(!out.contains("likeOf: \"\""))
+    }
+
+    @Test("a supplied optional .url value renders live instead of commented out")
+    func renderEntrySuppliedOptionalURL() throws {
+        let note = try #require(ContentTypeRegistry().descriptor(id: "note"))
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+        let withValue = ContentScaffold.renderEntry(
+            descriptor: note, title: nil, now: now,
+            fieldValues: ["audience": "https://example.com/friends"])
+        #expect(withValue.contains("\naudience: \"https://example.com/friends\""))
+        #expect(!withValue.contains("# audience:"))
+
+        // An explicitly empty value is treated the same as no value: commented out (#913).
+        let withEmpty = ContentScaffold.renderEntry(
+            descriptor: note, title: nil, now: now, fieldValues: ["audience": ""])
+        #expect(withEmpty.contains("# audience: \"\""))
+    }
+
+    @Test("renderEntry escapes a supplied value and ignores unknown field names")
+    func renderEntrySuppliedValueEscaping() throws {
+        let bookmark = try #require(ContentTypeRegistry().descriptor(id: "bookmark"))
+        let out = ContentScaffold.renderEntry(
+            descriptor: bookmark,
+            title: "Title",
+            now: Date(timeIntervalSince1970: 1_750_000_000),
+            fieldValues: ["bookmarkOf": "https://example.com/a\"b", "notAField": "ignored"])
+        #expect(out.contains("bookmarkOf: \"https://example.com/a\\\"b\""))
+        #expect(!out.contains("notAField"))
+    }
+
+    @Test("an empty fieldValues reproduces the pre-#916 output for every collection type")
+    func renderEntryEmptyFieldValuesIsUnchanged() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        for descriptor in ContentTypeRegistry.builtIns where descriptor.collection != nil {
+            let withDefault = ContentScaffold.renderEntry(descriptor: descriptor, title: "Title", now: now)
+            let withEmpty = ContentScaffold.renderEntry(
+                descriptor: descriptor, title: "Title", now: now, fieldValues: [:])
+            #expect(withDefault == withEmpty, "\(descriptor.id)")
+            // Required .url fields still scaffold as an empty live line when nothing is supplied —
+            // the create path (NativeContentOperations) is what refuses to write that, not the
+            // renderer, which stays a pure formatter.
+            for field in descriptor.requiredURLFields {
+                #expect(withDefault.contains("\(field.name): \"\""), "\(descriptor.id).\(field.name)")
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+swift test --package-path . --filter ContentScaffold
+```
+
+Expected: FAIL to compile — `extra argument 'fieldValues' in call`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/ContentScaffold.swift`, replace the `renderEntry` signature line:
+
+```swift
+    public static func renderEntry(descriptor: ContentTypeDescriptor, title: String?, now: Date) -> String {
+```
+
+with:
+
+```swift
+    public static func renderEntry(
+        descriptor: ContentTypeDescriptor,
+        title: String?,
+        now: Date,
+        fieldValues: [String: String] = [:]
+    ) -> String {
+```
+
+Extend its doc comment (the three `///` lines directly above) with a fourth line:
+
+```swift
+    /// `fieldValues` supplies caller-collected values by field name for the scalar-string kinds
+    /// (`.string`, `.text`, `.url`, `.image`); an absent key falls back to the title-like/empty
+    /// default. Still pure — an empty `fieldValues` renders exactly what it rendered before (#916).
+```
+
+Replace the two scalar-string cases in the `switch field.kind` block:
+
+```swift
+            case .string, .text, .url, .image:
+                let value = ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
+                lines.append("\(field.name): \"\(escapeYAML(value))\"")
+            // Optional `.url` fields scaffold commented-out: an emitted `""` is not a valid URL
+            // under `z.string().url()`, unlike `.string`/`.text`/`.image`'s bare `z.string()`,
+            // which accepts an empty string. Mirrors the `.datetime`/`.date` comment-out rationale
+            // above. Required ones (bookmarkOf, inReplyTo, likeOf) stay live — those entries are
+            // already incomplete without them, same as every other required field.
+            case .url:
+                let value = ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
+                lines.append("\(field.required ? "" : "# ")\(field.name): \"\(escapeYAML(value))\"")
+```
+
+with:
+
+```swift
+            case .string, .text, .image:
+                lines.append("\(field.name): \"\(escapeYAML(scalarValue(field, title: title, fieldValues: fieldValues)))\"")
+            // A `.url` line is commented out only when the field is optional *and* nothing was
+            // supplied: an emitted `""` is not a valid URL under `z.string().url()`, unlike
+            // `.string`/`.text`/`.image`'s bare `z.string()`, which accepts an empty string.
+            // Mirrors the `.datetime`/`.date` comment-out rationale above (#913). A supplied value
+            // always renders live — that is how the create path pre-fills the required
+            // `bookmarkOf`/`inReplyTo`/`likeOf` so a new entry is schema-valid on first write
+            // (#916). Required fields with nothing supplied still render an empty live line; the
+            // create path refuses to write that, keeping this function a pure formatter.
+            case .url:
+                let value = scalarValue(field, title: title, fieldValues: fieldValues)
+                let isLive = field.required || !value.isEmpty
+                lines.append("\(isLive ? "" : "# ")\(field.name): \"\(escapeYAML(value))\"")
+```
+
+Add this private helper immediately after `renderEntry`'s closing brace:
+
+```swift
+    /// The value for a scalar-string field: the caller's supplied value if there is one, otherwise
+    /// the entry title for a title-like field, otherwise empty.
+    private static func scalarValue(
+        _ field: ContentTypeField,
+        title: String?,
+        fieldValues: [String: String]
+    ) -> String {
+        if let supplied = fieldValues[field.name] { return supplied }
+        return ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (title ?? "") : ""
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+swift test --package-path . --filter ContentScaffold
+```
+
+Expected: PASS, including every pre-existing test in the suite — `renderEntryNote`, `optionalURLFieldsScaffoldCommented`, `renderEntryAlbumAndLike`, and `businessTypeFrontmatter` all still assert the no-`fieldValues` behavior and must stay green untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentScaffold.swift Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+git commit -m "feat(core): let renderEntry take caller-supplied field values (#916)"
+```
+
+---
+
+### Task 4: `slugFromURL`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentScaffold.swift`
+- Test: `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentScaffold.slugify` (already exists).
+- Produces: `ContentScaffold.slugFromURL(_ value: String, now: Date) -> String`. Used by Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `struct ContentScaffoldTests`:
+
+```swift
+    @Test("slugFromURL combines the UTC date, host, and last path segment")
+    func slugFromURLShape() {
+        // 1_750_000_000 == 2025-06-15T15:06:40Z
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        #expect(ContentScaffold.slugFromURL("https://example.com/blog/hello-world", now: now)
+                == "2025-06-15-example-com-hello-world")
+        #expect(ContentScaffold.slugFromURL("https://www.example.com/a/b/", now: now)
+                == "2025-06-15-example-com-b")
+        #expect(ContentScaffold.slugFromURL("https://example.com/", now: now)
+                == "2025-06-15-example-com")
+        #expect(ContentScaffold.slugFromURL("https://example.com", now: now)
+                == "2025-06-15-example-com")
+        // Query and fragment are not part of the slug.
+        #expect(ContentScaffold.slugFromURL("https://example.com/post?utm=x#frag", now: now)
+                == "2025-06-15-example-com-post")
+    }
+
+    @Test("slugFromURL returns empty for a value with no host, so callers can fall back")
+    func slugFromURLNoHost() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        #expect(ContentScaffold.slugFromURL("", now: now).isEmpty)
+        #expect(ContentScaffold.slugFromURL("not a url", now: now).isEmpty)
+        #expect(ContentScaffold.slugFromURL("/relative/path", now: now).isEmpty)
+        #expect(ContentScaffold.slugFromURL("mailto:a@b.c", now: now).isEmpty)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+swift test --package-path . --filter ContentScaffold
+```
+
+Expected: FAIL to compile — `type 'ContentScaffold' has no member 'slugFromURL'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/ContentScaffold.swift`, add immediately after `postRelativePath`:
+
+```swift
+    /// Derive a slug from a target URL, for content types with no title field to slugify — `reply`
+    /// and `like` are identified by what they point at, not by a name (#916).
+    ///
+    /// `yyyy-MM-dd` (UTC, same clock and formatter family `renderEntry` uses) + the host with a
+    /// leading `www.` dropped + the last non-empty path component, all through `slugify`. Query and
+    /// fragment are ignored. The date prefix keeps entries chronologically sortable and makes
+    /// collisions practically impossible — two replies to the same URL on the same day — while
+    /// keeping the permalink descriptive; it matches the IndieWeb convention for replies and likes.
+    ///
+    /// Returns `""` when `value` has no host, so callers fall back to their own default rather than
+    /// producing a date-only slug that says nothing about the entry.
+    public static func slugFromURL(_ value: String, now: Date) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let components = URLComponents(string: trimmed),
+              let host = components.host, !host.isEmpty
+        else { return "" }
+
+        let bareHost = host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+        let lastSegment = components.path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .last
+            .map(String.init) ?? ""
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let day = String(formatter.string(from: now).prefix(10))
+
+        return slugify([day, bareHost, lastSegment].filter { !$0.isEmpty }.joined(separator: "-"))
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+swift test --package-path . --filter ContentScaffold
+```
+
+Expected: PASS.
+
+If `"not a url"` unexpectedly yields a non-empty slug, `URLComponents(string:)` accepted the space — that value has no host either way, so check the assertion that actually failed before changing anything.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentScaffold.swift Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+git commit -m "feat(core): derive a dated slug from a target URL (#916)"
+```
+
+---
+
+### Task 5: Validate and slug at the write boundary
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/NativeContentOperations.swift` (`createTyped`, lines ~134–178)
+- Test: `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentFieldValidation.isAbsoluteURL` (Task 1), `ContentTypeDescriptor.requiredURLFields` (Task 2), `ContentScaffold.renderEntry(…fieldValues:)` (Task 3), `ContentScaffold.slugFromURL` (Task 4).
+- Produces: `NativeContentOperations.createTyped(siteID:typeID:title:slug:fieldValues:registry:onProgress:)`, `fieldValues` defaulting to `[:]`. Used by Task 6.
+
+- [ ] **Step 1: Update the one existing test this intentionally breaks**
+
+`createTypedLike` in `Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift` currently creates a like with no URL — exactly the #916 bug. Replace the whole test:
+
+```swift
+    @Test("createTyped writes a like to its collection and commits")
+    func createTypedLike() async throws {
+        let (ops, root, spy) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "like", title: "Cool post", slug: nil,
+            fieldValues: ["likeOf": "https://example.com/post"])
+        #expect(result == .created(filePath: "src/content/likes/cool-post.md", identifier: "cool-post"))
+        let written = try String(
+            contentsOf: root.appendingPathComponent("src/content/likes/cool-post.md"), encoding: .utf8)
+        #expect(written.contains("likeOf: \"https://example.com/post\""))
+        #expect(written.contains("publishDate:"))
+        let calls = await spy.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.1 == "src/content/likes/cool-post.md")
+        #expect(calls.first?.2 == "anglesite: add likes cool-post")
+    }
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append inside `struct NativeContentOperationsTests`:
+
+```swift
+    @Test("createTyped refuses to write an entry missing a required .url value")
+    func createTypedRejectsMissingRequiredURL() async {
+        let (ops, root, spy) = makeOps()
+        // The #916 regression guard: this is what the New Collection sheet used to do.
+        let result = await ops.createTyped(siteID: "s1", typeID: "like", title: "Cool post", slug: nil)
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("likeOf"))
+        #expect(!FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("src/content/likes/cool-post.md").path))
+        let calls = await spy.calls
+        #expect(calls.isEmpty)
+    }
+
+    @Test("createTyped refuses a required .url value that isn't an absolute URL")
+    func createTypedRejectsMalformedRequiredURL() async {
+        let (ops, root, _) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "bookmark", title: "Cool post", slug: nil,
+            fieldValues: ["bookmarkOf": "example.com/post"])
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("bookmarkOf"))
+        #expect(!FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("src/content/bookmarks/cool-post.md").path))
+    }
+
+    @Test("createTyped refuses a supplied optional .url value that isn't an absolute URL")
+    func createTypedRejectsMalformedOptionalURL() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "note", title: "Hello", slug: nil,
+            fieldValues: ["audience": "nope"])
+        guard case let .failed(reason) = result else { Issue.record("expected .failed"); return }
+        #expect(reason.contains("audience"))
+    }
+
+    @Test("createTyped writes a bookmark with its target URL live in the frontmatter")
+    func createTypedBookmarkWritesURL() async throws {
+        let (ops, root, _) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "bookmark", title: "Cool post", slug: nil,
+            fieldValues: ["bookmarkOf": "https://example.com/blog/hello-world"])
+        #expect(result == .created(filePath: "src/content/bookmarks/cool-post.md", identifier: "cool-post"))
+        let written = try String(
+            contentsOf: root.appendingPathComponent("src/content/bookmarks/cool-post.md"), encoding: .utf8)
+        #expect(written.contains("bookmarkOf: \"https://example.com/blog/hello-world\""))
+        #expect(written.contains("title: \"Cool post\""))
+    }
+
+    @Test("a titleless type with no title derives its slug from the target URL")
+    func createTypedDerivesSlugFromURL() async {
+        let (ops, _, spy) = makeOps()   // now == 2025-06-15T15:06:40Z
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "reply", title: "", slug: nil,
+            fieldValues: ["inReplyTo": "https://example.com/blog/hello-world"])
+        #expect(result == .created(
+            filePath: "src/content/replies/2025-06-15-example-com-hello-world.md",
+            identifier: "2025-06-15-example-com-hello-world"))
+        let calls = await spy.calls
+        #expect(calls.first?.2 == "anglesite: add replies 2025-06-15-example-com-hello-world")
+    }
+
+    @Test("an explicit slug still beats both the title and the URL")
+    func createTypedExplicitSlugWins() async {
+        let (ops, _, _) = makeOps()
+        let result = await ops.createTyped(
+            siteID: "s1", typeID: "reply", title: "", slug: "my-reply",
+            fieldValues: ["inReplyTo": "https://example.com/blog/hello-world"])
+        #expect(result == .created(filePath: "src/content/replies/my-reply.md", identifier: "my-reply"))
+    }
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+```bash
+swift test --package-path . --filter NativeContentOperations
+```
+
+Expected: FAIL to compile — `extra argument 'fieldValues' in call`.
+
+- [ ] **Step 4: Write the implementation**
+
+In `Sources/AnglesiteCore/NativeContentOperations.swift`, change the `createTyped` signature from:
+
+```swift
+    public func createTyped(
+        siteID: String,
+        typeID: String,
+        title: String,
+        slug: String?,
+        registry: ContentTypeRegistry = ContentTypeRegistry(),
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+```
+
+to:
+
+```swift
+    public func createTyped(
+        siteID: String,
+        typeID: String,
+        title: String,
+        slug: String?,
+        fieldValues: [String: String] = [:],
+        registry: ContentTypeRegistry = ContentTypeRegistry(),
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+```
+
+Extend its doc comment with:
+
+```swift
+    /// `fieldValues` carries values collected before the write (the New Collection sheet's URL
+    /// rows). Every required `.url` field must have one that passes
+    /// `ContentFieldValidation.isAbsoluteURL`, and any supplied optional `.url` must too — this is
+    /// the boundary that makes a schema-invalid entry unwritable by *any* caller, not just the
+    /// sheet (#916). Note the `ContentOperationsService` protocol witness above is title-only, so a
+    /// non-native runtime cannot carry field values; unreachable today, and widening the protocol
+    /// would ripple into `RemoteSandboxSiteRuntime` (#66) / `LocalContainerSiteRuntime` (#69) for no
+    /// present benefit — same reasoning as the `createTypedSingleton` TODO below.
+```
+
+Insert this validation block immediately after the existing `guard let collection = descriptor.collection` block and before the `let cleanTitle` line:
+
+```swift
+        for field in descriptor.fields where field.kind == .url {
+            let supplied = fieldValues[field.name]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if field.required {
+                guard let supplied, ContentFieldValidation.isAbsoluteURL(supplied) else {
+                    return .failed(reason:
+                        "\(descriptor.displayName) needs an absolute URL for \(field.name), "
+                        + "e.g. https://example.com/post")
+                }
+            } else if let supplied, !supplied.isEmpty, !ContentFieldValidation.isAbsoluteURL(supplied) {
+                return .failed(reason:
+                    "\(field.name) must be an absolute URL, e.g. https://example.com/post")
+            }
+        }
+```
+
+Replace the three slug lines:
+
+```swift
+        let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanSlug = (slug ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalSlug = ContentScaffold.slugify(cleanSlug.isEmpty ? (cleanTitle.isEmpty ? descriptor.id : cleanTitle) : cleanSlug)
+```
+
+with:
+
+```swift
+        let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanSlug = (slug ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        // Slug precedence: explicit → title → target URL → type id. The URL step is what gives
+        // `reply`/`like` a meaningful permalink now that they no longer ask for a throwaway title
+        // (#916); it uses the first required `.url` field in declaration order, which is the only
+        // one each of bookmark/reply/like declares.
+        let urlSlug = descriptor.requiredURLFields.first
+            .flatMap { fieldValues[$0.name] }
+            .map { ContentScaffold.slugFromURL($0, now: now()) } ?? ""
+        let slugSource = [cleanSlug, cleanTitle, urlSlug].first { !$0.isEmpty } ?? descriptor.id
+        let finalSlug = ContentScaffold.slugify(slugSource)
+```
+
+Finally, pass the values through to the renderer — change:
+
+```swift
+        let contents = ContentScaffold.renderEntry(
+            descriptor: descriptor, title: cleanTitle.isEmpty ? nil : cleanTitle, now: now())
+```
+
+to:
+
+```swift
+        let contents = ContentScaffold.renderEntry(
+            descriptor: descriptor, title: cleanTitle.isEmpty ? nil : cleanTitle, now: now(),
+            fieldValues: fieldValues)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+swift test --package-path . --filter NativeContentOperations
+```
+
+Expected: PASS, including the pre-existing `createTypedUnknown` and `createTypedRejectsSingleton` (both fail before reaching the new validation, so their `.failed` reasons are unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NativeContentOperations.swift Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+git commit -m "fix(core): require a valid URL before writing a typed entry (#916)"
+```
+
+---
+
+### Task 6: Thread `fieldValues` through `ContentCreationWorkflow`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentCreationWorkflow.swift` (`TypedSlugCreator` typealias ~line 17, the `native(…)` factory's `typedSlugCreator` closure ~line 105, and the `createTyped(…slug:)` overload ~line 213)
+- Test: `Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift`
+
+**Interfaces:**
+- Consumes: `NativeContentOperations.createTyped(…fieldValues:)` (Task 5).
+- Produces:
+  - `ContentCreationWorkflow.TypedSlugCreator = @Sendable (String, String, String, String?, [String: String], ProgressHandler?) async -> ContentCreateResult`
+  - `ContentCreationWorkflow.createTyped(siteID:typeID:title:slug:fieldValues:onProgress:)`, `fieldValues` defaulting to `[:]`. Used by Task 7.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `struct ContentCreationWorkflowTests` in `Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift`:
+
+```swift
+    @Test("createTyped forwards fieldValues to the typed slug creator")
+    func createTypedForwardsFieldValues() async throws {
+        let root = try makeTempDir(prefix: "content-workflow")
+        let seen = SeenFieldValues()
+        let operations = FakeCreateOperations { _, _, _ in
+            .failed(reason: "unexpected")
+        } createPost: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        } createTyped: { _, _, _, _ in
+            .failed(reason: "unexpected")
+        }
+        let workflow = ContentCreationWorkflow(
+            operations: operations,
+            contentGraph: nil,
+            siteDirectory: { _ in root },
+            typedSlugCreator: { _, _, _, _, fieldValues, _ in
+                await seen.record(fieldValues)
+                return .created(filePath: "src/content/likes/x.md", identifier: "x")
+            }
+        )
+
+        _ = await workflow.createTyped(
+            siteID: Self.siteID, typeID: "like", title: "", slug: nil,
+            fieldValues: ["likeOf": "https://example.com/post"])
+
+        #expect(await seen.values == ["likeOf": "https://example.com/post"])
+    }
+```
+
+and add this actor at file scope, next to the existing `private struct FakeCreateOperations`:
+
+```swift
+private actor SeenFieldValues {
+    private(set) var values: [String: String] = [:]
+    func record(_ v: [String: String]) { values = v }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+swift test --package-path . --filter ContentCreationWorkflow
+```
+
+Expected: FAIL to compile — `contextual closure type … expects 5 arguments, but 6 were used`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/ContentCreationWorkflow.swift`, change the `TypedSlugCreator` typealias from:
+
+```swift
+    public typealias TypedSlugCreator = @Sendable (
+        _ siteID: String,
+        _ typeID: String,
+        _ title: String,
+        _ slug: String?,
+        _ onProgress: ProgressHandler?
+    ) async -> ContentCreateResult
+```
+
+to:
+
+```swift
+    public typealias TypedSlugCreator = @Sendable (
+        _ siteID: String,
+        _ typeID: String,
+        _ title: String,
+        _ slug: String?,
+        _ fieldValues: [String: String],
+        _ onProgress: ProgressHandler?
+    ) async -> ContentCreateResult
+```
+
+In the `native(…)` factory, change the `typedSlugCreator` closure from:
+
+```swift
+            typedSlugCreator: { siteID, typeID, title, slug, onProgress in
+                await native.createTyped(
+                    siteID: siteID,
+                    typeID: typeID,
+                    title: title,
+                    slug: slug,
+                    onProgress: onProgress
+                )
+            },
+```
+
+to:
+
+```swift
+            typedSlugCreator: { siteID, typeID, title, slug, fieldValues, onProgress in
+                await native.createTyped(
+                    siteID: siteID,
+                    typeID: typeID,
+                    title: title,
+                    slug: slug,
+                    fieldValues: fieldValues,
+                    onProgress: onProgress
+                )
+            },
+```
+
+Change the explicit-slug `createTyped` overload from:
+
+```swift
+    public func createTyped(
+        siteID: String,
+        typeID: String,
+        title: String,
+        slug: String?,
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        let result: ContentCreateResult
+        if let typedSlugCreator {
+            result = await typedSlugCreator(siteID, typeID, title, slug, onProgress)
+        } else {
+```
+
+to:
+
+```swift
+    /// `fieldValues` carries values collected before the write (required `.url` fields — #916). It
+    /// reaches `NativeContentOperations` only through `typedSlugCreator`; the `operations` fallback
+    /// is the title-only `ContentOperationsService` witness and necessarily drops them.
+    public func createTyped(
+        siteID: String,
+        typeID: String,
+        title: String,
+        slug: String?,
+        fieldValues: [String: String] = [:],
+        onProgress: ProgressHandler? = nil
+    ) async -> ContentCreateResult {
+        let result: ContentCreateResult
+        if let typedSlugCreator {
+            result = await typedSlugCreator(siteID, typeID, title, slug, fieldValues, onProgress)
+        } else {
+```
+
+Leave the rest of the method body unchanged.
+
+Finally, fix the one pre-existing test closure that now has the wrong arity — in `createTypedRefreshesGraphAndKnowledgeIndex` (~line 161), change:
+
+```swift
+            typedSlugCreator: { siteID, typeID, title, slug, _ in
+```
+
+to:
+
+```swift
+            typedSlugCreator: { siteID, typeID, title, slug, _, _ in
+```
+
+- [ ] **Step 4: Run the full core suite to verify it passes**
+
+```bash
+swift test --package-path .
+```
+
+Expected: PASS, whole package. This is the first point where every core-side change is in place, so run the full suite rather than a filter.
+
+Do not run this concurrently with another agent's `swift test` — parallel full-suite runs cause spurious FoundationModels failures and hangs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentCreationWorkflow.swift Tests/AnglesiteCoreTests/ContentCreationWorkflowTests.swift
+git commit -m "feat(core): thread field values through the create workflow (#916)"
+```
+
+---
+
+### Task 7: Collect the URLs in the New Collection sheet
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift` (`createCollectionEntry`, ~line 1049)
+- Modify: `Sources/AnglesiteApp/NewContentSheets.swift` (`NewCollectionEntrySheet`, lines 156–254)
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift` (the `newCollectionPresented` sheet closure, ~line 700)
+
+**Interfaces:**
+- Consumes: `ContentCreationWorkflow.createTyped(…fieldValues:)` (Task 6), `ContentFieldValidation.isAbsoluteURL` (Task 1), `ContentTypeDescriptor.titleField` / `.requiredURLFields` (Task 2).
+- Produces: nothing consumed by later tasks.
+
+There is no CI-runnable test target for the app (hosted `xcodebuild test` can't launch a macOS-27 `.app` on CI runners — see `CLAUDE.md` ▸ Build), so this task is verified by a compiling build plus the manual GUI check in Step 6.
+
+- [ ] **Step 1: Widen the model's pass-through**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, change `createCollectionEntry` from:
+
+```swift
+    func createCollectionEntry(
+        title: String,
+        slug: String?,
+        descriptor: ContentTypeDescriptor
+    ) async -> ContentCreateResult {
+        guard let site else { return .siteNotFound }
+        let result = await contentCreation.createTyped(
+            siteID: site.id,
+            typeID: descriptor.id,
+            title: title,
+            slug: slug
+        )
+```
+
+to:
+
+```swift
+    func createCollectionEntry(
+        title: String,
+        slug: String?,
+        descriptor: ContentTypeDescriptor,
+        fieldValues: [String: String] = [:]
+    ) async -> ContentCreateResult {
+        guard let site else { return .siteNotFound }
+        let result = await contentCreation.createTyped(
+            siteID: site.id,
+            typeID: descriptor.id,
+            title: title,
+            slug: slug,
+            fieldValues: fieldValues
+        )
+```
+
+Leave the rest of the method (the `.created` refresh + undo registration) unchanged.
+
+- [ ] **Step 2: Widen the sheet's callback and add URL state**
+
+In `Sources/AnglesiteApp/NewContentSheets.swift`, change `NewCollectionEntrySheet`'s stored properties and initializer from:
+
+```swift
+struct NewCollectionEntrySheet: View {
+    let descriptors: [ContentTypeDescriptor]
+    let onCreate: (String, String?, ContentTypeDescriptor) async -> ContentCreateResult
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var title = ""
+    @State private var slug = ""
+    @State private var selectedID: String
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+
+    init(
+        descriptors: [ContentTypeDescriptor],
+        onCreate: @escaping (String, String?, ContentTypeDescriptor) async -> ContentCreateResult
+    ) {
+```
+
+to:
+
+```swift
+struct NewCollectionEntrySheet: View {
+    let descriptors: [ContentTypeDescriptor]
+    let onCreate: (String, String?, ContentTypeDescriptor, [String: String]) async -> ContentCreateResult
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var title = ""
+    @State private var slug = ""
+    @State private var selectedID: String
+    /// Values for the selected type's required `.url` fields, keyed by field name. A bookmark,
+    /// reply, or like is schema-invalid without one, so these are collected before the write rather
+    /// than scaffolded empty (#916).
+    @State private var urlValues: [String: String] = [:]
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+
+    init(
+        descriptors: [ContentTypeDescriptor],
+        onCreate: @escaping (String, String?, ContentTypeDescriptor, [String: String]) async -> ContentCreateResult
+    ) {
+```
+
+- [ ] **Step 3: Render the URL rows and make Title conditional**
+
+Still in `NewCollectionEntrySheet`, change the `Section("Collection Entry")` block from:
+
+```swift
+                    Section("Collection Entry") {
+                        Picker("Type", selection: $selectedID) {
+                            ForEach(descriptors) { descriptor in
+                                Text(descriptor.displayName).tag(descriptor.id)
+                            }
+                        }
+                        TextField("Title", text: $title)
+                        TextField("Slug", text: $slug, prompt: Text("optional"))
+                    }
+```
+
+to:
+
+```swift
+                    Section("Collection Entry") {
+                        Picker("Type", selection: $selectedID) {
+                            ForEach(descriptors) { descriptor in
+                                Text(descriptor.displayName).tag(descriptor.id)
+                            }
+                        }
+                        // A reply or like has no title field — it is identified by its target URL,
+                        // so asking for a title would collect a value the entry never stores (#916).
+                        if selectedDescriptor?.titleField != nil {
+                            TextField("Title", text: $title)
+                        }
+                        // Field names match the inspector's labels in `TypedEntryForm`.
+                        ForEach(requiredURLFields, id: \.name) { field in
+                            TextField(
+                                field.name,
+                                text: urlBinding(field.name),
+                                prompt: Text(verbatim: "https://example.com/post"))
+                        }
+                        TextField("Slug", text: $slug, prompt: Text("optional"))
+                        if hasMalformedURL {
+                            Text("Enter an absolute URL, e.g. https://example.com/post")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .onChange(of: selectedID) { urlValues = [:] }
+```
+
+Add these computed helpers immediately after the existing `selectedCollection` property:
+
+```swift
+    private var requiredURLFields: [ContentTypeField] {
+        selectedDescriptor?.requiredURLFields ?? []
+    }
+
+    private func urlBinding(_ name: String) -> Binding<String> {
+        Binding(get: { urlValues[name] ?? "" }, set: { urlValues[name] = $0 })
+    }
+
+    private func trimmedURL(_ name: String) -> String {
+        (urlValues[name] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Every required `.url` field holds a value the write boundary will accept.
+    private var urlFieldsAreValid: Bool {
+        requiredURLFields.allSatisfy { ContentFieldValidation.isAbsoluteURL(trimmedURL($0.name)) }
+    }
+
+    /// A field the user has started typing into that isn't a valid URL yet — drives the hint below
+    /// the fields. Empty fields don't nag; they just leave Create disabled.
+    private var hasMalformedURL: Bool {
+        requiredURLFields.contains {
+            let value = trimmedURL($0.name)
+            return !value.isEmpty && !ContentFieldValidation.isAbsoluteURL(value)
+        }
+    }
+
+    /// Types without a title field impose no title requirement.
+    private var titleIsSatisfied: Bool {
+        selectedDescriptor?.titleField == nil
+            || !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+```
+
+- [ ] **Step 4: Gate Create on the URLs and pass them through**
+
+Still in `NewCollectionEntrySheet`, change the confirmation toolbar item's `.disabled` modifier from:
+
+```swift
+                    .disabled(isCreating || selectedCollection == nil || title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+```
+
+to:
+
+```swift
+                    .disabled(isCreating || selectedCollection == nil || !titleIsSatisfied || !urlFieldsAreValid)
+```
+
+and change `create()` from:
+
+```swift
+    private func create() {
+        guard let descriptor = selectedDescriptor, selectedCollection != nil else { return }
+        let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanSlug = slug.trimmingCharacters(in: .whitespacesAndNewlines)
+        isCreating = true
+        errorMessage = nil
+        Task {
+            let result = await onCreate(cleanTitle, cleanSlug.isEmpty ? nil : cleanSlug, descriptor)
+```
+
+to:
+
+```swift
+    private func create() {
+        guard let descriptor = selectedDescriptor, selectedCollection != nil else { return }
+        let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanSlug = slug.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanURLs = requiredURLFields.reduce(into: [String: String]()) { values, field in
+            values[field.name] = trimmedURL(field.name)
+        }
+        isCreating = true
+        errorMessage = nil
+        Task {
+            let result = await onCreate(
+                cleanTitle, cleanSlug.isEmpty ? nil : cleanSlug, descriptor, cleanURLs)
+```
+
+Leave the rest of `create()` (the `MainActor.run` result switch) unchanged.
+
+- [ ] **Step 5: Update the call site**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, change the `newCollectionPresented` sheet closure from:
+
+```swift
+            ) { title, slug, descriptor in
+                await model.createCollectionEntry(title: title, slug: slug, descriptor: descriptor)
+            }
+```
+
+to:
+
+```swift
+            ) { title, slug, descriptor, fieldValues in
+                await model.createCollectionEntry(
+                    title: title, slug: slug, descriptor: descriptor, fieldValues: fieldValues)
+            }
+```
+
+- [ ] **Step 6: Build and verify manually**
+
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+If the project file is missing or stale (a fresh worktree, or `project.yml` changed), run `xcodegen generate` first. If the build fails with `vendor-node.sh: Operation not permitted`, the generated project picked up `ENABLE_USER_SCRIPT_SANDBOXING=YES` — re-run `xcodegen generate` and decline Xcode's "recommended settings" prompt. If it fails on "Check container resources", `rsync` `Resources/container-{image,kernel,initfs}` from the main checkout.
+
+Then run the app and check **File ▸ New ▸ Collection Entry…**:
+
+1. Select **Like** — the Title row is gone, an `likeOf` row is present, Create is disabled.
+2. Type `example.com` into `likeOf` — the "Enter an absolute URL" hint appears, Create stays disabled.
+3. Type `https://example.com/blog/hello-world` — the hint clears, Create enables.
+4. Create it. The new file is `src/content/likes/<today>-example-com-hello-world.md` and its frontmatter has a live `likeOf: "https://example.com/blog/hello-world"`.
+5. Switch the Picker to **Bookmark** — the Title row reappears and the `likeOf` value is cleared, replaced by an empty `bookmarkOf` row.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindowModel.swift Sources/AnglesiteApp/NewContentSheets.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(ui): collect required URLs in the New Collection sheet (#916)"
+```
+
+---
+
+### Task 8: Localization catalog and final verification
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/Localizable.xcstrings` (generated)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+Task 7 adds one new user-visible literal — `"Enter an absolute URL, e.g. https://example.com/post"` — and removes none (the `"Title"` row is conditionally hidden, not deleted). The catalog merge only happens in the Xcode IDE, so a CLI-only build needs the manual sync from `CONTRIBUTING.md`.
+
+- [ ] **Step 1: Build, then sync the catalog**
+
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+xcrun xcstringstool sync Sources/AnglesiteApp/Localizable.xcstrings \
+  --stringsdata $(find ~/Library/Developer/Xcode/DerivedData/Anglesite-*/Build/Intermediates.noindex/Anglesite.build/Debug/Anglesite.build/Objects-normal/arm64 -name "*.stringsdata") \
+  --skip-marking-strings-stale
+```
+
+`--skip-marking-strings-stale` is mandatory: without it, `sync` deletes any key absent from the given `.stringsdata` set, which can empty the whole 700+-key catalog.
+
+- [ ] **Step 2: Review the catalog diff**
+
+```bash
+git diff --stat Sources/AnglesiteApp/Localizable.xcstrings
+git diff Sources/AnglesiteApp/Localizable.xcstrings | head -60
+```
+
+Expected: a small diff adding the `"Enter an absolute URL, e.g. https://example.com/post"` key. If the diff is large or removes keys, discard it (`git checkout -- Sources/AnglesiteApp/Localizable.xcstrings`), run a clean build (`xcodebuild … clean build`), and re-sync before committing.
+
+- [ ] **Step 3: Run the full verification set**
+
+```bash
+swift test --package-path .
+```
+
+Expected: PASS, whole package.
+
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+```bash
+scripts/check-localization-catalog.sh
+```
+
+Expected: PASS.
+
+The JS overlay (`JS/edit-overlay/`) and `Resources/Template/` are untouched by this change, so their suites don't need running.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/Localizable.xcstrings
+git commit -m "chore(l10n): sync string catalog for the URL hint (#916)"
+```
+
+- [ ] **Step 5: Open the PR**
+
+Build the PR body from `.github/PULL_REQUEST_TEMPLATE.md`'s actual headings — **Summary**, **Paired PR check**, **Test plan** — not a generic Summary/Test-plan shape. Under **Paired PR check**, state that this is app-only: no MCP schema change and no `Resources/Template/` change, so no sibling PR in `Anglesite/anglesite` is needed.
+
+```bash
+git push -u origin claude/issue-916-beb1c1
+gh issue edit 916 --remove-label "🛠️ In Progress"
+```
+
+Open the PR only after the push succeeds — an unpushed commit isn't in the PR.
+
+---
+
+## Notes for the implementer
+
+- **`MicropubContentCommitter`** (`Sources/AnglesiteCore/MicropubContentCommitter.swift:118`) calls `renderEntry` with no `fieldValues`. It is deliberately left alone: the default `[:]` preserves its current output exactly. Micropub's own required-URL handling is a separate concern.
+- **The `ContentOperationsService` protocol is not widened.** Its `createTyped(siteID:typeID:title:onProgress:)` witness stays title-only. After Task 5, calling *that* witness for a bookmark/reply/like returns `.failed` — which is correct (it can't supply a valid URL) and is what `createTypedRejectsMissingRequiredURL` locks in.
+- **Collision behavior is unchanged.** Two replies to the same URL on the same day still hit the existing "A replies entry already exists at …" failure, which the sheet surfaces; the user types an explicit slug. Auto-suffixing was considered and left out of scope.

--- a/docs/superpowers/specs/2026-07-27-required-url-scaffold-design.md
+++ b/docs/superpowers/specs/2026-07-27-required-url-scaffold-design.md
@@ -1,0 +1,215 @@
+# Required `.url` fields collected at creation — design (#916)
+
+- **Date:** 2026-07-27
+- **Status:** Proposed
+- **Issue:** [#916 — ContentScaffold: required `.url` fields scaffold an invalid empty value](https://github.com/Anglesite/Anglesite-app/issues/916)
+- **Related:** [#913 — audience field on typed content](https://github.com/Anglesite/Anglesite-app/pull/913) (fixed the optional-`.url` half), [#369](https://github.com/Anglesite/Anglesite-app/issues/369), [#344 — V-1.2 personal content types](https://github.com/Anglesite/Anglesite-app/issues/344)
+
+## Problem
+
+`ContentScaffold.renderEntry` scaffolds every required `.url` field as a live `field: ""` line.
+`bookmarkOf`, `inReplyTo`, and `likeOf` are `z.string().url()` (required) in
+`Resources/Template/src/content.config.ts`, and an empty string is not a valid URL. So a freshly
+created bookmark, reply, or like is written **and committed** in a state that fails Astro
+content-collection validation — `astro check`, the dev-server render, and the build all reject it
+until the user fills in the URL and re-saves.
+
+No `createTyped` call site accepts per-field values, so there is no way to pre-fill the URL at
+creation time.
+
+## Decision
+
+**Collect the required URL in the New Collection sheet and thread it through to the scaffold**, so
+the first write is already schema-valid. Validation is enforced at the write boundary in
+`NativeContentOperations`, not only in the sheet.
+
+### Why not the other two options in the issue
+
+The issue proposed three fixes. Two do not survive scrutiny:
+
+**Comment out required `.url` fields too** (mirroring #913's optional treatment) does *not* fix the
+bug. A commented-out required field is a *missing* required field, which Zod rejects exactly as it
+rejects an invalid one. `astro check` still fails; only the error message changes. This option
+trades one invalid file for another while also breaking the "required fields stay live" convention
+established by the `.datetime`/`.date` cases.
+
+**Relax `bookmarkOf`/`inReplyTo`/`likeOf` to `.optional()`** makes the file validate by making the
+schema weaker than the domain. A `bookmark` with no `bookmarkOf` is not a bookmark; the h-entry
+projection would emit an empty `u-bookmark-of`, and the same for `u-in-reply-to` and `u-like-of`.
+Permanently weakening the published microformat contract to work around a creation-time gap is the
+wrong trade.
+
+Prompting is also the better UX independent of the schema. `bookmark`, `reply`, and `like` are
+*defined* by their target URL. `reply` and `like` don't even have a `title` field — yet
+`NewCollectionEntrySheet` today requires a Title (used only to derive the slug, then discarded).
+The sheet asks for the one thing that doesn't matter and not the one that does.
+
+## Design
+
+### 1. Scaffold accepts caller-supplied field values
+
+`ContentScaffold.renderEntry` gains a `fieldValues: [String: String] = [:]` parameter. One uniform
+rule applies across the four scalar-string kinds (`.string`, `.text`, `.url`, `.image`):
+
+```
+value = fieldValues[field.name] ?? (title-like field ? title : "")
+```
+
+A `.url` line stays commented out only when the field is **optional and no value was supplied**. A
+supplied value always renders live, for optional and required fields alike.
+
+Every other kind is untouched. With an empty `fieldValues`, output is byte-identical to today's, so
+#798's `draft: true` default and #913's optional-`.url` comment-out behavior are both preserved.
+
+The parameter is pure input to a pure function — `renderEntry` stays side-effect-free.
+
+### 2. URL validation
+
+New file `Sources/AnglesiteCore/ContentFieldValidation.swift`:
+
+```swift
+public enum ContentFieldValidation {
+    /// Parseable, with a scheme and a non-empty host.
+    public static func isAbsoluteURL(_ value: String) -> Bool
+}
+```
+
+This mirrors the rule `IntegrationPlanner` already applies to its own `.url` fields
+(`Sources/AnglesiteCore/IntegrationPlanner.swift`): require a **host**, not merely a parseable
+scheme, so `"https:"` and `"mailto:a@b.c"` are rejected. That is strictly tighter than Zod's
+`z.string().url()`, so anything accepted here is accepted by `astro check`.
+
+It lives in its own small type rather than on `ContentScaffold` — scaffolding renders, it doesn't
+validate — and in `AnglesiteCore` so it is portable and testable without the app target.
+
+### 3. Enforcement at the write boundary
+
+`NativeContentOperations.createTyped` gains `fieldValues: [String: String] = [:]` and, before
+writing:
+
+- every **required** `.url` field of the descriptor must have a supplied value that passes
+  `isAbsoluteURL`, else `.failed(reason:)` naming the field;
+- any supplied **optional** `.url` value must also pass, else `.failed(reason:)`.
+
+This is the actual guarantee. The sheet's own disabled-Create state is a UX affordance; the write
+boundary is what makes it impossible for any caller — a future App Intent, a test, an FM tool — to
+commit an invalid entry.
+
+### 4. Slug derivation for title-less types
+
+`ContentScaffold.slugFromURL(_ value: String, now: Date) -> String`, pure:
+
+1. `yyyy-MM-dd` from `now` in UTC, matching the ISO8601 formatter `renderEntry` already uses;
+2. the URL's host, with a leading `www.` dropped;
+3. the last non-empty path component (query and fragment ignored);
+4. joined and run through `slugify`.
+
+Returns `""` if the value doesn't parse or has no host.
+
+```
+https://example.com/blog/hello-world  →  2026-07-27-example-com-hello-world
+https://example.com/                  →  2026-07-27-example-com
+https://www.example.com/a/b/          →  2026-07-27-example-com-b
+```
+
+The date prefix makes collisions practically impossible (two replies to the same URL on the same
+day), keeps entries chronologically sortable, and matches the IndieWeb convention for replies and
+likes. The sheet's optional Slug field still overrides it.
+
+Slug precedence in `createTyped` becomes:
+
+```
+explicit slug → title → URL-derived → descriptor.id
+```
+
+The URL-derived step uses the value supplied for the **first** entry in
+`descriptor.requiredURLFields`, i.e. declaration order. Each of `bookmark`, `reply`, and `like` has
+exactly one, and in all three it is the first field of the descriptor; declaration order gives a
+deterministic answer if a future type declares more.
+
+`descriptor.id` is today's final fallback and is retained. Collision behavior is unchanged: an
+existing file at the target path still returns `.failed(reason: "A <collection> entry already
+exists at …")`, which the sheet surfaces, and the user can type an explicit slug.
+
+### 5. Descriptor helpers
+
+Two computed properties on `ContentTypeDescriptor`, so the sheet and the scaffold share one
+definition instead of each carrying its own notion of "the title field":
+
+- `titleField: ContentTypeField?` — the first field named `title`, `name`, or `itemReviewed`.
+  `ContentScaffold`'s private `titleLikeFieldNames` set moves behind this.
+- `requiredURLFields: [ContentTypeField]` — required fields of kind `.url`, in declaration order.
+
+### 6. New Collection sheet
+
+`NewCollectionEntrySheet` (`Sources/AnglesiteApp/NewContentSheets.swift`):
+
+- The **Title** row renders only when `descriptor.titleField != nil`. `bookmark` keeps it; `reply`
+  and `like` lose it, along with the throwaway-Title requirement.
+- One `TextField` per `descriptor.requiredURLFields` entry, labeled with the **raw field name** —
+  the same convention `TypedEntryForm` already uses for the inspector
+  (`Sources/AnglesiteApp/TypedEntryEditorView.swift`) — with a `https://example.com/…` prompt.
+- **Create** is enabled when the collection resolves, every required URL passes `isAbsoluteURL`,
+  and — for title-bearing types only — the title is non-empty.
+- A malformed URL shows an inline message in the existing `errorMessage` style.
+- Per-field values reset when the type Picker changes.
+
+### 7. Threading
+
+```
+NewCollectionEntrySheet
+  → SiteWindowModel.createCollectionEntry(title:slug:descriptor:fieldValues:)
+  → ContentCreationWorkflow.createTyped(siteID:typeID:title:slug:fieldValues:)
+  → NativeContentOperations.createTyped(…fieldValues:)
+```
+
+`ContentCreationWorkflow`'s `TypedSlugCreator` typealias gains the parameter, as does the closure
+`ContentCreationWorkflow.native(…)` installs.
+
+### Known gap (documented, not fixed)
+
+The `ContentOperationsService` protocol witness is `createTyped(siteID:typeID:title:onProgress:)` —
+title-only — so a non-native runtime cannot carry field values. This is unreachable today:
+`ContentCreationWorkflow.native(…)` always installs `typedSlugCreator`, and the protocol-only path
+is exercised only by tests. Widening the protocol would ripple into
+`RemoteSandboxSiteRuntime` (#66) and `LocalContainerSiteRuntime` (#69) for no present benefit, so
+this design adds a code comment alongside the existing `createTypedSingleton` TODO in
+`NativeContentOperations` rather than changing the protocol.
+
+## Testing
+
+- **`ContentScaffoldTests`**
+  - a supplied required `.url` renders as a live, valid line;
+  - a supplied *optional* `.url` renders live rather than commented;
+  - an empty `fieldValues` reproduces today's output exactly, for a representative descriptor of
+    each shape (bookmark, reply, note, event);
+  - `slugFromURL` over the cases above plus unparseable input, a host-only URL, a trailing slash,
+    and a value with a query string.
+- **`ContentFieldValidationTests`** (new) — accepts `https://example.com`, `http://a.b/c?d=e`;
+  rejects `""`, `"not a url"`, `"https:"`, `"mailto:a@b.c"`, `"/relative/path"`.
+- **`NativeContentOperationsTests`**
+  - bookmark with a valid URL writes a live `bookmarkOf` line and commits;
+  - bookmark with an invalid URL returns `.failed` and leaves no file on disk;
+  - bookmark with no `fieldValues` at all returns `.failed` (the #916 regression guard);
+  - like with no title derives the dated URL slug.
+
+Verification before the PR:
+
+```sh
+swift test --package-path .
+xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+
+The sheet adds user-visible strings, so `Sources/AnglesiteApp/Localizable.xcstrings` needs the
+`xcstringstool sync` step from `CONTRIBUTING.md` and the reviewed diff committed alongside.
+
+## Out of scope
+
+- **Template schema changes.** `content.config.ts` is unchanged; this is app-only, so no paired
+  sidecar PR is needed.
+- **The typed entry inspector.** `TypedEntryForm` already lets the user edit `.url` fields after
+  creation and is not made to validate them here — a separate concern from the create path.
+- **Collision disambiguation.** Auto-suffixing a colliding slug (`-2`, `-3`) would change behavior
+  for every content type, not just the ones #916 touches.
+- **Prompting for required non-`.url` fields.** An empty required `.string` is incomplete but not
+  schema-*invalid*; the existing convention stands.


### PR DESCRIPTION
## Summary

- A freshly created **bookmark / reply / like** was written *and committed* with a live `bookmarkOf: ""` / `inReplyTo: ""` / `likeOf: ""`. Those fields are `z.string().url()` (required) in the template, and an empty string is not a valid URL — so the new entry failed `astro check`, the dev-server render, and the build until the user filled it in and re-saved. The New Collection sheet now collects that URL, and `NativeContentOperations.createTyped` refuses to write an entry whose required `.url` values are missing or malformed — so the guarantee lives at the write boundary, not in the sheet's disabled button.
- `reply` and `like` have no `title` field, yet the sheet demanded a Title purely to derive a slug and then discarded it. They now show a URL row instead, and their slug comes from the target URL: `https://example.com/blog/hello-world` → `2026-07-27-example-com-hello-world`. Slug precedence is explicit → title → URL-derived → type id.
- The issue proposed two other fixes; both were rejected on the merits and the reasoning is recorded in the design doc. Commenting out the required field swaps "invalid URL" for "missing required field" — Zod rejects both, so `astro check` still fails. Relaxing `bookmarkOf`/`inReplyTo`/`likeOf` to `.optional()` would make the file validate by making the schema weaker than the domain, emitting an empty `u-bookmark-of` in the published microformat.

Design: [`docs/superpowers/specs/2026-07-27-required-url-scaffold-design.md`](docs/superpowers/specs/2026-07-27-required-url-scaffold-design.md) · Plan: [`docs/superpowers/plans/2026-07-27-required-url-scaffold.md`](docs/superpowers/plans/2026-07-27-required-url-scaffold.md)

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

No MCP message-schema change, and `Resources/Template/src/content.config.ts` is deliberately untouched — the template schema is correct as written; the app was the thing producing values it rejects.

## Test plan

- [x] `swift test --package-path .` — 2745/2747. The two failures are `FoundationModelAssistantTests` ("Session ended without producing a response"), **confirmed pre-existing**: a clean `origin/main` worktree fails the same suite with the same two issues. This branch does not touch FoundationModels.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [x] `scripts/check-localization-catalog.sh` — PASS
- [x] Manual smoke (UI-touching), against a throwaway site, on a build of this branch's HEAD:
  1. **Page ▸ Collections ▸ New Collection…**, type **Like** → no Title row, a `likeOf` row, **Create** disabled.
  2. Typed `example.com` → "Enter an absolute URL" hint appeared, Create stayed disabled.
  3. Typed `https://example.com/blog/hello-world` → hint cleared, Create enabled.
  4. Switched to **Bookmark** → Title row returned, `bookmarkOf` empty (no carry-over from `likeOf`).
  5. **Regression check for the type-switch state leak:** typed a Title on Bookmark, switched back to Like (Title row hides but the value would persist), filled the URL, created. Result: `src/content/likes/2026-07-27-example-com-hello-world.md` — the *URL-derived* slug, not the leftover title — with a live `likeOf: "https://example.com/blog/hello-world"`, committed as `anglesite: add likes 2026-07-27-example-com-hello-world`.
- [x] **Acceptance criterion verified with a negative control.** The created file was parsed and validated against the `likes` schema transcribed from `content.config.ts` (`socialFields` + `likeOf: z.string().url()` + `publishDate: z.coerce.date()` + `draft`, `.strict()`), alongside the pre-#916 shape:
  ```
  PASS  app-created entry (this branch)
  FAIL  pre-#916 shape (negative control)
          likeOf: Invalid url
  ```

### Review notes

The final whole-branch review found a defect worse than the one being fixed: `URLComponents` rejects an interior space but **accepts a newline**, and `ContentScaffold.escapeYAML` escapes only `\` and `"` — so `https://example.com/post\nevil: true` passed validation and split the frontmatter into an unparseable file. Fixed in `b95a2de3`, together with a trim-vs-persist mismatch where the validated string wasn't the string written. `escapeYAML`'s remaining unreachable newline paths are #1009.

Follow-ups filed rather than scope-crept into this PR: #1008 (`CONTRIBUTING.md`'s `xcstringstool sync` glob pulls `.stringsdata` from sibling worktrees and corrupts the catalog — hit for real here), #1009, #1010 (required-field marker on the new URL rows), #1011, #1016.

Closes #916.

🤖 Generated with [Claude Code](https://claude.com/claude-code)