### PR TITLE
feat(#371): community discovery search in the join flow

### DIFF
--- a/Sources/AnglesiteApp/CommunitiesModel.swift
+++ b/Sources/AnglesiteApp/CommunitiesModel.swift
@@ -64,6 +64,11 @@ final class CommunitiesModel {
     /// clicked away from can't overwrite the newer selection's timeline (or stomp its
     /// `isLoadingTimeline`) once it finally lands — mirrors `FollowersModel.generation`.
     private var timelineGeneration = 0
+    /// Bumped at the top of every `searchDiscovery()` call, checked before writing
+    /// `discoveryResults`/`discoveryErrorMessage`/`isSearchingDiscovery` — otherwise a search for
+    /// an earlier, now-stale query (or a slower response from an earlier request) could land after
+    /// a newer one and silently overwrite its results. Mirrors `timelineGeneration`.
+    private var discoveryGeneration = 0
     private let secretStore: any SecretStore
     /// Injected (default `.shared`) purely so `searchDiscovery()` is testable without touching the
     /// real `UserDefaults.standard` — every other read/write in this file talks to `.shared`
@@ -142,6 +147,10 @@ final class CommunitiesModel {
 
     // MARK: - Join
 
+    /// Every failure path here must set `errorMessage` — `joinFromDiscovery(_:)` below has no
+    /// other way to tell a failed join from a successful one, since it reuses this method rather
+    /// than getting its own return value. A future early-return added here without setting
+    /// `errorMessage` would silently make Discovery report success for a join that didn't happen.
     func join() async {
         let input = joinHandleText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !input.isEmpty else { return }
@@ -199,21 +208,31 @@ final class CommunitiesModel {
     var discoveryInstance: String { appSettings.communitySearchInstance }
 
     func searchDiscovery() async {
+        discoveryGeneration &+= 1
+        let token = discoveryGeneration
         let query = discoveryQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {
             discoveryResults = []
             discoveryErrorMessage = nil
+            isSearchingDiscovery = false
             return
         }
         isSearchingDiscovery = true
         discoveryErrorMessage = nil
-        defer { isSearchingDiscovery = false }
         do {
             let client = CommunitySearchClient(transport: searchTransport)
-            discoveryResults = try await client.search(query: query, instance: discoveryInstance)
+            let results = try await client.search(query: query, instance: discoveryInstance)
+            // A newer `searchDiscovery()` call landed while this one was in flight — its own
+            // search owns `discoveryResults`/`isSearchingDiscovery` now, so this stale call must
+            // touch neither.
+            guard token == discoveryGeneration else { return }
+            discoveryResults = results
+            isSearchingDiscovery = false
         } catch {
+            guard token == discoveryGeneration else { return }
             discoveryResults = []
             discoveryErrorMessage = "Couldn't search \(discoveryInstance): \(error)"
+            isSearchingDiscovery = false
         }
     }
 

--- a/Sources/AnglesiteApp/CommunitiesModel.swift
+++ b/Sources/AnglesiteApp/CommunitiesModel.swift
@@ -40,6 +40,16 @@ final class CommunitiesModel {
     private(set) var isJoining = false
     var joinHandleText = ""
     var errorMessage: String?
+    /// Drives the Discovery sheet (V-5.4, #371) — the join flow's "Find a community" browse/search
+    /// step, opened from a button beside the existing handle/URL join bar.
+    var discoveryPresented = false
+    var discoveryQuery = ""
+    private(set) var discoveryResults: [CommunitySearchResult] = []
+    private(set) var isSearchingDiscovery = false
+    /// Separate from `errorMessage`: a failed search is a recoverable, in-panel state (try a
+    /// different query or instance), not the alert-worthy failure `errorMessage`'s `.alert` binds
+    /// to — the owner is still mid-search, not stuck on a blocking dialog.
+    var discoveryErrorMessage: String?
     /// Non-nil ⟺ the "Leave this community?" confirmation is showing — mirrors
     /// `SiteWindowModel.deleteConfirmation`'s item-based-confirmation pattern.
     var leaveConfirmation: JoinedCommunity?
@@ -55,23 +65,37 @@ final class CommunitiesModel {
     /// `isLoadingTimeline`) once it finally lands — mirrors `FollowersModel.generation`.
     private var timelineGeneration = 0
     private let secretStore: any SecretStore
+    /// Injected (default `.shared`) purely so `searchDiscovery()` is testable without touching the
+    /// real `UserDefaults.standard` — every other read/write in this file talks to `.shared`
+    /// directly (matching `ChatView`/`EsiPreviewMode`'s convention), but nothing else in this class
+    /// needed a settings value a test would want to control, so this is the first seam of its kind
+    /// here. The join sheet's own `@AppStorage(AppSettings.Key.communitySearchInstance)` field
+    /// still targets `.standard` unconditionally (SwiftUI's property wrapper has no injection
+    /// point), which is fine in production since `AppSettings.shared` wraps that same store.
+    private let appSettings: AppSettings
     private let resolverTransport: CommunityActorResolver.Transport
     private let membershipTransport: CommunityMembershipClient.Transport
     private let timelineTransport: GroupTimelineClient.Transport
+    private let searchTransport: CommunitySearchClient.Transport
 
     init(
         secretStore: any SecretStore = PlatformSecretStore.make(),
+        appSettings: AppSettings = .shared,
         resolverTransport: @escaping CommunityActorResolver.Transport
             = CommunityActorResolver.defaultTransport,
         membershipTransport: @escaping CommunityMembershipClient.Transport
             = CommunityMembershipClient.defaultTransport,
         timelineTransport: @escaping GroupTimelineClient.Transport
-            = GroupTimelineClient.defaultTransport
+            = GroupTimelineClient.defaultTransport,
+        searchTransport: @escaping CommunitySearchClient.Transport
+            = CommunitySearchClient.defaultTransport
     ) {
         self.secretStore = secretStore
+        self.appSettings = appSettings
         self.resolverTransport = resolverTransport
         self.membershipTransport = membershipTransport
         self.timelineTransport = timelineTransport
+        self.searchTransport = searchTransport
     }
 
     /// Records which site this pane talks to and loads the joined-communities ledger from disk.
@@ -164,6 +188,48 @@ final class CommunitiesModel {
         } catch {
             errorMessage = "Couldn't join \(input): \(error)"
         }
+    }
+
+    // MARK: - Discovery (V-5.4, #371)
+
+    /// Reads `appSettings.communitySearchInstance` directly rather than caching it in model state
+    /// — the join sheet's instance field binds to the same `UserDefaults` key via `@AppStorage`,
+    /// so (in production, where `appSettings` is `.shared`) a change there is visible here on the
+    /// very next search with no extra plumbing.
+    var discoveryInstance: String { appSettings.communitySearchInstance }
+
+    func searchDiscovery() async {
+        let query = discoveryQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            discoveryResults = []
+            discoveryErrorMessage = nil
+            return
+        }
+        isSearchingDiscovery = true
+        discoveryErrorMessage = nil
+        defer { isSearchingDiscovery = false }
+        do {
+            let client = CommunitySearchClient(transport: searchTransport)
+            discoveryResults = try await client.search(query: query, instance: discoveryInstance)
+        } catch {
+            discoveryResults = []
+            discoveryErrorMessage = "Couldn't search \(discoveryInstance): \(error)"
+        }
+    }
+
+    /// One-tap join from a search result — routes through the exact same `join()` (and therefore
+    /// `CommunityActorResolver`/`CommunityMembershipClient.follow(target:)`) path #368 already
+    /// ships for a typed handle, just pre-filled from the result's `actorID` instead. Re-resolving
+    /// through `join()` (rather than constructing a `JoinedCommunity` straight from the search
+    /// result) keeps this on the one code path that enforces HTTPS and re-fetches the actor
+    /// document as ground truth, instead of trusting a second, independent copy of that logic.
+    func joinFromDiscovery(_ result: CommunitySearchResult) async {
+        joinHandleText = result.actorID.absoluteString
+        await join()
+        guard errorMessage == nil else { return }
+        discoveryPresented = false
+        discoveryQuery = ""
+        discoveryResults = []
     }
 
     // MARK: - Leave

--- a/Sources/AnglesiteApp/CommunitiesView.swift
+++ b/Sources/AnglesiteApp/CommunitiesView.swift
@@ -63,6 +63,11 @@ struct CommunitiesView: View {
                 + Text(community.displayName ?? community.id)
                 + Text(".")
         }
+        // Discovery (V-5.4, #371): browse/search step feeding this same join flow, opened from
+        // the magnifying-glass button beside the handle/URL bar in `sidebar`.
+        .sheet(isPresented: $communities.discoveryPresented) {
+            CommunityDiscoverySheet(communities: communities)
+        }
     }
 
     /// `title` is static UI copy and localizes via the `LocalizedStringKey` overload. `detail` is
@@ -96,6 +101,17 @@ struct CommunitiesView: View {
                     .disabled(
                         communities.joinHandleText.trimmingCharacters(in: .whitespaces).isEmpty
                             || communities.isJoining)
+                // Discovery (V-5.4, #371): a keyword-search alternative to typing a handle/URL
+                // directly. A separate button rather than folding into the text field above — the
+                // field still doubles as the target for a result the sheet hands back, matching
+                // `AddRedirectSheet`'s "prefill and let the owner review" precedent rather than
+                // joining silently from inside the sheet.
+                Button {
+                    communities.discoveryPresented = true
+                } label: {
+                    Image(systemName: "magnifyingglass")
+                }
+                .help("Find a community by keyword")
             }
             .padding()
 
@@ -176,5 +192,101 @@ struct CommunitiesView: View {
                 Button("Open in Browser") { NSWorkspace.shared.open(url) }
             }
         }
+    }
+}
+
+/// The Discovery sheet (V-5.4, #371): keyword search over a chosen instance's own communities,
+/// one-tap join into the same path `sidebar`'s handle/URL bar uses. `instance` binds directly to
+/// `AppSettings.Key.communitySearchInstance` via `@AppStorage` — the same key
+/// `CommunitiesModel.discoveryInstance` reads — mirroring `AdvancedSettingsView`'s
+/// `sitesRootOverride` plain-text-override pattern rather than threading the value through the
+/// model.
+private struct CommunityDiscoverySheet: View {
+    @Bindable var communities: CommunitiesModel
+    @AppStorage(AppSettings.Key.communitySearchInstance)
+    private var instance: String = CommunitySearchClient.defaultInstance
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var queryFieldFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Find a Community").font(.headline)
+
+            TextField("Keyword", text: $communities.discoveryQuery)
+                .textFieldStyle(.roundedBorder)
+                .focused($queryFieldFocused)
+                .onSubmit { Task { await communities.searchDiscovery() } }
+
+            LabeledContent("Source") {
+                TextField("Instance, e.g. lemmy.world", text: $instance)
+                    .textFieldStyle(.roundedBorder)
+            }
+            // The privacy stance the issue calls for (#371): this search goes only to the
+            // instance above, never to an Anglesite-run directory — worth saying plainly next to
+            // the field the owner controls it from.
+            Text("Searches only the instance above. Anglesite doesn't run or query a directory of its own.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let discoveryErrorMessage = communities.discoveryErrorMessage {
+                Label(discoveryErrorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.callout)
+            }
+
+            Group {
+                if communities.isSearchingDiscovery {
+                    ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if communities.discoveryResults.isEmpty {
+                    Text(
+                        communities.discoveryQuery.trimmingCharacters(in: .whitespaces).isEmpty
+                            ? "Type a keyword and press Return to search."
+                            : "No communities found."
+                    )
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List(communities.discoveryResults) { result in
+                        discoveryRow(result)
+                    }
+                }
+            }
+            .frame(minHeight: 240)
+
+            HStack {
+                Spacer()
+                Button("Close") { dismiss() }
+            }
+        }
+        .padding()
+        .frame(minWidth: 420, idealWidth: 480, minHeight: 420)
+        .onAppear { queryFieldFocused = true }
+    }
+
+    @ViewBuilder
+    private func discoveryRow(_ result: CommunitySearchResult) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                // `result.title`/`.name` are remote-supplied and already `DisplayString.safe`'d by
+                // `CommunitySearchClient` (bidi/control scalars stripped), but that guard doesn't
+                // strip markdown syntax — same reasoning as the leave-confirmation alert above, so
+                // this uses `Text(String)`'s plain-`StringProtocol` overload rather than the
+                // markdown-parsing `LocalizedStringKey` one.
+                Text(result.title ?? result.name).font(.headline).lineLimit(1)
+                Text(subtitle(for: result)).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            }
+            Spacer()
+            Button("Join") { Task { await communities.joinFromDiscovery(result) } }
+                .disabled(communities.isJoining)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func subtitle(for result: CommunitySearchResult) -> String {
+        var text = "!\(result.name)@\(result.instance)"
+        if let count = result.subscriberCount {
+            text += " · \(count) member" + (count == 1 ? "" : "s")
+        }
+        return text
     }
 }

