### PR TITLE
feat(#1030): add beehiiv newsletter provider

### DIFF
--- a/Resources/Template/integrations/docs/newsletter-setup.md
+++ b/Resources/Template/integrations/docs/newsletter-setup.md
@@ -13,6 +13,7 @@ site itself):
 1. **Get an API key.**
    - **Buttondown**: sign up at buttondown.email, then Settings → API → copy the key.
    - **Mailchimp**: sign up at mailchimp.com, create an audience, then Account → Extras → API keys → create a key. Also note the Audience ID (Audience → Settings → Audience name and defaults).
+   - **beehiiv**: sign up at beehiiv.com (the free Launch plan includes API access), then Settings → API → create a key. Also note your publication ID (starts with `pub_`, shown on the same page).
 
 2. **From a terminal, in this site's directory, store the secrets:**
 
@@ -22,11 +23,17 @@ site itself):
    npx wrangler secret put SITE_DOMAIN --config worker/subscribe-wrangler.toml
    ```
 
-   Paste the API key, `buttondown` or `mailchimp`, and your site's domain
-   (e.g. `example.com`) when prompted. If you're using Mailchimp, also run:
+   Paste the API key, `buttondown`, `mailchimp`, or `beehiiv`, and your site's
+   domain (e.g. `example.com`) when prompted. If you're using Mailchimp, also run:
 
    ```sh
    npx wrangler secret put MAILCHIMP_LIST_ID --config worker/subscribe-wrangler.toml
