### PR TITLE
fix(#987): surface contentActionError for remaining silent paths

### DIFF
--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1242,6 +1242,19 @@ final class SiteWindowModel {
         }
     }
 
+    /// Shared by every content-action failure path below whose `contentCreation` call resolves
+    /// `.siteNotFound` (#987) — matches `NewContentSheets`' wording for the same case, so a user
+    /// who hits this from a create flow and a content-action flow sees consistent text.
+    private static let siteNotFoundMessage = "This site is no longer available."
+
+    /// Reports a Navigator row that outlived its `SiteContentGraph` entry (#987) — a page/post
+    /// deleted outside the app, or a rescan racing the action. Falls back to a generic phrase
+    /// when `navigator` itself no longer has the row either (e.g. no `loadAndStart()` ran, as in
+    /// most of this file's own tests).
+    private func reportUnresolvedRow(id: String) {
+        contentActionError = "\(navigator?.item(for: id)?.title ?? "This item") is no longer part of this site's content."
+    }
+
     /// The `ContentUndoCoordinator` applier: realize `mutation.before` at its path — write those
     /// exact bytes, or delete the file when `before` is nil. Both halves route through
     /// `contentCreation`, so an undo commits and rescans the content graph exactly like the
@@ -1274,6 +1287,7 @@ final class SiteWindowModel {
                 reopenSurfaces(for: mutation.relativePath)
                 return .failed
             case .siteNotFound:
+                contentActionError = Self.siteNotFoundMessage
                 reopenSurfaces(for: mutation.relativePath)
                 return .failed
             }
@@ -1296,6 +1310,7 @@ final class SiteWindowModel {
             }
             return .failed
         case .siteNotFound:
+            contentActionError = Self.siteNotFoundMessage
             return .failed
         }
     }
@@ -1361,6 +1376,7 @@ final class SiteWindowModel {
             // A failed delete never touched the file, so put back what closing it took away.
             reopenSurfaces(for: relPath)
         case .siteNotFound:
+            contentActionError = Self.siteNotFoundMessage
             reopenSurfaces(for: relPath)
         }
     }
@@ -1389,6 +1405,7 @@ final class SiteWindowModel {
             result = await contentCreation.duplicatePost(
                 siteID: site.id, relativePath: post.filePath, collection: post.collection, title: sourceTitle)
         } else {
+            reportUnresolvedRow(id: id)
             return
         }
 
@@ -1404,7 +1421,7 @@ final class SiteWindowModel {
         case .failed(let reason):
             contentActionError = reason
         case .siteNotFound:
-            break
+            contentActionError = Self.siteNotFoundMessage
         }
     }
 
