### PR TITLE
fix(#1124): stop SITE_URL from shadowing a confirmed custom domain

### DIFF
--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -327,11 +327,14 @@ public actor DeployCommand {
                 if let configDirectory {
                     try? DeployedRoutesSnapshot.save(currentRoutes, to: configDirectory)
                 }
-                Self.persistSiteURL(url, siteDirectory: siteDirectory)
-                Self.persistWorkerDeployed(siteDirectory: siteDirectory)
+                // Runs before `persistSiteURL` (#1077/#1124): a fresh confirmation from *this*
+                // deploy persists `CF_DOMAIN_ATTACHED` as a side effect, which `persistSiteURL`
+                // checks to decide whether to leave `SITE_URL` alone.
                 let domainAttachOutcome = await customDomainAttachCommand.attach(
                     siteDirectory: siteDirectory, apiToken: token, source: "deploy:\(siteID)")
                 onDomainAttach?(domainAttachOutcome)
+                Self.persistSiteURL(url, siteDirectory: siteDirectory)
+                Self.persistWorkerDeployed(siteDirectory: siteDirectory)
                 if let configDirectory {
                     await Self.uploadSourceBundleIfConfigured(
                         siteDirectory: siteDirectory, configDirectory: configDirectory,
@@ -415,15 +418,26 @@ public actor DeployCommand {
     /// built before the URL was known, so the placeholder still ships on a site's first deploy —
     /// every deploy after that carries the real host.
     ///
-    /// Written unconditionally, even when a custom domain (`DOMAIN`/`SITE_DOMAIN`) is already
-    /// configured (#1085): nothing in the deploy pipeline actually attaches a custom domain yet
-    /// (#1077), so that value is never verified to be live. `SITE_URL` is the one field guaranteed
-    /// to be the site's real, reachable address — `DeployCoordinator.resolveSiteURL` prefers it
-    /// over the possibly-dead custom domain for exactly that reason. Best-effort — a write failure
-    /// must never turn a successful deploy into a failed one.
+    /// Written even when a custom domain (`DOMAIN`/`SITE_DOMAIN`) is configured but not yet
+    /// confirmed live (#1085): before #1077, nothing in the deploy pipeline attached a custom
+    /// domain, so an unverified `DOMAIN` was never trustworthy and `SITE_URL` — the site's real,
+    /// reachable address — had to win `DeployCoordinator.resolveSiteURL`'s precedence regardless.
+    ///
+    /// Skipped once `CF_DOMAIN_ATTACHED` matches `DOMAIN` — the same "confirmed" signal
+    /// `CustomDomainAttachCommand.attach` itself checks (#1077) — because at that point `DOMAIN`
+    /// *is* verified live, and overwriting `SITE_URL` with the workers.dev host would shadow it in
+    /// `resolveSiteURL`'s precedence forever after, silently undoing every confirmed domain attach
+    /// on its very next deploy. Callers must call `customDomainAttachCommand.attach` (and let it
+    /// persist `CF_DOMAIN_ATTACHED`) before this, so a domain confirmed *in this same deploy* is
+    /// already visible to the check. Best-effort — a write failure must never turn a successful
+    /// deploy into a failed one.
     static func persistSiteURL(_ url: URL, siteDirectory: URL) {
         let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
         let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        if let domain = SiteConfigFile.value(forKey: "DOMAIN", in: config),
+           SiteConfigFile.value(forKey: "CF_DOMAIN_ATTACHED", in: config) == domain {
+            return
+        }
         let updated = SiteConfigFile.upsert([("SITE_URL", url.absoluteString)], into: config)
         guard updated != config else { return }
         try? updated.write(to: configURL, atomically: true, encoding: .utf8)

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -1104,6 +1104,23 @@ struct DeployCommandTests {
         #expect(!config.contains("old.example.workers.dev"))
     }
 
+    @Test("persistSiteURL skips the write once CF_DOMAIN_ATTACHED confirms the configured DOMAIN (#1077)")
+    func persistSiteURLSkipsOnceCustomDomainConfirmed() {
+        let siteDir = privateSiteDir()
+        defer { try? FileManager.default.removeItem(at: siteDir) }
+        // Unlike `customDomainDoesNotStopSiteURLPersistence` above (DOMAIN configured but never
+        // verified live), CF_DOMAIN_ATTACHED here matches DOMAIN exactly — the same "confirmed"
+        // signal `CustomDomainAttachCommand.attach` itself checks — so the custom domain is the
+        // site's real, verified address and must not be shadowed by the workers.dev host.
+        try? "DOMAIN=example.com\nCF_DOMAIN_ATTACHED=example.com\n".write(
+            to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        DeployCommand.persistSiteURL(URL(string: "https://new.example.workers.dev")!, siteDirectory: siteDir)
+
+        let config = try! String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(!config.contains("SITE_URL="))
+    }
+
     // MARK: Bundle-upload orchestration (#799)
 
     @Test("a successful deploy uploads the source bundle when CF_SOURCE_BUCKET is configured")
@@ -1311,6 +1328,11 @@ struct DeployCommandTests {
         #expect(observed == .confirmed(hostname: "example.com"))
         let config = try String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(config.contains("CF_DOMAIN_ATTACHED=example.com"))
+        // #1124: a domain confirmed attached *in this same deploy* must win immediately —
+        // `persistSiteURL` must not overwrite SITE_URL with the workers.dev host and shadow it,
+        // or `DeployCoordinator.resolveSiteURL`'s DOMAIN fallback (which `DeployModel`'s
+        // succeeded-phase display URL relies on) never sees the custom domain.
+        #expect(!config.contains("SITE_URL="))
     }
 
     @Test("a domain-attach outcome of .notConnected doesn't block the deploy from succeeding")


### PR DESCRIPTION
Closes #1124

## Summary

- `DeployCommand.persistSiteURL` unconditionally overwrote `.site-config`'s `SITE_URL` with the workers.dev host on every deploy (#1085's fix), and `DeployCoordinator.resolveSiteURL` always prefers `SITE_URL` over `DOMAIN` — so #1077's custom-domain-attach + display-URL-swap logic could never actually surface the custom domain, since `persistSiteURL` kept re-shadowing it on every single deploy.
- `persistSiteURL` now skips its write once `CF_DOMAIN_ATTACHED` matches `DOMAIN` (the same "confirmed" signal `CustomDomainAttachCommand.attach` itself checks), and the attach call now runs before `persistSiteURL` so a domain confirmed within *this* deploy is already visible to the check.
- Fixes the two failing `DeployModelTests` cases from #1119 ("A confirmed domain attach swaps the succeeded phase's URL to the custom domain" and "A second deploy after a successful attach still shows the custom domain, with no network call (#1077)"), tracked in #1124.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite-skills#123 -->

## Test plan

- [x] `swift test --package-path .` — full suite passes (3004+ tests across all targets), including the previously-failing `DeployModelTests` and two new `DeployCommandTests` covering the `persistSiteURL` guard directly.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] Manual smoke (if UI-touching): not UI-touching — no manual smoke performed.