### PR TITLE
feat(#368): V-5.1a Communities — join/leave + group timeline

### DIFF
--- a/Sources/AnglesiteApp/CommunitiesModel.swift
+++ b/Sources/AnglesiteApp/CommunitiesModel.swift
@@ -100,7 +100,13 @@ final class CommunitiesModel {
             var ledger = CommunitiesLedger(communities: joined)
             ledger.record(community)
             joined = ledger.communities
-            try? persist(ledger)
+            do {
+                try persist(ledger)
+            } catch {
+                errorMessage =
+                    "Joined \(community.displayName ?? input), but couldn't save it locally: "
+                    + "\(error). It may not appear after restarting the app."
+            }
             joinHandleText = ""
             state = .loaded
         } catch {
@@ -120,6 +126,7 @@ final class CommunitiesModel {
 
     func confirmLeave() async {
         guard let community = leaveConfirmation else { return }
+        errorMessage = nil
         guard let ownActorURL, let publishToken else {
             errorMessage = "This site has no known public URL yet — deploy it at least once first."
             leaveConfirmation = nil
@@ -133,7 +140,13 @@ final class CommunitiesModel {
             var ledger = CommunitiesLedger(communities: joined)
             ledger.remove(actorID: community.actorID)
             joined = ledger.communities
-            try? persist(ledger)
+            do {
+                try persist(ledger)
+            } catch {
+                errorMessage =
+                    "Left \(community.displayName ?? community.id), but couldn't update the local "
+                    + "record: \(error). It may still appear after restarting the app."
+            }
             if selectedCommunityID == community.id {
                 selectedCommunityID = nil
                 timeline = []
@@ -164,6 +177,7 @@ final class CommunitiesModel {
               let community = joined.first(where: { $0.id == selectedCommunityID }),
               let outboxURL = community.outboxURL
         else { return }
+        errorMessage = nil
         isLoadingTimeline = true
         defer { isLoadingTimeline = false }
         let client = GroupTimelineClient(transport: timelineTransport)

--- a/Sources/AnglesiteApp/CommunitiesModel.swift
+++ b/Sources/AnglesiteApp/CommunitiesModel.swift
@@ -198,6 +198,10 @@ final class CommunitiesModel {
             if selectedCommunityID == community.id {
                 selectedCommunityID = nil
                 timeline = []
+                // Invalidates any in-flight loadTimeline() for the community just left, so it
+                // can't repopulate `timeline` after the selection has already moved on — same
+                // staleness guard `selectCommunity(_:)` uses.
+                timelineGeneration &+= 1
             }
         } catch {
             errorMessage = "Couldn't leave \(community.displayName ?? community.id): \(error)"
@@ -223,7 +227,13 @@ final class CommunitiesModel {
         guard let selectedCommunityID,
               let community = joined.first(where: { $0.id == selectedCommunityID }),
               let outboxURL = community.outboxURL
-        else { return }
+        else {
+            // A prior call may have left `isLoadingTimeline` set (e.g. still in flight for a
+            // community just switched away from); this call owns the current selection now, and
+            // it has nothing to load, so the spinner must not be left stuck on.
+            isLoadingTimeline = false
+            return
+        }
         let token = timelineGeneration
         errorMessage = nil
         isLoadingTimeline = true

--- a/Sources/AnglesiteApp/CommunitiesModel.swift
+++ b/Sources/AnglesiteApp/CommunitiesModel.swift
@@ -1,0 +1,182 @@
+// Sources/AnglesiteApp/CommunitiesModel.swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the main-pane Communities view (Website ▸ Communities…, V-5.1a #368): resolve a handle
+/// or URL, join/leave a fediverse `Group`, and read its public timeline. App glue only — protocol
+/// logic lives in `AnglesiteCore` (`CommunityActorResolver`, `CommunityMembershipClient`,
+/// `GroupTimelineClient`, `CommunitiesLedger`).
+///
+/// The three transports are injected at init — matching `FollowersModel.followersTransport`'s
+/// constructor-injection convention, not a per-call-site closure — because each client
+/// (`CommunityActorResolver`/`CommunityMembershipClient`/`GroupTimelineClient`) is still built
+/// fresh per call around the *current* `ownActorURL`/`publishToken` (those can change if the site
+/// is republished mid-session), but the transport underneath it stays fixed for the model's
+/// lifetime, exactly like `followersTransport` does for `FollowersModel`'s client.
+@MainActor
+@Observable
+final class CommunitiesModel {
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded
+        case noSiteURL
+        case notActivated
+        case unreachable(String)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var joined: [JoinedCommunity] = []
+    private(set) var selectedCommunityID: String?
+    private(set) var timeline: [GroupPost] = []
+    private(set) var isLoadingTimeline = false
+    var joinHandleText = ""
+    var errorMessage: String?
+    /// Non-nil ⟺ the "Leave this community?" confirmation is showing — mirrors
+    /// `SiteWindowModel.deleteConfirmation`'s item-based-confirmation pattern.
+    var leaveConfirmation: JoinedCommunity?
+
+    private var siteID: String?
+    private var configDirectory: URL?
+    private var siteURL: URL?
+    private var ownActorURL: URL?
+    private let secretStore: any SecretStore
+    private let resolverTransport: CommunityActorResolver.Transport
+    private let membershipTransport: CommunityMembershipClient.Transport
+    private let timelineTransport: GroupTimelineClient.Transport
+
+    init(
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        resolverTransport: @escaping CommunityActorResolver.Transport
+            = CommunityActorResolver.defaultTransport,
+        membershipTransport: @escaping CommunityMembershipClient.Transport
+            = CommunityMembershipClient.defaultTransport,
+        timelineTransport: @escaping GroupTimelineClient.Transport
+            = GroupTimelineClient.defaultTransport
+    ) {
+        self.secretStore = secretStore
+        self.resolverTransport = resolverTransport
+        self.membershipTransport = membershipTransport
+        self.timelineTransport = timelineTransport
+    }
+
+    /// Records which site this pane talks to and loads the joined-communities ledger from disk.
+    /// No network I/O. Called once per site open from `SiteWindowModel.loadAndStart()`, mirroring
+    /// `FollowersModel.configure(site:)`.
+    func configure(site: CurrentSite) {
+        siteID = site.id
+        configDirectory = site.configDirectory
+        joined = CommunitiesLedger.load(from: site.configDirectory)?.communities ?? []
+        siteURL = DeployCoordinator.resolveSiteURL(siteDirectory: site.sourceDirectory).flatMap { URL(string: $0) }
+        ownActorURL = siteURL.map { ActivityPubActor.actorURL(siteURL: $0) }
+        state = joined.isEmpty ? .idle : .loaded
+    }
+
+    private var publishToken: String? {
+        guard let siteID else { return nil }
+        return try? secretStore.read(account: SecretAccounts.activityPubPublishToken(siteID: siteID))
+    }
+
+    // MARK: - Join
+
+    func join() async {
+        let input = joinHandleText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !input.isEmpty else { return }
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        errorMessage = nil
+        do {
+            let resolved = try await CommunityActorResolver(transport: resolverTransport).resolve(input)
+            let membership = CommunityMembershipClient(
+                ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+            let activityID = try await membership.follow(target: resolved.actorID)
+            let community = JoinedCommunity(
+                actorID: resolved.actorID, outboxURL: resolved.outboxURL,
+                handle: resolved.handle, displayName: resolved.name ?? resolved.preferredUsername,
+                joinedAt: Date(), followActivityID: activityID)
+            var ledger = CommunitiesLedger(communities: joined)
+            ledger.record(community)
+            joined = ledger.communities
+            try? persist(ledger)
+            joinHandleText = ""
+            state = .loaded
+        } catch {
+            errorMessage = "Couldn't join \(input): \(error)"
+        }
+    }
+
+    // MARK: - Leave
+
+    func requestLeave(_ community: JoinedCommunity) {
+        leaveConfirmation = community
+    }
+
+    func cancelLeave() {
+        leaveConfirmation = nil
+    }
+
+    func confirmLeave() async {
+        guard let community = leaveConfirmation else { return }
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            leaveConfirmation = nil
+            return
+        }
+        do {
+            let membership = CommunityMembershipClient(
+                ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+            try await membership.unfollow(
+                target: community.actorID, followActivityID: community.followActivityID)
+            var ledger = CommunitiesLedger(communities: joined)
+            ledger.remove(actorID: community.actorID)
+            joined = ledger.communities
+            try? persist(ledger)
+            if selectedCommunityID == community.id {
+                selectedCommunityID = nil
+                timeline = []
+            }
+            leaveConfirmation = nil
+        } catch {
+            errorMessage = "Couldn't leave \(community.displayName ?? community.id): \(error)"
+            leaveConfirmation = nil
+        }
+    }
+
+    private func persist(_ ledger: CommunitiesLedger) throws {
+        guard let configDirectory else { return }
+        try ledger.save(to: configDirectory)
+    }
+
+    // MARK: - Timeline
+
+    func selectCommunity(_ id: String) {
+        guard id != selectedCommunityID else { return }
+        selectedCommunityID = id
+        timeline = []
+        Task { await loadTimeline() }
+    }
+
+    func loadTimeline() async {
+        guard let selectedCommunityID,
+              let community = joined.first(where: { $0.id == selectedCommunityID }),
+              let outboxURL = community.outboxURL
+        else { return }
+        isLoadingTimeline = true
+        defer { isLoadingTimeline = false }
+        let client = GroupTimelineClient(transport: timelineTransport)
+        do {
+            let head = try await client.collection(at: outboxURL)
+            guard let firstPage = head.firstPage else {
+                timeline = []
+                return
+            }
+            let page = try await client.page(at: firstPage)
+            timeline = page.items
+        } catch {
+            errorMessage = "Couldn't load \(community.displayName ?? community.id)'s timeline: \(error)"
+        }
+    }
+}

--- a/Sources/AnglesiteApp/CommunitiesModel.swift
+++ b/Sources/AnglesiteApp/CommunitiesModel.swift
@@ -21,9 +21,13 @@ final class CommunitiesModel {
         case idle
         case loading
         case loaded
+        /// No public URL — the site has never been published. The only failure mode this model
+        /// can genuinely observe: `configure(site:)`/`resolveSite()` do no network I/O, they only
+        /// read the ledger and the site's local `.site-config`, so there's no HTTP status to
+        /// classify the way `FollowersModel.State` classifies a Worker response into
+        /// `.notActivated`/`.unreachable`. Those two cases were copied from that sibling type but
+        /// never had a trigger here, so they aren't carried over.
         case noSiteURL
-        case notActivated
-        case unreachable(String)
     }
 
     private(set) var state: State = .idle
@@ -39,8 +43,14 @@ final class CommunitiesModel {
 
     private var siteID: String?
     private var configDirectory: URL?
+    private var sourceDirectory: URL?
     private var siteURL: URL?
     private var ownActorURL: URL?
+    /// Bumped by every `selectCommunity(_:)`. `loadTimeline()` captures it as a `token` at entry
+    /// and checks it after each `await`, so a slower load for a community the owner already
+    /// clicked away from can't overwrite the newer selection's timeline (or stomp its
+    /// `isLoadingTimeline`) once it finally lands — mirrors `FollowersModel.generation`.
+    private var timelineGeneration = 0
     private let secretStore: any SecretStore
     private let resolverTransport: CommunityActorResolver.Transport
     private let membershipTransport: CommunityMembershipClient.Transport
@@ -67,10 +77,35 @@ final class CommunitiesModel {
     func configure(site: CurrentSite) {
         siteID = site.id
         configDirectory = site.configDirectory
+        sourceDirectory = site.sourceDirectory
         joined = CommunitiesLedger.load(from: site.configDirectory)?.communities ?? []
-        siteURL = DeployCoordinator.resolveSiteURL(siteDirectory: site.sourceDirectory).flatMap { URL(string: $0) }
-        ownActorURL = siteURL.map { ActivityPubActor.actorURL(siteURL: $0) }
+        resolveSite()
+    }
+
+    /// Re-reads the site's public URL from its `.site-config`.
+    ///
+    /// Split out of ``configure(site:)`` — which runs once per site open, from
+    /// `SiteWindowModel.loadAndStart()` — so ``retry()`` can run it again without needing a
+    /// `CurrentSite`. Without that, `.noSiteURL` would be a dead end: it tells the owner to
+    /// publish the site, and the pane could never notice that they did, until the window is
+    /// closed and reopened. Still no network I/O — this reads one local config file, exactly as
+    /// `configure` always did. Mirrors `FollowersModel.resolveSite()`.
+    private func resolveSite() {
+        guard let sourceDirectory else { return }
+        siteURL = DeployCoordinator.resolveSiteURL(siteDirectory: sourceDirectory).flatMap { URL(string: $0) }
+        guard let siteURL else {
+            ownActorURL = nil
+            state = .noSiteURL
+            return
+        }
+        ownActorURL = ActivityPubActor.actorURL(siteURL: siteURL)
         state = joined.isEmpty ? .idle : .loaded
+    }
+
+    /// The `.noSiteURL` state's Try Again: re-resolves the site URL, which is what makes
+    /// `.noSiteURL` genuinely recoverable from inside the pane once the owner publishes.
+    func retry() async {
+        resolveSite()
     }
 
     private var publishToken: String? {
@@ -90,6 +125,14 @@ final class CommunitiesModel {
         errorMessage = nil
         do {
             let resolved = try await CommunityActorResolver(transport: resolverTransport).resolve(input)
+            // Already joined: `CommunitiesLedger.record(_:)` would no-op on the duplicate
+            // `actorID` anyway, but skipping here avoids a needless `Follow` POST to the remote
+            // server and discarding its (unused) freshly-returned activity id.
+            if let existing = joined.first(where: { $0.actorID == resolved.actorID }) {
+                joinHandleText = ""
+                selectCommunity(existing.id)
+                return
+            }
             let membership = CommunityMembershipClient(
                 ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
             let activityID = try await membership.follow(target: resolved.actorID)
@@ -126,10 +169,15 @@ final class CommunitiesModel {
 
     func confirmLeave() async {
         guard let community = leaveConfirmation else { return }
+        // Cleared synchronously, before any `await` — matching `SiteWindowModel.confirmDelete()`
+        // (#968/#969). `CommunitiesView`'s leave-confirmation alert now uses a no-op `isPresented`
+        // setter, so its getter (`leaveConfirmation != nil`) drives visibility directly: leaving
+        // this set for the duration of the network round-trip below let SwiftUI re-present the
+        // same alert and fire a second `unfollow` before the first completed.
+        leaveConfirmation = nil
         errorMessage = nil
         guard let ownActorURL, let publishToken else {
             errorMessage = "This site has no known public URL yet — deploy it at least once first."
-            leaveConfirmation = nil
             return
         }
         do {
@@ -151,10 +199,8 @@ final class CommunitiesModel {
                 selectedCommunityID = nil
                 timeline = []
             }
-            leaveConfirmation = nil
         } catch {
             errorMessage = "Couldn't leave \(community.displayName ?? community.id): \(error)"
-            leaveConfirmation = nil
         }
     }
 
@@ -169,6 +215,7 @@ final class CommunitiesModel {
         guard id != selectedCommunityID else { return }
         selectedCommunityID = id
         timeline = []
+        timelineGeneration &+= 1
         Task { await loadTimeline() }
     }
 
@@ -177,20 +224,28 @@ final class CommunitiesModel {
               let community = joined.first(where: { $0.id == selectedCommunityID }),
               let outboxURL = community.outboxURL
         else { return }
+        let token = timelineGeneration
         errorMessage = nil
         isLoadingTimeline = true
-        defer { isLoadingTimeline = false }
         let client = GroupTimelineClient(transport: timelineTransport)
         do {
             let head = try await client.collection(at: outboxURL)
+            // A newer `selectCommunity(_:)` landed while this was in flight — its own load owns
+            // `timeline`/`isLoadingTimeline` now, so this stale call must touch neither.
+            guard token == timelineGeneration else { return }
             guard let firstPage = head.firstPage else {
                 timeline = []
+                isLoadingTimeline = false
                 return
             }
             let page = try await client.page(at: firstPage)
+            guard token == timelineGeneration else { return }
             timeline = page.items
+            isLoadingTimeline = false
         } catch {
+            guard token == timelineGeneration else { return }
             errorMessage = "Couldn't load \(community.displayName ?? community.id)'s timeline: \(error)"
+            isLoadingTimeline = false
         }
     }
 }

--- a/Sources/AnglesiteApp/CommunitiesView.swift
+++ b/Sources/AnglesiteApp/CommunitiesView.swift
@@ -28,11 +28,16 @@ struct CommunitiesView: View {
         } message: { message in
             Text(message)
         }
+        // The setter has NO side effect, and each button is solely responsible for clearing
+        // `leaveConfirmation` — matching `SiteWindow`'s `deleteConfirmation` dialog (#968/#969).
+        // A clearing setter runs *after* Leave's synchronous action but *before* the `Task` it
+        // spawns gets to run, so `confirmLeave()`'s `guard let community = leaveConfirmation`
+        // would always see nil and silently return — no unfollow, ever.
         .alert(
             "Leave this community?",
             isPresented: Binding(
                 get: { communities.leaveConfirmation != nil },
-                set: { if !$0 { communities.cancelLeave() } }),
+                set: { _ in }),
             presenting: communities.leaveConfirmation
         ) { community in
             Button("Leave", role: .destructive) { Task { await communities.confirmLeave() } }
@@ -119,7 +124,7 @@ struct CommunitiesView: View {
         }
         .padding(.vertical, 4)
         .contextMenu {
-            if let url = post.url {
+            if let url = post.url, ActorProfileFetcher.isHTTPS(url) {
                 Button("Open in Browser") { NSWorkspace.shared.open(url) }
             }
         }

--- a/Sources/AnglesiteApp/CommunitiesView.swift
+++ b/Sources/AnglesiteApp/CommunitiesView.swift
@@ -1,0 +1,127 @@
+// Sources/AnglesiteApp/CommunitiesView.swift
+import SwiftUI
+import AppKit
+import AnglesiteCore
+
+/// Main-pane Communities surface (Website ▸ Communities…, V-5.1a #368): join/leave fediverse
+/// Group actors and read a per-group timeline. Mirrors `FollowersView`/`MicrosubReaderView`'s
+/// wiring shape — a dedicated pane with its own model, no in-content pane picker.
+struct CommunitiesView: View {
+    @Bindable var communities: CommunitiesModel
+
+    var body: some View {
+        HSplitView {
+            sidebar
+                .frame(minWidth: 220, idealWidth: 260, maxWidth: 340)
+            timelinePane
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .navigationSubtitle("Communities")
+        .alert(
+            "Communities error",
+            isPresented: Binding(
+                get: { communities.errorMessage != nil },
+                set: { if !$0 { communities.errorMessage = nil } }),
+            presenting: communities.errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) { communities.errorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
+        .alert(
+            "Leave this community?",
+            isPresented: Binding(
+                get: { communities.leaveConfirmation != nil },
+                set: { if !$0 { communities.cancelLeave() } }),
+            presenting: communities.leaveConfirmation
+        ) { community in
+            Button("Leave", role: .destructive) { Task { await communities.confirmLeave() } }
+            Button("Cancel", role: .cancel) { communities.cancelLeave() }
+        } message: { community in
+            Text("This site will stop receiving posts from \(community.displayName ?? community.id).")
+        }
+    }
+
+    @ViewBuilder
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                TextField("!community@instance or URL", text: $communities.joinHandleText)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { Task { await communities.join() } }
+                Button("Join") { Task { await communities.join() } }
+                    .disabled(communities.joinHandleText.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding()
+
+            if communities.joined.isEmpty {
+                Text("No communities joined yet — enter a handle above, like !birding@lemmy.ml.")
+                    .foregroundStyle(.secondary)
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            } else {
+                List(selection: Binding(
+                    get: { communities.selectedCommunityID },
+                    set: { if let id = $0 { communities.selectCommunity(id) } }
+                )) {
+                    ForEach(communities.joined) { community in
+                        communityRow(community).tag(community.id)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func communityRow(_ community: JoinedCommunity) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(community.displayName ?? community.handle ?? community.actorID.absoluteString)
+                .font(.headline)
+                .lineLimit(1)
+            if let handle = community.handle {
+                Text(handle).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            }
+        }
+        .padding(.vertical, 2)
+        .contextMenu {
+            Button("Leave…", role: .destructive) { communities.requestLeave(community) }
+        }
+    }
+
+    @ViewBuilder
+    private var timelinePane: some View {
+        if communities.selectedCommunityID == nil {
+            Text("Select a community to see its timeline.")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if communities.isLoadingTimeline {
+            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if communities.timeline.isEmpty {
+            Text("No posts yet.")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(communities.timeline) { post in
+                timelineRow(post)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func timelineRow(_ post: GroupPost) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(post.title ?? post.contentHTML ?? post.id)
+                .font(.headline)
+                .lineLimit(2)
+            if let author = post.authorName {
+                Text(author).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+        .contextMenu {
+            if let url = post.url {
+                Button("Open in Browser") { NSWorkspace.shared.open(url) }
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteApp/CommunitiesView.swift
+++ b/Sources/AnglesiteApp/CommunitiesView.swift
@@ -10,11 +10,20 @@ struct CommunitiesView: View {
     @Bindable var communities: CommunitiesModel
 
     var body: some View {
-        HSplitView {
-            sidebar
-                .frame(minWidth: 220, idealWidth: 260, maxWidth: 340)
-            timelinePane
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        Group {
+            switch communities.state {
+            case .noSiteURL:
+                message(
+                    "This site hasn't been published yet",
+                    detail: Text("Publish it at least once, then you can join communities."))
+            case .idle, .loading, .loaded:
+                HSplitView {
+                    sidebar
+                        .frame(minWidth: 220, idealWidth: 260, maxWidth: 340)
+                    timelinePane
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
         }
         .navigationSubtitle("Communities")
         .alert(
@@ -43,8 +52,37 @@ struct CommunitiesView: View {
             Button("Leave", role: .destructive) { Task { await communities.confirmLeave() } }
             Button("Cancel", role: .cancel) { communities.cancelLeave() }
         } message: { community in
-            Text("This site will stop receiving posts from \(community.displayName ?? community.id).")
+            // `community.displayName` is remote-supplied (a hostile Group's own actor-document
+            // `name`, already run through `DisplayString.safe` — which strips bidi/control
+            // scalars, not markdown syntax). The interpolated-`LocalizedStringKey` overload
+            // markdown-parses its content, so embedding it there directly would let a Group named
+            // e.g. `[Your Site](https://phish.example)` render as a live link inside a destructive
+            // confirmation. `Text(String)` binds to the plain-`StringProtocol` overload instead —
+            // verbatim, no markdown — matching `FollowersView`'s `Text(reason)` precedent.
+            Text("This site will stop receiving posts from ")
+                + Text(community.displayName ?? community.id)
+                + Text(".")
         }
+    }
+
+    /// `title` is static UI copy and localizes via the `LocalizedStringKey` overload. `detail` is
+    /// pre-built `Text` rather than `String` so the call site controls whether its content
+    /// localizes — mirrors `FollowersView.message(_:detail:)`. `.noSiteURL` is the only state this
+    /// pane can genuinely observe (`CommunitiesModel.configure`/`resolveSite` do no network I/O,
+    /// unlike `FollowersModel`'s Worker-backed `.notActivated`/`.unreachable`), so there's only
+    /// ever one message here, but the shape stays parallel in case that changes. Try Again calls
+    /// `retry()`, which re-resolves the site URL — what makes `.noSiteURL` recoverable without
+    /// closing and reopening the window once the owner publishes.
+    @ViewBuilder
+    private func message(_ title: LocalizedStringKey, detail: Text) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.title2)
+            detail.foregroundStyle(.secondary)
+            Button("Try Again") { Task { await communities.retry() } }
+                .padding(.top, 4)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -4,6 +4,9 @@
     "" : {
 
     },
+    "!community@instance or URL" : {
+
+    },
     "%@ %@" : {
       "localizations" : {
         "en" : {
@@ -152,6 +155,9 @@
 
     },
     "%lld%%" : {
+
+    },
+    "." : {
 
     },
     "/" : {
@@ -703,6 +709,15 @@
 
     },
     "Commit and push working-tree changes to your current branch" : {
+
+    },
+    "Communities" : {
+
+    },
+    "Communities error" : {
+
+    },
+    "Communities…" : {
 
     },
     "Complete Sign In" : {
@@ -1370,6 +1385,9 @@
     "Installed" : {
 
     },
+    "Join" : {
+
+    },
     "Just a few" : {
 
     },
@@ -1401,6 +1419,15 @@
 
     },
     "Learning %@’s conventions…" : {
+
+    },
+    "Leave" : {
+
+    },
+    "Leave this community?" : {
+
+    },
+    "Leave…" : {
 
     },
     "Left" : {
@@ -1571,6 +1598,9 @@
     "No changes needed." : {
 
     },
+    "No communities joined yet — enter a handle above, like !birding@lemmy.ml." : {
+
+    },
     "No component usage learned yet." : {
 
     },
@@ -1602,6 +1632,9 @@
 
     },
     "No matching graph nodes" : {
+
+    },
+    "No posts yet." : {
 
     },
     "No redirects yet. Add one below." : {
@@ -1851,6 +1884,9 @@
 
     },
     "Publish it at least once, then followers will appear here." : {
+
+    },
+    "Publish it at least once, then you can join communities." : {
 
     },
     "Publish to GitHub" : {
@@ -2209,6 +2245,9 @@
     "Select Parent" : {
 
     },
+    "Select a community to see its timeline." : {
+
+    },
     "Select a node" : {
 
     },
@@ -2543,6 +2582,9 @@
 
     },
     "This site hasn't been published yet" : {
+
+    },
+    "This site will stop receiving posts from " : {
 
     },
     "This will remove the file from your site. You can bring it back with Edit ▸ Undo." : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -771,6 +771,8 @@ struct SiteWindow: View {
             MicrosubReaderView(reader: model.reader)
         case .followers:
             FollowersView(followers: model.followers)
+        case .communities:
+            CommunitiesView(communities: model.communities)
         case .preview:
             previewPane(for: site)
         }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -13,6 +13,7 @@ enum MainPaneMode: Equatable {
     case cleanup        // Site ▸ Cleanup… (#714 moved it out of the sidebar)
     case reader         // Website ▸ Reader… (V-4.3, #365)
     case followers      // Website ▸ Followers… (V-4.2, #364)
+    case communities    // Website ▸ Communities… (V-5.1a, #368)
 }
 
 enum ActiveEditor {
@@ -139,6 +140,9 @@ final class SiteWindowModel {
     /// Drives the main-pane Followers view (Website ▸ Followers…, V-4.2 #364): the site's public
     /// ActivityPub followers collection, with lazily-enriched display identities.
     var followers = FollowersModel()
+    /// Drives the main-pane Communities view (Website ▸ Communities…, V-5.1a #368): join/leave
+    /// fediverse Group actors and read a per-group timeline.
+    var communities = CommunitiesModel()
     var harden = HardenModel()
     var onionRouting = OnionRoutingModel()
     var domain = DomainModel()
@@ -303,6 +307,17 @@ final class SiteWindowModel {
             activeEditor = nil
             inspectorContext = nil
             mainPaneMode = .followers
+        }
+    }
+
+    /// Switches the main pane to Communities (Website ▸ Communities…, V-5.1a #368). Mirrors
+    /// `presentFollowers()`'s leave-current-surface-first guard.
+    func presentCommunities() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            inspectorContext = nil
+            mainPaneMode = .communities
         }
     }
 
@@ -1527,6 +1542,7 @@ final class SiteWindowModel {
         cleanup.configure(site: currentSite)
         reader.configure(site: currentSite)
         followers.configure(site: currentSite)
+        communities.configure(site: currentSite)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -58,6 +58,9 @@ struct WebsiteCommands: Commands {
             Button("Followers…") { model?.presentFollowers() }
                 .disabled(model == nil)
 
+            Button("Communities…") { model?.presentCommunities() }
+                .disabled(model == nil)
+
             // Ellipsis items open a sheet for further input, per the HIG.
             Button("Harden…") { model?.harden.openSheet() }
                 .disabled(model?.canRunHarden != true)

--- a/Sources/AnglesiteCore/CommunitiesLedger.swift
+++ b/Sources/AnglesiteCore/CommunitiesLedger.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// One community this site has joined (V-5.1a, #368).
+public struct JoinedCommunity: Codable, Equatable, Sendable, Identifiable {
+    public let actorID: URL
+    /// For `GroupTimelineClient` — `nil` if the actor document didn't advertise one.
+    public let outboxURL: URL?
+    public let handle: String?
+    public let displayName: String?
+    public let joinedAt: Date
+    /// The `Follow` activity id `CommunityMembershipClient.follow(target:)` returned — threaded
+    /// back into `unfollow(target:followActivityID:)` on leave.
+    public let followActivityID: String?
+
+    public var id: String { actorID.absoluteString }
+
+    public init(
+        actorID: URL, outboxURL: URL?, handle: String?, displayName: String?, joinedAt: Date,
+        followActivityID: String?
+    ) {
+        self.actorID = actorID
+        self.outboxURL = outboxURL
+        self.handle = handle
+        self.displayName = displayName
+        self.joinedAt = joinedAt
+        self.followActivityID = followActivityID
+    }
+}
+
+/// Durable per-site record of which fediverse communities this site has joined —
+/// `Config/activitypub-communities.json`, app-owned, never in git. There is no public "following"
+/// collection to read this back from (`@dwk/activitypub` exposes `followers`, not `following`, as
+/// a public AS2 collection), so this ledger — not the Worker — is the source of truth for what the
+/// Communities pane lists. Same shape and crash-safety contract as `ActivityPubOutboxLedger`.
+public struct CommunitiesLedger: Codable, Equatable, Sendable {
+    public static let filename = "activitypub-communities.json"
+
+    public private(set) var communities: [JoinedCommunity]
+
+    public init(communities: [JoinedCommunity] = []) {
+        self.communities = communities
+    }
+
+    public func contains(actorID: URL) -> Bool {
+        communities.contains { $0.actorID == actorID }
+    }
+
+    /// No-ops if `actorID` is already recorded — matches `ActivityPubOutboxLedger.record`'s
+    /// idempotent-insert contract.
+    public mutating func record(_ community: JoinedCommunity) {
+        guard !contains(actorID: community.actorID) else { return }
+        communities.append(community)
+    }
+
+    public mutating func remove(actorID: URL) {
+        communities.removeAll { $0.actorID == actorID }
+    }
+
+    private struct Envelope: Codable {
+        let communities: [JoinedCommunity]
+    }
+
+    public static func load(from configDirectory: URL) -> CommunitiesLedger? {
+        let url = configDirectory.appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let envelope = try? decoder.decode(Envelope.self, from: data) else { return nil }
+        return CommunitiesLedger(communities: envelope.communities)
+    }
+
+    public func save(to configDirectory: URL) throws {
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(Envelope(communities: communities))
+        try data.write(to: configDirectory.appendingPathComponent(Self.filename), options: .atomic)
+    }
+}

--- a/Sources/AnglesiteCore/CommunityActorResolver.swift
+++ b/Sources/AnglesiteCore/CommunityActorResolver.swift
@@ -102,6 +102,9 @@ public struct CommunityActorResolver: Sendable {
             throw CommunityActorResolverError.webfingerFailed(
                 status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
         }
+        // URLSession follows redirects transparently, so this body may not have come from
+        // the webfinger endpoint at all. Re-check where it actually landed before trusting it.
+        if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
         struct Link: Decodable { let rel: String?; let type: String?; let href: String? }
         struct DTO: Decodable { let links: [Link]? }
         let dto: DTO

--- a/Sources/AnglesiteCore/CommunityActorResolver.swift
+++ b/Sources/AnglesiteCore/CommunityActorResolver.swift
@@ -1,0 +1,179 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// A remote actor resolved from a fediverse handle or a pasted URL — the join flow's first step
+/// (V-5.1a, #368). Carries just enough to display a confirmation ("Join Birding (Lemmy)?"),
+/// address a `Follow`, and read the group's timeline.
+public struct ResolvedCommunityActor: Sendable, Equatable {
+    /// The actor document's own `id` — the canonical IRI to address a `Follow`'s `object` at.
+    /// May differ from the URL that was fetched (webfinger's `self` link, or a pasted URL that
+    /// redirected).
+    public let actorID: URL
+    /// The actor's public outbox collection, for `GroupTimelineClient`. `nil` for an actor
+    /// document that doesn't advertise one — the timeline pane degrades to "no timeline available".
+    public let outboxURL: URL?
+    public let type: String?
+    public let preferredUsername: String?
+    public let name: String?
+    /// The `@name@host` (or `!name@host`) form the owner typed, sanitized for display.
+    public let handle: String?
+
+    public init(
+        actorID: URL, outboxURL: URL?, type: String?, preferredUsername: String?, name: String?,
+        handle: String?
+    ) {
+        self.actorID = actorID
+        self.outboxURL = outboxURL
+        self.type = type
+        self.preferredUsername = preferredUsername
+        self.name = name
+        self.handle = handle
+    }
+}
+
+public enum CommunityActorResolverError: Error, Equatable, Sendable {
+    case invalidHandle
+    case insecureURL
+    case webfingerFailed(status: Int, body: String)
+    /// The webfinger response had no `rel: "self"` AS2 link to follow.
+    case noActorLink
+    case requestFailed(status: Int, body: String)
+    case decodingFailed(String)
+}
+
+/// Resolves a fediverse handle (`!community@host`, `@user@host`, bare `name@host`) or a pasted
+/// actor URL to its actor document. Mirrors `@dwk/webfinger`'s `lookup.ts` (`parseHandle`,
+/// `webfingerQueryUrl`, `selectActorLink`, `resolveHandle`) client-side in Swift: this app makes
+/// its own outbound request as the signed-in user, so — like `ActorProfileFetcher` — it needs
+/// HTTPS-only and a byte cap, not the server-side SSRF guard `@dwk/activitypub`'s own resolver
+/// applies (that guard exists because *that* resolution runs inside a shared Cloudflare Worker).
+public struct CommunityActorResolver: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let transport: Transport
+
+    public init(transport: @escaping Transport = CommunityActorResolver.defaultTransport) {
+        self.transport = transport
+    }
+
+    public func resolve(_ input: String) async throws -> ResolvedCommunityActor {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let url = URL(string: trimmed), let scheme = url.scheme, url.host != nil,
+           ["http", "https"].contains(scheme.lowercased()) {
+            try Self.requireHTTPS(url)
+            return try await fetchActor(at: url, handle: nil)
+        }
+        guard let (name, host) = Self.parseHandle(trimmed) else {
+            throw CommunityActorResolverError.invalidHandle
+        }
+        let actorURL = try await webfingerResolve(name: name, host: host)
+        return try await fetchActor(at: actorURL, handle: DisplayString.safe("@\(name)@\(host)"))
+    }
+
+    /// Strips an optional leading `@`/`!` sigil, then splits on the *last* `@` so a name segment
+    /// that itself contains `@` (unlikely, but not this code's job to reject) still yields the
+    /// intended host. Returns `nil` for input with no `@` at all — the "not a handle" signal that
+    /// sends the caller down the URL path (which will itself reject it as invalid).
+    static func parseHandle(_ input: String) -> (name: String, host: String)? {
+        var body = input
+        if body.hasPrefix("@") || body.hasPrefix("!") { body.removeFirst() }
+        guard let atIndex = body.lastIndex(of: "@") else { return nil }
+        let name = String(body[body.startIndex..<atIndex])
+        let host = String(body[body.index(after: atIndex)...])
+        guard !name.isEmpty, !host.isEmpty else { return nil }
+        return (name, host)
+    }
+
+    private func webfingerResolve(name: String, host: String) async throws -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = "/.well-known/webfinger"
+        components.queryItems = [URLQueryItem(name: "resource", value: "acct:\(name)@\(host)")]
+        guard let webfingerURL = components.url else { throw CommunityActorResolverError.invalidHandle }
+
+        var request = URLRequest(url: webfingerURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = ActorProfileFetcher.timeout
+        let (data, http) = try await send(request)
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunityActorResolverError.webfingerFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        struct Link: Decodable { let rel: String?; let type: String?; let href: String? }
+        struct DTO: Decodable { let links: [Link]? }
+        let dto: DTO
+        do {
+            dto = try JSONDecoder().decode(DTO.self, from: data)
+        } catch {
+            throw CommunityActorResolverError.decodingFailed("\(error)")
+        }
+        guard let href = dto.links?.first(where: {
+            $0.rel == "self" && ($0.type?.contains("activity+json") == true || $0.type?.contains("ld+json") == true)
+        })?.href, let actorURL = URL(string: href) else {
+            throw CommunityActorResolverError.noActorLink
+        }
+        try Self.requireHTTPS(actorURL)
+        return actorURL
+    }
+
+    private func fetchActor(at url: URL, handle: String?) async throws -> ResolvedCommunityActor {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(ActivityPubFollowersClient.acceptHeader, forHTTPHeaderField: "Accept")
+        request.timeoutInterval = ActorProfileFetcher.timeout
+        let (data, http) = try await send(request)
+        if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunityActorResolverError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        struct DTO: Decodable {
+            let id: String
+            let type: String?
+            let preferredUsername: String?
+            let name: String?
+            let outbox: String?
+        }
+        do {
+            let dto = try JSONDecoder().decode(DTO.self, from: data)
+            guard let actorID = URL(string: dto.id) else {
+                throw CommunityActorResolverError.decodingFailed("actor id is not a URL: \(dto.id)")
+            }
+            return ResolvedCommunityActor(
+                actorID: actorID,
+                outboxURL: dto.outbox.flatMap(URL.init(string:)),
+                type: dto.type,
+                preferredUsername: dto.preferredUsername.map(DisplayString.safe),
+                name: dto.name.map(DisplayString.safe),
+                handle: handle)
+        } catch let error as CommunityActorResolverError {
+            throw error
+        } catch {
+            throw CommunityActorResolverError.decodingFailed("\(error)")
+        }
+    }
+
+    private func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        do {
+            return try await transport(request)
+        } catch {
+            throw CommunityActorResolverError.requestFailed(status: 0, body: "\(error)")
+        }
+    }
+
+    static func requireHTTPS(_ url: URL) throws {
+        guard url.scheme?.lowercased() == "https" else { throw CommunityActorResolverError.insecureURL }
+    }
+
+    private static let session = CappedHTTPTransport.session(
+        requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
+
+    public static let defaultTransport: Transport = { request in
+        try await CappedHTTPTransport.fetch(
+            request, session: session, cap: ActorProfileFetcher.maximumResponseBytes,
+            tooLarge: { CommunityActorResolverError.requestFailed(status: 0, body: "response too large (\($0) bytes)") })
+    }
+}

--- a/Sources/AnglesiteCore/CommunityActorResolver.swift
+++ b/Sources/AnglesiteCore/CommunityActorResolver.swift
@@ -98,13 +98,13 @@ public struct CommunityActorResolver: Sendable {
         request.httpMethod = "GET"
         request.timeoutInterval = ActorProfileFetcher.timeout
         let (data, http) = try await send(request)
+        // URLSession follows redirects transparently, so this body may not have come from
+        // the webfinger endpoint at all. Re-check where it actually landed before trusting it.
+        if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
         guard (200..<300).contains(http.statusCode) else {
             throw CommunityActorResolverError.webfingerFailed(
                 status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
         }
-        // URLSession follows redirects transparently, so this body may not have come from
-        // the webfinger endpoint at all. Re-check where it actually landed before trusting it.
-        if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
         struct Link: Decodable { let rel: String?; let type: String?; let href: String? }
         struct DTO: Decodable { let links: [Link]? }
         let dto: DTO

--- a/Sources/AnglesiteCore/CommunityActorResolver.swift
+++ b/Sources/AnglesiteCore/CommunityActorResolver.swift
@@ -52,6 +52,12 @@ public enum CommunityActorResolverError: Error, Equatable, Sendable {
 public struct CommunityActorResolver: Sendable {
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
+    /// Defense-in-depth for a caller-injected `Transport` that might not itself be capped — the
+    /// `defaultTransport` already enforces this via `CappedHTTPTransport`, but a webfinger document
+    /// and an actor document are both similarly small, so this reuses `ActorProfileFetcher`'s cap
+    /// rather than `GroupTimelineClient`'s larger one (outbox pages embed multiple activities).
+    public static let maximumResponseBytes = ActorProfileFetcher.maximumResponseBytes
+
     private let transport: Transport
 
     public init(transport: @escaping Transport = CommunityActorResolver.defaultTransport) {
@@ -105,6 +111,12 @@ public struct CommunityActorResolver: Sendable {
             throw CommunityActorResolverError.webfingerFailed(
                 status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
         }
+        // The default transport already aborts mid-stream past the cap; this re-check holds an
+        // injected transport to the same limit, mirroring `GroupTimelineClient.fetch`.
+        guard data.count <= Self.maximumResponseBytes else {
+            throw CommunityActorResolverError.requestFailed(
+                status: 0, body: "response too large (\(data.count) bytes)")
+        }
         struct Link: Decodable { let rel: String?; let type: String?; let href: String? }
         struct DTO: Decodable { let links: [Link]? }
         let dto: DTO
@@ -132,6 +144,12 @@ public struct CommunityActorResolver: Sendable {
         guard (200..<300).contains(http.statusCode) else {
             throw CommunityActorResolverError.requestFailed(
                 status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        // The default transport already aborts mid-stream past the cap; this re-check holds an
+        // injected transport to the same limit, mirroring `GroupTimelineClient.fetch`.
+        guard data.count <= Self.maximumResponseBytes else {
+            throw CommunityActorResolverError.requestFailed(
+                status: 0, body: "response too large (\(data.count) bytes)")
         }
         struct DTO: Decodable {
             let id: String

--- a/Sources/AnglesiteCore/CommunityMembershipClient.swift
+++ b/Sources/AnglesiteCore/CommunityMembershipClient.swift
@@ -1,0 +1,100 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum CommunityMembershipError: Error, Equatable, Sendable {
+    case requestFailed(status: Int, body: String)
+    case decodingFailed(String)
+}
+
+/// Joins/leaves a fediverse `Group` (V-5.1a, #368) by POSTing `Follow`/`Undo(Follow)` to this
+/// site's own outbox — the same owner-gated endpoint and `publishToken` bearer
+/// `ActivityPubOutboxBackfill` already uses (`@dwk/activitypub`'s "Owner-published Follow /
+/// Undo(Follow) now record the relationship and deliver to the target actor" behavior, phase 2).
+/// This site's Worker is the trusted party here (it holds the signing key and does the actual
+/// federated delivery), so — unlike `CommunityActorResolver` — there is no HTTPS/size-cap guard
+/// on this client itself; the target IRI it's given already passed through that resolver.
+public struct CommunityMembershipClient: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let outboxURL: URL
+    private let ownActorURL: URL
+    private let publishToken: String
+    private let transport: Transport
+
+    public init(
+        ownActorURL: URL, publishToken: String,
+        transport: @escaping Transport = CommunityMembershipClient.defaultTransport
+    ) {
+        self.ownActorURL = ownActorURL
+        self.outboxURL = ownActorURL.appendingPathComponent("outbox")
+        self.publishToken = publishToken
+        self.transport = transport
+    }
+
+    /// Returns the activity id the outbox reports back — persist it (`CommunitiesLedger`) so
+    /// `unfollow` can reference the exact original `Follow` in its `Undo`.
+    @discardableResult
+    public func follow(target: URL) async throws -> String {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Follow",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        let data = try await post(body)
+        return Self.activityID(from: data) ?? target.absoluteString
+    }
+
+    /// `followActivityID` is the id `follow(target:)` returned, if this membership was joined
+    /// through this client (the common case). When it's `nil` — e.g. membership predates this
+    /// feature — a synthetic nested `Follow` object stands in, a shape most AP implementations
+    /// accept for `Undo` since the concrete activity id was never recorded client-side.
+    public func unfollow(target: URL, followActivityID: String?) async throws {
+        let followObject: Any = followActivityID ?? [
+            "type": "Follow",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Undo",
+            "actor": ownActorURL.absoluteString,
+            "object": followObject,
+        ]
+        _ = try await post(body)
+    }
+
+    private func post(_ activity: [String: Any]) async throws -> Data {
+        var request = URLRequest(url: outboxURL)
+        request.httpMethod = "POST"
+        request.setValue("application/activity+json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: activity)
+
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw CommunityMembershipError.requestFailed(status: 0, body: "\(error)")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunityMembershipError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        return data
+    }
+
+    static func activityID(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return json["id"] as? String
+    }
+
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+}

--- a/Sources/AnglesiteCore/GroupTimelineClient.swift
+++ b/Sources/AnglesiteCore/GroupTimelineClient.swift
@@ -1,0 +1,150 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// One post from a joined community's public timeline (V-5.1a, #368) — deliberately minimal:
+/// enough to render a row and open the original. `id` is the wrapped object's `id` when present
+/// (a real post), else the bare activity id (an item this parser couldn't unwrap further, still
+/// worth a stub row so the timeline's count matches the collection's).
+public struct GroupPost: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let title: String?
+    public let contentHTML: String?
+    public let url: URL?
+    public let publishedAt: Date?
+    public let authorName: String?
+
+    public init(
+        id: String, title: String?, contentHTML: String?, url: URL?, publishedAt: Date?,
+        authorName: String?
+    ) {
+        self.id = id
+        self.title = title
+        self.contentHTML = contentHTML
+        self.url = url
+        self.publishedAt = publishedAt
+        self.authorName = authorName
+    }
+}
+
+public struct GroupTimelinePage: Sendable, Equatable {
+    public let items: [GroupPost]
+    public let next: URL?
+
+    public init(items: [GroupPost], next: URL?) {
+        self.items = items
+        self.next = next
+    }
+}
+
+public enum GroupTimelineError: Error, Equatable, Sendable {
+    /// The outbox URL, or the URL a redirect actually landed on, wasn't `https`.
+    case insecureURL
+    case requestFailed(status: Int, body: String)
+    case decodingFailed(String)
+}
+
+/// Reads a Group actor's public outbox (V-5.1a, #368) — the per-group timeline. Same
+/// unauthenticated, HTTPS-only, capped, AS2-collection-paging shape as `ActivityPubFollowersClient`
+/// (the collection) and `ActorProfileFetcher` (the HTTPS/size guard — this outbox is exactly as
+/// attacker-influenced as a follower's actor document, just a bigger one), but the collection
+/// belongs to an arbitrary *remote* Group rather than this site's own followers, and each item is
+/// a full (or partial) activity to render rather than a bare actor IRI. AS2 is loose about wire
+/// shape here (a bare activity-id string, or a fully embedded activity), so this parses with
+/// `JSONSerialization` — like `ActivityPubOutboxBackfill.activityID(from:)` — rather than fighting
+/// `Decodable` over a heterogeneous array.
+public struct GroupTimelineClient: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// 1 MB. A single actor document (`ActorProfileFetcher`'s 256 KB cap) is a few KB, but an
+    /// outbox page embeds several full activities at once — generous enough for a real page of
+    /// posts while still rejecting a pathological response.
+    public static let maximumResponseBytes = 1024 * 1024
+
+    private let transport: Transport
+
+    public init(transport: @escaping Transport = GroupTimelineClient.defaultTransport) {
+        self.transport = transport
+    }
+
+    public func collection(at outboxURL: URL) async throws -> (totalItems: Int, firstPage: URL?) {
+        let json = try await fetch(outboxURL)
+        let totalItems = json["totalItems"] as? Int ?? 0
+        let firstPage = (json["first"] as? String).flatMap(URL.init(string:))
+        return (totalItems, firstPage)
+    }
+
+    public func page(at url: URL) async throws -> GroupTimelinePage {
+        let json = try await fetch(url)
+        let rawItems = (json["orderedItems"] as? [Any]) ?? []
+        let items = rawItems.compactMap(Self.post(from:))
+        let next = (json["next"] as? String).flatMap(URL.init(string:))
+        return GroupTimelinePage(items: items, next: next)
+    }
+
+    private func fetch(_ url: URL) async throws -> [String: Any] {
+        try Self.requireHTTPS(url)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(ActivityPubFollowersClient.acceptHeader, forHTTPHeaderField: "Accept")
+        request.timeoutInterval = ActorProfileFetcher.timeout
+
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw GroupTimelineError.requestFailed(status: 0, body: "\(error)")
+        }
+        // URLSession follows redirects transparently, so this body may not have come from `url`
+        // at all — re-check where it actually landed, exactly like `ActorProfileFetcher`.
+        if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
+        guard (200..<300).contains(http.statusCode) else {
+            throw GroupTimelineError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw GroupTimelineError.decodingFailed("not a JSON object")
+        }
+        return json
+    }
+
+    static func requireHTTPS(_ url: URL) throws {
+        guard url.scheme?.lowercased() == "https" else { throw GroupTimelineError.insecureURL }
+    }
+
+    /// Unwraps one `Create`/`Announce` level to reach the actual post object; a bare-string item
+    /// (just an activity IRI, no embedded object) becomes an id-only stub rather than being
+    /// dropped, so the rendered row count still matches `totalItems`.
+    static func post(from item: Any) -> GroupPost? {
+        if let bareID = item as? String {
+            return GroupPost(
+                id: bareID, title: nil, contentHTML: nil, url: nil, publishedAt: nil, authorName: nil)
+        }
+        guard let activity = item as? [String: Any] else { return nil }
+        let object = (activity["object"] as? [String: Any]) ?? activity
+        guard let id = object["id"] as? String ?? activity["id"] as? String else { return nil }
+
+        let publishedAt = (object["published"] as? String).flatMap {
+            ISO8601DateFormatter().date(from: $0)
+        }
+        return GroupPost(
+            id: id,
+            title: (object["name"] as? String).map(DisplayString.safe),
+            contentHTML: object["content"] as? String,
+            url: (object["url"] as? String).flatMap(URL.init(string:)),
+            publishedAt: publishedAt,
+            authorName: (object["attributedTo"] as? String).map(DisplayString.safe))
+    }
+
+    private static let session = CappedHTTPTransport.session(
+        requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
+
+    public static let defaultTransport: Transport = { request in
+        try await CappedHTTPTransport.fetch(
+            request, session: session, cap: GroupTimelineClient.maximumResponseBytes,
+            tooLarge: { GroupTimelineError.requestFailed(status: 0, body: "response too large (\($0) bytes)") })
+    }
+}

--- a/Sources/AnglesiteCore/GroupTimelineClient.swift
+++ b/Sources/AnglesiteCore/GroupTimelineClient.swift
@@ -105,6 +105,11 @@ public struct GroupTimelineClient: Sendable {
             throw GroupTimelineError.requestFailed(
                 status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
         }
+        // The default transport already aborts mid-stream past the cap; this re-check holds an
+        // injected transport to the same limit.
+        guard data.count <= Self.maximumResponseBytes else {
+            throw GroupTimelineError.requestFailed(status: 0, body: "response too large (\(data.count) bytes)")
+        }
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw GroupTimelineError.decodingFailed("not a JSON object")
         }

--- a/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+++ b/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
@@ -156,6 +156,149 @@ struct CommunitiesModelTests {
         #expect(CommunitiesLedger.load(from: config)?.communities.isEmpty == true)
     }
 
+    @Test("a ledger-persistence failure after a successful join surfaces errorMessage without losing the join")
+    func joinSurfacesErrorWhenLedgerPersistFails() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("communities-model-test-\(UUID().uuidString)")
+        let source = root.appendingPathComponent("Source")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "DOMAIN=example.com\n".write(
+            to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        // `configDirectory` itself is a plain FILE, not a directory, so `CommunitiesLedger.save`'s
+        // `createDirectory(at:)` throws — simulating a local disk-write failure after the remote
+        // Follow has already succeeded.
+        let config = root.appendingPathComponent("Config")
+        try Data().write(to: config)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let fake = FakeTransport([
+            "https://lemmy.ml/c/birding": (200, """
+                {"id":"https://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+                 "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+                """),
+            "https://example.com/users/site/outbox":
+                (202, #"{"id":"https://example.com/users/site/outbox/1"}"#),
+        ])
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.joinHandleText = "https://lemmy.ml/c/birding"
+
+        await model.join()
+
+        // The remote Follow succeeded and in-memory state reflects it...
+        #expect(model.joined.count == 1)
+        #expect(model.joinHandleText.isEmpty)
+        // ...but the local write failed, and that must not be silent.
+        #expect(model.errorMessage != nil)
+    }
+
+    @Test("a ledger-persistence failure after a successful leave surfaces errorMessage without losing the leave")
+    func confirmLeaveSurfacesErrorWhenLedgerPersistFails() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let community = JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: "@birding@lemmy.ml", displayName: "Birding", joinedAt: Date(),
+            followActivityID: "https://example.com/users/site/outbox/1")
+        ledger.record(community)
+        try ledger.save(to: config)
+
+        let fake = FakeTransport(["https://example.com/users/site/outbox": (202, "{}")])
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.joined.count == 1)
+
+        // Simulate the local disk becoming unwritable between `configure()` and `confirmLeave()`:
+        // replace the config directory with a plain file, so `CommunitiesLedger.save`'s
+        // `createDirectory` throws even though the remote Undo will still succeed.
+        try FileManager.default.removeItem(at: config)
+        try Data().write(to: config)
+
+        model.requestLeave(community)
+        await model.confirmLeave()
+
+        // The remote Undo succeeded and in-memory state reflects it...
+        #expect(model.joined.isEmpty)
+        #expect(model.leaveConfirmation == nil)
+        // ...but the local write failed, and that must not be silent.
+        #expect(model.errorMessage != nil)
+    }
+
+    @Test("confirmLeave clears a stale errorMessage on success")
+    func confirmLeaveClearsStaleError() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let community = JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: "@birding@lemmy.ml", displayName: "Birding", joinedAt: Date(),
+            followActivityID: "https://example.com/users/site/outbox/1")
+        ledger.record(community)
+        try ledger.save(to: config)
+
+        let fake = FakeTransport(["https://example.com/users/site/outbox": (202, "{}")])
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.errorMessage = "stale error from an earlier failure"
+
+        model.requestLeave(community)
+        await model.confirmLeave()
+
+        #expect(model.errorMessage == nil)
+    }
+
+    @Test("loadTimeline clears a stale errorMessage on success")
+    func loadTimelineClearsStaleError() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let community = JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: "@birding@lemmy.ml", displayName: "Birding", joinedAt: Date(),
+            followActivityID: nil)
+        ledger.record(community)
+        try ledger.save(to: config)
+
+        let fake = FakeTransport([
+            "https://lemmy.ml/c/birding/outbox": (200, """
+                {"id":"https://lemmy.ml/c/birding/outbox","type":"OrderedCollection","totalItems":1,
+                 "first":"https://lemmy.ml/c/birding/outbox?page=1"}
+                """),
+            "https://lemmy.ml/c/birding/outbox?page=1": (200, """
+                {"id":"https://lemmy.ml/c/birding/outbox?page=1","type":"OrderedCollectionPage",
+                 "orderedItems":[]}
+                """),
+        ])
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        // `selectCommunity` already fires `loadTimeline()` in a fire-and-forget `Task`; the
+        // explicit `await` below is what the test actually waits on, so the redundant first load
+        // is harmless (same fetch, same result) rather than a race — same pattern as
+        // `loadTimelinePopulates` above.
+        model.selectCommunity(community.id)
+        model.errorMessage = "stale error from an earlier failure"
+        await model.loadTimeline()
+
+        #expect(model.errorMessage == nil)
+    }
+
     @Test("loadTimeline populates from the selected community's outbox")
     func loadTimelinePopulates() async throws {
         let (config, source) = try Self.makeSiteDirectories()

--- a/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+++ b/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
@@ -28,21 +28,54 @@ struct CommunitiesModelTests {
     actor FakeTransport {
         private var responses: [String: (status: Int, body: String)]
         private(set) var requestedURLs: [URL] = []
+        /// URLs whose response is held back until `release(_:)` is called — lets a test hold one
+        /// request open while it observes or triggers other model behavior (Findings 3/4).
+        private var gatedURLs: Set<String> = []
+        private var gateContinuations: [String: CheckedContinuation<Void, Never>] = [:]
+        private var arrivedURLs: Set<String> = []
+        private var arrivalContinuations: [String: CheckedContinuation<Void, Never>] = [:]
 
         init(_ responses: [String: (status: Int, body: String)] = [:]) {
             self.responses = responses
         }
 
-        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+        func gate(_ url: String) { gatedURLs.insert(url) }
+
+        /// Releases a gated URL, letting its held-open request return.
+        func release(_ url: String) {
+            gatedURLs.remove(url)
+            gateContinuations.removeValue(forKey: url)?.resume()
+        }
+
+        /// Suspends until `url` has been requested at least once — so a test can synchronize on
+        /// "the gated request is now in flight" without racing the `Task` that issues it.
+        func waitUntilRequested(_ url: String) async {
+            if arrivedURLs.contains(url) { return }
+            await withCheckedContinuation { continuation in
+                arrivalContinuations[url] = continuation
+            }
+        }
+
+        private func waitIfGated(_ url: String) async {
+            guard gatedURLs.contains(url) else { return }
+            await withCheckedContinuation { continuation in
+                gateContinuations[url] = continuation
+            }
+        }
+
+        private func respond(to request: URLRequest) async -> (Data, HTTPURLResponse) {
             let url = request.url!
             requestedURLs.append(url)
+            arrivedURLs.insert(url.absoluteString)
+            arrivalContinuations.removeValue(forKey: url.absoluteString)?.resume()
+            await waitIfGated(url.absoluteString)
             let (status, body) = responses[url.absoluteString] ?? (404, "not found")
             let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
             return (Data(body.utf8), http)
         }
 
         nonisolated var transport: @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse) {
-            { request in try await self.respond(to: request) }
+            { request in await self.respond(to: request) }
         }
     }
 
@@ -56,14 +89,22 @@ struct CommunitiesModelTests {
     /// A fixture site directory with a `.site-config` declaring a public URL, so
     /// `DeployCoordinator.resolveSiteURL` resolves without a real deploy.
     private static func makeSiteDirectories() throws -> (config: URL, source: URL) {
+        try makeSiteDirectories(domain: "example.com")
+    }
+
+    /// `domain: nil` models a site that has never been published (no `.site-config` at all) — the
+    /// `.noSiteURL` state.
+    private static func makeSiteDirectories(domain: String?) throws -> (config: URL, source: URL) {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("communities-model-test-\(UUID().uuidString)")
         let config = root.appendingPathComponent("Config")
         let source = root.appendingPathComponent("Source")
         try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
-        try "DOMAIN=example.com\n".write(
-            to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        if let domain {
+            try "DOMAIN=\(domain)\n".write(
+                to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        }
         return (config, source)
     }
 
@@ -340,5 +381,212 @@ struct CommunitiesModelTests {
         #expect(model.timeline.count == 1)
         #expect(model.timeline.first?.title == "Osprey sighting")
         #expect(model.isLoadingTimeline == false)
+    }
+
+    // MARK: - Finding 3: confirmLeave clears leaveConfirmation before the network round-trip
+
+    /// Before the fix, `leaveConfirmation = nil` ran *after* `await membership.unfollow(...)`
+    /// completed — so `CommunitiesView`'s alert (whose `isPresented` getter is
+    /// `leaveConfirmation != nil`) stayed presentable for the whole in-flight duration, and a
+    /// second tap could re-enter `confirmLeave()` and fire a second `unfollow`. Proven here by
+    /// holding the unfollow request open and asserting `leaveConfirmation` is already nil while
+    /// it's still in flight — mirroring `SiteWindowModel.confirmDelete()`'s synchronous clear.
+    @Test("confirmLeave clears leaveConfirmation synchronously, before the unfollow completes")
+    func confirmLeaveClearsConfirmationBeforeNetworkCompletes() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let community = JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: "@birding@lemmy.ml", displayName: "Birding", joinedAt: Date(),
+            followActivityID: "https://example.com/users/site/outbox/1")
+        ledger.record(community)
+        try ledger.save(to: config)
+
+        let unfollowURL = "https://example.com/users/site/outbox"
+        let fake = FakeTransport([unfollowURL: (202, "{}")])
+        await fake.gate(unfollowURL)
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.requestLeave(community)
+        #expect(model.leaveConfirmation == community)
+
+        let leaveTask = Task { await model.confirmLeave() }
+        // Wait for the unfollow request to actually be in flight (held open by the gate) before
+        // asserting — otherwise this races the Task's own scheduling.
+        await fake.waitUntilRequested(unfollowURL)
+
+        #expect(model.leaveConfirmation == nil)
+
+        await fake.release(unfollowURL)
+        await leaveTask.value
+
+        #expect(model.joined.isEmpty)
+    }
+
+    // MARK: - Finding 4: loadTimeline discards a stale, slower-than-newer-selection load
+
+    /// Selects community A (whose outbox fetch is held open), then quickly selects community B
+    /// (whose outbox answers immediately). Before the fix, A's slower response — once released —
+    /// would land after B's and overwrite `timeline` with A's stale posts. The generation/token
+    /// guard should make A's late-arriving load a no-op: B's page is never even fetched... no,
+    /// A's page fetch is what should never happen, since `loadTimeline` returns right after the
+    /// stale collection-head check.
+    @Test("selecting a new community discards a still-in-flight load for the previous one")
+    func selectCommunityDiscardsStaleTimeline() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let communityA = JoinedCommunity(
+            actorID: URL(string: "https://a.example/actor")!,
+            outboxURL: URL(string: "https://a.example/outbox")!,
+            handle: "@a@a.example", displayName: "A", joinedAt: Date(), followActivityID: nil)
+        let communityB = JoinedCommunity(
+            actorID: URL(string: "https://b.example/actor")!,
+            outboxURL: URL(string: "https://b.example/outbox")!,
+            handle: "@b@b.example", displayName: "B", joinedAt: Date(), followActivityID: nil)
+        ledger.record(communityA)
+        ledger.record(communityB)
+        try ledger.save(to: config)
+
+        let aOutbox = "https://a.example/outbox"
+        let aPage = "https://a.example/outbox?page=1"
+        let bOutbox = "https://b.example/outbox"
+        let bPage = "https://b.example/outbox?page=1"
+        let fake = FakeTransport([
+            aOutbox: (200, """
+                {"id":"\(aOutbox)","type":"OrderedCollection","totalItems":1,"first":"\(aPage)"}
+                """),
+            aPage: (200, """
+                {"id":"\(aPage)","type":"OrderedCollectionPage","orderedItems":[
+                  {"id":"https://a.example/post/1","type":"Create",
+                   "object":{"id":"https://a.example/post/1","type":"Page","name":"A post"}}
+                ]}
+                """),
+            bOutbox: (200, """
+                {"id":"\(bOutbox)","type":"OrderedCollection","totalItems":1,"first":"\(bPage)"}
+                """),
+            bPage: (200, """
+                {"id":"\(bPage)","type":"OrderedCollectionPage","orderedItems":[
+                  {"id":"https://b.example/post/1","type":"Create",
+                   "object":{"id":"https://b.example/post/1","type":"Page","name":"B post"}}
+                ]}
+                """),
+        ])
+        await fake.gate(aOutbox)
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        // Select A: fires a fire-and-forget load that immediately blocks on the gated outbox
+        // fetch.
+        model.selectCommunity(communityA.id)
+        await fake.waitUntilRequested(aOutbox)
+
+        // Select B before A's load has finished — bumps the generation counter. Explicitly await
+        // the load (redundant with `selectCommunity`'s own fire-and-forget `Task`, but this is
+        // what the test actually synchronizes on, same pattern as the other `loadTimeline` tests
+        // above).
+        model.selectCommunity(communityB.id)
+        await model.loadTimeline()
+
+        #expect(model.timeline.count == 1)
+        #expect(model.timeline.first?.title == "B post")
+        #expect(model.isLoadingTimeline == false)
+
+        // Release A's gate and let its stale load resume. It should discover its token is stale
+        // right after the collection-head fetch and return without ever requesting A's page or
+        // touching `timeline`/`isLoadingTimeline`.
+        await fake.release(aOutbox)
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(model.timeline.first?.title == "B post")
+        #expect(model.isLoadingTimeline == false)
+        let requested = await fake.requestedURLs.map(\.absoluteString)
+        #expect(!requested.contains(aPage))
+    }
+
+    // MARK: - Finding 7: joining an already-joined community doesn't re-POST a Follow
+
+    @Test("join is a no-op if the resolved actor is already joined")
+    func joinSkipsNetworkForAlreadyJoinedCommunity() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let fake = FakeTransport([
+            "https://lemmy.ml/c/birding": (200, """
+                {"id":"https://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+                 "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+                """),
+            "https://example.com/users/site/outbox":
+                (202, #"{"id":"https://example.com/users/site/outbox/1"}"#),
+        ])
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.joinHandleText = "https://lemmy.ml/c/birding"
+        await model.join()
+        #expect(model.joined.count == 1)
+        let followRequestsAfterFirstJoin = await fake.requestedURLs.count
+
+        model.joinHandleText = "https://lemmy.ml/c/birding"
+        await model.join()
+
+        #expect(model.joined.count == 1)
+        #expect(model.joinHandleText.isEmpty)
+        // Re-resolving the actor is fine (needed to know it's the same one), but no new POST to
+        // the outbox (the Follow) should have happened.
+        let requestedAfterSecondJoin = await fake.requestedURLs
+        let followPOSTCount = requestedAfterSecondJoin.filter {
+            $0.absoluteString == "https://example.com/users/site/outbox"
+        }.count
+        #expect(followPOSTCount == 1)
+        #expect(followRequestsAfterFirstJoin >= 1)
+    }
+
+    // MARK: - Finding 5: .noSiteURL is real and retry() recovers it
+
+    @Test("configure sets state to .noSiteURL when the site has never been published")
+    func configureSetsNoSiteURLForUnpublishedSite() async throws {
+        let (config, source) = try Self.makeSiteDirectories(domain: nil)
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        let model = Self.model(secretStore: secretStore, fake: FakeTransport())
+
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        #expect(model.state == .noSiteURL)
+    }
+
+    /// Before the fix, `.noSiteURL` was dead code — nothing ever set it, and there was no way to
+    /// notice a site had been published after the pane opened short of closing and reopening the
+    /// window. `retry()` re-reads the site's `.site-config`, so publishing the site becomes
+    /// recoverable from inside the pane, mirroring `FollowersModel.retry()`.
+    @Test("retry re-resolves the site URL, so publishing recovers .noSiteURL")
+    func retryRecoversNoSiteURL() async throws {
+        let (config, source) = try Self.makeSiteDirectories(domain: nil)
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        let model = Self.model(secretStore: secretStore, fake: FakeTransport())
+
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.state == .noSiteURL)
+
+        // The owner goes and publishes, exactly as the message asks.
+        try "DOMAIN=example.com\n".write(
+            to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        await model.retry()
+
+        #expect(model.state == .idle)
     }
 }

--- a/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+++ b/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
@@ -1,0 +1,201 @@
+// Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("CommunitiesModel")
+@MainActor
+struct CommunitiesModelTests {
+    /// In-memory `SecretStore` so `configure(site:)` can read a publish token without touching
+    /// the Keychain — mirrors how `MicrosubReaderModel`'s own tests stub credential storage.
+    final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+        var values: [String: String] = [:]
+        func read(account: String) throws -> String? { values[account] }
+        func write(_ value: String, account: String) throws { values[account] = value }
+        func delete(account: String) throws { values.removeValue(forKey: account) }
+    }
+
+    /// Routes every request by exact URL to a canned (status, body). `CommunityActorResolver`,
+    /// `CommunityMembershipClient`, and `GroupTimelineClient` all share the same `Transport`
+    /// signature (`@Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)`), so this one
+    /// fake — handed to all three init parameters — stands in for the whole network surface a
+    /// test exercises: webfinger, the resolved actor document, this site's own outbox POST, and
+    /// the joined community's outbox GET.
+    actor FakeTransport {
+        private var responses: [String: (status: Int, body: String)]
+        private(set) var requestedURLs: [URL] = []
+
+        init(_ responses: [String: (status: Int, body: String)] = [:]) {
+            self.responses = responses
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            let url = request.url!
+            requestedURLs.append(url)
+            let (status, body) = responses[url.absoluteString] ?? (404, "not found")
+            let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse) {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
+    private static func site(configDirectory: URL, sourceDirectory: URL) -> CurrentSite {
+        CurrentSite(
+            id: "site-1", name: "Test Site",
+            packageURL: sourceDirectory.deletingLastPathComponent(),
+            sourceDirectory: sourceDirectory, configDirectory: configDirectory)
+    }
+
+    /// A fixture site directory with a `.site-config` declaring a public URL, so
+    /// `DeployCoordinator.resolveSiteURL` resolves without a real deploy.
+    private static func makeSiteDirectories() throws -> (config: URL, source: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("communities-model-test-\(UUID().uuidString)")
+        let config = root.appendingPathComponent("Config")
+        let source = root.appendingPathComponent("Source")
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "DOMAIN=example.com\n".write(
+            to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        return (config, source)
+    }
+
+    private static func model(secretStore: InMemorySecretStore, fake: FakeTransport) -> CommunitiesModel {
+        CommunitiesModel(
+            secretStore: secretStore,
+            resolverTransport: fake.transport,
+            membershipTransport: fake.transport,
+            timelineTransport: fake.transport)
+    }
+
+    @Test("join resolves the handle, follows it, and records it in the ledger")
+    func joinRecordsCommunity() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let fake = FakeTransport([
+            "https://lemmy.ml/c/birding": (200, """
+                {"id":"https://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+                 "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+                """),
+            "https://example.com/users/site/outbox":
+                (202, #"{"id":"https://example.com/users/site/outbox/1"}"#),
+        ])
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.joinHandleText = "https://lemmy.ml/c/birding"
+
+        await model.join()
+
+        #expect(model.joined.count == 1)
+        #expect(model.joined.first?.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(model.joined.first?.followActivityID == "https://example.com/users/site/outbox/1")
+        #expect(model.joinHandleText.isEmpty)
+        #expect(model.errorMessage == nil)
+
+        // Persisted, not just in memory.
+        let reloaded = CommunitiesLedger.load(from: config)
+        #expect(reloaded?.communities.count == 1)
+    }
+
+    @Test("a resolver failure surfaces errorMessage and records nothing")
+    func joinResolveFailureSurfacesError() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let fake = FakeTransport(["https://lemmy.ml/c/ghost": (404, "not found")])
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.joinHandleText = "https://lemmy.ml/c/ghost"
+
+        await model.join()
+
+        #expect(model.joined.isEmpty)
+        #expect(model.errorMessage != nil)
+    }
+
+    @Test("confirmLeave unfollows and removes the community from the ledger")
+    func confirmLeaveRemovesCommunity() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let community = JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: "@birding@lemmy.ml", displayName: "Birding", joinedAt: Date(),
+            followActivityID: "https://example.com/users/site/outbox/1")
+        ledger.record(community)
+        try ledger.save(to: config)
+
+        let fake = FakeTransport(["https://example.com/users/site/outbox": (202, "{}")])
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.joined.count == 1)
+
+        model.requestLeave(community)
+        #expect(model.leaveConfirmation == community)
+
+        await model.confirmLeave()
+
+        #expect(model.joined.isEmpty)
+        #expect(model.leaveConfirmation == nil)
+        #expect(CommunitiesLedger.load(from: config)?.communities.isEmpty == true)
+    }
+
+    @Test("loadTimeline populates from the selected community's outbox")
+    func loadTimelinePopulates() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let community = JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: "@birding@lemmy.ml", displayName: "Birding", joinedAt: Date(),
+            followActivityID: nil)
+        ledger.record(community)
+        try ledger.save(to: config)
+
+        let fake = FakeTransport([
+            "https://lemmy.ml/c/birding/outbox": (200, """
+                {"id":"https://lemmy.ml/c/birding/outbox","type":"OrderedCollection","totalItems":1,
+                 "first":"https://lemmy.ml/c/birding/outbox?page=1"}
+                """),
+            "https://lemmy.ml/c/birding/outbox?page=1": (200, """
+                {"id":"https://lemmy.ml/c/birding/outbox?page=1","type":"OrderedCollectionPage",
+                 "orderedItems":[
+                   {"id":"https://lemmy.ml/activities/1","type":"Create",
+                    "object":{"id":"https://lemmy.ml/post/1","type":"Page","name":"Osprey sighting"}}
+                 ]}
+                """),
+        ])
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        // `selectCommunity` already fires `loadTimeline()` in a fire-and-forget `Task`; the
+        // explicit `await` below is what the test actually waits on, so the redundant first load
+        // is harmless (same fetch, same result) rather than a race.
+        model.selectCommunity(community.id)
+        await model.loadTimeline()
+
+        #expect(model.timeline.count == 1)
+        #expect(model.timeline.first?.title == "Osprey sighting")
+        #expect(model.isLoadingTimeline == false)
+    }
+}

--- a/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+++ b/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
@@ -514,6 +514,55 @@ struct CommunitiesModelTests {
         #expect(!requested.contains(aPage))
     }
 
+    @Test("selecting a community with no outbox clears a stuck loading spinner")
+    func selectingCommunityWithNoOutboxClearsStuckSpinner() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let communityA = JoinedCommunity(
+            actorID: URL(string: "https://a.example/actor")!,
+            outboxURL: URL(string: "https://a.example/outbox")!,
+            handle: "@a@a.example", displayName: "A", joinedAt: Date(), followActivityID: nil)
+        // No `outboxURL` — the actor document this was resolved from didn't advertise one.
+        let communityB = JoinedCommunity(
+            actorID: URL(string: "https://b.example/actor")!,
+            outboxURL: nil,
+            handle: "@b@b.example", displayName: "B", joinedAt: Date(), followActivityID: nil)
+        ledger.record(communityA)
+        ledger.record(communityB)
+        try ledger.save(to: config)
+
+        let aOutbox = "https://a.example/outbox"
+        let fake = FakeTransport([
+            aOutbox: (200, """
+                {"id":"\(aOutbox)","type":"OrderedCollection","totalItems":0}
+                """),
+        ])
+        await fake.gate(aOutbox)
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        // Select A: its load blocks on the gated outbox fetch, leaving `isLoadingTimeline` true.
+        model.selectCommunity(communityA.id)
+        await fake.waitUntilRequested(aOutbox)
+        #expect(model.isLoadingTimeline == true)
+
+        // Select B before A's load resolves. B has no outbox, so `loadTimeline()` bails at its
+        // entry guard — before this fix, that guard didn't touch `isLoadingTimeline`, leaving it
+        // stuck at A's `true` with nothing left to ever clear it.
+        model.selectCommunity(communityB.id)
+        await model.loadTimeline()
+
+        #expect(model.isLoadingTimeline == false)
+        #expect(model.timeline.isEmpty)
+
+        await fake.release(aOutbox)
+    }
+
     // MARK: - Finding 7: joining an already-joined community doesn't re-POST a Follow
 
     @Test("join is a no-op if the resolved actor is already joined")

--- a/Tests/AnglesiteCoreTests/CommunitiesLedgerTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunitiesLedgerTests.swift
@@ -1,0 +1,68 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("CommunitiesLedger")
+struct CommunitiesLedgerTests {
+    private static func sample(handle: String = "@birding@lemmy.ml") -> JoinedCommunity {
+        JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: handle,
+            displayName: "Birding",
+            joinedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            followActivityID: "https://example.com/users/site/outbox/1")
+    }
+
+    @Test("record then contains reports true for the same actorID")
+    func recordAndContains() {
+        var ledger = CommunitiesLedger()
+        #expect(!ledger.contains(actorID: Self.sample().actorID))
+        ledger.record(Self.sample())
+        #expect(ledger.contains(actorID: Self.sample().actorID))
+        #expect(ledger.communities.count == 1)
+    }
+
+    @Test("recording the same actorID twice does not duplicate")
+    func recordIsIdempotent() {
+        var ledger = CommunitiesLedger()
+        ledger.record(Self.sample())
+        ledger.record(Self.sample(handle: "@birding@lemmy.ml"))
+        #expect(ledger.communities.count == 1)
+    }
+
+    @Test("remove drops the matching community and leaves the rest")
+    func remove() {
+        var ledger = CommunitiesLedger()
+        ledger.record(Self.sample())
+        let other = JoinedCommunity(
+            actorID: URL(string: "https://mastodon.social/c/other")!, outboxURL: nil,
+            handle: nil, displayName: nil, joinedAt: Date(), followActivityID: nil)
+        ledger.record(other)
+
+        ledger.remove(actorID: Self.sample().actorID)
+
+        #expect(ledger.communities == [other])
+    }
+
+    @Test("save then load round-trips through JSON on disk")
+    func saveAndLoadRoundTrip() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("communities-ledger-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        var ledger = CommunitiesLedger()
+        ledger.record(Self.sample())
+        try ledger.save(to: tempDir)
+
+        let loaded = try #require(CommunitiesLedger.load(from: tempDir))
+        #expect(loaded == ledger)
+    }
+
+    @Test("load returns nil when no ledger file exists yet")
+    func loadMissingFileReturnsNil() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("communities-ledger-missing-\(UUID().uuidString)")
+        #expect(CommunitiesLedger.load(from: tempDir) == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
@@ -195,6 +195,54 @@ struct CommunityActorResolverTests {
         #expect(await fake.requestCount == 1)
     }
 
+    /// Defense-in-depth: `defaultTransport` is already capped via `CappedHTTPTransport`, but a
+    /// caller-injected `Transport` (like this test's `FakeTransport`) might not be. The padding
+    /// keeps the body *valid* JSON that decodes cleanly but for the size — an invalid/garbage
+    /// oversized body would throw `.decodingFailed` regardless of whether the byte-cap guard
+    /// exists, making the test vacuous (this exact mistake was already made and caught once for
+    /// `GroupTimelineClientTests.rejectsOversizedBody`).
+    @Test("rejects an oversized actor document")
+    func rejectsOversizedActorDocument() async throws {
+        let maxBytes = CommunityActorResolver.maximumResponseBytes
+        let prefix = #"{"id":"https://lemmy.ml/c/birding","type":"Group","padding":""#
+        let suffix = "\"}"
+        let paddingLength = maxBytes - prefix.utf8.count - suffix.utf8.count + 1
+        let oversizedBody = prefix + String(repeating: "x", count: paddingLength) + suffix
+        let byteCount = Data(oversizedBody.utf8).count
+        #expect(byteCount > maxBytes)
+
+        let fake = FakeTransport(["https://lemmy.ml/c/birding": (200, oversizedBody)])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        await #expect(throws: CommunityActorResolverError.requestFailed(
+            status: 0, body: "response too large (\(byteCount) bytes)")) {
+            _ = try await resolver.resolve("https://lemmy.ml/c/birding")
+        }
+    }
+
+    /// Same guard, exercised through the webfinger call site rather than the actor-document one —
+    /// `webfingerResolve` and `fetchActor` each need their own check since neither funnels through
+    /// a single shared post-status point.
+    @Test("rejects an oversized webfinger response")
+    func rejectsOversizedWebfingerResponse() async throws {
+        let maxBytes = CommunityActorResolver.maximumResponseBytes
+        let prefix = #"{"subject":"acct:birding@lemmy.ml","links":[],"padding":""#
+        let suffix = "\"}"
+        let paddingLength = maxBytes - prefix.utf8.count - suffix.utf8.count + 1
+        let oversizedBody = prefix + String(repeating: "x", count: paddingLength) + suffix
+        let byteCount = Data(oversizedBody.utf8).count
+        #expect(byteCount > maxBytes)
+
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:birding@lemmy.ml"
+        let fake = FakeTransport([webfingerURL: (200, oversizedBody)])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        await #expect(throws: CommunityActorResolverError.requestFailed(
+            status: 0, body: "response too large (\(byteCount) bytes)")) {
+            _ = try await resolver.resolve("!birding@lemmy.ml")
+        }
+    }
+
     @Test("HTTPS check must come before status check for webfinger redirect handling")
     func webfingerRejectInsecureRedirectWithErrorStatus() async throws {
         // This test proves the ordering fix: a redirect to an insecure URL with a non-2xx

--- a/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
@@ -144,4 +144,54 @@ struct CommunityActorResolverTests {
             _ = try await resolver.resolve("!birding@lemmy.ml")
         }
     }
+
+    @Test("rejects a webfinger response that redirects to an insecure URL")
+    func webfingerRejectHTTPRedirect() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:birding@lemmy.ml"
+        // Create a transport that simulates a redirect by returning an HTTPURLResponse
+        // with a different (insecure) URL than the one that was requested.
+        actor RedirectingTransport {
+            private let body: String
+            private(set) var requestCount = 0
+
+            init(body: String) {
+                self.body = body
+            }
+
+            private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+                let url = request.url!
+                requestCount += 1
+                // For the webfinger URL, return a response that appears to come from http://
+                // (simulating a transparent redirect), which should be rejected.
+                let responseURL: URL
+                if url.absoluteString.contains("webfinger") {
+                    let httpURL = url.absoluteString.replacingOccurrences(of: "https://", with: "http://")
+                    responseURL = URL(string: httpURL)!
+                } else {
+                    // Actor fetch should not reach this point if webfinger check works
+                    throw CommunityActorResolverError.requestFailed(status: 500, body: "should not fetch actor")
+                }
+                let http = HTTPURLResponse(url: responseURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (Data(body.utf8), http)
+            }
+
+            nonisolated var transport: CommunityActorResolver.Transport {
+                { request in try await self.respond(to: request) }
+            }
+        }
+
+        let fake = RedirectingTransport(body: """
+            {"subject":"acct:birding@lemmy.ml","links":[
+              {"rel":"self","type":"application/activity+json","href":"https://lemmy.ml/c/birding"}
+            ]}
+            """)
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        await #expect(throws: CommunityActorResolverError.insecureURL) {
+            _ = try await resolver.resolve("!birding@lemmy.ml")
+        }
+
+        // Verify that we only made the webfinger request, not the actor fetch
+        #expect(await fake.requestCount == 1)
+    }
 }

--- a/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("CommunityActorResolver")
+struct CommunityActorResolverTests {
+    /// Answers each requested URL from a fixed table; unmatched URLs 404. Mirrors
+    /// `ActivityPubFollowersClientTests.FakeTransport` but needs per-URL routing since resolving a
+    /// handle makes two requests (webfinger, then the actor document) to two different URLs.
+    actor FakeTransport {
+        private var responses: [String: (status: Int, body: String)]
+        private(set) var requestedURLs: [URL] = []
+        private(set) var requestedHeaders: [[String: String]] = []
+
+        init(_ responses: [String: (status: Int, body: String)]) {
+            self.responses = responses
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            let url = request.url!
+            requestedURLs.append(url)
+            requestedHeaders.append(request.allHTTPHeaderFields ?? [:])
+            let (status, body) = responses[url.absoluteString] ?? (404, "not found")
+            let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: CommunityActorResolver.Transport {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
+    private static let actorDocument = """
+    {"id":"https://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+     "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+    """
+
+    @Test("resolves a !community@host handle via webfinger then the actor document")
+    func resolvesHandle() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:birding@lemmy.ml"
+        let fake = FakeTransport([
+            webfingerURL: (200, """
+                {"subject":"acct:birding@lemmy.ml","links":[
+                  {"rel":"self","type":"application/activity+json","href":"https://lemmy.ml/c/birding"}
+                ]}
+                """),
+            "https://lemmy.ml/c/birding": (200, Self.actorDocument),
+        ])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        let resolved = try await resolver.resolve("!birding@lemmy.ml")
+
+        #expect(resolved.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(resolved.outboxURL?.absoluteString == "https://lemmy.ml/c/birding/outbox")
+        #expect(resolved.type == "Group")
+        #expect(resolved.name == "Birding")
+    }
+
+    @Test("resolves a bare @user@host handle the same way")
+    func resolvesAtHandle() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:birding@lemmy.ml"
+        let fake = FakeTransport([
+            webfingerURL: (200, """
+                {"subject":"acct:birding@lemmy.ml","links":[
+                  {"rel":"self","type":"application/activity+json","href":"https://lemmy.ml/c/birding"}
+                ]}
+                """),
+            "https://lemmy.ml/c/birding": (200, Self.actorDocument),
+        ])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        let resolved = try await resolver.resolve("@birding@lemmy.ml")
+
+        #expect(resolved.actorID.absoluteString == "https://lemmy.ml/c/birding")
+    }
+
+    @Test("resolves a pasted actor URL directly, skipping webfinger")
+    func resolvesURL() async throws {
+        let fake = FakeTransport(["https://lemmy.ml/c/birding": (200, Self.actorDocument)])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        let resolved = try await resolver.resolve("https://lemmy.ml/c/birding")
+
+        #expect(resolved.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(await fake.requestedURLs.count == 1)
+    }
+
+    @Test("sends the AS2 Accept header when fetching the actor document")
+    func sendsAcceptHeader() async throws {
+        let fake = FakeTransport(["https://lemmy.ml/c/birding": (200, Self.actorDocument)])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+        _ = try await resolver.resolve("https://lemmy.ml/c/birding")
+
+        let headers = await fake.requestedHeaders
+        #expect(headers.last?["Accept"] == ActivityPubFollowersClient.acceptHeader)
+    }
+
+    @Test("rejects a plain http URL")
+    func rejectsInsecureURL() async throws {
+        let fake = FakeTransport([:])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+        await #expect(throws: CommunityActorResolverError.insecureURL) {
+            _ = try await resolver.resolve("http://lemmy.ml/c/birding")
+        }
+    }
+
+    @Test("rejects unparseable input")
+    func rejectsInvalidHandle() async throws {
+        let fake = FakeTransport([:])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+        await #expect(throws: CommunityActorResolverError.invalidHandle) {
+            _ = try await resolver.resolve("not a handle or url")
+        }
+    }
+
+    @Test("surfaces a webfinger 404 as webfingerFailed")
+    func webfingerNotFound() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:ghost@lemmy.ml"
+        let fake = FakeTransport([webfingerURL: (404, "no such account")])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        await #expect(throws: CommunityActorResolverError.webfingerFailed(
+            status: 404, body: "no such account")) {
+            _ = try await resolver.resolve("!ghost@lemmy.ml")
+        }
+    }
+
+    @Test("surfaces a webfinger response with no self link as noActorLink")
+    func webfingerNoSelfLink() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:birding@lemmy.ml"
+        let fake = FakeTransport([
+            webfingerURL: (200, """
+                {"subject":"acct:birding@lemmy.ml","links":[
+                  {"rel":"http://webfinger.net/rel/profile-page","href":"https://lemmy.ml/c/birding"}
+                ]}
+                """),
+        ])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        await #expect(throws: CommunityActorResolverError.noActorLink) {
+            _ = try await resolver.resolve("!birding@lemmy.ml")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
@@ -194,4 +194,42 @@ struct CommunityActorResolverTests {
         // Verify that we only made the webfinger request, not the actor fetch
         #expect(await fake.requestCount == 1)
     }
+
+    @Test("HTTPS check must come before status check for webfinger redirect handling")
+    func webfingerRejectInsecureRedirectWithErrorStatus() async throws {
+        // This test proves the ordering fix: a redirect to an insecure URL with a non-2xx
+        // status must throw .insecureURL (the redirect check), not .webfingerFailed (which
+        // would leak the insecure endpoint's error response). Before the fix, the wrong order
+        // (status check first) would throw .webfingerFailed; after the fix, it throws .insecureURL.
+        actor MaliciousRedirectTransport {
+            private(set) var requestCount = 0
+
+            private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+                let url = request.url!
+                requestCount += 1
+                // Simulate a redirect to an insecure URL with a non-2xx status
+                let httpURL = url.absoluteString.replacingOccurrences(of: "https://", with: "http://")
+                let responseURL = URL(string: httpURL)!
+                let errorBody = "500 Internal Server Error from insecure endpoint"
+                let http = HTTPURLResponse(url: responseURL, statusCode: 500, httpVersion: nil, headerFields: nil)!
+                return (Data(errorBody.utf8), http)
+            }
+
+            nonisolated var transport: CommunityActorResolver.Transport {
+                { request in try await self.respond(to: request) }
+            }
+        }
+
+        let fake = MaliciousRedirectTransport()
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        // Must throw .insecureURL, not .webfingerFailed, to avoid leaking the insecure
+        // endpoint's error response
+        await #expect(throws: CommunityActorResolverError.insecureURL) {
+            _ = try await resolver.resolve("!birding@lemmy.ml")
+        }
+
+        // Verify that we only made the webfinger request, not the actor fetch
+        #expect(await fake.requestCount == 1)
+    }
 }

--- a/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("CommunityMembershipClient")
+struct CommunityMembershipClientTests {
+    actor FakeTransport {
+        private let status: Int
+        private let body: String
+        private(set) var requestedURLs: [URL] = []
+        private(set) var requestedHeaders: [[String: String]] = []
+        private(set) var requestedBodies: [[String: Any]] = []
+
+        init(status: Int = 202, body: String = "{}") {
+            self.status = status
+            self.body = body
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            requestedURLs.append(request.url!)
+            requestedHeaders.append(request.allHTTPHeaderFields ?? [:])
+            if let bodyData = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any] {
+                requestedBodies.append(json)
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: CommunityMembershipClient.Transport {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
+    private static func client(_ fake: FakeTransport) -> CommunityMembershipClient {
+        CommunityMembershipClient(
+            ownActorURL: URL(string: "https://example.com/users/site")!,
+            publishToken: "secret-token",
+            transport: fake.transport)
+    }
+
+    @Test("POSTs a Follow activity to this site's own outbox")
+    func postsFollow() async throws {
+        let fake = FakeTransport(status: 202, body: #"{"id":"https://example.com/users/site/outbox/1"}"#)
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+
+        let activityID = try await Self.client(fake).follow(target: target)
+
+        #expect(activityID == "https://example.com/users/site/outbox/1")
+        #expect(await fake.requestedURLs.first?.absoluteString == "https://example.com/users/site/outbox")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Follow")
+        #expect(body?["object"] as? String == "https://lemmy.ml/c/birding")
+        #expect(body?["actor"] as? String == "https://example.com/users/site")
+    }
+
+    @Test("falls back to the target URL as the activity id when the response carries none")
+    func followWithoutIDInResponse() async throws {
+        let fake = FakeTransport(status: 202, body: "{}")
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+
+        let activityID = try await Self.client(fake).follow(target: target)
+
+        #expect(activityID == "https://lemmy.ml/c/birding")
+    }
+
+    @Test("POSTs an Undo(Follow) referencing the original activity id")
+    func postsUndoWithActivityID() async throws {
+        let fake = FakeTransport()
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+
+        try await Self.client(fake).unfollow(
+            target: target, followActivityID: "https://example.com/users/site/outbox/1")
+
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Undo")
+        #expect(body?["object"] as? String == "https://example.com/users/site/outbox/1")
+    }
+
+    @Test("synthesizes a nested Follow object for Undo when no activity id is known")
+    func postsUndoWithoutActivityID() async throws {
+        let fake = FakeTransport()
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+
+        try await Self.client(fake).unfollow(target: target, followActivityID: nil)
+
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Undo")
+        let nestedFollow = body?["object"] as? [String: Any]
+        #expect(nestedFollow?["type"] as? String == "Follow")
+        #expect(nestedFollow?["object"] as? String == "https://lemmy.ml/c/birding")
+    }
+
+    @Test("maps a non-2xx status to requestFailed")
+    func mapsNon2xx() async throws {
+        let fake = FakeTransport(status: 403, body: "forbidden")
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 403, body: "forbidden")) {
+            _ = try await Self.client(fake).follow(target: target)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
+++ b/Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
@@ -99,4 +99,15 @@ struct GroupTimelineClientTests {
             _ = try await GroupTimelineClient(transport: fake.transport).collection(at: url)
         }
     }
+
+    @Test("rejects an oversized response body")
+    func rejectsOversizedBody() async throws {
+        // Create a body larger than maximumResponseBytes (1 MB)
+        let oversizedBody = String(repeating: "x", count: GroupTimelineClient.maximumResponseBytes + 1)
+        let fake = FakeTransport(body: oversizedBody)
+        let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox"))
+        await #expect(throws: GroupTimelineError.self) {
+            _ = try await GroupTimelineClient(transport: fake.transport).collection(at: url)
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
+++ b/Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
@@ -1,0 +1,102 @@
+// Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("GroupTimelineClient")
+struct GroupTimelineClientTests {
+    actor FakeTransport {
+        private let status: Int
+        private let body: String
+        private(set) var requestedURLs: [URL] = []
+
+        init(status: Int = 200, body: String) {
+            self.status = status
+            self.body = body
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            requestedURLs.append(request.url!)
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: GroupTimelineClient.Transport {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
+    @Test("reads the outbox collection head")
+    func readsCollectionHead() async throws {
+        let fake = FakeTransport(body: """
+        {"id":"https://lemmy.ml/c/birding/outbox","type":"OrderedCollection","totalItems":2,
+         "first":"https://lemmy.ml/c/birding/outbox?page=1"}
+        """)
+        let outboxURL = try #require(URL(string: "https://lemmy.ml/c/birding/outbox"))
+        let result = try await GroupTimelineClient(transport: fake.transport).collection(at: outboxURL)
+
+        #expect(result.totalItems == 2)
+        #expect(result.firstPage?.absoluteString == "https://lemmy.ml/c/birding/outbox?page=1")
+    }
+
+    @Test("decodes a page of Create-wrapped Note activities into GroupPosts")
+    func decodesCreateWrappedPage() async throws {
+        let fake = FakeTransport(body: """
+        {"id":"https://lemmy.ml/c/birding/outbox?page=1","type":"OrderedCollectionPage",
+         "orderedItems":[
+           {"id":"https://lemmy.ml/activities/1","type":"Create",
+            "object":{"id":"https://lemmy.ml/post/1","type":"Page","name":"Osprey sighting",
+                      "content":"<p>Saw one today</p>","url":"https://lemmy.ml/post/1",
+                      "published":"2026-07-20T12:00:00Z",
+                      "attributedTo":"https://lemmy.ml/u/alice"}}
+         ],
+         "next":"https://lemmy.ml/c/birding/outbox?page=2"}
+        """)
+        let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox?page=1"))
+        let page = try await GroupTimelineClient(transport: fake.transport).page(at: url)
+
+        #expect(page.items.count == 1)
+        #expect(page.items[0].id == "https://lemmy.ml/post/1")
+        #expect(page.items[0].title == "Osprey sighting")
+        #expect(page.items[0].contentHTML == "<p>Saw one today</p>")
+        #expect(page.items[0].url?.absoluteString == "https://lemmy.ml/post/1")
+        #expect(page.next?.absoluteString == "https://lemmy.ml/c/birding/outbox?page=2")
+    }
+
+    @Test("falls back to a bare-id stub for an item with no embedded object")
+    func decodesBareIDItem() async throws {
+        let fake = FakeTransport(body: """
+        {"id":"https://lemmy.ml/c/birding/outbox?page=1","type":"OrderedCollectionPage",
+         "orderedItems":["https://lemmy.ml/activities/2"]}
+        """)
+        let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox?page=1"))
+        let page = try await GroupTimelineClient(transport: fake.transport).page(at: url)
+
+        #expect(page.items.count == 1)
+        #expect(page.items[0].id == "https://lemmy.ml/activities/2")
+        #expect(page.items[0].title == nil)
+    }
+
+    @Test("maps a non-2xx status to requestFailed")
+    func mapsNon2xx() async throws {
+        let fake = FakeTransport(status: 404, body: "not found")
+        let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox"))
+        await #expect(throws: GroupTimelineError.requestFailed(status: 404, body: "not found")) {
+            _ = try await GroupTimelineClient(transport: fake.transport).collection(at: url)
+        }
+    }
+
+    /// The outbox belongs to an arbitrary remote Group, the same trust level as a follower's
+    /// actor document (`ActorProfileFetcher`) — this guard is load-bearing, not decorative.
+    @Test("rejects a plain http outbox URL")
+    func rejectsInsecureURL() async throws {
+        let fake = FakeTransport(body: "{}")
+        let url = try #require(URL(string: "http://lemmy.ml/c/birding/outbox"))
+        await #expect(throws: GroupTimelineError.insecureURL) {
+            _ = try await GroupTimelineClient(transport: fake.transport).collection(at: url)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
+++ b/Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
@@ -102,11 +102,21 @@ struct GroupTimelineClientTests {
 
     @Test("rejects an oversized response body")
     func rejectsOversizedBody() async throws {
-        // Create a body larger than maximumResponseBytes (1 MB)
-        let oversizedBody = String(repeating: "x", count: GroupTimelineClient.maximumResponseBytes + 1)
+        let maxBytes = GroupTimelineClient.maximumResponseBytes
+        // Build oversized valid JSON: {"padding":"xxxx..."}
+        // Overhead: {"padding":""} = 14 bytes, so padding needs maxBytes - 13 to total maxBytes + 1
+        let paddingLength = maxBytes - 13
+        let oversizedBody = "{\"padding\":\"\(String(repeating: "x", count: paddingLength))\"}"
+
+        let bodyBytes = Data(oversizedBody.utf8)
+        let byteCount = bodyBytes.count
+        // Confirm it's actually oversized
+        #expect(byteCount > maxBytes)
+
         let fake = FakeTransport(body: oversizedBody)
         let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox"))
-        await #expect(throws: GroupTimelineError.self) {
+
+        await #expect(throws: GroupTimelineError.requestFailed(status: 0, body: "response too large (\(byteCount) bytes)")) {
             _ = try await GroupTimelineClient(transport: fake.transport).collection(at: url)
         }
     }

--- a/docs/superpowers/plans/2026-07-27-v5-1a-communities-participate.md
+++ b/docs/superpowers/plans/2026-07-27-v5-1a-communities-participate.md
@@ -1111,7 +1111,7 @@ git commit -m "feat(#368): persist which communities a site has joined"
 
 **Interfaces:**
 - Consumes: `CommunityActorResolver.resolve(_:)`, `CommunityMembershipClient.follow(target:)`/`.unfollow(target:followActivityID:)`, `GroupTimelineClient.collection(at:)`/`.page(at:)`, `CommunitiesLedger`, `ActivityPubActor.actorURL(siteURL:)`, `DeployCoordinator.resolveSiteURL(siteDirectory:)`, `SecretStore`/`SecretAccounts.activityPubPublishToken(siteID:)`, `CurrentSite`.
-- Produces: `@MainActor @Observable final class CommunitiesModel { func configure(site: CurrentSite); func join() async; func requestLeave(_ community: JoinedCommunity); func confirmLeave() async; func cancelLeave(); func selectCommunity(_ id: String); func loadTimeline() async }` plus published state used by Task 6's view: `state`, `joined`, `selectedCommunityID`, `timeline`, `isLoadingTimeline`, `joinHandleText`, `errorMessage`, `leaveConfirmation`.
+- Produces: `@MainActor @Observable final class CommunitiesModel { init(secretStore:resolverTransport:membershipTransport:timelineTransport:); func configure(site: CurrentSite); func join() async; func requestLeave(_ community: JoinedCommunity); func confirmLeave() async; func cancelLeave(); func selectCommunity(_ id: String); func loadTimeline() async }` plus published state used by Task 6's view: `state`, `joined`, `selectedCommunityID`, `timeline`, `isLoadingTimeline`, `joinHandleText`, `errorMessage`, `leaveConfirmation`. Test seams are three transports injected at **init** (`resolverTransport`/`membershipTransport`/`timelineTransport`, each defaulting to its client's `.defaultTransport`) — matching `FollowersModel`'s `followersTransport` init parameter and `MicrosubReaderModel`'s constructor-injection convention, not per-call-site closures.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -1137,6 +1137,33 @@ struct CommunitiesModelTests {
         func delete(account: String) throws { values.removeValue(forKey: account) }
     }
 
+    /// Routes every request by exact URL to a canned (status, body). `CommunityActorResolver`,
+    /// `CommunityMembershipClient`, and `GroupTimelineClient` all share the same `Transport`
+    /// signature (`@Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)`), so this one
+    /// fake — handed to all three init parameters — stands in for the whole network surface a
+    /// test exercises: webfinger, the resolved actor document, this site's own outbox POST, and
+    /// the joined community's outbox GET.
+    actor FakeTransport {
+        private var responses: [String: (status: Int, body: String)]
+        private(set) var requestedURLs: [URL] = []
+
+        init(_ responses: [String: (status: Int, body: String)] = [:]) {
+            self.responses = responses
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            let url = request.url!
+            requestedURLs.append(url)
+            let (status, body) = responses[url.absoluteString] ?? (404, "not found")
+            let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse) {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
     private static func site(configDirectory: URL, sourceDirectory: URL) -> CurrentSite {
         CurrentSite(
             id: "site-1", name: "Test Site",
@@ -1158,29 +1185,38 @@ struct CommunitiesModelTests {
         return (config, source)
     }
 
+    private static func model(secretStore: InMemorySecretStore, fake: FakeTransport) -> CommunitiesModel {
+        CommunitiesModel(
+            secretStore: secretStore,
+            resolverTransport: fake.transport,
+            membershipTransport: fake.transport,
+            timelineTransport: fake.transport)
+    }
+
     @Test("join resolves the handle, follows it, and records it in the ledger")
     func joinRecordsCommunity() async throws {
         let (config, source) = try Self.makeSiteDirectories()
         defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
         let secretStore = InMemorySecretStore()
         secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let fake = FakeTransport([
+            "https://lemmy.ml/c/birding": (200, """
+                {"id":"https://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+                 "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+                """),
+            "https://example.com/users/site/outbox":
+                (202, #"{"id":"https://example.com/users/site/outbox/1"}"#),
+        ])
 
-        let model = CommunitiesModel(secretStore: secretStore)
+        let model = Self.model(secretStore: secretStore, fake: fake)
         model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
         model.joinHandleText = "https://lemmy.ml/c/birding"
 
-        await model.join(
-            resolver: { _ in
-                ResolvedCommunityActor(
-                    actorID: URL(string: "https://lemmy.ml/c/birding")!,
-                    outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
-                    type: "Group", preferredUsername: "birding", name: "Birding", handle: nil)
-            },
-            follow: { _, _ in "https://example.com/users/site/outbox/1" }
-        )
+        await model.join()
 
         #expect(model.joined.count == 1)
         #expect(model.joined.first?.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(model.joined.first?.followActivityID == "https://example.com/users/site/outbox/1")
         #expect(model.joinHandleText.isEmpty)
         #expect(model.errorMessage == nil)
 
@@ -1195,15 +1231,13 @@ struct CommunitiesModelTests {
         defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
         let secretStore = InMemorySecretStore()
         secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let fake = FakeTransport(["https://lemmy.ml/c/ghost": (404, "not found")])
 
-        let model = CommunitiesModel(secretStore: secretStore)
+        let model = Self.model(secretStore: secretStore, fake: fake)
         model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
-        model.joinHandleText = "!ghost@lemmy.ml"
+        model.joinHandleText = "https://lemmy.ml/c/ghost"
 
-        await model.join(
-            resolver: { _ in throw CommunityActorResolverError.noActorLink },
-            follow: { _, _ in "unused" }
-        )
+        await model.join()
 
         #expect(model.joined.isEmpty)
         #expect(model.errorMessage != nil)
@@ -1225,19 +1259,18 @@ struct CommunitiesModelTests {
         ledger.record(community)
         try ledger.save(to: config)
 
-        let model = CommunitiesModel(secretStore: secretStore)
+        let fake = FakeTransport(["https://example.com/users/site/outbox": (202, "{}")])
+        let model = Self.model(secretStore: secretStore, fake: fake)
         model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
         #expect(model.joined.count == 1)
 
         model.requestLeave(community)
         #expect(model.leaveConfirmation == community)
 
-        var unfollowedTarget: URL?
-        await model.confirmLeave(unfollow: { target, _ in unfollowedTarget = target })
+        await model.confirmLeave()
 
         #expect(model.joined.isEmpty)
         #expect(model.leaveConfirmation == nil)
-        #expect(unfollowedTarget?.absoluteString == "https://lemmy.ml/c/birding")
         #expect(CommunitiesLedger.load(from: config)?.communities.isEmpty == true)
     }
 
@@ -1257,20 +1290,27 @@ struct CommunitiesModelTests {
         ledger.record(community)
         try ledger.save(to: config)
 
-        let model = CommunitiesModel(secretStore: secretStore)
+        let fake = FakeTransport([
+            "https://lemmy.ml/c/birding/outbox": (200, """
+                {"id":"https://lemmy.ml/c/birding/outbox","type":"OrderedCollection","totalItems":1,
+                 "first":"https://lemmy.ml/c/birding/outbox?page=1"}
+                """),
+            "https://lemmy.ml/c/birding/outbox?page=1": (200, """
+                {"id":"https://lemmy.ml/c/birding/outbox?page=1","type":"OrderedCollectionPage",
+                 "orderedItems":[
+                   {"id":"https://lemmy.ml/activities/1","type":"Create",
+                    "object":{"id":"https://lemmy.ml/post/1","type":"Page","name":"Osprey sighting"}}
+                 ]}
+                """),
+        ])
+        let model = Self.model(secretStore: secretStore, fake: fake)
         model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
-        model.selectCommunity(community.id)
 
-        await model.loadTimeline(
-            fetchCollection: { _ in (1, URL(string: "https://lemmy.ml/c/birding/outbox?page=1")) },
-            fetchPage: { _ in
-                GroupTimelinePage(
-                    items: [GroupPost(
-                        id: "https://lemmy.ml/post/1", title: "Osprey sighting", contentHTML: nil,
-                        url: nil, publishedAt: nil, authorName: nil)],
-                    next: nil)
-            }
-        )
+        // `selectCommunity` already fires `loadTimeline()` in a fire-and-forget `Task`; the
+        // explicit `await` below is what the test actually waits on, so the redundant first load
+        // is harmless (same fetch, same result) rather than a race.
+        model.selectCommunity(community.id)
+        await model.loadTimeline()
 
         #expect(model.timeline.count == 1)
         #expect(model.timeline.first?.title == "Osprey sighting")
@@ -1297,12 +1337,12 @@ import AnglesiteCore
 /// logic lives in `AnglesiteCore` (`CommunityActorResolver`, `CommunityMembershipClient`,
 /// `GroupTimelineClient`, `CommunitiesLedger`).
 ///
-/// `join`/`confirmLeave`/`loadTimeline` take their network-calling collaborators as parameters
-/// (rather than storing injected clients on `self`) because each one needs a fresh
-/// `CommunityMembershipClient`/`GroupTimelineClient` built around the *current* `ownActorURL` and
-/// `publishToken` — those can change if the site is republished mid-session — while still letting
-/// tests substitute the actual network call with a stub. Production call sites pass the real
-/// client methods; see the `join()`/`confirmLeave()`/`loadTimeline()` no-argument overloads below.
+/// The three transports are injected at init — matching `FollowersModel.followersTransport`'s
+/// constructor-injection convention, not a per-call-site closure — because each client
+/// (`CommunityActorResolver`/`CommunityMembershipClient`/`GroupTimelineClient`) is still built
+/// fresh per call around the *current* `ownActorURL`/`publishToken` (those can change if the site
+/// is republished mid-session), but the transport underneath it stays fixed for the model's
+/// lifetime, exactly like `followersTransport` does for `FollowersModel`'s client.
 @MainActor
 @Observable
 final class CommunitiesModel {
@@ -1331,9 +1371,23 @@ final class CommunitiesModel {
     private var siteURL: URL?
     private var ownActorURL: URL?
     private let secretStore: any SecretStore
+    private let resolverTransport: CommunityActorResolver.Transport
+    private let membershipTransport: CommunityMembershipClient.Transport
+    private let timelineTransport: GroupTimelineClient.Transport
 
-    init(secretStore: any SecretStore = PlatformSecretStore.make()) {
+    init(
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        resolverTransport: @escaping CommunityActorResolver.Transport
+            = CommunityActorResolver.defaultTransport,
+        membershipTransport: @escaping CommunityMembershipClient.Transport
+            = CommunityMembershipClient.defaultTransport,
+        timelineTransport: @escaping GroupTimelineClient.Transport
+            = GroupTimelineClient.defaultTransport
+    ) {
         self.secretStore = secretStore
+        self.resolverTransport = resolverTransport
+        self.membershipTransport = membershipTransport
+        self.timelineTransport = timelineTransport
     }
 
     /// Records which site this pane talks to and loads the joined-communities ledger from disk.
@@ -1356,15 +1410,6 @@ final class CommunitiesModel {
     // MARK: - Join
 
     func join() async {
-        await join(
-            resolver: { try await CommunityActorResolver().resolve($0) },
-            follow: { target, membership in try await membership.follow(target: target) })
-    }
-
-    func join(
-        resolver: @escaping (String) async throws -> ResolvedCommunityActor,
-        follow: @escaping (URL, CommunityMembershipClient) async throws -> String
-    ) async {
         let input = joinHandleText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !input.isEmpty else { return }
         guard let ownActorURL, let publishToken else {
@@ -1373,9 +1418,10 @@ final class CommunitiesModel {
         }
         errorMessage = nil
         do {
-            let resolved = try await resolver(input)
-            let membership = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken)
-            let activityID = try await follow(resolved.actorID, membership)
+            let resolved = try await CommunityActorResolver(transport: resolverTransport).resolve(input)
+            let membership = CommunityMembershipClient(
+                ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+            let activityID = try await membership.follow(target: resolved.actorID)
             let community = JoinedCommunity(
                 actorID: resolved.actorID, outboxURL: resolved.outboxURL,
                 handle: resolved.handle, displayName: resolved.name ?? resolved.preferredUsername,
@@ -1402,17 +1448,17 @@ final class CommunitiesModel {
     }
 
     func confirmLeave() async {
-        await confirmLeave(unfollow: { target, followActivityID in
-            guard let ownActorURL, let publishToken else { return }
-            let membership = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken)
-            try await membership.unfollow(target: target, followActivityID: followActivityID)
-        })
-    }
-
-    func confirmLeave(unfollow: @escaping (URL, String?) async throws -> Void) async {
         guard let community = leaveConfirmation else { return }
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            leaveConfirmation = nil
+            return
+        }
         do {
-            try await unfollow(community.actorID, community.followActivityID)
+            let membership = CommunityMembershipClient(
+                ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+            try await membership.unfollow(
+                target: community.actorID, followActivityID: community.followActivityID)
             var ledger = CommunitiesLedger(communities: joined)
             ledger.remove(actorID: community.actorID)
             joined = ledger.communities
@@ -1443,28 +1489,20 @@ final class CommunitiesModel {
     }
 
     func loadTimeline() async {
-        await loadTimeline(
-            fetchCollection: { url in try await GroupTimelineClient().collection(at: url) },
-            fetchPage: { url in try await GroupTimelineClient().page(at: url) })
-    }
-
-    func loadTimeline(
-        fetchCollection: @escaping (URL) async throws -> (totalItems: Int, firstPage: URL?),
-        fetchPage: @escaping (URL) async throws -> GroupTimelinePage
-    ) async {
         guard let selectedCommunityID,
               let community = joined.first(where: { $0.id == selectedCommunityID }),
               let outboxURL = community.outboxURL
         else { return }
         isLoadingTimeline = true
         defer { isLoadingTimeline = false }
+        let client = GroupTimelineClient(transport: timelineTransport)
         do {
-            let head = try await fetchCollection(outboxURL)
+            let head = try await client.collection(at: outboxURL)
             guard let firstPage = head.firstPage else {
                 timeline = []
                 return
             }
-            let page = try await fetchPage(firstPage)
+            let page = try await client.page(at: firstPage)
             timeline = page.items
         } catch {
             errorMessage = "Couldn't load \(community.displayName ?? community.id)'s timeline: \(error)"

--- a/docs/superpowers/plans/2026-07-27-v5-1a-communities-participate.md
+++ b/docs/superpowers/plans/2026-07-27-v5-1a-communities-participate.md
@@ -1,0 +1,1780 @@
+# V-5.1a Communities — Join/Leave + Group Timeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an Anglesite site join and leave existing fediverse `Group` actors (Lemmy, PieFed, Mbin, Friendica communities) by handle or URL, and read a per-group timeline, from a new Communities pane in the site window.
+
+**Architecture:** Four new `AnglesiteCore` types provide the protocol plumbing — a handle/URL resolver (webfinger + direct AS2 fetch), an outbound `Follow`/`Undo(Follow)` client reusing the site's existing ActivityPub publish token, a paged reader for a remote Group's public outbox, and a local JSON ledger of joined communities (there is no public "following" collection to query back, so membership is app-recorded, mirroring `ActivityPubOutboxLedger`). One new `AnglesiteApp` model/view pair (`CommunitiesModel`/`CommunitiesView`) orchestrates them, wired into `SiteWindowModel`/`SiteWindow`/`WebsiteCommands` exactly like the existing Followers and Reader panes (V-4.2/#364, V-4.3/#365).
+
+**Tech Stack:** Swift 6.4, SwiftUI, `Observation`, Swift Testing (`Testing` framework, not XCTest), `URLSession`/`CappedHTTPTransport` for capped remote fetches, Keychain-backed `SecretStore` for the existing per-site ActivityPub publish token.
+
+## Global Constraints
+
+- Every new client mirrors the injectable-`Transport` shape already used by `ActivityPubFollowersClient`/`ActorProfileFetcher`/`MicrosubClient`: `public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)`, defaulting to a production transport, so nothing needs real networking in tests.
+- Every fetch of a **remote, attacker-influenced** host (webfinger, an arbitrary actor document, a Group's outbox) is HTTPS-only (re-checked after redirects, `ActorProfileFetcher.requireHTTPS` pattern) and byte-capped via `CappedHTTPTransport`, same as `ActorProfileFetcher`.
+- Every remote-supplied display string (name, handle, host) is sanitized through `DisplayString.safe` before it reaches a view, same as `ActorHandle`/`ActorProfile` already do.
+- Outbound `Follow`/`Undo(Follow)` POSTs go to **this site's own** `<actor>/outbox` with `Authorization: Bearer <publishToken>` — the same endpoint and the same `SecretAccounts.activityPubPublishToken(siteID:)` secret `ActivityPubOutboxBackfill` already uses. No new secret, no new provisioning.
+- Scope is **read + join/leave only** (the issue's own title and plan). Posting *to* a community (`audience` field on typed content) is #369, and directory browse/search is #371 — both out of scope here.
+- Every new Swift Testing suite follows the existing `@Suite("TypeName") struct TypeNameTests` / `actor FakeTransport` convention seen in `Tests/AnglesiteCoreTests/ActivityPubFollowersClientTests.swift`.
+- Conventional commits, one per task, referencing `#368`.
+
+---
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `Sources/AnglesiteCore/CommunityActorResolver.swift` | Parse a handle/URL, resolve it (webfinger or direct fetch) to a `ResolvedCommunityActor`. |
+| `Sources/AnglesiteCore/CommunityMembershipClient.swift` | POST `Follow`/`Undo(Follow)` to this site's own outbox. |
+| `Sources/AnglesiteCore/GroupTimelineClient.swift` | Page a remote Group's public outbox into `GroupPost`s. |
+| `Sources/AnglesiteCore/CommunitiesLedger.swift` | `Config/activitypub-communities.json` — which groups this site has joined. |
+| `Sources/AnglesiteApp/CommunitiesModel.swift` | `@Observable` model driving the Communities pane. |
+| `Sources/AnglesiteApp/CommunitiesView.swift` | SwiftUI view: join field, joined-community list, per-group timeline. |
+| `Sources/AnglesiteApp/SiteWindowModel.swift` | Add `.communities` pane mode + `presentCommunities()` + `communities.configure(site:)`. |
+| `Sources/AnglesiteApp/SiteWindow.swift` | Add the `.communities` switch case. |
+| `Sources/AnglesiteApp/WebsiteCommands.swift` | Add "Communities…" menu item. |
+| `Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift` | Resolver tests. |
+| `Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift` | Follow/Undo client tests. |
+| `Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift` | Timeline paging tests. |
+| `Tests/AnglesiteCoreTests/CommunitiesLedgerTests.swift` | Ledger persistence tests. |
+| `Tests/AnglesiteAppTests/CommunitiesModelTests.swift` | Model orchestration tests. |
+
+---
+
+### Task 1: `CommunityActorResolver` — handle/URL → actor document
+
+**Files:**
+- Create: `Sources/AnglesiteCore/CommunityActorResolver.swift`
+- Test: `Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift`
+
+**Interfaces:**
+- Produces: `public struct ResolvedCommunityActor: Sendable, Equatable { public let actorID: URL; public let outboxURL: URL?; public let type: String?; public let preferredUsername: String?; public let name: String?; public let handle: String? }`, `public enum CommunityActorResolverError: Error, Equatable, Sendable { case invalidHandle, insecureURL, webfingerFailed(status: Int, body: String), noActorLink, requestFailed(status: Int, body: String), decodingFailed(String) }`, `public struct CommunityActorResolver: Sendable { public init(transport: Transport = .defaultTransport); public func resolve(_ input: String) async throws -> ResolvedCommunityActor }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("CommunityActorResolver")
+struct CommunityActorResolverTests {
+    /// Answers each requested URL from a fixed table; unmatched URLs 404. Mirrors
+    /// `ActivityPubFollowersClientTests.FakeTransport` but needs per-URL routing since resolving a
+    /// handle makes two requests (webfinger, then the actor document) to two different URLs.
+    actor FakeTransport {
+        private var responses: [String: (status: Int, body: String)]
+        private(set) var requestedURLs: [URL] = []
+        private(set) var requestedHeaders: [[String: String]] = []
+
+        init(_ responses: [String: (status: Int, body: String)]) {
+            self.responses = responses
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            let url = request.url!
+            requestedURLs.append(url)
+            requestedHeaders.append(request.allHTTPHeaderFields ?? [:])
+            let (status, body) = responses[url.absoluteString] ?? (404, "not found")
+            let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: CommunityActorResolver.Transport {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
+    private static let actorDocument = """
+    {"id":"https://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+     "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+    """
+
+    @Test("resolves a !community@host handle via webfinger then the actor document")
+    func resolvesHandle() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:birding@lemmy.ml"
+        let fake = FakeTransport([
+            webfingerURL: (200, """
+                {"subject":"acct:birding@lemmy.ml","links":[
+                  {"rel":"self","type":"application/activity+json","href":"https://lemmy.ml/c/birding"}
+                ]}
+                """),
+            "https://lemmy.ml/c/birding": (200, Self.actorDocument),
+        ])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        let resolved = try await resolver.resolve("!birding@lemmy.ml")
+
+        #expect(resolved.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(resolved.outboxURL?.absoluteString == "https://lemmy.ml/c/birding/outbox")
+        #expect(resolved.type == "Group")
+        #expect(resolved.name == "Birding")
+    }
+
+    @Test("resolves a bare @user@host handle the same way")
+    func resolvesAtHandle() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:birding@lemmy.ml"
+        let fake = FakeTransport([
+            webfingerURL: (200, """
+                {"subject":"acct:birding@lemmy.ml","links":[
+                  {"rel":"self","type":"application/activity+json","href":"https://lemmy.ml/c/birding"}
+                ]}
+                """),
+            "https://lemmy.ml/c/birding": (200, Self.actorDocument),
+        ])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        let resolved = try await resolver.resolve("@birding@lemmy.ml")
+
+        #expect(resolved.actorID.absoluteString == "https://lemmy.ml/c/birding")
+    }
+
+    @Test("resolves a pasted actor URL directly, skipping webfinger")
+    func resolvesURL() async throws {
+        let fake = FakeTransport(["https://lemmy.ml/c/birding": (200, Self.actorDocument)])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        let resolved = try await resolver.resolve("https://lemmy.ml/c/birding")
+
+        #expect(resolved.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(await fake.requestedURLs.count == 1)
+    }
+
+    @Test("sends the AS2 Accept header when fetching the actor document")
+    func sendsAcceptHeader() async throws {
+        let fake = FakeTransport(["https://lemmy.ml/c/birding": (200, Self.actorDocument)])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+        _ = try await resolver.resolve("https://lemmy.ml/c/birding")
+
+        let headers = await fake.requestedHeaders
+        #expect(headers.last?["Accept"] == ActivityPubFollowersClient.acceptHeader)
+    }
+
+    @Test("rejects a plain http URL")
+    func rejectsInsecureURL() async throws {
+        let fake = FakeTransport([:])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+        await #expect(throws: CommunityActorResolverError.insecureURL) {
+            _ = try await resolver.resolve("http://lemmy.ml/c/birding")
+        }
+    }
+
+    @Test("rejects unparseable input")
+    func rejectsInvalidHandle() async throws {
+        let fake = FakeTransport([:])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+        await #expect(throws: CommunityActorResolverError.invalidHandle) {
+            _ = try await resolver.resolve("not a handle or url")
+        }
+    }
+
+    @Test("surfaces a webfinger 404 as webfingerFailed")
+    func webfingerNotFound() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:ghost@lemmy.ml"
+        let fake = FakeTransport([webfingerURL: (404, "no such account")])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        await #expect(throws: CommunityActorResolverError.webfingerFailed(
+            status: 404, body: "no such account")) {
+            _ = try await resolver.resolve("!ghost@lemmy.ml")
+        }
+    }
+
+    @Test("surfaces a webfinger response with no self link as noActorLink")
+    func webfingerNoSelfLink() async throws {
+        let webfingerURL = "https://lemmy.ml/.well-known/webfinger?resource=acct:birding@lemmy.ml"
+        let fake = FakeTransport([
+            webfingerURL: (200, """
+                {"subject":"acct:birding@lemmy.ml","links":[
+                  {"rel":"http://webfinger.net/rel/profile-page","href":"https://lemmy.ml/c/birding"}
+                ]}
+                """),
+        ])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        await #expect(throws: CommunityActorResolverError.noActorLink) {
+            _ = try await resolver.resolve("!birding@lemmy.ml")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail (type doesn't exist yet)**
+
+Run: `swift test --package-path . --filter CommunityActorResolverTests`
+Expected: FAIL — "cannot find type 'CommunityActorResolver' in scope"
+
+- [ ] **Step 3: Implement `CommunityActorResolver`**
+
+```swift
+// Sources/AnglesiteCore/CommunityActorResolver.swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// A remote actor resolved from a fediverse handle or a pasted URL — the join flow's first step
+/// (V-5.1a, #368). Carries just enough to display a confirmation ("Join Birding (Lemmy)?"),
+/// address a `Follow`, and read the group's timeline.
+public struct ResolvedCommunityActor: Sendable, Equatable {
+    /// The actor document's own `id` — the canonical IRI to address a `Follow`'s `object` at.
+    /// May differ from the URL that was fetched (webfinger's `self` link, or a pasted URL that
+    /// redirected).
+    public let actorID: URL
+    /// The actor's public outbox collection, for `GroupTimelineClient`. `nil` for an actor
+    /// document that doesn't advertise one — the timeline pane degrades to "no timeline available".
+    public let outboxURL: URL?
+    public let type: String?
+    public let preferredUsername: String?
+    public let name: String?
+    /// The `@name@host` (or `!name@host`) form the owner typed, sanitized for display.
+    public let handle: String?
+
+    public init(
+        actorID: URL, outboxURL: URL?, type: String?, preferredUsername: String?, name: String?,
+        handle: String?
+    ) {
+        self.actorID = actorID
+        self.outboxURL = outboxURL
+        self.type = type
+        self.preferredUsername = preferredUsername
+        self.name = name
+        self.handle = handle
+    }
+}
+
+public enum CommunityActorResolverError: Error, Equatable, Sendable {
+    case invalidHandle
+    case insecureURL
+    case webfingerFailed(status: Int, body: String)
+    /// The webfinger response had no `rel: "self"` AS2 link to follow.
+    case noActorLink
+    case requestFailed(status: Int, body: String)
+    case decodingFailed(String)
+}
+
+/// Resolves a fediverse handle (`!community@host`, `@user@host`, bare `name@host`) or a pasted
+/// actor URL to its actor document. Mirrors `@dwk/webfinger`'s `lookup.ts` (`parseHandle`,
+/// `webfingerQueryUrl`, `selectActorLink`, `resolveHandle`) client-side in Swift: this app makes
+/// its own outbound request as the signed-in user, so — like `ActorProfileFetcher` — it needs
+/// HTTPS-only and a byte cap, not the server-side SSRF guard `@dwk/activitypub`'s own resolver
+/// applies (that guard exists because *that* resolution runs inside a shared Cloudflare Worker).
+public struct CommunityActorResolver: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let transport: Transport
+
+    public init(transport: @escaping Transport = CommunityActorResolver.defaultTransport) {
+        self.transport = transport
+    }
+
+    public func resolve(_ input: String) async throws -> ResolvedCommunityActor {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let url = URL(string: trimmed), let scheme = url.scheme, url.host != nil,
+           ["http", "https"].contains(scheme.lowercased()) {
+            try Self.requireHTTPS(url)
+            return try await fetchActor(at: url, handle: nil)
+        }
+        guard let (name, host) = Self.parseHandle(trimmed) else {
+            throw CommunityActorResolverError.invalidHandle
+        }
+        let actorURL = try await webfingerResolve(name: name, host: host)
+        return try await fetchActor(at: actorURL, handle: DisplayString.safe("@\(name)@\(host)"))
+    }
+
+    /// Strips an optional leading `@`/`!` sigil, then splits on the *last* `@` so a name segment
+    /// that itself contains `@` (unlikely, but not this code's job to reject) still yields the
+    /// intended host. Returns `nil` for input with no `@` at all — the "not a handle" signal that
+    /// sends the caller down the URL path (which will itself reject it as invalid).
+    static func parseHandle(_ input: String) -> (name: String, host: String)? {
+        var body = input
+        if body.hasPrefix("@") || body.hasPrefix("!") { body.removeFirst() }
+        guard let atIndex = body.lastIndex(of: "@") else { return nil }
+        let name = String(body[body.startIndex..<atIndex])
+        let host = String(body[body.index(after: atIndex)...])
+        guard !name.isEmpty, !host.isEmpty else { return nil }
+        return (name, host)
+    }
+
+    private func webfingerResolve(name: String, host: String) async throws -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = "/.well-known/webfinger"
+        components.queryItems = [URLQueryItem(name: "resource", value: "acct:\(name)@\(host)")]
+        guard let webfingerURL = components.url else { throw CommunityActorResolverError.invalidHandle }
+
+        var request = URLRequest(url: webfingerURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = ActorProfileFetcher.timeout
+        let (data, http) = try await send(request)
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunityActorResolverError.webfingerFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        struct Link: Decodable { let rel: String?; let type: String?; let href: String? }
+        struct DTO: Decodable { let links: [Link]? }
+        let dto: DTO
+        do {
+            dto = try JSONDecoder().decode(DTO.self, from: data)
+        } catch {
+            throw CommunityActorResolverError.decodingFailed("\(error)")
+        }
+        guard let href = dto.links?.first(where: {
+            $0.rel == "self" && ($0.type?.contains("activity+json") == true || $0.type?.contains("ld+json") == true)
+        })?.href, let actorURL = URL(string: href) else {
+            throw CommunityActorResolverError.noActorLink
+        }
+        try Self.requireHTTPS(actorURL)
+        return actorURL
+    }
+
+    private func fetchActor(at url: URL, handle: String?) async throws -> ResolvedCommunityActor {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(ActivityPubFollowersClient.acceptHeader, forHTTPHeaderField: "Accept")
+        request.timeoutInterval = ActorProfileFetcher.timeout
+        let (data, http) = try await send(request)
+        if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunityActorResolverError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        struct DTO: Decodable {
+            let id: String
+            let type: String?
+            let preferredUsername: String?
+            let name: String?
+            let outbox: String?
+        }
+        do {
+            let dto = try JSONDecoder().decode(DTO.self, from: data)
+            guard let actorID = URL(string: dto.id) else {
+                throw CommunityActorResolverError.decodingFailed("actor id is not a URL: \(dto.id)")
+            }
+            return ResolvedCommunityActor(
+                actorID: actorID,
+                outboxURL: dto.outbox.flatMap(URL.init(string:)),
+                type: dto.type,
+                preferredUsername: dto.preferredUsername.map(DisplayString.safe),
+                name: dto.name.map(DisplayString.safe),
+                handle: handle)
+        } catch let error as CommunityActorResolverError {
+            throw error
+        } catch {
+            throw CommunityActorResolverError.decodingFailed("\(error)")
+        }
+    }
+
+    private func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        do {
+            return try await transport(request)
+        } catch {
+            throw CommunityActorResolverError.requestFailed(status: 0, body: "\(error)")
+        }
+    }
+
+    static func requireHTTPS(_ url: URL) throws {
+        guard url.scheme?.lowercased() == "https" else { throw CommunityActorResolverError.insecureURL }
+    }
+
+    private static let session = CappedHTTPTransport.session(
+        requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
+
+    public static let defaultTransport: Transport = { request in
+        try await CappedHTTPTransport.fetch(
+            request, session: session, cap: ActorProfileFetcher.maximumResponseBytes,
+            tooLarge: { CommunityActorResolverError.requestFailed(status: 0, body: "response too large (\($0) bytes)") })
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter CommunityActorResolverTests`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CommunityActorResolver.swift Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
+git commit -m "feat(#368): resolve a community handle or URL to its actor document"
+```
+
+---
+
+### Task 2: `CommunityMembershipClient` — outbound Follow/Undo(Follow)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/CommunityMembershipClient.swift`
+- Test: `Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift`
+
+**Interfaces:**
+- Consumes: `ResolvedCommunityActor.actorID` (Task 1) as the `Follow`/`Undo` target; `ActivityPubActor.actorURL(siteURL:)` (existing) as this site's own actor, whose `/outbox` this POSTs to.
+- Produces: `public struct CommunityMembershipClient: Sendable { public init(ownActorURL: URL, publishToken: String, transport: Transport = .defaultTransport); public func follow(target: URL) async throws -> String /* activity id */; public func unfollow(target: URL, followActivityID: String?) async throws }`, `public enum CommunityMembershipError: Error, Equatable, Sendable { case requestFailed(status: Int, body: String), decodingFailed(String) }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("CommunityMembershipClient")
+struct CommunityMembershipClientTests {
+    actor FakeTransport {
+        private let status: Int
+        private let body: String
+        private(set) var requestedURLs: [URL] = []
+        private(set) var requestedHeaders: [[String: String]] = []
+        private(set) var requestedBodies: [[String: Any]] = []
+
+        init(status: Int = 202, body: String = "{}") {
+            self.status = status
+            self.body = body
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            requestedURLs.append(request.url!)
+            requestedHeaders.append(request.allHTTPHeaderFields ?? [:])
+            if let bodyData = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any] {
+                requestedBodies.append(json)
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: CommunityMembershipClient.Transport {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
+    private static func client(_ fake: FakeTransport) -> CommunityMembershipClient {
+        CommunityMembershipClient(
+            ownActorURL: URL(string: "https://example.com/users/site")!,
+            publishToken: "secret-token",
+            transport: fake.transport)
+    }
+
+    @Test("POSTs a Follow activity to this site's own outbox")
+    func postsFollow() async throws {
+        let fake = FakeTransport(status: 202, body: #"{"id":"https://example.com/users/site/outbox/1"}"#)
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+
+        let activityID = try await Self.client(fake).follow(target: target)
+
+        #expect(activityID == "https://example.com/users/site/outbox/1")
+        #expect(await fake.requestedURLs.first?.absoluteString == "https://example.com/users/site/outbox")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Follow")
+        #expect(body?["object"] as? String == "https://lemmy.ml/c/birding")
+        #expect(body?["actor"] as? String == "https://example.com/users/site")
+    }
+
+    @Test("falls back to the target URL as the activity id when the response carries none")
+    func followWithoutIDInResponse() async throws {
+        let fake = FakeTransport(status: 202, body: "{}")
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+
+        let activityID = try await Self.client(fake).follow(target: target)
+
+        #expect(activityID == "https://lemmy.ml/c/birding")
+    }
+
+    @Test("POSTs an Undo(Follow) referencing the original activity id")
+    func postsUndoWithActivityID() async throws {
+        let fake = FakeTransport()
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+
+        try await Self.client(fake).unfollow(
+            target: target, followActivityID: "https://example.com/users/site/outbox/1")
+
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Undo")
+        #expect(body?["object"] as? String == "https://example.com/users/site/outbox/1")
+    }
+
+    @Test("synthesizes a nested Follow object for Undo when no activity id is known")
+    func postsUndoWithoutActivityID() async throws {
+        let fake = FakeTransport()
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+
+        try await Self.client(fake).unfollow(target: target, followActivityID: nil)
+
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Undo")
+        let nestedFollow = body?["object"] as? [String: Any]
+        #expect(nestedFollow?["type"] as? String == "Follow")
+        #expect(nestedFollow?["object"] as? String == "https://lemmy.ml/c/birding")
+    }
+
+    @Test("maps a non-2xx status to requestFailed")
+    func mapsNon2xx() async throws {
+        let fake = FakeTransport(status: 403, body: "forbidden")
+        let target = try #require(URL(string: "https://lemmy.ml/c/birding"))
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 403, body: "forbidden")) {
+            _ = try await Self.client(fake).follow(target: target)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter CommunityMembershipClientTests`
+Expected: FAIL — "cannot find type 'CommunityMembershipClient' in scope"
+
+- [ ] **Step 3: Implement `CommunityMembershipClient`**
+
+```swift
+// Sources/AnglesiteCore/CommunityMembershipClient.swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum CommunityMembershipError: Error, Equatable, Sendable {
+    case requestFailed(status: Int, body: String)
+    case decodingFailed(String)
+}
+
+/// Joins/leaves a fediverse `Group` (V-5.1a, #368) by POSTing `Follow`/`Undo(Follow)` to this
+/// site's own outbox — the same owner-gated endpoint and `publishToken` bearer
+/// `ActivityPubOutboxBackfill` already uses (`@dwk/activitypub`'s "Owner-published Follow /
+/// Undo(Follow) now record the relationship and deliver to the target actor" behavior, phase 2).
+/// This site's Worker is the trusted party here (it holds the signing key and does the actual
+/// federated delivery), so — unlike `CommunityActorResolver` — there is no HTTPS/size-cap guard
+/// on this client itself; the target IRI it's given already passed through that resolver.
+public struct CommunityMembershipClient: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let outboxURL: URL
+    private let ownActorURL: URL
+    private let publishToken: String
+    private let transport: Transport
+
+    public init(
+        ownActorURL: URL, publishToken: String,
+        transport: @escaping Transport = CommunityMembershipClient.defaultTransport
+    ) {
+        self.ownActorURL = ownActorURL
+        self.outboxURL = ownActorURL.appendingPathComponent("outbox")
+        self.publishToken = publishToken
+        self.transport = transport
+    }
+
+    /// Returns the activity id the outbox reports back — persist it (`CommunitiesLedger`) so
+    /// `unfollow` can reference the exact original `Follow` in its `Undo`.
+    @discardableResult
+    public func follow(target: URL) async throws -> String {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Follow",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        let data = try await post(body)
+        return Self.activityID(from: data) ?? target.absoluteString
+    }
+
+    /// `followActivityID` is the id `follow(target:)` returned, if this membership was joined
+    /// through this client (the common case). When it's `nil` — e.g. membership predates this
+    /// feature — a synthetic nested `Follow` object stands in, a shape most AP implementations
+    /// accept for `Undo` since the concrete activity id was never recorded client-side.
+    public func unfollow(target: URL, followActivityID: String?) async throws {
+        let followObject: Any = followActivityID ?? [
+            "type": "Follow",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Undo",
+            "actor": ownActorURL.absoluteString,
+            "object": followObject,
+        ]
+        _ = try await post(body)
+    }
+
+    private func post(_ activity: [String: Any]) async throws -> Data {
+        var request = URLRequest(url: outboxURL)
+        request.httpMethod = "POST"
+        request.setValue("application/activity+json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: activity)
+
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw CommunityMembershipError.requestFailed(status: 0, body: "\(error)")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunityMembershipError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        return data
+    }
+
+    static func activityID(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return json["id"] as? String
+    }
+
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter CommunityMembershipClientTests`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CommunityMembershipClient.swift Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+git commit -m "feat(#368): send Follow/Undo(Follow) to join and leave a community"
+```
+
+---
+
+### Task 3: `GroupTimelineClient` — a Group's public outbox, paged
+
+**Files:**
+- Create: `Sources/AnglesiteCore/GroupTimelineClient.swift`
+- Test: `Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift`
+
+**Interfaces:**
+- Consumes: `ResolvedCommunityActor.outboxURL` (Task 1) as the collection to page.
+- Produces: `public struct GroupPost: Sendable, Equatable, Identifiable { public let id: String; public let title: String?; public let contentHTML: String?; public let url: URL?; public let publishedAt: Date?; public let authorName: String? }`, `public struct GroupTimelinePage: Sendable, Equatable { public let items: [GroupPost]; public let next: URL? }`, `public struct GroupTimelineClient: Sendable { public init(transport: Transport = .defaultTransport); public func collection(at outboxURL: URL) async throws -> (totalItems: Int, firstPage: URL?); public func page(at url: URL) async throws -> GroupTimelinePage }`, `public enum GroupTimelineError: Error, Equatable, Sendable { case requestFailed(status: Int, body: String), decodingFailed(String) }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("GroupTimelineClient")
+struct GroupTimelineClientTests {
+    actor FakeTransport {
+        private let status: Int
+        private let body: String
+        private(set) var requestedURLs: [URL] = []
+
+        init(status: Int = 200, body: String) {
+            self.status = status
+            self.body = body
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            requestedURLs.append(request.url!)
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: GroupTimelineClient.Transport {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
+    @Test("reads the outbox collection head")
+    func readsCollectionHead() async throws {
+        let fake = FakeTransport(body: """
+        {"id":"https://lemmy.ml/c/birding/outbox","type":"OrderedCollection","totalItems":2,
+         "first":"https://lemmy.ml/c/birding/outbox?page=1"}
+        """)
+        let outboxURL = try #require(URL(string: "https://lemmy.ml/c/birding/outbox"))
+        let result = try await GroupTimelineClient(transport: fake.transport).collection(at: outboxURL)
+
+        #expect(result.totalItems == 2)
+        #expect(result.firstPage?.absoluteString == "https://lemmy.ml/c/birding/outbox?page=1")
+    }
+
+    @Test("decodes a page of Create-wrapped Note activities into GroupPosts")
+    func decodesCreateWrappedPage() async throws {
+        let fake = FakeTransport(body: """
+        {"id":"https://lemmy.ml/c/birding/outbox?page=1","type":"OrderedCollectionPage",
+         "orderedItems":[
+           {"id":"https://lemmy.ml/activities/1","type":"Create",
+            "object":{"id":"https://lemmy.ml/post/1","type":"Page","name":"Osprey sighting",
+                      "content":"<p>Saw one today</p>","url":"https://lemmy.ml/post/1",
+                      "published":"2026-07-20T12:00:00Z",
+                      "attributedTo":"https://lemmy.ml/u/alice"}}
+         ],
+         "next":"https://lemmy.ml/c/birding/outbox?page=2"}
+        """)
+        let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox?page=1"))
+        let page = try await GroupTimelineClient(transport: fake.transport).page(at: url)
+
+        #expect(page.items.count == 1)
+        #expect(page.items[0].id == "https://lemmy.ml/post/1")
+        #expect(page.items[0].title == "Osprey sighting")
+        #expect(page.items[0].contentHTML == "<p>Saw one today</p>")
+        #expect(page.items[0].url?.absoluteString == "https://lemmy.ml/post/1")
+        #expect(page.next?.absoluteString == "https://lemmy.ml/c/birding/outbox?page=2")
+    }
+
+    @Test("falls back to a bare-id stub for an item with no embedded object")
+    func decodesBareIDItem() async throws {
+        let fake = FakeTransport(body: """
+        {"id":"https://lemmy.ml/c/birding/outbox?page=1","type":"OrderedCollectionPage",
+         "orderedItems":["https://lemmy.ml/activities/2"]}
+        """)
+        let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox?page=1"))
+        let page = try await GroupTimelineClient(transport: fake.transport).page(at: url)
+
+        #expect(page.items.count == 1)
+        #expect(page.items[0].id == "https://lemmy.ml/activities/2")
+        #expect(page.items[0].title == nil)
+    }
+
+    @Test("maps a non-2xx status to requestFailed")
+    func mapsNon2xx() async throws {
+        let fake = FakeTransport(status: 404, body: "not found")
+        let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox"))
+        await #expect(throws: GroupTimelineError.requestFailed(status: 404, body: "not found")) {
+            _ = try await GroupTimelineClient(transport: fake.transport).collection(at: url)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter GroupTimelineClientTests`
+Expected: FAIL — "cannot find type 'GroupTimelineClient' in scope"
+
+- [ ] **Step 3: Implement `GroupTimelineClient`**
+
+```swift
+// Sources/AnglesiteCore/GroupTimelineClient.swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// One post from a joined community's public timeline (V-5.1a, #368) — deliberately minimal:
+/// enough to render a row and open the original. `id` is the wrapped object's `id` when present
+/// (a real post), else the bare activity id (an item this parser couldn't unwrap further, still
+/// worth a stub row so the timeline's count matches the collection's).
+public struct GroupPost: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let title: String?
+    public let contentHTML: String?
+    public let url: URL?
+    public let publishedAt: Date?
+    public let authorName: String?
+
+    public init(
+        id: String, title: String?, contentHTML: String?, url: URL?, publishedAt: Date?,
+        authorName: String?
+    ) {
+        self.id = id
+        self.title = title
+        self.contentHTML = contentHTML
+        self.url = url
+        self.publishedAt = publishedAt
+        self.authorName = authorName
+    }
+}
+
+public struct GroupTimelinePage: Sendable, Equatable {
+    public let items: [GroupPost]
+    public let next: URL?
+
+    public init(items: [GroupPost], next: URL?) {
+        self.items = items
+        self.next = next
+    }
+}
+
+public enum GroupTimelineError: Error, Equatable, Sendable {
+    case requestFailed(status: Int, body: String)
+    case decodingFailed(String)
+}
+
+/// Reads a Group actor's public outbox (V-5.1a, #368) — the per-group timeline. Same
+/// unauthenticated, capped, AS2-collection-paging shape as `ActivityPubFollowersClient`, but the
+/// collection belongs to an arbitrary *remote* Group rather than this site's own followers, and
+/// each item is a full (or partial) activity to render rather than a bare actor IRI. AS2 is loose
+/// about wire shape here (a bare activity-id string, or a fully embedded activity), so this parses
+/// with `JSONSerialization` — like `ActivityPubOutboxBackfill.activityID(from:)` — rather than
+/// fighting `Decodable` over a heterogeneous array.
+public struct GroupTimelineClient: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    private let transport: Transport
+
+    public init(transport: @escaping Transport = GroupTimelineClient.defaultTransport) {
+        self.transport = transport
+    }
+
+    public func collection(at outboxURL: URL) async throws -> (totalItems: Int, firstPage: URL?) {
+        let json = try await fetch(outboxURL)
+        let totalItems = json["totalItems"] as? Int ?? 0
+        let firstPage = (json["first"] as? String).flatMap(URL.init(string:))
+        return (totalItems, firstPage)
+    }
+
+    public func page(at url: URL) async throws -> GroupTimelinePage {
+        let json = try await fetch(url)
+        let rawItems = (json["orderedItems"] as? [Any]) ?? []
+        let items = rawItems.compactMap(Self.post(from:))
+        let next = (json["next"] as? String).flatMap(URL.init(string:))
+        return GroupTimelinePage(items: items, next: next)
+    }
+
+    private func fetch(_ url: URL) async throws -> [String: Any] {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(ActivityPubFollowersClient.acceptHeader, forHTTPHeaderField: "Accept")
+        request.timeoutInterval = ActorProfileFetcher.timeout
+
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw GroupTimelineError.requestFailed(status: 0, body: "\(error)")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw GroupTimelineError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw GroupTimelineError.decodingFailed("not a JSON object")
+        }
+        return json
+    }
+
+    /// Unwraps one `Create`/`Announce` level to reach the actual post object; a bare-string item
+    /// (just an activity IRI, no embedded object) becomes an id-only stub rather than being
+    /// dropped, so the rendered row count still matches `totalItems`.
+    static func post(from item: Any) -> GroupPost? {
+        if let bareID = item as? String {
+            return GroupPost(
+                id: bareID, title: nil, contentHTML: nil, url: nil, publishedAt: nil, authorName: nil)
+        }
+        guard let activity = item as? [String: Any] else { return nil }
+        let object = (activity["object"] as? [String: Any]) ?? activity
+        guard let id = object["id"] as? String ?? activity["id"] as? String else { return nil }
+
+        let publishedAt = (object["published"] as? String).flatMap {
+            ISO8601DateFormatter().date(from: $0)
+        }
+        return GroupPost(
+            id: id,
+            title: (object["name"] as? String).map(DisplayString.safe),
+            contentHTML: object["content"] as? String,
+            url: (object["url"] as? String).flatMap(URL.init(string:)),
+            publishedAt: publishedAt,
+            authorName: (object["attributedTo"] as? String).map(DisplayString.safe))
+    }
+
+    public static let defaultTransport: Transport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter GroupTimelineClientTests`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/GroupTimelineClient.swift Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
+git commit -m "feat(#368): read a joined community's public outbox as a timeline"
+```
+
+---
+
+### Task 4: `CommunitiesLedger` — which groups this site has joined
+
+**Files:**
+- Create: `Sources/AnglesiteCore/CommunitiesLedger.swift`
+- Test: `Tests/AnglesiteCoreTests/CommunitiesLedgerTests.swift`
+
+**Interfaces:**
+- Produces: `public struct JoinedCommunity: Codable, Equatable, Sendable, Identifiable { public let actorID: URL; public let outboxURL: URL?; public let handle: String?; public let displayName: String?; public let joinedAt: Date; public let followActivityID: String?; public var id: String }`, `public struct CommunitiesLedger: Codable, Equatable, Sendable { public init(communities: [JoinedCommunity] = []); public private(set) var communities: [JoinedCommunity]; public func contains(actorID: URL) -> Bool; public mutating func record(_ community: JoinedCommunity); public mutating func remove(actorID: URL); public static func load(from configDirectory: URL) -> CommunitiesLedger?; public func save(to configDirectory: URL) throws; public static let filename: String }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteCoreTests/CommunitiesLedgerTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("CommunitiesLedger")
+struct CommunitiesLedgerTests {
+    private static func sample(handle: String = "@birding@lemmy.ml") -> JoinedCommunity {
+        JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: handle,
+            displayName: "Birding",
+            joinedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            followActivityID: "https://example.com/users/site/outbox/1")
+    }
+
+    @Test("record then contains reports true for the same actorID")
+    func recordAndContains() {
+        var ledger = CommunitiesLedger()
+        #expect(!ledger.contains(actorID: Self.sample().actorID))
+        ledger.record(Self.sample())
+        #expect(ledger.contains(actorID: Self.sample().actorID))
+        #expect(ledger.communities.count == 1)
+    }
+
+    @Test("recording the same actorID twice does not duplicate")
+    func recordIsIdempotent() {
+        var ledger = CommunitiesLedger()
+        ledger.record(Self.sample())
+        ledger.record(Self.sample(handle: "@birding@lemmy.ml"))
+        #expect(ledger.communities.count == 1)
+    }
+
+    @Test("remove drops the matching community and leaves the rest")
+    func remove() {
+        var ledger = CommunitiesLedger()
+        ledger.record(Self.sample())
+        let other = JoinedCommunity(
+            actorID: URL(string: "https://mastodon.social/c/other")!, outboxURL: nil,
+            handle: nil, displayName: nil, joinedAt: Date(), followActivityID: nil)
+        ledger.record(other)
+
+        ledger.remove(actorID: Self.sample().actorID)
+
+        #expect(ledger.communities == [other])
+    }
+
+    @Test("save then load round-trips through JSON on disk")
+    func saveAndLoadRoundTrip() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("communities-ledger-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        var ledger = CommunitiesLedger()
+        ledger.record(Self.sample())
+        try ledger.save(to: tempDir)
+
+        let loaded = try #require(CommunitiesLedger.load(from: tempDir))
+        #expect(loaded == ledger)
+    }
+
+    @Test("load returns nil when no ledger file exists yet")
+    func loadMissingFileReturnsNil() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("communities-ledger-missing-\(UUID().uuidString)")
+        #expect(CommunitiesLedger.load(from: tempDir) == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter CommunitiesLedgerTests`
+Expected: FAIL — "cannot find type 'CommunitiesLedger' in scope"
+
+- [ ] **Step 3: Implement `CommunitiesLedger`**
+
+```swift
+// Sources/AnglesiteCore/CommunitiesLedger.swift
+import Foundation
+
+/// One community this site has joined (V-5.1a, #368).
+public struct JoinedCommunity: Codable, Equatable, Sendable, Identifiable {
+    public let actorID: URL
+    /// For `GroupTimelineClient` — `nil` if the actor document didn't advertise one.
+    public let outboxURL: URL?
+    public let handle: String?
+    public let displayName: String?
+    public let joinedAt: Date
+    /// The `Follow` activity id `CommunityMembershipClient.follow(target:)` returned — threaded
+    /// back into `unfollow(target:followActivityID:)` on leave.
+    public let followActivityID: String?
+
+    public var id: String { actorID.absoluteString }
+
+    public init(
+        actorID: URL, outboxURL: URL?, handle: String?, displayName: String?, joinedAt: Date,
+        followActivityID: String?
+    ) {
+        self.actorID = actorID
+        self.outboxURL = outboxURL
+        self.handle = handle
+        self.displayName = displayName
+        self.joinedAt = joinedAt
+        self.followActivityID = followActivityID
+    }
+}
+
+/// Durable per-site record of which fediverse communities this site has joined —
+/// `Config/activitypub-communities.json`, app-owned, never in git. There is no public "following"
+/// collection to read this back from (`@dwk/activitypub` exposes `followers`, not `following`, as
+/// a public AS2 collection), so this ledger — not the Worker — is the source of truth for what the
+/// Communities pane lists. Same shape and crash-safety contract as `ActivityPubOutboxLedger`.
+public struct CommunitiesLedger: Codable, Equatable, Sendable {
+    public static let filename = "activitypub-communities.json"
+
+    public private(set) var communities: [JoinedCommunity]
+
+    public init(communities: [JoinedCommunity] = []) {
+        self.communities = communities
+    }
+
+    public func contains(actorID: URL) -> Bool {
+        communities.contains { $0.actorID == actorID }
+    }
+
+    /// No-ops if `actorID` is already recorded — matches `ActivityPubOutboxLedger.record`'s
+    /// idempotent-insert contract.
+    public mutating func record(_ community: JoinedCommunity) {
+        guard !contains(actorID: community.actorID) else { return }
+        communities.append(community)
+    }
+
+    public mutating func remove(actorID: URL) {
+        communities.removeAll { $0.actorID == actorID }
+    }
+
+    private struct Envelope: Codable {
+        let communities: [JoinedCommunity]
+    }
+
+    public static func load(from configDirectory: URL) -> CommunitiesLedger? {
+        let url = configDirectory.appendingPathComponent(filename)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let envelope = try? decoder.decode(Envelope.self, from: data) else { return nil }
+        return CommunitiesLedger(communities: envelope.communities)
+    }
+
+    public func save(to configDirectory: URL) throws {
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(Envelope(communities: communities))
+        try data.write(to: configDirectory.appendingPathComponent(Self.filename), options: .atomic)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter CommunitiesLedgerTests`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CommunitiesLedger.swift Tests/AnglesiteCoreTests/CommunitiesLedgerTests.swift
+git commit -m "feat(#368): persist which communities a site has joined"
+```
+
+---
+
+### Task 5: `CommunitiesModel` — orchestration
+
+**Files:**
+- Create: `Sources/AnglesiteApp/CommunitiesModel.swift`
+- Test: `Tests/AnglesiteAppTests/CommunitiesModelTests.swift`
+
+**Interfaces:**
+- Consumes: `CommunityActorResolver.resolve(_:)`, `CommunityMembershipClient.follow(target:)`/`.unfollow(target:followActivityID:)`, `GroupTimelineClient.collection(at:)`/`.page(at:)`, `CommunitiesLedger`, `ActivityPubActor.actorURL(siteURL:)`, `DeployCoordinator.resolveSiteURL(siteDirectory:)`, `SecretStore`/`SecretAccounts.activityPubPublishToken(siteID:)`, `CurrentSite`.
+- Produces: `@MainActor @Observable final class CommunitiesModel { func configure(site: CurrentSite); func join() async; func requestLeave(_ community: JoinedCommunity); func confirmLeave() async; func cancelLeave(); func selectCommunity(_ id: String); func loadTimeline() async }` plus published state used by Task 6's view: `state`, `joined`, `selectedCommunityID`, `timeline`, `isLoadingTimeline`, `joinHandleText`, `errorMessage`, `leaveConfirmation`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("CommunitiesModel")
+@MainActor
+struct CommunitiesModelTests {
+    /// In-memory `SecretStore` so `configure(site:)` can read a publish token without touching
+    /// the Keychain — mirrors how `MicrosubReaderModel`'s own tests stub credential storage.
+    final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+        var values: [String: String] = [:]
+        func read(account: String) throws -> String? { values[account] }
+        func write(_ value: String, account: String) throws { values[account] = value }
+        func delete(account: String) throws { values.removeValue(forKey: account) }
+    }
+
+    private static func site(configDirectory: URL, sourceDirectory: URL) -> CurrentSite {
+        CurrentSite(
+            id: "site-1", name: "Test Site",
+            packageURL: sourceDirectory.deletingLastPathComponent(),
+            sourceDirectory: sourceDirectory, configDirectory: configDirectory)
+    }
+
+    /// A fixture site directory with a `.site-config` declaring a public URL, so
+    /// `DeployCoordinator.resolveSiteURL` resolves without a real deploy.
+    private static func makeSiteDirectories() throws -> (config: URL, source: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("communities-model-test-\(UUID().uuidString)")
+        let config = root.appendingPathComponent("Config")
+        let source = root.appendingPathComponent("Source")
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "DOMAIN=example.com\n".write(
+            to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        return (config, source)
+    }
+
+    @Test("join resolves the handle, follows it, and records it in the ledger")
+    func joinRecordsCommunity() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        let model = CommunitiesModel(secretStore: secretStore)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.joinHandleText = "https://lemmy.ml/c/birding"
+
+        await model.join(
+            resolver: { _ in
+                ResolvedCommunityActor(
+                    actorID: URL(string: "https://lemmy.ml/c/birding")!,
+                    outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+                    type: "Group", preferredUsername: "birding", name: "Birding", handle: nil)
+            },
+            follow: { _, _ in "https://example.com/users/site/outbox/1" }
+        )
+
+        #expect(model.joined.count == 1)
+        #expect(model.joined.first?.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(model.joinHandleText.isEmpty)
+        #expect(model.errorMessage == nil)
+
+        // Persisted, not just in memory.
+        let reloaded = CommunitiesLedger.load(from: config)
+        #expect(reloaded?.communities.count == 1)
+    }
+
+    @Test("a resolver failure surfaces errorMessage and records nothing")
+    func joinResolveFailureSurfacesError() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        let model = CommunitiesModel(secretStore: secretStore)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.joinHandleText = "!ghost@lemmy.ml"
+
+        await model.join(
+            resolver: { _ in throw CommunityActorResolverError.noActorLink },
+            follow: { _, _ in "unused" }
+        )
+
+        #expect(model.joined.isEmpty)
+        #expect(model.errorMessage != nil)
+    }
+
+    @Test("confirmLeave unfollows and removes the community from the ledger")
+    func confirmLeaveRemovesCommunity() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let community = JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: "@birding@lemmy.ml", displayName: "Birding", joinedAt: Date(),
+            followActivityID: "https://example.com/users/site/outbox/1")
+        ledger.record(community)
+        try ledger.save(to: config)
+
+        let model = CommunitiesModel(secretStore: secretStore)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.joined.count == 1)
+
+        model.requestLeave(community)
+        #expect(model.leaveConfirmation == community)
+
+        var unfollowedTarget: URL?
+        await model.confirmLeave(unfollow: { target, _ in unfollowedTarget = target })
+
+        #expect(model.joined.isEmpty)
+        #expect(model.leaveConfirmation == nil)
+        #expect(unfollowedTarget?.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(CommunitiesLedger.load(from: config)?.communities.isEmpty == true)
+    }
+
+    @Test("loadTimeline populates from the selected community's outbox")
+    func loadTimelinePopulates() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        var ledger = CommunitiesLedger()
+        let community = JoinedCommunity(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!,
+            outboxURL: URL(string: "https://lemmy.ml/c/birding/outbox")!,
+            handle: "@birding@lemmy.ml", displayName: "Birding", joinedAt: Date(),
+            followActivityID: nil)
+        ledger.record(community)
+        try ledger.save(to: config)
+
+        let model = CommunitiesModel(secretStore: secretStore)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.selectCommunity(community.id)
+
+        await model.loadTimeline(
+            fetchCollection: { _ in (1, URL(string: "https://lemmy.ml/c/birding/outbox?page=1")) },
+            fetchPage: { _ in
+                GroupTimelinePage(
+                    items: [GroupPost(
+                        id: "https://lemmy.ml/post/1", title: "Osprey sighting", contentHTML: nil,
+                        url: nil, publishedAt: nil, authorName: nil)],
+                    next: nil)
+            }
+        )
+
+        #expect(model.timeline.count == 1)
+        #expect(model.timeline.first?.title == "Osprey sighting")
+        #expect(model.isLoadingTimeline == false)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter CommunitiesModelTests`
+Expected: FAIL — "cannot find type 'CommunitiesModel' in scope"
+
+- [ ] **Step 3: Implement `CommunitiesModel`**
+
+```swift
+// Sources/AnglesiteApp/CommunitiesModel.swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the main-pane Communities view (Website ▸ Communities…, V-5.1a #368): resolve a handle
+/// or URL, join/leave a fediverse `Group`, and read its public timeline. App glue only — protocol
+/// logic lives in `AnglesiteCore` (`CommunityActorResolver`, `CommunityMembershipClient`,
+/// `GroupTimelineClient`, `CommunitiesLedger`).
+///
+/// `join`/`confirmLeave`/`loadTimeline` take their network-calling collaborators as parameters
+/// (rather than storing injected clients on `self`) because each one needs a fresh
+/// `CommunityMembershipClient`/`GroupTimelineClient` built around the *current* `ownActorURL` and
+/// `publishToken` — those can change if the site is republished mid-session — while still letting
+/// tests substitute the actual network call with a stub. Production call sites pass the real
+/// client methods; see the `join()`/`confirmLeave()`/`loadTimeline()` no-argument overloads below.
+@MainActor
+@Observable
+final class CommunitiesModel {
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded
+        case noSiteURL
+        case notActivated
+        case unreachable(String)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var joined: [JoinedCommunity] = []
+    private(set) var selectedCommunityID: String?
+    private(set) var timeline: [GroupPost] = []
+    private(set) var isLoadingTimeline = false
+    var joinHandleText = ""
+    var errorMessage: String?
+    /// Non-nil ⟺ the "Leave this community?" confirmation is showing — mirrors
+    /// `SiteWindowModel.deleteConfirmation`'s item-based-confirmation pattern.
+    var leaveConfirmation: JoinedCommunity?
+
+    private var siteID: String?
+    private var configDirectory: URL?
+    private var siteURL: URL?
+    private var ownActorURL: URL?
+    private let secretStore: any SecretStore
+
+    init(secretStore: any SecretStore = PlatformSecretStore.make()) {
+        self.secretStore = secretStore
+    }
+
+    /// Records which site this pane talks to and loads the joined-communities ledger from disk.
+    /// No network I/O. Called once per site open from `SiteWindowModel.loadAndStart()`, mirroring
+    /// `FollowersModel.configure(site:)`.
+    func configure(site: CurrentSite) {
+        siteID = site.id
+        configDirectory = site.configDirectory
+        joined = CommunitiesLedger.load(from: site.configDirectory)?.communities ?? []
+        siteURL = DeployCoordinator.resolveSiteURL(siteDirectory: site.sourceDirectory).flatMap { URL(string: $0) }
+        ownActorURL = siteURL.map { ActivityPubActor.actorURL(siteURL: $0) }
+        state = joined.isEmpty ? .idle : .loaded
+    }
+
+    private var publishToken: String? {
+        guard let siteID else { return nil }
+        return try? secretStore.read(account: SecretAccounts.activityPubPublishToken(siteID: siteID))
+    }
+
+    // MARK: - Join
+
+    func join() async {
+        await join(
+            resolver: { try await CommunityActorResolver().resolve($0) },
+            follow: { target, membership in try await membership.follow(target: target) })
+    }
+
+    func join(
+        resolver: @escaping (String) async throws -> ResolvedCommunityActor,
+        follow: @escaping (URL, CommunityMembershipClient) async throws -> String
+    ) async {
+        let input = joinHandleText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !input.isEmpty else { return }
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        errorMessage = nil
+        do {
+            let resolved = try await resolver(input)
+            let membership = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken)
+            let activityID = try await follow(resolved.actorID, membership)
+            let community = JoinedCommunity(
+                actorID: resolved.actorID, outboxURL: resolved.outboxURL,
+                handle: resolved.handle, displayName: resolved.name ?? resolved.preferredUsername,
+                joinedAt: Date(), followActivityID: activityID)
+            var ledger = CommunitiesLedger(communities: joined)
+            ledger.record(community)
+            joined = ledger.communities
+            try? persist(ledger)
+            joinHandleText = ""
+            state = .loaded
+        } catch {
+            errorMessage = "Couldn't join \(input): \(error)"
+        }
+    }
+
+    // MARK: - Leave
+
+    func requestLeave(_ community: JoinedCommunity) {
+        leaveConfirmation = community
+    }
+
+    func cancelLeave() {
+        leaveConfirmation = nil
+    }
+
+    func confirmLeave() async {
+        await confirmLeave(unfollow: { target, followActivityID in
+            guard let ownActorURL, let publishToken else { return }
+            let membership = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken)
+            try await membership.unfollow(target: target, followActivityID: followActivityID)
+        })
+    }
+
+    func confirmLeave(unfollow: @escaping (URL, String?) async throws -> Void) async {
+        guard let community = leaveConfirmation else { return }
+        do {
+            try await unfollow(community.actorID, community.followActivityID)
+            var ledger = CommunitiesLedger(communities: joined)
+            ledger.remove(actorID: community.actorID)
+            joined = ledger.communities
+            try? persist(ledger)
+            if selectedCommunityID == community.id {
+                selectedCommunityID = nil
+                timeline = []
+            }
+            leaveConfirmation = nil
+        } catch {
+            errorMessage = "Couldn't leave \(community.displayName ?? community.id): \(error)"
+            leaveConfirmation = nil
+        }
+    }
+
+    private func persist(_ ledger: CommunitiesLedger) throws {
+        guard let configDirectory else { return }
+        try ledger.save(to: configDirectory)
+    }
+
+    // MARK: - Timeline
+
+    func selectCommunity(_ id: String) {
+        guard id != selectedCommunityID else { return }
+        selectedCommunityID = id
+        timeline = []
+        Task { await loadTimeline() }
+    }
+
+    func loadTimeline() async {
+        await loadTimeline(
+            fetchCollection: { url in try await GroupTimelineClient().collection(at: url) },
+            fetchPage: { url in try await GroupTimelineClient().page(at: url) })
+    }
+
+    func loadTimeline(
+        fetchCollection: @escaping (URL) async throws -> (totalItems: Int, firstPage: URL?),
+        fetchPage: @escaping (URL) async throws -> GroupTimelinePage
+    ) async {
+        guard let selectedCommunityID,
+              let community = joined.first(where: { $0.id == selectedCommunityID }),
+              let outboxURL = community.outboxURL
+        else { return }
+        isLoadingTimeline = true
+        defer { isLoadingTimeline = false }
+        do {
+            let head = try await fetchCollection(outboxURL)
+            guard let firstPage = head.firstPage else {
+                timeline = []
+                return
+            }
+            let page = try await fetchPage(firstPage)
+            timeline = page.items
+        } catch {
+            errorMessage = "Couldn't load \(community.displayName ?? community.id)'s timeline: \(error)"
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter CommunitiesModelTests`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/CommunitiesModel.swift Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+git commit -m "feat(#368): add CommunitiesModel to orchestrate join/leave/timeline"
+```
+
+---
+
+### Task 6: `CommunitiesView` — the SwiftUI pane
+
+**Files:**
+- Create: `Sources/AnglesiteApp/CommunitiesView.swift`
+
+**Interfaces:**
+- Consumes: `CommunitiesModel` (Task 5)'s full public surface.
+- Produces: `struct CommunitiesView: View { @Bindable var communities: CommunitiesModel }`, used by Task 7's `SiteWindow.swift` switch case.
+
+- [ ] **Step 1: Implement `CommunitiesView`**
+
+No test file — this is a SwiftUI layout, like `FollowersView`/`MicrosubReaderView`, neither of which has a dedicated test file; behavior lives in the already-tested `CommunitiesModel`. Verified instead by the manual QA in Task 8.
+
+```swift
+// Sources/AnglesiteApp/CommunitiesView.swift
+import SwiftUI
+import AppKit
+import AnglesiteCore
+
+/// Main-pane Communities surface (Website ▸ Communities…, V-5.1a #368): join/leave fediverse
+/// Group actors and read a per-group timeline. Mirrors `FollowersView`/`MicrosubReaderView`'s
+/// wiring shape — a dedicated pane with its own model, no in-content pane picker.
+struct CommunitiesView: View {
+    @Bindable var communities: CommunitiesModel
+
+    var body: some View {
+        HSplitView {
+            sidebar
+                .frame(minWidth: 220, idealWidth: 260, maxWidth: 340)
+            timelinePane
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .navigationSubtitle("Communities")
+        .alert(
+            "Communities error",
+            isPresented: Binding(
+                get: { communities.errorMessage != nil },
+                set: { if !$0 { communities.errorMessage = nil } }),
+            presenting: communities.errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) { communities.errorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
+        .alert(
+            "Leave this community?",
+            isPresented: Binding(
+                get: { communities.leaveConfirmation != nil },
+                set: { if !$0 { communities.cancelLeave() } }),
+            presenting: communities.leaveConfirmation
+        ) { community in
+            Button("Leave", role: .destructive) { Task { await communities.confirmLeave() } }
+            Button("Cancel", role: .cancel) { communities.cancelLeave() }
+        } message: { community in
+            Text("This site will stop receiving posts from \(community.displayName ?? community.id).")
+        }
+    }
+
+    @ViewBuilder
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                TextField("!community@instance or URL", text: $communities.joinHandleText)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { Task { await communities.join() } }
+                Button("Join") { Task { await communities.join() } }
+                    .disabled(communities.joinHandleText.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding()
+
+            if communities.joined.isEmpty {
+                Text("No communities joined yet — enter a handle above, like !birding@lemmy.ml.")
+                    .foregroundStyle(.secondary)
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            } else {
+                List(selection: Binding(
+                    get: { communities.selectedCommunityID },
+                    set: { if let id = $0 { communities.selectCommunity(id) } }
+                )) {
+                    ForEach(communities.joined) { community in
+                        communityRow(community).tag(community.id)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func communityRow(_ community: JoinedCommunity) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(community.displayName ?? community.handle ?? community.actorID.absoluteString)
+                .font(.headline)
+                .lineLimit(1)
+            if let handle = community.handle {
+                Text(handle).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            }
+        }
+        .padding(.vertical, 2)
+        .contextMenu {
+            Button("Leave…", role: .destructive) { communities.requestLeave(community) }
+        }
+    }
+
+    @ViewBuilder
+    private var timelinePane: some View {
+        if communities.selectedCommunityID == nil {
+            Text("Select a community to see its timeline.")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if communities.isLoadingTimeline {
+            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if communities.timeline.isEmpty {
+            Text("No posts yet.")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(communities.timeline) { post in
+                timelineRow(post)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func timelineRow(_ post: GroupPost) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(post.title ?? post.contentHTML ?? post.id)
+                .font(.headline)
+                .lineLimit(2)
+            if let author = post.authorName {
+                Text(author).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+        .contextMenu {
+            if let url = post.url {
+                Button("Open in Browser") { NSWorkspace.shared.open(url) }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Sources/AnglesiteApp/CommunitiesView.swift
+git commit -m "feat(#368): add the Communities pane's SwiftUI layout"
+```
+
+---
+
+### Task 7: Wire Communities into the site window
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:9-16` (the `MainPaneMode` enum), `Sources/AnglesiteApp/SiteWindowModel.swift:139-142` (child model declarations), `Sources/AnglesiteApp/SiteWindowModel.swift:298-307` (`presentFollowers()`), `Sources/AnglesiteApp/SiteWindowModel.swift:1528-1529` (`loadAndStart()`'s configure calls)
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:770-773` (the main-pane switch)
+- Modify: `Sources/AnglesiteApp/WebsiteCommands.swift:55-59` (the Website menu)
+
+**Interfaces:**
+- Consumes: `CommunitiesModel` (Task 5), `CommunitiesView` (Task 6).
+
+- [ ] **Step 1: Add the `.communities` pane mode**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, extend the enum:
+
+```swift
+enum MainPaneMode: Equatable {
+    case preview
+    case editor(FileRef)
+    case graph
+    case cleanup        // Site ▸ Cleanup… (#714 moved it out of the sidebar)
+    case reader         // Website ▸ Reader… (V-4.3, #365)
+    case followers      // Website ▸ Followers… (V-4.2, #364)
+    case communities    // Website ▸ Communities… (V-5.1a, #368)
+}
+```
+
+- [ ] **Step 2: Add the child model**
+
+Immediately after the existing `followers` declaration:
+
+```swift
+    /// Drives the main-pane Followers view (Website ▸ Followers…, V-4.2 #364): the site's public
+    /// ActivityPub followers collection, with lazily-enriched display identities.
+    var followers = FollowersModel()
+    /// Drives the main-pane Communities view (Website ▸ Communities…, V-5.1a #368): join/leave
+    /// fediverse Group actors and read a per-group timeline.
+    var communities = CommunitiesModel()
+```
+
+- [ ] **Step 3: Add `presentCommunities()`**
+
+Immediately after `presentFollowers()`:
+
+```swift
+    /// Switches the main pane to Communities (Website ▸ Communities…, V-5.1a #368). Mirrors
+    /// `presentFollowers()`'s leave-current-surface-first guard.
+    func presentCommunities() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            inspectorContext = nil
+            mainPaneMode = .communities
+        }
+    }
+```
+
+- [ ] **Step 4: Configure it on site open**
+
+In `loadAndStart()`, immediately after the existing configure calls:
+
+```swift
+        reader.configure(site: currentSite)
+        followers.configure(site: currentSite)
+        communities.configure(site: currentSite)
+```
+
+- [ ] **Step 5: Add the main-pane switch case**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, immediately after the `.followers` case (line 773):
+
+```swift
+        case .reader:
+            MicrosubReaderView(reader: model.reader)
+        case .followers:
+            FollowersView(followers: model.followers)
+        case .communities:
+            CommunitiesView(communities: model.communities)
+```
+
+- [ ] **Step 6: Add the Website menu item**
+
+In `Sources/AnglesiteApp/WebsiteCommands.swift`, immediately after the `Followers…` button:
+
+```swift
+            Button("Followers…") { model?.presentFollowers() }
+                .disabled(model == nil)
+
+            Button("Communities…") { model?.presentCommunities() }
+                .disabled(model == nil)
+```
+
+- [ ] **Step 7: Regenerate the Xcode project and build**
+
+`Sources/AnglesiteApp/CommunitiesModel.swift`/`CommunitiesView.swift` are new files under a path XcodeGen already globs (`Sources/AnglesiteApp/**`), so no `project.yml` change is needed — but the gitignored `.xcodeproj` must still be regenerated to pick them up.
+
+Run: `xcodegen generate`
+Expected: regenerates `Anglesite.xcodeproj` without error.
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 8: Run the full test suite**
+
+Run: `swift test --package-path .`
+Expected: all suites PASS, including the five new ones from Tasks 1–5.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindowModel.swift Sources/AnglesiteApp/SiteWindow.swift Sources/AnglesiteApp/WebsiteCommands.swift
+git commit -m "feat(#368): wire the Communities pane into the site window"
+```
+
+---
+
+### Task 8: Manual acceptance
+
+**Files:** none — this is verification, not code.
+
+The issue's acceptance criteria ("join a Lemmy community by handle from the app; its posts appear in the group timeline; leaving stops delivery") need a real Lemmy peer and a deployed site, so they aren't automatable inline — same constraint the design spec's own test-strategy section notes. `AppliesEditEndToEndTests`-style container-gated e2e (`ANGLESITE_CONTAINER_E2E=1`) against the composed Worker is a reasonable fast-follow but is **out of scope for this plan**: it needs its own container-fixture design (a deployed test site plus a live or fixture Lemmy peer) that would meaningfully bloat this PR. Flag it explicitly rather than silently dropping it — either as a follow-up issue or a note in the PR body's Test plan.
+
+- [ ] **Step 1: Manual QA against a real site**
+
+1. Open (or create) a site with ActivityPub turned on and already published (Settings ▸ Workers).
+2. Website ▸ Communities…
+3. Enter `!<some active Lemmy community>@<lemmy instance>` (e.g. a real, small, active community — check `https://join-lemmy.org/instances` for one) and click Join.
+4. Confirm the community appears in the sidebar list and its timeline loads with recent posts.
+5. Context-menu ▸ Leave…, confirm. Confirm the community disappears from the list and the timeline pane returns to "Select a community…".
+6. Quit and reopen the site window; confirm the joined-communities list survived (persisted in `Config/activitypub-communities.json`) until the Leave step ran.
+
+Record the outcome (pass/fail + any deviations) in the PR body's Test plan section.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Join (#368 plan item 1) → Tasks 1–2 + `CommunitiesModel.join()`. Communities section (item 2) → Tasks 5–7. Per-group timeline (item 3) → Task 3 + `CommunitiesModel.loadTimeline()`. Leave (item 4) → Task 2's `unfollow` + `CommunitiesModel.confirmLeave()`. Swift Testing against a stubbed client (test strategy) → Tasks 1–5's suites. Manual acceptance against a live Lemmy community → Task 8. Container-gated e2e is explicitly called out as deferred, not silently dropped.
+- **Out of scope, called out, not silently dropped:** posting to a community (`audience` field, #369) and directory browse/search (#371) — neither appears in any task above; #368's own issue body doesn't ask for them either.
+- **Type consistency check:** `ResolvedCommunityActor.actorID`/`.outboxURL` (Task 1) flow unchanged into `JoinedCommunity.actorID`/`.outboxURL` (Task 4) and `CommunityMembershipClient.follow(target:)`'s `target: URL` (Task 2). `CommunityMembershipClient.follow(target:)`'s returned `String` flows into `JoinedCommunity.followActivityID` and back into `unfollow(target:followActivityID:)`. `GroupTimelineClient.page(at:)`'s `GroupTimelinePage.items: [GroupPost]` flows unchanged into `CommunitiesModel.timeline` and `CommunitiesView`'s `ForEach`.

--- a/docs/superpowers/plans/2026-07-27-v5-1a-communities-participate.md
+++ b/docs/superpowers/plans/2026-07-27-v5-1a-communities-participate.md
@@ -663,7 +663,7 @@ git commit -m "feat(#368): send Follow/Undo(Follow) to join and leave a communit
 
 **Interfaces:**
 - Consumes: `ResolvedCommunityActor.outboxURL` (Task 1) as the collection to page.
-- Produces: `public struct GroupPost: Sendable, Equatable, Identifiable { public let id: String; public let title: String?; public let contentHTML: String?; public let url: URL?; public let publishedAt: Date?; public let authorName: String? }`, `public struct GroupTimelinePage: Sendable, Equatable { public let items: [GroupPost]; public let next: URL? }`, `public struct GroupTimelineClient: Sendable { public init(transport: Transport = .defaultTransport); public func collection(at outboxURL: URL) async throws -> (totalItems: Int, firstPage: URL?); public func page(at url: URL) async throws -> GroupTimelinePage }`, `public enum GroupTimelineError: Error, Equatable, Sendable { case requestFailed(status: Int, body: String), decodingFailed(String) }`.
+- Produces: `public struct GroupPost: Sendable, Equatable, Identifiable { public let id: String; public let title: String?; public let contentHTML: String?; public let url: URL?; public let publishedAt: Date?; public let authorName: String? }`, `public struct GroupTimelinePage: Sendable, Equatable { public let items: [GroupPost]; public let next: URL? }`, `public struct GroupTimelineClient: Sendable { public init(transport: Transport = .defaultTransport); public func collection(at outboxURL: URL) async throws -> (totalItems: Int, firstPage: URL?); public func page(at url: URL) async throws -> GroupTimelinePage }`, `public enum GroupTimelineError: Error, Equatable, Sendable { case insecureURL, requestFailed(status: Int, body: String), decodingFailed(String) }`.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -758,6 +758,17 @@ struct GroupTimelineClientTests {
             _ = try await GroupTimelineClient(transport: fake.transport).collection(at: url)
         }
     }
+
+    /// The outbox belongs to an arbitrary remote Group, the same trust level as a follower's
+    /// actor document (`ActorProfileFetcher`) — this guard is load-bearing, not decorative.
+    @Test("rejects a plain http outbox URL")
+    func rejectsInsecureURL() async throws {
+        let fake = FakeTransport(body: "{}")
+        let url = try #require(URL(string: "http://lemmy.ml/c/birding/outbox"))
+        await #expect(throws: GroupTimelineError.insecureURL) {
+            _ = try await GroupTimelineClient(transport: fake.transport).collection(at: url)
+        }
+    }
 }
 ```
 
@@ -811,19 +822,28 @@ public struct GroupTimelinePage: Sendable, Equatable {
 }
 
 public enum GroupTimelineError: Error, Equatable, Sendable {
+    /// The outbox URL, or the URL a redirect actually landed on, wasn't `https`.
+    case insecureURL
     case requestFailed(status: Int, body: String)
     case decodingFailed(String)
 }
 
 /// Reads a Group actor's public outbox (V-5.1a, #368) — the per-group timeline. Same
-/// unauthenticated, capped, AS2-collection-paging shape as `ActivityPubFollowersClient`, but the
-/// collection belongs to an arbitrary *remote* Group rather than this site's own followers, and
-/// each item is a full (or partial) activity to render rather than a bare actor IRI. AS2 is loose
-/// about wire shape here (a bare activity-id string, or a fully embedded activity), so this parses
-/// with `JSONSerialization` — like `ActivityPubOutboxBackfill.activityID(from:)` — rather than
-/// fighting `Decodable` over a heterogeneous array.
+/// unauthenticated, HTTPS-only, capped, AS2-collection-paging shape as `ActivityPubFollowersClient`
+/// (the collection) and `ActorProfileFetcher` (the HTTPS/size guard — this outbox is exactly as
+/// attacker-influenced as a follower's actor document, just a bigger one), but the collection
+/// belongs to an arbitrary *remote* Group rather than this site's own followers, and each item is
+/// a full (or partial) activity to render rather than a bare actor IRI. AS2 is loose about wire
+/// shape here (a bare activity-id string, or a fully embedded activity), so this parses with
+/// `JSONSerialization` — like `ActivityPubOutboxBackfill.activityID(from:)` — rather than fighting
+/// `Decodable` over a heterogeneous array.
 public struct GroupTimelineClient: Sendable {
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// 1 MB. A single actor document (`ActorProfileFetcher`'s 256 KB cap) is a few KB, but an
+    /// outbox page embeds several full activities at once — generous enough for a real page of
+    /// posts while still rejecting a pathological response.
+    public static let maximumResponseBytes = 1024 * 1024
 
     private let transport: Transport
 
@@ -847,6 +867,8 @@ public struct GroupTimelineClient: Sendable {
     }
 
     private func fetch(_ url: URL) async throws -> [String: Any] {
+        try Self.requireHTTPS(url)
+
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue(ActivityPubFollowersClient.acceptHeader, forHTTPHeaderField: "Accept")
@@ -859,6 +881,9 @@ public struct GroupTimelineClient: Sendable {
         } catch {
             throw GroupTimelineError.requestFailed(status: 0, body: "\(error)")
         }
+        // URLSession follows redirects transparently, so this body may not have come from `url`
+        // at all — re-check where it actually landed, exactly like `ActorProfileFetcher`.
+        if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
         guard (200..<300).contains(http.statusCode) else {
             throw GroupTimelineError.requestFailed(
                 status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
@@ -867,6 +892,10 @@ public struct GroupTimelineClient: Sendable {
             throw GroupTimelineError.decodingFailed("not a JSON object")
         }
         return json
+    }
+
+    static func requireHTTPS(_ url: URL) throws {
+        guard url.scheme?.lowercased() == "https" else { throw GroupTimelineError.insecureURL }
     }
 
     /// Unwraps one `Create`/`Announce` level to reach the actual post object; a bare-string item
@@ -893,10 +922,13 @@ public struct GroupTimelineClient: Sendable {
             authorName: (object["attributedTo"] as? String).map(DisplayString.safe))
     }
 
+    private static let session = CappedHTTPTransport.session(
+        requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
+
     public static let defaultTransport: Transport = { request in
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
-        return (data, http)
+        try await CappedHTTPTransport.fetch(
+            request, session: session, cap: GroupTimelineClient.maximumResponseBytes,
+            tooLarge: { GroupTimelineError.requestFailed(status: 0, body: "response too large (\($0) bytes)") })
     }
 }
 ```
@@ -904,7 +936,7 @@ public struct GroupTimelineClient: Sendable {
 - [ ] **Step 4: Run the tests to verify they pass**
 
 Run: `swift test --package-path . --filter GroupTimelineClientTests`
-Expected: PASS (4 tests)
+Expected: PASS (5 tests)
 
 - [ ] **Step 5: Commit**
 


### PR DESCRIPTION
## Summary

- Adds V-5.1a Communities (Stage 1, #368): join and leave existing fediverse `Group` actors (Lemmy/PieFed/Mbin communities) by handle or URL, and read a per-group timeline, from a new **Communities** pane (Website ▸ Communities…).
- New `AnglesiteCore` types: `CommunityActorResolver` (webfinger + direct actor-document resolution, HTTPS-only + byte-capped), `CommunityMembershipClient` (outbound `Follow`/`Undo(Follow)` via this site's own outbox), `GroupTimelineClient` (paged reader for a Group's public outbox), `CommunitiesLedger` (local record of joined communities — there's no public "following" collection to query back, so the app is the source of truth).
- Scope is deliberately **join/leave/read-timeline only**; posting *to* a community (#369) and directory browse/search (#371) are separate, already-filed, out-of-scope issues.
- Both gating dependencies (V-4 app build #363/#364/#365, and a conformant `@dwk/workers` release with FEP-1b12 group participation, `@dwk/activitypub` 0.1.0-beta.5) had already shipped, so this closes out V-5.1a's `🚫 Blocked` status.
- Implementation plan with full task/design rationale: `docs/superpowers/plans/2026-07-27-v5-1a-communities-participate.md`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

## Test plan

- [x] `swift test --package-path .` — 2756 tests / 357 suites; only 2 pre-existing, unrelated `FoundationModelAssistantTests` failures (on-device FoundationModels unavailable in this sandboxed dev environment).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke: needs a live Lemmy community + a published site with ActivityPub on to exercise join/leave/timeline end-to-end. Checklist documented in the plan (Task 8) but not run in this session — recommend running it before/at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)