### PR TITLE
docs(#1141): retrofit doc comments across AnglesiteIntents

### DIFF
--- a/Sources/AnglesiteIntents/AnglesiteShortcuts.swift
+++ b/Sources/AnglesiteIntents/AnglesiteShortcuts.swift
@@ -7,6 +7,11 @@ import AppIntents
 /// `SiteEntity` value that the user pipes into `DeploySiteIntent`, whose confirmation still
 /// gates the deploy. No extra `opensIntent` plumbing is needed for v0.
 public struct AnglesiteShortcuts: AppShortcutsProvider {
+    /// The curated phrase list, built with `AppShortcutsProvider`'s result builder. Apple caps
+    /// this at 10 shortcuts, and the ten below spend the whole budget — which is why the Bucket 3
+    /// integration intents get no phrase (see the note at the end of the builder). When adding or
+    /// removing an entry, update `phraseExposedIntentNames` in the same commit; a sync-guard test
+    /// compares the two counts.
     public static var appShortcuts: [AppShortcut] {
         AppShortcut(
             intent: DeploySiteIntent(),

--- a/Sources/AnglesiteIntents/Bootstrap.swift
+++ b/Sources/AnglesiteIntents/Bootstrap.swift
@@ -6,26 +6,6 @@ private let log = Logger(subsystem: "io.dwk.anglesite", category: "spotlight-ind
 private let contentLog = Logger(subsystem: "io.dwk.anglesite", category: "content-spotlight-indexer")
 private let relevantLog = Logger(subsystem: "io.dwk.anglesite", category: "relevant-entities")
 
-/// Public entry point that registers production dependencies with `AppDependencyManager` and
-/// hooks the Spotlight indexer to `SiteStore.shared`.
-///
-/// Async so the call site can await handler installation before driving any `SiteStore`
-/// mutations — that way a caller in an async context (e.g. #101's system MCP entry from a
-/// non-UI process) gets the indexer reliably set up before they touch the store.
-///
-/// `contentGraph` is the single, app-lifetime `SiteContentGraph` instance the app owns and
-/// passes in. We register it with `AppDependencyManager` so `@Dependency private var graph:
-/// SiteContentGraph` resolves to the same instance in every `PageEntityQuery` /
-/// `PostEntityQuery` / `ImageEntityQuery` instantiation by the AppIntents runtime. A.1's
-/// design explicitly rules out a process-wide `SiteContentGraph.shared` — ownership stays
-/// with the app, threaded through here.
-///
-/// The kicker `try await SiteStore.shared.load()` inside is belt-and-suspenders for the
-/// SwiftUI case: `AppDelegate.applicationDidFinishLaunching` can only fire-and-forget us in a
-/// `Task`, which races with the launcher view's own `task` modifier. The handler is registered
-/// before the load here, so the load *will* emit even if the launcher already raced ahead and
-/// missed it — emission is idempotent (the indexer dedups by id set).
-
 /// Fallback interpreter used when the Xcode-27 / `FoundationModels` toolchain is absent (CI).
 /// Always throws `.unavailable` so the intent's catch path surfaces the "needs Apple Intelligence"
 /// dialog rather than a fatalError from the missing `@Dependency` factory.
@@ -35,7 +15,33 @@ private struct UnavailableEditInterpreter: EditInterpreting {
     }
 }
 
+/// Namespace for the intents-side process setup. Caseless — there is no instance state; all
+/// the wiring lands in `AppDependencyManager` registrations and the long-lived change handlers
+/// installed by ``bootstrap(contentGraph:)``.
 public enum AnglesiteIntents {
+    /// Public entry point that registers production dependencies with `AppDependencyManager` and
+    /// hooks the Spotlight indexer to `SiteStore.shared`.
+    ///
+    /// Async so the call site can await handler installation before driving any `SiteStore`
+    /// mutations — that way a caller in an async context (e.g. #101's system MCP entry from a
+    /// non-UI process) gets the indexer reliably set up before they touch the store.
+    ///
+    /// `contentGraph` is the single, app-lifetime `SiteContentGraph` instance the app owns and
+    /// passes in. We register it with `AppDependencyManager` so `@Dependency private var graph:
+    /// SiteContentGraph` resolves to the same instance in every ``PageEntityQuery`` /
+    /// ``PostEntityQuery`` / ``ImageEntityQuery`` instantiation by the AppIntents runtime. A.1's
+    /// design explicitly rules out a process-wide `SiteContentGraph.shared` — ownership stays
+    /// with the app, threaded through here.
+    ///
+    /// The kicker `try await SiteStore.shared.load()` inside is belt-and-suspenders for the
+    /// SwiftUI case: `AppDelegate.applicationDidFinishLaunching` can only fire-and-forget us in a
+    /// `Task`, which races with the launcher view's own `task` modifier. The handler is registered
+    /// before the load here, so the load *will* emit even if the launcher already raced ahead and
+    /// missed it — emission is idempotent (the indexer dedups by id set).
+    ///
+    /// - Returns: The ``ContentSpotlightIndexer`` wired to `contentGraph`, so the app can hand it
+    ///   to surfaces that probe index state (the Siri-readiness checks in `SiteWindowModel`).
+    ///   Discardable for callers that only need the side-effectful registrations.
     @discardableResult
     public static func bootstrap(contentGraph: SiteContentGraph) async -> ContentSpotlightIndexer {
         // Singleton-factory: the closure always returns the same pre-constructed `contentGraph`

--- a/Sources/AnglesiteIntents/ConfirmationOverride.swift
+++ b/Sources/AnglesiteIntents/ConfirmationOverride.swift
@@ -1,7 +1,22 @@
 /// Test seam for the confirmation outcome. `requestConfirmation` is not introspectable under
 /// `swift test` (no intentsd / registered app), so the decline-path test drives this instead.
-public enum ConfirmationDecision: Sendable { case confirm, decline }
+public enum ConfirmationDecision: Sendable {
+    /// Proceed as if the user accepted Siri's confirmation dialog — the intent falls through
+    /// to the apply step.
+    case confirm
+    /// Abort as if the user declined — ``EditContentIntent`` returns its "Okay, I won't
+    /// change …" dialog before applying anything, leaving the page untouched.
+    case decline
+}
 
+/// `@TaskLocal` binding point for ``ConfirmationDecision``. ``EditContentIntent`` consults
+/// ``scoped`` before calling `requestConfirmation`: a bound value short-circuits the real Siri
+/// dialog entirely (there is no way to programmatically answer one), while `nil` — always the
+/// case in production — falls through to the real confirmation. Same task-local pattern as
+/// `ContentGraphOverride` / `SiteOperationsOverride`.
 public enum ConfirmationOverride {
+    /// The decision for the current task tree. Defaults to `nil` (real confirmation dialog);
+    /// tests bind it with `ConfirmationOverride.$scoped.withValue(...)` around the intent's
+    /// perform call.
     @TaskLocal public static var scoped: ConfirmationDecision?
 }

--- a/Sources/AnglesiteIntents/ContentEntities.swift
+++ b/Sources/AnglesiteIntents/ContentEntities.swift
@@ -7,19 +7,35 @@ import Foundation
 /// An Anglesite page, addressable by Siri/Shortcuts. Backed live by `SiteContentGraph` —
 /// no cache, so the entity never goes stale relative to the graph state.
 public struct PageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
-    public let id: String            // "{siteID}:page:{route}" — same as SiteContentGraph.Page.id
-    public let displayName: String   // title ?? route
+    /// Stable identifier `"{siteID}:page:{route}"` — identical to `SiteContentGraph.Page.id`,
+    /// so Spotlight results and persisted Shortcuts references round-trip through
+    /// ``PageEntityQuery/entities(for:)`` with no mapping table.
+    public let id: String
+    /// The page's title, falling back to its route when the front matter has none — matching
+    /// what Spotlight shows as the result title, so a title-less page is still findable.
+    public let displayName: String
+    /// Site-relative route (e.g. `/about/`), exposed as a Shortcuts property so workflows can
+    /// filter or display it.
     @Property(title: "Route") public var route: String
+    /// Owning site's stable UUID string, tying the entity back to its `SiteStore` site and
+    /// `SiteContentGraph` partition.
     @Property(title: "Site") public var siteID: String
 
+    /// "Page" — the type name Siri/Shortcuts show in parameter pickers and disambiguation.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Page" }
 
+    /// Title plus route subtitle, so identically-titled pages on different routes stay
+    /// distinguishable in Siri's disambiguation list.
     public var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(title: "\(displayName)", subtitle: "\(route)")
     }
 
+    /// The query AppIntents uses to resolve `@Parameter` page references and drive Spotlight
+    /// indexing for this entity type.
     public static let defaultQuery = PageEntityQuery()
 
+    /// Projects a live graph row into the entity. The title-to-route fallback for
+    /// ``displayName`` lives here so every graph-sourced entity gets it consistently.
     public init(_ page: SiteContentGraph.Page) {
         self.id = page.id
         self.displayName = page.title ?? page.route
@@ -27,6 +43,8 @@ public struct PageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         self.siteID = page.siteID
     }
 
+    /// Memberwise initializer for callers without a graph row (test fixtures, reconstruction
+    /// from a persisted identifier). Applies no fallback logic — values are stored as given.
     public init(id: String, displayName: String, route: String, siteID: String) {
         self.id = id
         self.displayName = displayName
@@ -40,6 +58,8 @@ public struct PageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
 public struct PageEntityQuery: EntityStringQuery {
     @Dependency private var graph: SiteContentGraph
 
+    /// Required by the AppIntents runtime, which instantiates queries itself; the graph arrives
+    /// via `@Dependency` (registered in `AnglesiteIntents.bootstrap(contentGraph:)`), not here.
     public init() {}
 
     private var resolved: SiteContentGraph {
@@ -48,11 +68,16 @@ public struct PageEntityQuery: EntityStringQuery {
         ContentGraphOverride.scoped ?? graph
     }
 
+    /// Round-trips persisted identifiers (Spotlight results, saved Shortcuts) back to live
+    /// entities. Unknown ids are silently dropped — a since-deleted page just vanishes from an
+    /// old shortcut instead of failing the whole run.
     public func entities(for identifiers: [String]) async throws -> [PageEntity] {
         // Single actor hop for all ids (#170); the graph preserves input order and skips unknowns.
         await resolved.pages(ids: identifiers).map(PageEntity.init)
     }
 
+    /// Natural-language lookup across every loaded site, newest-first with id as the stable
+    /// tiebreaker. An empty/whitespace query deliberately returns `[]` — see the guard comment.
     public func entities(matching string: String) async throws -> [PageEntity] {
         // Empty / whitespace-only query → []. The graph's searchPages returns everything on
         // empty input; surfacing that here would double up with suggestedEntities() during
@@ -72,6 +97,9 @@ public struct PageEntityQuery: EntityStringQuery {
             .map(PageEntity.init)
     }
 
+    /// Every page across all loaded sites, newest-first — what Shortcuts offers before the user
+    /// types anything. Distinct from ``entities(matching:)`` so the two surfaces never overlap
+    /// during AppIntents' disambiguation prefetch.
     public func suggestedEntities() async throws -> [PageEntity] {
         let g = resolved
         var all: [SiteContentGraph.Page] = []
@@ -87,6 +115,8 @@ public struct PageEntityQuery: EntityStringQuery {
             .map(PageEntity.init)
     }
 
+    /// No default: with multiple sites loaded there is no meaningful "first page", so parameter
+    /// resolution always prompts rather than silently picking one.
     public func defaultResult() async -> PageEntity? { nil }
 }
 
@@ -94,17 +124,35 @@ public struct PageEntityQuery: EntityStringQuery {
 
 /// An Anglesite blog post / content-collection entry, addressable by Siri/Shortcuts.
 public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
-    public let id: String            // "{siteID}:post:{slug}"
-    public let displayName: String   // title
+    /// Stable identifier `"{siteID}:post:{slug}"` — identical to `SiteContentGraph.Post.id`, so
+    /// Spotlight/Shortcuts references round-trip through ``PostEntityQuery/entities(for:)``.
+    public let id: String
+    /// The post's front-matter title. Unlike ``PageEntity/displayName`` there is no fallback —
+    /// a collection entry always has a title in the graph.
+    public let displayName: String
+    /// URL slug within its collection, exposed as a Shortcuts property for filtering/display.
     @Property(title: "Slug") public var slug: String
+    /// Astro content-collection directory name (`blog`, `notes`, …) the entry lives in.
     @Property(title: "Collection") public var collection: String
+    /// Human-readable content-type display name (the typed dimension of #351), derived from the
+    /// collection via ``contentTypeName(forCollection:)`` — surfaced so Shortcuts/Spotlight show
+    /// "Note"/"Recipe" rather than a raw directory name.
     @Property(title: "Type") public var contentType: String
+    /// Front-matter draft flag; surfaced in the subtitle so unpublished work is visibly marked
+    /// in Siri results before the user acts on it.
     public let isDraft: Bool
+    /// Front-matter tags, carried so index/search layers can use them without re-reading the
+    /// file. Not a `@Property` today — plain storage keeps adding one later non-breaking.
     public let tags: [String]
+    /// Owning site's stable UUID string, tying the entity back to its `SiteStore` site and
+    /// `SiteContentGraph` partition.
     @Property(title: "Site") public var siteID: String
 
+    /// "Post" — the type name Siri/Shortcuts show in parameter pickers and disambiguation.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Post" }
 
+    /// Title plus `collection/slug` subtitle, with an explicit "(draft)" marker so drafts are
+    /// distinguishable from published entries in Siri's disambiguation list.
     public var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(
             title: "\(displayName)",
@@ -112,6 +160,8 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         )
     }
 
+    /// The query AppIntents uses to resolve `@Parameter` post references and drive Spotlight
+    /// indexing for this entity type.
     public static let defaultQuery = PostEntityQuery()
 
     /// Typed dimension (#351): map a post's collection back to its content type's display name via
@@ -121,6 +171,8 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         ContentTypeRegistry.default.descriptor(forCollection: collection)?.displayName ?? collection
     }
 
+    /// Projects a live graph row into the entity, deriving ``contentType`` from the collection
+    /// so no caller can index a blank "Type" attribute.
     public init(_ post: SiteContentGraph.Post) {
         self.id = post.id
         self.displayName = post.title
@@ -132,6 +184,10 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
         self.contentType = Self.contentTypeName(forCollection: post.collection)
     }
 
+    /// Memberwise initializer for callers without a graph row (test fixtures, freshly created
+    /// posts — see `AddPostIntent`). Defaults lean conservative: `isDraft` is `true` because the
+    /// creation flows that use this init scaffold drafts, and an empty `contentType` is derived
+    /// from `collection` at assignment (a default parameter can't reference another parameter).
     public init(id: String, displayName: String, slug: String, collection: String,
                 siteID: String, isDraft: Bool = true, tags: [String] = [],
                 contentType: String = "") {
@@ -153,17 +209,24 @@ public struct PostEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
 public struct PostEntityQuery: EntityStringQuery {
     @Dependency private var graph: SiteContentGraph
 
+    /// Required by the AppIntents runtime, which instantiates queries itself; the graph arrives
+    /// via `@Dependency` (registered in `AnglesiteIntents.bootstrap(contentGraph:)`), not here.
     public init() {}
 
     private var resolved: SiteContentGraph {
         ContentGraphOverride.scoped ?? graph
     }
 
+    /// Round-trips persisted identifiers back to live entities; unknown ids are silently
+    /// dropped. Same contract as ``PageEntityQuery/entities(for:)``.
     public func entities(for identifiers: [String]) async throws -> [PostEntity] {
         // Single actor hop for all ids (#170); the graph preserves input order and skips unknowns.
         await resolved.posts(ids: identifiers).map(PostEntity.init)
     }
 
+    /// Natural-language lookup across every loaded site, newest-first. Matching spans title,
+    /// slug, tags, and collection (delegated to the graph's `searchPosts`); an empty query
+    /// deliberately returns `[]` — see the guard comment.
     public func entities(matching string: String) async throws -> [PostEntity] {
         // Empty / whitespace-only query → []. The graph's searchPosts returns everything on
         // empty input; surfacing that here would double up with suggestedEntities() during
@@ -183,6 +246,8 @@ public struct PostEntityQuery: EntityStringQuery {
             .map(PostEntity.init)
     }
 
+    /// Every post across all loaded sites, newest-first — kept distinct from
+    /// ``entities(matching:)`` so the two surfaces never overlap during disambiguation prefetch.
     public func suggestedEntities() async throws -> [PostEntity] {
         let g = resolved
         var all: [SiteContentGraph.Post] = []
@@ -198,6 +263,7 @@ public struct PostEntityQuery: EntityStringQuery {
             .map(PostEntity.init)
     }
 
+    /// No default — same multi-site reasoning as ``PageEntityQuery/defaultResult()``.
     public func defaultResult() async -> PostEntity? { nil }
 }
 
@@ -205,8 +271,14 @@ public struct PostEntityQuery: EntityStringQuery {
 
 /// An image asset under `public/images/` (or anywhere referenced), addressable by Siri/Shortcuts.
 public struct ImageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
-    public let id: String            // "{siteID}:image:{relativePath}"
-    public let displayName: String   // fileName
+    /// Stable identifier `"{siteID}:image:{relativePath}"` — identical to
+    /// `SiteContentGraph.Image.id`, so Spotlight/Shortcuts references round-trip through
+    /// ``ImageEntityQuery/entities(for:)``.
+    public let id: String
+    /// The image's file name (no directory), matching what Spotlight shows as the result title.
+    public let displayName: String
+    /// Path relative to the site source (e.g. `public/images/hero.jpg`), exposed as a Shortcuts
+    /// property; also the subtitle, since file names alone often collide across directories.
     @Property(title: "Path") public var relativePath: String
     /// Project-relative source file paths that reference this image (per `DeadAssetScanner`,
     /// not routes — may include non-page files like `.css`/`.ts` alongside actual pages).
@@ -214,16 +286,25 @@ public struct ImageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
     /// isn't a source-breaking AppEntity schema change for Shortcuts persistence / donated
     /// interactions.
     public let usedOnPages: [String]
+    /// Owning site's stable UUID string, tying the entity back to its `SiteStore` site and
+    /// `SiteContentGraph` partition.
     @Property(title: "Site") public var siteID: String
 
+    /// "Image" — the type name Siri/Shortcuts show in parameter pickers and disambiguation.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Image" }
 
+    /// File name plus relative-path subtitle, so same-named images in different directories
+    /// stay distinguishable in Siri's disambiguation list.
     public var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(title: "\(displayName)", subtitle: "\(relativePath)")
     }
 
+    /// The query AppIntents uses to resolve `@Parameter` image references and drive Spotlight
+    /// indexing for this entity type.
     public static let defaultQuery = ImageEntityQuery()
 
+    /// Projects a live graph row into the entity. The only initializer — images are never
+    /// synthesized outside the graph, so no memberwise variant exists.
     public init(_ image: SiteContentGraph.Image) {
         self.id = image.id
         self.displayName = image.fileName
@@ -238,17 +319,24 @@ public struct ImageEntity: AppEntity, IndexedEntity, Identifiable, Sendable {
 public struct ImageEntityQuery: EntityStringQuery {
     @Dependency private var graph: SiteContentGraph
 
+    /// Required by the AppIntents runtime, which instantiates queries itself; the graph arrives
+    /// via `@Dependency` (registered in `AnglesiteIntents.bootstrap(contentGraph:)`), not here.
     public init() {}
 
     private var resolved: SiteContentGraph {
         ContentGraphOverride.scoped ?? graph
     }
 
+    /// Round-trips persisted identifiers back to live entities; unknown ids are silently
+    /// dropped. Same contract as ``PageEntityQuery/entities(for:)``.
     public func entities(for identifiers: [String]) async throws -> [ImageEntity] {
         // Single actor hop for all ids (#170); the graph preserves input order and skips unknowns.
         await resolved.images(ids: identifiers).map(ImageEntity.init)
     }
 
+    /// Natural-language lookup across every loaded site, newest-first. Matching spans file name
+    /// and relative path (delegated to the graph's `searchImages`); an empty query deliberately
+    /// returns `[]` — see the guard comment.
     public func entities(matching string: String) async throws -> [ImageEntity] {
         // Empty / whitespace-only query → []. The graph's searchImages returns everything on
         // empty input; surfacing that here would double up with suggestedEntities() during
@@ -268,6 +356,8 @@ public struct ImageEntityQuery: EntityStringQuery {
             .map(ImageEntity.init)
     }
 
+    /// Every image across all loaded sites, newest-first — kept distinct from
+    /// ``entities(matching:)`` so the two surfaces never overlap during disambiguation prefetch.
     public func suggestedEntities() async throws -> [ImageEntity] {
         let g = resolved
         var all: [SiteContentGraph.Image] = []
@@ -283,5 +373,6 @@ public struct ImageEntityQuery: EntityStringQuery {
             .map(ImageEntity.init)
     }
 
+    /// No default — same multi-site reasoning as ``PageEntityQuery/defaultResult()``.
     public func defaultResult() async -> ImageEntity? { nil }
 }

--- a/Sources/AnglesiteIntents/ContentHelpIntents.swift
+++ b/Sources/AnglesiteIntents/ContentHelpIntents.swift
@@ -9,22 +9,34 @@ import Foundation
 /// and it's reserved for higher-traffic intents; ReviewCopyIntent stays discoverable via the
 /// Shortcuts app and via `SiteEntityQuery` resolution.
 public struct ReviewCopyIntent: AppIntent {
+    /// Action name in the Shortcuts library. Says "Site Copy", not just "Copy", to avoid
+    /// reading as a clipboard/duplicate action out of context.
     public static let title: LocalizedStringResource = "Review Site Copy"
+    /// Shortcuts-editor blurb; names the audit dimensions so users know what "review" covers.
     public static let description = IntentDescription(
         "Review a site's written copy for clarity, tone, and calls to action.")
 
+    /// The site to audit, resolved by ``SiteEntityQuery`` so "review copy on my portfolio"
+    /// matches by name.
     @Parameter(title: "Site") public var site: SiteEntity
 
+    /// Required by the AppIntents runtime; parameters are populated after init.
     public init() {}
+    /// Convenience for programmatic invocation with the site already resolved (tests, chaining
+    /// from another intent's `SiteEntity` result).
     public init(site: SiteEntity) {
         self.init()
         self.site = site
     }
 
+    /// One-line Shortcuts-editor rendering: "Review copy on <site>".
     public static var parameterSummary: some ParameterSummary {
         Summary("Review copy on \(\.$site)")
     }
 
+    /// Runs the audit and speaks/shows the summary. All outcome branching lives in the private
+    /// `run()` so the internal `performForTesting()` can share it — `IntentDialog` exposes no
+    /// way to read its text back out of a real `perform()` result.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         .result(dialog: IntentDialog(stringLiteral: try await run()))
     }
@@ -73,21 +85,34 @@ extension ReviewCopyIntent {
 /// Not registered in AnglesiteShortcuts: same phrase-budget reasoning as `ReviewCopyIntent` —
 /// stays discoverable via the Shortcuts app and via `SiteEntityQuery` resolution.
 public struct PlanSocialMediaIntent: AppIntent {
+    /// Action name in the Shortcuts library.
     public static let title: LocalizedStringResource = "Plan Social Media"
+    /// Shortcuts-editor blurb; "plan and content calendar" signals the persisted-markdown
+    /// deliverable, not just a spoken reply.
     public static let description = IntentDescription(
         "Generate a social media plan and content calendar for a site.")
 
+    /// The site to plan for, resolved by ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// Planning horizon. Defaults to 4; `run()` clamps it to 1…8 rather than erroring, so a
+    /// Shortcut passing a wild value still gets a usable plan.
     @Parameter(title: "Weeks", default: 4) public var weeks: Int
 
+    /// Required by the AppIntents runtime; parameters are populated after init.
     public init() {}
 
+    /// One-line Shortcuts-editor rendering, with `weeks` demoted to the disclosure group so the
+    /// summary stays a single sentence.
     public static var parameterSummary: some ParameterSummary {
         Summary("Plan social media for \(\.$site)") {
             \.$weeks
         }
     }
 
+    /// Generates the plan, confirms with the user (this intent writes
+    /// `docs/social-calendar.md` into the site repo), then saves and reports. Branching lives
+    /// in the private `run()` shared with the internal `performForTesting()` — see
+    /// ``ReviewCopyIntent/perform()``.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         .result(dialog: IntentDialog(stringLiteral: try await run()))
     }
@@ -139,20 +164,33 @@ extension PlanSocialMediaIntent {
 /// `PlanSocialMediaIntent` — stays discoverable via the Shortcuts app and via `SiteEntityQuery`
 /// resolution.
 public struct RepurposePostIntent: AppIntent {
+    /// Action name in the Shortcuts library.
     public static let title: LocalizedStringResource = "Repurpose Post"
+    /// Shortcuts-editor blurb; "platform-sized" flags that variants come pre-fitted to each
+    /// platform's length limits.
     public static let description = IntentDescription(
         "Draft platform-sized social posts from one of a site's blog posts.")
 
+    /// The site owning the post, resolved by ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// The post to repurpose, identified by slug and loaded straight from the repo via
+    /// `PostSource` (not resolved through ``PostEntityQuery``, whose graph is only populated
+    /// while the site is open in a window). An unknown slug fails with a spoken error naming it.
     @Parameter(title: "Post Slug", description: "The post's slug, e.g. 'coast-trip'.")
     public var slug: String
 
+    /// Required by the AppIntents runtime; parameters are populated after init.
     public init() {}
 
+    /// One-line Shortcuts-editor rendering: "Repurpose <slug> from <site>".
     public static var parameterSummary: some ParameterSummary {
         Summary("Repurpose \(\.$slug) from \(\.$site)")
     }
 
+    /// Drafts the variants and returns them twice: the full text block as the intent's *value*
+    /// (pipeable into a share/clipboard action in a Shortcut) and a short summary as the spoken
+    /// *dialog*. Branching lives in the private `run()` shared with the internal
+    /// `performForTesting()` — see ``ReviewCopyIntent/perform()``.
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<String> {
         let (value, dialog) = try await run()
         return .result(value: value, dialog: IntentDialog(stringLiteral: dialog))

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -20,23 +20,38 @@ import Foundation
 
 // MARK: - Search
 
+/// Searches one site's pages, posts, and images in a single pass, returning uniform
+/// ``ContentMatchEntity`` projections so an agent or Shortcut can search-then-act across all
+/// three content kinds without running three typed queries. Read-only against
+/// `SiteContentGraph`; no MCP round-trip.
 public struct SearchContentIntent: AppIntent {
+    /// The verb phrase Shortcuts/Siri/Spotlight show for this action.
     public static let title: LocalizedStringResource = "Search Site Content"
+    /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Search a site's pages, posts, and images.")
 
+    /// The site to search, resolved by ``SiteEntityQuery`` from the recents registry.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// Free-text term. A blank/whitespace query returns no matches rather than the whole
+    /// content graph (#234) — see `matches(graph:siteID:query:)`.
     @Parameter(
         title: "Search",
         description: "Words to match against page titles, post titles, slugs, tags, and image filenames."
     ) public var query: String
     @Dependency private var graph: SiteContentGraph
 
+    /// Required by `AppIntent`; the AppIntents runtime fills the `@Parameter` values after
+    /// construction.
     public init() {}
 
+    /// The sentence the Shortcuts editor renders: "Search *site* for *query*".
     public static var parameterSummary: some ParameterSummary {
         Summary("Search \(\.$site) for \(\.$query)")
     }
 
+    /// Gathers matches (test override first, then the `@Dependency` graph) and speaks the
+    /// per-kind counts. All real logic lives in the static helpers below so it's testable
+    /// without the AppIntents runtime.
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<[ContentMatchEntity]> {
         let g = ContentGraphOverride.scoped ?? graph
         let matches = await Self.matches(graph: g, siteID: site.id, query: query)
@@ -85,19 +100,29 @@ public struct SearchContentIntent: AppIntent {
 /// Lists a site's content of one type (#351). The typed counterpart to `SearchContentIntent`:
 /// resolves the type's collection from the registry and filters the graph's posts by it.
 public struct FindContentByTypeIntent: AppIntent {
+    /// The verb phrase Shortcuts/Siri/Spotlight show for this action.
     public static let title: LocalizedStringResource = "Find Content by Type"
+    /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("List a site's content of a given type, e.g. events or reviews.")
 
+    /// The site whose content to list, resolved by ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// The typed kind to filter by — an `AppEnum` so Shortcuts offers a picker instead of a
+    /// free-text collection name.
     @Parameter(title: "Type") public var contentType: ContentTypeAppEnum
     @Dependency private var graph: SiteContentGraph
 
+    /// Required by `AppIntent`; the AppIntents runtime fills the `@Parameter` values after
+    /// construction.
     public init() {}
 
+    /// The sentence the Shortcuts editor renders: "Find *type* in *site*".
     public static var parameterSummary: some ParameterSummary {
         Summary("Find \(\.$contentType) in \(\.$site)")
     }
 
+    /// Filters the graph's posts to the type's collection and speaks the count, using the
+    /// registry display name so the dialog says "events", not a raw enum value.
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<[PostEntity]> {
         let g = ContentGraphOverride.scoped ?? graph
         let results = await Self.matches(graph: g, siteID: site.id, type: contentType)
@@ -126,17 +151,27 @@ public struct FindContentByTypeIntent: AppIntent {
 
 // MARK: - Status
 
+/// Speaks a one-sentence content inventory — pages, posts (with draft count), images — for a
+/// site. The quick "how much is on my site?" Siri/Shortcuts query; read-only against
+/// `SiteContentGraph`.
 public struct SiteStatusIntent: AppIntent {
+    /// The verb phrase Shortcuts/Siri/Spotlight show for this action.
     public static let title: LocalizedStringResource = "Site Content Status"
+    /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Report how much content a site has.")
 
+    /// The site to report on, resolved by ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var graph: SiteContentGraph
 
+    /// Required by `AppIntent`; the AppIntents runtime fills the `@Parameter` values after
+    /// construction.
     public init() {}
 
+    /// The sentence the Shortcuts editor renders: "Status of *site*".
     public static var parameterSummary: some ParameterSummary { Summary("Status of \(\.$site)") }
 
+    /// Counts the site's content (test override first) and speaks the summary.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let dialog = await Self.dialog(graph: ContentGraphOverride.scoped ?? graph, siteID: site.id, siteName: site.displayName)
         return .result(dialog: IntentDialog(stringLiteral: dialog))
@@ -163,17 +198,28 @@ public struct SiteStatusIntent: AppIntent {
 /// route rides along on the open request; `SiteWindow` consumes it and navigates the preview's
 /// WKWebView to that page once the dev server is ready (cold-open included).
 public struct PreviewSiteIntent: AppIntent {
+    /// The verb phrase Shortcuts/Siri/Spotlight show for this action.
     public static let title: LocalizedStringResource = "Preview Site"
+    /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Open a site's live preview in Anglesite.")
+    /// Previewing is a GUI outcome — the app must come forward for the requested window to be
+    /// seen, so this can't run as a background intent.
     public static let openAppWhenRun = true
 
+    /// The site to preview, resolved by ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// Optional page to navigate to once the dev server is up; `nil` opens the site's root.
     @Parameter(title: "Page") public var page: PageEntity?
 
+    /// Required by `AppIntent`; the AppIntents runtime fills the `@Parameter` values after
+    /// construction.
     public init() {}
 
+    /// The sentence the Shortcuts editor renders: "Preview *site*".
     public static var parameterSummary: some ParameterSummary { Summary("Preview \(\.$site)") }
 
+    /// Posts the open request to ``WindowRouter`` (main-actor — the router is UI state the
+    /// "Sites" scene observes) and confirms; the window itself opens asynchronously.
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         WindowRouter.shared.requestOpen(siteID: site.id, route: page?.route)
@@ -183,27 +229,41 @@ public struct PreviewSiteIntent: AppIntent {
 
 // MARK: - Add Page
 
+/// Scaffolds a new page via `ContentOperationsService` and returns the created ``PageEntity``
+/// (nil on failure) so a Shortcut can chain create → preview. Long-running/cancellable on
+/// Xcode 27 (see the gated extension at the bottom of this file): first use may spawn the
+/// plugin's Node MCP server, which can exceed the default intent budget.
 public struct AddPageIntent: AppIntent {
+    /// The verb phrase Shortcuts/Siri/Spotlight show for this action.
     public static let title: LocalizedStringResource = "Add Page"
+    /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Scaffold a new page on a site with Anglesite.")
 
+    /// The site to add the page to, resolved by ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// The page title; also the source of the derived route when none is given.
     @Parameter(
         title: "Name",
         description: "The page title, e.g. “About” or “Contact”."
     ) public var name: String
+    /// Optional explicit route; `nil` lets the create path derive one from `name`.
     @Parameter(
         title: "Route",
         description: "Optional URL path relative to the site root, e.g. “/about”. Derived from the name when omitted."
     ) public var route: String?
     @Dependency private var content: any ContentOperationsService
 
+    /// Required by `AppIntent`; the AppIntents runtime fills the `@Parameter` values after
+    /// construction.
     public init() {}
 
+    /// The sentence the Shortcuts editor renders: "Add page *name* to *site*".
     public static var parameterSummary: some ParameterSummary {
         Summary("Add page \(\.$name) to \(\.$site)")
     }
 
+    /// Runs the create through the service (test override first), then speaks the outcome and
+    /// returns the created entity — or a cancellation dialog when the user hit Cancel mid-run.
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<PageEntity?> {
         let scoped = ContentOperationsOverride.scoped
         let svc = scoped ?? content
@@ -243,32 +303,46 @@ extension AddPageIntent {
 
 // MARK: - Add Post
 
+/// Scaffolds a new draft post via `ContentOperationsService` and returns the created
+/// ``PostEntity`` (nil on failure). Same long-running/cancellable shape as ``AddPageIntent``
+/// (gated extension at the bottom of this file).
 public struct AddPostIntent: AppIntent {
+    /// The verb phrase Shortcuts/Siri/Spotlight show for this action.
     public static let title: LocalizedStringResource = "Add Post"
+    /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Scaffold a new draft post on a site with Anglesite.")
 
+    /// The site to add the post to, resolved by ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// The post title. Named `title2` only because `title` collides with the `AppIntent.title`
+    /// static requirement; it still presents to the user as "Title".
     @Parameter(
         title: "Title",
         description: "The post title."
     ) public var title2: String
+    /// Optional collection to file the post in; `nil` uses the site's default.
     @Parameter(
         title: "Collection",
         description: "Optional content collection to add the post to, e.g. “blog”. Uses the site default when omitted."
     ) public var collection: String?
+    /// Optional explicit slug; `nil` lets the create path derive one from the title.
     @Parameter(
         title: "Slug",
         description: "Optional URL slug for the post, e.g. “my-first-post”. Derived from the title when omitted."
     ) public var slug: String?
     @Dependency private var content: any ContentOperationsService
 
+    /// Required by `AppIntent`; the AppIntents runtime fills the `@Parameter` values after
+    /// construction.
     public init() {}
 
-    // `title` is taken by `AppIntent.title`; the parameter is `title2` but presents as "Title".
+    /// The sentence the Shortcuts editor renders: "Add post *title* to *site*".
     public static var parameterSummary: some ParameterSummary {
         Summary("Add post \(\.$title2) to \(\.$site)")
     }
 
+    /// Runs the create through the service (test override first), then speaks the outcome and
+    /// returns the created entity — or a cancellation dialog when the user hit Cancel mid-run.
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<PostEntity?> {
         let scoped = ContentOperationsOverride.scoped
         let svc = scoped ?? content
@@ -319,9 +393,22 @@ extension AddPostIntent: LongRunningIntent, CancellableIntent {}
 
 // MARK: - Dialog formatting (pure, unit-testable)
 
+/// Every spoken/dialog string the content intents produce, as pure static formatters. Keeping
+/// the wording here — never inline in a `perform()` — is what makes it unit-testable without
+/// the AppIntents runtime (the promise in this file's header).
 public enum ContentDialogs {
-    public enum CreateKind: String, Sendable { case page, post }
+    /// Which create operation a dialog refers to — picks the noun in the
+    /// ``ContentDialogs/canceled(kind:siteName:)`` / ``ContentDialogs/created(_:kind:siteName:)``
+    /// wording.
+    public enum CreateKind: String, Sendable {
+        /// A route-addressed page (``AddPageIntent``).
+        case page
+        /// A collection-addressed post (``AddPostIntent``).
+        case post
+    }
 
+    /// Spoken result for ``FindContentByTypeIntent``: "Found 3 events." Pass a registry display
+    /// name — `pluralize` below is only correct for the built-in type names.
     public static func findByType(typeName: String, count: Int) -> String {
         let plural = pluralize(typeName, count)
         guard count > 0 else { return "No \(plural) found." }
@@ -339,6 +426,8 @@ public enum ContentDialogs {
         return lower + "s"
     }
 
+    /// Spoken result for ``SearchContentIntent``: per-kind counts as a natural-language list,
+    /// with zero-count kinds omitted; a blank query prompts for a term instead (#234).
     public static func search(query: String, pageCount: Int, postCount: Int, imageCount: Int) -> String {
         // #234: a blank query means "no term given", not "no results" — prompt instead of echoing `Nothing matched “”.`.
         guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -353,11 +442,15 @@ public enum ContentDialogs {
         return "Found \(list(parts)) matching “\(query)”."
     }
 
+    /// Spoken result for ``SiteStatusIntent``. The draft count rides along parenthetically, and
+    /// only when nonzero — "0 drafts" is noise for the common all-published case.
     public static func status(siteName: String, pages: Int, posts: Int, drafts: Int, images: Int) -> String {
         let draftNote = drafts > 0 ? " (\(drafts) draft\(drafts == 1 ? "" : "s"))" : ""
         return "\(siteName) has \(count(pages, "page")), \(count(posts, "post"))\(draftNote), and \(count(images, "image"))."
     }
 
+    /// Spoken confirmation for ``PreviewSiteIntent`` — page-specific when a page was requested,
+    /// so the user hears which page is about to appear.
     public static func preview(siteName: String, pageName: String? = nil) -> String {
         if let pageName { return "Opening the \(pageName) page of \(siteName)." }
         return "Opening \(siteName)."
@@ -371,6 +464,8 @@ public enum ContentDialogs {
         }
     }
 
+    /// Maps a `ContentCreateResult` to its spoken outcome. Success names the created identifier
+    /// (route or slug) so the user hears where the content landed, not just that it worked.
     public static func created(_ result: ContentCreateResult, kind: CreateKind, siteName: String) -> String {
         switch result {
         case .created(_, let identifier):

--- a/Sources/AnglesiteIntents/ContentMatchEntity.swift
+++ b/Sources/AnglesiteIntents/ContentMatchEntity.swift
@@ -4,9 +4,17 @@ import AnglesiteCore
 /// The kind of content a search match refers to. An `AppEnum` so it appears as a typed
 /// field in the auto-derived MCP/Shortcuts schema (not just a string).
 public enum ContentMatchKind: String, AppEnum, Sendable {
-    case page, post, image
+    /// The match is a route-addressed page (projected from a ``PageEntity``).
+    case page
+    /// The match is a collection entry (projected from a ``PostEntity``).
+    case post
+    /// The match is a media asset (projected from an ``ImageEntity``).
+    case image
 
+    /// Type name shown in Shortcuts and the derived MCP schema.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Kind" }
+    /// Capitalized labels for pickers and result subtitles; the raw values stay lowercase for
+    /// the schema.
     public static var caseDisplayRepresentations: [ContentMatchKind: DisplayRepresentation] {
         [.page: "Page", .post: "Post", .image: "Image"]
     }
@@ -17,30 +25,45 @@ public enum ContentMatchKind: String, AppEnum, Sendable {
 /// match straight to any intent that resolves the concrete type. `SearchContentIntent`
 /// returns these so an agent can search-then-act across all three content kinds at once.
 public struct ContentMatchEntity: AppEntity, Identifiable, Sendable {
+    /// The underlying concrete entity's id, unchanged ("{siteID}:{kind}:{path}") — the property
+    /// that lets ``ContentMatchEntityQuery`` route resolution back to the concrete queries.
     public let id: String
+    /// Which concrete entity type this match projects — the discriminator agents branch on.
     @Property(title: "Kind") public var kind: ContentMatchKind
+    /// The entity's display name (page/post title or image filename).
     @Property(title: "Title") public var title: String
-    @Property(title: "Path") public var path: String   // route | slug | relativePath
+    /// Kind-specific locator: a page's route, a post's slug, or an image's relative path.
+    @Property(title: "Path") public var path: String
+    /// The owning site's id, so a match can be scoped back without re-parsing `id`.
     @Property(title: "Site") public var siteID: String
 
+    /// Type name shown in Shortcuts and the derived MCP schema.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Match" }
 
+    /// Title + "kind: path" subtitle, so mixed-kind result lists stay distinguishable at a
+    /// glance.
     public var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(title: "\(title)", subtitle: "\(kind.rawValue): \(path)")
     }
 
+    /// Required by `AppEntity`; see ``ContentMatchEntityQuery`` for the id-routing behavior.
     public static let defaultQuery = ContentMatchEntityQuery()
 
+    /// Memberwise. Prefer the projection initializers below when starting from a concrete
+    /// entity — they keep the id/kind/path invariants aligned by construction.
     public init(id: String, kind: ContentMatchKind, title: String, path: String, siteID: String) {
         self.id = id; self.kind = kind; self.title = title; self.path = path; self.siteID = siteID
     }
 
+    /// Projects a page hit (`path` = route).
     public init(_ p: PageEntity) {
         self.init(id: p.id, kind: .page, title: p.displayName, path: p.route, siteID: p.siteID)
     }
+    /// Projects a post hit (`path` = slug).
     public init(_ p: PostEntity) {
         self.init(id: p.id, kind: .post, title: p.displayName, path: p.slug, siteID: p.siteID)
     }
+    /// Projects an image hit (`path` = site-relative file path).
     public init(_ i: ImageEntity) {
         self.init(id: i.id, kind: .image, title: i.displayName, path: i.relativePath, siteID: i.siteID)
     }
@@ -49,8 +72,11 @@ public struct ContentMatchEntity: AppEntity, Identifiable, Sendable {
 /// Resolves `ContentMatchEntity` ids by routing each id to the concrete entity query based on
 /// its ":page:" / ":post:" / ":image:" segment, then projecting. Input order is preserved.
 public struct ContentMatchEntityQuery: EntityQuery {
+    /// Stateless — resolution state lives in the concrete queries this delegates to.
     public init() {}
 
+    /// Splits `identifiers` by kind segment, resolves each batch through its concrete query, and
+    /// reassembles in the caller's order (ids that no longer resolve are silently dropped).
     public func entities(for identifiers: [String]) async throws -> [ContentMatchEntity] {
         let pages = try await PageEntityQuery()
             .entities(for: identifiers.filter { $0.contains(":page:") }).map(ContentMatchEntity.init)
@@ -62,5 +88,7 @@ public struct ContentMatchEntityQuery: EntityQuery {
         return identifiers.compactMap { byID[$0] }
     }
 
+    /// Deliberately empty: a match only exists relative to a search query, so there is no
+    /// sensible standing list for Shortcuts to suggest.
     public func suggestedEntities() async throws -> [ContentMatchEntity] { [] }
 }

--- a/Sources/AnglesiteIntents/ContentOperationsOverride.swift
+++ b/Sources/AnglesiteIntents/ContentOperationsOverride.swift
@@ -6,5 +6,7 @@ import AnglesiteCore
 /// to a fake service before invoking the create intents; the intents read
 /// `ContentOperationsOverride.scoped ?? self.content`, so production flows through `@Dependency`.
 public enum ContentOperationsOverride {
+    /// The fake service bound for the current task tree; `nil` (production, and any task a test
+    /// didn't wrap) means the intents fall through to their `@Dependency`-resolved service.
     @TaskLocal public static var scoped: (any ContentOperationsService)?
 }

--- a/Sources/AnglesiteIntents/ContentSpotlightIndexer.swift
+++ b/Sources/AnglesiteIntents/ContentSpotlightIndexer.swift
@@ -11,11 +11,18 @@ import AnglesiteCore
 /// diff/upsert sequencing without hitting the live system index daemon. One method pair per
 /// entity type because `deleteAppEntities(identifiedBy:ofType:)` is type-specific.
 public protocol ContentSpotlightBackend: Sendable {
+    /// Upserts pages into the index. Id-keyed, so re-indexing an unchanged set is harmless.
     func indexPages(_ entities: [PageEntity]) async throws
+    /// Upserts posts into the index. Id-keyed, so re-indexing an unchanged set is harmless.
     func indexPosts(_ entities: [PostEntity]) async throws
+    /// Upserts images into the index. Id-keyed, so re-indexing an unchanged set is harmless.
     func indexImages(_ entities: [ImageEntity]) async throws
+    /// Removes pages by entity id. Idempotent — deleting an absent id is a no-op, which the
+    /// indexer's replay-on-failure recovery relies on.
     func deletePages(identifiers: [String]) async throws
+    /// Removes posts by entity id. Idempotent, as `deletePages(identifiers:)`.
     func deletePosts(identifiers: [String]) async throws
+    /// Removes images by entity id. Idempotent, as `deletePages(identifiers:)`.
     func deleteImages(identifiers: [String]) async throws
 }
 
@@ -50,6 +57,8 @@ public actor ContentSpotlightIndexer {
     private var inFlight: Set<String> = []
     private var dirty: Set<String> = []
 
+    /// The backend is injected (rather than hard-wiring `CSSearchableIndex`) so tests can
+    /// observe the diff/upsert sequencing without touching the live system index daemon.
     public init(graph: SiteContentGraph, backend: any ContentSpotlightBackend) {
         self.graph = graph
         self.backend = backend
@@ -58,7 +67,10 @@ public actor ContentSpotlightIndexer {
     /// Result returned to callers (today: tests + the bootstrap log) so they can assert/observe
     /// the diff outcome. Counts are summed across all three entity types.
     public struct Outcome: Sendable, Equatable {
+        /// Entities upserted this pass — the full current snapshot, not a changed-only delta,
+        /// because the backend upsert is id-keyed and cheap to repeat.
         public let indexed: Int
+        /// Ids deleted this pass (present in the previous snapshot, absent from the current one).
         public let removed: Int
     }
 
@@ -66,10 +78,15 @@ public actor ContentSpotlightIndexer {
     /// `lastIndexed` set this indexer maintains — the truthful "what we've put in the index" count
     /// without querying the system daemon. Returns zeros for an unknown / never-indexed site.
     public struct IndexedCounts: Sendable, Equatable {
+        /// Pages currently published to Spotlight for the site.
         public let pages: Int
+        /// Posts currently published to Spotlight for the site.
         public let posts: Int
+        /// Images currently published to Spotlight for the site.
         public let images: Int
+        /// Sum across all three types — the "N items indexed" number for status UI.
         public var total: Int { pages + posts + images }
+        /// Memberwise; public so tests and status UI can build expected values.
         public init(pages: Int, posts: Int, images: Int) {
             self.pages = pages
             self.posts = posts
@@ -77,6 +94,8 @@ public actor ContentSpotlightIndexer {
         }
     }
 
+    /// The current published-to-Spotlight counts for `siteID` — see ``IndexedCounts`` for what
+    /// "published" means here. Zeros for an unknown or never-indexed site.
     public func indexedCounts(for siteID: String) -> IndexedCounts {
         guard let state = lastIndexed[siteID] else { return IndexedCounts(pages: 0, posts: 0, images: 0) }
         return IndexedCounts(pages: state.pageIDs.count, posts: state.postIDs.count, images: state.imageIDs.count)

--- a/Sources/AnglesiteIntents/ContentTypeAppEnum.swift
+++ b/Sources/AnglesiteIntents/ContentTypeAppEnum.swift
@@ -7,12 +7,45 @@ import AnglesiteCore
 /// (`ContentTypeAppEnumTests`) — adding a built-in collection type fails that test until a case
 /// is added here. `businessProfile` (page singleton) is intentionally absent (#351 scope).
 public enum ContentTypeAppEnum: String, AppEnum, Sendable, CaseIterable {
-    case note, article, photo, album, bookmark, reply, like
-    case announcement, event, review
+    // Personal IndieWeb post types (h-entry family, #344).
+
+    /// Short, title-less microblog post — body, date, tags only.
+    case note
+    /// Long-form titled post with a summary (schema.org `Article`).
+    case article
+    /// A single image with a caption.
+    case photo
+    /// An ordered set of images published as one entry.
+    case album
+    /// A saved external URL (`u-bookmark-of`) with optional commentary.
+    case bookmark
+    /// A response to an external URL (`u-in-reply-to`). Identified by its target, not a title —
+    /// the create UI hides the Title row for it (#916).
+    case reply
+    /// A lightweight endorsement of an external URL (`u-like-of`); target-identified like
+    /// ``reply``, and body-less.
+    case like
+
+    // Small-business types (#345).
+
+    /// A dated business news item (schema.org `NewsArticle` — deliberately not the COVID-era
+    /// `SpecialAnnouncement`).
+    case announcement
+    /// A happening with start/end dates and a location (h-event → schema.org `Event`).
+    case event
+    /// A rated review of a named item (h-review → schema.org `Review`).
+    case review
+
+    // Identity and directory types (h-card collections, #462).
+
+    /// A directory entry for a person — name, role, photo, bio (h-card → schema.org `Person`).
     case member
 
+    /// Type name shown in Shortcuts and the derived MCP schema.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Content Type" }
 
+    /// Picker labels, mirroring the registry descriptors' `displayName`s — the drift-guard test
+    /// keeps this map total over the cases.
     public static let caseDisplayRepresentations: [ContentTypeAppEnum: DisplayRepresentation] = [
         .note: "Note", .article: "Article", .photo: "Photo", .album: "Album",
         .bookmark: "Bookmark", .reply: "Reply", .like: "Like",

--- a/Sources/AnglesiteIntents/DesignInterviewIntents.swift
+++ b/Sources/AnglesiteIntents/DesignInterviewIntents.swift
@@ -8,18 +8,28 @@ import Foundation
 /// `PreviewSiteIntent` uses for its page-route navigation. The interview itself runs in the GUI
 /// panel, not as a multi-turn App Intent — Siri's role is only the entry point.
 public struct StartDesignInterviewIntent: AppIntent {
+    /// The verb phrase Shortcuts/Siri/Spotlight show for this action.
     public static let title: LocalizedStringResource = "Start Design Interview"
+    /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Start a conversation to design your site's look and feel.")
+    /// The interview is a GUI conversation — the app must come forward for the sheet to appear,
+    /// so this can't run as a background intent.
     public static let openAppWhenRun = true
 
+    /// The site whose look and feel the interview will redesign, resolved by ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
 
+    /// Required by `AppIntent`; the AppIntents runtime fills the `@Parameter` value after
+    /// construction.
     public init() {}
 
+    /// The sentence the Shortcuts editor renders: "Start a design interview for *site*".
     public static var parameterSummary: some ParameterSummary {
         Summary("Start a design interview for \(\.$site)")
     }
 
+    /// Posts the interview request to ``WindowRouter`` (main-actor — the router is UI state) and
+    /// hands off; the sheet is presented asynchronously once the site window exists.
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         WindowRouter.shared.requestDesignInterview(siteID: site.id)

--- a/Sources/AnglesiteIntents/DomainIntents.swift
+++ b/Sources/AnglesiteIntents/DomainIntents.swift
@@ -4,7 +4,13 @@ import Foundation
 
 // MARK: - Dialog formatting (pure, unit-testable)
 
+/// Pure dialog strings for the three DNS intents. No AppIntents types, so these are fully
+/// unit-testable without the AppIntents runtime — same split as ``ContentDialogs`` and
+/// ``IntegrationDialogs``.
 public enum DomainDialogs {
+    /// One line per record, each prefixed with `DNSRecordLabeler`'s purpose label (e.g.
+    /// "Mail routing") so a non-technical owner hears what a record is *for*, not just its
+    /// raw type/name/content triple.
     public static func recordsSummary(_ records: [DNSRecord], domain: String) -> String {
         if records.isEmpty { return "\(domain) has no DNS records." }
         let lines = records.map { record in
@@ -12,12 +18,17 @@ public enum DomainDialogs {
         }
         return "\(domain) has \(records.count) DNS record\(records.count == 1 ? "" : "s"):\n" + lines.joined(separator: "\n")
     }
+    /// Success dialog for ``AddDNSRecordIntent``. Echoes type/name/domain back so the user can
+    /// catch a mis-heard parameter even after confirming.
     public static func added(type: String, name: String, domain: String) -> String {
         "Added a \(type) record for \(name) on \(domain)."
     }
+    /// Success dialog for ``DeleteDNSRecordIntent``.
     public static func deleted(domain: String) -> String {
         "Deleted the DNS record from \(domain)."
     }
+    /// Failure dialog shared by all three DNS intents; `reason` is the human-readable rendering
+    /// of a `DomainOperationError`.
     public static func failed(reason: String, domain: String) -> String {
         "Couldn't finish that on \(domain): \(reason)."
     }
@@ -41,19 +52,32 @@ private func domainErrorMessage(_ error: DomainOperationError, domain: String) -
 
 // MARK: - List DNS Records
 
+/// Read-only Siri/Shortcuts entry point for a domain's DNS records, backed by
+/// `DomainOperationsService` (Cloudflare under the hood). The only DNS intent with no
+/// confirmation gate — listing mutates nothing.
 public struct ListDNSRecordsIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation.
     public static let title: LocalizedStringResource = "List DNS Records"
+    /// Longer explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("List the current DNS records for a domain.")
 
+    /// The zone to list, as a bare domain name (e.g. `example.com`); the service resolves it
+    /// to a Cloudflare zone and reports `zoneNotFound` when it doesn't exist on the account.
     @Parameter(title: "Domain") public var domain: String
     @Dependency private var ops: any DomainOperationsService
 
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
     public init() {}
 
+    /// Shortcuts-editor sentence: "List DNS records for (domain)".
     public static var parameterSummary: some ParameterSummary {
         Summary("List DNS records for \(\.$domain)")
     }
 
+    /// Lists the records and speaks a purpose-labeled summary. Resolves the service through
+    /// ``DomainOperationsOverride`` first so tests can inject a fake without the `@Dependency`
+    /// container.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let svc = DomainOperationsOverride.scoped ?? ops
         let dialog = await run(svc: svc)
@@ -72,27 +96,48 @@ public struct ListDNSRecordsIntent: AppIntent {
 
 // MARK: - Add DNS Record
 
+/// Siri/Shortcuts entry point for creating a DNS record. Mutating, so `perform()` requires an
+/// explicit user confirmation before touching the zone — the app advises but never silently
+/// rewrites an owner's DNS.
 public struct AddDNSRecordIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation.
     public static let title: LocalizedStringResource = "Add DNS Record"
+    /// Longer explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription(
         "Add a DNS record (TXT, CNAME, A, AAAA, or MX) to a domain."
     )
 
+    /// The zone to add to, as a bare domain name (e.g. `example.com`).
     @Parameter(title: "Domain") public var domain: String
+    /// Record type, as the uppercase DNS mnemonic (TXT, CNAME, A, AAAA, or MX). A free string
+    /// rather than an `AppEnum` so the service — not the Siri surface — owns which types are
+    /// accepted.
     @Parameter(title: "Type", description: "TXT, CNAME, A, AAAA, or MX.") public var type: String
+    /// Record name (host), e.g. `www` or `@`.
     @Parameter(title: "Name") public var name: String
+    /// Record content/value — the target hostname, IP address, or TXT payload depending on `type`.
     @Parameter(title: "Content") public var content: String
+    /// Time-to-live in seconds. Defaults to `1`, which Cloudflare interprets as "automatic" —
+    /// the right answer for owners who never think about TTLs.
     @Parameter(title: "TTL", default: 1) public var ttl: Int
+    /// MX preference value; ignored for other record types. Optional so non-mail records don't
+    /// prompt for it.
     @Parameter(title: "Priority", description: "Required for MX records — lower is a more preferred mail server.")
     public var priority: Int?
     @Dependency private var ops: any DomainOperationsService
 
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
     public init() {}
 
+    /// Shortcuts-editor sentence: "Add a (type) record to (domain)".
     public static var parameterSummary: some ParameterSummary {
         Summary("Add a \(\.$type) record to \(\.$domain)")
     }
 
+    /// Confirms with the user, then adds the record and reports the outcome as dialog. The
+    /// confirmation is skipped when ``DomainOperationsOverride`` is bound — `requestConfirmation`
+    /// needs the live Siri/Shortcuts runtime, which unit tests don't have.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let svc = DomainOperationsOverride.scoped ?? ops
         if DomainOperationsOverride.scoped == nil {
@@ -114,22 +159,37 @@ public struct AddDNSRecordIntent: AppIntent {
 
 // MARK: - Delete DNS Record
 
+/// Siri/Shortcuts entry point for removing a DNS record. Addresses the record by opaque
+/// provider ID rather than type/name matching, so a delete can never fuzzy-match the wrong
+/// record — the destructive intent gets the most precise addressing.
 public struct DeleteDNSRecordIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation.
     public static let title: LocalizedStringResource = "Delete DNS Record"
+    /// Longer explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription(
         "Delete a DNS record from a domain by its record identifier."
     )
 
+    /// The zone to delete from, as a bare domain name (e.g. `example.com`).
     @Parameter(title: "Domain") public var domain: String
+    /// The provider-side record identifier, as surfaced by a prior ``ListDNSRecordsIntent``
+    /// run — deletion is ID-addressed, never name-matched.
     @Parameter(title: "Record ID", description: "From a prior List DNS Records call.") public var recordID: String
     @Dependency private var ops: any DomainOperationsService
 
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
     public init() {}
 
+    /// Shortcuts-editor sentence: "Delete a DNS record from (domain)".
     public static var parameterSummary: some ParameterSummary {
         Summary("Delete a DNS record from \(\.$domain)")
     }
 
+    /// Confirms with the user (wording flags irreversibility), then deletes and reports the
+    /// outcome as dialog. The confirmation is skipped when ``DomainOperationsOverride`` is
+    /// bound — `requestConfirmation` needs the live Siri/Shortcuts runtime, which unit tests
+    /// don't have.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let svc = DomainOperationsOverride.scoped ?? ops
         if DomainOperationsOverride.scoped == nil {

--- a/Sources/AnglesiteIntents/DomainOperationsOverride.swift
+++ b/Sources/AnglesiteIntents/DomainOperationsOverride.swift
@@ -5,5 +5,7 @@ import AnglesiteCore
 /// before invoking the domain intents; the intents read `DomainOperationsOverride.scoped ?? self.ops`,
 /// so production flows through `@Dependency`.
 public enum DomainOperationsOverride {
+    /// The injected fake service, or `nil` in production. Task-local (not a plain static) so
+    /// parallel tests can each bind their own fake without racing on shared mutable state.
     @TaskLocal public static var scoped: (any DomainOperationsService)?
 }

--- a/Sources/AnglesiteIntents/EditContentIntent.swift
+++ b/Sources/AnglesiteIntents/EditContentIntent.swift
@@ -13,12 +13,19 @@ import Foundation
 ///    dry-runs via the bridge to get a before/after preview, confirms with the user, and applies.
 /// 4. Plugin applies the structured patch and the reply status drives the final dialog.
 public struct EditContentIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation.
     public static let title: LocalizedStringResource = "Edit Content"
+    /// Longer explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription(
         "Apply a natural-language edit to an onscreen element of a site."
     )
 
+    /// The target element, resolved by Siri from "this heading" / "that image" via
+    /// `appEntityUIElementProvider` (B.4 / #148). Transient — only resolvable while the
+    /// WKWebView is still showing the page that produced it (see ``ElementEntity``).
     @Parameter(title: "Element") public var element: ElementEntity
+    /// The user's spoken change request, kept as raw natural language; the on-device
+    /// interpreter (not Siri parameter resolution) turns it into a structured op.
     @Parameter(
         title: "Change",
         description: "A natural-language description of the change to apply, e.g. make it bigger or change the color to teal."
@@ -26,12 +33,19 @@ public struct EditContentIntent: AppIntent {
     @Dependency private var bridge: IntentEditBridge
     @Dependency private var interpreter: any EditInterpreting
 
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
     public init() {}
 
+    /// Shortcuts-editor sentence: "Change (element) — (instruction)".
     public static var parameterSummary: some ParameterSummary {
         Summary("Change \(\.$element) \u{2014} \(\.$instruction)")
     }
 
+    /// Runs the interpret → dry-run → confirm → apply pipeline described on the type. Every
+    /// early exit before the confirmation (bad selector, interpretation failure, dry-run
+    /// refusal, user decline) returns a dialog without writing anything — the source tree is
+    /// only touched after the user has seen the before/after preview and confirmed.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let bridge = IntentEditBridgeOverride.scoped ?? self.bridge
         let interp = EditInterpreterOverride.scoped ?? self.interpreter

--- a/Sources/AnglesiteIntents/EditInterpreterOverride.swift
+++ b/Sources/AnglesiteIntents/EditInterpreterOverride.swift
@@ -2,5 +2,8 @@ import AnglesiteCore
 
 /// Test seam: inject a fake `EditInterpreting` so `perform` doesn't touch the on-device model.
 public enum EditInterpreterOverride {
+    /// The injected fake interpreter, or `nil` in production (where ``EditContentIntent``
+    /// falls through to its `@Dependency`-resolved interpreter). Task-local so parallel tests
+    /// can each bind their own fake without racing on shared mutable state.
     @TaskLocal public static var scoped: (any EditInterpreting)?
 }

--- a/Sources/AnglesiteIntents/ElementEntity.swift
+++ b/Sources/AnglesiteIntents/ElementEntity.swift
@@ -14,20 +14,36 @@ import Foundation
 /// shape used by `EditMessage`, encoded so it survives `AppEntity` persistence as a plain
 /// `String`. Call `selectorJSON()` to materialize the `JSONValue` for routing.
 public struct ElementEntity: AppEntity, Identifiable, Sendable {
-    public let id: String              // "{siteID}:element:{elementID}"
-    public let displayName: String     // "h1 — Welcome to my site"
+    /// `"{siteID}:element:{elementID}"` — compose via ``ElementEntity/makeID(siteID:elementID:)``
+    /// so the prefix-based kind routing shared with the indexed entities keeps working.
+    public let id: String
+    /// Human-readable label like `"h1 — Welcome to my site"`; compose via
+    /// ``ElementEntity/makeDisplayName(tag:hint:)`` so truncation and whitespace collapsing
+    /// stay uniform.
+    public let displayName: String
+    /// Owning site's stable UUID — routes the edit to the right window's bridge/provider.
     public let siteID: String
-    public let selector: String        // JSON-encoded `ElementInfo`
+    /// JSON-encoded `ElementInfo` selector (see the type-level note on why it's a `String`);
+    /// decode with ``ElementEntity/selectorJSON()``, never by hand.
+    public let selector: String
+    /// Source path of the page the element was observed on (e.g. `src/pages/about.astro`) —
+    /// the file an `apply_edit` patch targets.
     public let pagePath: String
 
+    /// Kind name Siri/Shortcuts shows for this entity type.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Element" }
 
+    /// Title is the tag+hint display name; subtitle is the page path, which disambiguates
+    /// identical elements (e.g. two "h1 — Welcome" on different pages).
     public var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(title: "\(displayName)", subtitle: "\(pagePath)")
     }
 
+    /// Resolution goes through ``ElementEntityQuery`` — live-provider-backed, never Spotlight.
     public static let defaultQuery = ElementEntityQuery()
 
+    /// Memberwise initializer; public because entities are constructed outside this target
+    /// (by ``PreviewAnnotationProvider``'s mapping and by tests).
     public init(id: String, displayName: String, siteID: String, selector: String, pagePath: String) {
         self.id = id
         self.displayName = displayName
@@ -96,8 +112,13 @@ extension ElementEntity {
 /// In production the registry path is the one that fires; the TaskLocal exists so unit tests
 /// can drive a stub without coupling to `@MainActor` shared state.
 public struct ElementEntityQuery: EntityQuery {
+    /// Stateless — all lookup state lives in the provider/registry the query consults.
     public init() {}
 
+    /// Resolves entity IDs against the live provider. Unresolvable IDs are silently dropped
+    /// (not errors): these entities are transient by design, so a stale ID after a page
+    /// navigation is the normal case, and Siri handles a missing entity better than a thrown
+    /// failure.
     public func entities(for identifiers: [String]) async throws -> [ElementEntity] {
         var out: [ElementEntity] = []
         for id in identifiers {
@@ -108,6 +129,7 @@ public struct ElementEntityQuery: EntityQuery {
         return out
     }
 
+    /// Elements Siri may offer proactively ("edit this heading" without a prior selection).
     public func suggestedEntities() async throws -> [ElementEntity] {
         if let provider = await ElementEntityProviderOverride.scoped {
             return await provider.suggestedElementEntities()
@@ -139,6 +161,8 @@ public struct ElementEntityQuery: EntityQuery {
 /// resolution falls through to `PreviewAnnotationProviderRegistry.shared`.
 @MainActor
 public enum ElementEntityProviderOverride {
+    /// The injected stub provider, or `nil` in production. Task-local so parallel tests can
+    /// each bind their own stub without racing on shared mutable state.
     @TaskLocal public static var scoped: ElementEntityProviding?
 }
 
@@ -147,6 +171,10 @@ public enum ElementEntityProviderOverride {
 /// provider's state machine.
 @MainActor
 public protocol ElementEntityProviding: AnyObject, Sendable {
+    /// Resolves an entity ID back to a live element, or `nil` when the page that produced it
+    /// has navigated away — callers must treat `nil` as "gone", not as an error.
     func elementEntity(forID id: String) -> ElementEntity?
+    /// The provider's current proactive-suggestion set, already capped by the provider
+    /// (`suggestedEntityCap`) so aggregating across windows stays bounded.
     func suggestedElementEntities() -> [ElementEntity]
 }

--- a/Sources/AnglesiteIntents/IntegrationIntents.swift
+++ b/Sources/AnglesiteIntents/IntegrationIntents.swift
@@ -7,12 +7,17 @@ import Foundation
 /// Pure dialog strings for the three integration intents. No AppIntents types, so these are
 /// fully unit-testable without the AppIntents runtime.
 public enum IntegrationDialogs {
+    /// Success dialog once `IntegrationOperationsService.apply` reports `.done`.
     public static func applied(integration: String, siteName: String) -> String {
         "Set up \(integration) on \(siteName)."
     }
+    /// Failure dialog for both a plan-stage error and an apply-stage `.failed` terminal state;
+    /// `reason` carries whichever message the service surfaced.
     public static func failed(reason: String, siteName: String) -> String {
         "Couldn't finish that on \(siteName): \(reason)."
     }
+    /// Frames a plan summary as a review prompt, for flows that read the plan back before
+    /// applying (the shipped intents confirm with a shorter fixed sentence instead).
     public static func planPrompt(summary: String) -> String {
         "Here's the plan:\n\(summary)"
     }
@@ -47,24 +52,42 @@ private func applyIntegration(
 
 // MARK: - Add Booking
 
+/// Siri/Shortcuts entry point for the booking integration (`IntegrationID.booking`). Thin
+/// shim: parameters become an `Answers` dict and the shared plan→apply path does the rest,
+/// so Siri and the GUI wizard exercise the exact same integration machinery.
 public struct AddBookingIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation.
     public static let title: LocalizedStringResource = "Add Booking"
+    /// Longer explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription(
         "Add a Cal.com or Calendly booking widget to a site."
     )
 
+    /// The target site, resolved from the recents registry via ``SiteEntity``'s query.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// Booking provider key (`cal` or `calendly`) — validated by the integration's plan step,
+    /// not here, so the accepted set stays owned by the descriptor.
     @Parameter(title: "Provider", description: "cal or calendly.") public var provider: String
+    /// The owner's username/handle on the chosen provider — what the embedded widget points at.
     @Parameter(title: "Username") public var username: String
+    /// Widget placement (`inline`, `floating`, or `button`); optional, defaulting to `inline`
+    /// so a spoken invocation doesn't have to know placements exist.
     @Parameter(title: "Placement", description: "inline, floating, or button.") public var style: String?
     @Dependency private var ops: any IntegrationOperationsService
 
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
     public init() {}
 
+    /// Shortcuts-editor sentence: "Add booking to (site)".
     public static var parameterSummary: some ParameterSummary {
         Summary("Add booking to \(\.$site)")
     }
 
+    /// Confirms (booking wires an external widget into the site), then runs plan→apply and
+    /// reports the outcome as dialog. The confirmation is skipped when
+    /// ``IntegrationOperationsOverride`` is bound — `requestConfirmation` needs the live
+    /// Siri/Shortcuts runtime, which unit tests don't have.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let svc = IntegrationOperationsOverride.scoped ?? ops
         let answers: Answers = [
@@ -85,23 +108,38 @@ public struct AddBookingIntent: AppIntent {
 
 // MARK: - Add Donations
 
+/// Siri/Shortcuts entry point for the donations integration (`IntegrationID.donations`).
+/// Same thin plan→apply shim shape as ``AddBookingIntent``.
 public struct AddDonationsIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation.
     public static let title: LocalizedStringResource = "Add Donations"
+    /// Longer explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription(
         "Add a donation button (Stripe, Liberapay, or GitHub Sponsors) to a site."
     )
 
+    /// The target site, resolved from the recents registry via ``SiteEntity``'s query.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// Donation provider key (`stripe`, `liberapay`, or `githubSponsors`) — validated by the
+    /// integration's plan step, not here.
     @Parameter(title: "Provider", description: "stripe, liberapay, or githubSponsors.") public var provider: String
+    /// The provider-hosted donation URL the button links to — the owner pastes it rather than
+    /// the app holding any payment credentials.
     @Parameter(title: "Donation link") public var link: String
     @Dependency private var ops: any IntegrationOperationsService
 
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
     public init() {}
 
+    /// Shortcuts-editor sentence: "Add donations to (site)".
     public static var parameterSummary: some ParameterSummary {
         Summary("Add donations to \(\.$site)")
     }
 
+    /// Confirms, then runs plan→apply and reports the outcome as dialog. The confirmation is
+    /// skipped when ``IntegrationOperationsOverride`` is bound — `requestConfirmation` needs
+    /// the live Siri/Shortcuts runtime, which unit tests don't have.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let svc = IntegrationOperationsOverride.scoped ?? ops
         let answers: Answers = [
@@ -120,24 +158,41 @@ public struct AddDonationsIntent: AppIntent {
 
 // MARK: - Add Comments (giscus)
 
+/// Siri/Shortcuts entry point for giscus comments (`IntegrationID.giscus`). Deliberately a
+/// reduced surface relative to the GUI wizard — see the hardcoded-answers note in `perform()`.
 public struct AddGiscusIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation. "Add Comments"
+    /// (not "Add giscus") — users ask for the capability, not the vendor.
     public static let title: LocalizedStringResource = "Add Comments"
+    /// Longer explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription(
         "Add giscus GitHub-Discussions-backed comments to a site's blog posts."
     )
 
+    /// The target site, resolved from the recents registry via ``SiteEntity``'s query.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// GitHub repository in `owner/repo` form whose Discussions back the comments.
     @Parameter(title: "Repository", description: "owner/repo.") public var repo: String
+    /// giscus's opaque repository ID (from giscus.app setup) — required alongside `repo`
+    /// because the embed script can't look it up itself.
     @Parameter(title: "Repository ID") public var repoId: String
+    /// giscus's opaque Discussions-category ID (from giscus.app setup).
     @Parameter(title: "Category ID") public var categoryId: String
     @Dependency private var ops: any IntegrationOperationsService
 
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
     public init() {}
 
+    /// Shortcuts-editor sentence: "Add comments to (site)".
     public static var parameterSummary: some ParameterSummary {
         Summary("Add comments to \(\.$site)")
     }
 
+    /// Confirms, then runs plan→apply with category ("Announcements") and mapping ("pathname")
+    /// hardcoded — a deliberate v1 reduction to keep the Siri surface minimal (see inline
+    /// note). The confirmation is skipped when ``IntegrationOperationsOverride`` is bound —
+    /// `requestConfirmation` needs the live Siri/Shortcuts runtime, which unit tests don't have.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let svc = IntegrationOperationsOverride.scoped ?? ops
         // Deliberate API reduction (v1): category and mapping are hardcoded below rather than
@@ -163,10 +218,25 @@ public struct AddGiscusIntent: AppIntent {
 
 // MARK: - Add Store (router)
 
+/// Siri-facing mirror of `StoreCategory` (AnglesiteCore) for ``AddStoreIntent``'s "what are
+/// you selling?" question. Raw values match the core enum case-for-case so the internal
+/// `core` bridge can convert by rawValue; keep the two in lockstep when adding cases.
 public enum StoreCategoryAppEnum: String, AppEnum, Sendable, CaseIterable {
-    case service, donations, digitalDownloads, physicalGoods, software
+    /// A service or one-off — routes to a Stripe-preset buy button.
+    case service
+    /// Donations or fundraising — routes to the donations integration.
+    case donations
+    /// Digital downloads — routes via ``DigitalPreferenceAppEnum`` (Polar by default).
+    case digitalDownloads
+    /// Physical goods — routes via ``CatalogSizeAppEnum`` (Snipcart or Shopify Buy Button).
+    case physicalGoods
+    /// Software or SaaS licensing — routes to Paddle.
+    case software
 
+    /// Kind name Siri/Shortcuts shows for this choice list.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Store Category" }
+    /// Owner-language phrasing for each choice — what the user is selling, never the
+    /// integration vendor that answering will route to.
     public static let caseDisplayRepresentations: [StoreCategoryAppEnum: DisplayRepresentation] = [
         .service: "A service or one-off",
         .donations: "Donations or fundraising",
@@ -178,10 +248,18 @@ public enum StoreCategoryAppEnum: String, AppEnum, Sendable, CaseIterable {
     var core: StoreCategory { StoreCategory(rawValue: rawValue)! }
 }
 
+/// Siri-facing mirror of `DigitalPreference` (AnglesiteCore) — the digital-downloads
+/// follow-up question. Raw values match the core enum so the internal `core` bridge can
+/// convert by rawValue.
 public enum DigitalPreferenceAppEnum: String, AppEnum, Sendable, CaseIterable {
-    case polar, lemonSqueezy
+    /// Polar — the default route (a Polar-preset buy button) when no preference is given.
+    case polar
+    /// Lemon Squeezy — routes to the dedicated Lemon Squeezy integration.
+    case lemonSqueezy
 
+    /// Kind name Siri/Shortcuts shows for this choice list.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Digital Platform" }
+    /// Display phrasing for each platform choice.
     public static let caseDisplayRepresentations: [DigitalPreferenceAppEnum: DisplayRepresentation] = [
         .polar: "Polar", .lemonSqueezy: "Lemon Squeezy",
     ]
@@ -189,10 +267,18 @@ public enum DigitalPreferenceAppEnum: String, AppEnum, Sendable, CaseIterable {
     var core: DigitalPreference { DigitalPreference(rawValue: rawValue)! }
 }
 
+/// Siri-facing mirror of `CatalogSize` (AnglesiteCore) — the physical-goods follow-up
+/// question. Raw values match the core enum so the internal `core` bridge can convert by
+/// rawValue.
 public enum CatalogSizeAppEnum: String, AppEnum, Sendable, CaseIterable {
-    case few, catalog
+    /// Just a few products — the default route (Snipcart) when no answer is given.
+    case few
+    /// A full, growing catalog — routes to the Shopify Buy Button integration.
+    case catalog
 
+    /// Kind name Siri/Shortcuts shows for this choice list.
     public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Catalog Size" }
+    /// Display phrasing for each size choice.
     public static let caseDisplayRepresentations: [CatalogSizeAppEnum: DisplayRepresentation] = [
         .few: "Just a few", .catalog: "A full, growing catalog",
     ]
@@ -200,28 +286,52 @@ public enum CatalogSizeAppEnum: String, AppEnum, Sendable, CaseIterable {
     var core: CatalogSize { CatalogSize(rawValue: rawValue)! }
 }
 
+/// Siri/Shortcuts entry point for the "Add a Store" wizard. Unlike the single-integration
+/// intents above, this one routes: `AddStoreRouter` picks the right commerce integration
+/// from what the owner is selling (plus at most one follow-up answer), mirroring the GUI
+/// wizard, so the owner never has to know vendor names to get the right setup.
 public struct AddStoreIntent: AppIntent {
+    /// Display name in the Shortcuts action library and Siri disambiguation.
     public static let title: LocalizedStringResource = "Add a Store"
+    /// Longer explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription(
         "Answer a couple of questions and Anglesite sets up the right commerce integration."
     )
 
+    /// The target site, resolved from the recents registry via ``SiteEntity``'s query.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// The routing question — determines which integration gets set up.
     @Parameter(title: "What are you selling?") public var category: StoreCategoryAppEnum
+    /// Follow-up for ``StoreCategoryAppEnum/digitalDownloads`` only; other categories ignore
+    /// it. Optional so the router's Polar default applies when unanswered.
     @Parameter(title: "Digital platform", description: "polar or lemonSqueezy — only used for digital downloads.")
     public var digitalPreference: DigitalPreferenceAppEnum?
+    /// Follow-up for ``StoreCategoryAppEnum/physicalGoods`` only; other categories ignore it.
+    /// Optional so the router's Snipcart default applies when unanswered.
     @Parameter(title: "Catalog size", description: "few or catalog — only used for physical goods.")
     public var catalogSize: CatalogSizeAppEnum?
+    /// Escape hatch for the routed integration's remaining fields, as `key=value` pairs
+    /// parsed by `SetupIntegrationArguments.parseConfig` — the routed target isn't known until
+    /// runtime, so its fields can't be typed `@Parameter`s here. Missing required fields
+    /// surface as a plan-stage reprompt rather than a hard failure.
     @Parameter(title: "Details", description: "Remaining field values as key=value pairs, e.g. checkoutUrl=https://buy.stripe.com/xyz.")
     public var config: String?
     @Dependency private var ops: any IntegrationOperationsService
 
+    /// AppIntents requires a parameterless initializer; the framework populates `@Parameter`s
+    /// after construction.
     public init() {}
 
+    /// Shortcuts-editor sentence: "Add a store to (site)".
     public static var parameterSummary: some ParameterSummary {
         Summary("Add a store to \(\.$site)")
     }
 
+    /// Routes, plans, confirms, applies. Planning happens *before* the confirmation so a
+    /// missing-field reprompt reaches the user without them confirming an apply that could
+    /// never run; only a plan that succeeded gets confirmed and applied. The confirmation is
+    /// skipped when ``IntegrationOperationsOverride`` is bound — `requestConfirmation` needs
+    /// the live Siri/Shortcuts runtime, which unit tests don't have.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         let svc = IntegrationOperationsOverride.scoped ?? ops
         let (route, descriptor, answers) = resolvedRoute()

--- a/Sources/AnglesiteIntents/IntegrationOperationsOverride.swift
+++ b/Sources/AnglesiteIntents/IntegrationOperationsOverride.swift
@@ -6,5 +6,7 @@ import AnglesiteCore
 /// a fake service before invoking the integration intents; the intents read
 /// `IntegrationOperationsOverride.scoped ?? self.ops`, so production flows through `@Dependency`.
 public enum IntegrationOperationsOverride {
+    /// The injected fake service, or `nil` in production. Task-local (not a plain static) so
+    /// parallel tests can each bind their own fake without racing on shared mutable state.
     @TaskLocal public static var scoped: (any IntegrationOperationsService)?
 }

--- a/Sources/AnglesiteIntents/OperationDescriptor.swift
+++ b/Sources/AnglesiteIntents/OperationDescriptor.swift
@@ -12,14 +12,22 @@ public struct OperationDescriptor: Sendable, Equatable {
     public let displayName: String
     /// The intent's Swift type name, e.g. "DeploySiteIntent". The coverage-anchor key; unique.
     public let intentTypeName: String
+    /// How far the operation's writes reach — the axis confirmation and risk decisions key off.
     public let sideEffect: OperationSideEffect
+    /// Whether the intent gates on a user confirmation before running. Declared here so tests can
+    /// enforce that risky operations (deploy, DNS mutations) never silently drop their prompt.
     public let requiresConfirmation: Bool
+    /// Whether a running invocation can be cancelled from the system UI. Mirrors the intent's
+    /// `CancellableIntent` adoption, which the auto-derived schema can't express.
     public let isCancellable: Bool
+    /// The shape of the value the intent returns, so agents know what they can chain into.
     public let resultShape: OperationResult
     /// The `mcpbridge`-assigned tool name, once Apple's naming convention is pinned (D.5/#166).
     /// `nil` for all current entries — forward-looking, not asserted by any test.
     public let mcpToolName: String?
 
+    /// Memberwise initializer. Every field except `mcpToolName` is required so a new registry
+    /// entry can't accidentally omit the metadata the coverage tests assert on.
     public init(
         operationID: String,
         displayName: String,
@@ -58,13 +66,19 @@ public enum OperationSideEffect: Sendable, Equatable {
 
 /// The shape an agent gets back. The associated string is the entity type name.
 public enum OperationResult: Sendable, Equatable {
+    /// The operation returns only a dialog — nothing an agent can chain into a follow-up.
     case none
+    /// A single entity of the named type (e.g. `"SiteEntity"`), chainable into another intent.
     case entity(String)
+    /// A list of entities of the named type — search/find operations that fan out.
     case entities(String)
 }
 
 /// The canonical registry — the single source of truth for Siri-facing operation metadata.
 public enum AnglesiteOperations {
+    /// Every registered descriptor, one per Siri-facing intent. Coverage tests diff this list
+    /// against the real intent types, so adding an intent without a descriptor (or vice versa)
+    /// fails fast rather than shipping an operation the system MCP schema misrepresents.
     public static let all: [OperationDescriptor] = [
         OperationDescriptor(
             operationID: "deploy-site", displayName: "Deploy Site",

--- a/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProvider.swift
@@ -27,11 +27,16 @@ import Foundation
 /// explicit author annotation) outrank generic-page fallback.
 @MainActor
 public final class PreviewAnnotationProvider: ElementEntityProviding, Sendable {
+    /// The site this provider annotates — fixed at construction because the provider is
+    /// window-scoped (one per site window), not shared across sites.
     public let siteID: String
     private let graph: SiteContentGraph
     private var annotated: [(rect: CGRect, entity: any AppEntity)] = []
     private var elementsByID: [String: ElementEntity] = [:]
 
+    /// Creates a provider bound to one site window. `graph` is the shared `SiteContentGraph`
+    /// actor — injected (rather than reaching for a singleton) so tests can supply an isolated
+    /// graph.
     public init(siteID: String, graph: SiteContentGraph) {
         self.siteID = siteID
         self.graph = graph
@@ -83,6 +88,9 @@ public final class PreviewAnnotationProvider: ElementEntityProviding, Sendable {
 
     // MARK: ElementEntityProviding
 
+    /// ``ElementEntityProviding`` requirement — same lookup as ``entity(for:)``, exposed under
+    /// the protocol name so ``ElementEntityQuery`` can resolve ids without knowing the concrete
+    /// provider type.
     public func elementEntity(forID id: String) -> ElementEntity? {
         elementsByID[id]
     }

--- a/Sources/AnglesiteIntents/PreviewAnnotationProviderRegistry.swift
+++ b/Sources/AnglesiteIntents/PreviewAnnotationProviderRegistry.swift
@@ -18,6 +18,8 @@ import Foundation
 /// actor. Tests use the lighter-weight `ElementEntityProviderOverride.scoped` TaskLocal seam.
 @MainActor
 public final class PreviewAnnotationProviderRegistry: Sendable {
+    /// The process-wide registry every production caller goes through — a singleton because
+    /// ``ElementEntityQuery`` is instantiated by the AppIntents runtime and has no injection point.
     public static let shared = PreviewAnnotationProviderRegistry()
 
     private var providers: [String: PreviewAnnotationProvider] = [:]
@@ -27,14 +29,20 @@ public final class PreviewAnnotationProviderRegistry: Sendable {
     /// instances from silently routing queries to the wrong store.
     internal init() {}
 
+    /// Bind `provider` as the live provider for `siteID`, replacing any previous binding —
+    /// last registration wins, which is what a window re-creating its provider on siteID
+    /// change needs.
     public func register(_ provider: PreviewAnnotationProvider, for siteID: String) {
         providers[siteID] = provider
     }
 
+    /// Drop the binding for `siteID` (window closed). Safe to call when nothing is registered,
+    /// so `onDisappear` doesn't need to track whether registration ever happened.
     public func unregister(siteID: String) {
         providers.removeValue(forKey: siteID)
     }
 
+    /// The live provider for `siteID`, or `nil` when that site has no open window.
     public func provider(for siteID: String) -> PreviewAnnotationProvider? {
         providers[siteID]
     }

--- a/Sources/AnglesiteIntents/RelevantEntitiesUpdater.swift
+++ b/Sources/AnglesiteIntents/RelevantEntitiesUpdater.swift
@@ -6,6 +6,9 @@ import AnglesiteCore
 /// `RelevantEntitiesUpdaterTests` can verify the top-N/dedup behavior without touching the
 /// live App Intents relevance API. Mirrors `SpotlightIndexBackend`.
 public protocol RelevantEntitiesBackend: Sendable {
+    /// Replace the published relevant-entity set with `entities`. Each call is a full snapshot,
+    /// not a delta — the updater already diffed, so a backend that gets called should publish
+    /// everything it's given.
     func update(_ entities: [SiteEntity]) async throws
 }
 
@@ -19,6 +22,9 @@ public protocol RelevantEntitiesBackend: Sendable {
 /// snapshot) is a no-op. `lastPushedIDs` advances only on success, so a thrown backend error
 /// replays on the next snapshot.
 public actor RelevantEntitiesUpdater {
+    /// The production instance, wired to the live (currently no-op, see `LiveRelevantEntitiesBackend`)
+    /// relevance backend. A singleton so `bootstrap`'s change-stream consumer and any future
+    /// callers share one `lastPushedIDs` diff state.
     public static let shared = RelevantEntitiesUpdater(backend: LiveRelevantEntitiesBackend())
 
     /// Result returned to callers (today: tests only) so they can assert the diff outcome.
@@ -26,8 +32,11 @@ public actor RelevantEntitiesUpdater {
         /// Size of the top-N candidate window this refresh considered — NOT necessarily the
         /// number sent to the backend. When `skipped` is true the backend was not called at all.
         public let count: Int
+        /// `true` when the top-N ids matched the last successful push (in order) and the
+        /// backend was not called.
         public let skipped: Bool
 
+        /// Memberwise initializer — public so test assertions can build expected outcomes.
         public init(count: Int, skipped: Bool) {
             self.count = count
             self.skipped = skipped
@@ -38,11 +47,17 @@ public actor RelevantEntitiesUpdater {
     private let maxCount: Int
     private var lastPushedIDs: [String] = []
 
+    /// Creates an updater over `backend`. `maxCount` defaults to 3 — the relevance surface is a
+    /// suggestion strip, not a browser, so publishing more than the lead few MRU sites just
+    /// dilutes it; tests shrink it to exercise the window edge.
     public init(backend: any RelevantEntitiesBackend, maxCount: Int = 3) {
         self.backend = backend
         self.maxCount = maxCount
     }
 
+    /// Publish the top-N of `sites` (already MRU-ordered by the caller) if they differ from the
+    /// last successful push — see the type doc for the ordered-diff semantics. Rethrows backend
+    /// errors without advancing the diff state, so the next snapshot retries.
     @discardableResult
     public func refresh(_ sites: [SiteStore.Site]) async throws -> Outcome {
         let top = Array(sites.prefix(maxCount))

--- a/Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessIntentProbes.swift
@@ -5,7 +5,10 @@ import AppIntents  // load-bearing: AnglesiteShortcuts.appShortcuts default-arg 
 /// Confirms Anglesite's App Shortcuts are registered (the surface Siri/Spotlight enumerate).
 /// Count is injectable; the default reads the live provider.
 public struct AppIntentsRegistrationProbe: ReadinessProbe {
+    /// Stable finding id (`ReadinessProbe` requirement) — keyed, not display text, so UI can
+    /// track a finding across runs.
     public let id = "intents.registration"
+    /// Human-facing row title shown in the readiness report.
     public let title = "App Intents & Shortcuts"
     /// `nil` means "read the live count at `check()` time". Resolving it lazily (rather than as a
     /// default argument) avoids reading the provider at struct-construction time, which can run
@@ -13,10 +16,15 @@ public struct AppIntentsRegistrationProbe: ReadinessProbe {
     /// is a static `@AppShortcutsBuilder` literal, so the live count is environment-independent.
     private let shortcutCount: Int?
 
+    /// Pass a count to pin the probe's input in tests; the `nil` default defers to the live
+    /// ``AnglesiteShortcuts`` provider at check time (see `shortcutCount` for why lazily).
     public init(shortcutCount: Int? = nil) {
         self.shortcutCount = shortcutCount
     }
 
+    /// `.ok` when at least one App Shortcut is registered; `.warning` (with a relaunch
+    /// remediation) when none are — an empty provider means Siri/Spotlight can't discover
+    /// Anglesite at all.
     public func check() async -> ReadinessFinding {
         let shortcutCount = self.shortcutCount ?? AnglesiteShortcuts.appShortcuts.count
         if shortcutCount > 0 {
@@ -32,14 +40,21 @@ public struct AppIntentsRegistrationProbe: ReadinessProbe {
 /// Reports whether the build includes Swift 6.4 View Annotations (the onscreen-awareness path
 /// that lets Siri act on the site you're viewing). Compile-time gated; injectable for tests.
 public struct ViewAnnotationsProbe: ReadinessProbe {
+    /// Stable finding id (`ReadinessProbe` requirement).
     public let id = "view.annotations"
+    /// Human-facing row title shown in the readiness report.
     public let title = "Onscreen awareness (View Annotations)"
     private let compiled: Bool
 
+    /// The default reads the compile-time truth (``builtWithAnnotations``); tests inject the
+    /// other branch, since a single binary can only ever exercise one side of the `#if`.
     public init(compiled: Bool = ViewAnnotationsProbe.builtWithAnnotations) {
         self.compiled = compiled
     }
 
+    /// Whether this binary was compiled with Swift 6.4+, where the view-annotation APIs exist.
+    /// A computed property (not a stored `let`) so the `#if compiler` check reads as one
+    /// expression at the probe's default-argument site.
     public static var builtWithAnnotations: Bool {
         #if compiler(>=6.4)
         return true
@@ -48,6 +63,8 @@ public struct ViewAnnotationsProbe: ReadinessProbe {
         #endif
     }
 
+    /// `.ok` when built with annotations; `.unsupported` (not `.warning`) otherwise — the user
+    /// can't fix a compile-time gap short of installing a newer build, so nagging is wrong.
     public func check() async -> ReadinessFinding {
         if compiled {
             return ReadinessFinding(id: id, title: title, level: .ok,
@@ -62,16 +79,22 @@ public struct ViewAnnotationsProbe: ReadinessProbe {
 /// Reports whether Anglesite's tools are exposed to the system-wide MCP bridge. Unbuilt today
 /// (Phase D, #135) — defaults to `.unsupported`; flips to a real check when #164/#101 land.
 public struct SystemMCPBridgeProbe: ReadinessProbe {
+    /// Stable finding id (`ReadinessProbe` requirement).
     public let id = "mcp.bridge"
+    /// Human-facing row title shown in the readiness report.
     public let title = "System-wide MCP bridge"
     private let registered: Bool
 
     // TODO(#135): replace the `false` default with a live system-MCP-bridge registration check
     // once Phase D lands (#164/#101). Until then this probe truthfully reports `.unsupported`.
+    /// The `false` default is honest, not a stub-smell: system-MCP exposure is unbuilt (Phase D,
+    /// #135), so production constructs an always-`.unsupported` probe by design.
     public init(registered: Bool = false) {
         self.registered = registered
     }
 
+    /// `.ok` when tools are registered with the bridge; `.unsupported` otherwise. Uses
+    /// `.unsupported` rather than `.warning` because there is nothing the user can do about it.
     public func check() async -> ReadinessFinding {
         if registered {
             return ReadinessFinding(id: id, title: title, level: .ok,

--- a/Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift
+++ b/Sources/AnglesiteIntents/SiriReadinessSpotlightProbe.swift
@@ -5,6 +5,8 @@ import CoreSpotlight
 /// standing up a full `ContentSpotlightIndexer` + backend just to vary a count. The production
 /// indexer conforms below.
 public protocol SpotlightIndexCounting: Sendable {
+    /// Per-type counts of what the indexer last published for `siteID`. Reads the indexer's own
+    /// bookkeeping, not the live Spotlight daemon — cheap, and sufficient for a readiness signal.
     func indexedCounts(for siteID: String) async -> ContentSpotlightIndexer.IndexedCounts
 }
 
@@ -13,12 +15,17 @@ extension ContentSpotlightIndexer: SpotlightIndexCounting {}
 /// Reports how many of a site's items are published to the Spotlight semantic index Siri reads.
 /// `indexingAvailable` is injected; the default reads `CSSearchableIndex.isIndexingAvailable()`.
 public struct SpotlightIndexProbe: ReadinessProbe {
+    /// Stable finding id (`ReadinessProbe` requirement).
     public let id = "site.spotlight"
+    /// Human-facing row title shown in the readiness report.
     public let title = "Spotlight index"
     private let siteID: String
     private let counter: any SpotlightIndexCounting
     private let indexingAvailable: Bool
 
+    /// Creates a probe for one site. `indexingAvailable` is captured at construction (not read
+    /// inside `check()`) so tests can exercise the Spotlight-disabled branch without touching
+    /// the real `CSSearchableIndex` availability state.
     public init(
         siteID: String,
         counter: any SpotlightIndexCounting,
@@ -29,6 +36,9 @@ public struct SpotlightIndexProbe: ReadinessProbe {
         self.indexingAvailable = indexingAvailable
     }
 
+    /// Warns (with remediation) when Spotlight is off or nothing is indexed yet; `.ok` with the
+    /// item count otherwise. Both failure modes are `.warning`, not errors — the site still
+    /// works, Siri just can't see into it.
     public func check() async -> ReadinessFinding {
         guard indexingAvailable else {
             return ReadinessFinding(id: id, title: title, level: .warning,

--- a/Sources/AnglesiteIntents/SiteEntity.swift
+++ b/Sources/AnglesiteIntents/SiteEntity.swift
@@ -10,11 +10,17 @@ import Foundation
 /// the explicit override is omitted here (the metadata processor requires its removal).
 @AppEntity(schema: .wordProcessor.document)
 public struct SiteEntity: Sendable {
+    /// The stable site UUID from `SiteStore.Site.id` — path-independent (#242), so a Shortcut
+    /// that captured an entity keeps resolving after the package moves or is renamed.
     public let id: String
+    /// The site's display name, exposed as a schema `@Property` so Siri can match it by voice.
     @Property(title: "Name")
     public var name: String
+    /// When the site's `Source/` directory was created; `nil` when the filesystem won't say.
     @Property(title: "Creation Date")
     public var creationDate: Date?
+    /// Last modification of the `Source/` directory itself — see the note in `init(_:)` about
+    /// in-file edits not bumping this.
     @Property(title: "Modification Date")
     public var modificationDate: Date?
 
@@ -28,12 +34,19 @@ public struct SiteEntity: Sendable {
     /// entity via the macro init.
     public var directory: URL?
 
+    /// How Siri/Shortcuts render the entity: name as title, package path as subtitle — the path
+    /// is the disambiguator when two sites share a name.
     public var displayRepresentation: DisplayRepresentation {
         DisplayRepresentation(title: "\(name)", subtitle: "\(directory?.path(percentEncoded: false) ?? "")")
     }
 
+    /// `AppEntity` requirement — the query the system uses whenever it must resolve a
+    /// ``SiteEntity`` on its own (Shortcuts re-resolution, Siri disambiguation).
     public static let defaultQuery = SiteEntityQuery()
 
+    /// Memberwise initializer. Prefer `init(_:)` from a `SiteStore.Site` — it fills the dates
+    /// from the filesystem and sets `directory` correctly; this one exists for tests and for
+    /// the field-by-field cases where no live `Site` is at hand.
     public init(id: String, name: String, creationDate: Date?, modificationDate: Date?, directory: URL? = nil) {
         self.id = id
         self.name = name
@@ -42,8 +55,10 @@ public struct SiteEntity: Sendable {
         self.directory = directory
     }
 
+    /// Builds the entity from a live registry entry, reading creation/modification dates off the
+    /// `Source/` directory. Directory mtime misses in-file edits (only add/remove/rename bumps
+    /// it); revisit with git timestamps after #68.
     public init(_ site: SiteStore.Site) {
-        // Directory mtime misses in-file edits; revisit with git timestamps after #68.
         let keys: Set<URLResourceKey> = [.creationDateKey, .contentModificationDateKey]
         let values = try? site.sourceDirectory.resourceValues(forKeys: keys)
         self.init(
@@ -61,10 +76,13 @@ public struct SiteEntity: Sendable {
 public struct SiteEntityQuery: EntityStringQuery {
     private let store: SiteStore
 
+    /// The no-argument initializer AppIntents requires — binds to the shared `SiteStore`,
+    /// which is what every production resolution goes through.
     public init() {
         self.store = .shared
     }
 
+    /// Test seam: bind the query to an isolated store instead of the shared registry.
     public init(store: SiteStore) {
         self.store = store
     }
@@ -74,19 +92,28 @@ public struct SiteEntityQuery: EntityStringQuery {
         return await store.sites
     }
 
+    /// Exact-id resolution — the path Shortcuts uses to re-resolve a previously captured
+    /// entity. Unknown ids are silently dropped (deleted sites), not errors.
     public func entities(for identifiers: [String]) async throws -> [SiteEntity] {
         await allSites().filter { identifiers.contains($0.id) }.map(SiteEntity.init)
     }
 
+    /// Case-insensitive substring match on the site name, for Siri utterances like
+    /// "my portfolio site". Substring (not prefix/equality) because users rarely say the
+    /// exact registered name.
     public func entities(matching string: String) async throws -> [SiteEntity] {
         let needle = string.lowercased()
         return await allSites().filter { $0.name.lowercased().contains(needle) }.map(SiteEntity.init)
     }
 
+    /// Every registered site, unfiltered — site counts are small (this is a personal publishing
+    /// app), so the disambiguation picker can afford the full list.
     public func suggestedEntities() async throws -> [SiteEntity] {
         await allSites().map(SiteEntity.init)
     }
 
+    /// The single registered site when there is exactly one, so Siri can skip the "which site?"
+    /// prompt entirely; `nil` (forcing disambiguation) in every other case.
     public func defaultResult() async -> SiteEntity? {
         let sites = await allSites()
         return sites.count == 1 ? sites.first.map(SiteEntity.init) : nil

--- a/Sources/AnglesiteIntents/SiteEntityAnnotation.swift
+++ b/Sources/AnglesiteIntents/SiteEntityAnnotation.swift
@@ -18,6 +18,10 @@ public enum SiteEntityAnnotation {
     /// Reverse-DNS style; the suffix matches the SwiftUI scene that publishes it.
     public static let activityType = "io.dwk.anglesite.site-window"
 
+    /// Builds the activity for one site window: title + `siteID` in `userInfo`, plus (on Swift
+    /// 6.4+) the typed `appEntityIdentifier`. Deliberately opts out of Handoff, public indexing,
+    /// and search — this is local window state, not a portable document; #71 (iOS thin client)
+    /// revisits with SyncableEntity.
     public static func makeSiteUserActivity(_ entity: SiteEntity) -> NSUserActivity {
         let activity = NSUserActivity(activityType: activityType)
         activity.title = entity.displayName

--- a/Sources/AnglesiteIntents/SiteIntents.swift
+++ b/Sources/AnglesiteIntents/SiteIntents.swift
@@ -14,19 +14,30 @@ import AnglesiteCore
 /// Xcode 26.3 (Swift 6.3) the intents fall back to plain `AppIntent` with inline `await` calls
 /// (no extended budget, no Cancel UI). See #128 for cleanup once CI catches up.
 
+/// Deploys a site to production via `SiteOperations`. The only intent that both confirms with
+/// the user *and* still runs the pre-deploy security gate — confirmation guards against
+/// accidental voice/Shortcut triggers; the scan inside `DeployCommand` guards the content.
 public struct DeploySiteIntent: AppIntent {
+    /// The verb Siri/Shortcuts display and match against.
     public static let title: LocalizedStringResource = "Deploy Site"
+    /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Deploy a site to production with Anglesite.")
 
+    /// The site to deploy, resolved through ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
 
+    /// Required by `AppIntent` — the runtime constructs the intent, then fills `@Parameter`s.
     public init() {}
 
+    /// Shortcuts editor sentence: "Deploy *site*".
     public static var parameterSummary: some ParameterSummary { Summary("Deploy \(\.$site)") }
 
-    // Returns the site as a value (like AuditSiteIntent) so an agent/Shortcut can chain
-    // deploy→backup or audit→deploy→backup. The MCP bridge surfaces this as a typed output.
+    /// Confirms, resolves the site, and runs the deploy — long-running and cancellable on
+    /// Xcode 27 (see the file-level note), inline otherwise.
+    ///
+    /// Returns the site as a value (like ``AuditSiteIntent``) so an agent/Shortcut can chain
+    /// deploy→backup or audit→deploy→backup. The MCP bridge surfaces this as a typed output.
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<SiteEntity> {
         let scoped = SiteOperationsOverride.scoped
         let ops: any SiteOperationsService
@@ -69,19 +80,30 @@ public struct DeploySiteIntent: AppIntent {
     }
 }
 
+/// Commits and pushes a site backup via `SiteOperations`. No confirmation — backup is additive
+/// (snapshot to a draft branch, `.createsContent` in ``AnglesiteOperations``), so prompting
+/// would only train users to click through.
 public struct BackupSiteIntent: AppIntent {
+    /// The verb Siri/Shortcuts display and match against.
     public static let title: LocalizedStringResource = "Back Up Site"
+    /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Commit and push a site backup with Anglesite.")
 
+    /// The site to back up, resolved through ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
 
+    /// Required by `AppIntent` — the runtime constructs the intent, then fills `@Parameter`s.
     public init() {}
 
+    /// Shortcuts editor sentence: "Back up *site*".
     public static var parameterSummary: some ParameterSummary { Summary("Back up \(\.$site)") }
 
-    // Returns the site as a value (like Audit/Deploy) so an agent/Shortcut can chain backup
-    // into a follow-up site operation. The MCP bridge surfaces this as a typed output.
+    /// Resolves the site and runs the backup — long-running and cancellable on Xcode 27 (a git
+    /// push on a slow connection can exceed the default budget), inline otherwise.
+    ///
+    /// Returns the site as a value (like Audit/Deploy) so an agent/Shortcut can chain backup
+    /// into a follow-up site operation. The MCP bridge surfaces this as a typed output.
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<SiteEntity> {
         let scoped = SiteOperationsOverride.scoped
         let ops = scoped ?? self.ops
@@ -110,18 +132,29 @@ public struct BackupSiteIntent: AppIntent {
     }
 }
 
+/// Runs the site audit via `SiteOperations` and speaks the findings. Read-only (build +
+/// runners, nothing persisted), so no confirmation gate.
 public struct AuditSiteIntent: AppIntent {
+    /// The verb Siri/Shortcuts display and match against — "Check", not "Audit", per the
+    /// app's plain-language UX (audiences here are site owners, not engineers).
     public static let title: LocalizedStringResource = "Check Site"
+    /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Run an Anglesite audit and report findings.")
 
+    /// The site to check, resolved through ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
 
+    /// Required by `AppIntent` — the runtime constructs the intent, then fills `@Parameter`s.
     public init() {}
 
+    /// Shortcuts editor sentence: "Check *site*".
     public static var parameterSummary: some ParameterSummary { Summary("Check \(\.$site)") }
 
-    // Returns the site as a value so a Shortcut can pipe it straight into Deploy (audit→deploy).
+    /// Resolves the site and runs the audit — long-running and cancellable on Xcode 27 (a full
+    /// audit builds the site first), inline otherwise.
+    ///
+    /// Returns the site as a value so a Shortcut can pipe it straight into Deploy (audit→deploy).
     public func perform() async throws -> some IntentResult & ProvidesDialog & ReturnsValue<SiteEntity> {
         let scoped = SiteOperationsOverride.scoped
         let ops = scoped ?? self.ops
@@ -155,16 +188,27 @@ public struct AuditSiteIntent: AppIntent {
 /// entity parameter to be named `target` — that contract is also why Shortcuts can chain
 /// "find a site" → "open that site" by piping the resolved entity straight in.
 public struct OpenSiteIntent: OpenIntent {
+    /// The verb Siri/Shortcuts display and match against.
     public static let title: LocalizedStringResource = "Open Site"
+    /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Open a site window in Anglesite.")
+    /// `true` because opening a window is the whole point — a background invocation with no
+    /// foregrounded app would succeed invisibly.
     public static let openAppWhenRun = true
 
+    /// The site to open. Named `target` because the `OpenIntent` protocol requires it — that
+    /// contract is what lets Spotlight/Shortcuts pipe a resolved entity in (see the type doc).
     @Parameter(title: "Site") public var target: SiteEntity
 
+    /// Required by `AppIntent` — the runtime constructs the intent, then fills `@Parameter`s.
     public init() {}
 
+    /// Shortcuts editor sentence: "Open *site*".
     public static var parameterSummary: some ParameterSummary { Summary("Open \(\.$target)") }
 
+    /// Routes the request through ``WindowRouter`` because an intent can't call SwiftUI's
+    /// `openWindow`; the "Sites" scene observes the router and opens/focuses the window.
+    /// `@MainActor` since the router is.
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         WindowRouter.shared.requestOpen(siteID: target.id)

--- a/Sources/AnglesiteIntents/SiteOperationsOverride.swift
+++ b/Sources/AnglesiteIntents/SiteOperationsOverride.swift
@@ -15,5 +15,7 @@ import AnglesiteCore
 /// In production the override is always `nil` and the intent resolves through
 /// `@Dependency` as designed.
 public enum SiteOperationsOverride {
+    /// The task-scoped fake. Always `nil` in production; when bound, intents skip both
+    /// `@Dependency` resolution and `requestConfirmation` (no UI surface under `swift test`).
     @TaskLocal public static var scoped: (any SiteOperationsService)?
 }

--- a/Sources/AnglesiteIntents/SpotlightIndexer.swift
+++ b/Sources/AnglesiteIntents/SpotlightIndexer.swift
@@ -12,7 +12,11 @@ extension SiteEntity: IndexedEntity {}
 /// Pluggable seam over `CSSearchableIndex` so `SpotlightIndexerTests` can verify the diff/upsert
 /// sequencing without hitting the live system index daemon.
 public protocol SpotlightIndexBackend: Sendable {
+    /// Upsert `entities` into the index. Id-keyed, so re-indexing an unchanged entity is a
+    /// harmless overwrite — the indexer relies on that rather than diffing entity contents.
     func index(_ entities: [SiteEntity]) async throws
+    /// Remove the entries with these ids. Must be idempotent: the indexer's retry posture
+    /// replays deletes after a failed upsert (see ``SpotlightIndexer/reindex(_:)``).
     func deleteEntities(identifiers: [String]) async throws
 }
 
@@ -23,18 +27,25 @@ public protocol SpotlightIndexBackend: Sendable {
 /// "fold a stream of `SiteStore` mutations into the index" use case driven by
 /// `SiteStore.setChangeHandler` (see `AnglesiteIntents.bootstrap`).
 public actor SpotlightIndexer {
+    /// The production instance, bound to the system index. A singleton so every `SiteStore`
+    /// mutation folds into one `lastIndexedIDs` diff state — two indexers would fight over
+    /// deletes.
     public static let shared = SpotlightIndexer(backend: LiveSpotlightBackend())
 
     private let backend: any SpotlightIndexBackend
     private var lastIndexedIDs: Set<String> = []
 
+    /// Creates an indexer over `backend` with an empty diff baseline — the first `reindex`
+    /// therefore upserts everything and deletes nothing, which is the right cold-start behavior.
     public init(backend: any SpotlightIndexBackend) {
         self.backend = backend
     }
 
     /// Result returned to callers (today: tests only) so they can assert the diff outcome.
     public struct Outcome: Sendable, Equatable {
+        /// How many entities were (re-)upserted this call — the full snapshot size, not a delta.
         public let indexed: Int
+        /// How many previously-indexed ids were deleted because they left the snapshot.
         public let removed: Int
     }
 

--- a/Sources/AnglesiteIntents/ThemeCatalogOverride.swift
+++ b/Sources/AnglesiteIntents/ThemeCatalogOverride.swift
@@ -6,5 +6,7 @@ import AnglesiteCore
 /// fake catalog before invoking `ApplyThemeIntent`, which reads
 /// `ThemeCatalogOverride.scoped ?? self.catalog`, so production flows through `@Dependency`.
 public enum ThemeCatalogOverride {
+    /// The task-scoped fake catalog. Always `nil` in production; a bound value also signals
+    /// "under test" to ``ApplyThemeIntent``, which then skips its `requestConfirmation` gate.
     @TaskLocal public static var scoped: ThemeCatalog?
 }

--- a/Sources/AnglesiteIntents/ThemeIntents.swift
+++ b/Sources/AnglesiteIntents/ThemeIntents.swift
@@ -13,19 +13,29 @@ import Foundation
 /// context and calls the `URL` overload directly — there is no phantom
 /// `AnglesitePackage(sourceDirectory:)` initializer; it does not exist.)
 public struct ApplyThemeIntent: AppIntent {
+    /// The verb Siri/Shortcuts display and match against.
     public static let title: LocalizedStringResource = "Apply Theme"
+    /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Apply a built-in visual theme to a site.")
 
+    /// The site whose design tokens the theme rewrites, resolved through ``SiteEntityQuery``.
     @Parameter(title: "Site") public var site: SiteEntity
+    /// The catalog id of the theme. A plain string (not an `AppEnum`) so the catalog can grow
+    /// without a schema change; an unrecognized id gets a dialog listing what's available
+    /// rather than an error.
     @Parameter(title: "Theme", description: "e.g. warm, classic, bold, elegant.") public var themeID: String
     @Dependency private var catalog: ThemeCatalog
 
+    /// Required by `AppIntent` — the runtime constructs the intent, then fills `@Parameter`s.
     public init() {}
 
+    /// Shortcuts editor sentence: "Apply *theme* theme to *site*".
     public static var parameterSummary: some ParameterSummary {
         Summary("Apply \(\.$themeID) theme to \(\.$site)")
     }
 
+    /// Looks up the theme, confirms (a theme rewrites the site's visual identity in place),
+    /// and applies it through `DesignApplyService` — all dialog wording lives in `run()`.
     public func perform() async throws -> some IntentResult & ProvidesDialog {
         .result(dialog: IntentDialog(stringLiteral: try await run()))
     }

--- a/Sources/AnglesiteIntents/WindowRouter.swift
+++ b/Sources/AnglesiteIntents/WindowRouter.swift
@@ -6,6 +6,9 @@ import Observation
 @MainActor
 @Observable
 public final class WindowRouter {
+    /// The process-wide router. A singleton (with a private init) because both ends of the
+    /// hand-off — intents on one side, the observing SwiftUI scenes on the other — have no
+    /// common injection point.
     public static let shared = WindowRouter()
     private init() {}
 
@@ -23,6 +26,10 @@ public final class WindowRouter {
     /// site root (a plain "preview my site" issued after a prior page navigation).
     public private(set) var pendingNavigation: [String: String?] = [:]
 
+    /// Requests that `siteID`'s window open (or focus), optionally navigating its preview:
+    /// `route` navigates there, an explicit `nil` resets to the site root — passing `nil` still
+    /// records a pending navigation, which is why an already-open window reacts to a plain
+    /// "preview my site".
     public func requestOpen(siteID: String, route: String? = nil) {
         // `updateValue` (not `pendingNavigation[siteID] = route`) so a `nil` route records the
         // key with a nil value — "reset to root" — instead of removing the entry.
@@ -62,6 +69,8 @@ public final class WindowRouter {
     /// Mirrors `requested`/`requestOpen` for the open-existing path.
     public private(set) var newSiteRequested = false
 
+    /// Flags a pending File ▸ New Site request for the "Sites" launcher to consume — see
+    /// ``newSiteRequested`` for the contract.
     public func requestNewSite() { newSiteRequested = true }
 
     /// Called by the launcher once it has consumed the request.


### PR DESCRIPTION
## Summary

- Phase 2 of the doc-comment retrofit tracked in #1141: documents all previously-undocumented public API across AnglesiteIntents' 32 files (~400 doc comments) — intents, entities and their queries, app enums, dialogs, task-local test overrides, Spotlight/Siri-readiness probes, and `WindowRouter`.
- Single-line enum `case` lists were split so each case carries its own rationale; raw values and `CaseIterable` order are unchanged (the `ContentTypeAppEnumTests` drift guard still passes).
- Reattaches an orphaned doc block in `Bootstrap.swift` to the `bootstrap(contentGraph:)` declaration it describes. Comments only otherwise — no behavior changes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --target AnglesiteIntents --warnings-as-errors` — clean (all new symbol links verified against target/gating rules in `docs/comment-style-guide.md`).
- [x] `swift test --filter AnglesiteIntentsTests` — 248 tests in 43 suites, all pass.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run separately; the diff is doc comments only and the target compiles during DocC symbol-graph extraction.
