### PR TITLE
ci: replace CodeQL default setup with tuned advanced workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,101 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Matches the weekly cadence of the default setup this replaces.
+    - cron: '17 3 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Default setup's `javascript` and `javascript-typescript` entries are the same
+          # extractor under two names (recent CodeQL merged the JS/TS analyzers) — one
+          # matrix entry covers both. Actions workflow YAML has no build step to speed up;
+          # it's here for parity with the language list default setup was scanning.
+          - language: actions
+            build-mode: none
+            runs-on: ubuntu-latest
+          - language: javascript-typescript
+            build-mode: none
+            runs-on: ubuntu-latest
+          # Swift needs an actual compile to build the CodeQL database. `build-mode: manual`
+          # (below) replaces autobuild's build-strategy guessing with the one build we already
+          # know is correct and minimal: the same `Anglesite` scheme/Debug config `build-test`
+          # in ci.yml uses — no release build, no test targets, no sibling-plugin checkout.
+          - language: swift
+            build-mode: manual
+            runs-on: macos-26
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: ${{ matrix.language == 'swift' && 30 || 10 }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Select latest available Xcode
+        if: matrix.language == 'swift'
+        # Same toolchain selection as ci.yml's build-test job — see the comment there for why
+        # Xcode 26.3 is excluded and macos-26 is required (Swift 6.2.x task-allocator bug).
+        run: |
+          set -euo pipefail
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
+          echo "Selecting: $LATEST"
+          sudo xcode-select -s "$LATEST"
+
+      - name: Install XcodeGen (pinned)
+        if: matrix.language == 'swift'
+        env:
+          # Keep in sync with ci.yml's xcodeproj-sync/appintents-schema jobs.
+          XCODEGEN_VERSION: 2.45.4
+          XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" -o /tmp/xcodegen.zip
+          echo "${XCODEGEN_SHA256}  /tmp/xcodegen.zip" | shasum -a 256 --check
+          unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
+          test -x /tmp/xcodegen-dist/xcodegen/bin/xcodegen \
+            || { echo "error: xcodegen binary not found at expected path after unzip — check zip layout" >&2; exit 1; }
+          echo "/tmp/xcodegen-dist/xcodegen/bin" >> "$GITHUB_PATH"
+
+      - name: Generate Xcode project
+        if: matrix.language == 'swift'
+        run: xcodegen generate
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Build (Swift, Debug — deliberately no cache)
+        if: matrix.language == 'swift'
+        # No DerivedData/SwiftPM cache here on purpose: CodeQL's Swift extractor only sees
+        # source files that actually get *compiled* during this step. An incremental build
+        # restored from cache can skip recompiling unchanged files, so they'd silently drop
+        # out of the CodeQL database (under-analysis, not a build failure) instead of
+        # producing a stale-but-complete scan. ci.yml's own SwiftPM cache is for its
+        # build/test lanes, not this one — don't copy it here without checking that tradeoff.
+        run: xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

- Replace GitHub's CodeQL "default setup" with a custom `.github/workflows/codeql.yml` (advanced setup), matrixed over `actions`, `javascript-typescript`, and `swift`.
- For `swift`, use `build-mode: manual` with the same targeted `xcodebuild -scheme Anglesite -configuration Debug build` the `build-test` job in `ci.yml` already uses, instead of autobuild's build-strategy guessing — this was the long pole in the 11+ minute default-setup run.
- Collapse default setup's separate `javascript`/`javascript-typescript` entries into one matrix entry (recent CodeQL merged those extractors, so they were very likely double-scanning the same files).
- Disabled the repo's CodeQL default setup via the API (`code-scanning/default-setup` → `not-configured`) so the two configurations don't conflict — GitHub errors if both are active for the same language.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] `swift test --package-path .` — not applicable, no Swift source changed.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not applicable, no Swift source changed; the workflow itself runs this same command as its Swift CodeQL build step.
- [ ] Manual smoke — not applicable (no UI change). Real verification is watching this PR's own `CodeQL / Analyze (*)` checks run green under the new workflow, and comparing wall-clock against the previous `(dynamic)` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)