### PR TITLE
fix(#1079): migrate astro.config off deprecated remarkPlugins

### DIFF
--- a/Resources/Template/astro.config.ts
+++ b/Resources/Template/astro.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "astro/config";
+import { unified } from "@astrojs/markdown-remark";
 import keystatic from "@keystatic/astro";
 import react from "@astrojs/react";
 import { readConfig } from "./scripts/config.ts";
@@ -23,11 +24,10 @@ const isDev = isKeystaticDev(process.argv);
 export default defineConfig({
   site,
   integrations: [anglesiteHarness(), redirects(), co2Badge(), ...(isDev ? [react(), keystatic()] : [])],
-  // Astro 7's default markdown processor (Sätteri) no longer carries remark itself, so
-  // `remarkPlugins` requires `@astrojs/markdown-remark` as an explicit dependency (#682).
-  // Without it Astro fails config validation outright rather than silently skipping the
-  // plugin — so if the embeds pipeline ever goes inert, check that dependency first.
+  // Astro 7's default markdown processor (Sätteri) no longer carries remark itself, so custom
+  // remark plugins go through `unified()` from `@astrojs/markdown-remark`, an explicit
+  // dependency (#682) — the top-level `markdown.remarkPlugins` shorthand is deprecated (#1079).
   markdown: {
-    remarkPlugins: [remarkEmbeds],
+    processor: unified({ remarkPlugins: [remarkEmbeds] }),
   },
 });


### PR DESCRIPTION
## Summary

- `Resources/Template/astro.config.ts` configured markdown plugins via the top-level `markdown.remarkPlugins`, which Astro 7 flags as deprecated (noisy on every deploy log).
- Switched to the current API: `markdown.processor: unified({ remarkPlugins: [remarkEmbeds] })`, using `unified` imported from `@astrojs/markdown-remark` (already a direct dependency per #682).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: N/A — template-only change, no MCP schema touched.

## Test plan

- [x] `swift test --package-path .`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [x] Manual smoke: `npx astro build` in `Resources/Template/` — confirmed the deprecation warning is gone from the build log and the site still builds successfully (27 pages). Also ran `npx astro check` (0 errors) and `npm run test:scripts` (580/582 passed, 2 pre-existing skips).

Closes #1079.