### PR TITLE
fix(#1084): re-sync wrangler.toml into the guest before deploy

### DIFF
--- a/Sources/AnglesiteCore/DeployExecutor.swift
+++ b/Sources/AnglesiteCore/DeployExecutor.swift
@@ -116,6 +116,40 @@ public struct ContainerDeployExecutor: DeployExecutor {
         source: String
     ) async -> DeployStepResult {
         // `siteDirectory` is the HOST path — the guest always uses /workspace/site.
+        //
+        // #1084: `/workspace/site` is a one-time `git clone` taken when the container booted
+        // (`ContainerizationControl.start`) — it only reflects whatever was committed at that
+        // moment. `SocialWorkerProvisionCommand.persistConfig`/`WorkerNameRename.apply` write the
+        // site's concrete `wrangler.toml` (worker bindings, `main`, resource ids) straight to this
+        // HOST directory as an uncommitted change, so a container that booted before that write
+        // (the common case — the preview container is already running when the owner turns on a
+        // social feature and deploys) still has the ORIGINAL static-only `wrangler.toml` in its
+        // clone. Without re-syncing here, `wrangler deploy` publishes an assets-only Worker with no
+        // `main` script attached at all, even though the host's `wrangler.toml` is correct — every
+        // dynamic route 404s and `wrangler tail` refuses to attach. Only `.wrangler` needs this:
+        // `astro build` and the preflight scan never read `wrangler.toml` (confirmed against
+        // `Resources/Template`), so re-syncing before them would be pure overhead.
+        if step == .wrangler, let syncArgv = Self.wranglerTomlSyncArgv(hostSiteDirectory: siteDirectory) {
+            do {
+                let syncResult = try await control.exec(
+                    siteID: siteID,
+                    argv: syncArgv,
+                    environment: [:],
+                    workingDirectory: "/workspace/site",
+                    onOutput: { _, _ in }
+                )
+                guard syncResult.exitCode == 0 else {
+                    return DeployStepResult(
+                        exitCode: nil,
+                        output: "couldn't sync wrangler.toml into the container (exit \(syncResult.exitCode))"
+                    )
+                }
+            } catch is CancellationError {
+                return DeployStepResult(exitCode: nil, output: "")
+            } catch {
+                return DeployStepResult(exitCode: nil, output: "couldn't sync wrangler.toml into the container: \(error)")
+            }
+        }
         let argv = Self.guestArgv(for: step, siteDirectory: siteDirectory)
         // Stream guest output to LogCenter LIVE (matching the host path): the `@escaping @Sendable`
         // `onOutput` callback yields each (line, stream) into an AsyncStream (`yield` is nonisolated
@@ -283,6 +317,21 @@ public struct ContainerDeployExecutor: DeployExecutor {
 
     private static func guestEnvironment(from hostEnvironment: [String: String]) -> [String: String] {
         hostEnvironment.filter { guestEnvAllowlist.contains($0.key) }
+    }
+
+    // MARK: wrangler.toml sync (#1084)
+
+    /// Returns the guest shell argv that overwrites `wrangler.toml` (in the guest's current working
+    /// directory) with `hostSiteDirectory`'s current `wrangler.toml` content — `nil` when the host
+    /// file can't be read, meaning there's nothing to sync (the boot-time clone's copy is the best
+    /// we have). Base64-encodes the content so it embeds directly in the `sh -c` string with no
+    /// shell-quoting/escaping surface, mirroring `ContainerizationControl.writeGuestFile`.
+    static func wranglerTomlSyncArgv(hostSiteDirectory: URL) -> [String]? {
+        guard let contents = try? String(
+            contentsOf: hostSiteDirectory.appendingPathComponent("wrangler.toml"), encoding: .utf8
+        ) else { return nil }
+        let encoded = Data(contents.utf8).base64EncodedString()
+        return ["sh", "-c", "echo \(encoded) | base64 -d > wrangler.toml"]
     }
 
     // MARK: argv mapping

--- a/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift
@@ -273,6 +273,115 @@ struct ContainerDeployExecutorTests {
         #expect(calls[0].siteID == "my-special-site")
     }
 
+    // MARK: - #1084: wrangler.toml re-sync before `wrangler deploy`
+
+    /// A real host directory with a `wrangler.toml` on disk, modelling the site's `Source/`
+    /// working tree after `SocialWorkerProvisionCommand.persistConfig` has written a
+    /// features-enabled config there.
+    private func makeHostSiteDirectory(wranglerToml: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try wranglerToml.write(to: dir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    @Test("wrangler step re-syncs the host's current wrangler.toml into the guest before deploying")
+    func wranglerStepResyncsTomlBeforeDeploy() async throws {
+        // Models the exact #1084 scenario: the guest's /workspace/site clone is stale (it was
+        // cloned before the site turned on a social feature), but the HOST wrangler.toml — just
+        // written by SocialWorkerProvisionCommand.persistConfig — already has `main` and the
+        // worker's bindings. Without a re-sync, `wrangler deploy` would run against the guest's
+        // stale, assets-only copy and publish a Worker with no script attached at all.
+        let freshToml = "name = \"my-site\"\nmain = \"worker/worker.ts\"\n\n[assets]\ndirectory = \"dist\"\n"
+        let hostSiteDirectory = try makeHostSiteDirectory(wranglerToml: freshToml)
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+
+        let result = await executor.run(
+            step: .wrangler,
+            siteDirectory: hostSiteDirectory,
+            environment: ["CLOUDFLARE_API_TOKEN": "tok123"],
+            source: "deploy:site-abc"
+        )
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 2, "expected a sync exec followed by the deploy exec")
+
+        // First call: writes the fresh host content into the guest's wrangler.toml, never
+        // interpolating the content directly into the shell string.
+        #expect(calls[0].argv[0] == "sh")
+        #expect(calls[0].argv[1] == "-c")
+        #expect(calls[0].argv[2].contains("base64 -d > wrangler.toml"))
+        #expect(!calls[0].argv[2].contains("main = "), "content must travel base64-encoded, never spliced in literally")
+        #expect(calls[0].cwd == "/workspace/site")
+
+        // Decode what was actually sent and confirm it's the fresh host content.
+        let script = calls[0].argv[2]
+        let base64Part = script
+            .replacingOccurrences(of: "echo ", with: "")
+            .replacingOccurrences(of: " | base64 -d > wrangler.toml", with: "")
+        let decoded = Data(base64Encoded: base64Part).flatMap { String(data: $0, encoding: .utf8) }
+        #expect(decoded == freshToml)
+
+        // Second call: the actual deploy, unchanged.
+        #expect(calls[1].argv == ["npx", "wrangler", "deploy"])
+        #expect(result.exitCode == 0)
+    }
+
+    @Test("build and preflight steps do not re-sync wrangler.toml (neither reads it)")
+    func nonWranglerStepsSkipResync() async throws {
+        let hostSiteDirectory = try makeHostSiteDirectory(wranglerToml: "name = \"my-site\"\n")
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+
+        _ = await executor.run(step: .build, siteDirectory: hostSiteDirectory, environment: [:], source: "src")
+        _ = await executor.run(step: .preflight, siteDirectory: hostSiteDirectory, environment: [:], source: "src")
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 2, "no sync call for either step")
+        #expect(calls[0].argv == ["npm", "run", "build"])
+        #expect(calls[1].argv == ["npx", "tsx", "scripts/pre-deploy-check.ts", "--json"])
+    }
+
+    @Test("wrangler step skips the sync when the host has no wrangler.toml yet")
+    func wranglerStepSkipsSyncWhenHostFileMissing() async {
+        let fake = fakePassing()
+        let executor = makeExecutor(fake: fake)
+
+        _ = await executor.run(
+            step: .wrangler,
+            siteDirectory: URL(fileURLWithPath: "/host/does-not-exist-\(UUID().uuidString)"),
+            environment: ["CLOUDFLARE_API_TOKEN": "tok"],
+            source: "deploy:site-abc"
+        )
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].argv == ["npx", "wrangler", "deploy"])
+    }
+
+    @Test("a failed wrangler.toml sync fails the step without ever attempting `wrangler deploy`")
+    func failedSyncPreventsDeploy() async throws {
+        let hostSiteDirectory = try makeHostSiteDirectory(wranglerToml: "name = \"my-site\"\n")
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.virtualizationUnavailable),
+            execResult: ContainerExecResult(exitCode: 1, stdout: "", stderr: "disk full")
+        )
+        let executor = makeExecutor(fake: fake)
+
+        let result = await executor.run(
+            step: .wrangler,
+            siteDirectory: hostSiteDirectory,
+            environment: ["CLOUDFLARE_API_TOKEN": "tok"],
+            source: "deploy:site-abc"
+        )
+
+        let calls = await fake.execCalls
+        #expect(calls.count == 1, "must not fall through to `wrangler deploy` after a failed sync")
+        #expect(result.exitCode == nil)
+        #expect(result.output.contains("sync"))
+    }
+
     // MARK: - #748 capability defaults
 
     @Test("HostDeployExecutor reports no owned path claims by default")

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -18,7 +18,12 @@ struct DeployExecutorSelectionTests {
     // A successful scan JSON so the full build→preflight→wrangler flow runs without blocking.
     private let scanOK = #"{"version":1,"ok":true,"failures":[],"warnings":[]}"#
     private let wranglerOut = "Published site (1s)\n  https://site.example.workers.dev"
-    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    // A fresh, isolated subdirectory per test — NOT the raw shared system temp root. These tests
+    // only care about step routing/count, but #1084's fix makes `ContainerDeployExecutor` read
+    // `siteDirectory/wrangler.toml` off disk before the `.wrangler` step; the bare temp root is
+    // shared process-wide, so a leftover `wrangler.toml` from an unrelated test (or a prior local
+    // run) would silently change these tests' exec-call counts.
+    private let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
 
     // MARK: - Container path
 


### PR DESCRIPTION
## Summary

- The guest container's `/workspace/site` is a one-time `git clone` taken when the container boots. When a site activates server-side workers (ActivityPub, IndieAuth, …) after that container is already running, `SocialWorkerProvisionCommand.persistConfig`/`WorkerNameRename.apply` write the updated `wrangler.toml` (`main`, bindings, resource ids) only to the **host** `Source/` directory, as an uncommitted change the guest's stale clone never sees.
- Every subsequent `wrangler deploy` therefore ran against the guest's stale, static-only `wrangler.toml` — publishing an assets-only Worker with **no script attached at all**, so every dynamic route (`/.well-known/webfinger`, `/inbox`, …) 404s and `wrangler tail` refuses to attach.
- `ContainerDeployExecutor.run()` now re-syncs the host's current `wrangler.toml` into the guest immediately before the `.wrangler` step (only that step needs it — `astro build` and `pre-deploy-check.ts` never read `wrangler.toml`). A failed sync fails the deploy rather than silently falling through to `wrangler deploy` with a stale config.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

N/A — no MCP message schema change; this is entirely in the app's deploy pipeline (`Sources/AnglesiteCore/DeployExecutor.swift`).

## Test plan

- [x] `swift test --package-path .` — full suite (2975+ tests across 6 targets) passes.
- [x] `xcodebuild`/`scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `BUILD SUCCEEDED`.
- [x] New tests in `Tests/AnglesiteCoreTests/ContainerDeployExecutorTests.swift` cover: the sync happening before `wrangler deploy` with the correct content, `.build`/`.preflight` skipping the sync (neither reads `wrangler.toml`), skipping the sync when the host has no `wrangler.toml` yet, and a failed sync short-circuiting before `wrangler deploy` ever runs.
- [x] Fixing this surfaced a latent test-hygiene issue in `DeployExecutorSelectionTests.swift` (three tests used the raw shared system temp directory as `siteDirectory`, so a leftover `wrangler.toml` from another test run silently changed exec-call counts once file content became observable) — fixed by isolating each test to its own temp subdirectory.
- [ ] Manual smoke: not performed (would require a live Cloudflare deploy with ActivityPub enabled to confirm `/.well-known/webfinger` responds post-fix; the fix is verified via the unit tests above, which assert the exact guest-side exec sequence and content).