### PR TITLE
ci(#1061): scope SwiftPM caches to repo name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,14 +189,22 @@ jobs:
       # match instead of requiring an exact one). SwiftPM's own incremental build tracking
       # handles the rest — a partial-match restore never produces wrong output, only a
       # partially-warm cache.
+      #
+      # Also keyed on github.repository (#1061): the runner workspace path is
+      # /__w/<owner>/<repo>, and Swift's precompiled module cache (.pcm files) bakes in that
+      # absolute path at compile time. Anglesite/Anglesite-app was renamed to Anglesite/Anglesite
+      # mid-stream, which changed the workspace path without changing Package.resolved's hash —
+      # every run since restored a pre-rename .build whose .pcm files pointed at the now-gone
+      # path, failing every build with "missing required module 'SwiftShims'". Repository name
+      # is part of the key so a future rename busts the cache instead of silently poisoning it.
       - name: Cache SwiftPM build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .build
-          key: swiftpm-linux-6.3.3-noble-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          key: swiftpm-linux-6.3.3-noble-${{ github.repository }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
           restore-keys: |
-            swiftpm-linux-6.3.3-noble-${{ hashFiles('Package.resolved') }}-
-            swiftpm-linux-6.3.3-noble-
+            swiftpm-linux-6.3.3-noble-${{ github.repository }}-${{ hashFiles('Package.resolved') }}-
+            swiftpm-linux-6.3.3-noble-${{ github.repository }}-
 
       - name: Build (debug)
         run: swift build -c debug
@@ -272,17 +280,17 @@ jobs:
           xcodebuild -version
           node --version
 
-      # See the linux-build-test cache step for the key-scheme rationale. Namespaced by the
-      # selected Xcode build so a runner-image toolchain bump can't restore incompatible
-      # object files.
+      # See the linux-build-test cache step for the key-scheme rationale (including the
+      # github.repository segment, #1061). Namespaced by the selected Xcode build so a
+      # runner-image toolchain bump can't restore incompatible object files.
       - name: Cache SwiftPM build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .build
-          key: swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          key: swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ github.repository }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
           restore-keys: |
-            swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
-            swiftpm-macos-${{ steps.xcode.outputs.version }}-
+            swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ github.repository }}-${{ hashFiles('Package.resolved') }}-
+            swiftpm-macos-${{ steps.xcode.outputs.version }}-${{ github.repository }}-
 
       - name: Build (debug)
         run: swift build -c debug
@@ -333,14 +341,15 @@ jobs:
       # A distinct key namespace (`swiftpm-tsan-...`, not `swiftpm-macos-...`) — `--sanitize
       # thread` recompiles every unit with different flags, so sharing a cache with the plain
       # debug build would mean this lane can never hit and just pays the upload for nothing.
+      # See the linux-build-test cache step for the github.repository segment's rationale (#1061).
       - name: Cache SwiftPM build (ThreadSanitizer)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .build
-          key: swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          key: swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ github.repository }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
           restore-keys: |
-            swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
-            swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-
+            swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ github.repository }}-${{ hashFiles('Package.resolved') }}-
+            swiftpm-tsan-macos-${{ steps.xcode.outputs.version }}-${{ github.repository }}-
 
       - name: Run concurrency suites under ThreadSanitizer
         run: scripts/test-concurrency-tsan.sh


### PR DESCRIPTION
## Summary

- Found while fixing #1059 (sidecar checkout 404): even with that fixed, `build-test`, `Concurrency suites (ThreadSanitizer)`, and `Linux (portable SwiftPM targets)` still fail repo-wide (including `main`) with `error: missing required module 'SwiftShims'`.
- Root cause: `Anglesite/Anglesite-app` was renamed to `Anglesite/Anglesite`, changing the GitHub Actions runner workspace path from `/__w/Anglesite-app/Anglesite-app` to `/__w/Anglesite/Anglesite`. Swift's precompiled module cache (`.pcm` files) bakes in the absolute build path at compile time, and the three `actions/cache` steps for `.build` key only on `hashFiles('Package.resolved')` — unaffected by the rename — so every run since restores a pre-rename cache whose `.pcm` files point at the now-gone path.
- Fix: add `${{ github.repository }}` to all three SwiftPM cache keys (Linux, macOS, macOS TSan) so a rename busts the cache instead of silently poisoning it.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP schema change — CI-only.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses.
- [ ] `swift test --package-path .` — not run; no Swift source changed, only the workflow's cache-key expressions.
- [x] Will confirm on this PR's own CI run that `build-test`, TSan, and Linux get past the module-cache failure (first run pays a cold-cache cost since the key changed; that's expected).

Closes #1061.