### PR TITLE
feat(#1117): repeating structured-group field kind (objectArray)

### DIFF
--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -168,6 +168,10 @@ final class TypedEntryEditorModel: InspectorEditorModel {
         Binding(get: { [weak self] in if case .list(let a)? = self?.values[name] { return a }; return [] },
                 set: { [weak self] in self?.values[name] = .list($0) })
     }
+    func recordsBinding(_ name: String) -> Binding<[[String: TypedContentEditor.FieldValue]]> {
+        Binding(get: { [weak self] in if case .records(let r)? = self?.values[name] { return r }; return [] },
+                set: { [weak self] in self?.values[name] = .records($0) })
+    }
 
     // MARK: Private
 

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -59,6 +59,8 @@ struct TypedEntryForm: View {
         case .stringArray, .imageArray:
             StringListEditor(title: label, items: model.listBinding(field.name),
                              pickFile: field.kind == .imageArray)
+        case .objectArray(let memberFields):
+            ObjectArrayEditor(title: label, memberFields: memberFields, records: model.recordsBinding(field.name))
         case .markdown:
             EmptyView()   // handled by the Body section
         }
@@ -130,5 +132,109 @@ private struct StringListEditor: View {
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
         if panel.runModal() == .OK, let url = panel.url { rows.append(Row(value: url.lastPathComponent)) }
+    }
+}
+
+/// An add/remove list editor for `objectArray` fields — one collapsible-free block per record, each
+/// rendering its member fields inline. Rows carry stable UUID identity, mirroring `StringListEditor`,
+/// so deleting a row never re-binds a surviving row's editor to the wrong record.
+private struct ObjectArrayEditor: View {
+    let title: String
+    let memberFields: [ContentTypeField]
+    @Binding var records: [[String: TypedContentEditor.FieldValue]]
+
+    private struct Row: Identifiable, Equatable {
+        let id = UUID()
+        var values: [String: TypedContentEditor.FieldValue]
+    }
+    @State private var rows: [Row] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            ForEach($rows) { $row in
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(memberFields, id: \.name) { field in
+                        memberControl(for: field, in: $row.values)
+                    }
+                    HStack {
+                        Spacer()
+                        Button(role: .destructive) { rows.removeAll { $0.id == row.id } } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+                .padding(8)
+                .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary))
+            }
+            Button { rows.append(Row(values: emptyRecord())) } label: {
+                Label("Add", systemImage: "plus.circle")
+            }
+            .buttonStyle(.borderless)
+        }
+        .onAppear { syncRowsFromRecords() }
+        .onChange(of: records) { _, new in
+            if new != rows.map(\.values) { rows = new.map(Row.init(values:)) }
+        }
+        .onChange(of: rows) { _, new in
+            let mapped = new.map(\.values)
+            if mapped != records { records = mapped }
+        }
+    }
+
+    private func emptyRecord() -> [String: TypedContentEditor.FieldValue] {
+        Dictionary(uniqueKeysWithValues: memberFields.map { ($0.name, TypedContentEditor.defaultValue(for: $0.kind)) })
+    }
+
+    private func syncRowsFromRecords() {
+        if records != rows.map(\.values) { rows = records.map(Row.init(values:)) }
+    }
+
+    @ViewBuilder
+    private func memberControl(for field: ContentTypeField, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> some View {
+        let label = field.name + (field.required ? " *" : "")
+        switch field.kind {
+        case .bool:
+            Toggle(label, isOn: flagBinding(field.name, in: values))
+        case .date, .datetime:
+            DatePicker(label, selection: dateBinding(field.name, in: values),
+                       displayedComponents: field.kind == .date ? [.date] : [.date, .hourAndMinute])
+        case .number:
+            TextField(label, text: numberBinding(field.name, in: values))
+        default:
+            TextField(label, text: textBinding(field.name, in: values))
+        }
+    }
+
+    private func textBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<String> {
+        Binding(
+            get: { if case .text(let s)? = values.wrappedValue[name] { return s }; return "" },
+            set: { values.wrappedValue[name] = .text($0) }
+        )
+    }
+
+    private func flagBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<Bool> {
+        Binding(
+            get: { if case .flag(let b)? = values.wrappedValue[name] { return b }; return false },
+            set: { values.wrappedValue[name] = .flag($0) }
+        )
+    }
+
+    private func dateBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<Date> {
+        Binding(
+            get: { if case .date(let d)? = values.wrappedValue[name] { return d ?? Date() }; return Date() },
+            set: { values.wrappedValue[name] = .date($0) }
+        )
+    }
+
+    private func numberBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<String> {
+        Binding(
+            get: {
+                if case .number(let n)? = values.wrappedValue[name], let n { return String(n) }
+                return ""
+            },
+            set: { values.wrappedValue[name] = .number(Double($0)) }
+        )
     }
 }

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -148,6 +148,11 @@ private struct ObjectArrayEditor: View {
         var values: [String: TypedContentEditor.FieldValue]
     }
     @State private var rows: [Row] = []
