### PR TITLE
feat(#676): drag & drop completeness

### DIFF
--- a/Sources/AnglesiteApp/SiteNavigatorModel.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorModel.swift
@@ -44,6 +44,11 @@ final class SiteNavigatorModel {
     /// Full post records from the last `refresh()`, so `canPublish`/`canUnpublish` (#798) can read
     /// a row's collection and current draft state without an extra actor hop.
     private var postsByID: [String: SiteContentGraph.Post] = [:]
+    /// Synchronous id → source-file cache for `.route` (page/post) rows, rebuilt with `nodes` in
+    /// `refresh()`. `.draggable(_:)`'s payload closure runs synchronously at drag-start and can't
+    /// await the graph actor, so rename/delete's `graph.page(id:)`/`graph.post(id:)` pattern
+    /// doesn't work here — this cache exists so `fileURL(for:)` can answer immediately (#676).
+    private var routeFileURLs: [String: URL] = [:]
     private let contentTypeRegistry = ContentTypeRegistry()
 
     private let graph: SiteContentGraph
@@ -94,6 +99,16 @@ final class SiteNavigatorModel {
     }
 
     func target(for id: String) -> NavigatorTarget? { nodesByID[id]?.target }
+
+    /// The `Source/`-relative file URL backing a draggable row, or nil when the row has no single
+    /// backing file (directories, website settings) or isn't a `.route` row. `NavigatorTarget` also
+    /// has a `.file(FileRef)` case, but no `URLTreeNode.Kind` currently produces it — components and
+    /// styles moved out of this tree in #714 slice 1 — so this only handles `.route` today; add a
+    /// `.file` branch returning `ref.url` if `.file` rows come back.
+    func fileURL(for id: String) -> URL? {
+        guard case .route = target(for: id) else { return nil }
+        return routeFileURLs[id]
+    }
 
     /// Bridge for callbacks that still traffic in `NavigatorItem` (delete/duplicate/repurpose
     /// plumbing in SiteWindow/SiteWindowModel predates the tree).
@@ -266,6 +281,14 @@ final class SiteNavigatorModel {
         // gate against a post set that's out of sync with what's actually shown in the sidebar.
         postIDs = Set(posts.map(\.id))
         postsByID = Dictionary(uniqueKeysWithValues: posts.map { ($0.id, $0) })
+        if let sourceDirectory {
+            var fileURLs: [String: URL] = [:]
+            for page in pages { fileURLs[page.id] = sourceDirectory.appendingPathComponent(page.filePath) }
+            for post in posts { fileURLs[post.id] = sourceDirectory.appendingPathComponent(post.filePath) }
+            routeFileURLs = fileURLs
+        } else {
+            routeFileURLs = [:]
+        }
         let tree = buildSiteURLTree(
             websiteTitle: websiteTitle, pages: pages, posts: posts, feedCollections: feeds)
         nodes = tree

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -79,32 +79,40 @@ struct SiteNavigatorView: View {
                 }
                 .task { editingFocused = true }
                 .tag(node.id)
+        } else if let url = model.fileURL(for: node.id) {
+            // Draggable out to Finder/another app (#676) — only rows backed by a single source
+            // file (today: page/post `.route` rows) qualify; see `fileURL(for:)`.
+            rowLabel(for: node).draggable(url)
         } else {
-            Label { Text(node.title) } icon: { icon(for: node) }
-                .tag(node.id)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .contextMenu {
-                    if model.canRename(node.id) {
-                        Button("Rename") { model.beginEditing(node.id) }
-                    }
-                    if model.canDuplicate(node.id), let item = model.item(for: node.id) {
-                        Button("Duplicate") { onDuplicateRequested(item) }
-                    }
-                    if model.canRepurpose(node.id), let item = model.item(for: node.id) {
-                        Button("Repurpose Post…") { onRepurposeRequested(item) }
-                    }
-                    if model.canPublish(node.id), let item = model.item(for: node.id) {
-                        Button("Publish") { onPublishRequested(item) }
-                    }
-                    if model.canUnpublish(node.id), let item = model.item(for: node.id) {
-                        Button("Unpublish") { onUnpublishRequested(item) }
-                    }
-                    if model.canDelete(node.id), let item = model.item(for: node.id) {
-                        Button("Delete", role: .destructive) { onDeleteRequested(item) }
-                    }
-                }
+            rowLabel(for: node)
         }
+    }
+
+    private func rowLabel(for node: URLTreeNode) -> some View {
+        Label { Text(node.title) } icon: { icon(for: node) }
+            .tag(node.id)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .contextMenu {
+                if model.canRename(node.id) {
+                    Button("Rename") { model.beginEditing(node.id) }
+                }
+                if model.canDuplicate(node.id), let item = model.item(for: node.id) {
+                    Button("Duplicate") { onDuplicateRequested(item) }
+                }
+                if model.canRepurpose(node.id), let item = model.item(for: node.id) {
+                    Button("Repurpose Post…") { onRepurposeRequested(item) }
+                }
+                if model.canPublish(node.id), let item = model.item(for: node.id) {
+                    Button("Publish") { onPublishRequested(item) }
+                }
+                if model.canUnpublish(node.id), let item = model.item(for: node.id) {
+                    Button("Unpublish") { onUnpublishRequested(item) }
+                }
+                if model.canDelete(node.id), let item = model.item(for: node.id) {
+                    Button("Delete", role: .destructive) { onDeleteRequested(item) }
+                }
+            }
     }
 
     /// #714 icon table: globe (website settings) / house (home) / doc.richtext (pages, entries) /

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -159,6 +159,9 @@ struct SitesLauncherView: View {
                 .padding(.vertical, 2)
             }
             .buttonStyle(.plain)
+            // Draggable out to Finder/Terminal/another app (#676) — offers the package URL
+            // regardless of validity (a dead bookmark is still a real path on disk).
+            .draggable(site.packageURL)
             // A dead bookmark (needsReauthorization) still lets the row respond to a click — it
             // routes to the same "Locate…" recovery as the context-menu action — rather than
             // going fully dead with no way to fix it in place (#776).

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -164,13 +164,16 @@ struct SitesLauncherView: View {
                 .padding(.vertical, 2)
             }
             .buttonStyle(.plain)
-            // Draggable out to Finder/Terminal/another app (#676) — offers the package URL
-            // regardless of validity (a dead bookmark is still a real path on disk).
-            .draggable(site.packageURL)
             // A dead bookmark (needsReauthorization) still lets the row respond to a click — it
             // routes to the same "Locate…" recovery as the context-menu action — rather than
             // going fully dead with no way to fix it in place (#776).
             .disabled(!site.isValid && !site.needsReauthorization)
+            // Draggable out to Finder/Terminal/another app (#676) — offers the package URL
+            // regardless of validity (a dead bookmark is still a real path on disk), and must
+            // come AFTER .disabled(...) above so the drag isn't scoped inside that disabled
+            // subtree — otherwise a row with missing files couldn't be dragged out at all,
+            // contradicting this comment.
+            .draggable(site.packageURL)
             .accessibilityValue(site.isValid
                                  ? "Valid"
                                  : (site.needsReauthorization ? "Needs re-authorization" : "Missing required files"))

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -19,6 +19,11 @@ struct SitesLauncherView: View {
     private static var didAutoOpenAttempt = false
 
     @State private var sites: [SiteStore.Site] = []
+    /// Drives a visible highlight while a file-URL drag hovers `siteList` (#676). Lights up for
+    /// any file-URL drag, not only valid `.anglesite` packages — see the design doc's "Drop-
+    /// highlight fidelity" decision. The drop itself still only accepts `.anglesite` packages,
+    /// unchanged below.
+    @State private var isDropTargeted = false
     @State private var loadError: String?
     @State private var deciding = true
     /// Guards `presentNewSite()` against a double-trigger while it is preparing (it `await`s
@@ -209,6 +214,17 @@ struct SitesLauncherView: View {
                 }
             }
             return true
+        } isTargeted: { targeted in
+            isDropTargeted = targeted
+        }
+        .overlay {
+            // Explicit targeted feedback (#676) — the system's default drag highlight is subtle
+            // enough that #524's drop target had no clearly visible accepted/rejected state.
+            if isDropTargeted {
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(Color.accentColor, lineWidth: 3)
+                    .allowsHitTesting(false)
+            }
         }
         .confirmationDialog(
             "Remove “\(siteToRemoveName)” from Anglesite?",

--- a/Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift
@@ -144,6 +144,77 @@ struct SiteNavigatorModelTests {
 
         #expect(model.deletableSelection() == nil)
     }
+
+    @Test("fileURL(for:) resolves a route (page) target to its sourceDirectory-relative file")
+    func fileURLResolvesRouteTarget() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date())],
+            posts: [], images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(flatten(model.nodes).first { $0.title == "About" }?.id)
+
+        #expect(model.fileURL(for: id) == root.appendingPathComponent("src/pages/about.astro"))
+    }
+
+    @Test("fileURL(for:) resolves a route (post) target to its sourceDirectory-relative file")
+    func fileURLResolvesPostRouteTarget() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [],
+            posts: [SiteContentGraph.Post(
+                id: "site-1:post:hello", siteID: "site-1", collection: "blog", slug: "hello",
+                title: "Hello", draft: false, publishDate: Date(), tags: [],
+                filePath: "src/content/blog/hello.md", lastModified: Date())],
+            images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(flatten(model.nodes).first { $0.title == "Hello" }?.id)
+
+        #expect(model.fileURL(for: id) == root.appendingPathComponent("src/content/blog/hello.md"))
+    }
+
+    @Test("fileURL(for:) is nil for the website-settings row")
+    func fileURLNilForWebsiteSettingsRow() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date())],
+            posts: [], images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(model.nodes.first { $0.kind == .website }?.id)
+
+        #expect(model.fileURL(for: id) == nil)
+    }
+
+    @Test("fileURL(for:) is nil for an unknown id")
+    func fileURLNilForUnknownID() {
+        let model = SiteNavigatorModel(graph: SiteContentGraph())
+        #expect(model.fileURL(for: "nonexistent") == nil)
+    }
 }
 
 /// `saveRedirect` writes through `RedirectsStore` to `Source/redirects.json` (#530) — the

