### PR TITLE
fix(#746): dedupe route claims by (path, match), not path alone

### DIFF
--- a/Sources/AnglesiteCore/WorkerRouteClaims.swift
+++ b/Sources/AnglesiteCore/WorkerRouteClaims.swift
@@ -138,12 +138,29 @@ public enum WorkerRouteClaims {
             }
         }
 
-        var ownersByPath: [String: [String]] = [:]
-        for entry in owned {
-            ownersByPath[entry.claim.path, default: []].append(entry.owner)
+        // Keyed by (path, match) rather than path alone: an exact claim and a prefix claim that
+        // normalize to the same path are not a collision — a prefix claim covers only its
+        // descendants (see the overlap loop below), never the path itself. Two claims of the
+        // *same* match kind at the same path always collide, since exact-exact and prefix-prefix
+        // both claim identical coverage. A single worker legitimately declares both kinds at the
+        // same path (e.g. an exact POST plus a prefix GET for descendants), which the old
+        // path-only key falsely flagged as a duplicate.
+        struct DuplicateKey: Hashable, Comparable {
+            let path: String
+            let matchRawValue: String
+
+            static func < (lhs: Self, rhs: Self) -> Bool {
+                (lhs.path, lhs.matchRawValue) < (rhs.path, rhs.matchRawValue)
+            }
         }
-        if let (path, owners) = ownersByPath.sorted(by: { $0.key < $1.key }).first(where: { $0.value.count > 1 }) {
-            throw ValidationError.duplicateClaim(path: path, owners: owners.sorted())
+        var ownersByPathAndMatch: [DuplicateKey: [String]] = [:]
+        for entry in owned {
+            let key = DuplicateKey(path: entry.claim.path, matchRawValue: entry.claim.match.rawValue)
+            ownersByPathAndMatch[key, default: []].append(entry.owner)
+        }
+        if let (key, owners) = ownersByPathAndMatch.sorted(by: { $0.key < $1.key })
+            .first(where: { $0.value.count > 1 }) {
+            throw ValidationError.duplicateClaim(path: key.path, owners: owners.sorted())
         }
 
         let sorted = owned.sorted {

--- a/Tests/AnglesiteCoreTests/WorkerRouteClaimsTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerRouteClaimsTests.swift
@@ -180,6 +180,33 @@ struct WorkerRouteClaimsTests {
         }
     }
 
+    @Test("a worker's own exact and prefix claims at the same normalized path don't collide (micropub-shaped)")
+    func exactAndPrefixSameOwnerSamePathCoexist() throws {
+        let claims = try WorkerRouteClaims.activeClaims(
+            catalog: [descriptor(id: "micropub", routes: [
+                claim("/media", match: .exact, methods: ["POST"]),
+                claim("/media/", match: .prefix, methods: ["GET"], specificationURL: spec),
+            ])],
+            activeIDs: ["micropub"])
+        #expect(claims.count == 2)
+        #expect(claims.map(\.claim.path) == ["/media", "/media"])
+        #expect(claims.map(\.claim.match) == [.exact, .prefix])
+    }
+
+    @Test("rejects two prefix claims for the same path, naming both owners")
+    func rejectsDuplicatePrefix() {
+        #expect(throws: WorkerRouteClaims.ValidationError.duplicateClaim(
+            path: "/api", owners: ["a", "b"])
+        ) {
+            try WorkerRouteClaims.activeClaims(
+                catalog: [
+                    descriptor(id: "b", routes: [claim("/api", match: .prefix, specificationURL: spec)]),
+                    descriptor(id: "a", routes: [claim("/api", match: .prefix, specificationURL: spec)]),
+                ],
+                activeIDs: ["a", "b"])
+        }
+    }
+
     @Test("disjoint sibling claims from different workers coexist")
     func acceptsDisjointClaims() throws {
         let claims = try WorkerRouteClaims.activeClaims(


### PR DESCRIPTION
## Summary

- Deploying any site with the micropub worker active failed with `worker route claims are invalid: route "/media" is claimed more than once (by: micropub, micropub)`, even though micropub's two `/media` routes (exact POST, prefix GET) don't actually conflict.
- Root cause: `WorkerRouteClaims.activeClaims` grouped claims into `ownersByPath` keyed only by the normalized path, so an exact `/media` claim and a prefix `/media/` claim (normalized to `/media`) collapsed into one key and were flagged as duplicates — even though the overlap-aware logic just below already understands that a prefix claim covers only its descendants, not the path itself, and would have accepted them correctly.
- Fix: key the dedup check by `(path, match)` instead of `path` alone, so same-worker exact/prefix pairs at the same path coexist while two claims of the same match kind at the same path (a genuine collision) are still caught.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP schema or catalog change — this only touches app-side route-claim validation logic in `WorkerRouteClaims.swift`.

## Test plan

- [x] `swift test --package-path .` (full suite, 2840+ tests across all targets, 0 failures)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (BUILD SUCCEEDED)
- [x] New regression tests: a micropub-shaped case (same worker, exact `/media` POST + prefix `/media/` GET) now coexists without error; added a genuine same-match duplicate case (two prefix claims at the same path) to confirm real collisions are still rejected.