### PR TITLE
docs(#1141): retrofit doc comments, Core Community-DeployCoord

### DIFF
--- a/Sources/AnglesiteCore/CommunityActorResolver.swift
+++ b/Sources/AnglesiteCore/CommunityActorResolver.swift
@@ -14,12 +14,22 @@ public struct ResolvedCommunityActor: Sendable, Equatable {
     /// The actor's public outbox collection, for `GroupTimelineClient`. `nil` for an actor
     /// document that doesn't advertise one — the timeline pane degrades to "no timeline available".
     public let outboxURL: URL?
+    /// The actor document's self-declared AS2 `type` (`Group`, `Person`, …), passed through
+    /// unfiltered — the join flow works for any FEP-1b12 software, so this is display context
+    /// ("Join Birding (Lemmy)?"), not a gate.
     public let type: String?
+    /// The actor's `preferredUsername`, sanitized via ``DisplayString`` — remote-controlled text
+    /// that ends up in UI.
     public let preferredUsername: String?
+    /// The actor's display `name`, sanitized via ``DisplayString`` for the same reason as
+    /// ``preferredUsername``.
     public let name: String?
     /// The `@name@host` (or `!name@host`) form the owner typed, sanitized for display.
     public let handle: String?
 
+    /// Memberwise initializer — public so tests and previews can build resolved actors without a
+    /// network round-trip; production values come from ``CommunityActorResolver/resolve(_:)``,
+    /// which is where the HTTPS and sanitization guarantees are enforced.
     public init(
         actorID: URL, outboxURL: URL?, type: String?, preferredUsername: String?, name: String?,
         handle: String?
@@ -33,13 +43,24 @@ public struct ResolvedCommunityActor: Sendable, Equatable {
     }
 }
 
+/// Failures from ``CommunityActorResolver``. `Equatable` so tests (and retry logic) can match on
+/// the exact failure rather than string-compare error dumps.
 public enum CommunityActorResolverError: Error, Equatable, Sendable {
+    /// The input parsed as neither a fediverse handle nor an http(s) URL.
     case invalidHandle
+    /// A URL somewhere in the chain (input, redirect landing, webfinger `self` link, or the
+    /// actor's own `id`) wasn't HTTPS — every IRI the join flow later addresses must be secure.
     case insecureURL
+    /// The webfinger endpoint answered outside 2xx. `body` is capped at the first 400 bytes —
+    /// enough to diagnose, without echoing an arbitrary remote payload into logs/UI.
     case webfingerFailed(status: Int, body: String)
     /// The webfinger response had no `rel: "self"` AS2 link to follow.
     case noActorLink
+    /// The actor-document fetch failed (non-2xx, transport error as status 0, or an injected
+    /// transport exceeding the byte cap). Same 400-byte body cap as ``webfingerFailed(status:body:)``.
     case requestFailed(status: Int, body: String)
+    /// A response wasn't the JSON shape expected; carries the underlying decoding error's
+    /// description (stringified so the case stays `Equatable`).
     case decodingFailed(String)
 }
 
@@ -50,6 +71,8 @@ public enum CommunityActorResolverError: Error, Equatable, Sendable {
 /// HTTPS-only and a byte cap, not the server-side SSRF guard `@dwk/activitypub`'s own resolver
 /// applies (that guard exists because *that* resolution runs inside a shared Cloudflare Worker).
 public struct CommunityActorResolver: Sendable {
+    /// Injection seam for tests — lets suites feed canned webfinger/actor responses without a
+    /// network. Production uses ``defaultTransport``, which enforces the byte cap mid-stream.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     /// Defense-in-depth for a caller-injected `Transport` that might not itself be capped — the
@@ -60,10 +83,20 @@ public struct CommunityActorResolver: Sendable {
 
     private let transport: Transport
 
+    /// Creates a resolver, defaulting to the capped HTTPS ``defaultTransport``; pass a custom
+    /// ``Transport`` only in tests (the post-fetch guards re-apply the byte cap either way).
     public init(transport: @escaping Transport = CommunityActorResolver.defaultTransport) {
         self.transport = transport
     }
 
+    /// Resolves owner input to a confirmed remote actor: a pasted `http(s)` URL is fetched
+    /// directly (skipping webfinger), anything else must parse as a handle and goes through
+    /// `/.well-known/webfinger` first. Either path ends in the same actor-document fetch, so the
+    /// resulting ``ResolvedCommunityActor`` carries the same guarantees (HTTPS-validated
+    /// `actorID`, sanitized display strings) regardless of how the input arrived.
+    ///
+    /// - Throws: ``CommunityActorResolverError`` for invalid input, an insecure URL at any hop,
+    ///   or a failed/oversized/undecodable response.
     public func resolve(_ input: String) async throws -> ResolvedCommunityActor {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         if let url = URL(string: trimmed), let scheme = url.scheme, url.host != nil,
@@ -203,6 +236,9 @@ public struct CommunityActorResolver: Sendable {
     private static let session = CappedHTTPTransport.session(
         requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
 
+    /// Production transport: a shared `CappedHTTPTransport` session that aborts mid-stream once
+    /// ``maximumResponseBytes`` is exceeded — a hostile server can't make the app buffer an
+    /// unbounded body before the post-fetch size check runs.
     public static let defaultTransport: Transport = { request in
         try await CappedHTTPTransport.fetch(
             request, session: session, cap: ActorProfileFetcher.maximumResponseBytes,

--- a/Sources/AnglesiteCore/CommunityMembershipClient.swift
+++ b/Sources/AnglesiteCore/CommunityMembershipClient.swift
@@ -3,8 +3,16 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// Failures from ``CommunityMembershipClient``'s outbox POSTs. `Equatable` so tests can assert
+/// on the exact failure rather than string-compare error dumps.
 public enum CommunityMembershipError: Error, Equatable, Sendable {
+    /// The outbox POST failed — non-2xx from the Worker, or a transport error (reported as
+    /// status 0). `body` is capped at the first 400 bytes, enough to diagnose without echoing an
+    /// arbitrary payload into logs/UI.
     case requestFailed(status: Int, body: String)
+    /// Reserved for a response body that can't be interpreted; currently unused because
+    /// ``CommunityMembershipClient/follow(target:)`` degrades gracefully when the outbox reply
+    /// carries no activity id instead of failing.
     case decodingFailed(String)
 }
 
@@ -16,6 +24,8 @@ public enum CommunityMembershipError: Error, Equatable, Sendable {
 /// federated delivery), so — unlike `CommunityActorResolver` — there is no HTTPS/size-cap guard
 /// on this client itself; the target IRI it's given already passed through that resolver.
 public struct CommunityMembershipClient: Sendable {
+    /// Injection seam for tests — lets suites capture the outbox request and feed canned
+    /// responses without a network. Production uses ``defaultTransport``.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     private let outboxURL: URL
@@ -23,6 +33,15 @@ public struct CommunityMembershipClient: Sendable {
     private let publishToken: String
     private let transport: Transport
 
+    /// Creates a client for one site's own actor. The outbox endpoint isn't a parameter — it's
+    /// derived as `ownActorURL/outbox`, the shape `@dwk/activitypub` guarantees, so a caller
+    /// can't accidentally point the bearer-authenticated POST at some other endpoint.
+    ///
+    /// - Parameters:
+    ///   - ownActorURL: This site's own actor IRI (the `actor` in every activity posted).
+    ///   - publishToken: The owner-gated bearer token the Worker's outbox requires — the same
+    ///     credential `ActivityPubOutboxBackfill` uses.
+    ///   - transport: Test seam; defaults to ``defaultTransport``.
     public init(
         ownActorURL: URL, publishToken: String,
         transport: @escaping Transport = CommunityMembershipClient.defaultTransport
@@ -92,6 +111,9 @@ public struct CommunityMembershipClient: Sendable {
         return json["id"] as? String
     }
 
+    /// Production transport: plain `URLSession.shared`, deliberately *without* the byte-cap
+    /// wrapper the read-side clients use — the responder here is this site's own trusted Worker,
+    /// not an arbitrary remote instance (see the type-level doc).
     public static let defaultTransport: Transport = { request in
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }

--- a/Sources/AnglesiteCore/CommunitySearchClient.swift
+++ b/Sources/AnglesiteCore/CommunitySearchClient.swift
@@ -8,16 +8,29 @@ import FoundationNetworking
 /// input, skipping webfinger) and from there into `CommunityMembershipClient.follow(target:)` —
 /// the same join path #368 already ships, just fed from a search result instead of a typed handle.
 public struct CommunitySearchResult: Sendable, Equatable, Identifiable {
+    /// `Identifiable` conformance for the result list — the actor IRI string, which is the only
+    /// value guaranteed unique across instances (two instances can both host a `birding`).
     public var id: String { actorID.absoluteString }
+    /// The community's actor IRI, already guaranteed HTTPS — insecure results are dropped during
+    /// decoding rather than surfaced as rows that fail on tap.
     public let actorID: URL
+    /// The community's short machine name (`birding`), sanitized via ``DisplayString`` —
+    /// remote-controlled text that ends up in UI.
     public let name: String
+    /// The community's human-readable title, sanitized like ``name``; `nil` when the instance
+    /// doesn't provide one.
     public let title: String?
     /// The host the community actually lives on — read from `actorID`, not the instance that was
     /// queried: Lemmy's federated search can surface communities from other instances than the
     /// one asked, and the join flow's confirmation should say where the community really is.
     public let instance: String
+    /// Subscriber count for the result row's popularity hint; `nil` when the instance omits
+    /// counts rather than showing a misleading zero.
     public let subscriberCount: Int?
 
+    /// Memberwise initializer — public so tests and previews can build result rows directly;
+    /// production values come from ``CommunitySearchClient/search(query:instance:)``, which is
+    /// where the HTTPS filter and display sanitization happen.
     public init(actorID: URL, name: String, title: String?, instance: String, subscriberCount: Int?) {
         self.actorID = actorID
         self.name = name
@@ -27,11 +40,23 @@ public struct CommunitySearchResult: Sendable, Equatable, Identifiable {
     }
 }
 
+/// Failures from ``CommunitySearchClient``. `Equatable` so tests can match the exact failure
+/// rather than string-compare error dumps.
 public enum CommunitySearchError: Error, Equatable, Sendable {
+    /// The query was empty after trimming — caught client-side so the sheet can validate before
+    /// any network round-trip.
     case emptyQuery
+    /// The instance field couldn't be turned into a host — empty, or unparseable as a bare
+    /// host, `host:port`, or http(s) URL.
     case invalidInstance
+    /// The search URL (or the URL a redirect actually landed on) wasn't HTTPS.
     case insecureURL
+    /// The search request failed — non-2xx, a transport error (status 0), or an injected
+    /// transport exceeding the byte cap. `body` is capped at the first 400 bytes, enough to
+    /// diagnose without echoing an arbitrary remote payload into logs/UI.
     case requestFailed(status: Int, body: String)
+    /// The response wasn't the Lemmy search shape expected; carries the underlying decoding
+    /// error's description (stringified so the case stays `Equatable`).
     case decodingFailed(String)
 }
 
@@ -56,20 +81,36 @@ public enum CommunitySearchError: Error, Equatable, Sendable {
 /// PieFed, Mbin, Friendica, Hubzilla, PeerTube); search is an additive discovery aid on top of
 /// that, not a replacement for it.
 public struct CommunitySearchClient: Sendable {
+    /// Injection seam for tests — lets suites feed canned search responses without a network.
+    /// Production uses ``defaultTransport``, which enforces the byte cap mid-stream.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     /// A search response is a short list of communities, not an outbox page of activities — reuses
     /// `ActorProfileFetcher`'s cap/timeouts rather than defining its own, same reuse `CommunityActorResolver`
     /// already does for the same reason.
     public static let maximumResponseBytes = ActorProfileFetcher.maximumResponseBytes
+    /// Pre-filled instance for the join sheet's search field — the largest general-purpose Lemmy
+    /// instance, whose federated search surfaces communities from across the network. A starting
+    /// point only: the field stays editable (issue #371's "source is configurable" requirement),
+    /// and this client never falls back to it on its own.
     public static let defaultInstance = "lemmy.world"
 
     private let transport: Transport
 
+    /// Creates a search client, defaulting to the capped HTTPS ``defaultTransport``; pass a
+    /// custom ``Transport`` only in tests (the post-fetch guards re-apply the byte cap either way).
     public init(transport: @escaping Transport = CommunitySearchClient.defaultTransport) {
         self.transport = transport
     }
 
+    /// Runs a keyword community search against `instance`'s `/api/v3/search`, returning up to 20
+    /// results sorted by all-time popularity. Results whose own `actor_id` isn't a secure URL
+    /// are silently dropped (they couldn't be joined through ``CommunityActorResolver`` anyway),
+    /// and all display strings are sanitized — so every returned row is safe to show and safe to
+    /// tap.
+    ///
+    /// - Throws: ``CommunitySearchError`` for an empty query, an unusable or insecure instance,
+    ///   or a failed/oversized/undecodable response.
     public func search(query: String, instance: String) async throws -> [CommunitySearchResult] {
         let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedQuery.isEmpty else { throw CommunitySearchError.emptyQuery }
@@ -185,6 +226,9 @@ public struct CommunitySearchClient: Sendable {
     private static let session = CappedHTTPTransport.session(
         requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
 
+    /// Production transport: a shared `CappedHTTPTransport` session that aborts mid-stream once
+    /// ``maximumResponseBytes`` is exceeded — a hostile instance can't make the app buffer an
+    /// unbounded body before the post-fetch size check runs.
     public static let defaultTransport: Transport = { request in
         try await CappedHTTPTransport.fetch(
             request, session: session, cap: maximumResponseBytes,

--- a/Sources/AnglesiteCore/CompletionNotice.swift
+++ b/Sources/AnglesiteCore/CompletionNotice.swift
@@ -6,8 +6,15 @@ import Foundation
 /// `LiveRegionAnnouncer` for the same boundary). The app-target `CompletionNotifier` renders
 /// one of these into a `UNNotificationRequest` (#526).
 public struct CompletionNotice: Equatable, Sendable {
+    /// Outcome headline ("Deploy Succeeded", "Backup Failed") — the operation and its result,
+    /// never the site name, which goes in ``subtitle`` so banners for different sites stay
+    /// distinguishable at a glance.
     public let title: String
+    /// The site's display name — kept out of ``title`` so the headline stays a fixed,
+    /// scannable phrase per outcome.
     public let subtitle: String
+    /// The detail line: what happened, where, and (for failures) the reason the user needs in
+    /// order to act.
     public let body: String
     /// Site to focus when the notification is clicked — the notifier routes it through
     /// `WindowRouter` so the matching site window is opened/focused.
@@ -19,6 +26,8 @@ public struct CompletionNotice: Equatable, Sendable {
     /// (sound) for the outcomes the user actually has to act on.
     public let isFailure: Bool
 
+    /// Memberwise initializer — public for tests; app code should get notices from
+    /// ``CompletionNoticeBuilder`` so the wording and identifier conventions stay in one place.
     public init(title: String, subtitle: String, body: String, siteID: String, identifier: String, isFailure: Bool) {
         self.title = title
         self.subtitle = subtitle
@@ -36,14 +45,22 @@ public enum CompletionNoticeBuilder {
 
     // MARK: Deploy
 
+    /// Terminal deploy phases, mirrored from the app-target deploy model (see the type-level
+    /// doc for why the mirror exists). Distinguishes ``blocked(failureCount:)`` from plain
+    /// failure because a blocked deploy is the security gate doing its job, not an error.
     public enum DeployOutcome: Equatable, Sendable {
+        /// Deploy published successfully; `url` is the live site and `duration` the wall time,
+        /// rendered via ``CompletionNoticeBuilder/formatDuration(_:)``.
         case succeeded(url: String, duration: TimeInterval)
+        /// Deploy errored; `reason` is shown verbatim as the notification body.
         case failed(reason: String)
         /// Pre-deploy security scan blocked the deploy; `failureCount` is the number of
         /// must-fix findings.
         case blocked(failureCount: Int)
     }
 
+    /// Builds the deploy notice. All three outcomes share one identifier (`deploy.<siteID>`) so
+    /// a retry's result replaces the earlier banner instead of stacking next to it.
     public static func deploy(siteName: String, siteID: String, outcome: DeployOutcome) -> CompletionNotice {
         let identifier = "deploy.\(siteID)"
         switch outcome {
@@ -74,12 +91,21 @@ public enum CompletionNoticeBuilder {
 
     // MARK: Backup
 
+    /// Terminal backup phases. `noChanges` is its own case — a clean tree is a *successful*
+    /// backup that just has nothing to push, and wording it as such avoids the owner reading
+    /// "no changes" as a failure.
     public enum BackupOutcome: Equatable, Sendable {
+        /// A commit was pushed; the notice shows the short SHA and `remote/branch` so the owner
+        /// can find it from any git host's UI.
         case succeeded(commitSHA: String, branch: String, remote: String)
+        /// The working tree was already clean — success, with nothing to push.
         case noChanges
+        /// Backup errored; `reason` is shown verbatim as the notification body.
         case failed(reason: String)
     }
 
+    /// Builds the backup notice, under the stable identifier `backup.<siteID>` so a newer
+    /// outcome replaces the older banner (see ``CompletionNotice/identifier``).
     public static func backup(siteName: String, siteID: String, outcome: BackupOutcome) -> CompletionNotice {
         let identifier = "backup.\(siteID)"
         switch outcome {
@@ -109,11 +135,18 @@ public enum CompletionNoticeBuilder {
 
     // MARK: Audit
 
+    /// Terminal audit phases. An audit that *found issues* still `succeeded` — findings are the
+    /// audit's product, not its failure; `failed` means the audit itself couldn't run.
     public enum AuditOutcome: Equatable, Sendable {
+        /// The audit ran to completion; counts per severity bucket drive the summary line
+        /// (empty buckets are omitted from the wording).
         case succeeded(criticalCount: Int, warningCount: Int, infoCount: Int)
+        /// The audit itself errored before producing findings; `reason` is shown verbatim.
         case failed(reason: String)
     }
 
+    /// Builds the audit notice, under the stable identifier `audit.<siteID>` so a newer outcome
+    /// replaces the older banner (see ``CompletionNotice/identifier``).
     public static func audit(siteName: String, siteID: String, outcome: AuditOutcome) -> CompletionNotice {
         let identifier = "audit.\(siteID)"
         switch outcome {
@@ -162,6 +195,10 @@ public enum CompletionNoticeBuilder {
 /// the fraction is "how far through the pipeline", not a fabricated percentage of wall time.
 /// Unknown phases return `nil` → the Dock overlay renders indeterminate.
 public enum DeployDockProgress {
+    /// Maps a deploy phase's raw name to its pipeline-position fraction, or `nil` for a phase
+    /// this table doesn't know (→ indeterminate Dock bar). Keyed by string rather than an enum
+    /// so the app-target deploy model's phase type doesn't have to be mirrored down here —
+    /// an unrecognized phase degrades gracefully instead of failing to compile.
     public static func fraction(forPhase phase: String) -> Double? {
         switch phase {
         // Fractions are step-start positions, weighted toward the two long steps

--- a/Sources/AnglesiteCore/ComponentCanvasMessages.swift
+++ b/Sources/AnglesiteCore/ComponentCanvasMessages.swift
@@ -3,23 +3,44 @@ import Foundation
 /// JS → native messages from the component-harness canvas overlay module.
 /// Wire shapes are defined in JS/edit-overlay/src/component-canvas.ts.
 public enum ComponentCanvasDecodeError: Error, Equatable {
+    /// The body's `type` field named a different message — "not mine", so the dispatcher can
+    /// keep routing, as opposed to ``malformed``, which means the right message arrived broken.
     case wrongType
+    /// The `type` matched but a required field was missing or mistyped — a real wire-format
+    /// mismatch worth surfacing, not just a message meant for another decoder.
     case malformed
 }
 
+/// The canvas overlay reporting a click on a rendered element, carrying the element's
+/// `data-astro-source-loc` annotation so the outline can highlight the matching node (via
+/// ``ComponentOutline/node(atLine:column:in:)`` — see its doc for why line matches exactly but
+/// column doesn't). All fields optional: a click can land on chrome with no source annotation,
+/// and that's still a selection worth reporting (it clears the outline highlight).
 public struct CanvasSelectionMessage: Sendable, Equatable {
+    /// The wire `type` discriminator `AnglesiteMessageDispatcher` routes on.
     public static let messageType = "anglesite:canvas-selection"
 
+    /// The clicked element's source file as Astro stamps it (vite-rooted, e.g.
+    /// `/src/components/Card.astro`) — match it via ``ComponentOutline/fileMatches(_:relativePath:)``,
+    /// not string equality.
     public let file: String?
+    /// 1-based source line from the `data-astro-source-loc` annotation.
     public let line: Int?
+    /// Column from the annotation — the END of the element's opening tag, not its start (see
+    /// ``ComponentOutline/node(atLine:column:in:)``).
     public let column: Int?
 
+    /// Memberwise initializer — public for tests; production instances come from
+    /// ``decode(from:)`` on the script-message body.
     public init(file: String?, line: Int?, column: Int?) {
         self.file = file
         self.line = line
         self.column = column
     }
 
+    /// Decodes a `WKScriptMessage` body. Returns `.failure(.wrongType)` for another message's
+    /// body so the dispatcher can try the next decoder; missing fields are *not* an error here
+    /// (every field is optional by design), so this never returns `.malformed`.
     public static func decode(from body: Any) -> Result<CanvasSelectionMessage, ComponentCanvasDecodeError> {
         guard let dict = body as? [String: Any], dict["type"] as? String == messageType else {
             return .failure(.wrongType)
@@ -32,15 +53,26 @@ public struct CanvasSelectionMessage: Sendable, Equatable {
     }
 }
 
+/// The canvas overlay reporting the selected element's resolved CSS — what the browser actually
+/// computed, so the style inspector can show effective values (inherited, cascaded, defaulted)
+/// rather than only the declarations present in the component's own `<style>` block.
 public struct ComputedStylesReport: Sendable, Equatable {
+    /// The wire `type` discriminator `AnglesiteMessageDispatcher` routes on.
     public static let messageType = "anglesite:computed-styles"
 
+    /// Computed property → value pairs, exactly as the overlay read them from
+    /// `getComputedStyle` (the overlay chooses which properties to report).
     public let styles: [String: String]
 
+    /// Memberwise initializer — public for tests; production instances come from
+    /// ``decode(from:)`` on the script-message body.
     public init(styles: [String: String]) {
         self.styles = styles
     }
 
+    /// Decodes a `WKScriptMessage` body. Returns `.failure(.wrongType)` for another message's
+    /// body so the dispatcher can try the next decoder; unlike ``CanvasSelectionMessage``, the
+    /// `styles` map is required, so a matching-type body without it is `.malformed`.
     public static func decode(from body: Any) -> Result<ComputedStylesReport, ComponentCanvasDecodeError> {
         guard let dict = body as? [String: Any], dict["type"] as? String == messageType else {
             return .failure(.wrongType)

--- a/Sources/AnglesiteCore/ComponentModel.swift
+++ b/Sources/AnglesiteCore/ComponentModel.swift
@@ -3,27 +3,76 @@ import Foundation
 /// Decoded result of the plugin's `get_component_model` MCP tool — a
 /// read-only structured view of one `.astro` component (spec §2.2).
 public struct ComponentModel: Sendable, Equatable, Codable {
+    /// Content hash of the component file this model was parsed from. Every structure/style
+    /// write op sends it back as `baseVersion` — the plugin rejects an edit whose base no longer
+    /// matches the file on disk, so a model gone stale (external edit, concurrent editor) can
+    /// never silently clobber newer content.
     public let version: String
+    /// Project-relative path of the `.astro` file (e.g. `src/components/Card.astro`) — the
+    /// same path the write ops address, so model and edits always name the file identically.
     public let path: String
+    /// Root of the markup tree — a synthetic `.fragment` wrapping the top-level nodes (skipped
+    /// by ``ComponentOutline/rows(from:)`` so outline depth 0 is real markup).
     public let template: Node
+    /// The `---`-fenced frontmatter block, or `nil` when the component has none.
     public let frontmatter: Frontmatter?
+    /// Rules parsed from the component's scoped `<style>` blocks, in source order — each rule's
+    /// span is the address the CSS write ops (``ComponentStyleEditBuilder``) target.
     public let styles: [StyleRule]
+    /// The component's client-side `<script>` block, or `nil` when there isn't one. Surfaced
+    /// read-only — the editor has no structured script ops; scripts are edited as source.
     public let clientScript: ScriptZone?
 
+    /// One markup node. `Identifiable` by the parser-assigned ``id``, which is also how the
+    /// structure write ops (``ComponentStructureEditBuilder``) address nodes — valid only
+    /// against the model ``ComponentModel/version`` they came from.
     public struct Node: Sendable, Equatable, Codable, Identifiable {
+        /// Parser-assigned stable identifier, the address every structure edit uses.
         public let id: String
+        /// What sort of node this is — drives sealing, extractability, and palette behavior
+        /// (see ``Kind``).
         public let kind: Kind
+        /// Tag or component name; `nil` for kinds that have none (fragment, expression, text).
         public let tag: String?
+        /// The opening tag's attributes, in source order. Empty (never absent) after decoding.
         public let attrs: [Attr]
+        /// Byte span of the node's full source extent, for source-tab highlighting and
+        /// span-addressed edits.
         public let span: Span
+        /// Line/column of the START of the opening tag — deliberately different from the
+        /// canvas's `data-astro-source-loc` (END of the opening tag); the reconciliation lives
+        /// in ``ComponentOutline/node(atLine:column:in:)``.
         public let loc: Loc?
+        /// Literal text for `.text` nodes (and raw source for `.expression`); `nil` otherwise.
         public let text: String?
+        /// Child nodes in document order. Empty (never absent) after decoding. For a
+        /// `.component` node these are the slot-fill markup authored at the use site — real
+        /// content, but sealed off in the outline (spec §4.1).
         public let children: [Node]
 
+        /// Node taxonomy from the plugin's parser. The distinctions matter to the editor:
+        /// `.component` seals its subtree, only `.element`/`.component` are extractable, and
+        /// `.fragment` exists solely as the synthetic root.
         public enum Kind: String, Sendable, Codable {
-            case fragment, element, component, expression, slot, text
+            /// Synthetic grouping node with no tag of its own — the tree root wrapping the
+            /// component's top-level markup.
+            case fragment
+            /// A plain HTML element.
+            case element
+            /// An imported component instance — sealed in the outline: configured via
+            /// attrs/props, its definition edited in its own editor, never inline.
+            case component
+            /// A `{…}` template expression — dynamic output the structured editor can't
+            /// safely rewrite, surfaced as an opaque node.
+            case expression
+            /// A `<slot>` outlet marking where a parent's slot-fill content lands.
+            case slot
+            /// A literal text run.
+            case text
         }
 
+        /// Memberwise initializer — public so tests can build trees directly; production trees
+        /// come from decoding the plugin's `get_component_model` payload.
         public init(id: String, kind: Kind, tag: String?, attrs: [Attr], span: Span, loc: Loc?, text: String?, children: [Node]) {
             self.id = id
             self.kind = kind
@@ -35,6 +84,9 @@ public struct ComponentModel: Sendable, Equatable, Codable {
             self.children = children
         }
 
+        /// Custom decoding that defaults `attrs`/`children` to empty and `span` to an unknown
+        /// span when the wire omits them — the plugin elides empty collections, and the Swift
+        /// side prefers non-optional collections over sprinkling `?? []` at every use site.
         public init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             id = try c.decode(String.self, forKey: .id)
@@ -48,9 +100,14 @@ public struct ComponentModel: Sendable, Equatable, Codable {
         }
     }
 
+    /// One attribute on a node's opening tag.
     public struct Attr: Sendable, Equatable, Codable {
+        /// Attribute name as written in source.
         public let name: String
+        /// Attribute value; `nil` for a boolean/valueless attribute (`disabled`), which is
+        /// distinct from an empty string (`alt=""`).
         public let value: String?
+        /// Memberwise initializer — public for tests; production values decode from the wire.
         public init(name: String, value: String?) {
             self.name = name
             self.value = value
@@ -59,20 +116,29 @@ public struct ComponentModel: Sendable, Equatable, Codable {
 
     /// Wire format is a two-element array `[start, end]`, either may be null.
     public struct Span: Sendable, Equatable, Codable {
+        /// Byte offset of the span's start in the source file; `nil` when the parser couldn't
+        /// determine it.
         public let start: Int?
+        /// Byte offset one past the span's end; `nil` when the parser couldn't determine it.
         public let end: Int?
 
+        /// Memberwise initializer — public for tests; production values decode from the wire's
+        /// `[start, end]` array form.
         public init(start: Int?, end: Int?) {
             self.start = start
             self.end = end
         }
 
+        /// Decodes the wire's positional `[start, end]` array (see the type-level doc) —
+        /// `Codable` synthesis would expect a keyed `{start, end}` object instead.
         public init(from decoder: Decoder) throws {
             var c = try decoder.unkeyedContainer()
             start = try c.decodeIfPresent(Int.self) ?? nil
             end = try c.decodeIfPresent(Int.self) ?? nil
         }
 
+        /// Re-encodes the positional array form, keeping round-trips byte-compatible with the
+        /// wire format (explicit `null` for a missing element, never a dropped one).
         public func encode(to encoder: Encoder) throws {
             var c = encoder.unkeyedContainer()
             try c.encode(start)
@@ -80,25 +146,45 @@ public struct ComponentModel: Sendable, Equatable, Codable {
         }
     }
 
+    /// A 1-based line/column source position — the START of a node's opening tag, which is why
+    /// canvas-selection matching can't compare columns directly (the canvas annotation is the
+    /// END of the opening tag; see ``ComponentOutline/node(atLine:column:in:)``).
     public struct Loc: Sendable, Equatable, Codable {
+        /// 1-based source line.
         public let line: Int
+        /// 1-based source column of the opening tag's start.
         public let column: Int
+        /// Memberwise initializer — public for tests; production values decode from the wire.
         public init(line: Int, column: Int) {
             self.line = line
             self.column = column
         }
     }
 
+    /// The component's `---`-fenced frontmatter: raw source for the Source tab plus the parsed
+    /// `Props` interface, which is what drives the editor's prop knobs (``Prop``).
     public struct Frontmatter: Sendable, Equatable, Codable {
+        /// The frontmatter's raw TypeScript source, verbatim.
         public let source: String
+        /// Byte span of the frontmatter block within the file.
         public let span: Span
+        /// Props parsed from the frontmatter's `Props` interface; empty when none is declared.
         public let props: [Prop]
     }
 
+    /// One declared prop from the frontmatter's `Props` interface — enough for the editor to
+    /// render a knob and pick a sample value (`KnobDefaults`) without re-parsing TypeScript.
     public struct Prop: Sendable, Equatable, Codable {
+        /// The prop's name as declared.
         public let name: String
+        /// The declared TypeScript type, as source text — matched by string (`"string"`,
+        /// `"number"`, …) for knob defaults, not resolved semantically.
         public let type: String
+        /// True when the declaration is optional (`name?:`).
         public let optional: Bool
+        /// The default value's source text from a destructuring default, if any — quoted as
+        /// written, so consumers strip quotes themselves (see `KnobDefaults`). Decoded from the
+        /// wire key `default`, which is a Swift keyword.
         public let defaultValue: String?
 
         enum CodingKeys: String, CodingKey {
@@ -106,6 +192,7 @@ public struct ComponentModel: Sendable, Equatable, Codable {
             case defaultValue = "default"
         }
 
+        /// Memberwise initializer — public for tests; production values decode from the wire.
         public init(name: String, type: String, optional: Bool, defaultValue: String?) {
             self.name = name
             self.type = type
@@ -114,21 +201,36 @@ public struct ComponentModel: Sendable, Equatable, Codable {
         }
     }
 
+    /// One CSS rule from the component's scoped `<style>` block. Its ``span`` is the rule's
+    /// address for the CSS write ops — ``ComponentStyleEditBuilder`` sends it as `ruleSpan`
+    /// rather than a selector string, so two rules with identical selectors stay unambiguous.
     public struct StyleRule: Sendable, Equatable, Codable {
+        /// The rule's selector text, verbatim.
         public let selector: String
+        /// The enclosing `@media` condition, or `nil` for a top-level rule.
         public let media: String?
+        /// Byte span of the whole rule in the file — the identity the write ops target.
         public let span: Span
+        /// The rule's declarations in source order.
         public let declarations: [Declaration]
     }
 
+    /// One `property: value` declaration inside a ``StyleRule``.
     public struct Declaration: Sendable, Equatable, Codable {
+        /// The CSS property name.
         public let property: String
+        /// The declared value, verbatim.
         public let value: String
+        /// Byte span of this declaration within the file.
         public let span: Span
     }
 
+    /// The component's client-side `<script>` block, kept as raw source — the structured editor
+    /// has no script ops, so this exists for display and source-tab navigation only.
     public struct ScriptZone: Sendable, Equatable, Codable {
+        /// The script's source text, verbatim.
         public let source: String
+        /// Byte span of the script block within the file.
         public let span: Span
     }
 }

--- a/Sources/AnglesiteCore/ComponentModelClient.swift
+++ b/Sources/AnglesiteCore/ComponentModelClient.swift
@@ -3,10 +3,17 @@ import Foundation
 /// Fetches a component's structured model from the plugin's
 /// `get_component_model` MCP tool.
 public struct ComponentModelClient: Sendable {
+    /// Injection seam matching ``MCPClient/callTool(name:arguments:)``'s shape, so tests can
+    /// feed canned tool results without a live MCP connection.
     public typealias ToolCaller = @Sendable (_ name: String, _ arguments: JSONValue) async throws -> MCPClient.ToolCallResult
 
     private let toolCaller: ToolCaller
 
+    /// Production initializer. Takes a *provider* closure rather than a client because the MCP
+    /// connection comes up asynchronously after the site's runtime starts — resolving it per
+    /// call means a fetch made before the connection exists fails cleanly with
+    /// ``ModelError/notConnected`` instead of pinning a stale (or nil-forever) client at
+    /// construction time.
     public init(mcpClient: @escaping @Sendable () async -> MCPClient?) {
         self.toolCaller = { name, args in
             guard let client = await mcpClient() else { throw ModelError.notConnected }
@@ -19,13 +26,21 @@ public struct ComponentModelClient: Sendable {
         self.toolCaller = toolCaller
     }
 
+    /// Failures from ``fetch(path:)``, kept `Equatable` and reason-coded so the editor model
+    /// can pick per-failure UI (banner vs. Source-tab degradation) via ``friendlyMessage``.
     public enum ModelError: Error, Equatable {
-        /// `reason` is the plugin's machine-readable code (`"parse-failed"`, `"read-failed"`,
-        /// `"invalid-input"`, `"internal-error"`) from its `anglesite:component-model-failed`
-        /// envelope; `"unknown"` if the tool result didn't decode as that envelope at all.
-        /// `detail` is the plugin's human-readable message.
+        /// The client provider returned no live MCP connection — the site runtime isn't up yet
+        /// (or went away), so no tool call was attempted at all.
         case notConnected
+        /// The tool ran but reported an error result. `reason` is the plugin's machine-readable
+        /// code (`"parse-failed"`, `"read-failed"`, `"invalid-input"`, `"internal-error"`) from
+        /// its `anglesite:component-model-failed` envelope; `"unknown"` if the tool result
+        /// didn't decode as that envelope at all. `detail` is the plugin's human-readable
+        /// message.
         case toolFailed(reason: String, detail: String)
+        /// The tool succeeded but its payload didn't decode as ``ComponentModel`` — an
+        /// app/plugin schema mismatch, which is why ``friendlyMessage`` suggests updating the
+        /// bundled plugin.
         case decodeFailed(String)
     }
 
@@ -35,6 +50,12 @@ public struct ComponentModelClient: Sendable {
         let detail: String
     }
 
+    /// Fetches the structured model for the component at project-relative `path` (e.g.
+    /// `src/components/Card.astro`). Joins all text content blocks before decoding, and decodes
+    /// the plugin's failure envelope on error results so callers get a reason-coded
+    /// ``ModelError/toolFailed(reason:detail:)`` rather than an opaque string.
+    ///
+    /// - Throws: ``ModelError``.
     public func fetch(path: String) async throws -> ComponentModel {
         let result = try await toolCaller("get_component_model", .object(["path": .string(path)]))
         let text = result.content.compactMap(\.text).joined(separator: "\n")

--- a/Sources/AnglesiteCore/ComponentOutline.swift
+++ b/Sources/AnglesiteCore/ComponentOutline.swift
@@ -11,16 +11,26 @@ import UniformTypeIdentifiers
 /// Pure presentation logic for the Component Editor, kept in Core so it is
 /// testable without the app target (hosted app tests don't run on CI).
 public enum ComponentOutline {
+    /// One flattened outline entry — the tree pre-walked into a flat list (with explicit
+    /// ``depth``) because SwiftUI's `List` renders and indents a flat array far more
+    /// predictably than a recursive `OutlineGroup` for this editor's needs.
     public struct Row: Sendable, Equatable, Identifiable {
+        /// The model node this row presents.
         public let node: ComponentModel.Node
+        /// Nesting depth for indentation. 0 is the component's top-level markup — the synthetic
+        /// fragment root is skipped by ``ComponentOutline/rows(from:)``.
         public let depth: Int
         /// True for a `kind == .component` node — its children are real markup (slot-fill
         /// content authored at the use site), but the outline treats the instance as opaque
         /// (spec §4.1): configure it via its attrs/props, or double-click to edit the
         /// component's own definition.
         public let isSealed: Bool
+        /// `Identifiable` conformance — the node's own parser-assigned id, so SwiftUI selection
+        /// state survives a model refetch (ids are stable across re-parses of unchanged nodes).
         public var id: String { node.id }
 
+        /// Memberwise initializer — public for tests; production rows come from
+        /// ``ComponentOutline/rows(from:)``, which is what enforces the sealing walk.
         public init(node: ComponentModel.Node, depth: Int, isSealed: Bool = false) {
             self.node = node
             self.depth = depth
@@ -111,7 +121,12 @@ public enum ComponentOutline {
     /// drag-reorder and palette-insert. Kept here (not the View) so the geometry and the
     /// index math it feeds are unit-testable.
     public enum DropZone: Equatable, Sendable {
-        case before, into, after
+        /// Insert as the row's preceding sibling (top third of the row).
+        case before
+        /// Insert as the row's child (middle third) — reparenting, not reordering.
+        case into
+        /// Insert as the row's following sibling (bottom third).
+        case after
     }
 
     /// Classifies `y` (row-local, per SwiftUI's `dropDestination` contract) into a `DropZone`:
@@ -177,6 +192,12 @@ public enum ComponentOutline {
 /// Builds harness-route URLs for the component canvas (route injected by the
 /// template's anglesite-harness integration).
 public enum HarnessURL {
+    /// Builds the harness route for one component, or `nil` for a path the harness can't render
+    /// — only `.astro` files under `src/components/` or `src/layouts/` have harness routes, so
+    /// a `nil` here is the caller's signal to show no canvas rather than a 404. Props travel as
+    /// a single JSON blob in one `props` query parameter, percent-encoded strictly (see the
+    /// inline comment) so values containing `+`/`&`/`=` survive the harness's
+    /// `URLSearchParams` decoding intact.
     public static func build(base: URL, componentPath: String, props: [String: String]) -> URL? {
         let prefixes = ["src/components/", "src/layouts/"]
         guard let prefix = prefixes.first(where: { componentPath.hasPrefix($0) }),
@@ -206,6 +227,10 @@ public enum HarnessURL {
 
 /// Sample prop values that make any component render standalone.
 public enum KnobDefaults {
+    /// Initial knob value for `prop`: the component's own declared default (quotes stripped —
+    /// ``ComponentModel/Prop/defaultValue`` carries them as written in source) when there is
+    /// one, else a benign per-type sample so the harness never renders `undefined` into the
+    /// preview. Unknown types get `""` rather than a guess.
     public static func value(for prop: ComponentModel.Prop) -> String {
         if let declared = prop.defaultValue {
             return declared.trimmingCharacters(in: CharacterSet(charactersIn: "\"'`"))
@@ -224,14 +249,20 @@ public enum KnobDefaults {
 /// component file being edited (guards against a cross-editor drop landing on the wrong
 /// component's tree) and the node being moved.
 public struct ComponentDragItem: Codable, Sendable, Transferable {
+    /// Identifies the component file whose tree the node belongs to — the drop target compares
+    /// this against its own file and refuses a mismatch (the cross-editor guard).
     public let fileID: String
+    /// The dragged node's id within that file's model tree.
     public let nodeID: String
 
+    /// Memberwise initializer for the drag source.
     public init(fileID: String, nodeID: String) {
         self.fileID = fileID
         self.nodeID = nodeID
     }
 
+    /// Codable transfer under the app's own exported UTI, so this payload only matches
+    /// Anglesite's own drop targets — a drop into another app carries nothing it would render.
     public static var transferRepresentation: some TransferRepresentation {
         CodableRepresentation(contentType: .anglesiteComponentDragItem)
     }
@@ -239,14 +270,20 @@ public struct ComponentDragItem: Codable, Sendable, Transferable {
 
 /// Drag payload for a palette row being dropped into the outline or onto the canvas (Task 17/18).
 public struct PaletteDragPayload: Codable, Sendable, Transferable {
+    /// The palette item's display label, carried along for drop-feedback UI.
     public let label: String
+    /// What to insert on drop — feeds straight into
+    /// `ComponentStructureEditBuilder.insertNode`'s `node` parameter.
     public let kind: ComponentStructureEditBuilder.NodeSpec
 
+    /// Memberwise initializer for the palette drag source.
     public init(label: String, kind: ComponentStructureEditBuilder.NodeSpec) {
         self.label = label
         self.kind = kind
     }
 
+    /// Codable transfer under the app's own exported UTI — same Anglesite-only matching
+    /// rationale as `ComponentDragItem`.
     public static var transferRepresentation: some TransferRepresentation {
         CodableRepresentation(contentType: .anglesitePaletteDragPayload)
     }
@@ -259,9 +296,13 @@ public struct PaletteDragPayload: Codable, Sendable, Transferable {
 /// (only the first-registered type actually receives drops at the AppKit level), so both drag
 /// sources must share one `Transferable` type and one `.dropDestination` call.
 public enum OutlineDragPayload: Codable, Sendable, Transferable {
+    /// An existing outline row being reordered/reparented.
     case move(ComponentDragItem)
+    /// A palette item being inserted as a new node.
     case insert(PaletteDragPayload)
 
+    /// Codable transfer under its own exported UTI — distinct from the two wrapped payloads'
+    /// UTIs, since this is the type the shared `.dropDestination` registers for.
     public static var transferRepresentation: some TransferRepresentation {
         CodableRepresentation(contentType: .anglesiteOutlineDragPayload)
     }

--- a/Sources/AnglesiteCore/ComponentPalette.swift
+++ b/Sources/AnglesiteCore/ComponentPalette.swift
@@ -3,12 +3,24 @@ import Foundation
 /// Palette contents for the Component Editor's outline pane (spec §4.1): curated HTML
 /// elements, `<slot>`, and the site's own project components. Pure/testable — no SwiftUI.
 public enum ComponentPalette {
+    /// One palette entry, ready for both display (label + SF Symbol) and insertion (the
+    /// ``ComponentStructureEditBuilder/NodeSpec`` a drop hands to `insert-node`).
     public struct Item: Sendable, Equatable, Identifiable {
+        /// Stable list identity, namespaced by origin (`element:p`, `slot`,
+        /// `component:<fileID>`) so a project component named after an HTML tag can't collide
+        /// with the curated entry for that tag.
         public let id: String
+        /// Display label — the curated entry's human name ("Paragraph"), or the component's
+        /// tag name.
         public let label: String
+        /// What dropping this item inserts — feeds straight into
+        /// ``ComponentStructureEditBuilder/insertNode(id:path:baseVersion:parentId:index:node:)``.
         public let kind: ComponentStructureEditBuilder.NodeSpec
+        /// SF Symbol name for the palette row's icon.
         public let systemImage: String
 
+        /// Memberwise initializer — public for tests; production items come from
+        /// ``ComponentPalette/items(projectComponents:excluding:)``.
         public init(id: String, label: String, kind: ComponentStructureEditBuilder.NodeSpec, systemImage: String) {
             self.id = id
             self.label = label
@@ -32,6 +44,10 @@ public enum ComponentPalette {
         ("div", "Div", "square.dashed"),
     ]
 
+    /// Assembles the palette: the curated elements, `<slot>`, then the site's own components
+    /// sorted by name. `current` (the component being edited) is excluded — inserting a
+    /// component into itself is direct recursion, refused at the source rather than left for
+    /// the render to blow up on.
     public static func items(projectComponents: [FileRef], excluding current: FileRef?) -> [Item] {
         var result = curated.map { Item(id: "element:\($0.tag)", label: $0.label, kind: .element(tag: $0.tag), systemImage: $0.systemImage) }
         result.append(Item(id: "slot", label: "Slot", kind: .slot(), systemImage: "tray"))

--- a/Sources/AnglesiteCore/ComponentStructureEditBuilder.swift
+++ b/Sources/AnglesiteCore/ComponentStructureEditBuilder.swift
@@ -6,8 +6,16 @@ import Foundation
 public enum ComponentStructureEditBuilder {
     /// New-node spec for `insertNode` — mirrors the plugin's `component.node` schema.
     public enum NodeSpec: Equatable, Codable {
+        /// A plain HTML element, inserted by tag name — the plugin owns what the new element's
+        /// markup looks like, so the app only names the tag.
         case element(tag: String)
+        /// A project-component instance. `componentPath` is the component's project-relative
+        /// path — the plugin resolves the actual import specifier relative to the *edited*
+        /// file and adds the frontmatter `import` itself, so the app never computes `../`
+        /// chains.
         case component(tag: String, componentPath: String)
+        /// A `<slot>` outlet; `name` maps to the wire's `slotName` for a named slot, omitted
+        /// entirely (not sent as null) for the default slot.
         case slot(name: String? = nil)
 
         var jsonValue: JSONValue {
@@ -24,6 +32,10 @@ public enum ComponentStructureEditBuilder {
         }
     }
 
+    /// Builds the `insert-node` message: add `node` under `parentId` at child position `index`.
+    /// `baseVersion` is the model's content hash (``ComponentModel/version``) — the plugin
+    /// rejects the edit if the file changed since that model was fetched, which is the only
+    /// thing keeping node-id-addressed edits safe against concurrent modification.
     public static func insertNode(
         id: String,
         path: String,
@@ -48,6 +60,10 @@ public enum ComponentStructureEditBuilder {
         )
     }
 
+    /// Builds the `move-node` message: reparent/reorder `nodeId` under `newParentId` at
+    /// `newIndex`. The plugin computes `newIndex` against the child list *after* removing the
+    /// dragged node — a same-parent move where the node started earlier must pre-adjust via
+    /// ``ComponentOutline/adjustedMoveIndex(targetIndex:draggedIndex:)`` or land one slot off.
     public static func moveNode(
         id: String,
         path: String,
@@ -72,6 +88,8 @@ public enum ComponentStructureEditBuilder {
         )
     }
 
+    /// Builds the `remove-node` message: delete `nodeId` and its whole subtree. Same
+    /// `baseVersion` staleness guard as ``insertNode(id:path:baseVersion:parentId:index:node:)``.
     public static func removeNode(
         id: String,
         path: String,

--- a/Sources/AnglesiteCore/ComponentStyleEditBuilder.swift
+++ b/Sources/AnglesiteCore/ComponentStyleEditBuilder.swift
@@ -11,6 +11,11 @@ public enum ComponentStyleEditBuilder {
         .array(ruleSpan.map { $0.map(JSONValue.int) ?? .null })
     }
 
+    /// Builds the `set-style-property` message: set (or add) one declaration in the rule at
+    /// `ruleSpan`. Rules are addressed by byte span rather than selector text so two rules
+    /// with identical selectors stay unambiguous; `baseVersion` is the model's content hash
+    /// (``ComponentModel/version``), which the plugin checks so a stale span can never patch
+    /// the wrong bytes.
     public static func setStyleProperty(
         id: String,
         path: String,
@@ -35,6 +40,9 @@ public enum ComponentStyleEditBuilder {
         )
     }
 
+    /// Builds the `remove-style-property` message: delete one declaration from the rule at
+    /// `ruleSpan`. Same span-addressing and `baseVersion` staleness guard as
+    /// ``setStyleProperty(id:path:baseVersion:ruleSpan:property:value:)``.
     public static func removeStyleProperty(
         id: String,
         path: String,
@@ -57,6 +65,9 @@ public enum ComponentStyleEditBuilder {
         )
     }
 
+    /// Builds the `set-rule-selector` message: rewrite the selector of the rule at `ruleSpan`,
+    /// leaving its declarations untouched. Span addressing is what makes this safe — a
+    /// selector-addressed rename couldn't distinguish the rule being renamed from a duplicate.
     public static func setRuleSelector(
         id: String,
         path: String,
@@ -79,6 +90,10 @@ public enum ComponentStyleEditBuilder {
         )
     }
 
+    /// Builds the `add-style-rule` message: append a new rule (optionally inside an `@media`
+    /// block) with the given declarations. The only CSS op with no `ruleSpan` — there is no
+    /// existing rule to address yet. `media` is omitted from the payload entirely when `nil`
+    /// (top-level rule), not sent as null.
     public static func addStyleRule(
         id: String,
         path: String,

--- a/Sources/AnglesiteCore/ComponentStyleGrouping.swift
+++ b/Sources/AnglesiteCore/ComponentStyleGrouping.swift
@@ -10,13 +10,19 @@ public enum ComponentStyleGrouping {
     /// prior write in the same gesture may have shifted byte offsets (same reason the previous
     /// flat rendering carried `ruleIndex` alongside each rule).
     public struct IndexedRule: Sendable, Equatable {
+        /// Position in the model's flat `styles` array — the value to hand back to
+        /// `ComponentEditorModel.ruleSpan(atIndex:)`, never an offset within this group.
         public let index: Int
+        /// The rule as parsed from the component source, unchanged by grouping.
         public let rule: ComponentModel.StyleRule
     }
 
     /// One media-scoped (or unscoped, `media == nil`) run of rules.
     public struct Group: Sendable, Equatable {
+        /// The `@media` condition shared by every rule in this group (the condition only, no
+        /// `@media` keyword), or `nil` for the base rules rendered outside any section header.
         public let media: String?
+        /// The group's rules in source order, each carrying its original flat index.
         public let rules: [IndexedRule]
     }
 

--- a/Sources/AnglesiteCore/ComponentViewportPreset.swift
+++ b/Sources/AnglesiteCore/ComponentViewportPreset.swift
@@ -5,10 +5,20 @@ import Foundation
 /// (`ComponentStyleGrouping`). Pure/testable — `ComponentEditorView` maps each case to an SF
 /// Symbol and applies `.width` as a `.frame` constraint on the harness `WKWebView`.
 public enum ComponentViewportPreset: String, CaseIterable, Identifiable, Sendable {
-    case mobile, tablet, desktop, fill
+    /// iPhone-class width (375 pt).
+    case mobile
+    /// iPad-class portrait width (768 pt).
+    case tablet
+    /// Common laptop/desktop width (1440 pt).
+    case desktop
+    /// No fixed width — the canvas tracks the available pane width.
+    case fill
 
+    /// `Identifiable` via the raw value — stable across launches, so a persisted selection
+    /// survives case reordering.
     public var id: String { rawValue }
 
+    /// Display name for the viewport picker.
     public var label: String {
         switch self {
         case .mobile: "Mobile"
@@ -18,6 +28,8 @@ public enum ComponentViewportPreset: String, CaseIterable, Identifiable, Sendabl
         }
     }
 
+    /// SF Symbol for the viewport picker — device glyphs for the fixed widths, the
+    /// expand-arrows glyph for ``fill``.
     public var systemImage: String {
         switch self {
         case .mobile: "iphone"

--- a/Sources/AnglesiteCore/ContainerCommandRunner.swift
+++ b/Sources/AnglesiteCore/ContainerCommandRunner.swift
@@ -11,6 +11,9 @@ public struct ContainerCommandRunner: Sendable {
     private let siteID: String
     private let logCenter: LogCenter
 
+    /// Creates a runner bound to `siteID`'s already-running container. Every line of command
+    /// output streams into `logCenter` (default: the shared debug-pane log — logs are sacred,
+    /// so provisioning output is never dropped even though callers only see the final result).
     public init(control: any LocalContainerControl, siteID: String, logCenter: LogCenter = .shared) {
         self.control = control
         self.siteID = siteID

--- a/Sources/AnglesiteCore/ContentAssistant.swift
+++ b/Sources/AnglesiteCore/ContentAssistant.swift
@@ -52,7 +52,10 @@ public protocol ContentAssistant: Sendable {
 /// The situational context handed to a ``ContentAssistant`` for a single request: which site,
 /// where it lives on disk, what the user is currently looking at, and the conversation so far.
 public struct AssistantContext: Sendable {
+    /// Stable id of the site this request concerns.
     public let siteID: String
+    /// Root of the site's on-disk source, for backends that read files directly
+    /// (RAG enrichment, page lookups).
     public let siteDirectory: URL
     /// Route of the page currently shown in the preview pane, if any (e.g. `/about`).
     public let currentPageRoute: String?
@@ -69,6 +72,9 @@ public struct AssistantContext: Sendable {
     /// are considered during the pre-prompt enrichment search.
     public let searchOptions: SiteKnowledgeIndex.SearchOptions
 
+    /// Memberwise initializer. Everything beyond the site identity defaults to empty/absent, so
+    /// one-shot feature calls (alt text, summaries) stay terse while conversational callers layer
+    /// on history and selection.
     public init(
         siteID: String,
         siteDirectory: URL,
@@ -90,13 +96,23 @@ public struct AssistantContext: Sendable {
 
 /// One turn in a ``AssistantContext/conversationHistory``.
 public struct AssistantMessage: Sendable, Equatable {
+    /// Who produced this turn.
     public let role: Role
+    /// The turn's plain-text body.
     public let content: String
 
+    /// Speaker of a conversation turn — the conventional chat-completion role triple, so
+    /// history round-trips to any backend without translation.
     public enum Role: Sendable, Equatable {
-        case user, assistant, system
+        /// The site owner's message.
+        case user
+        /// A prior model reply.
+        case assistant
+        /// App-injected instructions or framing, not authored by the user.
+        case system
     }
 
+    /// Memberwise initializer.
     public init(role: Role, content: String) {
         self.role = role
         self.content = content
@@ -106,15 +122,23 @@ public struct AssistantMessage: Sendable, Equatable {
 /// Static capability descriptor for a ``ContentAssistant`` backend. Used to gate features
 /// (vision, tools) and route requests by tier.
 public struct AssistantCapabilities: Sendable, Equatable {
+    /// `true` when the backend delivers incremental chunks (vs. buffering a full reply into a
+    /// single yield).
     public let supportsStreaming: Bool
+    /// Whether the guided-generation path is available — callers gate structured features on
+    /// this, not on toolchain conditionals.
     public let supportsStructuredOutput: Bool
+    /// Whether the backend accepts image input.
     public let supportsVision: Bool
+    /// Whether the backend can invoke tools during generation.
     public let supportsTools: Bool
     /// Maximum input context window in tokens, or `nil` when the backend doesn't expose one.
     public let maxContextTokens: Int?
     /// Human-readable provider label, e.g. "On-Device" or "Private Cloud Compute".
     public let providerName: String
 
+    /// Memberwise initializer. Every field is required — a new backend must decide each
+    /// capability explicitly rather than inheriting silent defaults.
     public init(
         supportsStreaming: Bool,
         supportsStructuredOutput: Bool,

--- a/Sources/AnglesiteCore/ContentAssistantFactory.swift
+++ b/Sources/AnglesiteCore/ContentAssistantFactory.swift
@@ -6,6 +6,10 @@ import Foundation
 /// slice 5's escalation) lands, this factory is the one place that changes. `nil` below the
 /// Xcode-27 toolchain (no FoundationModels — see #128), matching `SiteGraphExplainerFactory`.
 public enum ContentAssistantFactory {
+    /// Returns a `FoundationModelAssistant` targeting `tier`, or `nil` on a pre-Xcode-27
+    /// toolchain where `FoundationModels` can't be linked (#128). Callers must treat `nil` as
+    /// "assistant unavailable" (surface `ContentHelpDialogs.assistantUnavailable(feature:)` or
+    /// degrade the feature), never as an error to retry.
     public static func make(tier: FoundationModelTier) -> (any ContentAssistant)? {
         #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelAssistant(tier: tier)

--- a/Sources/AnglesiteCore/ContentCreationWorkflow.swift
+++ b/Sources/AnglesiteCore/ContentCreationWorkflow.swift
@@ -7,7 +7,13 @@ import Foundation
 /// create. `SiteContentGraph.load` emits the graph change that drives the semantic indexer, so UI
 /// and App Intent callers get the same refresh behavior.
 public struct ContentCreationWorkflow: ContentOperationsService {
+    /// Resolves a site id to its on-disk `Source/` root, or `nil` when unknown — the same seam
+    /// the underlying operations service uses, needed here again for the post-mutation rescan.
     public typealias SiteDirectoryResolver = @Sendable (_ siteID: String) async -> URL?
+    /// Template-aware page create. A closure seam (like every alias below) because these
+    /// operations aren't on the ``ContentOperationsService`` protocol — the workflow layers them
+    /// on optionally, so tests stub only what they exercise and runtimes wire only what they
+    /// support.
     public typealias PageTemplateCreator = @Sendable (
         _ siteID: String,
         _ title: String,
@@ -15,6 +21,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         _ template: ContentScaffold.PageTemplate,
         _ onProgress: ProgressHandler?
     ) async -> ContentCreateResult
+    /// Typed-entry create carrying the explicit slug and the pre-collected `fieldValues`
+    /// (required `.url` fields — #916) that the protocol's title-only witness can't express.
     public typealias TypedSlugCreator = @Sendable (
         _ siteID: String,
         _ typeID: String,
@@ -23,13 +31,21 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         _ fieldValues: [String: String],
         _ onProgress: ProgressHandler?
     ) async -> ContentCreateResult
+    /// Deletes the content file at `relativePath` (relative to the site root).
     public typealias ContentDeleter = @Sendable (_ siteID: String, _ relativePath: String) async -> ContentDeleteResult
+    /// Re-writes previously captured `contents` at `relativePath` — the undo half of delete (#586).
     public typealias ContentRestorer = @Sendable (_ siteID: String, _ relativePath: String, _ contents: String) async -> ContentCreateResult
+    /// Copies the page at `relativePath` into a new file titled `title`.
     public typealias PageDuplicator = @Sendable (_ siteID: String, _ relativePath: String, _ title: String) async -> ContentCreateResult
+    /// Copies the collection entry at `relativePath` into a new entry titled `title`.
     public typealias PostDuplicator = @Sendable (_ siteID: String, _ relativePath: String, _ collection: String, _ title: String) async -> ContentCreateResult
+    /// Takes the draft entry at `relativePath` live.
     public typealias PostPublisher = @Sendable (_ siteID: String, _ relativePath: String, _ collection: String) async -> ContentCreateResult
+    /// Returns the published entry at `relativePath` to draft.
     public typealias PostUnpublisher = @Sendable (_ siteID: String, _ relativePath: String, _ collection: String) async -> ContentCreateResult
+    /// Scaffolds a new blank `.astro` component named `name` (New Component…, #516).
     public typealias ComponentCreator = @Sendable (_ siteID: String, _ name: String) async -> ContentCreateResult
+    /// Copies the component at `relativePath` under a derived name.
     public typealias ComponentDuplicator = @Sendable (_ siteID: String, _ relativePath: String) async -> ContentCreateResult
 
     private let operations: any ContentOperationsService
@@ -47,6 +63,11 @@ public struct ContentCreationWorkflow: ContentOperationsService {
     private let componentCreator: ComponentCreator?
     private let componentDuplicator: ComponentDuplicator?
 
+    /// Memberwise initializer. Any operation closure left `nil` makes that operation report
+    /// `.failed("… not configured …")` rather than trap — a workflow only supports what its
+    /// runtime wired up, and tests stub exactly the seams they exercise. `contentGraph`/
+    /// `knowledgeIndex` are optional for the same reason: without them, mutations still happen,
+    /// just with no post-mutation rescan or index upsert.
     public init(
         operations: any ContentOperationsService,
         contentGraph: SiteContentGraph?,
@@ -79,6 +100,10 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         self.componentDuplicator = componentDuplicator
     }
 
+    /// The production wiring: `NativeContentOperations` (with the settings-gated page-copy
+    /// generator) behind every seam, so all operations are configured. The closure indirection —
+    /// rather than widening ``ContentOperationsService`` — keeps the extra operations off the
+    /// protocol until remote runtimes can implement them too (see the protocol's TODO).
     public static func native(
         contentGraph: SiteContentGraph?,
         knowledgeIndex: SiteKnowledgeIndex? = nil,
@@ -140,6 +165,9 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         )
     }
 
+    /// Delegates to the wrapped service, then rescans and republishes the content graph on
+    /// success so the Navigator, search, and the semantic indexer see the new page without
+    /// waiting for the next site-open scan. (Same post-create refresh on every create below.)
     public func createPage(
         siteID: String,
         name: String,
@@ -156,6 +184,9 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         return result
     }
 
+    /// Template-aware page create. Falls back to the plain (Standard-scaffold) create when no
+    /// `pageTemplateCreator` was wired, so a template choice degrades to a working page instead
+    /// of a "not configured" failure.
     public func createPage(
         siteID: String,
         title: String,
@@ -178,6 +209,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         return result
     }
 
+    /// Delegates to the wrapped service and refreshes the content graph on success
+    /// (see ``createPage(siteID:name:route:onProgress:)``).
     public func createPost(
         siteID: String,
         title: String,
@@ -196,6 +229,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         return result
     }
 
+    /// Delegates to the wrapped service and refreshes the content graph on success
+    /// (see ``createPage(siteID:name:route:onProgress:)``).
     public func createTyped(
         siteID: String,
         typeID: String,
@@ -269,6 +304,9 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         }
     }
 
+    /// Deletes via the wired closure, rescanning the graph on success. The only mutation whose
+    /// rescan passes no index path — there is nothing to upsert into the knowledge index for a
+    /// file that's gone.
     public func deleteContent(siteID: String, relativePath: String) async -> ContentDeleteResult {
         guard let contentDeleter else { return .failed(reason: "Delete is not configured for this workflow") }
         let result = await contentDeleter(siteID, relativePath)
@@ -287,6 +325,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         return result
     }
 
+    /// Duplicates a page via the wired closure — `.failed` when unwired — and refreshes the
+    /// graph on success, like every create.
     public func duplicatePage(siteID: String, relativePath: String, title: String) async -> ContentCreateResult {
         guard let pageDuplicator else { return .failed(reason: "Duplicate is not configured for this workflow") }
         let result = await pageDuplicator(siteID, relativePath, title)
@@ -294,6 +334,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         return result
     }
 
+    /// Duplicates a collection entry via the wired closure — `.failed` when unwired — and
+    /// refreshes the graph on success, like every create.
     public func duplicatePost(siteID: String, relativePath: String, collection: String, title: String) async -> ContentCreateResult {
         guard let postDuplicator else { return .failed(reason: "Duplicate is not configured for this workflow") }
         let result = await postDuplicator(siteID, relativePath, collection, title)
@@ -301,6 +343,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         return result
     }
 
+    /// Takes a draft entry live via the wired closure. Refreshes the graph on success so the
+    /// entry's draft badge updates everywhere at once.
     public func publish(siteID: String, relativePath: String, collection: String) async -> ContentCreateResult {
         guard let postPublisher else { return .failed(reason: "Publish is not configured for this workflow") }
         let result = await postPublisher(siteID, relativePath, collection)
@@ -308,6 +352,8 @@ public struct ContentCreationWorkflow: ContentOperationsService {
         return result
     }
 
+    /// Returns a published entry to draft via the wired closure; refreshes the graph on success,
+    /// mirroring ``publish(siteID:relativePath:collection:)``.
     public func unpublish(siteID: String, relativePath: String, collection: String) async -> ContentCreateResult {
         guard let postUnpublisher else { return .failed(reason: "Unpublish is not configured for this workflow") }
         let result = await postUnpublisher(siteID, relativePath, collection)

--- a/Sources/AnglesiteCore/ContentHelpDialogs.swift
+++ b/Sources/AnglesiteCore/ContentHelpDialogs.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Pure dialog/summary strings shared by the content-help App Intents and GUI (#465), kept in
 /// Core (pattern: `IntegrationDialogs`) so CI unit-tests them without the AppIntents runtime.
 public enum ContentHelpDialogs {
+    /// Result summary for a copy-review run. Zero findings is a distinct "all clear" sentence
+    /// (not "found 0 suggestions"), and the skipped-pages tail only appears when something was
+    /// actually skipped — Siri reads these aloud, so every clause has to earn its place.
     public static func copyReview(findingCount: Int, pageCount: Int, skippedCount: Int, siteName: String) -> String {
         var d: String
         if findingCount == 0 {
@@ -14,14 +17,22 @@ public enum ContentHelpDialogs {
         return d
     }
 
+    /// Fallback line for any content-help entry point when `ContentAssistantFactory` returns no
+    /// backend. Parameterized on the feature name so one string serves every intent.
     public static func assistantUnavailable(feature: String) -> String {
         "\(feature) needs Apple Intelligence, which isn't available on this Mac right now."
     }
 
+    /// Confirmation for a saved social-media plan. Names the on-disk destination
+    /// (`docs/social-calendar.md`) so the owner can find the file outside the app — git is the
+    /// source of truth, and the plan is theirs to edit anywhere.
     public static func socialPlanSaved(weeks: Int, siteName: String) -> String {
         "Saved a \(weeks)-week social media plan for \(siteName) to docs/social-calendar.md."
     }
 
+    /// Summary for a repurpose-post run: platform drafts written, plus — only when nonzero — how
+    /// many platforms couldn't fit their length limit, so a partial success reads as such rather
+    /// than a silent one.
     public static func repurposeSummary(postTitle: String, platformCount: Int, failedCount: Int) -> String {
         var d = "Drafted \(platformCount) platform post\(platformCount == 1 ? "" : "s") for \"\(postTitle)\"."
         if failedCount > 0 { d += " \(failedCount) platform\(failedCount == 1 ? "" : "s") couldn't fit their length limit." }

--- a/Sources/AnglesiteCore/ContentListing.swift
+++ b/Sources/AnglesiteCore/ContentListing.swift
@@ -14,8 +14,12 @@ import Foundation
 /// A missing top-level array (`pages`/`posts`/`images`) decodes to empty — an older or partial
 /// plugin that only reports pages doesn't fail the whole parse.
 public struct ContentListing: Sendable, Equatable {
+    /// Routable pages, ids already site-scoped (`{siteID}:page:{route}`).
     public let pages: [SiteContentGraph.Page]
+    /// Collection entries, ids already site-scoped (`{siteID}:post:{slug}`).
     public let posts: [SiteContentGraph.Post]
+    /// Site images with their referencing pages, ids already site-scoped
+    /// (`{siteID}:image:{relativePath}`).
     public let images: [SiteContentGraph.Image]
 
     /// Parse the `list_content` JSON text, stamping `siteID` and constructing site-scoped ids.

--- a/Sources/AnglesiteCore/ContentOperationsService.swift
+++ b/Sources/AnglesiteCore/ContentOperationsService.swift
@@ -5,7 +5,11 @@ import Foundation
 /// server — `create_page` / `create_post` — so they're injectable behind a test seam the way
 /// `SiteOperationsService` is for deploy/backup/audit.
 public protocol ContentOperationsService: Sendable {
+    /// Scaffold a new page. `name` seeds the title; a `nil` route is derived from it. Progress
+    /// steps stream through `onProgress` so intent and GUI callers can show the same phases.
     func createPage(siteID: String, name: String, route: String?, onProgress: ProgressHandler?) async -> ContentCreateResult
+    /// Scaffold a new collection entry. `nil`/empty `collection` falls back to the standard
+    /// `posts` collection; a `nil` slug is derived from `title`.
     func createPost(siteID: String, title: String, collection: String?, slug: String?, onProgress: ProgressHandler?) async -> ContentCreateResult
     /// Scaffold a typed entry (V-1.2 personal/business content types) from the content-type registry.
     /// `typeID` is a registry id (`note`, `article`, …); `title` seeds the name/title field and the
@@ -17,12 +21,16 @@ public protocol ContentOperationsService: Sendable {
 }
 
 public extension ContentOperationsService {
+    /// Progress-less convenience — the requirement with `onProgress: nil`, so callers with no
+    /// progress UI (tests, batch paths) don't have to spell it.
     func createPage(siteID: String, name: String, route: String?) async -> ContentCreateResult {
         await createPage(siteID: siteID, name: name, route: route, onProgress: nil)
     }
+    /// Progress-less convenience — the requirement with `onProgress: nil`.
     func createPost(siteID: String, title: String, collection: String?, slug: String?) async -> ContentCreateResult {
         await createPost(siteID: siteID, title: title, collection: collection, slug: slug, onProgress: nil)
     }
+    /// Progress-less convenience — the requirement with `onProgress: nil`.
     func createTyped(siteID: String, typeID: String, title: String) async -> ContentCreateResult {
         await createTyped(siteID: siteID, typeID: typeID, title: title, onProgress: nil)
     }
@@ -40,6 +48,8 @@ public enum ContentCreateResult: Sendable, Equatable {
 
 /// Outcome of a `delete_content` call.
 public enum ContentDeleteResult: Sendable, Equatable {
+    /// The file was removed; `filePath` is relative to the site root, matching
+    /// ``ContentCreateResult/created(filePath:identifier:)``.
     case deleted(filePath: String)
     /// The site id didn't resolve to a known site directory.
     case siteNotFound

--- a/Sources/AnglesiteCore/ContentScaffold.swift
+++ b/Sources/AnglesiteCore/ContentScaffold.swift
@@ -4,19 +4,31 @@ import Foundation
 /// Pure, side-effect-free scaffolding for new pages and posts. Byte-faithful to the Node
 /// sidecar's `create-content.mjs` so switching the create backend produces no git churn.
 public enum ContentScaffold {
+    /// A page-scaffold variant for New Page. A struct rather than an enum so the list can grow
+    /// beyond ``builtIns`` without a source-breaking change; identity and rendering both key off
+    /// the `id` string (an unknown id falls back to the standard body in `renderPage`).
     public struct PageTemplate: Sendable, Equatable, Hashable, Identifiable {
+        /// Stable template id that ``ContentScaffold/renderPage(title:layoutImport:template:description:)``
+        /// dispatches on.
         public let id: String
+        /// User-facing name shown in the New Page template picker.
         public let displayName: String
 
+        /// Memberwise initializer — public so future template sources beyond ``builtIns`` don't
+        /// need this file changed.
         public init(id: String, displayName: String) {
             self.id = id
             self.displayName = displayName
         }
 
+        /// Title plus a placeholder paragraph — the default when no template is chosen.
         public static let standard = PageTemplate(id: "standard", displayName: "Standard Page")
+        /// Hero section plus a highlights list.
         public static let landing = PageTemplate(id: "landing", displayName: "Landing Page")
+        /// Contact prompt with a placeholder `mailto:` address for the owner to replace.
         public static let contact = PageTemplate(id: "contact", displayName: "Contact Page")
 
+        /// The templates the New Page UI offers, in menu order.
         public static let builtIns: [PageTemplate] = [.standard, .landing, .contact]
     }
 
@@ -42,10 +54,14 @@ public enum ContentScaffold {
         return "/" + segments.joined(separator: "/")
     }
 
+    /// Where a scaffolded page lands, relative to the site root: `/about` →
+    /// `src/pages/about.astro`. Expects a route already through ``normalizeRoute(_:)``.
     public static func pageRelativePath(normalizedRoute: String) -> String {
         "src/pages" + normalizedRoute + ".astro"
     }
 
+    /// Where a scaffolded collection entry lands, relative to the site root:
+    /// `src/content/<collection>/<slug>.md`.
     public static func postRelativePath(collection: String, slug: String) -> String {
         "src/content/\(collection)/\(slug).md"
     }
@@ -80,6 +96,8 @@ public enum ContentScaffold {
         return slugify([day, bareHost, lastSegment].filter { !$0.isEmpty }.joined(separator: "-"))
     }
 
+    /// Where a per-site singleton data record lands, relative to the site root:
+    /// `src/data/<slot>.json` — a data module the template imports, not a routable page.
     public static func singletonRelativePath(slot: String) -> String {
         "src/data/\(slot).json"
     }
@@ -91,6 +109,10 @@ public enum ContentScaffold {
         return String(repeating: "../", count: depth) + "layouts/BaseLayout.astro"
     }
 
+    /// Full `.astro` source for a new page: `BaseLayout` import plus the template's body. A `nil`
+    /// `description` defaults to `"\(title)."` so every scaffolded page ships with a non-empty
+    /// meta description. The body deliberately has no `<main>` wrapper — `BaseLayout` owns the
+    /// page's single main landmark (#1012), so pages contribute content only.
     public static func renderPage(
         title: String,
         layoutImport: String,
@@ -143,6 +165,9 @@ public enum ContentScaffold {
         """ + "\n"
     }
 
+    /// Markdown source for a new post: quoted, escaped frontmatter with `publishDate` set to
+    /// `now` (ISO-8601 with fractional seconds, matching the sidecar's `toISOString()` output
+    /// byte-for-byte) and `draft: true` — new entries start unpublished.
     public static func renderPost(title: String, now: Date, description: String = "") -> String {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]

--- a/Sources/AnglesiteCore/ContentScanner.swift
+++ b/Sources/AnglesiteCore/ContentScanner.swift
@@ -26,6 +26,10 @@ public enum ContentScanner {
         + ContentTypeRegistry.builtIns.compactMap(\.collection)
     )).sorted()
 
+    /// Walks the site once and builds the full listing, also resolving each image's
+    /// `usedOnPages` via `DeadAssetScanner.referencedPaths` in the same pass so orphaned images
+    /// can be flagged without a second walk. Synchronous, blocking filesystem I/O — callers run
+    /// it off the main actor (see ``SiteContentGraph/rescan(siteID:projectRoot:)``).
     public static func scan(projectRoot: URL, siteID: String) -> ContentListing {
         let referencedPaths = DeadAssetScanner.referencedPaths(projectRoot: projectRoot)
         return ContentListing(

--- a/Sources/AnglesiteCore/ContentTypeRegistry.swift
+++ b/Sources/AnglesiteCore/ContentTypeRegistry.swift
@@ -19,17 +19,29 @@ public struct ContentTypeField: Sendable, Equatable {
     /// The shape of a field's value. Maps to an editor control and to a Zod type at the
     /// template layer (#351); kept deliberately small.
     public enum Kind: Sendable, Equatable {
-        case string        // single-line text
-        case text          // multi-line plain text
-        case markdown      // multi-line rich body
+        /// Single-line text.
+        case string
+        /// Multi-line plain text.
+        case text
+        /// Multi-line rich body.
+        case markdown
+        /// A boolean flag (e.g. `draft`).
         case bool
-        case date          // calendar date, no time
-        case datetime      // ISO 8601 date-time with time + timezone (mf2 `dt-*` properties)
+        /// Calendar date, no time.
+        case date
+        /// ISO 8601 date-time with time + timezone (mf2 `dt-*` properties).
+        case datetime
+        /// A URL value; required `.url` fields gate the create flow — see
+        /// ``ContentTypeDescriptor/requiredURLFields``.
         case url
-        case image         // a site-relative media path
+        /// A site-relative media path.
+        case image
+        /// A numeric value (e.g. a review rating).
         case number
-        case stringArray   // e.g. tags
-        case imageArray    // an ordered list of site-relative media paths (e.g. album photos)
+        /// An ordered list of strings (e.g. tags).
+        case stringArray
+        /// An ordered list of site-relative media paths (e.g. album photos).
+        case imageArray
         /// A repeating group of small structured records (e.g. h-resume `experience`/`education`
         /// entries) — an ordered list of member fields, each an existing scalar `Kind`. By
         /// convention `fields` excludes `.markdown`, `.stringArray`, `.imageArray`, and nested
@@ -50,10 +62,17 @@ public struct ContentTypeField: Sendable, Equatable {
         case objectArray(fields: [ContentTypeField])
     }
 
+    /// The frontmatter key, exactly as it appears in an entry's YAML. Field-name keys in
+    /// ``ContentTypeProjections`` reference these values.
     public let name: String
+    /// The value's shape — drives both the editor control and the generated Zod type.
     public let kind: Kind
+    /// Whether the projected template schema requires a value. Required fields shape the create
+    /// flow (see ``ContentTypeDescriptor/requiredURLFields`` for the `.url` consequence).
     public let required: Bool
 
+    /// Creates a field. The first two parameters are deliberately unlabeled so the built-in
+    /// catalog's descriptor declarations read as a compact table.
     public init(_ name: String, _ kind: Kind, required: Bool = false) {
         self.name = name
         self.kind = kind
@@ -83,6 +102,7 @@ public struct ContentTypeProjections: Sendable, Equatable {
     /// the template layer never has to guess; richer typing can be added per-field later.
     public let schemaType: String?
 
+    /// Creates a projection set; the individual properties document the contract each map carries.
     public init(
         microformat: String,
         microformatProperties: [String: String],
@@ -115,7 +135,9 @@ public struct ContentTypeProjections: Sendable, Equatable {
 /// already uses: route-addressed pages under `src/pages`, or slug-addressed entries in a content
 /// collection under `src/content/<collection>`.
 public enum ContentStorage: Sendable, Equatable {
+    /// A route-addressed page under `src/pages`.
     case page
+    /// A slug-addressed entry in the named content collection under `src/content/<collection>`.
     case collection(String)
     /// One record per site, stored as a data module (not a route, not a collection). The
     /// associated value is the shared slot name; descriptors that share a slot are mutually
@@ -130,10 +152,15 @@ public struct ContentTypeDescriptor: Sendable, Equatable, Identifiable {
     public let id: String
     /// Human-facing label (e.g. `Business Profile`).
     public let displayName: String
+    /// Where instances live on disk — see ``ContentStorage``.
     public let storage: ContentStorage
+    /// The frontmatter schema, in declaration order.
     public let fields: [ContentTypeField]
+    /// How this type projects to microformats2 and schema.org — see ``ContentTypeProjections``.
     public let projections: ContentTypeProjections
 
+    /// Creates a descriptor. Pure declarative data — invariants (unique field names, the
+    /// `.objectArray` member-kind convention) are enforced by review and tests, not here.
     public init(
         id: String,
         displayName: String,
@@ -217,6 +244,7 @@ public struct ContentTypeRegistry: Sendable, Equatable {
         insert(descriptor)
     }
 
+    /// The descriptor registered under `id`, or `nil` if none is. O(1).
     public func descriptor(id: String) -> ContentTypeDescriptor? {
         byID[id]
     }
@@ -240,6 +268,8 @@ public struct ContentTypeRegistry: Sendable, Equatable {
         order.compactMap { byID[$0] }
     }
 
+    /// All registered type ids in registration order — the key sequence behind ``all``, without
+    /// materializing the descriptors.
     public var ids: [String] { order }
 }
 

--- a/Sources/AnglesiteCore/ContentTypeResolver.swift
+++ b/Sources/AnglesiteCore/ContentTypeResolver.swift
@@ -12,6 +12,11 @@ public enum ContentTypeResolver {
     /// become user-renamable.
     static let pageTypesByPath: [String: String] = ["src/pages/about.md": "businessProfile"]
 
+    /// The content type owning `path`, or `nil` when the file isn't typed content. `path` is
+    /// project-relative; leading `./`/`/` and backslash separators are normalized, and matching is
+    /// case-insensitive so a case-insensitive APFS volume's spelling still resolves. Collection
+    /// membership wins over the page-singleton map (a collection entry can never also be a
+    /// `src/pages` path, so the order is only about checking the cheap directory match first).
     public static func descriptor(
         forRelativePath path: String,
         registry: ContentTypeRegistry = ContentTypeRegistry()

--- a/Sources/AnglesiteCore/ContentUndoCoordinator.swift
+++ b/Sources/AnglesiteCore/ContentUndoCoordinator.swift
@@ -61,6 +61,8 @@ public final class ContentUndoCoordinator {
         /// Carried on the record so it survives onto the redo entry unchanged.
         public let actionName: String
 
+        /// Creates a record; each property documents its own contract. `id` defaults to a fresh
+        /// identity — every registration is a distinct record, including a ``reversed`` twin.
         public init(id: UUID = UUID(), relativePath: String, before: String?, after: String?, actionName: String) {
             self.id = id
             self.relativePath = relativePath
@@ -112,6 +114,9 @@ public final class ContentUndoCoordinator {
     /// to observe the settled stack state deterministically.
     private(set) var pendingApply: Task<Void, Never>?
 
+    /// Creates a coordinator that realizes popped records through `apply`. Attach
+    /// ``undoManager`` separately — the coordinator is typically built before the window (and
+    /// therefore its undo manager) exists, and registration is a safe no-op until one is set.
     public init(apply: @escaping Applier) {
         self.apply = apply
     }

--- a/Sources/AnglesiteCore/ConversationTranscript.swift
+++ b/Sources/AnglesiteCore/ConversationTranscript.swift
@@ -6,12 +6,37 @@ import Foundation
 /// these rows can be unit-tested in `AnglesiteCore` without the App shell (#161). `ChatModel`
 /// re-exports this as `ChatModel.Message` via a typealias, so its SwiftUI views are unaffected.
 public struct ChatMessage: Identifiable, Equatable, Sendable {
-    public enum Role: Equatable, Sendable { case user, assistant, system, error, edit, annotation, citation }
+    /// What kind of row this is. Beyond the classic user/assistant pair, the transcript carries
+    /// out-of-band rows (`edit`, `annotation`, `citation`) that render as cards, not speech
+    /// bubbles, and carry their payload in the matching `*Metadata` property.
+    public enum Role: Equatable, Sendable {
+        /// A prompt the user typed.
+        case user
+        /// A streamed model response.
+        case assistant
+        /// App-generated status text (e.g. the "Cancelled." row).
+        case system
+        /// An in-band failure — a `.failed` event or a non-clean backend exit.
+        case error
+        /// An assistant-applied content edit; payload in ``ChatMessage/editMetadata``.
+        case edit
+        /// A preview annotation; payload in ``ChatMessage/annotationMetadata``.
+        case annotation
+        /// RAG citation chips for a turn; payload in ``ChatMessage/citationMetadata``.
+        case citation
+    }
 
+    /// Stable row identity — SwiftUI list identity, and how the transcript tracks its in-flight
+    /// assistant row across out-of-band mutations.
     public let id: UUID
+    /// What kind of row this is — see ``Role``.
     public let role: Role
+    /// The row's text. Mutable because streamed `.textDelta` events append to it in place.
     public var content: String
+    /// Tool invocations within this assistant turn, in arrival order.
     public var toolCalls: [ChatToolCall]
+    /// Creation time. Drives ``ConversationTranscript/insertByTimestamp(_:)``'s chronological
+    /// re-insertion after an optimistic drop.
     public let timestamp: Date
     /// Only set on `role: .edit` rows. Carries file + commit + undone flag.
     public var editMetadata: ChatEditMetadata?
@@ -20,6 +45,8 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
     /// Only set on `role: .citation` rows. Carries the retrieved files for this turn.
     public var citationMetadata: ChatCitationMetadata?
 
+    /// Creates a row. Everything past `role`/`content` defaults, so ordinary user/assistant rows
+    /// stay one-liners and only the out-of-band roles pass their metadata payload.
     public init(
         id: UUID = UUID(),
         role: Role,
@@ -43,12 +70,21 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
 
 /// One tool invocation within an assistant turn. `id` pairs a `.toolUse` with its later `.toolResult`.
 public struct ChatToolCall: Identifiable, Equatable, Sendable {
+    /// The provider's tool-use id (not a UUID) — what pairs this call with its later result.
     public let id: String
+    /// The tool name as the provider reported it. `"(unbound)"` marks a result that arrived
+    /// with no matching call (see ``ConversationTranscript/apply(_:)``).
     public let name: String
+    /// The tool input pre-rendered for the tool-call card — see
+    /// ``ConversationTranscript/renderJSON(_:)``.
     public let inputDisplay: String
+    /// The returned content once the paired `.toolResult` arrives; `nil` while still pending.
     public var result: String?
+    /// Whether ``result`` is a tool-reported failure.
     public var isError: Bool
 
+    /// Creates a call row, pending by default — `result`/`isError` are filled in later when the
+    /// paired result event streams in.
     public init(id: String, name: String, inputDisplay: String, result: String? = nil, isError: Bool = false) {
         self.id = id
         self.name = name
@@ -58,10 +94,16 @@ public struct ChatToolCall: Identifiable, Equatable, Sendable {
     }
 }
 
+/// Payload of a `.edit` row: which file an assistant-applied edit touched, the commit that
+/// captured it, and whether it has since been undone.
 public struct ChatEditMetadata: Equatable, Sendable {
+    /// The edited file, as the apply reported it.
     public let file: String
+    /// The commit that captured the edit — the handle its undo (a revert) operates on.
     public let commit: String
+    /// Set once the edit has been reverted, so the row's Undo affordance can reflect it.
     public var undone: Bool
+    /// Creates the payload; the properties document each field's contract.
     public init(file: String, commit: String, undone: Bool) {
         self.file = file
         self.commit = commit
@@ -69,13 +111,21 @@ public struct ChatEditMetadata: Equatable, Sendable {
     }
 }
 
+/// Payload of an `.annotation` row: just the id of the backing annotation record, which the
+/// row renders from rather than duplicating its content into the transcript.
 public struct ChatAnnotationMetadata: Equatable, Sendable {
+    /// Identity of the annotation this row mirrors.
     public let annotationID: String
+    /// Creates the payload.
     public init(annotationID: String) { self.annotationID = annotationID }
 }
 
+/// Payload of a `.citation` row: the files retrieved as RAG context for one turn, surfaced as
+/// clickable chips below the assistant's response.
 public struct ChatCitationMetadata: Equatable, Sendable {
+    /// The retrieved files, in the order the backend reported them.
     public let citations: [RetrievedCitation]
+    /// Creates the payload.
     public init(citations: [RetrievedCitation]) { self.citations = citations }
 }
 
@@ -102,6 +152,8 @@ public struct ConversationTranscript: Equatable, Sendable {
     /// Names the backend in the `.backendExited` error string (e.g. "On-Device", "Claude").
     private let providerName: String
 
+    /// Creates an empty transcript. `providerName` names the backend in the `.backendExited`
+    /// error row (e.g. "On-Device", "Claude") so the user can tell which one died.
     public init(providerName: String = "assistant") {
         self.providerName = providerName
     }

--- a/Sources/AnglesiteCore/ConversationalAssistant.swift
+++ b/Sources/AnglesiteCore/ConversationalAssistant.swift
@@ -35,11 +35,17 @@ public enum AssistantEvent: Sendable, Equatable {
 /// Cache-specific token fields are intentionally omitted here; callers that need backend-specific
 /// telemetry should read the concrete backend directly.
 public struct AssistantUsage: Sendable, Equatable {
+    /// Prompt tokens consumed this turn.
     public let inputTokens: Int
+    /// Completion tokens produced this turn.
     public let outputTokens: Int
+    /// Estimated cost in US dollars, or `nil` for backends with no metering (e.g. on-device).
     public let costUSD: Double?
+    /// Wall-clock turn duration in milliseconds, if the backend reports one.
     public let durationMs: Int?
 
+    /// Creates a usage record. Cost and duration default to `nil` since not every backend
+    /// reports them (see the type doc for what's deliberately omitted).
     public init(inputTokens: Int, outputTokens: Int, costUSD: Double? = nil, durationMs: Int? = nil) {
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
@@ -51,6 +57,9 @@ public struct AssistantUsage: Sendable, Equatable {
 /// Errors thrown by a ``ContentAssistant`` when a requested capability isn't supported by the
 /// backend (for example, not every backend can do FoundationModels guided generation).
 public enum AssistantError: Error, Sendable, Equatable {
+    /// The backend can't perform the requested capability; the associated message names what
+    /// was asked for. Callers should have consulted ``ContentAssistant/capabilities`` first —
+    /// this is the backstop, not the routing mechanism.
     case unsupported(String)
     /// Thrown by ``ContentAssistant/generate(prompt:context:)`` when the underlying stream produces
     /// a `.failed` event — i.e. the backend reported an in-band error that `generate()` cannot yield

--- a/Sources/AnglesiteCore/CopyEditAuditor.swift
+++ b/Sources/AnglesiteCore/CopyEditAuditor.swift
@@ -4,12 +4,19 @@ import Foundation
 /// call at a time (chunk-first — every call fits the on-device window); GUI/intents/tools depend
 /// only on this protocol so tests can inject fakes.
 public protocol CopyEditAuditing: Sendable {
+    /// Audits every chunk and aggregates the results into one report. Never throws by design —
+    /// a failed chunk degrades to a named skipped route, and total unavailability travels in
+    /// ``CopyEditReport/unavailableMessage``, so every front-door always gets a renderable
+    /// report. `preamble` is prepended verbatim to each chunk's prompt (site-voice guidance);
+    /// `siteID`/`siteDirectory` scope the assistant context.
     func audit(chunks: [ContentChunk], preamble: String?, siteID: String, siteDirectory: URL) async -> CopyEditReport
 }
 
 /// `nil` below the Xcode-27 toolchain — callers hide/disable the feature (pattern:
 /// `SiteGraphExplainerFactory`).
 public enum CopyEditAuditorFactory {
+    /// The FoundationModels-backed auditor on the Xcode-27 toolchain; `nil` elsewhere so callers
+    /// hide or disable the feature rather than shipping a degraded audit (see the type doc).
     public static func makeDefault() -> (any CopyEditAuditing)? {
         #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelCopyEditAuditor()
@@ -25,11 +32,18 @@ public enum CopyEditAuditorFactory {
 import FoundationModels
 import OSLog
 
+/// The production ``CopyEditAuditing`` implementation: one FoundationModels guided-generation
+/// call per chunk, so every request fits the on-device context window regardless of site size.
 public struct FoundationModelCopyEditAuditor: CopyEditAuditing {
     private static let logger = Logger(subsystem: "io.dwk.anglesite", category: "CopyEditAuditor")
 
+    /// Creates an auditor. Stateless — the assistant is resolved per ``audit(chunks:preamble:siteID:siteDirectory:)``
+    /// call, so runtime availability changes (Apple Intelligence toggled) are always seen fresh.
     public init() {}
 
+    /// Chunk-first FM audit. Partial results over aborts (spec §6): a single failed chunk
+    /// becomes a named skip, while the assistant going *unavailable* mid-run stops the audit
+    /// with an explanation instead of silently skipping every remaining page.
     public func audit(chunks: [ContentChunk], preamble: String?, siteID: String, siteDirectory: URL) async -> CopyEditReport {
         // Heavy generation requests the PCC tier through the shared seam (#464); today that is
         // backed on-device, and chunking keeps each call correct at 4K regardless.

--- a/Sources/AnglesiteCore/CopyEditPrompt.swift
+++ b/Sources/AnglesiteCore/CopyEditPrompt.swift
@@ -4,6 +4,8 @@ import Foundation
 /// non-gated. Facts-only framing follows `SiteGraphExplainPrompt`: the model reviews ONLY the
 /// provided page text and must quote excerpts verbatim so `CopyRewriteApplier` can find them.
 public enum CopyEditPrompt {
+    /// The 10-point review checklist, verbatim. Public so tests and any surface that explains
+    /// the audit to the user share the exact wording the model was actually given.
     public static let checklist = """
     1. Clarity — would a first-time visitor instantly understand what this page offers?
     2. Benefits over features — does the copy say what the visitor gets, not just what the business does?
@@ -17,6 +19,12 @@ public enum CopyEditPrompt {
     10. Mobile readability — any walls of text?
     """
 
+    /// Assembles the guided-generation prompt for one chunk: optional `preamble` (site-voice
+    /// guidance) first, then the checklist, framing rules, and the page text. The "quote
+    /// excerpts verbatim, character for character" demand is load-bearing — both
+    /// ``CopyRewriteApplier`` and ``CopyEditReportBuilder``'s hallucination filter match
+    /// excerpts by exact substring. Findings are capped at 5 per page to keep the review
+    /// high-impact rather than exhaustive.
     public static func build(chunk: ContentChunk, preamble: String?) -> String {
         var sections: [String] = []
         if let preamble { sections.append(preamble) }

--- a/Sources/AnglesiteCore/CopyEditReport.swift
+++ b/Sources/AnglesiteCore/CopyEditReport.swift
@@ -1,7 +1,15 @@
 import Foundation
 
+/// Impact ranking for a copy finding. Raw values are the sort keys — `high` is 0 so a plain
+/// ascending sort lists the most impactful findings first (see ``CopyEditReportBuilder``).
 public enum CopyFindingSeverity: Int, Sendable, Equatable, Comparable, CaseIterable {
-    case high = 0, medium = 1, low = 2
+    /// Most impactful; sorts first.
+    case high = 0
+    /// Middling impact.
+    case medium = 1
+    /// Least impactful — also the fallback for an unrecognized model label, per
+    /// ``CopyFindingSeverity/init(label:)``.
+    case low = 2
 
     /// Model output is a free string under `@Guide` — parse defensively, unknown → `.low`.
     public init(label: String) {
@@ -12,18 +20,29 @@ public enum CopyFindingSeverity: Int, Sendable, Equatable, Comparable, CaseItera
         }
     }
 
+    /// Raw-value order: `high < medium < low` — "less" means *more* severe, chosen so ascending
+    /// sorts put high-severity findings first without a custom comparator at every sort site.
     public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
 }
 
 /// Non-gated twin of `GeneratedCopyFinding` so aggregation is CI-testable (the `@Generable`
 /// type only exists on the Xcode-27 toolchain).
 public struct CopyFindingDraft: Sendable, Equatable {
+    /// Checklist category, as the model emitted it (free string).
     public let category: String
+    /// Free-string severity label; parsed defensively by ``CopyFindingSeverity/init(label:)``.
     public let severity: String
+    /// The model's verbatim quote from the page. Load-bearing: a draft whose excerpt doesn't
+    /// occur exactly in the chunk text is treated as hallucinated and dropped by
+    /// ``CopyEditReportBuilder``.
     public let excerpt: String
+    /// One-sentence plain-language statement of the problem.
     public let issue: String
+    /// The proposed replacement text, in the site's voice.
     public let suggestedRewrite: String
 
+    /// Creates a draft; everything is kept as raw strings here — parsing and verification happen
+    /// at aggregation time, where they can be CI-tested.
     public init(category: String, severity: String, excerpt: String, issue: String, suggestedRewrite: String) {
         self.category = category
         self.severity = severity
@@ -33,17 +52,32 @@ public struct CopyFindingDraft: Sendable, Equatable {
     }
 }
 
+/// One verified finding in the final report: a ``CopyFindingDraft`` that survived the
+/// verbatim-excerpt check, joined to its page's route/title/file and given a stable id.
 public struct CopyFinding: Sendable, Equatable, Identifiable {
+    /// Stable identity, `filePath#index` over the page's verified findings — deterministic for
+    /// a given report, so selection survives list refreshes.
     public let id: String
+    /// The page's URL route (what the user recognizes the page by).
     public let route: String
+    /// The page title, if the chunk carried one.
     public let title: String?
+    /// The page's source file — the write target when ``suggestedRewrite`` is applied.
     public let filePath: String
+    /// Checklist category, carried through from the draft.
     public let category: String
+    /// Parsed severity; drives the report's severity-major sort.
     public let severity: CopyFindingSeverity
+    /// The verbatim quote — already verified to occur in the page text, so
+    /// `CopyRewriteApplier.apply` can locate it.
     public let excerpt: String
+    /// One-sentence plain-language statement of the problem.
     public let issue: String
+    /// The proposed replacement text, in the site's voice.
     public let suggestedRewrite: String
 
+    /// Creates a finding. Normally only ``CopyEditReportBuilder`` does — it owns the id scheme
+    /// and the excerpt verification this type's fields assume.
     public init(id: String, route: String, title: String?, filePath: String, category: String,
                 severity: CopyFindingSeverity, excerpt: String, issue: String, suggestedRewrite: String) {
         self.id = id
@@ -61,13 +95,19 @@ public struct CopyFinding: Sendable, Equatable, Identifiable {
 /// Whole-site audit result. Per spec §5.1 a failed chunk degrades to `skippedRoutes` — the
 /// report never aborts and never hides a gap.
 public struct CopyEditReport: Sendable, Equatable {
+    /// Verified findings, sorted severity-major then by route.
     public let findings: [CopyFinding]
+    /// How many pages were actually reviewed (with or without findings) — shown alongside
+    /// ``skippedRoutes`` so "no findings" is distinguishable from "nothing was audited".
     public let auditedCount: Int
+    /// Routes whose chunk failed to audit, named individually so the gap is visible.
     public let skippedRoutes: [String]
     /// Non-nil when the audit couldn't run at all (e.g. Apple Intelligence off at runtime) —
     /// carries the user-facing explanation. Front-doors show this instead of a skip list.
     public let unavailableMessage: String?
 
+    /// Creates a report. Prefer ``CopyEditReportBuilder/report(results:unavailableMessage:)``,
+    /// which derives the counts, skip list, and sort from raw per-chunk results.
     public init(findings: [CopyFinding], auditedCount: Int, skippedRoutes: [String], unavailableMessage: String? = nil) {
         self.findings = findings
         self.auditedCount = auditedCount
@@ -76,7 +116,13 @@ public struct CopyEditReport: Sendable, Equatable {
     }
 }
 
+/// Aggregates per-chunk generation results into a ``CopyEditReport``: verifies excerpts, mints
+/// stable ids, and applies the severity-major sort. Pure and non-gated so the aggregation is
+/// CI-testable without FoundationModels.
 public enum CopyEditReportBuilder {
+    /// Builds the report. A `nil` `drafts` entry means that chunk failed and becomes a skipped
+    /// route; drafts whose excerpt isn't a verbatim substring of the chunk text are dropped as
+    /// hallucinated (see the inline note for the reasoning and the accepted edge case).
     public static func report(results: [(chunk: ContentChunk, drafts: [CopyFindingDraft]?)],
                               unavailableMessage: String? = nil) -> CopyEditReport {
         var findings: [CopyFinding] = []

--- a/Sources/AnglesiteCore/CopyRewriteApplier.swift
+++ b/Sources/AnglesiteCore/CopyRewriteApplier.swift
@@ -5,6 +5,9 @@ import Foundation
 /// copy-to-clipboard) when the excerpt doesn't appear verbatim — never fuzzy-match, never
 /// batch-rewrite.
 public enum CopyRewriteApplier {
+    /// The file contents with the first exact `excerpt` occurrence replaced by `rewrite`, or
+    /// `nil` when `excerpt` is empty or absent — the caller then disables Apply and offers the
+    /// rewrite as copy-to-clipboard instead (see the type doc for why there is no fuzzy match).
     public static func apply(excerpt: String, rewrite: String, contents: String) -> String? {
         guard !excerpt.isEmpty, let range = contents.range(of: excerpt) else { return nil }
         return contents.replacingCharacters(in: range, with: rewrite)

--- a/Sources/AnglesiteCore/CustomDomainAttachCommand.swift
+++ b/Sources/AnglesiteCore/CustomDomainAttachCommand.swift
@@ -5,6 +5,8 @@ import Foundation
 /// right after a successful `wrangler deploy` — best-effort, never turns a successful deploy into
 /// a failed one.
 public actor CustomDomainAttachCommand {
+    /// Outcome of one post-deploy attach attempt. Every case is deliberately non-fatal — the
+    /// deploy already succeeded, so callers report these, never fail on them.
     public enum Result: Sendable, Equatable {
         /// No transfer domain configured — nothing to do.
         case skipped
@@ -20,6 +22,8 @@ public actor CustomDomainAttachCommand {
 
     private let client: any CloudflareWriting
 
+    /// Creates the command. The default client talks to the live Cloudflare API; tests inject a
+    /// fake ``CloudflareWriting``.
     public init(client: any CloudflareWriting = HTTPCloudflareClient()) {
         self.client = client
     }

--- a/Sources/AnglesiteCore/DNSRecordLabeler.swift
+++ b/Sources/AnglesiteCore/DNSRecordLabeler.swift
@@ -3,6 +3,9 @@
 /// step. Order matters: more specific rules (DMARC/SPF/Bluesky) are checked before the generic
 /// TXT fallback.
 public enum DNSRecordLabeler {
+    /// The plain-English purpose label for `record`. Matching is case-insensitive across type,
+    /// name, and content; anything unrecognized becomes `"Other"` rather than surfacing a raw
+    /// record type at an owner who came here to publish a website, not to learn DNS.
     public static func label(for record: DNSRecord) -> String {
         let type = record.type.uppercased()
         let name = record.name.lowercased()

--- a/Sources/AnglesiteCore/DPoPKeyPair.swift
+++ b/Sources/AnglesiteCore/DPoPKeyPair.swift
@@ -107,7 +107,13 @@ public struct DPoPKeyPair: Sendable {
     }
 }
 
+/// Why a ``DPoPKeyPair`` operation couldn't run at all — distinct from a server-side proof
+/// rejection, which surfaces through the HTTP response instead.
 public enum DPoPError: Error, Sendable {
+    /// CryptoKit isn't available on this platform, so proofs can't be signed. This is a
+    /// deliberate dead end rather than a fallback: a platform without CryptoKit has no sign-in
+    /// UI either, so no code path should ever reach signing there (matches
+    /// `CloudflareOAuthClient.codeChallenge(for:)`'s posture).
     case unavailable
 }
 

--- a/Sources/AnglesiteCore/DeadAssetScanner.swift
+++ b/Sources/AnglesiteCore/DeadAssetScanner.swift
@@ -50,17 +50,45 @@ import Foundation
 /// alias with no matching `paths` entry stays unresolved and can flag a live file as unused. Same
 /// mitigation as the regex blind spots above: confirmation-gated, git-tracked delete.
 public enum DeadAssetScanner {
+    /// One file with zero resolved inbound references — something the Navigator's Cleanup
+    /// section *offers* for deletion, never deletes automatically: the regex-based extraction
+    /// documented on ``DeadAssetScanner`` can under-count references, so explicit user
+    /// confirmation (plus git recoverability) is the mitigation for that class of false positive.
     public struct CleanupCandidate: Sendable, Equatable, Identifiable {
+        /// The project-relative path, doubling as the stable identity — unique within a scan,
+        /// and stable across rescans so SwiftUI list diffs don't churn.
         public let id: String
+        /// Project-relative POSIX path of the unused file (e.g. `src/components/Old.astro`).
         public let path: String
+        /// Which class of file this is — drives the UI's grouping, iconography, and wording.
         public let kind: Kind
+        /// The file's content-modification time, so the UI can hint at how stale a candidate is
+        /// before the user decides whether to delete it.
         public let lastModified: Date
+        /// Resolved inbound references counted for this file. Always `0` for anything `scan`
+        /// returns — carried explicitly rather than implied so the UI can show the evidence
+        /// behind the "unused" claim instead of asserting it.
         public let referenceCount: Int
 
+        /// The only file classes ever offered for cleanup — deliberately narrow. JS/TS files are
+        /// never candidates (see ``DeadAssetScanner``'s non-goals: their import resolution has
+        /// materially more edge cases than this scanner attempts).
         public enum Kind: String, Sendable, Equatable, CaseIterable {
-            case component, layout, image, page
+            /// An unused `.astro` file under `src/components/`.
+            case component
+            /// An unused `.astro` file under `src/layouts/`.
+            case layout
+            /// An unused entry from the caller-supplied `images` list (typically
+            /// `public/images/**`).
+            case image
+            /// An orphan page — zero inbound *links*, not zero file references. Never produced
+            /// by `scan` itself; `ProjectCleanupReport.build` maps `LinkGraph` orphan pages into
+            /// this shape so the Cleanup section can present one merged list.
+            case page
         }
 
+        /// Memberwise initializer — public so `ProjectCleanupReport` (and tests) can synthesize
+        /// candidates that didn't come from a `scan` call, e.g. the orphan-page rows above.
         public init(id: String, path: String, kind: Kind, lastModified: Date, referenceCount: Int) {
             self.id = id
             self.path = path

--- a/Sources/AnglesiteCore/DefaultHealthCheckRunner.swift
+++ b/Sources/AnglesiteCore/DefaultHealthCheckRunner.swift
@@ -14,6 +14,10 @@ public struct DefaultHealthCheckRunner: HealthCheckRunner {
     private let resolveBuildCommand: @Sendable (URL) -> DeployCommand.LaunchPlan
     private let preflight: DeployCommand.PreflightChecker
 
+    /// Every dependency is an injectable seam with a production default, so tests can drive a
+    /// full health run without spawning real processes; note the *build* default is
+    /// ``DeployCommand/resolveBuildCommand`` (which reports host-Node retirement), so a
+    /// default-constructed runner only works where a container runtime injects a real resolver.
     public init(
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
@@ -26,6 +30,10 @@ public struct DefaultHealthCheckRunner: HealthCheckRunner {
         self.preflight = preflight
     }
 
+    /// Builds the site, then scans the fresh `dist/` — the `HealthCheckRunner` requirement.
+    /// Any non-zero/terminated build throws `HealthRunnerError.build(_:)` with a human-readable
+    /// reason; a scan that ran but found problems is *not* a throw — it comes back as the
+    /// returned outcome, so the badge can render the remediation `PreDeployCheck` computed.
     public func run(siteID: String, siteDirectory: URL) async throws -> PreDeployCheck.Outcome {
         // 1. Build. Stream output under a health-namespaced source so the Debug pane
         //    can distinguish health rebuilds from deploy rebuilds.

--- a/Sources/AnglesiteCore/DependencyBaseline.swift
+++ b/Sources/AnglesiteCore/DependencyBaseline.swift
@@ -6,6 +6,8 @@ import Foundation
 /// check ran). This is app-owned state, never committed to the site's git repo
 /// (`Config/` is outside `Source/` — see the `.anglesite` package model).
 public enum DependencyBaseline {
+    /// The baseline's file name inside a site's `Config/` directory — exposed so scaffolding,
+    /// import, and tests all point at the same file instead of re-hardcoding the name.
     public static let filename = "dependency-baseline.json"
 
     /// `nil` (not a throw) when the file is absent or unreadable — that's the
@@ -16,6 +18,9 @@ public enum DependencyBaseline {
         return try? JSONDecoder().decode([String: String].self, from: data)
     }
 
+    /// Atomically replaces the baseline with `packages`. Written at scaffold time and again by
+    /// ``DependencySyncApplier`` after an accepted update, so the *next* 3-way diff treats the
+    /// just-applied ranges as "never touched by the user" rather than re-offering them.
     public static func save(_ packages: [String: String], to configDirectory: URL) throws {
         let url = configDirectory.appendingPathComponent(filename)
         let data = try JSONEncoder().encode(packages)

--- a/Sources/AnglesiteCore/DependencySync.swift
+++ b/Sources/AnglesiteCore/DependencySync.swift
@@ -1,9 +1,15 @@
 /// One offered version-range bump for a single package.
 public struct DependencyUpdateOffer: Sendable, Equatable {
+    /// The npm package name, exactly as it appears in `package.json`'s dependency maps.
     public let name: String
+    /// The version range currently in the site's `package.json` — shown to the user so the
+    /// offer reads as a concrete before/after, not just "an update is available".
     public let currentRange: String
+    /// The bundled template's newer range that replaces `currentRange` if the offer is accepted.
     public let offeredRange: String
 
+    /// Memberwise initializer — offers are normally produced by ``DependencySync/diff(site:baseline:template:)``;
+    /// this exists so tests (and previews) can construct them directly.
     public init(name: String, currentRange: String, offeredRange: String) {
         self.name = name
         self.currentRange = currentRange
@@ -16,6 +22,12 @@ public struct DependencyUpdateOffer: Sendable, Equatable {
 /// offers a version bump for a package present in both the site and the template —
 /// never adds or removes a package name.
 public enum DependencySync {
+    /// Computes the offers: for every package present in both `site` and `template` where the
+    /// template's range is strictly newer (per `DependencyVersionComparator`), offer the bump —
+    /// but when a `baseline` exists, only if the site's range still matches it, i.e. the user
+    /// never touched that package since scaffolding; a hand-edited range is theirs to keep.
+    /// `baseline == nil` is the legacy fallback for pre-baseline sites: a straight
+    /// site-vs-template diff (spec §3). Results are sorted by package name for stable UI order.
     public static func diff(
         site: [String: String],
         baseline: [String: String]?,

--- a/Sources/AnglesiteCore/DependencySyncApplier.swift
+++ b/Sources/AnglesiteCore/DependencySyncApplier.swift
@@ -8,11 +8,24 @@ import Foundation
 /// are best-effort (`try?`) once the package.json rewrite itself has succeeded —
 /// none of them are things the user's file-open flow should hard-fail on.
 public enum DependencySyncApplier {
+    /// The only failures `apply` surfaces — both about the `package.json` rewrite itself. Every
+    /// later step (lockfile delete, baseline save, version stamp) is deliberately best-effort
+    /// and never reaches the caller (see the type doc comment).
     public enum ApplyError: Error, Equatable {
+        /// `Source/package.json` couldn't be read — nothing was modified.
         case readFailed
+        /// The rewritten `package.json` couldn't be written back; the atomic write means the
+        /// original file is still intact.
         case writeFailed
     }
 
+    /// Applies accepted `offers` to the site: rewrites `Source/package.json`'s version ranges,
+    /// then best-effort deletes the stale lockfile, folds the offered ranges into the
+    /// ``DependencyBaseline``, and stamps `.site-config`'s `ANGLESITE_VERSION` with
+    /// `runningAppVersion` so ``DependencySyncChecker``'s fast-path gate skips this site until
+    /// the app itself updates again.
+    /// - Throws: `ApplyError` only when `package.json` can't be read or written — the one step
+    ///   whose failure would leave the offer silently unapplied.
     public static func apply(
         _ offers: [DependencyUpdateOffer],
         sourceDirectory: URL,

--- a/Sources/AnglesiteCore/DependencySyncChecker.swift
+++ b/Sources/AnglesiteCore/DependencySyncChecker.swift
@@ -5,6 +5,12 @@ import Foundation
 /// unreadable/malformed input degrades to "nothing to offer" (spec §7), since
 /// this is a diagnostic convenience feature that must never block a site opening.
 public enum DependencySyncChecker {
+    /// Runs the whole check for one site, returning the offers to surface (empty = nothing to
+    /// show). The fast path: when `.site-config`'s `ANGLESITE_VERSION` stamp already matches
+    /// `runningAppVersion`, this app version has previously scaffolded or synced the site, so
+    /// the package.json reads and 3-way diff are skipped entirely (spec §3.1) — the stamp is
+    /// what keeps this cheap enough to run on every site open. Any unreadable or malformed
+    /// input degrades to `[]` per the type contract.
     public static func check(
         sourceDirectory: URL,
         configDirectory: URL,

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -30,7 +30,12 @@ import Foundation
 /// executor wraps its `waitForExit` in a cancellation handler that SIGTERMs the in-flight
 /// subprocess), so a cancelled build/wrangler is actually killed rather than orphaned.
 public actor DeployCommand {
+    /// Terminal outcome of one `deploy(...)` call. Every failure mode is a case, not a thrown
+    /// error — `deploy` never throws, so UI callers switch exhaustively over this instead of
+    /// also maintaining a separate error path.
     public enum Result: Sendable, Equatable {
+        /// Wrangler exited 0 and a deployed URL was parsed from its output. `duration` covers
+        /// the wrangler step only — build and preflight time are excluded.
         case succeeded(url: URL, duration: TimeInterval)
         /// The pre-deploy security scan refused the deploy. Carries the structured
         /// failures (and any warnings) so the UI can render a sheet with no override.
@@ -49,10 +54,17 @@ public actor DeployCommand {
 
     /// How to run a subprocess for a site directory — or why it can't be run.
     public enum LaunchPlan: Sendable, Equatable {
+        /// Spawn `executable` with `arguments` (the caller supplies cwd and environment).
         case run(executable: URL, arguments: [String])
+        /// The command can't run at all in this configuration; `reason` is user-facing text
+        /// (e.g. `HostNodeRetirement`'s explanation) surfaced instead of a spawn attempt.
         case unavailable(reason: String)
     }
 
+    /// Maps a site directory to how — or whether — a deploy-related subprocess can run there.
+    /// The host-side defaults on this type (`resolveBuildCommand`, `resolveWranglerCommand`) all
+    /// return `.unavailable` since embedded Node was retired; container runtimes inject real
+    /// resolvers.
     public typealias CommandResolver = @Sendable (_ siteDirectory: URL) -> LaunchPlan
     /// Returns the Cloudflare API token, or `nil` if none is configured. Production callers use
     /// `DeployCommand.keychainTokenSource` (Keychain with an env-var fallback for development);
@@ -78,6 +90,10 @@ public actor DeployCommand {
     /// inject a fake list or a throwing closure.
     public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
 
+    /// The token seam this command was constructed with. Exposed so `DeployModel.runDeploy` can
+    /// forward the exact same seam into companion commands (e.g. `SocialWorkerProvisionCommand`)
+    /// instead of letting them silently default to the production implementation and diverge
+    /// from a test's injected fake — see `workerScriptNamesSource` below for the full rationale.
     public nonisolated let tokenSource: TokenSource
     /// Exposed (like `tokenSource`) so callers that build a parallel `SocialWorkerProvisionCommand`
     /// alongside this `DeployCommand` — `DeployModel.runDeploy` — can forward the exact same seam
@@ -90,6 +106,10 @@ public actor DeployCommand {
     public nonisolated let customDomainAttachCommand: CustomDomainAttachCommand
     private let executor: any DeployExecutor
 
+    /// All four dependencies are injectable seams with production defaults, so tests can drive a
+    /// full deploy — token gate, name-conflict check, every step — with a literal token, a
+    /// canned script-name list, and a scripted executor, never touching the network or spawning
+    /// a process.
     public init(
         tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
         workerScriptNamesSource: @escaping WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -18,6 +18,10 @@ public enum DeployCoordinator {
     /// baseline and the resolved `[WorkerDescriptor]`s `SocialWorkerProvisionCommand.provision`
     /// takes directly now that composition is descriptor-driven (#708).
     public struct WorkerActivationPlan: Sendable, Equatable {
+        /// The worker ids that will actually deploy — explicit user activations plus
+        /// content-triggered ones, per `WorkerActivation.effectiveActiveIDs`. The other three
+        /// fields are all derived from this set; it's carried alongside them because it also
+        /// becomes the *next* deploy's `lastDeployedWorkerIDs` baseline on success.
         public let effectiveActiveIDs: Set<String>
         /// Ids present in the previous deploy's baseline but not in `effectiveActiveIDs` — the
         /// caller decides whether/how to surface this (`DeployModel` logs it to the debug pane).
@@ -31,6 +35,9 @@ public enum DeployCoordinator {
         /// to the debug pane, mirroring `SiteOperations.deployWithWorkerComposition`).
         public let unresolvedIDs: Set<String>
 
+        /// Memberwise initializer — plans are normally produced by
+        /// ``DeployCoordinator/planWorkerActivation(siteID:siteDirectory:settings:catalog:contentGraph:)``;
+        /// this exists so tests can construct one directly.
         public init(
             effectiveActiveIDs: Set<String>, removedIDs: Set<String>,
             workers: [WorkerDescriptor], unresolvedIDs: Set<String>
@@ -78,13 +85,6 @@ public enum DeployCoordinator {
         )
     }
 
-    /// Worker-name resolution precedence (#740): prefer the site's already-established Worker name
-    /// (`.site-config`'s `CF_PROJECT_NAME`, set at the first successful deploy or by a
-    /// worker-name-conflict rename) over re-deriving one from the site's display name. Falling back
-    /// to re-derivation on every deploy would silently regenerate `wrangler.toml` under the
-    /// original (still-taken) name basis after a rename-and-retry, defeating the rename. Only a
-    /// genuinely first-ever deploy (no candidate name recorded yet) falls through to the derived
-    /// slug of `siteName ?? siteID`.
     /// The `LogCenter` source tags whose lines feed the Deploy drawer's visible/copyable log
     /// (`DeployModel.logLines`, filtered from the shared subscription by `sources.contains`).
     /// Must list every source a deploy-time subprocess can log under, or its output is silently
@@ -103,6 +103,13 @@ public enum DeployCoordinator {
         ["deploy:\(siteID)", "deploy:\(siteID):build", "worker-provision:\(siteID)"]
     }
 
+    /// Worker-name resolution precedence (#740): prefer the site's already-established Worker name
+    /// (`.site-config`'s `CF_PROJECT_NAME`, set at the first successful deploy or by a
+    /// worker-name-conflict rename) over re-deriving one from the site's display name. Falling back
+    /// to re-derivation on every deploy would silently regenerate `wrangler.toml` under the
+    /// original (still-taken) name basis after a rename-and-retry, defeating the rename. Only a
+    /// genuinely first-ever deploy (no candidate name recorded yet) falls through to the derived
+    /// slug of `siteName ?? siteID`.
     public static func resolveWorkerSiteName(siteDirectory: URL, siteID: String, siteName: String?) -> String {
         let existingConfig = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
         return SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: existingConfig)


### PR DESCRIPTION
## Summary

- Phase 4 of the doc-comment retrofit tracked in #1141: second alphabetical chunk of AnglesiteCore (42 files, `CommunityActorResolver` … `DeployCoordinator`, ~370 doc comments) — community clients, the component model/outline/palette and edit builders, content assistant/creation/scaffold/scanner/type registry, the copy-edit pipeline, dependency sync, and the deploy command/coordinator.
- Two accuracy fixes to existing docs found along the way: `ComponentModelClient.ModelError.notConnected` carried `toolFailed`'s envelope-code text (now each case documents itself), and `DeployCoordinator`'s #740 worker-name-precedence paragraph sat on `deployLogSources` instead of `resolveWorkerSiteName`, which it describes.
- Single-line enum `case` lists split so each case carries its rationale; raw values and `CaseIterable` order unchanged. Comments only otherwise — no behavior changes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` — clean.
- [x] `swift test --filter AnglesiteCoreTests` — 3,050 tests in 384 suites; 2 failures, both the known "FoundationModelAssistant" concurrent-`swift test` FM-contention flake (same two tests fail identically on unmodified checkouts — see #1148/#1152). `FoundationModelAssistant.swift` is not touched by this diff.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run separately; comments-only diff, target compiles during DocC symbol-graph extraction.