+    /// In-progress number text per row, per member field — the nested-row counterpart of
+    /// `TypedEntryEditorModel.numberDrafts`. Keyed by row identity so two rows editing the same
+    /// member field never share (and clobber) each other's draft. Without it a mid-edit draft like
+    /// "3." (on its way to "3.5") parses as nil and snaps the field back to empty.
+    @State private var numberDrafts: [Row.ID: [String: String]] = [:]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -155,11 +160,11 @@ private struct ObjectArrayEditor: View {
             ForEach($rows) { $row in
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(memberFields, id: \.name) { field in
-                        memberControl(for: field, in: $row.values)
+                        memberControl(for: field, in: $row.values, rowID: row.id)
                     }
                     HStack {
                         Spacer()
-                        Button(role: .destructive) { rows.removeAll { $0.id == row.id } } label: {
+                        Button(role: .destructive) { removeRow(row.id) } label: {
                             Image(systemName: "minus.circle")
                         }
                         .buttonStyle(.borderless)
@@ -175,12 +180,20 @@ private struct ObjectArrayEditor: View {
         }
         .onAppear { syncRowsFromRecords() }
         .onChange(of: records) { _, new in
-            if new != rows.map(\.values) { rows = new.map(Row.init(values:)) }
+            if new != rows.map(\.values) {
+                rows = new.map(Row.init(values:))
+                numberDrafts.removeAll()   // rows were replaced wholesale (e.g. reload from disk)
+            }
         }
         .onChange(of: rows) { _, new in
             let mapped = new.map(\.values)
             if mapped != records { records = mapped }
         }
+    }
+
+    private func removeRow(_ id: Row.ID) {
+        rows.removeAll { $0.id == id }
+        numberDrafts[id] = nil
     }
 
     private func emptyRecord() -> [String: TypedContentEditor.FieldValue] {
@@ -192,18 +205,46 @@ private struct ObjectArrayEditor: View {
     }
 
     @ViewBuilder
-    private func memberControl(for field: ContentTypeField, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> some View {
+    private func memberControl(for field: ContentTypeField,
+                               in values: Binding<[String: TypedContentEditor.FieldValue]>,
+                               rowID: Row.ID) -> some View {
         let label = field.name + (field.required ? " *" : "")
+        // Exhaustive on purpose — no `default:`. A catch-all rendered the four kinds a member field
+        // must not use (see `ContentTypeField.Kind.objectArray`) as an ordinary TextField bound to
+        // `.text`, while `TypedContentEditor.decode`/`encode` expect `.list`/`.records` there — a
+        // working-looking control that corrupts the record on save. Listing every kind also makes
+        // the compiler flag a newly added `Kind` here instead of letting it fall into that trap.
         switch field.kind {
+        case .string, .text, .url, .image:
+            HStack {
+                TextField(label, text: textBinding(field.name, in: values))
+                if field.kind == .image {
+                    Button("Choose…") { chooseFile(for: field.name, in: values) }
+                }
+            }
         case .bool:
             Toggle(label, isOn: flagBinding(field.name, in: values))
         case .date, .datetime:
             DatePicker(label, selection: dateBinding(field.name, in: values),
                        displayedComponents: field.kind == .date ? [.date] : [.date, .hourAndMinute])
         case .number:
-            TextField(label, text: numberBinding(field.name, in: values))
-        default:
-            TextField(label, text: textBinding(field.name, in: values))
+            TextField(label, text: numberBinding(field.name, in: values, rowID: rowID))
+        case .markdown, .stringArray, .imageArray, .objectArray:
+            // Fail visibly rather than silently. `verbatim:` deliberately: this is a
+            // descriptor-authoring diagnostic that no shipped descriptor can reach, not user copy.
+            Text(verbatim: "\(field.name) — unsupported member field kind")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func chooseFile(for name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            values.wrappedValue[name] = .text(url.lastPathComponent)
         }
     }
 
@@ -228,13 +269,37 @@ private struct ObjectArrayEditor: View {
         )
     }
 
-    private func numberBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<String> {
+    /// Mirrors `TypedEntryEditorModel.numberBinding` one level down: a per-row draft buffer so a
+    /// mid-edit unparseable value never clobbers the stored number, and integral display formatting
+    /// so a valid "1" doesn't immediately redisplay as "1.0".
+    private func numberBinding(_ name: String,
+                               in values: Binding<[String: TypedContentEditor.FieldValue]>,
+                               rowID: Row.ID) -> Binding<String> {
         Binding(
             get: {
-                if case .number(let n)? = values.wrappedValue[name], let n { return String(n) }
+                if let draft = numberDrafts[rowID]?[name] { return draft }
+                if case .number(let n)? = values.wrappedValue[name], let n { return Self.displayNumber(n) }
                 return ""
             },
-            set: { values.wrappedValue[name] = .number(Double($0)) }
+            set: { raw in
+                numberDrafts[rowID, default: [:]][name] = raw
+                let trimmed = raw.trimmingCharacters(in: .whitespaces)
+                // Only overwrite the stored value when the draft parses (or is cleared). A mid-edit
+                // unparseable draft like "3." must not clobber a previously valid number with nil.
+                if trimmed.isEmpty {
+                    values.wrappedValue[name] = .number(nil)
+                } else if let parsed = Double(trimmed) {
+                    values.wrappedValue[name] = .number(parsed)
+                }
+            }
         )
+    }
+
+    /// Integral values render without a trailing ".0"; the magnitude guard avoids the `Int(_:)`
+    /// overflow trap. Mirrors `TypedEntryEditorModel.displayNumber` (private there) — keep the two
+    /// in step so a number reads identically at top level and inside a record row.
+    private static func displayNumber(_ n: Double) -> String {
+        if n == n.rounded(), abs(n) < 1e15 { return String(Int(n)) }
+        return String(n)
     }
 }

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -61,8 +61,6 @@ struct TypedEntryForm: View {
                              pickFile: field.kind == .imageArray)
         case .markdown:
             EmptyView()   // handled by the Body section
-        case .objectArray:
-            EmptyView()   // handled by the Records section
         }
     }
 

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -61,6 +61,8 @@ struct TypedEntryForm: View {
                              pickFile: field.kind == .imageArray)
         case .markdown:
             EmptyView()   // handled by the Body section
+        case .objectArray:
+            EmptyView()   // handled by the Records section
         }
     }
 

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -196,7 +196,7 @@ public enum ContentScaffold {
                 lines.append("\(field.name): \(field.name == "draft" ? "true" : "false")")
             case .number:
                 lines.append("\(field.name): 0")
-            case .stringArray, .imageArray:
+            case .stringArray, .imageArray, .objectArray:
                 lines.append("\(field.name): []")
             case .string, .text, .image:
                 lines.append("\(field.name): \"\(escapeYAML(scalarValue(field, title: title, fieldValues: fieldValues)))\"")
@@ -259,7 +259,7 @@ public enum ContentScaffold {
                 value = "false"
             case .number:
                 value = "0"
-            case .stringArray, .imageArray:
+            case .stringArray, .imageArray, .objectArray:
                 value = "[]"
             case .string, .text, .url, .image, .date, .datetime:
                 let filled = ContentTypeDescriptor.titleLikeFieldNames.contains(field.name) ? (name ?? "") : ""

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -36,6 +36,18 @@ public struct ContentTypeField: Sendable, Equatable {
         /// `.objectArray` — enforced by review/tests, not the type system, matching this registry's
         /// existing preference for documented invariants over new type machinery. No built-in
         /// descriptor declares this yet (#964 adds the first: h-resume).
+        ///
+        /// **Hand-authored keys inside a record are not preserved across an edit.**
+        /// `FrontmatterDocument` promises that form-only editing never silently drops a
+        /// hand-authored key — but that promise stops at the top level. One level down, inside a
+        /// record, `TypedContentEditor.decode`/`encode` only round-trip the member fields declared
+        /// here: an extra key a person wrote into one record item survives an *unedited*
+        /// round-trip (the whole field is still verbatim), and is dropped the moment that field is
+        /// edited through the app, because `encode` re-emits records from `fields` alone.
+        /// Accepted for now — no descriptor uses `.objectArray` yet, so nothing is at risk — but
+        /// preserving unknown per-record keys needs its own design (records would have to carry
+        /// their unparsed extras through the editor), so weigh it before the first real adopter
+        /// ships.
         case objectArray(fields: [ContentTypeField])
     }
 

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -18,7 +18,7 @@ import Foundation
 public struct ContentTypeField: Sendable, Equatable {
     /// The shape of a field's value. Maps to an editor control and to a Zod type at the
     /// template layer (#351); kept deliberately small.
-    public enum Kind: String, Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
         case string        // single-line text
         case text          // multi-line plain text
         case markdown      // multi-line rich body
@@ -30,6 +30,13 @@ public struct ContentTypeField: Sendable, Equatable {
         case number
         case stringArray   // e.g. tags
         case imageArray    // an ordered list of site-relative media paths (e.g. album photos)
+        /// A repeating group of small structured records (e.g. h-resume `experience`/`education`
+        /// entries) — an ordered list of member fields, each an existing scalar `Kind`. By
+        /// convention `fields` excludes `.markdown`, `.stringArray`, `.imageArray`, and nested
+        /// `.objectArray` — enforced by review/tests, not the type system, matching this registry's
+        /// existing preference for documented invariants over new type machinery. No built-in
+        /// descriptor declares this yet (#964 adds the first: h-resume).
+        case objectArray(fields: [ContentTypeField])
     }
 
     public let name: String

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -423,7 +423,7 @@ public enum DeadAssetScanner {
                 switch value {
                 case .string(let s): rawValues = [s]
                 case .array(let arr): rawValues = arr
-                case .bool, .number, .date: rawValues = []
+                case .bool, .number, .date, .objectArray: rawValues = []
                 }
                 for raw in rawValues {
                     if let resolved = resolve(raw, relativeTo: relPath) {

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -21,6 +21,24 @@ public enum FrontmatterValue: Equatable, Sendable {
     /// verbatim, unescaped. It is always produced by `TypedContentEditor.format()`
     /// (`ISO8601DateFormatter` output or its 10-char date-only prefix), which satisfies that.
     case date(String)
+    /// A repeating group of small structured records — e.g. h-resume `experience` entries. Each
+    /// inner `[FrontmatterRecordField]` is one record's fields in declared order; the outer array
+    /// is the ordered list of records. Record field values are conventionally scalar (`.string`,
+    /// `.bool`, `.number`, `.date`) — never `.array`/`.objectArray` — matching
+    /// `ContentTypeField.Kind.objectArray`'s member-field restriction; nothing in this codebase
+    /// constructs a nested shape, so `FrontmatterDocument.render`'s scalar renderer treats one as
+    /// an empty fallback rather than recursing.
+    case objectArray([[FrontmatterRecordField]])
+}
+
+/// One name/value pair inside a `FrontmatterValue.objectArray` record, in declaration order.
+public struct FrontmatterRecordField: Equatable, Sendable {
+    public let name: String
+    public let value: FrontmatterValue
+    public init(_ name: String, _ value: FrontmatterValue) {
+        self.name = name
+        self.value = value
+    }
 }
 
 /// Native port of `server/content-frontmatter.mjs` (Bucket 1, #275).

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -153,8 +153,7 @@ public struct FrontmatterDocument: Equatable, Sendable {
             // Numbers serialize unquoted so YAML reads them as numbers (a quoted "4" fails a
             // collection's z.number() schema). Integral values drop the decimal point; the
             // magnitude guard avoids the Int(_:) overflow trap.
-            let formatted = (n == n.rounded() && abs(n) < 1e15) ? String(Int(n)) : String(n)
-            return "\(key): \(formatted)"
+            return "\(key): \(formatNumber(n))"
         case .date(let s):
             // Already-formatted date scalar, emitted unquoted (matching ContentScaffold) so YAML
             // reads it as a date — a quoted scalar fails a non-coercing date schema.
@@ -162,6 +161,43 @@ public struct FrontmatterDocument: Equatable, Sendable {
         case .array(let items):
             if items.isEmpty { return "\(key): []" }
             return ([ "\(key):" ] + items.map { "  - \(Frontmatter.doubleQuoted($0))" }).joined(separator: "\n")
+        case .objectArray(let records):
+            if records.isEmpty { return "\(key): []" }
+            var lines = ["\(key):"]
+            for record in records {
+                if let first = record.first {
+                    lines.append("  - \(first.name): \(renderScalar(first.value))")
+                    for field in record.dropFirst() {
+                        lines.append("    \(field.name): \(renderScalar(field.value))")
+                    }
+                } else {
+                    lines.append("  - {}")
+                }
+            }
+            return lines.joined(separator: "\n")
+        }
+    }
+
+    private static func formatNumber(_ n: Double) -> String {
+        (n == n.rounded() && abs(n) < 1e15) ? String(Int(n)) : String(n)
+    }
+
+    /// Renders one record field's value the same way its top-level `render(key:value:)` counterpart
+    /// would, minus the `key: ` prefix (the caller supplies that at either 2- or 4-space indent).
+    /// Exhaustive over every `FrontmatterValue` case for compiler-checked totality, even though
+    /// record fields are conventionally scalar-only (see `FrontmatterValue.objectArray`'s doc
+    /// comment) — `.array`/`.objectArray` never actually reach here in practice.
+    private static func renderScalar(_ value: FrontmatterValue) -> String {
+        switch value {
+        case .string(let s): return Frontmatter.doubleQuoted(s)
+        case .bool(let b): return "\(b)"
+        case .number(let n): return formatNumber(n)
+        case .date(let s): return s
+        case .array(let items):
+            if items.isEmpty { return "[]" }
+            return "[" + items.map { Frontmatter.doubleQuoted($0) }.joined(separator: ", ") + "]"
+        case .objectArray:
+            return "[]"
         }
     }
 }

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -117,66 +117,72 @@ public struct FrontmatterDocument: Equatable, Sendable {
             var verbatim = [line]
             let value: FrontmatterValue
             if rawValue.isEmpty {
-                if j + 1 < block.count,
-                   let firstItemText = Frontmatter.blockArrayItem(block[j + 1]),
-                   Frontmatter.splitKeyValue(firstItemText) != nil,
-                   j + 2 < block.count,
-                   recordContinuation(block[j + 2],
-                                      dashIndent: dashIndent(of: block[j + 1])) != nil {
-                    // Block array of records: `  - field: value` starts a record; deeper-indented
-                    // `field: value` lines continue it.
-                    //
-                    // Detection deliberately demands *two* pieces of evidence — the first item
-                    // parses as `key: value` **and** the very next line is a deeper-indented
-                    // continuation field. "The first item contains a colon" alone is far too weak:
-                    // `Frontmatter.splitKeyValue` splits on the first colon with no space required,
-                    // so unquoted flat-array items like `- https://example.com` (key "https") or
-                    // `- Monday: 9:00-17:00` (key "Monday") match it. Those are exactly the shapes
-                    // of two shipped `.stringArray` fields — `member.links` and
-                    // `businessProfile.hours` — and misreading one as an object array makes
-                    // `TypedContentEditor.decode` yield an empty list, which the next save writes
-                    // back over the author's real data. Requiring a continuation line rules those
-                    // out, because a flat item is always followed by another `-` item or the end
-                    // of the block.
-                    //
-                    // Documented trade-off: a *single-field* record (`- title: X` with nothing
-                    // indented under it) is read as a flat string list, not an object array. That
-                    // is acceptable — every planned use of this primitive (h-resume
-                    // `experience`/`education`: title/org/start/end/description) has several fields
-                    // per record, so a continuation line is always present. Losing real data is
-                    // not an acceptable price for supporting the degenerate one-field case.
-                    var records: [[FrontmatterRecordField]] = []
-                    var k = j + 1
-                    while k < block.count, let itemText = Frontmatter.blockArrayItem(block[k]) {
-                        let itemIndent = dashIndent(of: block[k])
-                        var record: [FrontmatterRecordField] = []
-                        if let (fieldKey, fieldRaw) = Frontmatter.splitKeyValue(itemText) {
-                            record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
-                        }
-                        verbatim.append(block[k])
-                        k += 1
-                        while k < block.count,
-                              let (fieldKey, fieldRaw) = recordContinuation(block[k], dashIndent: itemIndent) {
-                            record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
-                            verbatim.append(block[k])
-                            k += 1
-                        }
-                        records.append(record)
+                // A bare `key:` header followed by `- …` lines is either a flat string list or a
+                // list of records (`  - field: value` starts a record; deeper-indented
+                // `field: value` lines continue it). Walk the block **once**, building both
+                // readings, then let what the whole block actually contained decide.
+                //
+                // The rule: it is an object array iff at least one record anywhere in the block
+                // consumed a continuation line.
+                //
+                // Why not "the first item parses as `key: value`" — that alone is far too weak.
+                // `Frontmatter.splitKeyValue` splits on the first colon with no space required, so
+                // unquoted flat-array items like `- https://example.com` (key "https") or
+                // `- Monday: 9:00-17:00` (key "Monday") match it. Those are exactly the shapes of
+                // two shipped `.stringArray` fields — `member.links` and `businessProfile.hours` —
+                // and misreading one as an object array makes `TypedContentEditor.decode` yield an
+                // empty list, which the next save writes back over the author's real data.
+                //
+                // Why the evidence must come from the *whole* block, not a peek at the first
+                // record: records need not be uniform. A hand-edited, incrementally filled-in list
+                // can easily put the short record first —
+                //
+                //     experience:
+                //       - title: "Engineer"
+                //       - title: "Intern"
+                //         org: "Acme"
+                //
+                // — and judging from the first record alone would call that flat, stranding
+                // `org: "Acme"` as an orphaned raw line detached from `experience` and showing the
+                // editor zero rows. Scanning the whole block gets both orderings right.
+                //
+                // Documented trade-off: a block whose records are *all* single-field (nothing
+                // indented under any dash) is read as a flat string list. Nothing in the source
+                // distinguishes it from a flat list of `key: value`-shaped strings, and every
+                // planned use of this primitive (h-resume `experience`/`education`:
+                // title/org/start/end/description) has several fields in at least one record.
+                // Losing real data is not an acceptable price for the degenerate case.
+                var records: [[FrontmatterRecordField]] = []
+                var items: [String] = []
+                var sawContinuation = false
+                var k = j + 1
+                while k < block.count, let itemText = Frontmatter.blockArrayItem(block[k]) {
+                    let itemIndent = dashIndent(of: block[k])
+                    var record: [FrontmatterRecordField] = []
+                    if let (fieldKey, fieldRaw) = Frontmatter.splitKeyValue(itemText) {
+                        record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
                     }
-                    value = .objectArray(records)
-                    j = k
-                } else {
-                    // Possible block array on following `- item` lines.
-                    var items: [String] = []
-                    var k = j + 1
-                    while k < block.count, let item = Frontmatter.blockArrayItem(block[k]) {
-                        items.append(Frontmatter.unquote(item))
+                    items.append(Frontmatter.unquote(itemText))
+                    verbatim.append(block[k])
+                    k += 1
+                    while k < block.count,
+                          let (fieldKey, fieldRaw) = recordContinuation(block[k], dashIndent: itemIndent) {
+                        record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
                         verbatim.append(block[k])
+                        sawContinuation = true
                         k += 1
                     }
-                    value = items.isEmpty ? .string("") : .array(items)
-                    j = k
+                    records.append(record)
                 }
+                // With no continuation anywhere, the inner loop consumed nothing, so `k` and
+                // `verbatim` are exactly what a flat-only walk would have produced — the two
+                // readings only diverge once there is record evidence.
+                if sawContinuation {
+                    value = .objectArray(records)
+                } else {
+                    value = items.isEmpty ? .string("") : .array(items)
+                }
+                j = k
             } else {
                 value = Frontmatter.parseScalarOrArray(rawValue)
                 j += 1

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -119,30 +119,46 @@ public struct FrontmatterDocument: Equatable, Sendable {
             if rawValue.isEmpty {
                 if j + 1 < block.count,
                    let firstItemText = Frontmatter.blockArrayItem(block[j + 1]),
-                   Frontmatter.splitKeyValue(firstItemText) != nil {
+                   Frontmatter.splitKeyValue(firstItemText) != nil,
+                   j + 2 < block.count,
+                   recordContinuation(block[j + 2],
+                                      dashIndent: dashIndent(of: block[j + 1])) != nil {
                     // Block array of records: `  - field: value` starts a record; deeper-indented
-                    // `field: value` lines continue it. Heuristic: a flat string array item that
-                    // itself looks like `word: value` would be misread as a record start — not a
-                    // shape this codebase's flat arrays (tags/hours/image paths) ever produce.
+                    // `field: value` lines continue it.
+                    //
+                    // Detection deliberately demands *two* pieces of evidence — the first item
+                    // parses as `key: value` **and** the very next line is a deeper-indented
+                    // continuation field. "The first item contains a colon" alone is far too weak:
+                    // `Frontmatter.splitKeyValue` splits on the first colon with no space required,
+                    // so unquoted flat-array items like `- https://example.com` (key "https") or
+                    // `- Monday: 9:00-17:00` (key "Monday") match it. Those are exactly the shapes
+                    // of two shipped `.stringArray` fields — `member.links` and
+                    // `businessProfile.hours` — and misreading one as an object array makes
+                    // `TypedContentEditor.decode` yield an empty list, which the next save writes
+                    // back over the author's real data. Requiring a continuation line rules those
+                    // out, because a flat item is always followed by another `-` item or the end
+                    // of the block.
+                    //
+                    // Documented trade-off: a *single-field* record (`- title: X` with nothing
+                    // indented under it) is read as a flat string list, not an object array. That
+                    // is acceptable — every planned use of this primitive (h-resume
+                    // `experience`/`education`: title/org/start/end/description) has several fields
+                    // per record, so a continuation line is always present. Losing real data is
+                    // not an acceptable price for supporting the degenerate one-field case.
                     var records: [[FrontmatterRecordField]] = []
                     var k = j + 1
                     while k < block.count, let itemText = Frontmatter.blockArrayItem(block[k]) {
-                        let dashIndent = block[k].prefix(while: { $0 == " " }).count
+                        let itemIndent = dashIndent(of: block[k])
                         var record: [FrontmatterRecordField] = []
                         if let (fieldKey, fieldRaw) = Frontmatter.splitKeyValue(itemText) {
                             record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
                         }
                         verbatim.append(block[k])
                         k += 1
-                        while k < block.count {
-                            let contLine = block[k]
-                            let contIndent = contLine.prefix(while: { $0 == " " }).count
-                            let trimmed = contLine.trimmingCharacters(in: .whitespaces)
-                            guard contIndent > dashIndent, !trimmed.hasPrefix("-"),
-                                  let (fieldKey, fieldRaw) = Frontmatter.splitKeyValue(trimmed)
-                            else { break }
+                        while k < block.count,
+                              let (fieldKey, fieldRaw) = recordContinuation(block[k], dashIndent: itemIndent) {
                             record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
-                            verbatim.append(contLine)
+                            verbatim.append(block[k])
                             k += 1
                         }
                         records.append(record)
@@ -170,6 +186,26 @@ public struct FrontmatterDocument: Equatable, Sendable {
         }
         return FrontmatterDocument(segments: segments, indexByKey: indexByKey, body: body,
                                    newline: newline, hadFrontmatter: true, hasBodySection: hasBodySection)
+    }
+
+    /// Leading-space count of a block-array item line — the indent its record's continuation lines
+    /// must exceed.
+    private static func dashIndent(of line: String) -> Int {
+        line.prefix(while: { $0 == " " }).count
+    }
+
+    /// If `line` continues the record started by a `- key: value` item whose dash sits at
+    /// `dashIndent`, returns that continuation's parsed `key: value`; otherwise `nil`.
+    ///
+    /// A continuation is indented strictly deeper than the dash, is not itself a new `-` item, and
+    /// parses as `key: value`. Single source of truth for that shape: `parse` uses it both to
+    /// *detect* an object array (peeking at the line after the first item) and to *consume* each
+    /// record's remaining fields, so the two can't drift apart.
+    private static func recordContinuation(_ line: String, dashIndent: Int) -> (key: String, value: String)? {
+        guard Self.dashIndent(of: line) > dashIndent else { return nil }
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.hasPrefix("-") else { return nil }
+        return Frontmatter.splitKeyValue(trimmed)
     }
 
     // MARK: Render (mirrors ContentScaffold: double-quoted scalars, `[]` empty arrays, block lists)

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -117,16 +117,50 @@ public struct FrontmatterDocument: Equatable, Sendable {
             var verbatim = [line]
             let value: FrontmatterValue
             if rawValue.isEmpty {
-                // Possible block array on following `- item` lines.
-                var items: [String] = []
-                var k = j + 1
-                while k < block.count, let item = Frontmatter.blockArrayItem(block[k]) {
-                    items.append(Frontmatter.unquote(item))
-                    verbatim.append(block[k])
-                    k += 1
+                if j + 1 < block.count,
+                   let firstItemText = Frontmatter.blockArrayItem(block[j + 1]),
+                   Frontmatter.splitKeyValue(firstItemText) != nil {
+                    // Block array of records: `  - field: value` starts a record; deeper-indented
+                    // `field: value` lines continue it. Heuristic: a flat string array item that
+                    // itself looks like `word: value` would be misread as a record start — not a
+                    // shape this codebase's flat arrays (tags/hours/image paths) ever produce.
+                    var records: [[FrontmatterRecordField]] = []
+                    var k = j + 1
+                    while k < block.count, let itemText = Frontmatter.blockArrayItem(block[k]) {
+                        let dashIndent = block[k].prefix(while: { $0 == " " }).count
+                        var record: [FrontmatterRecordField] = []
+                        if let (fieldKey, fieldRaw) = Frontmatter.splitKeyValue(itemText) {
+                            record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
+                        }
+                        verbatim.append(block[k])
+                        k += 1
+                        while k < block.count {
+                            let contLine = block[k]
+                            let contIndent = contLine.prefix(while: { $0 == " " }).count
+                            let trimmed = contLine.trimmingCharacters(in: .whitespaces)
+                            guard contIndent > dashIndent, !trimmed.hasPrefix("-"),
+                                  let (fieldKey, fieldRaw) = Frontmatter.splitKeyValue(trimmed)
+                            else { break }
+                            record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
+                            verbatim.append(contLine)
+                            k += 1
+                        }
+                        records.append(record)
+                    }
+                    value = .objectArray(records)
+                    j = k
+                } else {
+                    // Possible block array on following `- item` lines.
+                    var items: [String] = []
+                    var k = j + 1
+                    while k < block.count, let item = Frontmatter.blockArrayItem(block[k]) {
+                        items.append(Frontmatter.unquote(item))
+                        verbatim.append(block[k])
+                        k += 1
+                    }
+                    value = items.isEmpty ? .string("") : .array(items)
+                    j = k
                 }
-                value = items.isEmpty ? .string("") : .array(items)
-                j = k
             } else {
                 value = Frontmatter.parseScalarOrArray(rawValue)
                 j += 1

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -132,6 +132,12 @@ public enum MicropubContentSync {
         case .imageArray:
             let strings = values.compactMap(plainText)
             return strings.isEmpty ? nil : .list(strings)
+        // No field in the built-in registry maps a raw mf2 property to `.objectArray` today (h-resume
+        // lands in #964, and even then p-experience/p-education are nested h-event/h-card mf2
+        // objects this bridge doesn't attempt to flatten back into records) — this arm exists only
+        // for switch exhaustiveness, mirroring the `.bool` arm above.
+        case .objectArray:
+            return .records([])
         }
     }
 

--- a/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
+++ b/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
@@ -313,6 +313,11 @@ public actor SiteKnowledgeIndex {
         case .array(let values): return values.joined(separator: " ")
         case .number(let n): return n == n.rounded() && abs(n) < 1e15 ? String(Int(n)) : String(n)
         case .date(let s): return s
+        case .objectArray(let records):
+            // Object array: flatten all field values for indexing
+            return records.flatMap { record in
+                record.map { field in frontmatterText(field.value) }
+            }.joined(separator: " ")
         }
     }
 

--- a/Sources/AnglesiteCore/SyndicationFrontmatter.swift
+++ b/Sources/AnglesiteCore/SyndicationFrontmatter.swift
@@ -80,7 +80,7 @@ public enum SyndicationFrontmatter {
         case .array(let items): return items.filter { !$0.isEmpty }
         case .string(let s): return s.isEmpty ? [] : [s]
         case .bool(let b): return [b ? "true" : "false"]
-        case .number, .date: return nil  // write-only cases; parseScalarOrArray never produces them
+        case .number, .date, .objectArray: return nil  // write-only cases; parseScalarOrArray never produces them
         }
     }
 }

--- a/Sources/AnglesiteCore/TypedContentEditor.swift
+++ b/Sources/AnglesiteCore/TypedContentEditor.swift
@@ -14,6 +14,7 @@ public enum TypedContentEditor {
         case date(Date?)
         case number(Double?)
         case list([String])
+        case records([[String: FieldValue]])
     }
 
     public struct Values: Equatable, Sendable {
@@ -32,6 +33,7 @@ public enum TypedContentEditor {
         case .date, .datetime: return .date(nil)
         case .number: return .number(nil)
         case .stringArray, .imageArray: return .list([])
+        case .objectArray: return .records([])
         }
     }
 
@@ -98,6 +100,18 @@ public enum TypedContentEditor {
         case .stringArray, .imageArray:
             if case .array(let a) = value { return .list(a) }
             return .list([])
+        case .objectArray(let memberFields):
+            guard case .objectArray(let records) = value else { return .records([]) }
+            let decoded = records.map { record -> [String: FieldValue] in
+                let raw = Dictionary(record.map { ($0.name, $0.value) }, uniquingKeysWith: { _, latest in latest })
+                var dict: [String: FieldValue] = [:]
+                for member in memberFields {
+                    dict[member.name] = raw[member.name].map { decode($0, kind: member.kind) }
+                        ?? defaultValue(for: member.kind)
+                }
+                return dict
+            }
+            return .records(decoded)
         }
     }
 
@@ -115,6 +129,15 @@ public enum TypedContentEditor {
         // a nil (cleared) number falls back to an empty quoted scalar.
         case .number(let n): return n.map { .number($0) } ?? .string("")
         case .list(let a): return .array(a)
+        case .records(let recordDicts):
+            guard case .objectArray(let memberFields) = kind else { return nil }
+            let records: [[FrontmatterRecordField]] = recordDicts.map { dict in
+                memberFields.compactMap { member -> FrontmatterRecordField? in
+                    guard let v = dict[member.name], let encoded = encode(v, kind: member.kind) else { return nil }
+                    return FrontmatterRecordField(member.name, encoded)
+                }
+            }
+            return .objectArray(records)
         }
     }
 

--- a/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
@@ -31,6 +31,13 @@ struct ContentConfigDriftTests {
         case .number: return "z.number()"
         case .bool: return "z.boolean()"
         case .stringArray, .imageArray: return "z.array(z.string())"
+        case .objectArray(let fields):
+            let memberExprs = fields.compactMap { field -> String? in
+                guard let expr = zod(for: field.kind) else { return nil }
+                let full = field.kind == .bool ? "\(expr).default(false)" : (field.required ? expr : "\(expr).optional()")
+                return "\(field.name): \(full)"
+            }
+            return "z.array(z.object({ \(memberExprs.joined(separator: ", ")) }))"
         }
     }
 
@@ -114,6 +121,15 @@ struct ContentConfigDriftTests {
     func parsesExportLine() {
         let line = "export const collections = { blog, notes: notes, articles };"
         #expect(Self.collectionNames(inExport: line) == ["blog", "notes", "articles"])
+    }
+
+    @Test("zod(for:) renders an objectArray field as z.array(z.object({...})) with member requiredness")
+    func zodForObjectArray() {
+        let kind = ContentTypeField.Kind.objectArray(fields: [
+            ContentTypeField("title", .string, required: true),
+            ContentTypeField("org", .string),
+        ])
+        #expect(Self.zod(for: kind) == "z.array(z.object({ title: z.string(), org: z.string().optional() }))")
     }
 
     @Test("content.config.ts declares exactly the registry collections plus the allowlist")

--- a/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
@@ -329,4 +329,28 @@ struct ContentScaffoldTests {
         #expect(ContentScaffold.slugFromURL("/relative/path", now: now).isEmpty)
         #expect(ContentScaffold.slugFromURL("mailto:a@b.c", now: now).isEmpty)
     }
+
+    @Test("renderEntry scaffolds an empty array for an objectArray field")
+    func renderEntryScaffoldsEmptyObjectArray() {
+        let descriptor = ContentTypeDescriptor(
+            id: "resumeFixture", displayName: "Resume Fixture", storage: .collection("resumeFixtures"),
+            fields: [ContentTypeField("experience", .objectArray(fields: [
+                ContentTypeField("title", .string, required: true),
+            ]))],
+            projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
+        let out = ContentScaffold.renderEntry(descriptor: descriptor, title: nil, now: Date())
+        #expect(out.contains("experience: []"))
+    }
+
+    @Test("renderSingleton scaffolds an empty array for an objectArray field")
+    func renderSingletonScaffoldsEmptyObjectArray() {
+        let descriptor = ContentTypeDescriptor(
+            id: "resumeSingletonFixture", displayName: "Resume Singleton Fixture", storage: .singleton("resumeFixture"),
+            fields: [ContentTypeField("experience", .objectArray(fields: [
+                ContentTypeField("title", .string, required: true),
+            ]))],
+            projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
+        let out = ContentScaffold.renderSingleton(descriptor: descriptor, name: nil)
+        #expect(out.contains("\"experience\": []"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
@@ -156,6 +156,31 @@ struct ContentTypeRegistryTests {
         #expect(album.projections.microformatProperties["publishDate"] == "dt-published")
     }
 
+    @Test("objectArray kind carries its ordered member fields and compares by value")
+    func objectArrayKindCarriesMemberFields() {
+        let memberFields = [
+            ContentTypeField("title", .string, required: true),
+            ContentTypeField("organization", .string, required: true),
+            ContentTypeField("startDate", .date, required: true),
+            ContentTypeField("endDate", .date),
+            ContentTypeField("description", .text),
+        ]
+        let field = ContentTypeField("experience", .objectArray(fields: memberFields))
+        guard case .objectArray(let fields) = field.kind else {
+            Issue.record("expected .objectArray")
+            return
+        }
+        #expect(fields.map(\.name) == ["title", "organization", "startDate", "endDate", "description"])
+        #expect(fields.first?.kind == .string)
+        #expect(fields.first?.required == true)
+
+        // Equatable: same fields in the same order compare equal; a different order does not.
+        let same = ContentTypeField("experience", .objectArray(fields: memberFields))
+        #expect(field == same)
+        let reordered = ContentTypeField("experience", .objectArray(fields: memberFields.reversed()))
+        #expect(field != reordered)
+    }
+
     @Test("like is an h-entry with u-like-of and no schema.org type")
     func likeDescriptor() {
         let like = try! #require(ContentTypeRegistry().descriptor(id: "like"))

--- a/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
@@ -128,4 +128,35 @@ struct FrontmatterDocumentTests {
         #expect(doc.serialized() == src)                  // both occurrences preserved
         #expect(doc.value(for: "title") == .string("B"))  // get addresses the last
     }
+
+    @Test("setting an object-array value renders block-mapping-list YAML")
+    func setObjectArray() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
+        doc.set(.objectArray([
+            [FrontmatterRecordField("title", .string("Engineer")), FrontmatterRecordField("start", .date("2020-01-01"))],
+            [FrontmatterRecordField("title", .string("Intern")), FrontmatterRecordField("start", .date("2018-06-01"))],
+        ]), for: "experience")
+        let out = doc.serialized()
+        #expect(out.contains("""
+        experience:
+          - title: "Engineer"
+            start: 2020-01-01
+          - title: "Intern"
+            start: 2018-06-01
+        """))
+    }
+
+    @Test("setting an empty object-array value renders an inline empty array")
+    func setEmptyObjectArray() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
+        doc.set(.objectArray([]), for: "experience")
+        #expect(doc.serialized().contains("experience: []"))
+    }
+
+    @Test("an object-array record with no fields renders as an empty mapping item")
+    func setObjectArrayEmptyRecord() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
+        doc.set(.objectArray([[]]), for: "experience")
+        #expect(doc.serialized().contains("experience:\n  - {}"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
@@ -275,6 +275,52 @@ struct FrontmatterDocumentTests {
                 == .array(["Monday: 9:00-17:00", "Tuesday: 9:00-17:00"]))
     }
 
+    @Test("a short FIRST record doesn't hide a later record's continuation")
+    func objectArrayDetectedWhenOnlyLaterRecordHasContinuation() {
+        // Records need not be uniform, and a hand-edited list is very likely to be filled in
+        // unevenly. Detection reads the whole block, so evidence in the *second* record counts:
+        // judging from the first record alone would call this flat and strand `org: "Acme"` as an
+        // orphaned raw line detached from `experience` (zero rows in the editor, on read).
+        let src = """
+        ---
+        experience:
+          - title: "Engineer"
+          - title: "Intern"
+            org: "Acme"
+        ---
+        Body.
+        """ + "\n"
+        let doc = FrontmatterDocument.parse(src)
+        #expect(doc.value(for: "experience") == .objectArray([
+            [FrontmatterRecordField("title", .string("Engineer"))],
+            [FrontmatterRecordField("title", .string("Intern")),
+             FrontmatterRecordField("org", .string("Acme"))],
+        ]))
+        #expect(doc.serialized() == src)   // every line still belongs to `experience`
+    }
+
+    @Test("a short LAST record is still part of the object array")
+    func objectArrayDetectedWhenOnlyEarlierRecordHasContinuation() {
+        // The mirror image of the case above — the same whole-block rule has to cover both
+        // orderings, so pin the direction the detection peek used to get right by luck.
+        let src = """
+        ---
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+          - title: "Intern"
+        ---
+        Body.
+        """ + "\n"
+        let doc = FrontmatterDocument.parse(src)
+        #expect(doc.value(for: "experience") == .objectArray([
+            [FrontmatterRecordField("title", .string("Engineer")),
+             FrontmatterRecordField("org", .string("Acme"))],
+            [FrontmatterRecordField("title", .string("Intern"))],
+        ]))
+        #expect(doc.serialized() == src)
+    }
+
     @Test("a single-field record is read as a flat list (documented detection trade-off)")
     func singleFieldRecordReadsAsFlatList() {
         let src = """
@@ -286,8 +332,10 @@ struct FrontmatterDocumentTests {
         Body.
         """ + "\n"
         let doc = FrontmatterDocument.parse(src)
-        // No continuation line ⟹ not enough evidence to call this an object array. Every planned
-        // real use of `.objectArray` has multi-field records, so this costs nothing in practice.
+        // No continuation line *anywhere in the block* ⟹ nothing in the source distinguishes this
+        // from a flat list of `key: value`-shaped strings, so it reads as one. Every planned real
+        // use of `.objectArray` has multiple fields in at least one record (see the case above),
+        // so this costs nothing in practice.
         #expect(doc.value(for: "experience") == .array(["title: \"Engineer\"", "title: \"Intern\""]))
         #expect(doc.serialized() == src)   // still verbatim when untouched
     }

--- a/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
@@ -212,4 +212,83 @@ struct FrontmatterDocumentTests {
                 == .objectArray([[FrontmatterRecordField("title", .string("Senior Engineer")),
                                    FrontmatterRecordField("org", .string("Acme"))]]))
     }
+
+    // MARK: Object-array detection must not swallow flat string arrays (#1117 final review)
+    //
+    // `Frontmatter.splitKeyValue` splits on the first colon with no space required, so plenty of
+    // legitimate *unquoted* flat-array items look like `key: value`. Misclassifying one as an
+    // object array makes `TypedContentEditor.decode` hand the editor an empty list, and the next
+    // save writes that emptiness back over the author's data. Both cases below are real shipped
+    // `.stringArray` fields (`businessProfile.hours`, `member.links`) as a person would hand-author
+    // them, without quotes.
+
+    @Test("unquoted `Monday: 9:00-17:00` hours parse as a flat string array, not an object array")
+    func unquotedHoursStayFlat() {
+        let src = """
+        ---
+        title: "Acme"
+        hours:
+          - Monday: 9:00-17:00
+          - Tuesday: 9:00-17:00
+        ---
+        Body.
+        """ + "\n"
+        let doc = FrontmatterDocument.parse(src)
+        #expect(doc.value(for: "hours") == .array(["Monday: 9:00-17:00", "Tuesday: 9:00-17:00"]))
+    }
+
+    @Test("unquoted URL list items parse as a flat string array, not an object array")
+    func unquotedURLsStayFlat() {
+        let src = """
+        ---
+        name: "Someone"
+        links:
+          - https://example.com
+          - https://mastodon.social/@me
+        ---
+        Body.
+        """ + "\n"
+        let doc = FrontmatterDocument.parse(src)
+        #expect(doc.value(for: "links") == .array(["https://example.com", "https://mastodon.social/@me"]))
+    }
+
+    @Test("editing another field preserves an unquoted hours list verbatim")
+    func unquotedHoursSurviveUnrelatedEdit() {
+        let src = """
+        ---
+        title: "Acme"
+        hours:
+          - Monday: 9:00-17:00
+          - Tuesday: 9:00-17:00
+        ---
+        Body.
+        """ + "\n"
+        var doc = FrontmatterDocument.parse(src)
+        doc.set(.string("Acme Inc."), for: "title")
+        let out = doc.serialized()
+        #expect(out.contains("title: \"Acme Inc.\""))
+        // The untouched field keeps its original unquoted source lines…
+        #expect(out.contains("hours:\n  - Monday: 9:00-17:00\n  - Tuesday: 9:00-17:00"))
+        // …and still reads back as the same flat list (the parse-side misclassification that
+        // caused the data loss is what this pins).
+        #expect(FrontmatterDocument.parse(out).value(for: "hours")
+                == .array(["Monday: 9:00-17:00", "Tuesday: 9:00-17:00"]))
+    }
+
+    @Test("a single-field record is read as a flat list (documented detection trade-off)")
+    func singleFieldRecordReadsAsFlatList() {
+        let src = """
+        ---
+        experience:
+          - title: "Engineer"
+          - title: "Intern"
+        ---
+        Body.
+        """ + "\n"
+        let doc = FrontmatterDocument.parse(src)
+        // No continuation line ⟹ not enough evidence to call this an object array. Every planned
+        // real use of `.objectArray` has multi-field records, so this costs nothing in practice.
+        #expect(doc.value(for: "experience") == .array(["title: \"Engineer\"", "title: \"Intern\""]))
+        #expect(doc.serialized() == src)   // still verbatim when untouched
+    }
 }

--- a/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
@@ -159,4 +159,57 @@ struct FrontmatterDocumentTests {
         doc.set(.objectArray([[]]), for: "experience")
         #expect(doc.serialized().contains("experience:\n  - {}"))
     }
+
+    @Test("reads a block object-array into ordered records")
+    func readsObjectArray() {
+        let src = """
+        ---
+        title: "Resume"
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+            start: 2020-01-01
+          - title: "Intern"
+            org: "Other Co"
+            start: 2018-06-01
+        ---
+        Body.
+        """ + "\n"
+        let doc = FrontmatterDocument.parse(src)
+        #expect(doc.value(for: "experience") == .objectArray([
+            [FrontmatterRecordField("title", .string("Engineer")),
+             FrontmatterRecordField("org", .string("Acme")),
+             FrontmatterRecordField("start", .string("2020-01-01"))],
+            [FrontmatterRecordField("title", .string("Intern")),
+             FrontmatterRecordField("org", .string("Other Co")),
+             FrontmatterRecordField("start", .string("2018-06-01"))],
+        ]))
+    }
+
+    @Test("unedited object-array round-trip is the identity")
+    func objectArrayIdentity() {
+        let src = """
+        ---
+        title: "Resume"
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+        ---
+        Body.
+        """ + "\n"
+        #expect(FrontmatterDocument.parse(src).serialized() == src)
+    }
+
+    @Test("editing an object-array field re-renders only that field")
+    func objectArrayEditRoundTrips() {
+        let src = "---\ntitle: \"Resume\"\nexperience:\n  - title: \"Engineer\"\n    org: \"Acme\"\n---\nBody.\n"
+        var doc = FrontmatterDocument.parse(src)
+        doc.set(.objectArray([[FrontmatterRecordField("title", .string("Senior Engineer")),
+                                FrontmatterRecordField("org", .string("Acme"))]]), for: "experience")
+        let out = doc.serialized()
+        #expect(out.contains("title: \"Senior Engineer\""))
+        #expect(FrontmatterDocument.parse(out).value(for: "experience")
+                == .objectArray([[FrontmatterRecordField("title", .string("Senior Engineer")),
+                                   FrontmatterRecordField("org", .string("Acme"))]]))
+    }
 }

--- a/Tests/AnglesiteCoreTests/FrontmatterTests.swift
+++ b/Tests/AnglesiteCoreTests/FrontmatterTests.swift
@@ -149,4 +149,20 @@ struct FrontmatterTests {
             #expect(fm["title"] == .string(original), "round-trip failed for \(original.debugDescription)")
         }
     }
+
+    @Test("an object-array field doesn't corrupt sibling top-level fields (Frontmatter.parse is not record-aware by design)")
+    func objectArrayFieldDoesNotCorruptSiblings() {
+        let src = """
+        ---
+        title: "Resume"
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+        draft: true
+        ---
+        """
+        let fm = Frontmatter.parse(src)
+        #expect(fm["title"] == .string("Resume"))
+        #expect(fm["draft"] == .bool(true))
+    }
 }

--- a/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
@@ -47,6 +47,17 @@ struct MicropubContentSyncTests {
         #expect(MicropubContentSync.plainText(from: nil) == nil)
     }
 
+    // MARK: - fieldValue
+
+    @Test("fieldValue returns an empty records value for an objectArray field (no mf2 mapping exists for it)")
+    func fieldValueObjectArrayIsEmptyRecords() {
+        let field = ContentTypeField("experience", .objectArray(fields: [
+            ContentTypeField("title", .string, required: true),
+        ]))
+        let result = MicropubContentSync.fieldValue(for: field, rawProperty: "experience", properties: [:])
+        #expect(result == .records([]))
+    }
+
     // MARK: - values(for:properties:updatedAt:slug:)
 
     private static let anUpdatedAt = 1_753_300_000

--- a/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
@@ -193,9 +193,16 @@ struct TypedContentEditorTests {
                 ])),
             ],
             projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
-        let src = "---\nexperience:\n  - title: \"Engineer\"\n---\n"
+        // The second record omits `org`. The first carries both fields deliberately: a block whose
+        // *first* item has no deeper-indented continuation line is read as a flat string array, not
+        // an object array — the documented detection trade-off that keeps unquoted flat arrays like
+        // `businessProfile.hours` from being misread as records (see `FrontmatterDocument.parse`).
+        let src = "---\nexperience:\n  - title: \"Engineer\"\n    org: \"Acme\"\n  - title: \"Intern\"\n---\n"
         let v = TypedContentEditor.read(src, descriptor: resume)
-        #expect(v["experience"] == .records([["title": .text("Engineer"), "org": .text("")]]))
+        #expect(v["experience"] == .records([
+            ["title": .text("Engineer"), "org": .text("Acme")],
+            ["title": .text("Intern"), "org": .text("")],
+        ]))
     }
 
     @Test("template about.md reads as businessProfile with marker preserved")

--- a/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+++ b/Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
@@ -144,6 +144,60 @@ struct TypedContentEditorTests {
         #expect(out.contains("type: businessProfile"))   // unknown-to-schema key preserved
     }
 
+    @Test("write round-trips an objectArray field into block-mapping-list YAML")
+    func writeObjectArray() {
+        let resume = ContentTypeDescriptor(
+            id: "resumeFixture", displayName: "Resume Fixture", storage: .collection("resumeFixtures"),
+            fields: [
+                ContentTypeField("experience", .objectArray(fields: [
+                    ContentTypeField("title", .string, required: true),
+                    ContentTypeField("org", .string, required: true),
+                    ContentTypeField("start", .date, required: true),
+                ])),
+                ContentTypeField("body", .markdown),
+            ],
+            projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
+
+        let src = "---\nexperience: []\n---\n\nBody.\n"
+        var v = TypedContentEditor.read(src, descriptor: resume)
+        #expect(v["experience"] == .records([]))
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let start = iso.date(from: "2020-01-01T00:00:00.000Z")!
+        v["experience"] = .records([
+            ["title": .text("Engineer"), "org": .text("Acme"), "start": .date(start)],
+        ])
+        let out = TypedContentEditor.write(v, into: src, descriptor: resume)
+        #expect(out.contains("""
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+            start: 2020-01-01
+        """))
+
+        let reread = TypedContentEditor.read(out, descriptor: resume)
+        #expect(reread["experience"] == .records([
+            ["title": .text("Engineer"), "org": .text("Acme"), "start": .date(start)],
+        ]))
+    }
+
+    @Test("objectArray record fields fall back to defaults when a record omits one")
+    func objectArrayRecordFillsMissingMemberDefaults() {
+        let resume = ContentTypeDescriptor(
+            id: "resumeFixture2", displayName: "Resume Fixture 2", storage: .collection("resumeFixtures2"),
+            fields: [
+                ContentTypeField("experience", .objectArray(fields: [
+                    ContentTypeField("title", .string, required: true),
+                    ContentTypeField("org", .string),
+                ])),
+            ],
+            projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
+        let src = "---\nexperience:\n  - title: \"Engineer\"\n---\n"
+        let v = TypedContentEditor.read(src, descriptor: resume)
+        #expect(v["experience"] == .records([["title": .text("Engineer"), "org": .text("")]]))
+    }
+
     @Test("template about.md reads as businessProfile with marker preserved")
     func aboutPage() {
         let profile = ContentTypeRegistry().descriptor(id: "businessProfile")!

--- a/docs/superpowers/plans/2026-07-30-content-type-object-array-field.md
+++ b/docs/superpowers/plans/2026-07-30-content-type-object-array-field.md
@@ -1,0 +1,1031 @@
+# Repeating Structured-Group Field Kind Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new `ContentTypeField.Kind` case representing a repeating group of small structured records (e.g. an h-resume `experience` entry: title/org/start/end/description) so it round-trips through YAML frontmatter, the generic SwiftUI content editor, and the Zod-drift test — with no new content type or Astro rendering (that's issue #964's job once this primitive exists).
+
+**Architecture:** Three existing layers each gain one new case, bottom-up:
+1. `FrontmatterValue` (raw YAML shape) gains `.objectArray([[FrontmatterRecordField]])` — an ordered list of ordered name/value records. `FrontmatterDocument` gains parse/render support for the corresponding block-YAML shape (`  - field: value` / `    field2: value2`).
+2. `ContentTypeField.Kind` gains `.objectArray(fields: [ContentTypeField])` — the schema: an ordered list of member fields, each an existing scalar `Kind`. This requires dropping `Kind`'s `String` raw-value backing (confirmed unused via `.rawValue`/`Kind(rawValue:)` grep — nothing depends on it), since Swift enums cannot mix raw values with associated values.
+3. `TypedContentEditor.FieldValue` (UI-bound shape) gains `.records([[String: FieldValue]])`. `defaultValue`/`decode`/`encode` bridge all three layers using `Kind.objectArray`'s member-field list to know each record field's name and sub-`Kind`.
+
+Every other exhaustive `switch`/`if case` over `ContentTypeField.Kind` (`ContentScaffold.renderEntry`/`renderSingleton`, `MicropubContentSync.fieldValue`, `TypedEntryEditorView.control(for:)`, and the test-only `ContentConfigDriftTests.zod(for:)`) gets a matching arm so the module keeps compiling. No built-in `ContentTypeDescriptor` declares `.objectArray` yet — this is pure plumbing; #964 registers the first real use.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Test`/`#expect`), SwiftUI (macOS 27+ `Form`).
+
+## Global Constraints
+
+- **No raw-value regression**: `ContentTypeField.Kind` drops `: String` — confirmed nothing reads `.rawValue` or calls `Kind(rawValue:)` anywhere in `Sources/`/`Tests/` (grepped). If a build error surfaces a use this plan missed, stop and re-grep before proceeding.
+- **Member fields are scalar-only by convention, not by the type system**: `.objectArray(fields:)`'s `fields` should never itself contain `.stringArray`, `.imageArray`, `.markdown`, or a nested `.objectArray`. This is documented in a doc comment, matching this codebase's existing preference for convention-enforced invariants over new type machinery (e.g. `ContentTypeProjections`'s "object-valued property contract").
+- **No Astro/rendering work** (`Resources/Template/src/layouts/`, mf2 output, JSON-LD) — out of scope per the issue; that's #964.
+- **No new `ContentTypeDescriptor`** (no h-resume type) — out of scope per the issue; that's #964.
+- **No changes to `Resources/Template/src/content.config.ts` / `content-schemas.ts`** — there is no new collection to declare (no descriptor uses `.objectArray` yet), so there is nothing to add to those files. The issue's mention of "the matching `z.array(z.object({...}))` shape" is satisfied by `ContentConfigDriftTests.zod(for:)` (Task 7) staying exhaustive and correct — that helper *is* this codebase's Swift-side stand-in for "what the hand-authored Zod schema should look like," since the Swift descriptor and the TS schema are independently hand-maintained (per the file's own doc comment) and there is no real collection yet to add a Zod block for.
+- **`Frontmatter.parse` (the lightweight `list_content` scanner) is NOT updated** — its docstring already scopes it to "exactly" `title`/`slug`/`draft`/`publishDate`/`date`/`tags`, none of which will ever be `.objectArray`. Verified (Task 2) that an object-array field present in a scanned file degrades gracefully: the scanner's outer loop already skips indented continuation lines as non-top-level, so a misread `experience` field can't corrupt parsing of the fields callers actually read.
+- Every new production code path gets a real `@Test`, per this repo's Swift Testing convention (`Tests/AnglesiteCoreTests/*Tests.swift`, `@Suite`/`@Test`/`#expect`).
+- Run `swift test --package-path .` after each task; run `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` after Task 8 (the only task touching `Sources/AnglesiteApp`) and again at the end.
+- Commit after each task (Conventional Commits, subject ≤72 chars, reference **#1117**).
+
+---
+
+### Task 1: `FrontmatterValue.objectArray` + `FrontmatterRecordField` + serialization
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/Frontmatter.swift:14-24` (the `FrontmatterValue` enum)
+- Modify: `Sources/AnglesiteCore/FrontmatterDocument.swift:143-166` (`render(key:value:)`)
+- Test: `Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift`
+
+**Interfaces:**
+- Produces: `public struct FrontmatterRecordField: Equatable, Sendable { public let name: String; public let value: FrontmatterValue; public init(_ name: String, _ value: FrontmatterValue) }` and `FrontmatterValue.objectArray([[FrontmatterRecordField]])` — consumed by Task 2 (parsing) and Task 4 (`TypedContentEditor`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift` (inside `struct FrontmatterDocumentTests`, after the existing `appendsNewKey` test):
+
+```swift
+    @Test("setting an object-array value renders block-mapping-list YAML")
+    func setObjectArray() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
+        doc.set(.objectArray([
+            [FrontmatterRecordField("title", .string("Engineer")), FrontmatterRecordField("start", .date("2020-01-01"))],
+            [FrontmatterRecordField("title", .string("Intern")), FrontmatterRecordField("start", .date("2018-06-01"))],
+        ]), for: "experience")
+        let out = doc.serialized()
+        #expect(out.contains("""
+        experience:
+          - title: "Engineer"
+            start: 2020-01-01
+          - title: "Intern"
+            start: 2018-06-01
+        """))
+    }
+
+    @Test("setting an empty object-array value renders an inline empty array")
+    func setEmptyObjectArray() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
+        doc.set(.objectArray([]), for: "experience")
+        #expect(doc.serialized().contains("experience: []"))
+    }
+
+    @Test("an object-array record with no fields renders as an empty mapping item")
+    func setObjectArrayEmptyRecord() {
+        var doc = FrontmatterDocument.parse("---\ntitle: \"T\"\n---\nB\n")
+        doc.set(.objectArray([[]]), for: "experience")
+        #expect(doc.serialized().contains("experience:\n  - {}"))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter FrontmatterDocumentTests`
+Expected: FAIL to compile — `FrontmatterRecordField` and `FrontmatterValue.objectArray` don't exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/Frontmatter.swift`, replace the `FrontmatterValue` enum (lines 14–24) with:
+
+```swift
+public enum FrontmatterValue: Equatable, Sendable {
+    case string(String)
+    case bool(Bool)
+    case array([String])
+    case number(Double)
+    /// A preformatted date scalar emitted **unquoted**. `s` must be a safe bare YAML scalar — no
+    /// newlines, no `: ` (colon-space) sequences — because `FrontmatterDocument.render` emits it
+    /// verbatim, unescaped. It is always produced by `TypedContentEditor.format()`
+    /// (`ISO8601DateFormatter` output or its 10-char date-only prefix), which satisfies that.
+    case date(String)
+    /// A repeating group of small structured records — e.g. h-resume `experience` entries. Each
+    /// inner `[FrontmatterRecordField]` is one record's fields in declared order; the outer array
+    /// is the ordered list of records. Record field values are conventionally scalar (`.string`,
+    /// `.bool`, `.number`, `.date`) — never `.array`/`.objectArray` — matching
+    /// `ContentTypeField.Kind.objectArray`'s member-field restriction; nothing in this codebase
+    /// constructs a nested shape, so `FrontmatterDocument.render`'s scalar renderer treats one as
+    /// an empty fallback rather than recursing.
+    case objectArray([[FrontmatterRecordField]])
+}
+
+/// One name/value pair inside a `FrontmatterValue.objectArray` record, in declaration order.
+public struct FrontmatterRecordField: Equatable, Sendable {
+    public let name: String
+    public let value: FrontmatterValue
+    public init(_ name: String, _ value: FrontmatterValue) {
+        self.name = name
+        self.value = value
+    }
+}
+```
+
+In `Sources/AnglesiteCore/FrontmatterDocument.swift`, replace the `render(key:value:)` function (lines 143–166) with:
+
+```swift
+    private static func render(key: String, value: FrontmatterValue) -> String {
+        switch value {
+        case .string(let s):
+            return "\(key): \(Frontmatter.doubleQuoted(s))"
+        case .bool(let b):
+            // Bool fields canonicalize to true/false on write. YAML also accepts yes/no/on/off/1/0,
+            // but we intentionally normalize here (matching ContentScaffold) — an edited bool loses
+            // a non-canonical original spelling. Verbatim is still preserved for *unedited* bools.
+            return "\(key): \(b)"
+        case .number(let n):
+            // Numbers serialize unquoted so YAML reads them as numbers (a quoted "4" fails a
+            // collection's z.number() schema). Integral values drop the decimal point; the
+            // magnitude guard avoids the Int(_:) overflow trap.
+            return "\(key): \(formatNumber(n))"
+        case .date(let s):
+            // Already-formatted date scalar, emitted unquoted (matching ContentScaffold) so YAML
+            // reads it as a date — a quoted scalar fails a non-coercing date schema.
+            return "\(key): \(s)"
+        case .array(let items):
+            if items.isEmpty { return "\(key): []" }
+            return ([ "\(key):" ] + items.map { "  - \(Frontmatter.doubleQuoted($0))" }).joined(separator: "\n")
+        case .objectArray(let records):
+            if records.isEmpty { return "\(key): []" }
+            var lines = ["\(key):"]
+            for record in records {
+                if let first = record.first {
+                    lines.append("  - \(first.name): \(renderScalar(first.value))")
+                    for field in record.dropFirst() {
+                        lines.append("    \(field.name): \(renderScalar(field.value))")
+                    }
+                } else {
+                    lines.append("  - {}")
+                }
+            }
+            return lines.joined(separator: "\n")
+        }
+    }
+
+    private static func formatNumber(_ n: Double) -> String {
+        (n == n.rounded() && abs(n) < 1e15) ? String(Int(n)) : String(n)
+    }
+
+    /// Renders one record field's value the same way its top-level `render(key:value:)` counterpart
+    /// would, minus the `key: ` prefix (the caller supplies that at either 2- or 4-space indent).
+    /// Exhaustive over every `FrontmatterValue` case for compiler-checked totality, even though
+    /// record fields are conventionally scalar-only (see `FrontmatterValue.objectArray`'s doc
+    /// comment) — `.array`/`.objectArray` never actually reach here in practice.
+    private static func renderScalar(_ value: FrontmatterValue) -> String {
+        switch value {
+        case .string(let s): return Frontmatter.doubleQuoted(s)
+        case .bool(let b): return "\(b)"
+        case .number(let n): return formatNumber(n)
+        case .date(let s): return s
+        case .array(let items):
+            if items.isEmpty { return "[]" }
+            return "[" + items.map { Frontmatter.doubleQuoted($0) }.joined(separator: ", ") + "]"
+        case .objectArray:
+            return "[]"
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter FrontmatterDocumentTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/Frontmatter.swift Sources/AnglesiteCore/FrontmatterDocument.swift Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift
+git commit -m "feat(#1117): add FrontmatterValue.objectArray + serialization"
+```
+
+---
+
+### Task 2: `FrontmatterDocument.parse` support for object-array block YAML
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/FrontmatterDocument.swift:100-136` (`parse`'s block-array branch)
+- Test: `Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift`, `Tests/AnglesiteCoreTests/FrontmatterTests.swift`
+
+**Interfaces:**
+- Consumes: `FrontmatterRecordField`, `FrontmatterValue.objectArray` (Task 1).
+- Produces: `FrontmatterDocument.parse(_:)` now round-trips object-array YAML — consumed by Task 4's `TypedContentEditor.read`/`.write` (via the existing `FrontmatterDocument.value(for:)`/`.set(_:for:)` API, unchanged).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift`:
+
+```swift
+    @Test("reads a block object-array into ordered records")
+    func readsObjectArray() {
+        let src = """
+        ---
+        title: "Resume"
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+            start: 2020-01-01
+          - title: "Intern"
+            org: "Other Co"
+            start: 2018-06-01
+        ---
+        Body.
+        """ + "\n"
+        let doc = FrontmatterDocument.parse(src)
+        #expect(doc.value(for: "experience") == .objectArray([
+            [FrontmatterRecordField("title", .string("Engineer")),
+             FrontmatterRecordField("org", .string("Acme")),
+             FrontmatterRecordField("start", .string("2020-01-01"))],
+            [FrontmatterRecordField("title", .string("Intern")),
+             FrontmatterRecordField("org", .string("Other Co")),
+             FrontmatterRecordField("start", .string("2018-06-01"))],
+        ]))
+    }
+
+    @Test("unedited object-array round-trip is the identity")
+    func objectArrayIdentity() {
+        let src = """
+        ---
+        title: "Resume"
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+        ---
+        Body.
+        """ + "\n"
+        #expect(FrontmatterDocument.parse(src).serialized() == src)
+    }
+
+    @Test("editing an object-array field re-renders only that field")
+    func objectArrayEditRoundTrips() {
+        let src = "---\ntitle: \"Resume\"\nexperience:\n  - title: \"Engineer\"\n    org: \"Acme\"\n---\nBody.\n"
+        var doc = FrontmatterDocument.parse(src)
+        doc.set(.objectArray([[FrontmatterRecordField("title", .string("Senior Engineer")),
+                                FrontmatterRecordField("org", .string("Acme"))]]), for: "experience")
+        let out = doc.serialized()
+        #expect(out.contains("title: \"Senior Engineer\""))
+        #expect(FrontmatterDocument.parse(out).value(for: "experience")
+                == .objectArray([[FrontmatterRecordField("title", .string("Senior Engineer")),
+                                   FrontmatterRecordField("org", .string("Acme"))]]))
+    }
+```
+
+Add to `Tests/AnglesiteCoreTests/FrontmatterTests.swift` (documents the intentionally-unhandled-but-safe degradation from the Global Constraints section):
+
+```swift
+    @Test("an object-array field doesn't corrupt sibling top-level fields (Frontmatter.parse is not record-aware by design)")
+    func objectArrayFieldDoesNotCorruptSiblings() {
+        let src = """
+        ---
+        title: "Resume"
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+        draft: true
+        ---
+        """
+        let fm = Frontmatter.parse(src)
+        #expect(fm["title"] == .string("Resume"))
+        #expect(fm["draft"] == .bool(true))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter FrontmatterDocumentTests`
+Expected: FAIL — `readsObjectArray` gets `.array(["title: Engineer", "org: Acme", "start: 2020-01-01", "title: Intern", ...])` instead (today's flat-array misparse), and `objectArrayIdentity`/`objectArrayEditRoundTrips` fail the same way.
+
+Run: `swift test --package-path . --filter FrontmatterTests`
+Expected: PASS already (this one documents existing, unchanged behavior — confirms the Global Constraints claim before Task 2 changes anything).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/FrontmatterDocument.swift`, replace the `if rawValue.isEmpty { ... }` branch inside `parse` (lines 119–129) with:
+
+```swift
+            if rawValue.isEmpty {
+                if j + 1 < block.count,
+                   let firstItemText = Frontmatter.blockArrayItem(block[j + 1]),
+                   Frontmatter.splitKeyValue(firstItemText) != nil {
+                    // Block array of records: `  - field: value` starts a record; deeper-indented
+                    // `field: value` lines continue it. Heuristic: a flat string array item that
+                    // itself looks like `word: value` would be misread as a record start — not a
+                    // shape this codebase's flat arrays (tags/hours/image paths) ever produce.
+                    var records: [[FrontmatterRecordField]] = []
+                    var k = j + 1
+                    while k < block.count, let itemText = Frontmatter.blockArrayItem(block[k]) {
+                        let dashIndent = block[k].prefix(while: { $0 == " " }).count
+                        var record: [FrontmatterRecordField] = []
+                        if let (fieldKey, fieldRaw) = Frontmatter.splitKeyValue(itemText) {
+                            record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
+                        }
+                        verbatim.append(block[k])
+                        k += 1
+                        while k < block.count {
+                            let contLine = block[k]
+                            let contIndent = contLine.prefix(while: { $0 == " " }).count
+                            let trimmed = contLine.trimmingCharacters(in: .whitespaces)
+                            guard contIndent > dashIndent, !trimmed.hasPrefix("-"),
+                                  let (fieldKey, fieldRaw) = Frontmatter.splitKeyValue(trimmed)
+                            else { break }
+                            record.append(FrontmatterRecordField(fieldKey, Frontmatter.parseScalarOrArray(fieldRaw)))
+                            verbatim.append(contLine)
+                            k += 1
+                        }
+                        records.append(record)
+                    }
+                    value = .objectArray(records)
+                    j = k
+                } else {
+                    // Possible block array on following `- item` lines.
+                    var items: [String] = []
+                    var k = j + 1
+                    while k < block.count, let item = Frontmatter.blockArrayItem(block[k]) {
+                        items.append(Frontmatter.unquote(item))
+                        verbatim.append(block[k])
+                        k += 1
+                    }
+                    value = items.isEmpty ? .string("") : .array(items)
+                    j = k
+                }
+            } else {
+                value = Frontmatter.parseScalarOrArray(rawValue)
+                j += 1
+            }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter FrontmatterDocumentTests`
+Run: `swift test --package-path . --filter FrontmatterTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/FrontmatterDocument.swift Tests/AnglesiteCoreTests/FrontmatterDocumentTests.swift Tests/AnglesiteCoreTests/FrontmatterTests.swift
+git commit -m "feat(#1117): parse block object-array YAML in FrontmatterDocument"
+```
+
+---
+
+### Task 3: `ContentTypeField.Kind.objectArray(fields:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentTypeRegistry.swift:21-33` (`Kind` enum)
+- Test: `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift`
+
+**Interfaces:**
+- Produces: `ContentTypeField.Kind.objectArray(fields: [ContentTypeField])`, `Kind` no longer conforms to `RawRepresentable`/`String`. Consumed by Tasks 4–8.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift` (inside `struct ContentTypeRegistryTests`, e.g. after `albumDescriptor`):
+
+```swift
+    @Test("objectArray kind carries its ordered member fields and compares by value")
+    func objectArrayKindCarriesMemberFields() {
+        let memberFields = [
+            ContentTypeField("title", .string, required: true),
+            ContentTypeField("organization", .string, required: true),
+            ContentTypeField("startDate", .date, required: true),
+            ContentTypeField("endDate", .date),
+            ContentTypeField("description", .text),
+        ]
+        let field = ContentTypeField("experience", .objectArray(fields: memberFields))
+        guard case .objectArray(let fields) = field.kind else {
+            Issue.record("expected .objectArray")
+            return
+        }
+        #expect(fields.map(\.name) == ["title", "organization", "startDate", "endDate", "description"])
+        #expect(fields.first?.kind == .string)
+        #expect(fields.first?.required == true)
+
+        // Equatable: same fields in the same order compare equal; a different order does not.
+        let same = ContentTypeField("experience", .objectArray(fields: memberFields))
+        #expect(field == same)
+        let reordered = ContentTypeField("experience", .objectArray(fields: memberFields.reversed()))
+        #expect(field != reordered)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter ContentTypeRegistryTests`
+Expected: FAIL to compile — `.objectArray(fields:)` doesn't exist; `Kind` is still a plain `String` raw-value enum.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/ContentTypeRegistry.swift`, replace the `Kind` enum (lines 21–33) with:
+
+```swift
+    public enum Kind: Sendable, Equatable {
+        case string        // single-line text
+        case text          // multi-line plain text
+        case markdown      // multi-line rich body
+        case bool
+        case date          // calendar date, no time
+        case datetime      // ISO 8601 date-time with time + timezone (mf2 `dt-*` properties)
+        case url
+        case image         // a site-relative media path
+        case number
+        case stringArray   // e.g. tags
+        case imageArray    // an ordered list of site-relative media paths (e.g. album photos)
+        /// A repeating group of small structured records (e.g. h-resume `experience`/`education`
+        /// entries) — an ordered list of member fields, each an existing scalar `Kind`. By
+        /// convention `fields` excludes `.markdown`, `.stringArray`, `.imageArray`, and nested
+        /// `.objectArray` — enforced by review/tests, not the type system, matching this registry's
+        /// existing preference for documented invariants over new type machinery. No built-in
+        /// descriptor declares this yet (#964 adds the first: h-resume).
+        case objectArray(fields: [ContentTypeField])
+    }
+```
+
+(No raw-value backing: confirmed via grep that nothing in `Sources/`/`Tests/` reads `ContentTypeField.Kind`'s `.rawValue` or calls `Kind(rawValue:)` — every `.rawValue` hit in the codebase belongs to an unrelated `Kind` enum on a different type.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift build --package-path .` (confirms the whole module still compiles — this is the step that will surface any missed exhaustive switch; expect it to fail here with "switch must be exhaustive" errors in `TypedContentEditor.swift`, `ContentScaffold.swift`, `MicropubContentSync.swift`, `TypedEntryEditorView.swift`, and `ContentConfigDriftTests.swift` — that's expected and is exactly what Tasks 4–7 fix. For this task, filter to just the registry test:)
+
+Run: `swift test --package-path . --filter ContentTypeRegistryTests`
+Expected: this specific test PASSES once the type exists, even though the full `swift build` won't succeed until Task 4 lands (`TypedContentEditor.swift` is in the same target). If `swift test --filter` refuses to build the target at all (likely, since it's one SwiftPM target), proceed straight to Task 4 in the same sitting before running the build/test gate — note this in the commit message.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentTypeRegistry.swift Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+git commit -m "feat(#1117): add ContentTypeField.Kind.objectArray(fields:)
+
+Drops Kind's String raw-value backing (nothing read .rawValue). The
+whole-module build won't pass until the exhaustive switches in the
+following tasks are updated — expected, not a regression."
+```
+
+---
+
+### Task 4: `TypedContentEditor.FieldValue.records` + decode/encode/defaultValue
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/TypedContentEditor.swift:11-17,28-36,80-102,106-119`
+- Test: `Tests/AnglesiteCoreTests/TypedContentEditorTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeField.Kind.objectArray(fields:)` (Task 3), `FrontmatterValue.objectArray`/`FrontmatterRecordField` (Tasks 1–2).
+- Produces: `TypedContentEditor.FieldValue.records([[String: FieldValue]])` — consumed by Task 8 (`TypedEntryEditorModel`/`TypedEntryEditorView`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/TypedContentEditorTests.swift` (inside `struct TypedContentEditorTests`, after `writeList`):
+
+```swift
+    @Test("write round-trips an objectArray field into block-mapping-list YAML")
+    func writeObjectArray() {
+        let resume = ContentTypeDescriptor(
+            id: "resumeFixture", displayName: "Resume Fixture", storage: .collection("resumeFixtures"),
+            fields: [
+                ContentTypeField("experience", .objectArray(fields: [
+                    ContentTypeField("title", .string, required: true),
+                    ContentTypeField("org", .string, required: true),
+                    ContentTypeField("start", .date, required: true),
+                ])),
+                ContentTypeField("body", .markdown),
+            ],
+            projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
+
+        let src = "---\nexperience: []\n---\n\nBody.\n"
+        var v = TypedContentEditor.read(src, descriptor: resume)
+        #expect(v["experience"] == .records([]))
+
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let start = iso.date(from: "2020-01-01T00:00:00.000Z")!
+        v["experience"] = .records([
+            ["title": .text("Engineer"), "org": .text("Acme"), "start": .date(start)],
+        ])
+        let out = TypedContentEditor.write(v, into: src, descriptor: resume)
+        #expect(out.contains("""
+        experience:
+          - title: "Engineer"
+            org: "Acme"
+            start: 2020-01-01
+        """))
+
+        let reread = TypedContentEditor.read(out, descriptor: resume)
+        #expect(reread["experience"] == .records([
+            ["title": .text("Engineer"), "org": .text("Acme"), "start": .date(start)],
+        ]))
+    }
+
+    @Test("objectArray record fields fall back to defaults when a record omits one")
+    func objectArrayRecordFillsMissingMemberDefaults() {
+        let resume = ContentTypeDescriptor(
+            id: "resumeFixture2", displayName: "Resume Fixture 2", storage: .collection("resumeFixtures2"),
+            fields: [
+                ContentTypeField("experience", .objectArray(fields: [
+                    ContentTypeField("title", .string, required: true),
+                    ContentTypeField("org", .string),
+                ])),
+            ],
+            projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
+        let src = "---\nexperience:\n  - title: \"Engineer\"\n---\n"
+        let v = TypedContentEditor.read(src, descriptor: resume)
+        #expect(v["experience"] == .records([["title": .text("Engineer"), "org": .text("")]]))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift build --package-path .`
+Expected: FAIL — non-exhaustive switches in `defaultValue(for:)`, `decode(_:kind:)`, `encode(_:kind:)` (no `.objectArray`/`.records` arm yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/TypedContentEditor.swift`, add a case to `FieldValue` (after `case list([String])`, line 16):
+
+```swift
+        case records([[String: FieldValue]])
+```
+
+Add an arm to `defaultValue(for:)` (after the `.stringArray, .imageArray` arm, line 34):
+
+```swift
+        case .objectArray: return .records([])
+```
+
+Replace `decode(_:kind:)` (lines 80–102) with:
+
+```swift
+    private static func decode(_ value: FrontmatterValue, kind: ContentTypeField.Kind) -> FieldValue {
+        switch kind {
+        case .string, .text, .url, .image, .markdown:
+            if case .string(let s) = value { return .text(s) }
+            return .text("")
+        case .bool:
+            if case .bool(let b) = value { return .flag(b) }
+            return .flag(false)
+        case .date, .datetime:
+            // `FrontmatterValue.date` is write-only — `Frontmatter.parse` only ever yields a date
+            // scalar as `.string`, so matching `.string` here is exhaustive in practice. If that
+            // invariant is ever relaxed, add a `.date` arm: the `.date(nil)` fallback would
+            // otherwise silently drop a valid date.
+            if case .string(let s) = value { return .date(parseDate(s)) }
+            return .date(nil)
+        case .number:
+            if case .string(let s) = value { return .number(Double(s)) }
+            return .number(nil)
+        case .stringArray, .imageArray:
+            if case .array(let a) = value { return .list(a) }
+            return .list([])
+        case .objectArray(let memberFields):
+            guard case .objectArray(let records) = value else { return .records([]) }
+            let decoded = records.map { record -> [String: FieldValue] in
+                let raw = Dictionary(record.map { ($0.name, $0.value) }, uniquingKeysWith: { _, latest in latest })
+                var dict: [String: FieldValue] = [:]
+                for member in memberFields {
+                    dict[member.name] = raw[member.name].map { decode($0, kind: member.kind) }
+                        ?? defaultValue(for: member.kind)
+                }
+                return dict
+            }
+            return .records(decoded)
+        }
+    }
+```
+
+Replace `encode(_:kind:)` (lines 106–119) with:
+
+```swift
+    private static func encode(_ value: FieldValue, kind: ContentTypeField.Kind) -> FrontmatterValue? {
+        switch value {
+        case .text(let s): return .string(s)
+        case .flag(let b): return .bool(b)
+        // Dates serialize unquoted (FrontmatterValue.date) so they satisfy a non-coercing date
+        // schema and stay consistent with ContentScaffold; a nil (cleared) date falls back to an
+        // empty quoted scalar.
+        case .date(let d): return d.map { .date(format($0, kind: kind)) } ?? .string("")
+        // Numbers serialize unquoted (FrontmatterValue.number) so they satisfy a z.number() schema;
+        // a nil (cleared) number falls back to an empty quoted scalar.
+        case .number(let n): return n.map { .number($0) } ?? .string("")
+        case .list(let a): return .array(a)
+        case .records(let recordDicts):
+            guard case .objectArray(let memberFields) = kind else { return nil }
+            let records: [[FrontmatterRecordField]] = recordDicts.map { dict in
+                memberFields.compactMap { member -> FrontmatterRecordField? in
+                    guard let v = dict[member.name], let encoded = encode(v, kind: member.kind) else { return nil }
+                    return FrontmatterRecordField(member.name, encoded)
+                }
+            }
+            return .objectArray(records)
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift build --package-path .`
+Expected: builds clean (no more non-exhaustive-switch errors from this file; `ContentScaffold.swift`/`MicropubContentSync.swift`/`TypedEntryEditorView.swift`/`ContentConfigDriftTests.swift` still fail until Tasks 5–7 — expected).
+
+Run: `swift test --package-path . --filter TypedContentEditorTests`
+Expected: PASS (once Tasks 5–7 also land and the target builds — if `swift test` won't build the whole target yet, defer running this filter until Task 7 is also done, and say so in the commit message).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/TypedContentEditor.swift Tests/AnglesiteCoreTests/TypedContentEditorTests.swift
+git commit -m "feat(#1117): encode/decode objectArray fields in TypedContentEditor"
+```
+
+---
+
+### Task 5: `ContentScaffold.renderEntry`/`renderSingleton` exhaustiveness
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/ContentScaffold.swift:182-215,255-267`
+- Test: `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeField.Kind.objectArray` (Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/ContentScaffoldTests.swift` (match the file's existing `@Suite`/`@Test` style — check the top of the file for its exact suite name/imports before inserting):
+
+```swift
+    @Test("renderEntry scaffolds an empty array for an objectArray field")
+    func renderEntryScaffoldsEmptyObjectArray() {
+        let descriptor = ContentTypeDescriptor(
+            id: "resumeFixture", displayName: "Resume Fixture", storage: .collection("resumeFixtures"),
+            fields: [ContentTypeField("experience", .objectArray(fields: [
+                ContentTypeField("title", .string, required: true),
+            ]))],
+            projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
+        let out = ContentScaffold.renderEntry(descriptor: descriptor, title: nil, now: Date())
+        #expect(out.contains("experience: []"))
+    }
+
+    @Test("renderSingleton scaffolds an empty array for an objectArray field")
+    func renderSingletonScaffoldsEmptyObjectArray() {
+        let descriptor = ContentTypeDescriptor(
+            id: "resumeSingletonFixture", displayName: "Resume Singleton Fixture", storage: .singleton("resumeFixture"),
+            fields: [ContentTypeField("experience", .objectArray(fields: [
+                ContentTypeField("title", .string, required: true),
+            ]))],
+            projections: ContentTypeProjections(microformat: "h-resume", microformatProperties: [:], schemaType: nil))
+        let out = ContentScaffold.renderSingleton(descriptor: descriptor, name: nil)
+        #expect(out.contains("\"experience\": []"))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift build --package-path .`
+Expected: FAIL — non-exhaustive switch in `renderEntry`/`renderSingleton`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/ContentScaffold.swift`, in `renderEntry`'s switch (around line 199), change:
+
+```swift
+            case .stringArray, .imageArray:
+                lines.append("\(field.name): []")
+```
+to:
+```swift
+            case .stringArray, .imageArray, .objectArray:
+                lines.append("\(field.name): []")
+```
+
+In `renderSingleton`'s switch (around line 262), change:
+
+```swift
+            case .stringArray, .imageArray:
+                value = "[]"
+```
+to:
+```swift
+            case .stringArray, .imageArray, .objectArray:
+                value = "[]"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift build --package-path .`
+Run: `swift test --package-path . --filter ContentScaffoldTests`
+Expected: builds; new tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContentScaffold.swift Tests/AnglesiteCoreTests/ContentScaffoldTests.swift
+git commit -m "feat(#1117): scaffold objectArray fields as an empty array"
+```
+
+---
+
+### Task 6: `MicropubContentSync.fieldValue` exhaustiveness
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/MicropubContentSync.swift:107-135`
+- Test: `Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift`
+
+**Interfaces:**
+- Consumes: `ContentTypeField.Kind.objectArray` (Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift` (near the other `fieldValue`-adjacent tests, or in a new `// MARK: - fieldValue` section):
+
+```swift
+    @Test("fieldValue returns an empty records value for an objectArray field (no mf2 mapping exists for it)")
+    func fieldValueObjectArrayIsEmptyRecords() {
+        let field = ContentTypeField("experience", .objectArray(fields: [
+            ContentTypeField("title", .string, required: true),
+        ]))
+        let result = MicropubContentSync.fieldValue(for: field, rawProperty: "experience", properties: [:])
+        #expect(result == .records([]))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift build --package-path .`
+Expected: FAIL — non-exhaustive switch in `fieldValue(for:rawProperty:properties:)`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Sources/AnglesiteCore/MicropubContentSync.swift`, add an arm to `fieldValue`'s switch (after the `.imageArray` arm, around line 134):
+
+```swift
+        // No field in the built-in registry maps a raw mf2 property to `.objectArray` today (h-resume
+        // lands in #964, and even then p-experience/p-education are nested h-event/h-card mf2
+        // objects this bridge doesn't attempt to flatten back into records) — this arm exists only
+        // for switch exhaustiveness, mirroring the `.bool` arm above.
+        case .objectArray:
+            return .records([])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift build --package-path .`
+Run: `swift test --package-path . --filter MicropubContentSyncTests`
+Expected: builds; new test PASSes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/MicropubContentSync.swift Tests/AnglesiteCoreTests/MicropubContentSyncTests.swift
+git commit -m "feat(#1117): exhaustiveness arm for objectArray in MicropubContentSync"
+```
+
+---
+
+### Task 7: `ContentConfigDriftTests.zod(for:)` exhaustiveness
+
+**Files:**
+- Modify: `Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift:25-35`
+
+**Interfaces:**
+- Consumes: `ContentTypeField.Kind.objectArray` (Task 3).
+- Produces: the canonical Zod-expression shape a future h-resume-era `content.config.ts` should match — `z.array(z.object({ ... }))` — satisfying the issue's "matching shape" ask without a real collection to attach it to yet (see Global Constraints).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift` (inside `struct ContentConfigDriftTests`, after `titleFieldPerType`-style tests — actually this suite has no such test; add near the bottom, after `parsesExportLine`):
+
+```swift
+    @Test("zod(for:) renders an objectArray field as z.array(z.object({...})) with member requiredness")
+    func zodForObjectArray() {
+        let kind = ContentTypeField.Kind.objectArray(fields: [
+            ContentTypeField("title", .string, required: true),
+            ContentTypeField("org", .string),
+        ])
+        #expect(Self.zod(for: kind) == "z.array(z.object({ title: z.string(), org: z.string().optional() }))")
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift build --package-path .`
+Expected: FAIL — non-exhaustive switch in `zod(for:)` (the last remaining compile error from Task 3's change).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift`, replace `zod(for kind:)` (lines 25–35) with:
+
+```swift
+    static func zod(for kind: ContentTypeField.Kind) -> String? {
+        switch kind {
+        case .markdown: return nil
+        case .string, .text, .image: return "z.string()"
+        case .url: return "z.string().url()"
+        case .date, .datetime: return "z.coerce.date()"
+        case .number: return "z.number()"
+        case .bool: return "z.boolean()"
+        case .stringArray, .imageArray: return "z.array(z.string())"
+        case .objectArray(let fields):
+            let memberExprs = fields.compactMap { field -> String? in
+                guard let expr = zod(for: field.kind) else { return nil }
+                let full = field.kind == .bool ? "\(expr).default(false)" : (field.required ? expr : "\(expr).optional()")
+                return "\(field.name): \(full)"
+            }
+            return "z.array(z.object({ \(memberExprs.joined(separator: ", ")) }))"
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift build --package-path .`
+Expected: the whole `AnglesiteCore` target (and its test target) now builds clean — this was the last non-exhaustive switch.
+
+Run: `swift test --package-path .`
+Expected: full SwiftPM suite PASSES, including every test added in Tasks 1–7.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
+git commit -m "feat(#1117): zod(for:) exhaustiveness arm for objectArray"
+```
+
+---
+
+### Task 8: SwiftUI nested-row editor (`TypedEntryEditorModel` + `TypedEntryEditorView`)
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/TypedEntryEditorModel.swift:167-170` (add `recordsBinding`)
+- Modify: `Sources/AnglesiteApp/TypedEntryEditorView.swift:36-65` (add `.objectArray` arm + new `ObjectArrayEditor` view)
+
+**Interfaces:**
+- Consumes: `TypedContentEditor.FieldValue.records` (Task 4), `ContentTypeField.Kind.objectArray(fields:)` (Task 3).
+- No new test file: this repo has no existing direct unit tests for `TypedEntryEditorModel`'s other `Binding` accessors (`textBinding`, `listBinding`, etc. are untested directly, exercised only via `TypedContentEditor`'s own tests and manual/GUI verification) — `recordsBinding` follows the same precedent. Verified by `scripts/build-app.sh` (compiles the SwiftUI code, confirms `control(for:)` is exhaustive) — this Kind has no built-in descriptor yet (#964 adds the first), so there's no live screen to interactively click through today.
+
+- [ ] **Step 1: Add `recordsBinding` to `TypedEntryEditorModel`**
+
+In `Sources/AnglesiteApp/TypedEntryEditorModel.swift`, add after `listBinding` (line 167–170):
+
+```swift
+    func recordsBinding(_ name: String) -> Binding<[[String: TypedContentEditor.FieldValue]]> {
+        Binding(get: { [weak self] in if case .records(let r)? = self?.values[name] { return r }; return [] },
+                set: { [weak self] in self?.values[name] = .records($0) })
+    }
+```
+
+- [ ] **Step 2: Run the app build to verify it fails**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: FAIL — `TypedEntryEditorView.control(for:)`'s switch is non-exhaustive (`.objectArray` has no arm), since `ContentTypeField.Kind` changed in Task 3.
+
+- [ ] **Step 3: Add the `.objectArray` arm and the `ObjectArrayEditor` view**
+
+In `Sources/AnglesiteApp/TypedEntryEditorView.swift`, add a case to `control(for:)`'s switch (after the `.stringArray, .imageArray` arm, before `.markdown`, around line 62):
+
+```swift
+        case .objectArray(let memberFields):
+            ObjectArrayEditor(title: label, memberFields: memberFields, records: model.recordsBinding(field.name))
+```
+
+Add a new view after `StringListEditor` (end of file, after line 134):
+
+```swift
+/// An add/remove list editor for `objectArray` fields — one collapsible-free block per record, each
+/// rendering its member fields inline. Rows carry stable UUID identity, mirroring `StringListEditor`,
+/// so deleting a row never re-binds a surviving row's editor to the wrong record.
+private struct ObjectArrayEditor: View {
+    let title: String
+    let memberFields: [ContentTypeField]
+    @Binding var records: [[String: TypedContentEditor.FieldValue]]
+
+    private struct Row: Identifiable, Equatable {
+        let id = UUID()
+        var values: [String: TypedContentEditor.FieldValue]
+    }
+    @State private var rows: [Row] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            ForEach($rows) { $row in
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(memberFields, id: \.name) { field in
+                        memberControl(for: field, in: $row.values)
+                    }
+                    HStack {
+                        Spacer()
+                        Button(role: .destructive) { rows.removeAll { $0.id == row.id } } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+                .padding(8)
+                .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary))
+            }
+            Button { rows.append(Row(values: emptyRecord())) } label: {
+                Label("Add", systemImage: "plus.circle")
+            }
+            .buttonStyle(.borderless)
+        }
+        .onAppear { syncRowsFromRecords() }
+        .onChange(of: records) { _, new in
+            if new != rows.map(\.values) { rows = new.map(Row.init(values:)) }
+        }
+        .onChange(of: rows) { _, new in
+            let mapped = new.map(\.values)
+            if mapped != records { records = mapped }
+        }
+    }
+
+    private func emptyRecord() -> [String: TypedContentEditor.FieldValue] {
+        Dictionary(uniqueKeysWithValues: memberFields.map { ($0.name, TypedContentEditor.defaultValue(for: $0.kind)) })
+    }
+
+    private func syncRowsFromRecords() {
+        if records != rows.map(\.values) { rows = records.map(Row.init(values:)) }
+    }
+
+    @ViewBuilder
+    private func memberControl(for field: ContentTypeField, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> some View {
+        let label = field.name + (field.required ? " *" : "")
+        switch field.kind {
+        case .bool:
+            Toggle(label, isOn: flagBinding(field.name, in: values))
+        case .date, .datetime:
+            DatePicker(label, selection: dateBinding(field.name, in: values),
+                       displayedComponents: field.kind == .date ? [.date] : [.date, .hourAndMinute])
+        case .number:
+            TextField(label, text: numberBinding(field.name, in: values))
+        default:
+            TextField(label, text: textBinding(field.name, in: values))
+        }
+    }
+
+    private func textBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<String> {
+        Binding(
+            get: { if case .text(let s)? = values.wrappedValue[name] { return s }; return "" },
+            set: { values.wrappedValue[name] = .text($0) }
+        )
+    }
+
+    private func flagBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<Bool> {
+        Binding(
+            get: { if case .flag(let b)? = values.wrappedValue[name] { return b }; return false },
+            set: { values.wrappedValue[name] = .flag($0) }
+        )
+    }
+
+    private func dateBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<Date> {
+        Binding(
+            get: { if case .date(let d)? = values.wrappedValue[name] { return d ?? Date() }; return Date() },
+            set: { values.wrappedValue[name] = .date($0) }
+        )
+    }
+
+    private func numberBinding(_ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>) -> Binding<String> {
+        Binding(
+            get: {
+                if case .number(let n)? = values.wrappedValue[name], let n { return String(n) }
+                return ""
+            },
+            set: { values.wrappedValue[name] = .number(Double($0)) }
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run the app build to verify it passes**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: builds clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/TypedEntryEditorModel.swift Sources/AnglesiteApp/TypedEntryEditorView.swift
+git commit -m "feat(#1117): nested-row SwiftUI editor for objectArray fields"
+```
+
+---
+
+### Task 9: Full verification and PR prep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full Swift package test suite**
+
+Run: `swift test --package-path .`
+Expected: all suites PASS, including every `@Test` added in Tasks 1–7.
+
+- [ ] **Step 2: Full app build**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: builds clean.
+
+- [ ] **Step 3: Check for `Resources/Template/` coupling**
+
+Per `CONTRIBUTING.md` ▸ Testing: "If you touch `Resources/Template/`, run `swift test` too — some Swift tests couple to the template markup." This plan does not touch `Resources/Template/` (confirmed: no task modifies any file under that directory) — record this explicitly in the PR body's Test plan rather than silently omitting the check.
+
+- [ ] **Step 4: Re-read `CONTRIBUTING.md` ▸ "Commits and pull requests" immediately before opening the PR**
+
+Confirm: commit subjects ≤72 chars (all of Tasks 1–8's are); PR body uses `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings (**Summary**, **Paired PR check**, **Test plan**); Paired PR check states this is **not** an MCP-schema change (no sidecar PR needed) — it's `Sources/AnglesiteCore`/`Sources/AnglesiteApp`-only, template-adjacent work is limited to the test-only `ContentConfigDriftTests.swift`.
+
+- [ ] **Step 5: Remove the in-progress label and open the PR**
+
+```bash
+gh issue edit 1117 --remove-label "🛠️ In Progress"
+```
+
+Then commit is already done per-task; open the PR with `gh pr create` using the template headings from Step 4.


### PR DESCRIPTION
## Summary

- Adds `ContentTypeField.Kind.objectArray(fields:)` — a repeating group of small structured records (e.g. an h-resume `experience`/`education` entry: title/org/start/end/description) — threaded end-to-end through `FrontmatterValue`/`FrontmatterDocument` (YAML round-trip), `TypedContentEditor` (the per-field-`Kind` editor bridge), `ContentScaffold`, `MicropubContentSync`, a test-only Zod-drift guard, and a new interactive SwiftUI nested-row editor (add/remove rows, type-appropriate per-member controls).
- Pure plumbing: no built-in `ContentTypeDescriptor` declares this kind yet — the shipped app's behavior is unchanged. This unblocks #964 (h-resume) to register the first real user.
- Includes a fix (found by a final whole-branch review, not part of the original task list) for a parsing heuristic that could otherwise misclassify real shipped `.stringArray` fields — `businessProfile.hours` and `member.links` — as object-array records when hand-edited without quotes, which would have silently destroyed that data on next save. The corrected heuristic requires evidence of a multi-field record anywhere in the block before committing to the object-array reading, closing both that gap and a second-order asymmetric-record variant the fix's own re-review caught.

Closes #1117.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

No MCP message schema changes, and `Resources/Template/` is untouched — this is an app-only content-type/editor primitive.

## Test plan

- [x] `swift test --package-path .` — 2991 tests across 378 suites, all passing (one unrelated `FoundationModelAssistantTests` live-on-device-model flake observed across two separate full-suite runs during development, on a file this branch never touches — the final clean run before this PR passed it too).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — `** BUILD SUCCEEDED **`.
- [ ] Manual smoke (if UI-touching): the new `ObjectArrayEditor` SwiftUI control has no reachable entry point in the shipped app yet — no built-in descriptor uses `.objectArray`, so there's nothing to click through until #964 registers one.

## Design notes

Implemented via [`docs/superpowers/plans/2026-07-30-content-type-object-array-field.md`](docs/superpowers/plans/2026-07-30-content-type-object-array-field.md) using subagent-driven development: 8 implementation tasks, each independently reviewed, followed by a final whole-branch review that caught and fixed the parsing-heuristic issue above (two fix rounds, both independently re-verified). A handful of documented, non-blocking follow-ups for whoever builds #964 are noted inline in code comments (e.g. `Kind.objectArray`'s doc comment on extra per-record keys not surviving an edit, and `SiteKnowledgeIndex`'s objectArray arm remaining unreachable since it only reads via the lightweight `Frontmatter.parse`).