### PR TITLE
feat(#1034): add Kit newsletter provider

### DIFF
--- a/Resources/Template/integrations/docs/newsletter-setup.md
+++ b/Resources/Template/integrations/docs/newsletter-setup.md
@@ -14,6 +14,7 @@ site itself):
    - **Buttondown**: sign up at buttondown.email, then Settings → API → copy the key.
    - **Mailchimp**: sign up at mailchimp.com, create an audience, then Account → Extras → API keys → create a key. Also note the Audience ID (Audience → Settings → Audience name and defaults).
    - **beehiiv**: sign up at beehiiv.com (the free Launch plan includes API access), then Settings → API → create a key. Also note your publication ID (starts with `pub_`, shown on the same page).
+   - **Kit**: sign up at kit.com (the free Newsletter plan includes API access), then Settings → Developer → create a V4 API key. Also create a form (Grow → Landing Pages & Forms) with **double opt-in enabled** in its settings, and note the form ID — the number in the form's URL.
 
 2. **From a terminal, in this site's directory, store the secrets:**
 
@@ -23,8 +24,9 @@ site itself):
    npx wrangler secret put SITE_DOMAIN --config worker/subscribe-wrangler.toml
    ```
 
-   Paste the API key, `buttondown`, `mailchimp`, or `beehiiv`, and your site's
-   domain (e.g. `example.com`) when prompted. If you're using Mailchimp, also run:
+   Paste the API key, `buttondown`, `mailchimp`, `beehiiv`, or `kit`, and your
+   site's domain (e.g. `example.com`) when prompted. If you're using Mailchimp,
+   also run:
 
    ```sh
    npx wrangler secret put MAILCHIMP_LIST_ID --config worker/subscribe-wrangler.toml
@@ -34,6 +36,12 @@ site itself):
 
    ```sh
    npx wrangler secret put BEEHIIV_PUBLICATION_ID --config worker/subscribe-wrangler.toml
+   ```
+
+   If you're using Kit, also run:
+
+   ```sh
+   npx wrangler secret put KIT_FORM_ID --config worker/subscribe-wrangler.toml
    ```
 
 3. **Deploy the Worker:**

--- a/Resources/Template/integrations/worker/subscribe-worker.js
+++ b/Resources/Template/integrations/worker/subscribe-worker.js
@@ -6,10 +6,11 @@
  * ../../../docs/newsletter-setup.md (staged to docs/newsletter-setup.md).
  *
  * Secrets (set via `wrangler secret put`):
- *   NEWSLETTER_API_KEY     — Buttondown, Mailchimp, or beehiiv API key
- *   NEWSLETTER_PLATFORM    — "buttondown", "mailchimp", or "beehiiv"
+ *   NEWSLETTER_API_KEY     — Buttondown, Mailchimp, beehiiv, or Kit API key
+ *   NEWSLETTER_PLATFORM    — "buttondown", "mailchimp", "beehiiv", or "kit"
  *   MAILCHIMP_LIST_ID      — Mailchimp audience/list ID (Mailchimp only)
  *   BEEHIIV_PUBLICATION_ID — beehiiv publication ID, "pub_…" (beehiiv only)
+ *   KIT_FORM_ID            — Kit form ID for double opt-in (Kit only)
  *   SITE_DOMAIN            — For CORS origin validation
  */
 
@@ -104,6 +105,37 @@ async function subscribeBeehiiv(email, apiKey, publicationId) {
   return { ok: false, errors: ["Subscribe failed. Please try again later."] };
 }
 
