### PR TITLE
docs(#1141): retrofit doc comments, Core A11y-CommunitiesLedger

### DIFF
--- a/Sources/AnglesiteCore/A11yAuditRunner.swift
+++ b/Sources/AnglesiteCore/A11yAuditRunner.swift
@@ -17,10 +17,20 @@ import Foundation
 /// The runner stays thin and stateless — all the parsing is a single static method
 /// so it's trivially testable without spawning `tsx`.
 public struct A11yAuditRunner: AuditRunner {
+    /// Fixed to `.accessibility` — `AuditCommand` uses the category to attribute this runner's
+    /// findings and to record it in `runnersExecuted`/`runnersSkipped`.
     public let category: AuditReport.Finding.Category = .accessibility
 
+    /// Nothing to configure — the runner is stateless by design (see the type doc); everything
+    /// it needs arrives per-call in `run(...)`.
     public init() {}
 
+    /// Runs the audit script through `executor` and parses its `--json` stdout into findings.
+    ///
+    /// Exit codes 0/1/2 all mean "the script ran" — the code encodes severity, which the
+    /// returned findings already reflect, so none of them is treated as a failure. Anything
+    /// else (including a nil exit code from a pre-spawn refusal) throws `Error.scriptFailed`,
+    /// so the UI can say "the audit couldn't run" instead of silently reporting a clean result.
     public func run(
         siteDirectory: URL,
         executor: any AuditExecutor,
@@ -51,9 +61,19 @@ public struct A11yAuditRunner: AuditRunner {
         return try Self.parse(json: Data(jsonString.utf8))
     }
 
+    /// Why a run produced no findings at all. Conforms to `CustomStringConvertible` because
+    /// `AuditCommand` records a thrown runner error via `"\(error)"` interpolation — see the
+    /// `description` note below for why that text must stay owner-facing.
     public enum Error: Swift.Error, Equatable, CustomStringConvertible {
+        /// The script exited with an unexpected code — or never spawned at all (`exitCode` nil:
+        /// pre-spawn refusal, container not running, or a thrown exec). `output` carries whatever
+        /// it printed, which is often already an owner-facing message.
         case scriptFailed(exitCode: Int32?, output: String)
+        /// The script ran (accepted exit code) but its stdout contained no JSON object to parse.
         case noJSONInOutput
+        /// The report used a severity outside the known `"error"`/`"warning"`/`"notice"` set.
+        /// Thrown rather than guessed at, so a vocabulary change in `a11y-audit.ts` fails loudly
+        /// instead of silently miscategorizing findings.
         case unknownSeverity(String)
 
         /// Owner-facing text — this is what ends up in `AuditReport.SkippedRunner.reason` (via

--- a/Sources/AnglesiteCore/ACPAgentConnection.swift
+++ b/Sources/AnglesiteCore/ACPAgentConnection.swift
@@ -4,10 +4,20 @@ import Foundation
 /// protocol for editor<->agent communication. Non-secret fields only; a `.remote` connection's
 /// bearer token lives in `SecretStore` under `SecretAccounts.acpAgentToken(id:)`, keyed by `id`.
 public struct ACPAgentConnection: Codable, Identifiable, Sendable, Equatable {
+    /// Stable identity — also the Keychain key for a `.remote` connection's bearer token
+    /// (`SecretAccounts.acpAgentToken(id:)`), so it must survive renames and transport edits;
+    /// only deleting the connection retires it.
     public let id: UUID
+    /// Owner-chosen display name. Surfaced as the assistant's `providerName` in chat, so it's
+    /// how the owner tells which agent is answering.
     public var name: String
+    /// How the app reaches this agent — see `Transport` for the consequences of each choice.
     public var transport: Transport
 
+    /// The two ways an ACP agent can be reached. The choice also decides which filesystem the
+    /// agent sees: a `.stdio` agent works on the container's clone of the site, a `.remote`
+    /// agent only on paths meaningful to its own host — see `ACPAssistant`'s working-directory
+    /// note.
     public enum Transport: Codable, Sendable, Equatable {
         /// Launched inside the open site's container, alongside the dev server and MCP sidecar.
         case stdio(command: String, arguments: [String])
@@ -15,6 +25,8 @@ public struct ACPAgentConnection: Codable, Identifiable, Sendable, Equatable {
         case remote(url: URL)
     }
 
+    /// Memberwise init. Pass a fresh `UUID` for a new connection; reuse the existing `id` when
+    /// editing one, since it keys the stored bearer token (see `id`).
     public init(id: UUID, name: String, transport: Transport) {
         self.id = id
         self.name = name

--- a/Sources/AnglesiteCore/ACPAssistant.swift
+++ b/Sources/AnglesiteCore/ACPAssistant.swift
@@ -57,6 +57,11 @@ public actor ACPAssistant: ConversationalAssistant {
     /// handshake are deferred to the first turn (see the type doc).
     ///
     /// - Parameters:
+    ///   - connection: the agent's transport coordinates (stdio command or remote endpoint) —
+    ///     which transport gets built on the first turn follows from its `transport` case.
+    ///   - siteID: the site whose container a `.stdio` agent execs into; also scopes secrets.
+    ///   - sourceDirectory: the site's host `Source/` directory, exposed to the agent as its
+    ///     working context.
     ///   - containerControlProvider: consulted per connection attempt for `.stdio` transports.
     ///     The default ("no container") makes a `.stdio` turn fail with
     ///     `ACPAssistantError.containerUnavailable` rather than hang.

--- a/Sources/AnglesiteCore/ACPAssistant.swift
+++ b/Sources/AnglesiteCore/ACPAssistant.swift
@@ -16,8 +16,13 @@ import FoundationModels
 /// + single-turn prompt/response) to make "switch which model answers chat" real. No multi-turn
 /// tool-permission UI yet — `ACPClient` auto-declines any `session/request_permission`.
 public actor ACPAssistant: ConversationalAssistant {
+    /// Supplies the site's *current* container control, or `nil` when no container is running.
+    /// A closure rather than a captured value because the container comes and goes with the
+    /// preview lifecycle — it's resolved at connect time (first turn), not at init.
     public typealias ContainerControlProvider = @Sendable () async -> (siteID: String, control: any LocalContainerControl)?
 
+    /// Failures reaching the agent at all, as opposed to protocol-level errors once connected
+    /// (those are `ACPClient.ACPError`).
     public enum ACPAssistantError: Error, Sendable, Equatable {
         /// A `.stdio` connection is active but no container is currently running for this site
         /// (e.g. the preview hasn't finished starting yet).
@@ -48,6 +53,18 @@ public actor ACPAssistant: ConversationalAssistant {
         }
     }
 
+    /// Creates the assistant without connecting anything — transport construction and the ACP
+    /// handshake are deferred to the first turn (see the type doc).
+    ///
+    /// - Parameters:
+    ///   - containerControlProvider: consulted per connection attempt for `.stdio` transports.
+    ///     The default ("no container") makes a `.stdio` turn fail with
+    ///     `ACPAssistantError.containerUnavailable` rather than hang.
+    ///   - secretStore: where a `.remote` connection's bearer token is read from, keyed by
+    ///     `connection.id`. A read failure degrades to an unauthenticated request — the remote
+    ///     agent rejects it if a token was actually required.
+    ///   - transportFactory: test seam. When set it replaces the production transport selection
+    ///     entirely, and `containerControlProvider`/`secretStore` go unused.
     public init(
         connection: ACPAgentConnection,
         siteID: String,
@@ -80,6 +97,10 @@ public actor ACPAssistant: ConversationalAssistant {
         }
     }
 
+    /// Static, connection-independent capabilities: streaming and tools yes (ACP agents call
+    /// tools mid-turn, surfaced as `.toolUse`/`.toolResult` events), structured output no —
+    /// guided generation is FoundationModels-only. `providerName` echoes the owner-chosen
+    /// connection name so chat shows which agent is answering.
     public nonisolated var capabilities: AssistantCapabilities {
         AssistantCapabilities(
             supportsStreaming: true, supportsStructuredOutput: false, supportsVision: false,
@@ -87,6 +108,10 @@ public actor ACPAssistant: ConversationalAssistant {
         )
     }
 
+    /// `ContentAssistant`'s plain-text path, implemented by flattening ``converse(prompt:context:)``'s
+    /// event stream: only `.textDelta` text survives, `.failed` becomes a thrown
+    /// `AssistantError.streamFailed`, and tool/thinking events are dropped — callers that need
+    /// those use `converse` directly.
     public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
         let events = try await converse(prompt: prompt, context: context)
         return AsyncThrowingStream { continuation in
@@ -105,11 +130,20 @@ public actor ACPAssistant: ConversationalAssistant {
     }
 
     #if compiler(>=6.4) && canImport(FoundationModels)
+    /// Always throws `AssistantError.unsupported`: guided generation is defined by
+    /// FoundationModels' `Generable` machinery, which an external ACP agent can't participate
+    /// in. Declared only under the same toolchain gate as the protocol requirement it satisfies
+    /// (see the gate note at the top of this file).
     public func generateStructured<T: Generable & Sendable>(prompt: String, context: AssistantContext, resultType: T.Type) async throws -> T {
         throw AssistantError.unsupported("ACP agents do not support FoundationModels guided generation")
     }
     #endif
 
+    /// Streams one conversational turn. The first call performs the lazy connect — transport
+    /// construction, ACP `initialize`, `session/new` — and later calls reuse both, so the agent
+    /// keeps conversation context across turns. Throws (rather than yielding `.failed`) only
+    /// for setup problems (no container for a `.stdio` connection, handshake failure), per
+    /// `ConversationalAssistant`'s contract.
     public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
         let client = try await connectedClient()
         let sessionID = try await ensureSession(client: client)
@@ -128,11 +162,18 @@ public actor ACPAssistant: ConversationalAssistant {
         }
     }
 
+    /// Cancels the current turn via `session/cancel` — and only the turn: the client and its
+    /// transport deliberately stay connected so a follow-up message in the same session keeps
+    /// working. Full teardown happens in `deinit` (see the note there). No-op before the first
+    /// turn ever starts.
     public func cancel() async {
         guard let client, let sessionID else { return }
         await client.cancelSession(sessionID: sessionID)
     }
 
+    /// Drops the session id so the next ``converse(prompt:context:)`` starts a fresh
+    /// `session/new`. The connected client/transport is kept — only the agent-side conversation
+    /// context is discarded.
     public func resetSession() async {
         sessionID = nil
     }

--- a/Sources/AnglesiteCore/ACPClient.swift
+++ b/Sources/AnglesiteCore/ACPClient.swift
@@ -11,8 +11,14 @@ import Foundation
 /// has no tool-permission UI (see the ACP agent settings design spec §4.4/§5), so an agent that
 /// attempts a tool call during the proof-of-concept turn is told "no" rather than left hanging.
 public actor ACPClient {
+    /// Protocol-level failures. These surface to `ACPAssistant` as thrown errors during setup
+    /// calls, or in-band as `.failed(message:)` events mid-turn.
     public enum ACPError: Error, Sendable, Equatable {
+        /// The server answered, but the payload was missing a required field (e.g. `session/new`
+        /// without a `sessionId`). Carries a short description of what was expected.
         case invalidResponse(String)
+        /// The server returned a JSON-RPC error object for a request; `code`/`message` come
+        /// straight off the wire.
         case rpcError(code: Int, message: String)
         /// A call was made after `stop()` (or before the client has ever started). Mirrors
         /// `MCPClient.MCPError.notInitialized` — fail fast instead of registering a pending
@@ -41,6 +47,8 @@ public actor ACPClient {
     /// defaults (10s / 10s / 120s). Not `public` — reachable only via `@testable import`.
     private var requestTimeoutOverrideForTesting: TimeInterval?
 
+    /// Creates a client over `transport`. Nothing is opened or sent until ``initialize()`` —
+    /// construction stays cheap and non-blocking, matching `ACPAssistant`'s lazy-connect design.
     public init(transport: any ACPTransport) {
         self.transport = transport
     }
@@ -50,6 +58,10 @@ public actor ACPClient {
         requestTimeoutOverrideForTesting = timeout
     }
 
+    /// Opens the transport, starts the inbound reader task, and performs the ACP `initialize`
+    /// handshake (10s timeout). Declares the `fs` read/write capabilities as unavailable —
+    /// this slice implements no filesystem request handlers, so advertising them would leave a
+    /// conformant agent's `fs/*` requests hanging.
     public func initialize() async throws {
         try await transport.open()
         readerTask = Task { [weak self] in
@@ -63,6 +75,9 @@ public actor ACPClient {
         _ = try await sendRequest(method: "initialize", params: params, timeout: requestTimeoutOverrideForTesting ?? 10)
     }
 
+    /// Creates a new ACP session rooted at `cwd` and returns its server-assigned id. Passes an
+    /// empty `mcpServers` list — wiring the site's MCP sidecar into agent sessions is out of
+    /// this proof-of-concept's scope (see the type doc).
     public func newSession(cwd: String) async throws -> String {
         let result = try await sendRequest(
             method: "session/new",
@@ -108,6 +123,10 @@ public actor ACPClient {
         return stream
     }
 
+    /// Sends the `session/cancel` notification for the in-flight turn. Best-effort by design
+    /// (`try?`): cancellation carries no response to wait on, and the turn's own
+    /// `session/prompt` request resolves its stream either way — a failed cancel just means the
+    /// agent finishes the turn it was asked to abandon.
     public func cancelSession(sessionID: String) async {
         try? await sendNotification(
             method: "session/cancel",
@@ -116,6 +135,11 @@ public actor ACPClient {
         )
     }
 
+    /// Tears the client down: cancels the reader task, closes the transport (for a `.stdio`
+    /// agent, terminating the in-container guest process — see `ACPAssistant`'s `deinit` note
+    /// on the leak this prevents), and fails/finishes everything in flight so no caller is left
+    /// awaiting a response that can never arrive. Terminal — later sends throw
+    /// `ACPError.stopped`; there is no restart.
     public func stop() async {
         isStopped = true
         readerTask?.cancel()

--- a/Sources/AnglesiteCore/ACPContainerExecTransport.swift
+++ b/Sources/AnglesiteCore/ACPContainerExecTransport.swift
@@ -20,6 +20,15 @@ public actor ACPContainerExecTransport: ACPTransport {
     private let stream: AsyncStream<JSONValue>
     private let continuation: AsyncStream<JSONValue>.Continuation
 
+    /// Captures the launch parameters without spawning anything — the guest process starts in
+    /// ``open()``.
+    ///
+    /// - Parameters:
+    ///   - workingDirectory: defaults to `/workspace/site`, the fixed guest path every site repo
+    ///     is cloned to inside its container (the same convention `ACPAssistant` and
+    ///     `DeployExecutor` rely on).
+    ///   - logCenter: injectable for tests; production uses the shared instance so the agent's
+    ///     output lands in the debug pane alongside everything else.
     public init(
         control: any LocalContainerControl,
         siteID: String,
@@ -37,6 +46,10 @@ public actor ACPContainerExecTransport: ACPTransport {
         (self.stream, self.continuation) = AsyncStream<JSONValue>.makeStream(bufferingPolicy: .unbounded)
     }
 
+    /// Spawns the agent process in the container via `execInteractive`. Stdout lines that parse
+    /// as JSON become inbound messages; non-JSON stdout (a startup banner, say) is logged but
+    /// deliberately skipped rather than failing the stream, and stderr is log-only — an agent
+    /// that chats on stderr can't corrupt the protocol channel.
     public func open() async throws {
         let logSource = "acp:\(siteID)"
         handle = try await control.execInteractive(
@@ -55,20 +68,31 @@ public actor ACPContainerExecTransport: ACPTransport {
         )
     }
 
+    /// Writes one newline-framed JSON-RPC message to the guest process's stdin. Throws
+    /// `ACPTransportError.notOpen` if ``open()`` hasn't run (or failed) — fail fast rather than
+    /// queue writes for a process that doesn't exist.
     public func send(_ message: JSONValue) async throws {
         guard let handle else { throw ACPTransportError.notOpen }
         let data = try JSONSerialization.data(withJSONObject: message.rawValue)
         try await handle.write(data + Data("\n".utf8))
     }
 
+    /// The parsed-stdout message stream. `nonisolated` (the stream/continuation pair is created
+    /// at init and never reassigned) so `ACPClient` can obtain it without an actor hop, even
+    /// before ``open()``.
     public nonisolated func inbound() -> AsyncStream<JSONValue> { stream }
 
+    /// Terminates the guest process and finishes the inbound stream, so the consumer's
+    /// `for await` loop ends instead of hanging on a process that will never print again.
     public func close() async {
         await handle?.terminate()
         continuation.finish()
     }
 }
 
+/// Errors shared by `ACPTransport` conformers (only the stdio transport throws it today —
+/// `ACPHTTPTransport` has no open/closed state to violate).
 public enum ACPTransportError: Error, Sendable, Equatable {
+    /// `send` was called before `open()` succeeded — there is no guest process to write to.
     case notOpen
 }

--- a/Sources/AnglesiteCore/ACPContainerExecTransport.swift
+++ b/Sources/AnglesiteCore/ACPContainerExecTransport.swift
@@ -24,6 +24,10 @@ public actor ACPContainerExecTransport: ACPTransport {
     /// ``open()``.
     ///
     /// - Parameters:
+    ///   - control: the container runtime whose `execInteractive` spawns the agent in the guest.
+    ///   - siteID: selects which site's live container to exec into.
+    ///   - command: the agent executable to run inside the guest.
+    ///   - arguments: arguments passed to `command` verbatim.
     ///   - workingDirectory: defaults to `/workspace/site`, the fixed guest path every site repo
     ///     is cloned to inside its container (the same convention `ACPAssistant` and
     ///     `DeployExecutor` rely on).

--- a/Sources/AnglesiteCore/ACPHTTPTransport.swift
+++ b/Sources/AnglesiteCore/ACPHTTPTransport.swift
@@ -44,8 +44,11 @@ public actor ACPHTTPTransport: ACPTransport {
     /// `Authorization: Bearer` header on **every** POST — there is no persistent connection to
     /// authenticate once, so each request must carry its own credentials.
     ///
-    /// - Parameter urlSession: injectable so tests can substitute a `URLProtocol`-backed
-    ///   session; defaults to `.shared`.
+    /// - Parameters:
+    ///   - endpoint: the remote agent's HTTP endpoint; every request POSTs here.
+    ///   - bearerToken: per-request credential (see above); `nil` sends unauthenticated requests.
+    ///   - urlSession: injectable so tests can substitute a `URLProtocol`-backed
+    ///     session; defaults to `.shared`.
     public init(endpoint: URL, bearerToken: SessionToken? = nil, urlSession: URLSession = .shared) {
         self.endpoint = endpoint
         self.bearerToken = bearerToken

--- a/Sources/AnglesiteCore/ACPHTTPTransport.swift
+++ b/Sources/AnglesiteCore/ACPHTTPTransport.swift
@@ -16,8 +16,13 @@ import FoundationNetworking
 /// `ACPClient.consumeInbound` already routes each yielded message correctly regardless of order —
 /// a notification (no "id") to `routeSessionUpdate`, a response (has "id") to `resolvePending`.
 public actor ACPHTTPTransport: ACPTransport {
+    /// Transport-level failures for one POST exchange.
     public enum HTTPError: Error, Sendable, Equatable {
+        /// The endpoint answered with a non-2xx status. Only the status is kept — an error body
+        /// from a remote agent isn't protocol traffic, so it isn't retained or decoded.
         case http(status: Int)
+        /// The response wasn't HTTP at all, or a bounded `application/json` body failed to
+        /// decode as JSON.
         case badResponse
         /// A single SSE line (the accumulated `data:` payload since the last event boundary)
         /// exceeded `maxLineBytes` without a terminating blank line — guards against unbounded
@@ -35,6 +40,12 @@ public actor ACPHTTPTransport: ACPTransport {
     private let stream: AsyncStream<JSONValue>
     private let continuation: AsyncStream<JSONValue>.Continuation
 
+    /// Creates the transport. `bearerToken`, when present, is sent as an
+    /// `Authorization: Bearer` header on **every** POST — there is no persistent connection to
+    /// authenticate once, so each request must carry its own credentials.
+    ///
+    /// - Parameter urlSession: injectable so tests can substitute a `URLProtocol`-backed
+    ///   session; defaults to `.shared`.
     public init(endpoint: URL, bearerToken: SessionToken? = nil, urlSession: URLSession = .shared) {
         self.endpoint = endpoint
         self.bearerToken = bearerToken
@@ -42,8 +53,17 @@ public actor ACPHTTPTransport: ACPTransport {
         (self.stream, self.continuation) = AsyncStream<JSONValue>.makeStream(bufferingPolicy: .unbounded)
     }
 
+    /// No-op: no persistent connection; the first send does the work.
     public func open() async throws { /* no persistent connection; first send does the work */ }
 
+    /// POSTs one JSON-RPC message and yields whatever comes back onto ``inbound()``.
+    ///
+    /// An SSE response is read incrementally and this call returns as soon as the response
+    /// matching the outgoing request's id arrives (see the type doc for why "stream ended" is
+    /// not a safe termination signal); a notification POST (no id) reads until the stream ends.
+    /// The read loops cooperatively check `Task.isCancelled` so `ACPClient`'s timeout
+    /// cancellation actually tears the connection down rather than abandoning it — see
+    /// `ACPClient.sendRequest`'s doc comment.
     public func send(_ message: JSONValue) async throws {
         // The id of the outgoing request, if any (absent for notifications). Used below to stop
         // reading the SSE stream as soon as the matching response arrives, rather than waiting for
@@ -200,8 +220,16 @@ public actor ACPHTTPTransport: ACPTransport {
         return obj["result"] != nil || obj["error"] != nil
     }
 
+    /// Messages decoded from every ``send(_:)``'s response — final responses and any
+    /// `session/update` notifications the server pushed on an SSE stream, in arrival order.
+    /// One shared stream across sends; `ACPClient.consumeInbound` routes each message by the
+    /// presence/value of its id. `nonisolated` (the stream is created at init and never
+    /// reassigned) so the consumer can attach without an actor hop.
     public nonisolated func inbound() -> AsyncStream<JSONValue> { stream }
 
+    /// Finishes the inbound stream so the consumer's loop ends. There is no connection to tear
+    /// down — an in-flight ``send(_:)`` is bounded by its caller's timeout/cancellation, not by
+    /// `close`.
     public func close() async { continuation.finish() }
 
     private func decode(_ payload: String) -> JSONValue? {

--- a/Sources/AnglesiteCore/ActivityAssertion.swift
+++ b/Sources/AnglesiteCore/ActivityAssertion.swift
@@ -18,6 +18,10 @@ public enum ActivityAssertion {
         private let lock = NSLock()
         private var onRelease: (@Sendable () -> Void)?
 
+        /// `onRelease` runs exactly once — on the first ``release()`` call, or in `deinit` if
+        /// the caller drops the lease without releasing. Public so tests can construct a lease
+        /// around a counting closure (see the type doc for why the raw `ProcessInfo` token is
+        /// never what's stored).
         public init(onRelease: @escaping @Sendable () -> Void) {
             self.onRelease = onRelease
         }

--- a/Sources/AnglesiteCore/ActivityPubFollowers.swift
+++ b/Sources/AnglesiteCore/ActivityPubFollowers.swift
@@ -101,9 +101,12 @@ public struct ActivityPubFollowersClient: Sendable {
 
     /// Creates a client for one site's collection.
     ///
-    /// - Parameter siteURL: the site's public origin. The followers URL is derived through
-    ///   `ActivityPubActor`, so callers never construct (and can never mistype) collection URLs
-    ///   themselves.
+    /// - Parameters:
+    ///   - siteURL: the site's public origin. The followers URL is derived through
+    ///     `ActivityPubActor`, so callers never construct (and can never mistype) collection URLs
+    ///     themselves.
+    ///   - transport: injectable for tests; defaults to ``defaultTransport``, the capped
+    ///     HTTPS-enforcing production path.
     public init(
         siteURL: URL,
         transport: @escaping Transport = ActivityPubFollowersClient.defaultTransport

--- a/Sources/AnglesiteCore/ActivityPubFollowers.swift
+++ b/Sources/AnglesiteCore/ActivityPubFollowers.swift
@@ -32,11 +32,14 @@ import FoundationNetworking
 
 /// The `OrderedCollection` head of the followers collection.
 public struct FollowersCollection: Sendable, Equatable {
+    /// The server-reported follower count — what the pane displays without fetching a single
+    /// page. Paging itself follows `next` links and never counts against this.
     public let totalItems: Int
     /// `nil` when `totalItems == 0` — `@dwk/activitypub` omits `first` entirely for an empty
     /// collection, which is how the genuine empty state is detected without a second request.
     public let firstPage: URL?
 
+    /// Memberwise init, public so tests can build fixture heads without a decoder round trip.
     public init(totalItems: Int, firstPage: URL?) {
         self.totalItems = totalItems
         self.firstPage = firstPage
@@ -45,21 +48,29 @@ public struct FollowersCollection: Sendable, Equatable {
 
 /// One `OrderedCollectionPage` of follower actor IRIs, newest follower first.
 public struct FollowersPage: Sendable, Equatable {
+    /// Follower actor IRIs on this page, in the server's newest-first order (preserved, not
+    /// re-sorted — the client has nothing better to sort by than the server's own recency).
     public let items: [URL]
     /// `nil` on the last page. Paging follows this link rather than counting against
     /// `totalItems`, so the client never needs to know the server's page size.
     public let next: URL?
 
+    /// Memberwise init, public so tests can build fixture pages without a decoder round trip.
     public init(items: [URL], next: URL?) {
         self.items = items
         self.next = next
     }
 }
 
+/// Failures reading the followers collection, shaped so the Fediverse pane can render them
+/// directly — which is why bodies are pre-truncated (see
+/// `ActivityPubFollowersClient.maximumErrorBodyCharacters`) rather than passed through raw.
 public enum ActivityPubFollowersError: Error, Equatable, Sendable {
     /// Non-2xx, or a transport failure (`status: 0`). `503` means ActivityPub isn't provisioned
     /// for this site; `404` means the Worker isn't deployed. The pane distinguishes them.
     case requestFailed(status: Int, body: String)
+    /// 2xx, but the body didn't decode as the expected AS2 shape. Carries the decoder's own
+    /// description — diagnostic text for the Debug pane, not owner-facing copy.
     case decodingFailed(String)
 }
 
@@ -70,6 +81,8 @@ public enum ActivityPubFollowersError: Error, Equatable, Sendable {
 /// is served unauthenticated straight from the actor's Durable Object, so there is no bearer
 /// token, no DPoP proof, and no nonce retry here.
 public struct ActivityPubFollowersClient: Sendable {
+    /// Injectable network seam: takes the fully-formed request, returns body + response. Tests
+    /// substitute a canned closure; production uses ``defaultTransport``.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     /// The `Accept` AS2 requires; Fediverse servers content-negotiate on it and will serve HTML
@@ -86,6 +99,11 @@ public struct ActivityPubFollowersClient: Sendable {
     private let followersURL: URL
     private let transport: Transport
 
+    /// Creates a client for one site's collection.
+    ///
+    /// - Parameter siteURL: the site's public origin. The followers URL is derived through
+    ///   `ActivityPubActor`, so callers never construct (and can never mistype) collection URLs
+    ///   themselves.
     public init(
         siteURL: URL,
         transport: @escaping Transport = ActivityPubFollowersClient.defaultTransport

--- a/Sources/AnglesiteCore/ActivityPubKeyProvisioning.swift
+++ b/Sources/AnglesiteCore/ActivityPubKeyProvisioning.swift
@@ -9,15 +9,32 @@ import Security
 /// first time a caller asks — never regenerated, since rotating the signing key breaks
 /// federation trust with existing followers (#363 design doc, "Keypair generation & storage").
 public enum ActivityPubKeyProvisioning {
+    /// The per-site secret bundle handed to Worker provisioning as deploy-time secrets. Stable
+    /// across calls for a given site — see the type doc's never-regenerate rationale.
     public struct Secrets: Sendable, Equatable {
+        /// PKCS#8 PEM — the WebCrypto-importable private-key format `@dwk/activitypub`
+        /// requires (Security framework's native PKCS#1 export won't import there).
         public let privateKeyPem: String
+        /// SPKI PEM. Re-derived from the private key on every call rather than persisted — one
+        /// less stored secret that could drift out of sync with its private half.
         public let publicKeyPem: String
+        /// Random 256-bit base64url bearer token authorizing publish/fan-out POSTs to the
+        /// site's own Worker (e.g. the outbox backfill's `Authorization` header).
         public let publishToken: String
     }
 
+    /// Why secret generation or key-format conversion failed. These surface in deploy logs;
+    /// the associated strings carry the underlying Security-framework description where one
+    /// exists.
     public enum Error: Swift.Error {
+        /// `SecKeyCreateRandomKey`/`SecRandomCopyBytes` failed — no key material was produced.
         case keyGenerationFailed(String)
+        /// Converting between key representations failed (Security-framework export/import, or
+        /// the PEM/DER wrapping done in this file).
         case exportFailed(String)
+        /// No Security framework on this platform. The portable (non-Darwin) targets compile
+        /// this type but can't provision secrets — they throw at runtime instead of failing to
+        /// build (see the note on `generatePrivateKeyPem`).
         case unsupportedPlatform
     }
 

--- a/Sources/AnglesiteCore/ActivityPubOutboxBackfill.swift
+++ b/Sources/AnglesiteCore/ActivityPubOutboxBackfill.swift
@@ -16,16 +16,27 @@ import FoundationNetworking
 /// adjust here if the accepted shape differs before this is wired live (design doc §3, Task 6's
 /// blocking note).
 public struct ActivityPubOutboxBackfill: Sendable {
+    /// Injectable network seam: takes the fully-formed request, returns body + response. Tests
+    /// substitute a canned closure; production uses ``defaultTransport``.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
+    /// One entry's result, returned (not just logged) so callers and tests can assert what
+    /// happened without parsing `LogCenter` output.
     public struct Outcome: Equatable, Sendable {
+        /// The entry's canonical page URL — also its identity in `ActivityPubOutboxLedger`.
         public let canonicalURL: String
+        /// True when the outbox returned 2xx — even if the local ledger write then failed
+        /// (see `detail`); acceptance is the server's fact, ledger state is ours.
         public let accepted: Bool
+        /// The failure description, or the ledger-write warning on an otherwise-accepted entry;
+        /// `nil` on full success.
         public let detail: String?
     }
 
     private let transport: Transport
 
+    /// Creates the runner. Everything site-specific arrives per-call in `backfill(...)`, so one
+    /// instance serves any site; `transport` is the only injectable.
     public init(transport: @escaping Transport = ActivityPubOutboxBackfill.defaultTransport) {
         self.transport = transport
     }
@@ -141,6 +152,8 @@ public struct ActivityPubOutboxBackfill: Sendable {
         return json["id"] as? String
     }
 
+    /// Production transport: a plain `URLSession` request (matching
+    /// `ActivityPubFollowersClient.defaultTransport`'s shape).
     public static let defaultTransport: Transport = { request in
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }

--- a/Sources/AnglesiteCore/ActivityPubOutboxLedger.swift
+++ b/Sources/AnglesiteCore/ActivityPubOutboxLedger.swift
@@ -6,12 +6,20 @@ import Foundation
 /// POSSE tracks outbound copies posted to *other* platforms, this tracks entries synced into
 /// *this site's own* outbox — different concepts that happen to share a JSON-ledger pattern.
 public struct ActivityPubOutboxLedger: Codable, Equatable, Sendable {
+    /// One synced content entry.
     public struct Entry: Codable, Equatable, Sendable {
+        /// The entry's canonical page URL — the dedupe key ``ActivityPubOutboxLedger/contains(canonicalURL:)``
+        /// and ``ActivityPubOutboxLedger/record(_:)`` match on. Chosen over the activity id
+        /// because it's the identity that's stable across deploys and known *before* the POST.
         public let canonicalURL: String
         /// The activity id the outbox DO returned for this insert.
         public let activityID: String
+        /// When the outbox accepted the entry (the backfill run's reference date — not the
+        /// content's own publish date, which lives in the activity itself).
         public let syncedAt: Date
 
+        /// Memberwise init, public so `ActivityPubOutboxBackfill` (and tests) can record
+        /// entries directly.
         public init(canonicalURL: String, activityID: String, syncedAt: Date) {
             self.canonicalURL = canonicalURL
             self.activityID = activityID
@@ -19,14 +27,22 @@ public struct ActivityPubOutboxLedger: Codable, Equatable, Sendable {
         }
     }
 
+    /// The ledger's filename inside the site's `Config/` directory — app-owned state beside the
+    /// repo, never inside it (see the type doc).
     public static let filename = "activitypub-outbox.json"
 
+    /// All recorded entries, in sync order. `private(set)` so the only mutation path is
+    /// ``record(_:)`` and its idempotent-insert contract can't be bypassed.
     public private(set) var entries: [Entry]
 
+    /// Starts a ledger, empty by default — "brand-new site" and `load(from:)` returning `nil`
+    /// deliberately collapse to the same starting state.
     public init(entries: [Entry] = []) {
         self.entries = entries
     }
 
+    /// Whether `canonicalURL` has already been synced — the filter `ActivityPubOutboxBackfill`
+    /// applies before POSTing anything.
     public func contains(canonicalURL: String) -> Bool {
         entries.contains { $0.canonicalURL == canonicalURL }
     }
@@ -42,6 +58,10 @@ public struct ActivityPubOutboxLedger: Codable, Equatable, Sendable {
         let entries: [Entry]
     }
 
+    /// Reads the ledger from `configDirectory` — `nil` for a missing *or* undecodable file.
+    /// Both collapse to "start fresh" on purpose: the worst consequence is re-posting entries
+    /// the outbox already accepted, which is preferable to a corrupt ledger blocking the whole
+    /// backfill.
     public static func load(from configDirectory: URL) -> ActivityPubOutboxLedger? {
         let url = configDirectory.appendingPathComponent(filename)
         guard let data = try? Data(contentsOf: url) else { return nil }
@@ -51,6 +71,9 @@ public struct ActivityPubOutboxLedger: Codable, Equatable, Sendable {
         return ActivityPubOutboxLedger(entries: envelope.entries)
     }
 
+    /// Writes the ledger atomically (a crash mid-write leaves the previous file intact, per the
+    /// crash-safety contract in the type doc), creating `configDirectory` if needed. Output is
+    /// pretty-printed with sorted keys so successive writes diff cleanly.
     public func save(to configDirectory: URL) throws {
         try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
         let encoder = JSONEncoder()

--- a/Sources/AnglesiteCore/ActorProfile.swift
+++ b/Sources/AnglesiteCore/ActorProfile.swift
@@ -8,12 +8,23 @@ import FoundationNetworking
 /// Only the icon's *URL* is kept, never image bytes: `AvatarLoader` fetches the image per visible
 /// row, which keeps the persisted cache small and stops the app becoming an image store.
 public struct ActorProfile: Codable, Equatable, Sendable {
+    /// The actor's IRI — the profile's identity, and (in string form) the key
+    /// ``ActorProfileCache`` stores it under.
     public let actor: URL
+    /// The instance-supplied username, already routed through ``DisplayString/safe(_:)``: both
+    /// name fields are freely attacker-controlled and can carry bidi-control scalars that make a
+    /// rendered name impersonate a trusted one.
     public let preferredUsername: String?
+    /// The instance-supplied display name, sanitized the same way as ``preferredUsername``.
     public let name: String?
+    /// The avatar's URL — never its bytes (see the type-level note), and only when served over
+    /// HTTPS; a plaintext avatar is dropped rather than failing the whole profile.
     public let iconURL: URL?
+    /// When the profile was fetched, driving ``ActorProfileCache``'s time-to-live expiry.
     public let fetchedAt: Date
 
+    /// Memberwise initializer — public because the synthesized one would be internal, and tests
+    /// plus cache fixtures need to build profiles without going through a fetch.
     public init(
         actor: URL,
         preferredUsername: String?,
@@ -29,11 +40,19 @@ public struct ActorProfile: Codable, Equatable, Sendable {
     }
 }
 
+/// Why a profile fetch was rejected. Every case is non-fatal to callers — the follower row
+/// simply falls back to its derived handle — but the cases stay distinct so tests can pin
+/// *which* defense fired.
 public enum ActorProfileError: Error, Equatable, Sendable {
     /// The actor IRI, or the URL a redirect actually landed on, wasn't `https`.
     case insecureURL
+    /// The body exceeded ``ActorProfileFetcher/maximumResponseBytes``. Carries the byte count
+    /// observed when the transfer was cut off.
     case responseTooLarge(Int)
+    /// The server answered outside 2xx. Carries the HTTP status.
     case requestFailed(status: Int)
+    /// The body wasn't a decodable actor document. Carries the underlying error's description
+    /// as a `String` because `Error` itself isn't `Equatable`.
     case decodingFailed(String)
 }
 
@@ -44,6 +63,9 @@ public enum ActorProfileError: Error, Equatable, Sendable {
 /// after redirects), a hard byte cap enforced *during* transfer, and a short timeout. Callers
 /// treat every failure as non-fatal — the row falls back to its derived handle.
 public struct ActorProfileFetcher: Sendable {
+    /// Injection seam for the HTTP layer, so tests exercise the defenses without a network.
+    /// Returns the `HTTPURLResponse` (not just data) because ``profile(for:now:)`` must re-check
+    /// the URL a redirect actually landed on.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     /// 256 KB. An actor document is a few KB; anything approaching this is pathological.
@@ -59,10 +81,17 @@ public struct ActorProfileFetcher: Sendable {
 
     private let transport: Transport
 
+    /// Creates a fetcher. The default transport is the capped, streaming production one — inject
+    /// a ``Transport`` only to fake the network in tests.
     public init(transport: @escaping Transport = ActorProfileFetcher.defaultTransport) {
         self.transport = transport
     }
 
+    /// Fetches and decodes the actor document at `actor`, applying every defense described on
+    /// the type. `now` is injectable so tests can pin the resulting `fetchedAt`.
+    ///
+    /// - Throws: ``ActorProfileError`` — callers treat any case as "no enrichment for this row",
+    ///   never as fatal.
     public func profile(for actor: URL, now: Date = Date()) async throws -> ActorProfile {
         try Self.requireHTTPS(actor)
 

--- a/Sources/AnglesiteCore/ActorProfileCache.swift
+++ b/Sources/AnglesiteCore/ActorProfileCache.swift
@@ -7,6 +7,8 @@ import Foundation
 /// the site's git repo (#242). Follows `POSSESyndicationLog`'s shape: an envelope-wrapped JSON
 /// file, ISO-8601 dates, atomic write, and `nil` rather than a throw on a corrupt file.
 public struct ActorProfileCache: Equatable, Sendable {
+    /// The cache's filename inside `Config/`. Namespaced with an `activitypub-` prefix because
+    /// `Config/` is a flat directory shared by every app-owned per-site store.
     public static let filename = "activitypub-follower-profiles.json"
 
     /// Seven days. Display names and avatars change rarely, so a few days of staleness costs
@@ -18,6 +20,8 @@ public struct ActorProfileCache: Equatable, Sendable {
     /// normalizations to key on directly.
     private var profiles: [String: ActorProfile]
 
+    /// Builds a cache from a flat profile list (the persisted envelope's shape). When two entries
+    /// share an actor IRI the later one wins — last write is the freshest.
     public init(profiles: [ActorProfile] = []) {
         self.profiles = profiles.reduce(into: [:]) { $0[$1.actor.absoluteString] = $1 }
     }
@@ -29,12 +33,17 @@ public struct ActorProfileCache: Equatable, Sendable {
         return cached
     }
 
+    /// Stores (or replaces) the entry for the profile's actor. Expiry is applied on read and on
+    /// save, never here — storing a fresh fetch must always win over whatever it replaces.
     public mutating func store(_ profile: ActorProfile) {
         profiles[profile.actor.absoluteString] = profile
     }
 
     private struct Envelope: Codable { let profiles: [ActorProfile] }
 
+    /// Loads the cache from `configDirectory`, or `nil` when the file is missing or corrupt —
+    /// a bad cache costs only re-fetches, so it's discarded silently rather than surfaced as an
+    /// error the owner can't act on.
     public static func load(from configDirectory: URL) -> ActorProfileCache? {
         guard let data = try? Data(contentsOf: configDirectory.appendingPathComponent(filename))
         else { return nil }

--- a/Sources/AnglesiteCore/AddStoreRouter.swift
+++ b/Sources/AnglesiteCore/AddStoreRouter.swift
@@ -2,17 +2,38 @@
 
 /// What the owner is selling — mirrors the plugin's `add-store` skill intake question.
 public enum StoreCategory: String, CaseIterable, Sendable {
-    case service, donations, digitalDownloads, physicalGoods, software
+    /// A service the owner provides (consulting, sessions, commissions) — a single buy button
+    /// suffices, no catalog.
+    case service
+    /// Tips/donations rather than a sale — routes to the dedicated donations integration, not a
+    /// checkout.
+    case donations
+    /// Downloadable files (ebooks, presets, music) — the one category with a platform follow-up,
+    /// ``DigitalPreference``.
+    case digitalDownloads
+    /// Physical products that ship — the one category with a size follow-up, ``CatalogSize``.
+    case physicalGoods
+    /// Software licensing/subscriptions — routed to Paddle, the merchant-of-record option built
+    /// for that billing model.
+    case software
 }
 
 /// Digital-download platform preference — only relevant when `category == .digitalDownloads`.
 public enum DigitalPreference: String, CaseIterable, Sendable {
-    case polar, lemonSqueezy
+    /// Polar via the buy-button integration — the default when the owner doesn't answer the
+    /// follow-up (see ``AddStoreRouter/route(category:digitalPreference:catalogSize:)``).
+    case polar
+    /// The dedicated Lemon Squeezy overlay integration.
+    case lemonSqueezy
 }
 
 /// Physical-goods catalog size — only relevant when `category == .physicalGoods`.
 public enum CatalogSize: String, CaseIterable, Sendable {
-    case few, catalog
+    /// A handful of products — Snipcart, which needs no external dashboard. The default when the
+    /// owner doesn't answer the follow-up.
+    case few
+    /// A full catalog — Shopify Buy Button, whose dashboard earns its setup cost at this scale.
+    case catalog
 }
 
 /// Deterministic routing for the "Add a Store" wizard entry point: given what the owner is
@@ -21,15 +42,26 @@ public enum CatalogSize: String, CaseIterable, Sendable {
 /// `add-store` skill routing table, minus the revenue-tracking webhook step (deferred — see
 /// docs/superpowers/specs/2026-07-05-add-store-wizard-router-design.md).
 public enum AddStoreRouter {
+    /// The wizard's destination: which integration to open, and which provider it should be
+    /// pre-set to when that integration offers a choice.
     public struct Route: Sendable, Equatable {
+        /// The integration whose ``IntegrationDescriptor`` sheet the wizard opens.
         public let integrationID: IntegrationID
+        /// Raw provider identifier (e.g. `stripe`, `polar`) the opened integration should
+        /// pre-select, or `nil` when the integration has no provider choice to make.
         public let presetProvider: String?
+        /// Memberwise initializer — public so tests can assert routes without invoking
+        /// ``AddStoreRouter/route(category:digitalPreference:catalogSize:)``.
         public init(integrationID: IntegrationID, presetProvider: String?) {
             self.integrationID = integrationID
             self.presetProvider = presetProvider
         }
     }
 
+    /// Resolves the owner's answers to a ``Route``. The follow-up parameters are only consulted
+    /// for the category they belong to, and an unanswered follow-up falls back to a sensible
+    /// default (Polar for downloads, Snipcart for physical goods) — the wizard must always land
+    /// somewhere, never dead-end on a skipped question.
     public static func route(
         category: StoreCategory,
         digitalPreference: DigitalPreference? = nil,

--- a/Sources/AnglesiteCore/AltTextGenerator.swift
+++ b/Sources/AnglesiteCore/AltTextGenerator.swift
@@ -32,6 +32,12 @@ public struct AltTextGenerator: Sendable {
     private let apply: Applier
     private let log: @Sendable (String) async -> Void
 
+    /// Creates a generator for one site.
+    ///
+    /// `isEnabled` is a closure rather than a captured `Bool` so the owner's setting is re-read
+    /// on every edit — toggling it takes effect immediately without rebuilding the edit pipeline.
+    /// `log` defaults to a no-op because failures here are best-effort by design; production
+    /// passes the debug-pane logger so swallowed errors still leave a trace ("logs are sacred").
     public init(
         siteID: String,
         siteDirectory: URL,

--- a/Sources/AnglesiteCore/AltTextPromptBuilder.swift
+++ b/Sources/AnglesiteCore/AltTextPromptBuilder.swift
@@ -6,6 +6,10 @@ import Foundation
 /// from `AltTextGenerator` and `SiteAssistantSessionFactory` so it's directly unit-testable
 /// without constructing either.
 public enum AltTextPromptBuilder {
+    /// Returns `basePrompt` prefixed with a guidance preamble when the site's conventions carry
+    /// real signal; otherwise the bare prompt unchanged. Each guidance line is gated on an
+    /// override or a positive sample size so a freshly created site's zero-valued defaults never
+    /// masquerade as learned style.
     public static func build(basePrompt: String, conventions: ProjectConventions?) -> String {
         guard let conventions, let preamble = guidance(from: conventions) else { return basePrompt }
         return "\(preamble)\n\n\(basePrompt)"

--- a/Sources/AnglesiteCore/AnglesiteSiteModelExports.swift
+++ b/Sources/AnglesiteCore/AnglesiteSiteModelExports.swift
@@ -1,4 +1,10 @@
 import AnglesiteSiteModel
 
+/// Re-export of `AnglesiteSiteModel.AnglesitePackage` — the single source of truth for the
+/// `.anglesite` package layout (#242) — so code that already imports AnglesiteCore reaches the
+/// package model without a second import. A typealias rather than `@_exported import` keeps the
+/// surface deliberate: only the symbols named here leak through.
 public typealias AnglesitePackage = AnglesiteSiteModel.AnglesitePackage
+/// Re-export of `AnglesiteSiteModel.ProjectValidator` (the "is this directory an Anglesite site?"
+/// sentinel check), forwarded for the same single-import reason as ``AnglesitePackage``.
 public typealias ProjectValidator = AnglesiteSiteModel.ProjectValidator

--- a/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
+++ b/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
@@ -10,6 +10,8 @@ import Foundation
 /// rest, so the flow degrades rather than breaks (verified pre-fill behavior last on 2026-06-16 for
 /// the original five groups).
 public enum AnglesiteTokenTemplate {
+    /// The token's display name, pre-filled into the dashboard form so the owner can recognize —
+    /// and later audit or revoke — the app's token among any others on their account.
     public static let tokenName = "Anglesite"
 
     /// Dashboard permission-group keys with their access level. Order is display order.
@@ -42,6 +44,11 @@ public enum AnglesiteTokenTemplate {
         ("registrar", "edit"),
     ]
 
+    /// The dashboard deep link that pre-fills the whole template: name, all accounts/zones (the
+    /// one token must cover every site the owner deploys), and ``permissionGroups`` encoded as a
+    /// JSON array in a query param. Built with `URLComponents` so that JSON payload is
+    /// percent-escaped rather than hand-assembled. See the type-level note for what happens if
+    /// Cloudflare stops honoring these undocumented params.
     public static var createTokenURL: URL {
         let permissions = "[" + permissionGroups
             .map { #"{"key":"\#($0.key)","type":"\#($0.type)"}"# }

--- a/Sources/AnglesiteCore/AnimationCatalog.swift
+++ b/Sources/AnglesiteCore/AnimationCatalog.swift
@@ -6,22 +6,46 @@ import Foundation
 /// builds AnglesiteCore, so no AppKit/Darwin-only APIs belong here — the AppKit-facing gallery UI
 /// lives in `Sources/AnglesiteApp/AnimationsGalleryView.swift`.
 public struct AnimationCatalogEntry: Sendable, Codable, Identifiable, Hashable {
+    /// `Identifiable` conformance for SwiftUI lists — the component export name, which the
+    /// manifest keeps unique, so no separate id field is needed.
     public var id: String { component }
+    /// The `@astroanimate/core` export name (e.g. `FadeInText`) — the stable key everything else
+    /// (demo pages, snippets, identity) derives from.
     public let component: String
+    /// Short human title shown in the gallery grid.
     public let title: String
+    /// Plain-language description written for site owners, not developers — the gallery's
+    /// audience. Named `ownerDescription` to keep that framing explicit (and to stay clear of
+    /// `CustomStringConvertible`'s `description`).
     public let ownerDescription: String
+    /// Which gallery section the entry belongs to.
     public let category: AnimationCategory
+    /// The props worth tuning, mapped to a human hint about each (e.g. `"duration"` →
+    /// `"seconds (default 0.6)"`) — display strings for the gallery, not machine-readable
+    /// defaults.
     public let keyProps: [String: String]
+    /// Ready-to-paste Astro usage snippet, import line included.
     public let snippet: String
 }
 
 /// `category` values from the manifest schema: `text | cards | buttons | backgrounds | navigation`.
 public enum AnimationCategory: String, Sendable, Codable, CaseIterable, Hashable {
-    case text, cards, buttons, backgrounds, navigation
+    /// Headline/body text effects (fades, reveals).
+    case text
+    /// Card and container entrance/hover effects.
+    case cards
+    /// Button hover and press feedback.
+    case buttons
+    /// Full-bleed background motion.
+    case backgrounds
+    /// Menu and navigation transitions.
+    case navigation
 }
 
 /// Decodes the template's curated Astro Animate catalog and locates its prerendered demo pages.
 public struct AnimationCatalog: Sendable {
+    /// Every curated entry, preserving manifest order — the template's curation order *is* the
+    /// gallery's display order, so no re-sorting happens app-side.
     public let entries: [AnimationCatalogEntry]
 
     /// Mirrors the manifest's top-level shape (`{ "version": 1, "components": [...] }`); only

--- a/Sources/AnglesiteCore/AnnotationFeed.swift
+++ b/Sources/AnglesiteCore/AnnotationFeed.swift
@@ -11,15 +11,32 @@ import Foundation
 /// chat messages"): there is no standalone sticky-note UI in the app to remove; the chat panel
 /// is the only surface that displays annotations.
 public struct Annotation: Sendable, Equatable, Identifiable, Codable {
+    /// Store-assigned identifier (an 8-character nanoid — see ``AnnotationStore``); the handle
+    /// `resolve_annotation` takes, so it must survive round-trips unchanged.
     public let id: String
+    /// The page route the note was pinned on, used to scope `list_annotations` to the page the
+    /// owner is looking at.
     public let path: String
+    /// CSS selector of the pinned element, so the overlay can re-highlight the note's target on
+    /// a later visit.
     public let selector: String
+    /// The component source file the overlay resolved for the element, when it could — lets a
+    /// fix land in the owning component rather than being hunted down from the rendered page.
+    /// `nil` when resolution failed; the note is still useful without it.
     public let sourceFile: String?
+    /// The owner's note, verbatim.
     public let text: String
+    /// Whether the note has been addressed. Resolved annotations stay in the file (for history)
+    /// but are filtered out of every listing.
     public let resolved: Bool
+    /// When the note was created.
     public let createdAt: Date
+    /// When the note was resolved; `nil` while it's still open.
     public let resolvedAt: Date?
 
+    /// Memberwise initializer mirroring the JSON shape. The defaults (`sourceFile`/`resolvedAt`
+    /// as `nil`) match the fields the plugin omits rather than nulls, so fixtures read like the
+    /// file does.
     public init(
         id: String,
         path: String,

--- a/Sources/AnglesiteCore/AnnotationStore.swift
+++ b/Sources/AnglesiteCore/AnnotationStore.swift
@@ -21,6 +21,8 @@ public enum AnnotationStore {
     /// nanoid alphabet from `annotations.mjs` — 64 URL-safe characters indexed by `byte & 63`.
     private static let alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
 
+    /// The store's two refusals, mirroring the errors `annotations.mjs` throws so callers see
+    /// the same failure modes whichever store backs them.
     public enum AnnotationStoreError: Error, Equatable {
         /// `add` rejected because `maxUnresolved` unresolved annotations already exist.
         case limitReached(Int)

--- a/Sources/AnglesiteCore/AnnouncedPost.swift
+++ b/Sources/AnglesiteCore/AnnouncedPost.swift
@@ -27,10 +27,15 @@ import Foundation
 public struct AnnouncedPost: Codable, Sendable, Equatable, Identifiable {
     /// AS2 object type of the wrapped post, per the Worker's own classification.
     public enum ObjectType: String, Codable, Sendable, Equatable {
+        /// AS2 `Note` — a short, microblog-style post.
         case note
+        /// AS2 `Article` — long-form writing.
         case article
+        /// AS2 `Page` — a standalone web page.
         case page
+        /// AS2 `Video`.
         case video
+        /// AS2 `Event`.
         case event
     }
 
@@ -39,10 +44,18 @@ public struct AnnouncedPost: Codable, Sendable, Equatable, Identifiable {
     /// Not live-updated — if the member later changes their name/photo, the old values persist
     /// in the snapshot, same as `ReceivedInteraction.Author`.
     public struct Author: Codable, Sendable, Equatable {
+        /// The member's display name at announce time.
         public let name: String?
+        /// The member's own profile/site URL. Web-scheme-validated by the enclosing
+        /// ``AnnouncedPost``'s initializer, because it flows into an `href`.
         public let url: URL?
+        /// The member's avatar URL at announce time. Same web-scheme validation as ``url``, for
+        /// the same reason (it flows into a `src`).
         public let photo: URL?
 
+        /// Memberwise initializer. Deliberately non-throwing: the scheme checks live in
+        /// ``AnnouncedPost``'s initializer, the single choke point every constructed post — with
+        /// or without an author — must pass through.
         public init(name: String?, url: URL?, photo: URL?) {
             self.name = name
             self.url = url
@@ -71,8 +84,13 @@ public struct AnnouncedPost: Codable, Sendable, Equatable, Identifiable {
     /// For example: `"data/community-posts/ap-abc123.json"`
     public var gitPath: String { "data/community-posts/\(id).json" }
 
+    /// Construction-time rejections enforcing the type-level sanitisation contract.
     public enum ValidationError: Error, Sendable {
+        /// The id contained characters outside `[A-Za-z0-9_-]` — rejected so ``gitPath`` can
+        /// never be steered outside `data/community-posts/`.
         case invalidID(String)
+        /// A URL destined for `href`/`src` carried a non-`http(s)` scheme (`javascript:`,
+        /// `data:`, …).
         case insecureURL(URL)
     }
 
@@ -85,6 +103,13 @@ public struct AnnouncedPost: Codable, Sendable, Equatable, Identifiable {
         }
     }
 
+    /// Validating initializer — the choke point for programmatic construction, enforcing the
+    /// type-level sanitisation contract. Note the synthesized `Decodable` path does *not* run
+    /// these checks; decoded files rely on the template's zod validation downstream.
+    ///
+    /// - Throws: ``ValidationError/invalidID(_:)`` when `id` strays outside `[A-Za-z0-9_-]+`, or
+    ///   ``ValidationError/insecureURL(_:)`` when `sourceURL` — or the author's `url`/`photo` —
+    ///   isn't `http`/`https`.
     public init(
         id: String,
         objectType: ObjectType,

--- a/Sources/AnglesiteCore/AnnouncedPostSync.swift
+++ b/Sources/AnglesiteCore/AnnouncedPostSync.swift
@@ -40,10 +40,17 @@ public enum AnnouncedPostSync {
         let announcedAt: Date?
     }
 
+    /// Failures from fetching or parsing an outbox collection. `Equatable` so tests can assert
+    /// on the exact failure; ``AnnouncedPostSync/pullAndCommit(outboxURL:siteDirectory:configDirectory:transport:now:)``
+    /// itself swallows these (returning 0) since a transient network error just means "try again
+    /// on the next site-open".
     public enum OutboxError: Error, Equatable, Sendable {
         /// The outbox URL, or the URL a redirect actually landed on, wasn't `https`.
         case insecureURL
+        /// A non-2xx response, a transport error (status 0), or an over-cap response body.
+        /// `body` carries a truncated excerpt for diagnostics, not for parsing.
         case requestFailed(status: Int, body: String)
+        /// The response wasn't the JSON object shape an AS2 collection page must be.
         case decodingFailed(String)
     }
 

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -12,28 +12,57 @@ public final class AppSettings: @unchecked Sendable {
 
     /// UserDefaults keys. Public so the SwiftUI side can use them with `@AppStorage`.
     public enum Key {
+        /// Backs ``AppSettings/templatePathOverride``.
         public static let templatePathOverride = "anglesite.templatePathOverride"
+        /// Backs ``AppSettings/sitesRootOverride``.
         public static let sitesRootOverride    = "anglesite.sitesRootOverride"
+        /// Host component of ``AppSettings/lanRuntimeConfiguration``; empty/absent means no
+        /// LAN runtime is configured.
         public static let lanRuntimeHost        = "anglesite.lanRuntimeHost"
+        /// Preview-port component of ``AppSettings/lanRuntimeConfiguration``. Stored as a string
+        /// (the Settings text field's empty state means "default").
         public static let lanRuntimePreviewPort = "anglesite.lanRuntimePreviewPort"
+        /// MCP-port component of ``AppSettings/lanRuntimeConfiguration``. Stored as a string
+        /// (the Settings text field's empty state means "default").
         public static let lanRuntimeMCPPort     = "anglesite.lanRuntimeMCPPort"
+        /// Backs ``AppSettings/debugPaneEnabled``.
         public static let debugPaneEnabled   = "anglesite.debugPaneEnabled"
+        /// Backs ``AppSettings/esiPreviewUnprocessed``.
         public static let esiPreviewUnprocessed = "anglesite.esiPreviewUnprocessed"
+        /// Backs ``AppSettings/lastOpenedSiteID``.
         public static let lastOpenedSiteID   = "anglesite.lastOpenedSiteID"
+        /// Backs ``AppSettings/sitesRootBookmark``.
         public static let sitesRootBookmark  = "anglesite.sitesRootBookmark"
+        /// Backs ``AppSettings/autoGenerateAltText``.
         public static let autoGenerateAltText = "anglesite.autoGenerateAltText"
+        /// Backs ``AppSettings/autoGeneratePageCopy``.
         public static let autoGeneratePageCopy = "anglesite.autoGeneratePageCopy"
+        /// Backs ``AppSettings/announcesLiveUpdates``.
         public static let announcesLiveUpdates = "anglesite.announcesLiveUpdates"
+        /// Backs ``AppSettings/notifiesOnCompletion``.
         public static let notifiesOnCompletion = "anglesite.notifiesOnCompletion"
+        /// Backs ``AppSettings/playsDialupSoundEffect``.
         public static let playsDialupSoundEffect = "anglesite.playsDialupSoundEffect"
+        /// One-shot flag consumed by ``AppSettings/removeLegacyChatBackendDefaultsIfNeeded()`` so
+        /// the legacy-key cleanup runs exactly once per defaults suite.
         public static let didCleanLegacyChatBackendDefaults = "anglesite.didCleanLegacyChatBackendDefaults"
+        /// Login component of ``AppSettings/gitHubAccount``; its presence is what makes the
+        /// composite non-`nil`.
         public static let gitHubAccountLogin = "anglesite.gitHubAccount.login"
+        /// Display-name component of ``AppSettings/gitHubAccount``.
         public static let gitHubAccountName = "anglesite.gitHubAccount.name"
+        /// Avatar-URL component of ``AppSettings/gitHubAccount``.
         public static let gitHubAccountAvatarURL = "anglesite.gitHubAccount.avatarURL"
+        /// Verified flag for ``AppSettings/cloudflareAccount`` — the gate for the composite,
+        /// since a verified token may legitimately carry no name/email to show.
         public static let cloudflareAccountVerified = "anglesite.cloudflareAccount.verified"
+        /// Account-name component of ``AppSettings/cloudflareAccount``.
         public static let cloudflareAccountName = "anglesite.cloudflareAccount.name"
+        /// Account-email component of ``AppSettings/cloudflareAccount``.
         public static let cloudflareAccountEmail = "anglesite.cloudflareAccount.email"
+        /// Backs ``AppSettings/activeAssistantBackend``.
         public static let activeAssistantBackend = "anglesite.activeAssistantBackend"
+        /// Backs ``AppSettings/communitySearchInstance``.
         public static let communitySearchInstance = "anglesite.communitySearchInstance"
     }
 
@@ -76,11 +105,18 @@ public final class AppSettings: @unchecked Sendable {
         return resolved
     }
 
+    /// Creates a settings facade over an arbitrary defaults suite — the seam that lets tests use
+    /// a scratch `UserDefaults` instead of polluting (and depending on) the developer's real
+    /// `standard` domain; `ubiquityContainerResolver` is likewise injectable so tests can fake
+    /// iCloud availability (#865). App code should use ``shared``.
     public init(defaults: UserDefaults, ubiquityContainerResolver: UbiquityContainerResolving = FileManager.default) {
         self.defaults = defaults
         self.ubiquityContainerResolver = ubiquityContainerResolver
     }
     #else
+    /// Creates a settings facade over an arbitrary defaults suite — the seam that lets tests use
+    /// a scratch `UserDefaults` instead of polluting (and depending on) the developer's real
+    /// `standard` domain. App code should use ``shared``.
     public init(defaults: UserDefaults) {
         self.defaults = defaults
     }
@@ -379,6 +415,9 @@ public enum SitesRootSource: Sendable, Equatable {
 /// is *always* available in Debug builds. In Release it stays hidden unless the user opts in
 /// (Settings → Advanced) or holds ⌥ while launching the app.
 public enum DebugPaneVisibility {
+    /// True when any one of the three access routes applies — Debug build, the Settings opt-in
+    /// (``AppSettings/debugPaneEnabled``), or ⌥ held at launch. A pure function of its inputs so
+    /// the policy is testable without a real bundle or keyboard state.
     public static func menuItemVisible(isDebugBuild: Bool, settingEnabled: Bool, optionHeldAtLaunch: Bool) -> Bool {
         isDebugBuild || settingEnabled || optionHeldAtLaunch
     }

--- a/Sources/AnglesiteCore/AppVersion.swift
+++ b/Sources/AnglesiteCore/AppVersion.swift
@@ -3,6 +3,10 @@ import Foundation
 /// The running app's short version string (`CFBundleShortVersionString`), used to
 /// stamp/compare against a site's `.site-config` `ANGLESITE_VERSION` (spec §3.1).
 public enum AppVersion {
+    /// Reads the short version string from `bundle`. Optional because a SwiftPM test bundle (or
+    /// any non-app host) has no `CFBundleShortVersionString` — callers must treat "unknown
+    /// version" as a real case, not force-unwrap. The `bundle` parameter exists for exactly that
+    /// test seam; production uses the default `.main`.
     public static func current(in bundle: Bundle = .main) -> String? {
         bundle.infoDictionary?["CFBundleShortVersionString"] as? String
     }

--- a/Sources/AnglesiteCore/AppleScriptCommandService.swift
+++ b/Sources/AnglesiteCore/AppleScriptCommandService.swift
@@ -6,12 +6,24 @@ import Foundation
 /// already async Swift. Keep policy, site resolution, and result formatting here so the app target
 /// can stay a small Apple Event adapter instead of growing another operation stack.
 public struct AppleScriptCommandService: Sendable {
+    /// Failures a script author can cause and fix. `LocalizedError` because the Apple Event
+    /// adapter reports `errorDescription` verbatim as the AppleScript error message — these
+    /// strings are the scripting UX, not internal diagnostics.
     public enum CommandError: LocalizedError, Equatable {
+        /// The site specifier was empty or all whitespace.
         case emptySiteSpecifier
+        /// No registered site matched the specifier by UUID, path, or exact name.
         case siteNotFound(String)
+        /// More than one registered site matched (e.g. two sites share a display name).
+        /// `matches` carries the candidate names so the script author can disambiguate —
+        /// guessing on the caller's behalf could deploy or edit the wrong site.
         case ambiguousSite(String, matches: [String])
+        /// `deploy` was called without `with allowing unattended` (see
+        /// ``AppleScriptCommandService/deploySite(_:allowingUnattended:)``).
         case deployRequiresUnattendedOptIn(String)
 
+        /// The AppleScript-facing message for each case — phrased as instructions to the script
+        /// author, since this is what the `osascript` error surface shows.
         public var errorDescription: String? {
             switch self {
             case .emptySiteSpecifier:
@@ -32,6 +44,9 @@ public struct AppleScriptCommandService: Sendable {
     private let graph: SiteContentGraph
     private let loadSites: @Sendable () async throws -> Void
 
+    /// Every dependency is injectable so the command policy is testable without a real site on
+    /// disk; the defaults wire up the production stack (`nil` rather than default expressions for
+    /// the service parameters because their defaults derive from `store`).
     public init(
         store: SiteStore = .shared,
         operations: (any SiteOperationsService)? = nil,
@@ -49,6 +64,11 @@ public struct AppleScriptCommandService: Sendable {
         )
     }
 
+    /// Resolves a script-supplied specifier to exactly one registered site, trying UUID
+    /// (case-insensitive), then canonicalized package/`Source/` path, then exact display name —
+    /// most-unambiguous first, so a UUID can never be shadowed by a same-looking name. Ambiguity
+    /// throws ``CommandError/ambiguousSite(_:matches:)`` rather than picking a winner: scripts
+    /// run unattended, and acting on the wrong site is worse than failing.
     public func resolveSite(_ specifier: String) async throws -> SiteStore.Site {
         let needle = specifier.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else { throw CommandError.emptySiteSpecifier }
@@ -78,12 +98,19 @@ public struct AppleScriptCommandService: Sendable {
         throw CommandError.siteNotFound(needle)
     }
 
+    /// Resolves the site and bumps its recency in ``SiteStore`` (best-effort — a failed touch
+    /// shouldn't fail the open). The actual window presentation is the app target's job; this
+    /// returns the resolved site for the adapter to hand to the scene layer.
     public func openSite(_ specifier: String) async throws -> SiteStore.Site {
         let site = try await resolveSite(specifier)
         try? await store.touch(id: site.id)
         return site
     }
 
+    /// Deploys the site and returns the human-readable outcome dialog. Publishing to the live
+    /// site from an unattended script is consequential enough that it requires the explicit
+    /// AppleScript opt-in (`with allowing unattended`) — without it this throws instead of
+    /// deploying, so an automation can't publish by accident.
     public func deploySite(_ specifier: String, allowingUnattended: Bool) async throws -> String {
         let site = try await resolveSite(specifier)
         guard allowingUnattended else {
@@ -92,16 +119,22 @@ public struct AppleScriptCommandService: Sendable {
         return SiteOperations.dialog(forDeploy: await operations.deploy(site: site))
     }
 
+    /// Backs up the site and returns the outcome as ``SiteOperations``'s dialog string — results
+    /// are AppleScript display text, not structured data, matching how scripts consume them.
     public func backupSite(_ specifier: String) async throws -> String {
         let site = try await resolveSite(specifier)
         return SiteOperations.dialog(forBackup: await operations.backup(site: site))
     }
 
+    /// Runs the structured audit (``AuditCommand``) and returns its outcome dialog. No opt-in
+    /// needed — unlike deploy, an audit only reads the site.
     public func auditSite(_ specifier: String) async throws -> String {
         let site = try await resolveSite(specifier)
         return SiteOperations.dialog(forAudit: await operations.audit(site: site))
     }
 
+    /// One-sentence content summary (pages, posts, drafts, images) from ``SiteContentGraph`` —
+    /// prose rather than a record because AppleScript callers display it directly.
     public func siteStatus(_ specifier: String) async throws -> String {
         let site = try await resolveSite(specifier)
         let posts = await graph.posts(for: site.id)
@@ -111,6 +144,10 @@ public struct AppleScriptCommandService: Sendable {
         return "\(site.name) has \(Self.count(pages, "page")), \(Self.count(posts.count, "post")) (\(Self.count(drafts, "draft"))), and \(Self.count(images, "image"))."
     }
 
+    /// Creates a page through the same native content workflow the app UI uses. A blank `route`
+    /// is normalized to `nil` (AppleScript optional parameters often arrive as empty strings) so
+    /// the workflow derives the route from `name`. Creation failures are reported in the returned
+    /// dialog string, not thrown — only site resolution throws.
     public func addPage(_ specifier: String, name: String, route: String?) async throws -> String {
         let site = try await resolveSite(specifier)
         let cleanRoute = Self.nilIfBlank(route)
@@ -118,6 +155,9 @@ public struct AppleScriptCommandService: Sendable {
         return Self.createdDialog(result, kind: "page", siteName: site.name)
     }
 
+    /// Creates a post, mirroring ``addPage(_:name:route:)``: blank `collection`/`slug` normalize
+    /// to `nil` so the workflow applies its own defaults, and creation failures come back as
+    /// dialog text rather than thrown errors.
     public func addPost(_ specifier: String, title: String, collection: String?, slug: String?) async throws -> String {
         let site = try await resolveSite(specifier)
         let result = await content.createPost(

--- a/Sources/AnglesiteCore/ApplyEditTool.swift
+++ b/Sources/AnglesiteCore/ApplyEditTool.swift
@@ -14,7 +14,11 @@ public struct ApplyEditTool: Tool, Sendable {
     /// The tool's stable name. Exposed statically so callers (e.g. `FoundationModelAssistant`'s
     /// `.started` event) can report the attached tools without constructing an instance.
     public static let toolName = "applyEdit"
+    /// `Tool` conformance — always ``toolName``, kept as an instance property only because the
+    /// protocol requires one.
     public let name = ApplyEditTool.toolName
+    /// `Tool` conformance: the prompt-visible description the on-device model reads to decide
+    /// when (and how) to invoke this tool — instructions to the model, not UI copy.
     public let description = "Apply a structured text, attribute, or image edit to a specific element in a page's source file. Provide the source file path, an element selector (or a simple tag like h1), the operation kind, and the replacement value."
 
     private let bridge: IntentEditBridge
@@ -24,12 +28,20 @@ public struct ApplyEditTool: Tool, Sendable {
     /// selector because it's a real, resolved selector rather than a guess.
     private let contextSelector: JSONValue?
 
+    /// A tool instance is scoped to one site and one selection snapshot: pass the overlay's
+    /// resolved `ElementInfo` as `contextSelector` (or `nil` when nothing is selected) at
+    /// construction, since FoundationModels tools can't receive per-call context beyond the
+    /// model-generated arguments.
     public init(bridge: IntentEditBridge, siteID: String, contextSelector: JSONValue?) {
         self.bridge = bridge
         self.siteID = siteID
         self.contextSelector = contextSelector
     }
 
+    /// `Tool` conformance. Never throws in practice: every outcome — applied, ambiguous
+    /// selector, unresolvable selector, bridge failure — is returned as a sentence for the model
+    /// to relay or act on, because a thrown error would end the model's turn instead of letting
+    /// it recover (e.g. by asking the user to select an element).
     public func call(arguments: GeneratedEditCommand) async throws -> String {
         guard let selector = resolveSelector(arguments.selector) else {
             return "Couldn't identify which element to edit — select one in the preview, or name a simple tag like h1."

--- a/Sources/AnglesiteCore/AssistantBackendResolver.swift
+++ b/Sources/AnglesiteCore/AssistantBackendResolver.swift
@@ -13,6 +13,12 @@ public enum AssistantBackendResolver {
         return UUID(uuidString: String(raw.dropFirst(4)))
     }
 
+    /// Builds an ``ACPAssistant`` for the currently-selected agent, or `nil` when Foundation
+    /// Models should handle the session instead. Every failure mode — a `"foundationModels"`
+    /// setting, a malformed backend string, an unreadable agent store, an agent that was removed
+    /// after being selected — collapses to `nil` deliberately: the setting is advisory, and a
+    /// broken selection must degrade to the always-available on-device path rather than leave the
+    /// user with no assistant at all.
     public static func resolveActiveACPAssistant(
         siteID: String,
         sourceDirectory: URL,

--- a/Sources/AnglesiteCore/AstroHTMLValidator.swift
+++ b/Sources/AnglesiteCore/AstroHTMLValidator.swift
@@ -1,9 +1,20 @@
 import Foundation
 
+/// Seam for validating an owner-pasted custom analytics HTML snippet before it's saved into the
+/// site config. A protocol (rather than the concrete validator) so the plist editor can be tested
+/// with a canned validator instead of a live container.
 public protocol CustomAnalyticsHTMLValidating: Sendable {
+    /// `nil` when the snippet is acceptable; otherwise an owner-facing message explaining why it
+    /// was rejected — or why it *couldn't be checked*, which also blocks the save: an unvalidated
+    /// snippet is injected into every page head, so "can't verify" must not pass silently.
     func validationMessage(for html: String, siteDirectory: URL) async -> String?
 }
 
+/// Validates custom analytics HTML by feeding it through the site's own `@astrojs/compiler`
+/// inside the container guest — the exact parser that will consume the snippet at build time, so
+/// "valid here" can't drift from "builds there". Requires the site's `node_modules` to be
+/// installed and its container to be running; both absences produce an explanatory message rather
+/// than a pass (host Node is retired, #70, so there is no host-side fallback parse).
 public struct AstroHTMLValidator: CustomAnalyticsHTMLValidating, Sendable {
     /// Reached lazily, at the moment validation actually runs — never resolved eagerly at
     /// construction time — mirroring `DeployModel`/`PreviewModel.activeContainerControl()`
@@ -13,10 +24,16 @@ public struct AstroHTMLValidator: CustomAnalyticsHTMLValidating, Sendable {
 
     private let containerControlProvider: ContainerControlProvider
 
+    /// The default provider always returns `nil` ("no container"), which makes an undecorated
+    /// validator fail safe — it reports validation as unavailable instead of approving snippets
+    /// it never checked.
     public init(containerControlProvider: @escaping ContainerControlProvider = { nil }) {
         self.containerControlProvider = containerControlProvider
     }
 
+    /// See ``CustomAnalyticsHTMLValidating/validationMessage(for:siteDirectory:)``. An empty or
+    /// whitespace-only snippet is trivially valid (there is nothing to inject); everything else
+    /// must round-trip through the compiler in the guest.
     public func validationMessage(for html: String, siteDirectory: URL) async -> String? {
         let snippet = html.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !snippet.isEmpty else { return nil }

--- a/Sources/AnglesiteCore/AuditCommand.swift
+++ b/Sources/AnglesiteCore/AuditCommand.swift
@@ -7,7 +7,13 @@ import Foundation
 /// `source` is the `LogCenter` tag the runner should use for any subprocess output
 /// (`audit:<siteID>:<runner>`), so the drawer/sheet can distinguish phases.
 public protocol AuditRunner: Sendable {
+    /// The single category every finding from this runner belongs to — also how
+    /// ``AuditCommand`` labels the runner in `runnersExecuted`/`runnersSkipped`, so one runner
+    /// never spans categories.
     var category: AuditReport.Finding.Category { get }
+    /// Produces this category's findings against the already-built site (``AuditCommand`` runs
+    /// the build step first). Returning `[]` means "checked, clean"; throwing means "couldn't
+    /// check" — ``AuditCommand`` records the throw as a skip rather than failing the audit.
     func run(
         siteDirectory: URL,
         executor: any AuditExecutor,
@@ -35,7 +41,13 @@ public protocol AuditRunner: Sendable {
 /// what counts as a "passing" audit — that's the UI's job (e.g. show a green
 /// badge if no `.critical` findings, regardless of warnings).
 public actor AuditCommand {
+    /// Terminal outcome of one audit run. "Succeeded" means the pipeline completed, not that the
+    /// site is clean — a report full of critical findings is still `.succeeded`; only a failed
+    /// build (or cancellation) produces `.failed`, because runners can't audit output that
+    /// doesn't exist.
     public enum Result: Sendable, Equatable {
+        /// The build completed and the runners were attempted; `report` aggregates their
+        /// findings and skips. `duration` covers the whole pipeline for the UI's "took Ns" line.
         case succeeded(report: AuditReport, duration: TimeInterval)
         /// `logTail` carries the captured `audit:<siteID>:build` lines so the failure
         /// sheet can show *why* the build failed without the owner having to open the
@@ -49,16 +61,25 @@ public actor AuditCommand {
     /// `resolveA11yCommand` values below live here for the same reason `DeployCommand` keeps
     /// `LaunchPlan`/`CommandResolver` even though only `HostDeployExecutor` uses them now.
     public enum LaunchPlan: Sendable, Equatable {
+        /// Spawn this executable (host-side, via `ProcessSupervisor`) for the step.
         case run(executable: URL, arguments: [String])
+        /// The step can't run in this environment; `reason` becomes the step's failure output.
+        /// This is the production default for every host-side step — host Node is retired (#70).
         case unavailable(reason: String)
     }
 
+    /// Maps a site directory to a ``LaunchPlan`` for one step — the injection point tests use to
+    /// substitute a stub executable for the retired host toolchain.
     public typealias CommandResolver = @Sendable (_ siteDirectory: URL) -> LaunchPlan
 
     private let logCenter: LogCenter
     private let executor: any AuditExecutor
     private let runners: [any AuditRunner]
 
+    /// The defaults produce a command that fails explicitly rather than silently: the default
+    /// ``HostAuditExecutor`` refuses both steps post host-Node retirement (#70), so production
+    /// callers must inject a ``ContainerAuditExecutor`` for a live container. Tests swap
+    /// `executor`/`runners` for fakes.
     public init(
         logCenter: LogCenter = .shared,
         executor: any AuditExecutor = HostAuditExecutor(),

--- a/Sources/AnglesiteCore/AuditExecutor.swift
+++ b/Sources/AnglesiteCore/AuditExecutor.swift
@@ -19,9 +19,13 @@ public enum AuditStep: Sendable {
 ///   reason text for pre-spawn refusals. Also streamed line-by-line to `LogCenter` under the
 ///   caller-supplied source during execution.
 public struct AuditStepResult: Sendable, Equatable {
+    /// `nil` distinguishes "never ran / was killed" from "ran and exited" — callers branch on
+    /// that before ever comparing against zero.
     public let exitCode: Int32?
+    /// Captured stdout (or the refusal reason when `exitCode` is `nil`); see the type doc.
     public let output: String
 
+    /// Memberwise; public so executor fakes in tests can fabricate step results directly.
     public init(exitCode: Int32?, output: String) {
         self.exitCode = exitCode
         self.output = output
@@ -34,6 +38,9 @@ public struct AuditStepResult: Sendable, Equatable {
 /// of `DeployExecutor` — `HostAuditExecutor` fails explicitly after host Node retirement (#70);
 /// `ContainerAuditExecutor` runs inside a live container once one is available.
 public protocol AuditExecutor: Sendable {
+    /// Runs one step to completion, streaming its output to `LogCenter` under `source` as it
+    /// goes ("logs are sacred"). Non-throwing by design: every failure mode is encoded in
+    /// ``AuditStepResult`` so ``AuditCommand`` has exactly one result shape to interpret.
     func run(step: AuditStep, siteDirectory: URL, source: String) async -> AuditStepResult
 }
 
@@ -48,6 +55,8 @@ public struct ContainerAuditExecutor: AuditExecutor {
     private let siteID: String
     private let logCenter: LogCenter
 
+    /// Bound to one already-running container (`control` + `siteID`) at construction — the
+    /// executor doesn't boot containers, it only execs into the one the open site owns.
     public init(
         control: any LocalContainerControl,
         siteID: String,
@@ -58,6 +67,10 @@ public struct ContainerAuditExecutor: AuditExecutor {
         self.logCenter = logCenter
     }
 
+    /// Execs the step's argv in the guest at `/workspace/site` (the container's clone of the
+    /// site — `siteDirectory` is unused here since the guest works on its own copy). Errors are
+    /// folded into the result: cancellation and exec failures come back as a `nil` exit code
+    /// with an actionable message, per the ``AuditExecutor`` contract.
     public func run(step: AuditStep, siteDirectory: URL, source: String) async -> AuditStepResult {
         let argv = Self.guestArgv(for: step)
         // Stream guest output to LogCenter LIVE — see `ContainerDeployExecutor.run` for the full
@@ -132,6 +145,9 @@ public struct HostAuditExecutor: AuditExecutor {
     private let logCenter: LogCenter
     private let resolveCommand: @Sendable (AuditStep) -> AuditCommand.CommandResolver
 
+    /// `resolveCommand` is the only way to make this executor actually spawn anything — the
+    /// default refuses every step (see ``defaultResolver``), so only a caller that explicitly
+    /// injects a resolver (tests, mainly) gets host processes.
     public init(
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
@@ -143,6 +159,9 @@ public struct HostAuditExecutor: AuditExecutor {
         self.resolveCommand = resolveCommand
     }
 
+    /// Resolves the step to a ``AuditCommand/LaunchPlan`` and either spawns it under
+    /// `ProcessSupervisor` (streaming to `LogCenter`, terminated on task cancellation) or
+    /// returns the plan's refusal reason as a `nil`-exit-code result.
     public func run(step: AuditStep, siteDirectory: URL, source: String) async -> AuditStepResult {
         let resolver = resolveCommand(step)
         let plan = resolver(siteDirectory)
@@ -196,6 +215,9 @@ public struct HostAuditExecutor: AuditExecutor {
         }
     }
 
+    /// Maps each step to its `AuditCommand.resolve*Command` refusal — the single place the
+    /// "host Node is retired" (#70) policy is applied for audits, so no step can quietly grow a
+    /// host-spawning default again.
     public static let defaultResolver: @Sendable (AuditStep) -> AuditCommand.CommandResolver = { step in
         switch step {
         case .build:

--- a/Sources/AnglesiteCore/AuditReport.swift
+++ b/Sources/AnglesiteCore/AuditReport.swift
@@ -8,22 +8,44 @@ import Foundation
 /// can surface "the perf runner couldn't run because Lighthouse isn't installed"
 /// without turning the whole audit into a failure.
 public struct AuditReport: Sendable, Equatable {
+    /// One issue reported by one runner, in the common shape all categories share — the report
+    /// UI renders every category through the same row, so runners normalize into this rather
+    /// than each exposing its own result type.
     public struct Finding: Sendable, Equatable, Hashable, Identifiable {
+        /// The audit dimension a finding (and its runner — see `AuditRunner.category`) belongs
+        /// to. Raw string values double as the `audit:<siteID>:<category>` log-source segment.
         public enum Category: String, Sendable, Equatable, Codable, CaseIterable {
-            case security, accessibility, performance, seo
+            /// Produced by `SecurityTxtAuditRunner` (#843) today.
+            case security
+            /// Produced by `A11yAuditRunner` (the template's `a11y-audit.ts` script).
+            case accessibility
+            /// Reserved: no shipped runner yet (#86 follow-up); declared now so the UI's
+            /// category handling doesn't churn when one lands.
+            case performance
+            /// Reserved: no shipped runner yet (#86 follow-up), same as `performance`.
+            case seo
         }
 
+        /// How urgently a finding needs the owner's attention. The UI keys its pass/fail badge
+        /// off `critical` alone — warnings and info don't fail an audit.
         public enum Severity: String, Sendable, Equatable, Codable, Comparable, CaseIterable {
-            case critical, warning, info
+            /// Must-fix: the kind of finding that turns the audit badge red.
+            case critical
+            /// Should-fix; doesn't block a "passing" audit.
+            case warning
+            /// Advisory only.
+            case info
 
-            // Critical first → reverse-sorted natural order is fine for UI lists.
+            /// Critical first → reverse-sorted natural order is fine for UI lists.
             public static func < (lhs: Severity, rhs: Severity) -> Bool {
                 let order: [Severity: Int] = [.critical: 0, .warning: 1, .info: 2]
                 return (order[lhs] ?? 99) < (order[rhs] ?? 99)
             }
         }
 
+        /// Which audit dimension this belongs to — always the producing runner's category.
         public let category: Category
+        /// See ``Severity``; drives sort order and the report's pass/fail badge.
         public let severity: Severity
         /// Short label (e.g. an audit rule ID like `"alt-text"`). Free-form but
         /// expected to be compact enough to render as a header.
@@ -37,6 +59,8 @@ public struct AuditReport: Sendable, Equatable {
         /// pre-deploy security → file path, etc.).
         public let location: String?
 
+        /// Memberwise. `remediation`/`location` take no default `nil` on purpose: a runner must
+        /// say explicitly that it has nothing to offer, rather than omitting them by accident.
         public init(
             category: Category,
             severity: Severity,
@@ -53,6 +77,10 @@ public struct AuditReport: Sendable, Equatable {
             self.location = location
         }
 
+        /// Content-derived identity (no stored UUID), so the *same* issue keeps the same `id`
+        /// across audit re-runs — SwiftUI lists update in place instead of tearing down every
+        /// row each time the audit runs. `severity` is deliberately excluded: a rule whose
+        /// severity classification changes is still the same finding.
         public var id: String {
             "\(category.rawValue):\(title):\(detail):\(location ?? "")"
         }
@@ -61,19 +89,31 @@ public struct AuditReport: Sendable, Equatable {
     /// A runner that ran but threw mid-way. The category identifies which check;
     /// the reason is the runner's localized error description.
     public struct SkippedRunner: Sendable, Equatable {
+        /// Which check didn't complete — so the UI can say *what* wasn't verified, not just
+        /// that something failed.
         public let category: Finding.Category
+        /// The runner's error, stringified for display; skips are owner-facing, not retryable
+        /// program state.
         public let reason: String
 
+        /// Memberwise; public so tests and executor fakes can construct skips directly.
         public init(category: Finding.Category, reason: String) {
             self.category = category
             self.reason = reason
         }
     }
 
+    /// All runners' issues, concatenated in runner-declaration order (not sorted here — display
+    /// ordering is the UI's decision).
     public let findings: [Finding]
+    /// Categories whose runner completed, even with zero findings — the distinction that lets
+    /// "clean" mean "checked and clean" rather than "never checked".
     public let runnersExecuted: [Finding.Category]
+    /// Categories whose runner threw; see ``SkippedRunner``.
     public let runnersSkipped: [SkippedRunner]
 
+    /// Memberwise; assembled by `AuditCommand.audit(siteID:siteDirectory:onProgress:)` in
+    /// production, directly by tests.
     public init(
         findings: [Finding],
         runnersExecuted: [Finding.Category],

--- a/Sources/AnglesiteCore/AvatarLoader.swift
+++ b/Sources/AnglesiteCore/AvatarLoader.swift
@@ -3,10 +3,16 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// Why an avatar fetch was refused. Every case is a *guard* firing, not a bug — avatar URLs are
+/// attacker-chosen (see ``AvatarLoader``), so callers treat any of these as "show the placeholder"
+/// rather than something to surface or retry.
 public enum AvatarLoadError: Error, Equatable, Sendable {
     /// The avatar URL, or the URL a redirect actually landed on, wasn't `https`.
     case insecureURL
+    /// The transfer exceeded ``AvatarLoader/maximumResponseBytes`` — aborted mid-stream by the
+    /// default transport, so a hostile instance can't even make the app finish the download.
     case responseTooLarge(Int)
+    /// A non-2xx response.
     case requestFailed(status: Int)
 }
 
@@ -24,6 +30,9 @@ public enum AvatarLoadError: Error, Equatable, Sendable {
 /// MainActor and against a pixel-dimension bound. There is no cache here — the profile cache
 /// stores only the URL by design, and an in-memory per-row load is the intended cost.
 public struct AvatarLoader: Sendable {
+    /// Fetch seam so tests can serve canned bytes without a network. Note the injected transport
+    /// is still held to the byte cap after the fact — only the default transport can abort
+    /// mid-stream.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     /// 2 MB. Comfortably above a real Fediverse avatar (Mastodon caps uploads well below this)
@@ -44,11 +53,18 @@ public struct AvatarLoader: Sendable {
     private let transport: Transport
     private let gate: ConcurrencyGate
 
+    /// Each `init` creates its own concurrency gate, so the ``maxConcurrentLoads`` bound is
+    /// per-instance: share one loader per pane (as `FollowersModel` does) rather than
+    /// constructing one per row, or the bound stops bounding anything.
     public init(transport: @escaping Transport = AvatarLoader.defaultTransport) {
         self.transport = transport
         self.gate = ConcurrencyGate(limit: Self.maxConcurrentLoads)
     }
 
+    /// Fetches the avatar bytes under the full guard set — HTTPS (including post-redirect),
+    /// byte cap, deadlines, and the shared concurrency gate (so a fast scroll queues loads
+    /// instead of fanning them all out at once). Throws ``AvatarLoadError`` for guard
+    /// violations; transport errors propagate as-is.
     public func data(for url: URL) async throws -> Data {
         // The one expression of the HTTPS rule, shared with the actor-document fetch.
         guard ActorProfileFetcher.isHTTPS(url) else { throw AvatarLoadError.insecureURL }

--- a/Sources/AnglesiteCore/BackupCommand.swift
+++ b/Sources/AnglesiteCore/BackupCommand.swift
@@ -21,8 +21,18 @@ import Foundation
 /// Then the action steps stream their output to `LogCenter` under
 /// `backup:<siteID>`, so the drawer UI can show progress in real time.
 public actor BackupCommand {
+    /// Terminal outcome of one ``BackupCommand/backup(siteID:siteDirectory:onProgress:)`` run.
+    /// Deliberately a
+    /// three-way enum rather than a thrown error: a clean, in-sync tree is a normal outcome the
+    /// UI narrates ("nothing to back up"), not a failure, and refusals carry a user-facing
+    /// `reason` string instead of an error type callers would have to translate.
     public enum Result: Sendable, Equatable {
+        /// A push landed on `origin`. `commitSHA` is the pushed HEAD — which may be a commit from
+        /// a *prior* cancelled backup rather than one this run created (the clean-tree-but-ahead
+        /// recovery path, #246).
         case succeeded(commitSHA: String, branch: String, remote: String)
+        /// Clean working tree *and* HEAD in sync with `origin/<branch>` — nothing was committed
+        /// or pushed. A clean tree alone isn't enough; see pre-flight check 3 on the type.
         case noChanges
         /// `exitCode` is `nil` for pre-spawn refusals (on `main`, no remote) and for
         /// spawn failures; otherwise it's the failing git subprocess's exit code.
@@ -46,6 +56,10 @@ public actor BackupCommand {
     private let streamer: GitStreamer
     private let clock: @Sendable () -> Date
 
+    /// Creates a backup command with injectable seams; production callers take the defaults
+    /// (`defaultRunner`/`defaultStreamer` — in-process SwiftGit2 on Darwin, subprocess `git`
+    /// elsewhere). `clock` feeds the commit-message timestamp so tests can pin it to a known
+    /// instant instead of matching a live `Date()`.
     public init(
         runner: @escaping GitRunner = BackupCommand.defaultRunner,
         streamer: @escaping GitStreamer = BackupCommand.defaultStreamer,
@@ -56,6 +70,13 @@ public actor BackupCommand {
         self.clock = clock
     }
 
+    /// Runs the full pre-flight + `add` → `commit` → `push` sequence described on the type.
+    /// Never throws — every failure mode folds into ``Result`` so all callers (menu command,
+    /// Siri/Shortcuts intent) share one rendering path. `onProgress` receives coarse phase
+    /// markers (staging/committing/pushing) for intent progress UI; detailed log lines stream to
+    /// `LogCenter` under `backup:<siteID>` independently. Cooperative cancellation is honored
+    /// between steps — a cancel mid-sequence yields `.failed`, and a commit stranded by a cancel
+    /// before its push is recovered by the *next* backup (#246).
     public func backup(siteID: String, siteDirectory: URL, onProgress: ProgressHandler? = nil) async -> Result {
         let source = "backup:\(siteID)"
 

--- a/Sources/AnglesiteCore/BrandVoiceGuidance.swift
+++ b/Sources/AnglesiteCore/BrandVoiceGuidance.swift
@@ -43,6 +43,9 @@ public enum BrandVoiceGuidance {
 /// Reads `BUSINESS_TYPE` from the site's `Source/.site-config`, the same key the markdown
 /// skills used. `nil` when the file or key is absent.
 public enum SiteBusinessType {
+    /// Reads `BUSINESS_TYPE` fresh from disk on every call — the file is tiny and callers only
+    /// ask at prompt-build time, so caching would just risk staleness after an external edit
+    /// (`.site-config` lives in `Source/`, which the owner can edit outside the app).
     public static func read(sourceDirectory: URL) -> String? {
         let url = sourceDirectory.appendingPathComponent(".site-config")
         guard let contents = try? String(contentsOf: url, encoding: .utf8) else { return nil }
@@ -52,6 +55,10 @@ public enum SiteBusinessType {
 
 /// Reads display values from `Source/.site-config`, falling back sensibly.
 public enum SiteConfigValues {
+    /// The site's display name: `SITE_NAME` from `.site-config` when present and non-empty,
+    /// otherwise the source directory's own name — a plain checkout with no config still gets a
+    /// usable label. `nil` only when even the directory name is empty, so callers can supply
+    /// their own placeholder for that degenerate case.
     public static func siteName(sourceDirectory: URL) -> String? {
         let url = sourceDirectory.appendingPathComponent(".site-config")
         if let contents = try? String(contentsOf: url, encoding: .utf8),

--- a/Sources/AnglesiteCore/BrandVoiceInterview.swift
+++ b/Sources/AnglesiteCore/BrandVoiceInterview.swift
@@ -4,11 +4,17 @@ import Foundation
 /// audience, three-ish personality words, brand terms, phrases to avoid. Formality is
 /// captured as tone words rather than a separate axis.
 public struct BrandVoiceAnswers: Sendable, Equatable {
+    /// Who the site speaks to, in the owner's own words. Free text; empty means unanswered.
     public var audience: String
+    /// The "three-ish personality words" answer — tone descriptors like "warm" or "direct".
     public var toneWords: [String]
+    /// Brand/product terms whose exact capitalization generated copy must reproduce.
     public var brandTerms: [String]
+    /// Words and phrases the owner never wants to see in generated copy.
     public var avoidPhrases: [String]
 
+    /// Memberwise initializer. Pass empty values for skipped questions — every consumer treats
+    /// empty as "unanswered" and leaves the existing convention alone, never as "clear it".
     public init(audience: String, toneWords: [String], brandTerms: [String], avoidPhrases: [String]) {
         self.audience = audience
         self.toneWords = toneWords
@@ -20,6 +26,9 @@ public struct BrandVoiceAnswers: Sendable, Equatable {
 /// Pure mapping from interview answers to `.userOverride` convention writes. Only non-empty
 /// answers are applied, so a partial interview never erases inferred signal.
 public enum BrandVoiceInterview {
+    /// Returns a copy of `conventions` with each non-empty answer applied as an override —
+    /// the pure, engine-free counterpart of ``BrandVoiceWriter/save(_:engine:store:siteID:)``
+    /// for callers that manage persistence themselves (and for tests).
     public static func apply(_ answers: BrandVoiceAnswers, to conventions: ProjectConventions) -> ProjectConventions {
         var out = conventions
         let audience = answers.audience.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -61,6 +70,10 @@ public enum BrandVoiceWriter {
         return true
     }
 
+    /// True when at least one answer is non-empty (audience judged after trimming) — the guard
+    /// `save` uses so an all-blank interview never seeds the engine or touches the store. Public
+    /// so callers (e.g. `SaveBrandVoiceTool`) can word their reply from the same predicate
+    /// instead of duplicating the emptiness rules.
     public static func hasContent(_ answers: BrandVoiceAnswers) -> Bool {
         !answers.audience.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             || !answers.toneWords.isEmpty || !answers.brandTerms.isEmpty || !answers.avoidPhrases.isEmpty

--- a/Sources/AnglesiteCore/BuildInfo.swift
+++ b/Sources/AnglesiteCore/BuildInfo.swift
@@ -1,10 +1,19 @@
 import Foundation
 
+/// Compile-time build identity — the "which build am I looking at" values the About panel and
+/// diagnostics render. Lives in AnglesiteCore (not the app target) so it's available without a
+/// bundle, e.g. under SwiftPM tests, where `Bundle.main` metadata doesn't exist.
 public enum BuildInfo {
+    /// The product name as shown in the About panel. A literal rather than a `Bundle` lookup so
+    /// it holds anywhere this module runs, bundle or not.
     public static let appName = "Anglesite"
-    // Bump manually at each phase milestone (tracked in docs/build-plan.md).
+    /// Current build-plan phase. Bump manually at each phase milestone (tracked in
+    /// docs/build-plan.md).
     public static let phase = "10"
 
+    /// One-line identity string for logs and diagnostics: app name, phase, and the host OS
+    /// version. Computed (not stored) so the OS version reflects the machine it runs on rather
+    /// than a build-time snapshot.
     public static var summary: String {
         "\(appName) · phase \(phase) · macOS \(ProcessInfo.processInfo.operatingSystemVersionString)"
     }

--- a/Sources/AnglesiteCore/BuildLogEnvelope.swift
+++ b/Sources/AnglesiteCore/BuildLogEnvelope.swift
@@ -10,6 +10,10 @@ import Foundation
 /// (#742). It only locates the envelope's boundaries within a larger string, then defers to
 /// `PreDeployCheck.parse` for everything after that.
 public enum BuildLogEnvelope {
+    /// What ``BuildLogEnvelope/extract(fromLog:exitCode:)`` found. Two-way by design: callers
+    /// choose a whole rendering path from this alone — the structured blocked/passed scan UI for
+    /// `.outcome`, or a plain log excerpt for `.rawExcerpt` — with no third "maybe" state to
+    /// handle.
     public enum Result: Sendable, Equatable {
         /// A `{"version":...}` JSON object was located and decoded (successfully or not — an
         /// unsupported/malformed envelope still surfaces as `.outcome(.error(...))`, matching

--- a/Sources/AnglesiteCore/BundleArtifact.swift
+++ b/Sources/AnglesiteCore/BundleArtifact.swift
@@ -28,12 +28,18 @@ import SwiftGit2
 /// (see `InProcessGit`'s doc comment and this module's `.serialized` test suites). Each call opens
 /// its own `Repository`/`git_indexer`/`git_packbuilder` handles and shares no state across calls.
 public struct BundleArtifact: SyncArtifact {
+    /// Creates a codec instance. Stateless by design — every operation opens and frees its own
+    /// libgit2 handles (see the type's concurrency note) — so instances are interchangeable and
+    /// free to construct at the call site.
     public init() {}
 
     private static let signatureLine = "# v2 git bundle"
 
     // MARK: - SyncArtifact
 
+    /// Writes the bundle: packs everything reachable from branches + tags + HEAD (the #283 ref
+    /// policy) via `git_packbuilder`, then lands header + pack with an atomic temp-file swap so a
+    /// concurrent reader (e.g. an iCloud upload racing this write) never observes a torn artifact.
     @discardableResult
     public func write(from sourceDirectory: URL, to artifactURL: URL) throws -> [SyncArtifactRef] {
         SwiftGit2Bootstrap.ensureInitialized
@@ -43,10 +49,17 @@ public struct BundleArtifact: SyncArtifact {
         return refs
     }
 
+    /// Header-only read: parses the ref lines up to the terminating blank line without ever
+    /// initializing libgit2 or touching the packfile — so it stays cheap, and works even on an
+    /// artifact whose pack wouldn't `verify`.
     public func refs(of artifactURL: URL) throws -> [SyncArtifactRef] {
         try Self.parseHeader(Self.readData(artifactURL)).refs
     }
 
+    /// Verifies by *actually indexing* the pack (into a throwaway scratch repository) rather than
+    /// re-implementing checksum math — `git_indexer` with `verify` on runs the same
+    /// checksum/delta-resolution path a real import does, so anything this accepts will also
+    /// `fetch`. A pack that indexes zero objects is rejected as `SyncArtifactError.emptyPack`.
     public func verify(artifactURL: URL) throws {
         SwiftGit2Bootstrap.ensureInitialized
         let data = try Self.readData(artifactURL)
@@ -60,6 +73,10 @@ public struct BundleArtifact: SyncArtifact {
         guard stats.indexedObjects > 0 else { throw SyncArtifactError.emptyPack }
     }
 
+    /// Imports the pack into the site repository's object database, then lands the header's refs
+    /// under the protocol's synthetic `refs/remotes/<namespace>/...` namespace. Objects land
+    /// before refs on purpose: a pack that indexes zero objects is refused up front, so refs can
+    /// never be created pointing at history that didn't arrive.
     @discardableResult
     public func fetch(into sourceDirectory: URL, namespace: String, from artifactURL: URL) throws -> [SyncArtifactRef] {
         SwiftGit2Bootstrap.ensureInitialized

--- a/Sources/AnglesiteCore/CSSColor.swift
+++ b/Sources/AnglesiteCore/CSSColor.swift
@@ -7,6 +7,9 @@ import SwiftUI
 /// Only handles #rgb/#rrggbb/#rrggbbaa hex forms — named colors and rgb()/hsl() fall back
 /// to the free-text field, which always remains available.
 public enum CSSColor {
+    /// Parses a hex CSS color (`#rgb`, `#rrggbb`, or `#rrggbbaa`) into a `Color`. Returns `nil`
+    /// for every other form — deliberately, so the caller falls back to the free-text field
+    /// instead of this bridge guessing at named colors or `rgb()`/`hsl()` syntax.
     public static func parse(_ value: String) -> Color? {
         var hex = value.trimmingCharacters(in: .whitespaces)
         guard hex.hasPrefix("#") else { return nil }
@@ -24,6 +27,10 @@ public enum CSSColor {
         return Color(red: r, green: g, blue: b, opacity: a)
     }
 
+    /// Formats a picker `Color` back to lowercase hex, emitting the 8-digit `#rrggbbaa` form
+    /// only when alpha is actually below 1 — round-tripping an opaque color must not grow an
+    /// alpha suffix the stylesheet never had. Falls back to `#000000` when the `Color` has no
+    /// resolvable `cgColor` (a dynamic/asset color), rather than throwing mid-edit.
     public static func format(_ color: Color) -> String {
         guard let cgColor = color.cgColor, let components = cgColor.components, components.count >= 3 else {
             return "#000000"
@@ -40,6 +47,9 @@ public enum CSSColor {
         return String(format: "#%02x%02x%02x%02x", r, g, b, a)
     }
 
+    /// CSS property names whose values get the ColorPicker affordance in the Styles panel. A
+    /// fixed allowlist (rather than sniffing the value) so shorthand and non-color properties
+    /// that merely *contain* a color keep the plain text field, where edits stay lossless.
     public static let colorProperties: Set<String> = [
         "color", "background-color", "border-color", "outline-color", "fill", "stroke",
         "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",

--- a/Sources/AnglesiteCore/ChatHistoryStore.swift
+++ b/Sources/AnglesiteCore/ChatHistoryStore.swift
@@ -9,9 +9,14 @@ import Foundation
 /// truncate; the file is expected to grow slowly enough that disk pressure isn't a concern
 /// for v0.5. (Bigger sites can `truncate -s 0 Config/chat-history.jsonl` manually.)
 public actor ChatHistoryStore {
+    /// Who (or what) produced an entry. String-backed so the raw values appear verbatim in the
+    /// JSONL, keeping the file filterable by external tools (`jq 'select(.role == "user")'`).
     public enum Role: String, Sendable, Codable, Equatable {
+        /// A message the site owner typed in the chat panel.
         case user
+        /// An assistant reply.
         case assistant
+        /// Output from a tool invocation, surfaced into the transcript.
         case tool
         /// An edit landed on the source — surfaced in chat with an inline Undo button.
         /// Metadata carries `file`, `commit`, `messageID`, and optional `undone`/`undoneNewCommit`
@@ -23,11 +28,19 @@ public actor ChatHistoryStore {
     /// `metadata` carries optional extras (toolUseID, isError, model, etc.) without bloating
     /// the top-level fields.
     public struct Entry: Sendable, Codable, Equatable {
+        /// When the entry was recorded. Encoded as ISO-8601 (see the store's encoder), so the
+        /// file stays sortable and greppable as plain text.
         public let timestamp: Date
+        /// Who produced the entry — drives which bubble/affordance the transcript renders.
         public let role: Role
+        /// The entry's text as shown in the transcript.
         public let content: String
+        /// Optional string-to-string extras (`toolUseID`, `isError`, `model`, edit bookkeeping…).
+        /// Deliberately stringly-typed: new keys never break old readers or old history files.
         public let metadata: [String: String]?
 
+        /// Creates an entry stamped `Date()` by default; pass an explicit `timestamp` only when
+        /// replaying or migrating existing history.
         public init(timestamp: Date = Date(), role: Role, content: String, metadata: [String: String]? = nil) {
             self.timestamp = timestamp
             self.role = role
@@ -36,14 +49,18 @@ public actor ChatHistoryStore {
         }
     }
 
+    /// The backing file's resolved location (`<configDirectory>/chat-history.jsonl`). Public so
+    /// callers and tests can address the file directly — the JSONL is meant to be readable
+    /// outside this store (see the type note).
     public let fileURL: URL
     private let fileManager: FileManager
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
+    /// Creates a store rooted at the site's app-owned `Config/` directory. `Config/` is used
+    /// directly — no nested `.anglesite/`, which was the pre-package layout (P3 import migrates
+    /// old history into `Config/`). `fileManager` is injectable for tests.
     public init(configDirectory: URL, fileManager: FileManager = .default) {
-        // Config/ is already the app-owned per-site dir (no nested .anglesite/ — that was the
-        // pre-package layout; P3 import migrates old history into Config/).
         self.fileURL = configDirectory.appendingPathComponent("chat-history.jsonl")
         self.fileManager = fileManager
         let encoder = JSONEncoder()

--- a/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
+++ b/Sources/AnglesiteCore/CloudflareAPITokenVerifier.swift
@@ -17,6 +17,8 @@ public struct CloudflareAPITokenVerifier: TokenVerifying {
     private let baseURL: URL
     private let transport: Transport
 
+    /// Creates a verifier. Both parameters exist for tests — `baseURL` points at a stub server,
+    /// `transport` fakes the HTTP layer entirely; production callers take the defaults.
     public init(
         baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
         transport: @escaping Transport = CloudflareAPITokenVerifier.defaultTransport
@@ -25,9 +27,12 @@ public struct CloudflareAPITokenVerifier: TokenVerifying {
         self.transport = transport
     }
 
+    /// Classifies `token` via `GET /user/tokens/verify`. Transient trouble is never blamed on
+    /// the token: connection failures map to `.network` and 429/5xx to `.unavailable`, so only a
+    /// response that decodes and says invalid/inactive yields `.invalidToken`. `siteDirectory`
+    /// is unused — verification is a pure API call now — but stays in the signature so
+    /// ``TokenVerifying`` callers and the MAS sandbox grant path don't change.
     public func verify(token: String, siteDirectory: URL) async -> Result<CloudflareAccount, TokenVerifyError> {
-        // `siteDirectory` is unused — verification is now a pure API call (kept for the protocol so
-        // callers and the MAS sandbox grant path don't change).
         let data: Data
         let http: HTTPURLResponse
         do {

--- a/Sources/AnglesiteCore/CloudflareCapabilityProber.swift
+++ b/Sources/AnglesiteCore/CloudflareCapabilityProber.swift
@@ -16,6 +16,8 @@ public struct CloudflareCapabilityProber: Sendable {
     private let baseURL: URL
     private let transport: CloudflareTransport
 
+    /// Creates a prober. Both parameters exist for tests — `baseURL` points at a stub server,
+    /// `transport` fakes the HTTP layer entirely; production callers take the defaults.
     public init(
         baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
         transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
@@ -24,6 +26,11 @@ public struct CloudflareCapabilityProber: Sendable {
         self.transport = transport
     }
 
+    /// Probes each known capability with one authenticated GET and returns the set that answered
+    /// with anything other than 401/403. Account-scoped probes are skipped entirely when the
+    /// token can't list an account, and zone-scoped probes when `zoneID` is `nil` — so absence
+    /// from the result means "not proven", not necessarily "denied"; gate optimistically-missing
+    /// capabilities by re-probing once the zone is known rather than caching this as final.
     public func probe(token: String, zoneID: String?) async -> TokenCapabilities {
         var caps = TokenCapabilities()
 

--- a/Sources/AnglesiteCore/CloudflareOAuthClient.swift
+++ b/Sources/AnglesiteCore/CloudflareOAuthClient.swift
@@ -14,8 +14,14 @@ import CryptoKit
 /// Domains rather than a custom URL scheme: Cloudflare's OAuth-client registration form only
 /// accepts `http(s)` redirect URIs.
 public enum CloudflareOAuthConfiguration {
+    /// The registered public client's ID. Committable because a PKCE public client has no
+    /// secret to protect (see the type note).
     public static let clientID = "e6705eb5f46254ecae0641b2e4da0ee2"
+    /// The #891 callback Worker, reached via Apple Associated Domains rather than a custom URL
+    /// scheme — Cloudflare's registration form only accepts `http(s)` redirect URIs.
     public static let redirectURI = URL(string: "https://auth.anglesite.dwk.io/oauth-callback")!
+    /// Cloudflare's OIDC discovery document; the authorize/token endpoints are resolved from
+    /// here at runtime rather than hardcoded, so they survive Cloudflare relocating them.
     public static let discoveryURL = URL(string: "https://dash.cloudflare.com/.well-known/openid-configuration")!
 }
 
@@ -33,8 +39,14 @@ struct OAuthDiscoveryDocument: Decodable, Sendable {
 
 /// The token response from Cloudflare's token endpoint.
 public struct OAuthToken: Decodable, Sendable, Equatable {
+    /// The bearer token subsequent Cloudflare API calls present.
     public let accessToken: String
+    /// The token type as the server reported it (expected `bearer`) — carried through verbatim
+    /// rather than asserted, so an unexpected value surfaces to the caller instead of failing
+    /// the decode.
     public let tokenType: String
+    /// Lifetime in seconds, when the server reports one. Optional because `expires_in` is a
+    /// recommended-not-required field of the token response.
     public let expiresIn: Int?
 
     enum CodingKeys: String, CodingKey {
@@ -44,6 +56,9 @@ public struct OAuthToken: Decodable, Sendable, Equatable {
     }
 }
 
+/// Failure modes of the OAuth flow, one case per phase (discovery → callback → exchange) so the
+/// presenting UI can word its recovery hint by where things broke. `Equatable` so tests can
+/// assert exact cases; where there's server-side detail to show, it rides along as a `String`.
 public enum CloudflareOAuthError: Error, Equatable, Sendable {
     /// Discovery document couldn't be fetched or decoded.
     case discoveryUnavailable(String)
@@ -61,6 +76,9 @@ public enum CloudflareOAuthError: Error, Equatable, Sendable {
 /// One authorize attempt: the URL to present plus what's needed to complete it once a callback
 /// URL comes back. `codeVerifier` never leaves this type except via `CloudflareOAuthClient.exchange`.
 public struct CloudflareOAuthRequest: Sendable {
+    /// The URL the caller presents in the browser session (`ASWebAuthenticationSession`) — the
+    /// only part of this value callers consume directly; the rest stays internal until the
+    /// callback comes back through `CloudflareOAuthClient`.
     public let authorizeURL: URL
     let state: String
     let codeVerifier: String
@@ -76,6 +94,9 @@ public struct CloudflareOAuthRequest: Sendable {
 /// or any UI, the same separation `TokenOnboarding` keeps from SwiftUI. Mirrors
 /// `CloudflareAPITokenVerifier`'s injected-`Transport` seam for the same reason.
 public struct CloudflareOAuthClient: Sendable {
+    /// One HTTP round trip. Injected so tests can drive discovery, callback, and exchange
+    /// handling without network — the same seam ``CloudflareAPITokenVerifier/Transport`` exists
+    /// for. Throws on connection failure.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     private let clientID: String
@@ -84,6 +105,9 @@ public struct CloudflareOAuthClient: Sendable {
     private let discoveryURL: URL
     private let transport: Transport
 
+    /// Creates a client. Everything except `scope` defaults to the registered Anglesite client
+    /// (``CloudflareOAuthConfiguration``) and the production transport; override for tests.
+    ///
     /// - scope: a Cloudflare OAuth scope name (== an API token permission-group name, e.g. the
     ///   dashboard's "User Details" Read). No default — the exact literal must come from the
     ///   registered client's available scopes (design doc §5's open item), not a guess baked in here.

--- a/Sources/AnglesiteCore/CloudflareReading.swift
+++ b/Sources/AnglesiteCore/CloudflareReading.swift
@@ -7,9 +7,17 @@ import FoundationNetworking
 
 /// Errors surfaced by the Cloudflare read client.
 public enum CloudflareError: Error, Equatable, Sendable {
+    /// Cloudflare answered 401/403 — the token is invalid, expired, or missing a scope. Kept
+    /// distinct from ``http(status:)`` so callers can point the user at the token, not the network.
     case unauthorized
+    /// Any other non-2xx status. The body wasn't consulted — Cloudflare's error envelope is only
+    /// decoded for 2xx responses whose `success` flag is false (see ``api(message:)``).
     case http(status: Int)
+    /// The request reached the API but Cloudflare reported failure in its response envelope
+    /// (`success: false`); `message` is the first error message Cloudflare returned.
     case api(message: String)
+    /// The response couldn't be interpreted at all — not HTTP, an unbuildable URL, or a body
+    /// that doesn't decode as the expected envelope.
     case malformedResponse
 }
 
@@ -17,12 +25,22 @@ public enum CloudflareError: Error, Equatable, Sendable {
 /// (write-only, no `id`/`proxied`) — this is the read-side shape used to list and display
 /// existing records.
 public struct DNSRecord: Sendable, Equatable, Identifiable {
+    /// Cloudflare's record id — the handle `CloudflareWriting.deleteDNSRecord` needs, and the
+    /// `Identifiable` identity SwiftUI lists key on.
     public let id: String
+    /// Record type as Cloudflare reports it (`A`, `CNAME`, `MX`, `TXT`, …). Left as a string
+    /// rather than an enum so unrecognized types still round-trip for display.
     public let type: String
+    /// Fully-qualified record name (e.g. `www.example.com`), not the zone-relative label.
     public let name: String
+    /// Raw record content exactly as stored (target hostname, IP, TXT payload, …).
     public let content: String
+    /// TTL in seconds; `1` is Cloudflare's sentinel for "automatic".
     public let ttl: Int
+    /// Whether traffic for this record routes through Cloudflare's proxy (the orange cloud).
+    /// Read-side only — `DNSRecordPayload` deliberately doesn't carry it.
     public let proxied: Bool
+    /// Memberwise initializer; the HTTP client and test fixtures build records directly.
     public init(id: String, type: String, name: String, content: String, ttl: Int, proxied: Bool) {
         self.id = id
         self.type = type

--- a/Sources/AnglesiteCore/CloudflareTokenVerifier.swift
+++ b/Sources/AnglesiteCore/CloudflareTokenVerifier.swift
@@ -5,9 +5,14 @@ import Foundation
 /// falls back to a generic "verified" message), and `email` is `nil` for token auth that isn't
 /// associated with a user email.
 public struct CloudflareAccount: Sendable, Equatable {
+    /// Account display name from the best-effort `GET /accounts` lookup; `nil` never means the
+    /// token is bad, only that the nicety wasn't available.
     public let name: String?
+    /// Email tied to the credential, when Cloudflare exposes one. API tokens usually have none —
+    /// this exists for auth shapes that do.
     public let email: String?
 
+    /// Memberwise initializer; verifiers assemble this from whatever the lookups yielded.
     public init(name: String?, email: String?) {
         self.name = name
         self.email = email
@@ -23,6 +28,8 @@ public enum TokenVerifyError: Error, Equatable, Sendable {
     /// We couldn't check the token at all (unexpected response, etc.).
     case unavailable(String)
 
+    /// The exact copy the token prompt shows for this failure. Kept on the error itself so every
+    /// entry point renders the same wording instead of re-translating cases ad hoc.
     public var userMessage: String {
         switch self {
         case .invalidToken:
@@ -39,5 +46,11 @@ public enum TokenVerifyError: Error, Equatable, Sendable {
 /// entry instead of failing later inside a deploy. The production conformer is
 /// `CloudflareAPITokenVerifier` (a native REST call — no Node/wrangler).
 public protocol TokenVerifying: Sendable {
+    /// Checks `token` against Cloudflare and classifies the outcome. Returns a `Result` instead of
+    /// throwing so every failure arrives pre-classified as a ``TokenVerifyError`` with its
+    /// user-facing copy attached. `siteDirectory` is part of the seam for historical reasons —
+    /// the production conformer's verification is a pure API call and ignores it (kept so callers
+    /// and the MAS sandbox-grant path didn't have to change when the wrangler-based verifier went
+    /// away).
     func verify(token: String, siteDirectory: URL) async -> Result<CloudflareAccount, TokenVerifyError>
 }

--- a/Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift
+++ b/Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift
@@ -5,23 +5,39 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// One Web Analytics (RUM) site registration from Cloudflare's `site_info/list` endpoint —
+/// the hostname it's registered for plus the tag that identifies it in beacon/analytics queries.
 public struct CloudflareWebAnalyticsSite: Sendable, Equatable {
+    /// Hostname the analytics site is registered under, as Cloudflare stores it (a bare host —
+    /// see ``CloudflareWebAnalyticsClient/matchingSite(for:in:)`` for how looser inputs match it).
     public let host: String
+    /// Cloudflare's `site_tag` — the stable identifier used to query this site's analytics.
     public let siteTag: String
 
+    /// Memberwise initializer; the client maps API rows into this, and tests build fixtures.
     public init(host: String, siteTag: String) {
         self.host = host
         self.siteTag = siteTag
     }
 }
 
+/// Failures resolving a Web Analytics site tag. Conforms to `LocalizedError` so callers can
+/// surface `errorDescription` directly as the user-facing message without a mapping layer.
 public enum CloudflareWebAnalyticsError: Error, LocalizedError, Sendable, Equatable {
+    /// The caller had no Cloudflare API token to send — nothing was requested.
     case missingToken
+    /// The token verified but `GET /accounts` returned no account to scope the site lookup to.
     case noAccount
+    /// No registered Web Analytics site matched the given host — usually means Web Analytics
+    /// simply hasn't been enabled for it in the Cloudflare dashboard.
     case noMatchingSite(String)
+    /// A 2xx response whose body didn't decode as the expected envelope.
     case invalidResponse
+    /// A non-2xx response; carries Cloudflare's own error message when one was decodable, else a
+    /// generic HTTP-status message.
     case api(String)
 
+    /// User-facing message for each failure — the reason this type adopts `LocalizedError`.
     public var errorDescription: String? {
         switch self {
         case .missingToken:
@@ -38,20 +54,30 @@ public enum CloudflareWebAnalyticsError: Error, LocalizedError, Sendable, Equata
     }
 }
 
+/// Seam for resolving a host's Web Analytics site tag, so callers (the plist editor's analytics
+/// wiring) can inject a fake instead of hitting the Cloudflare API in tests.
 public protocol CloudflareWebAnalyticsProviding: Sendable {
+    /// Resolves the `site_tag` for `host`, or throws ``CloudflareWebAnalyticsError`` when the
+    /// account has no Web Analytics registration matching it.
     func siteTag(for host: String, apiToken: String) async throws -> String
 }
 
+/// Production ``CloudflareWebAnalyticsProviding``: a thin v4 REST client that looks up the
+/// token's first account, lists its Web Analytics (RUM) sites, and matches by normalized host.
 public struct CloudflareWebAnalyticsClient: CloudflareWebAnalyticsProviding {
     private let baseURL: URL
     private let urlSession: URLSession
 
+    /// Both parameters exist for tests — point `baseURL` at a local stub server to exercise the
+    /// real request/decode path. Production callers take the defaults.
     public init(baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
                 urlSession: URLSession = .shared) {
         self.baseURL = baseURL
         self.urlSession = urlSession
     }
 
+    /// Resolves the site tag by scoping to the token's *first* account — Anglesite's Cloudflare
+    /// onboarding assumes a single-account token, so no account picker exists here.
     public func siteTag(for host: String, apiToken: String) async throws -> String {
         let accounts = try await accounts(apiToken: apiToken)
         guard let accountID = accounts.first?.id else { throw CloudflareWebAnalyticsError.noAccount }
@@ -62,6 +88,10 @@ public struct CloudflareWebAnalyticsClient: CloudflareWebAnalyticsProviding {
         return site.siteTag
     }
 
+    /// Finds the registration whose host matches `host` after normalization (lowercased, scheme
+    /// and path stripped) — a stored value like `https://Example.com/about` still matches
+    /// Cloudflare's bare-hostname records. Static and public so the matching rule is unit-testable
+    /// without any network.
     public static func matchingSite(for host: String, in sites: [CloudflareWebAnalyticsSite]) -> CloudflareWebAnalyticsSite? {
         let normalized = normalizeHost(host)
         return sites.first { normalizeHost($0.host) == normalized }

--- a/Sources/AnglesiteCore/CloudflareWriting.swift
+++ b/Sources/AnglesiteCore/CloudflareWriting.swift
@@ -3,20 +3,32 @@ import Foundation
 /// Write-side Cloudflare API seam. The concrete `HTTPCloudflareClient` talks to the
 /// v4 REST API; tests provide a mock. Token is passed per call (no Keychain coupling).
 public protocol CloudflareWriting: Sendable {
+    /// Turn on DNSSEC signing for the zone. Enable-only by design — the hardening flow never
+    /// needs to switch DNSSEC off, so the seam offers no disable.
     func enableDNSSEC(zoneID: String, apiToken: String) async throws
+    /// Set the zone-level "Always Use HTTPS" edge redirect (HTTP → HTTPS before origin).
     func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws
+    /// Write the zone's HSTS edge header (`security_header` setting). Parameters mirror
+    /// ``CloudflareZoneState/HSTS``, the read-side shape the audit grades.
     func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool,
                  apiToken: String) async throws
+    /// Create a DNS record. Not idempotent — Cloudflare stores duplicates without complaint, so
+    /// callers (e.g. `HardenExecutor`) only add records the zone state showed missing.
     func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws
     /// Delete a DNS record by its Cloudflare-assigned record id (from `listDNSRecords`).
     func deleteDNSRecord(zoneID: String, recordID: String, apiToken: String) async throws
+    /// Toggle Bot Fight Mode, the free-plan bot mitigation the audit recommends.
     func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws
+    /// Append a custom WAF rule to the zone's `http_request_firewall_custom` phase ruleset.
     func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws
+    /// Toggle Speed Brain (speculation-rules prefetching at the edge).
     func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws
+    /// Toggle Encrypted Client Hello (hides the SNI hostname from on-path observers).
     func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws
     /// Idempotent: creates the `http_response_compression` ruleset with a zstd-first rule, or
     /// appends the rule to the existing ruleset.
     func enableZstandardCompression(zoneID: String, apiToken: String) async throws
+    /// Toggle Page Shield's client-side script monitoring for the zone.
     func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws
     /// Enable/Disable Cloudflare's Onion Routing feature.
     func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws
@@ -30,12 +42,20 @@ public protocol CloudflareWriting: Sendable {
 
 /// Payload for creating a DNS record via the Cloudflare API.
 public struct DNSRecordPayload: Sendable, Equatable, Encodable {
+    /// DNS record type (`A`, `CNAME`, `MX`, `TXT`, `CAA`, …) as the API expects it.
     public let type: String
+    /// Record name; Cloudflare accepts `@` for the zone apex as well as fully-qualified names.
     public let name: String
+    /// Record content (target host, IP, quoted TXT payload, …), passed through verbatim.
     public let content: String
+    /// TTL in seconds; the default `1` is Cloudflare's sentinel for "automatic".
     public let ttl: Int
+    /// Only meaningful for record types with a priority field (MX/SRV/URI). `nil` — the default —
+    /// is omitted from the encoded JSON entirely (synthesized `Encodable` uses `encodeIfPresent`),
+    /// so priority-less record types never see a spurious field.
     public let priority: Int?
 
+    /// Defaults produce the common case: an automatic-TTL record with no priority field.
     public init(type: String, name: String, content: String, ttl: Int = 1, priority: Int? = nil) {
         self.type = type
         self.name = name
@@ -47,10 +67,17 @@ public struct DNSRecordPayload: Sendable, Equatable, Encodable {
 
 /// Payload for creating a custom WAF rule via the Cloudflare API.
 public struct WAFRulePayload: Sendable, Equatable, Encodable {
+    /// Human-readable rule description shown in the Cloudflare dashboard. Doubles as the identity
+    /// the hardening planner dedupes on (case-insensitively, against
+    /// ``CloudflareZoneState/wafCustomRules``) — so keep it stable for a given rule template.
     public let description: String
+    /// The rule's match expression in Cloudflare's Rules language (e.g. `(cf.client.bot)`).
     public let expression: String
+    /// What the rule does on match — a Cloudflare action name such as `block` or
+    /// `managed_challenge`, passed through verbatim.
     public let action: String
 
+    /// Memberwise initializer; the hardening planner builds these from its canned rule templates.
     public init(description: String, expression: String, action: String) {
         self.description = description
         self.expression = expression

--- a/Sources/AnglesiteCore/CloudflareZoneState.swift
+++ b/Sources/AnglesiteCore/CloudflareZoneState.swift
@@ -5,9 +5,13 @@ import Foundation
 public struct CloudflareZoneState: Sendable, Equatable {
     /// HSTS edge setting (Zone Settings → security_header). `nil` when disabled.
     public struct HSTS: Sendable, Equatable {
+        /// `max-age` directive in seconds — how long browsers pin HTTPS for the host.
         public var maxAge: Int
+        /// Whether the header carries `includeSubDomains`, extending the pin to every subdomain.
         public var includeSubdomains: Bool
+        /// Whether the header carries `preload` — required for hstspreload.org list submission.
         public var preload: Bool
+        /// Memberwise initializer; assembled from the zone's `security_header` setting.
         public init(maxAge: Int, includeSubdomains: Bool, preload: Bool) {
             self.maxAge = maxAge
             self.includeSubdomains = includeSubdomains
@@ -15,13 +19,19 @@ public struct CloudflareZoneState: Sendable, Equatable {
         }
     }
 
+    /// Whether DNSSEC is actually *active* for the zone — a pending/disabled signing state
+    /// reads as `false`, since only active signing protects resolvers.
     public var dnssecActive: Bool
     /// SSL/TLS encryption mode: "off" | "flexible" | "full" | "strict".
     public var sslMode: String
+    /// Whether the "Always Use HTTPS" edge redirect (HTTP → HTTPS) is enabled.
     public var alwaysUseHTTPS: Bool
+    /// HSTS edge header configuration; `nil` when the `security_header` setting is disabled.
     public var hsts: HSTS?
     /// Raw record contents (`content` field) for the relevant DNS types.
     public var caaRecords: [String]
+    /// Apex MX record contents — scoped to the zone apex so a subdomain's mail setup can't
+    /// count toward (or against) the apex email grading.
     public var mxRecords: [String]
     /// TXT records whose content starts with `v=spf1`.
     public var spfRecords: [String]
@@ -44,9 +54,15 @@ public struct CloudflareZoneState: Sendable, Equatable {
 
     /// A single custom WAF rule from the zone's firewall ruleset.
     public struct WAFCustomRule: Sendable, Equatable {
+        /// The rule's dashboard description — the identity the hardening planner matches
+        /// (case-insensitively) against ``WAFRulePayload/description`` to avoid re-creating a
+        /// rule that already exists.
         public var description: String
+        /// The rule's match expression in Cloudflare's Rules language, as stored.
         public var expression: String
+        /// The rule's action name (`block`, `managed_challenge`, …), as stored.
         public var action: String
+        /// Memberwise initializer; mapped from the ruleset listing by the HTTP client.
         public init(description: String, expression: String, action: String) {
             self.description = description
             self.expression = expression
@@ -56,15 +72,20 @@ public struct CloudflareZoneState: Sendable, Equatable {
 
     /// Page Shield script-monitor snapshot.
     public struct PageShieldState: Sendable, Equatable {
+        /// Whether Page Shield monitoring is on for the zone.
         public var enabled: Bool
         /// Unique, sorted hosts of scripts Page Shield has seen loading on the site.
         public var scriptHosts: [String]
+        /// Memberwise initializer; assembled from Page Shield's status + script listing calls.
         public init(enabled: Bool, scriptHosts: [String]) {
             self.enabled = enabled
             self.scriptHosts = scriptHosts
         }
     }
 
+    /// Memberwise initializer. Fields added after the original audit (Bot Fight Mode onward) are
+    /// defaulted so pre-existing call sites and test fixtures don't churn every time the audit
+    /// grows a new check.
     public init(dnssecActive: Bool, sslMode: String, alwaysUseHTTPS: Bool, hsts: HSTS?,
                 caaRecords: [String], mxRecords: [String], spfRecords: [String], dmarcRecords: [String],
                 botFightMode: Bool = false, wafCustomRules: [WAFCustomRule] = [],

--- a/Sources/AnglesiteCore/CollectionInspection.swift
+++ b/Sources/AnglesiteCore/CollectionInspection.swift
@@ -4,12 +4,17 @@ import Foundation
 /// assembled by the site window from the navigator node, the content graph, the feed probe, and
 /// the content-type registry. Read-mostly v1: pure display data, no write-back.
 public struct CollectionInspection: Sendable, Equatable {
+    /// Display title for the inspector header — the sidebar row's label, not a slug.
     public let title: String
+    /// The row's site route (e.g. `/posts`), shown so the owner can connect the sidebar
+    /// grouping to the published URL.
     public let route: String
     /// The `src/content` collection name; nil for a plain nested page folder.
     public let collection: String?
     /// Entries in the collection (graph posts), or child pages for a plain folder.
     public let entryCount: Int
+    /// Feeds the feed probe detected for this route (RSS/Atom/JSON), listed so the owner can see
+    /// what's already syndicated without hunting through files.
     public let feeds: [SiteFileTree.DetectedFeed]
     /// Registered content type's `displayName` (e.g. "Notes"); nil when unregistered.
     public let contentTypeName: String?
@@ -17,6 +22,9 @@ public struct CollectionInspection: Sendable, Equatable {
     /// dispatch picks the matching layout, so this names the template in use.
     public let microformat: String?
 
+    /// Memberwise initializer — the site window assembles this from its several sources
+    /// (navigator node, content graph, feed probe, content-type registry); no single one of them
+    /// could construct it alone.
     public init(
         title: String, route: String, collection: String?, entryCount: Int,
         feeds: [SiteFileTree.DetectedFeed], contentTypeName: String?, microformat: String?

--- a/Sources/AnglesiteCore/CombinedAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/CombinedAugmentedAssistant.swift
@@ -20,6 +20,14 @@ public actor CombinedAugmentedAssistant: ConversationalAssistant {
     private let index: SiteKnowledgeIndex
     private let graphSnapshotProvider: @Sendable () async -> SiteGraphExplorerSnapshot
 
+    /// Wraps `base` with combined graph + content-search enrichment.
+    ///
+    /// - Parameters:
+    ///   - base: The assistant that actually talks to the model; this decorator only rewrites the
+    ///     prompt it forwards.
+    ///   - index: Content-search index queried per turn for the knowledge block.
+    ///   - graphSnapshotProvider: Async closure (not a captured snapshot) so each turn reads the
+    ///     *current* site graph — the graph changes as the user edits.
     public init(
         base: any ConversationalAssistant,
         index: SiteKnowledgeIndex,
@@ -30,10 +38,16 @@ public actor CombinedAugmentedAssistant: ConversationalAssistant {
         self.graphSnapshotProvider = graphSnapshotProvider
     }
 
+    /// Pass-through to `base` — prompt enrichment adds no capability of its own, so advertising
+    /// anything beyond the wrapped backend's surface would mislead routing.
     public nonisolated var capabilities: AssistantCapabilities {
         base.capabilities
     }
 
+    /// Runs both retrievals against the untouched `prompt`, then forwards the enriched prompt to
+    /// `base`. When retrieval found anything, the returned stream is re-wrapped to yield one
+    /// leading `AssistantEvent.citations` event before the base events, so the chat panel can
+    /// show citation chips for the turn; with no hits, the base stream is returned as-is.
     public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
         let (enriched, citations) = await enrichedContext(prompt, context: context)
         let baseStream = try await base.converse(prompt: enriched, context: context)
@@ -50,12 +64,17 @@ public actor CombinedAugmentedAssistant: ConversationalAssistant {
         }
     }
 
+    /// Same enrichment as ``converse(prompt:context:)``, but the citations are discarded — the
+    /// plain-text stream has no event channel to carry them.
     public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
         let (enriched, _) = await enrichedContext(prompt, context: context)
         return try await base.generate(prompt: enriched, context: context)
     }
 
     #if compiler(>=6.4) && canImport(FoundationModels)
+    /// Enriches the prompt exactly like the streaming paths before delegating the guided
+    /// generation (`Generable`) call to `base` — structured output benefits from the same
+    /// grounding, it just has nowhere to surface citations.
     public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,
@@ -66,10 +85,14 @@ public actor CombinedAugmentedAssistant: ConversationalAssistant {
     }
     #endif
 
+    /// Forwards to `base` — the decorator holds no in-flight work of its own to cancel (its
+    /// retrieval awaits complete before the base call starts).
     public func cancel() async {
         await base.cancel()
     }
 
+    /// Forwards to `base`; enrichment is stateless per turn, so only the wrapped backend has
+    /// session state to reset.
     public func resetSession() async {
         await base.resetSession()
     }

--- a/Sources/AnglesiteCore/CommandFactory.swift
+++ b/Sources/AnglesiteCore/CommandFactory.swift
@@ -4,16 +4,27 @@ import Foundation
 /// returns the real zero-arg actors; tests inject a fake whose actors are built with the
 /// actors' existing closure seams to return canned `Result`s (see `SiteOperationsTests`).
 public protocol CommandFactory: Sendable {
+    /// A fresh ``DeployCommand`` for one deploy invocation.
     func deploy() -> DeployCommand
+    /// A fresh ``BackupCommand`` for one backup invocation.
     func backup() -> BackupCommand
+    /// A fresh ``AuditCommand`` for one security-audit invocation.
     func audit() -> AuditCommand
+    /// A fresh ``SocialWorkerProvisionCommand`` for one social-worker provisioning run.
     func socialWorkerProvision() -> SocialWorkerProvisionCommand
 }
 
+/// Production ``CommandFactory``: returns the real zero-arg command actors with their default
+/// (live) dependencies. Intents resolve this unless a test injects a canned-result factory.
 public struct LiveCommandFactory: CommandFactory {
+    /// Stateless — nothing to configure; the commands wire their own live dependencies.
     public init() {}
+    /// Returns a live ``DeployCommand``.
     public func deploy() -> DeployCommand { DeployCommand() }
+    /// Returns a live ``BackupCommand``.
     public func backup() -> BackupCommand { BackupCommand() }
+    /// Returns a live ``AuditCommand``.
     public func audit() -> AuditCommand { AuditCommand() }
+    /// Returns a live ``SocialWorkerProvisionCommand``.
     public func socialWorkerProvision() -> SocialWorkerProvisionCommand { SocialWorkerProvisionCommand() }
 }

--- a/Sources/AnglesiteCore/CommunitiesLedger.swift
+++ b/Sources/AnglesiteCore/CommunitiesLedger.swift
@@ -2,18 +2,29 @@ import Foundation
 
 /// One community this site has joined (V-5.1a, #368).
 public struct JoinedCommunity: Codable, Equatable, Sendable, Identifiable {
+    /// The community's canonical ActivityPub actor id URL — the identity key the ledger dedupes
+    /// and removes by.
     public let actorID: URL
     /// For `GroupTimelineClient` — `nil` if the actor document didn't advertise one.
     public let outboxURL: URL?
+    /// Fediverse handle (e.g. `@garden@example.social`), when discovery resolved one. Display
+    /// nicety only — never used as identity, since handles can change while ``actorID`` can't.
     public let handle: String?
+    /// The actor's self-declared display name, when the actor document carried one.
     public let displayName: String?
+    /// When this site joined — recorded locally at join time because no public collection
+    /// exists to recover it from later.
     public let joinedAt: Date
     /// The `Follow` activity id `CommunityMembershipClient.follow(target:)` returned — threaded
     /// back into `unfollow(target:followActivityID:)` on leave.
     public let followActivityID: String?
 
+    /// `Identifiable` via the actor id string, so SwiftUI lists key rows by the same identity
+    /// the ledger itself uses.
     public var id: String { actorID.absoluteString }
 
+    /// Memberwise initializer; the join flow assembles this from the fetched actor document plus
+    /// the follow call's returned activity id.
     public init(
         actorID: URL, outboxURL: URL?, handle: String?, displayName: String?, joinedAt: Date,
         followActivityID: String?
@@ -33,14 +44,20 @@ public struct JoinedCommunity: Codable, Equatable, Sendable, Identifiable {
 /// a public AS2 collection), so this ledger — not the Worker — is the source of truth for what the
 /// Communities pane lists. Same shape and crash-safety contract as `ActivityPubOutboxLedger`.
 public struct CommunitiesLedger: Codable, Equatable, Sendable {
+    /// The ledger's file name inside the site's `Config/` directory.
     public static let filename = "activitypub-communities.json"
 
+    /// The joined communities, in join order. `private(set)` so every mutation goes through
+    /// ``record(_:)``/``remove(actorID:)`` and their dedupe contract can't be bypassed.
     public private(set) var communities: [JoinedCommunity]
 
+    /// Starts empty by default — the state of a site that has never joined a community.
     public init(communities: [JoinedCommunity] = []) {
         self.communities = communities
     }
 
+    /// Whether `actorID` is already recorded — the membership check the Communities UI and
+    /// ``record(_:)``'s idempotence both rest on.
     public func contains(actorID: URL) -> Bool {
         communities.contains { $0.actorID == actorID }
     }
@@ -52,6 +69,8 @@ public struct CommunitiesLedger: Codable, Equatable, Sendable {
         communities.append(community)
     }
 
+    /// Removes the entry for `actorID`; a no-op when it was never recorded, so a leave that
+    /// races a stale UI can't fail.
     public mutating func remove(actorID: URL) {
         communities.removeAll { $0.actorID == actorID }
     }
@@ -60,6 +79,9 @@ public struct CommunitiesLedger: Codable, Equatable, Sendable {
         let communities: [JoinedCommunity]
     }
 
+    /// Reads the ledger from `configDirectory`, or `nil` when the file is absent or undecodable —
+    /// callers treat both as "no communities yet" rather than failing, since a fresh site
+    /// legitimately has no ledger file.
     public static func load(from configDirectory: URL) -> CommunitiesLedger? {
         let url = configDirectory.appendingPathComponent(filename)
         guard let data = try? Data(contentsOf: url) else { return nil }
@@ -69,6 +91,10 @@ public struct CommunitiesLedger: Codable, Equatable, Sendable {
         return CommunitiesLedger(communities: envelope.communities)
     }
 
+    /// Persists the ledger into `configDirectory` (creating it if needed). The write is atomic so
+    /// a crash mid-save can't leave a truncated file, and the JSON is pretty-printed with sorted
+    /// keys so successive saves diff cleanly — the same crash-safety contract as
+    /// `ActivityPubOutboxLedger`.
     public func save(to configDirectory: URL) throws {
         try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
         let encoder = JSONEncoder()


### PR DESCRIPTION
## Summary

- Phase 3 of the doc-comment retrofit tracked in #1141: first alphabetical chunk of AnglesiteCore (53 files, `A11yAuditRunner` … `CommunitiesLedger`, ~390 doc comments) — ACP transports/assistant, ActivityPub ledgers and key provisioning, the audit pipeline, AppSettings keys, the AppleScript command surface, brand voice, Cloudflare clients/payloads/zone state, and the communities ledger.
- Completes four `- Parameters:` blocks that the strict AnglesiteCore DocC build flagged as partial (DocC requires all-or-nothing parameter coverage per signature).
- Single-line enum `case` lists split so each case carries its rationale; raw values and `CaseIterable` order unchanged. Comments only otherwise — no behavior changes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` — clean.
- [x] `swift test --filter AnglesiteCoreTests` — 3,050 tests in 384 suites; 2 failures, both in "FoundationModelAssistant" (live on-device generation timing out on a machine saturated by concurrent agent `swift test` runs — the known FM-contention flake). `FoundationModelAssistant.swift` is **not touched by this diff**; the same two tests failed identically on an unmodified checkout during Phase 1's run (see #1148's test plan).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run separately; comments-only diff, target compiles during DocC symbol-graph extraction.
