### PR TITLE
fix(#1100): show a read-only inspector for plain pages

### DIFF
--- a/Sources/AnglesiteApp/GenericPageInspectorModel.swift
+++ b/Sources/AnglesiteApp/GenericPageInspectorModel.swift
@@ -1,0 +1,39 @@
+// Sources/AnglesiteApp/GenericPageInspectorModel.swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Read-only inspector fallback for a selected page/entry that isn't a registered content type
+/// (`ContentTypeResolver`) or a plain frontmatter page (`.md`/`.mdx`/`.markdown`) — most commonly
+/// a hand-authored `.astro` page. There's no safe generic way to parse and rewrite an Astro
+/// component's script frontmatter (it's JS, not YAML), so this path never edits; it exists so
+/// `View ▸ Inspector ▸ Show Inspector` (#1100) is available for every routed page instead of only
+/// the two typed/markdown cases, showing the same identity info Finder or the navigator already
+/// shows rather than leaving the panel permanently disabled.
+@MainActor
+@Observable
+final class GenericPageInspectorModel: InspectorEditorModel {
+    let file: FileRef
+    let route: String
+
+    let isDirty = false
+    let isSaving = false
+    let loadError: String? = nil
+    let isLoading = false
+    var conflictDiskContents: String? {
+        get { nil }
+        set { }
+    }
+
+    init(file: FileRef, route: String) {
+        self.file = file
+        self.route = route
+    }
+
+    func load() async {}
+    @discardableResult func save() async -> Bool { true }
+    func flushBeforeLeaving() async -> Bool { true }
+    func checkExternalChange() async {}
+    func keepMyChanges() {}
+    func reloadFromDisk() async {}
+}

--- a/Sources/AnglesiteApp/InspectorContext.swift
+++ b/Sources/AnglesiteApp/InspectorContext.swift
@@ -27,11 +27,15 @@ protocol InspectorEditorModel: AnyObject {
 enum InspectorContext: Identifiable {
     case typed(TypedEntryEditorModel)
     case page(PageMetadataModel)
+    /// A routed page/entry with no typed descriptor or frontmatter form — e.g. a plain `.astro`
+    /// page. Read-only identity only; see `GenericPageInspectorModel` (#1100).
+    case generic(GenericPageInspectorModel)
 
     var model: any InspectorEditorModel {
         switch self {
         case .typed(let m): m
         case .page(let m): m
+        case .generic(let m): m
         }
     }
     var id: String { model.file.id }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -2800,6 +2800,9 @@
     "This page already links to all related content." : {
 
     },
+    "This page has no editable metadata yet." : {
+
+    },
     "This page has no inbound links from other pages." : {
 
     },

--- a/Sources/AnglesiteApp/PageInspectorView.swift
+++ b/Sources/AnglesiteApp/PageInspectorView.swift
@@ -16,7 +16,27 @@ struct PageInspectorView: View {
             InspectorChrome(model: model) { TypedEntryForm(model: model) }
         case .page(let model):
             InspectorChrome(model: model) { PageMetadataForm(model: model) }
+        case .generic(let model):
+            InspectorChrome(model: model) { GenericPageInfoForm(model: model) }
         }
+    }
+}
+
+/// Read-only identity for a page with no editable metadata (e.g. a plain `.astro` page) — see
+/// `GenericPageInspectorModel` (#1100).
+private struct GenericPageInfoForm: View {
+    let model: GenericPageInspectorModel
+
+    var body: some View {
+        Form {
+            LabeledContent("Route", value: model.route)
+            Section {
+                Text("This page has no editable metadata yet.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
     }
 }
 

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1040,10 +1040,11 @@ final class SiteWindowModel {
         let relPath: String
         let group: FileGroup
         let displayName: String
+        let route: String
         if let page = await contentGraph.page(id: id) {
-            relPath = page.filePath; group = .pages; displayName = page.title ?? page.route
+            relPath = page.filePath; group = .pages; displayName = page.title ?? page.route; route = page.route
         } else if let post = await contentGraph.post(id: id) {
-            relPath = post.filePath; group = .posts; displayName = post.title
+            relPath = post.filePath; group = .posts; displayName = post.title; route = postRoute(for: post)
         } else {
             return nil
         }
@@ -1055,7 +1056,9 @@ final class SiteWindowModel {
         if isFrontmatterPage(relPath) {
             return .page(PageMetadataModel(file: file, sourceDirectory: source))
         }
-        return nil   // plain .astro / other → preview only
+        // Plain .astro / other: no safe generic way to parse or rewrite its frontmatter (JS, not
+        // YAML), so the panel stays read-only rather than staying unavailable (#1100).
+        return .generic(GenericPageInspectorModel(file: file, route: route))
     }
 
     private func isFrontmatterPage(_ relPath: String) -> Bool {

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -573,6 +573,45 @@ extension SiteWindowModelTests {
         #expect(model.inspectorContext == nil)
         #expect(model.preview.activeRoute == "/notes/")
     }
+
+    @Test("applyNavigatorSelection populates a read-only inspector for a plain .astro page (#1100)")
+    func applyNavigatorSelectionPlainAstroPageGetsGenericInspector() async throws {
+        let (root, packageURL, package) = try makeSitePackage()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Most of a real site's pages are plain .astro (only the "about" singleton and content
+        // collection entries get a typed/markdown editor) — Home is the common case that made the
+        // View ▸ Inspector ▸ Show Inspector command look permanently disabled (#1100).
+        let graph = SiteContentGraph()
+        await graph.load(
+            siteID: "site-a",
+            pages: [SiteContentGraph.Page(
+                id: "site-a:page:/", siteID: "site-a", route: "/",
+                filePath: "src/pages/index.astro", title: "Home", lastModified: Date()
+            )],
+            posts: [], images: []
+        )
+        let model = makeModel(contentGraph: graph)
+        model.site = SiteStore.Site(
+            id: "site-a", name: "Test", packageURL: packageURL,
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
+        )
+        let navModel = SiteNavigatorModel(graph: graph)
+        navModel.start(site: CurrentSite(id: "site-a", packageURL: packageURL, sourceDirectory: package.sourceURL), websiteTitle: "Test")
+        while navModel.nodes.isEmpty { await Task.yield() }
+        model.navigator = navModel
+
+        model.applyNavigatorSelection("site-a:page:/")
+
+        while model.inspectorContext == nil { await Task.yield() }
+        guard case .generic(let generic) = model.inspectorContext else {
+            Issue.record("expected a .generic read-only inspector context for a plain .astro page")
+            return
+        }
+        #expect(generic.route == "/")
+        #expect(generic.file.url == package.sourceURL.appendingPathComponent("src/pages/index.astro"))
+        #expect(generic.isDirty == false)
+    }
 }
 
 extension SiteWindowModelTests {

--- a/docs/superpowers/specs/2026-07-13-website-design-window-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-13-website-design-window-cleanup-design.md
@@ -160,8 +160,9 @@ it tracks weights and the three scales, in monochrome + hierarchical renditions.
   above the existing chrome. Selected tab persists per window via
   `@SceneStorage("siteInspector.tab")`.
 - **Metadata tab** — exactly today's content: `InspectorChrome` wrapping
-  `TypedEntryForm` or `PageMetadataForm`, including dirty/Save, off-main load, and
-  the external-change conflict alert.
+  `TypedEntryForm`, `PageMetadataForm`, or (since #1100) the read-only
+  `GenericPageInfoForm` fallback for a routed page with neither, including
+  dirty/Save, off-main load, and the external-change conflict alert.
 - **Style tab (v1)** — a "styles for the current selection" surface: hosts the
   Component Editor's styles panel when an element selection exists, otherwise a
   `ContentUnavailableView` ("Select something on the page"). Write operations


### PR DESCRIPTION
## Summary

- `View ▸ Inspector ▸ Show Inspector` was permanently disabled for any plain `.astro` page — including Home, which the navigator pins first — because `makeInspectorContext()` only produced a context for a registered content type (`ContentTypeResolver`) or a frontmatter (`.md`/`.mdx`/`.markdown`) page, returning `nil` otherwise.
- Add a read-only `GenericPageInspectorModel` fallback (route + a "no editable metadata yet" note) instead of an editable one — there's no safe generic way to parse or rewrite an Astro component's script frontmatter (it's JS, not YAML), so editing stays out of scope, but the panel now always has something to show for a routed selection.
- Add a regression test (`applyNavigatorSelectionPlainAstroPageGetsGenericInspector`) covering the actual repro: selecting a plain `.astro` page now yields `.generic` instead of `nil`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: N/A

## Test plan

- [x] `swift test --package-path .` (261 AnglesiteApp/Core/Bridge tests pass; the only full-suite failures are two known-flaky `FoundationModelAssistant` on-device tests and one debounce timing test, all pre-existing and unrelated — confirmed by re-running them in isolation, where they pass)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [x] Manual smoke: built and launched the app; confirmed via code trace + the new test that selecting a plain `.astro` page (e.g. Home) now populates `inspectorContext`, which drives `View ▸ Inspector ▸ Show Inspector`'s enabled state and the toolbar Inspector toggle identically.

Closes #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)