+async function subscribeKit(email, apiKey, formId) {
+  // Kit's double opt-in lives on forms, so a form ID is required: creating a
+  // subscriber alone would silently skip the confirmation email.
+  if (!formId) return { ok: false, errors: ["Newsletter service not configured."] };
+
+  const headers = {
+    "X-Kit-Api-Key": apiKey,
+    "Content-Type": "application/json",
+  };
+
+  // Upsert (200 update / 201 create) — the form endpoint below requires the
+  // subscriber to already exist.
+  const created = await fetch("https://api.kit.com/v4/subscribers", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ email_address: email }),
+  });
+  if (!created.ok) return { ok: false, errors: ["Subscribe failed. Please try again later."] };
+
+  // Adding to a double-opt-in form sends the confirmation email; 200 means
+  // already on the form, 201 means newly added.
+  const added = await fetch(`https://api.kit.com/v4/forms/${formId}/subscribers`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ email_address: email }),
+  });
+
+  if (added.ok) return { ok: true };
+  return { ok: false, errors: ["Subscribe failed. Please try again later."] };
+}
+
 export default {
   async fetch(request, env) {
     const origin = request.headers.get("Origin");
@@ -157,6 +189,8 @@ export default {
       result = await subscribeMailchimp(email, env.NEWSLETTER_API_KEY, env.MAILCHIMP_LIST_ID);
     } else if (platform === "beehiiv") {
       result = await subscribeBeehiiv(email, env.NEWSLETTER_API_KEY, env.BEEHIIV_PUBLICATION_ID);
+    } else if (platform === "kit") {
+      result = await subscribeKit(email, env.NEWSLETTER_API_KEY, env.KIT_FORM_ID);
     } else {
       result = { ok: false, errors: ["Newsletter service not configured."] };
     }

--- a/Resources/Template/integrations/worker/subscribe-wrangler.toml
+++ b/Resources/Template/integrations/worker/subscribe-wrangler.toml
@@ -2,10 +2,11 @@
 # Receives subscribe form submissions and forwards them to your newsletter platform.
 #
 # Secrets are set via: npx wrangler secret put <NAME> --config worker/subscribe-wrangler.toml
-#   NEWSLETTER_API_KEY     — Buttondown, Mailchimp, or beehiiv API key
-#   NEWSLETTER_PLATFORM    — "buttondown", "mailchimp", or "beehiiv"
+#   NEWSLETTER_API_KEY     — Buttondown, Mailchimp, beehiiv, or Kit API key
+#   NEWSLETTER_PLATFORM    — "buttondown", "mailchimp", "beehiiv", or "kit"
 #   MAILCHIMP_LIST_ID      — Mailchimp audience/list ID (Mailchimp only)
 #   BEEHIIV_PUBLICATION_ID — beehiiv publication ID, "pub_…" (beehiiv only)
+#   KIT_FORM_ID            — Kit form ID for double opt-in (Kit only)
 #   SITE_DOMAIN            — your site's domain, for CORS origin validation
 
 name = "newsletter-subscribe"

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -218,11 +218,12 @@ public enum IntegrationCatalog {
     static let newsletter = IntegrationDescriptor(
         id: .newsletter,
         displayName: "Newsletter",
-        summary: "Let visitors subscribe to email updates (Buttondown, Mailchimp, or beehiiv), via a Worker that keeps your API key off the client.",
+        summary: "Let visitors subscribe to email updates (Buttondown, Mailchimp, beehiiv, or Kit), via a Worker that keeps your API key off the client.",
         providers: [
             Provider(id: "buttondown", displayName: "Buttondown", cspDomains: []),
             Provider(id: "mailchimp", displayName: "Mailchimp", cspDomains: []),
             Provider(id: "beehiiv", displayName: "beehiiv", cspDomains: []),
+            Provider(id: "kit", displayName: "Kit", cspDomains: []),
         ],
         fields: [
             Field(key: "workerUrl", label: "Subscribe Worker URL", kind: .url,

--- a/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/IntegrationCatalogTests.swift
@@ -197,7 +197,7 @@ import Testing
 
     @Test func newsletterHasPlatformChoice() {
         let newsletter = IntegrationCatalog.descriptor(for: .newsletter)
-        #expect(Set(newsletter.providers.map(\.id)) == Set(["buttondown", "mailchimp", "beehiiv"]))
+        #expect(Set(newsletter.providers.map(\.id)) == Set(["buttondown", "mailchimp", "beehiiv", "kit"]))
     }
 
     @Test func newsletterWritesPlatformWorkerUrlAndButtonText() {

--- a/docs/superpowers/specs/2026-07-27-newsletter-beehiiv-provider-design.md
+++ b/docs/superpowers/specs/2026-07-27-newsletter-beehiiv-provider-design.md
@@ -81,10 +81,26 @@ concluded:
 - Verification: `swift test` (template-coupled suites included) — the Worker
   itself has no JS test harness today and this change does not introduce one.
 
+## Addendum: Kit provider (#1034, same day)
+
+With the free-plan question resolved, Kit is added as a fourth provider in a
+stacked follow-up:
+
+- `subscribeKit(email, apiKey, formId)` in the Worker: upsert the subscriber
+  (`POST /v4/subscribers`, `X-Kit-Api-Key` auth, 200 update / 201 create),
+  then add them to a form by email (`POST /v4/forms/{formId}/subscribers`,
+  200 already-on-form / 201 added). Kit's double opt-in lives on forms — the
+  form step is what sends the confirmation email — so `KIT_FORM_ID` is a
+  required secret and the Worker refuses to subscribe without it rather than
+  silently creating unconfirmed-by-policy subscribers.
+- Catalog gains `Provider(id: "kit", displayName: "Kit")`; setup docs tell
+  owners to create the form with double opt-in enabled.
+- Same non-goals as beehiiv: no send-via-API, no distinct already-subscribed
+  message (both Kit calls are idempotent upserts).
+
 ## Out of scope
 
-- Kit/EmailOctopus providers (revisit if requested; Kit needs the free-plan
-  API-key check first).
+- EmailOctopus provider (revisit if requested).
 - Any "send via API" ambition (beehiiv gates its Send API to Enterprise).
 - Wizard-driven Worker deployment (deploying the subscribe Worker remains
   the documented manual `wrangler` step).


### PR DESCRIPTION
## Summary

- Adds **Kit** (formerly ConvertKit) as a fourth newsletter provider: `subscribeKit()` in the subscribe Worker upserts the subscriber (`POST /v4/subscribers`, `X-Kit-Api-Key` auth) then adds them to a form by email (`POST /v4/forms/{id}/subscribers`) — Kit's double opt-in lives on forms, so `KIT_FORM_ID` is a **required** secret and the Worker returns "not configured" without it rather than silently skipping confirmation.
- Catalog gains `Provider(id: "kit")`; setup docs walk owners through creating a double-opt-in form and finding its ID; spec addendum records the resolved free-plan question (API keys + subscribers API are on every plan incl. the 10,000-subscriber free tier — the "eligible plan" caveat covers only broadcast sending).
- **Stacked on #1032** (beehiiv provider); retarget to `main` after that merges.

Closes #1034.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` (214 tests, 31 suites, pass)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (** BUILD SUCCEEDED **)
- [ ] Manual smoke (if UI-touching): not UI-touching — wizard renders the new provider from catalog data; `node --check` passes on the Worker script. Note: stacked PRs get no CI until retargeted to `main` with a fresh push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)