### PR TITLE
fix(#368): validate self-declared actor IRIs, sanitize post content

### DIFF
--- a/Sources/AnglesiteApp/CommunitiesModel.swift
+++ b/Sources/AnglesiteApp/CommunitiesModel.swift
@@ -35,6 +35,9 @@ final class CommunitiesModel {
     private(set) var selectedCommunityID: String?
     private(set) var timeline: [GroupPost] = []
     private(set) var isLoadingTimeline = false
+    /// Guards against a fast double-tap of Join firing two concurrent `follow()` POSTs for the
+    /// same target before the first call's result lands in `joined`.
+    private(set) var isJoining = false
     var joinHandleText = ""
     var errorMessage: String?
     /// Non-nil ⟺ the "Leave this community?" confirmation is showing — mirrors
@@ -118,6 +121,12 @@ final class CommunitiesModel {
     func join() async {
         let input = joinHandleText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !input.isEmpty else { return }
+        // Without this, a fast double-tap of the Join button before `joined` reflects the first
+        // call's result races two `follow()` POSTs for the same target: the already-joined check
+        // below only catches a *second* call once the *first* has actually landed in `joined`.
+        guard !isJoining else { return }
+        isJoining = true
+        defer { isJoining = false }
         guard let ownActorURL, let publishToken else {
             errorMessage = "This site has no known public URL yet — deploy it at least once first."
             return

--- a/Sources/AnglesiteApp/CommunitiesView.swift
+++ b/Sources/AnglesiteApp/CommunitiesView.swift
@@ -93,7 +93,9 @@ struct CommunitiesView: View {
                     .textFieldStyle(.roundedBorder)
                     .onSubmit { Task { await communities.join() } }
                 Button("Join") { Task { await communities.join() } }
-                    .disabled(communities.joinHandleText.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .disabled(
+                        communities.joinHandleText.trimmingCharacters(in: .whitespaces).isEmpty
+                            || communities.isJoining)
             }
             .padding()
 

--- a/Sources/AnglesiteCore/CommunityActorResolver.swift
+++ b/Sources/AnglesiteCore/CommunityActorResolver.swift
@@ -163,9 +163,20 @@ public struct CommunityActorResolver: Sendable {
             guard let actorID = URL(string: dto.id) else {
                 throw CommunityActorResolverError.decodingFailed("actor id is not a URL: \(dto.id)")
             }
+            // `id`/`outbox` are the remote server's own claims about itself, not the transport
+            // layer's — the fetch URL and any redirect were already validated above, but a
+            // hostile or misconfigured actor document can still self-declare an insecure `id`.
+            // `actorID` feeds straight into `CommunityMembershipClient`'s Follow/Undo payload
+            // (whose own doc comment assumes this resolver already enforced HTTPS), so it must
+            // hold to the same rule as every other IRI here. `outboxURL` is read-only and
+            // optional — the timeline pane already treats a missing one as "no timeline
+            // available" — so an insecure one degrades to `nil` instead of failing the resolve.
+            try Self.requireHTTPS(actorID)
+            let outboxURL = dto.outbox.flatMap(URL.init(string:))
+                .flatMap { ActorProfileFetcher.isHTTPS($0) ? $0 : nil }
             return ResolvedCommunityActor(
                 actorID: actorID,
-                outboxURL: dto.outbox.flatMap(URL.init(string:)),
+                outboxURL: outboxURL,
                 type: dto.type,
                 preferredUsername: dto.preferredUsername.map(DisplayString.safe),
                 name: dto.name.map(DisplayString.safe),

--- a/Sources/AnglesiteCore/GroupTimelineClient.swift
+++ b/Sources/AnglesiteCore/GroupTimelineClient.swift
@@ -138,7 +138,9 @@ public struct GroupTimelineClient: Sendable {
         return GroupPost(
             id: id,
             title: (object["name"] as? String).map(DisplayString.safe),
-            contentHTML: object["content"] as? String,
+            // `CommunitiesView` falls back to rendering this verbatim when there's no `title`,
+            // so it needs the same bidi/control-scalar stripping as `title`/`authorName`.
+            contentHTML: (object["content"] as? String).map(DisplayString.safe),
             url: (object["url"] as? String).flatMap(URL.init(string:)),
             publishedAt: publishedAt,
             authorName: (object["attributedTo"] as? String).map(DisplayString.safe))

--- a/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+++ b/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
@@ -602,6 +602,49 @@ struct CommunitiesModelTests {
         #expect(followRequestsAfterFirstJoin >= 1)
     }
 
+    /// The already-joined check above only helps once the *first* `join()` has actually landed in
+    /// `joined` — it can't stop a second call that starts while the first is still awaiting the
+    /// resolve/follow round-trip. `isJoining` closes that gap directly.
+    @Test("a second concurrent join() call is a no-op while the first is still in flight")
+    func joinIgnoresConcurrentCallWhileInFlight() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let actorURL = "https://lemmy.ml/c/birding"
+        let fake = FakeTransport([
+            actorURL: (200, """
+                {"id":"\(actorURL)","type":"Group","preferredUsername":"birding",
+                 "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+                """),
+            "https://example.com/users/site/outbox":
+                (202, #"{"id":"https://example.com/users/site/outbox/1"}"#),
+        ])
+        await fake.gate(actorURL)
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.joinHandleText = actorURL
+
+        // Fire the first join and let it block on the gated actor-document fetch — `isJoining`
+        // should already be set by the time this call is observably in flight.
+        let firstJoin = Task { await model.join() }
+        await fake.waitUntilRequested(actorURL)
+        #expect(model.isJoining == true)
+
+        // A second call while the first hasn't resolved yet must bail immediately, before ever
+        // touching the network.
+        await model.join()
+        let requestCountAfterSecondCall = await fake.requestedURLs.count
+
+        await fake.release(actorURL)
+        await firstJoin.value
+
+        #expect(model.joined.count == 1)
+        #expect(model.isJoining == false)
+        #expect(requestCountAfterSecondCall == 1)
+    }
+
     // MARK: - Finding 5: .noSiteURL is real and retry() recovers it
 
     @Test("configure sets state to .noSiteURL when the site has never been published")

--- a/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityActorResolverTests.swift
@@ -88,6 +88,43 @@ struct CommunityActorResolverTests {
         #expect(await fake.requestedURLs.count == 1)
     }
 
+    /// The actor document's `id` is attacker-controlled content (the remote server writes it, not
+    /// the transport layer), so an insecure self-declared `id` must be rejected exactly like an
+    /// insecure fetch URL or redirect — it's the same trust boundary, just expressed in the body
+    /// instead of the response's URL. `CommunityMembershipClient`'s own doc comment assumes every
+    /// IRI reaching it from this resolver has already been validated as HTTPS; this is where that
+    /// guarantee has to actually hold.
+    @Test("rejects a self-declared insecure actor id")
+    func rejectsSelfDeclaredInsecureActorID() async throws {
+        let fake = FakeTransport(["https://lemmy.ml/c/birding": (200, """
+            {"id":"http://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+             "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+            """)])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        await #expect(throws: CommunityActorResolverError.insecureURL) {
+            _ = try await resolver.resolve("https://lemmy.ml/c/birding")
+        }
+    }
+
+    /// `outboxURL` is best-effort (the timeline pane already treats a missing one as "no timeline
+    /// available") — so unlike `actorID`, a self-declared insecure `outbox` degrades to `nil`
+    /// rather than failing the whole resolve; the join/leave flow that only needs `actorID`
+    /// shouldn't break over a field it doesn't use.
+    @Test("drops a self-declared insecure outbox URL rather than trusting it")
+    func dropsSelfDeclaredInsecureOutboxURL() async throws {
+        let fake = FakeTransport(["https://lemmy.ml/c/birding": (200, """
+            {"id":"https://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+             "name":"Birding","outbox":"http://lemmy.ml/c/birding/outbox"}
+            """)])
+        let resolver = CommunityActorResolver(transport: fake.transport)
+
+        let resolved = try await resolver.resolve("https://lemmy.ml/c/birding")
+
+        #expect(resolved.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(resolved.outboxURL == nil)
+    }
+
     @Test("sends the AS2 Accept header when fetching the actor document")
     func sendsAcceptHeader() async throws {
         let fake = FakeTransport(["https://lemmy.ml/c/birding": (200, Self.actorDocument)])

--- a/Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
+++ b/Tests/AnglesiteCoreTests/GroupTimelineClientTests.swift
@@ -66,6 +66,29 @@ struct GroupTimelineClientTests {
         #expect(page.next?.absoluteString == "https://lemmy.ml/c/birding/outbox?page=2")
     }
 
+    /// `content` is exactly as attacker-controlled as `name`/`attributedTo` (the remote Group's
+    /// own server writes it) and `CommunitiesView` falls back to rendering it verbatim
+    /// (`post.title ?? post.contentHTML ?? post.id`), so it needs the same
+    /// `DisplayString.safe` bidi/control-scalar stripping `title`/`authorName` already get right
+    /// next to it — otherwise a hostile post with no `name` can smuggle a
+    /// U+202E RIGHT-TO-LEFT OVERRIDE (or similar) into the timeline row to visually spoof it.
+    @Test("strips bidi-control scalars from contentHTML, matching title/authorName")
+    func sanitizesContentHTML() async throws {
+        let fake = FakeTransport(body: """
+        {"id":"https://lemmy.ml/c/birding/outbox?page=1","type":"OrderedCollectionPage",
+         "orderedItems":[
+           {"id":"https://lemmy.ml/activities/3","type":"Create",
+            "object":{"id":"https://lemmy.ml/post/3","type":"Note",
+                      "content":"safe\\u202Eevil"}}
+         ]}
+        """)
+        let url = try #require(URL(string: "https://lemmy.ml/c/birding/outbox?page=1"))
+        let page = try await GroupTimelineClient(transport: fake.transport).page(at: url)
+
+        #expect(page.items.count == 1)
+        #expect(page.items[0].contentHTML == "safeevil")
+    }
+
     @Test("falls back to a bare-id stub for an item with no embedded object")
     func decodesBareIDItem() async throws {
         let fake = FakeTransport(body: """


### PR DESCRIPTION
## Summary

- Follow-up to #1029 (V-5.1a Communities), addressing findings from an automated post-merge advisory review posted to that PR after it merged.
- `CommunityActorResolver.fetchActor` now HTTPS-validates the actor document's own `id`/`outbox` fields, not just the fetch URL and any redirect target. `CommunityMembershipClient`'s doc comment already assumed this held ("the target IRI it's given already passed through that resolver") but a hostile actor document self-declaring `"id": "http://..."` slipped past every existing check and would have reached the `Follow`/`Undo` payload POSTed to the site's own outbox. A self-declared insecure `outbox` degrades to `nil` (it's optional/read-only) rather than failing the whole resolve.
- `GroupTimelineClient.post(from:)` now runs `contentHTML` through `DisplayString.safe`, matching the treatment `title`/`authorName` already get right next to it.
- `CommunitiesModel.join()` gains an `isJoining` guard against a fast double-tap firing two concurrent `follow()` calls before the first lands.
- All three fixes follow TDD (failing test confirmed before the fix, passing after) and reuse patterns already established elsewhere in this codebase (`ActorProfileFetcher.isHTTPS`, `DisplayString.safe`, the `isLoadingTimeline`/generation-token busy-guard style already in `CommunitiesModel`).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

## Test plan

- [x] `swift test --package-path .` — targeted suites (`CommunityActorResolverTests`, `GroupTimelineClientTests`, `CommunitiesModelTests`, plus siblings) all pass with new regression tests for each fix.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] Manual smoke: no UI-visible behavior change (all three fixes are either invisible validation tightening or a busy-guard); the manual Communities acceptance checklist from #1029's plan still applies for the feature as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)