### PR TITLE
fix(#1085): fall back to live SITE_URL over a dead custom domain

### DIFF
--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -401,16 +401,15 @@ public actor DeployCommand {
     /// built before the URL was known, so the placeholder still ships on a site's first deploy —
     /// every deploy after that carries the real host.
     ///
-    /// Skipped when a custom domain is already configured (`DOMAIN`/`SITE_DOMAIN`): that value
-    /// wins per `WebsiteAnalyticsAsset.bestHost`'s precedence, and overwriting it here would
-    /// silently revert a custom-domain site back to its workers.dev host on every deploy.
-    /// Best-effort — a write failure must never turn a successful deploy into a failed one.
+    /// Written unconditionally, even when a custom domain (`DOMAIN`/`SITE_DOMAIN`) is already
+    /// configured (#1085): nothing in the deploy pipeline actually attaches a custom domain yet
+    /// (#1077), so that value is never verified to be live. `SITE_URL` is the one field guaranteed
+    /// to be the site's real, reachable address — `DeployCoordinator.resolveSiteURL` prefers it
+    /// over the possibly-dead custom domain for exactly that reason. Best-effort — a write failure
+    /// must never turn a successful deploy into a failed one.
     static func persistSiteURL(_ url: URL, siteDirectory: URL) {
         let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
         let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
-        guard WebsiteAnalyticsAsset.configValue("DOMAIN", in: config) == nil,
-              WebsiteAnalyticsAsset.configValue("SITE_DOMAIN", in: config) == nil
-        else { return }
         let updated = SiteConfigFile.upsert([("SITE_URL", url.absoluteString)], into: config)
         guard updated != config else { return }
         try? updated.write(to: configURL, atomically: true, encoding: .utf8)

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -109,20 +109,28 @@ public enum DeployCoordinator {
             ?? SiteSlug.derive(from: siteName ?? siteID)
     }
 
-    /// The site's best-known public URL for `WorkerComposition`'s `SITE_URL` var (#359): a
-    /// custom domain (`DOMAIN`/`SITE_DOMAIN`, `WebsiteAnalyticsAsset.bestHost`'s own precedence)
-    /// wins, given a scheme since those keys store a bare host; otherwise the workers.dev host
-    /// `DeployCommand.persistSiteURL` writes after the site's first successful deploy. `nil`
-    /// before any deploy has ever run and no custom domain is configured — the composed Worker
-    /// degrades gracefully without it (worker.ts's queue consumer no-ops).
+    /// The site's best-known public URL for `WorkerComposition`'s `SITE_URL` var (#359) — the
+    /// address the composed Worker uses for its own outbound requests, e.g. `CommunityMembershipClient`'s
+    /// ActivityPub actor ID and outbox (#1085). The workers.dev host `DeployCommand.persistSiteURL`
+    /// records after every successful deploy wins whenever it's present: nothing in the deploy
+    /// pipeline actually attaches a custom domain yet (#1077), so a configured `DOMAIN`/
+    /// `SITE_DOMAIN` is never verified to be live, and trusting it unconditionally over a
+    /// known-working host silently breaks federation the moment the custom domain doesn't resolve.
+    /// A custom domain is used only as a last resort, before any deploy has ever persisted
+    /// `SITE_URL` — the best guess available at that point. `nil` before any deploy has ever run
+    /// and no custom domain is configured — the composed Worker degrades gracefully without it
+    /// (worker.ts's queue consumer no-ops).
     public static func resolveSiteURL(siteDirectory: URL) -> String? {
         let config = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        if let siteURL = WebsiteAnalyticsAsset.configValue("SITE_URL", in: config) {
+            return siteURL
+        }
         if let domain = WebsiteAnalyticsAsset.configValue("DOMAIN", in: config)
             ?? WebsiteAnalyticsAsset.configValue("SITE_DOMAIN", in: config) {
             let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : "https://\(trimmed)"
         }
-        return WebsiteAnalyticsAsset.configValue("SITE_URL", in: config)
+        return nil
     }
 
     /// Persists the newly-provisioned Cloudflare resources and advances the `lastDeployedWorkerIDs`

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -627,7 +627,7 @@ struct DeployCommandTests {
         #expect(SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == "true")
     }
 
-    @Test("CF_WORKER_DEPLOYED is written even for a .transfer-domain site (where SITE_URL is not)")
+    @Test("CF_WORKER_DEPLOYED and SITE_URL are both written for a .transfer-domain site (#1085)")
     func workerDeployedMarkerNotConfoundedByCustomDomain() async {
         let siteDir = makeSiteDirectory()
         let configURL = siteDir.appendingPathComponent(".site-config")
@@ -640,8 +640,11 @@ struct DeployCommandTests {
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
         let config = try! String(contentsOf: configURL, encoding: .utf8)
-        #expect(SiteConfigFile.value(forKey: "SITE_URL", in: config) == nil, "SITE_URL is skipped when DOMAIN is set")
-        #expect(SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == "true", "but CF_WORKER_DEPLOYED must still be written")
+        // Nothing attaches DOMAIN to a live Worker yet (#1077), so SITE_URL must still be
+        // recorded as the real, reachable fallback (#1085) — it's no longer skipped just
+        // because a custom domain is configured.
+        #expect(SiteConfigFile.value(forKey: "SITE_URL", in: config) == "https://x.workers.dev")
+        #expect(SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == "true")
     }
 
     /// Writes `.site-config` with the given `CF_PROJECT_NAME` and, if `deployedBefore`, a
@@ -1064,8 +1067,8 @@ struct DeployCommandTests {
         #expect(config?.contains("SITE_URL=https://s.example.workers.dev") == true)
     }
 
-    @Test("a custom DOMAIN already in .site-config is not overwritten by the workers.dev URL")
-    func customDomainWinsOverWorkersDevURL() async {
+    @Test("a custom DOMAIN already in .site-config does not stop SITE_URL from being recorded (#1085)")
+    func customDomainDoesNotStopSiteURLPersistence() async {
         let siteDir = privateSiteDir()
         defer { try? FileManager.default.removeItem(at: siteDir) }
         try? "DOMAIN=example.com\n".write(
@@ -1078,9 +1081,12 @@ struct DeployCommandTests {
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
 
+        // Nothing in the deploy pipeline actually attaches a custom domain yet (#1077), so
+        // `DOMAIN` is never verified to be live — SITE_URL must still be recorded as the real,
+        // reachable fallback `DeployCoordinator.resolveSiteURL` prefers (#1085).
         let config = try? String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(config?.contains("DOMAIN=example.com") == true)
-        #expect(config?.contains("SITE_URL=") == false)
+        #expect(config?.contains("SITE_URL=https://s.example.workers.dev") == true)
     }
 
     @Test("persistSiteURL upserts without clobbering unrelated keys")

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -162,22 +162,22 @@ struct DeployCoordinatorTests {
 
     // MARK: - resolveSiteURL
 
-    @Test("resolveSiteURL prefers DOMAIN over everything else")
-    func resolveSiteURLPrefersDomain() throws {
+    @Test("resolveSiteURL prefers the persisted SITE_URL over an unverified custom domain (#1085)")
+    func resolveSiteURLPrefersSiteURLOverDomain() throws {
         let dir = try temporaryDirectory()
         try "DOMAIN=example.com\nSITE_URL=https://my-site.workers.dev\n".write(
             to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
-        #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == "https://example.com")
+        #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == "https://my-site.workers.dev")
     }
 
-    @Test("resolveSiteURL falls back to the persisted SITE_URL when no custom domain is set")
-    func resolveSiteURLFallsBackToSiteURL() throws {
+    @Test("resolveSiteURL falls back to DOMAIN before any deploy has ever persisted SITE_URL")
+    func resolveSiteURLFallsBackToDomain() throws {
         let dir = try temporaryDirectory()
-        try "SITE_URL=https://my-site.workers.dev\n".write(
+        try "DOMAIN=example.com\n".write(
             to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
-        #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == "https://my-site.workers.dev")
+        #expect(DeployCoordinator.resolveSiteURL(siteDirectory: dir) == "https://example.com")
     }
 
     @Test("resolveSiteURL returns nil before any deploy has ever persisted a host")


### PR DESCRIPTION
## Summary

- `DeployCommand.persistSiteURL` now always records `SITE_URL` after a successful deploy, instead of skipping it whenever a custom `DOMAIN`/`SITE_DOMAIN` is configured.
- `DeployCoordinator.resolveSiteURL` now prefers that persisted `SITE_URL` over `DOMAIN`/`SITE_DOMAIN`, falling back to the custom domain only before any deploy has ever recorded a real host.
- Root cause: nothing in the deploy pipeline actually attaches a custom domain yet (#1077), so a `DOMAIN` value from the "Transfer an existing domain" wizard flow is never verified to be live. Trusting it unconditionally broke the site's own outbound requests (ActivityPub actor ID/outbox, WebSub pings, webmention self-links) whenever the domain didn't resolve.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 2900/2902 pass; the 2 failures are pre-existing on-device `FoundationModelAssistantTests` flakiness (`Session ended without producing a response`), unrelated to this change and reproducible in isolation on `main`-derived state with no files touched here.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds.
- [ ] Manual smoke: not run (no live Cloudflare account / real domain transfer available in this environment); covered by updated unit tests in `DeployCommandTests.swift` and `DeployCoordinatorTests.swift` instead.

Fixes #1085