### PR TITLE
perf(#1045): slice timeline metadata before rendering entries

### DIFF
--- a/Resources/Template/src/lib/collection-index-astro.ts
+++ b/Resources/Template/src/lib/collection-index-astro.ts
@@ -34,12 +34,17 @@ export interface IndexItem {
   Content: RenderResult["Content"];
 }
 
+// The metadata half of `IndexItem` plus the source `entry`, ahead of the `render()` call that
+// produces `Content`. Sorting/slicing (`getTimelineItems`) happens on this cheap shape so
+// `render()` — the expensive part — only runs on the entries that survive the cap.
+type IndexItemMeta = Omit<IndexItem, "Content"> & { entry: any };
+
 // `entry` is whatever `getCollection` hands back (a real content-layer entry, not a
 // reconstructed object) — `render()` needs the original entry, not a copy, and `data`/`body`/
 // `id` are read straight off it. Typed loosely (matching `feed-data.ts`'s `as any` collection
 // param) because this loops over every collection in `FEED_COLLECTIONS` rather than one typed
 // literal.
-async function toIndexItem(collection: string, entry: any): Promise<IndexItem> {
+function toIndexItemMeta(collection: string, entry: any): IndexItemMeta {
   const cfg = FEED_COLLECTIONS[collection];
   if (!cfg) throw new Error(`[collection-index] no feed config for collection "${collection}"`);
   const data = entry.data as Record<string, unknown>;
@@ -48,7 +53,6 @@ async function toIndexItem(collection: string, entry: any): Promise<IndexItem> {
   if (Number.isNaN(date.getTime())) {
     throw new Error(`[collection-index] entry "${entry.id}" has a missing or invalid ${cfg.dateField}`);
   }
-  const { Content } = await render(entry);
   return {
     collection,
     id: entry.id,
@@ -63,33 +67,44 @@ async function toIndexItem(collection: string, entry: any): Promise<IndexItem> {
     hasBody: Boolean((entry.body as string | undefined)?.trim()),
     targetUrl: targetUrlFor(collection, data),
     targetClass: targetClassFor(collection),
-    Content,
+    entry,
   };
 }
 
-/// Fetch one collection's entries as `IndexItem`s, unsorted. Drafts are excluded in PROD only —
-/// matching `blog/index.astro` and `[collection]/[...slug].astro`'s page-route convention (a dev
-/// preview shows drafts with `DraftBadge`), unlike `feed-data.ts`'s unconditional exclusion (a
-/// feed is syndication data, not a live preview).
-async function mapEntries(collection: string): Promise<IndexItem[]> {
+// Renders `meta.entry` into `Content`, the one part of `IndexItem` that costs build time.
+async function withContent({ entry, ...item }: IndexItemMeta): Promise<IndexItem> {
+  const { Content } = await render(entry);
+  return { ...item, Content };
+}
+
+/// Fetch one collection's entries as `IndexItemMeta`s, unsorted. Drafts are excluded in PROD
+/// only — matching `blog/index.astro` and `[collection]/[...slug].astro`'s page-route convention
+/// (a dev preview shows drafts with `DraftBadge`), unlike `feed-data.ts`'s unconditional exclusion
+/// (a feed is syndication data, not a live preview).
+async function mapEntryMetas(collection: string): Promise<IndexItemMeta[]> {
   const entries = await getCollection(collection as any, ({ data }: any) =>
     import.meta.env.PROD ? !data.draft : true,
   );
-  return Promise.all(entries.map((entry: any) => toIndexItem(collection, entry)));
+  return entries.map((entry: any) => toIndexItemMeta(collection, entry));
 }
 
 /// One collection's entries, reverse-chronological — what each `<collection>/index.astro` lists.
+/// Every entry is shown (no cap), so metadata and `Content` are built together.
 export async function getIndexItems(collection: string): Promise<IndexItem[]> {
-  return (await mapEntries(collection)).sort((a, b) => b.date.valueOf() - a.date.valueOf());
+  const items = await Promise.all((await mapEntryMetas(collection)).map(withContent));
+  return items.sort((a, b) => b.date.valueOf() - a.date.valueOf());
 }
 
 /// Combined reverse-chronological stream across all eight feed collections (blog plus the seven
 /// micropost/titled collections) — the page-side equivalent of `feed-data.ts`'s
-/// `getCombinedItems`, capped at the same default limit.
+/// `getCombinedItems`, capped at the same default limit. Sorts and slices metadata first, then
+/// renders `Content` only for the entries that survive the cap — build cost scales with `limit`,
+/// not with total post count.
 export async function getTimelineItems(limit = 50): Promise<IndexItem[]> {
-  const all: IndexItem[] = [];
+  const allMetas: IndexItemMeta[] = [];
   for (const collection of Object.keys(FEED_COLLECTIONS)) {
-    all.push(...(await mapEntries(collection)));
+    allMetas.push(...(await mapEntryMetas(collection)));
   }
-  return all.sort((a, b) => b.date.valueOf() - a.date.valueOf()).slice(0, limit);
+  const surviving = allMetas.sort((a, b) => b.date.valueOf() - a.date.valueOf()).slice(0, limit);
+  return Promise.all(surviving.map(withContent));
 }


### PR DESCRIPTION
Closes #1045

## Summary

- `getTimelineItems` called `render(entry)` for every entry across all eight feed collections before sorting and slicing to the 50-item cap, so build cost scaled with total post count instead of the display limit.
- Split `IndexItem` construction into a cheap metadata step (`toIndexItemMeta`) and a `render()` step (`withContent`); `getTimelineItems` now sorts/slices metadata first and renders `Content` only for the surviving entries.
- `getIndexItems` (per-collection index pages, no cap) still renders every entry — unchanged behavior there.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (all suites pass except two unrelated, pre-existing `FoundationModelAssistant` on-device streaming flakes — "Session ended without producing a response" — untouched by this change)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (not run — no app-target code touched)
- [x] `npm test` in `Resources/Template/` (598 tsx tests + 35 vitest tests, all pass)
- [x] `npx astro build` output for `/timeline/index.html` diffed byte-identical before/after this change