### PR TITLE
fix(#1011): gate New Collection title on schema required-ness

### DIFF
--- a/Sources/AnglesiteApp/NewContentSheets.swift
+++ b/Sources/AnglesiteApp/NewContentSheets.swift
@@ -195,8 +195,13 @@ struct NewCollectionEntrySheet: View {
                         }
                         // A reply or like has no title field — it is identified by its target URL,
                         // so asking for a title would collect a value the entry never stores (#916).
+                        // A bookmark's title is schema-optional (its target URL is the point), so
+                        // it's shown but not required — an empty title falls back to a URL-derived
+                        // slug in NativeContentOperations.createTyped (#1011).
                         if selectedDescriptor?.titleField != nil {
-                            TextField("Title", text: $title)
+                            TextField(
+                                "Title", text: $title,
+                                prompt: selectedDescriptor?.titleIsRequired == true ? nil : Text("optional"))
                         }
                         // Field names match the inspector's labels in `TypedEntryForm`.
                         ForEach(requiredURLFields, id: \.name) { field in
@@ -286,9 +291,10 @@ struct NewCollectionEntrySheet: View {
         }
     }
 
-    /// Types without a title field impose no title requirement.
+    /// Only a schema-required title field imposes a requirement — a type whose title is optional
+    /// (e.g. `bookmark`, defined by its target URL) or absent imposes none (#1011).
     private var titleIsSatisfied: Bool {
-        selectedDescriptor?.titleField == nil
+        selectedDescriptor?.titleIsRequired != true
             || !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -172,6 +172,13 @@ public struct ContentTypeDescriptor: Sendable, Equatable, Identifiable {
         fields.first { Self.titleLikeFieldNames.contains($0.name) }
     }
 
+    /// Whether this type's title field, if it has one, is required by the schema. `bookmark`'s
+    /// `title` is `z.string().optional()` — present, but not required — so the create UI must gate
+    /// on this rather than on `titleField != nil` (#1011).
+    public var titleIsRequired: Bool {
+        titleField?.required ?? false
+    }
+
     /// Required `.url` fields, in declaration order. The template schemas these project to are
     /// `z.string().url()`, which rejects an empty string, so the create path must collect a value
     /// for each one before writing rather than scaffolding a placeholder (#916).

--- a/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentTypeRegistryTests.swift
@@ -350,6 +350,26 @@ struct ContentTypeRegistryTests {
         #expect(like.titleField == nil)
     }
 
+    @Test("titleIsRequired reflects the title field's own required-ness, not just its presence (#1011)")
+    func titleIsRequiredPerType() throws {
+        let registry = ContentTypeRegistry()
+        let article = try #require(registry.descriptor(id: "article"))
+        let bookmark = try #require(registry.descriptor(id: "bookmark"))
+        let event = try #require(registry.descriptor(id: "event"))
+        let review = try #require(registry.descriptor(id: "review"))
+        let reply = try #require(registry.descriptor(id: "reply"))
+        let like = try #require(registry.descriptor(id: "like"))
+
+        #expect(article.titleIsRequired)   // title: z.string()
+        #expect(event.titleIsRequired)     // name: z.string()
+        #expect(review.titleIsRequired)    // itemReviewed: z.string()
+        // bookmark's title is z.string().optional() — present, but not required (#1011).
+        #expect(!bookmark.titleIsRequired)
+        // reply and like have no title-like field at all, so there is nothing to require.
+        #expect(!reply.titleIsRequired)
+        #expect(!like.titleIsRequired)
+    }
+
     @Test("requiredURLFields lists required .url fields in declaration order")
     func requiredURLFieldsPerType() throws {
         let registry = ContentTypeRegistry()


### PR DESCRIPTION
Closes #1011

## Summary

- `bookmark`'s `title` is `z.string().optional()` in `content.config.ts`, but `NewCollectionEntrySheet` disabled Create for *any* type with a title field, required or not.
- Added `ContentTypeDescriptor.titleIsRequired` (`titleField?.required ?? false`) and gated the Create button on it instead of on `titleField != nil`.
- Also checked the other title-bearing types per the issue's suggestion: `article`, `album`, `event` (`name`), and `review` (`itemReviewed`) all have `required: true`, so their behavior is unchanged — only `bookmark` was affected.
- The Title field now shows an "optional" prompt when the selected type's title isn't required. An empty bookmark title already falls through to the URL-derived slug in `NativeContentOperations.createTyped` (built for `reply`/`like` in #916), so no scaffolding changes were needed.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 3035 tests, all passing except 2 pre-existing `FoundationModelAssistant` on-device streaming failures ("Session ended without producing a response") reproducible only under this machine's current heavy concurrent-agent load; unrelated to the changed files (matches known FM-contention flakiness in this repo).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — BUILD SUCCEEDED.
- [ ] Manual smoke: not run (no interactive session available here) — new unit test (`titleIsRequiredPerType`) covers the gating logic for `article`/`bookmark`/`event`/`review`/`reply`/`like`.