### PR TITLE
feat: optional dial-up modem sound effect

### DIFF
--- a/Sources/AnglesiteApp/DialupSoundEffectPlayer.swift
+++ b/Sources/AnglesiteApp/DialupSoundEffectPlayer.swift
@@ -19,14 +19,32 @@ protocol DialupSoundEffectPlaying {
 /// in `AnglesiteCoreTests`.
 @MainActor
 final class DialupSoundEffectPlayer: DialupSoundEffectPlaying {
+    /// The AVFoundation objects that are expensive to build (synthesized PCM buffer, audio
+    /// engine, player node) — bundled together so they can be constructed lazily on first real
+    /// playback instead of unconditionally in `init`. Building `AVAudioEngine` and touching
+    /// `engine.mainMixerNode` forces CoreAudio HAL unit instantiation on first use, so this must
+    /// stay off the `init` path: two independent players are constructed per site window
+    /// regardless of whether the setting is on.
+    private struct PreparedAudio {
+        let engine: AVAudioEngine
+        let playerNode: AVAudioPlayerNode
+        let buffer: AVAudioPCMBuffer
+    }
+
     private let settings: AppSettings
-    private let engine = AVAudioEngine()
-    private let playerNode = AVAudioPlayerNode()
-    private let buffer: AVAudioPCMBuffer
+    private var prepared: PreparedAudio?
     private var isPlaying = false
 
     init(settings: AppSettings = .shared) {
         self.settings = settings
+    }
+
+    /// Synthesizes the audio and builds the engine/buffer/node graph, unless that already
+    /// happened. Only called from `play()`, after the settings-and-idempotency guard passes —
+    /// so this cost is paid at most once per player, and never at all while the setting stays
+    /// off.
+    private func prepare() -> PreparedAudio {
+        if let prepared { return prepared }
         let samples = DialupModemSoundEffect.samples()
         // Mono, matches `DialupModemSoundEffect.sampleRate` — always valid, so the failable
         // initializers below can't realistically return nil for these fixed, known-good inputs.
@@ -38,41 +56,48 @@ final class DialupSoundEffectPlayer: DialupSoundEffectPlaying {
         for (index, sample) in samples.enumerated() {
             channelData[index] = sample
         }
-        self.buffer = pcmBuffer
+        let engine = AVAudioEngine()
+        let playerNode = AVAudioPlayerNode()
         engine.attach(playerNode)
         // Freshly attached nodes with this fixed, known-good format can't realistically fail to
         // connect, so a thrown error here (macOS 27's throwing `connectNode` replaces the
         // deprecated non-throwing `connect`) is discarded like the force-unwraps above.
         try? engine.connectNode(playerNode, to: engine.mainMixerNode, format: format)
+        let result = PreparedAudio(engine: engine, playerNode: playerNode, buffer: pcmBuffer)
+        prepared = result
+        return result
     }
 
     func play() {
         guard settings.playsDialupSoundEffect, !isPlaying else { return }
         isPlaying = true
+        let prepared = prepare()
         do {
-            try engine.start()
+            try prepared.engine.start()
         } catch {
             // Purely decorative — a failure to start the audio engine (e.g. no output device)
             // should never surface to the user or block the operation it's soundtracking.
             isPlaying = false
             return
         }
-        playerNode.scheduleBuffer(buffer, at: nil, options: .loops)
+        prepared.playerNode.scheduleBuffer(prepared.buffer, at: nil, options: .loops)
         do {
             // macOS 27's throwing `playAudio` replaces the deprecated non-throwing `play`.
-            try playerNode.playAudio()
+            try prepared.playerNode.playAudio()
         } catch {
             // Same rationale as the `engine.start()` failure above: never surface or block.
             isPlaying = false
-            playerNode.stop()
-            engine.stop()
+            prepared.playerNode.stop()
+            prepared.engine.stop()
         }
     }
 
     func stop() {
         guard isPlaying else { return }
         isPlaying = false
-        playerNode.stop()
-        engine.stop()
+        // `isPlaying` can only be true after `play()` has already run `prepare()`, so `prepared`
+        // is guaranteed non-nil here.
+        prepared!.playerNode.stop()
+        prepared!.engine.stop()
     }
 }

--- a/Sources/AnglesiteApp/DialupSoundEffectPlayer.swift
+++ b/Sources/AnglesiteApp/DialupSoundEffectPlayer.swift
@@ -1,0 +1,78 @@
+import AVFoundation
+import AnglesiteCore
+
+/// Plays (or doesn't) the synthesized dial-up modem sound effect
+/// (`DialupModemSoundEffect`) while a "loading" operation is in flight — dev-server startup,
+/// deploy. `play()` checks `AppSettings.shared.playsDialupSoundEffect` first and never touches
+/// the audio engine when the setting is off.
+@MainActor
+protocol DialupSoundEffectPlaying {
+    /// Starts the looping handshake sound if the setting is on and it isn't already playing.
+    /// No-op when the setting is off. Idempotent while already playing.
+    func play()
+    /// Stops playback. Idempotent while already stopped.
+    func stop()
+}
+
+/// Thin `AVFoundation` glue by design — deliberately untested directly (mirrors
+/// `CompletionNotifier`'s shape). The audio it plays (`DialupModemSoundEffect`) is unit-tested
+/// in `AnglesiteCoreTests`.
+@MainActor
+final class DialupSoundEffectPlayer: DialupSoundEffectPlaying {
+    private let settings: AppSettings
+    private let engine = AVAudioEngine()
+    private let playerNode = AVAudioPlayerNode()
+    private let buffer: AVAudioPCMBuffer
+    private var isPlaying = false
+
+    init(settings: AppSettings = .shared) {
+        self.settings = settings
+        let samples = DialupModemSoundEffect.samples()
+        // Mono, matches `DialupModemSoundEffect.sampleRate` — always valid, so the failable
+        // initializers below can't realistically return nil for these fixed, known-good inputs.
+        let format = AVAudioFormat(
+            standardFormatWithSampleRate: DialupModemSoundEffect.sampleRate, channels: 1)!
+        let pcmBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))!
+        pcmBuffer.frameLength = AVAudioFrameCount(samples.count)
+        let channelData = pcmBuffer.floatChannelData![0]
+        for (index, sample) in samples.enumerated() {
+            channelData[index] = sample
+        }
+        self.buffer = pcmBuffer
+        engine.attach(playerNode)
+        // Freshly attached nodes with this fixed, known-good format can't realistically fail to
+        // connect, so a thrown error here (macOS 27's throwing `connectNode` replaces the
+        // deprecated non-throwing `connect`) is discarded like the force-unwraps above.
+        try? engine.connectNode(playerNode, to: engine.mainMixerNode, format: format)
+    }
+
+    func play() {
+        guard settings.playsDialupSoundEffect, !isPlaying else { return }
+        isPlaying = true
+        do {
+            try engine.start()
+        } catch {
+            // Purely decorative — a failure to start the audio engine (e.g. no output device)
+            // should never surface to the user or block the operation it's soundtracking.
+            isPlaying = false
+            return
+        }
+        playerNode.scheduleBuffer(buffer, at: nil, options: .loops)
+        do {
+            // macOS 27's throwing `playAudio` replaces the deprecated non-throwing `play`.
+            try playerNode.playAudio()
+        } catch {
+            // Same rationale as the `engine.start()` failure above: never surface or block.
+            isPlaying = false
+            playerNode.stop()
+            engine.stop()
+        }
+    }
+
+    func stop() {
+        guard isPlaying else { return }
+        isPlaying = false
+        playerNode.stop()
+        engine.stop()
+    }
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1949,6 +1949,12 @@
     "Plan social media for ${site}" : {
 
     },
+    "Play dial-up sound while loading" : {
+
+    },
+    "Plays a nostalgic dial-up modem sound while the dev server starts up or a deploy is running. Purely decorative — off by default." : {
+
+    },
     "Point at a checkout of the plugin (e.g. `../anglesite`) to iterate without rebuilding the app." : {
 
     },
@@ -2612,6 +2618,9 @@
 
     },
     "Software or SaaS" : {
+
+    },
+    "Sound" : {
 
     },
     "Source" : {

--- a/Sources/AnglesiteApp/SettingsView.swift
+++ b/Sources/AnglesiteApp/SettingsView.swift
@@ -25,6 +25,7 @@ private struct GeneralSettingsView: View {
     @AppStorage(AppSettings.Key.autoGeneratePageCopy) private var autoGeneratePageCopy: Bool = true
     @AppStorage(AppSettings.Key.announcesLiveUpdates) private var announcesLiveUpdates: Bool = true
     @AppStorage(AppSettings.Key.notifiesOnCompletion) private var notifiesOnCompletion: Bool = true
+    @AppStorage(AppSettings.Key.playsDialupSoundEffect) private var playsDialupSoundEffect: Bool = false
 
     var body: some View {
         Form {
@@ -42,6 +43,13 @@ private struct GeneralSettingsView: View {
             Section("Notifications") {
                 Toggle("Notify when site operations finish", isOn: $notifiesOnCompletion)
                 Text("Posts a notification when a Deploy, Backup, or Audit finishes while Anglesite is in the background — success or failure. Clicking the notification brings the site's window to the front. Delivery starts quietly; promote or silence Anglesite in System Settings › Notifications.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Sound") {
+                Toggle("Play dial-up sound while loading", isOn: $playsDialupSoundEffect)
+                Text("Plays a nostalgic dial-up modem sound while the dev server starts up or a deploy is running. Purely decorative — off by default.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -254,9 +254,11 @@ final class SiteWindowModel {
             if case .succeeded = phase { self?.sync.backupCompleted() }
         }
         let deployHook = deploy.onPhaseTransition
+        let deploySound: DialupSoundEffectPlaying = DialupSoundEffectPlayer()
         deploy.onPhaseTransition = { [weak self] siteID, phase in
             deployHook?(siteID, phase)
             if case .succeeded = phase { self?.sync.deployCompleted() }
+            if case .running = phase { deploySound.play() } else { deploySound.stop() }
         }
     }
 

--- a/Sources/AnglesiteApp/StartupProgressModel.swift
+++ b/Sources/AnglesiteApp/StartupProgressModel.swift
@@ -16,6 +16,7 @@ final class StartupProgressModel {
 
     private let timingStore: StartupTimingStore
     private let logCenter: LogCenter
+    private let soundEffect: DialupSoundEffectPlaying
     private let clock: @Sendable () -> TimeInterval
 
     private var estimator = StartupProgressEstimator()
@@ -26,10 +27,19 @@ final class StartupProgressModel {
     init(
         timingStore: StartupTimingStore = .shared,
         logCenter: LogCenter = .shared,
+        // `soundEffect` can't default directly to `DialupSoundEffectPlayer()` here: under this
+        // project's Swift 5.10 language mode (project.yml's SWIFT_VERSION, not Swift 6 mode),
+        // a default-argument expression that calls a `@MainActor`-isolated initializer is
+        // rejected as a call "in a synchronous nonisolated context," even though this
+        // initializer's enclosing type (and thus the init itself) is `@MainActor`. Defaulting
+        // to `nil` and constructing the real player in the (actor-isolated) init body sidesteps
+        // that restriction while keeping the same effective default and injectability for tests.
+        soundEffect: DialupSoundEffectPlaying? = nil,
         clock: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
     ) {
         self.timingStore = timingStore
         self.logCenter = logCenter
+        self.soundEffect = soundEffect ?? DialupSoundEffectPlayer()
         self.clock = clock
     }
 
@@ -57,6 +67,7 @@ final class StartupProgressModel {
     func stop() {
         logTask?.cancel(); logTask = nil
         tickTask?.cancel(); tickTask = nil
+        soundEffect.stop()
     }
 
     // MARK: - Internals
@@ -67,6 +78,7 @@ final class StartupProgressModel {
         self.siteID = siteID
         estimator = StartupProgressEstimator(profile: timingStore.profile(for: siteID))
         estimator.ingest(runtimeState: .starting(siteID: siteID), at: clock())
+        soundEffect.play()
         publish()
         subscribeToLogs(siteID: siteID)
         startTicker()

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -25,6 +25,7 @@ public final class AppSettings: @unchecked Sendable {
         public static let autoGeneratePageCopy = "anglesite.autoGeneratePageCopy"
         public static let announcesLiveUpdates = "anglesite.announcesLiveUpdates"
         public static let notifiesOnCompletion = "anglesite.notifiesOnCompletion"
+        public static let playsDialupSoundEffect = "anglesite.playsDialupSoundEffect"
         public static let didCleanLegacyChatBackendDefaults = "anglesite.didCleanLegacyChatBackendDefaults"
         public static let gitHubAccountLogin = "anglesite.gitHubAccount.login"
         public static let gitHubAccountName = "anglesite.gitHubAccount.name"
@@ -191,6 +192,14 @@ public final class AppSettings: @unchecked Sendable {
             return defaults.bool(forKey: Key.notifiesOnCompletion)
         }
         set { defaults.set(newValue, forKey: Key.notifiesOnCompletion) }
+    }
+
+    /// Whether Anglesite plays a synthesized dial-up modem handshake sound while the dev server
+    /// starts up (`StartupProgressModel`) or a deploy runs (`DeployModel`). Purely decorative —
+    /// off by default, so `false` when absent needs no inversion trick.
+    public var playsDialupSoundEffect: Bool {
+        get { defaults.bool(forKey: Key.playsDialupSoundEffect) }
+        set { defaults.set(newValue, forKey: Key.playsDialupSoundEffect) }
     }
 
     /// The site that was most-recently focused. Used by the Sites launcher to auto-open

--- a/Sources/AnglesiteCore/DialupModemSoundEffect.swift
+++ b/Sources/AnglesiteCore/DialupModemSoundEffect.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// A stylized, deterministic approximation of a Hayes-era K56flex modem handshake — not a
+/// decode of K56flex's largely undocumented proprietary bitstream, but shaped like one: DTMF
+/// dialing, the real ITU V.25 2100 Hz answer tone (with its echo-canceller-defeating phase
+/// reversal), a digital-probe-style burst standing in for 56K's line-probing step, a couple of
+/// negotiation sweeps, and a noise-like training burst. See
+/// docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md.
+///
+/// Pure `Foundation` math only (no `AVFoundation`) so this keeps compiling and testing on the
+/// Linux CI lane along with the rest of `AnglesiteCore`.
+public enum DialupModemSoundEffect {
+    /// Standard CD-quality sample rate; `DialupSoundEffectPlayer` builds its `AVAudioFormat`
+    /// to match.
+    public static let sampleRate: Double = 44_100
+
+    /// The number the handshake "dials": 802-748-1210, The Kingdom Connection BBS.
+    public static let dialedDigits = "8027481210"
+
+    /// One loop cycle's worth of samples, each within `[-1, 1]`. Pure function — calling this
+    /// twice with the same `sampleRate` returns identical output.
+    public static func samples(sampleRate: Double = sampleRate) -> [Float] {
+        var result: [Float] = []
+        result += dialTone(sampleRate: sampleRate)
+        result += dtmfDialing(sampleRate: sampleRate)
+        result += silence(duration: 0.3, sampleRate: sampleRate)
+        result += answerTone(sampleRate: sampleRate)
+        result += digitalProbeBurst(sampleRate: sampleRate)
+        result += negotiationSweeps(sampleRate: sampleRate)
+        result += trainingNoise(sampleRate: sampleRate)
+        return result
+    }
+
+    // MARK: - Segments
+
+    private static func dialTone(sampleRate: Double) -> [Float] {
+        mixedTone(frequencies: [350, 440], duration: 0.4, amplitude: 0.2, sampleRate: sampleRate)
+    }
+
+    /// DTMF low/high frequency pairs per digit (ITU-T Q.23).
+    private static let dtmfFrequencies: [Character: (low: Double, high: Double)] = [
+        "1": (697, 1209), "2": (697, 1336), "3": (697, 1477),
+        "4": (770, 1209), "5": (770, 1336), "6": (770, 1477),
+        "7": (852, 1209), "8": (852, 1336), "9": (852, 1477),
+        "0": (941, 1336),
+    ]
+
+    private static func dtmfDialing(sampleRate: Double) -> [Float] {
+        var result: [Float] = []
+        for digit in dialedDigits {
+            guard let pair = dtmfFrequencies[digit] else { continue }
+            result += mixedTone(
+                frequencies: [pair.low, pair.high], duration: 0.08, amplitude: 0.25, sampleRate: sampleRate)
+            result += silence(duration: 0.04, sampleRate: sampleRate)
+        }
+        return result
+    }
+
+    /// ITU-T V.25 answer tone: a continuous 2100 Hz tone whose phase reverses every ~450 ms, so
+    /// an echo canceller at the far end can detect and disable itself.
+    private static func answerTone(sampleRate: Double) -> [Float] {
+        var result: [Float] = []
+        for segment in 0..<3 {
+            let phase = segment.isMultiple(of: 2) ? 0.0 : Double.pi
+            result += sineWave(
+                frequency: 2100, duration: 0.45, amplitude: 0.3, sampleRate: sampleRate, phase: phase)
+        }
+        return result
+    }
+
+    /// Stands in for the line-probing step unique to 56K (K56flex/x2/V.90) handshakes and absent
+    /// from a plain V.34 33.6K handshake.
+    private static func digitalProbeBurst(sampleRate: Double) -> [Float] {
+        chirp(startFrequency: 300, endFrequency: 3300, duration: 0.15, amplitude: 0.25, sampleRate: sampleRate)
+            + chirp(startFrequency: 3300, endFrequency: 300, duration: 0.15, amplitude: 0.25, sampleRate: sampleRate)
+    }
+
+    private static func negotiationSweeps(sampleRate: Double) -> [Float] {
+        chirp(startFrequency: 1000, endFrequency: 3000, duration: 0.3, amplitude: 0.2, sampleRate: sampleRate)
+            + chirp(startFrequency: 1200, endFrequency: 2800, duration: 0.3, amplitude: 0.2, sampleRate: sampleRate)
+    }
+
+    /// A deterministic noise-like burst standing in for the scrambled carrier training sequence,
+    /// built from summed non-harmonic sine components rather than a seeded PRNG.
+    private static func trainingNoise(sampleRate: Double) -> [Float] {
+        let componentFrequencies: [Double] = [733, 911, 1237, 1583, 1871, 2203, 2617, 2999]
+        let sampleCount = Int((0.7 * sampleRate).rounded())
+        var result = [Float](repeating: 0, count: sampleCount)
+        for frequency in componentFrequencies {
+            for index in 0..<sampleCount {
+                let t = Double(index) / sampleRate
+                result[index] += Float(sin(2 * .pi * frequency * t) / Double(componentFrequencies.count))
+            }
+        }
+        for index in 0..<sampleCount {
+            result[index] *= 0.5
+        }
+        applyEdgeFades(&result, sampleRate: sampleRate)
+        return result
+    }
+
+    // MARK: - Primitives
+
+    private static func mixedTone(
+        frequencies: [Double], duration: Double, amplitude: Double, sampleRate: Double
+    ) -> [Float] {
+        let sampleCount = Int((duration * sampleRate).rounded())
+        var result = [Float](repeating: 0, count: sampleCount)
+        for frequency in frequencies {
+            for index in 0..<sampleCount {
+                let t = Double(index) / sampleRate
+                result[index] += Float(sin(2 * .pi * frequency * t) * amplitude / Double(frequencies.count))
+            }
+        }
+        applyEdgeFades(&result, sampleRate: sampleRate)
+        return result
+    }
+
+    private static func sineWave(
+        frequency: Double, duration: Double, amplitude: Double, sampleRate: Double, phase: Double = 0
+    ) -> [Float] {
+        let sampleCount = Int((duration * sampleRate).rounded())
+        var result = [Float](repeating: 0, count: sampleCount)
+        for index in 0..<sampleCount {
+            let t = Double(index) / sampleRate
+            result[index] = Float(sin(2 * .pi * frequency * t + phase) * amplitude)
+        }
+        applyEdgeFades(&result, sampleRate: sampleRate)
+        return result
+    }
+
+    /// Linear frequency sweep from `startFrequency` to `endFrequency`, using the proper
+    /// quadratic phase integral (not just `frequency(t) * t`) so the sweep is a real chirp.
+    private static func chirp(
+        startFrequency: Double, endFrequency: Double, duration: Double, amplitude: Double, sampleRate: Double
+    ) -> [Float] {
+        let sampleCount = Int((duration * sampleRate).rounded())
+        var result = [Float](repeating: 0, count: sampleCount)
+        let rate = (endFrequency - startFrequency) / duration
+        for index in 0..<sampleCount {
+            let t = Double(index) / sampleRate
+            let phase = 2 * .pi * (startFrequency * t + rate * t * t / 2)
+            result[index] = Float(sin(phase) * amplitude)
+        }
+        applyEdgeFades(&result, sampleRate: sampleRate)
+        return result
+    }
+
+    private static func silence(duration: Double, sampleRate: Double) -> [Float] {
+        [Float](repeating: 0, count: Int((duration * sampleRate).rounded()))
+    }
+
+    /// 5ms linear fade in/out so concatenated segments don't click at the seams.
+    private static func applyEdgeFades(_ samples: inout [Float], sampleRate: Double) {
+        let fadeSamples = min(samples.count / 2, Int((0.005 * sampleRate).rounded()))
+        guard fadeSamples > 0 else { return }
+        for index in 0..<fadeSamples {
+            let gain = Float(index) / Float(fadeSamples)
+            samples[index] *= gain
+            samples[samples.count - 1 - index] *= gain
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/AppSettingsTests.swift
+++ b/Tests/AnglesiteCoreTests/AppSettingsTests.swift
@@ -101,6 +101,19 @@ final class AppSettingsTests {
         #expect(settings.notifiesOnCompletion)
     }
 
+    @Test("playsDialupSoundEffect defaults to false") func playsDialupSoundEffectDefaultsToFalse() {
+        let settings = AppSettings(defaults: defaults)
+        #expect(!settings.playsDialupSoundEffect)
+    }
+
+    @Test("playsDialupSoundEffect round trip") func playsDialupSoundEffectRoundTrip() {
+        let settings = AppSettings(defaults: defaults)
+        settings.playsDialupSoundEffect = true
+        #expect(settings.playsDialupSoundEffect)
+        settings.playsDialupSoundEffect = false
+        #expect(!settings.playsDialupSoundEffect)
+    }
+
     @Test("legacy chat backend defaults are cleaned once") func legacyChatBackendDefaultsCleanedOnce() {
         defaults.set(false, forKey: "anglesite.preferFoundationModels")
         defaults.set(true, forKey: "anglesite.didMigrateAssistantDefault")

--- a/Tests/AnglesiteCoreTests/DialupModemSoundEffectTests.swift
+++ b/Tests/AnglesiteCoreTests/DialupModemSoundEffectTests.swift
@@ -1,0 +1,43 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct DialupModemSoundEffectTests {
+
+    @Test("Loop cycle is about five seconds of audio")
+    func loopDuration() {
+        let samples = DialupModemSoundEffect.samples()
+        let seconds = Double(samples.count) / DialupModemSoundEffect.sampleRate
+        #expect(seconds > 4.5 && seconds < 5.5)
+    }
+
+    @Test("Every sample stays within [-1, 1]")
+    func samplesInRange() {
+        let samples = DialupModemSoundEffect.samples()
+        #expect(samples.allSatisfy { $0 >= -1 && $0 <= 1 })
+    }
+
+    @Test("Generation is deterministic")
+    func deterministic() {
+        #expect(DialupModemSoundEffect.samples() == DialupModemSoundEffect.samples())
+    }
+
+    @Test("Loop is not silent")
+    func notSilent() {
+        let samples = DialupModemSoundEffect.samples()
+        let peak = samples.map { abs($0) }.max() ?? 0
+        #expect(peak > 0.05)
+    }
+
+    @Test("Dials the Kingdom Connection's number")
+    func dialsExpectedNumber() {
+        #expect(DialupModemSoundEffect.dialedDigits == "8027481210")
+    }
+
+    @Test("A different sample rate still produces in-range, non-empty audio")
+    func differentSampleRate() {
+        let samples = DialupModemSoundEffect.samples(sampleRate: 22_050)
+        #expect(!samples.isEmpty)
+        #expect(samples.allSatisfy { $0 >= -1 && $0 <= 1 })
+    }
+}

--- a/docs/qa/e2e-acceptance-1-initial-launch.md
+++ b/docs/qa/e2e-acceptance-1-initial-launch.md
@@ -81,7 +81,7 @@ Open Settings (⌘,).
 
 Expected — fixed-size window with three tabs:
 
-- **General**: "Auto-generate alt text for dropped images" **ON**; "Auto-suggest descriptions for new pages and posts" **ON**; "Notify when site operations finish" **ON**; "Announce live updates to VoiceOver" **ON**.
+- **General**: "Auto-generate alt text for dropped images" **ON**; "Auto-suggest descriptions for new pages and posts" **ON**; "Notify when site operations finish" **ON**; "Play dial-up sound while loading" **OFF**; "Announce live updates to VoiceOver" **ON**.
 - **Advanced**: plugin path override empty (placeholder "(use bundled plugin)"); Sites root empty (placeholder `~/Sites/`); Credentials section shows the Cloudflare API token row with **no stored token**; "Show Debug Pane menu item" **OFF**; LAN runtime section hidden in Release (no diagnostics opt-in yet).
 - No runtime-selection toggle exists anywhere (runtime choice is automatic).
 

--- a/docs/superpowers/plans/2026-07-28-dialup-modem-sound-effect.md
+++ b/docs/superpowers/plans/2026-07-28-dialup-modem-sound-effect.md
@@ -1,0 +1,733 @@
+# Dial-up Modem Sound Effect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional, off-by-default synthesized dial-up modem sound effect that plays while the dev server is starting up and while a deploy is running.
+
+**Architecture:** A pure sample-synthesis type (`DialupModemSoundEffect`) lives in `AnglesiteCore` and is unit-tested there. A thin `AVAudioEngine`-based player (`DialupSoundEffectPlayer`, behind a `DialupSoundEffectPlaying` protocol) lives in `AnglesiteApp`/`AnglesiteAppCore` and is wired into the two existing "loading" state machines — `StartupProgressModel` (dev-server startup) and `DeployModel.onPhaseTransition` via `SiteWindowModel` (deploy) — without a shared/coordinated player instance. A single new `AppSettings` toggle, surfaced in `SettingsView`, gates both triggers.
+
+**Tech Stack:** Swift 6.4, SwiftPM (`AnglesiteCore`, `AnglesiteAppCore` targets), AVFoundation (`AVAudioEngine`/`AVAudioPlayerNode`/`AVAudioPCMBuffer`), Swift Testing.
+
+## Global Constraints
+
+- No third-party dependencies — Apple frameworks only (AVFoundation).
+- The sample generator (`AnglesiteCore`) must use only `Foundation` trig math — no `AVFoundation` import — so it keeps compiling and testing on the Linux CI lane.
+- All synthesized sample values stay within `[-1, 1]`.
+- Sample generation is deterministic: no `Date()`/`Math.random()`-style time-seeded randomness.
+- DTMF dial sequence is exactly `8027481210` (802-748-1210, The Kingdom Connection BBS).
+- Handshake flavor is K56flex-shaped (V.25 2100 Hz answer tone with phase reversal, then a digital-probe-style burst, then negotiation sweeps, then training noise) — not a literal x2/V.90 decode.
+- New setting key: `AppSettings.Key.playsDialupSoundEffect` = `"anglesite.playsDialupSoundEffect"`, plain `Bool`, defaults to `false` (absent-defaults-to-false; no inversion trick).
+- `DialupSoundEffectPlayer` (the `AVAudioEngine`-touching class) and its wiring into `StartupProgressModel`/`SiteWindowModel` stay untested directly — matches the existing `CompletionNotifier` convention in this codebase. Only the pure sample generator and the `AppSettings` property get unit tests.
+- Every task that touches `Sources/AnglesiteApp/` must be verified with `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (not just `swift test`), and any new user-visible `Text`/`Toggle` string needs the String Catalog sync described in `CONTRIBUTING.md`.
+- Conventional commit subjects, ≤72 characters.
+
+---
+
+### Task 1: Synthesize the dial-up modem sound (`AnglesiteCore`)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DialupModemSoundEffect.swift`
+- Test: `Tests/AnglesiteCoreTests/DialupModemSoundEffectTests.swift`
+
+**Interfaces:**
+- Consumes: nothing (pure `Foundation` math only).
+- Produces: `public enum DialupModemSoundEffect` with `public static let sampleRate: Double`, `public static let dialedDigits: String`, and `public static func samples(sampleRate: Double = sampleRate) -> [Float]`. Later tasks (`DialupSoundEffectPlayer` in Task 3) call `DialupModemSoundEffect.samples()` and `DialupModemSoundEffect.sampleRate`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/DialupModemSoundEffectTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct DialupModemSoundEffectTests {
+
+    @Test("Loop cycle is about five seconds of audio")
+    func loopDuration() {
+        let samples = DialupModemSoundEffect.samples()
+        let seconds = Double(samples.count) / DialupModemSoundEffect.sampleRate
+        #expect(seconds > 4.5 && seconds < 5.5)
+    }
+
+    @Test("Every sample stays within [-1, 1]")
+    func samplesInRange() {
+        let samples = DialupModemSoundEffect.samples()
+        #expect(samples.allSatisfy { $0 >= -1 && $0 <= 1 })
+    }
+
+    @Test("Generation is deterministic")
+    func deterministic() {
+        #expect(DialupModemSoundEffect.samples() == DialupModemSoundEffect.samples())
+    }
+
+    @Test("Loop is not silent")
+    func notSilent() {
+        let samples = DialupModemSoundEffect.samples()
+        let peak = samples.map { abs($0) }.max() ?? 0
+        #expect(peak > 0.05)
+    }
+
+    @Test("Dials the Kingdom Connection's number")
+    func dialsExpectedNumber() {
+        #expect(DialupModemSoundEffect.dialedDigits == "8027481210")
+    }
+
+    @Test("A different sample rate still produces in-range, non-empty audio")
+    func differentSampleRate() {
+        let samples = DialupModemSoundEffect.samples(sampleRate: 22_050)
+        #expect(!samples.isEmpty)
+        #expect(samples.allSatisfy { $0 >= -1 && $0 <= 1 })
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter DialupModemSoundEffectTests`
+Expected: FAIL to build — `DialupModemSoundEffect` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/DialupModemSoundEffect.swift`:
+
+```swift
+import Foundation
+
+/// A stylized, deterministic approximation of a Hayes-era K56flex modem handshake — not a
+/// decode of K56flex's largely undocumented proprietary bitstream, but shaped like one: DTMF
+/// dialing, the real ITU V.25 2100 Hz answer tone (with its echo-canceller-defeating phase
+/// reversal), a digital-probe-style burst standing in for 56K's line-probing step, a couple of
+/// negotiation sweeps, and a noise-like training burst. See
+/// docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md.
+///
+/// Pure `Foundation` math only (no `AVFoundation`) so this keeps compiling and testing on the
+/// Linux CI lane along with the rest of `AnglesiteCore`.
+public enum DialupModemSoundEffect {
+    /// Standard CD-quality sample rate; `DialupSoundEffectPlayer` builds its `AVAudioFormat`
+    /// to match.
+    public static let sampleRate: Double = 44_100
+
+    /// The number the handshake "dials": 802-748-1210, The Kingdom Connection BBS.
+    public static let dialedDigits = "8027481210"
+
+    /// One loop cycle's worth of samples, each within `[-1, 1]`. Pure function — calling this
+    /// twice with the same `sampleRate` returns identical output.
+    public static func samples(sampleRate: Double = sampleRate) -> [Float] {
+        var result: [Float] = []
+        result += dialTone(sampleRate: sampleRate)
+        result += dtmfDialing(sampleRate: sampleRate)
+        result += silence(duration: 0.3, sampleRate: sampleRate)
+        result += answerTone(sampleRate: sampleRate)
+        result += digitalProbeBurst(sampleRate: sampleRate)
+        result += negotiationSweeps(sampleRate: sampleRate)
+        result += trainingNoise(sampleRate: sampleRate)
+        return result
+    }
+
+    // MARK: - Segments
+
+    private static func dialTone(sampleRate: Double) -> [Float] {
+        mixedTone(frequencies: [350, 440], duration: 0.4, amplitude: 0.2, sampleRate: sampleRate)
+    }
+
+    /// DTMF low/high frequency pairs per digit (ITU-T Q.23).
+    private static let dtmfFrequencies: [Character: (low: Double, high: Double)] = [
+        "1": (697, 1209), "2": (697, 1336), "3": (697, 1477),
+        "4": (770, 1209), "5": (770, 1336), "6": (770, 1477),
+        "7": (852, 1209), "8": (852, 1336), "9": (852, 1477),
+        "0": (941, 1336),
+    ]
+
+    private static func dtmfDialing(sampleRate: Double) -> [Float] {
+        var result: [Float] = []
+        for digit in dialedDigits {
+            guard let pair = dtmfFrequencies[digit] else { continue }
+            result += mixedTone(
+                frequencies: [pair.low, pair.high], duration: 0.08, amplitude: 0.25, sampleRate: sampleRate)
+            result += silence(duration: 0.04, sampleRate: sampleRate)
+        }
+        return result
+    }
+
+    /// ITU-T V.25 answer tone: a continuous 2100 Hz tone whose phase reverses every ~450 ms, so
+    /// an echo canceller at the far end can detect and disable itself.
+    private static func answerTone(sampleRate: Double) -> [Float] {
+        var result: [Float] = []
+        for segment in 0..<3 {
+            let phase = segment.isMultiple(of: 2) ? 0.0 : Double.pi
+            result += sineWave(
+                frequency: 2100, duration: 0.45, amplitude: 0.3, sampleRate: sampleRate, phase: phase)
+        }
+        return result
+    }
+
+    /// Stands in for the line-probing step unique to 56K (K56flex/x2/V.90) handshakes and absent
+    /// from a plain V.34 33.6K handshake.
+    private static func digitalProbeBurst(sampleRate: Double) -> [Float] {
+        chirp(startFrequency: 300, endFrequency: 3300, duration: 0.15, amplitude: 0.25, sampleRate: sampleRate)
+            + chirp(startFrequency: 3300, endFrequency: 300, duration: 0.15, amplitude: 0.25, sampleRate: sampleRate)
+    }
+
+    private static func negotiationSweeps(sampleRate: Double) -> [Float] {
+        chirp(startFrequency: 1000, endFrequency: 3000, duration: 0.3, amplitude: 0.2, sampleRate: sampleRate)
+            + chirp(startFrequency: 1200, endFrequency: 2800, duration: 0.3, amplitude: 0.2, sampleRate: sampleRate)
+    }
+
+    /// A deterministic noise-like burst standing in for the scrambled carrier training sequence,
+    /// built from summed non-harmonic sine components rather than a seeded PRNG.
+    private static func trainingNoise(sampleRate: Double) -> [Float] {
+        let componentFrequencies: [Double] = [733, 911, 1237, 1583, 1871, 2203, 2617, 2999]
+        let sampleCount = Int((0.7 * sampleRate).rounded())
+        var result = [Float](repeating: 0, count: sampleCount)
+        for frequency in componentFrequencies {
+            for index in 0..<sampleCount {
+                let t = Double(index) / sampleRate
+                result[index] += Float(sin(2 * .pi * frequency * t) / Double(componentFrequencies.count))
+            }
+        }
+        for index in 0..<sampleCount {
+            result[index] *= 0.5
+        }
+        applyEdgeFades(&result, sampleRate: sampleRate)
+        return result
+    }
+
+    // MARK: - Primitives
+
+    private static func mixedTone(
+        frequencies: [Double], duration: Double, amplitude: Double, sampleRate: Double
+    ) -> [Float] {
+        let sampleCount = Int((duration * sampleRate).rounded())
+        var result = [Float](repeating: 0, count: sampleCount)
+        for frequency in frequencies {
+            for index in 0..<sampleCount {
+                let t = Double(index) / sampleRate
+                result[index] += Float(sin(2 * .pi * frequency * t) * amplitude / Double(frequencies.count))
+            }
+        }
+        applyEdgeFades(&result, sampleRate: sampleRate)
+        return result
+    }
+
+    private static func sineWave(
+        frequency: Double, duration: Double, amplitude: Double, sampleRate: Double, phase: Double = 0
+    ) -> [Float] {
+        let sampleCount = Int((duration * sampleRate).rounded())
+        var result = [Float](repeating: 0, count: sampleCount)
+        for index in 0..<sampleCount {
+            let t = Double(index) / sampleRate
+            result[index] = Float(sin(2 * .pi * frequency * t + phase) * amplitude)
+        }
+        applyEdgeFades(&result, sampleRate: sampleRate)
+        return result
+    }
+
+    /// Linear frequency sweep from `startFrequency` to `endFrequency`, using the proper
+    /// quadratic phase integral (not just `frequency(t) * t`) so the sweep is a real chirp.
+    private static func chirp(
+        startFrequency: Double, endFrequency: Double, duration: Double, amplitude: Double, sampleRate: Double
+    ) -> [Float] {
+        let sampleCount = Int((duration * sampleRate).rounded())
+        var result = [Float](repeating: 0, count: sampleCount)
+        let rate = (endFrequency - startFrequency) / duration
+        for index in 0..<sampleCount {
+            let t = Double(index) / sampleRate
+            let phase = 2 * .pi * (startFrequency * t + rate * t * t / 2)
+            result[index] = Float(sin(phase) * amplitude)
+        }
+        applyEdgeFades(&result, sampleRate: sampleRate)
+        return result
+    }
+
+    private static func silence(duration: Double, sampleRate: Double) -> [Float] {
+        [Float](repeating: 0, count: Int((duration * sampleRate).rounded()))
+    }
+
+    /// 5ms linear fade in/out so concatenated segments don't click at the seams.
+    private static func applyEdgeFades(_ samples: inout [Float], sampleRate: Double) {
+        let fadeSamples = min(samples.count / 2, Int((0.005 * sampleRate).rounded()))
+        guard fadeSamples > 0 else { return }
+        for index in 0..<fadeSamples {
+            let gain = Float(index) / Float(fadeSamples)
+            samples[index] *= gain
+            samples[samples.count - 1 - index] *= gain
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter DialupModemSoundEffectTests`
+Expected: PASS — all 6 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DialupModemSoundEffect.swift Tests/AnglesiteCoreTests/DialupModemSoundEffectTests.swift
+git commit -m "feat: synthesize dial-up modem handshake sound"
+```
+
+---
+
+### Task 2: Add the `playsDialupSoundEffect` setting (`AnglesiteCore`)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/AppSettings.swift:27` (add key), `:194` (add property after `notifiesOnCompletion`)
+- Test: `Tests/AnglesiteCoreTests/AppSettingsTests.swift`
+
+**Interfaces:**
+- Consumes: `AppSettings` class from Task-independent existing code (no dependency on Task 1).
+- Produces: `AppSettings.Key.playsDialupSoundEffect: String` and `AppSettings.playsDialupSoundEffect: Bool` (get/set). Task 3's `DialupSoundEffectPlayer` and Task 6's `SettingsView` both read/bind this property.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/AppSettingsTests.swift` (near the `debugPaneEnabled` tests, same file):
+
+```swift
+    @Test("playsDialupSoundEffect defaults to false") func playsDialupSoundEffectDefaultsToFalse() {
+        let settings = AppSettings(defaults: defaults)
+        #expect(!settings.playsDialupSoundEffect)
+    }
+
+    @Test("playsDialupSoundEffect round trip") func playsDialupSoundEffectRoundTrip() {
+        let settings = AppSettings(defaults: defaults)
+        settings.playsDialupSoundEffect = true
+        #expect(settings.playsDialupSoundEffect)
+        settings.playsDialupSoundEffect = false
+        #expect(!settings.playsDialupSoundEffect)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter AppSettingsTests`
+Expected: FAIL to build — `playsDialupSoundEffect` is not a member of `AppSettings`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/AppSettings.swift`, add the key right after `notifiesOnCompletion` (currently line 27):
+
+```swift
+        public static let notifiesOnCompletion = "anglesite.notifiesOnCompletion"
+        public static let playsDialupSoundEffect = "anglesite.playsDialupSoundEffect"
+```
+
+Add the property right after the `notifiesOnCompletion` property block (currently ends at line 194, just before `lastOpenedSiteID`):
+
+```swift
+    /// Whether Anglesite plays a synthesized dial-up modem handshake sound while the dev server
+    /// starts up (`StartupProgressModel`) or a deploy runs (`DeployModel`). Purely decorative —
+    /// off by default, so `false` when absent needs no inversion trick.
+    public var playsDialupSoundEffect: Bool {
+        get { defaults.bool(forKey: Key.playsDialupSoundEffect) }
+        set { defaults.set(newValue, forKey: Key.playsDialupSoundEffect) }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter AppSettingsTests`
+Expected: PASS — including the two new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/AppSettings.swift Tests/AnglesiteCoreTests/AppSettingsTests.swift
+git commit -m "feat: add playsDialupSoundEffect setting"
+```
+
+---
+
+### Task 3: Playback glue — `DialupSoundEffectPlayer` (`AnglesiteApp`)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/DialupSoundEffectPlayer.swift`
+
+**Interfaces:**
+- Consumes: `DialupModemSoundEffect.samples()` / `.sampleRate` (Task 1), `AppSettings.shared.playsDialupSoundEffect` (Task 2).
+- Produces: `@MainActor protocol DialupSoundEffectPlaying { func play(); func stop() }` and `@MainActor final class DialupSoundEffectPlayer: DialupSoundEffectPlaying` with `init(settings: AppSettings = .shared)`. Task 4 (`StartupProgressModel`) and Task 5 (`SiteWindowModel`) both construct `DialupSoundEffectPlayer()` and call `.play()`/`.stop()`.
+
+This class is deliberately **not** unit tested (see Global Constraints) — same shape as `CompletionNotifier`. Verification is a successful build, not a test run.
+
+- [ ] **Step 1: Write the implementation**
+
+Create `Sources/AnglesiteApp/DialupSoundEffectPlayer.swift`:
+
+```swift
+import AVFoundation
+import AnglesiteCore
+
+/// Plays (or doesn't) the synthesized dial-up modem sound effect
+/// (`DialupModemSoundEffect`) while a "loading" operation is in flight — dev-server startup,
+/// deploy. `play()` checks `AppSettings.shared.playsDialupSoundEffect` first and never touches
+/// the audio engine when the setting is off.
+@MainActor
+protocol DialupSoundEffectPlaying {
+    /// Starts the looping handshake sound if the setting is on and it isn't already playing.
+    /// No-op when the setting is off. Idempotent while already playing.
+    func play()
+    /// Stops playback. Idempotent while already stopped.
+    func stop()
+}
+
+/// Thin `AVFoundation` glue by design — deliberately untested directly (mirrors
+/// `CompletionNotifier`'s shape). The audio it plays (`DialupModemSoundEffect`) is unit-tested
+/// in `AnglesiteCoreTests`.
+@MainActor
+final class DialupSoundEffectPlayer: DialupSoundEffectPlaying {
+    private let settings: AppSettings
+    private let engine = AVAudioEngine()
+    private let playerNode = AVAudioPlayerNode()
+    private let buffer: AVAudioPCMBuffer
+    private var isPlaying = false
+
+    init(settings: AppSettings = .shared) {
+        self.settings = settings
+        let samples = DialupModemSoundEffect.samples()
+        // Mono, matches `DialupModemSoundEffect.sampleRate` — always valid, so the failable
+        // initializers below can't realistically return nil for these fixed, known-good inputs.
+        let format = AVAudioFormat(
+            standardFormatWithSampleRate: DialupModemSoundEffect.sampleRate, channels: 1)!
+        let pcmBuffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))!
+        pcmBuffer.frameLength = AVAudioFrameCount(samples.count)
+        let channelData = pcmBuffer.floatChannelData![0]
+        for (index, sample) in samples.enumerated() {
+            channelData[index] = sample
+        }
+        self.buffer = pcmBuffer
+        engine.attach(playerNode)
+        engine.connect(playerNode, to: engine.mainMixerNode, format: format)
+    }
+
+    func play() {
+        guard settings.playsDialupSoundEffect, !isPlaying else { return }
+        isPlaying = true
+        do {
+            try engine.start()
+        } catch {
+            // Purely decorative — a failure to start the audio engine (e.g. no output device)
+            // should never surface to the user or block the operation it's soundtracking.
+            isPlaying = false
+            return
+        }
+        playerNode.scheduleBuffer(buffer, at: nil, options: .loops)
+        playerNode.play()
+    }
+
+    func stop() {
+        guard isPlaying else { return }
+        isPlaying = false
+        playerNode.stop()
+        engine.stop()
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the Xcode project and build**
+
+Run: `xcodegen generate`
+Expected: regenerates `Anglesite.xcodeproj` to pick up the new file (folder-referenced source, per `project.yml`).
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DialupSoundEffectPlayer.swift
+git commit -m "feat: add AVAudioEngine-based dial-up sound player"
+```
+
+---
+
+### Task 4: Wire the sound into dev-server startup (`StartupProgressModel`)
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/StartupProgressModel.swift:17-34` (properties + init), `:56-60` (`stop()`), `:64-73` (`begin(siteID:)`)
+
+**Interfaces:**
+- Consumes: `DialupSoundEffectPlaying` / `DialupSoundEffectPlayer` (Task 3).
+- Produces: no new public interface — `StartupProgressModel`'s existing `ingest(state:)` behavior gains a side effect.
+
+No new tests (see Global Constraints — this class has no dedicated test file today; `StartupProgressEstimatorTests` covers the pure estimator it wraps, and that's unaffected by this change). Verification is the full test suite staying green plus a clean build.
+
+- [ ] **Step 1: Add the dependency and wire it in**
+
+In `Sources/AnglesiteApp/StartupProgressModel.swift`, change:
+
+```swift
+    private let timingStore: StartupTimingStore
+    private let logCenter: LogCenter
+    private let clock: @Sendable () -> TimeInterval
+
+    private var estimator = StartupProgressEstimator()
+    private var siteID: String?
+    private var logTask: Task<Void, Never>?
+    private var tickTask: Task<Void, Never>?
+
+    init(
+        timingStore: StartupTimingStore = .shared,
+        logCenter: LogCenter = .shared,
+        clock: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
+        self.timingStore = timingStore
+        self.logCenter = logCenter
+        self.clock = clock
+    }
+```
+
+to:
+
+```swift
+    private let timingStore: StartupTimingStore
+    private let logCenter: LogCenter
+    private let soundEffect: DialupSoundEffectPlaying
+    private let clock: @Sendable () -> TimeInterval
+
+    private var estimator = StartupProgressEstimator()
+    private var siteID: String?
+    private var logTask: Task<Void, Never>?
+    private var tickTask: Task<Void, Never>?
+
+    init(
+        timingStore: StartupTimingStore = .shared,
+        logCenter: LogCenter = .shared,
+        soundEffect: DialupSoundEffectPlaying = DialupSoundEffectPlayer(),
+        clock: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
+        self.timingStore = timingStore
+        self.logCenter = logCenter
+        self.soundEffect = soundEffect
+        self.clock = clock
+    }
+```
+
+Change `stop()` from:
+
+```swift
+    func stop() {
+        logTask?.cancel(); logTask = nil
+        tickTask?.cancel(); tickTask = nil
+    }
+```
+
+to:
+
+```swift
+    func stop() {
+        logTask?.cancel(); logTask = nil
+        tickTask?.cancel(); tickTask = nil
+        soundEffect.stop()
+    }
+```
+
+Change `begin(siteID:)` from:
+
+```swift
+    private func begin(siteID: String) {
+        // Re-arm only on a genuinely new startup; ignore a duplicate `.starting` for the same site.
+        if self.siteID == siteID && estimator.isActive { return }
+        self.siteID = siteID
+        estimator = StartupProgressEstimator(profile: timingStore.profile(for: siteID))
+        estimator.ingest(runtimeState: .starting(siteID: siteID), at: clock())
+        publish()
+        subscribeToLogs(siteID: siteID)
+        startTicker()
+    }
+```
+
+to:
+
+```swift
+    private func begin(siteID: String) {
+        // Re-arm only on a genuinely new startup; ignore a duplicate `.starting` for the same site.
+        if self.siteID == siteID && estimator.isActive { return }
+        self.siteID = siteID
+        estimator = StartupProgressEstimator(profile: timingStore.profile(for: siteID))
+        estimator.ingest(runtimeState: .starting(siteID: siteID), at: clock())
+        soundEffect.play()
+        publish()
+        subscribeToLogs(siteID: siteID)
+        startTicker()
+    }
+```
+
+- [ ] **Step 2: Run the full test suite and build**
+
+Run: `swift test --package-path .`
+Expected: PASS — no regressions (in particular, nothing in `AnglesiteAppTests` constructs `StartupProgressModel()` with a real player mid-test in a way that would touch actual audio hardware, since the default `DialupSoundEffectPlayer()` only starts the engine when `AppSettings.shared.playsDialupSoundEffect` is `true`, which is `false` by default in a fresh `UserDefaults.standard` on a CI runner).
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/StartupProgressModel.swift
+git commit -m "feat: play dial-up sound while the dev server starts"
+```
+
+---
+
+### Task 5: Wire the sound into deploys (`SiteWindowModel`)
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:256-260`
+
+**Interfaces:**
+- Consumes: `DialupSoundEffectPlaying` / `DialupSoundEffectPlayer` (Task 3), `DeployModel.Phase` (existing).
+- Produces: no new public interface.
+
+No new tests (see Global Constraints — `SiteWindowModel`'s existing `backupHook`/`deployHook` closure composition has no dedicated unit tests today either). Verification is the full test suite staying green plus a clean build.
+
+- [ ] **Step 1: Layer the sound effect onto the existing deploy hook**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, change:
+
+```swift
+        let deployHook = deploy.onPhaseTransition
+        deploy.onPhaseTransition = { [weak self] siteID, phase in
+            deployHook?(siteID, phase)
+            if case .succeeded = phase { self?.sync.deployCompleted() }
+        }
+    }
+```
+
+to:
+
+```swift
+        let deployHook = deploy.onPhaseTransition
+        let deploySound: DialupSoundEffectPlaying = DialupSoundEffectPlayer()
+        deploy.onPhaseTransition = { [weak self] siteID, phase in
+            deployHook?(siteID, phase)
+            if case .succeeded = phase { self?.sync.deployCompleted() }
+            if case .running = phase { deploySound.play() } else { deploySound.stop() }
+        }
+    }
+```
+
+(`deploySound` is captured by value into the closure — it needs no `self` reference, so it plays/stops correctly for the run's whole lifetime independent of whether the window itself is still open, same as the rest of this hook.)
+
+- [ ] **Step 2: Run the full test suite and build**
+
+Run: `swift test --package-path .`
+Expected: PASS — no regressions.
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindowModel.swift
+git commit -m "feat: play dial-up sound while a deploy is running"
+```
+
+---
+
+### Task 6: Settings UI toggle
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SettingsView.swift:22-59` (`GeneralSettingsView`)
+
+**Interfaces:**
+- Consumes: `AppSettings.Key.playsDialupSoundEffect` (Task 2).
+- Produces: no new interface — a new `Toggle` bound via `@AppStorage`.
+
+- [ ] **Step 1: Add the toggle and its section**
+
+In `Sources/AnglesiteApp/SettingsView.swift`, change the `GeneralSettingsView` property list from:
+
+```swift
+private struct GeneralSettingsView: View {
+    @AppStorage(AppSettings.Key.autoGenerateAltText) private var autoGenerateAltText: Bool = true
+    @AppStorage(AppSettings.Key.autoGeneratePageCopy) private var autoGeneratePageCopy: Bool = true
+    @AppStorage(AppSettings.Key.announcesLiveUpdates) private var announcesLiveUpdates: Bool = true
+    @AppStorage(AppSettings.Key.notifiesOnCompletion) private var notifiesOnCompletion: Bool = true
+```
+
+to:
+
+```swift
+private struct GeneralSettingsView: View {
+    @AppStorage(AppSettings.Key.autoGenerateAltText) private var autoGenerateAltText: Bool = true
+    @AppStorage(AppSettings.Key.autoGeneratePageCopy) private var autoGeneratePageCopy: Bool = true
+    @AppStorage(AppSettings.Key.announcesLiveUpdates) private var announcesLiveUpdates: Bool = true
+    @AppStorage(AppSettings.Key.notifiesOnCompletion) private var notifiesOnCompletion: Bool = true
+    @AppStorage(AppSettings.Key.playsDialupSoundEffect) private var playsDialupSoundEffect: Bool = false
+```
+
+Then insert a new `Section("Sound")` between the existing `Section("Notifications")` and `Section("Accessibility")`:
+
+```swift
+            Section("Notifications") {
+                Toggle("Notify when site operations finish", isOn: $notifiesOnCompletion)
+                Text("Posts a notification when a Deploy, Backup, or Audit finishes while Anglesite is in the background — success or failure. Clicking the notification brings the site's window to the front. Delivery starts quietly; promote or silence Anglesite in System Settings › Notifications.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Sound") {
+                Toggle("Play dial-up sound while loading", isOn: $playsDialupSoundEffect)
+                Text("Plays a nostalgic dial-up modem sound while the dev server starts up or a deploy is running. Purely decorative — off by default.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Accessibility") {
+```
+
+- [ ] **Step 2: Regenerate the Xcode project and build**
+
+Run: `xcodegen generate` (no new file was added here, but this keeps the routine consistent — safe to run regardless).
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Sync the String Catalog**
+
+New user-visible literals (`"Sound"`, `"Play dial-up sound while loading"`, the caption text) only merge into `Sources/AnglesiteApp/Localizable.xcstrings` inside the Xcode IDE, not via CLI `xcodebuild build` alone. Per `CONTRIBUTING.md` ▸ "Commit String Catalog updates", derive the `.stringsdata` path from this worktree's own build settings and sync with `--skip-marking-strings-stale`:
+
+```bash
+BUILD_DIR=$(xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug -showBuildSettings 2>/dev/null | awk '/ BUILD_DIR =/{print $3}')
+xcrun xcstringstool sync Sources/AnglesiteApp/Localizable.xcstrings \
+  --stringsdata $(find "$(dirname "$BUILD_DIR")/Intermediates.noindex/Anglesite.build/Debug/Anglesite.build/Objects-normal/arm64" -name "*.stringsdata") \
+  --skip-marking-strings-stale
+```
+
+Review the resulting diff to `Localizable.xcstrings`: it should add only the new strings from this task (`"Sound"`, `"Play dial-up sound while loading"`, and the caption), not keys belonging to unrelated in-flight work. If it looks larger than that, re-run after a clean build scoped to this worktree rather than committing it as-is (see `CONTRIBUTING.md` for the full troubleshooting notes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SettingsView.swift Sources/AnglesiteApp/Localizable.xcstrings
+git commit -m "feat: add Settings toggle for the dial-up sound effect"
+```
+
+---
+
+### Task 7: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: PASS — all targets, including the new `DialupModemSoundEffectTests` and `AppSettingsTests` cases.
+
+- [ ] **Step 2: Full app build**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Manual smoke check**
+
+Open the built app (or `open Anglesite.xcodeproj` and run from Xcode), open Settings ▸ General, confirm the new "Sound" section shows "Play dial-up sound while loading" (off by default) with the expected caption. Turn it on, open or restart a site's dev server, and confirm the handshake sound plays and stops when the preview becomes ready. Trigger a deploy and confirm the sound plays during `.running` and stops at the end (success, failure, or blocked).
+
+- [ ] **Step 4: Confirm no stray changes**
+
+Run: `git status --short`
+Expected: clean (everything from Tasks 1–6 already committed).

--- a/docs/superpowers/plans/2026-07-28-phase-progress-panels.md
+++ b/docs/superpowers/plans/2026-07-28-phase-progress-panels.md
@@ -1,0 +1,621 @@
+# Three-Panel Phase Progress Strip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the plain progress indicator during dev-server startup and deploy with a three-panel, cumulative-fill strip inspired by AOL's classic sign-on animation.
+
+**Architecture:** Two small, pure phase→panel-count mappings live in `AnglesiteCore` (one for `StartupPhase`, one new `DeployPanelProgress` for deploy milestones) and are unit-tested there. A single reusable SwiftUI view, `PhaseProgressStrip`, renders the three cells in two sizes (full/compact) and lives in `AnglesiteApp`. It's wired into `StartupProgressView` (full size) and `DeployDrawerView` (compact size, replacing the `.running`-case spinner), each driven by its own pure mapping.
+
+**Tech Stack:** Swift 6.4, SwiftPM (`AnglesiteCore`, `AnglesiteAppCore`), SwiftUI, Swift Testing.
+
+## Global Constraints
+
+- This is a cumulative-fill strip — a cell that becomes filled **stays** filled at every later phase. It is never a single badge that swaps in place.
+- No settings toggle — this redesign is always on.
+- Cell 1 glyph: 🚶. Cell 2 glyph: 🏃. Cell 3: 👥 rendered over the real app icon (`NSApp.applicationIconImage`), not a generic glyph alone.
+- Status/caption text reuses each surface's existing phase-message strings (`StartupProgressModel.message`, `DeployModel.currentMilestone`) — no new copy is introduced by this plan.
+- `DeployPanelProgress` must NOT be built on top of `DeployDockProgress.fraction(forPhase:)` — that table has no entry for `websubPing`/`activityPubBackfill` and would regress the panel count. It is a small, self-contained mapping over the known milestone-phase strings.
+- Deploy's terminal states (`.failed`, `.blocked`, `.workerNameConflict`, `.webmentionPaidPlanConfirmationNeeded`) keep their existing icon treatment in `DeployDrawerView` — the strip only replaces the `.running`-case spinner.
+- `PhaseProgressStrip` (the SwiftUI view) stays untested directly — this codebase's convention for presentational views (verified by successful build, matching `StartupProgressView`/`DeployDrawerView` themselves, which also have no dedicated view tests).
+- The two pure mapping functions (`StartupPhase.panelFillCount`, `DeployPanelProgress.filledCount`) DO get unit tests, following `StartupProgressEstimatorTests`'s existing style.
+- Conventional commit subjects, ≤72 characters.
+
+---
+
+### Task 1: `StartupPhase.panelFillCount` (`AnglesiteCore`)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/StartupProgressEstimator.swift:40-48` (the `StartupPhase` enum)
+- Test: `Tests/AnglesiteCoreTests/StartupProgressEstimatorTests.swift`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `StartupPhase.panelFillCount: Int` (0...3). Task 5 (`StartupProgressView`) reads `model.phase.panelFillCount`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/StartupProgressEstimatorTests.swift` (anywhere in the `StartupProgressEstimatorTests` struct):
+
+```swift
+    @Test("panelFillCount maps each phase to the three-panel strip's fill count")
+    func panelFillCountMapsPhases() {
+        #expect(StartupPhase.idle.panelFillCount == 0)
+        #expect(StartupPhase.launching.panelFillCount == 1)
+        #expect(StartupPhase.building.panelFillCount == 1)
+        #expect(StartupPhase.connecting.panelFillCount == 2)
+        #expect(StartupPhase.ready.panelFillCount == 3)
+        #expect(StartupPhase.failed.panelFillCount == 0)
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --package-path . --filter StartupProgressEstimatorTests`
+Expected: FAIL to build — `panelFillCount` is not a member of `StartupPhase`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Sources/AnglesiteCore/StartupProgressEstimator.swift`, add this computed property to the `StartupPhase` enum, right after the existing `message` property (currently ending at line 47, just before the enum's closing `}`):
+
+```swift
+    /// How many of the three phase-progress-strip panels (see
+    /// docs/superpowers/specs/2026-07-28-phase-progress-panels-design.md) should read as filled
+    /// for this phase. Cumulative: once a panel fills at an earlier phase it stays filled at every
+    /// later phase — this only ever needs to name the count for the *current* phase because the
+    /// view renders "filled" as "index < filledCount", not a stateful toggle.
+    public var panelFillCount: Int {
+        switch self {
+        case .idle, .failed:        return 0
+        case .launching, .building: return 1
+        case .connecting:           return 2
+        case .ready:                return 3
+        }
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --package-path . --filter StartupProgressEstimatorTests`
+Expected: PASS — including the new test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/StartupProgressEstimator.swift Tests/AnglesiteCoreTests/StartupProgressEstimatorTests.swift
+git commit -m "feat: map StartupPhase to phase-progress-strip fill count"
+```
+
+---
+
+### Task 2: `DeployPanelProgress` (`AnglesiteCore`)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DeployPanelProgress.swift`
+- Test: `Tests/AnglesiteCoreTests/DeployPanelProgressTests.swift`
+
+**Interfaces:**
+- Consumes: nothing (pure).
+- Produces: `public enum DeployPanelProgress` with `public static func filledCount(currentMilestonePhase: String?, succeeded: Bool) -> Int`. Task 3 (`DeployModel`) provides the milestone phase string; Task 6 (`DeployDrawerView`) calls this function.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/DeployPanelProgressTests.swift`:
+
+```swift
+import Testing
+@testable import AnglesiteCore
+
+struct DeployPanelProgressTests {
+
+    @Test("No milestone yet reads as zero filled panels")
+    func noMilestone() {
+        #expect(DeployPanelProgress.filledCount(currentMilestonePhase: nil, succeeded: false) == 0)
+    }
+
+    @Test("preflightScan and building read as one filled panel")
+    func earlyMilestones() {
+        #expect(DeployPanelProgress.filledCount(currentMilestonePhase: "preflightScan", succeeded: false) == 1)
+        #expect(DeployPanelProgress.filledCount(currentMilestonePhase: "building", succeeded: false) == 1)
+    }
+
+    @Test("deploying and every later milestone read as two filled panels")
+    func lateMilestones() {
+        let phases = ["deploying", "finalizing", "webmentions", "syndicating", "websubPing", "activityPubBackfill"]
+        for phase in phases {
+            #expect(DeployPanelProgress.filledCount(currentMilestonePhase: phase, succeeded: false) == 2)
+        }
+    }
+
+    @Test("An unrecognized milestone string reads forward as two filled panels, not back to zero")
+    func unrecognizedMilestoneDefaultsForward() {
+        #expect(DeployPanelProgress.filledCount(currentMilestonePhase: "someFutureMilestone", succeeded: false) == 2)
+    }
+
+    @Test("succeeded always reads as three filled panels, regardless of milestone")
+    func succeededWins() {
+        #expect(DeployPanelProgress.filledCount(currentMilestonePhase: "preflightScan", succeeded: true) == 3)
+        #expect(DeployPanelProgress.filledCount(currentMilestonePhase: nil, succeeded: true) == 3)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter DeployPanelProgressTests`
+Expected: FAIL to build — `DeployPanelProgress` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/DeployPanelProgress.swift`:
+
+```swift
+import Foundation
+
+/// Maps a deploy's current milestone to how many of the three phase-progress-strip panels
+/// (see docs/superpowers/specs/2026-07-28-phase-progress-panels-design.md) should read as
+/// filled.
+///
+/// Deliberately NOT built on `DeployDockProgress.fraction(forPhase:)`
+/// (`Sources/AnglesiteCore/CompletionNotice.swift`): that table has no entry for
+/// `websubPing`/`activityPubBackfill` (returns `nil`, meant for "don't move the Dock tile"
+/// semantics), which would regress this panel count from 2 back to 1 on those two late-stage
+/// milestones. This is a small, self-contained switch over the known milestone-phase strings
+/// instead, with an unrecognized phase defaulting forward to 2 rather than back to 1 — a milestone
+/// this function doesn't recognize by name is still assumed to be past "deploying," since new
+/// milestones only ever get added after that step in practice.
+public enum DeployPanelProgress {
+    /// `succeeded` takes priority — a finished deploy always shows all three panels filled,
+    /// regardless of the last milestone phase seen.
+    public static func filledCount(currentMilestonePhase phase: String?, succeeded: Bool) -> Int {
+        if succeeded { return 3 }
+        switch phase {
+        case nil: return 0
+        case "preflightScan", "building": return 1
+        default: return 2
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter DeployPanelProgressTests`
+Expected: PASS — all 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DeployPanelProgress.swift Tests/AnglesiteCoreTests/DeployPanelProgressTests.swift
+git commit -m "feat: map deploy milestones to phase-progress-strip fill count"
+```
+
+---
+
+### Task 3: Track the milestone's phase id on `DeployModel`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift` — property declaration near line 35, and 7 assignment sites (listed below)
+
+**Interfaces:**
+- Consumes: `OperationProgress.phase: String` (existing, `Sources/AnglesiteCore/OperationProgress.swift:17`).
+- Produces: `DeployModel.currentMilestonePhase: String?`. Task 6 (`DeployDrawerView`) reads this and passes it to `DeployPanelProgress.filledCount(currentMilestonePhase:succeeded:)`.
+
+`DeployModel.currentMilestone` (existing) holds the human-readable *label* ("Deploying to production…") — `DeployPanelProgress` needs the stable *phase id* ("deploying") instead, which `DeployModel` doesn't currently expose. This task adds a sibling property tracking it, kept in lockstep with `currentMilestone` at every site that sets or clears it.
+
+No new tests for this task — `currentMilestone` itself (the property this mirrors) has no dedicated test coverage in `Tests/AnglesiteAppTests/DeployModelTests.swift` today either; the full suite passing is the verification.
+
+- [ ] **Step 1: Add the property**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, find:
+
+```swift
+    private(set) var currentMilestone: String?
+```
+
+Change to:
+
+```swift
+    private(set) var currentMilestone: String?
+    /// The stable milestone-phase id (`OperationProgress.phase`, e.g. `"deploying"`) behind
+    /// `currentMilestone`'s human-readable label — kept in lockstep with it everywhere it's set
+    /// or cleared. `DeployDrawerView` feeds this to `DeployPanelProgress.filledCount(...)`.
+    private(set) var currentMilestonePhase: String?
+```
+
+- [ ] **Step 2: Set it alongside every `currentMilestone = progress.label` assignment**
+
+There are two sites. First, find:
+
+```swift
+                    onProgress: { [weak self] progress in
+                        Task { @MainActor in
+                            self?.currentMilestone = progress.label
+                            self?.onMilestone?(siteID, progress)
+                        }
+                    }
+```
+
+Change to:
+
+```swift
+                    onProgress: { [weak self] progress in
+                        Task { @MainActor in
+                            self?.currentMilestone = progress.label
+                            self?.currentMilestonePhase = progress.phase
+                            self?.onMilestone?(siteID, progress)
+                        }
+                    }
+```
+
+Second, find:
+
+```swift
+    private func emitPostDeployMilestone(_ progress: OperationProgress, siteID: String) {
+        currentMilestone = progress.label
+        onMilestone?(siteID, progress)
+    }
+```
+
+Change to:
+
+```swift
+    private func emitPostDeployMilestone(_ progress: OperationProgress, siteID: String) {
+        currentMilestone = progress.label
+        currentMilestonePhase = progress.phase
+        onMilestone?(siteID, progress)
+    }
+```
+
+- [ ] **Step 3: Clear it alongside every `currentMilestone = nil` reset**
+
+There are five sites, all of the literal form `currentMilestone = nil` (two different indentation levels — 8 spaces at two sites, 12 spaces at three sites). For **every** occurrence of the line `currentMilestone = nil` in this file, add a `currentMilestonePhase = nil` line immediately after it, matching that occurrence's exact indentation. Use `grep -n "currentMilestone = nil" Sources/AnglesiteApp/DeployModel.swift` to find all five current line numbers before editing (line numbers shift after each edit, so re-run the grep after each one, or edit from the bottom of the file upward so earlier line numbers stay valid).
+
+For example, one site (8-space indent) looks like:
+
+```swift
+        logLines = []
+        currentMilestone = nil
+        failureSummary = nil
+```
+
+becomes:
+
+```swift
+        logLines = []
+        currentMilestone = nil
+        currentMilestonePhase = nil
+        failureSummary = nil
+```
+
+Another site (12-space indent) looks like:
+
+```swift
+            _ = await logTask.value
+            currentMilestone = nil
+            workerNameConflictPresented = false
+```
+
+becomes:
+
+```swift
+            _ = await logTask.value
+            currentMilestone = nil
+            currentMilestonePhase = nil
+            workerNameConflictPresented = false
+```
+
+Apply the same pattern (insert `currentMilestonePhase = nil` at matching indentation, immediately after `currentMilestone = nil`) at all five sites. When done, `grep -c "currentMilestonePhase = nil" Sources/AnglesiteApp/DeployModel.swift` must report `5`, and `grep -c "currentMilestone = nil" Sources/AnglesiteApp/DeployModel.swift` must also still report `5` (unchanged count — you added lines, not replaced them).
+
+- [ ] **Step 4: Run the full test suite and build**
+
+Run: `swift test --package-path .`
+Expected: PASS — no regressions.
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift
+git commit -m "feat: track deploy milestone phase id alongside its label"
+```
+
+---
+
+### Task 4: `PhaseProgressStrip` SwiftUI view (`AnglesiteApp`)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/PhaseProgressStrip.swift`
+
+**Interfaces:**
+- Consumes: `NSApp.applicationIconImage` (AppKit, already used the same way at `Sources/AnglesiteApp/DockProgressController.swift:61`).
+- Produces: `struct PhaseProgressStrip: View` with `init(filledCount: Int, size: PhaseProgressStrip.Size = .full)` and `enum PhaseProgressStrip.Size { case full, compact }`. Task 5 (`StartupProgressView`) uses `.full` (the default); Task 6 (`DeployDrawerView`) uses `.compact`.
+
+No tests for this task — presentational SwiftUI view, matches this codebase's convention (`StartupProgressView`/`DeployDrawerView` also have no dedicated view tests). Verified by successful build.
+
+- [ ] **Step 1: Write the implementation**
+
+Create `Sources/AnglesiteApp/PhaseProgressStrip.swift`:
+
+```swift
+import SwiftUI
+import AppKit
+
+/// Three-panel cumulative-fill progress indicator inspired by AOL's classic sign-on animation
+/// (see docs/superpowers/specs/2026-07-28-phase-progress-panels-design.md): three fixed cells
+/// that light up left-to-right as named phases complete and *stay* lit — never a single badge
+/// that swaps in place. The third cell shows the app's own icon behind a "group" glyph, echoing
+/// the reference animation's people-gathered-at-the-logo composition.
+struct PhaseProgressStrip: View {
+    /// 0...3. Cells at index `< filledCount` render filled/tinted; the rest render dimmed.
+    let filledCount: Int
+    var size: Size = .full
+
+    enum Size {
+        case full, compact
+
+        var cellDimension: CGFloat {
+            switch self {
+            case .full: return 56
+            case .compact: return 18
+            }
+        }
+
+        var glyphFontSize: CGFloat {
+            switch self {
+            case .full: return 28
+            case .compact: return 10
+            }
+        }
+
+        var cornerRadius: CGFloat {
+            switch self {
+            case .full: return 10
+            case .compact: return 4
+            }
+        }
+
+        var spacing: CGFloat {
+            switch self {
+            case .full: return 8
+            case .compact: return 3
+            }
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: size.spacing) {
+            cell(glyph: "🚶", filled: filledCount >= 1)
+            cell(glyph: "🏃", filled: filledCount >= 2)
+            groupCell(filled: filledCount >= 3)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Progress: \(filledCount) of 3 steps complete")
+    }
+
+    private func cell(glyph: String, filled: Bool) -> some View {
+        Text(glyph)
+            .font(.system(size: size.glyphFontSize))
+            .opacity(filled ? 1 : 0.35)
+            .frame(width: size.cellDimension, height: size.cellDimension)
+            .background(cellBackground(filled: filled))
+            .overlay(cellBorder(filled: filled))
+            .animation(.easeInOut(duration: 0.2), value: filled)
+    }
+
+    private func groupCell(filled: Bool) -> some View {
+        ZStack {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: size.cellDimension * 0.7, height: size.cellDimension * 0.7)
+                .opacity(filled ? 1 : 0.35)
+            Text("👥")
+                .font(.system(size: size.glyphFontSize))
+                .opacity(filled ? 1 : 0.35)
+        }
+        .frame(width: size.cellDimension, height: size.cellDimension)
+        .background(cellBackground(filled: filled))
+        .overlay(cellBorder(filled: filled))
+        .animation(.easeInOut(duration: 0.2), value: filled)
+    }
+
+    private func cellBackground(filled: Bool) -> some View {
+        RoundedRectangle(cornerRadius: size.cornerRadius)
+            .fill(filled ? Color.accentColor.opacity(0.18) : Color(nsColor: .quaternaryLabelColor).opacity(0.12))
+    }
+
+    private func cellBorder(filled: Bool) -> some View {
+        RoundedRectangle(cornerRadius: size.cornerRadius)
+            .strokeBorder(filled ? Color.accentColor.opacity(0.5) : Color.secondary.opacity(0.25))
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the Xcode project and build**
+
+Run: `xcodegen generate`
+Expected: regenerates `Anglesite.xcodeproj` to pick up the new file.
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PhaseProgressStrip.swift
+git commit -m "feat: add three-panel phase progress strip view"
+```
+
+---
+
+### Task 5: Wire the strip into dev-server startup (`StartupProgressView`)
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/StartupProgressView.swift:13-18`
+
+**Interfaces:**
+- Consumes: `StartupPhase.panelFillCount` (Task 1), `PhaseProgressStrip` (Task 4), `StartupProgressModel.phase: StartupPhase` (existing, already non-private).
+- Produces: no new interface — a visual addition to an existing view.
+
+- [ ] **Step 1: Insert the strip**
+
+In `Sources/AnglesiteApp/StartupProgressView.swift`, change:
+
+```swift
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            ProgressView(value: model.fraction)
+                .progressViewStyle(.linear)
+                .frame(maxWidth: 320)
+```
+
+to:
+
+```swift
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            PhaseProgressStrip(filledCount: model.phase.panelFillCount)
+            ProgressView(value: model.fraction)
+                .progressViewStyle(.linear)
+                .frame(maxWidth: 320)
+```
+
+Everything else in the file (the message `Text`, the `Show Logs` button, the `.frame`/`.animation` modifiers) stays unchanged.
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/StartupProgressView.swift
+git commit -m "feat: show the phase progress strip during dev-server startup"
+```
+
+---
+
+### Task 6: Wire the strip into deploy (`DeployDrawerView`)
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployDrawerView.swift:76-94` (`statusIcon`), and the header's title `VStack` (currently lines 41-51)
+
+**Interfaces:**
+- Consumes: `DeployPanelProgress.filledCount(currentMilestonePhase:succeeded:)` (Task 2), `PhaseProgressStrip` with `.compact` size (Task 4), `DeployModel.currentMilestonePhase`/`currentMilestone` (Task 3, existing).
+- Produces: no new interface.
+
+- [ ] **Step 1: Replace the `.running`-case spinner with the compact strip**
+
+In `Sources/AnglesiteApp/DeployDrawerView.swift`, change:
+
+```swift
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch model.phase {
+        case .running:
+            ProgressView().controlSize(.small)
+                .accessibilityLabel("Deploying")
+        case .succeeded:
+```
+
+to:
+
+```swift
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch model.phase {
+        case .running:
+            PhaseProgressStrip(
+                filledCount: DeployPanelProgress.filledCount(
+                    currentMilestonePhase: model.currentMilestonePhase, succeeded: false
+                ),
+                size: .compact
+            )
+            .accessibilityLabel("Deploying")
+        case .succeeded:
+```
+
+- [ ] **Step 2: Surface the milestone text next to the title**
+
+In the same file, find the header's title `VStack` (the one containing `Text(headerTitle)`):
+
+```swift
+            VStack(alignment: .leading, spacing: 1) {
+                Text(headerTitle).font(.headline)
+                if let subtitle = headerSubtitle {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+                if case .succeeded = model.phase, case .dirty = model.sourceBundleStatus {
+                    Text("Code changes not yet deployed to the CMS bundle.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+```
+
+Change to:
+
+```swift
+            VStack(alignment: .leading, spacing: 1) {
+                Text(headerTitle).font(.headline)
+                if let subtitle = headerSubtitle {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+                if case .running = model.phase, let milestone = model.currentMilestone {
+                    Text(milestone).font(.caption).foregroundStyle(.secondary)
+                }
+                if case .succeeded = model.phase, case .dirty = model.sourceBundleStatus {
+                    Text("Code changes not yet deployed to the CMS bundle.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+```
+
+(`headerSubtitle` already returns `nil` for `.running`, so this doesn't create a duplicate line — it's the only text shown alongside the title while a deploy is running.)
+
+- [ ] **Step 3: Build**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployDrawerView.swift
+git commit -m "feat: show the phase progress strip during deploy"
+```
+
+---
+
+### Task 7: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: PASS — all targets, including the new `StartupProgressEstimatorTests` case and `DeployPanelProgressTests`.
+
+- [ ] **Step 2: Full app build**
+
+Run: `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Manual smoke check**
+
+Open the built app, open or restart a site's dev server, and confirm: the three-panel strip appears above the progress bar, cell 1 fills while starting/building, cell 2 fills once connecting, cell 3 (app icon + 👥) fills only once ready — and none of the filled cells un-fill along the way. Trigger a deploy and confirm the compact strip appears in place of the drawer's old spinner, follows the same fill pattern through preflight/build/deploy/finalize, and the milestone text next to the title updates as it goes. Confirm a deploy failure still shows the existing red exclamation icon, not the strip.
+
+- [ ] **Step 4: Confirm no stray changes**
+
+Run: `git status --short`
+Expected: clean (everything from Tasks 1–6 already committed).

--- a/docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md
+++ b/docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md
@@ -1,0 +1,132 @@
+# Optional dial-up modem sound effect — design
+
+**Issue:** none tracked yet — small, additive settings feature.
+**Date:** 2026-07-28
+**Status:** Approved design; ready for implementation planning.
+
+## Goal
+
+Add an optional, off-by-default sound effect that plays a nostalgic dial-up
+modem handshake sound while the user is waiting on a long-running "loading"
+operation: the dev server starting up, and a deploy running. Purely decorative
+— no effect on functionality, timing, or state.
+
+## Decisions (locked in brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Audio source | Synthesized procedurally in Swift (no bundled recording, no licensing question) |
+| Triggers | Dev-server startup (`StartupProgressModel`) **and** deploy (`DeployModel.onPhaseTransition`) |
+| Overlap across windows | Per-window; two windows loading at once can play independently (no app-wide coordination) |
+| Overlap within one window | Not coordinated either — two independent `DialupSoundEffectPlayer` instances (one for startup, one for deploy); a rare simultaneous case would layer, not break |
+| Default | Off |
+| Scope boundary | Backup and Audit share the same `Phase`/`onPhaseTransition` shape and could get this later, but are explicitly out of scope for this change |
+
+## 1. Audio synthesis (`AnglesiteCore`)
+
+A new pure type, `DialupModemSoundEffect`, generates raw `[Float]` PCM samples
+for one ~5 second loop cycle using only
+`Foundation` trig math — no `AVFoundation` import, so it compiles and unit-tests
+on the Linux CI lane like the rest of `AnglesiteCore`. It's a stylized
+approximation of a real handshake, not a reproduction of any specific existing
+recording:
+
+- Dial tone (350 Hz + 440 Hz)
+- A few DTMF-style digit blips
+- The real ITU V.25 2100 Hz answer tone, including its periodic phase reversal
+- A couple of ascending chirp sweeps standing in for the negotiation tones
+- A filtered-noise burst standing in for the training sequence
+
+All sample values stay within `[-1, 1]`. Deterministic given the same inputs —
+no randomness seeded from wall-clock time.
+
+## 2. Playback (`AnglesiteApp` / `AnglesiteAppCore`)
+
+`DialupSoundEffectPlayer` (behind a small `DialupSoundEffectPlaying` protocol
+for injection) wraps `AVAudioEngine` + `AVAudioPlayerNode`:
+
+- Builds an `AVAudioPCMBuffer` from the synthesized samples once.
+- `play()` schedules the buffer with `.loops` so it repeats seamlessly for as
+  long as needed, and checks `AppSettings.shared.playsDialupSoundEffect` first
+  — a no-op (the audio engine is never touched) when the setting is off.
+- `stop()` halts the engine. No fade-out for v1 — an abrupt cutoff is
+  acceptable for this effect.
+- Both methods are idempotent (calling `play()` while already playing, or
+  `stop()` while already stopped, is a harmless no-op).
+
+This mirrors `CompletionNotifier`'s existing shape: the parts that are pure
+logic are unit-tested elsewhere, and this AppKit/AVFoundation-touching glue
+stays thin and untested directly, consistent with how `CompletionNotifier`
+itself (and `SiteWindowModel`'s existing hook-composition closures) are
+already handled in this codebase.
+
+## 3. Trigger wiring
+
+### Dev-server startup
+
+`StartupProgressModel` owns its own `DialupSoundEffectPlayer` instance
+internally (constructed the same way it already constructs its default
+`StartupTimingStore`/`LogCenter` dependencies). `begin(siteID:)` calls
+`play()`; `stop()` (already called from the `.ready`/`.failed`/`.idle`
+branches of `ingest(state:)`) calls the player's `stop()` too.
+
+### Deploy
+
+`SiteWindowModel.init` already layers extra per-window behavior onto
+`DeployModel.onPhaseTransition`, on top of `CompletionNotificationHub.wire(...)`
+(see the existing `sync.deployCompleted()` wrapping at
+`SiteWindowModel.swift:256-260`). Add a third layer there:
+
+```swift
+let deploySound = DialupSoundEffectPlayer()
+let deployHook = deploy.onPhaseTransition
+deploy.onPhaseTransition = { [weak self] siteID, phase in
+    deployHook?(siteID, phase)
+    if case .succeeded = phase { self?.sync.deployCompleted() }
+    if case .running = phase { deploySound.play() } else { deploySound.stop() }
+}
+```
+
+Sound plays only during `.running`; every other phase (`.idle`, `.succeeded`,
+`.failed`, `.blocked`, `.workerNameConflict`,
+`.webmentionPaidPlanConfirmationNeeded`) stops it — including the two "parked
+on a sheet, waiting for user input" phases, which is correct: nothing is
+actively loading while the user is looking at a token/conflict/confirmation
+sheet.
+
+## 4. Settings
+
+New `AppSettings.Key.playsDialupSoundEffect`
+(`"anglesite.playsDialupSoundEffect"`), plain `Bool`. Absent defaults to
+`false` via `defaults.bool(forKey:)`'s normal behavior — no
+inverted-from-absent trick needed since the default is off.
+
+Surfaced in `GeneralSettingsView` (`SettingsView.swift`) as a new "Sound"
+section:
+
+- Toggle: **"Play dial-up sound while loading"**
+- Caption: **"Plays a nostalgic dial-up modem sound while the dev server
+  starts up or a deploy is running. Purely decorative — off by default."**
+
+One toggle covers both triggers; no per-trigger settings.
+
+## 5. Testing
+
+- `AnglesiteCoreTests`: unit tests on the sample generator — correct
+  duration/sample count for the target sample rate, all values within
+  `[-1, 1]`, deterministic output across repeated calls, non-silent (not all
+  zeros).
+- `DialupSoundEffectPlayer` and the `SiteWindowModel`/`StartupProgressModel`
+  wiring stay untested directly, matching the existing convention in this
+  codebase — neither `StartupProgressModel` nor `SiteWindowModel`'s hook
+  composition closures (e.g. the existing `backupHook`/`deployHook` layering)
+  have dedicated unit tests today; only the pure `StartupProgressEstimator`
+  does (`StartupProgressEstimatorTests`).
+
+## Out of scope
+
+- Backup and Audit (`BackupModel`/`AuditModel`) share the same
+  `Phase`/`onPhaseTransition` shape and could get this sound later as an
+  obvious, small follow-up — not included here.
+- No volume control, no alternate sounds, no fade-out/in.
+- No bundled audio asset — everything is synthesized at runtime.

--- a/docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md
+++ b/docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md
@@ -32,7 +32,9 @@ approximation of a real handshake, not a reproduction of any specific existing
 recording:
 
 - Dial tone (350 Hz + 440 Hz)
-- A few DTMF-style digit blips
+- Real DTMF tones (standard low/high frequency pairs) dialing **802-748-1210**
+  — the number for [The Kingdom Connection](https://web.archive.org/web/19971021061542/http://www.kingcon.com/),
+  a BBS the user was once sysop of
 - The real ITU V.25 2100 Hz answer tone, including its periodic phase reversal
 - A couple of ascending chirp sweeps standing in for the negotiation tones
 - A filtered-noise burst standing in for the training sequence

--- a/docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md
+++ b/docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md
@@ -16,6 +16,7 @@ operation: the dev server starting up, and a deploy running. Purely decorative
 | Decision | Choice |
 |---|---|
 | Audio source | Synthesized procedurally in Swift (no bundled recording, no licensing question) |
+| Handshake flavor | K56flex — the standard Hayes' 56K modems actually spoke (Hayes/Rockwell/Lucent alliance), not the competing USR-backed x2 standard |
 | Triggers | Dev-server startup (`StartupProgressModel`) **and** deploy (`DeployModel.onPhaseTransition`) |
 | Overlap across windows | Per-window; two windows loading at once can play independently (no app-wide coordination) |
 | Overlap within one window | Not coordinated either — two independent `DialupSoundEffectPlayer` instances (one for startup, one for deploy); a rare simultaneous case would layer, not break |
@@ -36,8 +37,20 @@ recording:
   — the number for [The Kingdom Connection](https://web.archive.org/web/19971021061542/http://www.kingcon.com/),
   a BBS the user was once sysop of
 - The real ITU V.25 2100 Hz answer tone, including its periodic phase reversal
-- A couple of ascending chirp sweeps standing in for the negotiation tones
-- A filtered-noise burst standing in for the training sequence
+  (the V.8/V.8bis call-setup exchange every 56K-era handshake still opens with)
+- A short digital-probe-style tone burst standing in for the line-probing step
+  that's specific to 56K (K56flex/x2/V.90) handshakes and absent from a plain
+  V.34 33.6K handshake — the detail that actually marks this as a *56K* modem
+  rather than a generic dial-up one
+- A couple of ascending chirp sweeps standing in for the rest of the K56flex
+  negotiation tones
+- A filtered-noise burst standing in for the scrambled carrier-training sequence
+
+K56flex's exact proprietary bit-level training sequence was never publicly
+documented in enough acoustic detail to reproduce precisely, so this stays a
+stylized approximation shaped like a 56K handshake (probe step + the longer
+overall negotiation 56K added over 33.6K V.34) rather than a literal decode of
+the K56flex spec.
 
 All sample values stay within `[-1, 1]`. Deterministic given the same inputs —
 no randomness seeded from wall-clock time.

--- a/docs/superpowers/specs/2026-07-28-phase-progress-panels-design.md
+++ b/docs/superpowers/specs/2026-07-28-phase-progress-panels-design.md
@@ -56,11 +56,13 @@ Reuses each surface's existing named phases rather than inventing generic fracti
 - `filledCount = 3` at `.ready`
 - `filledCount = 0` at `.idle`/`.failed`
 
-**Deploy** (`DeployModel.Phase`, via the existing `DeployDockProgress.fraction(forPhase:)` milestone mapping — `Sources/AnglesiteCore/CompletionNotice.swift:164-178` — reused rather than duplicated):
-- `filledCount = 1` once `.running` starts (any milestone reported)
-- `filledCount = 2` at the `"deploying"` milestone (the actual upload-to-Cloudflare step, `fraction == 0.55` in the existing mapping)
-- `filledCount = 3` only at `.succeeded`
+**Deploy** (`DeployModel.Phase`, via a new `DeployPanelProgress.filledCount(currentMilestonePhase:succeeded:)` in `AnglesiteCore`):
+- `filledCount = 1` once `.running` starts, while the milestone phase is `"preflightScan"` or `"building"`
+- `filledCount = 2` from the `"deploying"` milestone onward (every later milestone — `finalizing`, `webmentions`, `syndicating`, `websubPing`, `activityPubBackfill` — also reads as 2, since they're all past the "actual upload" step)
+- `filledCount = 3` only when `succeeded` is `true`
 - `.failed`/`.blocked`/`.workerNameConflict`/`.webmentionPaidPlanConfirmationNeeded` keep their existing icon treatment in `DeployDrawerView`'s `statusIcon` — the strip is not shown for these terminal/parked states, only for `.running`
+
+Deliberately **not** built on top of `DeployDockProgress.fraction(forPhase:)` (`Sources/AnglesiteCore/CompletionNotice.swift:164-178`): that table has no entry for `websubPing`/`activityPubBackfill` (returns `nil`, meant for "don't move the Dock tile" semantics), which would make this panel count regress from 2 back to 1 on those two milestones. `DeployPanelProgress` is a small, self-contained switch over the eight known milestone-phase strings instead — no shared dependency, no gap.
 
 ## 3. Status text
 

--- a/docs/superpowers/specs/2026-07-28-phase-progress-panels-design.md
+++ b/docs/superpowers/specs/2026-07-28-phase-progress-panels-design.md
@@ -1,0 +1,83 @@
+# Three-panel phase progress strip — design
+
+**Issue:** none tracked yet — small, additive UI feature, pairs with the dial-up sound effect (docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md).
+**Date:** 2026-07-28
+**Status:** Approved design; ready for implementation planning.
+
+## Goal
+
+Replace the plain linear-progress-bar-only presentation of "loading" state (dev-server startup, deploy) with a nostalgic three-panel step indicator inspired by AOL's classic dial-up sign-on animation — three fixed boxes that fill in left-to-right as real, named phases complete, with the app's own icon appearing in the final box. Always-on (no settings toggle, unlike the dial-up sound) — this is a visual redesign, not a disruptive effect.
+
+## Reference
+
+AOL's sign-on sequence showed three permanently-visible boxes below the "AMERICA ONLINE" logo:
+
+1. Box 1: a plain running-figure icon — fills in first ("Dialing…")
+2. Box 2: the same figure with motion lines — fills in second, box 1 stays filled ("Connecting…")
+3. Box 3: a group of people clustered at the base of the AOL triangle logo — fills in last, boxes 1-2 stay filled ("Connected!")
+
+Each box, once filled, **stays filled** — this is a cumulative 3-step breadcrumb, not a single badge that swaps in place. A status caption below names the current step, and a horizontal rule (the existing determinate progress bar, in this adaptation) sits under that.
+
+## Decisions (locked in brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Mechanic | Cumulative fill — each box lights up and stays lit once its milestone is reached, not a single highlighted box that moves |
+| Where | Both dev-server startup (`StartupProgressView`) and deploy (`DeployDrawerView`) |
+| Gating | Always on — no settings toggle |
+| Icon style | Literal Unicode/emoji glyphs (🚶 / 🏃 / 👥), not SF Symbols — deliberately distinct from the app's normal monochrome iconography |
+| Box 3 | 👥 rendered over the real app icon (`NSApp.applicationIconImage`) in a `ZStack`, echoing AOL's people-on-the-triangle composition |
+| Status text | Reuses the app's own existing, contextually accurate phase messages (`StartupProgressEstimator.message`, deploy milestone `label`s) — **not** AOL's "Dialing…/Connecting…" copy, which is phone-modem framing that doesn't apply here |
+| Visual style | Native macOS materials (system fill, accent-color tint when filled, dimmed/outline when not yet reached) — a nostalgic homage, not a literal pixel skin of the 1996 UI |
+| API naming | "AOL" stays out of the actual Swift type name (e.g. `PhaseProgressStrip`) — fine as design-doc/comment context, not as an identifier |
+| Terminal states | `.failed`/`.blocked`/etc. in the deploy drawer keep their existing checkmark/X iconography — box 3 is not repurposed as a generic "success" icon there |
+
+## 1. `PhaseProgressStrip` component (`AnglesiteApp`)
+
+A new SwiftUI view, three fixed cells rendered left-to-right:
+
+- Cell 1: 🚶
+- Cell 2: 🏃
+- Cell 3: 👥 over `Image(nsImage: NSApp.applicationIconImage)` in a `ZStack`
+
+Takes a `filledCount: Int` (0...3) — cells `< filledCount` render filled/tinted (accent-color background, full-opacity glyph), cells `>= filledCount` render dimmed (outline-only, low-opacity glyph). A brief `.easeInOut` transition animates a cell's fill-state change, matching the existing `.animation(.easeInOut(duration: 0.2), value: model.message)` pattern already in `StartupProgressView.swift:26`.
+
+Two presentation sizes, since the two call sites have very different available space:
+- **Full** (`StartupProgressView`): larger cells (~56pt), used alongside the existing title/message/progress-bar/Show-Logs stack.
+- **Compact** (`DeployDrawerView`): small cells (~18pt), icon-only, replacing the current small spinner — the drawer already has its own title/subtitle line, so no separate caption duplication there.
+
+## 2. Phase → `filledCount` mapping
+
+Reuses each surface's existing named phases rather than inventing generic fraction thirds — box 2's boundary is each domain's actual "in-transit" step, mirroring AOL's box 2 being the one with motion lines:
+
+**Dev-server startup** (`StartupProgressModel`/`StartupPhase`):
+- `filledCount = 1` at `.launching` or `.building` ("working")
+- `filledCount = 2` at `.connecting` (the actual network step)
+- `filledCount = 3` at `.ready`
+- `filledCount = 0` at `.idle`/`.failed`
+
+**Deploy** (`DeployModel.Phase`, via the existing `DeployDockProgress.fraction(forPhase:)` milestone mapping — `Sources/AnglesiteCore/CompletionNotice.swift:164-178` — reused rather than duplicated):
+- `filledCount = 1` once `.running` starts (any milestone reported)
+- `filledCount = 2` at the `"deploying"` milestone (the actual upload-to-Cloudflare step, `fraction == 0.55` in the existing mapping)
+- `filledCount = 3` only at `.succeeded`
+- `.failed`/`.blocked`/`.workerNameConflict`/`.webmentionPaidPlanConfirmationNeeded` keep their existing icon treatment in `DeployDrawerView`'s `statusIcon` — the strip is not shown for these terminal/parked states, only for `.running`
+
+## 3. Status text
+
+No new copy. Both call sites already have accurate, contextual phase messages:
+- Startup: `StartupProgressModel.message` (already "Starting dev server…", "Building site…", "Connecting to preview…").
+- Deploy: `DeployModel.currentMilestone` (already populated from `OperationProgress.label`, e.g. "Running pre-deploy checks…", "Deploying to production…").
+
+The strip's caption is these existing strings, unchanged — this feature only adds the visual strip above/beside them.
+
+## 4. Testing
+
+- The `filledCount` mapping logic (phase → 0...3) is pure and belongs in `AnglesiteCore` alongside `StartupProgressEstimator`/`DeployDockProgress`, unit-tested the same way (`StartupProgressEstimatorTests`-style: exact phase in, exact `filledCount` out).
+- `PhaseProgressStrip` itself (the SwiftUI view) stays untested directly, matching this codebase's existing convention for presentational views.
+
+## Out of scope
+
+- No settings toggle (always on, per decision above).
+- No sound coupling — this is independent of `playsDialupSoundEffect`, though the two features are thematically paired and may ship as stacked PRs.
+- No change to deploy's terminal-state iconography (checkmark/X stay as-is).
+- No literal recreation of AOL's 1996 visual chrome (colors, borders, wordmark) — native macOS materials only.


### PR DESCRIPTION
## Summary

- Adds an optional, off-by-default synthesized dial-up modem handshake sound (K56flex-shaped — DTMF-dialing 802-748-1210, the number for [The Kingdom Connection](https://web.archive.org/web/19971021061542/http://www.kingcon.com/), a BBS the requester used to be sysop of) that plays while the dev server is starting up and while a deploy is running.
- Fully synthesized at runtime in `AnglesiteCore` (pure `Foundation` math, no bundled audio asset, no licensing question) and played via a thin `AVAudioEngine` wrapper in `AnglesiteApp`, gated by a new Settings ▸ General ▸ "Play dial-up sound while loading" toggle.
- Design + plan: `docs/superpowers/specs/2026-07-28-dialup-modem-sound-effect-design.md`, `docs/superpowers/plans/2026-07-28-dialup-modem-sound-effect.md`.
- Also includes two docs-only commits (`8f9eb684`, `9200ac52`, `9eb34850`) that are prep for a stacked follow-up PR (a related "phase progress strip" visual redesign) — no code from that feature is in this PR.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passes; one pre-existing, unrelated on-device Foundation Models flake (`FoundationModelAssistantTests.swift:490`, documented codebase flakiness) touches none of this PR's files. All new tests (`DialupModemSoundEffectTests`, `AppSettingsTests` additions) pass.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] Manual smoke: confirmed the built app launches and stays running without crashing. **Not verified in this session** (no GUI-automation tool available for the native macOS UI): the Settings ▸ General "Sound" section's appearance/copy, the sound actually playing/stopping during dev-server startup, and the sound playing/stopping during a deploy's running phase. Needs a human pass — steps are in the plan's Task 7 and in `docs/qa/e2e-acceptance-1-initial-launch.md`'s "Settings defaults" section (updated by this PR).