### PR TITLE
docs(#1041): comment style guide + DocC catalog + CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,15 @@ jobs:
     # doesn't exist"), so it's left out here. AnglesiteContainer/AnglesiteContainerProbe are
     # excluded the same way every other lane excludes them: the workflow-level
     # ANGLESITE_SKIP_CONTAINER=1 already drops those targets from the manifest entirely.
+    #
+    # AnglesiteAppCore is a separate, two-stage story: Package.swift gates that target behind
+    # `#if compiler(>=6.4) && canImport(Darwin)`, so on a runner whose active Xcode predates
+    # Xcode 27 (Swift 6.4), the target simply doesn't exist in the manifest — and
+    # `generate-documentation --target AnglesiteAppCore` doesn't skip gracefully in that case,
+    # it hard-errors ("no target named …"). So, same ARMED-but-skips-gracefully idiom as the
+    # appintents-schema job below: the 8 non-gated targets always build in one unconditional
+    # step, and AnglesiteAppCore gets its own step gated on the same `has27` detection, green
+    # with a ::warning:: until a runner ships Xcode 27, at which point it auto-activates.
     needs: changes
     if: needs.changes.outputs.swift == 'true'
     runs-on: macos-26
@@ -388,7 +397,25 @@ jobs:
       - name: Show toolchain versions
         run: swift --version
 
-      - name: Build documentation for every module (fails on any DocC error or warning)
+      - name: Detect Xcode 27 (AnglesiteAppCore needs Swift 6.4)
+        id: xcode
+        # AnglesiteAppCore is compiler(>=6.4)-gated in Package.swift, so it's simply absent from
+        # the manifest on an older toolchain — this lane is ARMED but skips that target
+        # gracefully (green, with a ::warning::) until a runner provides Xcode 27, then
+        # auto-activates and enforces, no edit needed.
+        run: |
+          set -euo pipefail
+          xcodebuild -version
+          MAJOR=$(xcodebuild -version | sed -n 's/^Xcode \([0-9]*\).*/\1/p')
+          if [ "${MAJOR:-0}" -ge 27 ]; then
+            echo "has27=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has27=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=AnglesiteAppCore docs skipped::Needs Xcode 27+, runner has ${MAJOR:-unknown}. Lane auto-activates once a runner provides Xcode 27."
+            echo "SKIPPED: AnglesiteAppCore is compiler(>=6.4)-gated and absent from the manifest on Xcode ${MAJOR:-unknown}; skipping its doc build."
+          fi
+
+      - name: Build documentation for the CI-buildable target subset (fails on any DocC error or warning)
         run: |
           swift package generate-documentation \
             --target AnglesiteSiteModel \
@@ -398,8 +425,14 @@ jobs:
             --target AnglesiteBridge \
             --target AnglesiteIOS \
             --target AnglesiteIntents \
-            --target AnglesiteAppCore \
             --target AnglesiteTestSupport \
+            --warnings-as-errors
+
+      - name: Build documentation for AnglesiteAppCore (Swift 6.4+ only)
+        if: steps.xcode.outputs.has27 == 'true'
+        run: |
+          swift package generate-documentation \
+            --target AnglesiteAppCore \
             --warnings-as-errors
 
   xcodeproj-sync:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,51 @@ jobs:
       - name: Run concurrency suites under ThreadSanitizer
         run: scripts/test-concurrency-tsan.sh
 
+  docs-docc:
+    name: DocC build (comment/doc-comment health check)
+    # No xcodegen/xcodebuild here — this job never touches the Xcode project. It exercises the
+    # SwiftPM library targets directly via `swift package generate-documentation`. The --target
+    # list below is deliberate and explicit, not "every target" — verified two things: (1) a
+    # target-less run sweeps in every dependency package too, including MarkdownEngine's own
+    # broken doc comments, which we don't own; (2) AnglesiteLANHost (an executableTarget) fails
+    # symbol-graph extraction with an unrelated tooling issue ("AnglesiteLANHost.symbolgraphs
+    # doesn't exist"), so it's left out here. AnglesiteContainer/AnglesiteContainerProbe are
+    # excluded the same way every other lane excludes them: the workflow-level
+    # ANGLESITE_SKIP_CONTAINER=1 already drops those targets from the manifest entirely.
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Select latest available Xcode
+        # Same rationale as build-test: this package needs Swift 6.4 (compiler(>=6.4) gates on
+        # AnglesiteAppCore), which the runner's default active Xcode may predate.
+        run: |
+          set -euo pipefail
+          ls -d /Applications/Xcode*.app 2>/dev/null | sort -V
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
+          echo "Selecting: $LATEST"
+          sudo xcode-select -s "$LATEST"
+
+      - name: Show toolchain versions
+        run: swift --version
+
+      - name: Build documentation for every module (fails on any DocC error or warning)
+        run: |
+          swift package generate-documentation \
+            --target AnglesiteSiteModel \
+            --target AnglesiteQuickLookSupport \
+            --target AnglesiteCore \
+            --target AnglesiteBridgeCore \
+            --target AnglesiteBridge \
+            --target AnglesiteIOS \
+            --target AnglesiteIntents \
+            --target AnglesiteAppCore \
+            --target AnglesiteTestSupport \
+            --warnings-as-errors
+
   xcodeproj-sync:
     name: Anglesite.xcodeproj ↔ project.yml in sync
     needs: changes
@@ -509,6 +554,7 @@ jobs:
       - linux-build-test
       - build-test
       - concurrency-tsan
+      - docs-docc
       - xcodeproj-sync
       - localization-catalog
       - appintents-schema

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ Notes:
 - **Git is the source of truth for sites** — the app must never become the only way to edit a site. A site's `Source/` repo stays clonable and editable outside the app.
 - **The app cannot bypass the template security gate** — `pre-deploy-check.ts` runs before every deploy; surface failures, don't add overrides.
 - **JS/TypeScript** (edit overlay) uses ES modules, vanilla APIs, and the existing oxlint/tsc/vitest toolchain.
+- **Comment and doc-comment conventions** are in [`docs/comment-style-guide.md`](docs/comment-style-guide.md) — read it before writing `///` doc comments on public API; CI fails on broken DocC symbol links or markup.
 
 ## Commits and pull requests
 

--- a/Package.swift
+++ b/Package.swift
@@ -304,6 +304,14 @@ var packageProducts: [Product] = [
 
 var packageDependencies: [Package.Dependency] = []
 
+// Apple's official DocC generation plugin (#1041) — build-time only, never linked into the
+// shipped app. Pinned to tag 1.5.0's commit, matching the revision-pin policy below (SwiftGit2 /
+// STTextView): a floating `from:` requirement previously shipped an unreviewed breaking change
+// (#774/#781/#783), so every dependency here is bumped deliberately.
+packageDependencies.append(
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", revision: "647c708be89f834fa6a6d4945442793a77ddf5b6")
+)
+
 #if canImport(Darwin)
 // Anglesite's patched fork of mbernson/SwiftGit2 — see #640 and Spikes/GitPackageSpike. Pinned
 // to a commit rather than a tag or branch: SwiftGit2 upstream has no tagged SPM release yet, and

--- a/Sources/AnglesiteApp/Anglesite.docc/AnglesiteAppCore.md
+++ b/Sources/AnglesiteApp/Anglesite.docc/AnglesiteAppCore.md
@@ -1,0 +1,24 @@
+# ``AnglesiteAppCore``
+
+The macOS app shell: SwiftUI views, view models, and window/scene coordination for Anglesite.
+
+## Overview
+
+Anglesite is a native macOS app for building and publishing static sites. This module holds
+almost all of the app's actual logic — the two Xcode-only entry-point files
+(`AnglesiteApp.swift`, `LiveSiteRuntimeFactory.swift`) live alongside it in
+`Sources/AnglesiteApp/` but aren't part of this SwiftPM target, since they depend on the
+Xcode-project-only `Anglesite` application target.
+
+This module is intentionally free of public API of its own — every type here is `internal`,
+consumed only by the app target in this same package. The real public API this app is built on
+lives one layer down:
+
+- `AnglesiteCore` — site model, process supervision, MCP client, and most business logic.
+- `AnglesiteSiteModel` — the `.anglesite` package format (`Source/` + `Config/`) that every site
+  is built from.
+- `AnglesiteBridge` — the `WKWebView` preview bridge.
+- `AnglesiteIntents` — Siri / Shortcuts / Spotlight integration via App Intents.
+
+Generate documentation for any of those directly to browse their public API — for example
+`swift package generate-documentation --target AnglesiteCore`.

--- a/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+++ b/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
@@ -4,14 +4,14 @@ import AnglesiteCore
 import AnglesiteBridgeCore
 
 /// `WKScriptMessageHandler` adapter for the `anglesite` namespace — the WKWebView-specific thin
-/// layer over ``AnglesiteMessageDispatcher`` (cross-platform port design §6 "AnglesiteBridgeCore
+/// layer over `AnglesiteMessageDispatcher` (cross-platform port design §6 "AnglesiteBridgeCore
 /// split"). All the message schema, decoding, and routing logic lives in the portable core; this
 /// class's own job is exactly two things `WKScriptMessage` requires: unwrap `message.body`/
 /// `.webView`, and evaluate the reply script back into the page.
 ///
 /// **API change vs prior versions:** the primary entry point is now
 /// `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)` (forwarding to
-/// ``AnglesiteMessageDispatcher/dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)``).
+/// `AnglesiteMessageDispatcher.dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)`).
 /// All current callers are internal to this repo (the `WKScriptMessageHandler` impl below, the
 /// unit tests — now in `AnglesiteBridgeCoreTests`, testing `AnglesiteMessageDispatcher` directly
 /// — and `PreviewView`'s production init) and use `dispatch` directly. The old `handle(body:via:)`
@@ -47,7 +47,7 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         super.init()
     }
 
-    /// Forwards to ``AnglesiteMessageDispatcher/dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)``
+    /// Forwards to `AnglesiteMessageDispatcher.dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)`
     /// — kept here so existing call sites (this class's own `userContentController`, and any
     /// code written against the pre-split API) don't need to change.
     public static func dispatch(

--- a/Sources/AnglesiteBridge/WebViewBridge.swift
+++ b/Sources/AnglesiteBridge/WebViewBridge.swift
@@ -10,7 +10,7 @@ import AnglesiteBridgeCore
 /// receive edit messages from the injected JS overlay.
 public enum WebViewBridge {
     /// The script-message namespace, shared with every platform adapter — see
-    /// ``AnglesiteMessageDispatcher/scriptMessageNamespace``.
+    /// `AnglesiteMessageDispatcher.scriptMessageNamespace`.
     public static let scriptMessageNamespace = AnglesiteMessageDispatcher.scriptMessageNamespace
 
     /// A `WKWebViewConfiguration` tuned for previewing a local Astro dev server. In Debug builds it
@@ -46,7 +46,7 @@ public enum WebViewBridge {
     /// Loads the bundled edit overlay (built by `scripts/build-overlay.sh`) as a `WKUserScript`,
     /// or returns `nil` when the bundle hasn't been produced (e.g. `swift test`, or a build where
     /// the prebuild script was skipped). The lookup + read is shared with every platform adapter
-    /// via ``AnglesiteOverlayBundle``; only the `WKUserScript` wrapping is WKWebView-specific.
+    /// via `AnglesiteOverlayBundle`; only the `WKUserScript` wrapping is WKWebView-specific.
     @MainActor
     public static func makeOverlayUserScript(in bundle: Bundle = .main) -> WKUserScript? {
         guard let source = AnglesiteOverlayBundle.source(in: bundle) else { return nil }

--- a/Sources/AnglesiteCore/ACPAgentStore.swift
+++ b/Sources/AnglesiteCore/ACPAgentStore.swift
@@ -11,6 +11,7 @@ public final class ACPAgentStore: @unchecked Sendable {
     /// - Parameters:
     ///   - persistenceURL: where to read/write `acp-agents.json`. Defaults to
     ///     `~/Library/Application Support/Anglesite/acp-agents.json`. Tests should pass a temp URL.
+    ///   - fileManager: Injectable for tests; defaults to `.default`.
     public init(persistenceURL: URL? = nil, fileManager: FileManager = .default) {
         self.fileManager = fileManager
         self.persistenceURL = persistenceURL ?? Self.defaultPersistenceURL(fileManager: fileManager)

--- a/Sources/AnglesiteCore/ApplyEditTool.swift
+++ b/Sources/AnglesiteCore/ApplyEditTool.swift
@@ -6,7 +6,7 @@ import Foundation
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
-/// A FoundationModels ``Tool`` that lets the on-device model apply a structured edit to an element
+/// A FoundationModels `Tool` that lets the on-device model apply a structured edit to an element
 /// on a page of the current site, routing through ``IntentEditBridge`` (and on to the plugin's
 /// edit pipeline). Reuses ``GeneratedEditCommand`` (#154) as its arguments so the model speaks one
 /// edit vocabulary.

--- a/Sources/AnglesiteCore/ContentUndoCoordinator.swift
+++ b/Sources/AnglesiteCore/ContentUndoCoordinator.swift
@@ -34,12 +34,12 @@ import Foundation
 ///
 /// - **Redo works here** (unlike #527, whose reverse-apply is a sidecar git revert with no
 ///   re-apply primitive). See ``register(_:)`` for the ordering that makes it work with an
-///   asynchronous applier.
+///   asynchronous applier. (`perform(_:)` is the private popped-record apply path.)
 /// - **Failure re-arms ⌘Z.** `UndoManager` pops the entry synchronously the instant ⌘Z fires,
 ///   long before the async apply resolves. On ``ApplyOutcome/failed`` the optimistically-registered
 ///   inverse is removed and, for a failed undo, the original record re-registered — the same shape
 ///   ``EditUndoCoordinator`` uses for its retryable outcome. A failed *redo* can only be dropped;
-///   see ``perform(_:)``.
+///   see `perform(_:)`.
 /// - **Out-of-band invalidation.** Each record registers against its own private token target, so
 ///   ``invalidate(id:)`` removes exactly one record (`removeAllActions(withTarget:)` on that
 ///   token) rather than clearing the stack. ``invalidateAll()`` drops every pending record — call
@@ -83,7 +83,7 @@ public final class ContentUndoCoordinator {
         case applied
         /// The write or delete didn't happen (git refused, no site open, I/O error). The
         /// coordinator drops the inverse it optimistically pushed. A failed **undo** is then
-        /// re-registered so ⌘Z can retry; a failed **redo** is dropped — see ``perform(_:)``.
+        /// re-registered so ⌘Z can retry; a failed **redo** is dropped — see `perform(_:)`.
         case failed
     }
 

--- a/Sources/AnglesiteCore/ExperimentStats.swift
+++ b/Sources/AnglesiteCore/ExperimentStats.swift
@@ -66,7 +66,10 @@ public enum ExperimentStats {
 
     /// Compare `treatment` against `control` under a Beta-Binomial model with uniform priors.
     ///
-    /// - Parameter confidenceThreshold: probability at which a side is declared the winner.
+    /// - Parameters:
+    ///   - control: The control variant's impression/conversion counts.
+    ///   - treatment: The treatment variant's impression/conversion counts.
+    ///   - confidenceThreshold: probability at which a side is declared the winner.
     public static func analyze(
         control: Variant,
         treatment: Variant,

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -67,7 +67,7 @@ import CoreSpotlight
 import OSLog
 
 /// A ``ContentAssistant`` backed by Apple's on-device `FoundationModels`. Streams free-form text
-/// and produces ``Generable`` structured output via guided generation.
+/// and produces `Generable` structured output via guided generation.
 ///
 /// Compiled into AnglesiteCore on both build targets; it needs no subprocess, so it is the
 /// on-device path usable from the sandboxed MAS build.
@@ -142,7 +142,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// (budget-fit `.focused(.items)`/`.compact` config) for local RAG over indexed site content,
     /// so ``capabilities`` always advertises `supportsTools` (C.8, #158). When **both** `editBridge`
     /// and `contentGraph` are supplied, ``ApplyEditTool`` + ``SearchContentTool`` are added too. The
-    /// one-shot ``generate``/``generateStructured`` paths carry no Spotlight tool, preserving their
+    /// one-shot `generate`/`generateStructured` paths carry no Spotlight tool, preserving their
     /// full context budget for generation.
     public init(
         tier: FoundationModelTier = .onDevice,
@@ -296,7 +296,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
     /// becomes `.cancelled`. Setup failure (model unavailable) propagates as a thrown error *before*
     /// the turn opens.
     ///
-    /// Unlike ``generate(prompt:context:)``, this reuses a **cached** ``LanguageModelSession`` across
+    /// Unlike ``generate(prompt:context:)``, this reuses a **cached** `LanguageModelSession` across
     /// turns so the on-device model remembers the conversation — without it, every message would hit
     /// a memoryless session and the chat would be a one-shot query box. The first turn fixes the
     /// session's instructions from its `context`; later context changes don't retroactively rewrite
@@ -371,7 +371,7 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         activeRelay = nil
     }
 
-    /// Discards the cached ``LanguageModelSession`` (and winds down any in-flight turn) so the next
+    /// Discards the cached `LanguageModelSession` (and winds down any in-flight turn) so the next
     /// ``converse(prompt:context:)`` opens a fresh conversation with no memory of prior turns. A
     /// still-running background drain holds its own session reference and finishes harmlessly.
     public func resetSession() async {

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Which Apple model substrate a ``FoundationModelAssistant`` targets.
+/// Which Apple model substrate a `FoundationModelAssistant` targets.
 ///
 /// Declared *outside* the `#if compiler(>=6.4)` gate because it has no `FoundationModels`
 /// dependency and can be referenced from package code compiled on older CI toolchains.
@@ -25,7 +25,7 @@ public enum FoundationModelTier: String, Sendable, Equatable, CaseIterable {
 }
 
 /// Deterministic context-budget helpers, usable without `FoundationModels`. Declared as a
-/// standalone type (not an extension on ``FoundationModelAssistant``) because that actor is
+/// standalone type (not an extension on `FoundationModelAssistant`) because that actor is
 /// declared inside the `#if compiler(>=6.4)` gate below and is therefore unavailable at this
 /// point in the file on older toolchains — extending it here would break compilation on CI's
 /// pre-6.4 `swift test` runners (#128).

--- a/Sources/AnglesiteCore/InboxSubmissionCommitter.swift
+++ b/Sources/AnglesiteCore/InboxSubmissionCommitter.swift
@@ -78,8 +78,12 @@ public enum InboxSubmissionCommitter {
     /// (safe for the caller to delete from KV staging). Returns an empty array — never throws —
     /// if there was nothing to write or the commit failed, so callers leave undeleted ids staged
     /// for the next site-open's pull rather than losing them.
-    /// - Parameter fileManager: Used only to create the `src/content/inbox` directory; per-submission
-    ///   file writes go through `Data.write(to:options:)` directly and do not go through this.
+    /// - Parameters:
+    ///   - submissions: The inbox submissions to write and commit.
+    ///   - siteDirectory: The site's `Source/` directory the submissions are written under.
+    ///   - fileManager: Used only to create the `src/content/inbox` directory; per-submission
+    ///     file writes go through `Data.write(to:options:)` directly and do not go through this.
+    ///   - gitCommitBatch: Injectable for tests; defaults to the real git commit implementation.
     public static func commit(
         submissions: [InboxKVClient.Submission],
         into siteDirectory: URL,

--- a/Sources/AnglesiteCore/LinkGraph.swift
+++ b/Sources/AnglesiteCore/LinkGraph.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Pure link-graph analysis over ``SiteKnowledgeIndex`` documents. No embeddings, no actors —
-/// reads ``Document.internalLinks`` to surface structural linking issues.
+/// reads ``SiteKnowledgeIndex/Document/internalLinks`` to surface structural linking issues.
 public enum LinkGraph {
     /// A missing reciprocal link: `sourcePath` is the page that should add a link,
     /// `targetPath` is the page it should link back to.

--- a/Sources/AnglesiteCore/SearchContentTool.swift
+++ b/Sources/AnglesiteCore/SearchContentTool.swift
@@ -5,7 +5,7 @@ import Foundation
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
-/// A FoundationModels ``Tool`` that lets the on-device model search the current site's pages and
+/// A FoundationModels `Tool` that lets the on-device model search the current site's pages and
 /// posts (by title, route, slug, collection, or tag) via ``SiteContentGraph`` — local RAG with no
 /// network call.
 public struct SearchContentTool: Tool, Sendable {

--- a/Sources/AnglesiteCore/SiteContentGraph.swift
+++ b/Sources/AnglesiteCore/SiteContentGraph.swift
@@ -193,11 +193,16 @@ public actor SiteContentGraph {
     /// other siteIDs are untouched. Always emits a change for `siteID`, unless discarded by
     /// the `generation` guard below.
     ///
-    /// - Parameter generation: A token from `beginScan(siteID:)`. When provided, this call is
-    ///   silently discarded (no state change, no emit) if a newer scan has since claimed a
-    ///   later generation for `siteID` — see `beginScan` (#666). `nil` (the default) skips the
-    ///   guard entirely, applying unconditionally; used by incremental/test callers that don't
-    ///   participate in the scan-race fence.
+    /// - Parameters:
+    ///   - siteID: The site whose entries are being replaced.
+    ///   - pages: The site's full new page payload.
+    ///   - posts: The site's full new post payload.
+    ///   - images: The site's full new image payload.
+    ///   - generation: A token from `beginScan(siteID:)`. When provided, this call is
+    ///     silently discarded (no state change, no emit) if a newer scan has since claimed a
+    ///     later generation for `siteID` — see `beginScan` (#666). `nil` (the default) skips the
+    ///     guard entirely, applying unconditionally; used by incremental/test callers that don't
+    ///     participate in the scan-race fence.
     public func load(
         siteID: String,
         pages: [Page],

--- a/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
@@ -12,8 +12,8 @@ import FoundationModels
 /// answer structural questions ("how is navigation generated", "why does this image appear
 /// here") that a text search over file contents can't answer.
 ///
-/// Reuses #614's per-node fact list (``SiteGraphExplainPrompt/facts(node:impact:dependsOn:referencedBy:)``)
-/// for up to ``SiteGraphAugmentedAssistant/maxSeedNodes`` nodes matched against the question's
+/// Reuses #614's per-node fact list (`SiteGraphExplainPrompt.facts(node:impact:dependsOn:referencedBy:)`)
+/// for up to `SiteGraphAugmentedAssistant.maxSeedNodes` nodes matched against the question's
 /// words. Contributes nothing when no node matches, so unrelated chat turns are unaffected.
 public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
     /// Largest number of matched nodes to ground a single question in — keeps the prompt within

--- a/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
+++ b/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
@@ -5,7 +5,7 @@ import Foundation
 /// short plain-language summary of the node's role on the site.
 ///
 /// Per the LLM policy (#459), this is on-device-only: the default backend is Apple's
-/// FoundationModels via ``FoundationModelAssistant``, there is no network fallback, and hosts
+/// FoundationModels via `FoundationModelAssistant`, there is no network fallback, and hosts
 /// without a usable model surface ``AssistantError/unavailable(_:)`` instead of degrading to a
 /// cloud call.
 public protocol SiteGraphNodeExplaining: Sendable {

--- a/Sources/AnglesiteCore/SiteSearchDestination.swift
+++ b/Sources/AnglesiteCore/SiteSearchDestination.swift
@@ -14,9 +14,14 @@ public enum SiteSearchDestination: Equatable, Sendable {
     /// Open this file (path relative to the site's `Source/`) in the editor.
     case file(path: String, group: FileGroup)
 
-    /// - Parameter navigatorRouteIDs: route → navigator node id for the rows currently on
-    ///   screen. Empty while a window's tree is still loading, which resolves everything to
-    ///   `.file` — a usable destination rather than a dropped hit.
+    /// - Parameters:
+    ///   - kind: The matched document's kind, used to pick the destination's `FileGroup` when it
+    ///     falls back to `.file`.
+    ///   - route: The matched document's route, if it has one. `nil` always falls back to `.file`.
+    ///   - path: The matched document's path relative to the site's `Source/`, used for `.file`.
+    ///   - navigatorRouteIDs: route → navigator node id for the rows currently on
+    ///     screen. Empty while a window's tree is still loading, which resolves everything to
+    ///     `.file` — a usable destination rather than a dropped hit.
     public static func resolve(
         kind: SiteKnowledgeIndex.Document.Kind,
         route: String?,

--- a/Sources/AnglesiteCore/SiteSearchIndex.swift
+++ b/Sources/AnglesiteCore/SiteSearchIndex.swift
@@ -81,8 +81,13 @@ public enum SiteSearchIndex {
     }
 
     /// Searches the index for documents matching the query.
-    /// - Parameter limit: Maximum number of results to return. Clamped to a minimum of 1 by
-    ///   the underlying `SiteKnowledgeIndex.SearchOptions`, so `limit: 0` still returns one hit.
+    /// - Parameters:
+    ///   - index: The site's knowledge index to search.
+    ///   - siteID: The site whose documents are searched.
+    ///   - query: The search text.
+    ///   - limit: Maximum number of results to return. Clamped to a minimum of 1 by
+    ///     the underlying `SiteKnowledgeIndex.SearchOptions`, so `limit: 0` still returns one hit.
+    ///   - kinds: Restricts results to these document kinds, or all kinds when `nil`.
     public static func search(
         _ index: SiteKnowledgeIndex,
         siteID: String,

--- a/Sources/AnglesiteCore/SuggestLinksTool.swift
+++ b/Sources/AnglesiteCore/SuggestLinksTool.swift
@@ -7,7 +7,7 @@ import FoundationModels
 import os
 
 /// Foundation Models tool that suggests internal pages to link to from a given page. Uses
-/// semantic similarity (``SemanticRanker.related``) filtered by existing links (``LinkGraph``).
+/// semantic similarity (``SemanticRanker/related(siteID:toDocID:limit:)``) filtered by existing links (``LinkGraph``).
 public struct SuggestLinksTool: Tool, Sendable {
     public static let toolName = "suggestLinks"
     public let name = SuggestLinksTool.toolName

--- a/Sources/AnglesiteCore/SyncEngine.swift
+++ b/Sources/AnglesiteCore/SyncEngine.swift
@@ -203,7 +203,7 @@ public actor SyncEngine {
     /// peer / integrity-check repair) — that already performs the equivalent of a pull, so this
     /// returns `.bootstrapped` without a separate fetch.
     ///
-    /// On genuine divergence, hands off to ``reconcileDivergence(repo:package:branchName:branchRefName:localOID:icloudOID:)``
+    /// On genuine divergence, hands off to `reconcileDivergence(repo:package:branchName:branchRefName:localOID:icloudOID:)`
     /// (#880, design doc §3) for full reconciliation — fast-forward/merge every NSFileVersion
     /// conflict version of the artifact alongside the current one, rather than just reporting the
     /// divergence.

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -118,6 +118,15 @@ public enum WorkerComposition {
     ///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
     ///     longer shadow an active dynamic route, while every unclaimed path keeps Cloudflare's
     ///     asset-first fallback. Omitted entirely when there are no active dynamic routes.
+    ///   - resources: The site's provisioned Cloudflare resource IDs (D1/KV/R2/queues).
+    ///   - inboxCaptureEnabled: Whether the inbox-capture route claim is appended to `routeClaims`.
+    ///   - inboxKVNamespaceID: The inbox KV namespace ID, required when `inboxCaptureEnabled`.
+    ///   - siteURL: The site's public URL, threaded into the composed Worker's config.
+    ///   - displayName: The site's display name (`SiteSettings.displayName`, already falling back
+    ///     to the site name by the time a caller passes it in — this function stays pure and does
+    ///     no fallback of its own), threaded into the ActivityPub actor's `AP_DISPLAY_NAME` var.
+    ///     `nil` when unknown; the composed Worker's actor document then falls back to a fixed
+    ///     generic name (`worker.ts`'s concern, not this function's).
     /// - Returns: A complete wrangler.toml string.
     /// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
     ///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``
@@ -130,11 +139,6 @@ public enum WorkerComposition {
         inboxCaptureEnabled: Bool = false,
         inboxKVNamespaceID: String? = nil,
         siteURL: String? = nil,
-        /// The site's display name (`SiteSettings.displayName`, already falling back to the site
-        /// name by the time a caller passes it in — this function stays pure and does no
-        /// fallback of its own), threaded into the ActivityPub actor's `AP_DISPLAY_NAME` var.
-        /// `nil` when unknown; the composed Worker's actor document then falls back to a fixed
-        /// generic name (`worker.ts`'s concern, not this function's).
         displayName: String? = nil
     ) throws -> String {
         guard isValidSiteName(siteName) else {

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -118,9 +118,18 @@ public enum WorkerComposition {
     ///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
     ///     longer shadow an active dynamic route, while every unclaimed path keeps Cloudflare's
     ///     asset-first fallback. Omitted entirely when there are no active dynamic routes.
-    ///   - resources: The site's provisioned Cloudflare resource IDs (D1/KV/R2/queues).
-    ///   - inboxCaptureEnabled: Whether the inbox-capture route claim is appended to `routeClaims`.
-    ///   - inboxKVNamespaceID: The inbox KV namespace ID, required when `inboxCaptureEnabled`.
+    ///   - resources: The site's provisioned Cloudflare resource identifiers and names — D1 and KV
+    ///     are ids (``ProvisionedResources/d1DatabaseID``, ``ProvisionedResources/kvNamespaceID``),
+    ///     while R2 and the queues are deterministic names, not ids (see
+    ///     ``ProvisionedResources`` for the per-field rationale).
+    ///   - inboxCaptureEnabled: Whether inbox-capture support is composed in: appends the
+    ///     inbox-capture route claim to `routeClaims`, and gates on the Worker's `main` entry
+    ///     point, the `[assets]` binding, the `[[kv_namespaces]]` block, and `[observability]`
+    ///     being emitted (alongside `hasSocialFeatures`, i.e. any active `workers`).
+    ///   - inboxKVNamespaceID: The inbox KV namespace ID. Optional even when
+    ///     `inboxCaptureEnabled` is `true` — if `nil` or empty, the emitted
+    ///     `[[kv_namespaces]]` block gets a placeholder empty `id` for provisioning to fill in
+    ///     later, rather than throwing.
     ///   - siteURL: The site's public URL, threaded into the composed Worker's config.
     ///   - displayName: The site's display name (`SiteSettings.displayName`, already falling back
     ///     to the site name by the time a caller passes it in — this function stays pure and does

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -123,9 +123,10 @@ public enum WorkerComposition {
     ///     while R2 and the queues are deterministic names, not ids (see
     ///     ``ProvisionedResources`` for the per-field rationale).
     ///   - inboxCaptureEnabled: Whether inbox-capture support is composed in: appends the
-    ///     inbox-capture route claim to `routeClaims`, and gates on the Worker's `main` entry
-    ///     point, the `[assets]` binding, the `[[kv_namespaces]]` block, and `[observability]`
-    ///     being emitted (alongside `hasSocialFeatures`, i.e. any active `workers`).
+    ///     inbox-capture route claim to `routeClaims`, and always gates the emitted
+    ///     `[[kv_namespaces]]` block. The Worker's `main` entry point, the `[assets]` binding,
+    ///     and `[observability]` are each gated on this flag *or* `hasSocialFeatures` (any
+    ///     active `workers`) — either one alone is enough to emit them.
     ///   - inboxKVNamespaceID: The inbox KV namespace ID. Optional even when
     ///     `inboxCaptureEnabled` is `true` — if `nil` or empty, the emitted
     ///     `[[kv_namespaces]]` block gets a placeholder empty `id` for provisioning to fill in

--- a/docs/comment-style-guide.md
+++ b/docs/comment-style-guide.md
@@ -25,7 +25,7 @@ documented files predate this rule and won't be mass-edited to add them. If you'
 of those files for an unrelated reason, bringing its doc comments up to this standard is welcome
 opportunistic cleanup, not required.
 
-Example (`Sources/AnglesiteCore/WorkerComposition.swift:109-124`):
+Example (`Sources/AnglesiteCore/WorkerComposition.swift:109-142`):
 
 ```swift
 /// Generates a wrangler.toml for a site with the given workers enabled.

--- a/docs/comment-style-guide.md
+++ b/docs/comment-style-guide.md
@@ -1,0 +1,103 @@
+# Comment style guide
+
+This repo generates an Xcode docset from `///` doc comments via DocC (see "Building docs
+locally" below). This guide describes how to write comments so that both the generated docset
+and the raw source stay useful to the next person (or agent) reading them.
+
+## Philosophy
+
+Comments explain **why**, not **what**. A well-named type or function already says what it does;
+repeating that in a comment is noise. Explain the constraint, the rationale, the workaround, or
+the non-obvious consequence instead. Most of this codebase already does this well — doc comments
+here tend to read like short design notes, often citing the issue that motivated them
+(`Sources/AnglesiteCore/NewSiteDraft.swift:90`, for example, explains *why* a field is optional,
+not just that it is).
+
+## Doc comments (`///`)
+
+Every `public`/`open` declaration gets a `///` doc comment: a lead sentence stating what the
+symbol is or does, followed by prose covering rationale, constraints, or edge cases where they
+exist.
+
+**Formal `- Parameter:`/`- Returns:`/`- Throws:` tags are required on new or changed public API**
+going forward. They're not required retroactively — most of this codebase's ~500 already-
+documented files predate this rule and won't be mass-edited to add them. If you're touching one
+of those files for an unrelated reason, bringing its doc comments up to this standard is welcome
+opportunistic cleanup, not required.
+
+Example (`Sources/AnglesiteCore/WorkerComposition.swift:109-124`):
+
+```swift
+/// Generates a wrangler.toml for a site with the given workers enabled.
+///
+/// - Parameters:
+///   - siteName: The Worker name (used as the Cloudflare Workers project name).
+///     Must match `[A-Za-z0-9_-]+`.
+///   - workers: The effective active `@dwk/workers` catalog descriptors. Empty = static-only
+///     deploy.
+///   - routeClaims: The effective active dynamic-route claims (#746), already validated by
+///     `WorkerRouteClaims.activeClaims`. Emitted as selective `[assets].run_worker_first`
+///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
+///     longer shadow an active dynamic route, while every unclaimed path keeps Cloudflare's
+///     asset-first fallback. Omitted entirely when there are no active dynamic routes.
+/// - Returns: A complete wrangler.toml string.
+/// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
+///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``
+///   for a claim that never passed `WorkerRouteClaims` validation.
+public static func generateWranglerToml(...) -> String
+```
+
+Skip the tags when a function has zero or one self-explanatory parameter, no meaningful return
+value, and doesn't throw — a bare lead-sentence doc comment is enough there. Use judgment: the
+tags exist to add clarity a signature doesn't already give you, not to pad every declaration.
+
+## DocC-specific syntax
+
+- **Symbol links:** double backticks (` ``TypeName`` `` or ` ``TypeName/member(_:)`` ``) create a
+  resolved, clickable link in the generated docset. Single backticks (`` `TypeName` ``) render as
+  plain code with no link — use those for code that isn't a real symbol in this package (a
+  parameter's literal value, a shell command, etc).
+- **Callouts:** `- Important:`, `- Note:`, and `- Warning:` render as highlighted callout boxes in
+  the docset. Use them sparingly, for things a reader could otherwise miss (a genuinely
+  surprising constraint, not routine information already covered in prose).
+- **`// MARK: -` vs `// MARK:`:** a `// MARK: -` (with the trailing dash) becomes a Topic section
+  divider in the generated docset, in addition to its usual Xcode jump-bar behavior. A plain
+  `// MARK:` (no dash) is jump-bar-only — invisible to DocC. Use the dash form when a MARK groups
+  related public API that should also read as a group in the docset; use the plain form for
+  private/internal organization that shouldn't show up there at all.
+- **`.docc` landing pages:** a catalog's landing page is a Markdown file named after the module it
+  documents (`AnglesiteAppCore.md` inside a catalog documents the `AnglesiteAppCore` module),
+  starting with `# \`\`ModuleName\`\`` and an optional `## Topics` section listing `<doc:>` or
+  double-backtick links to group related symbols. See
+  `Sources/AnglesiteApp/Anglesite.docc/AnglesiteAppCore.md` for a real example.
+
+## Inline comments (`//`)
+
+Line-level only, and only when the *why* isn't obvious from the code itself: a hidden constraint,
+a workaround for a specific bug (link the issue), a non-obvious invariant. If removing the
+comment wouldn't leave a future reader confused, don't write it. Don't describe what the next
+line does — the code already does that better than a comment can.
+
+## Building docs locally
+
+Two ways to generate documentation, depending on what you need:
+
+- **Fast, single-module iteration**:
+  ```sh
+  swift package generate-documentation --target AnglesiteCore --warnings-as-errors
+  ```
+  Add `--warnings-as-errors` to match CI's strictness while iterating locally. **Don't drop
+  `--target`** — with no target filter, the plugin documents every target in the whole dependency
+  graph, including vendored third-party packages whose doc comments you don't control and can't
+  fix. CI passes an explicit list of this repo's own targets; copy that list from
+  `.github/workflows/ci.yml`'s `docs-docc` job (or `AGENTS.md`/`CONTRIBUTING.md`) to generate docs
+  for everything at once.
+
+- **The full merged docset** — app entry point, every module, and the container runtime, as one
+  browsable archive in Xcode's Developer Documentation window (Product ▸ Build Documentation, or
+  ⌃⌘⇧D). **Local-only** — this needs `xcodebuild`, `xcodegen generate` to have already run, and a
+  Mac that can build `AnglesiteContainer` (the hosted CI runner can't, which is why CI uses the
+  `swift package` path above instead):
+  ```sh
+  xcodebuild docbuild -scheme Anglesite -destination 'platform=macOS'
+  ```

--- a/docs/comment-style-guide.md
+++ b/docs/comment-style-guide.md
@@ -54,9 +54,21 @@ tags exist to add clarity a signature doesn't already give you, not to pad every
 ## DocC-specific syntax
 
 - **Symbol links:** double backticks (` ``TypeName`` `` or ` ``TypeName/member(_:)`` ``) create a
-  resolved, clickable link in the generated docset. Single backticks (`` `TypeName` ``) render as
-  plain code with no link — use those for code that isn't a real symbol in this package (a
-  parameter's literal value, a shell command, etc).
+  resolved, clickable link in the generated docset — but DocC only resolves them for a symbol that
+  is both (a) `public`+ access level, and (b) in the *same SwiftPM target* as the file referencing
+  it (or a symbol that target genuinely re-exports). Single backticks (`` `TypeName` ``) render as
+  plain code with no link — use those for:
+  - a cross-module reference: a symbol defined in a different SwiftPM target than the file
+    referencing it (e.g. `` `AnglesiteMessageDispatcher` `` and `` `AnglesiteOverlayBundle` ``,
+    both defined in `AnglesiteBridgeCore`, referenced from `AnglesiteBridge`'s
+    `WebViewBridge.swift` and `AnglesiteScriptHandler.swift`) — DocC's default symbol graph
+    doesn't resolve these without an experimental cross-module-links flag this repo doesn't use;
+  - a `private`/`internal` symbol — DocC's symbol graph only includes public API, so these never
+    resolve regardless of which target they're in;
+  - code that isn't a real symbol in this package at all (a parameter's literal value, a shell
+    command, etc);
+  - an Apple SDK framework symbol — outside this package's symbol graph entirely, so it can never
+    resolve to a link here.
 - **Callouts:** `- Important:`, `- Note:`, and `- Warning:` render as highlighted callout boxes in
   the docset. Use them sparingly, for things a reader could otherwise miss (a genuinely
   surprising constraint, not routine information already covered in prose).

--- a/docs/comment-style-guide.md
+++ b/docs/comment-style-guide.md
@@ -68,7 +68,15 @@ tags exist to add clarity a signature doesn't already give you, not to pad every
   - code that isn't a real symbol in this package at all (a parameter's literal value, a shell
     command, etc);
   - an Apple SDK framework symbol — outside this package's symbol graph entirely, so it can never
-    resolve to a link here.
+    resolve to a link here;
+  - a symbol declared inside a `#if compiler(>=6.4)` (or similar toolchain-version) gate,
+    referenced from code *outside* that gate — CI builds this repo's own targets on whatever
+    Swift version its runners currently ship, which can be older than your local toolchain, so a
+    gated symbol simply isn't in the symbol graph there. This bit `FoundationModelAssistant`: two
+    doc comments in the same file, and one in `SiteGraphNodeExplainer.swift`, referenced it with
+    double backticks from code deliberately declared *outside* its `#if compiler(>=6.4)` gate (so
+    that code itself would still compile on an older toolchain) — the link resolved locally but
+    broke in CI, which runs an older Swift version than most contributors' machines.
 - **Callouts:** `- Important:`, `- Note:`, and `- Warning:` render as highlighted callout boxes in
   the docset. Use them sparingly, for things a reader could otherwise miss (a genuinely
   surprising constraint, not routine information already covered in prose).

--- a/docs/superpowers/plans/2026-07-27-comment-style-guide-docc.md
+++ b/docs/superpowers/plans/2026-07-27-comment-style-guide-docc.md
@@ -1,0 +1,1051 @@
+# Comment Style Guide + DocC Catalog + CI Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Anglesite-app a written comment style guide, a working DocC catalog, and a CI check that fails the build on broken doc comments — so `swift package generate-documentation` (and, locally, `xcodebuild docbuild`) produce a real, browsable Xcode docset.
+
+**Architecture:** Add `swift-docc-plugin` as a build-time-only SwiftPM dependency (pinned to an exact commit, matching this repo's existing dependency-pinning convention). Add one umbrella `.docc` landing-page catalog inside `Sources/AnglesiteApp/Anglesite.docc/`, auto-adopted by the existing `AnglesiteAppCore` SwiftPM target. Fix a finite, already-existing list of broken doc comments (found by actually running the tool against this repo, not guessed) so the new check can be strict from day one. Add a new `docs-docc` CI job that runs `swift package generate-documentation --warnings-as-errors` against an explicit list of our own SwiftPM library targets (never the whole dependency graph — vendored third-party packages have their own doc-comment issues we don't own) and fails the build on any DocC warning or error. Write `docs/comment-style-guide.md` describing the doc-comment conventions this enforces, linked from `CONTRIBUTING.md`.
+
+**Important process note:** every fact below (CLI flags, exit codes, which files are broken and why, the exact correct fix for each) was confirmed by actually running `swift package generate-documentation` against this real repository in a throwaway local edit, not inferred from documentation or static reading. Do not "simplify" any step below based on how DocC *should* behave — several of these findings (cross-module links failing without `--enable-experimental-combined-documentation`, `--target`-less runs sweeping in dependencies, parameter-validation being a warning by default but promoted to an error by `--warnings-as-errors`) contradicted the first-pass assumption and were only caught by running the real command.
+
+**Tech Stack:** Swift 6.4 / SwiftPM, Apple's `swift-docc-plugin`, GitHub Actions.
+
+## Global Constraints
+
+- Pin `swift-docc-plugin` to an exact `revision:`, not a `from:` semver range — this repo's established policy (see `SwiftGit2`/`STTextView` entries in `Package.swift`) after a floating version once shipped an unreviewed breaking API change (#774/#781/#783).
+- Do not retrofit existing doc comments across the ~500 already-documented files. The stricter `- Parameter:`/`- Returns:`/`- Throws:` tagging rule applies to new/changed public API going forward only. (Task 4 fixes a finite, already-broken list of ~15 files found by testing — that's bug-fixing, not the retrofit this line declines.)
+- Do not add a documentation-coverage CI gate. Only DocC build errors/warnings fail the new job.
+- `AnglesiteContainer`/`AnglesiteContainerProbe` are excluded from the new CI job the same way they're excluded from every other Swift CI lane (the workflow-level `ANGLESITE_SKIP_CONTAINER=1` env var already drops them from the SwiftPM manifest entirely — no extra logic needed in the new job). `AnglesiteLANHost` is also excluded — its symbol-graph extraction fails with an unrelated tooling issue (confirmed: `.build/.../AnglesiteLANHost.symbolgraphs doesn't exist`), not a doc-comment problem.
+- No per-module `.docc` catalogs. One umbrella catalog only.
+- The CI job must pass an explicit `--target` list of our own targets. Never run `generate-documentation` with no `--target` filter — confirmed it sweeps in every dependency package too (it tried to document the vendored `MarkdownEngine` package and hit that package's own broken doc comments, which we don't own and can't fix here).
+- Every step below was verified directly against a real Swift 6.4 toolchain — either in a scratch package or (for Task 4's fixes and the CI command itself) against this actual repository in a throwaway local edit that was reverted before writing this plan down. The exact CLI flags, exit codes, file-naming conventions, and the list of already-broken files are confirmed, not guessed.
+
+---
+
+### Task 1: Add `swift-docc-plugin` dependency
+
+**Files:**
+- Modify: `Package.swift` (add one `.package(...)` entry to `packageDependencies`)
+
+**Interfaces:**
+- Produces: `swift package generate-documentation` becomes available as a plugin command for every target in the package. No new Swift symbols.
+
+- [ ] **Step 1: Add the dependency**
+
+Open `Package.swift` and find this block (currently around line 305-314):
+
+```swift
+var packageDependencies: [Package.Dependency] = []
+
+#if canImport(Darwin)
+// Anglesite's patched fork of mbernson/SwiftGit2 — see #640 and Spikes/GitPackageSpike. Pinned
+// to a commit rather than a tag or branch: SwiftGit2 upstream has no tagged SPM release yet, and
+// pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
+// deliberately.
+packageDependencies.append(
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "446d4777ae4413c2faaa88425693ff29981e4b07")
+)
+```
+
+Add a new entry immediately before that `#if canImport(Darwin)` block (this dependency is a
+build-time plugin only, needed on every platform that runs `swift package generate-documentation`,
+so it does not need Darwin-gating):
+
+```swift
+var packageDependencies: [Package.Dependency] = []
+
+// Apple's official DocC generation plugin (#1041) — build-time only, never linked into the
+// shipped app. Pinned to tag 1.5.0's commit, matching the revision-pin policy below (SwiftGit2 /
+// STTextView): a floating `from:` requirement previously shipped an unreviewed breaking change
+// (#774/#781/#783), so every dependency here is bumped deliberately.
+packageDependencies.append(
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", revision: "647c708be89f834fa6a6d4945442793a77ddf5b6")
+)
+
+#if canImport(Darwin)
+// Anglesite's patched fork of mbernson/SwiftGit2 — see #640 and Spikes/GitPackageSpike. Pinned
+// to a commit rather than a tag or branch: SwiftGit2 upstream has no tagged SPM release yet, and
+// pinning to anglesite/main's tip would silently pick up unreviewed future commits. Bump
+// deliberately.
+packageDependencies.append(
+    .package(url: "https://github.com/Anglesite/SwiftGit2.git", revision: "446d4777ae4413c2faaa88425693ff29981e4b07")
+)
+```
+
+- [ ] **Step 2: Verify it resolves and builds**
+
+Run: `swift build -c debug`
+Expected: Build succeeds; output includes `Fetching https://github.com/swiftlang/swift-docc-plugin.git` and `Working copy of https://github.com/swiftlang/swift-docc-plugin.git resolved at 647c708be89f834fa6a6d4945442793a77ddf5b6` (or a cached-resolution equivalent on a second run), ending in `Build complete!`.
+
+- [ ] **Step 3: Verify the plugin command is available**
+
+Run: `swift package generate-documentation --help`
+Expected: Help text prints, including `--target <target>`, `--warnings-as-errors`, and `PLUGIN OPTIONS:`. No error about an unrecognized subcommand.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Package.swift
+git commit -m "build(#1041): add swift-docc-plugin dependency"
+```
+
+---
+
+### Task 2: Add the umbrella `.docc` catalog
+
+**Files:**
+- Create: `Sources/AnglesiteApp/Anglesite.docc/AnglesiteAppCore.md`
+
+**Interfaces:**
+- Consumes: nothing new — this is content-only, auto-discovered by the existing `AnglesiteAppCore` SwiftPM target (`Package.swift`'s `AnglesiteAppCore` target already declares `path: "Sources/AnglesiteApp"`; any `.docc` folder inside a target's source path is picked up by DocC automatically, no manifest change needed).
+- Produces: a landing page for the `AnglesiteAppCore` module's generated documentation.
+
+- [ ] **Step 1: Create the catalog directory and landing page**
+
+**Important — verified constraint:** `AnglesiteAppCore` (all of `Sources/AnglesiteApp/*.swift`
+except the two Xcode-only files) has essentially **zero `public`-access declarations** — confirmed
+with `grep -rln "public " Sources/AnglesiteApp/*.swift` (excluding those two files) and manually
+checking every hit: every match is the word "public" inside prose/comments (e.g. "public URL"),
+never the `public` access modifier. This makes sense: it's app-shell code consumed only by the
+`Anglesite` application target in the same package, never imported as a library elsewhere. Two
+consequences for the landing page:
+
+1. **Do not use double-backtick symbol links** (` ``AnglesiteCore`` `` etc.) to reference *other*
+   modules from this landing page. Verified directly in a scratch package: a double-backtick link
+   from one target's landing page to another target's module/type name fails to resolve
+   (`error: 'Core' doesn't exist at '/AppCore'`) unless the docs are built with
+   `--enable-experimental-combined-documentation` (an experimental flag, out of scope here). Use
+   plain single backticks for other module/type names instead — they render as code text with no
+   link attempt.
+2. **No `## Topics` section** listing symbols — there are no real public symbols in this target to
+   list, and a Topics entry pointing at a symbol that doesn't exist in the symbol graph fails the
+   same way.
+
+Create `Sources/AnglesiteApp/Anglesite.docc/AnglesiteAppCore.md` (the file must be named after the
+module it documents — `AnglesiteAppCore`, not `Anglesite` — for DocC to recognize it as that
+module's landing page; verified: a `Foo.docc/Foo.md` landing page was correctly picked up when
+generating docs for a target literally named `Foo`, in a scratch package built for this plan):
+
+```markdown
+# ``AnglesiteAppCore``
+
+The macOS app shell: SwiftUI views, view models, and window/scene coordination for Anglesite.
+
+## Overview
+
+Anglesite is a native macOS app for building and publishing static sites. This module holds
+almost all of the app's actual logic — the two Xcode-only entry-point files
+(`AnglesiteApp.swift`, `LiveSiteRuntimeFactory.swift`) live alongside it in
+`Sources/AnglesiteApp/` but aren't part of this SwiftPM target, since they depend on the
+Xcode-project-only `Anglesite` application target.
+
+This module is intentionally free of public API of its own — every type here is `internal`,
+consumed only by the app target in this same package. The real public API this app is built on
+lives one layer down:
+
+- `AnglesiteCore` — site model, process supervision, MCP client, and most business logic.
+- `AnglesiteSiteModel` — the `.anglesite` package format (`Source/` + `Config/`) that every site
+  is built from.
+- `AnglesiteBridge` — the `WKWebView` preview bridge.
+- `AnglesiteIntents` — Siri / Shortcuts / Spotlight integration via App Intents.
+
+Generate documentation for any of those directly to browse their public API — for example
+`swift package generate-documentation --target AnglesiteCore`.
+```
+
+- [ ] **Step 2: Verify the catalog is picked up**
+
+Run: `swift package generate-documentation --target AnglesiteAppCore --warnings-as-errors`
+Expected: Exit code `0`. Output includes `Building documentation for 'AnglesiteAppCore'...` and
+`Generated documentation archive at: .../AnglesiteAppCore.doccarchive`. (A `warning: '<package>':
+found 1 file(s) which are unhandled` line referencing the `Anglesite.docc` path is expected and
+harmless — verified separately that this specific warning comes from the underlying `swift build`
+resource scan, not from DocC itself, and does not affect `--warnings-as-errors`'s exit code.)
+
+- [ ] **Step 3: Spot-check the generated landing page**
+
+Run: `grep -l "native macOS app" .build/plugins/Swift-DocC/outputs/AnglesiteAppCore.doccarchive/data/documentation/anglesiteappcore.json`
+Expected: Prints the file path (a match) — confirms the landing-page prose made it into the built
+archive's JSON data, not just sitting unused on disk. (Default output location verified in a
+scratch package: `swift package generate-documentation --target <X>` with no `--output-path`
+writes to `.build/plugins/Swift-DocC/outputs/<X>.doccarchive`, and the module's JSON lands at
+`data/documentation/<lowercased-module-name>.json` inside it.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/Anglesite.docc/
+git commit -m "docs(#1041): add Anglesite.docc umbrella landing page"
+```
+
+---
+
+### Task 3: Write `docs/comment-style-guide.md`
+
+**Files:**
+- Create: `docs/comment-style-guide.md`
+- Modify: `CONTRIBUTING.md:67-75` (the "Code guidelines" section)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing consumed by later tasks — this is the human-facing document.
+
+- [ ] **Step 1: Write the guide**
+
+Create `docs/comment-style-guide.md`:
+
+```markdown
+# Comment style guide
+
+This repo generates an Xcode docset from `///` doc comments via DocC (see "Building docs
+locally" below). This guide describes how to write comments so that both the generated docset
+and the raw source stay useful to the next person (or agent) reading them.
+
+## Philosophy
+
+Comments explain **why**, not **what**. A well-named type or function already says what it does;
+repeating that in a comment is noise. Explain the constraint, the rationale, the workaround, or
+the non-obvious consequence instead. Most of this codebase already does this well — doc comments
+here tend to read like short design notes, often citing the issue that motivated them
+(`Sources/AnglesiteCore/NewSiteDraft.swift:90`, for example, explains *why* a field is optional,
+not just that it is).
+
+## Doc comments (`///`)
+
+Every `public`/`open` declaration gets a `///` doc comment: a lead sentence stating what the
+symbol is or does, followed by prose covering rationale, constraints, or edge cases where they
+exist.
+
+**Formal `- Parameter:`/`- Returns:`/`- Throws:` tags are required on new or changed public API**
+going forward. They're not required retroactively — most of this codebase's ~500 already-
+documented files predate this rule and won't be mass-edited to add them. If you're touching one
+of those files for an unrelated reason, bringing its doc comments up to this standard is welcome
+opportunistic cleanup, not required.
+
+Example (`Sources/AnglesiteCore/WorkerComposition.swift:109-124`):
+
+```swift
+/// Generates a wrangler.toml for a site with the given workers enabled.
+///
+/// - Parameters:
+///   - siteName: The Worker name (used as the Cloudflare Workers project name).
+///     Must match `[A-Za-z0-9_-]+`.
+///   - workers: The effective active `@dwk/workers` catalog descriptors. Empty = static-only
+///     deploy.
+///   - routeClaims: The effective active dynamic-route claims (#746), already validated by
+///     `WorkerRouteClaims.activeClaims`. Emitted as selective `[assets].run_worker_first`
+///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
+///     longer shadow an active dynamic route, while every unclaimed path keeps Cloudflare's
+///     asset-first fallback. Omitted entirely when there are no active dynamic routes.
+/// - Returns: A complete wrangler.toml string.
+/// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
+///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``
+///   for a claim that never passed `WorkerRouteClaims` validation.
+public static func generateWranglerToml(...) -> String
+```
+
+Skip the tags when a function has zero or one self-explanatory parameter, no meaningful return
+value, and doesn't throw — a bare lead-sentence doc comment is enough there. Use judgment: the
+tags exist to add clarity a signature doesn't already give you, not to pad every declaration.
+
+## DocC-specific syntax
+
+- **Symbol links:** double backticks (` ``TypeName`` `` or ` ``TypeName/member(_:)`` ``) create a
+  resolved, clickable link in the generated docset. Single backticks (`` `TypeName` ``) render as
+  plain code with no link — use those for code that isn't a real symbol in this package (a
+  parameter's literal value, a shell command, etc).
+- **Callouts:** `- Important:`, `- Note:`, and `- Warning:` render as highlighted callout boxes in
+  the docset. Use them sparingly, for things a reader could otherwise miss (a genuinely
+  surprising constraint, not routine information already covered in prose).
+- **`// MARK: -` vs `// MARK:`:** a `// MARK: -` (with the trailing dash) becomes a Topic section
+  divider in the generated docset, in addition to its usual Xcode jump-bar behavior. A plain
+  `// MARK:` (no dash) is jump-bar-only — invisible to DocC. Use the dash form when a MARK groups
+  related public API that should also read as a group in the docset; use the plain form for
+  private/internal organization that shouldn't show up there at all.
+- **`.docc` landing pages:** a catalog's landing page is a Markdown file named after the module it
+  documents (`AnglesiteAppCore.md` inside a catalog documents the `AnglesiteAppCore` module),
+  starting with `# \`\`ModuleName\`\`` and an optional `## Topics` section listing `<doc:>` or
+  double-backtick links to group related symbols. See
+  `Sources/AnglesiteApp/Anglesite.docc/AnglesiteAppCore.md` for a real example.
+
+## Inline comments (`//`)
+
+Line-level only, and only when the *why* isn't obvious from the code itself: a hidden constraint,
+a workaround for a specific bug (link the issue), a non-obvious invariant. If removing the
+comment wouldn't leave a future reader confused, don't write it. Don't describe what the next
+line does — the code already does that better than a comment can.
+
+## Building docs locally
+
+Two ways to generate documentation, depending on what you need:
+
+- **Fast, single-module iteration**:
+  ```sh
+  swift package generate-documentation --target AnglesiteCore --warnings-as-errors
+  ```
+  Add `--warnings-as-errors` to match CI's strictness while iterating locally. **Don't drop
+  `--target`** — with no target filter, the plugin documents every target in the whole dependency
+  graph, including vendored third-party packages whose doc comments you don't control and can't
+  fix. CI passes an explicit list of this repo's own targets; copy that list from
+  `.github/workflows/ci.yml`'s `docs-docc` job (or `AGENTS.md`/`CONTRIBUTING.md`) to generate docs
+  for everything at once.
+
+- **The full merged docset** — app entry point, every module, and the container runtime, as one
+  browsable archive in Xcode's Developer Documentation window (Product ▸ Build Documentation, or
+  ⌃⌘⇧D). **Local-only** — this needs `xcodebuild`, `xcodegen generate` to have already run, and a
+  Mac that can build `AnglesiteContainer` (the hosted CI runner can't, which is why CI uses the
+  `swift package` path above instead):
+  ```sh
+  xcodebuild docbuild -scheme Anglesite -destination 'platform=macOS'
+  ```
+```
+
+- [ ] **Step 2: Link it from CONTRIBUTING.md**
+
+In `CONTRIBUTING.md`, the "Code guidelines" section currently reads (lines 67-75):
+
+```markdown
+## Code guidelines
+
+- **Swift/SwiftUI with Apple frameworks only** — plain SwiftUI + actors, no TCA or third-party state libraries. New dependencies need explicit approval in an issue first.
+- **Process spawning is centralized** in `AnglesiteCore/ProcessSupervisor` — never call `Process()` from a view.
+- **Logs are sacred** — every spawned subprocess streams stdout+stderr to the debug pane. Don't silently discard output.
+- **Git is the source of truth for sites** — the app must never become the only way to edit a site. A site's `Source/` repo stays clonable and editable outside the app.
+- **The app cannot bypass the template security gate** — `pre-deploy-check.ts` runs before every deploy; surface failures, don't add overrides.
+- **JS/TypeScript** (edit overlay) uses ES modules, vanilla APIs, and the existing oxlint/tsc/vitest toolchain.
+```
+
+Add one line at the end of that list:
+
+```markdown
+- **Comment and doc-comment conventions** are in [`docs/comment-style-guide.md`](docs/comment-style-guide.md) — read it before writing `///` doc comments on public API; CI fails on broken DocC symbol links or markup.
+```
+
+- [ ] **Step 3: Verify the links resolve**
+
+Run: `test -f docs/comment-style-guide.md && grep -q "comment-style-guide.md" CONTRIBUTING.md && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/comment-style-guide.md CONTRIBUTING.md
+git commit -m "docs(#1041): add comment style guide, link from CONTRIBUTING.md"
+```
+
+---
+
+### Task 4: Fix pre-existing DocC diagnostics (a finite, already-broken list)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ApplyEditTool.swift:9`
+- Modify: `Sources/AnglesiteCore/SearchContentTool.swift:8`
+- Modify: `Sources/AnglesiteCore/FoundationModelAssistant.swift:70,145,299,374`
+- Modify: `Sources/AnglesiteCore/LinkGraph.swift:4`
+- Modify: `Sources/AnglesiteCore/ContentUndoCoordinator.swift:42,86`
+- Modify: `Sources/AnglesiteCore/SyncEngine.swift:206`
+- Modify: `Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift:15,16`
+- Modify: `Sources/AnglesiteCore/SuggestLinksTool.swift:10`
+- Modify: `Sources/AnglesiteBridge/AnglesiteScriptHandler.swift:7,14,50`
+- Modify: `Sources/AnglesiteBridge/WebViewBridge.swift:13,49`
+- Modify: `Sources/AnglesiteCore/ACPAgentStore.swift:11-14`
+- Modify: `Sources/AnglesiteCore/ExperimentStats.swift:67-74`
+- Modify: `Sources/AnglesiteCore/InboxSubmissionCommitter.swift:76-88`
+- Modify: `Sources/AnglesiteCore/SiteContentGraph.swift:192-207`
+- Modify: `Sources/AnglesiteCore/SiteSearchDestination.swift:17-25`
+- Modify: `Sources/AnglesiteCore/SiteSearchIndex.swift:83-92`
+- Modify: `Sources/AnglesiteCore/WorkerComposition.swift:109-139`
+
+**Why these and only these:** every one of these was found by actually running
+`swift package generate-documentation` (with `--target` scoped to just this repo's own targets,
+excluding vendored dependencies) against this real repository — not by grepping for a pattern.
+There are two categories:
+
+**Category A — broken double-backtick links.** A `` ``Symbol`` `` link is a real attempt to
+resolve a cross-reference; DocC hard-fails (unconditionally, with no flag needed to trigger it)
+when the target isn't in the local symbol graph. That happens for four different reasons here,
+each with a different correct fix:
+
+1. **Apple SDK framework symbols** (`Tool`, `Generable`, `LanguageModelSession`) — not part of
+   this package's own symbol graph, can't resolve without extra SDK symbol-graph setup that's out
+   of scope here. Fix: single backtick (plain code, no link attempt).
+2. **`private`/`internal` symbols** (`perform(_:)`, `reconcileDivergence(...)`, `maxSeedNodes`,
+   `facts(...)`) — DocC's symbol graph only includes `public`+ access levels by default; a link to
+   a non-public symbol can never resolve. Fix: single backtick. (Not: raise their access level —
+   that's a real API-surface change with its own review, out of scope for a doc-comment fix.)
+3. **Cross-module links** (`AnglesiteMessageDispatcher`, `AnglesiteOverlayBundle`, both defined in
+   `AnglesiteBridgeCore` but referenced from doc comments in the *different* `AnglesiteBridge`
+   target) — verified separately that a double-backtick link across target boundaries doesn't
+   resolve without `--enable-experimental-combined-documentation` (an experimental flag, out of
+   scope). Fix: single backtick.
+4. **Wrong DocC path syntax** (`Document.internalLinks`, `SemanticRanker.related` — using Swift's
+   dot-member-access notation instead of DocC's own `/`-separated link path) — these *are* real,
+   public, same-module symbols; the link syntax itself is just wrong. Fix: correct the syntax to
+   the real slash-separated path so the link actually resolves, rather than downgrading to plain
+   text.
+
+**Category B — stale `- Parameters:` blocks.** `--enable-parameters-and-returns-validation` (on by
+default) flags any function whose doc comment's `- Parameter(s):` list doesn't cover every
+parameter in the real signature — these seven functions grew parameters after their doc comment
+was last touched. Fix: add the missing entries.
+
+- [ ] **Step 1: Fix `ApplyEditTool.swift` and `SearchContentTool.swift` (Apple SDK symbol links)**
+
+In `Sources/AnglesiteCore/ApplyEditTool.swift`, change:
+
+```swift
+/// A FoundationModels ``Tool`` that lets the on-device model apply a structured edit to an element
+```
+to:
+```swift
+/// A FoundationModels `Tool` that lets the on-device model apply a structured edit to an element
+```
+
+In `Sources/AnglesiteCore/SearchContentTool.swift`, change:
+
+```swift
+/// A FoundationModels ``Tool`` that lets the on-device model search the current site's pages and
+```
+to:
+```swift
+/// A FoundationModels `Tool` that lets the on-device model search the current site's pages and
+```
+
+- [ ] **Step 2: Fix `FoundationModelAssistant.swift` (Apple SDK symbols + ambiguous sibling refs)**
+
+Four separate one-line changes in this file:
+
+Line 70, change:
+```swift
+/// and produces ``Generable`` structured output via guided generation.
+```
+to:
+```swift
+/// and produces `Generable` structured output via guided generation.
+```
+
+Line 145 (inside the `init`'s doc comment — `` ``generate``/``generateStructured`` `` fail to
+resolve as bare unqualified names from that scope, even though both are real public sibling
+methods; `generateStructured` is additionally overloaded), change:
+```swift
+    /// one-shot ``generate``/``generateStructured`` paths carry no Spotlight tool, preserving their
+```
+to:
+```swift
+    /// one-shot `generate`/`generateStructured` paths carry no Spotlight tool, preserving their
+```
+
+Line 299, change:
+```swift
+    /// Unlike ``generate(prompt:context:)``, this reuses a **cached** ``LanguageModelSession`` across
+```
+to:
+```swift
+    /// Unlike ``generate(prompt:context:)``, this reuses a **cached** `LanguageModelSession` across
+```
+(Only `LanguageModelSession` changes here — `` ``generate(prompt:context:)`` `` already resolves
+correctly since it's a fully-qualified reference to a real sibling method with no ambiguity.)
+
+Line 374, change:
+```swift
+    /// Discards the cached ``LanguageModelSession`` (and winds down any in-flight turn) so the next
+```
+to:
+```swift
+    /// Discards the cached `LanguageModelSession` (and winds down any in-flight turn) so the next
+```
+
+- [ ] **Step 3: Fix `LinkGraph.swift` (wrong DocC path syntax — real fix, not a downgrade)**
+
+`Document` is `SiteKnowledgeIndex.Document` (confirmed: `Sources/AnglesiteCore/SiteKnowledgeIndex.swift:9`), and `internalLinks` is a public property on it. The doc comment used Swift's
+dot-member syntax instead of DocC's slash-path syntax. In `Sources/AnglesiteCore/LinkGraph.swift`,
+change:
+
+```swift
+/// Pure link-graph analysis over ``SiteKnowledgeIndex`` documents. No embeddings, no actors —
+/// reads ``Document.internalLinks`` to surface structural linking issues.
+```
+to:
+```swift
+/// Pure link-graph analysis over ``SiteKnowledgeIndex`` documents. No embeddings, no actors —
+/// reads ``SiteKnowledgeIndex/Document/internalLinks`` to surface structural linking issues.
+```
+
+- [ ] **Step 4: Fix `ContentUndoCoordinator.swift` (private-symbol links)**
+
+`perform(_:)` (confirmed: `Sources/AnglesiteCore/ContentUndoCoordinator.swift:169`) is `private`,
+so it can never be in the public symbol graph. Two occurrences in the same file:
+
+Line 42, change:
+```swift
+///   re-apply primitive). See ``register(_:)`` for the ordering that makes it work with an
+///   asynchronous applier.
+```
+to:
+```swift
+///   re-apply primitive). See ``register(_:)`` for the ordering that makes it work with an
+///   asynchronous applier. (`perform(_:)` is the private popped-record apply path.)
+```
+
+Line 86, change:
+```swift
+///   ``EditUndoCoordinator`` uses for its retryable outcome. A failed *redo* can only be dropped;
+///   see ``perform(_:)``.
+```
+to:
+```swift
+///   ``EditUndoCoordinator`` uses for its retryable outcome. A failed *redo* can only be dropped;
+///   see `perform(_:)`.
+```
+
+- [ ] **Step 5: Fix `SyncEngine.swift` (private-symbol link)**
+
+`reconcileDivergence(...)` (confirmed: `Sources/AnglesiteCore/SyncEngine.swift:309`) is `private`.
+In `Sources/AnglesiteCore/SyncEngine.swift`, change:
+
+```swift
+    /// On genuine divergence, hands off to ``reconcileDivergence(repo:package:branchName:branchRefName:localOID:icloudOID:)``
+```
+to:
+```swift
+    /// On genuine divergence, hands off to `reconcileDivergence(repo:package:branchName:branchRefName:localOID:icloudOID:)`
+```
+
+- [ ] **Step 6: Fix `SiteGraphAugmentedAssistant.swift` (internal-symbol links)**
+
+`SiteGraphExplainPrompt.facts(...)` (confirmed: `Sources/AnglesiteCore/SiteGraphNodeExplainer.swift:40`) and this file's own
+`maxSeedNodes` (line 22) both have no access modifier, so they default to `internal` — outside the
+public symbol graph. In `Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift`, change:
+
+```swift
+/// Reuses #614's per-node fact list (``SiteGraphExplainPrompt/facts(node:impact:dependsOn:referencedBy:)``)
+/// for up to ``SiteGraphAugmentedAssistant/maxSeedNodes`` nodes matched against the question's
+/// words. Contributes nothing when no node matches, so unrelated chat turns are unaffected.
+```
+to:
+```swift
+/// Reuses #614's per-node fact list (`SiteGraphExplainPrompt.facts(node:impact:dependsOn:referencedBy:)`)
+/// for up to `SiteGraphAugmentedAssistant.maxSeedNodes` nodes matched against the question's
+/// words. Contributes nothing when no node matches, so unrelated chat turns are unaffected.
+```
+
+- [ ] **Step 7: Fix `SuggestLinksTool.swift` (wrong DocC path syntax — real fix)**
+
+`SemanticRanker.related` (confirmed: `Sources/AnglesiteCore/SemanticRanker.swift:103`, signature
+`related(siteID:toDocID:limit:)`) is a real public method; the dot syntax is just wrong. In
+`Sources/AnglesiteCore/SuggestLinksTool.swift`, change:
+
+```swift
+/// semantic similarity (``SemanticRanker.related``) filtered by existing links (``LinkGraph``).
+```
+to:
+```swift
+/// semantic similarity (``SemanticRanker/related(siteID:toDocID:limit:)``) filtered by existing links (``LinkGraph``).
+```
+
+- [ ] **Step 8: Fix `AnglesiteScriptHandler.swift` and `WebViewBridge.swift` (cross-module links)**
+
+`AnglesiteMessageDispatcher` and `AnglesiteOverlayBundle` are both `public enum`s defined in the
+`AnglesiteBridgeCore` target (confirmed:
+`Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift:23`,
+`Sources/AnglesiteBridgeCore/AnglesiteOverlayBundle.swift:7`), but referenced from doc comments in
+the *different* `AnglesiteBridge` target. In `Sources/AnglesiteBridge/AnglesiteScriptHandler.swift`,
+change (lines 6-8 and 12-14 of the class-level doc comment):
+
+```swift
+/// `WKScriptMessageHandler` adapter for the `anglesite` namespace — the WKWebView-specific thin
+/// layer over ``AnglesiteMessageDispatcher`` (cross-platform port design §6 "AnglesiteBridgeCore
+/// split"). All the message schema, decoding, and routing logic lives in the portable core; this
+/// class's own job is exactly two things `WKScriptMessage` requires: unwrap `message.body`/
+/// `.webView`, and evaluate the reply script back into the page.
+///
+/// **API change vs prior versions:** the primary entry point is now
+/// `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)` (forwarding to
+/// ``AnglesiteMessageDispatcher/dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)``).
+```
+to:
+```swift
+/// `WKScriptMessageHandler` adapter for the `anglesite` namespace — the WKWebView-specific thin
+/// layer over `AnglesiteMessageDispatcher` (cross-platform port design §6 "AnglesiteBridgeCore
+/// split"). All the message schema, decoding, and routing logic lives in the portable core; this
+/// class's own job is exactly two things `WKScriptMessage` requires: unwrap `message.body`/
+/// `.webView`, and evaluate the reply script back into the page.
+///
+/// **API change vs prior versions:** the primary entry point is now
+/// `dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)` (forwarding to
+/// `AnglesiteMessageDispatcher.dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)`).
+```
+
+And at line 50 (the `dispatch` static method's own doc comment), change:
+```swift
+    /// Forwards to ``AnglesiteMessageDispatcher/dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)``
+    /// — kept here so existing call sites (this class's own `userContentController`, and any
+```
+to:
+```swift
+    /// Forwards to `AnglesiteMessageDispatcher.dispatch(body:via:onVisibleElements:onCanvasSelection:onComputedStyles:)`
+    /// — kept here so existing call sites (this class's own `userContentController`, and any
+```
+
+In `Sources/AnglesiteBridge/WebViewBridge.swift`, line 13, change:
+```swift
+    /// ``AnglesiteMessageDispatcher/scriptMessageNamespace``.
+```
+to:
+```swift
+    /// `AnglesiteMessageDispatcher.scriptMessageNamespace`.
+```
+
+Line 49, change:
+```swift
+    /// via ``AnglesiteOverlayBundle``; only the `WKUserScript` wrapping is WKWebView-specific.
+```
+to:
+```swift
+    /// via `AnglesiteOverlayBundle`; only the `WKUserScript` wrapping is WKWebView-specific.
+```
+
+- [ ] **Step 9: Fix `ACPAgentStore.swift` (stale Parameters block)**
+
+`init(persistenceURL:fileManager:)` documents `persistenceURL` but not `fileManager`. In
+`Sources/AnglesiteCore/ACPAgentStore.swift`, change:
+
+```swift
+    /// - Parameters:
+    ///   - persistenceURL: where to read/write `acp-agents.json`. Defaults to
+    ///     `~/Library/Application Support/Anglesite/acp-agents.json`. Tests should pass a temp URL.
+    public init(persistenceURL: URL? = nil, fileManager: FileManager = .default) {
+```
+to:
+```swift
+    /// - Parameters:
+    ///   - persistenceURL: where to read/write `acp-agents.json`. Defaults to
+    ///     `~/Library/Application Support/Anglesite/acp-agents.json`. Tests should pass a temp URL.
+    ///   - fileManager: Injectable for tests; defaults to `.default`.
+    public init(persistenceURL: URL? = nil, fileManager: FileManager = .default) {
+```
+
+- [ ] **Step 10: Fix `ExperimentStats.swift` (stale Parameter block)**
+
+`analyze(control:treatment:confidenceThreshold:)` documents only `confidenceThreshold`. In
+`Sources/AnglesiteCore/ExperimentStats.swift`, change:
+
+```swift
+    /// Compare `treatment` against `control` under a Beta-Binomial model with uniform priors.
+    ///
+    /// - Parameter confidenceThreshold: probability at which a side is declared the winner.
+    public static func analyze(
+```
+to:
+```swift
+    /// Compare `treatment` against `control` under a Beta-Binomial model with uniform priors.
+    ///
+    /// - Parameters:
+    ///   - control: The control variant's impression/conversion counts.
+    ///   - treatment: The treatment variant's impression/conversion counts.
+    ///   - confidenceThreshold: probability at which a side is declared the winner.
+    public static func analyze(
+```
+
+- [ ] **Step 11: Fix `InboxSubmissionCommitter.swift` (stale Parameter block)**
+
+`commit(submissions:into:fileManager:gitCommitBatch:)` documents only `fileManager`. In
+`Sources/AnglesiteCore/InboxSubmissionCommitter.swift`, change:
+
+```swift
+    /// - Parameter fileManager: Used only to create the `src/content/inbox` directory; per-submission
+    ///   file writes go through `Data.write(to:options:)` directly and do not go through this.
+    public static func commit(
+        submissions: [InboxKVClient.Submission],
+        into siteDirectory: URL,
+        fileManager: FileManager = .default,
+        gitCommitBatch: @Sendable (URL, [String], String) async -> String? = processGitCommitBatch
+    ) async -> [String] {
+```
+to:
+```swift
+    /// - Parameters:
+    ///   - submissions: The inbox submissions to write and commit.
+    ///   - siteDirectory: The site's `Source/` directory the submissions are written under.
+    ///   - fileManager: Used only to create the `src/content/inbox` directory; per-submission
+    ///     file writes go through `Data.write(to:options:)` directly and do not go through this.
+    ///   - gitCommitBatch: Injectable for tests; defaults to the real git commit implementation.
+    public static func commit(
+        submissions: [InboxKVClient.Submission],
+        into siteDirectory: URL,
+        fileManager: FileManager = .default,
+        gitCommitBatch: @Sendable (URL, [String], String) async -> String? = processGitCommitBatch
+    ) async -> [String] {
+```
+
+- [ ] **Step 12: Fix `SiteContentGraph.swift` (stale Parameter block)**
+
+`load(siteID:pages:posts:images:generation:)` documents only `generation`. In
+`Sources/AnglesiteCore/SiteContentGraph.swift`, change:
+
+```swift
+    /// - Parameter generation: A token from `beginScan(siteID:)`. When provided, this call is
+    ///   silently discarded (no state change, no emit) if a newer scan has since claimed a
+    ///   later generation for `siteID` — see `beginScan` (#666). `nil` (the default) skips the
+    ///   guard entirely, applying unconditionally; used by incremental/test callers that don't
+    ///   participate in the scan-race fence.
+    public func load(
+        siteID: String,
+        pages: [Page],
+        posts: [Post],
+        images: [Image],
+        generation: Int? = nil
+    ) async {
+```
+to:
+```swift
+    /// - Parameters:
+    ///   - siteID: The site whose entries are being replaced.
+    ///   - pages: The site's full new page payload.
+    ///   - posts: The site's full new post payload.
+    ///   - images: The site's full new image payload.
+    ///   - generation: A token from `beginScan(siteID:)`. When provided, this call is
+    ///     silently discarded (no state change, no emit) if a newer scan has since claimed a
+    ///     later generation for `siteID` — see `beginScan` (#666). `nil` (the default) skips the
+    ///     guard entirely, applying unconditionally; used by incremental/test callers that don't
+    ///     participate in the scan-race fence.
+    public func load(
+        siteID: String,
+        pages: [Page],
+        posts: [Post],
+        images: [Image],
+        generation: Int? = nil
+    ) async {
+```
+
+- [ ] **Step 13: Fix `SiteSearchDestination.swift` (stale Parameter block)**
+
+`resolve(kind:route:path:navigatorRouteIDs:)` documents only `navigatorRouteIDs`. In
+`Sources/AnglesiteCore/SiteSearchDestination.swift`, change:
+
+```swift
+    /// - Parameter navigatorRouteIDs: route → navigator node id for the rows currently on
+    ///   screen. Empty while a window's tree is still loading, which resolves everything to
+    ///   `.file` — a usable destination rather than a dropped hit.
+    public static func resolve(
+        kind: SiteKnowledgeIndex.Document.Kind,
+        route: String?,
+        path: String,
+        navigatorRouteIDs: [String: String]
+    ) -> SiteSearchDestination {
+```
+to:
+```swift
+    /// - Parameters:
+    ///   - kind: The matched document's kind, used to pick the destination's `FileGroup` when it
+    ///     falls back to `.file`.
+    ///   - route: The matched document's route, if it has one. `nil` always falls back to `.file`.
+    ///   - path: The matched document's path relative to the site's `Source/`, used for `.file`.
+    ///   - navigatorRouteIDs: route → navigator node id for the rows currently on
+    ///     screen. Empty while a window's tree is still loading, which resolves everything to
+    ///     `.file` — a usable destination rather than a dropped hit.
+    public static func resolve(
+        kind: SiteKnowledgeIndex.Document.Kind,
+        route: String?,
+        path: String,
+        navigatorRouteIDs: [String: String]
+    ) -> SiteSearchDestination {
+```
+
+- [ ] **Step 14: Fix `SiteSearchIndex.swift` (stale Parameter block)**
+
+`search(_:siteID:query:limit:kinds:)` documents only `limit`. In
+`Sources/AnglesiteCore/SiteSearchIndex.swift`, change:
+
+```swift
+    /// Searches the index for documents matching the query.
+    /// - Parameter limit: Maximum number of results to return. Clamped to a minimum of 1 by
+    ///   the underlying `SiteKnowledgeIndex.SearchOptions`, so `limit: 0` still returns one hit.
+    public static func search(
+        _ index: SiteKnowledgeIndex,
+        siteID: String,
+        query: String,
+        limit: Int = 8,
+        kinds: Set<SiteKnowledgeIndex.Document.Kind>? = nil
+    ) async -> [Hit] {
+```
+to:
+```swift
+    /// Searches the index for documents matching the query.
+    /// - Parameters:
+    ///   - index: The site's knowledge index to search.
+    ///   - siteID: The site whose documents are searched.
+    ///   - query: The search text.
+    ///   - limit: Maximum number of results to return. Clamped to a minimum of 1 by
+    ///     the underlying `SiteKnowledgeIndex.SearchOptions`, so `limit: 0` still returns one hit.
+    ///   - kinds: Restricts results to these document kinds, or all kinds when `nil`.
+    public static func search(
+        _ index: SiteKnowledgeIndex,
+        siteID: String,
+        query: String,
+        limit: Int = 8,
+        kinds: Set<SiteKnowledgeIndex.Document.Kind>? = nil
+    ) async -> [Hit] {
+```
+
+- [ ] **Step 15: Fix `WorkerComposition.swift` (stale Parameters block + a misplaced doc comment)**
+
+`generateWranglerToml(...)` documents `siteName`/`workers`/`routeClaims` but not `resources`,
+`inboxCaptureEnabled`, `inboxKVNamespaceID`, `siteURL`, or `displayName`. `displayName` additionally
+has a `///` comment sitting *inside* the parameter list (between `siteURL` and `displayName`),
+which DocC never associates with the function's `- Parameters:` block since it isn't in the
+leading doc comment — that's why `displayName` still shows up as undocumented despite looking
+documented at a glance. In `Sources/AnglesiteCore/WorkerComposition.swift`, change:
+
+```swift
+    /// Generates a wrangler.toml for a site with the given workers enabled.
+    ///
+    /// - Parameters:
+    ///   - siteName: The Worker name (used as the Cloudflare Workers project name).
+    ///     Must match `[A-Za-z0-9_-]+`.
+    ///   - workers: The effective active `@dwk/workers` catalog descriptors. Empty = static-only
+    ///     deploy.
+    ///   - routeClaims: The effective active dynamic-route claims (#746), already validated by
+    ///     `WorkerRouteClaims.activeClaims`. Emitted as selective `[assets].run_worker_first`
+    ///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
+    ///     longer shadow an active dynamic route, while every unclaimed path keeps Cloudflare's
+    ///     asset-first fallback. Omitted entirely when there are no active dynamic routes.
+    /// - Returns: A complete wrangler.toml string.
+    /// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
+    ///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``
+    ///   for a claim that never passed `WorkerRouteClaims` validation.
+    public static func generateWranglerToml(
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim] = [],
+        resources: ProvisionedResources = .init(),
+        inboxCaptureEnabled: Bool = false,
+        inboxKVNamespaceID: String? = nil,
+        siteURL: String? = nil,
+        /// The site's display name (`SiteSettings.displayName`, already falling back to the site
+        /// name by the time a caller passes it in — this function stays pure and does no
+        /// fallback of its own), threaded into the ActivityPub actor's `AP_DISPLAY_NAME` var.
+        /// `nil` when unknown; the composed Worker's actor document then falls back to a fixed
+        /// generic name (`worker.ts`'s concern, not this function's).
+        displayName: String? = nil
+    ) throws -> String {
+```
+to:
+```swift
+    /// Generates a wrangler.toml for a site with the given workers enabled.
+    ///
+    /// - Parameters:
+    ///   - siteName: The Worker name (used as the Cloudflare Workers project name).
+    ///     Must match `[A-Za-z0-9_-]+`.
+    ///   - workers: The effective active `@dwk/workers` catalog descriptors. Empty = static-only
+    ///     deploy.
+    ///   - routeClaims: The effective active dynamic-route claims (#746), already validated by
+    ///     `WorkerRouteClaims.activeClaims`. Emitted as selective `[assets].run_worker_first`
+    ///     patterns so *only* claimed routes bypass asset-first serving — a static asset can no
+    ///     longer shadow an active dynamic route, while every unclaimed path keeps Cloudflare's
+    ///     asset-first fallback. Omitted entirely when there are no active dynamic routes.
+    ///   - resources: The site's provisioned Cloudflare resource IDs (D1/KV/R2/queues).
+    ///   - inboxCaptureEnabled: Whether the inbox-capture route claim is appended to `routeClaims`.
+    ///   - inboxKVNamespaceID: The inbox KV namespace ID, required when `inboxCaptureEnabled`.
+    ///   - siteURL: The site's public URL, threaded into the composed Worker's config.
+    ///   - displayName: The site's display name (`SiteSettings.displayName`, already falling back
+    ///     to the site name by the time a caller passes it in — this function stays pure and does
+    ///     no fallback of its own), threaded into the ActivityPub actor's `AP_DISPLAY_NAME` var.
+    ///     `nil` when unknown; the composed Worker's actor document then falls back to a fixed
+    ///     generic name (`worker.ts`'s concern, not this function's).
+    /// - Returns: A complete wrangler.toml string.
+    /// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
+    ///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``
+    ///   for a claim that never passed `WorkerRouteClaims` validation.
+    public static func generateWranglerToml(
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim] = [],
+        resources: ProvisionedResources = .init(),
+        inboxCaptureEnabled: Bool = false,
+        inboxKVNamespaceID: String? = nil,
+        siteURL: String? = nil,
+        displayName: String? = nil
+    ) throws -> String {
+```
+
+- [ ] **Step 16: Verify everything is now clean**
+
+Run (Task 1's `swift-docc-plugin` dependency must already be committed for this to work):
+
+```sh
+swift package generate-documentation \
+  --target AnglesiteSiteModel --target AnglesiteQuickLookSupport --target AnglesiteCore \
+  --target AnglesiteBridgeCore --target AnglesiteBridge --target AnglesiteIOS \
+  --target AnglesiteIntents --target AnglesiteAppCore --target AnglesiteTestSupport \
+  --warnings-as-errors
+```
+
+Expected: exit code `0`, ending with `Generated 9 documentation archives:`. If anything still
+fails, read the new diagnostic's file:line and fix it the same way (single backtick for
+unresolvable links, added `- Parameter:` entries for stale docs) before moving on — don't relax
+`--warnings-as-errors` to make a stubborn one pass.
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ApplyEditTool.swift Sources/AnglesiteCore/SearchContentTool.swift \
+  Sources/AnglesiteCore/FoundationModelAssistant.swift Sources/AnglesiteCore/LinkGraph.swift \
+  Sources/AnglesiteCore/ContentUndoCoordinator.swift Sources/AnglesiteCore/SyncEngine.swift \
+  Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift Sources/AnglesiteCore/SuggestLinksTool.swift \
+  Sources/AnglesiteBridge/AnglesiteScriptHandler.swift Sources/AnglesiteBridge/WebViewBridge.swift \
+  Sources/AnglesiteCore/ACPAgentStore.swift Sources/AnglesiteCore/ExperimentStats.swift \
+  Sources/AnglesiteCore/InboxSubmissionCommitter.swift Sources/AnglesiteCore/SiteContentGraph.swift \
+  Sources/AnglesiteCore/SiteSearchDestination.swift Sources/AnglesiteCore/SiteSearchIndex.swift \
+  Sources/AnglesiteCore/WorkerComposition.swift
+git commit -m "docs(#1041): fix broken DocC links and stale Parameter docs"
+```
+
+---
+
+### Task 5: Add the `docs-docc` CI job
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (add a new job after `concurrency-tsan`, before `xcodeproj-sync`; add it to the final `ci` job's `needs:` list)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks except that `Package.swift` (Task 1), the catalog (Task 2),
+  and the fixes (Task 4) must already be committed for this job to pass.
+- Produces: a new required-check job name `docs-docc` that later branch-protection config (out of
+  scope here) could reference.
+
+- [ ] **Step 1: Add the job**
+
+In `.github/workflows/ci.yml`, insert this new job immediately after the `concurrency-tsan` job
+(which ends around line 347, right before the `xcodeproj-sync:` job header):
+
+```yaml
+  docs-docc:
+    name: DocC build (comment/doc-comment health check)
+    # No xcodegen/xcodebuild here — this job never touches the Xcode project. It exercises the
+    # SwiftPM library targets directly via `swift package generate-documentation`. The --target
+    # list below is deliberate and explicit, not "every target" — verified two things: (1) a
+    # target-less run sweeps in every dependency package too, including MarkdownEngine's own
+    # broken doc comments, which we don't own; (2) AnglesiteLANHost (an executableTarget) fails
+    # symbol-graph extraction with an unrelated tooling issue ("AnglesiteLANHost.symbolgraphs
+    # doesn't exist"), so it's left out here. AnglesiteContainer/AnglesiteContainerProbe are
+    # excluded the same way every other lane excludes them: the workflow-level
+    # ANGLESITE_SKIP_CONTAINER=1 already drops those targets from the manifest entirely.
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Select latest available Xcode
+        # Same rationale as build-test: this package needs Swift 6.4 (compiler(>=6.4) gates on
+        # AnglesiteAppCore), which the runner's default active Xcode may predate.
+        run: |
+          set -euo pipefail
+          ls -d /Applications/Xcode*.app 2>/dev/null | sort -V
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
+          echo "Selecting: $LATEST"
+          sudo xcode-select -s "$LATEST"
+
+      - name: Show toolchain versions
+        run: swift --version
+
+      - name: Build documentation for every module (fails on any DocC error or warning)
+        run: |
+          swift package generate-documentation \
+            --target AnglesiteSiteModel \
+            --target AnglesiteQuickLookSupport \
+            --target AnglesiteCore \
+            --target AnglesiteBridgeCore \
+            --target AnglesiteBridge \
+            --target AnglesiteIOS \
+            --target AnglesiteIntents \
+            --target AnglesiteAppCore \
+            --target AnglesiteTestSupport \
+            --warnings-as-errors
+```
+
+- [ ] **Step 2: Register it in the `ci` aggregator job**
+
+In the same file, find the `ci:` job's `needs:` list (around line 493-502):
+
+```yaml
+    needs:
+      - changes
+      - edit-overlay
+      - help-book-links
+      - linux-build-test
+      - build-test
+      - concurrency-tsan
+      - xcodeproj-sync
+      - localization-catalog
+      - appintents-schema
+```
+
+Add `docs-docc` to it:
+
+```yaml
+    needs:
+      - changes
+      - edit-overlay
+      - help-book-links
+      - linux-build-test
+      - build-test
+      - concurrency-tsan
+      - docs-docc
+      - xcodeproj-sync
+      - localization-catalog
+      - appintents-schema
+```
+
+- [ ] **Step 3: Verify the exact CI command locally**
+
+Run:
+```sh
+swift package generate-documentation \
+  --target AnglesiteSiteModel --target AnglesiteQuickLookSupport --target AnglesiteCore \
+  --target AnglesiteBridgeCore --target AnglesiteBridge --target AnglesiteIOS \
+  --target AnglesiteIntents --target AnglesiteAppCore --target AnglesiteTestSupport \
+  --warnings-as-errors
+```
+Expected: Exit code `0`. Output ends with `Generated 9 documentation archives:` — no `error:`
+lines from `docc convert`. (Confirmed clean at the end of Task 4 — if this fails now, something
+regressed between Task 4 and here.)
+
+- [ ] **Step 4: Validate the YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML OK"`
+Expected: `YAML OK` (catches indentation mistakes before pushing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci(#1041): add docs-docc job, gate DocC warnings as errors"
+```
+
+---
+
+### Task 6: Manual full-docset verification (not CI-automatable)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Regenerate the Xcode project**
+
+Run: `xcodegen generate`
+Expected: Completes without error; `Anglesite.xcodeproj` is regenerated.
+
+- [ ] **Step 2: Build the full merged docset locally**
+
+Run: `xcodebuild docbuild -scheme Anglesite -destination 'platform=macOS'`
+Expected: Succeeds (this exercises `AnglesiteContainer` and the two Xcode-only entry-point files
+that the CI job's `swift package generate-documentation` path can't reach). Note any failure here
+in the PR body — this step can't run in CI (the hosted runner can't build `AnglesiteContainer`),
+so it's the one piece of this plan that stays a manual, PR-body-reported check per the design
+spec's Testing section.
+
+- [ ] **Step 3: Note the result in the PR body**
+
+Record whether Step 2 succeeded (and the Xcode/toolchain version used) under the PR's "Test plan"
+section, since this is the one verification CI cannot perform on its own.

--- a/docs/superpowers/specs/2026-07-27-comment-style-guide-design.md
+++ b/docs/superpowers/specs/2026-07-27-comment-style-guide-design.md
@@ -1,0 +1,152 @@
+# Comment style guide + DocC catalog + CI check — design (#1041)
+
+- **Date:** 2026-07-27
+- **Status:** Proposed
+- **Issue:** [#1041 — Add comment style guide + DocC catalog + CI check](https://github.com/Anglesite/Anglesite-app/issues/1041)
+
+## Decision
+
+Add a written comment style guide (`docs/comment-style-guide.md`) that codifies the convention this
+codebase already mostly follows — rationale-heavy `///` doc comments, not boilerplate restating the
+signature — and wire up real DocC tooling so that convention produces a browsable Xcode docset:
+
+1. A single, unified style guide document (no human/agent split — good comments serve both).
+2. A `swift-docc-plugin` dependency + one umbrella `.docc` landing-page catalog.
+3. A CI job that fails the build on DocC errors/warnings (broken symbol links, malformed markup),
+   scoped to what CI can actually build.
+
+This is guide-and-tooling only. It does **not** retrofit the ~500 files that already have doc
+comments to the stricter tagging standard below — that standard applies to new and changed public
+API going forward, checked in review, not enforced by an automated coverage gate in this pass.
+
+### Scope
+
+In scope: the style guide document, the DocC catalog, the `swift-docc-plugin` dependency, and one
+new CI job validating DocC build health across every SwiftPM library target.
+
+Out of scope: retrofitting existing doc comments; a documentation-coverage CI gate (only build
+errors/warnings are checked); fixing the `AnglesiteContainer` CI build wall (tracked implicitly by
+every existing `ANGLESITE_SKIP_CONTAINER` reference in `.github/workflows/ci.yml` — not this
+issue's problem to solve); per-module `.docc` catalogs (deferred — see Alternatives).
+
+## Background
+
+`Sources/` currently has 542 Swift files; 520 already carry `///` doc comments, mostly prose that
+explains *why* a type or function exists (often citing an issue number) rather than restating *what*
+the signature already says. Only 11 files use formal `- Parameter:`/`- Returns:`/`- Throws:` tags.
+`// MARK:` appears 307 times for jump-bar section grouping. There is no `.docc` catalog anywhere in
+the repo, no DocC build step in CI, and no written comment-style doc in `docs/` or
+`CONTRIBUTING.md`.
+
+`AnglesiteAppCore` (declared in `Package.swift`) is a real SwiftPM target with `path:
+"Sources/AnglesiteApp"`, excluding only `AnglesiteApp.swift` (the `@main` entry point) and
+`LiveSiteRuntimeFactory.swift`. So 122 of the app target's 124 files are already SwiftPM-buildable
+and DocC-documentable without an Xcode project — the app's substantial logic already lives where
+`swift package generate-documentation` can reach it, which is exactly what makes "document the app
+target too" tractable without touching `xcodebuild`.
+
+`.github/workflows/ci.yml` sets `ANGLESITE_SKIP_CONTAINER=1` at the workflow level specifically
+because the hosted runner "can neither build nor run" the native Apple Containerization graph that
+`AnglesiteContainer` depends on. Every existing Swift CI lane either inherits that skip or (in
+`appintents-schema`'s case) narrows its build to a single library target to avoid pulling
+`AnglesiteContainer` in. No CI lane builds the full `Anglesite` application scheme today. A DocC job
+that ran `xcodebuild docbuild -scheme Anglesite` would hit the same wall, since that scheme
+depends directly on the `AnglesiteContainer` product (`project.yml`).
+
+## 1. `docs/comment-style-guide.md`
+
+Linked from `CONTRIBUTING.md`'s "Code guidelines" section. Sections:
+
+1. **Philosophy** — comments explain *why*, not *what*; a well-named symbol already says what it
+   does. Matches `CLAUDE.md`'s existing "default to no comments" instinct and this repo's own
+   history of rationale-heavy prose.
+2. **Doc comments (`///`)** — required on every `public`/`open` declaration. Lead sentence, then
+   rationale/constraints in prose. Formal `- Parameter:`/`- Returns:`/`- Throws:` tags are
+   **required on new or changed public API going forward** — pulled examples from this codebase
+   (`WorkerComposition.swift:111`, `SiteContentGraph.swift:196`) rather than invented ones.
+3. **DocC syntax** — double-backtick symbol links (` ``TypeName`` `` resolves and links; single
+   backtick is plain code with no link), `- Important:`/`- Note:`/`- Warning:` callouts, `// MARK: -`
+   (trailing dash — becomes a DocC Topic divider) vs plain `// MARK:` (jump-bar only, invisible to
+   DocC), and how to structure a `.docc` catalog's landing page (`Topics` groups, `<doc:Symbol>`
+   links).
+4. **Inline comments (`//`)** — line-level only, only when the *why* isn't obvious from the code
+   (hidden constraint, workaround for a specific bug, non-obvious invariant). Explicitly: don't
+   restate what the next line does.
+5. **Existing-debt note** — states plainly that the ~500 already-documented files aren't being
+   retrofitted by this change, so nobody reads the new stricter tagging rule as "everything here is
+   now wrong."
+6. **Building docs locally** — two commands, both documented:
+   - `swift package generate-documentation --target <TargetName>` — fast, single-module, what CI
+     runs.
+   - `xcodebuild docbuild -scheme Anglesite -destination 'platform=macOS'` — the full merged
+     docset (app entry point + `AnglesiteContainer` + every module) as one browsable archive in
+     Xcode's Developer Documentation window. **Local-only** — requires a Mac that can build
+     `AnglesiteContainer`, which the hosted CI runner cannot.
+
+## 2. DocC catalog
+
+- Add `swift-docc-plugin` (`github.com/apple/swift-docc-plugin`) to `Package.swift` as a plugin
+  dependency. Build-time only — a SwiftPM command plugin, never linked into the shipped app; no
+  runtime, binary-size, or App Store review surface. This is a new dependency per
+  `CONTRIBUTING.md`'s "new dependencies need explicit approval" rule; approved in chat for this
+  issue.
+- New `Sources/AnglesiteApp/Anglesite.docc/` catalog directory, auto-adopted by `AnglesiteAppCore`
+  (DocC discovers any `.docc` folder inside a target's source tree with no extra configuration).
+  One landing page: a short architecture map (app shell → `AnglesiteCore`/`AnglesiteSiteModel` →
+  `AnglesiteBridge`/`AnglesiteIntents`/container runtime) with `<doc:>` links into each module's
+  key entry-point types.
+- No per-module catalogs. One umbrella landing page is the whole curated-content surface; every
+  other module's documentation is symbol-only (doc comments alone, no separate landing page to
+  maintain and let drift).
+
+## 3. CI job
+
+New `docs-docc` job in `.github/workflows/ci.yml`:
+
+- Gated the same way as `build-test`: `needs: changes`, `if: needs.changes.outputs.swift ==
+  'true'`.
+- Runs on `macos-26` (matches `build-test`/`concurrency-tsan` — needs a real Swift toolchain, not
+  Xcode/xcodegen).
+- No `xcodegen generate` step, no `.xcodeproj` — this job never touches the Xcode project. It runs
+  `swift package generate-documentation` per SwiftPM library target: `AnglesiteSiteModel`,
+  `AnglesiteQuickLookSupport`, `AnglesiteCore`, `AnglesiteBridgeCore`, `AnglesiteBridge`,
+  `AnglesiteIOS`, `AnglesiteIntents`, `AnglesiteLANHost`, `AnglesiteAppCore` — with
+  `--warnings-as-errors` so a broken symbol link or malformed DocC markup fails the build.
+- `AnglesiteContainer`/`AnglesiteContainerProbe` are excluded, consistent with every other CI
+  lane's `ANGLESITE_SKIP_CONTAINER=1` exclusion of the native container graph. This is a coverage
+  gap only in CI, not locally — `ANGLESITE_SKIP_CONTAINER` is never set on a contributor's own
+  machine, so `swift package generate-documentation --target AnglesiteContainer` works there today
+  with no extra setup.
+- Added to the final `ci` aggregator job's `needs:` list, so it's part of the required-checks
+  signal like every other lane.
+
+## Alternatives considered
+
+**Per-module `.docc` catalogs (rejected).** Every library target gets its own landing page +
+curated Topics groups. More thorough, but six-plus landing pages is real ongoing upkeep that will
+drift the first time a module's shape changes and nobody updates its catalog. The umbrella catalog
+gives one real "start here" page without that maintenance surface.
+
+**`xcodebuild docbuild -scheme Anglesite` in CI (rejected).** This was the original plan for
+validating "the app target too," but the scheme depends on `AnglesiteContainer`, which the hosted
+runner cannot build — every other CI lane already routes around this same wall. Building the docs
+job around it would either fail outright or require solving the container-build-in-CI problem
+first, which is a separate, larger effort outside this issue's scope.
+
+**Retrofit existing doc comments now (rejected).** Bringing ~500 files up to the new tagging
+standard in the same PR that introduces the standard is a large, separate mechanical effort with
+its own review burden. The guide states the new bar applies going forward; existing debt is
+tracked implicitly (any file touched for other reasons can be brought up to standard opportunistically,
+per `CONTRIBUTING.md`'s "opportunistic cleanup near the code you're touching is fine").
+
+## Testing
+
+- `swift build` succeeds with the new `swift-docc-plugin` dependency resolved.
+- `swift package generate-documentation --target AnglesiteCore` (and at least one other target)
+  succeeds locally and produces a `.doccarchive` with no warnings.
+- `swift package generate-documentation --target AnglesiteAppCore` picks up the new
+  `Anglesite.docc` landing page.
+- The new CI job passes on this PR's own branch (proof the mechanism works, not just the design).
+- `xcodebuild docbuild -scheme Anglesite -destination 'platform=macOS'` is exercised manually on a
+  real Mac (not CI) to confirm the full merged docset still builds end-to-end, and reported as a
+  manual verification step in the PR body since CI cannot run it.

--- a/docs/superpowers/specs/2026-07-27-comment-style-guide-design.md
+++ b/docs/superpowers/specs/2026-07-27-comment-style-guide-design.md
@@ -4,6 +4,28 @@
 - **Status:** Proposed
 - **Issue:** [#1041 — Add comment style guide + DocC catalog + CI check](https://github.com/Anglesite/Anglesite-app/issues/1041)
 
+## Addendum (post-approval, before implementation)
+
+Actually running `swift package generate-documentation` against this repo (not a scratch package)
+surfaced two corrections to the plan below, made before writing the implementation plan:
+
+1. **No `--target` filter sweeps in dependencies.** Without an explicit `--target` list, the plugin
+   documents every target in the whole dependency graph, including vendored third-party packages
+   (`MarkdownEngine` has its own broken doc comments we don't control). The CI job must enumerate
+   our own targets explicitly.
+2. **A bare DocC build (regardless of `--warnings-as-errors`) already fails today.** ~15 files in
+   `AnglesiteCore`/`AnglesiteBridge` have doc comments with unconditionally-broken double-backtick
+   links (mostly to Apple FoundationModels types DocC can't resolve, a couple of wrong-syntax
+   `Type.member` links that should be `Type/member`, and a few links to `private`/`internal`
+   symbols), and ~7 functions have `- Parameters:` blocks that have drifted out of sync with their
+   real signatures (DocC's default parameter-validation flags this as a warning). This is a finite,
+   already-broken, unrelated-to-this-task list — not the ~500-file retrofit the Decision above
+   declines. Confirmed in chat: fix this specific list as part of this PR, rather than softening
+   the CI check or narrowing its initial scope. `AnglesiteLANHost` (an `executableTarget`) is
+   additionally excluded from the CI job's target list — its symbol-graph extraction fails with an
+   unrelated SwiftPM/DocC-plugin issue (`AnglesiteLANHost.symbolgraphs doesn't exist`), independent
+   of doc-comment content.
+
 ## Decision
 
 Add a written comment style guide (`docs/comment-style-guide.md`) that codifies the convention this


### PR DESCRIPTION
## Summary

- Add `docs/comment-style-guide.md` codifying this repo's existing rationale-heavy `///` doc-comment convention, with DocC-specific syntax guidance (symbol links, callouts, `// MARK: -` topic dividers), linked from `CONTRIBUTING.md`.
- Add `swift-docc-plugin` (Apple, build-time-only) and a single umbrella `.docc` landing-page catalog (`Sources/AnglesiteApp/Anglesite.docc/AnglesiteAppCore.md`) so contributors can generate a real, browsable Xcode docset.
- Add a `docs-docc` CI job that runs `swift package generate-documentation --warnings-as-errors` against an explicit list of this repo's own SwiftPM targets, gating on broken DocC symbol links/markup going forward.
- Fix a finite, already-broken list of ~15 files' doc comments in `AnglesiteCore`/`AnglesiteBridge` (broken symbol links, stale `- Parameters:` blocks) found by actually running the tool — not a retrofit of the ~500 already-documented files, which stays out of scope per the design spec.

Design spec (with a post-approval addendum documenting two real-tool-run corrections to the original plan): `docs/superpowers/specs/2026-07-27-comment-style-guide-design.md`. Implementation plan: `docs/superpowers/plans/2026-07-27-comment-style-guide-docc.md`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 2807 tests, 2800 passed. 7 failures, all in `*RenderSmoke` suites, all failing on the same pre-existing cause (`Resources/Template/node_modules` missing `@astrojs/markdown-remark`, an Astro 7.1.3 requirement) — confirmed unrelated to this branch: `git diff --stat` against this branch's merge-base touches no file under `Resources/Template/` or `JS/`.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds (exercised via Task 6's `xcodebuild docbuild`, which builds the same scheme).
- [x] Manual: `xcodebuild docbuild -scheme Anglesite -destination 'platform=macOS'` → `** BUILD DOCUMENTATION SUCCEEDED **`, confirming the full merged docset (app entry point + `AnglesiteContainer` + every module) builds locally — this is the one verification CI cannot perform, since the hosted runner can't build `AnglesiteContainer` (documented as a local-only step in the design spec).

### Known limitation (disclosed, not a defect)

`AnglesiteAppCore` — the SwiftPM target the new umbrella `.docc` catalog belongs to — is gated behind `#if compiler(>=6.4)` in `Package.swift`, and this repo's hosted CI runners are currently on Swift 6.3.3/Xcode 26.6. The `docs-docc` job mirrors the existing `appintents-schema` job's "ARMED but skips gracefully" pattern (Xcode-major detection + `::warning::`) for that one target, so the 8 other targets are validated on every run, but the umbrella catalog itself won't get CI coverage until a runner ships Xcode 27 — it auto-activates then with no further changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)