### PR TITLE
docs(#1141): retrofit doc comments, small targets + TestSupport

### DIFF
--- a/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
+++ b/Sources/AnglesiteBridge/AnglesiteScriptHandler.swift
@@ -21,9 +21,17 @@ import AnglesiteBridgeCore
 /// `nil` for the optional handlers to preserve the apply-edit-only behavior, and match on the
 /// richer `DispatchResult` enum instead of `Result<EditReply, EditMessage.DecodeError>`.
 public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
+    // Re-exported dispatcher types, so call sites written against this class before the
+    // AnglesiteBridgeCore split (`AnglesiteScriptHandler.DispatchResult` etc.) keep compiling
+    // without importing the core module themselves.
+
+    /// Callback for `anglesite:visible-elements` reports (see `AnglesiteMessageDispatcher`).
     public typealias VisibleElementsHandler = AnglesiteMessageDispatcher.VisibleElementsHandler
+    /// Callback for `anglesite:canvas-selection` messages (see `AnglesiteMessageDispatcher`).
     public typealias CanvasSelectionHandler = AnglesiteMessageDispatcher.CanvasSelectionHandler
+    /// Callback for `anglesite:computed-styles` reports (see `AnglesiteMessageDispatcher`).
     public typealias ComputedStylesHandler = AnglesiteMessageDispatcher.ComputedStylesHandler
+    /// Outcome of dispatching one message body (see `AnglesiteMessageDispatcher.DispatchResult`).
     public typealias DispatchResult = AnglesiteMessageDispatcher.DispatchResult
 
     private let router: EditRouter
@@ -32,6 +40,14 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
     private let onComputedStyles: ComputedStylesHandler?
     private let logCenter: LogCenter
 
+    /// - Parameters:
+    ///   - router: Applies decoded `anglesite:apply-edit` messages and produces the reply the
+    ///     handler evaluates back into the page.
+    ///   - onVisibleElements: Optional callback for `anglesite:visible-elements` reports; `nil`
+    ///     means those messages are dropped (logged as such by the dispatcher's result).
+    ///   - onCanvasSelection: Optional callback for `anglesite:canvas-selection` messages.
+    ///   - onComputedStyles: Optional callback for `anglesite:computed-styles` reports.
+    ///   - logCenter: Destination for rejection/drop diagnostics — injectable for tests.
     public init(
         router: EditRouter,
         onVisibleElements: VisibleElementsHandler? = nil,
@@ -109,6 +125,10 @@ public final class AnglesiteScriptHandler: NSObject, WKScriptMessageHandler {
         }
     }
 
+    /// `WKScriptMessageHandler` entry point: filters to the `anglesite` namespace, dispatches the
+    /// raw body off the main thread, and evaluates any edit reply back into the page via
+    /// `message.webView`. Non-reply outcomes (drops, rejections) are logged, never surfaced to
+    /// the page — the JS overlay only awaits apply-edit replies.
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard message.name == WebViewBridge.scriptMessageNamespace else { return }
         let body = message.body

--- a/Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift
+++ b/Sources/AnglesiteBridgeCore/AnglesiteMessageDispatcher.swift
@@ -21,8 +21,12 @@ import AnglesiteCore
 /// 4. `anglesite:computed-styles` (a `ComputedStylesReport`) — dispatched to the optional
 ///    `onComputedStyles` callback, posted alongside a canvas selection. No reply.
 public enum AnglesiteMessageDispatcher {
+    /// Receives the decoded elements of an `anglesite:visible-elements` report (message type 2
+    /// above). Async so implementations can hop to their model's actor; no reply flows back.
     public typealias VisibleElementsHandler = @Sendable ([VisibleElement]) async -> Void
+    /// Receives a decoded `anglesite:canvas-selection` message (message type 3 above).
     public typealias CanvasSelectionHandler = @Sendable (CanvasSelectionMessage) async -> Void
+    /// Receives a decoded `anglesite:computed-styles` report (message type 4 above).
     public typealias ComputedStylesHandler = @Sendable (ComputedStylesReport) async -> Void
 
     /// The `WKUserContentController`/`WebKitUserContentManager`/WebView2 script-message name
@@ -51,14 +55,25 @@ public enum AnglesiteMessageDispatcher {
         /// Body was undecodable. Log and move on.
         case rejected(RejectionReason)
 
+        /// Why a message body couldn't be dispatched. The envelope-level cases come first
+        /// (the body never made it past the `type` peek); the `*Decode` cases carry the typed
+        /// decoder error for a body whose `type` matched a known message.
         public enum RejectionReason: Sendable, Equatable {
+            /// The body wasn't a dictionary at all.
             case notAnObject
+            /// The body has no `type` field.
             case missingType
+            /// The `type` field isn't a string.
             case wrongType
+            /// The `type` string doesn't name any known message; carries the unrecognized value.
             case unknownType(String)
+            /// `anglesite:apply-edit` matched but the payload failed `EditMessage.decode`.
             case editDecode(EditMessage.DecodeError)
+            /// `anglesite:visible-elements` matched but the payload failed to decode.
             case visibleElementsDecode(VisibleElementReport.DecodeError)
+            /// `anglesite:canvas-selection` matched but the payload failed to decode.
             case canvasSelectionDecode(ComponentCanvasDecodeError)
+            /// `anglesite:computed-styles` matched but the payload failed to decode.
             case computedStylesDecode(ComponentCanvasDecodeError)
         }
     }

--- a/Sources/AnglesiteContainer/BundledImage.swift
+++ b/Sources/AnglesiteContainer/BundledImage.swift
@@ -140,6 +140,9 @@ public enum BundledImage {
         provisioningReport.isProvisioned
     }
 
+    /// Per-artifact provisioning breakdown behind ``isProvisioned`` — resolves each of the three
+    /// bundled artifacts and captures the failure reason for any that's missing, so settings/debug
+    /// UI can say *which* artifact is absent instead of a bare "not provisioned".
     public static var provisioningReport: BundledImageProvisioningReport {
         BundledImageProvisioningReport(
             image: artifactStatus { try layoutURL() },
@@ -188,6 +191,9 @@ public enum BundledImage {
     }
 }
 
+/// A bundled container artifact failed to resolve — the app was built without the vendored
+/// container resources (see `scripts/vendor-container-image.sh`) and no env override points at a
+/// local copy.
 public enum BundledImageError: Error, Equatable {
     /// The OCI app layout is not vendored and no `ANGLESITE_CONTAINER_IMAGE` override was set.
     case imageLayoutNotProvisioned
@@ -197,15 +203,24 @@ public enum BundledImageError: Error, Equatable {
     case initfsNotProvisioned
 }
 
+/// Resolution status of all three bundled artifacts the container runtime needs to boot
+/// (see ``BundledImage/provisioningReport``).
 public struct BundledImageProvisioningReport: Sendable, Equatable {
+    /// Status of the app OCI image layout.
     public let image: BundledImageArtifactStatus
+    /// Status of the Linux kernel binary.
     public let kernel: BundledImageArtifactStatus
+    /// Status of the vminit initfs layout.
     public let initfs: BundledImageArtifactStatus
 
+    /// `true` only when all three artifacts resolved — the condition under which
+    /// `ContainerizationControl.start()` can succeed.
     public var isProvisioned: Bool {
         image.isProvisioned && kernel.isProvisioned && initfs.isProvisioned
     }
 
+    /// Human-readable "label: reason" lines for each missing artifact (empty when fully
+    /// provisioned) — ready for direct display in debug/settings UI.
     public var missingDescriptions: [String] {
         [
             image.missingDescription(label: "container image"),
@@ -215,10 +230,14 @@ public struct BundledImageProvisioningReport: Sendable, Equatable {
     }
 }
 
+/// Resolution outcome for one bundled artifact.
 public enum BundledImageArtifactStatus: Sendable, Equatable {
+    /// The artifact resolved; carries the path it resolved to (bundle resource or env override).
     case provisioned(path: String)
+    /// The artifact didn't resolve; carries the thrown error's description as the reason.
     case missing(reason: String)
 
+    /// `true` for ``provisioned(path:)``.
     public var isProvisioned: Bool {
         if case .provisioned = self { true } else { false }
     }

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -44,10 +44,33 @@ public struct ContainerizationControl: LocalContainerControl {
     /// Guest mountpoint for the read-only virtio-fs share of the host `Source/` repo (see `start()` step 3).
     private static let repoSharePath = "/run/anglesite-source"
 
+    /// - Parameter imageLayoutURL: Explicit OCI layout to boot from, for tests and the container
+    ///   probe; `nil` (the default) defers resolution to `BundledImage.layoutURL()` at `start()`
+    ///   time so construction itself can never fail.
     public init(imageLayoutURL: URL? = nil) {
         self.imageLayoutURLOverride = imageLayoutURL
     }
 
+    /// Boots the site's container VM end-to-end and returns once the preview is actually serving.
+    ///
+    /// The steps (numbered in the body): boot a bare Linux container with the host repo shared
+    /// read-only over virtio-fs, hydrate `/workspace/site` by cloning that share at `ref`, launch
+    /// `astro dev` + the MCP sidecar + the guest vsock bridges, stand up host-side
+    /// `VsockTCPProxy` listeners for both, and poll the preview URL until it answers. Every
+    /// failure path tears down whatever had started — a failed `start` never leaks a running VM.
+    ///
+    /// - Parameters:
+    ///   - siteID: Stable key for the container and its staged ext4 artifacts; also the handle
+    ///     `stop(siteID:)` tears down.
+    ///   - sourceRepo: The host `Source/` repo (or its resolved split-repo gitdir) to share and
+    ///     clone from.
+    ///   - ref: Branch or SHA to check out in the guest clone (two-step clone+checkout because
+    ///     `git clone --branch` rejects bare SHAs).
+    ///   - onOutput: Receives every guest process line and proxy event — the only visibility into
+    ///     the guest during boot (logs are sacred).
+    /// - Returns: The session carrying the host-side preview and MCP URLs.
+    /// - Throws: `LocalContainerError` classifying the failed stage (`.bootFailed`,
+    ///   `.cloneFailed`, …), or a `BundledImageError` when provisioning is incomplete.
     public func start(
         siteID: String,
         sourceRepo: URL,
@@ -191,6 +214,8 @@ public struct ContainerizationControl: LocalContainerControl {
         return LocalContainerSession(previewURL: previewURL, mcpURL: mcpURL)
     }
 
+    /// Tears down the site's container, proxies, and staged ext4 artifacts, then releases its
+    /// vmnet interface. Idempotent: stopping an unknown or already-stopped `siteID` is a no-op.
     public func stop(siteID: String) async throws {
         await live.teardown(siteID: siteID)
         await network.release(siteID: siteID)
@@ -217,8 +242,14 @@ public struct ContainerizationControl: LocalContainerControl {
     }
 
     /// See `LocalContainerControl.startWorkersDev` for the full contract.
-    /// - Parameter onState: Receives supervisor lifecycle transitions (#699); see
-    ///   `LocalContainerControl`'s 4-parameter requirement.
+    /// - Parameters:
+    ///   - siteID: The site whose container hosts the session — must already have a live
+    ///     container from `start(siteID:sourceRepo:ref:onOutput:)`, else this throws.
+    ///   - workers: The effective active `@dwk/workers` catalog descriptors composed into the
+    ///     ephemeral guest-side wrangler.toml.
+    ///   - onOutput: Receives every wrangler-dev/bridge output line (logs are sacred).
+    ///   - onState: Receives supervisor lifecycle transitions (#699); see
+    ///     `LocalContainerControl`'s 4-parameter requirement.
     public func startWorkersDev(
         siteID: String,
         workers: [WorkerDescriptor],

--- a/Sources/AnglesiteContainer/VirtualizationEntitlement.swift
+++ b/Sources/AnglesiteContainer/VirtualizationEntitlement.swift
@@ -5,6 +5,9 @@ import Security
 /// for unsigned/un-entitled builds (every CI build and any pre-approval distribution). Lives here
 /// because AnglesiteContainer is the only target that should ever consult it.
 public enum VirtualizationEntitlement {
+    /// `true` when the running process's code signature carries the virtualization entitlement.
+    /// Queried via `SecTask` (not a static build flag) so the answer reflects the binary as
+    /// actually signed — an ad-hoc or unsigned test build correctly reports `false`.
     public static var isPresent: Bool {
         guard let task = SecTaskCreateFromSelf(nil) else { return false }
         let value = SecTaskCopyValueForEntitlement(task, "com.apple.security.virtualization" as CFString, nil)

--- a/Sources/AnglesiteIOS/RemotePreviewWebView.swift
+++ b/Sources/AnglesiteIOS/RemotePreviewWebView.swift
@@ -9,8 +9,11 @@ import WebKit
 /// local containers, or the macOS `AnglesiteCore` runtime graph.
 @MainActor
 public struct RemotePreviewWebView: UIViewRepresentable {
+    /// `UIViewRepresentable` conformance: the represented view is the `WKWebView` itself.
     public typealias UIViewType = WKWebView
 
+    /// The script-message name the JS edit overlay posts to — must match
+    /// `AnglesiteMessageDispatcher.scriptMessageNamespace` on the macOS side.
     public static let defaultScriptMessageNamespace = "anglesite"
 
     private let url: URL
@@ -20,6 +23,9 @@ public struct RemotePreviewWebView: UIViewRepresentable {
     private let prepareBeforeLoad: ((WKWebView) async -> Void)?
     private let configureWebView: (WKWebView) -> Void
 
+    /// Simple variant: the wrapper builds a default `WKWebViewConfiguration`, registering
+    /// `scriptHandler` (if any) under `scriptMessageNamespace`. Use the `makeConfiguration:`
+    /// variant when the caller needs to own the whole configuration or do async pre-load work.
     public init(
         url: URL,
         scriptHandler: WKScriptMessageHandler? = nil,
@@ -52,6 +58,9 @@ public struct RemotePreviewWebView: UIViewRepresentable {
         self.configureWebView = configureWebView
     }
 
+    /// Builds the web view and kicks off the first load. When `prepareBeforeLoad` is set, the
+    /// load is deferred until it completes (async cookie-store writes must land before the first
+    /// request); `WKWebView` tolerates `load` arriving a beat after creation.
     public func makeUIView(context: Context) -> WKWebView {
         let configuration: WKWebViewConfiguration
         if let makeConfiguration {
@@ -80,12 +89,16 @@ public struct RemotePreviewWebView: UIViewRepresentable {
         return webView
     }
 
+    /// Reloads only when `url` actually changed, using the coordinator's `loadedURL` as the
+    /// dedupe marker — SwiftUI calls this on every unrelated state change, and an unconditional
+    /// `load` would interrupt the page mid-render.
     public func updateUIView(_ webView: WKWebView, context: Context) {
         guard context.coordinator.loadedURL != url else { return }
         context.coordinator.loadedURL = url
         webView.load(URLRequest(url: url))
     }
 
+    /// `UIViewRepresentable` conformance; the coordinator only tracks the last-loaded URL.
     public func makeCoordinator() -> RemotePreviewWebViewCoordinator {
         RemotePreviewWebViewCoordinator()
     }

--- a/Sources/AnglesiteIOS/RemotePreviewWebViewCoordinator.swift
+++ b/Sources/AnglesiteIOS/RemotePreviewWebViewCoordinator.swift
@@ -1,10 +1,15 @@
 #if os(iOS)
 import Foundation
 
+/// Coordinator for `RemotePreviewWebView`: remembers the last URL actually loaded so
+/// `updateUIView` can skip redundant reloads. Reference semantics are the point — SwiftUI
+/// recreates the (value-type) representable freely, but the coordinator persists.
 @MainActor
 public final class RemotePreviewWebViewCoordinator {
     var loadedURL: URL?
 
+    /// Public because `RemotePreviewWebView.makeCoordinator()` is public API and its return
+    /// type must be constructible; carries no configuration.
     public init() {}
 }
 #endif

--- a/Sources/AnglesiteMobile/RemoteSessionModel.swift
+++ b/Sources/AnglesiteMobile/RemoteSessionModel.swift
@@ -23,6 +23,7 @@ public final class RemoteSessionModel {
         didSet { defaults.set(gitRemoteString, forKey: Self.gitRemoteKey) }
     }
 
+    /// Branch or SHA the sandbox checks out after cloning. Defaults to `"main"` on first launch.
     public var gitRef: String {
         didSet { defaults.set(gitRef, forKey: Self.gitRefKey) }
     }
@@ -42,10 +43,14 @@ public final class RemoteSessionModel {
 
     // MARK: Session
 
+    /// SwiftUI-observable mirror of the runtime's state stream. Read-only to views: state
+    /// changes flow exclusively from the runtime's `observe()` stream via `start()`/`stop()`.
     public private(set) var state: SiteRuntimeState = .idle
     /// The session token for the *current* start attempt — the preview screen injects it as the
     /// auth-proxy cookie before the first `WKWebView` request (design 2026-06-23 §"Start session").
     public private(set) var sessionToken: SessionToken?
+    /// The MCP client for the current session, HTTP-transport only on iOS (nothing spawns).
+    /// `nil` between sessions; the edit pipeline holds it only while a session runs.
     public private(set) var mcpClient: MCPClient?
 
     private var runtime: RemoteSandboxSiteRuntime?
@@ -59,6 +64,14 @@ public final class RemoteSessionModel {
     private static let gitRefKey = "remoteSession.gitRef"
     private static let siteIDKey = "remoteSession.siteID"
 
+    /// Restores persisted configuration on construction.
+    ///
+    /// - Parameters:
+    ///   - defaults: Store for the non-secret fields — injectable so tests don't touch the real
+    ///     standard defaults.
+    ///   - secretStore: Store for the bearer token; `nil` (production) means the iOS Keychain.
+    ///     Resolved here rather than as a default argument because `KeychainStore()` shouldn't
+    ///     be constructed during test runs at all.
     public init(
         defaults: UserDefaults = .standard,
         secretStore: (any SecretStore)? = nil
@@ -80,11 +93,15 @@ public final class RemoteSessionModel {
         workerURL != nil && gitRemote != nil && !controlToken.isEmpty && !siteID.isEmpty
     }
 
+    /// ``workerURLString`` parsed and validated (http/https scheme required); `nil` while the
+    /// field is empty or malformed. The form binds the string, everything else consumes this.
     public var workerURL: URL? {
         guard let url = URL(string: workerURLString), url.scheme?.hasPrefix("http") == true else { return nil }
         return url
     }
 
+    /// ``gitRemoteString`` parsed and validated (any scheme accepted — https and ssh remotes are
+    /// both legitimate); `nil` while empty or malformed.
     public var gitRemote: URL? {
         guard let url = URL(string: gitRemoteString), url.scheme != nil else { return nil }
         return url
@@ -135,6 +152,8 @@ public final class RemoteSessionModel {
         }
     }
 
+    /// Ends the session: clears the token, client, and observation immediately (the UI drops to
+    /// `.idle` without waiting), then tells the sandbox to shut down asynchronously.
     public func stop() {
         guard let runtime else { return }
         self.runtime = nil

--- a/Sources/AnglesiteQuickLookSupport/PackagePreviewSummary.swift
+++ b/Sources/AnglesiteQuickLookSupport/PackagePreviewSummary.swift
@@ -5,26 +5,39 @@ import AnglesiteSiteModel
 /// built for the Quick Look preview/thumbnail extensions (#621). Reads only the `Info.plist`
 /// marker and file-layout counts — never parses content, never touches a dev server or container.
 public struct PackagePreviewSummary: Sendable, Equatable {
+    /// The site's user-visible name, from the `Info.plist` marker.
     public let displayName: String
+    /// When the package was created, from the `Info.plist` marker.
     public let createdDate: Date
+    /// Number of non-hidden entries directly under `Source/src/pages/` — a layout fact, not a
+    /// route count (nested routes and dynamic pages aren't resolved).
     public let pageCount: Int
     /// One entry per subdirectory of `Source/src/content/`, ordered by directory name.
     public let collectionCounts: [CollectionCount]
+    /// Most recent file modification under `Source/` (excluding generated trees; capped scan —
+    /// see `modificationScanEntryCap`). `nil` when the tree is unreadable or empty.
     public let sourceLastModified: Date?
     /// Set only when `Config/quicklook-thumbnail.png` actually exists — no writer for this cache
     /// exists yet; this is the read-if-present path for a future feature.
     public let cachedThumbnailURL: URL?
 
+    /// A content collection's directory name and entry count, for the preview's collections list.
     public struct CollectionCount: Sendable, Equatable {
+        /// The collection's directory name under `Source/src/content/`.
         public let name: String
+        /// Number of non-hidden entries directly inside the collection directory.
         public let count: Int
 
+        /// Memberwise initializer, public so the extensions' view code and tests can build
+        /// fixture values.
         public init(name: String, count: Int) {
             self.name = name
             self.count = count
         }
     }
 
+    /// Memberwise initializer, public for tests and previews; production code builds summaries
+    /// via ``summarize(_:fileManager:)``.
     public init(
         displayName: String,
         createdDate: Date,

--- a/Sources/AnglesiteSiteModel/AnglesitePackage.swift
+++ b/Sources/AnglesiteSiteModel/AnglesitePackage.swift
@@ -18,14 +18,20 @@ public struct AnglesitePackage: Sendable, Equatable {
     /// The package directory (`…/Name.anglesite`).
     public let url: URL
 
+    /// Wraps the package directory at `url` without touching disk — existence and marker
+    /// validity are checked separately (``isPackage(at:fileManager:)``, ``readMarker(fileManager:)``)
+    /// so callers can represent a package that is about to be created.
     public init(url: URL) {
         self.url = url
     }
 
     // MARK: - Layout
 
+    /// The identity marker plist at the package root (see ``Marker``).
     public var infoPlistURL: URL { url.appendingPathComponent("Info.plist", isDirectory: false) }
+    /// The externally-editable Astro project — the git-tracked, clonable unit (#72).
     public var sourceURL: URL { url.appendingPathComponent("Source", isDirectory: true) }
+    /// App-owned per-site state (settings, chat history, caches) — never part of the git repo.
     public var configURL: URL { url.appendingPathComponent("Config", isDirectory: true) }
 
     /// App-owned sync state, inside `Config/` (never in the `Source/` git repo).
@@ -78,11 +84,25 @@ public struct AnglesitePackage: Sendable, Equatable {
         // Identity + provenance are immutable: the point of the UUID redesign is that a package's
         // identity never changes after creation. Only `displayName` has a legitimate reason to
         // change (a rename), so it stays `var`.
+
+        /// The on-disk layout version this marker was written with (see
+        /// ``AnglesitePackage/currentFormatVersion``).
         public let formatVersion: Int
+        /// The package's stable, path-independent identity — moving or renaming the package
+        /// keeps the same site.
         public let siteID: UUID
+        /// The user-visible site name. The only mutable field: a rename must not mint a new
+        /// identity.
         public var displayName: String
+        /// When the package was created. Whole-second granularity (see `init`).
         public let createdDate: Date
 
+        /// Creates a marker, minting a fresh identity by default — pass explicit values only
+        /// when re-encoding an existing marker.
+        ///
+        /// `createdDate` is truncated to a whole second so an in-memory marker compares equal
+        /// to the one decoded back from `Info.plist` (XML plist dates carry no sub-second
+        /// precision).
         public init(
             formatVersion: Int = AnglesitePackage.currentFormatVersion,
             siteID: UUID = UUID(),
@@ -107,6 +127,7 @@ public struct AnglesitePackage: Sendable, Equatable {
         }
     }
 
+    /// Failures reading, writing, or creating a package's `Info.plist` marker.
     public enum PackageError: Error, Sendable {
         /// `Info.plist` is absent (or was deleted out from under us).
         case markerMissing(URL)
@@ -129,6 +150,9 @@ public struct AnglesitePackage: Sendable, Equatable {
         case readOnlyTooNew
     }
 
+    /// Classifies `marker` against the format this build writes: an older-or-equal
+    /// ``Marker/formatVersion`` is ``Compatibility/current`` (older layouts are always readable),
+    /// a newer one is ``Compatibility/readOnlyTooNew``.
     public static func compatibility(for marker: Marker) -> Compatibility {
         marker.formatVersion > currentFormatVersion ? .readOnlyTooNew : .current
     }

--- a/Sources/AnglesiteSiteModel/ProjectValidator.swift
+++ b/Sources/AnglesiteSiteModel/ProjectValidator.swift
@@ -22,10 +22,15 @@ import Foundation
 /// UI can surface an otherwise-valid site's missing optional markers). `Result.missingRequired`
 /// is the subset the UI uses to decide blocker vs. nice-to-have.
 public enum ProjectValidator {
+    /// Sentinels that must all be present for a directory to count as an Anglesite project
+    /// (the "required" tier described above).
     public static let requiredSentinels: [String] = [
         ".site-config",
         "astro.config.ts"
     ]
+    /// Optional integration markers (the "recommended" tier described above). Currently empty;
+    /// the tier is retained so future integrations can surface nice-to-haves without becoming
+    /// blockers.
     public static let recommendedSentinels: [String] = []
     /// Union of required + recommended — the full set a caller can check without caring about the
     /// tier split. No production code depends on it today (`SiteStore` validates via `validate`'s
@@ -33,15 +38,22 @@ public enum ProjectValidator {
     /// While `recommendedSentinels` is empty this equals `requiredSentinels`.
     public static let sentinels: [String] = requiredSentinels + recommendedSentinels
 
+    /// The outcome of validating one directory: which sentinels are missing, split by tier so
+    /// the UI can distinguish blockers from nice-to-haves.
     public struct Result: Sendable, Equatable {
+        /// The directory that was validated.
         public let directory: URL
         /// Every sentinel that's missing — required + recommended. Drives the sidebar caption.
         public let missing: [String]
         /// The subset of `missing` that's actually required. `isValid` is `missingRequired.isEmpty`.
         public let missingRequired: [String]
 
+        /// `true` when every **required** sentinel is present — missing recommended sentinels
+        /// don't invalidate a project.
         public var isValid: Bool { missingRequired.isEmpty }
 
+        /// Memberwise initializer, public so tests and previews can construct fixture results;
+        /// production code gets a `Result` from ``ProjectValidator/validate(_:fileManager:)``.
         public init(directory: URL, missing: [String], missingRequired: [String]) {
             self.directory = directory
             self.missing = missing

--- a/Tests/AnglesiteTestSupport/E2EServer.swift
+++ b/Tests/AnglesiteTestSupport/E2EServer.swift
@@ -15,14 +15,19 @@ public enum E2EServer {
     /// The spawned server process exited before it became ready. Carries the captured stderr so the
     /// real failure (e.g. `Cannot find package 'sharp'`) is visible in the test output.
     public struct ServerExited: Error, CustomStringConvertible {
+        /// How the process ended (exit code vs. signal), from the supervisor.
         public let reason: ProcessSupervisor.ExitReason
+        /// Everything the process wrote to stderr before dying; empty if nothing was captured.
         public let stderr: String
 
+        /// Memberwise initializer; `awaitReady` constructs this when the death task wins the race.
         public init(reason: ProcessSupervisor.ExitReason, stderr: String) {
             self.reason = reason
             self.stderr = stderr
         }
 
+        /// Multi-line message embedding the captured stderr, so the real crash cause lands
+        /// directly in the test failure output.
         public var description: String {
             """
             MCP server process exited (\(reason)) before becoming ready.
@@ -37,12 +42,16 @@ public enum E2EServer {
     /// crash stderr to report — conflating the two (e.g. `ServerExited(reason: .terminated, …)`)
     /// would send a reader chasing a phantom signal kill.
     public struct ServerTimedOut: Error, CustomStringConvertible {
+        /// The readiness budget that elapsed, in seconds.
         public let timeout: TimeInterval
 
+        /// Memberwise initializer; `awaitReady` constructs this when the timeout task wins the race.
         public init(timeout: TimeInterval) {
             self.timeout = timeout
         }
 
+        /// One-line message noting the process was still alive — the detail that distinguishes
+        /// this from a crash.
         public var description: String {
             "MCP server did not become ready within \(timeout)s (process still running)."
         }

--- a/Tests/AnglesiteTestSupport/TemplateBuildSerializer.swift
+++ b/Tests/AnglesiteTestSupport/TemplateBuildSerializer.swift
@@ -13,6 +13,8 @@ import Foundation
 /// A waiter whose task is cancelled drains itself from the queue and throws `CancellationError`,
 /// so a cancelled/timed-out test never wedges the lock for the suites behind it.
 public actor TemplateBuildSerializer {
+    /// The process-wide instance every render-smoke suite serializes through — mutual exclusion
+    /// only works if all suites share the same lock.
     public static let shared = TemplateBuildSerializer()
 
     private struct Waiter {
@@ -23,6 +25,8 @@ public actor TemplateBuildSerializer {
     private var locked = false
     private var waiters: [Waiter] = []
 
+    /// Public so a test can construct a private serializer to exercise the lock itself;
+    /// production test suites use ``shared``.
     public init() {}
 
     private func lock() async throws {

--- a/Tests/AnglesiteTestSupport/TestFixtures.swift
+++ b/Tests/AnglesiteTestSupport/TestFixtures.swift
@@ -45,7 +45,9 @@ public func writeSiteTree(prefix: String = "anglesite-test", _ files: [String: S
 /// the calling test with a readable message and the rest of the run continues — matching the
 /// soft-fail semantics of the old per-file `#expect` guards these helpers replaced.
 public struct TestFixtureError: Error, CustomStringConvertible {
+    /// The human-readable failure message, shown verbatim in the test output.
     public let description: String
+    /// Wraps the message; unlabeled because call sites read as `throw TestFixtureError("…")`.
     public init(_ description: String) { self.description = description }
 }
 


### PR DESCRIPTION
## Summary

- Phase 1 of the doc-comment retrofit tracked in #1141: documents every public/open declaration that lacked a `///` doc comment in the seven small SwiftPM targets — AnglesiteSiteModel, AnglesiteQuickLookSupport, AnglesiteBridge, AnglesiteBridgeCore, AnglesiteIOS, AnglesiteMobile, AnglesiteContainer — plus AnglesiteTestSupport (76 declarations across 14 files), per `docs/comment-style-guide.md`.
- Completes a pre-existing partial `- Parameters:` block on the 4-parameter `startWorkersDev` overload that failed `AnglesiteContainer`'s strict DocC build (not CI-gated, but now clean locally).
- Comments only — no behavior changes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --warnings-as-errors` for AnglesiteSiteModel, AnglesiteQuickLookSupport, AnglesiteBridgeCore, AnglesiteBridge, AnglesiteIOS, AnglesiteTestSupport (the CI `docs-docc` set touched here) — all clean.
- [x] Same for AnglesiteContainer (not CI-gated; hosted runners can't build it) — DocC diagnostics clean after the `startWorkersDev` fix.
- [x] `swift test --package-path .` — full run: 2 failing suites, both shown unrelated on re-run. "ComponentEditorModel draft state (#824)" (AnglesiteAppTests) passed on isolated re-run — the full run raced a *concurrent full-suite run from another agent session* plus a disk-full event. AnglesiteCoreTests re-run: 3,034 tests, 2 failures, both in "FoundationModelAssistant" (live on-device generation timing out on a saturated machine — the known concurrent-`swift test` FM contention); that suite's code is **byte-identical to `origin/main` in this diff** (this PR touches no AnglesiteCore file). RenderSmoke suites all pass.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; the diff is doc comments only and every touched target compiles during DocC symbol-graph extraction. (`AnglesiteMobile` is an Xcode-only target with no SwiftPM docs lane; its file compiles in the app build.)