--- a/docs/superpowers/plans/2026-07-27-drag-drop-completeness.md
+++ b/docs/superpowers/plans/2026-07-27-drag-drop-completeness.md
@@ -1,0 +1,530 @@
+# Drag & drop completeness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let sites and content items be dragged out of Anglesite (to Finder, Terminal, other apps), and give the launcher's existing drop target a visible targeted highlight.
+
+**Architecture:** Pure SwiftUI/AppKit additions to two existing views (`SitesLauncherView`, `SiteNavigatorView`) plus one small model accessor (`SiteNavigatorModel.fileURL(for:)`) backed by a new synchronous id→URL cache built during the model's existing refresh cycle. No new files, no new dependencies, no MCP/schema changes.
+
+**Tech Stack:** Swift 6.4, SwiftUI, `Transferable`/`.draggable(_:)`, Swift Testing.
+
+## Global Constraints
+
+- Swift/SwiftUI with Apple frameworks only — no new dependencies.
+- Conventional commits; subject ≤72 characters; reference `#676`.
+- Design doc: `docs/superpowers/specs/2026-07-27-drag-drop-completeness-design.md` — read it before starting if you need the "why", this plan covers the "how".
+- Drop-highlight fidelity is intentionally simple: it lights up for **any** file-URL drag over the launcher list, not just valid `.anglesite` packages (locked decision, see design doc). Do not add content-type validation.
+- Navigator drag-out only applies to `.route` targets (pages/posts) today — `.file` targets are currently unreachable (see Task 1) and `.directory`/`.websiteSettings` are explicitly out of scope.
+
+---
+
+### Task 1: `SiteNavigatorModel.fileURL(for:)` + `routeFileURLs` cache
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteNavigatorModel.swift:46` (new stored property, next to `postsByID`), `Sources/AnglesiteApp/SiteNavigatorModel.swift:252-274` (`refresh(siteID:siteRoot:)`), `Sources/AnglesiteApp/SiteNavigatorModel.swift:96` (near `target(for:)`, add the new accessor)
+- Test: `Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift`
+
+**Interfaces:**
+- Consumes: existing `SiteNavigatorModel.target(for id: String) -> NavigatorTarget?` (line 96), existing `refresh(siteID:siteRoot:)` locals `pages: [SiteContentGraph.Page]` and `posts: [SiteContentGraph.Post]` (both already fetched at the top of that function), `self.sourceDirectory: URL?` (set in `start(site:websiteTitle:)`), `SiteContentGraph.Page.filePath`/`.id` and `SiteContentGraph.Post.filePath`/`.id` (both `String`).
+- Produces: `func fileURL(for id: String) -> URL?` — later tasks (Task 2) call this to decide whether a navigator row is draggable and with what URL.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these three tests inside the existing `@Suite("SiteNavigatorModel")` struct in `Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift` (it already has a private top-level `flatten(_:)` helper you can reuse — do not redefine it):
+
+```swift
+    @Test("fileURL(for:) resolves a route (page) target to its sourceDirectory-relative file")
+    func fileURLResolvesRouteTarget() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date())],
+            posts: [], images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(flatten(model.nodes).first { $0.title == "About" }?.id)
+
+        #expect(model.fileURL(for: id) == root.appendingPathComponent("src/pages/about.astro"))
+    }
+
+    @Test("fileURL(for:) resolves a route (post) target to its sourceDirectory-relative file")
+    func fileURLResolvesPostRouteTarget() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [],
+            posts: [SiteContentGraph.Post(
+                id: "site-1:post:hello", siteID: "site-1", collection: "blog", slug: "hello",
+                title: "Hello", draft: false, publishDate: Date(), tags: [],
+                filePath: "src/content/blog/hello.md", lastModified: Date())],
+            images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(flatten(model.nodes).first { $0.title == "Hello" }?.id)
+
+        #expect(model.fileURL(for: id) == root.appendingPathComponent("src/content/blog/hello.md"))
+    }
+
+    @Test("fileURL(for:) is nil for the website-settings row")
+    func fileURLNilForWebsiteSettingsRow() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-1",
+            pages: [SiteContentGraph.Page(
+                id: "site-1:page:/about", siteID: "site-1", route: "/about",
+                filePath: "src/pages/about.astro", title: "About", lastModified: Date())],
+            posts: [], images: []
+        )
+        let model = SiteNavigatorModel(graph: graph)
+        model.start(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root), websiteTitle: "Test")
+        while model.nodes.isEmpty { await Task.yield() }
+        let id = try #require(model.nodes.first { $0.kind == .website }?.id)
+
+        #expect(model.fileURL(for: id) == nil)
+    }
+
+    @Test("fileURL(for:) is nil for an unknown id")
+    func fileURLNilForUnknownID() {
+        let model = SiteNavigatorModel(graph: SiteContentGraph())
+        #expect(model.fileURL(for: "nonexistent") == nil)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter SiteNavigatorModelTests`
+Expected: build error — `value of type 'SiteNavigatorModel' has no member 'fileURL'`
+
+- [ ] **Step 3: Add the `routeFileURLs` cache**
+
+In `Sources/AnglesiteApp/SiteNavigatorModel.swift`, add a new stored property right after the existing `postsByID` declaration (currently line 46):
+
+```swift
+    private var postsByID: [String: SiteContentGraph.Post] = [:]
+    private let contentTypeRegistry = ContentTypeRegistry()
+    /// Synchronous id → source-file cache for `.route` (page/post) rows, rebuilt with `nodes` in
+    /// `refresh()`. `.draggable(_:)`'s payload closure runs synchronously at drag-start and can't
+    /// await the graph actor, so rename/delete's `graph.page(id:)`/`graph.post(id:)` pattern
+    /// doesn't work here — this cache exists so `fileURL(for:)` can answer immediately (#676).
+    private var routeFileURLs: [String: URL] = [:]
+```
+
+- [ ] **Step 4: Populate the cache in `refresh(siteID:siteRoot:)`**
+
+In the same file, find `postsByID = Dictionary(uniqueKeysWithValues: posts.map { ($0.id, $0) })` inside `refresh(siteID:siteRoot:)` (currently line 268) and add the population right after it:
+
+```swift
+        postIDs = Set(posts.map(\.id))
+        postsByID = Dictionary(uniqueKeysWithValues: posts.map { ($0.id, $0) })
+        if let sourceDirectory {
+            var fileURLs: [String: URL] = [:]
+            for page in pages { fileURLs[page.id] = sourceDirectory.appendingPathComponent(page.filePath) }
+            for post in posts { fileURLs[post.id] = sourceDirectory.appendingPathComponent(post.filePath) }
+            routeFileURLs = fileURLs
+        } else {
+            routeFileURLs = [:]
+        }
+```
+
+- [ ] **Step 5: Add the `fileURL(for:)` accessor**
+
+In the same file, right after `func target(for id: String) -> NavigatorTarget? { nodesByID[id]?.target }` (currently line 96), add:
+
+```swift
+    /// The `Source/`-relative file URL backing a draggable row, or nil when the row has no single
+    /// backing file (directories, website settings) or isn't a `.route` row. `NavigatorTarget` also
+    /// has a `.file(FileRef)` case, but no `URLTreeNode.Kind` currently produces it — components and
+    /// styles moved out of this tree in #714 slice 1 — so this only handles `.route` today; add a
+    /// `.file` branch returning `ref.url` if `.file` rows come back.
+    func fileURL(for id: String) -> URL? {
+        guard case .route = target(for: id) else { return nil }
+        return routeFileURLs[id]
+    }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter SiteNavigatorModelTests`
+Expected: `Test run with 14 tests in 3 suites passed` (10 existing + 4 new)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteNavigatorModel.swift Tests/AnglesiteAppTests/SiteNavigatorModelTests.swift
+git commit -m "feat(#676): add SiteNavigatorModel.fileURL(for:) route cache"
+```
+
+---
+
+### Task 2: Wire navigator rows to drag out their source file
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteNavigatorView.swift:63-108` (`row(for:)`)
+
+**Interfaces:**
+- Consumes: `SiteNavigatorModel.fileURL(for id: String) -> URL?` (Task 1).
+- Produces: nothing new consumed by later tasks — this is the last navigator-side change.
+
+- [ ] **Step 1: Factor the non-editing row branch into `rowLabel(for:)` and add the drag source**
+
+In `Sources/AnglesiteApp/SiteNavigatorView.swift`, replace the current `row(for:)` method:
+
+```swift
+    @ViewBuilder
+    private func row(for node: URLTreeNode) -> some View {
+        if model.editingItemID == node.id {
+            TextField("Title", text: $model.draftTitle)
+                .textFieldStyle(.plain)
+                .focused($editingFocused)
+                .onSubmit { Task { await model.commitEditing() } }
+                .onExitCommand { model.cancelEditing() }   // Esc
+                .onChange(of: editingFocused) { _, focused in
+                    // TextField.onSubmit does not fire reliably inside a sidebar List on macOS — Return is
+                    // consumed by the list and only surfaces as focus loss. So commit on focus loss
+                    // (Return / Tab / click-away, Finder-style). Esc cancels first via onExitCommand,
+                    // which clears editingItemID, so this guard then skips the commit.
+                    if !focused && model.editingItemID == node.id {
+                        Task { await model.commitEditing() }
+                    }
+                }
+                .task { editingFocused = true }
+                .tag(node.id)
+        } else {
+            Label { Text(node.title) } icon: { icon(for: node) }
+                .tag(node.id)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .contextMenu {
+                    if model.canRename(node.id) {
+                        Button("Rename") { model.beginEditing(node.id) }
+                    }
+                    if model.canDuplicate(node.id), let item = model.item(for: node.id) {
+                        Button("Duplicate") { onDuplicateRequested(item) }
+                    }
+                    if model.canRepurpose(node.id), let item = model.item(for: node.id) {
+                        Button("Repurpose Post…") { onRepurposeRequested(item) }
+                    }
+                    if model.canPublish(node.id), let item = model.item(for: node.id) {
+                        Button("Publish") { onPublishRequested(item) }
+                    }
+                    if model.canUnpublish(node.id), let item = model.item(for: node.id) {
+                        Button("Unpublish") { onUnpublishRequested(item) }
+                    }
+                    if model.canDelete(node.id), let item = model.item(for: node.id) {
+                        Button("Delete", role: .destructive) { onDeleteRequested(item) }
+                    }
+                }
+        }
+    }
+```
+
+with:
+
+```swift
+    @ViewBuilder
+    private func row(for node: URLTreeNode) -> some View {
+        if model.editingItemID == node.id {
+            TextField("Title", text: $model.draftTitle)
+                .textFieldStyle(.plain)
+                .focused($editingFocused)
+                .onSubmit { Task { await model.commitEditing() } }
+                .onExitCommand { model.cancelEditing() }   // Esc
+                .onChange(of: editingFocused) { _, focused in
+                    // TextField.onSubmit does not fire reliably inside a sidebar List on macOS — Return is
+                    // consumed by the list and only surfaces as focus loss. So commit on focus loss
+                    // (Return / Tab / click-away, Finder-style). Esc cancels first via onExitCommand,
+                    // which clears editingItemID, so this guard then skips the commit.
+                    if !focused && model.editingItemID == node.id {
+                        Task { await model.commitEditing() }
+                    }
+                }
+                .task { editingFocused = true }
+                .tag(node.id)
+        } else if let url = model.fileURL(for: node.id) {
+            // Draggable out to Finder/another app (#676) — only rows backed by a single source
+            // file (today: page/post `.route` rows) qualify; see `fileURL(for:)`.
+            rowLabel(for: node).draggable(url)
+        } else {
+            rowLabel(for: node)
+        }
+    }
+
+    private func rowLabel(for node: URLTreeNode) -> some View {
+        Label { Text(node.title) } icon: { icon(for: node) }
+            .tag(node.id)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .contextMenu {
+                if model.canRename(node.id) {
+                    Button("Rename") { model.beginEditing(node.id) }
+                }
+                if model.canDuplicate(node.id), let item = model.item(for: node.id) {
+                    Button("Duplicate") { onDuplicateRequested(item) }
+                }
+                if model.canRepurpose(node.id), let item = model.item(for: node.id) {
+                    Button("Repurpose Post…") { onRepurposeRequested(item) }
+                }
+                if model.canPublish(node.id), let item = model.item(for: node.id) {
+                    Button("Publish") { onPublishRequested(item) }
+                }
+                if model.canUnpublish(node.id), let item = model.item(for: node.id) {
+                    Button("Unpublish") { onUnpublishRequested(item) }
+                }
+                if model.canDelete(node.id), let item = model.item(for: node.id) {
+                    Button("Delete", role: .destructive) { onDeleteRequested(item) }
+                }
+            }
+    }
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift test --package-path . --filter SiteNavigatorModelTests`
+Expected: `Build complete!` followed by the same `Test run with 14 tests in 3 suites passed` as Task 1 (this target-wide build is how a `SiteNavigatorView.swift` compile error would surface — there's no SwiftUI view-inspection library in this repo to unit-test `.draggable` wiring directly, see the design doc's Testing section).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteNavigatorView.swift
+git commit -m "feat(#676): drag navigator pages/posts out to Finder"
+```
+
+---
+
+### Task 3: Make launcher site rows draggable
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SitesLauncherView.swift:138-161` (`siteList`, the `Button` label content)
+
+**Interfaces:**
+- Consumes: `SiteStore.Site.packageURL: URL` (already read at line 150 for display).
+- Produces: nothing new consumed by later tasks.
+
+- [ ] **Step 1: Add `.draggable(site.packageURL)` to each row**
+
+In `Sources/AnglesiteApp/SitesLauncherView.swift`, find this block inside `siteList` (currently lines 139-165):
+
+```swift
+            Button {
+                open(site: site)
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: site.isValid
+                          ? "checkmark.circle.fill"
+                          : "exclamationmark.triangle.fill")
+                        .foregroundStyle(site.isValid ? Color.green : Color.orange)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(site.name).font(.body.monospaced())
+                        Text(site.packageURL.path)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+                .padding(.vertical, 2)
+            }
+            .buttonStyle(.plain)
+            // A dead bookmark (needsReauthorization) still lets the row respond to a click — it
+            // routes to the same "Locate…" recovery as the context-menu action — rather than
+            // going fully dead with no way to fix it in place (#776).
+            .disabled(!site.isValid && !site.needsReauthorization)
+```
+
+and insert `.draggable(site.packageURL)` between `.buttonStyle(.plain)` and the `.disabled(...)` line (and its preceding comment):
+
+```swift
+            Button {
+                open(site: site)
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: site.isValid
+                          ? "checkmark.circle.fill"
+                          : "exclamationmark.triangle.fill")
+                        .foregroundStyle(site.isValid ? Color.green : Color.orange)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(site.name).font(.body.monospaced())
+                        Text(site.packageURL.path)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+                .padding(.vertical, 2)
+            }
+            .buttonStyle(.plain)
+            // Draggable out to Finder/Terminal/another app (#676) — offers the package URL
+            // regardless of validity (a dead bookmark is still a real path on disk).
+            .draggable(site.packageURL)
+            // A dead bookmark (needsReauthorization) still lets the row respond to a click — it
+            // routes to the same "Locate…" recovery as the context-menu action — rather than
+            // going fully dead with no way to fix it in place (#776).
+            .disabled(!site.isValid && !site.needsReauthorization)
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift test --package-path . --filter SiteNavigatorModelTests`
+Expected: `Build complete!` (this rebuilds all of `AnglesiteAppCore`, including `SitesLauncherView.swift`, as a dependency of the test target — a compile error here fails the build step even though this file has no dedicated test suite).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SitesLauncherView.swift
+git commit -m "feat(#676): drag launcher site rows out to Finder"
+```
+
+---
+
+### Task 4: Visible targeted highlight on the launcher drop target
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SitesLauncherView.swift:21` (new `@State`), `Sources/AnglesiteApp/SitesLauncherView.swift:189-209` (`siteList`'s `.listStyle`/`.dropDestination`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: nothing new consumed by later tasks — this is the final task.
+
+- [ ] **Step 1: Add the targeted-state property**
+
+In `Sources/AnglesiteApp/SitesLauncherView.swift`, add a new `@State` property right after `@State private var sites: [SiteStore.Site] = []` (currently line 21):
+
+```swift
+    @State private var sites: [SiteStore.Site] = []
+    /// Drives a visible highlight while a file-URL drag hovers `siteList` (#676). Lights up for
+    /// any file-URL drag, not only valid `.anglesite` packages — see the design doc's "Drop-
+    /// highlight fidelity" decision. The drop itself still only accepts `.anglesite` packages,
+    /// unchanged below.
+    @State private var isDropTargeted = false
+```
+
+- [ ] **Step 2: Add the `isTargeted:` closure and a visible highlight overlay**
+
+In the same file, find (currently lines 189-209):
+
+```swift
+        .listStyle(.inset)
+        // Accept `.anglesite` packages dragged from Finder (#524) — same register path as
+        // Finder double-click (`onOpenURL`), including the MAS bookmark mint (a user drag
+        // conveys sandbox access to the dragged item).
+        .dropDestination(for: URL.self) { urls, _ in
+            let packages = urls.filter { $0.pathExtension == AnglesitePackage.packageExtension }
+            guard !packages.isEmpty else { return false }
+            Task { @MainActor in
+                for url in packages {
+                    do {
+                        let site = try await SiteActions.registerPackage(at: url)
+                        openWindow(value: site.id)
+                    } catch {
+                        NSAlert(error: SiteActions.ImportError(
+                            folderName: url.lastPathComponent, underlying: error
+                        )).runModal()
+                    }
+                }
+            }
+            return true
+        }
+```
+
+and replace it with:
+
+```swift
+        .listStyle(.inset)
+        // Accept `.anglesite` packages dragged from Finder (#524) — same register path as
+        // Finder double-click (`onOpenURL`), including the MAS bookmark mint (a user drag
+        // conveys sandbox access to the dragged item).
+        .dropDestination(for: URL.self) { urls, _ in
+            let packages = urls.filter { $0.pathExtension == AnglesitePackage.packageExtension }
+            guard !packages.isEmpty else { return false }
+            Task { @MainActor in
+                for url in packages {
+                    do {
+                        let site = try await SiteActions.registerPackage(at: url)
+                        openWindow(value: site.id)
+                    } catch {
+                        NSAlert(error: SiteActions.ImportError(
+                            folderName: url.lastPathComponent, underlying: error
+                        )).runModal()
+                    }
+                }
+            }
+            return true
+        } isTargeted: { targeted in
+            isDropTargeted = targeted
+        }
+        .overlay {
+            // Explicit targeted feedback (#676) — the system's default drag highlight is subtle
+            // enough that #524's drop target had no clearly visible accepted/rejected state.
+            if isDropTargeted {
+                RoundedRectangle(cornerRadius: 4)
+                    .strokeBorder(Color.accentColor, lineWidth: 3)
+                    .allowsHitTesting(false)
+            }
+        }
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `swift test --package-path . --filter SiteNavigatorModelTests`
+Expected: `Build complete!` (same rationale as Task 3 — no dedicated test suite for this view; the highlight is decorative UI state with no independently testable logic).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SitesLauncherView.swift
+git commit -m "feat(#676): visible targeted highlight on launcher drop target"
+```
+
+---
+
+### Task 5: Full verification pass + manual QA
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full SwiftPM test suite**
+
+Run: `swift test --package-path .`
+Expected: all suites pass, no failures (this also re-confirms the 4 new Task 1 tests alongside the full existing suite).
+
+- [ ] **Step 2: Build the app target**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Manual QA (drag-and-drop has no headless test path on macOS)**
+
+In the running app:
+1. Open the Sites launcher, drag a site row to the Desktop → confirm Finder offers to copy/move the `.anglesite` package, and the file appears at the drop location.
+2. Open a site window, drag a page or post row from the navigator to the Desktop → confirm the backing source file (e.g. `about.astro` or `hello.md`) copies to the drop location.
+3. Drag a `.anglesite` package from Finder over the launcher list → confirm the accent-colored highlight appears while hovering, and dropping it registers/opens the site as before (#524 behavior unchanged).
+4. Drag some other file (e.g. a `.txt` file) over the launcher list → confirm the same highlight appears (expected per the "simple hover highlight" decision — not a bug) but dropping it does nothing (no crash, no registration attempt).
+
+- [ ] **Step 4: Update the issue**
+
+Remove the in-progress label now that a PR is about to open:
+
+```bash
+gh issue edit 676 --remove-label "🛠️ In Progress"
+```

--- a/docs/superpowers/specs/2026-07-27-drag-drop-completeness-design.md
+++ b/docs/superpowers/specs/2026-07-27-drag-drop-completeness-design.md
@@ -1,0 +1,119 @@
+# Drag & drop completeness — design
+
+**Issue:** #676 — Drag & drop completeness: drag sites and content items out; richer drop feedback
+**Date:** 2026-07-27
+**Status:** Approved design; ready for implementation planning.
+
+## Goal
+
+Part of the Mac-assed app polish audit (mac-assed-app-spec.md). Today drag & drop
+in Anglesite is one-directional: the launcher accepts `.anglesite` package drops
+(`SitesLauncherView.swift`, #524), but nothing can be dragged *out* of the app, and
+the launcher's drop target gives no visible feedback beyond the system default.
+This closes both gaps:
+
+1. Launcher rows draggable out (as `.anglesite` package file URLs).
+2. Navigator items draggable out (as their `Source/` file URLs).
+3. Explicit `isTargeted` highlight on the launcher drop target.
+
+## Decisions (locked in brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Drop-highlight fidelity | Simple hover highlight — reuse `.dropDestination(for: URL.self)`'s existing `isTargeted:` closure. Highlights for any file-URL drag over the list, not just valid `.anglesite` packages. The drop-accept logic (filter to `.anglesite` extension) is unchanged. |
+| Navigator drag scope | Only `.route` (page/post) and `.file` (component/style/metadata) targets are draggable. `.directory` and `.websiteSettings` targets are not — no single backing file, and navigator reordering is an explicit non-goal (content order is filesystem/frontmatter-derived). |
+| Navigator route→file resolution | Add a synchronous `routeFileURLs: [String: URL]` cache built during `SiteNavigatorModel.refresh()` (alongside the existing `postsByID`/`postIDs` caches), since `.draggable`'s payload closure runs synchronously at drag-start and can't await the graph actor. |
+
+## 1. Launcher rows draggable
+
+`SitesLauncherView.swift`'s `siteList` renders each `SiteStore.Site` row as a
+`Button` label (line ~141). Add `.draggable(site.packageURL)` to the label's
+`HStack`. `URL` already conforms to `Transferable` — the launcher's own
+`dropDestination(for: URL.self)` proves this works round-trip in this app. No
+change needed for invalid/dead sites (`!site.isValid`): the package URL is still
+draggable even if the site can't currently be opened (e.g. `needsReauthorization`)
+since it's just a file-system path.
+
+## 2. Launcher drop highlight
+
+Extend the existing `.dropDestination(for: URL.self) { urls, _ in ... }` call
+(line ~193) with its `isTargeted:` trailing closure:
+
+```swift
+.dropDestination(for: URL.self) { urls, _ in
+    ... // unchanged accept logic
+} isTargeted: { targeted in
+    isDropTargeted = targeted
+}
+```
+
+Add `@State private var isDropTargeted = false` and apply a visible highlight
+(accent-colored border/background, matching platform drag-and-drop convention)
+to `siteList` when `isDropTargeted` is true. Since the highlight fires for any
+file-URL drag (not just `.anglesite` packages), no additional validation code is
+needed — the accept/reject distinction stays in the closure body as it is today.
+
+## 3. Navigator items draggable out
+
+`SiteNavigatorView.swift`'s `row(for:)` renders each `URLTreeNode` as a `Label`.
+Add a conditional `.draggable(url)` using a new accessor on `SiteNavigatorModel`:
+
+```swift
+func fileURL(for id: String) -> URL? {
+    guard let target = target(for: id) else { return nil }
+    switch target {
+    case .file(let ref): return ref.url
+    case .route: return routeFileURLs[id]
+    case .directory, .websiteSettings: return nil
+    }
+}
+```
+
+`routeFileURLs` is populated in `refresh(siteID:siteRoot:)` right where `pages`
+and `posts` are already fetched, mirroring how `postsByID` is built today:
+
+```swift
+var routeFileURLs: [String: URL] = [:]
+if let sourceDirectory {
+    for page in pages { routeFileURLs[page.id] = sourceDirectory.appendingPathComponent(page.filePath) }
+    for post in posts { routeFileURLs[post.id] = sourceDirectory.appendingPathComponent(post.filePath) }
+}
+```
+
+In the view, the non-editing row branch wraps its existing `Label` in an `if let`
+so only rows with a resolvable file URL become draggable:
+
+```swift
+if let url = model.fileURL(for: node.id) {
+    rowLabel(for: node).draggable(url)
+} else {
+    rowLabel(for: node)
+}
+```
+
+where `rowLabel(for:)` is the existing `Label { Text(node.title) } icon: { icon(for: node) }`
+plus its `.tag`/`.contextMenu` chain, factored out so it isn't duplicated between
+the two branches.
+
+## Testing
+
+- `AnglesiteCoreTests`: unit-test the `routeFileURLs` population logic (page/post
+  id → expected `sourceDirectory`-relative URL) if it's extracted into a testable
+  pure function; otherwise cover indirectly through `SiteNavigatorModel`'s existing
+  refresh tests.
+- No new Swift Testing target needed — this is additive to existing
+  `SiteNavigatorModel`/`SitesLauncherView` coverage.
+- Manual QA (drag-and-drop has no good headless test path on macOS): drag a
+  launcher row to Finder/Desktop, confirm the `.anglesite` package copies/moves;
+  drag a navigator page/component row to Finder, confirm the source file copies;
+  drag a `.anglesite` package (and, separately, some other file) over the launcher
+  list and confirm the highlight appears in both cases (simple-highlight decision
+  above — this is expected, not a bug).
+
+## Non-goals
+
+- Navigator drag-to-reorder (content order is filesystem/frontmatter-derived,
+  `.onMove` has no meaningful model behind it).
+- Content-type-validated drop highlighting (rejected in favor of the simpler
+  any-file-URL highlight — see Decisions table).
+- Dragging `.directory`/`.websiteSettings` navigator rows (no single backing file).

--- a/docs/superpowers/specs/2026-07-27-drag-drop-completeness-design.md
+++ b/docs/superpowers/specs/2026-07-27-drag-drop-completeness-design.md
@@ -60,14 +60,19 @@ Add a conditional `.draggable(url)` using a new accessor on `SiteNavigatorModel`
 
 ```swift
 func fileURL(for id: String) -> URL? {
-    guard let target = target(for: id) else { return nil }
-    switch target {
-    case .file(let ref): return ref.url
-    case .route: return routeFileURLs[id]
-    case .directory, .websiteSettings: return nil
-    }
+    guard case .route = target(for: id) else { return nil }
+    return routeFileURLs[id]
 }
 ```
+
+`NavigatorTarget` also has a `.file(FileRef)` case, but `URLTreeNode.Kind` has no
+case that currently produces it (components/styles moved out of the navigator
+tree in #714 slice 1 — see the `SiteNavigatorModelTests` comment on that), so
+`target(for:)` can never actually return `.file` today. Handling only `.route`
+here (rather than exhaustively naming the unreachable `.file`/`.directory`/
+`.websiteSettings` cases) avoids dead code for a case nothing can construct; when
+`.file` rows come back to the tree, this accessor gets a `case .file(let ref):
+return ref.url` branch alongside it.
 
 `routeFileURLs` is populated in `refresh(siteID:siteRoot:)` right where `pages`
 and `posts` are already fetched, mirroring how `postsByID` is built today:

--- a/docs/superpowers/specs/2026-07-27-drag-drop-completeness-design.md
+++ b/docs/superpowers/specs/2026-07-27-drag-drop-completeness-design.md
@@ -21,7 +21,7 @@ This closes both gaps:
 | Decision | Choice |
 |---|---|
 | Drop-highlight fidelity | Simple hover highlight — reuse `.dropDestination(for: URL.self)`'s existing `isTargeted:` closure. Highlights for any file-URL drag over the list, not just valid `.anglesite` packages. The drop-accept logic (filter to `.anglesite` extension) is unchanged. |
-| Navigator drag scope | Only `.route` (page/post) and `.file` (component/style/metadata) targets are draggable. `.directory` and `.websiteSettings` targets are not — no single backing file, and navigator reordering is an explicit non-goal (content order is filesystem/frontmatter-derived). |
+| Navigator drag scope | Only `.route` (page/post) targets are draggable today. `.file` (component/style/metadata) is unreachable — components/styles moved out of the navigator tree in #714 slice 1 — and `.directory`/`.websiteSettings` are not draggable (no single backing file, and navigator reordering is an explicit non-goal). |
 | Navigator route→file resolution | Add a synchronous `routeFileURLs: [String: URL]` cache built during `SiteNavigatorModel.refresh()` (alongside the existing `postsByID`/`postIDs` caches), since `.draggable`'s payload closure runs synchronously at drag-start and can't await the graph actor. |
 
 ## 1. Launcher rows draggable


### PR DESCRIPTION
## Summary

- Sites launcher rows are now draggable out to Finder/Terminal/another app as their `.anglesite` package URL.
- Site Navigator sidebar rows for pages/posts (`.route` targets) are now draggable out as their backing `Source/` file URL.
- The launcher's existing drop target (`.dropDestination`, #524) now shows a visible accent-colored highlight while a file is being dragged over it — for any file-URL drag, not just valid `.anglesite` packages (a deliberate, locked scope decision, not an oversight).

Design: `docs/superpowers/specs/2026-07-27-drag-drop-completeness-design.md`
Plan: `docs/superpowers/plans/2026-07-27-drag-drop-completeness.md`

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 2777 tests, 2 failures, both in `FoundationModelAssistant` (on-device Foundation Models flake, "Session ended without producing a response"); confirmed pre-existing and unrelated by re-running that suite in isolation with the same 2 failures on a clean rebuild — no relation to the SwiftUI files this PR touches.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **` (after `xcodegen generate`, needed to pick up files already merged upstream — unrelated pre-existing worktree staleness).
- [ ] Manual smoke (UI-touching, **not run in this environment** — no headless driving tool exists here for the native macOS app):
  1. Drag a launcher row to Desktop → confirm a real `.anglesite` package (not a `.webloc` stub) copies/moves.
  2. Drag a navigator page/post row to Desktop → confirm the real source file copies.
  3. Drag a `.anglesite` package (and separately some other file) over the launcher list → highlight appears in both cases (expected, not a bug); dropping the package registers/opens it, the other file does nothing.
  4. Drag a launcher row for a site whose window has **not** been opened this session (no active security-scoped grant) → confirm it still drags out successfully.
  5. Drag a launcher row for a site missing required files (not merely `needsReauthorization`) → confirm it drags out (this is what the modifier-order fix below addresses).
  6. Confirm navigator row selection still works normally on draggable rows.
  7. Confirm the launcher's targeted-highlight border clears after a completed drop, not just on drag-exit.

## Review notes

Built via superpowers subagent-driven-development: 5 plan tasks, each independently implemented + task-reviewed (all clean, no unresolved findings), followed by a final whole-branch review. The final review caught one real defect, fixed in a follow-up commit: `.disabled()` was applied before `.draggable()` on launcher rows, so a site missing required files (not just `needsReauthorization`) couldn't actually be dragged out — contradicting the code's own comment. Reordered so the drag escapes the disabled scope.

Two Important findings from that review could **not** be verified without manual GUI testing (items 1 and 4 in the checklist above): whether `.draggable(URL)` actually vends a real file-URL vs. a `.webloc` stub on export, and whether the launcher can drag out a site with no active security-scoped grant. Flagging explicitly rather than claiming they were checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)