### PR TITLE
fix(#1068): surface the real reason behind bookmark errors

### DIFF
--- a/Sources/AnglesiteCore/Platform/SecurityScopedBookmark.swift
+++ b/Sources/AnglesiteCore/Platform/SecurityScopedBookmark.swift
@@ -38,9 +38,21 @@ public struct SecurityScopedBookmarkResolution: Sendable, Equatable {
     }
 }
 
-public enum SecurityScopedBookmarkError: Error, Sendable {
+public enum SecurityScopedBookmarkError: Error, Sendable, LocalizedError {
     case createFailed(String)
     case resolveFailed(String)
+
+    /// Without this conformance, `.localizedDescription` bridges to a generic NSError
+    /// ("The operation couldn't be completed. (AnglesiteCore.SecurityScopedBookmarkError error
+    /// 0.)") and silently drops the underlying reason carried in the associated `String` — see
+    /// #1068, where that's exactly the message users saw at every call site that surfaces this
+    /// error (`SiteActions.ImportError`, the new-site "Registering" step).
+    public var errorDescription: String? {
+        switch self {
+        case .createFailed(let message), .resolveFailed(let message):
+            message
+        }
+    }
 }
 
 /// Placeholder for platforms without App Sandbox bookmarks (Linux/Windows). `create`/`resolve`

--- a/Tests/AnglesiteCoreTests/SecurityScopedBookmarkTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityScopedBookmarkTests.swift
@@ -29,4 +29,19 @@ final class SecurityScopedBookmarkTests: XCTestCase {
         let garbage = Data([0x01, 0x02, 0x03, 0x04])
         XCTAssertThrowsError(try SecurityScopedBookmark.resolve(garbage))
     }
+
+    /// #1068: without `LocalizedError` conformance, `.localizedDescription` on this enum bridges
+    /// to a generic NSError ("The operation couldn't be completed. (AnglesiteCore.
+    /// SecurityScopedBookmarkError error 0.)") and silently drops the actual underlying reason —
+    /// exactly the message users saw in the bug report, on both the recovery ("Locate…") and
+    /// brand-new-site paths.
+    func test_createFailed_localizedDescription_surfacesUnderlyingMessage() {
+        let error: Error = SecurityScopedBookmarkError.createFailed("the real underlying reason")
+        XCTAssertEqual(error.localizedDescription, "the real underlying reason")
+    }
+
+    func test_resolveFailed_localizedDescription_surfacesUnderlyingMessage() {
+        let error: Error = SecurityScopedBookmarkError.resolveFailed("the real underlying reason")
+        XCTAssertEqual(error.localizedDescription, "the real underlying reason")
+    }
 }


### PR DESCRIPTION
## Summary

- `SecurityScopedBookmarkError` didn't conform to `LocalizedError`, so calling `.localizedDescription` on it bridged to a generic NSError instead of returning the associated message — producing exactly the `AnglesiteCore.SecurityScopedBookmarkError error 0.` text reported in #1068, at every call site that surfaces this error (`SiteActions.ImportError` on the "Locate…" recovery flow, and the new-site wizard's "Registering" step).
- Root-caused via a failing test first (`SecurityScopedBookmarkTests`): asserting `.localizedDescription` on `.createFailed`/`.resolveFailed` reproduced the exact `error 0.`/`error 1.` messages from the bug report before the fix, and now returns the real underlying string after it.
- Scope note: this fixes the swallowed-message bug, which is real and verifiable independent of environment. #1068 also flagged an open question about whether `create()`/`resolve()` itself was genuinely failing (vs. an artifact of the reporting session's non-interactive/remote-desktop sandbox context) — that will now surface its actual reason instead of a generic code, making it diagnosable if it recurs.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (2902 tests; only pre-existing, unrelated `FoundationModelAssistant` on-device-model flakiness fails, same before and after this change)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds
- [ ] Manual smoke (if UI-touching): not performed — this is a headless agent session with no interactive GUI login, so the actual sandboxed "Locate…"/new-site-registration flows from #1068 couldn't be re-driven end to end. Recommend a quick manual check on the next interactive pass.