--- a/Sources/AnglesiteApp/CommunitiesView.swift
+++ b/Sources/AnglesiteApp/CommunitiesView.swift
@@ -112,6 +112,11 @@ struct CommunitiesView: View {
                     Image(systemName: "magnifyingglass")
                 }
                 .help("Find a community by keyword")
+                // An icon-only button's default VoiceOver label comes from the SF Symbol's own
+                // name ("magnifying glass"), which doesn't say what the button does — unlike the
+                // titled `Button`s elsewhere in this file (e.g. `communityRow`'s "Leave…"). Per
+                // the macOS accessibility standard (docs/mac-assed-app-spec.md).
+                .accessibilityLabel("Find a community by keyword")
             }
             .padding()
 
@@ -218,8 +223,19 @@ private struct CommunityDiscoverySheet: View {
                 .onSubmit { Task { await communities.searchDiscovery() } }
 
             LabeledContent("Source") {
-                TextField("Instance, e.g. lemmy.world", text: $instance)
-                    .textFieldStyle(.roundedBorder)
+                // `instance`'s raw stored value can be blank (or whitespace-only) — the field
+                // shows that as empty rather than silently normalizing it into the field itself
+                // (typing into a field that snaps back to a default on every keystroke would make
+                // it impossible to type a *new* instance from an empty start). But
+                // `CommunitiesModel.discoveryInstance`/`AppSettings.communitySearchInstance` DO
+                // fall back to `CommunitySearchClient.defaultInstance` for that same blank value —
+                // so the placeholder names that fallback explicitly, rather than a generic
+                // example, so an empty-looking field doesn't read as "search is broken" when it's
+                // actually about to search the default instance.
+                TextField(
+                    "Defaults to \(CommunitySearchClient.defaultInstance) if blank", text: $instance
+                )
+                .textFieldStyle(.roundedBorder)
             }
             // The privacy stance the issue calls for (#371): this search goes only to the
             // instance above, never to an Anglesite-run directory — worth saying plainly next to

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -980,6 +980,9 @@
     "Default Browser" : {
 
     },
+    "Defaults to %@ if blank" : {
+
+    },
     "Delete" : {
 
     },

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1253,6 +1253,12 @@
     "Find Previous" : {
 
     },
+    "Find a Community" : {
+
+    },
+    "Find a community by keyword" : {
+
+    },
     "Find…" : {
 
     },
@@ -1478,6 +1484,9 @@
     "Installed" : {
 
     },
+    "Instance, e.g. lemmy.world" : {
+
+    },
     "Join" : {
 
     },
@@ -1500,6 +1509,9 @@
 
     },
     "Key Props" : {
+
+    },
+    "Keyword" : {
 
     },
     "Kind" : {
@@ -1721,6 +1733,9 @@
     "No changes needed." : {
 
     },
+    "No communities found." : {
+
+    },
     "No communities joined yet — enter a handle above, like !sandbox@lemmy.sdf.org." : {
 
     },
@@ -1860,6 +1875,9 @@
 
     },
     "Open the live preview in your default browser" : {
+
+    },
+    "Open the preview first to start the runtime before auditing" : {
 
     },
     "Open the preview first to start the runtime before deploying" : {
@@ -2419,6 +2437,9 @@
     "Search graph" : {
 
     },
+    "Searches only the instance above. Anglesite doesn't run or query a directory of its own." : {
+
+    },
     "Searching freedesignmd.com…" : {
 
     },
@@ -2871,6 +2892,9 @@
       }
     },
     "Type" : {
+
+    },
+    "Type a keyword and press Return to search." : {
 
     },
     "URL" : {

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -34,6 +34,7 @@ public final class AppSettings: @unchecked Sendable {
         public static let cloudflareAccountName = "anglesite.cloudflareAccount.name"
         public static let cloudflareAccountEmail = "anglesite.cloudflareAccount.email"
         public static let activeAssistantBackend = "anglesite.activeAssistantBackend"
+        public static let communitySearchInstance = "anglesite.communitySearchInstance"
     }
 
     private enum LegacyKey {
@@ -132,6 +133,21 @@ public final class AppSettings: @unchecked Sendable {
     public var activeAssistantBackend: String {
         get { defaults.string(forKey: Key.activeAssistantBackend) ?? "foundationModels" }
         set { defaults.set(newValue, forKey: Key.activeAssistantBackend) }
+    }
+
+    /// Which instance's own `/api/v3/search` the Communities join flow's Discovery step
+    /// (`CommunitySearchClient`, V-5.4 #371) queries. Global, user-editable in the join sheet — not
+    /// a fixed Anglesite-run directory, so the query only ever goes to a source the owner chose.
+    /// Falls back to `CommunitySearchClient.defaultInstance` for both an absent *and* a
+    /// blanked-out override, so clearing the field in the sheet can't leave search silently
+    /// broken — mirrors `activeAssistantBackend`'s string-with-fallback shape.
+    public var communitySearchInstance: String {
+        get {
+            let stored = defaults.string(forKey: Key.communitySearchInstance)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return (stored?.isEmpty == false ? stored : nil) ?? CommunitySearchClient.defaultInstance
+        }
+        set { defaults.set(newValue, forKey: Key.communitySearchInstance) }
     }
 
     /// Security-scoped bookmark for the sites root, persisted so the sandboxed (MAS) build only

--- a/Sources/AnglesiteCore/CommunitySearchClient.swift
+++ b/Sources/AnglesiteCore/CommunitySearchClient.swift
@@ -1,0 +1,179 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// One community returned by a keyword search — the Discovery step's result row (V-5.4, #371).
+/// `actorID` is ready to feed straight into `CommunityActorResolver.resolve(_:)` (as a pasted-URL
+/// input, skipping webfinger) and from there into `CommunityMembershipClient.follow(target:)` —
+/// the same join path #368 already ships, just fed from a search result instead of a typed handle.
+public struct CommunitySearchResult: Sendable, Equatable, Identifiable {
+    public var id: String { actorID.absoluteString }
+    public let actorID: URL
+    public let name: String
+    public let title: String?
+    /// The host the community actually lives on — read from `actorID`, not the instance that was
+    /// queried: Lemmy's federated search can surface communities from other instances than the
+    /// one asked, and the join flow's confirmation should say where the community really is.
+    public let instance: String
+    public let subscriberCount: Int?
+
+    public init(actorID: URL, name: String, title: String?, instance: String, subscriberCount: Int?) {
+        self.actorID = actorID
+        self.name = name
+        self.title = title
+        self.instance = instance
+        self.subscriberCount = subscriberCount
+    }
+}
+
+public enum CommunitySearchError: Error, Equatable, Sendable {
+    case emptyQuery
+    case invalidInstance
+    case insecureURL
+    case requestFailed(status: Int, body: String)
+    case decodingFailed(String)
+}
+
+/// Searches a fediverse instance's own community directory by keyword (V-5.4, #371) — the
+/// Discovery step feeding #368's join flow, per the plan's constraint to consume an existing open
+/// network rather than host a new directory.
+///
+/// Queries Lemmy's own `GET /api/v3/search` (documented at
+/// https://join-lemmy.org/docs/contributors/04-api.html /
+/// https://mv-gh.github.io/lemmy_openapi_spec/; verified 2026-07-30 unauthenticated against
+/// `lemmy.world`, which returns `actor_id`/`counts.subscribers` with no auth header at all) —
+/// picked over lemmyverse.net's aggregate JSON dump (a static bulk export meant for offline
+/// analysis, not a live query API — using it as a search source would mean the app downloading,
+/// caching, and indexing a directory itself) and third-party fediverse search services (no stable
+/// public spec comparable to Lemmy's own API; see issue #371's source-selection comment for the
+/// full comparison). `instance` is caller-supplied and not defaulted here — the join sheet is
+/// where the user picks/edits it, matching the issue's "source is configurable in the sheet"
+/// requirement; this client only enforces that whatever instance it's given is queried securely.
+///
+/// This searches Lemmy communities specifically. It doesn't narrow what the join flow can join —
+/// `CommunityActorResolver` already resolves a handle or URL for any FEP-1b12 software (Mastodon,
+/// PieFed, Mbin, Friendica, Hubzilla, PeerTube); search is an additive discovery aid on top of
+/// that, not a replacement for it.
+public struct CommunitySearchClient: Sendable {
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// A search response is a short list of communities, not an outbox page of activities — reuses
+    /// `ActorProfileFetcher`'s cap/timeouts rather than defining its own, same reuse `CommunityActorResolver`
+    /// already does for the same reason.
+    public static let maximumResponseBytes = ActorProfileFetcher.maximumResponseBytes
+    public static let defaultInstance = "lemmy.world"
+
+    private let transport: Transport
+
+    public init(transport: @escaping Transport = CommunitySearchClient.defaultTransport) {
+        self.transport = transport
+    }
+
+    public func search(query: String, instance: String) async throws -> [CommunitySearchResult] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else { throw CommunitySearchError.emptyQuery }
+        guard let url = Self.searchURL(instance: instance, query: trimmedQuery) else {
+            throw CommunitySearchError.invalidInstance
+        }
+        try Self.requireHTTPS(url)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = ActorProfileFetcher.timeout
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw CommunitySearchError.requestFailed(status: 0, body: "\(error)")
+        }
+        // URLSession follows redirects transparently, so this body may not have come from the
+        // instance that was asked — re-check where it actually landed, mirroring
+        // `CommunityActorResolver`'s same guard on its own webfinger/actor fetches.
+        if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunitySearchError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        // The default transport already aborts mid-stream past the cap; this re-check holds an
+        // injected transport to the same limit, mirroring `CommunityActorResolver`.
+        guard data.count <= Self.maximumResponseBytes else {
+            throw CommunitySearchError.requestFailed(
+                status: 0, body: "response too large (\(data.count) bytes)")
+        }
+
+        struct CommunityDTO: Decodable {
+            let name: String
+            let title: String?
+            let actor_id: String
+        }
+        struct CountsDTO: Decodable { let subscribers: Int? }
+        struct CommunityViewDTO: Decodable {
+            let community: CommunityDTO
+            let counts: CountsDTO?
+        }
+        struct SearchResponseDTO: Decodable { let communities: [CommunityViewDTO]? }
+
+        let dto: SearchResponseDTO
+        do {
+            dto = try JSONDecoder().decode(SearchResponseDTO.self, from: data)
+        } catch {
+            throw CommunitySearchError.decodingFailed("\(error)")
+        }
+        return (dto.communities ?? []).compactMap { view in
+            // A result whose own `actor_id` isn't a secure URL can't be joined through
+            // `CommunityActorResolver` anyway (it enforces HTTPS on exactly this field) — drop it
+            // here rather than surfacing a row that fails the moment it's tapped.
+            guard let actorID = URL(string: view.community.actor_id),
+                  actorID.scheme?.lowercased() == "https", let host = actorID.host
+            else { return nil }
+            return CommunitySearchResult(
+                actorID: actorID,
+                name: DisplayString.safe(view.community.name),
+                title: view.community.title.map(DisplayString.safe),
+                instance: host,
+                subscriberCount: view.counts?.subscribers)
+        }
+    }
+
+    /// Accepts a bare host (`lemmy.world`) or a pasted `https://lemmy.world` URL — the join
+    /// sheet's search-instance field is free text, and users copy instance addresses from
+    /// anywhere (a link, an app's "about" page) that may or may not include the scheme.
+    private static func searchURL(instance: String, query: String) -> URL? {
+        let trimmed = instance.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let host: String
+        if let parsed = URL(string: trimmed), let parsedHost = parsed.host,
+           ["http", "https"].contains(parsed.scheme?.lowercased() ?? "") {
+            host = parsedHost
+        } else {
+            host = trimmed
+        }
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = "/api/v3/search"
+        components.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "type_", value: "Communities"),
+            URLQueryItem(name: "listing_type", value: "All"),
+            URLQueryItem(name: "sort", value: "TopAll"),
+            URLQueryItem(name: "limit", value: "20"),
+        ]
+        return components.url
+    }
+
+    private static func requireHTTPS(_ url: URL) throws {
+        guard url.scheme?.lowercased() == "https" else { throw CommunitySearchError.insecureURL }
+    }
+
+    private static let session = CappedHTTPTransport.session(
+        requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
+
+    public static let defaultTransport: Transport = { request in
+        try await CappedHTTPTransport.fetch(
+            request, session: session, cap: maximumResponseBytes,
+            tooLarge: { CommunitySearchError.requestFailed(status: 0, body: "response too large (\($0) bytes)") })
+    }
+}

