### PR TITLE
docs(#1141): retrofit doc comments, Core DeployExec-HTTPCF

### DIFF
--- a/Sources/AnglesiteCore/DeployExecutor.swift
+++ b/Sources/AnglesiteCore/DeployExecutor.swift
@@ -25,9 +25,15 @@ public enum DeployStep: Sendable {
 /// - `output`: captured stdout, used for URL/scan parsing by the caller. Also streamed
 ///   line-by-line to `LogCenter` under the caller-supplied source during execution.
 public struct DeployStepResult: Sendable, Equatable {
+    /// The process exit code, or `nil` for pre-spawn failures — see the type-level convention
+    /// above.
     public let exitCode: Int32?
+    /// Captured stdout for the caller to parse — see the type-level note above; the same lines
+    /// were already streamed live to `LogCenter` during execution.
     public let output: String
 
+    /// Memberwise initializer — public so executors in other files (and test fakes) can
+    /// construct results directly.
     public init(exitCode: Int32?, output: String) {
         self.exitCode = exitCode
         self.output = output
@@ -45,6 +51,12 @@ public struct DeployStepResult: Sendable, Equatable {
 /// The `source` parameter is the `LogCenter` source tag (e.g. `"deploy:<id>:build"`,
 /// `"deploy:<id>"`). Callers supply it so the right log row receives the output.
 public protocol DeployExecutor: Sendable {
+    /// Runs one deploy step at `siteDirectory`, streaming output to `LogCenter` under `source`.
+    ///
+    /// Deliberately non-throwing: every failure mode (unavailable substrate, spawn failure,
+    /// non-zero exit, cancellation) is encoded in ``DeployStepResult`` instead, so
+    /// ``DeployCommand`` renders one uniform failure path rather than juggling thrown errors
+    /// alongside exit codes.
     func run(
         step: DeployStep,
         siteDirectory: URL,
@@ -70,8 +82,14 @@ public protocol DeployExecutor: Sendable {
 }
 
 public extension DeployExecutor {
+    /// Default: no claims — an executor must override to opt in only when it can prove path
+    /// ownership (see the requirement's doc), so a new executor never inherits a speculative
+    /// claim by accident.
     func reportOwnedPathClaims() async -> [RuntimeOwnedPathClaim] { [] }
 
+    /// Default: `.unsupported`, so callers can tell "this substrate has no manifest seam" apart
+    /// from a build that ran and produced no findings — the distinction #744's cross-owner
+    /// collision protection depends on (see the requirement's doc).
     func runBuildWithClaimManifest(
         siteDirectory: URL,
         environment: [String: String],
@@ -97,6 +115,8 @@ public struct ContainerDeployExecutor: DeployExecutor {
     private let siteID: String
     private let logCenter: LogCenter
 
+    /// Creates an executor that runs steps in `siteID`'s container through `control`.
+    /// `logCenter` is injectable for tests; production uses the shared instance.
     public init(
         control: any LocalContainerControl,
         siteID: String,
@@ -109,6 +129,12 @@ public struct ContainerDeployExecutor: DeployExecutor {
 
     // MARK: DeployExecutor
 
+    /// Runs `step` in the guest at `/workspace/site`, streaming output live to `LogCenter`.
+    ///
+    /// `siteDirectory` is the HOST path — the guest always executes in its own boot-time clone.
+    /// The host path is consulted only where the clone can be stale or incomplete: the #1084
+    /// `wrangler.toml` re-sync before `.wrangler`, and `.site-config`'s `CF_SOURCE_BUCKET` for
+    /// `.bundleUpload` (see the inline rationale for both).
     public func run(
         step: DeployStep,
         siteDirectory: URL,
@@ -224,6 +250,12 @@ public struct ContainerDeployExecutor: DeployExecutor {
     /// for the same "never inside Source/" reason.
     static let wellKnownResultGuestPath = "/tmp/anglesite-wellknown-result.json"
 
+    /// Runs the `.build` step with the #748 claim manifest delivered through `/tmp` scratch
+    /// files in the guest (never `/workspace/site` — see the path constants above), then splits
+    /// the seam's JSON result blob out of stdout at the marker line so the ordinary build output
+    /// still reaches the caller intact. An encode failure or exec error degrades to
+    /// `.completed` with an empty seam result rather than throwing — same non-throwing contract
+    /// as ``run(step:siteDirectory:environment:source:)``.
     public func runBuildWithClaimManifest(
         siteDirectory: URL,
         environment: [String: String],
@@ -405,6 +437,9 @@ public struct HostDeployExecutor: DeployExecutor {
     /// Injectable per-step command resolver. Defaults to `HostDeployExecutor.defaultResolver`.
     private let resolveCommand: @Sendable (DeployStep) -> DeployCommand.CommandResolver
 
+    /// Creates a host-process executor. Inject `resolveCommand` in tests to point each step at a
+    /// shell fixture; the production default (``defaultResolver``) reports every step
+    /// unavailable, per the host-Node retirement rationale in the type doc.
     public init(
         supervisor: ProcessSupervisor = .shared,
         logCenter: LogCenter = .shared,
@@ -418,6 +453,10 @@ public struct HostDeployExecutor: DeployExecutor {
 
     // MARK: DeployExecutor
 
+    /// Resolves `step` to a host command and spawns it via `ProcessSupervisor`. An
+    /// `.unavailable` resolution short-circuits to a nil-exit-code result carrying the reason as
+    /// its output — the same shape a pre-spawn failure takes, so callers surface both
+    /// identically.
     public func run(
         step: DeployStep,
         siteDirectory: URL,

--- a/Sources/AnglesiteCore/DeployFailureSummary.swift
+++ b/Sources/AnglesiteCore/DeployFailureSummary.swift
@@ -4,10 +4,16 @@ import Foundation
 /// `DeployDrawerView`, and CI-run `AnglesiteCore` tests can all reference it; the `@Generable`
 /// counterpart (`GeneratedDeployFailureSummary`) lives behind the FoundationModels gate.
 public struct DeployFailureSummary: Equatable, Sendable {
+    /// What went wrong, phrased for the site owner rather than in build-log terms.
     public let summary: String
+    /// The model's best guess at the root cause — a guess, so views present it as such rather
+    /// than as a diagnosis.
     public let likelyCause: String
+    /// The concrete next step the owner can take.
     public let suggestedFix: String
 
+    /// Memberwise initializer — public so the gated FoundationModels summarizer (and test
+    /// fixtures) can construct summaries from outside this file.
     public init(summary: String, likelyCause: String, suggestedFix: String) {
         self.summary = summary
         self.likelyCause = likelyCause
@@ -19,12 +25,17 @@ public struct DeployFailureSummary: Equatable, Sendable {
 /// gated `AssistantContext`) so the protocol stays compilable on CI. A `nil` return means the
 /// on-device model was unavailable or generation failed — callers fall back to the raw log.
 public protocol DeployFailureSummarizing: Sendable {
+    /// Summarizes an already-digested failure log (callers pass `DeployLogDigest` output, not
+    /// the full raw log) — `nil` per the protocol doc's fallback contract.
     func summarize(failureLog: String, siteID: String, siteDirectory: URL) async -> DeployFailureSummary?
 }
 
 /// Fallback conformer used when `FoundationModels` isn't compiled in (CI / pre-Xcode-27).
 public struct NoopDeploySummarizer: DeployFailureSummarizing {
+    /// Creates the no-op summarizer; it holds no state.
     public init() {}
+    /// Always `nil`, which forces callers onto the raw-log fallback — the correct behavior when
+    /// no on-device model exists to summarize with.
     public func summarize(failureLog: String, siteID: String, siteDirectory: URL) async -> DeployFailureSummary? {
         nil
     }

--- a/Sources/AnglesiteCore/DeployFailureSummaryRequest.swift
+++ b/Sources/AnglesiteCore/DeployFailureSummaryRequest.swift
@@ -4,6 +4,10 @@ import Foundation
 /// target has no CI-run test bundle). Digests the raw log and short-circuits empty input before
 /// touching the model.
 public enum DeployFailureSummaryRequest {
+    /// Digests `logText` via ``DeployLogDigest`` and asks `summarizer` for a summary. Returns
+    /// `nil` without ever invoking the summarizer when the digest comes back empty — there is
+    /// nothing meaningful to summarize, and prompting the on-device model with empty input would
+    /// only waste its token budget and produce a hallucinated answer.
     public static func run(
         logText: String,
         siteID: String,

--- a/Sources/AnglesiteCore/DeployedRoutesSnapshot.swift
+++ b/Sources/AnglesiteCore/DeployedRoutesSnapshot.swift
@@ -5,6 +5,8 @@ import Foundation
 /// `DependencyBaseline`'s precedent), used solely as the "previous" side of
 /// `RouteCoverageScanner`'s diff.
 public enum DeployedRoutesSnapshot {
+    /// The snapshot's filename inside the package's `Config/` directory — public so tests and
+    /// callers resolve the same path this type reads and writes.
     public static let filename = "last-deployed-routes.json"
 
     /// `nil` (not a throw) when the file is absent or unreadable — the normal "no prior deploy
@@ -15,6 +17,9 @@ public enum DeployedRoutesSnapshot {
         return try? JSONDecoder().decode([String].self, from: data)
     }
 
+    /// Writes the route set, deduplicated and sorted so identical route sets always produce
+    /// byte-identical files (stable diffs), and atomically so a crash mid-write can't leave a
+    /// torn snapshot for the next ``load(from:)`` to misread as "no prior deploy."
     public static func save(_ routes: [String], to configDirectory: URL) throws {
         let url = configDirectory.appendingPathComponent(filename)
         let data = try JSONEncoder().encode(Array(Set(routes)).sorted())

--- a/Sources/AnglesiteCore/DesignApplyService.swift
+++ b/Sources/AnglesiteCore/DesignApplyService.swift
@@ -1,26 +1,52 @@
 // Sources/AnglesiteCore/DesignApplyService.swift
 import Foundation
 
+/// One design-apply request: the CSS tokens to write plus the human-readable documents that
+/// record why the design looks the way it does. Keeping the docs alongside the tokens means a
+/// design is never applied without its rationale landing in the repo too.
 public struct DesignApplyInput: Sendable {
+    /// CSS custom properties to upsert into `global.css`'s top-level `:root` block, keyed
+    /// *without* the `--` prefix (``DesignApplyService`` adds it). Empty means "no CSS change" —
+    /// the docs are still written (see the inline note in `apply`).
     public let cssVars: [String: String]
+    /// Full design rationale for `docs/DESIGN.md`; `nil` skips that file entirely (the file is
+    /// overwritten, not appended — it documents the *current* design).
     public let rationaleMarkdown: String?
+    /// Short brand description appended to `docs/brand.md` under a ``sourceLabel`` heading —
+    /// appended, not overwritten, so the brand doc accumulates a history of applied designs.
     public let brandSummary: String
+    /// Names the flow that produced this design (e.g. `design-interview`); becomes the heading
+    /// of the `docs/brand.md` entry so successive applies stay attributable to their source.
     public let sourceLabel: String
 
+    /// Memberwise initializer — public so both design flows (theme wizard and interview) can
+    /// build inputs from outside this file.
     public init(cssVars: [String: String], rationaleMarkdown: String?, brandSummary: String, sourceLabel: String) {
         self.cssVars = cssVars; self.rationaleMarkdown = rationaleMarkdown
         self.brandSummary = brandSummary; self.sourceLabel = sourceLabel
     }
 }
 
+/// Receipt of a successful apply — what changed, for callers to surface in confirmation UI.
 public struct AppliedDesign: Sendable, Equatable {
+    /// The CSS vars that were written (echoes the input's `cssVars`; empty when the apply was
+    /// docs-only).
     public let updatedVars: [String: String]
+    /// `Source/`-relative paths of every file written, in write order.
     public let writtenFiles: [String]
 }
 
+/// Why an apply failed. Distinguishes "the template file the tokens live in is missing or
+/// malformed" (the first two cases — nothing was written) from a mid-write I/O failure, where
+/// knowing what *did* get written matters.
 public enum DesignApplyError: Error, Sendable, Equatable {
+    /// `src/styles/global.css` couldn't be read — without it there is nowhere to put the tokens.
     case missingGlobalCSS
+    /// `global.css` exists but has no top-level `:root { }` block to upsert into; the service
+    /// refuses to guess a scope rather than inject tokens somewhere they'd be shadowed.
     case missingRootBlock
+    /// A write failed partway. `partiallyWritten` lists the `Source/`-relative paths already on
+    /// disk, so callers can report exactly what changed instead of implying nothing did.
     case writeFailed(message: String, partiallyWritten: [String])
 }
 
@@ -32,6 +58,14 @@ public enum DesignApplyService {
     static let rationaleRelativePath = "docs/DESIGN.md"
     static let brandRelativePath = "docs/brand.md"
 
+    /// Applies `input` to a site's `Source/` directory: upserts the CSS vars into `global.css`
+    /// (skipped when `cssVars` is empty — see the inline note), overwrites `docs/DESIGN.md` with
+    /// the rationale, and appends the brand summary to `docs/brand.md`.
+    ///
+    /// Returns `Result` rather than throwing so the partial-write list travels with the failure
+    /// (see ``DesignApplyError/writeFailed(message:partiallyWritten:)``). The CSS write happens
+    /// first: it's the one step that can fail *before* writing anything, so a failure there
+    /// leaves the site untouched.
     public static func apply(
         _ input: DesignApplyInput,
         to sourceDirectory: URL,
@@ -164,6 +198,9 @@ public enum DesignApplyService {
 }
 
 public extension DesignApplyService {
+    /// Package-typed convenience: resolves the `.anglesite` package's `Source/` directory and
+    /// applies there, so callers holding an `AnglesitePackage` don't reach into its layout
+    /// themselves.
     static func apply(
         _ input: DesignApplyInput,
         to package: AnglesitePackage,

--- a/Sources/AnglesiteCore/DesignAxes.swift
+++ b/Sources/AnglesiteCore/DesignAxes.swift
@@ -13,13 +13,22 @@ public struct DesignAxes: Sendable, Equatable, Codable {
     /// Subtle (0) <-> Bold (1)
     public var voice: Double
 
+    /// Memberwise initializer. Values are not clamped here — use
+    /// ``DesignAxesCatalog/adjusted(_:by:)`` for clamped mutation and
+    /// ``DesignAxesCatalog/isValid(_:)`` to vet axes from untrusted (persisted or
+    /// model-generated) sources.
     public init(temperature: Double, weight: Double, register: Double, time: Double, voice: Double) {
         self.temperature = temperature; self.weight = weight; self.register = register
         self.time = time; self.voice = voice
     }
 }
 
+/// Business-type presets and helpers for ``DesignAxes`` — the deterministic seed the design
+/// interview starts from, so an owner who skips the conversation entirely still gets a
+/// defensible default for their kind of business. Ported from the plugin's `scripts/design.ts`.
 public enum DesignAxesCatalog {
+    /// Neutral fallback for unknown or empty business types — deliberately a touch airy and
+    /// subtle rather than dead-center on every axis, matching the plugin's tuning.
     public static let balanced = DesignAxes(temperature: 0.5, weight: 0.4, register: 0.5, time: 0.5, voice: 0.4)
 
     /// Business-type -> default axes. Verbatim port of `BUSINESS_AXES` in `scripts/design.ts`.
@@ -82,6 +91,10 @@ public enum DesignAxesCatalog {
         return result
     }
 
+    /// `true` when every axis is a non-NaN value in [0, 1]. Guards axes that arrive from data
+    /// this module didn't produce (persisted config, model-generated values) —
+    /// ``adjusted(_:by:)`` already clamps its own writes, so this check exists for the paths
+    /// that bypass it.
     public static func isValid(_ axes: DesignAxes) -> Bool {
         [axes.temperature, axes.weight, axes.register, axes.time, axes.voice]
             .allSatisfy { !$0.isNaN && $0 >= 0 && $0 <= 1 }

--- a/Sources/AnglesiteCore/DesignConfigGenerator.swift
+++ b/Sources/AnglesiteCore/DesignConfigGenerator.swift
@@ -1,36 +1,66 @@
 import Foundation
 
+/// The generated font choices, as literal CSS `font-family` stacks ready to drop into custom
+/// properties — system/web-safe fonts only, so no font files ever ship with the site.
 public struct DesignTypography: Sendable, Equatable, Codable {
+    /// Font stack for headings and other display text.
     public let display: String
+    /// Font stack for body copy.
     public let body: String
+    /// Stable identifier naming the chosen combination (e.g. `classic-serif+modern-sans`) —
+    /// recorded in the design rationale so a human can tell which pairing won without diffing
+    /// font stacks.
     public let pairing: String
+    /// Memberwise initializer.
     public init(display: String, body: String, pairing: String) { self.display = display; self.body = body; self.pairing = pairing }
 }
 
+/// The generated spacing scale, smallest to largest, as literal CSS lengths (`rem` strings) so
+/// values flow straight into custom properties without a formatting step downstream.
 public struct DesignSpacing: Sendable, Equatable, Codable {
+    /// The five scale steps, smallest (`xs`) to largest (`xl`).
     public let xs, sm, md, lg, xl: String
+    /// Memberwise initializer.
     public init(xs: String, sm: String, md: String, lg: String, xl: String) {
         self.xs = xs; self.sm = sm; self.md = md; self.lg = lg; self.xl = xl
     }
 }
 
+/// The generated corner radii and box shadows, as literal CSS values — same "ready to write"
+/// rationale as ``DesignSpacing``.
 public struct DesignShape: Sendable, Equatable, Codable {
+    /// Radii (small/medium/large) and shadows (small/medium) as CSS value strings.
     public let radiusSm, radiusMd, radiusLg, shadowSm, shadowMd: String
+    /// Memberwise initializer.
     public init(radiusSm: String, radiusMd: String, radiusLg: String, shadowSm: String, shadowMd: String) {
         self.radiusSm = radiusSm; self.radiusMd = radiusMd; self.radiusLg = radiusLg
         self.shadowSm = shadowSm; self.shadowMd = shadowMd
     }
 }
 
+/// The complete generated design for one site — the single artifact ``DesignTokenWriter`` turns
+/// into template CSS vars and rationale markdown. `Codable` and carrying its own inputs
+/// (``axes``, ``siteType``, ``brandColor``) so a design can be persisted and regenerated or
+/// audited later without replaying the interview that produced it.
 public struct DesignConfig: Sendable, Equatable, Codable {
+    /// The axis positions this config was generated from.
     public let axes: DesignAxes
+    /// The generated color palette.
     public let palette: DesignPalette
+    /// The generated font pairing.
     public let typography: DesignTypography
+    /// The generated spacing scale.
     public let spacing: DesignSpacing
+    /// The generated radii and shadows.
     public let shape: DesignShape
+    /// The business type the design was generated for — an input, kept for provenance.
     public let siteType: String
+    /// The owner's brand color the palette was anchored to, or `nil` when it was derived from
+    /// the axes alone — also an input, kept for provenance.
     public let brandColor: String?
 
+    /// Memberwise initializer — prefer ``DesignConfigGenerator/config(axes:siteType:brandColor:)``,
+    /// which keeps the parts mutually consistent.
     public init(axes: DesignAxes, palette: DesignPalette, typography: DesignTypography,
                 spacing: DesignSpacing, shape: DesignShape, siteType: String, brandColor: String?) {
         self.axes = axes; self.palette = palette; self.typography = typography
@@ -38,6 +68,10 @@ public struct DesignConfig: Sendable, Equatable, Codable {
     }
 }
 
+/// Maps ``DesignAxes`` to a concrete ``DesignConfig`` with pure arithmetic — deterministic by
+/// design, so the same axes always regenerate the identical design with no model in the loop
+/// (the LLM's only job upstream is moving the axes; everything from there down is auditable
+/// math).
 public enum DesignConfigGenerator {
     private struct FontPairing {
         let display: String
@@ -69,6 +103,9 @@ public enum DesignConfigGenerator {
                     score: { $0.time * 1 + $0.temperature * 0.8 + (1 - $0.register) * 0.8 }),
     ]
 
+    /// Picks the highest-scoring built-in font pairing for `axes`. Each candidate scores itself
+    /// against the axes (see `fontPairings`), so adding a pairing means adding a scoring
+    /// closure, not editing a decision tree.
     public static func typography(for axes: DesignAxes) -> DesignTypography {
         let best = fontPairings.max { $0.score(axes) < $1.score(axes) } ?? fontPairings[0]
         return DesignTypography(display: best.display, body: best.body, pairing: best.pairing)
@@ -96,6 +133,9 @@ public enum DesignConfigGenerator {
         )
     }
 
+    /// Assembles the full ``DesignConfig`` from one set of axes — the single entry point (used
+    /// by `DesignInterviewModel.confirmAndApply`), so palette, typography, spacing, and shape
+    /// are always derived from the *same* axes and can't drift apart.
     public static func config(axes: DesignAxes, siteType: String, brandColor: String?) -> DesignConfig {
         DesignConfig(
             axes: axes,

--- a/Sources/AnglesiteCore/DesignInterviewDraft.swift
+++ b/Sources/AnglesiteCore/DesignInterviewDraft.swift
@@ -1,13 +1,44 @@
 import Foundation
 
+/// The fixed progression of the design interview. `Int`-raw so
+/// ``DesignInterviewDraft/advance()`` can step to the next stage numerically — declaration
+/// order is therefore load-bearing, not cosmetic.
 public enum ConversationStage: Int, Sendable, Equatable, CaseIterable {
-    case intent, mood, brandAnchor, axisConfirmation, done
+    /// What the site is for and who it's for — deliberately no visual-style talk yet.
+    case intent
+    /// The visual mood the owner wants, reflected back to them as axis shifts.
+    case mood
+    /// Whether an existing brand color or reference look should anchor the design.
+    case brandAnchor
+    /// Plain-language summary of the resulting axes for the owner to confirm or adjust.
+    case axisConfirmation
+    /// Interview complete; the design has been applied.
+    case done
 }
 
 /// A fixed nudge applied to one axis when the user's free text names a direction rather than a
 /// slider value (e.g. "make it warmer"). Each hint moves its axis by a flat 0.15, clamped to [0,1].
 public enum DesignAdjectiveHint: String, Sendable, CaseIterable {
-    case warmer, cooler, denser, airier, moreAuthoritative, morePlayful, moreClassic, moreContemporary, bolder, subtler
+    /// ``DesignAxes/temperature`` up — toward warm.
+    case warmer
+    /// ``DesignAxes/temperature`` down — toward cool.
+    case cooler
+    /// ``DesignAxes/weight`` up — toward dense.
+    case denser
+    /// ``DesignAxes/weight`` down — toward airy.
+    case airier
+    /// ``DesignAxes/register`` up — toward authoritative.
+    case moreAuthoritative
+    /// ``DesignAxes/register`` down — toward playful.
+    case morePlayful
+    /// ``DesignAxes/time`` down — toward classic.
+    case moreClassic
+    /// ``DesignAxes/time`` up — toward contemporary.
+    case moreContemporary
+    /// ``DesignAxes/voice`` up — toward bold.
+    case bolder
+    /// ``DesignAxes/voice`` down — toward subtle.
+    case subtler
 
     var keyPath: WritableKeyPath<DesignAxes, Double> {
         switch self {
@@ -27,13 +58,26 @@ public enum DesignAdjectiveHint: String, Sendable, CaseIterable {
     }
 }
 
+/// The mutable working state of one design interview — a plain value (no model or UI types), so
+/// the conversation's state transitions are testable without a live assistant and could be
+/// checkpointed cheaply.
 public struct DesignInterviewDraft: Sendable, Equatable {
+    /// Where the conversation currently is; stepped by ``advance()`` after each turn.
     public var stage: ConversationStage
+    /// The owner-declared business type — seeds ``axes`` and grounds every stage's prompt.
     public var businessType: String
+    /// Current axis positions: seeded from ``DesignAxesCatalog/defaults(forBusinessType:)``,
+    /// then refined by turns and ``applyAdjectiveHint(_:)`` nudges.
     public var axes: DesignAxes
+    /// The owner's brand color if one surfaced during the interview; `nil` lets the palette be
+    /// derived from the axes alone.
     public var brandColorHex: String?
+    /// Owner remarks that didn't map to a structured field — kept so nothing the owner said is
+    /// silently dropped when the draft is later reviewed or extended.
     public var freeTextNotes: [String]
 
+    /// Seeds a fresh draft at ``ConversationStage/intent`` with the business type's default
+    /// axes, so an owner who bails out early still has a usable design position.
     public init(businessType: String) {
         self.stage = .intent
         self.businessType = businessType
@@ -42,11 +86,15 @@ public struct DesignInterviewDraft: Sendable, Equatable {
         self.freeTextNotes = []
     }
 
+    /// Steps to the next ``ConversationStage``. A no-op at ``ConversationStage/done`` rather
+    /// than a trap, so the interview loop can advance unconditionally after every turn.
     public mutating func advance() {
         guard let next = ConversationStage(rawValue: stage.rawValue + 1) else { return }
         stage = next
     }
 
+    /// Applies `hint`'s fixed nudge to its axis, clamped via
+    /// ``DesignAxesCatalog/adjusted(_:by:)`` (see ``DesignAdjectiveHint`` for the magnitude).
     public mutating func applyAdjectiveHint(_ hint: DesignAdjectiveHint) {
         axes = DesignAxesCatalog.adjusted(axes, by: [hint.keyPath: hint.delta])
     }

--- a/Sources/AnglesiteCore/DesignInterviewModel.swift
+++ b/Sources/AnglesiteCore/DesignInterviewModel.swift
@@ -18,15 +18,26 @@ import AnglesiteSiteModel
 /// FoundationModels-gated implementation.
 @MainActor @Observable
 public final class DesignInterviewModel: Identifiable {
+    /// Stable identity so SwiftUI can distinguish multiple concurrent interviews (one per site
+    /// window) in lists and `ForEach`.
     public let id = UUID()
+    /// The conversation's working state. `internal(set)` so mutations flow through the model's
+    /// own methods — ``axisBinding(_:)`` is the deliberate slider-shaped exception.
     public internal(set) var draft: DesignInterviewDraft
+    /// Ordered (role, text) turns for the conversation view. Failures are appended as assistant
+    /// turns rather than thrown, so the view has exactly one rendering path.
     public internal(set) var transcript: [(role: String, text: String)] = []
+    /// Outcome of the most recent ``confirmAndApply()`` — `nil` until it has run; views key
+    /// their success/error presentation off this.
     public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
 
     private let assistant: any ConversationalAssistant
     private let package: AnglesitePackage
     private let siteID: String
 
+    /// Creates a model for one interview, seeding the draft from `businessType`'s default axes.
+    /// `assistant` is the injected seam described in the type doc — pass a fake in tests.
+    /// `siteID` only feeds `AssistantContext` attribution, hence the empty default.
     public init(businessType: String, assistant: any ConversationalAssistant, package: AnglesitePackage, siteID: String = "") {
         self.draft = DesignInterviewDraft(businessType: businessType)
         self.assistant = assistant
@@ -72,6 +83,8 @@ public final class DesignInterviewModel: Identifiable {
         draft.advance()
     }
 
+    /// Applies a directional adjective nudge ("warmer", "bolder", …) to the draft's axes — the
+    /// owner's low-friction alternative to dragging sliders.
     public func nudge(_ hint: DesignAdjectiveHint) {
         draft.applyAdjectiveHint(hint)
     }
@@ -95,6 +108,10 @@ public final class DesignInterviewModel: Identifiable {
         draft.stage = .axisConfirmation
     }
 
+    /// Generates the full ``DesignConfig`` from the confirmed axes and writes it through
+    /// ``DesignApplyService`` (the single design writer). Only a successful write advances the
+    /// stage to `.done` — a failed apply leaves the interview open so the owner can retry
+    /// instead of ending on an unapplied design.
     public func confirmAndApply() async {
         let config = DesignConfigGenerator.config(axes: draft.axes, siteType: draft.businessType, brandColor: draft.brandColorHex)
         let input = DesignApplyInput(
@@ -134,20 +151,31 @@ public extension DesignInterviewModel {
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
+/// Structured (`@Generable`) reply for one interview turn: the conversational text plus any
+/// per-axis deltas the model inferred from the owner's message. Feed the deltas through
+/// `DesignInterviewModel.applyTurnReplyDeltas(...)` — deliberately declared *outside* this
+/// compiler gate — so the clamping logic stays testable on toolchains without FoundationModels.
 @Generable
 public struct DesignInterviewTurnReply: Sendable {
+    /// The assistant's transcript-facing reply.
     @Guide(description: "Your conversational reply to the owner, 1-2 sentences.")
     public var replyText: String
+    /// Inferred change to the temperature axis; `nil` when the message implies none.
     @Guide(description: "Temperature axis change if the owner's message implies one, else omit.")
     public var temperatureDelta: Double?
+    /// Inferred change to the weight axis; `nil` when the message implies none.
     @Guide(description: "Weight axis change if the owner's message implies one, else omit.")
     public var weightDelta: Double?
+    /// Inferred change to the register axis; `nil` when the message implies none.
     @Guide(description: "Register axis change if the owner's message implies one, else omit.")
     public var registerDelta: Double?
+    /// Inferred change to the time axis; `nil` when the message implies none.
     @Guide(description: "Time axis change if the owner's message implies one, else omit.")
     public var timeDelta: Double?
+    /// Inferred change to the voice axis; `nil` when the message implies none.
     @Guide(description: "Voice axis change if the owner's message implies one, else omit.")
     public var voiceDelta: Double?
+    /// Hex brand color if the owner named one; `nil` otherwise.
     @Guide(description: "Hex color if the owner mentioned a brand color, else omit.")
     public var brandColorHex: String?
 }

--- a/Sources/AnglesiteCore/DesignInterviewPrompts.swift
+++ b/Sources/AnglesiteCore/DesignInterviewPrompts.swift
@@ -17,6 +17,9 @@ public enum DesignInterviewPrompts {
         return String(message.prefix(maxUserMessageCharacters)) + "…"
     }
 
+    /// Builds the grounding prompt for `stage`, folding the (truncated) owner message and the
+    /// draft's current facts into that stage's template. At ``ConversationStage/done`` there is
+    /// no stage left to ground, so the raw message passes through unchanged.
     public static func prompt(for stage: ConversationStage, draft: DesignInterviewDraft, userMessage: String) -> String {
         switch stage {
         case .intent: return intentPrompt(draft: draft, userMessage: userMessage)

--- a/Sources/AnglesiteCore/DesignInterviewTool.swift
+++ b/Sources/AnglesiteCore/DesignInterviewTool.swift
@@ -9,14 +9,25 @@ import FoundationModels
 /// starts or continues a session-scoped `DesignInterviewModel` the caller supplies, rather than
 /// owning conversation state itself.
 public struct DesignInterviewTool: Tool, Sendable {
+    /// Canonical tool name, exposed statically so call sites (tool registration, transcript
+    /// filtering) can reference it without constructing a tool instance.
     public static let toolName = "designInterview"
+    /// `Tool` requirement — always ``toolName``; the static exists so the name has one
+    /// spelling everywhere.
     public let name = DesignInterviewTool.toolName
+    /// `Tool` requirement — the model-facing summary the assistant uses to decide when to
+    /// invoke the interview.
     public let description = "Have a short conversation to design or redesign a site's look and feel."
 
+    /// Model-generated arguments for one interview turn. The `@Guide` descriptions are the
+    /// model-facing contract; keep them in sync with what `call(arguments:)` actually does.
     @Generable
     public struct Arguments {
+        /// The owner's message in this turn of the design conversation.
         @Guide(description: "The owner's message in this turn of the design conversation.")
         public var message: String
+        /// When `true`, the owner delegated the design entirely — `call(arguments:)` skips the
+        /// remaining questions and jumps straight to axis confirmation.
         @Guide(description: "Set to true if the owner wants Anglesite to just pick a design for them.")
         public var designForMe: Bool?
     }
@@ -30,9 +41,18 @@ public struct DesignInterviewTool: Tool, Sendable {
     public typealias ModelProvider = @Sendable () async throws -> DesignInterviewModel
 
     private let provider: ModelProvider
+    /// Wraps an already-constructed model in a constant provider — the GUI-sheet front door,
+    /// which owns its interview's lifetime directly.
     public init(model: DesignInterviewModel) { self.provider = { model } }
+    /// Takes a lazy provider — the chat front door (#665), which defers building the interview
+    /// until the assistant actually invokes the tool. See ``ModelProvider`` for why it throws.
     public init(provider: @escaping ModelProvider) { self.provider = provider }
 
+    /// One conversation turn. `designForMe == true` short-circuits the question flow
+    /// (``DesignInterviewModel``'s `skipToAxisConfirmation`) and returns a canned handoff
+    /// message; otherwise the owner's message is forwarded to the interview and the reply is
+    /// the interview's latest transcript entry — the tool relays conversation state, it never
+    /// synthesizes its own.
     public func call(arguments: Arguments) async throws -> String {
         let model = try await provider()
         if arguments.designForMe == true {

--- a/Sources/AnglesiteCore/DesignPaletteGenerator.swift
+++ b/Sources/AnglesiteCore/DesignPaletteGenerator.swift
@@ -2,20 +2,35 @@ import Foundation
 
 /// Color tokens for a generated design. Ported from the plugin's `scripts/design.ts` `Palette`.
 public struct DesignPalette: Sendable, Equatable, Codable {
+    /// Primary brand color (hex). Either the owner's own brand color verbatim, or derived
+    /// from the temperature axis when none was given.
     public let brand: String
+    /// Call-to-action color (hex) — hue-offset from ``brand`` (complementary for bold voice,
+    /// analogous otherwise) so CTAs read as related but distinct.
     public let accent: String
+    /// Page background (hex). Near-white normally; near-black when the axes select dark mode.
     public let bg: String
+    /// Raised-surface color for cards/panels (hex), one step off ``bg`` in the same hue family.
     public let surface: String
+    /// Body text color (hex) — contrast-corrected against ``bg`` to meet WCAG AA before the
+    /// palette is returned, so consumers can use it without re-checking.
     public let text: String
+    /// Secondary/muted text color (hex) — also contrast-corrected against ``bg``.
     public let muted: String
+    /// Hairline/divider color (hex).
     public let border: String
 
+    /// Memberwise initializer. All values are `#rrggbb` hex strings; ``DesignPaletteGenerator``
+    /// is the normal producer — construct directly only in tests or when decoding a stored design.
     public init(brand: String, accent: String, bg: String, surface: String, text: String, muted: String, border: String) {
         self.brand = brand; self.accent = accent; self.bg = bg; self.surface = surface
         self.text = text; self.muted = muted; self.border = border
     }
 }
 
+/// Namespace for deterministic palette derivation from ``DesignAxes``. A direct port of the
+/// plugin's `scripts/design.ts` color math — kept verbatim so the Swift path and the retired
+/// TypeScript path produce identical palettes for the same inputs.
 public enum DesignPaletteGenerator {
     /// Deterministic palette generation from design axes, ported verbatim from `generatePalette` in
     /// `scripts/design.ts`. If `brandColor` is a valid hex, it becomes the brand color and the rest

--- a/Sources/AnglesiteCore/DesignTokenWriter.swift
+++ b/Sources/AnglesiteCore/DesignTokenWriter.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// Translates a design — a generated ``DesignConfig`` or a built-in ``Theme`` — into the two
+/// artifacts the template actually consumes: the CSS custom-property values for
+/// `src/styles/global.css`, and the owner-facing `DESIGN.md` rationale. Pure string mapping;
+/// writing the files is the caller's job so this stays trivially testable.
 public enum DesignTokenWriter {
     /// Maps a generated ``DesignConfig`` onto the 12 CSS custom-property names
     /// `Resources/Template/src/styles/global.css` already declares. Tokens the engine computes but

--- a/Sources/AnglesiteCore/DomainOperationsService.swift
+++ b/Sources/AnglesiteCore/DomainOperationsService.swift
@@ -4,8 +4,16 @@ import Foundation
 /// `CloudflareError` for callers that want the detailed reason (e.g. to render the same
 /// messages `HardenModel` shows for its own Cloudflare calls).
 public enum DomainOperationError: Error, Equatable, Sendable {
+    /// No Cloudflare API token was available from the token provider (neither the
+    /// `CLOUDFLARE_API_TOKEN` env var nor the platform secret store) — the operation never
+    /// reached the network.
     case noToken
+    /// The token is valid but resolves no zone for `domain` — typically the domain isn't in
+    /// the token's Cloudflare account, or the token's zone scope excludes it.
     case zoneNotFound(domain: String)
+    /// Any Cloudflare API failure after zone resolution began, wrapping the underlying
+    /// ``CloudflareError``. Non-`CloudflareError` throws are folded into
+    /// ``CloudflareError/malformedResponse`` so this enum stays `Equatable`.
     case cloudflare(CloudflareError)
 }
 
@@ -14,18 +22,29 @@ public enum DomainOperationError: Error, Equatable, Sendable {
 /// `AnglesiteIntents` Domain intents (Siri) share one implementation, mirroring how
 /// `IntegrationOperationsService` backs both `IntegrationWizardModel` and `IntegrationIntents`.
 public protocol DomainOperationsService: Sendable {
+    /// Lists the zone's DNS records. Returns a `Result` rather than throwing so GUI and
+    /// intent callers can surface the same typed ``DomainOperationError`` without their own
+    /// catch-and-classify step.
     func listRecords(domain: String) async -> Result<[DNSRecord], DomainOperationError>
     /// `priority` is required by MX records (lower = higher priority mail server) and ignored
     /// by every other record type — `nil` for non-MX records.
     func addRecord(domain: String, type: String, name: String, content: String, ttl: Int, priority: Int?) async -> Result<Void, DomainOperationError>
+    /// Deletes one record by the Cloudflare record ID previously returned from
+    /// ``listRecords(domain:)`` — there is no delete-by-name, so callers must list first.
     func deleteRecord(domain: String, recordID: String) async -> Result<Void, DomainOperationError>
 }
 
+/// The production ``DomainOperationsService``, backed by the Cloudflare HTTP client. Every
+/// operation re-runs token lookup and zone resolution rather than caching either — the token
+/// can be revoked or replaced between calls, and correctness beats saving one lookup request
+/// at this call volume.
 public struct DomainOperations: DomainOperationsService {
     private let reader: any CloudflareReading
     private let writer: any CloudflareWriting
     private let tokenProvider: @Sendable () -> String?
 
+    /// All three dependencies are injectable seams for tests; the defaults (live HTTP client,
+    /// ``defaultTokenProvider``) are what production callers should use.
     public init(
         reader: any CloudflareReading = HTTPCloudflareClient(),
         writer: any CloudflareWriting = HTTPCloudflareClient(),
@@ -58,6 +77,7 @@ public struct DomainOperations: DomainOperationsService {
         }
     }
 
+    /// See ``DomainOperationsService/listRecords(domain:)``.
     public func listRecords(domain: String) async -> Result<[DNSRecord], DomainOperationError> {
         guard let token = tokenProvider() else { return .failure(.noToken) }
         switch await resolveZone(domain: domain, token: token) {
@@ -74,6 +94,7 @@ public struct DomainOperations: DomainOperationsService {
         }
     }
 
+    /// See ``DomainOperationsService/addRecord(domain:type:name:content:ttl:priority:)``.
     public func addRecord(domain: String, type: String, name: String, content: String, ttl: Int, priority: Int?) async -> Result<Void, DomainOperationError> {
         guard let token = tokenProvider() else { return .failure(.noToken) }
         switch await resolveZone(domain: domain, token: token) {
@@ -92,6 +113,7 @@ public struct DomainOperations: DomainOperationsService {
         }
     }
 
+    /// See ``DomainOperationsService/deleteRecord(domain:recordID:)``.
     public func deleteRecord(domain: String, recordID: String) async -> Result<Void, DomainOperationError> {
         guard let token = tokenProvider() else { return .failure(.noToken) }
         switch await resolveZone(domain: domain, token: token) {

--- a/Sources/AnglesiteCore/EditMessage.swift
+++ b/Sources/AnglesiteCore/EditMessage.swift
@@ -7,6 +7,8 @@ import Foundation
 /// an explicit `MessageType` case + decode update, which is the point: the WKWebView boundary is
 /// untrusted input, so the contract is closed-set by design.
 public struct EditMessage: Sendable, Equatable {
+    /// The closed set of accepted `type` tags. Raw values carry the `anglesite:` prefix so
+    /// overlay messages can't collide with any other script-message traffic in the page.
     public enum MessageType: String, Sendable, Equatable {
         /// Apply an edit to the underlying source — Phase 5 lands the server-side patcher and the
         /// exact `op` taxonomy. Until then this is the only accepted message type.
@@ -73,6 +75,8 @@ public struct EditMessage: Sendable, Equatable {
 
     /// Overlay-generated correlation ID so the JS side can match replies to the original message.
     public let id: String
+    /// Boundary tag — always ``MessageType/applyEdit`` today; kept as a field (not hardcoded)
+    /// so future message types extend the struct instead of forking it.
     public let type: MessageType
     /// Page path (e.g. `/about/`).
     public let path: String
@@ -93,6 +97,9 @@ public struct EditMessage: Sendable, Equatable {
     /// before committing. Defaults `false` so all existing call sites are unaffected.
     public let dryRun: Bool
 
+    /// Memberwise initializer for app-originated edits (intents, chat tools) — messages from
+    /// the overlay come through ``decode(from:)`` instead. Defaults mirror the wire format's
+    /// optionality: `dryRun` false so existing call sites are unaffected by its addition.
     public init(
         id: String,
         type: MessageType = .applyEdit,
@@ -131,10 +138,19 @@ public struct EditMessage: Sendable, Equatable {
         return .object(obj)
     }
 
+    /// Why ``decode(from:)`` rejected a message body. `Equatable` so tests can assert the
+    /// exact rejection, and each case carries enough context to log a useful diagnostic
+    /// without echoing the (untrusted) payload itself.
     public enum DecodeError: Error, Sendable, Equatable {
+        /// The `WKScriptMessage.body` wasn't a JSON object (dictionary) at all.
         case notAnObject
+        /// A required field was absent; the payload is the field name.
         case missingField(String)
+        /// A field was present but the wrong JSON type; `expected` names the type the
+        /// contract requires (e.g. `"string"`, `"object"`).
         case wrongType(field: String, expected: String)
+        /// The `type` tag isn't in ``MessageType`` — the closed-set rejection this boundary
+        /// exists for. Carries the unrecognized raw value.
         case unknownType(String)
     }
 

--- a/Sources/AnglesiteCore/EditRouter.swift
+++ b/Sources/AnglesiteCore/EditRouter.swift
@@ -4,7 +4,11 @@ import Foundation
 /// `Encodable` because it gets `JSONEncoder()`'d straight into a `evaluateJavaScript` call —
 /// `window.anglesite?._handleReply?.(<this object>)` — for the JS side to correlate via `id`.
 public struct EditReply: Sendable, Equatable, Encodable {
+    /// Correlation ID echoed back from the originating ``EditMessage`` — the only thing the
+    /// JS side uses to match a reply to its pending promise.
     public let id: String
+    /// What happened to the edit; drives both the overlay's UI reaction and which of the
+    /// optional fields below are meaningful.
     public let status: Status
     /// Human-readable detail. Always present for `.failed` / `.ambiguous`; optional for `.applied`.
     public let message: String?
@@ -27,6 +31,7 @@ public struct EditReply: Sendable, Equatable, Encodable {
     public let newFile: String?
     /// Preview-only: the source fragment before/after the would-be change (`.preview` status).
     public let before: String?
+    /// Preview-only counterpart to ``before`` — the fragment as it would read after the change.
     public let after: String?
     /// The op the preview/apply was for (e.g. "edit-style"). `nil` outside preview.
     public let op: String?
@@ -41,20 +46,39 @@ public struct EditReply: Sendable, Equatable, Encodable {
     /// free-form prose the plugin is free to reword.
     public let reason: String?
 
+    /// `replace-image-src` metadata: the final asset URLs the plugin wrote, which the overlay
+    /// swaps into the live `<img>` so the page reflects the edit without a full reload.
     public struct ImageResult: Sendable, Equatable, Encodable {
+        /// The rewritten `src` value.
         public let src: String
+        /// The rewritten `srcset` value, when the plugin generated responsive variants;
+        /// `nil` when the image has none.
         public let srcset: String?
 
+        /// Memberwise initializer — normally built by the router from the plugin's structured
+        /// reply.
         public init(src: String, srcset: String?) {
             self.src = src
             self.srcset = srcset
         }
     }
 
+    /// Reply outcome. Raw values are the wire strings the overlay's `_handleReply` switches on.
     public enum Status: String, Sendable, Equatable, Encodable {
-        case applied, failed, ambiguous, preview
+        /// The edit landed in source (and, when the site is a git repo, on the edits branch).
+        case applied
+        /// The edit was refused or errored; ``message`` (and ``reason``, when structured)
+        /// says why.
+        case failed
+        /// The selector matched more than one element, so applying would risk editing the
+        /// wrong one — the overlay should have the user disambiguate rather than guess.
+        case ambiguous
+        /// Dry-run result: nothing was written; ``before``/``after`` carry the would-be diff.
+        case preview
     }
 
+    /// Memberwise initializer. Every op-specific field defaults to `nil` so call sites only
+    /// name the fields their op family actually produces.
     public init(
         id: String,
         status: Status,
@@ -88,6 +112,10 @@ public struct EditReply: Sendable, Equatable, Encodable {
 /// backed by `MCPClient` calling the plugin's `anglesite:apply-edit` tool; until then the wired
 /// default is `LoggingEditRouter`.
 public protocol EditRouter: Sendable {
+    /// Applies (or previews, per `dryRun`) one edit and always produces a reply — the method
+    /// doesn't throw, because the overlay is waiting on a correlated response either way;
+    /// failures travel as ``EditReply/Status/failed`` rather than as errors that would leave
+    /// the JS side hanging.
     func apply(_ message: EditMessage) async -> EditReply
 }
 
@@ -105,10 +133,14 @@ public func resolveEditRouter(_ configured: EditRouter?) -> EditRouter {
 public struct LoggingEditRouter: EditRouter {
     private let logCenter: LogCenter
 
+    /// Injectable log destination; the default is the app-wide shared `LogCenter` feeding the
+    /// Debug pane.
     public init(logCenter: LogCenter = .shared) {
         self.logCenter = logCenter
     }
 
+    /// Logs what *would* have been applied, then replies ``EditReply/Status/failed`` — never
+    /// `.applied`, so no caller can mistake the stub for a real edit.
     public func apply(_ message: EditMessage) async -> EditReply {
         let target = message.selector.map { "\($0)" } ?? message.component.map { "\($0)" } ?? "?"
         await logCenter.append(

--- a/Sources/AnglesiteCore/EditRouterRegistry.swift
+++ b/Sources/AnglesiteCore/EditRouterRegistry.swift
@@ -15,6 +15,8 @@ import Foundation
 /// Last-writer-wins on duplicate siteID registration: opening the same site in a fresh window or
 /// rewriting the router via `setEditObserver(_:)` overwrites the prior registration.
 public actor EditRouterRegistry {
+    /// The single process-wide registry — the only instance production code should touch
+    /// (see `init`'s note on why external construction is blocked).
     public static let shared = EditRouterRegistry()
 
     private var routers: [String: EditRouter] = [:]
@@ -24,14 +26,22 @@ public actor EditRouterRegistry {
     /// accidental external instances from silently routing edits to the wrong store.
     internal init() {}
 
+    /// Registers (or replaces — last-writer-wins, see the type doc) the live router for a
+    /// site. Pair with ``unregister(siteID:)`` around the owner's lifecycle, or the strong
+    /// reference keeps the router alive after its window closes.
     public func register(_ router: EditRouter, for siteID: String) {
         routers[siteID] = router
     }
 
+    /// Removes a site's router. Safe to call for an unknown siteID (no-op), so owners can
+    /// unregister unconditionally on teardown.
     public func unregister(siteID: String) {
         routers.removeValue(forKey: siteID)
     }
 
+    /// The live router for a site, or `nil` when no window has that site open — callers
+    /// (intents) treat `nil` as "site not open" and tell the user, rather than falling back
+    /// to a router that couldn't reach the preview anyway.
     public func router(for siteID: String) -> EditRouter? {
         routers[siteID]
     }

--- a/Sources/AnglesiteCore/EditUndoCoordinator.swift
+++ b/Sources/AnglesiteCore/EditUndoCoordinator.swift
@@ -46,6 +46,8 @@ public final class EditUndoCoordinator {
         /// record's identity. Stable across transcript reloads, unlike chat-row UUIDs.
         public let commit: String
 
+        /// Memberwise initializer — built by the edit recorder from the applied reply's
+        /// `file` + `commit` pair.
         public init(file: String, commit: String) {
             self.file = file
             self.commit = commit
@@ -89,6 +91,9 @@ public final class EditUndoCoordinator {
     /// `await` it to observe the re-register-on-retryable behavior deterministically.
     private(set) var pendingPerform: Task<Void, Never>?
 
+    /// The ``Performer`` is fixed at construction; ``undoManager`` is deliberately *not* a
+    /// parameter — SwiftUI supplies it later (and can change it per focused window) via
+    /// `@Environment(\.undoManager)`, so it stays a settable property instead.
     public init(perform: @escaping Performer) {
         self.perform = perform
     }

--- a/Sources/AnglesiteCore/EditableFileSession.swift
+++ b/Sources/AnglesiteCore/EditableFileSession.swift
@@ -6,16 +6,30 @@ import Foundation
 /// session owns the raw file mechanics they share: off-main load/save, saved contents, modification
 /// date tracking, external-change decisions, conflict retention, and keep/reload resolution.
 public struct EditableFileSession: Sendable, Equatable {
+    /// The contents as last persisted (loaded, saved, or adopted from a reload) — the baseline
+    /// an owning model compares its live buffer against to decide "dirty".
     public private(set) var savedContents: String
+    /// The file's modification date at the last load/save. `nil` means the date couldn't be
+    /// read, which disables external-change detection for this file — see
+    /// ``missingModificationDateWarning(after:path:)`` for the log copy owners surface then.
     public private(set) var lastModified: Date?
+    /// The disk copy retained while an edit conflict is unresolved; non-`nil` means a
+    /// keep-mine/reload question is pending. Settable (not `private(set)`) so an owning model
+    /// can bind its conflict sheet's presentation directly to this field.
     public var conflictDiskContents: String?
 
+    /// Starts a session in the given state. The defaults describe "no file loaded yet";
+    /// non-default values exist for tests and for models that restore state.
     public init(savedContents: String = "", lastModified: Date? = nil, conflictDiskContents: String? = nil) {
         self.savedContents = savedContents
         self.lastModified = lastModified
         self.conflictDiskContents = conflictDiskContents
     }
 
+    /// Loads the file off the main actor, resets the session baseline to what's on disk, and
+    /// clears any pending conflict (a fresh load supersedes it). Returns the loaded contents
+    /// for the model to parse into its own state; `@discardableResult` for callers that only
+    /// need the session's bookkeeping updated.
     @discardableResult
     public mutating func load(from url: URL) async throws -> String {
         let loaded = try await Task.detached(priority: .userInitiated) {
@@ -27,6 +41,10 @@ public struct EditableFileSession: Sendable, Equatable {
         return loaded.contents
     }
 
+    /// Saves off the main actor and adopts `contents` as the new baseline, recording the
+    /// post-write modification date so the session's own write isn't later misread as an
+    /// external change. Clears any pending conflict — an explicit save is the caller choosing
+    /// its buffer over the disk copy.
     public mutating func save(_ contents: String, to url: URL) async throws {
         let mtime = try await Task.detached(priority: .userInitiated) {
             try FileDocumentIO.save(contents, to: url)
@@ -36,6 +54,13 @@ public struct EditableFileSession: Sendable, Equatable {
         conflictDiskContents = nil
     }
 
+    /// Checks the file against ``lastModified`` and applies the standard external-change
+    /// policy: a change under a clean buffer is adopted silently (baseline swapped to the disk
+    /// copy), a change under a dirty buffer is retained in ``conflictDiskContents`` for the
+    /// owner to put to the user. Returns what was detected so the model can react (re-parse,
+    /// present its sheet), or `nil` when the check itself failed (file unreadable/gone) —
+    /// deliberately indistinguishable from "nothing to do", since there's no useful recovery
+    /// at this layer.
     public mutating func externalChange(at url: URL, bufferIsDirty: Bool) async -> FileDocumentIO.ExternalChange? {
         let known = lastModified
         let change = try? await Task.detached(priority: .userInitiated) {
@@ -60,6 +85,11 @@ public struct EditableFileSession: Sendable, Equatable {
         return change
     }
 
+    /// Whether a dirty buffer may be flushed to disk on the way out (switching files, closing
+    /// the editor) without clobbering someone else's edit. Runs a last external-change check
+    /// first; `false` means a conflict was just detected (and retained in
+    /// ``conflictDiskContents``) — the owner must resolve it instead of writing. A clean
+    /// buffer is always flushable (trivially: there's nothing to write).
     public mutating func canFlushBeforeLeaving(file url: URL, bufferIsDirty: Bool) async -> Bool {
         guard bufferIsDirty else { return true }
         let change = await externalChange(at: url, bufferIsDirty: true)
@@ -69,10 +99,17 @@ public struct EditableFileSession: Sendable, Equatable {
         return true
     }
 
+    /// Resolves a pending conflict in favor of the in-app buffer: the retained disk copy is
+    /// discarded, and the caller's next ``save(_:to:)`` overwrites the external edit. Purely
+    /// local — nothing is written here.
     public mutating func keepMyChanges() {
         conflictDiskContents = nil
     }
 
+    /// Resolves a pending conflict in favor of the disk copy: adopts the retained contents as
+    /// the new baseline (with a fresh modification date) and returns them for the model to
+    /// re-parse into its buffer. Returns `nil` when no conflict was pending, so a stale sheet
+    /// action degrades to a no-op instead of clobbering state.
     public mutating func reloadFromConflict(file url: URL) async -> String? {
         guard let disk = conflictDiskContents else { return nil }
         savedContents = disk
@@ -81,10 +118,17 @@ public struct EditableFileSession: Sendable, Equatable {
         return disk
     }
 
+    /// Shared log copy for the ``lastModified``-is-`nil` situation, so every editor model
+    /// (FileEditorModel, PageMetadataModel, TypedEntryEditorModel) reports the degraded state
+    /// in identical words rather than three drifting variants.
     public static func missingModificationDateWarning(after operation: String, path: String) -> String {
         "No modification date for \(path) after \(operation); external-change detection is disabled for this file."
     }
 
+    /// Fire-and-forget save for paths where nothing is left alive to await or surface an
+    /// error (teardown, last-chance flushes). Static and non-mutating on purpose: it bypasses
+    /// session bookkeeping entirely, so it's only safe when the session is being discarded
+    /// anyway — anywhere else, use ``save(_:to:)``.
     public static func saveBestEffort(_ contents: String, to url: URL) {
         Task.detached(priority: .userInitiated) {
             try? FileDocumentIO.save(contents, to: url)

--- a/Sources/AnglesiteCore/EmailSetupPlanner.swift
+++ b/Sources/AnglesiteCore/EmailSetupPlanner.swift
@@ -14,26 +14,42 @@ public enum EmailSetupPlanner {
 
     /// First fork: "Do you use Apple devices (iPhone, Mac) for your business?"
     public enum Ecosystem: Sendable, Equatable {
+        /// The owner lives on Apple devices — routes to the Apple-first providers
+        /// (iCloud+ / Apple Business) via ``AppleTier``.
         case apple
+        /// Mixed or non-Apple devices — routes to the cross-platform recommendation.
         case mixedOrOther
     }
 
     /// Second fork on the Apple path: "Is this for you personally, or for a registered business?"
     public enum AppleTier: Sendable, Equatable {
+        /// A personal domain — iCloud+ custom domain covers it without a business account.
         case personal
+        /// A registered business — eligible for Apple Business Essentials (free ≤ 500 seats).
         case registeredBusiness
     }
 
     // MARK: - Providers
 
+    /// The closed set of email providers the planner knows DNS records for — the providers
+    /// from the retired skill's reference doc, no more. Raw values are stable kebab-case
+    /// identifiers, safe to persist or put in URLs.
     public enum Provider: String, Sendable, CaseIterable, Equatable {
+        /// iCloud+ Custom Email Domain — the Apple personal-tier pick.
         case icloudPlus = "icloud-plus"
+        /// Apple Business Essentials — the Apple registered-business pick. Same mail
+        /// infrastructure as iCloud+, so the two share MX/SPF records.
         case appleBusiness = "apple-business"
+        /// Fastmail — the primary cross-platform recommendation.
         case fastmail
+        /// Google Workspace — cross-platform alternative.
         case googleWorkspace = "google-workspace"
+        /// Proton Mail — cross-platform alternative; the privacy-focused option.
         case protonMail = "proton-mail"
+        /// Zoho Mail — cross-platform alternative; the budget option (free tier up to 5 users).
         case zohoMail = "zoho-mail"
 
+        /// Owner-facing product name, spelled the way the provider brands it.
         public var displayName: String {
             switch self {
             case .icloudPlus: return "iCloud+ Custom Email Domain"
@@ -83,7 +99,11 @@ public enum EmailSetupPlanner {
 
     // MARK: - Recommendation
 
+    /// What ``recommend(ecosystem:appleTier:)`` hands the UI: one primary pick with a
+    /// plain-English reason, plus alternatives only where the decision tree genuinely has
+    /// peers to offer (the app advises, it doesn't dump a comparison matrix on the owner).
     public struct Recommendation: Sendable, Equatable {
+        /// The primary pick the UI should lead with.
         public let provider: Provider
         /// Cross-platform alternatives shown alongside the primary pick (non-Apple path only).
         public let alternatives: [Provider]
@@ -123,14 +143,20 @@ public enum EmailSetupPlanner {
     /// A DNS record to pre-fill, shaped to match the app's DNS add-record flow
     /// (`DomainOperationsService.addRecord`). Email records are never proxied.
     public struct RecordTemplate: Sendable, Equatable {
+        /// DNS record type (`MX`, `TXT`, `CNAME`) — a plain string to match the add-record
+        /// flow's wire shape rather than introducing a parallel enum.
         public let type: String
+        /// Record name relative to the zone (`@` for the apex, `_dmarc`, `fm1._domainkey`, …).
         public let name: String
+        /// The record's value, fully known ahead of time — anything per-account lands in
+        /// ``ManualStep`` instead.
         public let content: String
         /// Mail server priority — only meaningful for MX records.
         public let priority: Int?
         /// Always `false` for email records (MX/SPF/DKIM/DMARC must bypass the proxy).
         public var proxied: Bool { false }
 
+        /// Memberwise initializer; `priority` defaults `nil` since only MX records carry one.
         public init(type: String, name: String, content: String, priority: Int? = nil) {
             self.type = type
             self.name = name
@@ -142,11 +168,18 @@ public enum EmailSetupPlanner {
     /// A step the owner must complete in the provider's own interface because the value is
     /// generated per-account (DKIM keys, Apple's domain-verification token).
     public struct ManualStep: Sendable, Equatable {
+        /// Short owner-facing label (e.g. "DKIM signature record").
         public let title: String
+        /// Click-path instructions telling the owner exactly where in the provider's
+        /// dashboard the generated value lives and what record to add here.
         public let instructions: String
     }
 
+    /// Everything the email-setup flow needs to execute for one provider: the records the app
+    /// can add on the owner's behalf, and the steps it must hand back to the owner because the
+    /// values are provider-issued.
     public struct DNSPlan: Sendable, Equatable {
+        /// The provider this plan was generated for.
         public let provider: Provider
         /// Records with fully known values, ready to pre-fill.
         public let records: [RecordTemplate]

--- a/Sources/AnglesiteCore/EmbeddingProvider.swift
+++ b/Sources/AnglesiteCore/EmbeddingProvider.swift
@@ -22,12 +22,23 @@ public protocol EmbeddingProvider: Sendable {
 /// Not semantically meaningful — only stable and content-sensitive, which is all the ranker,
 /// cache, and incremental-update tests need.
 public struct FakeEmbeddingProvider: EmbeddingProvider {
+    /// The fixed vector length; every ``embed(_:)`` result has exactly this many components.
     public let dimension: Int
 
+    /// Creates a provider with the given vector length, clamped to at least 1 so the
+    /// character-bucket projection always has somewhere to accumulate.
+    ///
+    /// The default of 8 keeps test vectors small and readable while still separating
+    /// distinct inputs well enough for ranking assertions.
     public init(dimension: Int = 8) {
         self.dimension = max(1, dimension)
     }
 
+    /// Projects the text into `dimension` character-count buckets and unit-normalizes.
+    ///
+    /// Deterministic by construction — no model, no randomness — so tests can assert on
+    /// exact ranking order. Throws ``EmbeddingError/emptyText`` for whitespace-only input,
+    /// matching the production provider's contract.
     public func embed(_ text: String) async throws -> [Float] {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw EmbeddingError.emptyText }

--- a/Sources/AnglesiteCore/ExperimentStats.swift
+++ b/Sources/AnglesiteCore/ExperimentStats.swift
@@ -22,10 +22,16 @@ public enum ExperimentStats {
 
     /// Conversion counts for a single variant.
     public struct Variant: Sendable, Equatable {
+        /// Display name shown in summaries (e.g. the variant label from the experiment config).
         public let name: String
+        /// How many visitors saw this variant.
         public let impressions: Int
+        /// How many of those visitors converted. Always `<= impressions` — the initializer clamps.
         public let conversions: Int
 
+        /// Creates a variant, sanitizing the counts: negatives are clamped to zero and
+        /// `conversions` is capped at `impressions`, so downstream math never sees an
+        /// impossible rate even if the analytics payload was corrupt.
         public init(name: String, impressions: Int, conversions: Int) {
             self.name = name
             self.impressions = max(0, impressions)
@@ -40,18 +46,28 @@ public enum ExperimentStats {
 
     /// Outcome of comparing a treatment against the control.
     public struct Result: Sendable, Equatable {
+        /// Which side (if either) cleared the confidence threshold. Carries the variant's
+        /// display name so callers can render a summary without re-fetching the config.
         public enum Winner: Sendable, Equatable {
+            /// The treatment beat the control at or above the confidence threshold.
             case treatment(name: String)
+            /// The control beat the treatment at or above the confidence threshold.
             case control(name: String)
+            /// Neither side reached the threshold — either too early, or genuinely too
+            /// close to call (disambiguate with ``ExperimentStats/hasSufficientData(control:treatment:)``).
             case inconclusive
         }
 
+        /// The verdict at the confidence threshold passed to
+        /// ``ExperimentStats/analyze(control:treatment:confidenceThreshold:)``.
         public let winner: Winner
         /// P(treatment rate > control rate) under Beta(1,1) priors. Exact, not simulated.
         public let probabilityTreatmentBeatsControl: Double
         /// Relative lift of the treatment over the control, in percent (posterior means).
         public let liftPercent: Double
+        /// The control's posterior mean conversion rate (``ExperimentStats/Variant/posteriorRate``).
         public let controlRate: Double
+        /// The treatment's posterior mean conversion rate (``ExperimentStats/Variant/posteriorRate``).
         public let treatmentRate: Double
     }
 
@@ -179,7 +195,10 @@ public enum ExperimentStats {
 
     /// One templated test idea from the default playbook.
     public struct Suggestion: Sendable, Equatable {
+        /// Short name of the element to test (e.g. "Hero headline").
         public let title: String
+        /// Owner-facing explanation of why this test tends to pay off — phrased for a
+        /// non-technical site owner, not an analyst.
         public let rationale: String
     }
 

--- a/Sources/AnglesiteCore/FileDocumentIO.swift
+++ b/Sources/AnglesiteCore/FileDocumentIO.swift
@@ -4,13 +4,20 @@ import Foundation
 /// The App view owns the text buffer + dirty flag; this type only touches disk and reports
 /// what changed. Keeping it stateless makes the reconcile rules unit-testable without UI.
 public enum FileDocumentIO {
+    /// A file's contents paired with the mtime observed at load time — the baseline the
+    /// editor later hands back to ``FileDocumentIO/externalChange(at:lastKnownModificationDate:bufferIsDirty:fileManager:)``
+    /// to detect writes made outside the app.
     public struct Loaded: Sendable, Equatable {
+        /// The file's full UTF-8 text at load time.
         public let contents: String
+        /// The on-disk modification date captured alongside the read, or `nil` if the
+        /// filesystem didn't report one. Keep this as the external-change baseline.
         public let modificationDate: Date?
     }
 
     /// What the editor should do when the on-disk file no longer matches what we last saw.
     public enum ExternalChange: Sendable, Equatable {
+        /// Disk still matches what we last saw (or the mtime is unavailable) — do nothing.
         case none
         /// Disk changed and the buffer is clean — safe to swap in `contents` silently.
         case reloadable(String)
@@ -18,18 +25,27 @@ public enum FileDocumentIO {
         case conflict(String)
     }
 
+    /// Reads the file as UTF-8 and captures its mtime in the same operation, so the caller
+    /// starts with a change-detection baseline that matches the contents it holds.
     public static func load(_ url: URL, fileManager: FileManager = .default) throws -> Loaded {
         let contents = try String(contentsOf: url, encoding: .utf8)
         let mtime = try modificationDate(of: url, fileManager: fileManager)
         return Loaded(contents: contents, modificationDate: mtime)
     }
 
+    /// Writes the buffer atomically and returns the resulting mtime, which the caller must
+    /// adopt as its new baseline — otherwise its own save would later be misread as an
+    /// external change. Discardable for callers that reload immediately afterwards.
     @discardableResult
     public static func save(_ contents: String, to url: URL, fileManager: FileManager = .default) throws -> Date? {
         try Data(contents.utf8).write(to: url, options: [.atomic])
         return try modificationDate(of: url, fileManager: fileManager)
     }
 
+    /// Decides what the editor should do about a possible external write, encoding the
+    /// reconcile rule in one testable place: only a strictly-newer disk mtime counts as a
+    /// change, and whether it's silently reloadable or a user-facing conflict depends
+    /// solely on `bufferIsDirty`. Reads the disk copy only when a change is detected.
     public static func externalChange(
         at url: URL,
         lastKnownModificationDate: Date?,

--- a/Sources/AnglesiteCore/FindLinkOpportunitiesTool.swift
+++ b/Sources/AnglesiteCore/FindLinkOpportunitiesTool.swift
@@ -9,21 +9,35 @@ import FoundationModels
 /// Foundation Models tool that audits a site's internal linking structure: orphan pages,
 /// missing reciprocal links, over-linked pages. Uses ``LinkGraph`` over the knowledge index.
 public struct FindLinkOpportunitiesTool: Tool, Sendable {
+    /// Stable wire name of the tool. A `static let` so callers (session config, tests,
+    /// transcript matching) can reference it without instantiating the tool.
     public static let toolName = "findLinkOpportunities"
+    /// `Tool` conformance — the name the model uses to invoke this tool.
     public let name = FindLinkOpportunitiesTool.toolName
+    /// `Tool` conformance — the natural-language capability summary the model reads when
+    /// deciding whether to call this tool, so it must name the concrete findings it produces.
     public let description = "Audit the site's internal linking: find orphan pages with no inbound links, missing reciprocal links, and over-linked pages."
 
+    /// No arguments: the audit always covers the whole site, so there is nothing for the
+    /// model to parameterize (and nothing for it to get wrong).
     @Generable
     public struct Arguments {}
 
     private let index: SiteKnowledgeIndex
     private let siteID: String
 
+    /// Creates the tool bound to one site's knowledge index; `siteID` scopes the audit so a
+    /// multi-window session never mixes documents across sites.
     public init(index: SiteKnowledgeIndex, siteID: String) {
         self.index = index
         self.siteID = siteID
     }
 
+    /// Runs the link audit and returns a plain-text report for the model to relay.
+    ///
+    /// Returns an explicit "no indexed documents" message rather than an empty report when
+    /// the index hasn't been populated yet — an empty-looking success would read as
+    /// "linking is healthy", which is the wrong conclusion before a site is open.
     public func call(arguments: Arguments) async throws -> String {
         let documents = await index.documents(siteID: siteID)
         guard !documents.isEmpty else {

--- a/Sources/AnglesiteCore/FoundationModelAssistant.swift
+++ b/Sources/AnglesiteCore/FoundationModelAssistant.swift
@@ -41,6 +41,9 @@ public enum FoundationModelContextBudget {
     public static let onDeviceTokenBudget = 4_096
     private static let charsPerTokenEstimate = 4
 
+    /// Estimates the token count of `text` via the ~4-chars/token proxy — deliberately rough,
+    /// since no on-device tokenizer is exposed to measure the real count. Deterministic, so
+    /// budget decisions are reproducible in tests.
     public static func estimatedTokens(for text: String) -> Int {
         text.count / charsPerTokenEstimate
     }
@@ -185,6 +188,10 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         }
     }
 
+    /// Advertised capabilities for this backend. `nonisolated` so UI code can read it without
+    /// an actor hop. The values describe what's *wired*, not per-call guarantees (see the
+    /// `supportsTools` note in the body); `maxContextTokens` and `providerName` are the only
+    /// observable differences between the two `FoundationModelTier`s in v1.
     public nonisolated var capabilities: AssistantCapabilities {
         AssistantCapabilities(
             supportsStreaming: true,
@@ -203,6 +210,11 @@ public actor FoundationModelAssistant: ConversationalAssistant {
 
     // MARK: ContentAssistant
 
+    /// One-shot streaming generation: builds a fresh session per call so independent
+    /// invocations (tool calls, alt-text, summaries) never bleed history into one another —
+    /// the deliberate opposite of ``converse(prompt:context:)``'s cached multi-turn session.
+    /// Throws `AssistantError.unavailable` before the stream opens when the on-device model
+    /// can't run on this host.
     public func generate(
         prompt: String,
         context: AssistantContext
@@ -250,6 +262,10 @@ public actor FoundationModelAssistant: ConversationalAssistant {
         }
     }
 
+    /// One-shot guided generation into a `Generable` type. Like ``generate(prompt:context:)``,
+    /// a fresh session per call — structured results (frontmatter, summaries, edit plans)
+    /// must not inherit a conversation's history, which could bias the schema-constrained
+    /// output. Throws `AssistantError.unavailable` when the on-device model can't run here.
     public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,

--- a/Sources/AnglesiteCore/FoundationModelDeploySummarizer.swift
+++ b/Sources/AnglesiteCore/FoundationModelDeploySummarizer.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Chooses the deploy-failure summarizer for the current toolchain. Non-gated so `DeployModel`
 /// can default its dependency without importing FoundationModels.
 public enum DeploySummarizerFactory {
+    /// Returns the best summarizer the current toolchain can build: the on-device
+    /// `FoundationModelDeploySummarizer` on Xcode 27+/Darwin, else a no-op that always
+    /// yields `nil` so callers degrade to showing the raw log. The branch is compile-time,
+    /// mirroring the `#if compiler(>=6.4)` gate below, which is why the return type is the
+    /// non-gated `any DeployFailureSummarizing` rather than a concrete type.
     public static func makeDefault() -> any DeployFailureSummarizing {
         #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelDeploySummarizer()
@@ -25,8 +30,14 @@ import os
 public struct FoundationModelDeploySummarizer: DeployFailureSummarizing {
     private let logger = Logger(subsystem: "dev.anglesite.app", category: "DeployFailureSummarizer")
 
+    /// Creates a summarizer. Stateless — the assistant session is built per `summarize` call,
+    /// so one instance can serve every deploy.
     public init() {}
 
+    /// Summarizes a failed deploy's log for a non-expert owner, or returns `nil` on any
+    /// failure (empty log, Apple Intelligence off, generation error) — the protocol contract
+    /// is best-effort, and the caller's raw-log fallback is always available. Failures are
+    /// logged rather than thrown so the deploy UI never blocks on summarization.
     public func summarize(failureLog: String, siteID: String, siteDirectory: URL) async -> DeployFailureSummary? {
         guard !failureLog.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
         let context = AssistantContext(siteID: siteID, siteDirectory: siteDirectory)

--- a/Sources/AnglesiteCore/FoundationModelEditInterpreter.swift
+++ b/Sources/AnglesiteCore/FoundationModelEditInterpreter.swift
@@ -8,24 +8,36 @@ import FoundationModels
 /// FM-independent `InterpretedEdit` so op-routing stays CI-testable without the live model.
 @Generable
 public struct GeneratedInterpretedEdit: Equatable, Sendable {
+    /// Which of the three edit shapes the model chose. Discriminates which of the fields
+    /// below are meaningful — the others are empty-string sentinels.
     @Guide(description: "The kind of change: text (replace the element's visible text), attribute (set an HTML attribute like alt or href), or style (a CSS property like color or font-size).")
     public var kind: InterpretedEditKindGen
 
+    /// Replacement text for a `.text` edit. Non-optional with an empty-string sentinel
+    /// (like every kind-specific field here) because guided generation fills every field;
+    /// the mapping in ``FoundationModelEditInterpreter/interpret(instruction:element:)``
+    /// converts empties back to `nil`.
     @Guide(description: "For a text edit: the full new visible text. Empty otherwise.")
     public var newText: String
 
+    /// Attribute name for an `.attribute` edit; empty-string sentinel otherwise.
     @Guide(description: "For an attribute edit: the attribute name (e.g. alt, href). Empty otherwise.")
     public var attributeName: String
 
+    /// Attribute value for an `.attribute` edit; empty-string sentinel otherwise.
     @Guide(description: "For an attribute edit: the new attribute value. Empty otherwise.")
     public var attributeValue: String
 
+    /// CSS property for a `.style` edit; empty-string sentinel otherwise.
     @Guide(description: "For a style edit: the CSS property (e.g. color, font-size). Empty otherwise.")
     public var styleProperty: String
 
+    /// CSS value for a `.style` edit; empty-string sentinel otherwise.
     @Guide(description: "For a style edit: the CSS value (e.g. teal, 2rem). Empty otherwise.")
     public var styleValue: String
 
+    /// User-facing one-sentence description of the change — this is what the confirmation
+    /// UI shows before the edit is applied, so the model is asked to keep it short.
     @Guide(description: "One short sentence describing the change, shown to the user before they confirm.")
     public var summary: String
 }
@@ -34,7 +46,12 @@ public struct GeneratedInterpretedEdit: Equatable, Sendable {
 /// bleed into the plain model type used by CI-testable op-routing.
 @Generable
 public enum InterpretedEditKindGen: String, Equatable, Sendable {
-    case text, attribute, style
+    /// Replace the element's visible text content.
+    case text
+    /// Set an HTML attribute (e.g. `alt`, `href`) on the element.
+    case attribute
+    /// Set a CSS property (e.g. `color`, `font-size`) on the element.
+    case style
 }
 
 /// FM-backed `EditInterpreting`. The `generate` closure is injected so unit tests can supply a
@@ -42,6 +59,9 @@ public enum InterpretedEditKindGen: String, Equatable, Sendable {
 /// to `FoundationModelAssistant.generateStructured` and maps model-unavailability to
 /// `EditInterpretationError.unavailable`.
 public struct FoundationModelEditInterpreter: EditInterpreting {
+    /// The injectable generation seam: everything the live model does, reduced to one
+    /// closure so tests can return a canned ``GeneratedInterpretedEdit`` and exercise the
+    /// mapping logic without Apple Intelligence being available.
     public typealias Generate = @Sendable (
         _ instruction: String,
         _ element: InterpretedElementContext
@@ -87,6 +107,9 @@ public struct FoundationModelEditInterpreter: EditInterpreting {
 
     // MARK: EditInterpreting
 
+    /// Runs the instruction through the injected generator and maps the guided-generation
+    /// result to the FM-independent `InterpretedEdit`, converting the empty-string
+    /// sentinels back to `nil` so downstream op-routing sees a conventional optional model.
     public func interpret(instruction: String, element: InterpretedElementContext) async throws -> InterpretedEdit {
         let g = try await generate(instruction, element)
         let kind: InterpretedEditKind = switch g.kind {

--- a/Sources/AnglesiteCore/FoundationModelPageCopyGenerator.swift
+++ b/Sources/AnglesiteCore/FoundationModelPageCopyGenerator.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Chooses the page-copy generator for the current toolchain. Non-gated so `NativeContentOperations`
 /// can default its dependency without importing FoundationModels.
 public enum PageCopyGeneratorFactory {
+    /// Returns the best generator the current toolchain can build: the on-device
+    /// `FoundationModelPageCopyGenerator` on Xcode 27+/Darwin, else a no-op that always
+    /// yields `nil` so callers fall through to their deterministic title-derived default.
+    /// The branch is compile-time, mirroring the `#if compiler(>=6.4)` gate below, which is
+    /// why the return type is the non-gated `any PageCopyGenerating`.
     public static func makeDefault() -> any PageCopyGenerating {
         #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelPageCopyGenerator()
@@ -21,8 +26,14 @@ import FoundationModels
 /// via guided generation. Any failure — including `AssistantError.unavailable` when Apple
 /// Intelligence is off — collapses to `nil` so the caller falls back to a deterministic default.
 public struct FoundationModelPageCopyGenerator: PageCopyGenerating {
+    /// Creates a generator. Stateless — the assistant session is built per call, so one
+    /// instance can serve every new-page flow.
     public init() {}
 
+    /// Suggests an SEO meta description for the given page title, or `nil` on any failure
+    /// (blank title, Apple Intelligence off, generation error, or a blank model output) —
+    /// the protocol contract is best-effort, and `nil` must always mean "use the
+    /// deterministic default", never "use an empty description".
     public func suggestDescription(title: String, siteID: String, siteDirectory: URL) async -> PageCopySuggestion? {
         let cleanTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleanTitle.isEmpty else { return nil }

--- a/Sources/AnglesiteCore/FreedesignmdCatalog.swift
+++ b/Sources/AnglesiteCore/FreedesignmdCatalog.swift
@@ -5,21 +5,41 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// One design system in the freedesignmd.com catalog, as listed by
+/// ``FreedesignmdCatalog/parseSystemList(html:)``.
 public struct FreedesignmdSystem: Sendable, Equatable, Identifiable {
+    /// URL slug on freedesignmd.com (`/system/<slug>`) — the stable key for follow-up
+    /// fetches and identity.
     public let slug: String
+    /// Human-readable system name as the catalog lists it.
     public let name: String
+    /// `Identifiable` conformance keyed on ``slug`` — the catalog's own stable identifier,
+    /// so SwiftUI lists don't churn when names are re-rendered.
     public var id: String { slug }
+    /// Creates a catalog entry from its slug and display name.
     public init(slug: String, name: String) { self.slug = slug; self.name = name }
 }
 
+/// A catalog entry paired with the description fetched from its detail page — the shape a
+/// picker UI needs once the user focuses one system.
 public struct FreedesignmdSystemDetail: Sendable, Equatable {
+    /// The catalog entry this detail belongs to.
     public let system: FreedesignmdSystem
+    /// The system page's meta description, per ``FreedesignmdCatalog/parseDescription(html:)``.
     public let description: String
+    /// Pairs a catalog entry with its fetched description.
     public init(system: FreedesignmdSystem, description: String) { self.system = system; self.description = description }
 }
 
+/// Failures from the ``FreedesignmdCatalog`` fetch/parse pipeline. Split so callers can
+/// distinguish a network/HTTP problem (retryable) from the site's markup no longer matching
+/// the parser (a code-level breakage worth surfacing differently).
 public enum FreedesignmdCatalogError: Error, Sendable, Equatable {
+    /// The HTTP request failed or returned a non-2xx/undecodable response; the payload
+    /// describes which URL misbehaved.
     case fetchFailed(String)
+    /// The page fetched fine but yielded zero systems — freedesignmd.com's server-rendered
+    /// JSON-LD markup has likely changed shape and the parsing regex needs updating.
     case parseFailed
 }
 
@@ -34,6 +54,11 @@ public enum FreedesignmdCatalog {
     private static let listItemPattern = #""url":"https://freedesignmd\.com/system/([a-z0-9-]+)","name":"([^"]+)""#
     private static let descriptionPattern = #"name="description" content="([^"]*)""#
 
+    /// Extracts the systems from a `/systems` page's server-rendered JSON-LD `ItemList`.
+    /// A tolerant regex rather than a JSON decode: the JSON-LD block is embedded in HTML and
+    /// its surrounding structure shifts between deploys, while the `url`/`name` pair shape
+    /// has stayed stable. Returns `[]` rather than throwing — the fetch wrapper decides
+    /// whether empty means ``FreedesignmdCatalogError/parseFailed``.
     public static func parseSystemList(html: String) -> [FreedesignmdSystem] {
         guard let re = try? NSRegularExpression(pattern: listItemPattern) else { return [] }
         let ns = html as NSString
@@ -42,6 +67,9 @@ public enum FreedesignmdCatalog {
         }
     }
 
+    /// Extracts a system page's `<meta name="description">` content, or `nil` when absent.
+    /// The meta description is the one piece of prose the site server-renders per system,
+    /// which is why it stands in for a richer detail payload here.
     public static func parseDescription(html: String) -> String? {
         guard let re = try? NSRegularExpression(pattern: descriptionPattern) else { return nil }
         let ns = html as NSString
@@ -66,6 +94,12 @@ public enum FreedesignmdCatalog {
         return systems
     }
 
+    /// Fetches a system's detail page and returns its meta description. Unlike
+    /// ``fetchSystemList(session:)``, a missing description is `nil`, not an error — a
+    /// system without one is a valid catalog entry, whereas an empty system list means the
+    /// markup broke.
+    ///
+    /// - Throws: ``FreedesignmdCatalogError/fetchFailed(_:)`` on a network/HTTP failure.
     public static func fetchDescription(slug: String, session: URLSession = .shared) async throws -> String? {
         let (data, response) = try await session.data(from: systemURL(slug: slug))
         guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode,

--- a/Sources/AnglesiteCore/Frontmatter.swift
+++ b/Sources/AnglesiteCore/Frontmatter.swift
@@ -12,9 +12,16 @@ import Foundation
 /// carries an already-formatted scalar (the editor decides date-only vs. full ISO by field kind),
 /// emitted verbatim, matching `ContentScaffold`'s unquoted dates.
 public enum FrontmatterValue: Equatable, Sendable {
+    /// A textual scalar — also what numeric and date scalars parse as (see the type note),
+    /// since ``Frontmatter/parse(_:)`` never guesses at types it wasn't asked to distinguish.
     case string(String)
+    /// A real YAML boolean (`true`/`false` unquoted) — kept distinct so scanner checks like
+    /// `draft == true` can't be satisfied by the string `"true"`.
     case bool(Bool)
+    /// A string array from either inline (`[a, b]`) or block (`- a`) form.
     case array([String])
+    /// Write-only numeric scalar (see the type note): never produced by ``Frontmatter/parse(_:)``,
+    /// but serialized **unquoted** by the editor so `z.number()` collection schemas still validate.
     case number(Double)
     /// A preformatted date scalar emitted **unquoted**. `s` must be a safe bare YAML scalar — no
     /// newlines, no `: ` (colon-space) sequences — because `FrontmatterDocument.render` emits it
@@ -33,8 +40,13 @@ public enum FrontmatterValue: Equatable, Sendable {
 
 /// One name/value pair inside a `FrontmatterValue.objectArray` record, in declaration order.
 public struct FrontmatterRecordField: Equatable, Sendable {
+    /// The field's YAML key within its record.
     public let name: String
+    /// The field's value — conventionally scalar (see ``FrontmatterValue/objectArray(_:)``'s
+    /// nesting restriction).
     public let value: FrontmatterValue
+    /// Creates a record field. Unlabeled parameters keep literal record construction
+    /// readable — these appear in bulk when building `objectArray` values.
     public init(_ name: String, _ value: FrontmatterValue) {
         self.name = name
         self.value = value

--- a/Sources/AnglesiteCore/FrontmatterDocument.swift
+++ b/Sources/AnglesiteCore/FrontmatterDocument.swift
@@ -42,13 +42,22 @@ public struct FrontmatterDocument: Equatable, Sendable {
     /// `serialized()` doesn't inject a newline the source never had.
     private let hasBodySection: Bool
 
+    /// The frontmatter keys in **source order** — the order a form editor should present fields
+    /// in, so the UI mirrors the file the author actually wrote. Raw passthrough segments
+    /// (comments, blank lines) are excluded.
     public var keys: [String] { segments.compactMap(\.key) }
 
+    /// The logical value for `key`, or `nil` when the key isn't present. With a malformed
+    /// duplicate key, this reads the last occurrence (see `indexByKey`).
     public func value(for key: String) -> FrontmatterValue? {
         guard let i = indexByKey[key] else { return nil }
         return segments[i].value
     }
 
+    /// Sets `key` to `value`, marking that one segment for re-render. This is the *only* way a
+    /// segment loses its verbatim source text — an edited key serializes in canonical form
+    /// (matching `ContentScaffold`'s rendering), while every untouched segment still round-trips
+    /// byte-for-byte. A key not present yet is appended at the end of the frontmatter block.
     public mutating func set(_ value: FrontmatterValue, for key: String) {
         if let i = indexByKey[key] {
             segments[i].value = value
@@ -59,6 +68,11 @@ public struct FrontmatterDocument: Equatable, Sendable {
         }
     }
 
+    /// Renders the document back to file text. Unedited segments (and the body) are reproduced
+    /// verbatim — so `parse(...).serialized()` with no intervening ``set(_:for:)`` is the identity
+    /// — while edited keys re-render canonically. The source's original line ending (`\r\n` vs
+    /// `\n`) is restored on the way out, and no trailing newline is invented for a source that
+    /// ended flush against its closing `---` fence.
     public func serialized() -> String {
         guard hadFrontmatter else { return body.replacingOccurrences(of: "\n", with: newline) }
         var lines: [String] = ["---"]
@@ -77,6 +91,11 @@ public struct FrontmatterDocument: Equatable, Sendable {
 
     // MARK: Parse
 
+    /// Parses `source` into an editable document. Never fails: a file with no leading `---` fence
+    /// (or an unterminated one) becomes a body-only document that serializes back unchanged, so
+    /// a malformed file can pass through the editor without being mangled. Every source line —
+    /// including comments, blank lines, and lines this parser doesn't understand — is retained
+    /// as a segment, which is what makes the unedited round-trip an identity.
     public static func parse(_ source: String) -> FrontmatterDocument {
         let newline = source.contains("\r\n") ? "\r\n" : "\n"
         let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")

--- a/Sources/AnglesiteCore/FrontmatterSchemaReader.swift
+++ b/Sources/AnglesiteCore/FrontmatterSchemaReader.swift
@@ -9,12 +9,20 @@ import Foundation
 /// names inside the `z.object({...})` block. Anything it doesn't recognize is left out rather
 /// than guessed, matching `Frontmatter.parse`'s "deliberately minimal" precedent.
 public enum FrontmatterSchemaReader {
+    /// Reads `<siteDirectory>/src/content.config.ts` and returns each collection's declared field
+    /// names, keyed by collection name. A missing or unreadable config yields `[:]` rather than an
+    /// error — no declared schema is a normal state (callers fall back to inferred conventions),
+    /// not a failure to surface.
     public static func read(siteDirectory: URL) -> [String: [String]] {
         let url = siteDirectory.appendingPathComponent("src/content.config.ts")
         guard let source = try? String(contentsOf: url, encoding: .utf8) else { return [:] }
         return collections(fromContentConfig: source)
     }
 
+    /// Extracts collection-name → field-name lists from content-config source text. Split out
+    /// from ``read(siteDirectory:)`` so the text scan is unit-testable without a site on disk.
+    /// Collections whose declaration doesn't match the template's `defineCollection` +
+    /// `z.object({...})` shape are omitted (left out rather than guessed).
     public static func collections(fromContentConfig source: String) -> [String: [String]] {
         var result: [String: [String]] = [:]
         for block in collectionBlocks(in: source) {

--- a/Sources/AnglesiteCore/GenerableTypes.swift
+++ b/Sources/AnglesiteCore/GenerableTypes.swift
@@ -32,18 +32,27 @@ public enum EditOperation: Equatable, Sendable {
 /// (future) `ApplyEditTool` (#156); `selector` matches the overlay/`IntentEditBridge` selector form.
 @Generable
 public struct GeneratedEditCommand: Equatable, Sendable {
+    /// Site-root-relative path of the source file to edit (e.g. `src/pages/about.md`).
     @Guide(description: "Path to the source file to edit, relative to the site root, e.g. 'src/pages/about.md'.")
     public var filePath: String
 
+    /// CSS selector identifying the target element, in the same form the edit overlay and
+    /// `IntentEditBridge` use — so the generated command plugs into the existing edit pipeline
+    /// without translation.
     @Guide(description: "CSS selector or element reference identifying what to edit, e.g. 'h1' or 'p:nth-of-type(2)'.")
     public var selector: String
 
+    /// Which kind of mutation to perform; determines how ``value`` is interpreted.
     @Guide(description: "The kind of edit: replaceText sets element text, replaceAttr sets an attribute, replaceImageSrc swaps an image source, applyInstruction forwards a natural-language change to the plugin.")
     public var operation: EditOperation
 
+    /// The edit's payload, interpreted per ``operation``: replacement text, attribute value,
+    /// image source, or a natural-language instruction.
     @Guide(description: "The replacement text, attribute value, image source, or natural-language instruction to apply, appropriate to the operation.")
     public var value: String
 
+    /// One-sentence rationale surfaced to the user *before* the edit applies — generated edits
+    /// are confirm-first, never silently applied.
     @Guide(description: "One short sentence explaining the change, shown to the user before they confirm it.")
     public var explanation: String
 }
@@ -51,15 +60,21 @@ public struct GeneratedEditCommand: Equatable, Sendable {
 /// SEO/page metadata generated for a page from its content. Consumed by `new-page` flows and #157.
 @Generable
 public struct GeneratedPageMeta: Equatable, Sendable {
+    /// Page title, targeted under 60 characters so search results don't truncate it.
     @Guide(description: "A concise, descriptive page title under 60 characters.")
     public var title: String
 
+    /// Meta description, targeted at 150–160 characters — the length search engines display in
+    /// full.
     @Guide(description: "A meta description summarizing the page in 150-160 characters.")
     public var description: String
 
+    /// URL slug in lowercase kebab-case. Model output is a *suggestion*; callers remain
+    /// responsible for filesystem/route validity.
     @Guide(description: "A URL-safe slug in lowercase kebab-case, e.g. 'about-our-team'.")
     public var slug: String
 
+    /// Lowercase topic tags (three to six) for the page's frontmatter.
     @Guide(description: "Three to six lowercase topic tags describing the page.")
     public var tags: [String]
 }
@@ -67,9 +82,14 @@ public struct GeneratedPageMeta: Equatable, Sendable {
 /// Alt text generated for an image, plus whether the image is purely decorative.
 @Generable
 public struct GeneratedAltText: Equatable, Sendable {
+    /// Descriptive alt text, targeted under 125 characters. Empty when ``isDecorative`` is
+    /// `true` — an empty `alt=""` is the accessibility-correct markup for decorative images,
+    /// not missing data.
     @Guide(description: "Descriptive alt text under 125 characters. Use an empty string when the image is decorative (and set isDecorative to true).")
     public var altText: String
 
+    /// Whether the image is purely decorative. Carried as an explicit flag so callers can
+    /// distinguish "deliberately empty alt" from a generation that produced nothing.
     @Guide(description: "True if the image is purely decorative and should have empty alt text.")
     public var isDecorative: Bool
 }
@@ -77,15 +97,19 @@ public struct GeneratedAltText: Equatable, Sendable {
 /// A summary of a piece of content with reading metadata.
 @Generable
 public struct ContentSummary: Equatable, Sendable {
+    /// Two-to-three sentence prose summary of the content.
     @Guide(description: "A two-to-three sentence summary of the content.")
     public var summary: String
 
+    /// Approximate word count as estimated by the model — display-grade, not an exact count.
     @Guide(description: "Approximate word count of the source content.")
     public var wordCount: Int
 
+    /// Estimated reading time in whole minutes, at the conventional ~200 words per minute.
     @Guide(description: "Estimated reading time in whole minutes (assume ~200 words per minute).")
     public var readingTimeMinutes: Int
 
+    /// Three to five key topics, as short phrases.
     @Guide(description: "Three to five key topics covered, as short phrases.")
     public var topics: [String]
 }
@@ -93,10 +117,16 @@ public struct ContentSummary: Equatable, Sendable {
 /// What kind of page a piece of content is. Drives layout/metadata defaults.
 @Generable
 public enum ContentClassification: Equatable, Sendable {
+    /// A dated article-style post (blog collection defaults).
     case blogPost
+    /// A marketing/conversion page (hero-first layout defaults).
     case landingPage
+    /// Reference or how-to material (docs layout defaults).
     case documentation
+    /// A work-showcase page (gallery/project layout defaults).
     case portfolio
+    /// Anything the model couldn't place in the fixed cases; the payload is its free-text
+    /// label, so an unanticipated content kind is surfaced rather than force-fitted.
     case other(String)
 }
 
@@ -104,12 +134,17 @@ public enum ContentClassification: Equatable, Sendable {
 /// `DeployFailureSummary` before it crosses the FoundationModels gate.
 @Generable
 public struct GeneratedDeployFailureSummary: Equatable, Sendable {
+    /// One or two plain-language sentences on what went wrong — written for the site owner,
+    /// not a developer reading build logs.
     @Guide(description: "One or two plain-language sentences explaining what went wrong with the deploy.")
     public var summary: String
 
+    /// The single most likely root cause, in one sentence.
     @Guide(description: "The single most likely root cause of the failure, in one sentence.")
     public var likelyCause: String
 
+    /// A concrete next step the owner can take; empty when none is clear (empty-string rather
+    /// than optional, because guided generation requires every field be produced).
     @Guide(description: "A concrete next step the site owner can take to fix it. Empty string if none is clear.")
     public var suggestedFix: String
 }
@@ -118,6 +153,8 @@ public struct GeneratedDeployFailureSummary: Equatable, Sendable {
 /// non-gated `PageCopySuggestion` before it crosses the FoundationModels gate.
 @Generable
 public struct GeneratedPageCopySuggestion: Equatable, Sendable {
+    /// One SEO meta-description sentence, under 160 characters and deliberately not a verbatim
+    /// echo of the page title (a repeated title wastes the search-snippet slot).
     @Guide(description: "A single concise SEO meta description sentence, under 160 characters, that does not repeat the title verbatim.")
     public var description: String
 }
@@ -126,9 +163,13 @@ public struct GeneratedPageCopySuggestion: Equatable, Sendable {
 /// (tone/brand-term fields the deterministic extractor can't compute from text alone).
 @Generable
 public struct GeneratedProjectConventions: Equatable, Sendable {
+    /// Three to five adjectives describing the site's writing tone — the judgment call a
+    /// deterministic text scan can't make.
     @Guide(description: "Three to five adjectives describing this site's writing tone, e.g. ['concise', 'playful', 'technical'].")
     public var toneDescriptors: [String]
 
+    /// Up to five brand/product terms with their canonical capitalization as actually used in
+    /// the site's text, so later generation preserves the owner's spelling.
     @Guide(description: "Up to five brand or product terms with their canonical capitalization as used in the text, e.g. ['Anglesite', 'Astro'].")
     public var brandTerms: [String]
 }
@@ -137,14 +178,24 @@ public struct GeneratedProjectConventions: Equatable, Sendable {
 /// the non-gated `CopyFindingDraft` before it crosses the FoundationModels gate.
 @Generable
 public struct GeneratedCopyFinding: Equatable, Sendable {
+    /// Checklist category token (`clarity`, `benefits`, `voice`, `cta`, `scannability`,
+    /// `reader-focus`, `jargon`, `social-proof`, `missing-info`, or `mobile`). Kept as a string
+    /// rather than an enum so an off-vocabulary answer degrades to display text instead of a
+    /// decode failure.
     @Guide(description: "Checklist category: clarity, benefits, voice, cta, scannability, reader-focus, jargon, social-proof, missing-info, or mobile.")
     public var category: String
+    /// Severity token: `high`, `medium`, or `low`.
     @Guide(description: "Severity: high, medium, or low.")
     public var severity: String
+    /// Verbatim excerpt of the problematic copy — exact characters matter, because the finding
+    /// is verified by substring-matching this against the page text (a paraphrased excerpt is
+    /// discarded as a hallucination) and `CopyRewriteApplier` locates the copy by the same match.
     @Guide(description: "Short excerpt of the problematic copy, quoted verbatim from the page text — exact characters, no paraphrase.")
     public var excerpt: String
+    /// One plain-language sentence describing what's wrong.
     @Guide(description: "One-sentence plain-language description of the issue.")
     public var issue: String
+    /// Suggested replacement copy, written in the site's own voice.
     @Guide(description: "Suggested replacement copy in the site's voice.")
     public var suggestedRewrite: String
 }
@@ -153,6 +204,8 @@ public struct GeneratedCopyFinding: Equatable, Sendable {
 /// highest-impact findings, per `CopyEditPrompt`.
 @Generable
 public struct GeneratedPageCopyFindings: Equatable, Sendable {
+    /// Up to 5 highest-impact findings; empty means the copy is strong — a valid answer, not a
+    /// failed generation.
     @Guide(description: "Up to 5 highest-impact findings for this page. Empty when the copy is strong.")
     public var findings: [GeneratedCopyFinding]
 }
@@ -161,6 +214,9 @@ public struct GeneratedPageCopyFindings: Equatable, Sendable {
 /// `SocialMediaPlan.bios` before it crosses the FoundationModels gate.
 @Generable
 public struct GeneratedSocialBio: Equatable, Sendable {
+    /// The profile bio text. The platform's character limit is stated in the prompt, but not
+    /// trusted: length enforcement stays in Swift, like every other char-limit policy in the
+    /// social pipeline.
     @Guide(description: "The profile bio text, within the stated character limit. No hashtags unless the platform calls for them.")
     public var bio: String
 }
@@ -169,8 +225,11 @@ public struct GeneratedSocialBio: Equatable, Sendable {
 /// the non-gated `SocialPillar` before it crosses the FoundationModels gate.
 @Generable
 public struct GeneratedSocialPillar: Equatable, Sendable {
+    /// Short pillar name (e.g. "Behind the scenes") — later calendar entries reference pillars
+    /// by this name, so it doubles as the pillar's identifier within a plan.
     @Guide(description: "Short pillar name, e.g. 'Behind the scenes'.")
     public var name: String
+    /// One sentence on what the pillar covers and why followers care.
     @Guide(description: "One sentence on what this pillar covers and why followers care.")
     public var detail: String
 }
@@ -178,6 +237,8 @@ public struct GeneratedSocialPillar: Equatable, Sendable {
 /// On-device guided-generation result for the full set of social content pillars (#465).
 @Generable
 public struct GeneratedSocialPillars: Equatable, Sendable {
+    /// The 3–5 pillars, balanced roughly 80% value/story to 20% promotional — the strategy
+    /// ratio the social-media skill prescribes.
     @Guide(description: "3 to 5 content pillars. Roughly 80% value/story content, 20% promotional.")
     public var pillars: [GeneratedSocialPillar]
 }
@@ -186,12 +247,17 @@ public struct GeneratedSocialPillars: Equatable, Sendable {
 /// the non-gated `SocialCalendarEntry` before it crosses the FoundationModels gate.
 @Generable
 public struct GeneratedSocialWeekEntry: Equatable, Sendable {
+    /// Day-of-week label (e.g. "Monday").
     @Guide(description: "Day of week, e.g. 'Monday'.")
     public var day: String
+    /// Platform name, echoed exactly as the prompt supplied it so the entry joins back to the
+    /// owner's chosen platform list without fuzzy matching.
     @Guide(description: "Platform name, exactly as given in the prompt.")
     public var platform: String
+    /// Pillar name, echoed exactly as the prompt supplied it (see ``GeneratedSocialPillar/name``).
     @Guide(description: "Pillar name, exactly as given in the prompt.")
     public var pillar: String
+    /// One concrete, shootable/writable post idea for that day.
     @Guide(description: "One concrete post idea the owner could shoot/write that day.")
     public var idea: String
 }
@@ -200,6 +266,8 @@ public struct GeneratedSocialWeekEntry: Equatable, Sendable {
 /// (chunk-first — see `SocialPlanPrompt`).
 @Generable
 public struct GeneratedSocialWeek: Equatable, Sendable {
+    /// The week's post schedule, respecting each platform's posts-per-week cadence from the
+    /// prompt.
     @Guide(description: "The week's post schedule, respecting each platform's posts-per-week cadence.")
     public var entries: [GeneratedSocialWeekEntry]
 }
@@ -209,6 +277,9 @@ public struct GeneratedSocialWeek: Equatable, Sendable {
 /// the char-limit policy (spec §5.3) is enforced in Swift, never trusted to the model.
 @Generable
 public struct GeneratedPlatformPost: Equatable, Sendable {
+    /// The complete, copy-paste-ready post text. The character limit lives in the prompt as a
+    /// request only — the Swift side re-checks length and retries/omits rather than truncating
+    /// (see the type-level note).
     @Guide(description: "The complete post text for the platform, within the stated character limit, ready to copy-paste.")
     public var text: String
 }

--- a/Sources/AnglesiteCore/GitHubAPITokenVerifier.swift
+++ b/Sources/AnglesiteCore/GitHubAPITokenVerifier.swift
@@ -10,10 +10,16 @@ import FoundationNetworking
 /// you're signed in as). `name` and `avatarURL` are best-effort niceties; `login` is always
 /// present on a valid token.
 public struct GitHubAccount: Sendable, Equatable {
+    /// The account's GitHub username (the `@handle`). The one field a valid token always yields,
+    /// so display code can rely on it without a fallback.
     public let login: String
+    /// The user's display name, if they've set one on their GitHub profile.
     public let name: String?
+    /// The profile avatar URL, if GitHub returned a parseable one.
     public let avatarURL: URL?
 
+    /// Memberwise initializer, public so tests and previews can fabricate accounts without a
+    /// network verify.
     public init(login: String, name: String?, avatarURL: URL?) {
         self.login = login
         self.name = name
@@ -30,6 +36,9 @@ public enum GitHubTokenVerifyError: Error, Equatable, Sendable {
     /// We couldn't check the token at all (rate limit, outage, unexpected response).
     case unavailable(String)
 
+    /// The user-facing copy Settings shows for this failure. Notably, ``invalidToken``'s message
+    /// carries the full token-creation recipe (fine-grained, All repositories, Contents +
+    /// Administration read/write) so the user can fix it without leaving the prompt.
     public var userMessage: String {
         switch self {
         case .invalidToken:
@@ -46,6 +55,10 @@ public enum GitHubTokenVerifyError: Error, Equatable, Sendable {
 /// the point of entry — and surfaces the connected identity for display, the same "verify then
 /// persist" shape as `TokenVerifying` (Cloudflare).
 public protocol GitHubTokenVerifying: Sendable {
+    /// Checks `token` against GitHub, returning the connected account on success. A `Result`
+    /// rather than `throws` so callers must classify every failure (bad token vs. offline vs.
+    /// GitHub outage) — each gets different user-facing copy via
+    /// ``GitHubTokenVerifyError/userMessage``.
     func verify(token: String) async -> Result<GitHubAccount, GitHubTokenVerifyError>
 }
 
@@ -59,6 +72,8 @@ public struct GitHubAPITokenVerifier: GitHubTokenVerifying {
     private let baseURL: URL
     private let transport: Transport
 
+    /// Both parameters exist for tests: `baseURL` points the client at a stub server, and
+    /// `transport` replaces the network entirely. Production uses the defaults.
     public init(
         baseURL: URL = URL(string: "https://api.github.com")!,
         transport: @escaping Transport = GitHubAPITokenVerifier.defaultTransport
@@ -67,6 +82,11 @@ public struct GitHubAPITokenVerifier: GitHubTokenVerifying {
         self.transport = transport
     }
 
+    /// Calls `GET /user` with the token and classifies the outcome. Only a 401 blames the token
+    /// (``GitHubTokenVerifyError/invalidToken``) — `/user` needs no specific scope, so a 403 is
+    /// far more likely a rate limit, and it's grouped with 429/5xx as
+    /// ``GitHubTokenVerifyError/unavailable(_:)`` rather than telling the user their token is bad
+    /// when it probably isn't.
     public func verify(token: String) async -> Result<GitHubAccount, GitHubTokenVerifyError> {
         var request = URLRequest(url: baseURL.appendingPathComponent("user"))
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")

--- a/Sources/AnglesiteCore/GitHubTokenOnboarding.swift
+++ b/Sources/AnglesiteCore/GitHubTokenOnboarding.swift
@@ -13,6 +13,9 @@ import Foundation
 /// gymnastics on the closures.
 @MainActor
 public struct GitHubTokenOnboarding {
+    /// What the flow decided — the caller's whole contract. Three-way rather than a thrown error
+    /// so "keep the prompt open" (``stay(message:)``) and "user walked away" (``abort``) can't be
+    /// conflated: only an explicit cancellation dismisses the prompt.
     public enum Outcome: Equatable {
         /// Token verified and persisted — the caller should retry the parked publish.
         case proceed(GitHubAccount)
@@ -24,6 +27,9 @@ public struct GitHubTokenOnboarding {
 
     private let verifier: GitHubTokenVerifying
 
+    /// The verifier is the only injected dependency — production passes
+    /// ``GitHubAPITokenVerifier``, tests a stub, keeping the flow's ordering logic testable
+    /// without network.
     public init(verifier: GitHubTokenVerifying) {
         self.verifier = verifier
     }

--- a/Sources/AnglesiteCore/GitInitRunner.swift
+++ b/Sources/AnglesiteCore/GitInitRunner.swift
@@ -9,11 +9,17 @@ import SwiftGit2
 /// `Source/` with no `.git`, and could never preview (#548).
 public enum GitInitError: LocalizedError, Sendable, Equatable {
     #if canImport(Darwin)
+    /// The in-process libgit2 `Repository.create` failed; carries SwiftGit2's error message
+    /// (there is no exit code or stderr — no subprocess ran).
     case failed(message: String)
     #else
+    /// `git init` exited nonzero; carries the exit code and captured stderr so the real reason
+    /// reaches the user instead of being discarded (the original #548 failure mode).
     case failed(exitCode: Int32, stderr: String)
     #endif
 
+    /// User-facing description including whatever detail the backend produced; falls back to
+    /// just the exit code when stderr was empty.
     public var errorDescription: String? {
         switch self {
         #if canImport(Darwin)
@@ -28,6 +34,11 @@ public enum GitInitError: LocalizedError, Sendable, Equatable {
     }
 }
 
+/// Initializes the git repository for a freshly scaffolded site's `Source/` — the step that
+/// makes "git is the source of truth" (#72) true from a site's first moment. Platform-split by
+/// necessity, not preference: under App Sandbox `/usr/bin/git` cannot execute at all (#640), so
+/// Darwin goes through in-process libgit2 (SwiftGit2), while off-Darwin keeps a plain `git init`
+/// subprocess. Both surface failure as `GitInitError` rather than discarding it (#548).
 public enum GitInitRunner {
     #if canImport(Darwin)
     /// Initializes a git repository at `sourceDirectory` via SwiftGit2 (in-process libgit2, no

--- a/Sources/AnglesiteCore/GreenHostChecker.swift
+++ b/Sources/AnglesiteCore/GreenHostChecker.swift
@@ -7,27 +7,45 @@ import FoundationNetworking
 /// so a definitive "not green" (a successful, negative answer) is never conflated with a failed
 /// check (network failure or an unreachable/broken API) — issue #684's explicit requirement.
 public enum GreenHostCheckResult: Equatable, Sendable {
+    /// The Green Web Foundation reports the host as running on verified green energy.
     case green
+    /// A definitive negative: the check succeeded and the host is *not* listed as green.
+    /// Distinct from any error case so it can be shown as a fact, not a shrug.
     case notGreen
 }
 
+/// Why a Greencheck lookup couldn't produce an answer — the "we don't know" side of the
+/// result/error split described on ``GreenHostCheckResult``.
 public enum GreenHostCheckError: Error, Equatable, Sendable {
+    /// The request never completed (DNS/connection failure) — likely the user's connectivity.
     case network
+    /// The API responded but unusably (rate limit, 5xx, or an undecodable body); carries the
+    /// user-facing message to display.
     case unavailable(String)
 }
 
+/// Seam for the Greencheck lookup so callers can be tested without the live Green Web
+/// Foundation API; ``GreenHostChecker`` is the production conformance.
 public protocol GreenHostChecking: Sendable {
+    /// Looks up `hostname` (a bare host, not a URL), answering green/not-green or an error.
+    /// A `Result` rather than `throws` so a failed check can never be mistaken for "not green"
+    /// (#684's explicit requirement).
     func check(hostname: String) async -> Result<GreenHostCheckResult, GreenHostCheckError>
 }
 
 /// Client for the Green Web Foundation's public Greencheck API (verified 2026-07-23 against
 /// developers.thegreenwebfoundation.org): `GET .../api/v3/greencheck/{hostname}` → `{"green": bool, ...}`.
 public struct GreenHostChecker: GreenHostChecking {
+    /// Performs one GET and returns its body + response; throws on connection failure. Same
+    /// injectable-HTTP seam shape as ``GitHubAPITokenVerifier/Transport``, for the same reason:
+    /// the response-classification logic is unit-testable without real network.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     private let baseURL: URL
     private let transport: Transport
 
+    /// Both parameters exist for tests (stub server / no network at all); production uses the
+    /// defaults.
     public init(
         baseURL: URL = URL(string: "https://api.thegreenwebfoundation.org/api/v3/greencheck")!,
         transport: @escaping Transport = GreenHostChecker.defaultTransport
@@ -36,6 +54,10 @@ public struct GreenHostChecker: GreenHostChecking {
         self.transport = transport
     }
 
+    /// GETs `{baseURL}/{hostname}` and maps the response: transport failure → `.network`,
+    /// 429/5xx or an undecodable body → `.unavailable`, otherwise the API's boolean `green`
+    /// field decides ``GreenHostCheckResult``. No status code ever maps to `.notGreen` — only
+    /// an explicit `"green": false` does.
     public func check(hostname: String) async -> Result<GreenHostCheckResult, GreenHostCheckError> {
         let request = URLRequest(url: baseURL.appendingPathComponent(hostname))
         let data: Data
@@ -58,6 +80,7 @@ public struct GreenHostChecker: GreenHostChecking {
 
     private struct GreenCheckResponse: Decodable { let green: Bool }
 
+    /// Production transport: a plain shared-`URLSession` GET.
     public static let defaultTransport: Transport = { request in
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }

--- a/Sources/AnglesiteCore/GroupTimelineClient.swift
+++ b/Sources/AnglesiteCore/GroupTimelineClient.swift
@@ -8,13 +8,24 @@ import FoundationNetworking
 /// (a real post), else the bare activity id (an item this parser couldn't unwrap further, still
 /// worth a stub row so the timeline's count matches the collection's).
 public struct GroupPost: Sendable, Equatable, Identifiable {
+    /// The post's ActivityPub IRI — the wrapped object's `id` for a real post, or the bare
+    /// activity id for a stub row (see the type-level note).
     public let id: String
+    /// The post's `name`, sanitized through ``DisplayString``; `nil` for untitled notes.
     public let title: String?
+    /// The post's `content` HTML, sanitized through ``DisplayString`` — it can be rendered as
+    /// the row's fallback text when there is no ``title``, so it gets the same bidi/control-
+    /// scalar stripping.
     public let contentHTML: String?
+    /// The post's own `url`, for opening the original in a browser; `nil` on stub rows.
     public let url: URL?
+    /// The object's `published` timestamp, when it parsed as ISO 8601.
     public let publishedAt: Date?
+    /// The `attributedTo` value (an actor IRI, not a resolved display name), sanitized through
+    /// ``DisplayString``.
     public let authorName: String?
 
+    /// Memberwise initializer, public so views and tests can build rows without parsing AS2.
     public init(
         id: String, title: String?, contentHTML: String?, url: URL?, publishedAt: Date?,
         authorName: String?
@@ -28,20 +39,31 @@ public struct GroupPost: Sendable, Equatable, Identifiable {
     }
 }
 
+/// One page of a Group outbox, plus the link to the next — the unit of incremental loading, so
+/// the timeline can render page-by-page instead of fetching a whole (possibly huge) outbox.
 public struct GroupTimelinePage: Sendable, Equatable {
+    /// The page's posts, in the collection's own order.
     public let items: [GroupPost]
+    /// The AS2 `next` page URL; `nil` on the last page.
     public let next: URL?
 
+    /// Memberwise initializer, public so tests can fabricate pages without AS2 fixtures.
     public init(items: [GroupPost], next: URL?) {
         self.items = items
         self.next = next
     }
 }
 
+/// Why a Group timeline fetch failed. Each case keeps enough context (status, truncated body,
+/// decode reason) to debug a remote server's behavior from a log line.
 public enum GroupTimelineError: Error, Equatable, Sendable {
     /// The outbox URL, or the URL a redirect actually landed on, wasn't `https`.
     case insecureURL
+    /// The request failed at the HTTP layer: a non-2xx status with a body excerpt capped at
+    /// 400 bytes, or `status: 0` for transport-level failures (connection error, over-size
+    /// response).
     case requestFailed(status: Int, body: String)
+    /// The response wasn't the expected JSON object; carries a short reason.
     case decodingFailed(String)
 }
 
@@ -55,6 +77,8 @@ public enum GroupTimelineError: Error, Equatable, Sendable {
 /// `JSONSerialization` — like `ActivityPubOutboxBackfill.activityID(from:)` — rather than fighting
 /// `Decodable` over a heterogeneous array.
 public struct GroupTimelineClient: Sendable {
+    /// Performs one GET and returns its body + response; throws on connection failure.
+    /// Injectable so the AS2 parsing and HTTPS/size guards are testable without network.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     /// 1 MB. A single actor document (`ActorProfileFetcher`'s 256 KB cap) is a few KB, but an
@@ -64,10 +88,15 @@ public struct GroupTimelineClient: Sendable {
 
     private let transport: Transport
 
+    /// The transport parameter exists for tests; production uses ``defaultTransport``, which
+    /// enforces the response-size cap mid-stream.
     public init(transport: @escaping Transport = GroupTimelineClient.defaultTransport) {
         self.transport = transport
     }
 
+    /// Fetches the outbox's top-level collection document: its advertised `totalItems` (0 when
+    /// absent) and the `first` page URL, `nil` when the collection is empty or inlined. Callers
+    /// use `totalItems` to decide whether the stub-row parse actually covered the collection.
     public func collection(at outboxURL: URL) async throws -> (totalItems: Int, firstPage: URL?) {
         let json = try await fetch(outboxURL)
         let totalItems = json["totalItems"] as? Int ?? 0
@@ -75,6 +104,9 @@ public struct GroupTimelineClient: Sendable {
         return (totalItems, firstPage)
     }
 
+    /// Fetches one outbox page and parses its `orderedItems` into ``GroupPost`` rows (bare-IRI
+    /// items become id-only stubs; genuinely unparseable items are dropped), plus the `next`
+    /// page URL for continued paging.
     public func page(at url: URL) async throws -> GroupTimelinePage {
         let json = try await fetch(url)
         let rawItems = (json["orderedItems"] as? [Any]) ?? []
@@ -149,6 +181,9 @@ public struct GroupTimelineClient: Sendable {
     private static let session = CappedHTTPTransport.session(
         requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
 
+    /// Production transport: a `CappedHTTPTransport` fetch that aborts mid-stream once
+    /// ``maximumResponseBytes`` is exceeded, so a hostile outbox can't buffer unbounded data
+    /// before the post-hoc size check runs.
     public static let defaultTransport: Transport = { request in
         try await CappedHTTPTransport.fetch(
             request, session: session, cap: GroupTimelineClient.maximumResponseBytes,

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -87,15 +87,20 @@ private struct CFPageShieldScript: Decodable, Sendable {
     let host: String?
 }
 
-/// Read-only Cloudflare v4 client. All methods are GETs.
+/// Cloudflare v4 API client. The base conformance here is the read side
+/// (``CloudflareReading``, all GETs); the write side (``CloudflareWriting`` — the hardening
+/// PUT/POST/PATCH/DELETE calls) is conformed in an extension below.
 public struct HTTPCloudflareClient: CloudflareReading {
     private static let base = "https://api.cloudflare.com/client/v4"
     private let transport: CloudflareTransport
 
+    /// The transport parameter exists for tests (fake responses, no network); production uses
+    /// ``defaultTransport``.
     public init(transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport) {
         self.transport = transport
     }
 
+    /// Production transport: a plain shared-`URLSession` request.
     public static let defaultTransport: CloudflareTransport = { request in
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw CloudflareError.malformedResponse }
@@ -154,12 +159,22 @@ public struct HTTPCloudflareClient: CloudflareReading {
         try await paginated("/zones/\(zoneID)/dns_records?per_page=100", apiToken: apiToken, as: CFDNSRecord.self)
     }
 
+    /// Looks the zone up via `GET /zones?name=…&status=active`, then re-checks the name
+    /// case-insensitively client-side — the API's `name=` filter is a match request, not a
+    /// guarantee, and a wrong zone id here would point every later read/write at someone
+    /// else's zone.
     public func resolveZoneID(domain: String, apiToken: String) async throws -> String? {
         let escaped = domain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? domain
         let zones = try await get("/zones?name=\(escaped)&status=active", apiToken: apiToken, as: [CFZone].self)
         return zones.first(where: { $0.name.lowercased() == domain.lowercased() })?.id
     }
 
+    /// Assembles the zone's security posture from a dozen endpoints. The five core reads
+    /// (DNSSEC, SSL mode, Always-Use-HTTPS, security header, DNS records) fan out concurrently
+    /// and *must* all succeed; the extended settings (Bot Fight Mode, WAF rules, Speed Brain,
+    /// ECH, zstd, Page Shield, Onion Routing) individually degrade to their "off"/absent value
+    /// on error instead — many tokens simply can't see those endpoints, and one 403 there
+    /// shouldn't sink the whole audit.
     public func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState {
         // Independent reads — fan out concurrently rather than paying 5× round-trip latency.
         async let dnssecCall = get("/zones/\(zoneID)/dnssec", apiToken: apiToken, as: CFDNSSEC.self)
@@ -263,6 +278,8 @@ public struct HTTPCloudflareClient: CloudflareReading {
         return .init(enabled: enabled, scriptHosts: hosts)
     }
 
+    /// Lists every DNS record in the zone, walking all pages (Cloudflare caps `per_page` at
+    /// 100, so a single-page read silently truncates larger zones).
     public func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] {
         let raw = try await paginated("/zones/\(zoneID)/dns_records?per_page=100", apiToken: apiToken, as: CFFullDNSRecord.self)
         return raw.map {
@@ -271,6 +288,9 @@ public struct HTTPCloudflareClient: CloudflareReading {
         }
     }
 
+    /// Lists all Worker script names visible to the token's **first** account (a personal
+    /// Cloudflare token virtually always sees exactly one), walking all pages. Throws
+    /// ``CloudflareError/api(message:)`` when the token can see no account at all.
     public func workerScriptNames(apiToken: String) async throws -> [String] {
         let accounts = try await get("/accounts?per_page=1", apiToken: apiToken, as: [CFAccount].self)
         guard let accountID = accounts.first?.id else {
@@ -313,16 +333,22 @@ public struct HTTPCloudflareClient: CloudflareReading {
 // MARK: - CloudflareWriting conformance
 
 extension HTTPCloudflareClient: CloudflareWriting {
+    /// `PUT /zones/{id}/dnssec` with `status: active`. Enable-only — the app hardens; it never
+    /// offers a "turn DNSSEC back off" path.
     public func enableDNSSEC(zoneID: String, apiToken: String) async throws {
         try await mutate(method: "PUT", "/zones/\(zoneID)/dnssec",
                          body: ["status": "active"], apiToken: apiToken)
     }
 
+    /// `PUT /zones/{id}/settings/always_use_https`, mapping `enabled` to the API's `"on"/"off"`
+    /// string values.
     public func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws {
         try await mutate(method: "PUT", "/zones/\(zoneID)/settings/always_use_https",
                          body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
     }
 
+    /// `PUT /zones/{id}/settings/security_header` with `enabled: true` fixed — callers choose
+    /// the HSTS parameters, not whether HSTS is on; disabling it is deliberately not offered.
     public func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool,
                          apiToken: String) async throws {
         struct HSTSBody: Encodable, Sendable {
@@ -343,21 +369,29 @@ extension HTTPCloudflareClient: CloudflareWriting {
                          body: body, apiToken: apiToken)
     }
 
+    /// `POST /zones/{id}/dns_records` — ``DNSRecordPayload`` encodes directly as the request
+    /// body, so what the seam accepts and what goes over the wire can't drift apart.
     public func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws {
         try await mutate(method: "POST", "/zones/\(zoneID)/dns_records",
                          body: record, apiToken: apiToken)
     }
 
+    /// `DELETE /zones/{id}/dns_records/{recordID}` (with an empty JSON body Cloudflare
+    /// tolerates, so the shared `mutate` helper needs no body-less variant).
     public func deleteDNSRecord(zoneID: String, recordID: String, apiToken: String) async throws {
         try await mutate(method: "DELETE", "/zones/\(zoneID)/dns_records/\(recordID)",
                          body: CFEmptyBody(), apiToken: apiToken)
     }
 
+    /// `PATCH /zones/{id}/bot_management` toggling `fight_mode`.
     public func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {
         try await mutate(method: "PATCH", "/zones/\(zoneID)/bot_management",
                          body: ["fight_mode": enabled], apiToken: apiToken)
     }
 
+    /// Appends `rule` to the zone's `http_request_firewall_custom` ruleset, creating that
+    /// ruleset first when the zone has never had one — a fresh zone has no custom-rules
+    /// ruleset, and a bare rule-POST would 404 there.
     public func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {
         let rulesets = try await get("/zones/\(zoneID)/rulesets", apiToken: apiToken, as: [CFRuleset].self)
         let existing = rulesets.first(where: { $0.phase == "http_request_firewall_custom" })
@@ -380,26 +414,39 @@ extension HTTPCloudflareClient: CloudflareWriting {
         }
     }
 
+    /// `PATCH /zones/{id}/settings/speed_brain`, mapping `enabled` to `"on"/"off"`.
     public func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {
         try await mutate(method: "PATCH", "/zones/\(zoneID)/settings/speed_brain",
                          body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
     }
 
+    /// `PATCH /zones/{id}/settings/ech` (Encrypted Client Hello), mapping `enabled` to
+    /// `"on"/"off"`.
     public func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {
         try await mutate(method: "PATCH", "/zones/\(zoneID)/settings/ech",
                          body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
     }
 
+    /// `PUT /zones/{id}/page_shield` — this endpoint takes a real boolean `enabled`, unlike the
+    /// `"on"/"off"`-string settings endpoints.
     public func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {
         try await mutate(method: "PUT", "/zones/\(zoneID)/page_shield",
                          body: ["enabled": enabled], apiToken: apiToken)
     }
 
+    /// `PATCH /zones/{id}/settings/opportunistic_onion` (Onion Routing for Tor visitors),
+    /// mapping `enabled` to `"on"/"off"`.
     public func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {
         try await mutate(method: "PATCH", "/zones/\(zoneID)/settings/opportunistic_onion",
                          body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
     }
 
+    /// Implements the attach as read-then-write: resolve the zone (short-circuiting to
+    /// ``CustomDomainAttachResult/zoneNotFound`` for the common "nameservers not delegated yet"
+    /// case before any account round-trip), list existing attachments for the hostname, and only
+    /// `PUT /accounts/{id}/workers/domains` when nothing owns it — an attachment held by a
+    /// *different* script comes back as ``CustomDomainAttachResult/conflict(ownedBy:)`` instead
+    /// of being silently repointed (#1077).
     public func attachWorkersCustomDomain(
         hostname: String, workerScriptName: String, apiToken: String
     ) async throws -> CustomDomainAttachResult {
@@ -434,6 +481,10 @@ extension HTTPCloudflareClient: CloudflareWriting {
         return .attached
     }
 
+    /// Adds a zstd-first (zstd → brotli → gzip) `compress_response` rule to the zone's
+    /// `http_response_compression` ruleset, creating the ruleset when absent. Idempotent by
+    /// inspection: an existing zstd rule means return without writing, so repeated hardening
+    /// runs don't stack duplicate rules.
     public func enableZstandardCompression(zoneID: String, apiToken: String) async throws {
         struct CompressionRule: Encodable, Sendable {
             struct Params: Encodable, Sendable {


### PR DESCRIPTION
## Summary

- Phase 5 of the doc-comment retrofit tracked in #1141: third alphabetical chunk of AnglesiteCore (39 files, `DeployExecutor` … `HTTPCloudflareClient`, ~380 doc comments) — deploy executors and failure summaries, the design interview pipeline, edit routing/undo/session types, the email setup planner, the FoundationModels assistants/interpreters/`@Generable` types, frontmatter, GitHub token onboarding, the green-host checker, group timeline, and the Cloudflare HTTP client.
- Corrects `HTTPCloudflareClient`'s stale type doc ("read-only, all GETs" — it has conformed to `CloudflareWriting` since the hardening work).
- Single-line enum `case` lists split so each case carries its rationale; raw values and `CaseIterable` order unchanged. Comments only otherwise — no behavior changes. Gated-symbol link rules from `docs/comment-style-guide.md` applied throughout the `#if compiler(>=6.4)` files.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` — clean.
- [x] `swift test --filter AnglesiteCoreTests` — 3,050 tests in 384 suites; 2 failures, both the known "FoundationModelAssistant" concurrent-`swift test` FM-contention flake. This chunk adds doc comments (only) to that file; the same two tests fail identically on branches that don't touch it at all (#1148, #1152, #1153), establishing the environmental baseline.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run separately; comments-only diff, target compiles during DocC symbol-graph extraction.
