### PR TITLE
fix(template): validate h-feed list pages in mf2 build gate

### DIFF
--- a/Resources/Template/scripts/microformats.test.ts
+++ b/Resources/Template/scripts/microformats.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { validateEntryHtml, validateResumeHtml, findRoots } from "./microformats.ts";
+import { validateEntryHtml, validateFeedHtml, validateResumeHtml, findRoots } from "./microformats.ts";
 
 const GOOD_ENTRY = `<!doctype html><html><body>
 <article class="h-entry">
@@ -191,4 +191,58 @@ test("an experience entry missing dt-start is flagged", () => {
   </article></body></html>`;
   const problems = validateResumeHtml(html, "resume/index.html");
   assert.ok(problems.some((p) => p.includes("experience[0] missing dt-start")), problems.join("; "));
+});
+
+// --- #1044 (mf2 build gate: h-feed list pages) -----------------------------
+
+const FEED_WITH_ENTRIES = `<!doctype html><html><body>
+<div class="h-feed">
+  <h1 class="p-name">Notes</h1>
+  <ul>
+    <li class="h-entry">
+      <a class="u-url" href="/notes/hi/"><time class="dt-published" datetime="2026-01-02">Jan 2</time></a>
+      <div class="e-content">Hi</div>
+    </li>
+    <li class="h-entry">
+      <a class="p-name u-url" href="/notes/second/">Second note title</a>
+      <time class="dt-published" datetime="2026-01-03">Jan 3</time>
+    </li>
+  </ul>
+</div></body></html>`;
+
+const EMPTY_FEED = `<!doctype html><html><body>
+<div class="h-feed">
+  <h1 class="p-name">Notes</h1>
+  <p>No notes yet.</p>
+</div></body></html>`;
+
+const FEED_WITH_BAD_ENTRY = `<!doctype html><html><body>
+<div class="h-feed">
+  <h1 class="p-name">Notes</h1>
+  <ul>
+    <li class="h-entry">
+      <time class="dt-published" datetime="2026-01-02">Jan 2</time>
+      <div class="e-content">Missing a permalink</div>
+    </li>
+  </ul>
+</div></body></html>`;
+
+const NO_FEED = `<!doctype html><html><body><p>Plain page, no mf2 at all.</p></body></html>`;
+
+test("h-feed with valid h-entry children passes", () => {
+  assert.deepEqual(validateFeedHtml(FEED_WITH_ENTRIES, "notes/index.html"), []);
+});
+
+test("empty h-feed (no children) is valid — an empty collection has nothing to list", () => {
+  assert.deepEqual(validateFeedHtml(EMPTY_FEED, "notes/index.html"), []);
+});
+
+test("h-feed child missing u-url is flagged, scoped to that child", () => {
+  const problems = validateFeedHtml(FEED_WITH_BAD_ENTRY, "notes/index.html");
+  assert.ok(problems.some((p) => p.includes("missing u-url")), problems.join("; "));
+});
+
+test("a page with no h-feed root is flagged", () => {
+  const problems = validateFeedHtml(NO_FEED, "notes/index.html");
+  assert.ok(problems.some((p) => p.includes("no h-feed root")), problems.join("; "));
 });

--- a/Resources/Template/scripts/microformats.ts
+++ b/Resources/Template/scripts/microformats.ts
@@ -15,7 +15,20 @@ export const ENTRY_DIRS = [
   "bookmarks", "replies", "likes", "announcements", "events", "reviews",
 ];
 
-type Mf2Item = { type: string[]; properties: Record<string, unknown[]> };
+/** The mf2 root type for a page-level feed of entries (`CollectionIndex.astro`, `/timeline/`). */
+const FEED_TYPE = "h-feed";
+
+/**
+ * The 7 micropost/titled collections whose own list page (`<collection>/index.html`) is an
+ * h-feed of h-entry children, rendered by `CollectionIndex.astro`. `blog`'s list page carries
+ * no mf2 markup at all, so it's deliberately excluded here — its index.html stays a plain,
+ * unvalidated page rather than being held to the h-feed shape.
+ */
+export const FEED_COLLECTION_DIRS = [
+  "notes", "articles", "photos", "albums", "bookmarks", "replies", "likes",
+];
+
+type Mf2Item = { type: string[]; properties: Record<string, unknown[]>; children?: Mf2Item[] };
 
 const isEntryType = (t: string): t is EntryType =>
   (ENTRY_TYPES as readonly string[]).includes(t);
