### PR TITLE
feat(template): a11y baseline: skip link, focus, motion, dark (#1012)

### DIFF
--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -42,8 +42,11 @@ const license = headLicense(Astro.props.license, siteLicense());
     <!-- anglesite:head-end -->
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to content</a>
     <!-- anglesite:nav -->
-    <slot />
+    <main id="main" tabindex="-1">
+      <slot />
+    </main>
     <Hcard />
     <Rights license={license} />
     <!-- anglesite:body-end -->

--- a/Resources/Template/src/pages/404.astro
+++ b/Resources/Template/src/pages/404.astro
@@ -3,11 +3,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout title="Page Not Found" description="The page you're looking for doesn't exist.">
-  <main class="not-found-page">
+  <div class="not-found-page">
     <h1>Page not found</h1>
     <p>The page you're looking for doesn't exist or may have moved.</p>
     <p><a href="/">Go back home</a></p>
-  </main>
+  </div>
 
   <style>
     .not-found-page {

--- a/Resources/Template/src/pages/blog/index.astro
+++ b/Resources/Template/src/pages/blog/index.astro
@@ -9,26 +9,24 @@ const posts = (
 ---
 
 <BaseLayout title="Blog" description="Read the latest posts and updates.">
-  <main>
-    <h1>Blog</h1>
-    <p><a href="/blog/rss.xml">Subscribe (RSS)</a> · <a href="/search/">Search the archive</a></p>
-    {
-      posts.length === 0 ? (
-        <p>No posts yet. Add a Markdown file in <code>src/content/blog/</code> to get started.</p>
-      ) : (
-        <ul>
-          {posts.map((post) => (
-            <li>
-              <DraftBadge draft={post.data.draft} />
-              <a href={`/blog/${post.id}/`}>{post.data.title}</a>
-              <time datetime={post.data.pubDate.toISOString()}>
-                {post.data.pubDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })}
-              </time>
-              {post.data.description && <p>{post.data.description}</p>}
-            </li>
-          ))}
-        </ul>
-      )
-    }
-  </main>
+  <h1>Blog</h1>
+  <p><a href="/blog/rss.xml">Subscribe (RSS)</a> · <a href="/search/">Search the archive</a></p>
+  {
+    posts.length === 0 ? (
+      <p>No posts yet. Add a Markdown file in <code>src/content/blog/</code> to get started.</p>
+    ) : (
+      <ul>
+        {posts.map((post) => (
+          <li>
+            <DraftBadge draft={post.data.draft} />
+            <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+            <time datetime={post.data.pubDate.toISOString()}>
+              {post.data.pubDate.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" })}
+            </time>
+            {post.data.description && <p>{post.data.description}</p>}
+          </li>
+        ))}
+      </ul>
+    )
+  }
 </BaseLayout>

--- a/Resources/Template/src/pages/index.astro
+++ b/Resources/Template/src/pages/index.astro
@@ -7,12 +7,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   title="Welcome — Your New Anglesite Business Website"
   description="Your business website is ready to set up in Anglesite."
 >
-  <main>
-    <section class="hero">
-      <h1>Welcome</h1>
-      <p>This site is ready to customize in Anglesite. Open the app to edit your pages, add content, and publish when you're ready.</p>
-      <p><a href="/blog/">Read the blog</a></p>
-      <!-- anglesite:hero-cta -->
-    </section>
-  </main>
+  <section class="hero">
+    <h1>Welcome</h1>
+    <p>This site is ready to customize in Anglesite. Open the app to edit your pages, add content, and publish when you're ready.</p>
+    <p><a href="/blog/">Read the blog</a></p>
+    <!-- anglesite:hero-cta -->
+  </section>
 </BaseLayout>

--- a/Resources/Template/src/pages/search.astro
+++ b/Resources/Template/src/pages/search.astro
@@ -18,7 +18,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <link slot="head" rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
 
   <!-- Keeps the search page itself out of its own results, where it would be pure noise. -->
-  <main data-pagefind-ignore>
+  <div data-pagefind-ignore>
     <h1>Search</h1>
 
     <pagefind-searchbox></pagefind-searchbox>
@@ -35,7 +35,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <a href="/rss.xml">subscribe by feed</a>.
       </p>
     </noscript>
-  </main>
+  </div>
 </BaseLayout>
 
 <!--

--- a/Resources/Template/src/styles/global.css
+++ b/Resources/Template/src/styles/global.css
@@ -11,6 +11,23 @@
   --radius-sm: 0.25rem;
   --radius-md: 0.5rem;
   --radius-lg: 1rem;
+  color-scheme: light dark;
+}
+
+/* Dark palette (#1012). Applying a built-in theme rewrites these declarations too
+   (ThemeApplier replaces `--key:` values file-wide), so a themed site stays a single
+   consistent palette in both schemes; the design-apply flow upserts only the top-level
+   `:root` block above and leaves this one alone. All pairs meet WCAG AA on
+   --color-background: text 14.4:1, muted 6.0:1 (4.5:1 on surface), links 6.8:1. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-primary: #60a5fa;
+    --color-accent: #fbbf24;
+    --color-background: #0f172a;
+    --color-surface: #1e293b;
+    --color-text: #e2e8f0;
+    --color-text-muted: #94a3b8;
+  }
 }
 
 *,
@@ -50,12 +67,41 @@ a:hover {
   text-decoration: underline;
 }
 
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* First focusable element on every page (BaseLayout). Visually hidden until it receives
+   keyboard focus, then shown as a small pill over the top-left corner. */
+.skip-link {
+  position: absolute;
+  inset-block-start: calc(var(--spacing-unit) * 2);
+  inset-inline-start: calc(var(--spacing-unit) * 2);
+  z-index: 100;
+  padding: calc(var(--spacing-unit) * 2) calc(var(--spacing-unit) * 4);
+  background-color: var(--color-primary);
+  color: var(--color-background);
+  border-radius: var(--radius-sm);
+  transform: translateY(calc(-100% - var(--spacing-unit) * 4));
+}
+
+.skip-link:focus {
+  transform: none;
+}
+
 main {
   flex: 1;
   width: 100%;
   max-width: 72rem;
   margin-inline: auto;
   padding-inline: calc(var(--spacing-unit) * 6);
+}
+
+/* The skip link's target: it takes programmatic focus (tabindex="-1") so assistive tech
+   follows the jump, but a focus ring around the whole content region is just noise. */
+main:focus {
+  outline: none;
 }
 
 .hero {
@@ -151,4 +197,18 @@ main {
   flex-direction: column;
   gap: calc(var(--spacing-unit) * 2);
   text-decoration: none;
+}
+
+/* Neutralize animation for visitors who ask for reduced motion — including anything
+   integrations or future components add on top of this sheet. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -70,40 +70,36 @@ public enum ContentScaffold {
         let description = description ?? "\(title)."
         let body: String
         switch template.id {
+        // No `<main>` wrapper: BaseLayout owns the page's single main landmark (#1012), so a
+        // scaffolded page contributes content only — a second `<main>` would nest invalidly.
         case PageTemplate.landing.id:
             body = """
-              <main>
-                <section>
-                  <p>Welcome</p>
-                  <h1>\(escapeHTML(title))</h1>
-                  <p>Add a short promise for this page.</p>
-                </section>
-                <section>
-                  <h2>Highlights</h2>
-                  <ul>
-                    <li>First thing visitors should know.</li>
-                    <li>Second thing visitors should know.</li>
-                    <li>Next step visitors can take.</li>
-                  </ul>
-                </section>
-              </main>
+              <section>
+                <p>Welcome</p>
+                <h1>\(escapeHTML(title))</h1>
+                <p>Add a short promise for this page.</p>
+              </section>
+              <section>
+                <h2>Highlights</h2>
+                <ul>
+                  <li>First thing visitors should know.</li>
+                  <li>Second thing visitors should know.</li>
+                  <li>Next step visitors can take.</li>
+                </ul>
+              </section>
             """
         case PageTemplate.contact.id:
             body = """
-              <main>
-                <h1>\(escapeHTML(title))</h1>
-                <p>Tell visitors how to reach you.</p>
-                <address>
-                  <a href="mailto:hello@example.com">hello@example.com</a>
-                </address>
-              </main>
+              <h1>\(escapeHTML(title))</h1>
+              <p>Tell visitors how to reach you.</p>
+              <address>
+                <a href="mailto:hello@example.com">hello@example.com</a>
+              </address>
             """
         default:
             body = """
-              <main>
-                <h1>\(escapeHTML(title))</h1>
-                <p>Add your content here.</p>
-              </main>
+              <h1>\(escapeHTML(title))</h1>
+              <p>Add your content here.</p>
             """
         }
         return """


### PR DESCRIPTION
## Summary

- Fixes #1012 — gives every scaffolded site the accessibility baseline the humane-design audit found missing: a skip link (WCAG 2.4.1), visible `:focus-visible` outlines (2.4.7), a global `prefers-reduced-motion` escape hatch (2.3.3), and a `prefers-color-scheme: dark` palette (all pairs AA-checked: text 14.4:1, muted 6.0:1, links 6.8:1 on the dark background).
- Moves the `<main>` landmark into `BaseLayout.astro` (`id="main"`, `tabindex="-1"`) so the skip link has a target on **every** page — including entry pages (`Hentry`/`Hevent`/`Hreview`/`BlogPost`) and `about.md`, which previously had **no** main landmark at all. The four pages that carried their own `<main>` are unwrapped (`404`/`search` keep their styling/`data-pagefind-ignore` hooks on inner `div`s), and `ContentScaffold.renderPage` no longer emits `<main>` so app-scaffolded pages don't nest a second landmark.
- The dark palette is shaped to coexist with the design machinery: `DesignApplyService.topLevelRootBlockRange` already skips a `:root` nested in a media query (it upserts only the top-level block), `ThemeApplier` rewrites `--key:` declarations file-wide so a built-in theme degrades to one consistent palette in both schemes, and `IntegrationPlanner.brandColor` still reads the first (light) `--color-primary` hex.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` — 2740 tests / 355 suites. Two failures in the initial run, both environmental and green on serial re-run: `DraftContentRenderSmoke` (races my concurrent template `npm run build` over the shared in-place `dist/`) and `FoundationModelAssistant` cancel-mid-stream (known live on-device FM flake; passed on re-run).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Manual smoke (if UI-touching): app UI untouched. Verified the built template output instead — see below.

## Template verification (CI template lane, run locally)

- [x] `npm test` — 450 pass / 0 fail
- [x] `npm run build` — `astro check` + build + microformats checker + Pagefind + `well-known.ts verify`, all green
- [x] `npm run test:worker` — 115 pass
- [x] Built-page checks: skip link is the first focusable element on every page; exactly **one** `<main>` per page (including `about/` and entry pages); dark-scheme, reduced-motion, and `color-scheme: light dark` rules present in the inlined CSS; nav integration still injects at its anchor between the skip link and `<main>`.

## Design notes

- **Existing-site skew:** already-scaffolded sites keep their current layout until the versioned template migration (#745) lands. Until then, a page created by the *new* app in an *old* site simply has no explicit `<main>` — the same landmark state that site's entry pages have today; nothing nests or breaks.
- **Themed sites and dark mode:** applying a built-in theme rewrites both light and dark declarations to the theme's single palette (documented in `global.css`); a design-interview apply updates only the light block and leaves the neutral dark palette in place. Neither path produces a broken half-state; per-scheme theme palettes can be a follow-up.
- The skip-link target suppresses its own focus ring (`main:focus { outline: none }`) since a ring around the entire content region is noise; interactive elements keep the new `:focus-visible` outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
