### PR TITLE
feat(#1027): Micro.blog compatibility — fix the feed layer

### DIFF
--- a/Resources/Template/src/components/CollectionIndex.astro
+++ b/Resources/Template/src/components/CollectionIndex.astro
@@ -1,0 +1,40 @@
+---
+// Shared page body for a single micropost/titled collection's `/<collection>/` index — the
+// `<collection>/index.astro` files are thin wrappers around this so the seven of them (notes,
+// photos, articles, albums, bookmarks, replies, likes) can't drift on structure. Mirrors
+// `blog/index.astro`'s shape (title, RSS subscribe link, empty-state hint naming the content
+// directory) but lists h-entry items inside an h-feed via `IndexEntry.astro`.
+import BaseLayout from "../layouts/BaseLayout.astro";
+import IndexEntry from "./IndexEntry.astro";
+import { getIndexItems } from "../lib/collection-index-astro.ts";
+import { FEED_COLLECTIONS } from "../lib/feeds.ts";
+
+interface Props {
+  collection: string;
+}
+
+const { collection } = Astro.props;
+const cfg = FEED_COLLECTIONS[collection];
+if (!cfg) throw new Error(`CollectionIndex: no feed config for collection "${collection}"`);
+const title = cfg.title;
+const lowerTitle = title.toLowerCase();
+const items = await getIndexItems(collection);
+---
+
+<BaseLayout title={title} description={`Read the latest ${lowerTitle}.`}>
+  <div class="h-feed">
+    <h1 class="p-name">{title}</h1>
+    <p><a href={`/${collection}/rss.xml`}>Subscribe (RSS)</a></p>
+    {
+      items.length === 0 ? (
+        <p>
+          No {lowerTitle} yet. Add a Markdown file in <code>src/content/{collection}/</code> to get started.
+        </p>
+      ) : (
+        <ul>
+          {items.map((item) => <IndexEntry item={item} />)}
+        </ul>
+      )
+    }
+  </div>
+</BaseLayout>

--- a/Resources/Template/src/components/IndexEntry.astro
+++ b/Resources/Template/src/components/IndexEntry.astro
@@ -1,0 +1,67 @@
+---
+// One <li class="h-entry"> for a collection index or /timeline/ page. Titled entries (articles,
+// albums, and titled bookmarks) render as a linked headline, matching `blog/index.astro`'s
+// spirit; title-less entries (notes, photos, replies, likes, and title-less bookmarks) render
+// their full body inline via `render(entry)`'s `<Content />` — the page-side equivalent of what
+// `feed-data.ts` does with markdown-remark for feeds. Do NOT redesign `Hentry.astro`: this is a
+// separate, list-context rendering of the same entries, not a replacement for their own
+// `/<collection>/<id>/` page.
+import type { IndexItem } from "../lib/collection-index-astro.ts";
+import { tagSlug } from "../lib/tags.ts";
+import DraftBadge from "./DraftBadge.astro";
+
+interface Props {
+  item: IndexItem;
+}
+
+const { item } = Astro.props;
+const { Content } = item;
+const iso = item.date.toISOString();
+const human = item.date.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: "UTC",
+});
+---
+
+<li class="h-entry">
+  <DraftBadge draft={item.draft} />
+  {
+    item.title ? (
+      <>
+        <a class="p-name u-url" href={item.permalink}>{item.title}</a>{" "}
+        <time class="dt-published" datetime={iso}>{human}</time>
+        {item.summary && <p class="p-summary">{item.summary}</p>}
+      </>
+    ) : (
+      <>
+        {item.image && <img class="u-photo" src={item.image} alt={item.caption ?? ""} />}
+        {(item.summary ?? item.caption) && <p class="p-summary">{item.summary ?? item.caption}</p>}
+        <div class="e-content">
+          {item.hasBody ? (
+            <Content />
+          ) : item.targetUrl && item.targetClass ? (
+            <a class={item.targetClass} href={item.targetUrl}>{item.targetUrl}</a>
+          ) : (
+            <Content />
+          )}
+        </div>
+        <a class="u-url" href={item.permalink}>
+          <time class="dt-published" datetime={iso}>{human}</time>
+        </a>
+      </>
+    )
+  }
+  {
+    item.tags && item.tags.length > 0 && (
+      <ul class="tags">
+        {item.tags.map((t) => (
+          <li>
+            <a class="p-category" href={`/tags/${tagSlug(t)}/`}>{t}</a>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+</li>

--- a/Resources/Template/src/content/notes/hello-note.md
+++ b/Resources/Template/src/content/notes/hello-note.md
@@ -1,5 +1,5 @@
 ---
 publishDate: 2026-06-26T12:00:00.000Z
-tags: ["hello"]
+tags: ["hello", "hello world"]
 ---
 This is your first note.

--- a/Resources/Template/src/layouts/Hentry.astro
+++ b/Resources/Template/src/layouts/Hentry.astro
@@ -94,7 +94,11 @@ const likeCite = cited(d.likeOf);
     </a>
     {tags.length > 0 && (
       <ul class="tags">
-        {tags.map((t) => <li><a class="p-category" href={`/tags/${t}`}>{t}</a></li>)}
+        {/* encodeURIComponent so a tag with a space (or other URL-unsafe character) still
+            resolves — must match `tags/[tag]/index.astro`'s `getStaticPaths` params exactly,
+            and the trailing slash matches this site's directory-style build output (see
+            `blog/index.astro`'s `/blog/${post.id}/` links). */}
+        {tags.map((t) => <li><a class="p-category" href={`/tags/${encodeURIComponent(t)}/`}>{t}</a></li>)}
       </ul>
     )}
     <LicenseLink license={license} />

--- a/Resources/Template/src/layouts/Hentry.astro
+++ b/Resources/Template/src/layouts/Hentry.astro
@@ -5,6 +5,7 @@ import type { HentryCollection } from "../lib/collections.ts";
 import { entrySchema, type HentryData } from "../lib/schema.ts";
 import { ownerName } from "../lib/profile.ts";
 import { licenseFor } from "../lib/licensing-data.ts";
+import { tagSlug } from "../lib/tags.ts";
 import BaseLayout from "./BaseLayout.astro";
 import SyndicationLinks from "../components/SyndicationLinks.astro";
 import DraftBadge from "../components/DraftBadge.astro";
@@ -94,11 +95,13 @@ const likeCite = cited(d.likeOf);
     </a>
     {tags.length > 0 && (
       <ul class="tags">
-        {/* encodeURIComponent so a tag with a space (or other URL-unsafe character) still
-            resolves — must match `tags/[tag]/index.astro`'s `getStaticPaths` params exactly,
-            and the trailing slash matches this site's directory-style build output (see
-            `blog/index.astro`'s `/blog/${post.id}/` links). */}
-        {tags.map((t) => <li><a class="p-category" href={`/tags/${encodeURIComponent(t)}/`}>{t}</a></li>)}
+        {/* href uses `tagSlug`, not the verbatim tag — must match `tags/[tag]/index.astro`'s
+            `getStaticPaths` params exactly (see `tags.ts`'s `tagSlug` for why: a raw "/" or "#"
+            in the tag text either crashes the build or 404s). The link TEXT stays the verbatim
+            tag — it's the mf2 `p-category` value and must remain human-readable. The trailing
+            slash matches this site's directory-style build output (see `blog/index.astro`'s
+            `/blog/${post.id}/` links). */}
+        {tags.map((t) => <li><a class="p-category" href={`/tags/${tagSlug(t)}/`}>{t}</a></li>)}
       </ul>
     )}
     <LicenseLink license={license} />

--- a/Resources/Template/src/lib/collection-index-astro.ts
+++ b/Resources/Template/src/lib/collection-index-astro.ts
@@ -1,0 +1,95 @@
+import { getCollection, render, type RenderResult } from "astro:content";
+import { FEED_COLLECTIONS } from "./feeds.ts";
+import { targetClassFor, targetUrlFor } from "./collection-index.ts";
+
+/**
+ * One entry's worth of data for a collection index page or `/timeline/` — the page-side
+ * equivalent of `feed-data.ts`'s `FeedItem`, but carrying the rendered `Content` component (so
+ * the page can inline the entry's full body) instead of pre-rendered `contentHtml`, plus the raw
+ * fields `IndexEntry.astro` needs to decide how to present an entry (image, target-URL fallback,
+ * tags). A title present (`title`) means "render as a linked headline" (articles, albums, and
+ * titled bookmarks); absent means "render full content inline" (notes, photos, replies, likes,
+ * and title-less bookmarks) — same `deriveTitle` truthiness `feeds.ts` uses to decide whether a
+ * feed item gets a `<title>`.
+ */
+export interface IndexItem {
+  collection: string;
+  id: string;
+  permalink: string;
+  date: Date;
+  draft: boolean;
+  title?: string;
+  summary?: string;
+  caption?: string;
+  image?: string;
+  tags?: string[];
+  /** Whether the entry's markdown body renders to non-empty content — when false, an
+   * interaction post (likes/replies/bookmarks) falls back to its target URL as a link in place
+   * of `Content` (mirrors `feeds.ts`'s `interactionContentFallback`). */
+  hasBody: boolean;
+  /** `likeOf`/`inReplyTo`/`bookmarkOf`, when the collection has one. */
+  targetUrl?: string;
+  /** The mf2 `u-*` class for `targetUrl` (`u-like-of`/`u-in-reply-to`/`u-bookmark-of`). */
+  targetClass?: string;
+  Content: RenderResult["Content"];
+}
+
+// `entry` is whatever `getCollection` hands back (a real content-layer entry, not a
+// reconstructed object) — `render()` needs the original entry, not a copy, and `data`/`body`/
+// `id` are read straight off it. Typed loosely (matching `feed-data.ts`'s `as any` collection
+// param) because this loops over every collection in `FEED_COLLECTIONS` rather than one typed
+// literal.
+async function toIndexItem(collection: string, entry: any): Promise<IndexItem> {
+  const cfg = FEED_COLLECTIONS[collection];
+  if (!cfg) throw new Error(`[collection-index] no feed config for collection "${collection}"`);
+  const data = entry.data as Record<string, unknown>;
+  const rawDate = data[cfg.dateField];
+  const date = rawDate instanceof Date ? rawDate : new Date(rawDate as string);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`[collection-index] entry "${entry.id}" has a missing or invalid ${cfg.dateField}`);
+  }
+  const { Content } = await render(entry);
+  return {
+    collection,
+    id: entry.id,
+    permalink: `/${collection}/${entry.id}/`,
+    date,
+    draft: Boolean(data.draft),
+    title: cfg.deriveTitle(entry) || undefined,
+    summary: typeof data.summary === "string" ? data.summary : undefined,
+    caption: typeof data.caption === "string" ? data.caption : undefined,
+    image: typeof data.image === "string" ? data.image : undefined,
+    tags: Array.isArray(data.tags) && data.tags.length > 0 ? (data.tags as string[]) : undefined,
+    hasBody: Boolean((entry.body as string | undefined)?.trim()),
+    targetUrl: targetUrlFor(collection, data),
+    targetClass: targetClassFor(collection),
+    Content,
+  };
+}
+
+/// Fetch one collection's entries as `IndexItem`s, unsorted. Drafts are excluded in PROD only —
+/// matching `blog/index.astro` and `[collection]/[...slug].astro`'s page-route convention (a dev
+/// preview shows drafts with `DraftBadge`), unlike `feed-data.ts`'s unconditional exclusion (a
+/// feed is syndication data, not a live preview).
+async function mapEntries(collection: string): Promise<IndexItem[]> {
+  const entries = await getCollection(collection as any, ({ data }: any) =>
+    import.meta.env.PROD ? !data.draft : true,
+  );
+  return Promise.all(entries.map((entry: any) => toIndexItem(collection, entry)));
+}
+
+/// One collection's entries, reverse-chronological — what each `<collection>/index.astro` lists.
+export async function getIndexItems(collection: string): Promise<IndexItem[]> {
+  return (await mapEntries(collection)).sort((a, b) => b.date.valueOf() - a.date.valueOf());
+}
+
+/// Combined reverse-chronological stream across all eight feed collections (blog plus the seven
+/// micropost/titled collections) — the page-side equivalent of `feed-data.ts`'s
+/// `getCombinedItems`, capped at the same default limit.
+export async function getTimelineItems(limit = 50): Promise<IndexItem[]> {
+  const all: IndexItem[] = [];
+  for (const collection of Object.keys(FEED_COLLECTIONS)) {
+    all.push(...(await mapEntries(collection)));
+  }
+  return all.sort((a, b) => b.date.valueOf() - a.date.valueOf()).slice(0, limit);
+}

--- a/Resources/Template/src/lib/collection-index.test.ts
+++ b/Resources/Template/src/lib/collection-index.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { targetClassFor, targetUrlFor } from "./collection-index.ts";
+
+test("targetClassFor: maps each interaction collection to its mf2 u-* class", () => {
+  assert.equal(targetClassFor("likes"), "u-like-of");
+  assert.equal(targetClassFor("replies"), "u-in-reply-to");
+  assert.equal(targetClassFor("bookmarks"), "u-bookmark-of");
+});
+
+test("targetClassFor: undefined for collections with no target-URL field", () => {
+  assert.equal(targetClassFor("notes"), undefined);
+  assert.equal(targetClassFor("photos"), undefined);
+  assert.equal(targetClassFor("articles"), undefined);
+  assert.equal(targetClassFor("albums"), undefined);
+  assert.equal(targetClassFor("blog"), undefined);
+});
+
+test("targetUrlFor: reads likeOf for likes", () => {
+  assert.equal(targetUrlFor("likes", { likeOf: "https://example.com/liked" }), "https://example.com/liked");
+});
+
+test("targetUrlFor: reads inReplyTo for replies", () => {
+  assert.equal(targetUrlFor("replies", { inReplyTo: "https://example.com/post" }), "https://example.com/post");
+});
+
+test("targetUrlFor: reads bookmarkOf for bookmarks", () => {
+  assert.equal(targetUrlFor("bookmarks", { bookmarkOf: "https://example.com/" }), "https://example.com/");
+});
+
+test("targetUrlFor: undefined for collections with no target-URL field", () => {
+  assert.equal(targetUrlFor("notes", { likeOf: "https://example.com/x" }), undefined);
+  assert.equal(targetUrlFor("photos", {}), undefined);
+});
+
+test("targetUrlFor: undefined when the field is missing, empty, or not a string", () => {
+  assert.equal(targetUrlFor("likes", {}), undefined);
+  assert.equal(targetUrlFor("likes", { likeOf: "" }), undefined);
+  assert.equal(targetUrlFor("likes", { likeOf: 42 }), undefined);
+});

--- a/Resources/Template/src/lib/collection-index.ts
+++ b/Resources/Template/src/lib/collection-index.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helpers shared by the collection index pages (`src/pages/<collection>/index.astro`) and
+ * the combined `/timeline/` page — kept free of the `astro:content` import so they stay
+ * unit-testable with plain `node:test` (same rationale as `tags.ts` / `content-schemas.ts`). The
+ * `astro:content`-importing half of this feature lives in `collection-index-astro.ts`.
+ */
+
+/**
+ * The mf2 `u-*` class an inline (title-less) entry's target-URL fallback link should carry,
+ * mirroring the properties `Hentry.astro` emits for a populated `bookmarkOf`/`inReplyTo`/
+ * `likeOf` field. `undefined` for collections with no such field (notes, photos, and every
+ * titled collection).
+ */
+export function targetClassFor(collection: string): string | undefined {
+  switch (collection) {
+    case "likes":
+      return "u-like-of";
+    case "replies":
+      return "u-in-reply-to";
+    case "bookmarks":
+      return "u-bookmark-of";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * An entry's outbound target URL for its collection (`likeOf`/`inReplyTo`/`bookmarkOf`), or
+ * `undefined` for collections with no such field or an entry missing it. Mirrors `feeds.ts`'s
+ * private `interactionContentFallback` target-URL lookup — index/timeline pages render the same
+ * fallback link inline (in place of an empty `e-content`) that the feeds render as `contentHtml`
+ * when a like/reply/bookmark's body is empty (#1021/#1022).
+ */
+export function targetUrlFor(collection: string, data: Record<string, unknown>): string | undefined {
+  const raw =
+    collection === "likes"
+      ? data.likeOf
+      : collection === "replies"
+        ? data.inReplyTo
+        : collection === "bookmarks"
+          ? data.bookmarkOf
+          : undefined;
+  return typeof raw === "string" && raw.length > 0 ? raw : undefined;
+}

--- a/Resources/Template/src/lib/collections.ts
+++ b/Resources/Template/src/lib/collections.ts
@@ -15,3 +15,12 @@ export const ENTRY_COLLECTIONS = [
   ...HENTRY_COLLECTIONS, "events", "reviews",
 ] as const;
 export type EntryCollection = (typeof ENTRY_COLLECTIONS)[number];
+
+/**
+ * The collections whose schema declares a `tags` field (see `content.config.ts` /
+ * `content-schemas.ts`) — the set `/tags/[tag]/` and `/tags/` aggregate over. `blog`, `replies`,
+ * and `likes` are h-entry collections but have no `tags` field, so they're deliberately excluded
+ * here even though they're in `HENTRY_COLLECTIONS` above.
+ */
+export const TAGGED_COLLECTIONS = ["notes", "articles", "photos", "albums", "bookmarks"] as const;
+export type TaggedCollection = (typeof TAGGED_COLLECTIONS)[number];

--- a/Resources/Template/src/lib/feed-data.ts
+++ b/Resources/Template/src/lib/feed-data.ts
@@ -4,6 +4,7 @@ import {
   FEED_COLLECTIONS,
   toFeedItem,
   sortAndLimit,
+  escapeXml,
   type FeedEntry,
   type FeedItem,
   type FeedAuthor,
@@ -22,13 +23,16 @@ function getProcessor(): Promise<MarkdownRenderer> {
 }
 
 /// Render an entry's markdown body to full HTML for the feed's `contentHtml`. Photos with no
-/// body (caption-only) fall back to the caption text so an entry with *some* text to syndicate
-/// never ends up with empty content.
+/// body (caption-only) fall back to the caption text, HTML-escaped and wrapped as a paragraph
+/// (the caption is plain text, but `contentHtml` is consumed as HTML everywhere it's rendered —
+/// JSON Feed `content_html`, Atom `<content type="html">`, RSS description — so a caption
+/// containing `&`/`<`/etc. must not be promoted into HTML unescaped), so an entry with *some*
+/// text to syndicate never ends up with empty content.
 async function renderContentHtml(entry: FeedEntry): Promise<string> {
   const body = entry.body?.trim();
   if (!body) {
     const caption = entry.data.caption;
-    return caption ? String(caption) : "";
+    return caption ? `<p>${escapeXml(String(caption))}</p>` : "";
   }
   const renderer = await getProcessor();
   const { code } = await renderer.render(body);

--- a/Resources/Template/src/lib/feed-data.ts
+++ b/Resources/Template/src/lib/feed-data.ts
@@ -1,6 +1,14 @@
 import { getCollection } from "astro:content";
 import { createMarkdownProcessor, type MarkdownRenderer } from "@astrojs/markdown-remark";
-import { FEED_COLLECTIONS, toFeedItem, sortAndLimit, type FeedEntry, type FeedItem } from "./feeds.ts";
+import {
+  FEED_COLLECTIONS,
+  toFeedItem,
+  sortAndLimit,
+  type FeedEntry,
+  type FeedItem,
+  type FeedAuthor,
+} from "./feeds.ts";
+import { siteProfile } from "./profile.ts";
 
 const PER_COLLECTION_LIMIT = 50;
 const COMBINED_LIMIT = 50;
@@ -56,4 +64,18 @@ export async function getCombinedItems(site: string, limit = COMBINED_LIMIT): Pr
     all.push(...(await mapCollection(collection, site)));
   }
   return sortAndLimit(all, limit);
+}
+
+/// Feed-level (channel/feed) author, derived from `siteProfile()` (`src/data/profile.json`).
+/// `siteProfile()` reads via `import.meta.glob`, which only resolves under Astro/Vite — this
+/// lookup belongs here (consumed by the 27 feed routes) rather than in `feeds.ts`, whose
+/// renderers take `author` as a plain parameter so pure node:test unit tests can inject it
+/// directly. Returns `undefined` when no name is configured (the default, unconfigured site),
+/// so every renderer omits author markup cleanly.
+export function feedAuthor(): FeedAuthor | undefined {
+  const profile = siteProfile();
+  const name = typeof profile.name === "string" && profile.name.length > 0 ? profile.name : undefined;
+  if (!name) return undefined;
+  const url = typeof profile.url === "string" && profile.url.length > 0 ? profile.url : undefined;
+  return url ? { name, url } : { name };
 }

--- a/Resources/Template/src/lib/feed-data.ts
+++ b/Resources/Template/src/lib/feed-data.ts
@@ -1,8 +1,31 @@
 import { getCollection } from "astro:content";
-import { FEED_COLLECTIONS, toFeedItem, sortAndLimit, type FeedItem } from "./feeds.ts";
+import { createMarkdownProcessor, type MarkdownRenderer } from "@astrojs/markdown-remark";
+import { FEED_COLLECTIONS, toFeedItem, sortAndLimit, type FeedEntry, type FeedItem } from "./feeds.ts";
 
 const PER_COLLECTION_LIMIT = 50;
 const COMBINED_LIMIT = 50;
+
+// Constructing a processor loads the remark/rehype plugin pipeline, so build it once and reuse
+// the same promise for every entry across every collection in a build rather than per-entry.
+let processorPromise: Promise<MarkdownRenderer> | undefined;
+function getProcessor(): Promise<MarkdownRenderer> {
+  if (!processorPromise) processorPromise = createMarkdownProcessor();
+  return processorPromise;
+}
+
+/// Render an entry's markdown body to full HTML for the feed's `contentHtml`. Photos with no
+/// body (caption-only) fall back to the caption text so an entry with *some* text to syndicate
+/// never ends up with empty content.
+async function renderContentHtml(entry: FeedEntry): Promise<string> {
+  const body = entry.body?.trim();
+  if (!body) {
+    const caption = entry.data.caption;
+    return caption ? String(caption) : "";
+  }
+  const renderer = await getProcessor();
+  const { code } = await renderer.render(body);
+  return code;
+}
 
 /// Map a collection's entries to feed items *without* sorting — callers that immediately re-sort
 /// (the combined feed) skip the wasted per-collection sort. Drafts are always excluded (#798): a
@@ -10,8 +33,12 @@ const COMBINED_LIMIT = 50;
 /// page routes above this filter is unconditional — dev or prod, a draft never appears in a feed.
 async function mapCollection(collection: string, site: string): Promise<FeedItem[]> {
   const entries = await getCollection(collection as any, (entry: any) => !entry.data.draft);
-  return entries.map((e: any) =>
-    toFeedItem(collection, { id: e.id, collection, data: e.data, body: e.body }, site),
+  return Promise.all(
+    entries.map(async (e: any) => {
+      const entry: FeedEntry = { id: e.id, collection, data: e.data, body: e.body };
+      const contentHtml = await renderContentHtml(entry);
+      return toFeedItem(collection, entry, site, contentHtml);
+    }),
   );
 }
 

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -26,38 +26,85 @@ test("config covers all eight collections", () => {
 });
 
 test("toFeedItem uses pubDate for blog and an absolute link", () => {
-  const item = toFeedItem("blog", entry("blog", { title: "Hi", pubDate: "2026-01-02" }), SITE);
+  const item = toFeedItem("blog", entry("blog", { title: "Hi", pubDate: "2026-01-02" }), SITE, "<p>Hi</p>");
   assert.equal(item.title, "Hi");
   assert.equal(item.link, "https://example.com/blog/hello/");
   assert.equal(item.date.getUTCFullYear(), 2026);
 });
 
-test("toFeedItem derives a title for a title-less note from its body", () => {
+test("toFeedItem passes the rendered contentHtml through unchanged", () => {
+  const item = toFeedItem(
+    "blog",
+    entry("blog", { title: "Hi", pubDate: "2026-01-02" }),
+    SITE,
+    "<p>Full <em>body</em>.</p>",
+  );
+  assert.equal(item.contentHtml, "<p>Full <em>body</em>.</p>");
+});
+
+test("toFeedItem leaves a note title-less rather than synthesizing one from its body", () => {
   const item = toFeedItem(
     "notes",
     entry("notes", { publishDate: "2026-01-02" }, "Just a quick thought about feeds."),
     SITE,
+    "<p>Just a quick thought about feeds.</p>",
   );
-  assert.ok(item.title.length > 0);
-  assert.ok(item.title.startsWith("Just a quick"));
+  assert.equal(item.title, undefined);
 });
 
-test("toFeedItem derives a title from the link host for a like", () => {
-  const item = toFeedItem(
+test("toFeedItem leaves a reply and a like title-less rather than deriving from the link host", () => {
+  const like = toFeedItem(
     "likes",
     entry("likes", { likeOf: "https://indieweb.org/post", publishDate: "2026-01-02" }),
     SITE,
+    "",
   );
-  assert.equal(item.title, "Liked indieweb.org");
+  assert.equal(like.title, undefined);
+
+  const reply = toFeedItem(
+    "replies",
+    entry("replies", { inReplyTo: "https://indieweb.org/post", publishDate: "2026-01-02" }),
+    SITE,
+    "",
+  );
+  assert.equal(reply.title, undefined);
+});
+
+test("toFeedItem leaves a photo title-less even when a caption is present", () => {
+  const item = toFeedItem(
+    "photos",
+    entry("photos", { caption: "Sunset over the bay", publishDate: "2026-01-02" }),
+    SITE,
+    "Sunset over the bay",
+  );
+  assert.equal(item.title, undefined);
+});
+
+test("toFeedItem uses the bookmark's title when present, otherwise leaves it title-less", () => {
+  const titled = toFeedItem(
+    "bookmarks",
+    entry("bookmarks", { title: "Great post", bookmarkOf: "https://indieweb.org/post", publishDate: "2026-01-02" }),
+    SITE,
+    "",
+  );
+  assert.equal(titled.title, "Great post");
+
+  const untitled = toFeedItem(
+    "bookmarks",
+    entry("bookmarks", { bookmarkOf: "https://indieweb.org/post", publishDate: "2026-01-02" }),
+    SITE,
+    "",
+  );
+  assert.equal(untitled.title, undefined);
 });
 
 test("toFeedItem throws on a missing or invalid date field", () => {
   assert.throws(
-    () => toFeedItem("notes", entry("notes", {}), SITE),
+    () => toFeedItem("notes", entry("notes", {}), SITE, ""),
     /missing or invalid publishDate/,
   );
   assert.throws(
-    () => toFeedItem("notes", entry("notes", { publishDate: "not-a-date" }), SITE),
+    () => toFeedItem("notes", entry("notes", { publishDate: "not-a-date" }), SITE, ""),
     /missing or invalid publishDate/,
   );
 });
@@ -73,12 +120,22 @@ test("sortAndLimit sorts newest first and caps", () => {
   assert.deepEqual(out.map((i) => i.title), ["2026-03-01", "2026-02-01"]);
 });
 
+const FULL_HTML = "<p>Paragraph one.</p>\n<p>Paragraph two.</p>";
+
 test("renderRss produces RSS XML with the item and escapes specials", async () => {
   const res = await renderRss({
     title: "All",
     description: "Everything",
     site: SITE,
-    items: [{ title: "A & B", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+    items: [
+      {
+        title: "A & B",
+        link: `${SITE}/blog/a/`,
+        date: new Date("2026-01-02"),
+        summary: "hi",
+        contentHtml: "",
+      },
+    ],
   });
   const xml = await res.text();
   assert.match(xml, /<rss/);
@@ -86,14 +143,68 @@ test("renderRss produces RSS XML with the item and escapes specials", async () =
   assert.match(xml, /example\.com\/blog\/a\//);
 });
 
+test("renderRss omits <title> for a title-less item and falls back to the summary for description", async () => {
+  const res = await renderRss({
+    title: "All",
+    description: "Everything",
+    site: SITE,
+    items: [{ link: `${SITE}/notes/a/`, date: new Date("2026-01-02"), summary: "hi", contentHtml: "" }],
+  });
+  const xml = await res.text();
+  assert.doesNotMatch(xml, /<title>hi<\/title>/);
+  assert.match(xml, /<description>hi<\/description>/);
+});
+
+test("renderRss uses the full HTML content as the description when present", async () => {
+  const res = await renderRss({
+    title: "All",
+    description: "Everything",
+    site: SITE,
+    items: [
+      { link: `${SITE}/notes/a/`, date: new Date("2026-01-02"), summary: "short", contentHtml: FULL_HTML },
+    ],
+  });
+  const xml = await res.text();
+  assert.match(xml, /Paragraph one\./);
+  assert.match(xml, /Paragraph two\./);
+  assert.doesNotMatch(xml, /<description>short<\/description>/);
+});
+
 test("renderAtom produces a feed with entry and self link", () => {
   const res = renderAtom({
     title: "All",
     site: SITE,
     feedUrl: `${SITE}/atom.xml`,
-    items: [{ title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+    items: [
+      { title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi", contentHtml: "" },
+    ],
   });
   assert.equal(res.headers.get("content-type"), "application/atom+xml; charset=utf-8");
+});
+
+test("renderAtom emits an empty <title> element for a title-less item", async () => {
+  const res = renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [{ link: `${SITE}/notes/a/`, date: new Date("2026-01-02"), summary: "hi", contentHtml: "" }],
+  });
+  const xml = await res.text();
+  assert.match(xml, /<title><\/title>/);
+});
+
+test("renderAtom emits the full HTML content as an escaped <content type=\"html\"> element", async () => {
+  const res = renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [
+      { title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi", contentHtml: FULL_HTML },
+    ],
+  });
+  const xml = await res.text();
+  assert.match(xml, /<content type="html">.*Paragraph one\..*Paragraph two\..*<\/content>/s);
+  assert.match(xml, /&lt;p&gt;Paragraph one\.&lt;\/p&gt;/);
 });
 
 test("renderJsonFeed produces valid JSON Feed 1.1", async () => {
@@ -101,12 +212,27 @@ test("renderJsonFeed produces valid JSON Feed 1.1", async () => {
     title: "All",
     site: SITE,
     feedUrl: `${SITE}/feed.json`,
-    items: [{ title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi" }],
+    items: [
+      { title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "hi", contentHtml: FULL_HTML },
+    ],
   });
   const feed = JSON.parse(await res.text());
   assert.equal(feed.version, "https://jsonfeed.org/version/1.1");
   assert.equal(feed.feed_url, `${SITE}/feed.json`);
   assert.equal(feed.items[0].url, `${SITE}/blog/a/`);
+  assert.equal(feed.items[0].content_html, FULL_HTML);
+});
+
+test("renderJsonFeed omits the title key for a title-less item and falls back to summary for content_html", async () => {
+  const res = renderJsonFeed({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/feed.json`,
+    items: [{ link: `${SITE}/notes/a/`, date: new Date("2026-01-02"), summary: "hi", contentHtml: "" }],
+  });
+  const feed = JSON.parse(await res.text());
+  assert.equal("title" in feed.items[0], false);
+  assert.equal(feed.items[0].content_html, "hi");
 });
 
 // --- WebSub discovery (V-3.3, #361) ---------------------------------------------------------

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -377,6 +377,118 @@ test("renderRss falls back to the permalink for <description> when contentHtml a
   assert.match(xml, new RegExp(`<description>${SITE.replace(/\./g, "\\.")}/likes/hello-like/</description>`));
 });
 
+// --- Plain text promoted into HTML-consuming fields must be HTML-escaped (Epic #1027 follow-up,
+// contrast interactionContentFallback above which already escapes on the same text→HTML
+// promotion) -----------------------------------------------------------------------------------
+
+// What feed-data.ts's `renderContentHtml` now produces for a caption-only photo: the caption
+// HTML-escaped and wrapped in a paragraph, so a caption like "Berries & cream <b>not bold</b>"
+// can never be misread by a reader as real markup.
+const CAPTION = "Berries & cream <b>not bold</b>";
+const CAPTION_CONTENT_HTML = "<p>Berries &amp; cream &lt;b&gt;not bold&lt;/b&gt;</p>";
+
+test("toFeedItem carries an escaped caption-derived contentHtml through unchanged", () => {
+  const item = toFeedItem(
+    "photos",
+    entry("photos", { caption: CAPTION, publishDate: "2026-01-02" }),
+    SITE,
+    CAPTION_CONTENT_HTML,
+  );
+  assert.equal(item.contentHtml, CAPTION_CONTENT_HTML);
+});
+
+test("renderRss emits the escaped caption HTML intact in <description>", async () => {
+  const item = toFeedItem(
+    "photos",
+    entry("photos", { caption: CAPTION, publishDate: "2026-01-02" }),
+    SITE,
+    CAPTION_CONTENT_HTML,
+  );
+  const xml = await (
+    await renderRss({ title: "Photos", description: "Photos", site: SITE, items: [item] })
+  ).text();
+  // @astrojs/rss XML-escapes the whole description text node once more on top of our escaped
+  // HTML, so a reader's single XML-unescape recovers CAPTION_CONTENT_HTML exactly.
+  assert.match(
+    xml,
+    /<description>&lt;p&gt;Berries &amp;amp; cream &amp;lt;b&amp;gt;not bold&amp;lt;\/b&amp;gt;&lt;\/p&gt;<\/description>/,
+  );
+  assert.doesNotMatch(xml, /<b>not bold<\/b>/);
+});
+
+test("renderAtom emits the escaped caption HTML intact in <content type=\"html\">", async () => {
+  const item = toFeedItem(
+    "photos",
+    entry("photos", { caption: CAPTION, publishDate: "2026-01-02" }),
+    SITE,
+    CAPTION_CONTENT_HTML,
+  );
+  const xml = await renderAtom({
+    title: "Photos",
+    site: SITE,
+    feedUrl: `${SITE}/photos/atom.xml`,
+    items: [item],
+  }).text();
+  assert.match(
+    xml,
+    /<content type="html">&lt;p&gt;Berries &amp;amp; cream &amp;lt;b&amp;gt;not bold&amp;lt;\/b&amp;gt;&lt;\/p&gt;<\/content>/,
+  );
+  assert.doesNotMatch(xml, /<b>not bold<\/b>/);
+});
+
+test("renderJsonFeed emits the escaped caption HTML intact in content_html", async () => {
+  const item = toFeedItem(
+    "photos",
+    entry("photos", { caption: CAPTION, publishDate: "2026-01-02" }),
+    SITE,
+    CAPTION_CONTENT_HTML,
+  );
+  const res = await renderJsonFeed({
+    title: "Photos",
+    site: SITE,
+    feedUrl: `${SITE}/photos/feed.json`,
+    items: [item],
+  });
+  const feed = JSON.parse(await res.text());
+  assert.equal(feed.items[0].content_html, CAPTION_CONTENT_HTML);
+});
+
+test("renderJsonFeed HTML-escapes a plain-text summary used as the content_html fallback", async () => {
+  const res = await renderJsonFeed({
+    title: "Notes",
+    site: SITE,
+    feedUrl: `${SITE}/notes/feed.json`,
+    items: [
+      {
+        link: `${SITE}/notes/a/`,
+        date: new Date("2026-01-02"),
+        summary: "5 < 10 & true",
+        contentHtml: "",
+      },
+    ],
+  });
+  const feed = JSON.parse(await res.text());
+  assert.equal(feed.items[0].content_html, "5 &lt; 10 &amp; true");
+});
+
+test("renderRss HTML-escapes a plain-text summary used as the <description> fallback", async () => {
+  const res = await renderRss({
+    title: "Notes",
+    description: "Notes",
+    site: SITE,
+    items: [
+      {
+        link: `${SITE}/notes/a/`,
+        date: new Date("2026-01-02"),
+        summary: "5 < 10 & true",
+        contentHtml: "",
+      },
+    ],
+  });
+  const xml = await res.text();
+  assert.match(xml, /<description>5 &amp;lt; 10 &amp;amp; true<\/description>/);
+});
+
 // --- Tags/categories and author metadata (#1023) ---------------------------------------------
 
 test("renderRss emits a <category> element per tag and none when the item has no tags", async () => {

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -109,6 +109,29 @@ test("toFeedItem gives an empty-body, title-less entry an empty summary rather t
   assert.equal(like.title, undefined);
 });
 
+test("toFeedItem carries entry.data.tags through to FeedItem.tags", () => {
+  const item = toFeedItem(
+    "articles",
+    entry("articles", { title: "Hi", publishDate: "2026-01-02", tags: ["astro", "feeds"] }),
+    SITE,
+    "<p>Hi</p>",
+  );
+  assert.deepEqual(item.tags, ["astro", "feeds"]);
+});
+
+test("toFeedItem leaves tags undefined when the entry has none or an empty array", () => {
+  const noTags = toFeedItem("blog", entry("blog", { title: "Hi", pubDate: "2026-01-02" }), SITE, "");
+  assert.equal(noTags.tags, undefined);
+
+  const emptyTags = toFeedItem(
+    "articles",
+    entry("articles", { title: "Hi", publishDate: "2026-01-02", tags: [] }),
+    SITE,
+    "",
+  );
+  assert.equal(emptyTags.tags, undefined);
+});
+
 test("toFeedItem throws on a missing or invalid date field", () => {
   assert.throws(
     () => toFeedItem("notes", entry("notes", {}), SITE, ""),
@@ -352,6 +375,147 @@ test("renderRss falls back to the permalink for <description> when contentHtml a
   });
   const xml = await res.text();
   assert.match(xml, new RegExp(`<description>${SITE.replace(/\./g, "\\.")}/likes/hello-like/</description>`));
+});
+
+// --- Tags/categories and author metadata (#1023) ---------------------------------------------
+
+test("renderRss emits a <category> element per tag and none when the item has no tags", async () => {
+  const withTags = await (
+    await renderRss({
+      title: "All",
+      description: "Everything",
+      site: SITE,
+      items: [
+        { title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "", contentHtml: "", tags: ["astro", "micro.blog"] },
+      ],
+    })
+  ).text();
+  assert.match(withTags, /<category>astro<\/category>/);
+  assert.match(withTags, /<category>micro\.blog<\/category>/);
+
+  const withoutTags = await (
+    await renderRss({
+      title: "All",
+      description: "Everything",
+      site: SITE,
+      items: [{ title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "", contentHtml: "" }],
+    })
+  ).text();
+  assert.doesNotMatch(withoutTags, /<category>/);
+});
+
+test("renderRss emits channel <dc:creator> with the dc xmlns declared when an author is given, and neither when not", async () => {
+  const withAuthor = await (
+    await renderRss({
+      title: "All",
+      description: "Everything",
+      site: SITE,
+      items: [],
+      author: { name: "Ada Lovelace" },
+    })
+  ).text();
+  assert.match(withAuthor, /xmlns:dc="http:\/\/purl\.org\/dc\/elements\/1\.1\/"/);
+  assert.match(withAuthor, /<dc:creator>Ada Lovelace<\/dc:creator>/);
+
+  const withoutAuthor = await (
+    await renderRss({ title: "All", description: "Everything", site: SITE, items: [] })
+  ).text();
+  assert.doesNotMatch(withoutAuthor, /xmlns:dc/);
+  assert.doesNotMatch(withoutAuthor, /dc:creator/);
+});
+
+test("renderRss combines hub and author customData, declaring both atom and dc xmlns", async () => {
+  const hub = websubHub(SITE, "/rss.xml", true)!;
+  const xml = await (
+    await renderRss({
+      title: "All",
+      description: "Everything",
+      site: SITE,
+      items: [],
+      hub,
+      author: { name: "Ada Lovelace" },
+    })
+  ).text();
+  assert.match(xml, /xmlns:atom="http:\/\/www\.w3\.org\/2005\/Atom"/);
+  assert.match(xml, /xmlns:dc="http:\/\/purl\.org\/dc\/elements\/1\.1\/"/);
+  assert.match(xml, /<dc:creator>Ada Lovelace<\/dc:creator>/);
+  assert.match(xml, /rel="hub"/);
+});
+
+test("renderAtom emits a <category term> per tag and none when the item has no tags", async () => {
+  const withTags = await renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [
+      { title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "", contentHtml: "", tags: ["astro", "micro.blog"] },
+    ],
+  }).text();
+  assert.match(withTags, /<category term="astro"\/>/);
+  assert.match(withTags, /<category term="micro\.blog"\/>/);
+
+  const withoutTags = await renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [{ title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "", contentHtml: "" }],
+  }).text();
+  assert.doesNotMatch(withoutTags, /<category/);
+});
+
+test("renderAtom emits a top-level <author> with <uri> when given a url, and omits <author> when not", async () => {
+  const withUrl = await renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [],
+    author: { name: "Ada Lovelace", url: "https://example.com/" },
+  }).text();
+  assert.match(withUrl, /<author>\s*<name>Ada Lovelace<\/name>\s*<uri>https:\/\/example\.com\/<\/uri>\s*<\/author>/);
+
+  const withoutUrl = await renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [],
+    author: { name: "Ada Lovelace" },
+  }).text();
+  assert.match(withoutUrl, /<author>\s*<name>Ada Lovelace<\/name>\s*<\/author>/);
+  assert.doesNotMatch(withoutUrl, /<uri>/);
+
+  const noAuthor = await renderAtom({ title: "All", site: SITE, feedUrl: `${SITE}/atom.xml`, items: [] }).text();
+  assert.doesNotMatch(noAuthor, /<author>/);
+});
+
+test("renderJsonFeed includes a tags array per item and omits the key when the item has none", async () => {
+  const res = await renderJsonFeed({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/feed.json`,
+    items: [
+      { title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "", contentHtml: "", tags: ["astro", "micro.blog"] },
+      { title: "B", link: `${SITE}/blog/b/`, date: new Date("2026-01-02"), summary: "", contentHtml: "" },
+    ],
+  });
+  const feed = JSON.parse(await res.text());
+  assert.deepEqual(feed.items[0].tags, ["astro", "micro.blog"]);
+  assert.equal("tags" in feed.items[1], false);
+});
+
+test("renderJsonFeed includes a top-level authors array when given an author, and omits it when not", async () => {
+  const withAuthor = await renderJsonFeed({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/feed.json`,
+    items: [],
+    author: { name: "Ada Lovelace", url: "https://example.com/" },
+  });
+  assert.deepEqual(JSON.parse(await withAuthor.text()).authors, [
+    { name: "Ada Lovelace", url: "https://example.com/" },
+  ]);
+
+  const withoutAuthor = await renderJsonFeed({ title: "All", site: SITE, feedUrl: `${SITE}/feed.json`, items: [] });
+  assert.equal("authors" in JSON.parse(await withoutAuthor.text()), false);
 });
 
 // --- WebSub discovery (V-3.3, #361) ---------------------------------------------------------

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -374,7 +374,7 @@ test("renderRss falls back to the permalink for <description> when contentHtml a
     ],
   });
   const xml = await res.text();
-  assert.match(xml, new RegExp(`<description>${SITE.replace(/\./g, "\\.")}/likes/hello-like/</description>`));
+  assert.ok(xml.includes(`<description>${SITE}/likes/hello-like/</description>`));
 });
 
 // --- Plain text promoted into HTML-consuming fields must be HTML-escaped (Epic #1027 follow-up,

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -275,6 +275,85 @@ test("renderRss, renderAtom, and renderJsonFeed never emit 'Untitled' for an emp
   assert.doesNotMatch(jsonFeed, /Untitled/);
 });
 
+// --- Target-URL content fallback for empty-body interaction posts (#1022 follow-up) ---------
+
+test("toFeedItem falls back to an escaped anchor to likeOf when the like has no body", () => {
+  const like = toFeedItem(
+    "likes",
+    entry("likes", { likeOf: "https://indieweb.org/post?a=1&b=2", publishDate: "2026-01-02" }, ""),
+    SITE,
+    "",
+  );
+  assert.equal(
+    like.contentHtml,
+    `<a href="https://indieweb.org/post?a=1&amp;b=2">https://indieweb.org/post?a=1&amp;b=2</a>`,
+  );
+});
+
+test("toFeedItem falls back to an escaped anchor to inReplyTo when the reply has no body", () => {
+  const reply = toFeedItem(
+    "replies",
+    entry("replies", { inReplyTo: "https://indieweb.org/post", publishDate: "2026-01-02" }, ""),
+    SITE,
+    "",
+  );
+  assert.equal(
+    reply.contentHtml,
+    `<a href="https://indieweb.org/post">https://indieweb.org/post</a>`,
+  );
+});
+
+test("toFeedItem falls back to an escaped anchor to bookmarkOf when the bookmark has no body", () => {
+  const bookmark = toFeedItem(
+    "bookmarks",
+    entry("bookmarks", { bookmarkOf: "https://indieweb.org/post", publishDate: "2026-01-02" }, ""),
+    SITE,
+    "",
+  );
+  assert.equal(
+    bookmark.contentHtml,
+    `<a href="https://indieweb.org/post">https://indieweb.org/post</a>`,
+  );
+});
+
+test("toFeedItem does not synthesize a target-URL fallback for collections without one", () => {
+  const note = toFeedItem(
+    "notes",
+    entry("notes", { publishDate: "2026-01-02" }, ""),
+    SITE,
+    "",
+  );
+  assert.equal(note.contentHtml, "");
+});
+
+test("toFeedItem leaves non-empty contentHtml untouched (no fallback applied)", () => {
+  const like = toFeedItem(
+    "likes",
+    entry("likes", { likeOf: "https://indieweb.org/post", publishDate: "2026-01-02" }, "some body"),
+    SITE,
+    "<p>rendered body</p>",
+  );
+  assert.equal(like.contentHtml, "<p>rendered body</p>");
+});
+
+test("renderRss falls back to the permalink for <description> when contentHtml and summary are both empty", async () => {
+  const res = await renderRss({
+    title: "Likes",
+    description: "Likes",
+    site: SITE,
+    items: [
+      {
+        link: `${SITE}/likes/hello-like/`,
+        date: new Date("2026-01-02"),
+        summary: "",
+        contentHtml: "",
+      },
+    ],
+  });
+  const xml = await res.text();
+  assert.match(xml, new RegExp(`<description>${SITE.replace(/\./g, "\\.")}/likes/hello-like/</description>`));
+});
+
 // --- WebSub discovery (V-3.3, #361) ---------------------------------------------------------
 
 test("websubHub returns hub + self URLs when enabled, undefined when not", () => {

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -98,6 +98,17 @@ test("toFeedItem uses the bookmark's title when present, otherwise leaves it tit
   assert.equal(untitled.title, undefined);
 });
 
+test("toFeedItem gives an empty-body, title-less entry an empty summary rather than a synthesized 'Untitled'", () => {
+  const like = toFeedItem(
+    "likes",
+    entry("likes", { likeOf: "https://indieweb.org/post", publishDate: "2026-01-02" }, ""),
+    SITE,
+    "",
+  );
+  assert.equal(like.summary, "");
+  assert.equal(like.title, undefined);
+});
+
 test("toFeedItem throws on a missing or invalid date field", () => {
   assert.throws(
     () => toFeedItem("notes", entry("notes", {}), SITE, ""),
@@ -233,6 +244,35 @@ test("renderJsonFeed omits the title key for a title-less item and falls back to
   const feed = JSON.parse(await res.text());
   assert.equal("title" in feed.items[0], false);
   assert.equal(feed.items[0].content_html, "hi");
+});
+
+// --- Empty-body entries never synthesize "Untitled" text (#1021/#1022 follow-up) -----------
+
+test("renderRss, renderAtom, and renderJsonFeed never emit 'Untitled' for an empty-body, title-less item", async () => {
+  const like = toFeedItem(
+    "likes",
+    entry("likes", { likeOf: "https://indieweb.org/post", publishDate: "2026-01-02" }, ""),
+    SITE,
+    "",
+  );
+
+  const rssXml = await (
+    await renderRss({ title: "Likes", description: "Likes", site: SITE, items: [like] })
+  ).text();
+  assert.doesNotMatch(rssXml, /Untitled/);
+
+  const atomXml = await renderAtom({
+    title: "Likes",
+    site: SITE,
+    feedUrl: `${SITE}/likes/atom.xml`,
+    items: [like],
+  }).text();
+  assert.doesNotMatch(atomXml, /Untitled/);
+
+  const jsonFeed = await (
+    await renderJsonFeed({ title: "Likes", site: SITE, feedUrl: `${SITE}/likes/feed.json`, items: [like] })
+  ).text();
+  assert.doesNotMatch(jsonFeed, /Untitled/);
 });
 
 // --- WebSub discovery (V-3.3, #361) ---------------------------------------------------------

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -33,7 +33,9 @@ export interface FeedCollectionConfig {
   deriveTitle(entry: FeedEntry): string | undefined;
 }
 
-function excerpt(body: string | undefined, max = 80): string {
+/** Exported for reuse by `/tags/[tag]/` (`tags.ts`), which needs the same title-less-entry
+ * fallback text as the feeds do. */
+export function excerpt(body: string | undefined, max = 80): string {
   const text = (body ?? "").replace(/\s+/g, " ").trim();
   if (text.length <= max) return text;
   return text.slice(0, max).trimEnd() + "…";

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -83,10 +83,33 @@ export function websubHub(
 }
 
 /**
+ * Fallback `contentHtml` for interaction posts (likes/replies/bookmarks) whose body rendered to
+ * nothing — a like/reply/bookmark with no commentary still has faithful content to syndicate:
+ * the target URL it points at. This is deliberately *not* prose ("Liked", "Re:", …) — a
+ * synthesized caption is exactly what #1021/#1022 removed; the target URL is the one piece of
+ * real content every interaction post has. Photos keep their existing caption fallback
+ * (`feed-data.ts`'s `renderContentHtml`) and are untouched here.
+ */
+function interactionContentFallback(collection: string, data: Record<string, any>): string {
+  const targetUrl =
+    collection === "likes"
+      ? data.likeOf
+      : collection === "replies"
+        ? data.inReplyTo
+        : collection === "bookmarks"
+          ? data.bookmarkOf
+          : undefined;
+  if (!targetUrl) return "";
+  const escaped = escapeXml(String(targetUrl));
+  return `<a href="${escaped}">${escaped}</a>`;
+}
+
+/**
  * Build a `FeedItem` from a content entry. `contentHtml` is the entry body already rendered to
  * HTML — rendering is async (`createMarkdownProcessor`) and lives in `feed-data.ts`, so it's
  * computed by the caller and passed in rather than made here, keeping this function synchronous
- * and easy to unit test.
+ * and easy to unit test. When the rendered body is empty, likes/replies/bookmarks fall back to
+ * a link to their target URL (`interactionContentFallback`) rather than shipping empty content.
  */
 export function toFeedItem(
   collection: string,
@@ -109,7 +132,7 @@ export function toFeedItem(
     link: new URL(`/${collection}/${entry.id}/`, site).href,
     date,
     summary: String(summary),
-    contentHtml,
+    contentHtml: contentHtml || interactionContentFallback(collection, entry.data),
   };
 }
 
@@ -144,9 +167,14 @@ export function renderRss(o: {
       title: i.title,
       link: i.link,
       pubDate: i.date,
-      // RSS 2.0 requires title *or* description on every item; description is always present,
-      // carrying the full HTML body when there is one and falling back to the short summary.
-      description: i.contentHtml || i.summary,
+      // Invariant: RSS 2.0 requires title *or* description on every item, so a title-less item
+      // must always have a non-empty description. `contentHtml` (full HTML body, or the
+      // interaction-post target-URL fallback from `toFeedItem`) carries it when present, then
+      // the short summary, then — for a pathological entry with no title, no content, and no
+      // summary — the permalink itself, which is never empty. `fast-xml-parser`'s `XMLBuilder`
+      // (used by `@astrojs/rss` under the hood) escapes text-node content automatically, so the
+      // raw `i.link` here doesn't need manual XML-escaping.
+      description: i.contentHtml || i.summary || i.link,
     })),
   });
 }

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -10,6 +10,14 @@ export interface FeedItem {
   summary: string;
   /** Full entry body rendered to HTML at build time (see `feed-data.ts`). */
   contentHtml: string;
+  /** `entry.data.tags`, when the collection's schema has the field and the entry set it. */
+  tags?: string[];
+}
+
+/** Feed-level (RSS channel / Atom feed / JSON Feed) attribution, sourced from `siteProfile()`. */
+export interface FeedAuthor {
+  name: string;
+  url?: string;
 }
 
 export type FeedEntry = {
@@ -127,12 +135,14 @@ export function toFeedItem(
     throw new Error(`[feeds] entry "${entry.id}" has a missing or invalid ${cfg.dateField}`);
   }
   const summary = (entry.data.summary ?? entry.data.caption ?? excerpt(entry.body, 280)) || "";
+  const tags = Array.isArray(entry.data.tags) && entry.data.tags.length > 0 ? entry.data.tags : undefined;
   return {
     title: cfg.deriveTitle(entry) || undefined,
     link: new URL(`/${collection}/${entry.id}/`, site).href,
     date,
     summary: String(summary),
     contentHtml: contentHtml || interactionContentFallback(collection, entry.data),
+    tags,
   };
 }
 
@@ -147,6 +157,8 @@ export function renderRss(o: {
   site: string;
   items: FeedItem[];
   hub?: WebSubHubAdvertisement;
+  /** Channel-level attribution, rendered as `<dc:creator>` (RSS 2.0 has no native author element). */
+  author?: FeedAuthor;
 }): Promise<Response> {
   // RSS 2.0 has no native link relations; WebSub discovery in RSS uses Atom link elements
   // inside <channel> (the convention websub.rocks and every major reader check).
@@ -154,13 +166,17 @@ export function renderRss(o: {
     ? `<atom:link rel="hub" href="${escapeXml(o.hub.hubUrl)}"/>` +
       `<atom:link rel="self" type="application/rss+xml" href="${escapeXml(o.hub.selfUrl)}"/>`
     : undefined;
+  const authorData = o.author ? `<dc:creator>${escapeXml(o.author.name)}</dc:creator>` : undefined;
+  const customData = [hubData, authorData].filter((s): s is string => Boolean(s)).join("") || undefined;
+  const xmlns: Record<string, string> = {};
+  if (o.hub) xmlns.atom = "http://www.w3.org/2005/Atom";
+  if (o.author) xmlns.dc = "http://purl.org/dc/elements/1.1/";
   return rss({
     title: o.title,
     description: o.description,
     site: o.site,
-    ...(hubData
-      ? { xmlns: { atom: "http://www.w3.org/2005/Atom" }, customData: hubData }
-      : {}),
+    ...(Object.keys(xmlns).length ? { xmlns } : {}),
+    ...(customData ? { customData } : {}),
     items: o.items.map((i) => ({
       // Zod's `title` field is optional and `@astrojs/rss` only emits <title> when truthy, so an
       // absent `i.title` correctly drops the element rather than rendering it empty.
@@ -175,6 +191,9 @@ export function renderRss(o: {
       // (used by `@astrojs/rss` under the hood) escapes text-node content automatically, so the
       // raw `i.link` here doesn't need manual XML-escaping.
       description: i.contentHtml || i.summary || i.link,
+      // `@astrojs/rss` maps a `categories` array to one <category> element per tag; `undefined`
+      // (no tags) is dropped, matching the title/description optionality above.
+      categories: i.tags,
     })),
   });
 }
@@ -195,32 +214,42 @@ export function renderAtom(o: {
   items: FeedItem[];
   /** WebSub hub URL; emits a `rel="hub"` link when set (`rel="self"` is always present). */
   hubUrl?: string;
+  /** Feed-level attribution, rendered as a top-level `<author>`. */
+  author?: FeedAuthor;
 }): Response {
   const updated = o.items[0]?.date ?? new Date(0);
   const entries = o.items
-    .map(
+    .map((i) => {
+      // One <category term="…"/> per tag; entries without tags emit none.
+      const categories = (i.tags ?? []).map((t) => `    <category term="${escapeXml(t)}"/>\n`).join("");
       // Known limitation: <id> uses the permalink rather than a permanent tag: IRI (RFC 4287
       // §4.2.6). Renaming a slug therefore reads as a new entry in readers that saw the old URL.
       // This matches most simple RSS libraries; a stable tag: URI is a future improvement.
       // Atom requires <title> on every entry (unlike RSS/JSON Feed); title-less items emit an
       // empty element rather than omitting the tag or faking a title.
-      (i) => `  <entry>
+      return `  <entry>
     <title>${escapeXml(i.title ?? "")}</title>
     <link href="${escapeXml(i.link)}"/>
     <id>${escapeXml(i.link)}</id>
     <updated>${i.date.toISOString()}</updated>
-    <summary>${escapeXml(i.summary)}</summary>
+${categories}    <summary>${escapeXml(i.summary)}</summary>
     <content type="html">${escapeXml(i.contentHtml)}</content>
-  </entry>`,
-    )
+  </entry>`;
+    })
     .join("\n");
+  const authorXml = o.author
+    ? `  <author>
+    <name>${escapeXml(o.author.name)}</name>
+${o.author.url ? `    <uri>${escapeXml(o.author.url)}</uri>\n` : ""}  </author>
+`
+    : "";
   const xml = `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>${escapeXml(o.title)}</title>
   <id>${escapeXml(o.site)}</id>
   <link href="${escapeXml(o.site)}"/>
   <link rel="self" href="${escapeXml(o.feedUrl)}"/>
-${o.hubUrl ? `  <link rel="hub" href="${escapeXml(o.hubUrl)}"/>\n` : ""}  <updated>${updated.toISOString()}</updated>
+${o.hubUrl ? `  <link rel="hub" href="${escapeXml(o.hubUrl)}"/>\n` : ""}${authorXml}  <updated>${updated.toISOString()}</updated>
 ${entries}
 </feed>
 `;
@@ -236,6 +265,8 @@ export function renderJsonFeed(o: {
   items: FeedItem[];
   /** WebSub hub URL; emits the JSON Feed `hubs` array when set. */
   hubUrl?: string;
+  /** Feed-level attribution, rendered as the top-level `authors` array. */
+  author?: FeedAuthor;
 }): Response {
   const feed = {
     version: "https://jsonfeed.org/version/1.1",
@@ -243,6 +274,7 @@ export function renderJsonFeed(o: {
     home_page_url: o.site,
     feed_url: o.feedUrl,
     ...(o.hubUrl ? { hubs: [{ type: "WebSub", url: o.hubUrl }] } : {}),
+    ...(o.author ? { authors: [{ name: o.author.name, url: o.author.url }] } : {}),
     items: o.items.map((i) => ({
       id: i.link,
       url: i.link,
@@ -254,6 +286,8 @@ export function renderJsonFeed(o: {
       // short summary when the body was empty.
       content_html: i.contentHtml || i.summary,
       date_published: i.date.toISOString(),
+      // Undefined (no tags) is dropped by JSON.stringify below.
+      tags: i.tags,
     })),
   };
   return new Response(JSON.stringify(feed, null, 2), {

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -27,7 +27,7 @@ export interface FeedCollectionConfig {
 
 function excerpt(body: string | undefined, max = 80): string {
   const text = (body ?? "").replace(/\s+/g, " ").trim();
-  if (text.length <= max) return text || "Untitled";
+  if (text.length <= max) return text;
   return text.slice(0, max).trimEnd() + "…";
 }
 

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -1,10 +1,15 @@
 import rss from "@astrojs/rss";
 
 export interface FeedItem {
-  title: string;
+  /** Absent for collections whose items have no natural title (notes, replies, likes, photos,
+   * and bookmarks without an explicit title) — a synthesized title (excerpt/"Re: host"/etc.) is
+   * not a real title, so we omit the field rather than fake one. */
+  title?: string;
   link: string; // absolute
   date: Date;
   summary: string;
+  /** Full entry body rendered to HTML at build time (see `feed-data.ts`). */
+  contentHtml: string;
 }
 
 export type FeedEntry = {
@@ -17,15 +22,7 @@ export type FeedEntry = {
 export interface FeedCollectionConfig {
   title: string;
   dateField: string;
-  deriveTitle(entry: FeedEntry): string;
-}
-
-function host(url: unknown): string {
-  try {
-    return new URL(String(url)).host;
-  } catch {
-    return String(url ?? "");
-  }
+  deriveTitle(entry: FeedEntry): string | undefined;
 }
 
 function excerpt(body: string | undefined, max = 80): string {
@@ -36,29 +33,13 @@ function excerpt(body: string | undefined, max = 80): string {
 
 export const FEED_COLLECTIONS: Record<string, FeedCollectionConfig> = {
   blog: { title: "Blog", dateField: "pubDate", deriveTitle: (e) => e.data.title },
-  notes: { title: "Notes", dateField: "publishDate", deriveTitle: (e) => excerpt(e.body) },
+  notes: { title: "Notes", dateField: "publishDate", deriveTitle: () => undefined },
   articles: { title: "Articles", dateField: "publishDate", deriveTitle: (e) => e.data.title },
-  photos: {
-    title: "Photos",
-    dateField: "publishDate",
-    deriveTitle: (e) => e.data.caption ?? "Photo",
-  },
+  photos: { title: "Photos", dateField: "publishDate", deriveTitle: () => undefined },
   albums: { title: "Albums", dateField: "publishDate", deriveTitle: (e) => e.data.title },
-  bookmarks: {
-    title: "Bookmarks",
-    dateField: "publishDate",
-    deriveTitle: (e) => e.data.title ?? host(e.data.bookmarkOf),
-  },
-  replies: {
-    title: "Replies",
-    dateField: "publishDate",
-    deriveTitle: (e) => "Re: " + host(e.data.inReplyTo),
-  },
-  likes: {
-    title: "Likes",
-    dateField: "publishDate",
-    deriveTitle: (e) => "Liked " + host(e.data.likeOf),
-  },
+  bookmarks: { title: "Bookmarks", dateField: "publishDate", deriveTitle: (e) => e.data.title },
+  replies: { title: "Replies", dateField: "publishDate", deriveTitle: () => undefined },
+  likes: { title: "Likes", dateField: "publishDate", deriveTitle: () => undefined },
 };
 
 /// Resolve the absolute site base URL from an Astro endpoint context, failing loudly when
@@ -101,7 +82,18 @@ export function websubHub(
   };
 }
 
-export function toFeedItem(collection: string, entry: FeedEntry, site: string): FeedItem {
+/**
+ * Build a `FeedItem` from a content entry. `contentHtml` is the entry body already rendered to
+ * HTML — rendering is async (`createMarkdownProcessor`) and lives in `feed-data.ts`, so it's
+ * computed by the caller and passed in rather than made here, keeping this function synchronous
+ * and easy to unit test.
+ */
+export function toFeedItem(
+  collection: string,
+  entry: FeedEntry,
+  site: string,
+  contentHtml: string,
+): FeedItem {
   const cfg = FEED_COLLECTIONS[collection];
   if (!cfg) throw new Error(`No feed config for collection "${collection}"`);
   const rawDate = entry.data[cfg.dateField];
@@ -113,10 +105,11 @@ export function toFeedItem(collection: string, entry: FeedEntry, site: string): 
   }
   const summary = (entry.data.summary ?? entry.data.caption ?? excerpt(entry.body, 280)) || "";
   return {
-    title: cfg.deriveTitle(entry) || "Untitled",
+    title: cfg.deriveTitle(entry) || undefined,
     link: new URL(`/${collection}/${entry.id}/`, site).href,
     date,
     summary: String(summary),
+    contentHtml,
   };
 }
 
@@ -146,10 +139,14 @@ export function renderRss(o: {
       ? { xmlns: { atom: "http://www.w3.org/2005/Atom" }, customData: hubData }
       : {}),
     items: o.items.map((i) => ({
+      // Zod's `title` field is optional and `@astrojs/rss` only emits <title> when truthy, so an
+      // absent `i.title` correctly drops the element rather than rendering it empty.
       title: i.title,
       link: i.link,
       pubDate: i.date,
-      description: i.summary,
+      // RSS 2.0 requires title *or* description on every item; description is always present,
+      // carrying the full HTML body when there is one and falling back to the short summary.
+      description: i.contentHtml || i.summary,
     })),
   });
 }
@@ -177,12 +174,15 @@ export function renderAtom(o: {
       // Known limitation: <id> uses the permalink rather than a permanent tag: IRI (RFC 4287
       // §4.2.6). Renaming a slug therefore reads as a new entry in readers that saw the old URL.
       // This matches most simple RSS libraries; a stable tag: URI is a future improvement.
+      // Atom requires <title> on every entry (unlike RSS/JSON Feed); title-less items emit an
+      // empty element rather than omitting the tag or faking a title.
       (i) => `  <entry>
-    <title>${escapeXml(i.title)}</title>
+    <title>${escapeXml(i.title ?? "")}</title>
     <link href="${escapeXml(i.link)}"/>
     <id>${escapeXml(i.link)}</id>
     <updated>${i.date.toISOString()}</updated>
     <summary>${escapeXml(i.summary)}</summary>
+    <content type="html">${escapeXml(i.contentHtml)}</content>
   </entry>`,
     )
     .join("\n");
@@ -218,8 +218,13 @@ export function renderJsonFeed(o: {
     items: o.items.map((i) => ({
       id: i.link,
       url: i.link,
+      // Undefined `title` is dropped by JSON.stringify below, matching JSON Feed's "title is
+      // optional" contract for items with no natural title.
       title: i.title,
       summary: i.summary,
+      // JSON Feed 1.1 requires content_html or content_text on every item; fall back to the
+      // short summary when the body was empty.
+      content_html: i.contentHtml || i.summary,
       date_published: i.date.toISOString(),
     })),
   };

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -191,8 +191,14 @@ export function renderRss(o: {
       // the short summary, then — for a pathological entry with no title, no content, and no
       // summary — the permalink itself, which is never empty. `fast-xml-parser`'s `XMLBuilder`
       // (used by `@astrojs/rss` under the hood) escapes text-node content automatically, so the
-      // raw `i.link` here doesn't need manual XML-escaping.
-      description: i.contentHtml || i.summary || i.link,
+      // raw `i.link` here doesn't need manual XML-escaping, and neither does `i.contentHtml`
+      // (already real HTML that needs exactly the one automatic escape pass to travel safely as
+      // XML text). `i.summary`, though, is plain text that readers still interpret as HTML once
+      // they XML-decode `<description>` — so when it's promoted to stand in for contentHtml it
+      // needs an *additional* HTML-escape pass first (`escapeXml` here) so that a literal "&" or
+      // "<" the author typed renders as that literal character rather than markup; the automatic
+      // XML-escape pass astro-rss applies on top only protects the transport encoding, not this.
+      description: i.contentHtml || escapeXml(i.summary) || i.link,
       // `@astrojs/rss` maps a `categories` array to one <category> element per tag; `undefined`
       // (no tags) is dropped, matching the title/description optionality above.
       categories: i.tags,
@@ -285,8 +291,12 @@ export function renderJsonFeed(o: {
       title: i.title,
       summary: i.summary,
       // JSON Feed 1.1 requires content_html or content_text on every item; fall back to the
-      // short summary when the body was empty.
-      content_html: i.contentHtml || i.summary,
+      // short summary when the body was empty. `i.summary` is plain text, but `content_html` is
+      // parsed as HTML by every consumer, so it needs HTML-escaping when it stands in for
+      // `contentHtml` (already real HTML, left untouched) — otherwise a literal "&"/"<" in the
+      // summary would be misread as an entity/tag instead of the literal character the author
+      // wrote.
+      content_html: i.contentHtml || escapeXml(i.summary),
       date_published: i.date.toISOString(),
       // Undefined (no tags) is dropped by JSON.stringify below.
       tags: i.tags,

--- a/Resources/Template/src/lib/tags-astro.ts
+++ b/Resources/Template/src/lib/tags-astro.ts
@@ -1,0 +1,47 @@
+import { getCollection } from "astro:content";
+import { TAGGED_COLLECTIONS } from "./collections.ts";
+import type { TaggedEntry } from "./tags.ts";
+
+/**
+ * Fetches every entry across `TAGGED_COLLECTIONS` that carries at least one tag, flattened into
+ * the plain-object shape `tags.ts`'s pure helpers (`groupByTag`, `tagCounts`, …) operate on.
+ * Lives in its own `astro:content`-importing file — separate from `tags.ts` — so that file can
+ * stay importable (and unit-testable with plain `node:test`) outside Astro's Vite pipeline,
+ * same rationale as `content-schemas.ts`. Shared by both `tags/index.astro` and
+ * `tags/[tag]/index.astro` so the two pages can't drift on which fields matter or how drafts
+ * are filtered.
+ *
+ * Drafts are excluded in PROD, matching `blog/index.astro` and `[collection]/[...slug].astro`'s
+ * convention — a draft's tags shouldn't surface (or inflate counts) on a page whose own entry
+ * page isn't built.
+ */
+export async function collectTaggedEntries(): Promise<TaggedEntry[]> {
+  const entries: TaggedEntry[] = [];
+  for (const collection of TAGGED_COLLECTIONS) {
+    const items = await getCollection(collection, ({ data }) =>
+      import.meta.env.PROD ? !(data as { draft?: boolean }).draft : true,
+    );
+    for (const item of items) {
+      const data = item.data as {
+        tags?: string[];
+        title?: string;
+        summary?: string;
+        caption?: string;
+        publishDate: Date;
+      };
+      const tags = Array.isArray(data.tags) ? data.tags : [];
+      if (tags.length === 0) continue;
+      entries.push({
+        id: item.id,
+        collection,
+        tags,
+        title: data.title,
+        summary: data.summary,
+        caption: data.caption,
+        body: item.body,
+        publishDate: data.publishDate,
+      });
+    }
+  }
+  return entries;
+}

--- a/Resources/Template/src/lib/tags.test.ts
+++ b/Resources/Template/src/lib/tags.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { groupByTag, labelFor, permalinkFor, sortedTagNames, tagCounts, type TaggedEntry } from "./tags.ts";
+
+function entry(overrides: Partial<TaggedEntry> & Pick<TaggedEntry, "id" | "collection">): TaggedEntry {
+  return {
+    tags: [],
+    publishDate: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+test("permalinkFor: builds the /<collection>/<id>/ shape used by [collection]/[...slug].astro", () => {
+  assert.equal(permalinkFor("notes", "hello-note"), "/notes/hello-note/");
+  assert.equal(permalinkFor("bookmarks", "some-link"), "/bookmarks/some-link/");
+});
+
+test("labelFor: a titled entry uses its title", () => {
+  const e = entry({ id: "post-1", collection: "articles", title: "Hello World" });
+  assert.equal(labelFor(e), "Hello World");
+});
+
+test("labelFor: a title-less entry falls back to a body excerpt", () => {
+  const e = entry({ id: "note-1", collection: "notes", body: "Just checking in from the road." });
+  assert.equal(labelFor(e), "Just checking in from the road.");
+});
+
+test("labelFor: a title-less entry prefers summary over an excerpt", () => {
+  const e = entry({ id: "article-1", collection: "articles", summary: "A short summary.", body: "Full body text." });
+  assert.equal(labelFor(e), "A short summary.");
+});
+
+test("labelFor: a title-less, summary-less entry prefers caption over an excerpt (photos)", () => {
+  const e = entry({ id: "photo-1", collection: "photos", caption: "An example photo.", body: "" });
+  assert.equal(labelFor(e), "An example photo.");
+});
+
+test("labelFor: a title-less entry with no body, summary, or caption falls back to its id", () => {
+  const e = entry({ id: "note-2", collection: "notes" });
+  assert.equal(labelFor(e), "note-2");
+});
+
+test("groupByTag: groups entries under each tag they carry, including multi-tag entries", () => {
+  const a = entry({ id: "a", collection: "notes", tags: ["hello", "indieweb"] });
+  const b = entry({ id: "b", collection: "photos", tags: ["hello"] });
+  const byTag = groupByTag([a, b]);
+  assert.deepEqual([...byTag.keys()].sort(), ["hello", "indieweb"]);
+  assert.equal(byTag.get("hello")?.length, 2);
+  assert.equal(byTag.get("indieweb")?.length, 1);
+});
+
+test("groupByTag: a tag with a space is preserved as its own key (no silent splitting)", () => {
+  const a = entry({ id: "a", collection: "notes", tags: ["hello world"] });
+  const byTag = groupByTag([a]);
+  assert.ok(byTag.has("hello world"));
+  assert.equal(byTag.size, 1);
+});
+
+test("groupByTag: sorts each tag's entries newest-first", () => {
+  const older = entry({ id: "older", collection: "notes", tags: ["hello"], publishDate: new Date("2026-01-01") });
+  const newer = entry({ id: "newer", collection: "notes", tags: ["hello"], publishDate: new Date("2026-02-01") });
+  const byTag = groupByTag([older, newer]);
+  assert.deepEqual(byTag.get("hello")?.map((e) => e.id), ["newer", "older"]);
+});
+
+test("sortedTagNames: alphabetical, independent of insertion order", () => {
+  const byTag = groupByTag([
+    entry({ id: "a", collection: "notes", tags: ["zebra"] }),
+    entry({ id: "b", collection: "notes", tags: ["apple"] }),
+  ]);
+  assert.deepEqual(sortedTagNames(byTag), ["apple", "zebra"]);
+});
+
+test("tagCounts: one entry per tag, alphabetical, with the right count", () => {
+  const byTag = groupByTag([
+    entry({ id: "a", collection: "notes", tags: ["hello", "indieweb"] }),
+    entry({ id: "b", collection: "photos", tags: ["hello"] }),
+  ]);
+  assert.deepEqual(tagCounts(byTag), [
+    { tag: "hello", count: 2 },
+    { tag: "indieweb", count: 1 },
+  ]);
+});

--- a/Resources/Template/src/lib/tags.test.ts
+++ b/Resources/Template/src/lib/tags.test.ts
@@ -1,6 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { groupByTag, labelFor, permalinkFor, sortedTagNames, tagCounts, type TaggedEntry } from "./tags.ts";
+import {
+  groupByTag,
+  groupBySlug,
+  labelFor,
+  permalinkFor,
+  sortedTagNames,
+  tagCounts,
+  tagGroupCounts,
+  tagSlug,
+  type TaggedEntry,
+} from "./tags.ts";
 
 function entry(overrides: Partial<TaggedEntry> & Pick<TaggedEntry, "id" | "collection">): TaggedEntry {
   return {
@@ -80,4 +90,84 @@ test("tagCounts: one entry per tag, alphabetical, with the right count", () => {
     { tag: "hello", count: 2 },
     { tag: "indieweb", count: 1 },
   ]);
+});
+
+// tagSlug: URL-safe route params. Free-text tags can contain characters that either crash
+// `astro build` (a literal "/" inside a getStaticPaths param) or 404 at request time (a "#"
+// percent-encodes to a href a standards-compliant static server can never match back to the
+// literal directory Astro wrote) — see Resources/Template/src/pages/tags/. tagSlug sidesteps
+// both by routing on a normalized [a-z0-9-]+ slug instead of the verbatim tag text.
+test("tagSlug: lowercases and hyphenates spaces", () => {
+  assert.equal(tagSlug("hello world"), "hello-world");
+});
+
+test("tagSlug: a tag containing a slash collapses to a single hyphen (would crash astro build as a param)", () => {
+  assert.equal(tagSlug("a/b"), "a-b");
+});
+
+test("tagSlug: a tag containing a hash collapses to a single hyphen (would 404 via percent-decoding mismatch)", () => {
+  assert.equal(tagSlug("c#d"), "c-d");
+});
+
+test("tagSlug: mixed case and punctuation runs collapse to one hyphen", () => {
+  assert.equal(tagSlug("C&AD"), "c-ad");
+});
+
+test("tagSlug: unicode is normalized (NFKD) before slugifying, dropping combining marks", () => {
+  assert.equal(tagSlug("café"), "cafe");
+});
+
+test("tagSlug: a tag with no [a-z0-9] characters falls back to a stable non-empty slug", () => {
+  const slug = tagSlug("###");
+  assert.ok(slug.length > 0);
+  assert.match(slug, /^[a-z0-9-]+$/);
+  assert.equal(slug, tagSlug("###"), "must be stable across calls");
+});
+
+test("groupBySlug: merges different spellings that share a slug into one group", () => {
+  const a = entry({ id: "a", collection: "notes", tags: ["Hello World"] });
+  const b = entry({ id: "b", collection: "photos", tags: ["hello world"] });
+  const bySlug = groupBySlug([a, b]);
+  assert.equal(bySlug.size, 1);
+  const group = bySlug.get("hello-world");
+  assert.ok(group);
+  assert.deepEqual(new Set(group?.tags), new Set(["Hello World", "hello world"]));
+  assert.deepEqual(
+    group?.entries.map((e) => e.id),
+    ["a", "b"],
+  );
+});
+
+test("groupBySlug: an entry whose two tags collapse to the same slug appears once in that group", () => {
+  const a = entry({ id: "a", collection: "notes", tags: ["Hello", "hello"] });
+  const bySlug = groupBySlug([a]);
+  assert.equal(bySlug.size, 1);
+  const group = bySlug.get("hello");
+  assert.equal(group?.entries.length, 1);
+  assert.deepEqual(new Set(group?.tags), new Set(["Hello", "hello"]));
+});
+
+test("groupBySlug: sorts each group's entries newest-first", () => {
+  const older = entry({ id: "older", collection: "notes", tags: ["hello"], publishDate: new Date("2026-01-01") });
+  const newer = entry({ id: "newer", collection: "notes", tags: ["hello"], publishDate: new Date("2026-02-01") });
+  const bySlug = groupBySlug([older, newer]);
+  assert.deepEqual(bySlug.get("hello")?.entries.map((e) => e.id), ["newer", "older"]);
+});
+
+test("tagGroupCounts: merges counts across spellings sharing a slug, alphabetical by slug", () => {
+  const bySlug = groupBySlug([
+    entry({ id: "a", collection: "notes", tags: ["zebra"] }),
+    entry({ id: "b", collection: "notes", tags: ["Hello"] }),
+    entry({ id: "c", collection: "photos", tags: ["hello"] }),
+  ]);
+  const counts = tagGroupCounts(bySlug);
+  assert.deepEqual(
+    counts.map(({ slug, count }) => ({ slug, count })),
+    [
+      { slug: "hello", count: 2 },
+      { slug: "zebra", count: 1 },
+    ],
+  );
+  assert.deepEqual(new Set(counts[0]!.tags), new Set(["Hello", "hello"]));
+  assert.deepEqual(counts[1]!.tags, ["zebra"]);
 });

--- a/Resources/Template/src/lib/tags.ts
+++ b/Resources/Template/src/lib/tags.ts
@@ -1,0 +1,77 @@
+import { excerpt } from "./feeds.ts";
+
+/**
+ * The subset of a tagged content entry that `/tags/[tag]/` and `/tags/` need. Kept as a plain
+ * object (rather than `CollectionEntry<TaggedCollection>`) so this stays importable — and
+ * unit-testable with plain `node:test` — outside Astro's `astro:content` virtual module, same
+ * rationale as `content-schemas.ts`.
+ */
+export interface TaggedEntry {
+  id: string;
+  collection: string;
+  tags: string[];
+  title?: string;
+  summary?: string;
+  caption?: string;
+  body?: string;
+  publishDate: Date;
+}
+
+/**
+ * Where a tagged entry's own page lives. Every collection in `TAGGED_COLLECTIONS` is routed
+ * through `[collection]/[...slug].astro`, which always publishes at `/<collection>/<id>/`
+ * (same shape `feeds.ts`'s `toFeedItem` uses for `FeedItem.link`) — `blog` is not among them
+ * (it has no `tags` field), so there's no `/blog/<id>/` special case to handle here.
+ */
+export function permalinkFor(collection: string, id: string): string {
+  return `/${collection}/${id}/`;
+}
+
+/**
+ * Display label for a tagged-entry link: the entry's title when it has one (articles, albums,
+ * and titled bookmarks); otherwise its summary/caption (notes have neither field, photos have
+ * `caption`); otherwise an excerpt of its body. Same fallback chain and order as `feeds.ts`'s
+ * `toFeedItem` (`entry.data.summary ?? entry.data.caption ?? excerpt(entry.body, …)`), so a
+ * title-less note/photo/bookmark reads the same way here as it does in a feed. Falls back to
+ * the entry id only in the unlikely case a title-less entry also has no summary, caption, or
+ * body text, so the link never renders with no visible text.
+ */
+export function labelFor(entry: Pick<TaggedEntry, "id" | "title" | "summary" | "caption" | "body">): string {
+  return entry.title || entry.summary || entry.caption || excerpt(entry.body, 80) || entry.id;
+}
+
+/**
+ * Group entries by tag, each tag's entries sorted reverse-chronologically (newest first) —
+ * matching `blog/index.astro`'s listing convention. An entry with multiple tags appears once
+ * per tag it carries.
+ */
+export function groupByTag(entries: TaggedEntry[]): Map<string, TaggedEntry[]> {
+  const byTag = new Map<string, TaggedEntry[]>();
+  for (const entry of entries) {
+    for (const tag of entry.tags) {
+      const list = byTag.get(tag);
+      if (list) list.push(entry);
+      else byTag.set(tag, [entry]);
+    }
+  }
+  for (const list of byTag.values()) {
+    list.sort((a, b) => b.publishDate.valueOf() - a.publishDate.valueOf());
+  }
+  return byTag;
+}
+
+/** Every tag name in a `groupByTag` map, alphabetically — a stable, deterministic order for
+ * both the `/tags/` index and `getStaticPaths` iteration. */
+export function sortedTagNames(byTag: Map<string, TaggedEntry[]>): string[] {
+  return [...byTag.keys()].sort((a, b) => a.localeCompare(b));
+}
+
+export interface TagCount {
+  tag: string;
+  count: number;
+}
+
+/** `{ tag, count }` for every tag, alphabetically — what `/tags/` renders. */
+export function tagCounts(byTag: Map<string, TaggedEntry[]>): TagCount[] {
+  return sortedTagNames(byTag).map((tag) => ({ tag, count: byTag.get(tag)!.length }));
+}

--- a/Resources/Template/src/lib/tags.ts
+++ b/Resources/Template/src/lib/tags.ts
@@ -75,3 +75,99 @@ export interface TagCount {
 export function tagCounts(byTag: Map<string, TaggedEntry[]>): TagCount[] {
   return sortedTagNames(byTag).map((tag) => ({ tag, count: byTag.get(tag)!.length }));
 }
+
+/**
+ * Deterministic, non-empty fallback for a tag whose slugification produces nothing (e.g. "###",
+ * which has no `[a-z0-9]` character to keep). Hex-joins the tag's own codepoints — stable across
+ * calls and, unlike a random id, reproducible from static content alone (no build-time state).
+ * `[...tag]` iterates by codepoint so astral characters (outside the BMP) aren't split into
+ * mismatched surrogate halves. Empty input (`tagSlug("")`) falls through to the literal "tag".
+ */
+function fallbackSlug(tag: string): string {
+  const hex = [...tag].map((ch) => ch.codePointAt(0)!.toString(16)).join("");
+  return hex || "tag";
+}
+
+/**
+ * URL-safe route param for a tag's `/tags/<slug>/` page. Tags are free text with no character
+ * restrictions, so two defects motivate slugifying rather than `encodeURIComponent`-ing the raw
+ * tag: a tag containing "/" makes an illegal `getStaticPaths` param and crashes `astro build`
+ * ("Missing parameter: tag"); a tag containing "#" percent-encodes to an href a
+ * standards-compliant static server can never match back to the literal directory Astro wrote
+ * (it percent-decodes the request before the filesystem lookup, and "%23" decodes to "#", not
+ * back to the on-disk "c%23d" Astro created). Lowercases, Unicode-normalizes (NFKD, so
+ * e.g. "café"'s precomposed é decomposes into "e" plus a combining mark), then collapses every
+ * run of non-`[a-z0-9]` characters (that combining mark included) to a single hyphen and trims
+ * leading/trailing hyphens. Falls back to `fallbackSlug` when nothing alphanumeric survives, so
+ * the route never gets an empty param.
+ */
+export function tagSlug(tag: string): string {
+  const slug = tag
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || fallbackSlug(tag);
+}
+
+/** One `/tags/<slug>/` page's worth of data: the slug itself, every verbatim tag spelling that
+ * maps to it (alphabetical), and the merged, deduped, newest-first entries tagged with any of
+ * them. */
+export interface TagGroup {
+  slug: string;
+  tags: string[];
+  entries: TaggedEntry[];
+}
+
+/**
+ * Group entries by `tagSlug`, not verbatim tag text, so spellings like "Hello World" and
+ * "hello world" share one `/tags/hello-world/` page instead of each getting their own (and, more
+ * importantly, so a tag containing "/" or "#" doesn't crash the build or 404 — see `tagSlug`).
+ * An entry carrying two tags that collapse to the same slug (e.g. "Hello" and "hello") appears
+ * only once in that slug's `entries`.
+ */
+export function groupBySlug(entries: TaggedEntry[]): Map<string, TagGroup> {
+  const bySlug = new Map<string, TagGroup>();
+  for (const entry of entries) {
+    const seenSlugsForEntry = new Set<string>();
+    for (const tag of entry.tags) {
+      const slug = tagSlug(tag);
+      let group = bySlug.get(slug);
+      if (!group) {
+        group = { slug, tags: [], entries: [] };
+        bySlug.set(slug, group);
+      }
+      if (!group.tags.includes(tag)) group.tags.push(tag);
+      if (!seenSlugsForEntry.has(slug)) {
+        group.entries.push(entry);
+        seenSlugsForEntry.add(slug);
+      }
+    }
+  }
+  for (const group of bySlug.values()) {
+    group.tags.sort((a, b) => a.localeCompare(b));
+    group.entries.sort((a, b) => b.publishDate.valueOf() - a.publishDate.valueOf());
+  }
+  return bySlug;
+}
+
+/** Every slug in a `groupBySlug` map, alphabetically — a stable, deterministic order for both
+ * the `/tags/` index and `getStaticPaths` iteration. */
+export function sortedSlugs(bySlug: Map<string, TagGroup>): string[] {
+  return [...bySlug.keys()].sort((a, b) => a.localeCompare(b));
+}
+
+export interface TagGroupCount {
+  slug: string;
+  tags: string[];
+  count: number;
+}
+
+/** `{ slug, tags, count }` for every slug, alphabetically — what `/tags/` renders. `count` merges
+ * across every verbatim spelling sharing that slug. */
+export function tagGroupCounts(bySlug: Map<string, TagGroup>): TagGroupCount[] {
+  return sortedSlugs(bySlug).map((slug) => {
+    const group = bySlug.get(slug)!;
+    return { slug, tags: group.tags, count: group.entries.length };
+  });
+}

--- a/Resources/Template/src/pages/albums/atom.xml.ts
+++ b/Resources/Template/src/pages/albums/atom.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "albums";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/albums/feed.json.ts
+++ b/Resources/Template/src/pages/albums/feed.json.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "albums";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/albums/index.astro
+++ b/Resources/Template/src/pages/albums/index.astro
@@ -1,0 +1,5 @@
+---
+import CollectionIndex from "../../components/CollectionIndex.astro";
+---
+
+<CollectionIndex collection="albums" />

--- a/Resources/Template/src/pages/albums/rss.xml.ts
+++ b/Resources/Template/src/pages/albums/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "albums";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
     site,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/articles/atom.xml.ts
+++ b/Resources/Template/src/pages/articles/atom.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "articles";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/articles/feed.json.ts
+++ b/Resources/Template/src/pages/articles/feed.json.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "articles";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/articles/index.astro
+++ b/Resources/Template/src/pages/articles/index.astro
@@ -1,0 +1,5 @@
+---
+import CollectionIndex from "../../components/CollectionIndex.astro";
+---
+
+<CollectionIndex collection="articles" />

--- a/Resources/Template/src/pages/articles/rss.xml.ts
+++ b/Resources/Template/src/pages/articles/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "articles";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
     site,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/atom.xml.ts
+++ b/Resources/Template/src/pages/atom.xml.ts
@@ -1,6 +1,6 @@
 import type { APIContext } from "astro";
 import { readConfig } from "../../scripts/config";
-import { getCombinedItems } from "../lib/feed-data.ts";
+import { getCombinedItems, feedAuthor } from "../lib/feed-data.ts";
 import { renderAtom, siteFrom, websubHub } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     feedUrl: new URL("/atom.xml", site).href,
     items: await getCombinedItems(site),
     hubUrl: websubHub(site, "/atom.xml", readConfig("WEBSUB_ENABLED") === "true")?.hubUrl,
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/blog/atom.xml.ts
+++ b/Resources/Template/src/pages/blog/atom.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "blog";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/blog/feed.json.ts
+++ b/Resources/Template/src/pages/blog/feed.json.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "blog";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/blog/rss.xml.ts
+++ b/Resources/Template/src/pages/blog/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "blog";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
     site,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/bookmarks/atom.xml.ts
+++ b/Resources/Template/src/pages/bookmarks/atom.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "bookmarks";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/bookmarks/feed.json.ts
+++ b/Resources/Template/src/pages/bookmarks/feed.json.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "bookmarks";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/bookmarks/index.astro
+++ b/Resources/Template/src/pages/bookmarks/index.astro
@@ -1,0 +1,5 @@
+---
+import CollectionIndex from "../../components/CollectionIndex.astro";
+---
+
+<CollectionIndex collection="bookmarks" />

--- a/Resources/Template/src/pages/bookmarks/rss.xml.ts
+++ b/Resources/Template/src/pages/bookmarks/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "bookmarks";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
     site,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/feed.json.ts
+++ b/Resources/Template/src/pages/feed.json.ts
@@ -1,6 +1,6 @@
 import type { APIContext } from "astro";
 import { readConfig } from "../../scripts/config";
-import { getCombinedItems } from "../lib/feed-data.ts";
+import { getCombinedItems, feedAuthor } from "../lib/feed-data.ts";
 import { renderJsonFeed, siteFrom, websubHub } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     feedUrl: new URL("/feed.json", site).href,
     items: await getCombinedItems(site),
     hubUrl: websubHub(site, "/feed.json", readConfig("WEBSUB_ENABLED") === "true")?.hubUrl,
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/index.astro
+++ b/Resources/Template/src/pages/index.astro
@@ -10,7 +10,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <section class="hero">
     <h1>Welcome</h1>
     <p>This site is ready to customize in Anglesite. Open the app to edit your pages, add content, and publish when you're ready.</p>
-    <p><a href="/blog/">Read the blog</a></p>
+    <p><a href="/blog/">Read the blog</a> · <a href="/timeline/">Timeline</a></p>
     <!-- anglesite:hero-cta -->
   </section>
 </BaseLayout>

--- a/Resources/Template/src/pages/likes/atom.xml.ts
+++ b/Resources/Template/src/pages/likes/atom.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "likes";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/likes/feed.json.ts
+++ b/Resources/Template/src/pages/likes/feed.json.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "likes";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/likes/index.astro
+++ b/Resources/Template/src/pages/likes/index.astro
@@ -1,0 +1,5 @@
+---
+import CollectionIndex from "../../components/CollectionIndex.astro";
+---
+
+<CollectionIndex collection="likes" />

--- a/Resources/Template/src/pages/likes/rss.xml.ts
+++ b/Resources/Template/src/pages/likes/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "likes";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
     site,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/notes/atom.xml.ts
+++ b/Resources/Template/src/pages/notes/atom.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "notes";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/notes/feed.json.ts
+++ b/Resources/Template/src/pages/notes/feed.json.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "notes";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/notes/index.astro
+++ b/Resources/Template/src/pages/notes/index.astro
@@ -1,0 +1,5 @@
+---
+import CollectionIndex from "../../components/CollectionIndex.astro";
+---
+
+<CollectionIndex collection="notes" />

--- a/Resources/Template/src/pages/notes/rss.xml.ts
+++ b/Resources/Template/src/pages/notes/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "notes";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
     site,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/photos/atom.xml.ts
+++ b/Resources/Template/src/pages/photos/atom.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "photos";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/photos/feed.json.ts
+++ b/Resources/Template/src/pages/photos/feed.json.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "photos";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/photos/index.astro
+++ b/Resources/Template/src/pages/photos/index.astro
@@ -1,0 +1,5 @@
+---
+import CollectionIndex from "../../components/CollectionIndex.astro";
+---
+
+<CollectionIndex collection="photos" />

--- a/Resources/Template/src/pages/photos/rss.xml.ts
+++ b/Resources/Template/src/pages/photos/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "photos";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
     site,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/replies/atom.xml.ts
+++ b/Resources/Template/src/pages/replies/atom.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderAtom, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "replies";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/atom.xml`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/replies/feed.json.ts
+++ b/Resources/Template/src/pages/replies/feed.json.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderJsonFeed, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "replies";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     feedUrl: new URL(`/${COLLECTION}/feed.json`, site).href,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/replies/index.astro
+++ b/Resources/Template/src/pages/replies/index.astro
@@ -1,0 +1,5 @@
+---
+import CollectionIndex from "../../components/CollectionIndex.astro";
+---
+
+<CollectionIndex collection="replies" />

--- a/Resources/Template/src/pages/replies/rss.xml.ts
+++ b/Resources/Template/src/pages/replies/rss.xml.ts
@@ -1,5 +1,5 @@
 import type { APIContext } from "astro";
-import { getCollectionItems } from "../../lib/feed-data.ts";
+import { getCollectionItems, feedAuthor } from "../../lib/feed-data.ts";
 import { renderRss, FEED_COLLECTIONS, siteFrom } from "../../lib/feeds.ts";
 
 const COLLECTION = "replies";
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     description: `${FEED_COLLECTIONS[COLLECTION].title} feed`,
     site,
     items: await getCollectionItems(COLLECTION, site),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/rss.xml.ts
+++ b/Resources/Template/src/pages/rss.xml.ts
@@ -1,6 +1,6 @@
 import type { APIContext } from "astro";
 import { readConfig } from "../../scripts/config";
-import { getCombinedItems } from "../lib/feed-data.ts";
+import { getCombinedItems, feedAuthor } from "../lib/feed-data.ts";
 import { renderRss, siteFrom, websubHub } from "../lib/feeds.ts";
 
 export async function GET(context: APIContext) {
@@ -11,5 +11,6 @@ export async function GET(context: APIContext) {
     site,
     items: await getCombinedItems(site),
     hub: websubHub(site, "/rss.xml", readConfig("WEBSUB_ENABLED") === "true"),
+    author: feedAuthor(),
   });
 }

--- a/Resources/Template/src/pages/tags/[tag]/index.astro
+++ b/Resources/Template/src/pages/tags/[tag]/index.astro
@@ -1,35 +1,41 @@
 ---
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import { collectTaggedEntries } from "../../../lib/tags-astro.ts";
-import { groupByTag, labelFor, permalinkFor, type TaggedEntry } from "../../../lib/tags.ts";
+import { groupBySlug, labelFor, permalinkFor, type TaggedEntry } from "../../../lib/tags.ts";
 
 export async function getStaticPaths() {
   const entries = await collectTaggedEntries();
 
-  // `params.tag` is the raw tag text, not pre-encoded — Astro's own router does the
-  // percent-encoding/decoding at request time (it matches an incoming `/tags/hello%20world/`
-  // against this route by decoding the segment back to "hello world" first). Pre-encoding here
-  // instead makes the *param itself* `%20`, which the router then can't match against a decoded
-  // request path. `Hentry.astro`'s `href={`/tags/${encodeURIComponent(t)}/`}` link only needs to
-  // carry the same raw tag text through `encodeURIComponent` for the browser request to decode
-  // back to this same param.
-  const byTag = groupByTag(entries);
-  return [...byTag.entries()].map(([tag, taggedEntries]) => ({
-    params: { tag },
-    props: { tag, entries: taggedEntries },
+  // `params.tag` is a `tagSlug` (a plain `[a-z0-9-]+` string), not the verbatim tag text —
+  // tags are free text with no character restrictions, and routing on the raw text has two
+  // failure modes: a tag containing "/" is an illegal getStaticPaths param and crashes
+  // `astro build`; a tag containing "#" percent-encodes to an href that a standards-compliant
+  // static server can never match back to the literal directory Astro wrote (it percent-decodes
+  // the request before the filesystem lookup). Routing by slug sidesteps both. Two different
+  // spellings that collapse to the same slug (e.g. "Hello World" and "hello world") share this
+  // one page — `tags` carries every verbatim spelling for the heading below, and `entries` is
+  // already deduped/merged across them by `groupBySlug`. `Hentry.astro`'s tag links use the
+  // same `tagSlug` for their `href` so the two routers can't drift.
+  const bySlug = groupBySlug(entries);
+  return [...bySlug.entries()].map(([slug, group]) => ({
+    params: { tag: slug },
+    props: { tags: group.tags, entries: group.entries },
   }));
 }
 
 interface Props {
-  tag: string;
+  tags: string[];
   entries: TaggedEntry[];
 }
 
-const { tag, entries } = Astro.props as Props;
+const { tags, entries } = Astro.props as Props;
+// The heading always shows the verbatim tag text(s), never the slug — the slug is only a URL
+// segment. Most groups have exactly one spelling; a shared slug joins them for display.
+const heading = tags.join(" / ");
 ---
 
-<BaseLayout title={`Tagged “${tag}”`} description={`Posts tagged “${tag}”.`}>
-  <h1>Tagged &ldquo;{tag}&rdquo;</h1>
+<BaseLayout title={`Tagged “${heading}”`} description={`Posts tagged “${heading}”.`}>
+  <h1>Tagged &ldquo;{heading}&rdquo;</h1>
   <p><a href="/tags/">All tags</a></p>
   <ul>
     {entries.map((entry) => (

--- a/Resources/Template/src/pages/tags/[tag]/index.astro
+++ b/Resources/Template/src/pages/tags/[tag]/index.astro
@@ -1,0 +1,41 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import { collectTaggedEntries } from "../../../lib/tags-astro.ts";
+import { groupByTag, labelFor, permalinkFor, type TaggedEntry } from "../../../lib/tags.ts";
+
+export async function getStaticPaths() {
+  const entries = await collectTaggedEntries();
+
+  // `params.tag` is the raw tag text, not pre-encoded — Astro's own router does the
+  // percent-encoding/decoding at request time (it matches an incoming `/tags/hello%20world/`
+  // against this route by decoding the segment back to "hello world" first). Pre-encoding here
+  // instead makes the *param itself* `%20`, which the router then can't match against a decoded
+  // request path. `Hentry.astro`'s `href={`/tags/${encodeURIComponent(t)}/`}` link only needs to
+  // carry the same raw tag text through `encodeURIComponent` for the browser request to decode
+  // back to this same param.
+  const byTag = groupByTag(entries);
+  return [...byTag.entries()].map(([tag, taggedEntries]) => ({
+    params: { tag },
+    props: { tag, entries: taggedEntries },
+  }));
+}
+
+interface Props {
+  tag: string;
+  entries: TaggedEntry[];
+}
+
+const { tag, entries } = Astro.props as Props;
+---
+
+<BaseLayout title={`Tagged “${tag}”`} description={`Posts tagged “${tag}”.`}>
+  <h1>Tagged &ldquo;{tag}&rdquo;</h1>
+  <p><a href="/tags/">All tags</a></p>
+  <ul>
+    {entries.map((entry) => (
+      <li>
+        <a href={permalinkFor(entry.collection, entry.id)}>{labelFor(entry)}</a>
+      </li>
+    ))}
+  </ul>
+</BaseLayout>

--- a/Resources/Template/src/pages/tags/index.astro
+++ b/Resources/Template/src/pages/tags/index.astro
@@ -1,0 +1,25 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { collectTaggedEntries } from "../../lib/tags-astro.ts";
+import { groupByTag, tagCounts } from "../../lib/tags.ts";
+
+const entries = await collectTaggedEntries();
+const counts = tagCounts(groupByTag(entries));
+---
+
+<BaseLayout title="Tags" description="Every tag used across this site's posts.">
+  <h1>Tags</h1>
+  {
+    counts.length === 0 ? (
+      <p>No tagged posts yet.</p>
+    ) : (
+      <ul>
+        {counts.map(({ tag, count }) => (
+          <li>
+            <a href={`/tags/${encodeURIComponent(tag)}/`}>{tag}</a> ({count})
+          </li>
+        ))}
+      </ul>
+    )
+  }
+</BaseLayout>

--- a/Resources/Template/src/pages/tags/index.astro
+++ b/Resources/Template/src/pages/tags/index.astro
@@ -1,10 +1,12 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { collectTaggedEntries } from "../../lib/tags-astro.ts";
-import { groupByTag, tagCounts } from "../../lib/tags.ts";
+import { groupBySlug, tagGroupCounts } from "../../lib/tags.ts";
 
 const entries = await collectTaggedEntries();
-const counts = tagCounts(groupByTag(entries));
+// Linked by slug (see tags.ts's `tagSlug` — free-text tags can't safely be used as a URL
+// segment as-is), displayed by verbatim tag text; counts merge across spellings sharing a slug.
+const counts = tagGroupCounts(groupBySlug(entries));
 ---
 
 <BaseLayout title="Tags" description="Every tag used across this site's posts.">
@@ -14,9 +16,9 @@ const counts = tagCounts(groupByTag(entries));
       <p>No tagged posts yet.</p>
     ) : (
       <ul>
-        {counts.map(({ tag, count }) => (
+        {counts.map(({ slug, tags, count }) => (
           <li>
-            <a href={`/tags/${encodeURIComponent(tag)}/`}>{tag}</a> ({count})
+            <a href={`/tags/${slug}/`}>{tags.join(" / ")}</a> ({count})
           </li>
         ))}
       </ul>

--- a/Resources/Template/src/pages/timeline/index.astro
+++ b/Resources/Template/src/pages/timeline/index.astro
@@ -1,0 +1,27 @@
+---
+// Combined reverse-chronological stream across all eight feed collections (blog, notes,
+// articles, photos, albums, bookmarks, replies, likes) — the browsable page-side equivalent of
+// the combined `/rss.xml` / `/atom.xml` / `/feed.json` feeds (`feed-data.ts`'s
+// `getCombinedItems`), capped at the same 50-item limit.
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import IndexEntry from "../../components/IndexEntry.astro";
+import { getTimelineItems } from "../../lib/collection-index-astro.ts";
+
+const items = await getTimelineItems();
+---
+
+<BaseLayout title="Timeline" description="Every post across this site, newest first.">
+  <div class="h-feed">
+    <h1 class="p-name">Timeline</h1>
+    <p><a href="/rss.xml">Subscribe (RSS)</a></p>
+    {
+      items.length === 0 ? (
+        <p>Nothing published yet.</p>
+      ) : (
+        <ul>
+          {items.map((item) => <IndexEntry item={item} />)}
+        </ul>
+      )
+    }
+  </div>
+</BaseLayout>

--- a/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift
@@ -57,10 +57,22 @@ struct FeedsRenderSmokeTests {
             #expect(try text("feed.json").contains("https://example.com/"))
             #expect(try text("blog/rss.xml").contains("<rss"))
 
-            // A title-less type (likes) still produces a non-empty title.
-            let likesJson = try text("likes/feed.json")
-            #expect(likesJson.contains("\"title\""))
-            #expect(!likesJson.contains("\"title\": \"\""))
+            // A title-less type (likes) carries no title key on its items at all — likes never
+            // had a real title, so #1021 drops the synthesized "Liked host" placeholder rather
+            // than emitting an empty or fake one. Parse JSON rather than substring-match, since
+            // the feed's own top-level `"title"` ("Likes") would otherwise false-positive.
+            func items(_ rel: String) throws -> [[String: Any]] {
+                let content = try text(rel)
+                let data = try #require(content.data(using: .utf8))
+                let feed = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+                return try #require(feed["items"] as? [[String: Any]])
+            }
+            let likesItems = try items("likes/feed.json")
+            #expect(likesItems.allSatisfy { $0["title"] == nil }, "likes items must not carry a title key")
+
+            // #1022: full body content lands in content_html, not just the short summary.
+            let notesContentHtml = try #require(items("notes/feed.json").first?["content_html"] as? String)
+            #expect(notesContentHtml.contains("This is your first note."))
         }
     }
 }

--- a/docs/microblog-external-blog.md
+++ b/docs/microblog-external-blog.md
@@ -7,15 +7,17 @@ the feed, verifying you own the site, optionally letting the Micro.blog apps
 post directly to your site via Micropub, and why Micro.blog doesn't need a
 dedicated POSSE client in Anglesite.
 
-It assumes a site that's already been deployed (`File ▸ Deploy…`, or the
-Deploy tab) with a working public URL.
+It assumes a site that's already been deployed — via the **Website ▸
+Publish…** menu command (⇧⌘P) or the toolbar's **Deploy** button — with a
+working public URL.
 
 ## 1. Register your feed
 
 Micro.blog treats "the feeds on your account" as the source of your own
-timeline — under **Account ▸ Edit Feeds & Cross-posting**, add your site's
-feed URL. Per Micro.blog's own docs: "adding feeds to your account on
-Micro.blog controls where *your own posts* come from" (see
+timeline — under **Account ▸ Edit Feeds & Cross-posting** (see
+[Connect an external blog](https://book.micro.blog/external-blogs-wordpress/)),
+add your site's feed URL. Per Micro.blog's own docs: "adding feeds to your
+account on Micro.blog controls where *your own posts* come from" (see
 [Micro.blog and feeds](https://book.micro.blog/microblog-and-feeds/)).
 
 Recommended: register the **JSON Feed**, `https://yoursite.example/feed.json`.
@@ -150,7 +152,8 @@ already pulls from the feed Anglesite publishes.
 
 ## References
 
-- [Micro.blog and feeds](https://book.micro.blog/microblog-and-feeds/) — Sources, cross-posting toggles, polling cadence
+- [Micro.blog and feeds](https://book.micro.blog/microblog-and-feeds/) — Sources section, cross-posting toggles, polling cadence
+- [Connect an external blog](https://book.micro.blog/external-blogs-wordpress/) — "Edit Feeds & Cross-posting" screen name/location
 - [RSS for microblogs](https://book.micro.blog/rss-for-microblogs/) — title-less items, full HTML in `<description>`
 - [JSON Feed](https://book.micro.blog/json-feed/) — `content_html`, title-less microblog posts
 - [IndieAuth](https://book.micro.blog/indieauth/) — `rel=me` verification, IndieAuth sign-in

--- a/docs/microblog-external-blog.md
+++ b/docs/microblog-external-blog.md
@@ -1,0 +1,157 @@
+# Connecting an Anglesite site to Micro.blog
+
+Micro.blog can follow any deployed Anglesite site as an "external blog": it
+polls your feed, adds new posts to your Micro.blog timeline, and (if you
+enable it) cross-posts them to other networks. This guide covers registering
+the feed, verifying you own the site, optionally letting the Micro.blog apps
+post directly to your site via Micropub, and why Micro.blog doesn't need a
+dedicated POSSE client in Anglesite.
+
+It assumes a site that's already been deployed (`File ▸ Deploy…`, or the
+Deploy tab) with a working public URL.
+
+## 1. Register your feed
+
+Micro.blog treats "the feeds on your account" as the source of your own
+timeline — under **Account ▸ Edit Feeds & Cross-posting**, add your site's
+feed URL. Per Micro.blog's own docs: "adding feeds to your account on
+Micro.blog controls where *your own posts* come from" (see
+[Micro.blog and feeds](https://book.micro.blog/microblog-and-feeds/)).
+
+Recommended: register the **JSON Feed**, `https://yoursite.example/feed.json`.
+`https://yoursite.example/rss.xml` also works and is advertised as an
+alternate on every page (`<link rel="alternate" ... href="/rss.xml">` in
+[`BaseLayout.astro`](../Resources/Template/src/layouts/BaseLayout.astro)),
+but JSON Feed is the closer match to Micro.blog's own microblog conventions
+(next section).
+
+Micro.blog checks feeds for external (non-Micro.blog-hosted) blogs "every
+few minutes," or immediately if it's notified of a new post — see
+[Micro.blog and feeds](https://book.micro.blog/microblog-and-feeds/).
+
+### Title-less posts already read correctly
+
+This epic changed how Anglesite renders short posts in feeds: **notes,
+replies, likes, and photos never carry a synthesized title** — the feed item
+omits `title` entirely rather than faking one from an excerpt (see
+`FEED_COLLECTIONS` and `toFeedItem` in
+[`feeds.ts`](../Resources/Template/src/lib/feeds.ts)). The full post body
+renders inline as `content_html` in JSON Feed, as the RSS `<description>`,
+and as Atom's `<content type="html">`.
+
+This matches Micro.blog's own textcasting model. JSON Feed's spec (which
+Micro.blog helped originate) exists in part for "microblogs, which are often
+plain text and without titles" — see
+[JSON Feed](https://book.micro.blog/json-feed/). Micro.blog's RSS guidance
+for microblog-style posts is the same: keep `<title>` off title-less items
+and put the full post in `<description>` rather than splitting it across
+`<description>`/`<content:encoded>` — see
+[RSS for microblogs](https://book.micro.blog/rss-for-microblogs/). Anglesite's
+RSS renderer already does this (`renderRss` in `feeds.ts` emits
+`i.contentHtml` as `<description>`, and only emits `<title>` when the item
+has one).
+
+Likes, replies, and bookmarks with no written commentary still emit
+something concrete rather than empty content: Anglesite falls back to a link
+to the target URL (`interactionContentFallback` in `feeds.ts`), so an
+"empty" like or reply still syndicates its point of reference.
+
+Tags (`entry.data.tags`) come through as `<category>` in RSS/Atom and JSON
+Feed's `tags` array; each tag also gets a browsable `/tags/<slug>/` page on
+your own site.
+
+## 2. Verify you own the site (rel=me)
+
+Micro.blog (and IndieAuth generally) verifies site ownership with
+bidirectional `rel="me"` links: your site links out to a profile (e.g. your
+Micro.blog profile), and that profile links back to your site. Micro.blog's
+docs put it as: "your profile on that platform also links back to your
+blog, confirming your blog and the profile are owned by the same person" —
+see [IndieAuth](https://book.micro.blog/indieauth/).
+
+Anglesite already supports this — no code changes were needed for this doc.
+From the site window: **Website ▸ Add Integration… ▸ IndieWeb**. That
+integration's "Profile link" fields (up to three) write `<link rel="me">`
+tags into every page's `<head>` (see the `indieweb` descriptor in
+[`IntegrationCatalog.swift`](../Sources/AnglesiteCore/IntegrationCatalog.swift)
+and its output in
+[`BaseLayout.astro`](../Resources/Template/src/layouts/BaseLayout.astro)).
+Add your `https://micro.blog/<you>` profile URL as one of the three, then
+add your site's URL to the "also known as" / website field on your
+Micro.blog profile so the link is mutual.
+
+Anglesite's IndieWeb integration also enables webmention/pingback discovery
+(a `webmention.io` username field) and the template unconditionally
+advertises `<link rel="indieauth-metadata" href="/.well-known/oauth-authorization-server">`
+for IndieAuth sign-in (OAuth Server Metadata / RFC 8414) — useful if you
+ever want to sign in to other IndieWeb tools with your Anglesite site as
+your identity, independent of Micro.blog.
+
+## 3. Enable cross-posting on Micro.blog's side
+
+Once your feed is added as a source, the same **Edit Feeds & Cross-posting**
+screen "controls which feeds cross-post to other platforms like Bluesky or
+Mastodon" — toggle the networks you want there. Per Micro.blog: "When
+Micro.blog sees a new post in your feed, it adds it to the Micro.blog
+timeline and also cross-posts it [to] those platforms that are enabled" —
+see [Micro.blog and feeds](https://book.micro.blog/microblog-and-feeds/).
+This is entirely configured on Micro.blog's side; Anglesite doesn't need to
+know which networks Micro.blog forwards to.
+
+## 4. Optional: post to your site from the Micro.blog apps (Micropub)
+
+Micro.blog's iOS and Mac apps can post to any site that implements
+[Micropub](https://book.micro.blog/micropub/), the same protocol Micro.blog
+uses for its own hosted blogs. Anglesite's site template composes
+`@dwk/micropub` into the per-site Cloudflare Worker
+(`handleMicropub` in
+[`worker.ts`](../Resources/Template/worker/worker.ts)), exposing
+`POST /micropub` and a media-upload endpoint, backed by IndieAuth-issued
+bearer tokens.
+
+To use it:
+
+1. Activate the **Micropub** worker for your site: **Site Settings ▸
+   Workers**, toggle it on. (This mirrors `SiteSettings.activeWorkerIDs` —
+   see `WorkerRow` in
+   [`PlistEditorModel.swift`](../Sources/AnglesiteApp/PlistEditorModel.swift).)
+   Until it's activated, `/micropub` returns `503` rather than posting
+   anything (`handleMicropub` checks for the required D1/IndieAuth bindings
+   before dispatching).
+2. Sign in to your site from a Micropub client via IndieAuth to get a
+   token.
+
+**Known gap:** Micro.blog's own docs say a self-hosted site needs to
+advertise its endpoint with `<link rel="micropub" href="https://example.com/micropub">`
+on the homepage for auto-discovery (see
+[Micropub](https://book.micro.blog/micropub/)). Anglesite's
+`BaseLayout.astro` does not yet emit that `<link>` tag (it advertises
+`rel="me"`, `rel="webmention"`, and `rel="indieauth-metadata"`, but not
+`rel="micropub"`), and the worker doesn't send a `Link:` HTTP header either.
+Until that's added, a Micropub client that requires auto-discovery may not
+find the endpoint automatically even after step 1 above. This is a
+follow-up for whoever picks up the Micropub-in-Micro.blog integration next,
+not something this docs-only change should silently paper over.
+
+## Why Micro.blog is not a POSSE target
+
+Micro.blog does **not** join the POSSE target list in
+[`POSSEClients.swift`](../Sources/AnglesiteCore/POSSEClients.swift)
+(currently Mastodon and Bluesky). Rationale: Micro.blog ingests the site's
+own feed (PESOS-free syndication at the platform edge), so a push-style
+POSSE client is redundant; cross-posting *from* Micro.blog onward is
+configured on Micro.blog itself.
+
+In other words: sections 1–3 above (feed registration, `rel=me`
+verification, cross-posting toggles) are the entire integration surface for
+syndicating *to* Micro.blog and onward. There's no "push a copy to
+Micro.blog" client to add to `POSSEClients.swift`, because Micro.blog
+already pulls from the feed Anglesite publishes.
+
+## References
+
+- [Micro.blog and feeds](https://book.micro.blog/microblog-and-feeds/) — Sources, cross-posting toggles, polling cadence
+- [RSS for microblogs](https://book.micro.blog/rss-for-microblogs/) — title-less items, full HTML in `<description>`
+- [JSON Feed](https://book.micro.blog/json-feed/) — `content_html`, title-less microblog posts
+- [IndieAuth](https://book.micro.blog/indieauth/) — `rel=me` verification, IndieAuth sign-in
+- [Micropub](https://book.micro.blog/micropub/) — posting API, endpoint discovery via `rel=micropub`

--- a/docs/superpowers/plans/2026-07-27-microblog-feed-layer.md
+++ b/docs/superpowers/plans/2026-07-27-microblog-feed-layer.md
@@ -1,0 +1,162 @@
+# Micro.blog compatibility — fix the feed layer (Epic #1027)
+
+Make a deployed Anglesite site work as a Micro.blog external blog: short notes render
+inline (full text, no headline), titled posts render as linked headlines, feeds carry
+full HTML content and metadata, tag links resolve, and micropost collections are
+browsable on the site itself.
+
+Issues: #1021, #1022 (blocking, one coordinated change), #1023, #1024, #1025, #1026.
+Reference: https://book.micro.blog (rss-for-microblogs, json-feed, microblog-and-feeds).
+
+## Global Constraints
+
+- **Worktree:** all work happens in
+  `/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/issue-700-ba3222`
+  on branch `claude/microblog-compatibility-feed-d0bfef`. `cd` there before any git or
+  build command. Never touch the main checkout.
+- **Template-only scope** plus the Swift tests that couple to the template
+  (`Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift`,
+  `IntegrationTemplateAssetsTests`, `ProjectValidatorTests`) and, for Task 5 only, docs
+  and possibly `Sources/AnglesiteCore/IntegrationCatalog.swift`. No paired sidecar PR.
+- **No new npm or Swift dependencies.** Markdown→HTML rendering must use
+  `@astrojs/markdown-remark` (already a direct dependency of the template).
+- **Micro.blog classification rule (binds Tasks 1–4):** presence of a `title` on a feed
+  item is the signal. Title-less microposts (notes, replies, likes, photos-without-title)
+  must carry **no synthesized title** in any feed format; titled collections
+  (blog, articles, albums, bookmarks-with-frontmatter-title) keep real titles. Never
+  fabricate a title from body text, captions, or link hosts.
+- **Feeds must stay valid:** RSS 2.0 items need at least one of title/description; Atom
+  entries require a `<title>` element (emit an empty one for title-less items); JSON
+  Feed 1.1 `title` is optional and must be omitted, not empty.
+- **Tests before push:** from `Resources/Template/`: `npm test` and `npm run build`
+  (build includes `astro check` + the mf2 checker `scripts/check-microformats.ts`).
+  From the repo root: `swift test --filter FeedsRenderSmoke`,
+  `swift test --filter IntegrationTemplateAssets`, `swift test --filter ProjectValidator`.
+- **Commits:** conventional format, subject ≤72 chars, issue number in subject,
+  one commit (or a small coherent series) per task, e.g.
+  `feat(#1021): drop synthesized titles from micropost feeds`. End body with the
+  Claude Fable co-author trailer.
+- **Drafts stay excluded from feeds** (#798 behavior in `feed-data.ts`) and the
+  existing WebSub advertisement behavior must be preserved unchanged.
+
+## Task 1 — #1021 + #1022: FeedItem overhaul (optional title, full HTML content)
+
+One coordinated change to `Resources/Template/src/lib/feeds.ts`,
+`src/lib/feed-data.ts`, their tests, and `Tests/AnglesiteCoreTests/FeedsRenderSmokeTests.swift`.
+
+- `FeedItem.title` becomes `string | undefined`; add `contentHtml: string` (full body
+  rendered to HTML).
+- `FEED_COLLECTIONS` per-collection title derivation:
+  - `blog`, `articles`, `albums`: `e.data.title` (required by schema, unchanged).
+  - `bookmarks`: `e.data.title` when present, otherwise **no title** (drop the
+    `host(bookmarkOf)` fallback — it is synthesized).
+  - `notes`, `replies`, `likes`: **no title, ever** (drop excerpt/"Re: host"/"Liked host").
+  - `photos`: **no title** (a caption is content, not a title; drop `caption ?? "Photo"`).
+  - Remove the `|| "Untitled"` hard guarantee in `toFeedItem`.
+- Full content: render `entry.body` (markdown) to HTML at build time with
+  `createMarkdownProcessor` from `@astrojs/markdown-remark` (module-level cached
+  processor promise; rendering happens in `feed-data.ts` since it is async — pass the
+  rendered HTML into `toFeedItem` or make the mapping async; keep `toFeedItem`'s
+  existing signature working for tests or update tests accordingly). For photos, if the
+  body is empty, fall back to the caption text as content. `summary` keeps its current
+  derivation (280-char excerpt) — it remains the *short* representation.
+- Renderers:
+  - RSS (`renderRss` via `@astrojs/rss`): item `title` only when present;
+    `description` carries the **full HTML** (`contentHtml`) when non-empty, else the
+    summary. (RSS 2.0 requires title *or* description — description always present.)
+  - Atom (`renderAtom`): always emit `<title>` — empty element for title-less items;
+    keep `<summary>` (plain-text summary, escaped) and add
+    `<content type="html">` with the escaped full HTML.
+  - JSON Feed (`renderJsonFeed`): omit `title` key when absent; add `content_html`
+    (JSON Feed 1.1 requires content_html or content_text on every item — use summary
+    as content_html fallback when body is empty); keep `summary`.
+- Update `src/lib/feeds.test.ts`: existing derive-title tests flip to assert *absence*
+  of titles for notes/replies/likes/photos; add renderer tests asserting (a) no
+  `<title>`/`title` for title-less items in RSS + JSON Feed, empty `<title/>` in Atom,
+  (b) full multi-paragraph HTML lands in RSS description, Atom `<content>`, JSON
+  `content_html`, (c) titled collections unchanged.
+- Update `FeedsRenderSmokeTests.swift`: the "likes still produces a non-empty title"
+  assertions (lines ~60–63) invert — the likes feed must carry **no** title keys on
+  items; add an assertion that the notes JSON feed carries `content_html` with the
+  note body. Keep the suite's build-lock pattern intact.
+
+## Task 2 — #1023: tags/categories + author metadata in feeds
+
+Builds on Task 1's `FeedItem`. Files: `feeds.ts`, `feed-data.ts`, `feeds.test.ts`.
+
+- `FeedItem` gains `tags?: string[]` populated from `entry.data.tags` (schema field
+  already exists on all micropost collections).
+- `renderRss`: per-item `<category>` elements (via `@astrojs/rss` item `categories`).
+- `renderAtom`: per-entry `<category term="…"/>`.
+- `renderJsonFeed`: per-item `tags` array.
+- Author: add an optional `author?: { name: string; url?: string }` option to
+  `renderAtom` (top-level `<author><name/><uri/></author>`) and `renderJsonFeed`
+  (top-level `authors: [{name, url}]`), and to `renderRss` as channel-level
+  `customData` `<dc:creator>` with the `dc` xmlns declared. Feed **routes** derive it
+  from `siteProfile()` (`src/lib/profile.ts` — name/url; profile.json absent → no
+  author emitted, all three renderers omit author cleanly). Wire all 27 feed routes
+  (8 collections × 3 + 3 root) — a small shared helper in `feed-data.ts` (e.g.
+  `feedAuthor()`) keeps the routes one-liners.
+- Tests: tags flow to all three formats; author present when passed, absent when not;
+  no dc xmlns when no author.
+
+## Task 3 — #1024: `/tags/<tag>` route
+
+- Add `Resources/Template/src/pages/tags/[tag]/index.astro` with `getStaticPaths`
+  aggregating `tags` across **all** content collections that declare a `tags` field
+  (blog, notes, articles, photos, albums, bookmarks, replies, likes — check
+  `content.config.ts` for the authoritative list; announcements/events/reviews too if
+  they have tags). Page lists that tag's entries reverse-chronologically as links
+  (titled entries by title, title-less by excerpt), each pointing at its permalink
+  (`/blog/<id>/` for blog, `/<collection>/<id>/` for the rest).
+- Add `Resources/Template/src/pages/tags/index.astro` — tag index listing every tag
+  with a count, linking to `/tags/<tag>/`.
+- Handle URL-encoding (tags with spaces) consistently with
+  `Hentry.astro`'s `href={`/tags/${t}`}` links — those existing links must resolve;
+  if encoding is needed, fix Hentry.astro's link generation in the same commit.
+- Drafts excluded in PROD (match `blog/index.astro`'s convention).
+- Sample content: at least one hello-* entry should carry a tag so the route builds
+  non-trivially — add a tag to `src/content/notes/hello-note.md` if none exists.
+- `npm run build` proves no 404-generating regressions; mf2 check passes.
+
+## Task 4 — #1025: browsable index + timeline pages for micropost collections
+
+- Add `index.astro` for each feed-only collection directory: `notes/`, `photos/`,
+  `articles/`, `bookmarks/`, `replies/`, `likes/`, `albums/`. Each is an h-feed:
+  microposts (notes/replies/likes/photos) render **full content inline** as h-entries;
+  titled collections (articles/albums/bookmarks) render as linked headlines, matching
+  `blog/index.astro`'s spirit. Reverse-chronological, drafts excluded in PROD, link to
+  the collection's RSS feed at the top.
+- Add a combined reverse-chronological stream page at
+  `src/pages/timeline/index.astro` across all eight feed collections (reuse the
+  aggregation shape of `feed-data.ts`'s `getCombinedItems`, but page-side with
+  `getCollection` so entries can render inline; a shared helper is fine).
+- Keep the homepage as-is, but add a link to `/timeline/` alongside the existing
+  `/blog/` link.
+- Markup: proper `h-feed`/`h-entry` classes so `scripts/check-microformats.ts`
+  passes on the new pages. Reuse existing components where sensible
+  (`DraftBadge.astro`; do NOT redesign `Hentry.astro`).
+- `npm run build` (includes mf2 check) + template tests pass;
+  `swift test --filter FeedsRenderSmoke` still passes (dist layout gains index.html
+  files, nothing removed).
+
+## Task 5 — #1026: Micro.blog setup docs + POSSE-target decision
+
+- Write `docs/microblog-external-blog.md`: end-to-end guide connecting a deployed
+  Anglesite site to Micro.blog — register the feed (recommend `/feed.json`, mention
+  `/rss.xml`), domain verification via existing `rel=me` support, enabling
+  cross-posting on Micro.blog's side, and that Micropub means the Micro.blog iOS app
+  can post directly to an Anglesite site. Note the feed behavior shipped by this epic
+  (title-less notes inline, full content).
+- **POSSE decision (record verbatim):** Micro.blog does **not** join the POSSE target
+  list in `POSSEClients.swift`. Rationale: Micro.blog ingests the site's own feed
+  (PESOS-free syndication at the platform edge), so a push-style POSSE client is
+  redundant; cross-posting *from* Micro.blog onward is configured on Micro.blog
+  itself. Document this in the new doc under a "Why Micro.blog is not a POSSE
+  target" heading.
+- Inspect `Sources/AnglesiteCore/IntegrationCatalog.swift`: if the IndieWeb
+  integration entry supports a lightweight setup-hint/link field, add a Micro.blog
+  mention pointing at the new doc; if that would require schema changes, skip the
+  Swift edit and note the follow-up in the doc instead. Keep this task doc-first.
+- Cross-link the doc from any existing docs index that lists site-help guides (check
+  `docs/` for a README or index convention; skip if none).


### PR DESCRIPTION
## Summary

- Fixes the feed layer for Micro.blog's rendering model (Epic #1027): title-less microposts (notes/replies/likes/photos, bookmarks without a frontmatter title) no longer get synthesized titles in any feed format, and all three formats now carry full post content as HTML (RSS `<description>`, Atom `<content type="html">`, JSON Feed `content_html`) rendered via `@astrojs/markdown-remark`, with a target-URL content fallback for empty-body likes/replies/bookmarks and an RSS-validity guarantee (`description = contentHtml || summary || link`). Feeds also gain per-item tags (RSS `<category>`, Atom `<category term>`, JSON Feed `tags`) and profile-derived author metadata (Atom `<author>`, JSON Feed `authors`, RSS `<dc:creator>`) across all 27 feed routes.
- Makes the site side browsable: `/tags/<slug>/` + `/tags/` pages (slug-based URLs so any free-text tag resolves — raw `/`/`#` tags previously crashed the build or 404'd), an `index.astro` h-feed for each of the 7 feed-only collections, and a combined `/timeline/` stream (all 8 collections, cap 50) with microposts inline and titled posts as linked headlines; the homepage links to it.
- Adds `docs/microblog-external-blog.md`: an end-to-end guide for registering an Anglesite site as a Micro.blog external blog (feed registration, `rel=me` verification, cross-posting, Micropub posting from the Micro.blog iOS app) and records the POSSE decision — Micro.blog is deliberately **not** added to `POSSEClients.swift` because feed ingestion at the platform edge makes a push-style client redundant.

Closes #1021, closes #1022, closes #1023, closes #1024, closes #1025, closes #1026.

Follow-ups filed from review: #1043 (feed content fidelity: photo `<img>`, absolute URLs, empty-summary noise), #1044 (h-feed-aware mf2 gate coverage for index/timeline pages), #1045 (timeline render-before-slice), #1046 (`rel="micropub"` discovery link).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

> Template-only (`Resources/Template/`) plus one Swift test file and docs — no MCP schema changes, so no sidecar PR.

## Test plan

- [x] `swift test --package-path .` — all runs pass (2777 tests / 358 suites in the main run), including the updated `FeedsRenderSmokeTests` (likes items now asserted title-less, notes `content_html` asserted)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED (after `xcodegen generate`)
- [x] Template: `npm test` 509 pass / 0 fail (2 pre-existing skips) and `npm run build` (astro check + mf2 gate) clean; rebuilt `dist/` inspected directly — notes item carries no `title` and full `content_html`, likes item carries the escaped target-URL anchor, `/tags/hello-world/`, all 7 collection indexes, and `/timeline/` build and resolve
- [ ] Manual smoke (if UI-touching): n/a — no app UI changes (template + docs + Swift test only)

## Review notes

Built via subagent-driven development: 5 tasks, each with an independent spec+quality review, plus a final whole-branch review (verdict: ready to merge). Review-driven fixes along the way: RSS 2.0 validity for empty-body items, slug-based tag URLs replacing raw-text params, HTML-escaping of captions/summaries promoted into HTML contexts, and doc accuracy corrections verified against book.micro.blog and app source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
