### PR TITLE
fix(#1009): make escapeYAML control-char-safe

### DIFF
--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -297,9 +297,35 @@ public enum ContentScaffold {
          .replacingOccurrences(of: ">", with: "&gt;")
     }
 
+    /// Escape a string for a double-quoted YAML scalar. Every scalar this renders sits on one
+    /// frontmatter line, so an unescaped newline (or other control character) would split the
+    /// block and produce unparseable frontmatter — mirrors `escapeJSON`'s reasoning, using YAML's
+    /// own named escapes (`\0`, `\a`, `\v`, `\e`, `\xXX`) in place of JSON's.
     static func escapeYAML(_ s: String) -> String {
-        s.replacingOccurrences(of: "\\", with: "\\\\")
-         .replacingOccurrences(of: "\"", with: "\\\"")
+        var out = ""
+        out.reserveCapacity(s.count)
+        for scalar in s.unicodeScalars {
+            switch scalar {
+            case "\\": out += "\\\\"
+            case "\"": out += "\\\""
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            case "\u{00}": out += "\\0"
+            case "\u{07}": out += "\\a"
+            case "\u{08}": out += "\\b"
+            case "\u{0B}": out += "\\v"
+            case "\u{0C}": out += "\\f"
+            case "\u{1B}": out += "\\e"
+            case let c where c.value < 0x20:
+                out += String(format: "\\x%02x", c.value)
+            case "\u{2028}": out += "\\L"
+            case "\u{2029}": out += "\\P"
+            default:
+                out.unicodeScalars.append(scalar)
+            }
+        }
+        return out
     }
 
     /// Escape a string for use as a JSON string value. Covers `\` and `"`, the named control

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -84,6 +84,27 @@ struct ContentScaffoldTests {
         #expect(out.contains("description: \"How we shipped it.\""))
     }
 
+    @Test("escapeYAML escapes newlines, carriage returns, tabs, and other control characters")
+    func escapeYAMLEscapesControlChars() {
+        #expect(ContentScaffold.escapeYAML("a\nb") == "a\\nb")
+        #expect(ContentScaffold.escapeYAML("a\rb") == "a\\rb")
+        #expect(ContentScaffold.escapeYAML("a\tb") == "a\\tb")
+        #expect(ContentScaffold.escapeYAML("a\u{0}b") == "a\\0b")
+        #expect(ContentScaffold.escapeYAML("a\u{1}b") == "a\\x01b")
+        // Existing backslash/quote handling must still work alongside the new escapes.
+        #expect(ContentScaffold.escapeYAML("back\\slash \"quote\"\n") == "back\\\\slash \\\"quote\\\"\\n")
+    }
+
+    @Test("renderPost keeps a title's interior newline from splitting the frontmatter block")
+    func renderPostTitleWithInteriorNewlineStaysOnOneLine() {
+        let date = Date(timeIntervalSince1970: 1_750_000_000)
+        let out = ContentScaffold.renderPost(title: "Line one\nLine two", now: date)
+        let frontmatter = out.components(separatedBy: "---\n")[1]
+        let titleLine = try! #require(frontmatter.split(separator: "\n", omittingEmptySubsequences: false)
+            .first { $0.hasPrefix("title:") })
+        #expect(titleLine == "title: \"Line one\\nLine two\"")
+    }
+
     @Test("renderEntry emits frontmatter for a note with body below the block, as a draft")
     func renderEntryNote() {
         let note = try! #require(ContentTypeRegistry().descriptor(id: "note"))


### PR DESCRIPTION
## Summary

- `ContentScaffold.escapeYAML` only escaped `\` and `"`; every scalar it renders sits on one double-quoted YAML frontmatter line, so an unescaped newline (or other control char) in a scaffolded value split the block and produced an unparseable content file.
- Made `escapeYAML` control-char-safe, mirroring `escapeJSON`'s existing coverage in the same file — named escapes for `\n \r \t \0 \a \b \v \f \e`, `\xXX` for any remaining C0 control char, and `\L`/`\P` for U+2028/U+2029 — using YAML's own escape syntax rather than JSON's.
- Not reachable through the app UI today (per the issue: the New Collection sheet's single-line `TextField` needs a paste to hit the title path, and no current caller passes a non-`.url` `fieldValues` entry raw); this closes the class of bug permanently rather than leaving it latent.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

N/A — no MCP message schema change; this is an app-side content-scaffolding fix in `Sources/AnglesiteCore/ContentScaffold.swift`.

## Test plan

- [x] `swift test --package-path .` — full suite passes for this change. Two unrelated pre-existing failures observed on this same commit before any of my changes (`DeployModelTests`'s two custom-domain-attach URL-swap tests, a regression from the just-merged #1077 fix in PR #1119) and one on-device `FoundationModelAssistant` live-model test flake (empty reply after ~509s) — neither touches `ContentScaffold` or its tests; filed the DeployModelTests regression separately rather than folding an unrelated fix into this PR.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `BUILD SUCCEEDED`.
- [ ] Manual smoke: not applicable — pure string-escaping fix with no reachable UI path today (see Summary); covered by unit tests (`escapeYAML` direct cases + a `renderPost` regression test asserting an interior-newline title stays on one frontmatter line).

Closes #1009.