### PR TITLE
fix(#1016): consolidate IntegrationPlanner URL check onto ContentFieldValidation

### DIFF
--- a/Sources/AnglesiteCore/ContentFieldValidation.swift
+++ b/Sources/AnglesiteCore/ContentFieldValidation.swift
@@ -1,21 +1,25 @@
 // Sources/AnglesiteCore/ContentFieldValidation.swift
 import Foundation
 
-/// Value checks for `ContentTypeField` values, applied before a content entry is written to disk.
+/// Value checks shared by anything that accepts a `ContentTypeField`-shaped value, applied before
+/// that value is persisted or otherwise acted on.
 ///
-/// Scaffolding renders; this validates. Kept separate from `ContentScaffold` so the create path can
+/// Scaffolding renders; this validates. Kept separate from `ContentScaffold` so a create path can
 /// reject a bad value *before* asking for a render, and so the rules are testable on their own.
+/// Not limited to content entries — `IntegrationPlanner` also validates its `.url` fields against
+/// `isAbsoluteURL` below, since a wizard field feeding a CSP domain has the same host and
+/// port/whitespace hazards as a `u-*` microformat property does.
 public enum ContentFieldValidation {
     /// Whether `value` is an absolute URL with a scheme **and** a non-empty host.
     ///
     /// Deliberately stricter than the template's `z.string().url()`, which accepts anything
     /// `new URL()` parses — including `mailto:` and other host-less schemes. A `.url` field feeds a
-    /// `u-*` microformat property (`u-bookmark-of`, `u-in-reply-to`, `u-like-of`), which needs a
-    /// dereferenceable target, so requiring a host is the useful rule. Anything accepted here is
-    /// accepted by `z.string().url()` — including the port range, see below — so a value that
-    /// passes never fails `astro check`.
+    /// `u-*` microformat property (`u-bookmark-of`, `u-in-reply-to`, `u-like-of`) or a CSP domain
+    /// entry, both of which need a dereferenceable target, so requiring a host is the useful rule.
+    /// Anything accepted here is accepted by `z.string().url()` — including the port range, see
+    /// below — so a value that passes never fails `astro check`.
     ///
-    /// Mirrors the same host-not-just-scheme rule `IntegrationPlanner` applies to its `.url` fields.
+    /// The single definition of "is this a URL" for the module — see #1016.
     public static func isAbsoluteURL(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,

--- a/Sources/AnglesiteCore/IntegrationPlanner.swift
+++ b/Sources/AnglesiteCore/IntegrationPlanner.swift
@@ -38,10 +38,11 @@ public enum IntegrationPlanner {
             switch field.kind {
             case .email where !value.contains("@"):
                 return .failure(.invalidValue(key: field.key, reason: "not an email address"))
-            // Require a host (not just a parseable scheme) so a value like "https:" or
-            // "mailto:foo@bar.com" fails here with a clear message, instead of silently
-            // producing no CSP entry later for a descriptor that uses addCSPDomains(fromFieldHost:).
-            case .url where URL(string: value)?.host == nil:
+            // Delegates to the single "is this a URL" rule (ContentFieldValidation.isAbsoluteURL)
+            // so a value like "https:" or "mailto:foo@bar.com" fails here with a clear message,
+            // instead of silently producing no CSP entry later for a descriptor that uses
+            // addCSPDomains(fromFieldHost:).
+            case .url where !ContentFieldValidation.isAbsoluteURL(value):
                 return .failure(.invalidValue(key: field.key, reason: "not an absolute URL (needs a host, e.g. https://example.com)"))
             case .path where value.contains(where: { $0.isWhitespace }):
                 return .failure(.invalidValue(key: field.key, reason: "must not contain whitespace"))


### PR DESCRIPTION
Closes #1016

## Summary

- `IntegrationPlanner`'s `.url` field case now delegates to `ContentFieldValidation.isAbsoluteURL` instead of its own `URL(string:)?.host == nil` check, so there is one "is this a URL" rule in `AnglesiteCore` instead of two.
- Re-documented `ContentFieldValidation`/`isAbsoluteURL`'s doc comments to reflect that the rule now serves both content-field validation and `IntegrationPlanner`'s wizard fields, rather than claiming to "mirror" a separate ad-hoc rule.
- Kept `IntegrationPlanner`'s existing user-facing failure message, per the issue's suggestion.

Surveyed the rest of `AnglesiteCore` for other ad-hoc `URL(string:)?.host` "is this a URL" checks; `IntegrationPlanner`'s `.path` case combines a leading-slash check with a host check for a different purpose (site-relative path *or* absolute URL) and isn't a duplicate of this rule, so left it alone.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` (3034 tests; 2 pre-existing, unrelated `FoundationModelAssistant` on-device-model failures — see note below)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (no UI/app-target code touched; change is confined to `AnglesiteCore`)
- [ ] Manual smoke (if UI-touching): N/A — non-UI validation logic change

Note: the 2 `FoundationModelAssistant` failures ("generate streams non-empty text", "abandoning a generate stream mid-generation drains without trapping (#201)") are in an unrelated on-device model test suite and unaffected by this diff; `IntegrationPlannerTests` and `ContentFieldValidationTests` (33 tests) pass, including the existing URL-rejection cases (`badURLFails`, `urlFieldRequiresHostNotJustScheme`).