### PR TITLE
fix(#1133): make GitIdentity.appFallback a fresh timestamp per call

### DIFF
--- a/Sources/AnglesiteCore/GitIdentity.swift
+++ b/Sources/AnglesiteCore/GitIdentity.swift
@@ -42,8 +42,9 @@ public enum GitIdentity {
     /// them instead.
     public static func signature(for repo: Repository) async -> Signature {
         if case .success(let configured) = repo.defaultSignature() { return configured }
-        await logSubstitution(appFallback)
-        return appFallback
+        let fallback = appFallback
+        await logSubstitution(fallback)
+        return fallback
     }
 
     /// Records that `substitute` stood in for a configured identity.

--- a/Sources/AnglesiteCore/GitIdentity.swift
+++ b/Sources/AnglesiteCore/GitIdentity.swift
@@ -28,7 +28,12 @@ public enum GitIdentity {
     /// app-attributed rather than a guessed personal identity: the app really is the author, and
     /// synthesizing a `user@host` address the way bare `git` does would put an address the user
     /// never chose — and can't receive mail at — into permanent, publishable history.
-    public static let appFallback = Signature(name: "Anglesite", email: "noreply@anglesite.app")
+    ///
+    /// Computed rather than `static let`: `Signature.init` defaults `time` to `Date()`, and a
+    /// `static let` would evaluate that default once and cache it for the process lifetime,
+    /// stamping every fallback-identity commit with the same frozen timestamp instead of its
+    /// actual commit time.
+    public static var appFallback: Signature { Signature(name: "Anglesite", email: "noreply@anglesite.app") }
 
     /// `repo`'s configured identity, falling back to ``appFallback``.
     ///

--- a/Tests/AnglesiteCoreTests/GitIdentityTests.swift
+++ b/Tests/AnglesiteCoreTests/GitIdentityTests.swift
@@ -1,0 +1,31 @@
+#if canImport(Darwin)
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// `GitIdentity.appFallback` must stamp a fresh `Date()` on every access — see #1133. A
+/// `static let` would evaluate `Signature.init`'s defaulted `time: Date()` once and cache it for
+/// the process lifetime, so every sandboxed fallback-identity commit would carry the same frozen
+/// timestamp instead of its actual commit time.
+@Suite("GitIdentity") struct GitIdentityTests {
+    @Test("appFallback stamps a fresh time on each access")
+    func appFallbackTimeAdvances() async throws {
+        let first = GitIdentity.appFallback
+        try await Task.sleep(for: .milliseconds(20))
+        let second = GitIdentity.appFallback
+
+        #expect(first.time != second.time)
+    }
+
+    @Test("appFallback keeps a stable name and email across accesses")
+    func appFallbackIdentityStable() {
+        let first = GitIdentity.appFallback
+        let second = GitIdentity.appFallback
+
+        #expect(first.name == second.name)
+        #expect(first.email == second.email)
+        #expect(first.name == "Anglesite")
+        #expect(first.email == "noreply@anglesite.app")
+    }
+}
+#endif


### PR DESCRIPTION
Closes #1133

## Summary

- `GitIdentity.appFallback` was a `static let`, so `Signature.init`'s defaulted `time: Date()` argument evaluated once and was cached for the process lifetime — every sandboxed fallback-identity commit reused that first-access timestamp instead of its real commit time.
- Changed `appFallback` to a computed `static var`, so `Date()` re-evaluates fresh on every access. `name`/`email` stay constant as before.
- Added `GitIdentityTests` asserting two accesses separated by a short delay produce distinct `time` values, and that `name`/`email` stay stable across accesses.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 3028/3029 passing; the one `FoundationModelAssistant` failure is the documented on-device Foundation Models context-window flake (unrelated file, no `GitIdentity`/`Generable` overlap). New `GitIdentityTests` pass.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] Manual smoke (if UI-touching): not UI-touching — no manual smoke needed.