@@ -1413,7 +1430,11 @@ final class SiteWindowModel {
     /// no-confirmation precedent as `duplicate(id:)`.
     @MainActor
     func publish(id: String) async {
-        guard let site, let post = await contentGraph.post(id: id) else { return }
+        guard let site else { return }
+        guard let post = await contentGraph.post(id: id) else {
+            reportUnresolvedRow(id: id)
+            return
+        }
         let result = await contentCreation.publish(
             siteID: site.id, relativePath: post.filePath, collection: post.collection)
         switch result {
@@ -1422,14 +1443,18 @@ final class SiteWindowModel {
         case .failed(let reason):
             contentActionError = reason
         case .siteNotFound:
-            break
+            contentActionError = Self.siteNotFoundMessage
         }
     }
 
     /// Unpublishes the post at `id` (#798): sets `draft: true`, leaving `publishDate` untouched.
     @MainActor
     func unpublish(id: String) async {
-        guard let site, let post = await contentGraph.post(id: id) else { return }
+        guard let site else { return }
+        guard let post = await contentGraph.post(id: id) else {
+            reportUnresolvedRow(id: id)
+            return
+        }
         let result = await contentCreation.unpublish(
             siteID: site.id, relativePath: post.filePath, collection: post.collection)
         switch result {
@@ -1438,7 +1463,7 @@ final class SiteWindowModel {
         case .failed(let reason):
             contentActionError = reason
         case .siteNotFound:
-            break
+            contentActionError = Self.siteNotFoundMessage
         }
     }
 

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -204,10 +204,10 @@ extension SiteWindowModelTests {
 
         #expect(model.deleteConfirmation == nil)
         // `SiteStore.shared` doesn't know "site-a" — `deleteContent` resolves `.siteNotFound`, so no
-        // redirect offer (correctly: nothing was actually deleted) and no error surfaced (`.siteNotFound`
-        // is a silent no-op in confirmDelete, matching `duplicateNoSiteIsNoOp`'s established expectation).
+        // redirect offer (correctly: nothing was actually deleted) and `contentActionError` reports
+        // it (#987 — this used to be a silent no-op here too).
         #expect(model.pendingRedirectOfferRoute == nil)
-        #expect(model.contentActionError == nil)
+        #expect(model.contentActionError == "This site is no longer available.")
     }
 
     // MARK: - ⌘Z for structural content operations (#675)
@@ -288,6 +288,130 @@ extension SiteWindowModelTests {
         #expect(model.activeEditor != nil)
         #expect(model.mainPaneMode == .editor(editor.file))
         #expect(FileManager.default.fileExists(atPath: fileURL.path))
+        #expect(model.contentActionError == "This site is no longer available.")
+    }
+}
+
+extension SiteWindowModelTests {
+    // MARK: - #987: content-action failure paths must surface `contentActionError`
+    //
+    // Distinct from the "no open site" no-op already covered above (`duplicateNoSiteIsNoOp`,
+    // `applyContentUndoNoSiteFails`) — that one stays a silent no-op by design (nothing to act
+    // on). These cover the two classes #987 flagged as actually reachable: a Navigator row that
+    // outlived its `SiteContentGraph` entry, and `contentCreation`'s own `.siteNotFound` (the
+    // site left `SiteStore.shared` mid-session).
+
+    private func makeUnregisteredSite() -> SiteStore.Site {
+        SiteStore.Site(
+            id: "site-a", name: "Test", packageURL: URL(fileURLWithPath: "/tmp/nonexistent.anglesite"),
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
+        )
+    }
+
+    @Test("duplicate reports an error when the row has no matching page or post")
+    func duplicateUnresolvedRowReportsError() async {
+        let model = makeModel()
+        model.site = makeUnregisteredSite()
+
+        await model.duplicate(id: "site-a:page:/ghost")
+
+        #expect(model.contentActionError == "This item is no longer part of this site's content.")
+    }
+
+    @Test("publish reports an error when the row has no matching post")
+    func publishUnresolvedRowReportsError() async {
+        let model = makeModel()
+        model.site = makeUnregisteredSite()
+
+        await model.publish(id: "site-a:post:ghost")
+
+        #expect(model.contentActionError == "This item is no longer part of this site's content.")
+    }
+
+    @Test("unpublish reports an error when the row has no matching post")
+    func unpublishUnresolvedRowReportsError() async {
+        let model = makeModel()
+        model.site = makeUnregisteredSite()
+
+        await model.unpublish(id: "site-a:post:ghost")
+
+        #expect(model.contentActionError == "This item is no longer part of this site's content.")
+    }
+
+    @Test("duplicate reports an error when contentCreation resolves .siteNotFound")
+    func duplicateSiteNotFoundReportsError() async {
+        let graph = SiteContentGraph()
+        let model = makeModel(contentGraph: graph)
+        model.site = makeUnregisteredSite()
+        let page = SiteContentGraph.Page(
+            id: "site-a:page:/about", siteID: "site-a", route: "/about",
+            filePath: "src/pages/about.astro", title: "About", lastModified: Date())
+        await graph.upsertPage(page)
+
+        await model.duplicate(id: page.id)
+
+        // `SiteStore.shared` doesn't know "site-a" — `duplicatePage` resolves `.siteNotFound`.
+        #expect(model.contentActionError == "This site is no longer available.")
+    }
+
+    @Test("publish reports an error when contentCreation resolves .siteNotFound")
+    func publishSiteNotFoundReportsError() async {
+        let graph = SiteContentGraph()
+        let model = makeModel(contentGraph: graph)
+        model.site = makeUnregisteredSite()
+        let post = SiteContentGraph.Post(
+            id: "site-a:post:hello-world", siteID: "site-a", collection: "blog", slug: "hello-world",
+            title: "Hello World", draft: true, publishDate: nil, tags: [],
+            filePath: "src/content/blog/hello-world.md", lastModified: Date()
+        )
+        await graph.upsertPost(post)
+
+        await model.publish(id: post.id)
+
+        #expect(model.contentActionError == "This site is no longer available.")
+    }
+
+    @Test("unpublish reports an error when contentCreation resolves .siteNotFound")
+    func unpublishSiteNotFoundReportsError() async {
+        let graph = SiteContentGraph()
+        let model = makeModel(contentGraph: graph)
+        model.site = makeUnregisteredSite()
+        let post = SiteContentGraph.Post(
+            id: "site-a:post:hello-world", siteID: "site-a", collection: "blog", slug: "hello-world",
+            title: "Hello World", draft: false, publishDate: nil, tags: [],
+            filePath: "src/content/blog/hello-world.md", lastModified: Date()
+        )
+        await graph.upsertPost(post)
+
+        await model.unpublish(id: post.id)
+
+        #expect(model.contentActionError == "This site is no longer available.")
+    }
+
+    @Test("applyContentUndo's delete branch reports an error when contentCreation resolves .siteNotFound")
+    func applyContentUndoDeleteBranchSiteNotFoundReportsError() async {
+        let model = makeModel()
+        model.site = makeUnregisteredSite()
+
+        let outcome = await model.applyContentUndo(ContentUndoCoordinator.Mutation(
+            relativePath: "src/pages/about.astro", before: nil, after: "<h1>About</h1>",
+            actionName: "Create \u{201C}About\u{201D}"))
+
+        #expect(outcome == .failed)
+        #expect(model.contentActionError == "This site is no longer available.")
+    }
+
+    @Test("applyContentUndo's restore branch reports an error when contentCreation resolves .siteNotFound")
+    func applyContentUndoRestoreBranchSiteNotFoundReportsError() async {
+        let model = makeModel()
+        model.site = makeUnregisteredSite()
+
+        let outcome = await model.applyContentUndo(ContentUndoCoordinator.Mutation(
+            relativePath: "src/pages/about.astro", before: "<h1>About</h1>", after: nil,
+            actionName: "Delete \u{201C}About\u{201D}"))
+
+        #expect(outcome == .failed)
+        #expect(model.contentActionError == "This site is no longer available.")
     }
 }
 


### PR DESCRIPTION
## Summary

- `confirmDelete`'s unresolved-row case already reported an error; the `.siteNotFound` branches across `confirmDelete`, `applyContentUndo`, `duplicate`, `publish`, and `unpublish` — plus the unresolved-row case in `duplicate`/`publish`/`unpublish` — still returned with no visible effect and no error, indistinguishable from a broken app for a user-initiated Navigator/menu command (exactly what #969 cost a smoke-test session to isolate, per #987).
- Adds a shared `reportUnresolvedRow(id:)` helper (stale-row message, falls back to a generic phrase when the Navigator itself no longer has the row) and a shared `siteNotFoundMessage` constant matching `NewContentSheets`' existing wording for the same case.
- Out of scope, per #987's own triage: `deleteCleanupCandidate`'s `guard let site else { return }` and confirmDelete's `guard let site, case .route = item.target else { return }` stay no-ops (nothing to act on with no site loaded); `deleteCleanupCandidate`'s `cleanup.delete` returning `Bool` would need a signature change to carry a reason, not just an assignment.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passes except 2 pre-existing `DeployModelTests` failures (custom-domain display swap, tracked/claimed under #1124; verified present on `main` before this change too, unrelated to `SiteWindowModel.swift`)
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [ ] Manual smoke: not run — this is model-layer only (`contentActionError` alert wiring is pre-existing in `SiteWindow.swift`); worth a GUI pass to confirm each alert reads sensibly against a live Navigator, per #987's own "not yet observed" caveat

Closes #987.