@@ -40,23 +53,22 @@ function entryTypesOf(roots: Mf2Item[]): EntryType[] {
  * problems; an empty list means the page is valid mf2 for our purposes.
  */
 export function validateEntryHtml(html: string, label: string, baseUrl = BASE_URL): string[] {
-  return validateRoots(findRoots(html, baseUrl), label);
+  return validateEntryRoots(findRoots(html, baseUrl), label);
 }
 
-/** Validate already-parsed roots — lets callers parse once and reuse the result. */
-function validateRoots(allRoots: Mf2Item[], label: string): string[] {
+/**
+ * Validate a single built list page's microformats: exactly one h-feed root whose h-entry
+ * children are each validated as entries. Returns a list of human-readable problems; an empty
+ * list means the page is valid mf2 for our purposes.
+ */
+export function validateFeedHtml(html: string, label: string, baseUrl = BASE_URL): string[] {
+  return validateFeedRoots(findRoots(html, baseUrl), label);
+}
+
+/** Validate a single entry item's properties — shared by a standalone entry-root page and by
+ * each h-entry child of an h-feed. */
+function validateEntryItem(item: Mf2Item, label: string): string[] {
   const problems: string[] = [];
-  const roots = allRoots.filter((i) => i.type.some(isEntryType));
-
-  if (roots.length === 0) {
-    problems.push(`${label}: no h-entry/h-review/h-event root item found`);
-    return problems;
-  }
-  if (roots.length > 1) {
-    problems.push(`${label}: expected exactly one entry root, found ${roots.length}`);
-  }
-
-  const item = roots[0];
   const type = item.type.find(isEntryType) as EntryType;
 
   // Every entry needs a permalink.
@@ -138,6 +150,49 @@ export function validateResumeHtml(html: string, label: string, baseUrl = BASE_U
   return problems;
 }
 
+/** Validate already-parsed roots for a standalone entry page — lets callers parse once and
+ * reuse the result. Exactly one entry root is required; an h-feed page uses
+ * `validateFeedRoots` instead, which allows any number of h-entry children. */
+function validateEntryRoots(allRoots: Mf2Item[], label: string): string[] {
+  const problems: string[] = [];
+  const roots = allRoots.filter((i) => i.type.some(isEntryType));
+
+  if (roots.length === 0) {
+    problems.push(`${label}: no h-entry/h-review/h-event root item found`);
+    return problems;
+  }
+  if (roots.length > 1) {
+    problems.push(`${label}: expected exactly one entry root, found ${roots.length}`);
+  }
+
+  return [...problems, ...validateEntryItem(roots[0], label)];
+}
+
+/**
+ * Validate already-parsed roots for a list page: exactly one h-feed root, whose h-entry
+ * children are each validated with `validateEntryItem`. Unlike a standalone entry page, zero
+ * children is valid (an empty collection renders no `<li class="h-entry">` items at all).
+ */
+function validateFeedRoots(allRoots: Mf2Item[], label: string): string[] {
+  const problems: string[] = [];
+  const feeds = allRoots.filter((i) => i.type.includes(FEED_TYPE));
+
+  if (feeds.length === 0) {
+    problems.push(`${label}: no h-feed root item found`);
+    return problems;
+  }
+  if (feeds.length > 1) {
+    problems.push(`${label}: expected exactly one h-feed root, found ${feeds.length}`);
+  }
+
+  const children = (feeds[0].children ?? []).filter((c) => c.type.some(isEntryType));
+  children.forEach((entry, i) => {
+    problems.push(...validateEntryItem(entry, `${label} [entry ${i + 1}]`));
+  });
+
+  return problems;
+}
+
 function walkHtml(dir: string): string[] {
   const out: string[] = [];
   let names: string[];
@@ -156,26 +211,41 @@ function walkHtml(dir: string): string[] {
 
 /**
  * Validate every built entry page under `distDir` and assert vocabulary coverage:
- * each of h-entry / h-review / h-event appears in at least one valid page.
+ * each of h-entry / h-review / h-event appears in at least one valid page. Also validates
+ * the h-feed list pages: each `FEED_COLLECTION_DIRS` collection's own index.html, plus the
+ * combined `/timeline/` stream.
  */
 export function validateDist(distDir: string): string[] {
   const problems: string[] = [];
   const seenAny = new Set<string>(); // type appeared on some page (valid or not)
-  const seenValid = new Set<string>(); // type appeared on a page with no problems
 
   for (const sub of ENTRY_DIRS) {
     const base = join(distDir, sub);
+    const isFeedCollection = (FEED_COLLECTION_DIRS as readonly string[]).includes(sub);
     for (const file of walkHtml(base)) {
       const rel = file.slice(base.length + 1); // "welcome/index.html" or "index.html"
-      if (!rel.includes("/")) continue; // skip the collection's own list page (index.html)
       const label = file.slice(distDir.length + 1);
+      if (!rel.includes("/")) {
+        // The collection's own list page. Feed collections render it as an h-feed of h-entry
+        // children (validated below); the rest (e.g. blog/index.html) carry no mf2 at all.
+        if (isFeedCollection) problems.push(...validateFeedHtml(readFileSync(file, "utf8"), label));
+        continue;
+      }
       const roots = findRoots(readFileSync(file, "utf8")); // parse once; reuse below
       const types = entryTypesOf(roots);
       for (const t of types) seenAny.add(t);
-      const pageProblems = validateRoots(roots, label);
-      problems.push(...pageProblems);
-      if (pageProblems.length === 0) for (const t of types) seenValid.add(t);
+      problems.push(...validateEntryRoots(roots, label));
     }
+  }
+
+  // /timeline/ combines all eight feed collections into one h-feed page. It has no per-entry
+  // subpages of its own, so it isn't walked via ENTRY_DIRS above — check its single file directly.
+  const timelineFile = join(distDir, "timeline", "index.html");
+  try {
+    const timelineHtml = readFileSync(timelineFile, "utf8");
+    problems.push(...validateFeedHtml(timelineHtml, "timeline/index.html"));
+  } catch {
+    // dist/timeline/index.html absent — not an error here (mirrors walkHtml's dir-absent case)
   }
 
   // Only report a coverage gap when a type is entirely absent. If pages of that type


### PR DESCRIPTION
Closes #1044

## Summary

- `validateDist` walked each `ENTRY_DIRS` collection but always skipped its own `index.html` (`if (!rel.includes("/")) continue`), and never looked at `/timeline/` at all — so the h-feed list pages `CollectionIndex.astro` renders (notes, articles, photos, albums, bookmarks, replies, likes) and the combined timeline stream had zero mf2 build-gate coverage.
- `validateRoots`' "exactly one entry root" assertion is structurally incompatible with an h-feed page carrying N h-entry children, so the fix adds an h-feed-aware path (`validateFeedHtml`/`validateFeedRoots`): exactly one h-feed root is required, zero children is valid (an empty collection renders none), and each child is validated with the same per-entry checks (`u-url`, `dt-published`, optional `p-name`) a standalone entry page uses.
- `blog/index.html` and `/tags/…` carry no mf2 markup at all and are deliberately left unvalidated/skipped — only `FEED_COLLECTION_DIRS` (the 7 micropost/titled collections) and `/timeline/` are checked as h-feed pages.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `npx tsx --test scripts/microformats.test.ts` — new h-feed unit tests (valid feed, empty feed, bad child, no h-feed root) plus existing entry-page tests, all pass.
- [x] `npm run build` (Resources/Template) — real `astro build` output validates cleanly with the new h-feed checks (`✓ microformats validation passed`), confirming no false positives against actual generated markup.
- [x] Manually corrupted a built `notes/index.html` (dropped the `h-feed` class) and reran `check-microformats.ts` — confirmed the gate now fails with `no h-feed root item found`, proving it was previously silent on this page.
- [x] `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter AnglesiteCoreTests` — all template-markup render-smoke suites pass (Business/Personal type, Feeds, JSON-LD, Community timeline, Site identity h-card). The only 2 failures are in the unrelated `FoundationModelAssistant` suite (known pre-existing flakiness, not touched by this change).