### PR TITLE
fix(#1078): deploy drawer link, copy-log, copy-URL redundancy

### DIFF
--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -39,7 +39,13 @@ struct DeployDrawerView: View {
         HStack(spacing: 10) {
             statusIcon
             VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
+                if case .succeeded(let url, _) = model.phase {
+                    Link(destination: url) {
+                        Text(headerTitle).font(.headline)
+                    }
+                } else {
+                    Text(headerTitle).font(.headline)
+                }
                 if let subtitle = headerSubtitle {
                     Text(subtitle).font(.caption).foregroundStyle(.secondary)
                 }
@@ -54,17 +60,12 @@ struct DeployDrawerView: View {
             }
             Spacer()
             if case .succeeded(let url, _) = model.phase {
-                // Standard share affordance for the deployed URL (#523) — Copy URL stays for the
-                // clipboard-first workflow.
+                // Standard share affordance for the deployed URL (#523) — its share sheet includes
+                // a Copy action, so a separate "Copy URL" button would just duplicate it (#1078).
                 ShareLink(item: url)
                     .labelStyle(.iconOnly)
                     .help("Share the deployed site's URL")
                     .accessibilityLabel("Share deployed URL")
-                Button("Copy URL") {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(url.absoluteString, forType: .string)
-                }
-                .accessibilityHint("Copies \(url.absoluteString) to the clipboard")
                 Button("Open in browser") {
                     NSWorkspace.shared.open(url)
                 }
@@ -237,9 +238,19 @@ struct DeployDrawerView: View {
         }
     }
 
+    /// Copy log is useful on any terminal outcome — even a successful deploy can carry warnings
+    /// (e.g. an Astro deprecation notice) worth reporting. Not offered mid-flight (`.running`)
+    /// since the log is still streaming.
+    private var canCopyLog: Bool {
+        switch model.phase {
+        case .succeeded, .failed: return true
+        case .idle, .running, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded: return false
+        }
+    }
+
     private var footer: some View {
         HStack {
-            if case .failed = model.phase {
+            if canCopyLog {
                 Button("Copy log") {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(model.logText, forType: .string)


### PR DESCRIPTION
## Summary

- The deployed URL in the drawer's header is now a clickable `Link`, not inert `Text`.
- "Copy log" is available on any terminal deploy outcome (`.succeeded` or `.failed`), not just failures — a successful deploy's log can still carry useful warnings (e.g. an Astro deprecation notice).
- Dropped the redundant "Copy URL" button: checked #523 (which added `ShareLink` "next to Copy URL") for context first, then removed it per direction — `ShareLink`'s own share sheet already offers a Copy action, so the standalone button was pure duplication.

Fixes #1078.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 260/262 Swift Testing tests pass; the only 2 failures are in `FoundationModelAssistantTests` ("Session ended without producing a response" on-device streaming errors), pre-existing and unrelated to this change (no `AnglesiteApp`/`DeployDrawerView` code touches that subsystem).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds.
- [x] Manual smoke: forced a `.succeeded` deploy phase in an isolated dev-build instance (temporary local-only default override, reverted before commit — no test code shipped) and confirmed in a live screenshot: the deployed URL renders as a blue clickable `Link`, "Copy log" appears in the footer and successfully copies the log text via the clipboard, and the header shows only the ShareLink icon + "Open in browser" (no more "Copy URL").