--- a/Sources/AnglesiteCore/CommunitySearchClient.swift
+++ b/Sources/AnglesiteCore/CommunitySearchClient.swift
@@ -137,22 +137,36 @@ public struct CommunitySearchClient: Sendable {
         }
     }
 
-    /// Accepts a bare host (`lemmy.world`) or a pasted `https://lemmy.world` URL — the join
-    /// sheet's search-instance field is free text, and users copy instance addresses from
-    /// anywhere (a link, an app's "about" page) that may or may not include the scheme.
+    /// Accepts a bare host (`lemmy.world`), a bare `host:port` (a self-hosted instance on a
+    /// non-standard port), or a pasted `https://lemmy.world[:port]` URL — the join sheet's
+    /// search-instance field is free text, and users copy instance addresses from anywhere (a
+    /// link, an app's "about" page) that may or may not include the scheme or a port.
     private static func searchURL(instance: String, query: String) -> URL? {
         let trimmed = instance.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         let host: String
+        let port: Int?
         if let parsed = URL(string: trimmed), let parsedHost = parsed.host,
            ["http", "https"].contains(parsed.scheme?.lowercased() ?? "") {
             host = parsedHost
+            port = parsed.port
+        } else if let colonIndex = trimmed.lastIndex(of: ":"),
+                  let parsedPort = Int(trimmed[trimmed.index(after: colonIndex)...]) {
+            // A bare `host:port` has no `//` authority marker, so `URL(string:)` parses the part
+            // before the colon as a *scheme* (RFC 3986 allows dots in a scheme) rather than a
+            // host — e.g. `URL(string: "lemmy.example:8080")` yields `scheme: "lemmy.example",
+            // host: nil`. Needs its own split rather than relying on `URL`'s parse.
+            host = String(trimmed[trimmed.startIndex..<colonIndex])
+            port = parsedPort
         } else {
             host = trimmed
+            port = nil
         }
+        guard !host.isEmpty else { return nil }
         var components = URLComponents()
         components.scheme = "https"
         components.host = host
+        components.port = port
         components.path = "/api/v3/search"
         components.queryItems = [
             URLQueryItem(name: "q", value: query),

--- a/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+++ b/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
@@ -108,12 +108,23 @@ struct CommunitiesModelTests {
         return (config, source)
     }
 
-    private static func model(secretStore: InMemorySecretStore, fake: FakeTransport) -> CommunitiesModel {
+    private static func model(
+        secretStore: InMemorySecretStore, fake: FakeTransport, appSettings: AppSettings = .shared
+    ) -> CommunitiesModel {
         CommunitiesModel(
             secretStore: secretStore,
+            appSettings: appSettings,
             resolverTransport: fake.transport,
             membershipTransport: fake.transport,
-            timelineTransport: fake.transport)
+            timelineTransport: fake.transport,
+            searchTransport: fake.transport)
+    }
+
+    /// A scratch `UserDefaults` suite, not `.standard` — discovery tests need to control
+    /// `communitySearchInstance` without leaking state into, or racing, every other test in the
+    /// process (Swift Testing runs `@Suite`s concurrently by default).
+    private static func scratchAppSettings() -> AppSettings {
+        AppSettings(defaults: UserDefaults(suiteName: "communities-model-test-\(UUID().uuidString)")!)
     }
 
     @Test("join resolves the handle, follows it, and records it in the ledger")
@@ -680,5 +691,136 @@ struct CommunitiesModelTests {
         await model.retry()
 
         #expect(model.state == .idle)
+    }
+
+    // MARK: - Discovery (V-5.4, #371)
+
+    @Test("searchDiscovery populates results from the configured instance")
+    func searchDiscoveryPopulatesResults() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        let appSettings = Self.scratchAppSettings()
+        appSettings.communitySearchInstance = "lemmy.example"
+        let searchURL = "https://lemmy.example/api/v3/search"
+            + "?q=birding&type_=Communities&listing_type=All&sort=TopAll&limit=20"
+        let fake = FakeTransport([
+            searchURL: (200, """
+                {"communities":[
+                  {"community":{"name":"birding","title":"Birding",
+                    "actor_id":"https://lemmy.example/c/birding"},
+                   "counts":{"subscribers":42}}
+                ]}
+                """),
+        ])
+
+        let model = Self.model(secretStore: secretStore, fake: fake, appSettings: appSettings)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.discoveryQuery = "birding"
+
+        await model.searchDiscovery()
+
+        #expect(model.discoveryResults.count == 1)
+        #expect(model.discoveryResults.first?.name == "birding")
+        #expect(model.discoveryResults.first?.subscriberCount == 42)
+        #expect(model.discoveryErrorMessage == nil)
+        #expect(model.isSearchingDiscovery == false)
+    }
+
+    @Test("searchDiscovery surfaces a discoveryErrorMessage without touching the blocking alert")
+    func searchDiscoveryFailureSurfacesInlineError() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        let appSettings = Self.scratchAppSettings()
+        appSettings.communitySearchInstance = "lemmy.example"
+        let searchURL = "https://lemmy.example/api/v3/search"
+            + "?q=birding&type_=Communities&listing_type=All&sort=TopAll&limit=20"
+        let fake = FakeTransport([searchURL: (500, "internal error")])
+
+        let model = Self.model(secretStore: secretStore, fake: fake, appSettings: appSettings)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.discoveryQuery = "birding"
+
+        await model.searchDiscovery()
+
+        #expect(model.discoveryResults.isEmpty)
+        #expect(model.discoveryErrorMessage != nil)
+        // A search hiccup is recoverable in-panel (try again), not the alert-worthy failure
+        // `errorMessage`'s `.alert` binds to.
+        #expect(model.errorMessage == nil)
+    }
+
+    @Test("searchDiscovery clears results for a blank query without making a request")
+    func searchDiscoveryBlankQueryClears() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        let fake = FakeTransport()
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.discoveryQuery = "   "
+
+        await model.searchDiscovery()
+
+        #expect(model.discoveryResults.isEmpty)
+        #expect(await fake.requestedURLs.isEmpty)
+    }
+
+    @Test("joinFromDiscovery routes a search result through the same join() path as a typed handle")
+    func joinFromDiscoveryUsesJoinPath() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let fake = FakeTransport([
+            "https://lemmy.ml/c/birding": (200, """
+                {"id":"https://lemmy.ml/c/birding","type":"Group","preferredUsername":"birding",
+                 "name":"Birding","outbox":"https://lemmy.ml/c/birding/outbox"}
+                """),
+            "https://example.com/users/site/outbox":
+                (202, #"{"id":"https://example.com/users/site/outbox/1"}"#),
+        ])
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.discoveryPresented = true
+        model.discoveryQuery = "birding"
+        let result = CommunitySearchResult(
+            actorID: URL(string: "https://lemmy.ml/c/birding")!, name: "birding", title: "Birding",
+            instance: "lemmy.ml", subscriberCount: 10)
+
+        await model.joinFromDiscovery(result)
+
+        #expect(model.joined.count == 1)
+        #expect(model.joined.first?.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(model.errorMessage == nil)
+        // A successful join closes the sheet and resets its search state.
+        #expect(model.discoveryPresented == false)
+        #expect(model.discoveryQuery.isEmpty)
+        #expect(model.discoveryResults.isEmpty)
+    }
+
+    @Test("joinFromDiscovery leaves the sheet open when the join fails")
+    func joinFromDiscoveryKeepsSheetOpenOnFailure() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let fake = FakeTransport(["https://lemmy.ml/c/ghost": (404, "not found")])
+
+        let model = Self.model(secretStore: secretStore, fake: fake)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        model.discoveryPresented = true
+        let result = CommunitySearchResult(
+            actorID: URL(string: "https://lemmy.ml/c/ghost")!, name: "ghost", title: nil,
+            instance: "lemmy.ml", subscriberCount: nil)
+
+        await model.joinFromDiscovery(result)
+
+        #expect(model.joined.isEmpty)
+        #expect(model.errorMessage != nil)
+        #expect(model.discoveryPresented == true)
     }
 }

