### PR TITLE
fix(#1013): GA4 label honesty; opt-in cloudflareinsights CSP

### DIFF
--- a/Resources/Template/public/_headers
+++ b/Resources/Template/public/_headers
@@ -6,7 +6,7 @@
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   Cross-Origin-Resource-Policy: same-site
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' cloudflareinsights.com; frame-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
   Cache-Control: public, max-age=0, must-revalidate
 
 /_astro/*

--- a/Resources/Template/scripts/csp.test.ts
+++ b/Resources/Template/scripts/csp.test.ts
@@ -17,19 +17,26 @@ test("parseAllowedDomains: dedupes, trims, sorts, drops blanks", () => {
 test("buildCSP: baseline when no integrations configured", () => {
   assert.equal(
     buildCSP(""),
-    "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' static.cloudflareinsights.com; " +
+    "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; " +
       "style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; " +
-      "connect-src 'self' cloudflareinsights.com; frame-src 'self'; object-src 'none'; " +
+      "connect-src 'self'; frame-src 'self'; object-src 'none'; " +
       "frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests",
   );
+});
+
+// The baseline must not pre-allow analytics origins the site isn't using (#1013): a
+// pre-widened allowlist would let an injected cloudflareinsights <script> execute even
+// on sites that never enabled analytics. The app adds these via SCRIPT_ALLOW on enable.
+test("buildCSP: baseline pre-allows no cloudflareinsights origins", () => {
+  assert.ok(!/cloudflareinsights/.test(buildCSP("")));
 });
 
 test("buildCSP: a configured domain lands in script/frame/connect/img/form-action only", () => {
   const csp = buildCSP("SCRIPT_ALLOW=giscus.app");
   // present in the five embed directives
-  assert.match(csp, /script-src 'self' 'wasm-unsafe-eval' static\.cloudflareinsights\.com giscus\.app;/);
+  assert.match(csp, /script-src 'self' 'wasm-unsafe-eval' giscus\.app;/);
   assert.match(csp, /img-src 'self' data: giscus\.app;/);
-  assert.match(csp, /connect-src 'self' cloudflareinsights\.com giscus\.app;/);
+  assert.match(csp, /connect-src 'self' giscus\.app;/);
   assert.match(csp, /frame-src 'self' giscus\.app;/);
   assert.match(csp, /form-action 'self' giscus\.app/);
   // absent from non-embed directives

--- a/Resources/Template/scripts/csp.ts
+++ b/Resources/Template/scripts/csp.ts
@@ -19,11 +19,14 @@ const BASE: Record<string, string[]> = {
   // 'wasm-unsafe-eval' is what lets the browser compile the WebAssembly module Pagefind's
   // search index reader is built on (/search, #974). It permits WASM compilation only — not
   // eval() or new Function() — so it doesn't widen the policy for ordinary script.
-  "script-src": ["'self'", "'wasm-unsafe-eval'", "static.cloudflareinsights.com"],
+  // No analytics origins here (#1013): the baseline stays as narrow as a site with analytics
+  // off actually needs. Enabling Cloudflare Web Analytics in the app adds its beacon origins
+  // via SCRIPT_ALLOW, the same opt-in path every other integration uses.
+  "script-src": ["'self'", "'wasm-unsafe-eval'"],
   "style-src": ["'self'", "'unsafe-inline'"],
   "img-src": ["'self'", "data:"],
   "font-src": ["'self'"],
-  "connect-src": ["'self'", "cloudflareinsights.com"],
+  "connect-src": ["'self'"],
   "frame-src": ["'self'"],
   "object-src": ["'none'"],
   "frame-ancestors": ["'none'"],

--- a/Sources/AnglesiteApp/IntegrationWizard.swift
+++ b/Sources/AnglesiteApp/IntegrationWizard.swift
@@ -68,7 +68,13 @@ struct IntegrationWizard: View {
                 get: { model.answers["provider"] ?? "" },
                 set: { model.answers["provider"] = $0 })) {
                 ForEach(model.descriptor?.providers ?? [], id: \.id) { provider in
-                    Text(provider.displayName).tag(provider.id)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(provider.displayName)
+                        if let note = provider.note {
+                            Text(note).font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    .tag(provider.id)
                 }
             }
             .pickerStyle(.inline)

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -363,7 +363,7 @@ public enum IntegrationCatalog {
     static let tracking = IntegrationDescriptor(
         id: .tracking,
         displayName: "Analytics",
-        summary: "Add privacy-friendly visitor analytics (Plausible, Fathom, or Google Analytics 4).",
+        summary: "Add visitor analytics: privacy-friendly options (Plausible, Fathom) or Google Analytics 4.",
         providers: [
             Provider(id: "plausible", displayName: "Plausible", cspDomains: ["plausible.io"]),
             Provider(id: "fathom", displayName: "Fathom", cspDomains: ["cdn.usefathom.com"]),
@@ -372,7 +372,8 @@ public enum IntegrationCatalog {
             // without these, connect-src silently drops every hit once the generated CSP is
             // enforced (see PR #473 review).
             Provider(id: "ga4", displayName: "Google Analytics 4",
-                     cspDomains: ["www.googletagmanager.com", "*.google-analytics.com", "*.analytics.google.com"]),
+                     cspDomains: ["www.googletagmanager.com", "*.google-analytics.com", "*.analytics.google.com"],
+                     note: "Shares visitor data with Google and generally requires visitor consent (GDPR/ePrivacy) — pair it with the Consent Banner integration."),
         ],
         fields: [
             Field(key: "domain", label: "Site domain", kind: .text,

--- a/Sources/AnglesiteCore/IntegrationDescriptor.swift
+++ b/Sources/AnglesiteCore/IntegrationDescriptor.swift
@@ -70,8 +70,11 @@ public struct Provider: Sendable, Equatable, Identifiable {
     public let id: String
     public let displayName: String
     public let cspDomains: [String]
-    public init(id: String, displayName: String, cspDomains: [String]) {
-        self.id = id; self.displayName = displayName; self.cspDomains = cspDomains
+    /// One-line disclosure shown under the provider's row in the picker — for caveats the
+    /// owner should know at the decision point (e.g. GA4's visitor-consent obligations).
+    public let note: String?
+    public init(id: String, displayName: String, cspDomains: [String], note: String? = nil) {
+        self.id = id; self.displayName = displayName; self.cspDomains = cspDomains; self.note = note
     }
 }
 

--- a/Sources/AnglesiteCore/SiteConfigFile.swift
+++ b/Sources/AnglesiteCore/SiteConfigFile.swift
@@ -21,12 +21,26 @@ public enum SiteConfigFile {
     }
 
     public static func addCSPDomains(_ domains: [String], into contents: String) -> String {
-        let existingLine = contents.split(separator: "\n").first { $0.hasPrefix("\(cspKey)=") }
-        let existing = existingLine.map { String($0.dropFirst(cspKey.count + 1)) }
-            .map { $0.split(separator: ",").map(String.init) } ?? []
+        let existing = cspDomains(in: contents)
         var merged = existing
         for d in domains where !merged.contains(d) { merged.append(d) }
         return upsert([(cspKey, merged.joined(separator: ","))], into: contents)
+    }
+
+    /// Drops `domains` from the `SCRIPT_ALLOW` list, leaving other entries in place.
+    /// No-op when the key is absent — it isn't created just to hold an empty value.
+    public static func removeCSPDomains(_ domains: [String], from contents: String) -> String {
+        guard contents.split(separator: "\n").contains(where: { $0.hasPrefix("\(cspKey)=") }) else {
+            return contents
+        }
+        let remaining = cspDomains(in: contents).filter { !domains.contains($0) }
+        return upsert([(cspKey, remaining.joined(separator: ","))], into: contents)
+    }
+
+    private static func cspDomains(in contents: String) -> [String] {
+        let existingLine = contents.split(separator: "\n").first { $0.hasPrefix("\(cspKey)=") }
+        return existingLine.map { String($0.dropFirst(cspKey.count + 1)) }
+            .map { $0.split(separator: ",").map(String.init) } ?? []
     }
 
     /// Reads a single `KEY=value` line's value from `.site-config`-formatted

--- a/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
+++ b/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
@@ -37,6 +37,12 @@ public enum WebsiteAnalyticsAsset {
     public static let configRelativePath = ".site-config"
     public static let dashboardURL = URL(string: "https://dash.cloudflare.com/?to=/:account/web-analytics")!
 
+    /// CSP origins the Cloudflare Web Analytics beacon needs: the script host and the
+    /// endpoint its event beacons POST to. The template's baseline CSP deliberately does
+    /// not pre-allow these (#1013) — they're added to SCRIPT_ALLOW only while the beacon
+    /// is enabled, and removed again when it's turned off.
+    public static let cloudflareCSPDomains = ["static.cloudflareinsights.com", "cloudflareinsights.com"]
+
     private static let blockStart = "<!-- anglesite:analytics-start -->"
     private static let blockEnd = "<!-- anglesite:analytics-end -->"
     private static let customStart = "<!-- anglesite:custom-analytics-start -->"
@@ -86,9 +92,15 @@ public enum WebsiteAnalyticsAsset {
 
         let configURL = siteDirectory.appendingPathComponent(configRelativePath)
         let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let cloudflareToken = settings.cloudflareToken.trimmingCharacters(in: .whitespacesAndNewlines)
         var updatedConfig = SiteConfigFile.upsert([
-            ("CF_WEB_ANALYTICS_TOKEN", settings.cloudflareToken.trimmingCharacters(in: .whitespacesAndNewlines))
+            ("CF_WEB_ANALYTICS_TOKEN", cloudflareToken)
         ], into: config)
+        if cloudflareToken.isEmpty {
+            updatedConfig = SiteConfigFile.removeCSPDomains(cloudflareCSPDomains, from: updatedConfig)
+        } else {
+            updatedConfig = SiteConfigFile.addCSPDomains(cloudflareCSPDomains, into: updatedConfig)
+        }
         let customDomains = customScriptDomains(from: settings.customHeadTag)
         if !customDomains.isEmpty {
             updatedConfig = SiteConfigFile.addCSPDomains(customDomains, into: updatedConfig)

--- a/Tests/AnglesiteCoreTests/SiteConfigFileTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigFileTests.swift
@@ -33,6 +33,22 @@ import Testing
         #expect(twice == "SCRIPT_ALLOW=app.cal.com\n")
     }
 
+    @Test func removesCSPDomainsLeavingOthersInPlace() {
+        let out = SiteConfigFile.removeCSPDomains(["static.cloudflareinsights.com", "cloudflareinsights.com"],
+                                                  from: "SCRIPT_ALLOW=existing.com,static.cloudflareinsights.com,cloudflareinsights.com\n")
+        #expect(out == "SCRIPT_ALLOW=existing.com\n")
+    }
+
+    @Test func removingAllCSPDomainsLeavesAnEmptyValue() {
+        let out = SiteConfigFile.removeCSPDomains(["app.cal.com"], from: "SCRIPT_ALLOW=app.cal.com\nSITE_NAME=Acme\n")
+        #expect(out == "SCRIPT_ALLOW=\nSITE_NAME=Acme\n")
+    }
+
+    @Test func removeCSPDomainsWithoutTheKeyIsANoOp() {
+        let contents = "SITE_NAME=Acme\n"
+        #expect(SiteConfigFile.removeCSPDomains(["app.cal.com"], from: contents) == contents)
+    }
+
     /// CRLF input must be normalized to LF: the output key is replaced and no \r appears.
     @Test func upsertNormalizesCRLF() {
         let crlf = "SITE_NAME=Acme\r\nBOOKING_PROVIDER=cal\r\n"

--- a/Tests/AnglesiteCoreTests/WebsiteAnalyticsAssetTests.swift
+++ b/Tests/AnglesiteCoreTests/WebsiteAnalyticsAssetTests.swift
@@ -102,6 +102,39 @@ struct WebsiteAnalyticsAssetTests {
         #expect(config.contains("www.googletagmanager.com"))
     }
 
+    // The template's baseline CSP no longer pre-allows the beacon's origins (#1013), so
+    // enabling the Cloudflare provider must widen SCRIPT_ALLOW itself — and disabling it
+    // must narrow the policy back, or the unused width lingers for every future build.
+    @Test("install adds Cloudflare CSP domains on enable and removes them on disable")
+    func installTogglesCloudflareCSPDomains() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let siteDir = root.appendingPathComponent("Source")
+        let layoutDir = siteDir.appendingPathComponent("src/layouts")
+        try fm.createDirectory(at: layoutDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        try layout.write(to: layoutDir.appendingPathComponent("BaseLayout.astro"), atomically: true, encoding: .utf8)
+        try "SCRIPT_ALLOW=existing.com\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        try WebsiteAnalyticsAsset.install(
+            WebsiteAnalyticsAsset.Settings(cloudflareToken: "cf-token"),
+            siteDirectory: siteDir,
+            fileManager: fm
+        )
+        let enabled = try String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(enabled.contains("SCRIPT_ALLOW=existing.com,static.cloudflareinsights.com,cloudflareinsights.com"))
+
+        try WebsiteAnalyticsAsset.install(
+            WebsiteAnalyticsAsset.Settings(),
+            siteDirectory: siteDir,
+            fileManager: fm
+        )
+        let disabled = try String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(disabled.contains("SCRIPT_ALLOW=existing.com\n"))
+        #expect(!disabled.contains("cloudflareinsights"))
+    }
+
     @Test("install rejects incomplete custom analytics HTML without changing the layout")
     func installRejectsIncompleteCustomHTML() throws {
         let fm = FileManager.default


### PR DESCRIPTION
Closes #1013

## Summary

- The tracking integration's summary no longer markets GA4 as "privacy-friendly": the label now attaches only to Plausible and Fathom, and the GA4 provider row carries a one-line disclosure (new optional `Provider.note`, rendered as a caption in the wizard's provider picker) that it shares visitor data with Google and generally requires visitor consent — pointing owners at the Consent Banner integration.
- The template's baseline CSP no longer pre-allows `static.cloudflareinsights.com` / `cloudflareinsights.com` with analytics off (`csp.ts` BASE + committed `public/_headers`). Enabling the Cloudflare Web Analytics beacon now widens `SCRIPT_ALLOW` and disabling it narrows it back, via `WebsiteAnalyticsAsset.install` and a new `SiteConfigFile.removeCSPDomains` — the same opt-in mechanism the custom-analytics path already uses.
- Already-scaffolded sites keep their old `_headers`; tightening them rides the versioned template migration (#745).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Template changes are app-only (`Resources/Template/`); no MCP schema change here.

## Test plan

- [x] `swift test --package-path .` — touched suites (`SiteConfigFileTests`, `WebsiteAnalyticsAsset`, 23 tests incl. 4 new) pass; full run green except two pre-existing `FoundationModelAssistant` streaming failures ("Session ended without producing a response") that reproduce in isolation on the unmodified branch base and touch no files in this diff (flagged separately).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [x] Template tests: `npx tsx --test scripts/csp.test.ts` — 18/18, including the byte-identical committed `_headers` check and a new no-cloudflareinsights baseline guard.
- [ ] Manual smoke (if UI-touching): provider picker shows the GA4 consent caption — not run (headless session).