### PR TITLE
fix(#368): use a real sandbox community as the join example

### DIFF
--- a/Sources/AnglesiteApp/CommunitiesView.swift
+++ b/Sources/AnglesiteApp/CommunitiesView.swift
@@ -100,7 +100,7 @@ struct CommunitiesView: View {
             .padding()
 
             if communities.joined.isEmpty {
-                Text("No communities joined yet — enter a handle above, like !birding@lemmy.ml.")
+                Text("No communities joined yet — enter a handle above, like !sandbox@lemmy.sdf.org.")
                     .foregroundStyle(.secondary)
                     .padding()
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1715,7 +1715,7 @@
     "No changes needed." : {
 
     },
-    "No communities joined yet — enter a handle above, like !birding@lemmy.ml." : {
+    "No communities joined yet — enter a handle above, like !sandbox@lemmy.sdf.org." : {
 
     },
     "No component usage learned yet." : {


### PR DESCRIPTION
## Summary

- The Communities pane's empty-state hint and Localizable.xcstrings example handle changed from `!birding@lemmy.ml` to `!sandbox@lemmy.sdf.org`.
- `birding@lemmy.ml` is a real hobby community on an instance that has an unrelated `URLSession`/CFNetwork interop quirk discovered during #368's manual acceptance QA (confirmed via a bare, unsandboxed `URLSession` test — `lemmy.world`, `lemmy.ca`, and `mastodon.social` all resolve fine, only `lemmy.ml` fails deterministically with `NSURLErrorNetworkConnectionLost`). `!sandbox@lemmy.sdf.org` is a real `Group` actor explicitly named/intended as a test space, on a long-running, reputable instance (SDF), with enough real posts (4) and subscribers (114) to actually demonstrate the group timeline populating.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite-skills#123 -->

## Test plan

- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] `swift test --package-path .` — not run for this change (AnglesiteApp isn't part of the SwiftPM test targets; this is a one-line string literal change with no logic).
- [x] Manual smoke: viewed the updated empty-state text in the running app during #368's QA session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)