### PR TITLE
docs(#1046): update Micropub discovery gap note, now shipped

### DIFF
--- a/docs/microblog-external-blog.md
+++ b/docs/microblog-external-blog.md
@@ -123,17 +123,19 @@ To use it:
 2. Sign in to your site from a Micropub client via IndieAuth to get a
    token.
 
-**Known gap:** Micro.blog's own docs say a self-hosted site needs to
-advertise its endpoint with `<link rel="micropub" href="https://example.com/micropub">`
+**Endpoint discovery:** Micro.blog's own docs say a self-hosted site needs
+to advertise its endpoint with `<link rel="micropub" href="https://example.com/micropub">`
 on the homepage for auto-discovery (see
-[Micropub](https://book.micro.blog/micropub/)). Anglesite's
-`BaseLayout.astro` does not yet emit that `<link>` tag (it advertises
-`rel="me"`, `rel="webmention"`, and `rel="indieauth-metadata"`, but not
-`rel="micropub"`), and the worker doesn't send a `Link:` HTTP header either.
-Until that's added, a Micropub client that requires auto-discovery may not
-find the endpoint automatically even after step 1 above. This is a
-follow-up for whoever picks up the Micropub-in-Micro.blog integration next,
-not something this docs-only change should silently paper over.
+[Micropub](https://book.micro.blog/micropub/)). Activating the worker in
+step 1 writes `MICROPUB_ENABLED=true` into the site's `.site-config`
+(`SocialWorkerProvisionCommand`), and
+[`BaseLayout.astro`](../Resources/Template/src/layouts/BaseLayout.astro)
+emits that `<link>` tag on every page when the flag is set (#1039) —
+alongside the existing `rel="me"`, `rel="webmention"`, and
+`rel="indieauth-metadata"` links — so auto-discovery works once the site
+is next deployed. The worker doesn't additionally send a `Link:` HTTP
+header; the HTML tag is what clients (including the Micro.blog apps) look
+for.
 
 ## Why Micro.blog is not a POSSE target
 


### PR DESCRIPTION
Closes #1046

## Summary

- The `rel="micropub"` discovery link #1046 asked for already landed via #1042 (filed as duplicate issue #1039): activating the Micropub worker writes `MICROPUB_ENABLED=true` into `.site-config`, and `BaseLayout.astro` emits `<link rel="micropub" href="/micropub">` when it's set.
- This PR finishes #1046's remaining ask: rewrite the now-stale "Known gap" paragraph in `docs/microblog-external-blog.md` to describe the shipped discovery behavior (and note the worker still doesn't send a `Link:` HTTP header — the HTML tag is what clients look for).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path .` — not run; docs-only change (no code, template, or test files touched)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; docs-only change
- [x] Verified the doc's claims against the merged #1042 diff (`MICROPUB_ENABLED` written by `SocialWorkerProvisionCommand`, gated `<link>` in `BaseLayout.astro`, no `Link:` header added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)