### PR TITLE
fix(#986): don't swallow prose between a bare < and next >

### DIFF
--- a/Resources/Template/scripts/embeds/normalize.test.ts
+++ b/Resources/Template/scripts/embeds/normalize.test.ts
@@ -194,8 +194,17 @@ test("htmlToText: no tag-like residue survives nested or malformed markup", () =
     assert.ok(!tagLike.test(htmlToText(input)), `${input} -> ${htmlToText(input)}`);
   }
   assert.equal(htmlToText("<img src=x onerror=y>safe"), "safe");
-  // Known, pre-existing lossiness (not introduced by the tag-strip loop): an unescaped `<`
-  // in prose swallows everything up to the next `>`, so "2 < 3 and 4 > 1" becomes "2 1".
-  // Platform APIs escape these as &lt;/&gt;, which decode after stripping and survive intact.
   assert.equal(htmlToText("2 &lt; 3 and 4 &gt; 1"), "2 < 3 and 4 > 1");
+});
+
+test("htmlToText: a bare < in prose is not mistaken for a tag opener (#986)", () => {
+  // A `<` not followed by a tag-shaped character (a name, `/`, `!`, or `?`) is prose, not
+  // markup — it must survive along with the text after it, instead of swallowing everything
+  // up to the next unrelated `>`.
+  assert.equal(htmlToText("2 < 3 and 4 > 1"), "2 < 3 and 4 > 1");
+  assert.equal(htmlToText("5<10 but 20>15"), "5<10 but 20>15");
+  assert.equal(htmlToText("a < b"), "a < b");
+  // A `<` immediately followed by a letter still reads as a (fake) tag and is stripped —
+  // this heuristic can't perfectly distinguish prose from markup, only improve on it.
+  assert.equal(htmlToText("x <y> z"), "x z");
 });

--- a/Resources/Template/scripts/embeds/normalize.ts
+++ b/Resources/Template/scripts/embeds/normalize.ts
@@ -18,12 +18,17 @@ const ENTITIES: Record<string, string> = {
  * might not escape its output. Escaping at render (`src/lib/embed-card.ts`) remains the actual
  * security boundary; this is defence in depth. Terminates because each pass strictly shortens
  * the string or leaves it unchanged.
+ *
+ * Only treats `<` as a tag opener when followed by a name character, `/`, `!`, or `?` — a bare
+ * `<` in prose (`2 < 3`, `5<10`) has no tag-shaped follower, so it's left alone instead of
+ * swallowing everything up to the next unrelated `>` (#986). This can't distinguish every case
+ * (`<b >` with a space, or an attribute value containing `>`) — that would need a real parser.
  */
 function stripTags(input: string): string {
   let out = input;
   for (let previous = ""; out !== previous; ) {
     previous = out;
-    out = out.replace(/<[^>]*>/g, "");
+    out = out.replace(/<[A-Za-z/!?][^>]*>/g, "");
   }
   return out;
 }


### PR DESCRIPTION
## Summary

- `htmlToText`'s `stripTags` regex (`Resources/Template/scripts/embeds/normalize.ts`) treated any `<` as a tag opener, so a bare `<` in prose (e.g. `og:description` scraped from an arbitrary site by the generic Open Graph adapter) deleted everything up to the next unrelated `>` — `"5<10 but 20>15"` silently became `"515"`.
- Changed the regex to only treat `<` as a tag opener when followed by a name character, `/`, `!`, or `?` (option 1 from the issue's fix sketch) — cheap, no new dependency, and fixes the reported cases without touching the entity-decoding path that already keeps escaped `&lt;`/`&gt;` intact.
- Added regression tests for the fixed cases and updated the existing "no tag-like residue" test's comment (the lossiness it documented is now fixed, not pre-existing).

Not a security issue — see the issue's discussion: `htmlToText`'s output is still escaped by `escapeHTML` before it becomes markup, and `stripTags` still loops until stable so no tag-like residue survives malformed input.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (pre-existing, unrelated `DeployModelTests` failure confirmed present on `main` at HEAD before this change; not touched by this diff)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] `npx tsx --test scripts/embeds/normalize.test.ts` and `npm run test:scripts` (Resources/Template) — all pass except a pre-existing, unrelated `a11y-audit`/`a11y-validate` failure (missing `html-validate` dependency in this environment)

Closes #986