### PR TITLE
feat(#1014): add PrivacyInfo.xcprivacy privacy manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Notes:
 
 This repo expects a sibling checkout of the sidecar repo, [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills), in a directory named `anglesite` next to this one (both under the same parent directory) — or set `ANGLESITE_SIDECAR_SRC` to point elsewhere (`ANGLESITE_PLUGIN_SRC` remains a compatibility alias). The sibling repo supplies the **MCP sidecar** (`server/`), which the container-image scripts (`scripts/vendor-container-image.sh`, `scripts/build-podman-image.sh`) stage into the dev-server image; the MCP end-to-end tests also spawn it directly from the checkout (`ANGLESITE_PLUGIN_PATH`). Nothing from the sibling repo is bundled into the app itself anymore (#466).
 
+## Privacy
+
+Anglesite collects no telemetry, analytics, or crash reports, and contacts no tracking domains. This is declared, not just asserted: [`Resources/PrivacyInfo.xcprivacy`](Resources/PrivacyInfo.xcprivacy) sets `NSPrivacyTracking` to `false` with empty tracking-domain and collected-data-type lists, and lists the required-reason APIs the app does use (`UserDefaults` for its own settings, file timestamps for internal conflict detection and content indexing, and on-device elapsed-time measurement for the startup progress bar) with Apple's approved reason codes for each.
+
 ## License
 
 ISC. See [LICENSE](LICENSE).

--- a/Resources/PrivacyInfo.xcprivacy
+++ b/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<!-- AppSettings (AnglesiteCore/AppSettings.swift) reads/writes UserDefaults.standard
+		     for the app's own settings; StartupTiming and SwiftUI @AppStorage bindings do the
+		     same. No app-group suite is used. -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<!-- File modification/creation timestamps are read for internal conflict detection
+		     (FileDocumentIO, PlistDocumentIO) and content indexing (DeadAssetScanner,
+		     SiteKnowledgeIndex, ContentScanner) on files inside the app's own document tree,
+		     and are also surfaced to the user via SiteEntity's AppIntents/Siri properties. -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<!-- StartupProgressModel uses ProcessInfo.systemUptime as an on-device monotonic clock
+		     to drive the startup progress bar; never sent off-device. -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -38,6 +38,7 @@ targets:
       - path: Sources/AnglesiteApp
       - path: Resources/Assets.xcassets
       - path: Resources/Anglesite.sdef
+      - path: Resources/PrivacyInfo.xcprivacy
       - path: Resources/Template
         type: folder
         buildPhase: resources


### PR DESCRIPTION
Closes #1014

## Summary

- Add `Resources/PrivacyInfo.xcprivacy` declaring `NSPrivacyTracking = false`, empty tracking-domain/collected-data-type lists, and the required-reason APIs the app actually uses — `UserDefaults` (`CA92.1`), file timestamps (`0A2A.1` internal + `C617.1` for `SiteEntity`'s user-visible AppIntents properties), and on-device elapsed-time measurement (`35F9.1` for `StartupProgressModel`'s `systemUptime` clock). Audited the codebase for disk-space required-reason APIs too — none found, so that category is omitted.
- Wire the manifest into `project.yml`'s `Anglesite` target sources so XcodeGen places it in the bundle root.
- Add a short Privacy section to `README.md` stating the zero-collection posture the manifest formalizes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 3034 tests pass; 2 pre-existing `FoundationModelAssistant` failures ("Session ended without producing a response") are unrelated on-device Foundation Models contention from other agents' concurrent `swift test --filter FoundationModelAssistant` runs on the same machine (confirmed via `ps aux` at the time), not caused by this change (a plist + project.yml resource entry touch no Swift code).
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds; confirmed `PrivacyInfo.xcprivacy` lands at `Anglesite.app/Contents/Resources/PrivacyInfo.xcprivacy` in the built bundle.
- [x] `plutil -lint Resources/PrivacyInfo.xcprivacy` — OK.
- [ ] Manual smoke (if UI-touching): N/A — no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)