### PR TITLE
fix(deploy): surface worker-provision wrangler output in the drawer

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -435,7 +435,7 @@ final class DeployModel {
         drawerPresented = presentation == .foreground
         blockedPresented = false
 
-        let sources = Set(["deploy:\(siteID)", "deploy:\(siteID):build"])
+        let sources = DeployCoordinator.deployLogSources(siteID: siteID)
 
         // Subscribe BEFORE the deploy starts so we can't miss early build lines.
         let subscription = await logCenter.subscribe()

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -85,6 +85,24 @@ public enum DeployCoordinator {
     /// original (still-taken) name basis after a rename-and-retry, defeating the rename. Only a
     /// genuinely first-ever deploy (no candidate name recorded yet) falls through to the derived
     /// slug of `siteName ?? siteID`.
+    /// The `LogCenter` source tags whose lines feed the Deploy drawer's visible/copyable log
+    /// (`DeployModel.logLines`, filtered from the shared subscription by `sources.contains`).
+    /// Must list every source a deploy-time subprocess can log under, or its output is silently
+    /// dropped from the debug pane — a `LogCenter.append` call still happens, it just never
+    /// reaches this filtered view, which reads as "nothing was logged" (CLAUDE.md's "every
+    /// spawned subprocess streams stdout+stderr into the debug pane" rule, violated by omission
+    /// rather than a missing `append` call). `"worker-provision:<siteID>"` is
+    /// `SocialWorkerProvisionCommand.provision`'s own `source` local — distinct from
+    /// `DeployCommand`'s `"deploy:<siteID>"` family — tagging every wrangler call it makes (D1/KV/
+    /// R2/Queue create, `d1 migrations apply`, ActivityPub secret pushes). Before this was added
+    /// here, a D1/KV/R2/Queue provisioning failure's real wrangler stderr never appeared in the
+    /// drawer even though `ContainerCommandRunner`/`defaultRunner` both already stream it into
+    /// `LogCenter` correctly — only unrelated `"deploy:<siteID>"`-tagged lines (e.g. the
+    /// conformance advisory) were visible.
+    public static func deployLogSources(siteID: String) -> Set<String> {
+        ["deploy:\(siteID)", "deploy:\(siteID):build", "worker-provision:\(siteID)"]
+    }
+
     public static func resolveWorkerSiteName(siteDirectory: URL, siteID: String, siteName: String?) -> String {
         let existingConfig = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
         return SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: existingConfig)

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -141,6 +141,25 @@ struct DeployCoordinatorTests {
         #expect(name == SiteSlug.derive(from: "site-1"))
     }
 
+    // MARK: - deployLogSources
+
+    @Test("deployLogSources includes worker-provision:<siteID> so SocialWorkerProvisionCommand's wrangler output reaches the drawer")
+    func deployLogSourcesIncludesWorkerProvision() {
+        let sources = DeployCoordinator.deployLogSources(siteID: "site-1")
+
+        #expect(sources.contains("worker-provision:site-1"))
+        #expect(sources.contains("deploy:site-1"))
+        #expect(sources.contains("deploy:site-1:build"))
+    }
+
+    @Test("deployLogSources scopes each source to the given siteID, not a different one")
+    func deployLogSourcesScopedToSiteID() {
+        let sources = DeployCoordinator.deployLogSources(siteID: "site-1")
+
+        #expect(!sources.contains("worker-provision:site-2"))
+        #expect(!sources.contains("deploy:site-2"))
+    }
+
     // MARK: - resolveSiteURL
 
     @Test("resolveSiteURL prefers DOMAIN over everything else")

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -18,6 +18,49 @@ private let v3Workers = [webmentionWorker, indieauthWorker, micropubWorker, webs
 
 @Suite("SocialWorkerProvisionCommand")
 struct SocialWorkerProvisionCommandTests {
+    @Test("first-ever deploy (no existing wrangler.toml/CF_PROJECT_NAME) sends a non-empty database name as the d1 create positional argument")
+    func firstDeployD1CreateArgumentsAreWellFormed() async throws {
+        // Regression coverage for a suspected first-deploy D1-provisioning bug: a brand-new site
+        // (empty `siteDirectory`, so `readPersistedResources` finds no wrangler.toml and
+        // `knownResources` defaults to `.init()`) with a D1-needing worker active. The concern was
+        // that `wrangler d1 create <name> --json` might reach the real subprocess with an empty/
+        // missing name positional (reproducing wrangler's own "Not enough non-option arguments"
+        // usage synopsis) — this asserts the exact argv `runWrangler` hands to the `CommandRunner`
+        // seam contains a well-formed, non-empty name in the correct position, so any future
+        // refactor that drops or empties it fails this test immediately.
+        let site = try temporaryDirectory()
+        #expect(!FileManager.default.fileExists(atPath: site.appendingPathComponent("wrangler.toml").path))
+        var capturedArguments: [[String]] = []
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: { _, arguments, _, _ in
+                capturedArguments.append(arguments)
+                if arguments.first == "d1" {
+                    return .init(stdout: #"{"result":{"uuid":"d1-id"}}"#, stderr: "", exitCode: 0)
+                }
+                return .init(stdout: "", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _, _ in .succeeded(url: URL(string: "https://example.com")!, duration: 0) }
+        )
+        let indieauth = worker(WorkerComposition.indieauthWorkerID, d1: true, kv: false, r2: false)
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site",
+            workers: [indieauth], knownResources: .init()
+        )
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let d1CreateCall = try #require(capturedArguments.first { $0.first == "d1" && $0.dropFirst().first == "create" })
+        #expect(d1CreateCall.count == 4, "expected exactly [\"d1\", \"create\", <name>, \"--json\"], got \(d1CreateCall)")
+        let name = d1CreateCall[2]
+        #expect(!name.isEmpty, "the database name positional must never be empty")
+        #expect(name == "my-site-social")
+        #expect(d1CreateCall == ["d1", "create", "my-site-social", "--json"])
+    }
+
     @Test("provisions V-2 D1 and KV, writes wrangler.toml, then deploys through DeployCommand seam")
     func provisionsV2Worker() async throws {
         let site = try temporaryDirectory()


### PR DESCRIPTION
## Summary

- Fixed a confirmed bug: `DeployModel.runDeploy`'s log-line filter (`sources`) only matched `"deploy:<siteID>"`/`"deploy:<siteID>:build"`, but `SocialWorkerProvisionCommand.provision` tags every wrangler call it makes (D1/KV/R2/Queue create, `d1 migrations apply`, ActivityPub secret pushes) with `"worker-provision:<siteID>"`. That output was reaching `LogCenter` correctly (both `ContainerCommandRunner` and `defaultRunner` already stream/append it) but was silently filtered out of the Deploy drawer's visible/copyable log — only unrelated `"deploy:<id>"`-tagged lines (e.g. the conformance advisory) ever showed up.
- Extracted the source-filter set into a new testable `DeployCoordinator.deployLogSources(siteID:)` (mirroring the existing #825 pattern of pulling `DeployModel` orchestration logic into `AnglesiteCore` for CI coverage) and pointed `DeployModel` at it.
- Added regression coverage in `DeployCoordinatorTests` for the new helper.
- Added the requested regression test in `SocialWorkerProvisionCommandTests` (`firstDeployD1CreateArgumentsAreWellFormed`) asserting the exact `d1 create` argv for a brand-new site (no existing `wrangler.toml`/`CF_PROJECT_NAME`) with a D1-needing worker active.

### Investigation note on the originally-suspected argument-construction bug

The initial report hypothesized that `wrangler d1 create <name> --json` could reach the real subprocess with an empty/missing `name` positional on a first-ever deploy (reproducing wrangler's own "Not enough non-option arguments" usage synopsis). I traced the full path — `SocialWorkerProvisionCommand.provision`'s D1 block (`name = "\(siteName)-social"`, always non-empty once `WorkerComposition.isValidSiteName` guards `siteName`), `DeployCoordinator.resolveWorkerSiteName`/`SiteSlug.derive` (never returns empty, falls back to `"untitled-site"`), `runWrangler`, `ContainerCommandRunner.run` (`argv = ["npx", "wrangler"] + arguments`, no shell involved), and `ContainerizationControl.exec` (`config.arguments = argv` set directly, no shell/quoting layer) — and could not find a path in the current codebase where that positional gets dropped or emptied. The new regression test locks in the correct contract so any future refactor that reintroduces such a bug fails immediately. Given the log-source bug above meant wrangler's *real* failure text for any D1/KV/R2/Queue provisioning error was never visible in the drawer, the next time a provisioning failure occurs its actual stderr will now be inspectable — if `wrangler d1 create` is still reached with a missing name after this fix ships, the drawer will finally show enough detail to isolate whether the cause is in Apple's Containerization argv plumbing or something else outside this codebase.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (253 tests, 33 suites, all passing)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (succeeds)
- [ ] Manual smoke: not performed — reproducing a real first-deploy D1 failure requires a live Cloudflare account and container runtime, which this change deliberately avoids per the task's guidance to prefer unit coverage over live Cloudflare resources.