### PR TITLE
ci: point at renamed sidecar repo, bust pre-rename SwiftPM caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,14 +189,21 @@ jobs:
       # match instead of requiring an exact one). SwiftPM's own incremental build tracking
       # handles the rest — a partial-match restore never produces wrong output, only a
       # partially-warm cache.
+      #
+      # The `v2` segment isn't a real version bump — it exists to stop restoring caches
+      # written before the Anglesite-app → Anglesite repo rename. Those caches' precompiled
+      # .pcm module files embed the old `/__w/Anglesite-app/Anglesite-app/...` workspace
+      # path, and SwiftPM refuses to reuse a module cache whose baked-in path doesn't match
+      # the current one ("missing required module 'SwiftShims'"). Bump again if this ever
+      # recurs after another workspace-path change.
       - name: Cache SwiftPM build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .build
-          key: swiftpm-linux-6.3.3-noble-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          key: swiftpm-linux-6.3.3-noble-v2-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
           restore-keys: |
-            swiftpm-linux-6.3.3-noble-${{ hashFiles('Package.resolved') }}-
-            swiftpm-linux-6.3.3-noble-
+            swiftpm-linux-6.3.3-noble-v2-${{ hashFiles('Package.resolved') }}-
+            swiftpm-linux-6.3.3-noble-v2-
 
       - name: Build (debug)
         run: swift build -c debug
@@ -225,7 +232,11 @@ jobs:
       - name: Checkout sibling Anglesite plugin
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: Anglesite/anglesite
+          # The sidecar repo was renamed Anglesite/anglesite -> Anglesite/anglesite-skills.
+          # `Anglesite/anglesite` now resolves (case-insensitively) back to *this* app repo
+          # (renamed Anglesite-app -> Anglesite), so it silently checks out the wrong repo
+          # and then fails fetching a tag that only exists in the real sidecar.
+          repository: Anglesite/anglesite-skills
           # Pinned to the plugin release the app currently exercises. get_component_model
           # (plugin #410, used by the Component Editor) shipped in v1.3.0 — bump this
           # pin again the next time a newer plugin feature becomes load-bearing for CI.
@@ -272,17 +283,17 @@ jobs:
           xcodebuild -version
           node --version
 
-      # See the linux-build-test cache step for the key-scheme rationale. Namespaced by the
-      # selected Xcode build so a runner-image toolchain bump can't restore incompatible
-      # object files.
+      # See the linux-build-test cache step for the key-scheme rationale, including the `v2`
+      # segment that stops restoring pre-repo-rename caches. Namespaced by the selected Xcode
+      # build so a runner-image toolchain bump can't restore incompatible object files.
       - name: Cache SwiftPM build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .build
-          key: swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          key: swiftpm-macos-v2-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
           restore-keys: |
-            swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
-            swiftpm-macos-${{ steps.xcode.outputs.version }}-
+            swiftpm-macos-v2-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
+            swiftpm-macos-v2-${{ steps.xcode.outputs.version }}-
 
       - name: Build (debug)
         run: swift build -c debug
@@ -333,14 +344,15 @@ jobs:
       # A distinct key namespace (`swiftpm-tsan-...`, not `swiftpm-macos-...`) — `--sanitize
       # thread` recompiles every unit with different flags, so sharing a cache with the plain
       # debug build would mean this lane can never hit and just pays the upload for nothing.
+      # `v2`: see the linux-build-test cache step — stops restoring pre-repo-rename caches.
       - name: Cache SwiftPM build (ThreadSanitizer)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .build
-          key: swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          key: swiftpm-tsan-macos-v2-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
           restore-keys: |
-            swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
-            swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-
+            swiftpm-tsan-macos-v2-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
+            swiftpm-tsan-macos-v2-${{ steps.xcode.outputs.version }}-
 
       - name: Run concurrency suites under ThreadSanitizer
         run: scripts/test-concurrency-tsan.sh


### PR DESCRIPTION
## Summary

- Fix CI failing on every PR (e.g. #1051) after the `Anglesite/anglesite` sidecar repo was renamed to `Anglesite/anglesite-skills`: the old slug now resolves (case-insensitively) back to *this* app repo, since it was separately renamed `Anglesite-app` → `Anglesite`. The "Checkout sibling Anglesite plugin" step in `build-test` was silently grabbing the wrong repo, then failing to fetch a `v1.3.0` tag that only exists in the real sidecar.
- Bust the `swiftpm-linux-*`, `swiftpm-macos-*`, and `swiftpm-tsan-macos-*` build caches (append a `v2` key segment). Caches saved before this repo's rename bake the old `/__w/Anglesite-app/Anglesite-app/...` workspace path into precompiled `.pcm` module files; restoring them under the new `/__w/Anglesite/Anglesite/...` path makes SwiftPM refuse to reuse them ("missing required module 'SwiftShims'"), which was failing the Linux build and the ThreadSanitizer concurrency suite.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite-app`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite`](https://github.com/Anglesite/anglesite) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — unaffected by this change (workflow-only), and the app-relevant suites already verified green in a separate branch during this session.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — unaffected by this change (workflow-only).
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses cleanly.
- [ ] Manual smoke: not applicable — no UI change. The real verification is this PR's own CI run going green; watch it after opening.

## Design notes

Scoped this narrowly to `.github/workflows/ci.yml`. A repo-wide sweep turned up dozens of docs/specs/scripts still referencing the old `Anglesite/anglesite` slug (`CONTRIBUTING.md`, `CLAUDE.md`, `AGENTS.md`, `README.md`, `SECURITY.md`, issue/PR templates, `scripts/lib/stage-dev-image-context.sh`, and many files under `docs/`) — none of those affect CI, so rewriting them here would turn a CI fix into an unrelated repo-wide rename sweep. Flagging separately rather than bundling it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)