### PR TITLE
refactor(app): adopt SettingsBox in AuditSheetView's skipped list

### DIFF
--- a/Sources/AnglesiteApp/AuditSheetView.swift
+++ b/Sources/AnglesiteApp/AuditSheetView.swift
@@ -245,14 +245,10 @@ struct AuditSheetView: View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Skipped").font(.subheadline.weight(.semibold))
             ForEach(skipped, id: \.category) { entry in
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(entry.category.rawValue.capitalized).font(.callout.weight(.medium))
+                SettingsBox(verbatimTitle: entry.category.rawValue.capitalized) {
                     Text(entry.reason).font(.caption).foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .padding(10)
-                .background(Color.secondary.opacity(0.06))
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             }
         }
     }


### PR DESCRIPTION
## Summary

- Code-review follow-up on #1051: converts `AuditSheetView`'s "Skipped" per-runner card to `SettingsBox` (title above content, matching the existing `SettingsBox(verbatimTitle:)` usage for `model.workerGroups` in `PlistEditorView.swift`).
- Evaluated the other four locations the reviewer flagged and left them unchanged — see Design notes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 228 tests in `AnglesiteSiteModelTests`/`AnglesiteCoreTests`/etc. pass; one pre-existing flake in `FoundationModelAssistantTests` (on-device Foundation Models suite, unrelated file/subsystem) — reproduced twice with a *different* test failing each run, confirming it's not caused by this change.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [ ] Manual smoke (if UI-touching): not run — no interactive Xcode/simulator session in this environment; the change is a single-property swap onto an already-shipped, previewed component (`SettingsBox`), so risk is low, but a visual check of the Audit sheet's "Skipped" section is worth a quick look before merge.

## Design notes

Reviewer flagged five ad hoc `.padding(10).background(Color.secondary.opacity(0.06)).clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))` call sites as candidates for `SettingsBox`. `SettingsBox` is shaped as `VStack(title, content)` plus a border-stroke overlay — matching its existing use for named group boxes (`Site Details`, `Providers`, and per-item `ForEach(model.workerGroups)` boxes). Checking each flagged site against that shape:

- **`AuditSheetView.swift` "Skipped" list (line 254, converted here)** — was already a bare `VStack(title, content)` with no leading/trailing accessory: a structural match, not just a styling match.
- **`HardenSheetView.swift:271`** (`auditFindingRow`) and **`AuditSheetView.swift:206`** (`findingRow`) — both are `HStack(leadingSeverityIcon, VStack(title, detail, remediation))`. `SettingsBox`'s title slot only accepts `Text`; there's no slot for a leading icon beside the title.
- **`DomainSheetView.swift:201`** (`recordRow`) — `HStack(VStack(label, detail), trailingDeleteButton)`. Moving the label into `SettingsBox`'s title would strand the delete button below the content instead of top-aligned beside the title, changing the interaction layout.
- **`ChatView.swift:316`** (`editRow`) — has a left accent-color rectangle and a trailing "Undo" control; a chat-message-row idiom, not a titled settings box.

Skipped these four rather than force a title onto a per-item list row where no natural title slot exists — that would either drop the trailing accessory or bury it below the content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)