### PR TITLE
feat(activitypub): snapshot announced community posts (#908)

### DIFF
--- a/Resources/Template/src/components/CommunityTimeline.astro
+++ b/Resources/Template/src/components/CommunityTimeline.astro
@@ -1,0 +1,109 @@
+---
+// CommunityTimeline.astro — renders a hosted community's announced-post snapshots
+// (member posts the group fanned out to its membership, per FEP-1b12). This is the render
+// half of V-5.2b (#908) — static, updated on rebuild. The snapshots are JSON files in
+// `data/community-posts/` (root-level, per AnnouncedPost.gitPath).
+//
+// This component ships now so the render pipeline round-trips end to end; the actual timeline
+// *page* that mounts it is #907's group-preset scope ("Timeline page ships in the 5.1b group
+// preset").
+//
+// Sanitisation contract (AnnouncedPost.swift): post `content` is rendered as text via Astro's
+// default escaping — never `set:html`.
+import { parseCommunityPosts, timeline, type AnnouncedPost } from "../lib/communityPosts.ts";
+
+const mods = import.meta.glob("../../data/community-posts/*.json", { eager: true });
+const posts = timeline(parseCommunityPosts(mods as Record<string, unknown>));
+
+function initial(post: AnnouncedPost): string {
+  const name = post.author?.name ?? new URL(post.sourceURL).hostname;
+  return name.trim().charAt(0).toUpperCase() || "?";
+}
+// Pin locale + UTC so static output is deterministic (same convention as the layouts).
+function human(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" });
+}
+---
+
+{
+  posts.length > 0 && (
+    <ol class="community-timeline">
+      {posts.map((post) => (
+        <li class="h-entry community-post" data-object-type={post.objectType}>
+          {post.author?.photo ? (
+            <img
+              class="avatar u-photo"
+              src={post.author.photo}
+              alt=""
+              loading="lazy"
+              referrerpolicy="no-referrer"
+            />
+          ) : (
+            <span class="avatar avatar-fallback">{initial(post)}</span>
+          )}
+          <div class="post-body">
+            <p class="post-meta">
+              {post.author?.url ? (
+                <a class="p-author h-card" href={post.author.url} rel="nofollow ugc">
+                  {post.author?.name ?? new URL(post.author.url).hostname}
+                </a>
+              ) : (
+                <span class="p-author h-card">{post.author?.name ?? new URL(post.sourceURL).hostname}</span>
+              )}
+              <a class="u-url" href={post.sourceURL} rel="nofollow ugc">
+                <time class="dt-published" datetime={post.published}>
+                  {human(post.published)}
+                </time>
+              </a>
+            </p>
+            {post.content && <p class="e-content">{post.content}</p>}
+          </div>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+<style>
+  .community-timeline {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  .community-post {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+  }
+  .avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    object-fit: cover;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .avatar-fallback {
+    background: var(--color-surface, #f8fafc);
+    color: var(--color-text-muted, #64748b);
+    font-family: var(--font-heading, system-ui);
+    font-size: 1rem;
+  }
+  .post-body {
+    min-width: 0;
+  }
+  .post-meta {
+    margin: 0 0 0.25rem;
+    font-size: 0.9rem;
+  }
+  .post-meta .u-url {
+    color: var(--color-text-muted, #64748b);
+    margin-left: 0.5rem;
+  }
+  .e-content {
+    margin: 0;
+    overflow-wrap: break-word;
+  }
+</style>

--- a/Resources/Template/src/lib/communityPosts.test.ts
+++ b/Resources/Template/src/lib/communityPosts.test.ts
@@ -1,0 +1,122 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseCommunityPosts, timeline, type AnnouncedPost } from "./communityPosts.ts";
+
+function raw(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "community-abc123",
+    objectType: "note",
+    sourceURL: "https://member.example/posts/42",
+    author: { name: "Jane Doe", url: "https://member.example", photo: "https://member.example/photo.jpg" },
+    content: "Hello, community!",
+    published: "2026-06-28T14:30:00Z",
+    announcedAt: "2026-06-28T14:30:05Z",
+    ...overrides,
+  };
+}
+
+/** Build a glob-shaped module map (JSON eager glob wraps each file in `{ default }`). */
+function mods(...files: Record<string, unknown>[]): Record<string, unknown> {
+  return Object.fromEntries(files.map((f, i) => [`../../data/community-posts/f${i}.json`, { default: f }]));
+}
+
+test("parses a valid announced post from a glob module map", () => {
+  const all = parseCommunityPosts(mods(raw()));
+  assert.equal(all.length, 1);
+  assert.equal(all[0].id, "community-abc123");
+  assert.equal(all[0].author?.name, "Jane Doe");
+});
+
+test("accepts a bare (non-default-wrapped) module value", () => {
+  const all = parseCommunityPosts({ "../../data/community-posts/x.json": raw() });
+  assert.equal(all.length, 1);
+});
+
+test("skips malformed files with a warning instead of throwing", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+  try {
+    const all = parseCommunityPosts(
+      mods(
+        raw(),
+        raw({ id: "../evil" }), // fails the [A-Za-z0-9_-]+ id rule
+        raw({ sourceURL: undefined }), // missing required field
+        raw({ objectType: "poke" }), // unknown enum value
+      ),
+    );
+    assert.equal(all.length, 1);
+    assert.equal(warnings.length, 3);
+    assert.match(warnings[0], /communityPosts/);
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+test("every AS2 object type parses", () => {
+  const all = parseCommunityPosts(
+    mods(
+      raw({ id: "a", objectType: "note" }),
+      raw({ id: "b", objectType: "article" }),
+      raw({ id: "c", objectType: "page" }),
+      raw({ id: "d", objectType: "video" }),
+      raw({ id: "e", objectType: "event" }),
+    ),
+  );
+  assert.equal(all.length, 5);
+});
+
+test("rejects non-http(s) URL schemes on sourceURL/author fields", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+  try {
+    const all = parseCommunityPosts(
+      mods(
+        raw({ id: "a", sourceURL: "javascript:alert(document.cookie)" }),
+        raw({ id: "b", author: { name: "Evil", url: "javascript:alert(1)" } }),
+        raw({ id: "c", author: { name: "Evil", photo: "javascript:alert(1)" } }),
+      ),
+    );
+    assert.equal(all.length, 0);
+    assert.equal(warnings.length, 3);
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+test("author and content are optional", () => {
+  const all = parseCommunityPosts(mods(raw({ author: undefined, content: undefined })));
+  assert.equal(all.length, 1);
+  assert.equal(all[0].author, undefined);
+  assert.equal(all[0].content, undefined);
+});
+
+test("timeline sorts newest announcedAt first", () => {
+  const all = parseCommunityPosts(
+    mods(
+      raw({ id: "earlier", announcedAt: "2026-07-01T00:00:00Z" }),
+      raw({ id: "later", announcedAt: "2026-07-02T00:00:00Z" }),
+      raw({ id: "middle", announcedAt: "2026-07-01T12:00:00Z" }),
+    ),
+  );
+  const sorted = timeline(all);
+  assert.deepEqual(
+    sorted.map((p: AnnouncedPost) => p.id),
+    ["later", "middle", "earlier"],
+  );
+});
+
+test("timeline does not mutate its input", () => {
+  const all = parseCommunityPosts(
+    mods(raw({ id: "a", announcedAt: "2026-07-01T00:00:00Z" }), raw({ id: "b", announcedAt: "2026-07-02T00:00:00Z" })),
+  );
+  const originalOrder = all.map((p) => p.id);
+  timeline(all);
+  assert.deepEqual(all.map((p) => p.id), originalOrder);
+});
+
+test("empty input yields an empty timeline", () => {
+  assert.deepEqual(parseCommunityPosts({}), []);
+  assert.deepEqual(timeline([]), []);
+});

--- a/Resources/Template/src/lib/communityPosts.ts
+++ b/Resources/Template/src/lib/communityPosts.ts
@@ -1,0 +1,77 @@
+/**
+ * Announced-post snapshots (`data/community-posts/{id}.json`) — the render half of V-5.2b
+ * (#908). The schema mirrors `AnnouncedPost.swift` (the authoritative contract, see
+ * `docs/superpowers/specs/2026-07-22-v5-communities-design.md` §4.3): one file per member post
+ * a hosted community announced to its membership, snapshotted from the Group actor's own Worker
+ * outbox into the site's git repo. FEP-1b12 is author-owns-post — the member's canonical copy
+ * stays on their own site; this is only the community's snapshot of what it announced.
+ *
+ * Pure logic only — the `import.meta.glob` call lives in `CommunityTimeline.astro` (the
+ * `feeds.ts`/`interactions.ts` pattern) so these functions stay testable under `npx tsx --test`.
+ *
+ * These files are third-party-derived and moderator-editable (moderation = delete the file, see
+ * #370), so a malformed one is skipped with a warning, never a build failure.
+ */
+import { z } from "astro/zod";
+
+const isoDate = z.string().refine((s) => !Number.isNaN(Date.parse(s)), { message: "not an ISO 8601 date" });
+
+/**
+ * `z.string().url()` accepts any scheme `new URL()` can parse, including `javascript:`. These
+ * fields are attacker-controlled (any fediverse member of the community can post), and flow
+ * straight into `href`/`src` in `CommunityTimeline.astro`, so scheme must be restricted to
+ * http(s) to close the stored-XSS vector. Mirrors `interactions.ts`'s `httpUrl`.
+ */
+const httpUrl = z.string().url().refine(
+  (s) => {
+    try {
+      return ["http:", "https:"].includes(new URL(s).protocol);
+    } catch {
+      return false;
+    }
+  },
+  { message: "must be an http(s) URL" },
+);
+
+const communityPostSchema = z.object({
+  /// Path-traversal guard: same rule as AnnouncedPost.swift's init.
+  id: z.string().regex(/^[A-Za-z0-9_-]+$/),
+  objectType: z.enum(["note", "article", "page", "video", "event"]),
+  sourceURL: httpUrl,
+  author: z
+    .object({
+      name: z.string().optional(),
+      url: httpUrl.optional(),
+      photo: httpUrl.optional(),
+    })
+    .optional(),
+  content: z.string().optional(),
+  published: isoDate,
+  announcedAt: isoDate,
+});
+
+export type AnnouncedPost = z.infer<typeof communityPostSchema>;
+
+/**
+ * Validates a glob module map (path → JSON module) into announced posts. Eager JSON globs wrap
+ * each file in `{ default }`; bare values are accepted too. Invalid files are skipped with a
+ * `console.warn` naming the file — mirrors `interactions.ts`'s `parseInteractions`.
+ */
+export function parseCommunityPosts(mods: Record<string, unknown>): AnnouncedPost[] {
+  const out: AnnouncedPost[] = [];
+  for (const [path, mod] of Object.entries(mods)) {
+    const value = mod && typeof mod === "object" && "default" in mod ? (mod as { default: unknown }).default : mod;
+    const parsed = communityPostSchema.safeParse(value);
+    if (!parsed.success) {
+      console.warn(`[communityPosts] skipping invalid snapshot ${path}: ${parsed.error.issues[0]?.message ?? "invalid"}`);
+      continue;
+    }
+    out.push(parsed.data);
+  }
+  return out;
+}
+
+/** Newest-first — the community timeline shows every announced post, unlike a per-entry comment thread. */
+export function timeline(posts: AnnouncedPost[]): AnnouncedPost[] {
+  return [...posts].sort((a, b) => Date.parse(b.announcedAt) - Date.parse(a.announcedAt));
+}

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -207,6 +207,11 @@ final class PreviewModel {
             // database (same gate as ReceivedInteractionSync — Micropub shares the database).
             _ = await MicropubContentSync.pullAndCommitIfConfigured(
                 siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #908: pull a hosted community's own announced-post outbox and snapshot it into the
+            // git working copy. No-ops for sites that aren't a hosted community
+            // (SiteSettings.communityOutboxURL unset — inert until #907 ships that site kind).
+            _ = await AnnouncedPostSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
             clearDevServerCommandInFlight(token: token)
         }
     }

--- a/Sources/AnglesiteCore/AnnouncedPost.swift
+++ b/Sources/AnglesiteCore/AnnouncedPost.swift
@@ -1,0 +1,93 @@
+// Sources/AnglesiteCore/AnnouncedPost.swift
+import Foundation
+
+/// Schema for a member post snapshotted from a hosted community's Worker outbox into `Source/`
+/// git (V-5.2b, #908). FEP-1b12 is author-owns-post: the member's canonical copy stays on their
+/// own site/actor; this is the community repo's snapshot of what the group announced to its
+/// membership. Sibling schema to `ReceivedInteraction` (V-3.4, #362) — same id/author-snapshot
+/// discipline — but the timeline *is* the page (not a comment thread) and the data always comes
+/// from this site's own hosted Group actor, never a third party's D1/webmention inbox.
+///
+/// One file per announced post at `Source/data/community-posts/{id}.json`. See
+/// `docs/superpowers/specs/2026-07-22-v5-communities-design.md` §4.3.
+///
+/// **Sanitisation contract:** `id` is validated at construction time — only `[A-Za-z0-9_-]+`
+/// is accepted — to prevent path-traversal through `gitPath`. `content` is stored as-is from the
+/// Worker; the Astro template must render it as text (e.g. `set:text`, never `set:html`).
+///
+/// **No verification-status field.** Unlike a webmention, a post only ever reaches this schema
+/// after the Worker has already validated it came from a current member and wrapped it in a
+/// Group-authored `Announce` (see `davidwkeith/workers` PR #401's "does not announce a
+/// non-member's post") — there is no unverified/pending state this schema could ever hold.
+public struct AnnouncedPost: Codable, Sendable, Equatable, Identifiable {
+    /// AS2 object type of the wrapped post, per the Worker's own classification.
+    public enum ObjectType: String, Codable, Sendable, Equatable {
+        case note
+        case article
+        case page
+        case video
+        case event
+    }
+
+    /// Frozen point-in-time snapshot of the member's identity at announce time.
+    ///
+    /// Not live-updated — if the member later changes their name/photo, the old values persist
+    /// in the snapshot, same as `ReceivedInteraction.Author`.
+    public struct Author: Codable, Sendable, Equatable {
+        public let name: String?
+        public let url: URL?
+        public let photo: URL?
+
+        public init(name: String?, url: URL?, photo: URL?) {
+            self.name = name
+            self.url = url
+            self.photo = photo
+        }
+    }
+
+    /// Stable, unique ID assigned by the Worker for the wrapped post.
+    public let id: String
+    /// AS2 type of the wrapped post.
+    public let objectType: ObjectType
+    /// Canonical URL of the member's own post — their site remains authoritative (FEP-1b12).
+    public let sourceURL: URL
+    /// Frozen point-in-time snapshot of the member's identity (optional).
+    public let author: Author?
+    /// Text content of the post. Stored as-is from the Worker — callers must render as text, not
+    /// raw HTML.
+    public let content: String?
+    /// When the member originally published the post (ISO 8601).
+    public let published: Date
+    /// When the group announced (fanned out) the post to its membership (ISO 8601).
+    public let announcedAt: Date
+
+    /// The relative path within `Source/` where this post is stored in git.
+    ///
+    /// For example: `"data/community-posts/ap-abc123.json"`
+    public var gitPath: String { "data/community-posts/\(id).json" }
+
+    public enum ValidationError: Error, Sendable {
+        case invalidID(String)
+    }
+
+    public init(
+        id: String,
+        objectType: ObjectType,
+        sourceURL: URL,
+        author: Author?,
+        content: String?,
+        published: Date,
+        announcedAt: Date
+    ) throws {
+        guard id.range(of: #"^[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil else {
+            throw ValidationError.invalidID(id)
+        }
+        self.id = id
+        self.objectType = objectType
+        self.sourceURL = sourceURL
+        self.author = author
+        self.content = content
+        self.published = published
+        self.announcedAt = announcedAt
+    }
+}

--- a/Sources/AnglesiteCore/AnnouncedPost.swift
+++ b/Sources/AnglesiteCore/AnnouncedPost.swift
@@ -12,8 +12,13 @@ import Foundation
 /// `docs/superpowers/specs/2026-07-22-v5-communities-design.md` §4.3.
 ///
 /// **Sanitisation contract:** `id` is validated at construction time — only `[A-Za-z0-9_-]+`
-/// is accepted — to prevent path-traversal through `gitPath`. `content` is stored as-is from the
-/// Worker; the Astro template must render it as text (e.g. `set:text`, never `set:html`).
+/// is accepted — to prevent path-traversal through `gitPath`. `sourceURL`/`author.url`/
+/// `author.photo` are restricted to `http`/`https` schemes at construction time too — these flow
+/// straight into `href`/`src` in `CommunityTimeline.astro`, so a `javascript:` (or other
+/// non-web) scheme is rejected here rather than relying entirely on the template's zod
+/// `httpUrl` refinement (`communityPosts.ts`) to catch it downstream. `content` is stored as-is
+/// from the Worker; the Astro template must render it as text (e.g. `set:text`, never
+/// `set:html`).
 ///
 /// **No verification-status field.** Unlike a webmention, a post only ever reaches this schema
 /// after the Worker has already validated it came from a current member and wrapped it in a
@@ -68,6 +73,16 @@ public struct AnnouncedPost: Codable, Sendable, Equatable, Identifiable {
 
     public enum ValidationError: Error, Sendable {
         case invalidID(String)
+        case insecureURL(URL)
+    }
+
+    /// `http`/`https` only — matches `communityPosts.ts`'s `httpUrl` zod refinement exactly.
+    /// Anything else (`javascript:`, `data:`, a scheme-less string `URL` still parsed) is rejected
+    /// rather than silently accepted and left for the template layer to catch.
+    private static func requireWebScheme(_ url: URL) throws {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+            throw ValidationError.insecureURL(url)
+        }
     }
 
     public init(
@@ -82,6 +97,9 @@ public struct AnnouncedPost: Codable, Sendable, Equatable, Identifiable {
         guard id.range(of: #"^[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil else {
             throw ValidationError.invalidID(id)
         }
+        try Self.requireWebScheme(sourceURL)
+        if let url = author?.url { try Self.requireWebScheme(url) }
+        if let photo = author?.photo { try Self.requireWebScheme(photo) }
         self.id = id
         self.objectType = objectType
         self.sourceURL = sourceURL

--- a/Sources/AnglesiteCore/AnnouncedPostCommitter.swift
+++ b/Sources/AnglesiteCore/AnnouncedPostCommitter.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Writes a hosted community's own announced-post outbox into the site's local git working
+/// copy as `data/community-posts/{id}.json` files — the "snapshot to git" half of #908, per the
+/// canonicality design (`docs/superpowers/specs/2026-07-22-v5-communities-design.md` §4.3). Like
+/// `ReceivedInteractionCommitter` (#362), this reconciles against the *full current set* every
+/// call rather than draining a staging queue: the Worker's outbox stays the permanent
+/// operational store, so a post a moderator un-announced (`Undo(Announce)`, #370) simply drops
+/// out of the fetched set and its stale snapshot file must be removed on the next reconcile too.
+public enum AnnouncedPostCommitter {
+    /// JSON encoding for one post's snapshot file: sorted keys (stable, clean diffs) and ISO 8601
+    /// dates, matching the Astro template's zod schema
+    /// (`Resources/Template/src/lib/communityPosts.ts`) and `AnnouncedPostTests`'s own round-trip
+    /// fixture.
+    public static func jsonData(for post: AnnouncedPost) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(post)
+    }
+
+    /// Reconciles `data/community-posts/` under `siteDirectory` against `posts` (the full,
+    /// current set from the community's own Worker outbox) and commits the result in one commit:
+    /// - a new or changed post is written (or overwritten) at its `gitPath`
+    /// - an existing snapshot file whose id is absent from `posts` is deleted
+    /// - unchanged files are left untouched, so a sync with nothing new is a true no-op — no
+    ///   empty commit, no git subprocess/libgit2 call at all
+    ///
+    /// Returns every id actually touched by the resulting commit — written (new or changed
+    /// content) or deleted (no longer in the outbox) — empty (never throws) if there was nothing
+    /// to reconcile, or if the git commit closure failed, so an interrupted or failed sync simply
+    /// re-attempts the same reconcile next time rather than losing state. An id whose file was
+    /// already up to date is not included: it wasn't part of this commit.
+    @discardableResult
+    public static func commit(
+        posts: [AnnouncedPost],
+        into siteDirectory: URL,
+        fileManager: FileManager = .default,
+        gitCommitBatch: @Sendable (URL, [String], String) async -> String? = InboxSubmissionCommitter.processGitCommitBatch
+    ) async -> [String] {
+        let postsDir = siteDirectory.appendingPathComponent("data/community-posts", isDirectory: true)
+        let currentIDs = Set(posts.map(\.id))
+
+        var relPaths: [String] = []
+        var writtenIDs: [String] = []
+        var deletedIDs: [String] = []
+
+        let existingFiles = (try? fileManager.contentsOfDirectory(at: postsDir, includingPropertiesForKeys: nil)) ?? []
+        for file in existingFiles where file.pathExtension == "json" {
+            let id = file.deletingPathExtension().lastPathComponent
+            guard !currentIDs.contains(id) else { continue }
+            guard (try? fileManager.removeItem(at: file)) != nil else { continue }
+            relPaths.append("data/community-posts/\(id).json")
+            deletedIDs.append(id)
+        }
+
+        if !posts.isEmpty {
+            try? fileManager.createDirectory(at: postsDir, withIntermediateDirectories: true)
+        }
+        for post in posts {
+            guard let data = try? jsonData(for: post) else { continue }
+            let fileURL = postsDir.appendingPathComponent("\(post.id).json")
+            if let existing = try? Data(contentsOf: fileURL), existing == data { continue }
+            guard (try? data.write(to: fileURL, options: .atomic)) != nil else { continue }
+            relPaths.append(post.gitPath)
+            writtenIDs.append(post.id)
+        }
+
+        guard !relPaths.isEmpty else { return [] }
+
+        let message = Self.commitMessage(writtenCount: writtenIDs.count, deletedCount: deletedIDs.count)
+        guard await gitCommitBatch(siteDirectory, relPaths, message) != nil else { return [] }
+        return writtenIDs + deletedIDs
+    }
+
+    /// Describes what actually changed, since a reconcile can be a pure write, a pure delete
+    /// (every post from a member was un-announced/banned away), or both at once.
+    static func commitMessage(writtenCount: Int, deletedCount: Int) -> String {
+        switch (writtenCount, deletedCount) {
+        case (let w, 0):
+            return w == 1 ? "chore: snapshot 1 announced post" : "chore: snapshot \(w) announced posts"
+        case (0, let d):
+            return d == 1 ? "chore: remove 1 announced post" : "chore: remove \(d) announced posts"
+        case (let w, let d):
+            return "chore: snapshot \(w) announced post\(w == 1 ? "" : "s"), remove \(d)"
+        }
+    }
+}

--- a/Sources/AnglesiteCore/AnnouncedPostSync.swift
+++ b/Sources/AnglesiteCore/AnnouncedPostSync.swift
@@ -2,7 +2,6 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
-import CryptoKit
 
 /// Orchestrates #908's "pull a hosted community's own announced-post outbox and snapshot it into
 /// the site's git working copy" step: page the Group actor's public `outbox`
@@ -115,7 +114,9 @@ public enum AnnouncedPostSync {
         static func announce(from item: Any) -> RawAnnounce? {
             guard let activity = item as? [String: Any], (activity["type"] as? String) == "Announce" else { return nil }
             guard let object = activity["object"] as? [String: Any], let id = object["id"] as? String else { return nil }
-            guard let sourceURL = URL(string: id) else { return nil }
+            guard let sourceURL = URL(string: id), let scheme = sourceURL.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https"
+            else { return nil }
 
             let objectType = (object["type"] as? String).flatMap { rawType -> AnnouncedPost.ObjectType? in
                 AnnouncedPost.ObjectType(rawValue: rawType.lowercased())
@@ -141,11 +142,24 @@ public enum AnnouncedPostSync {
     /// A member's post `id` doubles as `AnnouncedPost.id` and must satisfy its path-traversal
     /// guard (`[A-Za-z0-9_-]+`) — an AS2 IRI never does, so this derives a stable, safe id from
     /// it the same way other Worker-facing ids in this codebase are namespaced (`wm-`/`ap-`
-    /// prefixes elsewhere): a `community-` prefix over a SHA-256 digest of the wrapped object's
-    /// IRI, so the same post always maps to the same filename across syncs.
+    /// prefixes elsewhere): a `community-` prefix over a hash of the wrapped object's IRI, so the
+    /// same post always maps to the same filename across syncs.
+    ///
+    /// Hand-rolled FNV-1a rather than `CryptoKit`'s `SHA256`: this is a stable dedup/filename key,
+    /// not a security boundary, and `CryptoKit` isn't available on the Linux `AnglesiteCore`
+    /// build (`AnglesiteSiteModel`/`AnglesiteCore` are portable SwiftPM targets — see
+    /// `CONTRIBUTING.md` ▸ "Linux contributors welcome") — every other `CryptoKit` use in this
+    /// file's neighbors (`DPoPKeyPair`, `SessionToken`, …) is gated `#if canImport(CryptoKit)`
+    /// with a degraded fallback, which isn't an option here since this id needs to be identical
+    /// on every platform.
     static func fileID(for objectIRI: URL) -> String {
-        "community-" + SHA256.hash(data: Data(objectIRI.absoluteString.utf8))
-            .map { String(format: "%02x", $0) }.joined()
+        var hash: UInt64 = 0xcbf29ce484222325 // FNV-1a 64-bit offset basis
+        for byte in objectIRI.absoluteString.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x100000001b3 // FNV-1a 64-bit prime
+        }
+        let hex = String(hash, radix: 16)
+        return "community-" + String(repeating: "0", count: 16 - hex.count) + hex
     }
 
     /// Maps one raw announce to `AnnouncedPost`, resolving its author via `cache` (fresh lookup
@@ -210,7 +224,10 @@ public enum AnnouncedPostSync {
         }
 
         var cache = ActorProfileCache.load(from: configDirectory) ?? ActorProfileCache()
-        let fetcher = ActorProfileFetcher()
+        // Same injected transport as the outbox client — a test double for `community.example`
+        // must also answer `member.example` profile lookups, and production gets the real
+        // network either way.
+        let fetcher = ActorProfileFetcher(transport: transport)
         var posts: [AnnouncedPost] = []
         for raw in raws {
             if let post = await Self.makePost(from: raw, cache: &cache, fetcher: fetcher, now: now) {

--- a/Sources/AnglesiteCore/AnnouncedPostSync.swift
+++ b/Sources/AnglesiteCore/AnnouncedPostSync.swift
@@ -1,0 +1,242 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import CryptoKit
+
+/// Orchestrates #908's "pull a hosted community's own announced-post outbox and snapshot it into
+/// the site's git working copy" step: page the Group actor's public `outbox`
+/// (`AnnouncedPostSync.OutboxClient`), resolve each member's frozen author snapshot
+/// (`ActorProfileFetcher`/`ActorProfileCache`, same as `FollowersModel`'s enrichment), then
+/// reconcile + commit (`AnnouncedPostCommitter`). Designed to be called once per site-open
+/// (`PreviewModel.open(site:)`), alongside the other three per-site syncs.
+///
+/// Unlike `ReceivedInteractionSync`/`InboxSubmissionSync`, this needs **no Cloudflare API token**:
+/// a member's `Create` is only ever wrapped in an `Announce` and written into the Group's own
+/// `outbox` after the Worker has already validated membership (`davidwkeith/workers` PR #401 —
+/// "does not announce a non-member's post"), and that `outbox` is the same public,
+/// unauthenticated AS2 collection `GET <actor>/outbox` already serves. So this is a plain HTTPS
+/// fetch — the same trust/paging shape `GroupTimelineClient` (#368) uses to read a *remote*
+/// group's timeline, just pointed at this site's own actor instead.
+public enum AnnouncedPostSync {
+    /// Fetch transport for the outbox client — public so callers (`PreviewModel`, tests) can
+    /// inject a fake without reaching into the internal `OutboxClient` type.
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// Production transport — re-exposed at this (public) level since `OutboxClient` itself stays
+    /// internal (it's purely this sync's own plumbing, unlike `GroupTimelineClient`, which is a
+    /// public type in its own right for Stage 1a's participation UI).
+    public static let defaultTransport: Transport = OutboxClient.defaultTransport
+
+    /// One `Announce`d post, before author resolution. Kept separate from `AnnouncedPost` because
+    /// mapping the wrapped object's `attributedTo` IRI into a frozen name/photo snapshot requires
+    /// an async profile fetch — `OutboxClient.post(from:)` stays a pure, synchronous parse.
+    struct RawAnnounce: Sendable, Equatable {
+        let id: String
+        let objectType: AnnouncedPost.ObjectType
+        let sourceURL: URL
+        let attributedTo: URL?
+        let content: String?
+        let published: Date?
+        let announcedAt: Date?
+    }
+
+    public enum OutboxError: Error, Equatable, Sendable {
+        /// The outbox URL, or the URL a redirect actually landed on, wasn't `https`.
+        case insecureURL
+        case requestFailed(status: Int, body: String)
+        case decodingFailed(String)
+    }
+
+    /// Pages a Group actor's own public outbox. Same unauthenticated, HTTPS-only, capped,
+    /// AS2-collection-paging shape as `GroupTimelineClient` (the collection belongs to this
+    /// site's own actor here, rather than an arbitrary remote one).
+    struct OutboxClient: Sendable {
+        /// 1 MB — matches `GroupTimelineClient.maximumResponseBytes`: an outbox page embeds
+        /// several full activities at once.
+        static let maximumResponseBytes = 1024 * 1024
+
+        let transport: Transport
+
+        init(transport: @escaping Transport = OutboxClient.defaultTransport) {
+            self.transport = transport
+        }
+
+        func collection(at outboxURL: URL) async throws -> URL? {
+            let json = try await fetch(outboxURL)
+            return (json["first"] as? String).flatMap(URL.init(string:))
+        }
+
+        func page(at url: URL) async throws -> (items: [RawAnnounce], next: URL?) {
+            let json = try await fetch(url)
+            let rawItems = (json["orderedItems"] as? [Any]) ?? []
+            let items = rawItems.compactMap(Self.announce(from:))
+            let next = (json["next"] as? String).flatMap(URL.init(string:))
+            return (items, next)
+        }
+
+        private func fetch(_ url: URL) async throws -> [String: Any] {
+            try Self.requireHTTPS(url)
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.setValue(ActivityPubFollowersClient.acceptHeader, forHTTPHeaderField: "Accept")
+            request.timeoutInterval = ActorProfileFetcher.timeout
+
+            let data: Data
+            let http: HTTPURLResponse
+            do {
+                (data, http) = try await transport(request)
+            } catch {
+                throw OutboxError.requestFailed(status: 0, body: "\(error)")
+            }
+            if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
+            guard (200..<300).contains(http.statusCode) else {
+                throw OutboxError.requestFailed(
+                    status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+            }
+            guard data.count <= Self.maximumResponseBytes else {
+                throw OutboxError.requestFailed(status: 0, body: "response too large (\(data.count) bytes)")
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw OutboxError.decodingFailed("not a JSON object")
+            }
+            return json
+        }
+
+        static func requireHTTPS(_ url: URL) throws {
+            guard url.scheme?.lowercased() == "https" else { throw OutboxError.insecureURL }
+        }
+
+        /// Unwraps an `Announce` activity to the member's wrapped post. Only `Announce` items are
+        /// mapped — a hosted Group's outbox holds nothing else per #401 (a `Create` from a member
+        /// is *replaced* by the Announce, never stored alongside it), so anything else (a bare
+        /// activity-id string, a differently-typed activity) is skipped rather than guessed at.
+        static func announce(from item: Any) -> RawAnnounce? {
+            guard let activity = item as? [String: Any], (activity["type"] as? String) == "Announce" else { return nil }
+            guard let object = activity["object"] as? [String: Any], let id = object["id"] as? String else { return nil }
+            guard let sourceURL = URL(string: id) else { return nil }
+
+            let objectType = (object["type"] as? String).flatMap { rawType -> AnnouncedPost.ObjectType? in
+                AnnouncedPost.ObjectType(rawValue: rawType.lowercased())
+            } ?? .note
+            let attributedTo = (object["attributedTo"] as? String).flatMap(URL.init(string:))
+            let published = (object["published"] as? String).flatMap { ISO8601DateFormatter().date(from: $0) }
+            let announcedAt = (activity["published"] as? String).flatMap { ISO8601DateFormatter().date(from: $0) }
+            return RawAnnounce(
+                id: id, objectType: objectType, sourceURL: sourceURL, attributedTo: attributedTo,
+                content: (object["content"] as? String), published: published, announcedAt: announcedAt)
+        }
+
+        private static let session = CappedHTTPTransport.session(
+            requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
+
+        static let defaultTransport: Transport = { request in
+            try await CappedHTTPTransport.fetch(
+                request, session: session, cap: OutboxClient.maximumResponseBytes,
+                tooLarge: { OutboxError.requestFailed(status: 0, body: "response too large (\($0) bytes)") })
+        }
+    }
+
+    /// A member's post `id` doubles as `AnnouncedPost.id` and must satisfy its path-traversal
+    /// guard (`[A-Za-z0-9_-]+`) — an AS2 IRI never does, so this derives a stable, safe id from
+    /// it the same way other Worker-facing ids in this codebase are namespaced (`wm-`/`ap-`
+    /// prefixes elsewhere): a `community-` prefix over a SHA-256 digest of the wrapped object's
+    /// IRI, so the same post always maps to the same filename across syncs.
+    static func fileID(for objectIRI: URL) -> String {
+        "community-" + SHA256.hash(data: Data(objectIRI.absoluteString.utf8))
+            .map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Maps one raw announce to `AnnouncedPost`, resolving its author via `cache` (fresh lookup
+    /// first) and falling back to `fetcher` on a cache miss/expiry — mirrors
+    /// `FollowersModel`'s enrichment pattern. Returns `nil` only when `raw.published`/
+    /// `announcedAt` are both absent (an AS2 peer that omits `published` on both the activity and
+    /// its object leaves nothing to snapshot a timestamp from).
+    static func makePost(
+        from raw: RawAnnounce, cache: inout ActorProfileCache, fetcher: ActorProfileFetcher, now: Date
+    ) async -> AnnouncedPost? {
+        guard let published = raw.published ?? raw.announcedAt else { return nil }
+        let announcedAt = raw.announcedAt ?? published
+
+        var author: AnnouncedPost.Author?
+        if let actorURL = raw.attributedTo {
+            let profile: ActorProfile?
+            if let cached = cache.profile(for: actorURL, now: now) {
+                profile = cached
+            } else if let fetched = try? await fetcher.profile(for: actorURL, now: now) {
+                cache.store(fetched)
+                profile = fetched
+            } else {
+                profile = nil
+            }
+            author = profile.map { .init(name: $0.name ?? $0.preferredUsername, url: actorURL, photo: $0.iconURL) }
+                ?? .init(name: nil, url: actorURL, photo: nil)
+        }
+
+        return try? AnnouncedPost(
+            id: Self.fileID(for: raw.sourceURL),
+            objectType: raw.objectType,
+            sourceURL: raw.sourceURL,
+            author: author,
+            content: raw.content,
+            published: published,
+            announcedAt: announcedAt)
+    }
+
+    /// Pages every post currently in `outboxURL`'s Group actor outbox, resolves authors (loading/
+    /// saving the cache in `configDirectory`), and reconciles the result into `siteDirectory`.
+    /// Returns 0 (never throws) on a failed first-page fetch, so callers simply re-attempt on the
+    /// next site-open rather than surfacing a transient network error.
+    public static func pullAndCommit(
+        outboxURL: URL,
+        siteDirectory: URL,
+        configDirectory: URL,
+        transport: @escaping Transport = AnnouncedPostSync.defaultTransport,
+        now: Date = Date()
+    ) async -> Int {
+        let client = OutboxClient(transport: transport)
+        guard let firstPage = try? await client.collection(at: outboxURL) else { return 0 }
+
+        var raws: [RawAnnounce] = []
+        var next: URL? = firstPage
+        var pagesFetched = 0
+        // A generous, fixed cap rather than trusting a peer-controlled `next` chain to terminate.
+        while let pageURL = next, pagesFetched < 50 {
+            guard let page = try? await client.page(at: pageURL) else { break }
+            raws.append(contentsOf: page.items)
+            next = page.next
+            pagesFetched += 1
+        }
+
+        var cache = ActorProfileCache.load(from: configDirectory) ?? ActorProfileCache()
+        let fetcher = ActorProfileFetcher()
+        var posts: [AnnouncedPost] = []
+        for raw in raws {
+            if let post = await Self.makePost(from: raw, cache: &cache, fetcher: fetcher, now: now) {
+                posts.append(post)
+            }
+        }
+        try? cache.save(to: configDirectory, now: now)
+
+        return await AnnouncedPostCommitter.commit(posts: posts, into: siteDirectory).count
+    }
+
+    /// Reads the site's `SiteSettings`; no-ops (returns 0, no network call) unless
+    /// `communityOutboxURL` is set — i.e. this isn't a hosted community site (#907 hasn't
+    /// provisioned one yet, or this is an ordinary site). `configDirectory` is the package's
+    /// `Config/` directory (`AnglesitePackage.configURL`), a sibling of `siteDirectory`
+    /// (`AnglesitePackage.sourceURL`).
+    public static func pullAndCommitIfConfigured(
+        siteDirectory: URL,
+        configDirectory: URL,
+        transport: @escaping Transport = AnnouncedPostSync.defaultTransport
+    ) async -> Int {
+        guard let settings = try? SiteConfigStore.read(from: configDirectory),
+              let outboxURL = settings.communityOutboxURL
+        else { return 0 }
+        return await pullAndCommit(
+            outboxURL: outboxURL, siteDirectory: siteDirectory, configDirectory: configDirectory,
+            transport: transport)
+    }
+}

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -61,6 +61,11 @@ public struct SiteSettings: Sendable, Codable, Equatable {
     /// see `DeployModel.webmentionPaidPlanConfirmationPresented`.
     public var webmentionReceivePaidPlanAcknowledged: Bool?
 
+    /// This site's own hosted-community outbox URL (V-5.2b, #908) — set once #907's provisioning
+    /// flow creates a "Community" site kind and its Group actor Worker. `nil` on every other
+    /// site: `AnnouncedPostSync` no-ops without it, so this field is inert until #907 ships.
+    public var communityOutboxURL: URL?
+
     public init(
         displayName: String? = nil,
         inboxCaptureAccountID: String? = nil,
@@ -72,7 +77,8 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         activeWorkerIDs: [String]? = nil,
         lastDeployedWorkerIDs: [String]? = nil,
         provisionedWorkerResources: WorkerComposition.ProvisionedResources? = nil,
-        webmentionReceivePaidPlanAcknowledged: Bool? = nil
+        webmentionReceivePaidPlanAcknowledged: Bool? = nil,
+        communityOutboxURL: URL? = nil
     ) {
         self.displayName = displayName
         self.inboxCaptureAccountID = inboxCaptureAccountID
@@ -85,6 +91,7 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         self.lastDeployedWorkerIDs = lastDeployedWorkerIDs
         self.provisionedWorkerResources = provisionedWorkerResources
         self.webmentionReceivePaidPlanAcknowledged = webmentionReceivePaidPlanAcknowledged
+        self.communityOutboxURL = communityOutboxURL
     }
 }
 

--- a/Tests/AnglesiteCoreTests/AnnouncedPostCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/AnnouncedPostCommitterTests.swift
@@ -1,0 +1,159 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Serialized for the same reason as ReceivedInteractionCommitterTests: real `git` subprocesses
+// via raw `Process()` in `makeThrowawayGitRepo()` trip a rare CI heap-corruption crash when run
+// concurrently with the rest of the subprocess-heavy suite.
+@Suite(.serialized)
+struct AnnouncedPostCommitterTests {
+    private static func post(id: String, content: String = "Hello, community!") -> AnnouncedPost {
+        try! AnnouncedPost(
+            id: id, objectType: .note,
+            sourceURL: URL(string: "https://member.example/posts/42")!,
+            author: .init(name: "Alice", url: URL(string: "https://member.example"), photo: nil),
+            content: content,
+            published: Date(timeIntervalSince1970: 1_753_299_000),
+            announcedAt: Date(timeIntervalSince1970: 1_753_300_000))
+    }
+
+    @Test("commit writes each post to data/community-posts/{id}.json and returns their ids")
+    func commitWritesAndReturnsIDs() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let ids = await AnnouncedPostCommitter.commit(
+            posts: [Self.post(id: "ap-abc123")], into: siteDirectory)
+        #expect(ids == ["ap-abc123"])
+
+        let written = siteDirectory.appendingPathComponent("data/community-posts/ap-abc123.json")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+    }
+
+    @Test("commit returns empty for an empty post list with no existing files, without touching git")
+    func commitEmptyIsNoOp() async {
+        let ids = await AnnouncedPostCommitter.commit(
+            posts: [], into: URL(fileURLWithPath: "/nonexistent"))
+        #expect(ids.isEmpty)
+    }
+
+    @Test("commit deletes post files whose id is no longer present in the current set")
+    func commitDeletesStaleFiles() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        _ = await AnnouncedPostCommitter.commit(
+            posts: [Self.post(id: "ap-abc123"), Self.post(id: "ap-def456")],
+            into: siteDirectory)
+        let staleFile = siteDirectory.appendingPathComponent("data/community-posts/ap-def456.json")
+        #expect(FileManager.default.fileExists(atPath: staleFile.path))
+
+        // ap-def456 dropped out of the current set (moderator un-announced it, or the member
+        // was banned) - the next reconcile should remove its snapshot file. ap-abc123's content
+        // is unchanged, so it isn't rewritten - only the deletion shows up in the commit.
+        let ids = await AnnouncedPostCommitter.commit(
+            posts: [Self.post(id: "ap-abc123")], into: siteDirectory)
+        #expect(ids == ["ap-def456"])
+        #expect(!FileManager.default.fileExists(atPath: staleFile.path))
+    }
+
+    @Test("commit is a no-op when every post already matches what's on disk and nothing needs deleting")
+    func commitNoOpWhenNothingChanged() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let posts = [Self.post(id: "ap-abc123")]
+        let firstIDs = await AnnouncedPostCommitter.commit(posts: posts, into: siteDirectory)
+        #expect(firstIDs == ["ap-abc123"])
+
+        let callCount = CallCounter()
+        let secondIDs = await AnnouncedPostCommitter.commit(
+            posts: posts, into: siteDirectory,
+            gitCommitBatch: { _, _, _ in
+                await callCount.increment()
+                return "should-not-be-called"
+            })
+        #expect(secondIDs.isEmpty)
+        #expect(await callCount.value == 0)
+    }
+
+    @Test("commit re-writes a post file whose content changed since the last snapshot")
+    func commitRewritesChangedContent() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        _ = await AnnouncedPostCommitter.commit(
+            posts: [Self.post(id: "ap-abc123", content: "Hello, community!")], into: siteDirectory)
+
+        let ids = await AnnouncedPostCommitter.commit(
+            posts: [Self.post(id: "ap-abc123", content: "Edited: even better hello!")],
+            into: siteDirectory)
+        #expect(ids == ["ap-abc123"])
+
+        let written = siteDirectory.appendingPathComponent("data/community-posts/ap-abc123.json")
+        let data = try Data(contentsOf: written)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("Edited: even better hello!"))
+    }
+
+    @Test("commit returns empty (not throw) when the git commit closure fails")
+    func commitReturnsEmptyOnGitCommitFailure() async throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(
+            "community-posts-commit-fail-test-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let ids = await AnnouncedPostCommitter.commit(
+            posts: [Self.post(id: "ap-abc123")], into: dir,
+            gitCommitBatch: { _, _, _ in nil })
+        #expect(ids.isEmpty)
+    }
+
+    @Test("jsonData serializes with sorted keys and ISO 8601 dates")
+    func jsonDataFormat() throws {
+        let data = try AnnouncedPostCommitter.jsonData(for: Self.post(id: "ap-abc123"))
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("\"id\" : \"ap-abc123\""))
+        #expect(text.contains("\"objectType\" : \"note\""))
+        // ISO 8601, not epoch seconds/millis - the Astro template's zod schema expects this shape.
+        #expect(text.range(of: #""announcedAt" : "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z""#, options: .regularExpression) != nil)
+    }
+
+    /// Mirrors `ReceivedInteractionCommitterTests.makeThrowawayGitRepo`.
+    private static func makeThrowawayGitRepo() throws -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(
+            "community-posts-commit-test-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = dir
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return dir
+    }
+}
+
+private actor CallCounter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}

--- a/Tests/AnglesiteCoreTests/AnnouncedPostSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/AnnouncedPostSyncTests.swift
@@ -1,0 +1,302 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Serialized for the same reason as ReceivedInteractionSyncTests: real `git` subprocesses via
+// raw `Process()` in `makeThrowawayGitRepo()` trip a rare CI heap-corruption crash when run
+// concurrently with the rest of the subprocess-heavy suite.
+@Suite(.serialized)
+struct AnnouncedPostSyncTests {
+    private static func response(_ status: Int, url: String = "https://community.example/") -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: url)!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func announceJSON(
+        innerID: String = "https://member.example/posts/1",
+        objectType: String = "Note",
+        attributedTo: String? = "https://member.example/users/alice",
+        content: String? = "Hello, community!",
+        published: String? = "2026-07-01T00:00:00Z",
+        announcedPublished: String? = "2026-07-01T00:00:05Z"
+    ) -> [String: Any] {
+        var object: [String: Any] = ["id": innerID, "type": objectType]
+        if let attributedTo { object["attributedTo"] = attributedTo }
+        if let content { object["content"] = content }
+        if let published { object["published"] = published }
+        var activity: [String: Any] = ["type": "Announce", "object": object]
+        if let announcedPublished { activity["published"] = announcedPublished }
+        return activity
+    }
+
+    private static func pageBody(items: [[String: Any]], next: String? = nil) -> Data {
+        var page: [String: Any] = ["orderedItems": items]
+        if let next { page["next"] = next }
+        return try! JSONSerialization.data(withJSONObject: page)
+    }
+
+    private static func actorProfileBody(name: String, icon: String? = nil) -> Data {
+        var doc: [String: Any] = ["preferredUsername": "alice", "name": name]
+        if let icon { doc["icon"] = ["url": icon] }
+        return try! JSONSerialization.data(withJSONObject: doc)
+    }
+
+    // MARK: - RawAnnounce mapping
+
+    @Test("OutboxClient.announce unwraps an Announce into a RawAnnounce")
+    func announceUnwrapsRawAnnounce() {
+        let raw = AnnouncedPostSync.OutboxClient.announce(from: Self.announceJSON())
+        #expect(raw?.id == "https://member.example/posts/1")
+        #expect(raw?.objectType == .note)
+        #expect(raw?.attributedTo?.absoluteString == "https://member.example/users/alice")
+        #expect(raw?.content == "Hello, community!")
+    }
+
+    @Test("OutboxClient.announce skips non-Announce activities")
+    func announceSkipsNonAnnounce() {
+        let create: [String: Any] = ["type": "Create", "object": ["id": "x", "type": "Note"]]
+        #expect(AnnouncedPostSync.OutboxClient.announce(from: create) == nil)
+    }
+
+    @Test("OutboxClient.announce skips a bare activity-id string")
+    func announceSkipsBareString() {
+        #expect(AnnouncedPostSync.OutboxClient.announce(from: "https://example.com/activities/1") == nil)
+    }
+
+    @Test("OutboxClient.announce defaults an unrecognized object type to note")
+    func announceDefaultsUnknownObjectType() {
+        let raw = AnnouncedPostSync.OutboxClient.announce(from: Self.announceJSON(objectType: "Tombstone"))
+        #expect(raw?.objectType == .note)
+    }
+
+    // MARK: - makePost
+
+    @Test("makePost resolves the author from a cache hit without calling the fetcher")
+    func makePostUsesCacheHit() async throws {
+        let raw = try #require(AnnouncedPostSync.OutboxClient.announce(from: Self.announceJSON()))
+        let now = Date(timeIntervalSince1970: 1_753_400_000)
+        var cache = ActorProfileCache()
+        cache.store(ActorProfile(
+            actor: URL(string: "https://member.example/users/alice")!, preferredUsername: "alice",
+            name: "Alice", iconURL: URL(string: "https://member.example/alice.jpg"), fetchedAt: now))
+
+        let fetcher = ActorProfileFetcher(transport: { _ in
+            Issue.record("fetcher must not be called on a cache hit")
+            struct Unexpected: Error {}
+            throw Unexpected()
+        })
+
+        let post = await AnnouncedPostSync.makePost(from: raw, cache: &cache, fetcher: fetcher, now: now)
+        #expect(post?.author?.name == "Alice")
+        #expect(post?.author?.photo?.absoluteString == "https://member.example/alice.jpg")
+    }
+
+    @Test("makePost fetches and caches the author on a cache miss")
+    func makePostFetchesOnCacheMiss() async throws {
+        let raw = try #require(AnnouncedPostSync.OutboxClient.announce(from: Self.announceJSON()))
+        let now = Date(timeIntervalSince1970: 1_753_400_000)
+        var cache = ActorProfileCache()
+        let body = Self.actorProfileBody(name: "Alice", icon: "https://member.example/alice.jpg")
+        let fetcher = ActorProfileFetcher(transport: { _ in (body, Self.response(200, url: "https://member.example/users/alice")) })
+
+        let post = await AnnouncedPostSync.makePost(from: raw, cache: &cache, fetcher: fetcher, now: now)
+        #expect(post?.author?.name == "Alice")
+        #expect(cache.profile(for: URL(string: "https://member.example/users/alice")!, now: now) != nil)
+    }
+
+    @Test("makePost falls back to a bare author (IRI only) when the fetch fails")
+    func makePostFallsBackOnFetchFailure() async throws {
+        let raw = try #require(AnnouncedPostSync.OutboxClient.announce(from: Self.announceJSON()))
+        let now = Date(timeIntervalSince1970: 1_753_400_000)
+        var cache = ActorProfileCache()
+        let fetcher = ActorProfileFetcher(transport: { _ in (Data(), Self.response(500, url: "https://member.example/users/alice")) })
+
+        let post = await AnnouncedPostSync.makePost(from: raw, cache: &cache, fetcher: fetcher, now: now)
+        #expect(post?.author?.name == nil)
+        #expect(post?.author?.url?.absoluteString == "https://member.example/users/alice")
+    }
+
+    @Test("makePost returns a stable, path-safe id derived from the object IRI")
+    func makePostDerivesStableID() async throws {
+        let raw = try #require(AnnouncedPostSync.OutboxClient.announce(from: Self.announceJSON()))
+        var cache = ActorProfileCache()
+        let fetcher = ActorProfileFetcher(transport: { _ in (Data(), Self.response(500)) })
+        let now = Date()
+
+        let first = await AnnouncedPostSync.makePost(from: raw, cache: &cache, fetcher: fetcher, now: now)
+        let second = await AnnouncedPostSync.makePost(from: raw, cache: &cache, fetcher: fetcher, now: now)
+        #expect(first?.id == second?.id)
+        #expect(first?.id.range(of: #"^[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil)
+    }
+
+    @Test("makePost has no author when the object carries no attributedTo")
+    func makePostNoAttributedTo() async throws {
+        let raw = try #require(AnnouncedPostSync.OutboxClient.announce(from: Self.announceJSON(attributedTo: nil)))
+        var cache = ActorProfileCache()
+        let fetcher = ActorProfileFetcher(transport: { _ in
+            Issue.record("fetcher must not be called with no attributedTo")
+            struct Unexpected: Error {}
+            throw Unexpected()
+        })
+        let post = await AnnouncedPostSync.makePost(from: raw, cache: &cache, fetcher: fetcher, now: Date())
+        #expect(post?.author == nil)
+    }
+
+    // MARK: - pullAndCommit
+
+    @Test("pulls announced posts from the outbox and commits them")
+    func pullsAndCommits() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/outbox?page=1"])
+        let pageBody = Self.pageBody(items: [Self.announceJSON()])
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        let count = await AnnouncedPostSync.pullAndCommit(
+            outboxURL: URL(string: "https://community.example/users/birding/outbox")!,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/outbox") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (pageBody, Self.response(200)) }
+                if path.contains("/users/alice") { return (profileBody, Self.response(200)) }
+                return (Data(), Self.response(404))
+            })
+
+        #expect(count == 1)
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: siteDirectory.appendingPathComponent("data/community-posts"), includingPropertiesForKeys: nil)) ?? []
+        #expect(entries.count == 1)
+    }
+
+    @Test("returns 0 without touching git when the first-page fetch fails")
+    func firstPageFailureIsNoOp() async throws {
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let count = await AnnouncedPostSync.pullAndCommit(
+            outboxURL: URL(string: "https://community.example/users/birding/outbox")!,
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDirectory,
+            transport: { _ in (Data(), Self.response(500)) })
+        #expect(count == 0)
+    }
+
+    @Test("reconciles away a snapshot whose post is no longer in the outbox (moderator removed it)")
+    func reconcilesAwayRemovedPost() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let outboxURL = URL(string: "https://community.example/users/birding/outbox")!
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/outbox?page=1"])
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        _ = await AnnouncedPostSync.pullAndCommit(
+            outboxURL: outboxURL, siteDirectory: siteDirectory, configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/outbox") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (Self.pageBody(items: [Self.announceJSON()]), Self.response(200)) }
+                return (profileBody, Self.response(200))
+            })
+        let dir = siteDirectory.appendingPathComponent("data/community-posts")
+        #expect((try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil))?.count == 1)
+
+        // Second sync: the outbox is now empty (moderator un-announced the only post).
+        let count = await AnnouncedPostSync.pullAndCommit(
+            outboxURL: outboxURL, siteDirectory: siteDirectory, configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/outbox") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (Self.pageBody(items: []), Self.response(200)) }
+                return (profileBody, Self.response(200))
+            })
+        #expect(count == 1)
+        #expect(((try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []).isEmpty)
+    }
+
+    // MARK: - pullAndCommitIfConfigured
+
+    @Test("pullAndCommitIfConfigured no-ops when communityOutboxURL is unset")
+    func noOpsWithoutCommunityOutboxURL() async throws {
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let count = await AnnouncedPostSync.pullAndCommitIfConfigured(
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDirectory,
+            transport: { _ in
+                Issue.record("transport must not be called with no communityOutboxURL configured")
+                struct Unexpected: Error {}
+                throw Unexpected()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommitIfConfigured reads communityOutboxURL and syncs when set")
+    func syncsWhenConfigured() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+        try await SiteConfigStore(configDirectory: configDirectory).save(
+            SiteSettings(communityOutboxURL: URL(string: "https://community.example/users/birding/outbox")!))
+
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/outbox?page=1"])
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        let count = await AnnouncedPostSync.pullAndCommitIfConfigured(
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/outbox") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (Self.pageBody(items: [Self.announceJSON()]), Self.response(200)) }
+                return (profileBody, Self.response(200))
+            })
+        #expect(count == 1)
+    }
+
+    private static func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "community-posts-sync-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Mirrors `ReceivedInteractionSyncTests.makeThrowawayGitRepo`.
+    private static func makeThrowawayGitRepo() throws -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("community-posts-sync-repo-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = dir
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return dir
+    }
+}

--- a/Tests/AnglesiteCoreTests/AnnouncedPostSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/AnnouncedPostSyncTests.swift
@@ -68,6 +68,22 @@ struct AnnouncedPostSyncTests {
         #expect(raw?.objectType == .note)
     }
 
+    @Test("OutboxClient.announce rejects a wrapped object whose id isn't http(s)")
+    func announceRejectsNonWebSourceScheme() {
+        let raw = AnnouncedPostSync.OutboxClient.announce(from: Self.announceJSON(innerID: "urn:uuid:not-a-web-url"))
+        #expect(raw == nil)
+    }
+
+    @Test("fileID derives a stable, path-safe, 16-hex-char id from an object IRI")
+    func fileIDIsStableAndPathSafe() {
+        let url = URL(string: "https://member.example/posts/1")!
+        let first = AnnouncedPostSync.fileID(for: url)
+        let second = AnnouncedPostSync.fileID(for: url)
+        #expect(first == second)
+        #expect(first.range(of: #"^community-[0-9a-f]{16}$"#, options: .regularExpression) != nil)
+        #expect(first != AnnouncedPostSync.fileID(for: URL(string: "https://member.example/posts/2")!))
+    }
+
     // MARK: - makePost
 
     @Test("makePost resolves the author from a cache hit without calling the fetcher")
@@ -170,6 +186,11 @@ struct AnnouncedPostSyncTests {
         let entries = (try? FileManager.default.contentsOfDirectory(
             at: siteDirectory.appendingPathComponent("data/community-posts"), includingPropertiesForKeys: nil)) ?? []
         #expect(entries.count == 1)
+        // Confirms the injected transport actually serves the author-profile fetch too (not the
+        // real network) — asserts through the full sync path, not just `makePost` in isolation.
+        let written = try #require(entries.first)
+        let text = try String(contentsOf: written, encoding: .utf8)
+        #expect(text.contains("Alice"))
     }
 
     @Test("returns 0 without touching git when the first-page fetch fails")
@@ -183,6 +204,38 @@ struct AnnouncedPostSyncTests {
             configDirectory: configDirectory,
             transport: { _ in (Data(), Self.response(500)) })
         #expect(count == 0)
+    }
+
+    @Test("follows a multi-page next chain and collects posts from every page")
+    func followsMultiPageChain() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/outbox?page=1"])
+        let page1 = Self.pageBody(
+            items: [Self.announceJSON(innerID: "https://member.example/posts/1")],
+            next: "https://community.example/users/birding/outbox?page=2")
+        let page2 = Self.pageBody(items: [Self.announceJSON(innerID: "https://member.example/posts/2")])
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        let count = await AnnouncedPostSync.pullAndCommit(
+            outboxURL: URL(string: "https://community.example/users/birding/outbox")!,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/outbox") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (page1, Self.response(200)) }
+                if path.contains("page=2") { return (page2, Self.response(200)) }
+                return (profileBody, Self.response(200))
+            })
+
+        #expect(count == 2)
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: siteDirectory.appendingPathComponent("data/community-posts"), includingPropertiesForKeys: nil)) ?? []
+        #expect(entries.count == 2)
     }
 
     @Test("reconciles away a snapshot whose post is no longer in the outbox (moderator removed it)")

--- a/Tests/AnglesiteCoreTests/AnnouncedPostTests.swift
+++ b/Tests/AnglesiteCoreTests/AnnouncedPostTests.swift
@@ -1,0 +1,93 @@
+// Tests/AnglesiteCoreTests/AnnouncedPostTests.swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("AnnouncedPost")
+struct AnnouncedPostTests {
+    @Test("round-trips through JSON encoding")
+    func jsonRoundTrip() throws {
+        let post = try AnnouncedPost(
+            id: "ap-abc123",
+            objectType: .note,
+            sourceURL: URL(string: "https://member.example/posts/42")!,
+            author: AnnouncedPost.Author(
+                name: "Jane Doe",
+                url: URL(string: "https://member.example"),
+                photo: URL(string: "https://member.example/photo.jpg")
+            ),
+            content: "Hello, community!",
+            published: ISO8601DateFormatter().date(from: "2026-06-28T14:30:00Z")!,
+            announcedAt: ISO8601DateFormatter().date(from: "2026-06-28T14:30:05Z")!
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(post)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(AnnouncedPost.self, from: data)
+        #expect(decoded == post)
+    }
+
+    @Test("gitPath produces the expected file path")
+    func gitPath() throws {
+        let post = try AnnouncedPost(
+            id: "ap-abc123",
+            objectType: .note,
+            sourceURL: URL(string: "https://member.example/posts/42")!,
+            author: nil,
+            content: nil,
+            published: Date(),
+            announcedAt: Date()
+        )
+        #expect(post.gitPath == "data/community-posts/ap-abc123.json")
+    }
+
+    @Test("rejects IDs containing path-traversal sequences")
+    func rejectsPathTraversal() {
+        #expect(throws: AnnouncedPost.ValidationError.self) {
+            try AnnouncedPost(
+                id: "../../etc/passwd",
+                objectType: .note,
+                sourceURL: URL(string: "https://member.example/posts/42")!,
+                author: nil,
+                content: nil,
+                published: Date(),
+                announcedAt: Date()
+            )
+        }
+    }
+
+    @Test("author and content are optional")
+    func optionalFields() throws {
+        let post = try AnnouncedPost(
+            id: "ap-abc123",
+            objectType: .article,
+            sourceURL: URL(string: "https://member.example/posts/42")!,
+            author: nil,
+            content: nil,
+            published: Date(),
+            announcedAt: Date()
+        )
+        #expect(post.author == nil)
+        #expect(post.content == nil)
+    }
+
+    @Test("every AS2 object type round-trips")
+    func objectTypeCoverage() throws {
+        for objectType: AnnouncedPost.ObjectType in [.note, .article, .page, .video, .event] {
+            let post = try AnnouncedPost(
+                id: "ap-\(objectType.rawValue)",
+                objectType: objectType,
+                sourceURL: URL(string: "https://member.example/posts/42")!,
+                author: nil,
+                content: nil,
+                published: Date(),
+                announcedAt: Date()
+            )
+            #expect(post.objectType == objectType)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/AnnouncedPostTests.swift
+++ b/Tests/AnglesiteCoreTests/AnnouncedPostTests.swift
@@ -60,6 +60,61 @@ struct AnnouncedPostTests {
         }
     }
 
+    @Test("rejects a sourceURL with a non-http(s) scheme")
+    func rejectsInsecureSourceURL() {
+        #expect(throws: AnnouncedPost.ValidationError.self) {
+            try AnnouncedPost(
+                id: "ap-abc123",
+                objectType: .note,
+                sourceURL: URL(string: "javascript:alert(document.cookie)")!,
+                author: nil,
+                content: nil,
+                published: Date(),
+                announcedAt: Date()
+            )
+        }
+    }
+
+    @Test("rejects an author url/photo with a non-http(s) scheme")
+    func rejectsInsecureAuthorURLs() {
+        #expect(throws: AnnouncedPost.ValidationError.self) {
+            try AnnouncedPost(
+                id: "ap-abc123",
+                objectType: .note,
+                sourceURL: URL(string: "https://member.example/posts/42")!,
+                author: .init(name: "Evil", url: URL(string: "javascript:alert(1)"), photo: nil),
+                content: nil,
+                published: Date(),
+                announcedAt: Date()
+            )
+        }
+        #expect(throws: AnnouncedPost.ValidationError.self) {
+            try AnnouncedPost(
+                id: "ap-abc123",
+                objectType: .note,
+                sourceURL: URL(string: "https://member.example/posts/42")!,
+                author: .init(name: "Evil", url: nil, photo: URL(string: "javascript:alert(1)")),
+                content: nil,
+                published: Date(),
+                announcedAt: Date()
+            )
+        }
+    }
+
+    @Test("accepts a plain http (not just https) sourceURL/author URL")
+    func acceptsPlainHTTP() throws {
+        let post = try AnnouncedPost(
+            id: "ap-abc123",
+            objectType: .note,
+            sourceURL: URL(string: "http://member.example/posts/42")!,
+            author: .init(name: "Jane", url: URL(string: "http://member.example"), photo: nil),
+            content: nil,
+            published: Date(),
+            announcedAt: Date()
+        )
+        #expect(post.sourceURL.scheme == "http")
+    }
+
     @Test("author and content are optional")
     func optionalFields() throws {
         let post = try AnnouncedPost(

--- a/Tests/AnglesiteCoreTests/CommunityTimelineRenderSmokeTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityTimelineRenderSmokeTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+/// Render half of V-5.2b (#908): an `AnnouncedPost` snapshot written to its `gitPath` renders on
+/// the community timeline at build time. Round-trips the actual Swift contract —
+/// `AnnouncedPost` → JSONEncoder → the template's zod loader — so a schema drift on either side
+/// fails here.
+///
+/// There is no real page mounting `CommunityTimeline.astro` yet — the actual timeline page ships
+/// with #907's group-preset scope ("Timeline page ships in the 5.1b group preset"). So this test
+/// writes a temporary fixture page alongside the data fixtures, purely to exercise the render
+/// pipeline end to end; it is never committed as template content.
+///
+/// `.serialized`: both tests below write to the *same* fixture-page path (there's only one
+/// component to mount), so they must not run concurrently against each other — on top of the
+/// cross-suite `TemplateBuildSerializer` lock the build/assertions already hold.
+@Suite("Community timeline render smoke", .serialized)
+struct CommunityTimelineRenderSmokeTests {
+
+    /// Repo-root-relative path to the committed template. `swift test` runs with CWD = package root.
+    static var templateDir: URL { get throws { try templateRoot() } }
+
+    /// True when the template can actually be built: a Node binary plus an installed Astro.
+    static var buildable: Bool { ((try? templateDir).map { E2EPrerequisites.astroBuildable(templateDir: $0) }) ?? false }
+
+    private static let fixturePageMarkup = """
+    ---
+    import BaseLayout from "../layouts/BaseLayout.astro";
+    import CommunityTimeline from "../components/CommunityTimeline.astro";
+    ---
+
+    <BaseLayout title="Community timeline smoke fixture" description="Render-smoke fixture for #908, never shipped.">
+      <CommunityTimeline />
+    </BaseLayout>
+    """
+
+    private static func fixture(
+        id: String,
+        objectType: AnnouncedPost.ObjectType,
+        content: String?
+    ) throws -> AnnouncedPost {
+        try AnnouncedPost(
+            id: id,
+            objectType: objectType,
+            sourceURL: URL(string: "https://member.example/posts/42")!,
+            author: .init(name: "Jane Doe", url: URL(string: "https://member.example"), photo: nil),
+            content: content,
+            published: Date(timeIntervalSince1970: 1_782_000_000),
+            announcedAt: Date(timeIntervalSince1970: 1_782_000_300))
+    }
+
+    @Test("an announced post snapshot renders on the community timeline",
+          .enabled(if: CommunityTimelineRenderSmokeTests.buildable))
+    func rendersAnnouncedPost() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let templateDir = try Self.templateDir
+        let dist = templateDir.appendingPathComponent("dist", isDirectory: true)
+        let fixturePage = templateDir.appendingPathComponent("src/pages/community-timeline-smoke-fixture.astro")
+        let postFixture = templateDir.appendingPathComponent(
+            (try Self.fixture(id: "community-swiftsmoke", objectType: .note, content: nil)).gitPath)
+
+        // Hold the shared template-build lock across fixture setup, the build, *and* the
+        // assertions — sibling render-smoke suites rebuild the same template tree (see
+        // PersonalTypeRenderSmokeTests), and this suite's own two tests share one fixture page.
+        try await TemplateBuildSerializer.shared.serialize {
+            try? FileManager.default.removeItem(at: dist)
+            defer {
+                try? FileManager.default.removeItem(at: dist)
+                try? FileManager.default.removeItem(at: postFixture)
+                try? FileManager.default.removeItem(at: fixturePage)
+            }
+
+            let post = try Self.fixture(id: "community-swiftsmoke", objectType: .note, content: "A verified post from the Swift smoke test.")
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            try FileManager.default.createDirectory(at: postFixture.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try encoder.encode(post).write(to: postFixture)
+            try Self.fixturePageMarkup.write(to: fixturePage, atomically: true, encoding: .utf8)
+
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
+                currentDirectoryURL: templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+            let pageHTML = try String(
+                contentsOf: dist.appendingPathComponent("community-timeline-smoke-fixture/index.html"),
+                encoding: .utf8)
+            #expect(pageHTML.contains("h-entry community-post"))
+            #expect(pageHTML.contains("A verified post from the Swift smoke test."))
+            #expect(pageHTML.contains("Jane Doe"))
+        }
+    }
+
+    @Test("a post with an invalid path-traversal id is skipped, not built",
+          .enabled(if: CommunityTimelineRenderSmokeTests.buildable))
+    func skipsMalformedSnapshot() async throws {
+        let node = try #require(E2EPrerequisites.locateNode())
+        let templateDir = try Self.templateDir
+        let dist = templateDir.appendingPathComponent("dist", isDirectory: true)
+        let fixturePage = templateDir.appendingPathComponent("src/pages/community-timeline-smoke-fixture.astro")
+        let malformedURL = templateDir.appendingPathComponent("data/community-posts/malformed.json")
+
+        try await TemplateBuildSerializer.shared.serialize {
+            try? FileManager.default.removeItem(at: dist)
+            defer {
+                try? FileManager.default.removeItem(at: dist)
+                try? FileManager.default.removeItem(at: malformedURL)
+                try? FileManager.default.removeItem(at: fixturePage)
+            }
+
+            try FileManager.default.createDirectory(at: malformedURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            // Written directly (not through AnnouncedPost's own path-traversal guard) since this
+            // fixture simulates a malformed file reaching the template layer some other way.
+            try Data("""
+            {"id": "not valid!", "objectType": "note", "sourceURL": "https://member.example/x",
+             "published": "2026-06-28T14:30:00Z", "announcedAt": "2026-06-28T14:30:05Z"}
+            """.utf8).write(to: malformedURL)
+            try Self.fixturePageMarkup.write(to: fixturePage, atomically: true, encoding: .utf8)
+
+            let result = try await ProcessSupervisor.shared.run(
+                executable: node,
+                arguments: [E2EPrerequisites.astroCLIRelativePath, "build"],
+                currentDirectoryURL: templateDir)
+            try #require(result.exitCode == 0, "astro build failed: \(result.stdout)\n\(result.stderr)")
+
+            let pageHTML = try String(
+                contentsOf: dist.appendingPathComponent("community-timeline-smoke-fixture/index.html"),
+                encoding: .utf8)
+            #expect(!pageHTML.contains("h-entry community-post"))
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -185,4 +185,39 @@ struct SiteConfigStoreTests {
         let loaded = try await store.load()
         #expect(loaded.webmentionReceivePaidPlanAcknowledged == nil)
     }
+
+    @Test("communityOutboxURL round-trips through save/load")
+    func communityOutboxURLRoundTrips() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let settings = SiteSettings(communityOutboxURL: URL(string: "https://community.example/users/birding/outbox"))
+        try await store.save(settings)
+
+        let loaded = try await store.load()
+        #expect(loaded.communityOutboxURL == URL(string: "https://community.example/users/birding/outbox"))
+    }
+
+    @Test("a settings.plist written before communityOutboxURL existed still decodes (forward-compat)")
+    func decodesOldPlistWithoutCommunityOutboxURL() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        // Simulates a plist written by a build that predates this field.
+        let oldFormat = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>displayName</key>
+            <string>My Site</string>
+        </dict>
+        </plist>
+        """
+        try oldFormat.write(to: dir.appendingPathComponent("settings.plist"), atomically: true, encoding: .utf8)
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let loaded = try await store.load()
+        #expect(loaded.communityOutboxURL == nil)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `AnnouncedPost`/`AnnouncedPostCommitter`/`AnnouncedPostSync` in `AnglesiteCore`, mirroring `ReceivedInteraction`'s C.3 snapshot-to-git pattern, to pull a hosted community's own Group-actor outbox (unauthenticated public AS2 fetch — the Worker's `outbox` table already holds member-post `Announce`s, per `davidwkeith/workers` PR #401) and reconcile it into `Source/data/community-posts/`.
- Adds the matching Astro pieces (`src/lib/communityPosts.ts` + `src/components/CommunityTimeline.astro`) following the `interactions.ts`/`Interactions.astro` pattern from PR #901.
- Wires `AnnouncedPostSync.pullAndCommitIfConfigured` into `PreviewModel.open(site:)` alongside the other three per-site syncs, gated on a new `SiteSettings.communityOutboxURL` field that stays `nil` (and thus inert, no network call) on every existing site.
- Closes out the buildable half of #908 (V-5.2b). The actual timeline *page* that mounts `CommunityTimeline.astro` ships with #907's group-preset scope, per the issue's own plan; #907 also needs a not-yet-published `catalog.json` entry upstream, so it's still blocked. #370 (moderation tooling) remains blocked on #907 in addition to this.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

No MCP message schema changed, and no `@dwk/workers` `catalog.json` field was touched — `communityOutboxURL` is a purely app-side settings field.

## Test plan

- [x] `swift test --package-path .` — full suite passes (2952 tests / 377 suites in `AnglesiteCoreTests`, plus all other targets).
- [x] `xcodebuild`/`scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `BUILD SUCCEEDED`.
- [x] `npm test` in `Resources/Template/` — full suite passes (597 unit tests + 35 astro-render tests), including the new `communityPosts.test.ts` and `CommunityTimelineRenderSmokeTests.swift` (round-trips `AnnouncedPost` → JSONEncoder → the template's zod loader → rendered HTML via a temporary, non-committed fixture page).