### PR TITLE
fix(#1126): dodge inspector storm on search-field activation

### DIFF
--- a/Sources/AnglesiteApp/SiteSearchField.swift
+++ b/Sources/AnglesiteApp/SiteSearchField.swift
@@ -14,6 +14,9 @@ import AnglesiteCore
 struct SiteSearchFieldModifier: ViewModifier {
     @Bindable var model: SiteSearchModel
     let siteID: String?
+    /// Same binding `SiteWindow` passes to `.inspector(isPresented:)` — read (and, when
+    /// presented, written) by `focusSearchField` below to dodge #1126.
+    var inspectorPresented: Binding<Bool>
     let activate: (SiteSearchIndex.Hit) -> Void
 
     @FocusState private var searchFieldFocused: Bool
@@ -65,7 +68,24 @@ struct SiteSearchFieldModifier: ViewModifier {
             // inside `SiteSearchModel.search`.
             .task(id: model.request) { await model.search(siteID: siteID) }
             .focusedSceneValue(\.siteSearchActions, SiteSearchActions(
-                focusSearchField: { searchFieldFocused = true }
+                focusSearchField: {
+                    // Activating the search field inserts the scope bar — a toolbar re-layout
+                    // that, coalesced with a still-presented window inspector, hits the same
+                    // macOS 27 beta AppKit constraint-update storm as the pane-switch case
+                    // (#1126). Dismiss the inspector and give its own dismissal transaction a
+                    // moment to settle first, same mitigation as
+                    // `SiteWindowModel.clearInspectorThenSwitchPane`; skipped entirely when
+                    // there's no inspector presented to collide with.
+                    guard inspectorPresented.wrappedValue else {
+                        searchFieldFocused = true
+                        return
+                    }
+                    inspectorPresented.wrappedValue = false
+                    Task {
+                        try? await Task.sleep(for: .milliseconds(300))
+                        searchFieldFocused = true
+                    }
+                }
             ))
     }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -183,6 +183,21 @@ struct SiteWindow: View {
     private func siteUI(for site: SiteStore.Site) -> some View {
         @Bindable var bindableModel = model
 
+        // Shared with `SiteSearchFieldModifier` below (#1126): search-field activation is
+        // another "substantial toolbar re-layout while the inspector is presented" trigger for
+        // the same macOS 27 beta AppKit constraint-update storm as the pane-switch case, so it
+        // needs the same presented-state read the `.inspector(isPresented:)` modifier itself
+        // uses, not a copy that could drift out of sync.
+        let inspectorPresented = Binding(
+            get: { inspectorShown && model.inspectorSelection != nil },
+            set: { newValue in
+                // Only persist an explicit show/hide while there is something to inspect.
+                // When the selection is nil the panel is auto-hidden; ignore that write so
+                // it doesn't clobber the remembered preference (the bug: inspector never returns).
+                if model.inspectorSelection != nil { inspectorShown = newValue }
+            }
+        )
+
         NavigationSplitView(columnVisibility: Binding(
             get: { sidebarVisible ? .all : .detailOnly },
             set: { sidebarVisible = ($0 != .detailOnly) }
@@ -271,15 +286,7 @@ struct SiteWindow: View {
         }
         .animation(.easeInOut(duration: 0.18), value: model.deploy.drawerPresented)
         .animation(.easeInOut(duration: 0.18), value: model.backup.drawerPresented)
-        .inspector(isPresented: Binding(
-            get: { inspectorShown && model.inspectorSelection != nil },
-            set: { newValue in
-                // Only persist an explicit show/hide while there is something to inspect.
-                // When the selection is nil the panel is auto-hidden; ignore that write so
-                // it doesn't clobber the remembered preference (the bug: inspector never returns).
-                if model.inspectorSelection != nil { inspectorShown = newValue }
-            }
-        )) {
+        .inspector(isPresented: inspectorPresented) {
             if let selection = model.inspectorSelection {
                 SiteInspectorView(
                     selection: selection,
@@ -547,6 +554,7 @@ struct SiteWindow: View {
         .modifier(SiteSearchFieldModifier(
             model: model.search,
             siteID: site.id,
+            inspectorPresented: inspectorPresented,
             activate: { hit in model.openSearchHit(hit) }
         ))
         .sheet(isPresented: $bindableModel.deploy.blockedPresented) {


### PR DESCRIPTION
## Summary

- Companion to #1131: the issue's follow-up comment found a third trigger for the macOS 27 beta AppKit constraint-update storm, independent of the pane-switch case #1131 covers — activating the toolbar search field inserts the scope bar, and that toolbar re-layout alone (no pane switch, no inspector dismissal) hangs the window when the inspector is presented.
- `SiteSearchFieldModifier.focusSearchField` now dismisses the inspector and gives its transaction a moment to settle before focusing the field, reusing the 300ms-sleep mitigation `SiteWindowModel.clearInspectorThenSwitchPane` already applies to the pane-switch case (#1131). It reads/writes the same `Binding<Bool>` `SiteWindow` passes to `.inspector(isPresented:)`, factored out of that call site so the two can't drift out of sync.
- Not in scope here: the issue also lists "inspector toggle in component-editor mode (narrow)" as a confirmed trigger, which is a different code path (SwiftUI auto-presenting the inspector, not this modifier) and needs its own investigation — #1126 should stay open for it even after this and #1131 land.

Neither this PR nor #1131 closes #1126 alone — leaving the closing keyword off until both (and the remaining narrow-mode trigger) are addressed.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change needs a paired PR in `Anglesite/anglesite-skills`.

## Test plan

- [x] `swift test --package-path .` — full `SiteWindowModelTests` suite (45/45) passes unaffected; this change has no model-layer test coverage of its own since it's pure SwiftUI view code, consistent with the rest of `SiteWindow.swift`/`SiteSearchField.swift`.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — builds clean.
- [ ] Manual smoke: **not verified interactively** — same timing-dependent AppKit beta bug noted in #1131's test plan; a live repro (open a site, select a page so the inspector is presented, then ⇧⌘F / Edit ▸ Find ▸ Search Site…) is recommended on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)