### PR TITLE
fix(#961): route custom analytics HTML validation through container

### DIFF
--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -164,7 +164,8 @@ final class PlistEditorModel {
          graphSnapshotProvider: @escaping @MainActor () -> SiteGraphExplorerSnapshot? = { nil },
          onActiveWorkersChanged: @escaping (SiteSettings) async -> Void = { _ in },
          analyticsProvider: any CloudflareWebAnalyticsProviding = CloudflareWebAnalyticsClient(),
-         customAnalyticsValidator: any CustomAnalyticsHTMLValidating = AstroHTMLValidator(),
+         customAnalyticsValidator: (any CustomAnalyticsHTMLValidating)? = nil,
+         containerControlProvider: @escaping AstroHTMLValidator.ContainerControlProvider = { nil },
          keychain: KeychainStore = KeychainStore(),
          domainOperations: any DomainOperationsService = DomainOperations(),
          repoSecurity: any RepoSecurityReading & RepoSecurityWriting = HTTPGitHubClient(),
@@ -182,7 +183,11 @@ final class PlistEditorModel {
         self.graphSnapshotProvider = graphSnapshotProvider
         self.onActiveWorkersChanged = onActiveWorkersChanged
         self.analyticsProvider = analyticsProvider
+        // `customAnalyticsValidator` lets tests inject a fake directly; production leaves it nil
+        // and instead wires `containerControlProvider` through to the real `AstroHTMLValidator`,
+        // resolved lazily at validation time (#961).
         self.customAnalyticsValidator = customAnalyticsValidator
+            ?? AstroHTMLValidator(containerControlProvider: containerControlProvider)
         self.keychain = keychain
         self.domainOperations = domainOperations
         self.repoSecurity = repoSecurity

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -957,7 +957,8 @@ final class SiteWindowModel {
                     graphSnapshotProvider: { graphExplorer.snapshot },
                     onActiveWorkersChanged: { settings in
                         await preview.activeWorkersChanged(settings)
-                    }
+                    },
+                    containerControlProvider: { [preview] in await preview.activeContainerControl() }
                 ))
             }
             mainPaneMode = .editor(file)

