### PR TITLE
container: suspend the VM on window close instead of stopping it

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -3,6 +3,7 @@ import AppKit
 import AnglesiteCore
 import AnglesiteBridge
 import AnglesiteIntents
+import AnglesiteContainer
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -120,6 +121,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         Task {
             await ProcessSupervisor.shared.shutdownAll(timeout: 5)
+            await PausedContainerRegistry.shared.teardownAll()
             await MainActor.run { NSApp.reply(toApplicationShouldTerminate: true) }
         }
         return .terminateLater

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -224,7 +224,7 @@ final class PreviewModel {
             if let previousSiteID {
                 await EditRouterRegistry.shared.unregister(siteID: previousSiteID)
             }
-            await runtime.stop()
+            await runtime.suspend()
         }
     }
 

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -54,6 +54,18 @@ public struct ContainerizationControl: LocalContainerControl {
         ref: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> LocalContainerSession {
+        if let paused = await PausedContainerRegistry.shared.reclaim(siteID: siteID) {
+            if let session = try? await resumeSession(siteID: siteID, entry: paused, onOutput: onOutput) {
+                return session
+            }
+            // The paused entry is unusable (resume failed, or the proxies/readiness check that
+            // follows it failed) — it's already been removed from the registry by `reclaim`
+            // above, so this instance now owns tearing it down. Never leave the user stuck on a
+            // broken resume: fall through to a normal cold boot.
+            onOutput("[resume] resuming the paused VM failed; falling back to a cold boot", .stderr)
+            await PausedContainerRegistry.teardown(paused, siteID: siteID)
+        }
+
         // Resolves the split-repo gitfile layout (#888/#903): share the directory git can
         // actually clone (Source/ for an embedded .git, the resolved Config/repo.nosync/ gitdir
         // for a migrated package) — a Source/-only share leaves the gitfile's target invisible
@@ -353,6 +365,69 @@ public struct ContainerizationControl: LocalContainerControl {
     public func stopWorkersDev(siteID: String) async throws {
         await live.teardownWorkersDev(siteID: siteID)
     }
+
+    /// Resumes a VM `suspend(siteID:)` (Task 4) previously paused: unpauses it, re-dials fresh
+    /// host-side proxies for the preview and MCP ports (the guest's astro/mcp processes and their
+    /// vsock-bridge `socat` listeners never stopped — only the VM's execution was frozen — so a
+    /// fresh `dialVsock` reaches them immediately, per Task 1's probe), and waits briefly for the
+    /// preview port to answer before handing the resumed container back to `live`. Workers-dev is
+    /// NOT resumed here — `LocalContainerSiteRuntime.start()` recomputes and restarts it fresh via
+    /// `startWorkersDevIfActive` once this returns `.ready`, exactly as a cold boot would.
+    private func resumeSession(
+        siteID: String,
+        entry: PausedContainerRegistry.Entry,
+        onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
+    ) async throws -> LocalContainerSession {
+        let container = entry.container
+        onOutput("[resume] resuming paused VM", .stdout)
+        try await container.withVirtualMachineInstance { vm in try await vm.resume() }
+
+        let dial: VsockDialer = { port in try await container.dialVsock(port: port) }
+        let eventLimiter = EventRateLimiter()
+        let previewProxy = VsockTCPProxy(
+            guestPort: Self.previewPort, dial: dial,
+            onDialError: { error in
+                eventLimiter.log("[proxy:preview] dialVsock(\(Self.previewPort)) failed: \(error)", onOutput: onOutput)
+            },
+            onEvent: { event in eventLimiter.log("[proxy:preview] \(event)", onOutput: onOutput) })
+        let mcpProxy = VsockTCPProxy(
+            guestPort: Self.mcpPort, dial: dial,
+            onDialError: { error in
+                eventLimiter.log("[proxy:mcp] dialVsock(\(Self.mcpPort)) failed: \(error)", onOutput: onOutput)
+            },
+            onEvent: { event in eventLimiter.log("[proxy:mcp] \(event)", onOutput: onOutput) })
+
+        let previewURL: URL
+        let mcpURL: URL
+        do {
+            previewURL = try await previewProxy.start()
+            let mcpBase = try await mcpProxy.start()
+            mcpURL = mcpBase.appendingPathComponent("mcp")
+        } catch {
+            await previewProxy.stop()
+            await mcpProxy.stop()
+            throw LocalContainerError.bootFailed("resume proxy start failed: \(error)")
+        }
+
+        do {
+            try await waitUntilServing(previewURL, timeout: Self.resumeReadyTimeout)
+        } catch {
+            await previewProxy.stop()
+            await mcpProxy.stop()
+            throw LocalContainerError.bootFailed("resumed preview server did not become ready: \(error)")
+        }
+
+        onOutput("[resume] VM resumed", .stdout)
+        await live.store(
+            siteID: siteID, container: container,
+            proxies: [previewProxy, mcpProxy], ext4Artifacts: entry.ext4Artifacts)
+        return LocalContainerSession(previewURL: previewURL, mcpURL: mcpURL)
+    }
+
+    /// Bound on `waitUntilServing` after a resume: the guest process never died (only the VM's
+    /// execution froze), so it should answer almost immediately — unlike `previewReadyTimeout`
+    /// (300s), which budgets for a full cold `npm install`/`astro dev` start.
+    private static let resumeReadyTimeout: Duration = .seconds(20)
 
     /// Phases 0–2 of `start()`: resolve bundled artifacts, unpack rootfs/initfs, boot the VM.
     /// `sourceRepo: nil` boots a bare container (no virtio-fs share) — used by the vsock e2e test.

--- a/Sources/AnglesiteContainer/ContainerizationControl.swift
+++ b/Sources/AnglesiteContainer/ContainerizationControl.swift
@@ -196,6 +196,27 @@ public struct ContainerizationControl: LocalContainerControl {
         await network.release(siteID: siteID)
     }
 
+    /// `LocalContainerControl.suspend(siteID:)` conformance: pauses the VM in place instead of
+    /// tearing it down, handing the container off to the process-wide `PausedContainerRegistry` so
+    /// it survives this (per-window) `ContainerizationControl`/`LiveContainers` instance being
+    /// deallocated when the window closes. Deliberately does NOT call `network.release(siteID:)` —
+    /// the guest's virtual NIC must keep its allocated vmnet IP while paused, or a later `resume()`
+    /// would come back on a network the host has already handed to a different site.
+    public func suspend(siteID: String) async throws {
+        guard let container = await live.container(for: siteID) else {
+            throw LocalContainerError.bootFailed("suspend: no live container for siteID '\(siteID)'")
+        }
+        // Workers-dev isn't preserved across a suspend — `LocalContainerSiteRuntime.start()`
+        // recomputes and restarts it fresh via `startWorkersDevIfActive` after a resume, exactly
+        // as it would after a cold boot.
+        await live.teardownWorkersDev(siteID: siteID)
+        await live.stopProxiesOnly(siteID: siteID)
+        try await container.withVirtualMachineInstance { vm in try await vm.pause() }
+        let artifacts = await live.ext4Artifacts(for: siteID)
+        await live.forget(siteID: siteID)
+        await PausedContainerRegistry.shared.register(siteID: siteID, container: container, ext4Artifacts: artifacts)
+    }
+
     /// `LocalContainerControl.resetNetworking()` conformance (#812): drops this process's cached
     /// vmnet network so the next boot attempt builds a fresh one, without disturbing any
     /// currently-running site's container (see `SharedVmnetNetwork.reset()`) and without an app
@@ -1191,6 +1212,29 @@ actor LiveContainers {
     private var workersDevStateTasks: [String: Task<Void, Never>] = [:]
 
     func container(for siteID: String) -> LinuxContainer? { containers[siteID] }
+
+    /// The ext4 rootfs/initfs artifact paths recorded for `siteID`, or `[]` if none — read by
+    /// `suspend(siteID:)` to hand them off to `PausedContainerRegistry` before this instance
+    /// forgets the site entirely.
+    func ext4Artifacts(for siteID: String) -> [URL] { ext4Artifacts[siteID] ?? [] }
+
+    /// Drops all bookkeeping for `siteID` WITHOUT stopping anything — used by `suspend(siteID:)`
+    /// once the container and its ext4 artifacts have been handed off to
+    /// `PausedContainerRegistry`, so this (per-window) instance no longer believes it owns a site
+    /// whose lifecycle another owner now controls.
+    func forget(siteID: String) {
+        containers[siteID] = nil
+        proxies[siteID] = nil
+        ext4Artifacts[siteID] = nil
+    }
+
+    /// Stops just this site's host-side proxies, leaving the container and its ext4 artifacts
+    /// untouched — the proxy half of a full `teardown(siteID:)`, used by `suspend(siteID:)` (a
+    /// paused VM has nothing listening to proxy to; fresh proxies are re-dialed on resume).
+    func stopProxiesOnly(siteID: String) async {
+        for p in proxies[siteID] ?? [] { await p.stop() }
+        proxies[siteID] = nil
+    }
 
     func store(siteID: String, container: LinuxContainer, proxies ps: [VsockTCPProxy], ext4Artifacts artifacts: [URL]) {
         containers[siteID] = container

--- a/Sources/AnglesiteContainer/PausedContainerRegistry.swift
+++ b/Sources/AnglesiteContainer/PausedContainerRegistry.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Containerization
+
+/// Process-wide holder for site VMs that have been paused (not torn down) on window close —
+/// see docs/superpowers/plans/2026-07-27-suspend-container-on-window-close.md. Must be a true
+/// singleton (like `SharedVmnetNetwork.shared`/`RootfsTemplateCache.shared` in
+/// `ContainerizationControl.swift`), NOT owned by a `ContainerizationControl` instance: each
+/// `LiveSiteRuntimeFactory.makeRuntime` call constructs a fresh `ContainerizationControl()` (and
+/// thus a fresh, per-window `LiveContainers`) every time a site window opens — including
+/// reopening the same site after its previous window fully closed — so a paused container
+/// recorded anywhere per-window would become unreachable the moment that window's object graph
+/// deallocates.
+public actor PausedContainerRegistry {
+    public static let shared = PausedContainerRegistry()
+
+    /// Each paused VM still reserves its full 2 vCPU / 2GB (`ContainerizationControl.swift:445-446`)
+    /// — `pause()` freezes guest execution in place, it does not release the memory
+    /// Virtualization.framework allocated at boot. Capped so an unbounded number of backgrounded
+    /// site windows can't slowly exhaust host resources; worst case with this cap is
+    /// `maxPaused` × 2 vCPU/2GB paused, plus whatever the currently-focused window's own VM costs.
+    public static let maxPaused = 2
+
+    public struct Entry: Sendable {
+        public let container: LinuxContainer
+        public let ext4Artifacts: [URL]
+    }
+
+    private var entries: [String: Entry] = [:]
+    /// Least-recently-suspended siteID first.
+    private var order: [String] = []
+
+    public init() {}
+
+    /// Registers a newly-paused container for `siteID`, evicting (fully tearing down) the
+    /// least-recently-suspended entry first if this would exceed `maxPaused`.
+    public func register(siteID: String, container: LinuxContainer, ext4Artifacts: [URL]) async {
+        if let evictSiteID = Self.siteIDToEvict(order: order, capacity: Self.maxPaused),
+           let victim = entries.removeValue(forKey: evictSiteID) {
+            order.removeAll { $0 == evictSiteID }
+            await Self.teardown(victim, siteID: evictSiteID)
+        }
+        entries[siteID] = Entry(container: container, ext4Artifacts: ext4Artifacts)
+        order.append(siteID)
+    }
+
+    /// Removes and returns the paused entry for `siteID`, or `nil` if none is registered (a
+    /// site that's never been suspended, or one evicted/torn down since it was).
+    public func reclaim(siteID: String) -> Entry? {
+        guard let entry = entries.removeValue(forKey: siteID) else { return nil }
+        order.removeAll { $0 == siteID }
+        return entry
+    }
+
+    /// Tears down every currently-paused container — called once, at app quit
+    /// (`AppDelegate.applicationShouldTerminate`), so quitting never leaves an orphaned paused VM
+    /// or stale ext4 artifact on disk (nothing will ever resume them after the process exits).
+    public func teardownAll() async {
+        for (siteID, entry) in entries {
+            await Self.teardown(entry, siteID: siteID)
+        }
+        entries = [:]
+        order = []
+    }
+
+    /// Pure eviction decision, factored out so it's testable without a real `LinuxContainer`: the
+    /// least-recently-suspended siteID, once `order` would reach `capacity`, else `nil`.
+    static func siteIDToEvict(order: [String], capacity: Int) -> String? {
+        order.count >= capacity ? order.first : nil
+    }
+
+    /// Tears down one paused entry. The VM may still be genuinely paused (never resumed) —
+    /// `LinuxContainer.stop()` requires the underlying VM to be `.running`
+    /// (`VZVirtualMachineInstance.stop()`'s own `guard self.state == .running` throws "vm is not
+    /// running" otherwise, and a paused VM's `VirtualMachineInstanceState` reads `.unknown`, not
+    /// `.running` — `vzStateToInstanceState()` has no `.paused` case, see Task 1's probe finding).
+    /// So every paused entry must be resumed before it can be stopped cleanly. Best-effort
+    /// throughout (`try?`), matching every other teardown path in `ContainerizationControl.swift`.
+    static func teardown(_ entry: Entry, siteID: String) async {
+        try? await entry.container.withVirtualMachineInstance { vm in try await vm.resume() }
+        try? await entry.container.stop()
+        await SharedVmnetNetwork.shared.release(siteID: siteID)
+        for url in entry.ext4Artifacts { try? FileManager.default.removeItem(at: url) }
+    }
+}

--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -130,6 +130,20 @@ public protocol LocalContainerControl: Sendable {
     ) async throws -> LocalContainerSession
     func stop(siteID: String) async throws
 
+    /// Pauses the running VM for `siteID` in place instead of tearing it down — the guest's
+    /// astro/mcp/bridge processes freeze exactly where they are (Virtualization.framework
+    /// `pause()`, reached via `LinuxContainer.withVirtualMachineInstance`), rather than exiting. A
+    /// later `start(siteID:sourceRepo:ref:onOutput:)` call for the SAME siteID resumes this paused
+    /// VM (skipping the boot/clone/hydrate path entirely) if it's still registered in
+    /// `PausedContainerRegistry`, or boots fresh otherwise (first-ever open, or the paused entry
+    /// was evicted/reclaimed by app quit).
+    ///
+    /// Defaults to a full `stop(siteID:)` below for conformers with no pause capability of their
+    /// own (`PodmanContainerControl` on Linux, every test fake) — only `ContainerizationControl`
+    /// overrides this with a real pause. A conformer that inherits the default gets today's
+    /// existing behavior unchanged: "suspend" on window close is just "stop."
+    func suspend(siteID: String) async throws
+
     /// Run `argv` inside the named container's guest environment, streaming each output line to
     /// `onOutput` (tagged with the stream it came from — `.stdout`/`.stderr`) as it arrives, and
     /// returning the captured result when the process exits. No `Containerization`/`Virtualization`
@@ -206,6 +220,10 @@ public protocol LocalContainerControl: Sendable {
 
 extension LocalContainerControl {
     public func resetNetworking() async {}
+
+    public func suspend(siteID: String) async throws {
+        try await stop(siteID: siteID)
+    }
 
     public func startWorkersDev(
         siteID: String,

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -491,9 +491,21 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
         stateMachine.settle(gen: gen, to: .idle)
     }
 
+    /// `SiteRuntime.suspend()` conformance: pauses the container instead of tearing it down (see
+    /// `LocalContainerControl.suspend(siteID:)`). Otherwise identical to `stop()` — the MCP client
+    /// still disconnects and the knowledge/semantic/conventions indexes still unload, exactly as a
+    /// cold boot's `start()` already re-establishes them, since a resumed VM gets a fresh MCP HTTP
+    /// connection (the old one's underlying vsock proxy no longer exists — Task 5 re-dials a new
+    /// one on resume) rather than a preserved one.
+    public func suspend() async {
+        let gen = stateMachine.beginAttempt()
+        await teardown(suspending: true)
+        stateMachine.settle(gen: gen, to: .idle)
+    }
+
     // MARK: Internals
 
-    private func teardown() async {
+    private func teardown(suspending: Bool = false) async {
         // Snapshot-and-clear all bookkeeping before the first suspension: actors are reentrant,
         // so a superseding start()'s/stop()'s teardown can interleave while this one is suspended,
         // and a successful boot from a superseding start() can complete and install fresh
@@ -520,7 +532,11 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
             await conventionsEngine?.unload(siteID: siteID)
         }
         if let id = containerSiteID {
-            try? await control.stop(siteID: id)
+            if suspending {
+                try? await control.suspend(siteID: id)
+            } else {
+                try? await control.stop(siteID: id)
+            }
             // Explicit, not just supervisor-event-driven: the fake controls in tests never emit
             // .stopped, and a real teardown must never leave a stale row either way (#699).
             workersDevURLs[id] = nil

--- a/Sources/AnglesiteCore/SiteRuntime.swift
+++ b/Sources/AnglesiteCore/SiteRuntime.swift
@@ -74,6 +74,15 @@ public protocol SiteRuntimeContainerCapability: AnyObject, Sendable {
 public protocol SiteRuntime: Actor {
     func start(siteID: String, siteDirectory: URL) async
     func stop() async
+
+    /// Pauses this site's runtime instead of fully stopping it, when the substrate supports it —
+    /// e.g. `LocalContainerSiteRuntime` pauses the VM in place so a later `start(siteID:
+    /// siteDirectory:)` for the SAME siteID resumes in seconds instead of cold-booting. Defaults
+    /// to a full `stop()` below for every conformer without a pause capability
+    /// (`RemoteSandboxSiteRuntime`, `UnavailableSiteRuntime`) — closing a window against one of
+    /// those behaves exactly as it does today.
+    func suspend() async
+
     func observe() -> AsyncStream<SiteRuntimeState>
     var mcpClient: MCPClient { get }
     /// The container-only capability surface (deploy execution context, network reset, edit
@@ -92,4 +101,6 @@ public extension SiteRuntime {
     /// Default for every conformer that isn't `LocalContainerSiteRuntime`: no container-only
     /// capabilities to expose.
     nonisolated var containerCapability: (any SiteRuntimeContainerCapability)? { nil }
+
+    func suspend() async { await stop() }
 }

--- a/Tests/AnglesiteAppTests/PreviewModelSuspendOnCloseTests.swift
+++ b/Tests/AnglesiteAppTests/PreviewModelSuspendOnCloseTests.swift
@@ -29,12 +29,26 @@ struct PreviewModelSuspendOnCloseTests {
         let model = PreviewModel(runtime: runtime)
         let root = URL(fileURLWithPath: "/tmp/suspend-on-close-test")
         model.open(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root))
-        try await Task.sleep(for: .milliseconds(50))  // open() dispatches its boot in a Task
-
         model.close()
-        try await Task.sleep(for: .milliseconds(50))  // close() dispatches its teardown in a Task
+
+        // open()/close() both dispatch their runtime call in an unstructured Task — poll rather
+        // than guess a fixed delay, so this stays reliable under a slow/loaded full-suite run
+        // rather than only in isolation (a single fixed sleep flaked under full-suite CPU load).
+        await pollUntil(timeout: .seconds(5)) {
+            let suspended = await runtime.suspendCalls
+            let stopped = await runtime.stopCalls
+            return suspended > 0 || stopped > 0
+        }
 
         #expect(await runtime.suspendCalls == 1)
         #expect(await runtime.stopCalls == 0)
+    }
+
+    private func pollUntil(timeout: Duration, _ condition: () async -> Bool) async {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
     }
 }

--- a/Tests/AnglesiteAppTests/PreviewModelSuspendOnCloseTests.swift
+++ b/Tests/AnglesiteAppTests/PreviewModelSuspendOnCloseTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// Records whether `stop()` or `suspend()` was called, without doing anything else — isolates
+/// exactly the one behavior this test needs to prove: `PreviewModel.close()` must call `suspend()`,
+/// not `stop()`, so a closed-then-reopened site window can resume instead of cold-booting.
+private actor SpySiteRuntime: SiteRuntime {
+    private(set) var stopCalls = 0
+    private(set) var suspendCalls = 0
+    let mcpClient = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+    private let (stream, continuation) = AsyncStream<SiteRuntimeState>.makeStream()
+
+    func start(siteID: String, siteDirectory: URL) async {
+        continuation.yield(.ready(siteID: siteID, url: URL(string: "http://127.0.0.1:1")!, workersDevURL: nil))
+    }
+    func stop() async { stopCalls += 1 }
+    func suspend() async { suspendCalls += 1 }
+    func observe() -> AsyncStream<SiteRuntimeState> { stream }
+}
+
+@Suite("PreviewModel suspend-on-close")
+@MainActor
+struct PreviewModelSuspendOnCloseTests {
+    @Test
+    func closeSuspendsRatherThanStops() async throws {
+        let runtime = SpySiteRuntime()
+        let model = PreviewModel(runtime: runtime)
+        let root = URL(fileURLWithPath: "/tmp/suspend-on-close-test")
+        model.open(site: CurrentSite(id: "site-1", packageURL: root, sourceDirectory: root))
+        try await Task.sleep(for: .milliseconds(50))  // open() dispatches its boot in a Task
+
+        model.close()
+        try await Task.sleep(for: .milliseconds(50))  // close() dispatches its teardown in a Task
+
+        #expect(await runtime.suspendCalls == 1)
+        #expect(await runtime.stopCalls == 0)
+    }
+}

--- a/Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift
@@ -39,6 +39,27 @@ struct ContainerizationControlTests {
         try? await control.stop(siteID: "e2e")
     }
 
+    @Test("suspend pauses the VM without deleting its ext4 artifacts")
+    func suspendPausesWithoutDeletingArtifacts() async throws {
+        try #require(enabled, "set ANGLESITE_CONTAINER_E2E=1 on an entitled Apple-Silicon Mac")
+        let control = ContainerizationControl()
+        let siteID = "suspend-test-\(UUID().uuidString.prefix(8))"
+        let repo = try makeThrowawayAstroRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        _ = try await control.start(siteID: siteID, sourceRepo: repo, ref: "HEAD", onOutput: { _, _ in })
+        try await control.suspend(siteID: siteID)
+
+        let entry = await PausedContainerRegistry.shared.reclaim(siteID: siteID)
+        #expect(entry != nil)
+        for url in entry?.ext4Artifacts ?? [] {
+            #expect(FileManager.default.fileExists(atPath: url.path))
+        }
+        // Cleanup: reclaim() already removed it from the registry — tear it down for real so the
+        // test doesn't leak a paused VM.
+        if let entry { await PausedContainerRegistry.teardown(entry, siteID: siteID) }
+    }
+
     @Test("execInteractive echoes what's written to its stdin back out through onOutput")
     func execInteractiveEchoesStdin() async throws {
         try #require(enabled, "set ANGLESITE_CONTAINER_E2E=1 on an entitled Apple-Silicon Mac")

--- a/Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/ContainerizationControlTests.swift
@@ -60,6 +60,32 @@ struct ContainerizationControlTests {
         if let entry { await PausedContainerRegistry.teardown(entry, siteID: siteID) }
     }
 
+    @Test("start resumes a paused container instead of cold-booting")
+    func startResumesAPausedContainerInsteadOfColdBooting() async throws {
+        try #require(enabled, "set ANGLESITE_CONTAINER_E2E=1 on an entitled Apple-Silicon Mac")
+        let control = ContainerizationControl()
+        let siteID = "resume-test-\(UUID().uuidString.prefix(8))"
+        let repo = try makeThrowawayAstroRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let firstSession = try await control.start(siteID: siteID, sourceRepo: repo, ref: "HEAD", onOutput: { _, _ in })
+        try await control.suspend(siteID: siteID)
+        defer { Task { try? await control.stop(siteID: siteID) } }
+
+        let start = ContinuousClock.now
+        let resumedSession = try await control.start(siteID: siteID, sourceRepo: repo, ref: "HEAD", onOutput: { _, _ in })
+        let elapsed = ContinuousClock.now - start
+
+        // A resume never re-hydrates the guest (no clone/npm install/astro cold start), so it must
+        // land well under the ~186s+ a cold boot pays (`previewReadyTimeout`'s own doc comment) —
+        // 30s gives ample margin over VM-resume + proxy-redial + short readiness poll while still
+        // catching a regression that silently fell back to a full cold boot.
+        #expect(elapsed < .seconds(30))
+        #expect(resumedSession.previewURL != firstSession.previewURL || resumedSession.mcpURL != firstSession.mcpURL)
+
+        try await control.stop(siteID: siteID)
+    }
+
     @Test("execInteractive echoes what's written to its stdin back out through onOutput")
     func execInteractiveEchoesStdin() async throws {
         try #require(enabled, "set ANGLESITE_CONTAINER_E2E=1 on an entitled Apple-Silicon Mac")

--- a/Tests/AnglesiteContainerLocalTests/PausedContainerRegistryTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/PausedContainerRegistryTests.swift
@@ -1,0 +1,19 @@
+import Testing
+import Foundation
+@testable import AnglesiteContainer
+
+struct PausedContainerRegistryTests {
+    @Test
+    func evictsOldestOnlyWhenAtCapacity() {
+        #expect(PausedContainerRegistry.siteIDToEvict(order: [], capacity: 2) == nil)
+        #expect(PausedContainerRegistry.siteIDToEvict(order: ["a"], capacity: 2) == nil)
+        #expect(PausedContainerRegistry.siteIDToEvict(order: ["a", "b"], capacity: 2) == "a")
+        #expect(PausedContainerRegistry.siteIDToEvict(order: ["a", "b", "c"], capacity: 2) == "a")
+    }
+
+    @Test
+    func reclaimReturnsNilForUnknownSiteID() async {
+        let registry = PausedContainerRegistry()
+        #expect(await registry.reclaim(siteID: "never-registered") == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
+++ b/Tests/AnglesiteCoreTests/FakeLocalContainerControl.swift
@@ -4,6 +4,7 @@ import Foundation
 actor FakeLocalContainerControl: LocalContainerControl {
     var startResult: Result<LocalContainerSession, LocalContainerError>
     private(set) var stopped: [String] = []
+    private(set) var suspended: [String] = []
     private(set) var startedRepos: [(siteID: String, repo: URL, ref: String)] = []
     /// Overrides `LocalContainerControl`'s default no-op so tests can assert
     /// `resetNetworking()` calls actually reach the control, not just that the call compiles.
@@ -80,6 +81,8 @@ actor FakeLocalContainerControl: LocalContainerControl {
     }
 
     func stop(siteID: String) async throws { stopped.append(siteID) }
+
+    func suspend(siteID: String) async throws { suspended.append(siteID) }
 
     func resetNetworking() async { resetNetworkingCallCount += 1 }
 

--- a/Tests/AnglesiteCoreTests/LocalContainerControlSuspendDefaultTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerControlSuspendDefaultTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct LocalContainerControlSuspendDefaultTests {
+    /// A conformer that implements nothing beyond the protocol's required methods — proving the
+    /// default `suspend(siteID:)` extension (Task 3) really delegates to `stop(siteID:)` rather
+    /// than silently no-op'ing, which every conformer that hasn't opted into a real pause
+    /// (`PodmanContainerControl`, every existing test fake) relies on.
+    actor MinimalControl: LocalContainerControl {
+        private(set) var stopped: [String] = []
+
+        func start(siteID: String, sourceRepo: URL, ref: String,
+                   onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void) async throws -> LocalContainerSession {
+            LocalContainerSession(previewURL: URL(string: "http://127.0.0.1:1")!, mcpURL: URL(string: "http://127.0.0.1:2")!)
+        }
+        func stop(siteID: String) async throws { stopped.append(siteID) }
+        func exec(siteID: String, argv: [String], environment: [String: String], workingDirectory: String,
+                   onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void) async throws -> ContainerExecResult {
+            ContainerExecResult(exitCode: 0, stdout: "", stderr: "")
+        }
+        func execInteractive(siteID: String, argv: [String], environment: [String: String], workingDirectory: String,
+                              onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void) async throws -> InteractiveExecHandle {
+            InteractiveExecHandle(write: { _ in }, terminate: {})
+        }
+        func startWorkersDev(siteID: String, workers: [WorkerDescriptor],
+                              onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void) async throws -> URL {
+            URL(string: "http://127.0.0.1:3")!
+        }
+        func stopWorkersDev(siteID: String) async throws {}
+    }
+
+    @Test
+    func defaultSuspendDelegatesToStop() async throws {
+        let control = MinimalControl()
+        try await control.suspend(siteID: "site-1")
+        #expect(await control.stopped == ["site-1"])
+    }
+}

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -357,6 +357,28 @@ struct LocalContainerSiteRuntimeTests {
         #expect(await fake.stopped == ["s1"])
     }
 
+    @Test("suspend calls control.suspend, not control.stop")
+    func suspendCallsControlSuspendNotControlStop() async {
+        let (rt, fake) = makeRuntime(.success(Self.ok))
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+
+        await rt.suspend()
+
+        #expect(await fake.suspended == ["s1"])
+        #expect(await fake.stopped == [])
+    }
+
+    @Test("stop still calls control.stop, not control.suspend")
+    func stopStillCallsControlStopNotControlSuspend() async {
+        let (rt, fake) = makeRuntime(.success(Self.ok))
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+
+        await rt.stop()
+
+        #expect(await fake.stopped == ["s1"])
+        #expect(await fake.suspended == [])
+    }
+
     @Test("stop during suspended start: stale-generation guard drops the result")
     func staleGenerationGuard() async {
         let gated = GatedFakeLocalContainerControl(result: .success(Self.ok))


### PR DESCRIPTION
Closes #1038

## Summary

- Adds a process-wide `PausedContainerRegistry` (LRU-capped at 2) that holds a site's VM across window close, since `LiveSiteRuntimeFactory.makeRuntime` constructs a fresh `ContainerizationControl`/`LiveContainers` per window open.
- Adds `LocalContainerControl.suspend(siteID:)` / `SiteRuntime.suspend()` protocol seams (default to a full `stop()` for conformers without a pause capability — `PodmanContainerControl`, `RemoteSandboxSiteRuntime`, `UnavailableSiteRuntime`, every test fake) and a real `ContainerizationControl.suspend(siteID:)` override that pauses the VM via Virtualization.framework instead of tearing it down.
- Teaches `ContainerizationControl.start()` to reclaim and resume a paused VM before falling back to a cold boot (falls back cleanly if resume fails, so a broken paused entry can never strand the user).
- Wires `PreviewModel.close()` (window close) to `runtime.suspend()` and `applicationShouldTerminate` to `PausedContainerRegistry.shared.teardownAll()`, so nothing paused survives past the app's own process lifetime. `Site ▸ Stop Dev Server` is unchanged — it still calls `stop()`.

Task 1 (the pause/resume validation spike confirming the vsock layer survives a pause/resume cycle) already shipped in #1064. This PR covers Tasks 2–7 of the implementation plan (`docs/superpowers/plans/2026-07-27-suspend-container-on-window-close.md`); Task 8 is verification.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change needs a paired PR in `Anglesite/anglesite-skills`.

## Test plan

- [x] `swift test --package-path .` — full suite passes. Two pre-existing `FoundationModelAssistant` on-device tests ("Session ended without producing a response") are flaky regardless of this change (confirmed by rerun) and unrelated.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] `ANGLESITE_CONTAINER_TESTS=1 ANGLESITE_CONTAINER_E2E=1 swift test --package-path . --filter AnglesiteContainerLocalTests` — attempted on this entitled Apple-Silicon Mac, but blocked by host vmnet resource contention (`VMNET_MEM_FAILURE`) from other concurrently-running worktree agents on this machine at the time. The *pre-existing* `bootsAndServes` test (unrelated to this change) failed identically, confirming this is host contention, not a regression. Needs a clean re-run.
- [ ] Manual smoke: close/reopen a site window and confirm a fast resume (`[resume] resuming paused VM` log lines, not a cold `[boot] resolving bundled image/kernel artifacts`), confirm a 3rd/4th open evicts the LRU paused entry, confirm `Site ▸ Stop Dev Server` still fully stops, confirm app quit leaves no paused-VM ext4 artifacts behind. Not run in this environment (no interactive GUI session available) — needs a manual pass before merge.