--- a/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
+++ b/Tests/AnglesiteAppTests/CommunitiesModelTests.swift
@@ -768,6 +768,59 @@ struct CommunitiesModelTests {
         #expect(await fake.requestedURLs.isEmpty)
     }
 
+    /// Before the generation guard, a slow response to an earlier, now-stale query could land
+    /// after a newer one and silently overwrite its results — mirrors
+    /// `selectCommunityDiscardsStaleTimeline`'s proof for `loadTimeline()`'s own guard.
+    @Test("a slower response to an earlier search doesn't overwrite a newer search's results")
+    func searchDiscoveryDiscardsStaleResponse() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        let appSettings = Self.scratchAppSettings()
+        appSettings.communitySearchInstance = "lemmy.example"
+        let firstURL = "https://lemmy.example/api/v3/search"
+            + "?q=first&type_=Communities&listing_type=All&sort=TopAll&limit=20"
+        let secondURL = "https://lemmy.example/api/v3/search"
+            + "?q=second&type_=Communities&listing_type=All&sort=TopAll&limit=20"
+        let fake = FakeTransport([
+            firstURL: (200, """
+                {"communities":[
+                  {"community":{"name":"first","title":"First",
+                    "actor_id":"https://lemmy.example/c/first"}}
+                ]}
+                """),
+            secondURL: (200, """
+                {"communities":[
+                  {"community":{"name":"second","title":"Second",
+                    "actor_id":"https://lemmy.example/c/second"}}
+                ]}
+                """),
+        ])
+        await fake.gate(firstURL)
+
+        let model = Self.model(secretStore: secretStore, fake: fake, appSettings: appSettings)
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        model.discoveryQuery = "first"
+        let firstSearch = Task { await model.searchDiscovery() }
+        await fake.waitUntilRequested(firstURL)
+
+        // Search "second" before "first"'s gated response resolves — bumps the generation.
+        model.discoveryQuery = "second"
+        await model.searchDiscovery()
+
+        #expect(model.discoveryResults.map(\.name) == ["second"])
+        #expect(model.isSearchingDiscovery == false)
+
+        // Release "first"'s gate and let its stale response resume. It should discover its token
+        // is stale and return without touching `discoveryResults`/`isSearchingDiscovery`.
+        await fake.release(firstURL)
+        await firstSearch.value
+
+        #expect(model.discoveryResults.map(\.name) == ["second"])
+        #expect(model.isSearchingDiscovery == false)
+    }
+
     @Test("joinFromDiscovery routes a search result through the same join() path as a typed handle")
     func joinFromDiscoveryUsesJoinPath() async throws {
         let (config, source) = try Self.makeSiteDirectories()

--- a/Tests/AnglesiteCoreTests/CommunitySearchClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunitySearchClientTests.swift
@@ -1,0 +1,192 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("CommunitySearchClient")
+struct CommunitySearchClientTests {
+    /// Answers each requested URL from a fixed table; unmatched URLs 404. Mirrors
+    /// `CommunityActorResolverTests.FakeTransport` — search is a single request, but the same
+    /// per-URL routing keeps the fixture URL visible at the call site instead of hidden behind a
+    /// single-response stub.
+    actor FakeTransport {
+        private var responses: [String: (status: Int, body: String)]
+        private(set) var requestedURLs: [URL] = []
+
+        init(_ responses: [String: (status: Int, body: String)]) {
+            self.responses = responses
+        }
+
+        private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            let url = request.url!
+            requestedURLs.append(url)
+            let (status, body) = responses[url.absoluteString] ?? (404, "not found")
+            let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        nonisolated var transport: CommunitySearchClient.Transport {
+            { request in try await self.respond(to: request) }
+        }
+    }
+
+    private static let searchURL =
+        "https://lemmy.world/api/v3/search?q=birding&type_=Communities&listing_type=All&sort=TopAll&limit=20"
+
+    @Test("parses communities, reading instance from the result's own actor_id host")
+    func parsesResults() async throws {
+        // The instance queried (lemmy.world) differs from where this result actually lives
+        // (lemmy.ml) — Lemmy's federated search can surface communities from other instances than
+        // the one asked, and `instance` should reflect that, not the query target.
+        let fake = FakeTransport([Self.searchURL: (200, """
+            {"communities":[
+              {"community":{"name":"birding","title":"Birding",
+                "actor_id":"https://lemmy.ml/c/birding"},
+               "counts":{"subscribers":1234}}
+            ]}
+            """)])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        let results = try await client.search(query: "birding", instance: "lemmy.world")
+
+        #expect(results.count == 1)
+        #expect(results.first?.actorID.absoluteString == "https://lemmy.ml/c/birding")
+        #expect(results.first?.name == "birding")
+        #expect(results.first?.title == "Birding")
+        #expect(results.first?.instance == "lemmy.ml")
+        #expect(results.first?.subscriberCount == 1234)
+    }
+
+    @Test("builds the search URL with type_=Communities, listing_type=All, and the given query")
+    func buildsExpectedURL() async throws {
+        let fake = FakeTransport([Self.searchURL: (200, #"{"communities":[]}"#)])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        _ = try await client.search(query: "birding", instance: "lemmy.world")
+
+        let requested = await fake.requestedURLs
+        #expect(requested.map(\.absoluteString) == [Self.searchURL])
+    }
+
+    @Test("accepts a pasted https:// instance URL, not just a bare host")
+    func acceptsPastedInstanceURL() async throws {
+        let fake = FakeTransport([Self.searchURL: (200, #"{"communities":[]}"#)])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        _ = try await client.search(query: "birding", instance: "https://lemmy.world/")
+
+        let requested = await fake.requestedURLs
+        #expect(requested.map(\.absoluteString) == [Self.searchURL])
+    }
+
+    @Test("an empty communities field is an empty result, not an error")
+    func emptyResultsList() async throws {
+        let fake = FakeTransport([Self.searchURL: (200, #"{"communities":[]}"#)])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        let results = try await client.search(query: "birding", instance: "lemmy.world")
+
+        #expect(results.isEmpty)
+    }
+
+    @Test("a missing communities field is also an empty result")
+    func missingCommunitiesFieldIsEmpty() async throws {
+        let fake = FakeTransport([Self.searchURL: (200, "{}")])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        let results = try await client.search(query: "birding", instance: "lemmy.world")
+
+        #expect(results.isEmpty)
+    }
+
+    @Test("drops a result whose own actor_id is insecure rather than failing the whole search")
+    func dropsInsecureResult() async throws {
+        let fake = FakeTransport([Self.searchURL: (200, """
+            {"communities":[
+              {"community":{"name":"birding","title":"Birding",
+                "actor_id":"http://lemmy.ml/c/birding"}}
+            ]}
+            """)])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        let results = try await client.search(query: "birding", instance: "lemmy.world")
+
+        #expect(results.isEmpty)
+    }
+
+    @Test("throws emptyQuery for a blank query, without making a request")
+    func rejectsBlankQuery() async throws {
+        let fake = FakeTransport([:])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        await #expect(throws: CommunitySearchError.emptyQuery) {
+            _ = try await client.search(query: "   ", instance: "lemmy.world")
+        }
+        #expect(await fake.requestedURLs.isEmpty)
+    }
+
+    @Test("throws invalidInstance for a blank instance")
+    func rejectsBlankInstance() async throws {
+        let fake = FakeTransport([:])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        await #expect(throws: CommunitySearchError.invalidInstance) {
+            _ = try await client.search(query: "birding", instance: "  ")
+        }
+    }
+
+    @Test("surfaces a non-2xx status as requestFailed")
+    func surfacesErrorStatus() async throws {
+        let fake = FakeTransport([Self.searchURL: (500, "internal error")])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        await #expect(throws: CommunitySearchError.requestFailed(status: 500, body: "internal error")) {
+            _ = try await client.search(query: "birding", instance: "lemmy.world")
+        }
+    }
+
+    @Test("rejects a redirect to an insecure URL")
+    func rejectsInsecureRedirect() async throws {
+        actor RedirectingTransport {
+            private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
+                let insecureURL = URL(string: "http://lemmy.world/api/v3/search")!
+                let http = HTTPURLResponse(url: insecureURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (Data(#"{"communities":[]}"#.utf8), http)
+            }
+            nonisolated var transport: CommunitySearchClient.Transport {
+                { request in try await self.respond(to: request) }
+            }
+        }
+        let client = CommunitySearchClient(transport: RedirectingTransport().transport)
+
+        await #expect(throws: CommunitySearchError.insecureURL) {
+            _ = try await client.search(query: "birding", instance: "lemmy.world")
+        }
+    }
+
+    /// Defense-in-depth: `defaultTransport` is already capped via `CappedHTTPTransport`, but a
+    /// caller-injected `Transport` (like this test's `FakeTransport`) might not be — mirrors
+    /// `CommunityActorResolverTests.rejectsOversizedActorDocument`, including the same
+    /// keep-it-valid-JSON padding technique so the failure is provably the size guard, not a
+    /// decoding failure that would happen regardless.
+    @Test("rejects an oversized search response")
+    func rejectsOversizedResponse() async throws {
+        let maxBytes = CommunitySearchClient.maximumResponseBytes
+        let prefix = #"{"communities":[],"padding":""#
+        let suffix = "\"}"
+        let paddingLength = maxBytes - prefix.utf8.count - suffix.utf8.count + 1
+        let oversizedBody = prefix + String(repeating: "x", count: paddingLength) + suffix
+        let byteCount = Data(oversizedBody.utf8).count
+        #expect(byteCount > maxBytes)
+
+        let fake = FakeTransport([Self.searchURL: (200, oversizedBody)])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        await #expect(throws: CommunitySearchError.requestFailed(
+            status: 0, body: "response too large (\(byteCount) bytes)")) {
+            _ = try await client.search(query: "birding", instance: "lemmy.world")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/CommunitySearchClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunitySearchClientTests.swift
@@ -81,6 +81,32 @@ struct CommunitySearchClientTests {
         #expect(requested.map(\.absoluteString) == [Self.searchURL])
     }
 
+    @Test("accepts a bare host:port instance, a self-hosted-instance shape")
+    func acceptsBareHostPortInstance() async throws {
+        let expectedURL = "https://lemmy.example:8080/api/v3/search"
+            + "?q=birding&type_=Communities&listing_type=All&sort=TopAll&limit=20"
+        let fake = FakeTransport([expectedURL: (200, #"{"communities":[]}"#)])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        _ = try await client.search(query: "birding", instance: "lemmy.example:8080")
+
+        let requested = await fake.requestedURLs
+        #expect(requested.map(\.absoluteString) == [expectedURL])
+    }
+
+    @Test("carries the port through from a pasted https:// URL with a non-standard port")
+    func carriesPortFromPastedInstanceURL() async throws {
+        let expectedURL = "https://lemmy.example:8080/api/v3/search"
+            + "?q=birding&type_=Communities&listing_type=All&sort=TopAll&limit=20"
+        let fake = FakeTransport([expectedURL: (200, #"{"communities":[]}"#)])
+        let client = CommunitySearchClient(transport: fake.transport)
+
+        _ = try await client.search(query: "birding", instance: "https://lemmy.example:8080/")
+
+        let requested = await fake.requestedURLs
+        #expect(requested.map(\.absoluteString) == [expectedURL])
+    }
+
     @Test("an empty communities field is an empty result, not an error")
     func emptyResultsList() async throws {
         let fake = FakeTransport([Self.searchURL: (200, #"{"communities":[]}"#)])


### PR DESCRIPTION
## Summary

- Adds a keyword-search step (`CommunitySearchClient`) to the Communities join flow (V-5.4, Stage 1, #371): queries a user-chosen instance's own `GET /api/v3/search` (Lemmy's documented, unauthenticated public API) and returns community results ready to join.
- New "Find a community" sheet in `CommunitiesView` — search field, configurable source instance (`@AppStorage`, defaults to `lemmy.world`), results list, one-tap Join that routes through the same `CommunityActorResolver`/`CommunityMembershipClient.follow(target:)` path #368 already ships.
- Source-selection research (Lemmy `/api/v3/search` vs. lemmyverse.net's aggregate dump vs. third-party fediverse search services) is recorded in [issue #371's comment](https://github.com/Anglesite/Anglesite/issues/371#issuecomment-5133589932) per the issue's own plan step 1, verified live against `lemmy.world`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passes (2933+21+9+265 tests), including new `CommunitySearchClientTests` (11 tests) and new `CommunitiesModelTests` discovery cases (5 tests).
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — builds clean.
- [ ] Manual smoke: not run in this headless session — the sheet's layout/focus behavior should be eyeballed once in the app before merge.