### PR TITLE
fix(template): feed content fidelity — photo, URLs, summaries (#1043)

### DIFF
--- a/Resources/Template/src/components/IndexEntry.astro
+++ b/Resources/Template/src/components/IndexEntry.astro
@@ -39,9 +39,7 @@ const human = item.date.toLocaleDateString("en-US", {
         {item.image && <img class="u-photo" src={item.image} alt={item.caption ?? ""} />}
         {(item.summary ?? item.caption) && <p class="p-summary">{item.summary ?? item.caption}</p>}
         <div class="e-content">
-          {item.hasBody ? (
-            <Content />
-          ) : item.targetUrl && item.targetClass ? (
+          {!item.hasBody && item.targetUrl && item.targetClass ? (
             <a class={item.targetClass} href={item.targetUrl}>{item.targetUrl}</a>
           ) : (
             <Content />

--- a/Resources/Template/src/lib/feeds.test.ts
+++ b/Resources/Template/src/lib/feeds.test.ts
@@ -9,6 +9,8 @@ import {
   renderAtom,
   renderJsonFeed,
   websubHub,
+  absolutizeHtmlUrls,
+  photoImageHtml,
   type FeedEntry,
 } from "./feeds.ts";
 
@@ -689,4 +691,138 @@ test("renderJsonFeed emits a WebSub hubs array only when a hub URL is given", as
 
   const withoutHub = renderJsonFeed({ title: "All", site: SITE, feedUrl: `${SITE}/feed.json`, items: [] });
   assert.equal(JSON.parse(await withoutHub.text()).hubs, undefined);
+});
+
+// --- Feed content fidelity: photo image, absolute URLs, empty summaries (#1043) --------------
+
+test("photoImageHtml builds an absolutized, escaped <img> from data.image and data.caption", () => {
+  const html = photoImageHtml({ image: "/images/sunset.jpg", caption: "Sunset & bay" }, SITE);
+  assert.equal(html, `<img src="https://example.com/images/sunset.jpg" alt="Sunset &amp; bay">`);
+});
+
+test("photoImageHtml omits alt when there is no caption, and returns empty string with no image", () => {
+  assert.equal(photoImageHtml({ image: "/images/sunset.jpg" }, SITE), `<img src="https://example.com/images/sunset.jpg" alt="">`);
+  assert.equal(photoImageHtml({ caption: "no image field" }, SITE), "");
+});
+
+test("photoImageHtml leaves an already-absolute image URL unchanged", () => {
+  const html = photoImageHtml({ image: "https://cdn.example.com/sunset.jpg" }, SITE);
+  assert.equal(html, `<img src="https://cdn.example.com/sunset.jpg" alt="">`);
+});
+
+test("toFeedItem prepends the photo's image to contentHtml even when the entry has no body", () => {
+  const item = toFeedItem(
+    "photos",
+    entry("photos", { image: "/images/sunset.jpg", caption: "Sunset over the bay", publishDate: "2026-01-02" }),
+    SITE,
+    "<p>Sunset over the bay</p>",
+  );
+  assert.equal(
+    item.contentHtml,
+    `<img src="https://example.com/images/sunset.jpg" alt="Sunset over the bay"><p>Sunset over the bay</p>`,
+  );
+});
+
+test("toFeedItem prepends the photo's image even when the entry has a rendered body", () => {
+  const item = toFeedItem(
+    "photos",
+    entry("photos", { image: "/images/sunset.jpg", publishDate: "2026-01-02" }, "Some commentary."),
+    SITE,
+    "<p>Some commentary.</p>",
+  );
+  assert.equal(item.contentHtml, `<img src="https://example.com/images/sunset.jpg" alt=""><p>Some commentary.</p>`);
+});
+
+test("toFeedItem leaves a photo's contentHtml untouched when it has no image field", () => {
+  const item = toFeedItem(
+    "photos",
+    entry("photos", { caption: "No image field", publishDate: "2026-01-02" }),
+    SITE,
+    "<p>No image field</p>",
+  );
+  assert.equal(item.contentHtml, "<p>No image field</p>");
+});
+
+test("absolutizeHtmlUrls resolves relative src/href against the site origin", () => {
+  const html = absolutizeHtmlUrls(
+    `<p><img src="/images/x.png" alt=""></p><p><a href="/about/">about</a></p>`,
+    SITE,
+  );
+  assert.equal(
+    html,
+    `<p><img src="https://example.com/images/x.png" alt=""></p><p><a href="https://example.com/about/">about</a></p>`,
+  );
+});
+
+test("absolutizeHtmlUrls leaves already-absolute, protocol-relative, fragment, and mailto URLs unchanged", () => {
+  const html = absolutizeHtmlUrls(
+    `<a href="https://other.example/x">x</a>` +
+      `<img src="//cdn.example.com/y.png">` +
+      `<a href="#section">s</a>` +
+      `<a href="mailto:me@example.com">m</a>`,
+    SITE,
+  );
+  assert.equal(
+    html,
+    `<a href="https://other.example/x">x</a>` +
+      `<img src="//cdn.example.com/y.png">` +
+      `<a href="#section">s</a>` +
+      `<a href="mailto:me@example.com">m</a>`,
+  );
+});
+
+test("toFeedItem absolutizes relative URLs inside a note's rendered body", () => {
+  const item = toFeedItem(
+    "notes",
+    entry("notes", { publishDate: "2026-01-02" }, "See ![](/images/x.png) and [about](/about/)."),
+    SITE,
+    `<p>See <img src="/images/x.png" alt=""> and <a href="/about/">about</a>.</p>`,
+  );
+  assert.equal(
+    item.contentHtml,
+    `<p>See <img src="https://example.com/images/x.png" alt=""> and <a href="https://example.com/about/">about</a>.</p>`,
+  );
+});
+
+test("renderJsonFeed omits the summary key entirely for an empty summary, and includes it when present", async () => {
+  const res = await renderJsonFeed({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/feed.json`,
+    items: [
+      { title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "", contentHtml: "<p>hi</p>" },
+      { title: "B", link: `${SITE}/blog/b/`, date: new Date("2026-01-02"), summary: "hi", contentHtml: "<p>hi</p>" },
+    ],
+  });
+  const feed = JSON.parse(await res.text());
+  assert.equal("summary" in feed.items[0], false);
+  assert.equal(feed.items[1].summary, "hi");
+});
+
+test("renderAtom omits the <summary> element entirely for an empty summary, and includes it when present", async () => {
+  const xml = await renderAtom({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/atom.xml`,
+    items: [
+      { title: "A", link: `${SITE}/blog/a/`, date: new Date("2026-01-02"), summary: "", contentHtml: "<p>hi</p>" },
+      { title: "B", link: `${SITE}/blog/b/`, date: new Date("2026-01-02"), summary: "hi", contentHtml: "<p>hi</p>" },
+    ],
+  }).text();
+  const entries = xml.split("<entry>");
+  assert.doesNotMatch(entries[1], /<summary>/);
+  assert.match(entries[2], /<summary>hi<\/summary>/);
+});
+
+test("renderJsonFeed omits the url key from an author with no url (JSON.stringify drops undefined)", async () => {
+  const res = await renderJsonFeed({
+    title: "All",
+    site: SITE,
+    feedUrl: `${SITE}/feed.json`,
+    items: [],
+    author: { name: "Ada Lovelace" },
+  });
+  const feed = JSON.parse(await res.text());
+  assert.deepEqual(feed.authors, [{ name: "Ada Lovelace" }]);
+  assert.equal("url" in feed.authors[0], false);
 });

--- a/Resources/Template/src/lib/feeds.ts
+++ b/Resources/Template/src/lib/feeds.ts
@@ -114,12 +114,56 @@ function interactionContentFallback(collection: string, data: Record<string, any
   return `<a href="${escaped}">${escaped}</a>`;
 }
 
+/** Resolve a possibly root-relative path against the site origin; already-absolute URLs,
+ * protocol-relative URLs, and fragments pass through unchanged. Mirrors the `new URL(path, site)`
+ * pattern used elsewhere in the template (`schema.ts`'s `abs()`, `sitemap.ts`) for turning a
+ * content field's root-relative path into a URL usable outside the site's own pages. */
+function absolutizeUrl(pathOrUrl: string, site: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(pathOrUrl) || pathOrUrl.startsWith("//") || pathOrUrl.startsWith("#")) {
+    return pathOrUrl;
+  }
+  try {
+    return new URL(pathOrUrl, site).href;
+  } catch {
+    return pathOrUrl;
+  }
+}
+
+/**
+ * Rewrite every `src="…"`/`href="…"` attribute in a fragment of rendered markdown HTML to an
+ * absolute URL against `site`. A note or article body can write `![](/images/x.png)` or
+ * `[text](/about/)` — fine when the page itself is served from the site, but feed content
+ * travels into a reader with no notion of "relative to this site", so a relative URL there is
+ * simply broken (#1043).
+ */
+export function absolutizeHtmlUrls(html: string, site: string): string {
+  return html.replace(/\b(src|href)="([^"]*)"/g, (match, attr, value) =>
+    value ? `${attr}="${absolutizeUrl(value, site)}"` : match,
+  );
+}
+
+/**
+ * The `<img>` tag prepended to a photo entry's `contentHtml` (#1043) — without it, a body-less
+ * photo post syndicates as bare caption text and the photo itself never reaches the feed.
+ * `data.image` is the photos schema's root-relative path (`content.config.ts`); absolutized the
+ * same way a body's relative URLs are, since a feed reader has no site context to resolve it
+ * against.
+ */
+export function photoImageHtml(data: Record<string, any>, site: string): string {
+  const image = typeof data.image === "string" && data.image.length > 0 ? data.image : undefined;
+  if (!image) return "";
+  const alt = typeof data.caption === "string" ? data.caption : "";
+  return `<img src="${escapeXml(absolutizeUrl(image, site))}" alt="${escapeXml(alt)}">`;
+}
+
 /**
  * Build a `FeedItem` from a content entry. `contentHtml` is the entry body already rendered to
  * HTML — rendering is async (`createMarkdownProcessor`) and lives in `feed-data.ts`, so it's
  * computed by the caller and passed in rather than made here, keeping this function synchronous
  * and easy to unit test. When the rendered body is empty, likes/replies/bookmarks fall back to
  * a link to their target URL (`interactionContentFallback`) rather than shipping empty content.
+ * Relative URLs inside the rendered body are absolutized, and a photo entry gets its image
+ * prepended, regardless of whether it had a body (#1043).
  */
 export function toFeedItem(
   collection: string,
@@ -138,12 +182,15 @@ export function toFeedItem(
   }
   const summary = (entry.data.summary ?? entry.data.caption ?? excerpt(entry.body, 280)) || "";
   const tags = Array.isArray(entry.data.tags) && entry.data.tags.length > 0 ? entry.data.tags : undefined;
+  const absolutized = contentHtml ? absolutizeHtmlUrls(contentHtml, site) : contentHtml;
+  const body = absolutized || interactionContentFallback(collection, entry.data);
+  const withImage = collection === "photos" ? photoImageHtml(entry.data, site) + body : body;
   return {
     title: cfg.deriveTitle(entry) || undefined,
     link: new URL(`/${collection}/${entry.id}/`, site).href,
     date,
     summary: String(summary),
-    contentHtml: contentHtml || interactionContentFallback(collection, entry.data),
+    contentHtml: withImage,
     tags,
   };
 }
@@ -230,6 +277,9 @@ export function renderAtom(o: {
     .map((i) => {
       // One <category term="…"/> per tag; entries without tags emit none.
       const categories = (i.tags ?? []).map((t) => `    <category term="${escapeXml(t)}"/>\n`).join("");
+      // <summary> is optional in Atom (RFC 4287); an empty one is noise, not signal, so omit the
+      // element entirely rather than emitting `<summary></summary>`.
+      const summaryXml = i.summary ? `    <summary>${escapeXml(i.summary)}</summary>\n` : "";
       // Known limitation: <id> uses the permalink rather than a permanent tag: IRI (RFC 4287
       // §4.2.6). Renaming a slug therefore reads as a new entry in readers that saw the old URL.
       // This matches most simple RSS libraries; a stable tag: URI is a future improvement.
@@ -240,8 +290,7 @@ export function renderAtom(o: {
     <link href="${escapeXml(i.link)}"/>
     <id>${escapeXml(i.link)}</id>
     <updated>${i.date.toISOString()}</updated>
-${categories}    <summary>${escapeXml(i.summary)}</summary>
-    <content type="html">${escapeXml(i.contentHtml)}</content>
+${categories}${summaryXml}    <content type="html">${escapeXml(i.contentHtml)}</content>
   </entry>`;
     })
     .join("\n");
@@ -289,7 +338,10 @@ export function renderJsonFeed(o: {
       // Undefined `title` is dropped by JSON.stringify below, matching JSON Feed's "title is
       // optional" contract for items with no natural title.
       title: i.title,
-      summary: i.summary,
+      // An empty summary is noise, not signal — omit the key entirely rather than emitting
+      // `"summary": ""`. Unlike `title` above, JSON.stringify only drops `undefined`, not an
+      // empty *string*, so this needs an explicit conditional spread.
+      ...(i.summary ? { summary: i.summary } : {}),
       // JSON Feed 1.1 requires content_html or content_text on every item; fall back to the
       // short summary when the body was empty. `i.summary` is plain text, but `content_html` is
       // parsed as HTML by every consumer, so it needs HTML-escaping when it stands in for


### PR DESCRIPTION
Closes #1043

## Summary

- Photo posts with no body previously shipped only caption text to feed readers; the `image` field never reached `contentHtml`. Now the photo's `<img>` is always prepended to a photo entry's `contentHtml` (absolutized against the site origin), whether or not the entry has a body/caption.
- Relative `src`/`href` URLs inside rendered feed content (e.g. a note body with `![](/images/x.png)` or `[link](/about/)`) are now absolutized against the site origin — a feed reader has no notion of "relative to this site".
- `renderJsonFeed` and `renderAtom` no longer emit noisy empty-string `summary` fields (`"summary": ""` / `<summary></summary>`) when an item has no summary.
- Nits from the same review: added a JSON Feed test for the author-without-url state (relies on `JSON.stringify` dropping `undefined`), and simplified `IndexEntry.astro`'s redundant ternary whose `hasBody` branch and final fallback both rendered `<Content />`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passes; the only 2 failures (`FoundationModelAssistantTests` streaming tests, "Session ended without producing a response") are pre-existing on-device FoundationModels flakes unrelated to this change (no code in this PR touches Swift/FoundationModels).
- [x] `npx tsx --test src/lib/feeds.test.ts` (from `Resources/Template/`) — 58/58 pass, including new coverage for the photo image, URL absolutization, and empty-summary behavior.
- [x] `npm run test:scripts` (from `Resources/Template/`) — 601/601 pass (2 pre-existing skips).
- [x] `npm run test:astro` (from `Resources/Template/`) — 35/35 pass.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (this PR touches only `Resources/Template/`, no Swift/app code).
- [ ] Manual smoke: not applicable — no UI surface, template-only.