--- a/Sources/AnglesiteCore/AstroHTMLValidator.swift
+++ b/Sources/AnglesiteCore/AstroHTMLValidator.swift
@@ -5,23 +5,16 @@ public protocol CustomAnalyticsHTMLValidating: Sendable {
 }
 
 public struct AstroHTMLValidator: CustomAnalyticsHTMLValidating, Sendable {
-    public typealias CommandRunner = @Sendable (_ executable: URL, _ arguments: [String], _ cwd: URL?) async throws -> ProcessSupervisor.RunResult
+    /// Reached lazily, at the moment validation actually runs — never resolved eagerly at
+    /// construction time — mirroring `DeployModel`/`PreviewModel.activeContainerControl()`
+    /// (`SiteWindowModel.swift`'s `deploySite()`), since the container may not have finished
+    /// booting yet when `PlistEditorModel` (and this validator) are created.
+    public typealias ContainerControlProvider = @Sendable () async -> (siteID: String, control: any LocalContainerControl)?
 
-    private let nodeExecutable: @Sendable () -> URL?
-    private let run: CommandRunner
+    private let containerControlProvider: ContainerControlProvider
 
-    public init(
-        nodeExecutable: @escaping @Sendable () -> URL? = { nil },
-        run: @escaping CommandRunner = { executable, arguments, cwd in
-            try await ProcessSupervisor.shared.run(
-                executable: executable,
-                arguments: arguments,
-                currentDirectoryURL: cwd
-            )
-        }
-    ) {
-        self.nodeExecutable = nodeExecutable
-        self.run = run
+    public init(containerControlProvider: @escaping ContainerControlProvider = { nil }) {
+        self.containerControlProvider = containerControlProvider
     }
 
     public func validationMessage(for html: String, siteDirectory: URL) async -> String? {
@@ -32,41 +25,47 @@ public struct AstroHTMLValidator: CustomAnalyticsHTMLValidating, Sendable {
         guard fileManager.fileExists(atPath: siteDirectory.appendingPathComponent("node_modules/@astrojs/compiler/package.json").path) else {
             return "Custom analytics HTML couldn't be validated because Astro dependencies are missing. Run npm install in this site and try again."
         }
-        guard let node = nodeExecutable() else {
+        guard let (siteID, control) = await containerControlProvider() else {
             return HostNodeRetirement.reason("Custom analytics HTML validation") + "."
         }
 
-        let workDirectory = fileManager.temporaryDirectory
-            .appendingPathComponent("anglesite-astro-html-validation-\(UUID().uuidString)", isDirectory: true)
-        let cleanup: @Sendable () -> Void = {
-            try? FileManager.default.removeItem(at: workDirectory)
-        }
+        // The guest is a *cloned* copy of the site, not a host bind-mount, so host-written temp
+        // files never appear in it. Instead the snippet and the fixed validation script are
+        // base64-encoded and passed as positional shell parameters ($1/$2) — never spliced into
+        // the script text — mirroring `ContainerDeployExecutor.wellKnownSeamArgv`'s
+        // injection-safety pattern (`DeployExecutor.swift`).
+        let snippetBase64 = Data(snippet.utf8).base64EncodedString()
+        let scriptBase64 = Data(Self.validationScript.utf8).base64EncodedString()
+
         do {
-            return try await withTaskCancellationHandler {
-                try fileManager.createDirectory(at: workDirectory, withIntermediateDirectories: true)
-                defer { cleanup() }
-
-                let snippetURL = workDirectory.appendingPathComponent("custom-analytics.html")
-                let scriptURL = workDirectory.appendingPathComponent("validate-custom-analytics.mjs")
-                try snippet.write(to: snippetURL, atomically: true, encoding: .utf8)
-                try Self.validationScript.write(to: scriptURL, atomically: true, encoding: .utf8)
-
-                let result = try await run(
-                    node,
-                    [scriptURL.path, siteDirectory.path, snippetURL.path],
-                    siteDirectory
-                )
-                guard result.exitCode != 0 else { return nil }
-                let message = [result.stderr, result.stdout]
-                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                    .first { !$0.isEmpty }
-                return "Custom analytics HTML is invalid: \(Self.friendlyMessage(message))"
-            } onCancel: {
-                cleanup()
-            }
+            let result = try await control.exec(
+                siteID: siteID,
+                argv: Self.guestArgv(snippetBase64: snippetBase64, scriptBase64: scriptBase64),
+                environment: [:],
+                workingDirectory: "/workspace/site",
+                onOutput: { _, _ in }
+            )
+            guard result.exitCode != 0 else { return nil }
+            let message = [result.stderr, result.stdout]
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first { !$0.isEmpty }
+            return "Custom analytics HTML is invalid: \(Self.friendlyMessage(message))"
         } catch {
             return "Custom analytics HTML couldn't be validated: \(error.localizedDescription)"
         }
+    }
+
+    private static let snippetGuestPath = "/tmp/anglesite-custom-analytics.html"
+    private static let scriptGuestPath = "/tmp/anglesite-validate-custom-analytics.mjs"
+
+    static func guestArgv(snippetBase64: String, scriptBase64: String) -> [String] {
+        let script = """
+        trap 'rm -f \(snippetGuestPath) \(scriptGuestPath)' EXIT INT TERM
+        printf '%s' "$1" | base64 -d > \(snippetGuestPath)
+        printf '%s' "$2" | base64 -d > \(scriptGuestPath)
+        node \(scriptGuestPath) /workspace/site \(snippetGuestPath)
+        """
+        return ["sh", "-c", script, "sh", snippetBase64, scriptBase64]
     }
 
     private static func friendlyMessage(_ message: String?) -> String {

--- a/Tests/AnglesiteCoreTests/AstroHTMLValidatorTests.swift
+++ b/Tests/AnglesiteCoreTests/AstroHTMLValidatorTests.swift
@@ -4,15 +4,12 @@ import Testing
 
 @Suite("AstroHTMLValidator")
 struct AstroHTMLValidatorTests {
-    @Test("empty custom analytics HTML is valid without spawning Node")
-    func emptyHTMLDoesNotSpawnNode() async {
-        let validator = AstroHTMLValidator(
-            nodeExecutable: { URL(fileURLWithPath: "/usr/bin/node") },
-            run: { _, _, _ in
-                Issue.record("Empty HTML should not run Astro validation")
-                return ProcessSupervisor.RunResult(stdout: "", stderr: "", exitCode: 1)
-            }
-        )
+    @Test("empty custom analytics HTML is valid without touching the container")
+    func emptyHTMLDoesNotUseContainer() async {
+        let validator = AstroHTMLValidator(containerControlProvider: {
+            Issue.record("Empty HTML should not run Astro validation")
+            return nil
+        })
 
         let message = await validator.validationMessage(for: "   \n", siteDirectory: URL(fileURLWithPath: "/tmp/site"))
 
@@ -26,15 +23,18 @@ struct AstroHTMLValidatorTests {
         try fm.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: root) }
 
-        let validator = AstroHTMLValidator(nodeExecutable: { URL(fileURLWithPath: "/usr/bin/node") })
+        let validator = AstroHTMLValidator(containerControlProvider: {
+            Issue.record("Missing Astro dependencies should be caught before touching the container")
+            return nil
+        })
 
         let message = await validator.validationMessage(for: "<script></script>", siteDirectory: root)
 
         #expect(message?.contains("Astro dependencies are missing") == true)
     }
 
-    @Test("default validator reports container requirement when Astro deps exist")
-    func defaultValidatorReportsContainerRequirement() async throws {
+    @Test("no running container reports container requirement when Astro deps exist")
+    func noContainerReportsContainerRequirement() async throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try fm.createDirectory(
@@ -48,13 +48,14 @@ struct AstroHTMLValidatorTests {
         )
         defer { try? fm.removeItem(at: root) }
 
-        let message = await AstroHTMLValidator().validationMessage(for: "<script></script>", siteDirectory: root)
+        let validator = AstroHTMLValidator(containerControlProvider: { nil })
+        let message = await validator.validationMessage(for: "<script></script>", siteDirectory: root)
 
         #expect(message == "Custom analytics HTML validation must run in the container runtime; host Node has been retired.")
     }
 
-    @Test("runner failure is returned as invalid custom analytics HTML")
-    func runnerFailure() async throws {
+    @Test("guest exec failure is returned as invalid custom analytics HTML")
+    func guestExecFailure() async throws {
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try fm.createDirectory(
@@ -68,22 +69,57 @@ struct AstroHTMLValidatorTests {
         )
         defer { try? fm.removeItem(at: root) }
 
-        let validator = AstroHTMLValidator(
-            nodeExecutable: { URL(fileURLWithPath: "/usr/bin/node") },
-            run: { _, arguments, cwd in
-                #expect(arguments.count == 3)
-                #expect(cwd == root)
-                #expect((try? String(contentsOf: URL(fileURLWithPath: arguments[2]), encoding: .utf8)) == "<script></")
-                return ProcessSupervisor.RunResult(
-                    stdout: "",
-                    stderr: "Cannot read properties of undefined (reading 'map')",
-                    exitCode: 1
-                )
-            }
+        let control = FakeLocalContainerControl(
+            startResult: .failure(.bootFailed("unused")),
+            execResult: ContainerExecResult(
+                exitCode: 1,
+                stdout: "",
+                stderr: "Cannot read properties of undefined (reading 'map')"
+            )
         )
+        let validator = AstroHTMLValidator(containerControlProvider: { (siteID: "site-1", control: control) })
 
         let message = await validator.validationMessage(for: "<script></", siteDirectory: root)
 
         #expect(message == "Custom analytics HTML is invalid: Astro couldn't parse the snippet. Check for incomplete tags or script blocks.")
+
+        let calls = await control.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].siteID == "site-1")
+        #expect(calls[0].cwd == "/workspace/site")
+        #expect(calls[0].argv.first == "sh")
+
+        // The snippet is never spliced into the script text — it travels as a base64 positional
+        // parameter ($1), decoded in-guest. Confirm the exact snippet round-trips.
+        #expect(calls[0].argv.count == 6)
+        let snippetBase64 = calls[0].argv[4]
+        let decodedSnippet = try #require(Data(base64Encoded: snippetBase64))
+        #expect(String(data: decodedSnippet, encoding: .utf8) == "<script></")
+    }
+
+    @Test("successful guest exec reports valid HTML")
+    func guestExecSuccess() async throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(
+            at: root.appendingPathComponent("node_modules/@astrojs/compiler", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try "{}".write(
+            to: root.appendingPathComponent("node_modules/@astrojs/compiler/package.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? fm.removeItem(at: root) }
+
+        let control = FakeLocalContainerControl(
+            startResult: .failure(.bootFailed("unused")),
+            execResult: ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+        )
+        let validator = AstroHTMLValidator(containerControlProvider: { (siteID: "site-1", control: control) })
+
+        let message = await validator.validationMessage(for: "<script>ok</script>", siteDirectory: root)
+
+        #expect(message == nil)
     }
 }


### PR DESCRIPTION
## Summary

- `AstroHTMLValidator` defaulted its Node resolver to `{ nil }`, and no call site ever supplied a real one — custom analytics HTML validation always returned "must run in the container runtime; host Node has been retired" instead of actually validating.
- Replaced the host-`nodeExecutable`/`CommandRunner` shape with a lazily-resolved `containerControlProvider` (mirroring `DeployModel`/`PreviewModel.activeContainerControl()`), and route the `@astrojs/compiler` check through `LocalContainerControl.exec` in the site's running container.
- The snippet and the fixed validation script travel in as base64-encoded positional shell parameters (`$1`/`$2`), never spliced into script text — the same injection-safe pattern `ContainerDeployExecutor.wellKnownSeamArgv` already uses.
- Wired `PlistEditorModel` → `SiteWindowModel.openFile` with `containerControlProvider: { [preview] in await preview.activeContainerControl() }`, matching the existing `deploySite()` wiring exactly.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (`AstroHTMLValidatorTests` rewritten against `FakeLocalContainerControl`; full suite passes except a pre-existing, unrelated on-device `FoundationModelAssistant` flake — "Session ended without producing a response" — not touched by this change)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke: not run — exercising the real path needs a booted local container (`ANGLESITE_CONTAINER_TESTS=1`), which this environment doesn't have available.

Closes #961.