### PR TITLE
fix(#1075,#1076): fix worker-name-conflict false alarm+flash

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -167,6 +167,21 @@ final class DeployModel {
         return false
     }
 
+    /// True while a foreground sheet is presented and awaiting the user's response to a prior
+    /// deploy's outcome — a worker-name-conflict rename, a paid-plan confirmation, or the
+    /// no-override security-block modal. `phase` leaves `.running` as soon as one of these is
+    /// presented, so `isRunning` alone doesn't guard against a second deploy starting concurrently:
+    /// `runDeploy` unconditionally resets `blockedPresented` to `false` at the very start of every
+    /// run (foreground or background), and every terminal case in its result switch unconditionally
+    /// writes `workerNameConflictPresented`/`webmentionPaidPlanConfirmationPresented` for *its own*
+    /// outcome — so a second run's start or resolution would silently clobber a foreground sheet
+    /// the user is still looking at (#1076). Most visibly, `deployAutomatically`'s invisible publish
+    /// queue (#357) firing moments after a manual deploy parks on one of these dismisses it before
+    /// the user can act, since the background run's own reset/outcome always presents as `false`.
+    private var awaitingUserAction: Bool {
+        workerNameConflictPresented || webmentionPaidPlanConfirmationPresented || blockedPresented
+    }
+
     /// Renders the captured log lines as plain text for the "Copy log" affordance on failure.
     var logText: String {
         logLines.map(\.text).joined(separator: "\n")
@@ -229,6 +244,7 @@ final class DeployModel {
         siteName: String? = nil
     ) async -> InvisiblePublishQueue.Result {
         guard !isRunning else { return .deferred(reason: "another site operation is running") }
+        guard !awaitingUserAction else { return .deferred(reason: "a deploy prompt is waiting for a response") }
         guard hasUsableToken() else { return .deferred(reason: "Cloudflare credentials are not configured") }
         // Resolved once (there's no user-facing prompt gap on this background path to make a
         // second resolution meaningfully fresher) and reused both for the readiness guard and the
@@ -461,6 +477,7 @@ final class DeployModel {
         if let cc = containerControl {
             activeCommand = DeployCommand(
                 tokenSource: command.tokenSource,
+                workerScriptNamesSource: command.workerScriptNamesSource,
                 executor: ContainerDeployExecutor(
                     control: cc.control,
                     siteID: cc.siteID,
@@ -560,6 +577,15 @@ final class DeployModel {
                         }
                     }
                 )
+            },
+            // Forwards the same seam `activeCommand` uses for its own end-of-pipeline check (both
+            // are built from `command.workerScriptNamesSource` above), so `provision()`'s new
+            // pre-provisioning check (#1075) agrees with `deployer`'s — and so a test's injected
+            // fake `DeployCommand` governs both instead of this defaulting to the real network
+            // implementation.
+            workerScriptNamesSource: { [weak self] token in
+                guard let self else { return [] }
+                return try await self.command.workerScriptNamesSource(token)
             }
         )
 

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -74,7 +74,12 @@ public actor DeployCommand {
     public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
 
     public nonisolated let tokenSource: TokenSource
-    private let workerScriptNamesSource: WorkerScriptNamesSource
+    /// Exposed (like `tokenSource`) so callers that build a parallel `SocialWorkerProvisionCommand`
+    /// alongside this `DeployCommand` — `DeployModel.runDeploy` — can forward the exact same seam
+    /// into its own pre-provisioning conflict check (#1075) instead of silently defaulting to the
+    /// real network implementation and diverging from whatever this `DeployCommand` was built with
+    /// (production default or a test's injected fake).
+    public nonisolated let workerScriptNamesSource: WorkerScriptNamesSource
     private let executor: any DeployExecutor
 
     public init(
@@ -424,6 +429,27 @@ public actor DeployCommand {
         try? updated.write(to: configURL, atomically: true, encoding: .utf8)
     }
 
+    /// Marks this site's candidate Worker name as confirmed-ours, via `.site-config`'s
+    /// `CF_WORKER_PROVISIONED` — a second, earlier-firing signal `checkWorkerNameConflict` treats
+    /// the same as `CF_WORKER_DEPLOYED` (#1075). `CF_WORKER_DEPLOYED` alone only covers a *fully
+    /// succeeded* deploy, but `SocialWorkerProvisionCommand.provision()` can already have pushed
+    /// live Cloudflare state under this candidate name (`wrangler secret put` for ActivityPub, run
+    /// before the final `wrangler deploy`, auto-vivifies an empty Worker script under the target
+    /// name as a side effect) in an attempt that then failed for an unrelated reason before
+    /// `persistWorkerDeployed` ever ran. Without this second signal, a retry of that same site
+    /// would see its own auto-vivified script on the account and misreport it as a foreign
+    /// conflict. Called once, immediately after a fresh `checkWorkerNameConflict` pass at the very
+    /// start of provisioning — before any wrangler call that could touch the name — so a *genuine*
+    /// foreign collision is still caught before this site's own provisioning ever runs. Written
+    /// unconditionally like `persistWorkerDeployed`; best-effort, matching `persistSiteURL`.
+    static func persistWorkerProvisioned(siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil else { return }
+        let updated = SiteConfigFile.upsert([("CF_WORKER_PROVISIONED", "true")], into: config)
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
     /// Uploads `Source/`'s snapshot to R2 (`DeployStep.bundleUpload`) when `.site-config`'s
     /// `CF_SOURCE_BUCKET` is set, then persists the uploaded commit SHA into `Config/settings.plist`
     /// (#799, spec §C.4 — the code side of a future Worker-triggered bake). A no-op today for every
@@ -462,9 +488,11 @@ public actor DeployCommand {
     }
 
     /// Checks whether `.site-config`'s `CF_PROJECT_NAME` collides with an existing Worker on the
-    /// connected Cloudflare account, but only on a site's first deploy (`CF_WORKER_DEPLOYED` not
-    /// yet set). Returns `.workerNameConflict` on a confirmed collision, or `nil` when the check
-    /// doesn't apply (redeploy, no candidate name) or can't be confirmed — a Cloudflare API
+    /// connected Cloudflare account, but only when neither `CF_WORKER_DEPLOYED` (a full deploy has
+    /// already succeeded under this name) nor `CF_WORKER_PROVISIONED` (this site's own earlier
+    /// provisioning already confirmed the name as ours, #1075) is set yet. Returns
+    /// `.workerNameConflict` on a confirmed collision, or `nil` when the check doesn't apply
+    /// (redeploy, already-provisioned, no candidate name) or can't be confirmed — a Cloudflare API
     /// failure here must never block a deploy that would otherwise succeed (fail open).
     static func checkWorkerNameConflict(
         siteDirectory: URL,
@@ -474,6 +502,7 @@ public actor DeployCommand {
         let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
         let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
         guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
+              SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil,
               let candidateName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config)
         else { return nil }
         guard let names = try? await workerScriptNamesSource(apiToken) else { return nil }

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -13,9 +13,13 @@ public actor SocialWorkerProvisionCommand {
     public enum Result: Sendable, Equatable {
         case succeeded(url: URL, resources: WorkerComposition.ProvisionedResources, duration: TimeInterval)
         case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning], resources: WorkerComposition.ProvisionedResources)
-        /// The candidate Worker name is already in use on the connected Cloudflare account and
-        /// this site has never deployed before — mirrors `DeployCommand.Result.workerNameConflict`
-        /// rather than collapsing it, so callers can drive the same rename-and-retry UX (#740).
+        /// The candidate Worker name is already in use on the connected Cloudflare account by a
+        /// project this site's own local config doesn't already claim as its own (`.site-config`'s
+        /// `CF_WORKER_DEPLOYED`/`CF_WORKER_PROVISIONED`) — mirrors
+        /// `DeployCommand.Result.workerNameConflict` rather than collapsing it, so callers can
+        /// drive the same rename-and-retry UX (#740). Checked at the very start of `provision()`,
+        /// before any wrangler call runs against the name, so a genuine collision is caught before
+        /// this site's own D1/KV/R2/secret provisioning could touch a foreign project (#1075).
         case workerNameConflict(name: String, resources: WorkerComposition.ProvisionedResources)
         /// A Queue-backed worker (inbound Webmention #359, or the WebSub hub #361) is active but
         /// the site hasn't explicitly acknowledged that Cloudflare Queues require the Workers
@@ -67,19 +71,26 @@ public actor SocialWorkerProvisionCommand {
     private let keyPairSource: KeyPairSource
     private let secretRunner: SecretRunner
     private let deployer: Deployer
+    private let workerScriptNamesSource: DeployCommand.WorkerScriptNamesSource
 
     public init(
         tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
         runner: @escaping CommandRunner = SocialWorkerProvisionCommand.defaultRunner,
         keyPairSource: @escaping KeyPairSource = SocialWorkerProvisionCommand.defaultKeyPairSource,
         secretRunner: @escaping SecretRunner = SocialWorkerProvisionCommand.defaultSecretRunner,
-        deployer: @escaping Deployer = SocialWorkerProvisionCommand.defaultDeployer
+        deployer: @escaping Deployer = SocialWorkerProvisionCommand.defaultDeployer,
+        /// Same seam `DeployCommand` uses for its own end-of-pipeline conflict check
+        /// (`DeployCommand.defaultWorkerScriptNames` in production); injected here too so
+        /// `provision()` can run that same check *before* any wrangler call touches the
+        /// candidate name (#1075) instead of only after D1/KV/R2/secrets have already run.
+        workerScriptNamesSource: @escaping DeployCommand.WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames
     ) {
         self.tokenSource = tokenSource
         self.runner = runner
         self.keyPairSource = keyPairSource
         self.secretRunner = secretRunner
         self.deployer = deployer
+        self.workerScriptNamesSource = workerScriptNamesSource
     }
 
     public func provision(
@@ -144,6 +155,24 @@ public actor SocialWorkerProvisionCommand {
         let started = Date()
 
         var resources = knownResources == .init() ? Self.readPersistedResources(from: siteDirectory) : knownResources
+
+        // #1075: confirm the candidate Worker name before any wrangler call can touch it. Left
+        // solely to `deployer`'s own end-of-pipeline check (`DeployCommand.deploy` →
+        // `checkWorkerNameConflict`), a genuine foreign collision would go undetected until AFTER
+        // the D1/KV/R2/secret calls below already ran against that name — and the ActivityPub
+        // secret push in particular (`wrangler secret put`) auto-vivifies an empty Worker script
+        // under the target name as a side effect, which would then make a later retry of THIS
+        // site's own provisioning misreport its own prior attempt as a foreign conflict.
+        // Persisting `CF_WORKER_PROVISIONED` immediately on a pass (name free, or already
+        // confirmed ours by an earlier attempt) closes both gaps: a genuinely foreign name is
+        // still caught here, before any resource creation runs, while a retry of this site never
+        // re-flags its own provisioning history.
+        if case .workerNameConflict(let name)? = await DeployCommand.checkWorkerNameConflict(
+            siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
+        ) {
+            return .workerNameConflict(name: name, resources: resources)
+        }
+        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDirectory)
 
         if workers.contains(where: { $0.resources.needsD1 }) {
             if resources.d1DatabaseID == nil {

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -188,6 +188,48 @@ struct DeployModelTests {
         #expect(model.workerNameConflictPresented)
     }
 
+    @Test("An automatic background deploy defers instead of clobbering a foreground worker-name-conflict sheet (#1076)")
+    func backgroundDeployDefersWhileConflictSheetIsPresented() async {
+        let executor = GatedDeployExecutor()
+        await executor.resumeBuild()
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: executor
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        // A manual (foreground) deploy parks on the conflict sheet, same as
+        // `workerNameConflictParksAndPresents`.
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+        guard case .workerNameConflict = model.phase else {
+            Issue.record("expected .workerNameConflict, got \(model.phase)"); return
+        }
+        #expect(model.workerNameConflictPresented)
+
+        // The invisible-publish queue (#357) fires an automatic background deploy for the same
+        // site while the sheet is still up — resolved via a non-nil container control so it isn't
+        // deferred for the unrelated "runtime not ready" reason.
+        let fakeControl = RecordingLocalContainerControl()
+        let result = await model.deployAutomatically(
+            siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [],
+            containerControlProvider: { (siteID: "s", control: fakeControl) }
+        )
+
+        guard case .deferred = result else {
+            Issue.record("expected the automatic deploy to defer while the conflict sheet is up, got \(result)")
+            return
+        }
+        #expect(model.workerNameConflictPresented, "the foreground conflict sheet must still be showing, not silently dismissed")
+        guard case .workerNameConflict = model.phase else {
+            Issue.record("expected phase to still be .workerNameConflict, got \(model.phase)"); return
+        }
+    }
+
     @Test("An invalid rename target surfaces a plain-language error instead of the raw error enum")
     func renameWithInvalidNameSurfacesPlainLanguageError() async {
         let executor = GatedDeployExecutor()

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -725,6 +725,37 @@ struct DeployCommandTests {
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
     }
 
+    @Test("CF_WORKER_PROVISIONED already set skips the check regardless of remote state (#1075)")
+    func alreadyProvisionedSkipsCheck() async {
+        let siteDir = makeSiteDirectory(projectName: "my-site", deployedBefore: false)
+        // Marks the name as confirmed-ours without a full deploy ever having succeeded — the
+        // signal `SocialWorkerProvisionCommand.provision()` persists once its own pre-provisioning
+        // check passes, even if that attempt then fails for an unrelated reason.
+        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDir)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            // Even though the name is "taken" by this same call, a retry of this site's own
+            // provisioning must not be blocked.
+            workerScriptNamesSource: { _ in ["my-site"] },
+            executor: exec
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+    }
+
+    @Test("persistWorkerProvisioned is idempotent and never clears an already-set flag")
+    func persistWorkerProvisionedIsIdempotent() {
+        let siteDir = makeSiteDirectory()
+        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDir)
+        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDir)
+        let config = try! String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == "true")
+    }
+
     @Test("A thrown error from workerScriptNamesSource fails open and proceeds to build")
     func availabilityCheckErrorFailsOpen() async {
         let siteDir = makeSiteDirectory(projectName: "my-new-site", deployedBefore: false)

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -298,6 +298,99 @@ struct SocialWorkerProvisionCommandTests {
         #expect(await deployer.calls.isEmpty)
     }
 
+    @Test("A retry after an earlier attempt's own secret push isn't mistaken for a foreign Worker-name conflict (#1075)")
+    func retryAfterOwnSecretPushDoesNotFalselyConflict() async throws {
+        let site = try temporaryDirectory()
+        // Mirrors the reported repro: `.site-config` already carries this site's own established
+        // project name from an earlier (partially-failed) attempt.
+        try "CF_PROJECT_NAME=my-site\n".write(to: site.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        let remoteNames = ToggleableWorkerNames()
+        let deployCallCount = CallCounter()
+        let recorder = WranglerRecorder([:])
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: recorder.runner,
+            keyPairSource: { _ in
+                .init(privateKeyPem: "PRIVATE-PEM", publicKeyPem: "PUBLIC-PEM", publishToken: "TOKEN-VALUE")
+            },
+            secretRunner: { _, _, _, _, _ in
+                // Mirrors the real `wrangler secret put` side effect described in the bug report:
+                // once our own secret push succeeds, the account reports this name as an existing
+                // Worker script from then on.
+                await remoteNames.set(["my-site"])
+                return .init(stdout: "Success!", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _, _ in
+                let call = await deployCallCount.increment()
+                if call == 1 {
+                    // Attempt 1 fails for an unrelated reason AFTER secrets have already pushed.
+                    return .failed(reason: "pre-deploy scan could not run", exitCode: nil)
+                }
+                return .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1)
+            },
+            workerScriptNamesSource: { _ in await remoteNames.current }
+        )
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+
+        let firstResult = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [activitypub]
+        )
+        guard case .failed = firstResult else {
+            Issue.record("expected the first attempt to fail for the unrelated reason, got \(firstResult)")
+            return
+        }
+
+        let secondResult = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [activitypub]
+        )
+        guard case .succeeded = secondResult else {
+            Issue.record("expected the retry to succeed instead of reporting a false worker-name conflict, got \(secondResult)")
+            return
+        }
+    }
+
+    @Test("A genuinely foreign name collision is caught before any wrangler call touches it (#1075)")
+    func foreignConflictCaughtBeforeAnyProvisioning() async throws {
+        let site = try temporaryDirectory()
+        try "CF_PROJECT_NAME=my-site\n".write(to: site.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        var d1CallHappened = false
+        var secretRunnerCalled = false
+        var deployerCalled = false
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: { _, _, _, _ in
+                d1CallHappened = true
+                return .init(stdout: "", stderr: "unexpected call", exitCode: 1)
+            },
+            keyPairSource: { _ in .init(privateKeyPem: "x", publicKeyPem: "y", publishToken: "z") },
+            secretRunner: { _, _, _, _, _ in
+                secretRunnerCalled = true
+                return .init(stdout: "Success!", stderr: "", exitCode: 0)
+            },
+            deployer: { _, _, _, _ in
+                deployerCalled = true
+                return .succeeded(url: URL(string: "https://example.com")!, duration: 0)
+            },
+            // The account already has a script under this exact name — a genuinely foreign
+            // project this site's local config has no history with.
+            workerScriptNamesSource: { _ in ["my-site"] }
+        )
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: true, kv: false, r2: false)
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [activitypub]
+        )
+
+        guard case .workerNameConflict(let name, _) = result else {
+            Issue.record("expected .workerNameConflict, got \(result)")
+            return
+        }
+        #expect(name == "my-site")
+        #expect(!d1CallHappened, "must not create D1 resources against a name that isn't confirmed ours")
+        #expect(!secretRunnerCalled, "must not push ActivityPub secrets into a Worker name that isn't confirmed ours")
+        #expect(!deployerCalled, "must not reach the deployer once the pre-check finds a genuine conflict")
+    }
+
     @Test("fails before running wrangler when no token is available")
     func missingToken() async throws {
         let site = try temporaryDirectory()
@@ -1152,5 +1245,24 @@ private actor WranglerRecorder {
         seenArguments.append(arguments)
         seenEnvironments.append(environment)
         return responses[arguments] ?? .init(stdout: "unexpected arguments \(arguments)", stderr: "", exitCode: 127)
+    }
+}
+
+/// A mutable account-wide Worker-script-name list, so a test can simulate `wrangler secret put`'s
+/// side effect of auto-vivifying a script under the target name partway through a `provision()`
+/// call (#1075).
+private actor ToggleableWorkerNames {
+    private var names: [String] = []
+    func set(_ new: [String]) { names = new }
+    var current: [String] { names }
+}
+
+/// Thread-safe invocation counter for a fake `Deployer`, so a test can vary its response across
+/// successive `provision()` calls (e.g. fail the first attempt, succeed on retry).
+private actor CallCounter {
+    private var count = 0
+    func increment() -> Int {
+        count += 1
+        return count
     }
 }


### PR DESCRIPTION
## Summary

- **#1075**: `SocialWorkerProvisionCommand.provision()` now checks for a Worker-name conflict *before* any wrangler call touches the candidate name, not just at the very end (right before `wrangler deploy`). Previously, D1/KV/R2/secret calls ran first — and `wrangler secret put` (used for ActivityPub) auto-vivifies an empty Worker script as a side effect — so a retry after an earlier partial failure would see its own auto-created script and misreport it as a foreign conflict. A new `.site-config` flag (`CF_WORKER_PROVISIONED`) is persisted the moment the check passes, so a retry of the same site never re-flags its own provisioning history, while a genuinely foreign name is still caught before this site's own resources ever touch it.
- **#1076**: `DeployModel` let an automatic background deploy (the invisible-publish queue, #357) start while a foreground worker-name-conflict/blocked/paid-plan sheet was still awaiting the user — `phase` leaves `.running` as soon as one of those sheets is presented, so `isRunning` alone didn't guard against it. The background run's own terminal case then unconditionally reset the same presentation flags for *its own* outcome, silently dismissing the sheet the user was still looking at. `deployAutomatically` now defers instead of racing when one of those sheets is up.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (full suite passes; one pre-existing, unrelated on-device FoundationModels flake in `FoundationModelAssistantTests` — not touched by this change)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] New regression tests added: `DeployCommandTests` (`CF_WORKER_PROVISIONED` gating), `SocialWorkerProvisionCommandTests` (retry-doesn't-falsely-conflict + genuine-foreign-conflict-still-caught-before-provisioning), `DeployModelTests` (background deploy defers instead of clobbering the conflict sheet). Confirmed each new test fails without its corresponding fix.

Closes #1075, closes #1076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)