+   ```
+
+   If you're using beehiiv, also run:
+
+   ```sh
+   npx wrangler secret put BEEHIIV_PUBLICATION_ID --config worker/subscribe-wrangler.toml
    ```
 
 3. **Deploy the Worker:**

--- a/Resources/Template/integrations/worker/subscribe-worker.js
+++ b/Resources/Template/integrations/worker/subscribe-worker.js
@@ -6,10 +6,11 @@
  * ../../../docs/newsletter-setup.md (staged to docs/newsletter-setup.md).
  *
  * Secrets (set via `wrangler secret put`):
- *   NEWSLETTER_API_KEY  — Buttondown or Mailchimp API key
- *   NEWSLETTER_PLATFORM — "buttondown" or "mailchimp"
- *   MAILCHIMP_LIST_ID   — Mailchimp audience/list ID (Mailchimp only)
- *   SITE_DOMAIN         — For CORS origin validation
+ *   NEWSLETTER_API_KEY     — Buttondown, Mailchimp, or beehiiv API key
+ *   NEWSLETTER_PLATFORM    — "buttondown", "mailchimp", or "beehiiv"
+ *   MAILCHIMP_LIST_ID      — Mailchimp audience/list ID (Mailchimp only)
+ *   BEEHIIV_PUBLICATION_ID — beehiiv publication ID, "pub_…" (beehiiv only)
+ *   SITE_DOMAIN            — For CORS origin validation
  */
 
 const RATE_LIMIT_SECONDS = 30;
@@ -84,6 +85,25 @@ async function subscribeMailchimp(email, apiKey, listId) {
   return { ok: false, errors: ["Subscribe failed. Please try again later."] };
 }
 
+async function subscribeBeehiiv(email, apiKey, publicationId) {
+  const response = await fetch(
+    `https://api.beehiiv.com/v2/publications/${publicationId}/subscriptions`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      // beehiiv treats an existing subscriber as an upsert (no distinct
+      // "already subscribed" error), so any 2xx is success.
+      body: JSON.stringify({ email, double_opt_override: "on" }), // double opt-in
+    },
+  );
+
+  if (response.ok) return { ok: true };
+  return { ok: false, errors: ["Subscribe failed. Please try again later."] };
+}
+
 export default {
   async fetch(request, env) {
     const origin = request.headers.get("Origin");
@@ -135,6 +155,8 @@ export default {
       result = await subscribeButtondown(email, env.NEWSLETTER_API_KEY);
     } else if (platform === "mailchimp") {
       result = await subscribeMailchimp(email, env.NEWSLETTER_API_KEY, env.MAILCHIMP_LIST_ID);
+    } else if (platform === "beehiiv") {
+      result = await subscribeBeehiiv(email, env.NEWSLETTER_API_KEY, env.BEEHIIV_PUBLICATION_ID);
     } else {
       result = { ok: false, errors: ["Newsletter service not configured."] };
     }

--- a/Resources/Template/integrations/worker/subscribe-wrangler.toml
+++ b/Resources/Template/integrations/worker/subscribe-wrangler.toml
@@ -2,10 +2,11 @@
 # Receives subscribe form submissions and forwards them to your newsletter platform.
 #
 # Secrets are set via: npx wrangler secret put <NAME> --config worker/subscribe-wrangler.toml
-#   NEWSLETTER_API_KEY  — Buttondown or Mailchimp API key
-#   NEWSLETTER_PLATFORM — "buttondown" or "mailchimp"
-#   MAILCHIMP_LIST_ID   — Mailchimp audience/list ID (Mailchimp only)
-#   SITE_DOMAIN         — your site's domain, for CORS origin validation
+#   NEWSLETTER_API_KEY     — Buttondown, Mailchimp, or beehiiv API key
+#   NEWSLETTER_PLATFORM    — "buttondown", "mailchimp", or "beehiiv"
+#   MAILCHIMP_LIST_ID      — Mailchimp audience/list ID (Mailchimp only)
+#   BEEHIIV_PUBLICATION_ID — beehiiv publication ID, "pub_…" (beehiiv only)
+#   SITE_DOMAIN            — your site's domain, for CORS origin validation
 
 name = "newsletter-subscribe"
 main = "subscribe-worker.js"

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -218,10 +218,11 @@ public enum IntegrationCatalog {
     static let newsletter = IntegrationDescriptor(
         id: .newsletter,
         displayName: "Newsletter",
-        summary: "Let visitors subscribe to email updates (Buttondown or Mailchimp), via a Worker that keeps your API key off the client.",
+        summary: "Let visitors subscribe to email updates (Buttondown, Mailchimp, or beehiiv), via a Worker that keeps your API key off the client.",
         providers: [
             Provider(id: "buttondown", displayName: "Buttondown", cspDomains: []),
             Provider(id: "mailchimp", displayName: "Mailchimp", cspDomains: []),
+            Provider(id: "beehiiv", displayName: "beehiiv", cspDomains: []),
         ],
         fields: [
             Field(key: "workerUrl", label: "Subscribe Worker URL", kind: .url,

--- a/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -197,7 +197,7 @@ import Testing
 
     @Test func newsletterHasPlatformChoice() {
         let newsletter = IntegrationCatalog.descriptor(for: .newsletter)
-        #expect(Set(newsletter.providers.map(\.id)) == Set(["buttondown", "mailchimp"]))
+        #expect(Set(newsletter.providers.map(\.id)) == Set(["buttondown", "mailchimp", "beehiiv"]))
     }
 
     @Test func newsletterWritesPlatformWorkerUrlAndButtonText() {

--- a/docs/superpowers/specs/2026-07-27-newsletter-beehiiv-provider-design.md
+++ b/docs/superpowers/specs/2026-07-27-newsletter-beehiiv-provider-design.md
@@ -1,0 +1,85 @@
+# Newsletter integration: add beehiiv as a provider
+
+**Date:** 2026-07-27 · **Issue:** [#1030](https://github.com/Anglesite/Anglesite-app/issues/1030)
+
+## Background
+
+The newsletter integration proxies subscribe-form posts through a per-site
+Cloudflare Worker (`worker/subscribe-worker.js`) that calls the newsletter
+platform's REST API server-side, keeping the API key off the client. It
+currently supports Buttondown and Mailchimp.
+
+A July 2026 review of newsletter services (beehiiv, Ghost, Buttondown, Kit,
+MailerLite, EmailOctopus, Substack, Listmonk) against this architecture
+concluded:
+
+- **Buttondown stays the recommended default.** Its API is free on all plans
+  (since Jan 2025), double opt-in is the API default, it is email-first with
+  no ambition to replace the user's site, and RSS-to-email (+$9/mo) is the
+  only affordable "site publishes, service delivers" automation in the field.
+  Known limit: subscriber creation is capped at 100 requests/day by default.
+- **beehiiv is added as a provider.** Its free Launch plan (2,500
+  subscribers) includes the v2 subscriptions API, so the Worker integration
+  costs one fetch wrapper. Caveat owners should know: beehiiv's RSS-to-Send
+  is gated to its Max plan ($96+/mo), so on affordable tiers newsletters are
+  composed in beehiiv rather than driven from the site's RSS feed, and
+  beehiiv promotes its own hosted site/archive.
+- **Ghost is rejected.** No free tier; the Admin API the Worker would need is
+  gated to Ghost(Pro) Publisher ($29/mo) or self-hosting with Mailgun; auth
+  requires minting short-lived JWTs; and members created via the Admin API
+  bypass double opt-in entirely.
+- **Substack is rejected** (still no public subscribe API in 2026).
+- **Kit is deferred** — its 10,000-subscriber free tier is attractive, but
+  official docs contradict each other on whether free-plan accounts get API
+  keys; verify empirically before adding.
+- **MailerLite** (free tier cut to 250 subscribers in June 2026),
+  **EmailOctopus** (no RSS-to-email), and **Listmonk** (self-hosted Postgres
+  plus deliverability ownership — unrealistic for the audience) are not
+  added.
+
+## Design
+
+### Worker (`Resources/Template/integrations/worker/subscribe-worker.js`)
+
+- New `subscribeBeehiiv(email, apiKey, publicationId)`:
+  `POST https://api.beehiiv.com/v2/publications/{publicationId}/subscriptions`
+  with `Authorization: Bearer <apiKey>` and body
+  `{ email, double_opt_override: "on" }`.
+- Double opt-in is forced per-call, matching the posture the Mailchimp path
+  already takes (`status: "pending"`), rather than inheriting the
+  publication's setting.
+- Response mapping: any 2xx → success. beehiiv does not document a distinct
+  already-subscribed error (the endpoint behaves as an upsert), so repeat
+  subscribers see the normal success path. Non-2xx → the existing generic
+  failure message.
+- New secret `BEEHIIV_PUBLICATION_ID` (the `pub_…` id), analogous to
+  `MAILCHIMP_LIST_ID`. `NEWSLETTER_PLATFORM` gains the value `beehiiv`.
+- No CSP change — the API call happens in the Worker, not the browser.
+
+### Catalog (`Sources/AnglesiteCore/IntegrationCatalog.swift`)
+
+- Add `Provider(id: "beehiiv", displayName: "beehiiv", cspDomains: [])` to
+  the newsletter descriptor and name all three services in its summary.
+- Wizard fields unchanged: provider-specific config (API key, publication
+  id) lives in Worker secrets, exactly as Mailchimp's list id does today.
+
+### Docs (`Resources/Template/integrations/docs/newsletter-setup.md`)
+
+- beehiiv bullet in step 1 (free Launch plan includes the API; key from
+  Settings → API; note the `pub_…` publication ID).
+- Conditional `BEEHIIV_PUBLICATION_ID` secret in step 2.
+
+### Tests
+
+- `IntegrationCatalogTests` provider-set assertion updated to include
+  `beehiiv`.
+- Verification: `swift test` (template-coupled suites included) — the Worker
+  itself has no JS test harness today and this change does not introduce one.
+
+## Out of scope
+
+- Kit/EmailOctopus providers (revisit if requested; Kit needs the free-plan
+  API-key check first).
+- Any "send via API" ambition (beehiiv gates its Send API to Enterprise).
+- Wizard-driven Worker deployment (deploying the subscribe Worker remains
+  the documented manual `wrangler` step).

--- a/docs/superpowers/specs/2026-07-27-newsletter-beehiiv-provider-design.md
+++ b/docs/superpowers/specs/2026-07-27-newsletter-beehiiv-provider-design.md
@@ -29,9 +29,14 @@ concluded:
   requires minting short-lived JWTs; and members created via the Admin API
   bypass double opt-in entirely.
 - **Substack is rejected** (still no public subscribe API in 2026).
-- **Kit is deferred** — its 10,000-subscriber free tier is attractive, but
-  official docs contradict each other on whether free-plan accounts get API
-  keys; verify empirically before adding.
+- **Kit is deferred** — its 10,000-subscriber free tier is attractive. The
+  apparent documentation contradiction on free-plan API access resolved on
+  closer reading (2026-07-27): the developer docs' "eligible plan" caveat is
+  scoped to *sending broadcasts* via the API, while the help center states
+  API keys are available on any plan and the pricing matrix lists
+  subscriber-API access on the free Newsletter plan. A live check (free
+  signup → mint v4 key → `POST /v4/subscribers`) is still wanted before
+  adding the provider.
 - **MailerLite** (free tier cut to 250 subscribers in June 2026),
   **EmailOctopus** (no RSS-to-email), and **Listmonk** (self-hosted Postgres
   plus deliverability ownership — unrealistic for the audience) are not


### PR DESCRIPTION
## Summary

- Adds **beehiiv** as a third newsletter provider: `subscribeBeehiiv()` branch in the subscribe Worker (Bearer auth, forced double opt-in via `double_opt_override: "on"`, new `BEEHIIV_PUBLICATION_ID` secret mirroring `MAILCHIMP_LIST_ID`), a `Provider` row in `IntegrationCatalog`, and beehiiv steps in `newsletter-setup.md`.
- Commits the service-evaluation spec (`docs/superpowers/specs/2026-07-27-newsletter-beehiiv-provider-design.md`): beehiiv's free Launch plan includes the subscriptions API; **Ghost rejected** (Admin API gated to Ghost(Pro) Publisher $29/mo, JWT auth, API-added members skip double opt-in), **Substack rejected** (no public subscribe API), **Kit deferred** (contradictory docs on free-plan API keys). Buttondown remains the recommended default.
- Worker treats beehiiv 2xx as plain success (the endpoint upserts with no distinct already-subscribed error — also the privacy-friendlier behavior).

Closes #1030.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` (214 tests, 31 suites, pass; integration-filtered run 133 tests pass)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (** BUILD SUCCEEDED **)
- [ ] Manual smoke (if UI-touching): not UI-touching — wizard renders the new provider from catalog data; `node --check` passes on the edited Worker script

🤖 Generated with [Claude Code](https://claude.com/claude-code)