### PR TITLE
fix(#1101): route website audit build through the container

### DIFF
--- a/Sources/AnglesiteApp/AuditModel.swift
+++ b/Sources/AnglesiteApp/AuditModel.swift
@@ -35,8 +35,11 @@ final class AuditModel {
     private let command: AuditCommand
     private var inFlight: Task<Void, Never>?
 
-    init(command: AuditCommand = AuditCommand()) {
-        self.command = command
+    init(
+        command: AuditCommand? = nil,
+        containerControlProvider: @escaping AuditCommand.ContainerControlProvider = { nil }
+    ) {
+        self.command = command ?? AuditCommand(containerControlProvider: containerControlProvider)
     }
 
     var isRunning: Bool {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -83,7 +83,9 @@ final class SiteWindowModel {
     private(set) var invisiblePublishState: InvisiblePublishQueue.State = .idle
     var publish = PublishModel()
     var backup = BackupModel()
-    var audit = AuditModel()
+    /// Built in `init` (not a property default) — its `containerControlProvider` closure captures
+    /// `preview`, which doesn't exist until `init`'s body runs.
+    var audit: AuditModel
     /// Drives this site's iCloud git sync (#881): status surface, `NSMetadataQuery` bundle-change
     /// observation, and the conflict banner/resolution sheet. No-ops entirely for a package that
     /// doesn't live in iCloud Drive — see `SyncModel.start(package:)`.
@@ -228,13 +230,14 @@ final class SiteWindowModel {
         self.semanticRanker = semanticRanker
         self.conventionsEngine = conventionsEngine
         self.contentIndexerStore = contentIndexerStore
-        self.preview = PreviewModel(
+        let previewModel = PreviewModel(
             contentGraph: contentGraph,
             knowledgeIndex: knowledgeIndex,
             semanticRanker: semanticRanker,
             conventionsEngine: conventionsEngine,
             runtimeFactory: runtimeFactory
         )
+        self.preview = previewModel
         self.contentCreation = ContentCreationWorkflow.native(
             contentGraph: contentGraph,
             knowledgeIndex: knowledgeIndex,
@@ -244,6 +247,9 @@ final class SiteWindowModel {
         self.relatedPages = RelatedPagesModel(index: knowledgeIndex, ranker: semanticRanker)
         self.search = SiteSearchModel(index: knowledgeIndex)
         self.cleanup = ProjectCleanupModel(knowledgeIndex: knowledgeIndex, contentGraph: contentGraph)
+        self.audit = AuditModel(
+            containerControlProvider: { [previewModel] in await previewModel.activeContainerControl() }
+        )
         // Wired once here (not per-site in loadAndStart): the hooks capture nothing from self
         // and receive the run's site id from the model, so there is nothing to rebind on
         // window replay — see CompletionNotificationHub's own doc comment.

--- a/Sources/AnglesiteCore/A11yAuditRunner.swift
+++ b/Sources/AnglesiteCore/A11yAuditRunner.swift
@@ -17,7 +17,15 @@ import Foundation
 public struct A11yAuditRunner: AuditRunner {
     public let category: AuditReport.Finding.Category = .accessibility
 
-    public init() {}
+    /// Reached lazily, at the moment the script actually runs — mirrors
+    /// `AuditCommand.ContainerControlProvider` / `AstroHTMLValidator.ContainerControlProvider`.
+    public typealias ContainerControlProvider = @Sendable () async -> (siteID: String, control: any LocalContainerControl)?
+
+    private let containerControlProvider: ContainerControlProvider
+
+    public init(containerControlProvider: @escaping ContainerControlProvider = { nil }) {
+        self.containerControlProvider = containerControlProvider
+    }
 
     public func run(
         siteDirectory: URL,
@@ -25,6 +33,37 @@ public struct A11yAuditRunner: AuditRunner {
         logCenter: LogCenter,
         source: String
     ) async throws -> [AuditReport.Finding] {
+        let stdout = try await runScript(siteDirectory: siteDirectory, supervisor: supervisor)
+
+        // The stdout may contain the markdown report (always written) plus the JSON object.
+        // Find the JSON object by scanning for the first `{` and parsing from there.
+        guard let jsonStart = stdout.firstIndex(of: "{") else {
+            throw Error.noJSONInOutput
+        }
+        let jsonString = String(stdout[jsonStart...])
+        return try Self.parse(json: Data(jsonString.utf8))
+    }
+
+    /// Runs `a11y-audit.ts --json` in the site's running container when one is available — the
+    /// script needs the guest's Node/tsx toolchain, which no longer exists on the host after Node's
+    /// retirement (#70) — falling back to the host `ProcessSupervisor` path otherwise (tests, and
+    /// any caller that hasn't wired a container).
+    private func runScript(siteDirectory: URL, supervisor: ProcessSupervisor) async throws -> String {
+        if let (containerSiteID, control) = await containerControlProvider() {
+            let result = try await control.exec(
+                siteID: containerSiteID,
+                argv: ["npx", "tsx", "scripts/a11y-audit.ts", "--json"],
+                environment: [:],
+                workingDirectory: "/workspace/site",
+                onOutput: { _, _ in }
+            )
+            // Exit code is severity-aware — see the host-path comment below for the full contract.
+            guard [0, 1, 2].contains(result.exitCode) else {
+                throw Error.scriptFailed(exitCode: result.exitCode, stderr: result.stderr)
+            }
+            return result.stdout
+        }
+
         let scriptPath = siteDirectory.appendingPathComponent("scripts/a11y-audit.ts").path
         // Routed through the supervisor so the spawn goes through the one supervised path
         // (under MAS sandbox, inherits the app-held per-site folder grant).
@@ -45,14 +84,7 @@ public struct A11yAuditRunner: AuditRunner {
         guard [0, 1, 2].contains(result.exitCode) else {
             throw Error.scriptFailed(exitCode: result.exitCode, stderr: result.stderr)
         }
-
-        // The stdout may contain the markdown report (always written) plus the JSON object.
-        // Find the JSON object by scanning for the first `{` and parsing from there.
-        guard let jsonStart = result.stdout.firstIndex(of: "{") else {
-            throw Error.noJSONInOutput
-        }
-        let jsonString = String(result.stdout[jsonStart...])
-        return try Self.parse(json: Data(jsonString.utf8))
+        return result.stdout
     }
 
     public enum Error: Swift.Error, Equatable {

--- a/Sources/AnglesiteCore/AuditCommand.swift
+++ b/Sources/AnglesiteCore/AuditCommand.swift
@@ -52,21 +52,29 @@ public actor AuditCommand {
 
     public typealias CommandResolver = @Sendable (_ siteDirectory: URL) -> LaunchPlan
 
+    /// Reached lazily, at the moment the build step actually runs — mirrors
+    /// `DeployModel`/`AstroHTMLValidator`'s `ContainerControlProvider` (#823), since the container
+    /// may not have finished booting yet when `AuditCommand` is constructed.
+    public typealias ContainerControlProvider = @Sendable () async -> (siteID: String, control: any LocalContainerControl)?
+
     private let supervisor: ProcessSupervisor
     private let logCenter: LogCenter
     private let resolveBuildCommand: CommandResolver
+    private let containerControlProvider: ContainerControlProvider
     private let runners: [any AuditRunner]
 
     public init(
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
         resolveBuildCommand: @escaping CommandResolver = AuditCommand.resolveBuildCommand,
-        runners: [any AuditRunner] = AuditCommand.defaultRunners
+        containerControlProvider: @escaping ContainerControlProvider = { nil },
+        runners: [any AuditRunner]? = nil
     ) {
         self.supervisor = supervisor
         self.logCenter = logCenter
         self.resolveBuildCommand = resolveBuildCommand
-        self.runners = runners
+        self.containerControlProvider = containerControlProvider
+        self.runners = runners ?? AuditCommand.defaultRunners(containerControlProvider: containerControlProvider)
     }
 
     /// Run the audit pipeline against `siteDirectory`. Reaches `.succeeded` even when
@@ -124,6 +132,13 @@ public actor AuditCommand {
     private enum BuildOutcome { case success; case failure(Result) }
 
     private func runBuild(siteID: String, siteDirectory: URL) async -> BuildOutcome {
+        let source = "audit:\(siteID):build"
+        if let (containerSiteID, control) = await containerControlProvider() {
+            return await runContainerBuild(
+                containerSiteID: containerSiteID, control: control, siteDirectory: siteDirectory, source: source
+            )
+        }
+
         let plan = resolveBuildCommand(siteDirectory)
         let executable: URL
         let arguments: [String]
@@ -135,7 +150,6 @@ public actor AuditCommand {
             arguments = args
         }
 
-        let source = "audit:\(siteID):build"
         let handle: ProcessSupervisor.Handle
         do {
             handle = try await supervisor.launch(
@@ -173,19 +187,46 @@ public actor AuditCommand {
         }
     }
 
+    /// Runs `npm run build` inside the site's running container via `ContainerDeployExecutor` —
+    /// the same `.build` step the deploy path uses (`DeployExecutor.swift`) — instead of the host
+    /// process path, which is permanently unavailable after host Node's retirement (#70).
+    private func runContainerBuild(
+        containerSiteID: String,
+        control: any LocalContainerControl,
+        siteDirectory: URL,
+        source: String
+    ) async -> BuildOutcome {
+        let executor = ContainerDeployExecutor(control: control, siteID: containerSiteID, logCenter: logCenter)
+        let result = await executor.run(step: .build, siteDirectory: siteDirectory, environment: [:], source: source)
+        let tail = await logCenter.snapshot().filter { $0.source == source }
+        switch result.exitCode {
+        case 0:
+            return .success
+        case nil:
+            let reason = result.output.isEmpty ? "build was terminated" : result.output
+            return .failure(.failed(reason: reason, exitCode: nil, logTail: tail))
+        case let code?:
+            return .failure(.failed(reason: "build failed", exitCode: code, logTail: tail))
+        }
+    }
+
     // MARK: - Default seams
 
-    /// Host Node is retired (#70). Audits must run through the container runtime once validation
-    /// lands; until then the command fails explicitly instead of spawning embedded Node.
+    /// Host Node is retired (#70). Falls back to this only when `containerControlProvider` resolves
+    /// nil (no running container) — the production path runs the build inside the container instead
+    /// (see `runContainerBuild`).
     public static let resolveBuildCommand: CommandResolver = { siteDirectory in
         .unavailable(reason: HostNodeRetirement.reason("audit build"))
     }
 
     /// Default runner set: `A11yAuditRunner` plus `SecurityTxtAuditRunner` (#843). SEO / perf /
     /// link-check runners are mechanical follow-ups that slot into this list without changing
-    /// the actor or sheet UI (#86 follow-ups).
-    public static let defaultRunners: [any AuditRunner] = [
-        A11yAuditRunner(),
-        SecurityTxtAuditRunner()
-    ]
+    /// the actor or sheet UI (#86 follow-ups). `A11yAuditRunner` needs the same container access as
+    /// the build step — its script also requires the guest's Node/tsx toolchain.
+    public static func defaultRunners(containerControlProvider: @escaping ContainerControlProvider) -> [any AuditRunner] {
+        [
+            A11yAuditRunner(containerControlProvider: containerControlProvider),
+            SecurityTxtAuditRunner()
+        ]
+    }
 }

--- a/Tests/AnglesiteCoreTests/A11yAuditRunnerTests.swift
+++ b/Tests/AnglesiteCoreTests/A11yAuditRunnerTests.swift
@@ -62,4 +62,47 @@ struct A11yAuditRunnerTests {
         #expect(findings.count == 1)
         #expect(findings[0].remediation == nil)
     }
+
+    // MARK: - Container routing (#1101)
+
+    @Test("When a container is available, the script runs inside it via npx tsx")
+    func runsInContainerWhenAvailable() async throws {
+        let raw = #"{"issues": [{"page": "/", "rule": "alt-text", "severity": "error", "message": "Missing alt"}]}"#
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: raw, stderr: "")
+        )
+        let runner = A11yAuditRunner(containerControlProvider: { (siteID: "site-abc", control: fake) })
+        let findings = try await runner.run(
+            siteDirectory: URL(fileURLWithPath: "/host/irrelevant"),
+            supervisor: ProcessSupervisor(),
+            logCenter: LogCenter(),
+            source: "audit:site-abc:accessibility"
+        )
+        #expect(findings.count == 1)
+        #expect(findings[0].title == "alt-text")
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].siteID == "site-abc")
+        #expect(calls[0].argv == ["npx", "tsx", "scripts/a11y-audit.ts", "--json"])
+        #expect(calls[0].cwd == "/workspace/site")
+    }
+
+    @Test("A non-severity exit code from the container run is a runner failure")
+    func containerNonSeverityExitCodeThrows() async {
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 3, stdout: "", stderr: "tsx crashed")
+        )
+        let runner = A11yAuditRunner(containerControlProvider: { (siteID: "site-abc", control: fake) })
+        await #expect(throws: A11yAuditRunner.Error.self) {
+            try await runner.run(
+                siteDirectory: URL(fileURLWithPath: "/host/irrelevant"),
+                supervisor: ProcessSupervisor(),
+                logCenter: LogCenter(),
+                source: "audit:site-abc:accessibility"
+            )
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/AuditCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/AuditCommandTests.swift
@@ -213,6 +213,57 @@ struct AuditCommandTests {
         #expect(report.findings == [a, s, p])
         #expect(report.runnersExecuted == [.accessibility, .seo, .performance])
     }
+
+    // MARK: Container-routed build (#1101)
+
+    /// Before #1101, `AuditCommand` always used `resolveBuildCommand` (permanently `.unavailable`
+    /// after host Node's retirement) even when a container was running — the audit could never
+    /// succeed. This proves the build step now runs inside an available container instead.
+    @Test("Build runs inside the container when a containerControlProvider resolves one")
+    func buildRunsInContainerWhenAvailable() async {
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 0, stdout: "built", stderr: "")
+        )
+        let cmd = AuditCommand(
+            // A resolver that would fail the audit if it were ever consulted — proves the
+            // container path is taken instead of falling through to the host resolver.
+            resolveBuildCommand: { _ in .unavailable(reason: "should not be consulted") },
+            containerControlProvider: { (siteID: "site-abc", control: fake) },
+            runners: [FakeAuditRunner(category: .accessibility, result: .success([]))]
+        )
+        let result = await cmd.audit(siteID: "site-abc", siteDirectory: tmpDir)
+        guard case .succeeded = result else {
+            Issue.record("expected .succeeded, got \(result)")
+            return
+        }
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].argv == ["npm", "run", "build"])
+        #expect(calls[0].siteID == "site-abc")
+    }
+
+    @Test("A non-zero container build exit fails the audit with logTail from the guest output")
+    func containerBuildFailureCarriesLogTail() async {
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 1, stdout: "build broke", stderr: ""),
+            execStdoutLines: ["build broke"]
+        )
+        let cmd = AuditCommand(
+            resolveBuildCommand: { _ in .unavailable(reason: "should not be consulted") },
+            containerControlProvider: { (siteID: "site-abc", control: fake) },
+            runners: [FakeAuditRunner(category: .accessibility, result: .success([]))]
+        )
+        let result = await cmd.audit(siteID: "site-abc", siteDirectory: tmpDir)
+        guard case .failed(let reason, let exit, let tail) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        #expect(reason.lowercased().contains("build"))
+        #expect(exit == 1)
+        #expect(tail.contains { $0.text == "build broke" })
+    }
 }
 
 // MARK: - Fake runner


### PR DESCRIPTION
## Summary

- `AuditCommand`'s build step always returned `.unavailable` ("host Node has been retired"), so Website Audit could never run — a leftover stub from host Node's retirement (#70) that was never wired to the container runtime, matching the bug report (audit "thinks node has been retired").
- Wires `AuditCommand`'s build step to `ContainerDeployExecutor` when a `containerControlProvider` resolves a running container, mirroring `DeployModel` and #961/#1105's identical fix for `AstroHTMLValidator`. Falls back to the existing explicit-failure resolver when no container is running.
- `A11yAuditRunner`'s script also needs the guest's Node/tsx toolchain, so it now execs through the container too when one is available, falling back to the host `ProcessSupervisor` path otherwise (tests, or any caller without a container).
- `SiteWindowModel` now wires `AuditModel`'s `containerControlProvider` to `preview.activeContainerControl()`, same as `deploy`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (full suite passes except 2 pre-existing, unrelated `FoundationModelAssistant` on-device streaming failures)
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [x] Added container-routing tests: `AuditCommandTests` (build execs `npm run build` in the container, failure carries logTail) and `A11yAuditRunnerTests` (script execs in the container, non-severity exit code fails the runner)

Closes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)