### PR TITLE
feat(#1039): advertise rel=micropub discovery link

### DIFF
--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -38,6 +38,9 @@ const license = headLicense(Astro.props.license, siteLicense());
     {readConfig("WEBMENTION_RECEIVE_ENABLED") === "true" && (
       <link rel="webmention" href="/webmention" />
     )}
+    {readConfig("MICROPUB_ENABLED") === "true" && (
+      <link rel="micropub" href="/micropub" />
+    )}
     <slot name="head" />
     <!-- anglesite:head-end -->
   </head>

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -430,6 +430,16 @@ public actor SocialWorkerProvisionCommand {
             // `<link rel="webmention">` at an endpoint the Worker no longer serves.
             let hasWebmentionReceive = workers.contains(where: { $0.id == WorkerComposition.webmentionWorkerID })
             let webmentionReceiveEnabled = hasWebmentionReceive && resources.queueName != nil
+            // Same "actually live" contract for Micropub: the flag gates BaseLayout.astro's
+            // `<link rel="micropub">` discovery tag (Micropub/Micro.blog clients — including the
+            // Micro.blog iOS/Mac apps — resolve the posting endpoint from that link, per
+            // https://book.micro.blog/micropub/). Micropub has no bespoke queue of its own — it
+            // rides the shared per-site D1 database (bound as MICROPUB_DB) and R2 bucket (bound
+            // as MEDIA), both generic `resources` fields — so "actually live" here means those
+            // two ids were actually assigned by provisioning, not just that the worker is in the
+            // active set.
+            let hasMicropub = workers.contains(where: { $0.id == WorkerComposition.micropubWorkerID })
+            let micropubEnabled = hasMicropub && resources.d1DatabaseID != nil && resources.r2BucketName != nil
             // Same "actually live" contract for the WebSub hub: the flag gates the feeds'
             // rel="hub" advertisement (src/lib/feeds.ts), which must never point at an endpoint
             // the Worker doesn't serve or a hub whose Queue doesn't exist.
@@ -440,6 +450,7 @@ public actor SocialWorkerProvisionCommand {
             let updated = SiteConfigFile.upsert(
                 [
                     ("WEBMENTION_RECEIVE_ENABLED", webmentionReceiveEnabled ? "true" : "false"),
+                    ("MICROPUB_ENABLED", micropubEnabled ? "true" : "false"),
                     ("WEBSUB_ENABLED", websubEnabled ? "true" : "false"),
                 ], into: existing
             )

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -748,6 +748,59 @@ struct SocialWorkerProvisionCommandTests {
         #expect(SiteConfigFile.value(forKey: "WEBMENTION_RECEIVE_ENABLED", in: config) == "false")
     }
 
+    @Test("Micropub writes MICROPUB_ENABLED into .site-config, gating BaseLayout.astro's rel=micropub discovery tag")
+    func micropubWritesEnabledFlag() async throws {
+        let siteDirectory = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
+            ["r2", "bucket", "create", "my-site-media"]: .init(stdout: "Created bucket my-site-media", stderr: "", exitCode: 0),
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
+        ])
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" }, runner: recorder.runner,
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let indieauth = worker(WorkerComposition.indieauthWorkerID, d1: true, kv: false, r2: false)
+        let micropub = worker(WorkerComposition.micropubWorkerID, d1: true, kv: false, r2: true)
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [indieauth, micropub], acknowledgesPaidPlan: true)
+
+        let config = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "MICROPUB_ENABLED", in: config) == "true")
+    }
+
+    @Test("deactivating Micropub reconciles MICROPUB_ENABLED back to false")
+    func micropubDeactivationReconcilesFlagToFalse() async throws {
+        let siteDirectory = try temporaryDirectory()
+        let recorder = WranglerRecorder([
+            ["d1", "create", "my-site-social", "--json"]: .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0),
+            ["r2", "bucket", "create", "my-site-media"]: .init(stdout: "Created bucket my-site-media", stderr: "", exitCode: 0),
+            ["d1", "migrations", "apply", "AUTH_DB", "--remote"]: .init(stdout: "Migrations applied", stderr: "", exitCode: 0),
+        ])
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "tok" }, runner: recorder.runner,
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let indieauth = worker(WorkerComposition.indieauthWorkerID, d1: true, kv: false, r2: false)
+        let micropub = worker(WorkerComposition.micropubWorkerID, d1: true, kv: false, r2: true)
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [indieauth, micropub], acknowledgesPaidPlan: true)
+
+        let enabledConfig = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "MICROPUB_ENABLED", in: enabledConfig) == "true")
+
+        _ = await command.provision(
+            siteID: "site-1", siteDirectory: siteDirectory, siteName: "my-site",
+            workers: [indieauth], acknowledgesPaidPlan: true)
+
+        let disabledConfig = try String(contentsOf: siteDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "MICROPUB_ENABLED", in: disabledConfig) == "false")
+    }
+
     @Test("websub worker without paid-plan acknowledgment returns the confirmation-needed gate, no wrangler call")
     func websubWithoutAcknowledgmentBlocksBeforeAnyCall() async throws {
         let site = try temporaryDirectory()


### PR DESCRIPTION
## Summary

- `Resources/Template/worker/worker.ts` composes `@dwk/micropub` at `POST /micropub`, but `BaseLayout.astro` never advertised the endpoint — clients (including the Micro.blog iOS/Mac apps) discover the posting endpoint via `<link rel="micropub">`, per the [Micropub spec](https://book.micro.blog/micropub/), and auto-discovery silently failed even after a site owner activated the Micropub worker.
- Adds `<link rel="micropub" href="/micropub">` to `BaseLayout.astro`'s head, gated on the Micropub worker actually being live for the site — same pattern `WEBMENTION_RECEIVE_ENABLED` uses for `<link rel="webmention">`.
- `SocialWorkerProvisionCommand.persistConfig` now writes `MICROPUB_ENABLED` into `.site-config`, reconciled on every provision/deprovision the same way `WEBMENTION_RECEIVE_ENABLED`/`WEBSUB_ENABLED` are: `true` only once Micropub's D1 database and R2 bucket ids are actually assigned (Micropub has no bespoke queue of its own to key off, unlike webmention/websub).

Filed as [#1039](https://github.com/Anglesite/Anglesite-app/issues/1039), noticed while drafting `docs/microblog-external-blog.md` (#1026) under a "Known gap" heading — filed and fixed separately since it's a code fix, not a docs gap, and out of scope for the #1027 feed-layer epic.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite#123 -->

Template-only + provisioning-flag change, no MCP message schema touched.

## Test plan

- [x] `swift test --package-path .` — 2809 tests / 363 suites pass, including two new `MICROPUB_ENABLED` cases in `SocialWorkerProvisionCommandTests` (write-on-activate, reconcile-to-false-on-deactivate).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] Manual smoke (if UI-touching): not UI-touching — template + provisioning-flag change only.