### PR TITLE
fix(build): regenerate xcodeproj automatically before builds (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,11 @@ Toolchain: **Xcode 27+ / Swift 6.4** (required for SwiftUI 27's `@State` macro s
 open Anglesite.xcodeproj
 # Anglesite.xcodeproj is gitignored and generated from project.yml — after a
 # fresh clone or in a new worktree, run `xcodegen generate` first.
-# ⌘B in Xcode, or:
-xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+# ⌘B in Xcode, or use scripts/build-app.sh instead of a raw `xcodebuild` — it
+# regenerates the project first, so a checkout that went stale without
+# tripping scripts/git-hooks (e.g. synced via fetch+reset) never builds a
+# stale project (#123):
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
 ```
 
 Tests: `swift test --package-path .` runs the SwiftPM test targets (`AnglesiteSiteModelTests`, `AnglesiteCoreTests`, `AnglesiteBridgeTests`, and, on Swift 6.4+/Xcode 27, `AnglesiteIntentsTests`). `AnglesiteContainerLocalTests` is opt-in with `ANGLESITE_CONTAINER_TESTS=1`; its end-to-end cases also require `ANGLESITE_CONTAINER_E2E=1`. Most suites are Swift Testing (#74), with the remaining XCTest holdouts in `AnglesiteCoreTests` and `AnglesiteBridgeTests`. The MCP / apply-edit e2e tests (`AppliesEditEndToEndTests`, `MCPClientHTTPEndToEndTests`) need the sibling sidecar checkout + node; they're gated with Swift Testing's `.enabled(if:)` trait, so they skip cleanly when the checkout is absent — set `ANGLESITE_PLUGIN_PATH` to the sidecar checkout to make them run. If `swift build`/`swift test` seems to hang with no output, a stale SwiftPM process is likely holding the `.build` lock — check `pgrep -fl swift-test` and kill the orphan rather than assuming a bad test.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,10 @@ cd Anglesite
 # Xcode project, and enables the git hooks that keep it regenerated.
 scripts/setup-dev-env.sh
 
-# Build (ad-hoc signed — no Apple account required)
-xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+# Build (ad-hoc signed — no Apple account required). Use scripts/build-app.sh
+# instead of a raw `xcodebuild` — it regenerates the project first, so a checkout
+# that went stale without tripping the git hooks above never builds a stale one (#123).
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
 ```
 
 Key things to know:
@@ -32,7 +34,7 @@ Key things to know:
 - **Open `Anglesite.xcodeproj`, not `xed .`** — the latter opens `Package.swift`, which has no runnable target.
 - **Commit String Catalog updates.** App builds extract SwiftUI and `String(localized:)` literals into `Sources/AnglesiteApp/Localizable.xcstrings` because `SWIFT_EMIT_LOC_STRINGS` is enabled — but that catalog merge only happens in the **Xcode IDE**. A CLI-only `xcodebuild build` (the only option in a headless/agent workflow) still emits `.stringsdata` per file, it just never merges them into the `.xcstrings` catalog. If you add, remove, or rename user-visible text without an interactive Xcode session, run the merge yourself after building:
   ```sh
-  xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+  scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
   BUILD_DIR=$(xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug -showBuildSettings 2>/dev/null | awk '/ BUILD_DIR =/{print $3}')
   xcrun xcstringstool sync Sources/AnglesiteApp/Localizable.xcstrings \
     --stringsdata $(find "$(dirname "$BUILD_DIR")/Intermediates.noindex/Anglesite.build/Debug/Anglesite.build/Objects-normal/arm64" -name "*.stringsdata") \
@@ -51,7 +53,7 @@ Run the relevant suites before opening a PR:
 swift test --package-path .
 
 # App target builds
-xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
 
 # JS edit overlay (from JS/edit-overlay/, Node 22+)
 npm run lint && npm run typecheck && npm test

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ git config core.hooksPath scripts/git-hooks
 # of Sources/AnglesiteApp. CI runs this too, so it's not a required setup step.
 scripts/check-xcodeproj-sync.sh
 
-# Build via CLI (ad-hoc signed; no Apple account required)
-xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+# Build via CLI (ad-hoc signed; no Apple account required). Use scripts/build-app.sh
+# instead of a raw `xcodebuild` — it regenerates the project first, so a checkout
+# that went stale without tripping the git hooks above never builds a stale one (#123).
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
 
 # Or open in Xcode (note: `open Anglesite.xcodeproj`, NOT `xed .`)
 open Anglesite.xcodeproj

--- a/project.yml
+++ b/project.yml
@@ -50,8 +50,28 @@ targets:
         buildPhase: resources
         optional: true
     preBuildScripts:
-      # Guard first so a Release build with unvendored container resources fails
-      # before the remaining (slower) build phases run. Debug only warns.
+      # Regenerate the gitignored .xcodeproj from project.yml/Sources before anything
+      # else, so a checkout that advanced without tripping scripts/git-hooks (e.g. synced
+      # via fetch+reset instead of `git checkout`/`merge`/`rebase`) doesn't silently build
+      # a stale project and fail with a confusing `cannot find 'X' in scope` (#123).
+      # xcodegen generate is idempotent and ~1-2s. Caveat: Xcode has already resolved this
+      # invocation's Compile Sources list before this phase runs, so a project that just
+      # went stale still fails *this* build — but the rewritten pbxproj makes the very next
+      # build succeed without anyone having to remember to run `xcodegen generate` by hand.
+      # scripts/build-app.sh covers the CLI/agent case fully (regenerates before invoking
+      # xcodebuild at all); this phase is the equivalent backstop for ⌘B in Xcode.
+      # Best-effort like the other pre-build scripts below: warn and continue rather than
+      # fail the build if xcodegen isn't installed.
+      - name: Regenerate Xcode project
+        script: |
+          if command -v xcodegen >/dev/null 2>&1; then
+            xcodegen generate --quiet
+          else
+            echo "warning: xcodegen not found on PATH — skipping project regeneration (brew install xcodegen)." >&2
+          fi
+        basedOnDependencyAnalysis: false
+      # Guard first (among the rest) so a Release build with unvendored container
+      # resources fails before the remaining (slower) build phases run. Debug only warns.
       - name: Check container resources
         script: "\"${PROJECT_DIR}/scripts/check-container-resources.sh\""
         basedOnDependencyAnalysis: false
@@ -134,6 +154,16 @@ targets:
         buildPhase: resources
         optional: true
     preBuildScripts:
+      # See the Anglesite target's matching comment above (#123) — same backstop, this
+      # target just doesn't need the container-resources/help-index phases that follow it there.
+      - name: Regenerate Xcode project
+        script: |
+          if command -v xcodegen >/dev/null 2>&1; then
+            xcodegen generate --quiet
+          else
+            echo "warning: xcodegen not found on PATH — skipping project regeneration (brew install xcodegen)." >&2
+          fi
+        basedOnDependencyAnalysis: false
       - name: Build edit overlay
         script: "\"${PROJECT_DIR}/scripts/build-overlay.sh\""
         basedOnDependencyAnalysis: false

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Wrapper around xcodebuild that regenerates Anglesite.xcodeproj first.
+#
+# The gitignored .xcodeproj can go stale relative to project.yml or Sources/
+# whenever a checkout advances by something other than `git checkout`/`merge`/
+# `rebase` — those are the only triggers scripts/git-hooks/regenerate-xcodeproj.sh
+# watches. A checkout synced by other means (e.g. fetch+reset) bypasses those
+# hooks silently, and the next build fails with a confusing
+# `error: cannot find 'X' in scope` instead of a stale-project error (#123).
+#
+# xcodegen generate is idempotent and takes ~1-2s, so running it unconditionally
+# before every build removes that whole class of failure regardless of how the
+# checkout got to its current state.
+#
+# Usage: scripts/build-app.sh <xcodebuild args...>
+#   scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "error: xcodegen not found on PATH — install with: brew install xcodegen" >&2
+  exit 1
+fi
+
+xcodegen generate --quiet
+exec xcodebuild "$@"


### PR DESCRIPTION
## Summary

- `Anglesite.xcodeproj` is gitignored/generated from `project.yml`, and the only existing safety net (`scripts/git-hooks`' post-checkout/post-merge/post-rewrite) only fires on porcelain `checkout`/`merge`/`rebase` — a checkout that advances some other way (e.g. fetch+reset) goes stale silently and the next build fails with a confusing `cannot find 'X' in scope` instead of a clear stale-project error. Hit this twice in one session on two different checkouts.
- Added `scripts/build-app.sh`, a thin `xcodebuild` wrapper that runs `xcodegen generate --quiet` first (idempotent, ~1-2s); README/CONTRIBUTING/CLAUDE.md (AGENTS.md is a symlink) now point at it instead of raw `xcodebuild`.
- Added the same `xcodegen generate` call as the first `preBuildScripts` phase on both app targets in `project.yml`, so an Xcode ⌘B build self-heals too (within two builds — Xcode has already resolved the invocation's Compile Sources list before the phase runs).
- This is recommendation "(2) + (3)" from #123, which only partially landed before (git hooks + a CI sync-check shipped; the self-healing build path didn't).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — full build succeeds with the new pre-build phase wired in.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — wrapper builds successfully.
- [x] `scripts/check-xcodeproj-sync.sh` — CI's own project/source-tree sync guard still passes.
- [x] `shellcheck scripts/build-app.sh` — clean.
- [ ] `swift test --package-path .` — not run; no Swift source changed (project.yml/docs/new shell script only).