### PR TITLE
ci(#1066): bump sidecar e2e pin to v1.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,10 +237,12 @@ jobs:
           # (renamed Anglesite-app -> Anglesite), so it silently checks out the wrong repo
           # and then fails fetching a tag that only exists in the real sidecar.
           repository: Anglesite/anglesite-skills
-          # Pinned to the plugin release the app currently exercises. get_component_model
-          # (plugin #410, used by the Component Editor) shipped in v1.3.0 — bump this
-          # pin again the next time a newer plugin feature becomes load-bearing for CI.
-          ref: v1.3.0
+          # Pinned to the plugin release the app currently exercises. v1.8.0 carries
+          # the recordEdit git-identity fix (sidecar #429/#431) that this e2e lane's
+          # overlay -> patcher -> file-on-disk round-trip needs to actually exercise
+          # the apply-edit persistence path fixed for #1066 — bump this pin again the
+          # next time a newer plugin feature becomes load-bearing for CI.
+          ref: v1.8.0
           path: anglesite-plugin
 
       - name: Set up Node (for plugin MCP server tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,11 +237,11 @@ jobs:
           # (renamed Anglesite-app -> Anglesite), so it silently checks out the wrong repo
           # and then fails fetching a tag that only exists in the real sidecar.
           repository: Anglesite/anglesite-skills
-          # Pinned to the plugin release the app currently exercises. v1.8.0 carries
+          # Pinned to the sidecar release the app currently exercises. v1.8.0 carries
           # the recordEdit git-identity fix (sidecar #429/#431) that this e2e lane's
           # overlay -> patcher -> file-on-disk round-trip needs to actually exercise
           # the apply-edit persistence path fixed for #1066 — bump this pin again the
-          # next time a newer plugin feature becomes load-bearing for CI.
+          # next time a newer sidecar feature becomes load-bearing for CI.
           ref: v1.8.0
           path: anglesite-plugin
 


### PR DESCRIPTION
## Summary

- The `build-test` lane pins its sibling sidecar checkout to `anglesite-skills` `v1.3.0`, which predates the fix for #1066 (edit-overlay WYSIWYG edits never reaching canonical `Source/`).
- `anglesite-skills` [v1.8.0](https://github.com/Anglesite/anglesite-skills/releases/tag/v1.8.0) ships [#429](https://github.com/Anglesite/anglesite-skills/pull/429) (gives `recordEdit`'s `commit-tree` call a real git identity, so it no longer fails silently in the identity-less container guest) and [#431](https://github.com/Anglesite/anglesite-skills/pull/431) (logs any remaining `recordEdit` failure instead of swallowing it). Per #431's own description, "Anglesite-app#1066 itself is otherwise resolved by #429 once a release including it is cut and consumed there."
- This bumps the pin so the `build-test` lane's overlay → patcher → file-on-disk e2e round-trip actually exercises the fixed sidecar, and closes out the app-side follow-up #1066 was left tracking.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite-skills#123 -->

> The sidecar-side fix already shipped and is tagged: [Anglesite/anglesite-skills#429](https://github.com/Anglesite/anglesite-skills/pull/429) and [#431](https://github.com/Anglesite/anglesite-skills/pull/431), released as v1.8.0. This PR is the app-side consumption step — no further sidecar work needed.

## Test plan

- [x] `swift test --package-path .` — unaffected (no Swift changes; CI-only YAML edit)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; this change doesn't touch app code
- [ ] MCP/apply-edit e2e round-trip against the new pin — **could not run locally**: no sibling `anglesite-skills` checkout / `ANGLESITE_PLUGIN_PATH` available in this environment, so the gated Swift Testing suites skip cleanly rather than exercising the fix. Verification of the actual round-trip happens in CI's `build-test` lane once this PR runs, and/or via a manual re-run of the #81 smoke repro.

Fixes #1066