### PR TITLE
docs(#1141): retrofit doc comments, Core HTTPGitHub-MTASts

### DIFF
--- a/Sources/AnglesiteCore/HTTPGitHubClient.swift
+++ b/Sources/AnglesiteCore/HTTPGitHubClient.swift
@@ -10,10 +10,18 @@ public enum GitHubRepoAPIError: Error, Equatable, Sendable {
     /// The transport itself failed (DNS/offline/TLS/timeout) — never reached GitHub, so this is
     /// distinct from `.api`, which means GitHub responded with a rejection.
     case network
+    /// GitHub returned 401 or 403 — the token is invalid, expired, or missing the required scope.
+    /// Both statuses collapse into one case because the user-facing remedy is identical: fix the
+    /// token in Settings.
     case unauthorized
+    /// A 422 whose `errors[].message` says the repository name is taken. Split out from `.api`
+    /// so callers can offer a rename instead of showing a raw API message.
     case nameAlreadyExists
+    /// Any other non-2xx status with no more specific mapping.
     case http(status: Int)
+    /// A 422 rejection that isn't a name conflict — carries GitHub's own `message` for display.
     case api(message: String)
+    /// GitHub returned a success status but the body didn't decode into the expected shape.
     case malformedResponse
 }
 
@@ -27,6 +35,9 @@ public struct HTTPGitHubClient: Sendable {
     private static let base = "https://api.github.com"
     private let transport: GitHubAPITokenVerifier.Transport
 
+    /// Creates a client over the given transport. Reuses ``GitHubAPITokenVerifier``'s `Transport`
+    /// seam (rather than defining a parallel one) so tests mock all GitHub HTTP the same way; the
+    /// default is the real `URLSession`-backed transport.
     public init(transport: @escaping GitHubAPITokenVerifier.Transport = GitHubAPITokenVerifier.defaultTransport) {
         self.transport = transport
     }
@@ -125,6 +136,9 @@ public struct HTTPGitHubClient: Sendable {
 }
 
 extension HTTPGitHubClient: RepoSecurityReading, RepoSecurityWriting {
+    /// `GET /repos/{owner}/{repo}` → the `private` flag (see ``RepoSecurityReading``: a private
+    /// repo's advisory form is invisible to outside reporters, so this gates the whole
+    /// private-vulnerability-reporting flow).
     public func isPrivate(owner: String, name: String, token: String) async throws -> Bool {
         let data = try await send(repoRequest(method: "GET", path: "/repos/\(owner)/\(name)", token: token))
         guard let repo = try? JSONDecoder().decode(RepositoryResponse.self, from: data) else {
@@ -133,6 +147,8 @@ extension HTTPGitHubClient: RepoSecurityReading, RepoSecurityWriting {
         return repo.isPrivate
     }
 
+    /// `GET /repos/{owner}/{repo}/private-vulnerability-reporting` → whether the private advisory
+    /// channel is already enabled, so the app only offers to enable it when it's actually off.
     public func privateVulnerabilityReporting(owner: String, name: String, token: String) async throws -> Bool {
         let data = try await send(repoRequest(
             method: "GET", path: "/repos/\(owner)/\(name)/private-vulnerability-reporting", token: token))
@@ -142,6 +158,10 @@ extension HTTPGitHubClient: RepoSecurityReading, RepoSecurityWriting {
         return state.enabled
     }
 
+    /// `PUT /repos/{owner}/{repo}/private-vulnerability-reporting` — enable only, per
+    /// ``RepoSecurityWriting``'s contract (the app never disables a reporting channel it didn't
+    /// create). Requires admin access; a token without it surfaces as
+    /// ``GitHubRepoAPIError/unauthorized``.
     public func enablePrivateVulnerabilityReporting(owner: String, name: String, token: String) async throws {
         // A 204 with an empty body is the documented success response — nothing to decode.
         _ = try await send(repoRequest(

--- a/Sources/AnglesiteCore/HTTPRepoProvider.swift
+++ b/Sources/AnglesiteCore/HTTPRepoProvider.swift
@@ -14,6 +14,9 @@ public struct HTTPRepoProvider: RepoProvider {
     /// `createRepo`'s transport is mocked and there is no real GitHub repo to push into.
     private let remoteURL: @Sendable (RemoteRepo) -> String
 
+    /// Creates a provider. The defaults are the production configuration (real API client, Keychain
+    /// token, real GitHub HTTPS clone URLs); tests override `remoteURL` to point pushes at a local
+    /// bare repo, since a mocked `createRepo` never creates a real repository to push into.
     public init(
         client: HTTPGitHubClient = HTTPGitHubClient(),
         tokenProvider: @escaping InProcessGit.TokenProvider = InProcessGit.defaultTokenProvider,
@@ -31,6 +34,11 @@ public struct HTTPRepoProvider: RepoProvider {
         (try? tokenProvider())?.isEmpty == false
     }
 
+    /// Creates the remote repository, wires `origin` in `source`, and pushes its current branch.
+    ///
+    /// Every error is thrown as a user-facing `RepoBootstrapError`. Failures *after* `createRepo`
+    /// succeeds deliberately name the repository URL in their message: the remote now exists and
+    /// the user owns it, so a bare "couldn't push" would misleadingly suggest nothing happened.
     public func createAndPush(name: String, isPrivate: Bool, source: URL) async throws -> RemoteRepo {
         let token = try readToken()
 

--- a/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
+++ b/Sources/AnglesiteCore/HTTPSandboxControlClient.swift
@@ -12,6 +12,9 @@ public struct HTTPSandboxControlClient: SandboxControlClient {
     private let apiToken: String
     private let urlSession: URLSession
 
+    /// Creates a client for one deployed Control Worker. `workerBaseURL` and `apiToken` are the
+    /// values onboarding stored; `urlSession` is injectable so tests can stub HTTP without a
+    /// deployed Worker.
     public init(workerBaseURL: URL, apiToken: String, urlSession: URLSession = .shared) {
         self.workerBaseURL = workerBaseURL
         self.apiToken = apiToken
@@ -24,6 +27,9 @@ public struct HTTPSandboxControlClient: SandboxControlClient {
     private struct StatusResponse: Decodable { let siteID: String; let previewReady: Bool; let mcpReady: Bool }
     private struct StopBody: Encodable { let siteID: String }
 
+    /// `POST /start` — boots (or resumes) the sandbox and returns the preview + MCP tunnel URLs.
+    /// A response that doesn't decode is reported as ``SandboxControlError/startFailed(_:)``, same
+    /// as a Worker-reported boot failure — either way the session isn't usable.
     public func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
         let body = StartBody(siteID: siteID, gitRemote: gitRemote.absoluteString, gitRef: gitRef, token: token.value)
         let data = try await post("start", body: body)
@@ -35,10 +41,14 @@ public struct HTTPSandboxControlClient: SandboxControlClient {
         }
     }
 
+    /// `POST /stop` — asks the Worker to drop the tunnels and let the sandbox sleep. The response
+    /// body carries nothing useful, so only the status code matters.
     public func stop(siteID: String) async throws {
         _ = try await post("stop", body: StopBody(siteID: siteID))
     }
 
+    /// `POST /status` — probes preview/MCP readiness. Uses POST (not GET) like the other calls so
+    /// the Worker has a single authenticated JSON-body request shape to handle.
     public func status(siteID: String) async throws -> SandboxStatus {
         let data = try await post("status", body: StatusBody(siteID: siteID))
         do {

--- a/Sources/AnglesiteCore/HTTPTransport.swift
+++ b/Sources/AnglesiteCore/HTTPTransport.swift
@@ -12,9 +12,17 @@ import FoundationNetworking
 /// connection clears the session so a future re-`initialize` can recover (full container-restart
 /// recovery lands with #66/#69).
 public actor HTTPTransport: MCPTransport {
+    /// Transport-level failures. Distinguishes "the session is gone" (recoverable by
+    /// re-initializing) from plain HTTP rejections.
     public enum HTTPError: Error, Sendable, Equatable {
+        /// The server answered with a status other than 200/202/404 — no session-state conclusion
+        /// can be drawn, so the session id is kept.
         case http(status: Int)
+        /// The connection failed or the server returned 404 (the Streamable HTTP signal for an
+        /// expired session id). The stored session id is cleared either way, so a future
+        /// `initialize` can start a fresh session.
         case sessionLost
+        /// The response wasn't an HTTP response at all.
         case badResponse
     }
 
@@ -27,6 +35,10 @@ public actor HTTPTransport: MCPTransport {
     private let stream: AsyncStream<JSONValue>
     private let continuation: AsyncStream<JSONValue>.Continuation
 
+    /// Creates a transport for one `/mcp` endpoint. `bearerToken` is sent as an `Authorization`
+    /// header on every request — the remote-sandbox path requires it, the local container path
+    /// doesn't. `protocolVersion` is replayed verbatim in the `MCP-Protocol-Version` header;
+    /// `urlSession` is injectable for tests.
     public init(
         endpoint: URL,
         bearerToken: SessionToken? = nil,
@@ -40,8 +52,19 @@ public actor HTTPTransport: MCPTransport {
         (self.stream, self.continuation) = AsyncStream<JSONValue>.makeStream(bufferingPolicy: .unbounded)
     }
 
+    /// No-op: Streamable HTTP has no persistent connection to establish — the first `send` does
+    /// the work. Exists only to satisfy `MCPTransport`.
     public func open() async throws { /* no persistent connection; first send does the work */ }
 
+    /// POSTs one JSON-RPC message and funnels the decoded response into ``inbound()`` rather than
+    /// returning it — matching `MCPTransport`'s stream shape, so `MCPClient`'s request/response
+    /// correlation works identically over stdio and HTTP. SSE responses are read incrementally and
+    /// only until the first complete event (see the buffering note in the body); a 202 means a
+    /// notification was accepted and yields nothing.
+    ///
+    /// - Throws: ``HTTPError/sessionLost`` on connection failure or 404 (session id cleared),
+    ///   ``HTTPError/http(status:)`` for other non-success statuses, ``HTTPError/badResponse``
+    ///   for a non-HTTP response.
     public func send(_ message: JSONValue) async throws {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
@@ -155,8 +178,14 @@ public actor HTTPTransport: MCPTransport {
         return .continueReading
     }
 
+    /// The single stream of decoded server messages, fed by ``send(_:)``. `nonisolated` (the
+    /// stream and continuation are `let`s created at init) so the consumer can subscribe before
+    /// the first request without an actor hop.
     public nonisolated func inbound() -> AsyncStream<JSONValue> { stream }
 
+    /// Finishes ``inbound()`` and, if a session exists, sends a best-effort `DELETE` so the server
+    /// can reclaim it promptly — failures are ignored because the server expires abandoned
+    /// sessions on its own and there's nothing useful to do about them during teardown.
     public func close() async {
         continuation.finish()
         // Best-effort session teardown; ignore failures.

--- a/Sources/AnglesiteCore/HardenExecutor.swift
+++ b/Sources/AnglesiteCore/HardenExecutor.swift
@@ -4,26 +4,45 @@ public struct HardenExecutor: Sendable {
     private let reader: any CloudflareReading
     private let writer: any CloudflareWriting
 
+    /// Creates an executor. Reader and writer are separate seams (the
+    /// `CloudflareReading`/`CloudflareWriting` split) so tests can fake writes while still
+    /// exercising the post-apply re-read/re-audit path.
     public init(reader: any CloudflareReading, writer: any CloudflareWriting) {
         self.reader = reader
         self.writer = writer
     }
 
+    /// One plan item that failed to apply, paired with why. The error is captured as a display
+    /// string (`"\(error)"`) because the underlying error types are heterogeneous API failures the
+    /// caller can only show, not handle.
     public struct ItemFailure: Sendable {
+        /// The plan item that failed.
         public let item: HardenPlanItem
+        /// The stringified underlying error, for display.
         public let error: String
+        /// Creates a failure record.
         public init(item: HardenPlanItem, error: String) {
             self.item = item
             self.error = error
         }
     }
 
+    /// The outcome of one ``HardenExecutor/execute(plan:zoneID:domain:apiToken:)`` run. Always returned, never
+    /// thrown — partial success is the expected shape, so errors are folded in per item.
     public struct Result: Sendable {
+        /// How many plan items applied successfully.
         public let appliedCount: Int
+        /// The items that failed, each with its error. Empty means the whole plan applied.
         public let failedItems: [ItemFailure]
+        /// Findings from re-auditing the zone's fresh post-apply state. Empty either means the
+        /// zone audits clean *or* the re-read failed — check ``auditError`` before treating an
+        /// empty list as clean.
         public let postAuditFindings: [AuditReport.Finding]
+        /// Set when the post-apply re-read/re-audit itself failed (in which case
+        /// ``postAuditFindings`` is empty and says nothing about the zone).
         public let auditError: String?
 
+        /// Creates a result.
         public init(appliedCount: Int, failedItems: [ItemFailure],
                     postAuditFindings: [AuditReport.Finding], auditError: String? = nil) {
             self.appliedCount = appliedCount
@@ -33,6 +52,13 @@ public struct HardenExecutor: Sendable {
         }
     }
 
+    /// Applies every item in `plan`, then re-reads the zone and re-audits it so the caller can
+    /// show the actual resulting state rather than an optimistic prediction.
+    ///
+    /// Items are applied independently — one failure doesn't abort the rest, it's recorded in
+    /// ``Result/failedItems``. The re-audit derives `expectsMail` from the *fresh* MX records
+    /// (treating only a null MX as "no mail"), so a plan that just added a null MX doesn't get
+    /// re-flagged for missing mail hardening.
     public func execute(
         plan: HardenPlan,
         zoneID: String,

--- a/Sources/AnglesiteCore/HardenPlan.swift
+++ b/Sources/AnglesiteCore/HardenPlan.swift
@@ -1,12 +1,19 @@
 /// A computed set of Cloudflare hardening changes, ready for preview and opt-in application.
 public struct HardenPlan: Sendable, Equatable {
+    /// The changes to apply, in `HardenPlanner`'s emission order — which is also the order
+    /// ``summary`` previews them and `HardenExecutor` applies them.
     public let items: [HardenPlanItem]
+    /// True when the zone already matches the hardening baseline and there is nothing to apply.
     public var isEmpty: Bool { items.isEmpty }
 
+    /// Creates a plan. Normally produced by `HardenPlanner.plan(from:domain:)`; direct
+    /// construction is for tests.
     public init(items: [HardenPlanItem]) {
         self.items = items
     }
 
+    /// Human-readable preview shown before the user opts in: one `+`-prefixed line per item, or an
+    /// explicit "fully hardened" sentence — an empty preview would read as a bug, not success.
     public var summary: String {
         if items.isEmpty { return "Zone is fully hardened. No changes needed." }
         return items.map(\.description).joined(separator: "\n")
@@ -15,20 +22,43 @@ public struct HardenPlan: Sendable, Equatable {
 
 /// A single hardening change to apply to a Cloudflare zone.
 public enum HardenPlanItem: Sendable, Hashable, CustomStringConvertible {
+    /// Enable DNSSEC signing for the zone.
     case enableDNSSEC
+    /// Add a `0 issue "<ca>"` CAA record authorizing `ca` to issue certificates. Planned once per
+    /// CA in `HardenPlanner.freePlanCAs` — Cloudflare's free plan rotates between those CAs, so
+    /// authorizing only one would silently break the next renewal.
     case addCAARecord(ca: String)
+    /// Turn on Cloudflare's Always Use HTTPS redirect for all plain-HTTP requests.
     case enableAlwaysUseHTTPS
+    /// Enable HSTS with the given directives. The planner passes `preload: false` — preload-list
+    /// enrollment is effectively irreversible and shouldn't be a silent side effect of a
+    /// one-click hardening pass.
     case enableHSTS(maxAge: Int, includeSubdomains: Bool, preload: Bool)
+    /// Enable Bot Fight Mode, the free-plan automated-bot mitigation.
     case enableBotFightMode
+    /// Add an RFC 7505 null MX (`0 .`) declaring the domain receives no mail. Only planned for
+    /// zones with no existing MX records.
     case addNullMX
+    /// Add a `v=spf1 -all` TXT record so mail spoofed from this non-sending domain hard-fails SPF.
     case addSPFRejectAll
+    /// Add a `v=DMARC1; p=reject` record at `_dmarc.<domain>` so receivers discard spoofed mail
+    /// outright instead of quarantining it.
     case addDMARCReject
+    /// Create one WAF custom rule (from `HardenPlanner.curatedWAFRules`). The description doubles
+    /// as the dedupe key on re-plan, since Cloudflare assigns rule IDs server-side.
     case addWAFRule(description: String, expression: String, action: String)
+    /// Enable Speed Brain (speculative prefetching).
     case enableSpeedBrain
+    /// Enable Zstandard response compression.
     case enableZstandardCompression
+    /// Enable Encrypted Client Hello, hiding the requested hostname from on-path observers.
     case enableECH
+    /// Enable Page Shield's client-side script monitoring — monitoring only, so it can't break
+    /// the site the way a blocking policy could.
     case enablePageShieldMonitoring
 
+    /// One diff-style `+`-prefixed preview line; ``HardenPlan/summary`` joins these into the
+    /// opt-in preview the user approves.
     public var description: String {
         switch self {
         case .enableDNSSEC:

--- a/Sources/AnglesiteCore/HardenPlanner.swift
+++ b/Sources/AnglesiteCore/HardenPlanner.swift
@@ -47,6 +47,16 @@ public enum HardenPlanner {
         ),
     ]
 
+    /// Diffs `state` against the hardening baseline and returns only the missing pieces, so
+    /// applying the plan never duplicates records or re-toggles settings that are already right.
+    ///
+    /// Non-obvious choices: HSTS is (re-)planned when `max-age` is under one year, not just when
+    /// absent, since a short `max-age` defeats the point; the email trio (null MX / SPF `-all` /
+    /// DMARC reject) is planned **only** for zones with no MX records at all — a mail-receiving
+    /// domain must never be handed a null MX; and WAF rules are matched by case-insensitive
+    /// description because Cloudflare assigns rule IDs server-side, leaving the description as the
+    /// only stable client-side identity. `domain` names the DNS records (CAA/MX/SPF at the apex,
+    /// DMARC at `_dmarc.<domain>`).
     public static func plan(from state: CloudflareZoneState, domain: String) -> HardenPlan {
         var items: [HardenPlanItem] = []
 

--- a/Sources/AnglesiteCore/HeadlessRuntimePool.swift
+++ b/Sources/AnglesiteCore/HeadlessRuntimePool.swift
@@ -20,6 +20,9 @@ public protocol HeadlessRuntime: Sendable {
 ///
 /// `now`/`makeRuntime` are injectable so lifecycle is testable without a real clock or container.
 public actor HeadlessRuntimePool {
+    /// Produces a fresh, not-yet-started runtime for each cache miss. The seam that lets the app
+    /// inject its container-backed runtime while tests inject fakes — the pool itself never knows
+    /// what substrate it's pooling.
     public typealias RuntimeFactory = @Sendable () -> any HeadlessRuntime
 
     private struct Entry {
@@ -36,6 +39,11 @@ public actor HeadlessRuntimePool {
     private let now: @Sendable () -> Date
     private let makeRuntime: RuntimeFactory
 
+    /// Creates a pool. `now` is injectable so expiry is testable without real waiting. The default
+    /// `makeRuntime` produces ``UnavailableHeadlessRuntime`` — after host-Node retirement there is
+    /// no in-process fallback, so a pool nobody configured fails loudly (logged, `nil` runtime)
+    /// rather than silently spawning a host process. The app must inject its container-backed
+    /// factory to make headless edits actually work.
     public init(
         ttl: TimeInterval = 60,
         now: @escaping @Sendable () -> Date = { Date() },
@@ -112,20 +120,32 @@ public actor HeadlessRuntimePool {
     }
 }
 
+/// A ``HeadlessRuntime`` that always fails to start, logging why. ``HeadlessRuntimePool``'s
+/// default factory after host-Node retirement: an unconfigured pool surfaces "headless MCP is
+/// unavailable" in the debug pane instead of silently doing nothing (logs are sacred) or falling
+/// back to a host Node process that no longer exists.
 public actor UnavailableHeadlessRuntime: HeadlessRuntime {
+    /// A never-started client, present only because the protocol requires one — no caller reaches
+    /// it, since ``startHeadlessMCP(siteID:siteDirectory:)`` always fails and the pool discards
+    /// the runtime.
     public let mcpClient: MCPClient
     private let reason: String
 
+    /// Creates the placeholder. `reason` is the operator-facing explanation logged on every start
+    /// attempt; the default `mcpClient` is an idle client that exists only to satisfy the protocol.
     public init(reason: String, mcpClient: MCPClient = MCPClient(supervisor: .shared)) {
         self.reason = reason
         self.mcpClient = mcpClient
     }
 
+    /// Logs `reason` to the site's headless log stream and returns `false`, so the pool tears this
+    /// runtime down and caches nothing.
     public func startHeadlessMCP(siteID: String, siteDirectory: URL) async -> Bool {
         await LogCenter.shared.append(source: "headless:\(siteID)", stream: .stderr, text: reason)
         return false
     }
 
+    /// Stops the (never-started) client — a harmless no-op kept for protocol symmetry.
     public func stop() async {
         await mcpClient.stop()
     }

--- a/Sources/AnglesiteCore/HealthModel.swift
+++ b/Sources/AnglesiteCore/HealthModel.swift
@@ -19,30 +19,50 @@ import Observation
 @MainActor
 @Observable
 public final class HealthModel {
+    /// The four-way health-badge color, collapsed from the richer settled state so the view layer
+    /// never interprets outcomes itself.
     public enum BadgeState: Sendable, Equatable {
-        case unknown   // no scan has produced a result this session
-        case clean     // most recent outcome: passed, no warnings
-        case warnings  // most recent outcome: passed, with warnings
-        case failures  // most recent outcome: blocked / error / runner failure
+        /// No scan has produced a result this session.
+        case unknown
+        /// Most recent outcome: passed, no warnings.
+        case clean
+        /// Most recent outcome: passed, with warnings.
+        case warnings
+        /// Most recent outcome: blocked / error / runner failure.
+        case failures
     }
 
+    /// Why a run produced no `PreDeployCheck.Outcome` at all — distinct from a `.blocked`/`.error`
+    /// outcome, where the scan itself ran fine and it's the *site* that has problems.
     public enum FailureReason: Sendable, Equatable {
+        /// `npm run build` failed before the scan could run, with the runner's message.
         case buildFailed(String)
+        /// The scan step itself failed (runner crash or any non-build error), with the message.
         case scanFailed(String)
     }
 
+    /// The most recent scan outcome, or `nil` before any run settles this session.
     public private(set) var lastOutcome: PreDeployCheck.Outcome?
+    /// The most recent no-outcome failure. Cleared when a later run produces a real outcome,
+    /// because that outcome supersedes whatever the failure said.
     public private(set) var lastFailure: FailureReason?
+    /// When the last result (outcome or failure) was committed — the badge's "as of" timestamp.
     public private(set) var lastCheckedAt: Date?
+    /// Whether a re-check is in flight. Deliberately separate from the settled state so the view
+    /// can spin over the existing badge color instead of flickering back to `.unknown`.
     public private(set) var isRunning: Bool = false
 
     private nonisolated let runner: any HealthCheckRunner
     private var inFlight: Task<Void, Never>?
 
+    /// Creates the model around a scan runner — ``HealthCheckRunner`` is the seam that keeps this
+    /// state machine testable without a real build/scan pipeline.
     public init(runner: any HealthCheckRunner) {
         self.runner = runner
     }
 
+    /// Badge color derived from the settled state. A `lastFailure` wins over any stale
+    /// `lastOutcome`: an outcome the model couldn't refresh shouldn't keep the badge green.
     public var badgeState: BadgeState {
         if lastFailure != nil { return .failures }
         guard let outcome = lastOutcome else { return .unknown }
@@ -112,10 +132,19 @@ public final class HealthModel {
 /// fails before the scan can run, or `HealthRunnerError.scan(_:)` for any error
 /// after that. Any other error is reported by `HealthModel` as `.scanFailed("\(error)")`.
 public protocol HealthCheckRunner: Sendable {
+    /// Build the site and run the pre-deploy scan, returning its outcome. Throw
+    /// ``HealthRunnerError`` (see the protocol doc for the build/scan split) when no outcome can
+    /// be produced; respect task cancellation, since ``HealthModel/recheck(siteID:siteDirectory:)``
+    /// cancels superseded runs.
     func run(siteID: String, siteDirectory: URL) async throws -> PreDeployCheck.Outcome
 }
 
+/// The two no-outcome failure modes a ``HealthCheckRunner`` distinguishes. Split so the badge can
+/// tell the user "your site doesn't build" apart from "the checker itself broke" — the remedies
+/// are entirely different.
 public enum HealthRunnerError: Error, Sendable, Equatable {
+    /// `npm run build` failed before the scan could run.
     case build(String)
+    /// The scan failed after a successful build.
     case scan(String)
 }

--- a/Sources/AnglesiteCore/HeroImage.swift
+++ b/Sources/AnglesiteCore/HeroImage.swift
@@ -94,8 +94,14 @@ public enum HeroImage {
          .replacingOccurrences(of: "\"", with: "&quot;")
     }
 
+    /// Failures from ``HeroImage/install(from:headline:siteName:siteDirectory:fileManager:)``. Hero
+    /// generation is an optional scaffolder step, so callers surface these as warnings, never as
+    /// scaffold failures.
     public enum InstallError: Error, Sendable {
+        /// The generated image isn't at the URL Image Playground reported — nothing to copy.
         case sourceImageNotFound(URL)
+        /// `src/pages/index.astro` is missing, so there's no homepage to patch. A *drifted* (but
+        /// present) homepage is not an error — the anchor-guarded patch just no-ops.
         case homepageNotFound(URL)
     }
 

--- a/Sources/AnglesiteCore/HomepageWriter.swift
+++ b/Sources/AnglesiteCore/HomepageWriter.swift
@@ -4,7 +4,13 @@ import Foundation
 /// blurb by replacing the known template strings. Operates on known content (safe targeted
 /// replace, not a fuzzy patch).
 public enum HomepageWriter {
-    public enum WriteError: Error, Sendable { case homepageNotFound(URL) }
+    /// Failure cases for ``write(headline:blurb:tagline:siteDirectory:fileManager:)``.
+    public enum WriteError: Error, Sendable {
+        /// `src/pages/index.astro` was not where the scaffold put it — the associated URL is the
+        /// path that was checked. Failing loudly beats creating a homepage the template never
+        /// shipped (the targeted-replace strategy only makes sense against known content).
+        case homepageNotFound(URL)
+    }
 
     // The exact strings the template ships.
     static let titleLine =
@@ -15,6 +21,12 @@ public enum HomepageWriter {
     static let introLine =
         "<p>This site is ready to customize in Anglesite. Open the app to edit your pages, add content, and publish when you're ready.</p>"
 
+    /// Returns `source` with the template's placeholder title, `<h1>`, description, and intro
+    /// paragraph replaced by the owner's text. Pure string transform (no I/O) so it is directly
+    /// testable; inputs are whitespace-trimmed and HTML-escaped for their target context
+    /// (attribute vs. element text). An empty headline or blurb leaves the corresponding
+    /// template text in place rather than writing an empty element; the meta description takes
+    /// the blurb, falling back to the tagline when the blurb is empty.
     public static func fill(_ source: String, headline: String, blurb: String, tagline: String) -> String {
         var out = source
         let h = headline.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -35,6 +47,11 @@ public enum HomepageWriter {
         return out
     }
 
+    /// Applies ``fill(_:headline:blurb:tagline:)`` to the site's `src/pages/index.astro` in
+    /// place, writing atomically so a crash mid-write can't leave a truncated homepage.
+    ///
+    /// - Throws: ``WriteError/homepageNotFound(_:)`` when the scaffolded homepage is missing
+    ///   from `siteDirectory`.
     public static func write(headline: String, blurb: String, tagline: String,
                              siteDirectory: URL, fileManager: FileManager = .default) throws {
         let url = siteDirectory.appendingPathComponent("src/pages/index.astro")

--- a/Sources/AnglesiteCore/ImpactAnalysis.swift
+++ b/Sources/AnglesiteCore/ImpactAnalysis.swift
@@ -19,6 +19,8 @@ public enum ImpactAnalysis {
     /// through two layers of components is still affected); `referencedAssets` is the one
     /// forward-looking group — the assets the target itself directly references.
     public struct Report: Sendable, Equatable {
+        /// The analyzed node's id, echoed back so a report stays self-describing when it is
+        /// passed around or cached apart from the request that produced it.
         public let targetID: String
         /// Pages whose rendered output could change.
         public let affectedPages: [SiteGraphNode]

--- a/Sources/AnglesiteCore/InProcessBackend.swift
+++ b/Sources/AnglesiteCore/InProcessBackend.swift
@@ -19,10 +19,21 @@ import Darwin
 public actor InProcessBackend: SupervisorBackend {
     private var entries: [UUID: Entry] = [:]
 
+    /// Creates an empty backend. Per-process state is built lazily by each ``launch(_:restartPolicy:onRespawn:logCenter:)``,
+    /// so a single instance supervises any number of children concurrently.
     public init() {}
 
     // MARK: One-shot run
 
+    /// Spawns `spec`, drains stdout and stderr concurrently, and waits for exit. The exit
+    /// listener is registered *before* `run()` — a fast child can terminate before the first
+    /// `await`, and a handler installed after termination never fires — and the wait is
+    /// continuation-based rather than `waitUntilExit()`, which blocked a cooperative-pool thread
+    /// and deadlocked under load (see `ProcessSupervisorConcurrencyTests`).
+    ///
+    /// - Throws: ``SupervisorBackendError/spawnFailed(_:)`` when the executable can't be
+    ///   launched at all (missing binary, bad permissions); a non-zero exit is *not* an error —
+    ///   it comes back in ``ProcessResult/exitCode``.
     public func runOneShot(_ spec: SpawnSpec) async throws -> ProcessResult {
         let process = Process()
         process.executableURL = spec.executable
@@ -101,6 +112,11 @@ public actor InProcessBackend: SupervisorBackend {
 
     // MARK: Long-running launch
 
+    /// Spawns `spec` and starts its supervision loop (restart-on-crash backoff, `onRespawn`
+    /// callbacks, exit-waiter bookkeeping). Returns as soon as the first spawn succeeds; on a
+    /// spawn failure the entry is rolled back so nothing leaks. The handle's `pid` is
+    /// best-effort metadata — supervision (and every other method here) is keyed by the
+    /// handle's stable `id`, which survives respawns while the pid does not.
     public func launch(
         _ spec: SpawnSpec,
         restartPolicy: RestartPolicy,
@@ -136,6 +152,11 @@ public actor InProcessBackend: SupervisorBackend {
         return SpawnedProcessHandle(id: id, pid: entry.currentProcess?.processIdentifier ?? -1)
     }
 
+    /// Awaits the process's final disposition. Resolves only after `finalize` has drained both
+    /// log pipes, so a caller can `snapshot()` the ``LogCenter`` immediately afterwards without
+    /// losing the tail of the output. Unknown handles and already-finished processes resolve
+    /// immediately; cancelling the awaiting task resumes it with `.terminated` (each waiter is
+    /// keyed by its own UUID so cancellation removes exactly its own continuation).
     public func waitForExit(_ handle: SpawnedProcessHandle) async -> ProcessExitReason {
         guard let entry = entries[handle.id] else { return .terminated }
         if let reason = entry.finalReason { return reason }
@@ -165,10 +186,18 @@ public actor InProcessBackend: SupervisorBackend {
         cont.resume(returning: .terminated)
     }
 
+    /// Whether the *current incarnation* of the launch is running — during a crash-restart
+    /// backoff window this is `false` even though supervision is still live. Unknown handles
+    /// report `false`.
     public func isRunning(_ handle: SpawnedProcessHandle) async -> Bool {
         entries[handle.id]?.currentProcess?.isRunning ?? false
     }
 
+    /// Graceful-then-forceful stop: SIGTERM, poll for exit until `timeout`, then SIGKILL.
+    /// Marks the entry manually terminated *first*, so the supervision loop reports
+    /// `.terminated` and never treats the kill as a crash to restart — even if the process
+    /// happens to exit (or a restart backoff is in flight) while this runs. No-op for unknown
+    /// handles.
     public func terminate(_ handle: SpawnedProcessHandle, timeout: TimeInterval) async {
         guard let entry = entries[handle.id] else { return }
         entry.manuallyTerminated = true
@@ -186,6 +215,9 @@ public actor InProcessBackend: SupervisorBackend {
         }
     }
 
+    /// Terminates every supervised process in parallel and waits for each to fully finalize
+    /// (including log drainage), sharing one `timeout` per process rather than serializing —
+    /// this runs on app quit, where N children timing out sequentially would be user-visible.
     public func shutdownAll(timeout: TimeInterval) async {
         let handles = entries.values.map { SpawnedProcessHandle(id: $0.id, pid: $0.currentProcess?.processIdentifier ?? -1) }
         guard !handles.isEmpty else { return }
@@ -200,6 +232,11 @@ public actor InProcessBackend: SupervisorBackend {
         }
     }
 
+    /// Writes `bytes` to the process's stdin pipe.
+    ///
+    /// - Throws: ``SupervisorBackendError/unknownHandle`` when the handle is unknown *or* the
+    ///   launch didn't opt into stdin (`SpawnSpec.stdinPipe`) — without the opt-in no pipe was
+    ///   ever attached, so there is nothing to write to.
     public func writeStdin(_ handle: SpawnedProcessHandle, _ bytes: Data) async throws {
         guard let writer = entries[handle.id]?.stdinWriter else {
             throw SupervisorBackendError.unknownHandle
@@ -207,6 +244,10 @@ public actor InProcessBackend: SupervisorBackend {
         try writer.write(contentsOf: bytes)
     }
 
+    /// The raw stdin `FileHandle` for callers that stream continuously (e.g. an MCP stdio
+    /// transport) and don't want an actor hop per write. `nil` when the handle is unknown or the
+    /// launch didn't request stdin. Note the handle is replaced on respawn — long-lived callers
+    /// should re-fetch it from their `onRespawn` callback.
     public func stdinHandle(_ handle: SpawnedProcessHandle) async -> FileHandle? {
         entries[handle.id]?.stdinWriter
     }

--- a/Sources/AnglesiteCore/InProcessEditPersistence.swift
+++ b/Sources/AnglesiteCore/InProcessEditPersistence.swift
@@ -8,6 +8,23 @@ import SwiftGit2
 /// already-linked libgit2 wrapper. The host must still be at the commit the container edited;
 /// refusing divergence is safer than silently overwriting a native edit.
 public enum InProcessEditPersistence {
+    /// Imports the guest's exported edit (a thin git bundle carrying exactly one commit) into
+    /// the canonical `Source/` repository, materializes its tree into the worktree, and
+    /// re-commits it under the host's identity (via `GitIdentity`, since the sandboxed app
+    /// can't read `~/.gitconfig` — #969). Fast-forward only: the import is refused when
+    /// `Source/` has uncommitted changes or the exported commit's parent isn't the current
+    /// HEAD, because silently overwriting a native edit is worse than making the owner retry.
+    ///
+    /// The whole libgit2 sequence runs on a detached task — unbundling and tree
+    /// materialization are blocking file I/O that must not park a cooperative-pool thread.
+    ///
+    /// - Parameters:
+    ///   - bundleURL: The bundle file exported by the container runtime.
+    ///   - commit: The full OID the caller expects the bundle to carry; a mismatch is refused
+    ///     so a stale or tampered export can't land as a different edit.
+    ///   - sourceDirectory: The site's canonical `Source/` git repository.
+    /// - Throws: ``SiteRuntimePersistenceError/syncFailed(_:)`` for every refusal or libgit2
+    ///   failure, with a human-readable reason.
     public static func importBundle(_ bundleURL: URL, commit: String, into sourceDirectory: URL) async throws {
         try await Task.detached(priority: .userInitiated) {
             try await performImport(bundleURL, commit: commit, into: sourceDirectory)

--- a/Sources/AnglesiteCore/InProcessGit.swift
+++ b/Sources/AnglesiteCore/InProcessGit.swift
@@ -37,6 +37,10 @@ public enum InProcessGit {
     /// app-owned Keychain slot (`SecretAccounts.gitHubToken`); tests inject their own.
     public typealias TokenProvider = @Sendable () throws -> String?
 
+    /// The production ``TokenProvider``: reads the app-owned Keychain slot via
+    /// ``PlatformSecretStore``. It's the default argument of
+    /// ``stream(siteDirectory:arguments:source:tokenProvider:)``, so only tests (which must not
+    /// touch the real Keychain) ever pass a provider explicitly.
     public static let defaultTokenProvider: TokenProvider = {
         try PlatformSecretStore.make().readGitHubToken()
     }

--- a/Sources/AnglesiteCore/InboxKVClient.swift
+++ b/Sources/AnglesiteCore/InboxKVClient.swift
@@ -16,12 +16,23 @@ public struct InboxKVClient: Sendable {
     /// A visitor submission as staged by the Worker (`worker.ts`'s `handleInbox`) — field names
     /// and shape must match exactly, since the Worker is the writer and this is the reader.
     public struct Submission: Sendable, Equatable, Decodable {
+        /// Worker-assigned unique id — also the KV key suffix (`inbox:<id>`), which is what
+        /// ``InboxKVClient/deleteSubmission(id:)`` reconstructs to clear the entry.
         public let id: String
+        /// Visitor-supplied subject line, exactly as staged.
         public let subject: String
+        /// Visitor-supplied sender identity (typically an email address). Untrusted input —
+        /// treat as display text, not a validated address.
         public let from: String
+        /// Visitor-supplied message body, exactly as staged.
         public let message: String
+        /// Timestamp string as the Worker wrote it. Kept as a string deliberately: it
+        /// round-trips into content front matter rather than being computed on, and parsing it
+        /// here would only add a failure mode.
         public let receivedAt: String
 
+        /// Memberwise initializer, mainly for tests and previews — production values are
+        /// decoded straight from KV entries the Worker wrote.
         public init(id: String, subject: String, from: String, message: String, receivedAt: String) {
             self.id = id
             self.subject = subject
@@ -55,6 +66,10 @@ public struct InboxKVClient: Sendable {
     private let apiToken: String
     private let transport: CloudflareTransport
 
+    /// Creates a client bound to one KV namespace. The token is passed in rather than read from
+    /// the Keychain here (same DI posture as `HTTPCloudflareClient` — resolution stays the
+    /// caller's concern), and `baseURL`/`transport` exist so tests can point at a stub without
+    /// any network; production callers take their defaults.
     public init(
         accountID: String,
         namespaceID: String,

--- a/Sources/AnglesiteCore/IntegrationCatalog.swift
+++ b/Sources/AnglesiteCore/IntegrationCatalog.swift
@@ -46,7 +46,13 @@ public extension IntegrationDescriptor {
     }
 }
 
+/// The single registry of every integration the app can install. Descriptors are pure
+/// declarative data — ``IntegrationPlanner`` lowers one plus the wizard's answers into an
+/// ``OperationPlan`` — so adding an integration means adding a descriptor here (plus its staged
+/// assets under `Resources/Template/integrations/`), not writing new imperative setup code.
 public enum IntegrationCatalog {
+    /// Every registered descriptor, in the order pickers present them. Must cover every
+    /// ``IntegrationID`` — ``descriptor(for:)`` traps on an unregistered id.
     public static let all: [IntegrationDescriptor] = [
         booking, contact, donations, giscus, newsletter, consent, pwa, redirects,
         tracking, share, podcast,
@@ -55,6 +61,9 @@ public enum IntegrationCatalog {
         inbox, membership, carbonTxt, greenHostCheck, co2Badge,
     ]
 
+    /// Resolves an id to its registered descriptor. Deliberately `fatalError` rather than
+    /// optional: an ``IntegrationID`` case with no catalog entry is a programmer error caught
+    /// on first use, not a runtime condition callers should be forced to handle.
     public static func descriptor(for id: IntegrationID) -> IntegrationDescriptor {
         guard let d = all.first(where: { $0.id == id }) else {
             fatalError("Unregistered integration: \(id)")

--- a/Sources/AnglesiteCore/IntegrationDescriptor.swift
+++ b/Sources/AnglesiteCore/IntegrationDescriptor.swift
@@ -1,15 +1,74 @@
+/// Stable identity for each integration the wizard can install. `String`-backed so the id can
+/// be persisted and serialized; renaming a case is therefore a breaking change to anything that
+/// stored one. Every case must have a matching entry in ``IntegrationCatalog/all`` —
+/// ``IntegrationCatalog/descriptor(for:)`` traps otherwise.
 public enum IntegrationID: String, Sendable, CaseIterable {
-    case booking, contact, donations, giscus, newsletter, consent, pwa, redirects
-    case tracking, share, podcast
-    case indieweb, menu
-    case buyButton, lemonSqueezy, paddle, snipcart, shopifyBuyButton
-    case inbox, membership, carbonTxt, greenHostCheck, co2Badge
+    /// Time-booking widget (Cal.com or Calendly).
+    case booking
+    /// Contact form (Formspree) or plain mailto link.
+    case contact
+    /// Donation button (Stripe, Liberapay, or GitHub Sponsors).
+    case donations
+    /// GitHub-Discussions-backed blog comments.
+    case giscus
+    /// Email-subscribe form, proxied through a Worker that keeps the API key off the client.
+    case newsletter
+    /// Category-based cookie consent banner gating analytics/embeds/ads.
+    case consent
+    /// Progressive Web App: manifest, service worker, offline page, install prompt.
+    case pwa
+    /// A `public/_redirects` entry so an old URL keeps working after a page moves.
+    case redirects
+    /// Privacy-friendly visitor analytics (Plausible, Fathom, or GA4).
+    case tracking
+    /// Share-to-social buttons on blog posts.
+    case share
+    /// Podcast episode-player embed (Spotify or Transistor.fm).
+    case podcast
+    /// IndieWeb identity: `rel=me` links plus webmention/pingback endpoint discovery.
+    case indieweb
+    /// Configurable top navigation menu.
+    case menu
+    /// Single-product checkout link (Stripe or Polar).
+    case buyButton
+    /// Lemon Squeezy overlay checkout for digital products.
+    case lemonSqueezy
+    /// Paddle checkout for software licensing / SaaS billing.
+    case paddle
+    /// Snipcart cart for a small physical-product catalog.
+    case snipcart
+    /// Shopify Buy Button for a full product catalog with dashboard.
+    case shopifyBuyButton
+    /// Keystatic-curated inbox for visitor messages.
+    case inbox
+    /// Keystatic-curated public member directory.
+    case membership
+    /// Machine-readable sustainability disclosure at `/carbon.txt`.
+    case carbonTxt
+    /// Green Web Foundation hosting check, with a badge when the host is green.
+    case greenHostCheck
+    /// Build-time per-page CO2-estimate badge (CO2.js).
+    case co2Badge
 }
 
+/// A string carrying `{{token}}` placeholders resolved at plan time from the wizard's answers
+/// (plus derived tokens like `brandColor`/`siteName`). `ExpressibleByStringLiteral` so
+/// descriptor literals stay readable — a plain path with no tokens is a valid `Template` too.
 public struct Template: Sendable, Equatable, ExpressibleByStringLiteral {
+    /// The unresolved source text, tokens intact.
     public let raw: String
+    /// Wraps token-bearing (or plain) text. No validation happens here — an unknown token is
+    /// only visible once ``resolve(_:)`` leaves it in the output.
     public init(_ raw: String) { self.raw = raw }
+    /// String-literal form of `init(_:)`, so descriptors can write `"src/pages/book.astro"`
+    /// where a `Template` is expected.
     public init(stringLiteral raw: String) { self.raw = raw }
+    /// Substitutes `tokens` into the template. `{{#key}}…{{/key}}` sections are kept only when
+    /// `key` resolves to a non-empty value — letting a staged text asset conditionally include a
+    /// complete optional line or TOML entry without a bespoke operation (sections are
+    /// deliberately non-nesting) — then plain `{{key}}` placeholders are replaced. A placeholder
+    /// with no matching token survives verbatim, so a typo shows up in the output instead of
+    /// silently vanishing.
     public func resolve(_ tokens: [String: String]) -> String {
         var out = raw
         // A staged text asset can conditionally include a complete optional line or TOML entry
@@ -30,35 +89,81 @@ public struct Template: Sendable, Equatable, ExpressibleByStringLiteral {
     }
 }
 
-public struct Choice: Sendable, Equatable { public let value: String; public let label: String
+/// One selectable option of a ``FieldKind/choice(_:)`` field.
+public struct Choice: Sendable, Equatable {
+    /// The machine value stored as the answer (and matched by ``Condition/fieldEquals(key:value:)``).
+    public let value: String
+    /// The human-readable label the wizard displays for this option.
+    public let label: String
+    /// Pairs a stored value with its display label.
     public init(value: String, label: String) { self.value = value; self.label = label } }
 
+/// How a ``Field`` renders in the wizard and validates at plan time (`IntegrationPlanner`
+/// rejects a non-conforming answer with ``IntegrationError/invalidValue(key:reason:)``).
 public enum FieldKind: Sendable, Equatable {
-    case text, email, url
+    /// Free text; no validation.
+    case text
+    /// An email address (checked loosely — must contain `@`).
+    case email
+    /// An absolute URL. Validation requires a *host*, not just a parseable scheme, so a value
+    /// like `https:` can't silently produce no CSP entry for a descriptor using
+    /// `addCSPDomains(fromFieldHost:)`.
+    case url
     /// A site-relative path (e.g. `/old-page`) or an absolute URL, with no interior whitespace —
     /// for fields whose value ends up on a space-delimited line (e.g. `public/_redirects`), where
     /// an unvalidated `.text` value containing a space would silently corrupt the line format.
     case path
+    /// One of a fixed set of ``Choice`` options, rendered as a picker; an answer outside the
+    /// options is rejected at plan time.
     case choice([Choice])
+    /// A toggle. Stored as the strings `"true"`/`"false"` — ``Answers`` is string-typed
+    /// end-to-end so values flow into ``Template`` tokens and `.site-config` unchanged.
     case bool
 }
 
+/// A declarative predicate over the wizard's ``Answers``, gating both field visibility
+/// (``Field/visibleWhen``) and whether an ``Operation`` runs at all. Evaluated at plan time by
+/// `IntegrationPlanner` — keeping conditions as data (no closures) is what lets descriptors stay
+/// `Equatable`, diffable in tests, and structurally checkable by
+/// ``IntegrationDescriptor/validate()``.
 public enum Condition: Sendable, Equatable {
+    /// Unconditional: the field is always visible / the operation always runs.
     case always
+    /// True when the chosen provider (the reserved `"provider"` answer) matches this id.
     case providerIs(String)
+    /// True when the answer for `key` equals `value` exactly.
     case fieldEquals(key: String, value: String)
+    /// True when the answer for `key` is any of `values`. An empty list is always false —
+    /// ``IntegrationDescriptor/validate()`` flags that as a descriptor bug.
     case fieldIn(key: String, values: [String])
 }
 
+/// One wizard input: what to ask, how to render and validate it (``FieldKind``), and when to
+/// show it (``visibleWhen``).
 public struct Field: Sendable, Equatable, Identifiable {
+    /// The answer key — also the `{{key}}` token name the field's value resolves under in
+    /// ``Template`` placeholders. Unique within a descriptor.
     public let key: String
+    /// The label shown next to the control.
     public let label: String
+    /// Rendering and plan-time validation behavior.
     public let kind: FieldKind
+    /// Whether the field may be left empty. A *visible* non-optional field with no answer (and
+    /// no default) fails planning with ``IntegrationError/missingRequiredField(key:)``; hidden
+    /// fields are never required regardless.
     public let isOptional: Bool
+    /// Value used when the answer is missing or empty — filled in before visibility and
+    /// validation run, so a default can also satisfy a required field.
     public let defaultValue: String?
+    /// Optional explanatory text rendered under the control.
     public let help: String?
+    /// Visibility condition, letting one descriptor adapt its questions to the chosen provider
+    /// or an earlier answer instead of splitting into near-duplicate descriptors.
     public let visibleWhen: Condition
+    /// `Identifiable` for SwiftUI lists — the key is the natural unique id.
     public var id: String { key }
+    /// Creates a field. The defaults make the common case — a required, always-visible field
+    /// with no help text — terse in descriptor literals.
     public init(key: String, label: String, kind: FieldKind, isOptional: Bool = false,
                 defaultValue: String? = nil, help: String? = nil, visibleWhen: Condition = .always) {
         self.key = key; self.label = label; self.kind = kind; self.isOptional = isOptional
@@ -66,38 +171,71 @@ public struct Field: Sendable, Equatable, Identifiable {
     }
 }
 
+/// A third-party service choice within one integration (e.g. Cal.com vs. Calendly). Carrying
+/// each service's CSP domains here is what lets `addCSPDomains(fromProvider: true)` allow
+/// exactly the selected service's hosts — the feature would otherwise be silently blocked by
+/// the site's generated Content-Security-Policy.
 public struct Provider: Sendable, Equatable, Identifiable {
+    /// Stable id stored under the reserved `"provider"` answer and matched by
+    /// ``Condition/providerIs(_:)``.
     public let id: String
+    /// The name shown in the wizard's provider picker.
     public let displayName: String
+    /// Hosts this provider's scripts/embeds load from, folded into the site's CSP when the
+    /// provider is chosen. Empty for providers that load nothing external (e.g. a mailto link).
     public let cspDomains: [String]
     /// One-line disclosure shown under the provider's row in the picker — for caveats the
     /// owner should know at the decision point (e.g. GA4's visitor-consent obligations).
     public let note: String?
+    /// Creates a provider entry for a descriptor literal.
     public init(id: String, displayName: String, cspDomains: [String], note: String? = nil) {
         self.id = id; self.displayName = displayName; self.cspDomains = cspDomains; self.note = note
     }
 }
 
+/// One `.site-config` key written by ``Operation/writeConfig(_:when:)``. The value is a
+/// ``Template`` so it can carry a wizard answer (`{{token}}`) — this is the channel that moves
+/// answers from the wizard to the Astro build's `readConfig`.
 public struct ConfigEntry: Sendable, Equatable {
+    /// The `.site-config` key, conventionally `SCREAMING_SNAKE` namespaced by integration.
     public let key: String
+    /// The value template, resolved against the answers at plan time.
     public let value: Template
+    /// Pairs a config key with its value template.
     public init(key: String, value: Template) { self.key = key; self.value = value }
 }
 
 /// A relative path under the website template root (Resources/Template/).
-public struct TemplateRef: Sendable, Equatable { public let path: String
+public struct TemplateRef: Sendable, Equatable {
+    /// The template-root-relative path of the staged asset.
+    public let path: String
+    /// Wraps a template-relative path. Existence isn't checked here — a missing asset surfaces
+    /// at plan time as ``IntegrationError/missingTemplateAsset(path:)``, before anything is
+    /// written to the site.
     public init(_ path: String) { self.path = path } }
 
+/// One declarative setup step in a descriptor. Each operation is gated by its ``Condition`` and
+/// lowered by `IntegrationPlanner` into concrete `PlannedStep`s — descriptors never touch the
+/// filesystem themselves, so every failure surfaces at plan time, before anything is written.
 public enum Operation: Sendable, Equatable {
+    /// Copies a staged template asset byte-for-byte to `to` inside the site. Idempotent by
+    /// content: re-applying writes the same bytes, so reruns can't accumulate duplicates
+    /// (contrast ``appendLine(file:line:when:)``).
     case copyFile(from: TemplateRef, to: Template, when: Condition)
     /// Copies a staged text asset after resolving its `Template` tokens. This opt-in operation
     /// keeps ordinary staged assets byte-for-byte intact.
     case copyTemplatedFile(from: TemplateRef, to: Template, when: Condition)
+    /// Upserts the given entries into the site's `.site-config`, with each value's ``Template``
+    /// resolved against the answers first.
     case writeConfig([ConfigEntry], when: Condition)
     /// `fromFieldHost` names a `.url`-kind field whose value's host (e.g. a per-site
     /// Cloudflare Worker subdomain) is extracted at plan time and added alongside
     /// `extra`/provider domains — for endpoints that aren't a fixed per-provider domain.
     case addCSPDomains(fromProvider: Bool, extra: [String], fromFieldHost: String?, when: Condition)
+    /// Inserts `snippet` at a named anchor comment in `file`, wrapped in
+    /// ``MarkerInjector``-style delimiters so re-applying replaces the existing block in place
+    /// instead of stacking duplicates. `style` picks the delimiter syntax for the injection
+    /// site (HTML comment vs. `//` line).
     case injectAtAnchor(file: Template, anchor: String, snippet: Template, when: Condition, style: MarkerInjector.CommentStyle)
     /// Appends `line` to `file`, creating the file if it doesn't exist. Unlike `copyFile`, this
     /// is not idempotent-by-content-match — each call appends again. Use for accumulating files
@@ -105,13 +243,26 @@ public enum Operation: Sendable, Equatable {
     case appendLine(file: Template, line: Template, when: Condition)
 }
 
+/// The complete declarative definition of one installable integration: identity, wizard copy,
+/// provider choices, input fields, and the operations that install it. Deliberately pure data
+/// (`Equatable`, no closures) so ``validate()`` can structurally check a descriptor and tests
+/// can compare whole plans — all behavior lives in the planner/scaffolder, not here.
 public struct IntegrationDescriptor: Sendable, Equatable, Identifiable {
+    /// The catalog identity; also the `Identifiable` id.
     public let id: IntegrationID
+    /// The name shown in menus and as the wizard title.
     public let displayName: String
+    /// One-sentence pitch shown in the integration picker.
     public let summary: String
+    /// Selectable service backends. Empty when the integration has a single fixed
+    /// implementation — planning then skips the provider-choice requirement entirely.
     public let providers: [Provider]
+    /// The wizard's inputs, in presentation order. May be empty (e.g. greenHostCheck, whose
+    /// answers are computed by the app, not asked of the owner).
     public let fields: [Field]
+    /// The setup steps, applied in order once planned.
     public let operations: [Operation]
+    /// Memberwise initializer used by ``IntegrationCatalog``'s descriptor literals.
     public init(id: IntegrationID, displayName: String, summary: String,
                 providers: [Provider], fields: [Field], operations: [Operation]) {
         self.id = id; self.displayName = displayName; self.summary = summary

--- a/Sources/AnglesiteCore/IntegrationOperationsService.swift
+++ b/Sources/AnglesiteCore/IntegrationOperationsService.swift
@@ -1,9 +1,18 @@
 // Sources/AnglesiteCore/IntegrationOperationsService.swift
 import Foundation
 
+/// The seam between integration front-doors (wizard UI, intents) and the plan/apply machinery.
+/// A protocol rather than the concrete ``IntegrationOperations`` so callers can be tested
+/// against a stub that never resolves real sites or touches the filesystem.
 public protocol IntegrationOperationsService: Sendable {
+    /// The catalog of installable integrations, for pickers.
     func descriptors() -> [IntegrationDescriptor]
+    /// Resolves a descriptor plus the wizard's answers into a reviewable ``OperationPlan``,
+    /// without writing anything. Async because some integrations resolve external facts at plan
+    /// time (greenHostCheck's Green Web Foundation lookup).
     func plan(integrationID: IntegrationID, answers: Answers, siteID: String) async -> Result<OperationPlan, IntegrationError>
+    /// Applies a previously reviewed plan to the site, returning the terminal step (`.done` or
+    /// `.failed`) for the UI to surface.
     func apply(_ plan: OperationPlan, siteID: String) async -> IntegrationScaffolder.SetupStep
 }
 
@@ -14,6 +23,9 @@ private struct SendableFileManager: @unchecked Sendable {
     let value: FileManager
 }
 
+/// The production ``IntegrationOperationsService``: resolves the site's `Source/` directory and
+/// the template root through injected closures, folds plan-time external checks (greenHostCheck)
+/// into the answers before planning, and delegates the actual writes to ``IntegrationScaffolder``.
 public struct IntegrationOperations: IntegrationOperationsService {
     private let sourceDirectory: @Sendable (String) async -> URL?
     private let templateDirectory: @Sendable () -> URL?
@@ -21,6 +33,10 @@ public struct IntegrationOperations: IntegrationOperationsService {
     private let fm: SendableFileManager
     private let greenHostChecker: any GreenHostChecking
 
+    /// Creates a service with fully injectable seams: site and template resolution are closures
+    /// (rather than `SiteStore`/`TemplateRuntime` directly) so tests can run against temp
+    /// directories, and the `GreenHostChecking` dependency is injectable so the greenHostCheck
+    /// flow never hits the real API in tests. Production callers should use ``live()``.
     public init(sourceDirectory: @escaping @Sendable (String) async -> URL?,
                 templateDirectory: @escaping @Sendable () -> URL?,
                 fileManager: FileManager = .default,
@@ -34,8 +50,15 @@ public struct IntegrationOperations: IntegrationOperationsService {
         self.scaffolder = IntegrationScaffolder(fileManager: sfm.value)
     }
 
+    /// Forwards to ``IntegrationCatalog/all`` — the catalog is static data, so there is no
+    /// per-site filtering to do here.
     public func descriptors() -> [IntegrationDescriptor] { IntegrationCatalog.all }
 
+    /// Plans an integration against the resolved site. For `.greenHostCheck` the answers are
+    /// computed here first — the deploy host is resolved and checked against the Green Web
+    /// Foundation — and a "not green" result is deliberately *not* a failure: the check
+    /// succeeded, the badge just isn't offered, so it surfaces as a plan warning the review
+    /// step renders (issue #684).
     public func plan(integrationID: IntegrationID, answers: Answers, siteID: String) async -> Result<OperationPlan, IntegrationError> {
         guard let source = await sourceDirectory(siteID) else { return .failure(.siteNotFound) }
         guard let template = templateDirectory() else { return .failure(.templateUnavailable) }
@@ -79,6 +102,9 @@ public struct IntegrationOperations: IntegrationOperationsService {
                 "may need to register, or this may be a different domain than the one that's certified.")]))
     }
 
+    /// Applies the plan via ``IntegrationScaffolder``, consuming its progress stream and
+    /// returning only the terminal step — intermediate progress is the scaffolder stream's
+    /// concern; front-doors that call through this seam just need the outcome.
     public func apply(_ plan: OperationPlan, siteID: String) async -> IntegrationScaffolder.SetupStep {
         guard let source = await sourceDirectory(siteID) else {
             return .failed(step: "resolve", message: "Couldn't find that site.")

--- a/Sources/AnglesiteCore/IntegrationPlan.swift
+++ b/Sources/AnglesiteCore/IntegrationPlan.swift
@@ -1,31 +1,67 @@
-public typealias Answers = [String: String]   // field key → value; chosen provider under "provider"
+/// The wizard's collected inputs: field key → value, with the chosen provider under the
+/// reserved `"provider"` key. Deliberately stringly-typed — answers flow into ``Template``
+/// token resolution and `.site-config` values, both strings end-to-end, so a richer type would
+/// just be converted away at every boundary.
+public typealias Answers = [String: String]
 
+/// One concrete, condition-free write produced by lowering an ``Operation`` against the
+/// answers. Everything is resolved to literal strings here, so a plan can be shown for review
+/// and applied later without re-consulting the descriptor, the template, or the answers.
 public enum PlannedStep: Sendable, Equatable {
+    /// Write `contents` at `relativePath` under the site's `Source/` (from
+    /// `copyFile`/`copyTemplatedFile`; templated contents are already resolved).
     case createFile(relativePath: String, contents: String)
+    /// Set the given keys in `.site-config`, replacing any existing values.
     case upsertConfig([ConfigKV])
+    /// Insert `snippet` at `anchor` in `relativeFile`, delimited under `id` so a re-run
+    /// replaces the same block in place (`MarkerInjector`) instead of stacking duplicates.
     case injectAnchor(relativeFile: String, anchor: String, id: String, snippet: String, style: MarkerInjector.CommentStyle)
+    /// Allow these domains in the site's generated Content-Security-Policy.
     case addCSP([String])
+    /// Append `line` to `relativePath`, creating the file if needed. Duplicate detection
+    /// already happened at plan time (``IntegrationError/duplicateLine(file:)``), so applying
+    /// is a plain append.
     case appendLine(relativePath: String, line: String)
 }
 
+/// A fully resolved `.site-config` key/value pair — ``ConfigEntry`` after its value
+/// ``Template`` has been resolved, so applying needs no further context.
 public struct ConfigKV: Sendable, Equatable {
+    /// The `.site-config` key.
     public let key: String
+    /// The final literal value to write.
     public let value: String
+    /// Pairs a resolved key and value.
     public init(key: String, value: String) { self.key = key; self.value = value }
 }
 
+/// A non-fatal, user-facing note attached to a plan (a fallback brand color, a not-green host,
+/// …). The wizard's review step renders these; they never block applying the plan.
 public struct PlanWarning: Sendable, Equatable {
+    /// The user-facing warning text, already phrased for the site owner.
     public let message: String
+    /// Wraps the warning text.
     public init(_ message: String) { self.message = message }
 }
 
+/// The reviewable unit of integration setup: every write that will happen, in order, plus any
+/// warnings. Pure `Equatable` data so the wizard can show it before anything touches the site
+/// and tests can assert on exact plans — the plan/apply split is what guarantees a reviewed
+/// plan is applied verbatim.
 public struct OperationPlan: Sendable, Equatable {
+    /// Which integration this plan installs.
     public let integrationID: IntegrationID
+    /// The concrete writes, in application order.
     public let steps: [PlannedStep]
+    /// Non-fatal notes for the review step; never block applying.
     public let warnings: [PlanWarning]
+    /// Memberwise initializer (also used to re-wrap a plan with extra warnings, as the
+    /// greenHostCheck flow does).
     public init(integrationID: IntegrationID, steps: [PlannedStep], warnings: [PlanWarning]) {
         self.integrationID = integrationID; self.steps = steps; self.warnings = warnings
     }
+    /// One plain-language line per step (plus one per warning) for the wizard's review screen —
+    /// what will happen to the site, not the raw operation data.
     public var summary: String {
         var lines: [String] = []
         for step in steps {
@@ -42,12 +78,24 @@ public struct OperationPlan: Sendable, Equatable {
     }
 }
 
+/// Why planning an integration failed. All validation happens at plan time so
+/// ``IntegrationOperationsService/apply(_:siteID:)`` starts from a plan that already passed
+/// every one of these checks.
 public enum IntegrationError: Error, Equatable, Sendable {
+    /// A required, currently *visible* field has no answer and no default — hidden fields are
+    /// never required, so switching provider can't strand an invisible requirement.
     case missingRequiredField(key: String)
+    /// An answer failed its ``FieldKind`` validation; `reason` is already user-facing.
     case invalidValue(key: String, reason: String)
+    /// The `"provider"` answer names an id not in the descriptor's providers.
     case unknownProvider(String)
+    /// The descriptor offers providers but no `"provider"` answer was given.
     case providerRequired
+    /// The site id didn't resolve to a known site (e.g. it was removed from the recents
+    /// registry since the wizard opened).
     case siteNotFound
+    /// The website template root couldn't be resolved (`TemplateRuntime`), so there are no
+    /// staged assets to copy from.
     case templateUnavailable
     /// A staged asset the descriptor copies is absent from the template — a hard error, since
     /// proceeding would inject an `import` for a file that was never written.

--- a/Sources/AnglesiteCore/IntegrationPlanner.swift
+++ b/Sources/AnglesiteCore/IntegrationPlanner.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Resolves an ``IntegrationDescriptor`` plus the owner's ``Answers`` into a concrete
+/// ``OperationPlan`` — the read-only half of the bucket-3 integration framework.
+///
+/// Planning is separated from applying (``IntegrationScaffolder``) so every failure a
+/// descriptor can produce — missing provider, invalid field value, absent template asset,
+/// duplicate append — surfaces *before* anything is written to the site, and the resulting
+/// plan is pure data the wizard's review step can show the owner verbatim.
 public enum IntegrationPlanner {
     /// Pure: no writes. Reads `global.css` for derived tokens only.
     public static func plan(

--- a/Sources/AnglesiteCore/IntegrationScaffolder.swift
+++ b/Sources/AnglesiteCore/IntegrationScaffolder.swift
@@ -5,15 +5,40 @@ import Foundation
 /// streaming progress as `SetupStep` values. The only writer in the
 /// bucket-3 integration framework.
 public actor IntegrationScaffolder {
+    /// One progress event in an apply run. `done` and `failed` are terminal; `warning` is
+    /// informational and never stops the run.
     public enum SetupStep: Sendable, Equatable {
-        case writingFiles, configuring, done(integrationID: String)
+        /// File-creation, injection, and append steps are being applied to `Source/`.
+        case writingFiles
+        /// The batched `.site-config` mutations are being written (a single read-modify-write).
+        case configuring
+        /// Terminal: every step applied — or was skipped idempotently — for this integration.
+        case done(integrationID: String)
+        /// Non-fatal degradation, e.g. an owner-edited file was left untouched instead of
+        /// being overwritten. `step` names the phase the warning belongs to.
         case warning(step: String, message: String)
+        /// Terminal: the run stopped at `step` with a user-presentable `message`. Writes from
+        /// earlier steps are left in place — re-running the same plan is safe because every
+        /// step is idempotent.
         case failed(step: String, message: String)
     }
 
     private let fileManager: FileManager
+    /// Creates a scaffolder that writes through `fileManager` — injectable so tests can
+    /// substitute a throwing or in-memory file manager.
     public init(fileManager: FileManager = .default) { self.fileManager = fileManager }
 
+    /// Applies `plan`'s steps under `sourceDirectory`, yielding progress until a terminal
+    /// `done` or `failed` event.
+    ///
+    /// Idempotent by design: a file that already exists with identical contents is rewritten
+    /// harmlessly, while a file the owner has since edited is skipped with a `warning` rather
+    /// than clobbered — the owner's copy always wins. All `.site-config` mutations across the
+    /// plan are deferred and batched into one read-modify-write at the end, so two config
+    /// steps in the same plan can't race each other into a lost update.
+    ///
+    /// `nonisolated` so callers get the stream synchronously; the actual work hops onto the
+    /// actor inside the stream's backing task.
     public nonisolated func apply(_ plan: OperationPlan, in sourceDirectory: URL) -> AsyncStream<SetupStep> {
         AsyncStream(bufferingPolicy: .unbounded) { continuation in
             Task {

--- a/Sources/AnglesiteCore/IntegrationWizardModel.swift
+++ b/Sources/AnglesiteCore/IntegrationWizardModel.swift
@@ -2,39 +2,87 @@
 import Foundation
 import Observation
 
+/// Observable state machine behind the integration-wizard sheet — the UI driver of the
+/// bucket-3 framework.
+///
+/// One instance lives for the whole wizard session (per open sheet, not per attempt), so all
+/// cross-step state — `answers`, the computed plan, apply progress — lives here rather than in
+/// per-step views. Planning and applying are delegated to the injected
+/// ``IntegrationOperationsService``, so the model never touches the filesystem itself and can
+/// be exercised entirely by unit tests.
 @MainActor @Observable
 public final class IntegrationWizardModel: Identifiable {
-    public enum Step: Int, CaseIterable { case pickIntegration, pickProvider, fields, review, applying }
+    /// The wizard's pages in forward order; the `Int` raw values drive `advance()`/`back()`
+    /// arithmetic, so the declaration order *is* the navigation order.
+    public enum Step: Int, CaseIterable {
+        /// Choose which integration to set up.
+        case pickIntegration
+        /// Choose a provider — skipped entirely for provider-less descriptors (e.g. giscus).
+        case pickProvider
+        /// Fill in the descriptor's currently-visible fields.
+        case fields
+        /// Show the computed plan (or the planning error) for confirmation.
+        case review
+        /// The plan is being applied; forward navigation is disabled from here.
+        case applying
+    }
 
+    /// Stable identity for SwiftUI presentation (`Identifiable`); fresh per wizard session.
     public let id = UUID()
+    /// The page currently shown. Prefer `advance()`/`back()`/`startFromRouter(_:)` over setting
+    /// this directly — they implement the provider-step skip rules a raw assignment bypasses.
     public var step: Step = .pickIntegration
+    /// The integration chosen on the picker step; nil until the owner picks one.
     public var selectedID: IntegrationID?
+    /// Field answers keyed by field key, with the chosen provider under `"provider"` — the
+    /// ``Answers`` convention shared with ``IntegrationPlanner``.
     public var answers: Answers = [:]
+    /// The plan computed on entering `.review`; nil while planning is in flight or after a
+    /// failure. Settable only in-module so views can't publish a plan the service didn't produce.
     public internal(set) var plan: OperationPlan?
+    /// Owner-facing message when planning failed — already phrased by the
+    /// ``SetupIntegrationArguments`` reply builder, so views show it verbatim.
     public internal(set) var planError: String?
+    /// Terminal scaffolder events appended by `apply()`; views read the last element to render
+    /// the outcome.
     public internal(set) var progress: [IntegrationScaffolder.SetupStep] = []
 
     private let service: any IntegrationOperationsService
     private let siteID: String
 
+    /// Creates a wizard model bound to one site.
+    ///
+    /// - Parameters:
+    ///   - service: Backend used for the descriptor catalog, planning, and applying — the seam
+    ///     tests stub.
+    ///   - siteID: The site every service call targets; fixed for the wizard's lifetime.
     public init(service: any IntegrationOperationsService, siteID: String) {
         self.service = service
         self.siteID = siteID
     }
 
+    /// The descriptor for `selectedID`, resolved against the service's catalog; nil before an
+    /// integration is picked.
     public var descriptor: IntegrationDescriptor? {
         guard let id = selectedID else { return nil }
         return service.descriptors().first { $0.id == id }
     }
 
+    /// The catalog entries the picker step offers, in the service's order.
     public var descriptorsForPicker: [IntegrationDescriptor] { service.descriptors() }
 
+    /// The descriptor's fields filtered by their `visibleWhen` conditions against the current
+    /// answers — the same visibility rule ``IntegrationPlanner`` applies, so the wizard never
+    /// asks for a field the resulting plan would ignore.
     public var visibleFields: [Field] {
         guard let descriptor else { return [] }
         let provider = answers["provider"]
         return descriptor.fields.filter { IntegrationPlanner.isVisible($0.visibleWhen, answers: answers, providerID: provider) }
     }
 
+    /// Whether the current step's forward control should be enabled. `.applying` is always
+    /// false: once application starts the wizard has no forward navigation, only the terminal
+    /// progress display.
     public var canContinue: Bool {
         switch step {
         case .pickIntegration: return selectedID != nil
@@ -46,16 +94,18 @@ public final class IntegrationWizardModel: Identifiable {
         }
     }
 
+    /// Moves to the next step, skipping `.pickProvider` for provider-less integrations
+    /// (e.g. giscus), and (re)computes the plan on entering `.review`.
+    ///
+    /// Any stale plan is cleared synchronously *before* the async planning call, so the UI
+    /// never shows a previous attempt's result while a new one is in flight.
     public func advance() async {
-        // Skip the provider step for provider-less integrations (e.g. giscus).
         if step == .pickIntegration, descriptor?.providers.isEmpty == true {
             step = .fields; return
         }
         guard let next = Step(rawValue: step.rawValue + 1) else { return }
         step = next
         if step == .review, let id = selectedID {
-            // Clear any stale plan synchronously before the async call so the UI never shows
-            // a previous result while a new one is in flight.
             plan = nil
             planError = nil
             let result = await service.plan(integrationID: id, answers: answers, siteID: siteID)
@@ -72,11 +122,12 @@ public final class IntegrationWizardModel: Identifiable {
         }
     }
 
+    /// Moves to the previous step, mirroring `advance()`'s forward-skip: a provider-less
+    /// integration (e.g. giscus) never shows the provider step, so backing out of `.fields`
+    /// must hop straight to `.pickIntegration` rather than strand the user on an empty
+    /// `.pickProvider` screen (where `canContinue` would be false).
     public func back() {
         guard let prev = Step(rawValue: step.rawValue - 1) else { return }
-        // Mirror advance()'s forward-skip: a provider-less integration (e.g. giscus) never shows the
-        // provider step, so backing out of .fields must hop straight to .pickIntegration rather than
-        // strand the user on an empty .pickProvider screen (where canContinue would be false).
         if prev == .pickProvider, descriptor?.providers.isEmpty == true {
             step = .pickIntegration
             return
@@ -103,6 +154,9 @@ public final class IntegrationWizardModel: Identifiable {
         step = (descriptor?.providers.isEmpty == true || route.presetProvider != nil) ? .fields : .pickProvider
     }
 
+    /// Applies the reviewed plan via the service and records the terminal
+    /// ``IntegrationScaffolder/SetupStep`` in `progress`. Enters `.applying` first so
+    /// navigation locks; no-op when there is no plan to apply.
     public func apply() async {
         guard let plan else { return }
         step = .applying

--- a/Sources/AnglesiteCore/IntentEditBridgeOverride.swift
+++ b/Sources/AnglesiteCore/IntentEditBridgeOverride.swift
@@ -9,5 +9,9 @@
 /// `ContentOperationsOverride`, and `ElementEntityProviderOverride` — `public` so the
 /// `AnglesiteIntents` module's tests can bind it via `@testable import`. Production never sets it.
 public enum IntentEditBridgeOverride {
+    /// The task-local override ``IntentEditBridge``, if bound. Intents read
+    /// `IntentEditBridgeOverride.scoped ?? bridge` in `perform()`; only tests bind this
+    /// (via `$scoped.withValue(...)`) — production leaves it nil so `@Dependency` resolution
+    /// stays the live path.
     @TaskLocal public static var scoped: IntentEditBridge?
 }

--- a/Sources/AnglesiteCore/InterpretedEdit.swift
+++ b/Sources/AnglesiteCore/InterpretedEdit.swift
@@ -3,21 +3,36 @@ import Foundation
 /// The kind of change a natural-language instruction resolves to. Plain (no FoundationModels
 /// dependency) so the op-mapping compiles + tests on the CI toolchain.
 public enum InterpretedEditKind: String, Sendable, Equatable {
-    case text, attribute, style
+    /// Replace the element's text content.
+    case text
+    /// Set (or replace) a single attribute on the element.
+    case attribute
+    /// Set a single CSS declaration for the element.
+    case style
 }
 
 /// A model-independent representation of an interpreted edit. The FM-backed interpreter (gated
 /// behind `#if compiler(>=6.4)`) produces this; the op-mapping below is pure and CI-tested.
 public struct InterpretedEdit: Sendable, Equatable {
+    /// Which of the optional payload fields below are meaningful; `resolveOp()` enforces the
+    /// per-kind requirements.
     public let kind: InterpretedEditKind
+    /// Replacement text — required (non-empty) for `.text`, ignored otherwise.
     public let newText: String?
+    /// Attribute to set — required (non-empty) for `.attribute`.
     public let attributeName: String?
+    /// New attribute value — required for `.attribute`; empty is allowed (clearing a value is
+    /// a valid edit), unlike the other payloads.
     public let attributeValue: String?
+    /// CSS property to set — required (non-empty) for `.style`.
     public let styleProperty: String?
+    /// CSS value — required (non-empty) for `.style`.
     public let styleValue: String?
     /// One-line human phrasing of the change, for the confirmation dialog.
     public let summary: String
 
+    /// Memberwise initializer. Pass nil for the payload fields the `kind` doesn't use —
+    /// `resolveOp()` is the validity check, not this initializer.
     public init(kind: InterpretedEditKind, newText: String?, attributeName: String?, attributeValue: String?,
                 styleProperty: String?, styleValue: String?, summary: String) {
         self.kind = kind; self.newText = newText
@@ -41,23 +56,37 @@ public struct InterpretedEdit: Sendable, Equatable {
     }
 }
 
+/// A wire-ready edit operation: the sidecar op name plus its JSON payload, in the exact shape
+/// the MCP apply-edit path expects — so the intent layer never builds payload dictionaries.
 public struct ResolvedEditOp: Sendable, Equatable {
+    /// Sidecar op identifier: `replace-text`, `replace-attr`, or `edit-style`.
     public let op: String
+    /// The payload for `op`, already shaped as the sidecar expects it.
     public let value: JSONValue
+    /// Memberwise initializer; prefer deriving instances via `InterpretedEdit.resolveOp()`,
+    /// which enforces the per-kind payload requirements.
     public init(op: String, value: JSONValue) { self.op = op; self.value = value }
 }
 
 /// Context about the onscreen element the instruction targets.
 public struct InterpretedElementContext: Sendable, Equatable {
+    /// HTML tag name of the target element, grounding the model's interpretation.
     public let tag: String
+    /// The element's current text content, when it has any — lets the model produce a minimal
+    /// rewrite instead of inventing content.
     public let currentText: String?
+    /// Site-relative path of the page the element appears on.
     public let pagePath: String
+    /// Human-readable label for the element, as surfaced to the user.
     public let displayName: String
     /// Site the element belongs to. Required for the FM interpreter to build an `AssistantContext`.
     public let siteID: String?
     /// Root directory of the site on disk. Required for the FM interpreter's `AssistantContext`.
     public let siteDirectory: URL?
 
+    /// Memberwise initializer. `siteID`/`siteDirectory` default to nil because only the
+    /// FM-backed interpreter needs them (see their individual docs); the pure op-mapping path
+    /// works without a site.
     public init(tag: String, currentText: String?, pagePath: String, displayName: String,
                 siteID: String? = nil, siteDirectory: URL? = nil) {
         self.tag = tag; self.currentText = currentText; self.pagePath = pagePath
@@ -68,11 +97,16 @@ public struct InterpretedElementContext: Sendable, Equatable {
 /// Seam between the intent and the on-device model. The live implementation is FM-backed and
 /// `#if compiler(>=6.4)`-gated; tests inject a fake returning a canned `InterpretedEdit`.
 public protocol EditInterpreting: Sendable {
+    /// Interprets a natural-language `instruction` against `element` into a structured
+    /// ``InterpretedEdit``. Throws ``EditInterpretationError`` when interpretation can't run
+    /// at all; implementations may also surface model errors directly.
     func interpret(instruction: String, element: InterpretedElementContext) async throws -> InterpretedEdit
 }
 
 /// Thrown when on-device interpretation can't run (Apple Intelligence unavailable, etc.).
 public enum EditInterpretationError: Error, Sendable, Equatable {
+    /// On-device interpretation is not possible on this host (Apple Intelligence disabled,
+    /// model not downloaded, …). The message is user-facing.
     case unavailable(String)
     /// The element\'s site isn\'t open in Anglesite (siteID/siteDirectory missing from context).
     case siteUnavailable(String)

--- a/Sources/AnglesiteCore/InvisiblePublishQueue.swift
+++ b/Sources/AnglesiteCore/InvisiblePublishQueue.swift
@@ -6,26 +6,52 @@ import Foundation
 /// fact that the working tree still needs publishing, so an offline edit survives an app restart
 /// without duplicating source data in app-owned state.
 public actor InvisiblePublishQueue {
+    /// The queue's lifecycle, surfaced through the `onStateChange` observer so the UI can
+    /// mirror background publish activity without polling the actor.
     public enum State: Sendable, Equatable {
+        /// Nothing pending: the working tree is published (or was never edited).
         case idle
+        /// An edit landed and the idle window is counting down toward a publish.
         case debouncing
+        /// Pending work is parked until connectivity returns; reconnection publishes
+        /// immediately (the offline period already served as the debounce).
         case queuedOffline
+        /// A publish attempt is running; its ``Result`` decides the next state.
         case publishing
+        /// The pre-deploy security gate blocked the publish; mirrors
+        /// ``Result/blocked(failureCount:)``. The pending marker persists.
         case blocked(failureCount: Int)
+        /// The publish failed; mirrors ``Result/failed(reason:)``. The pending marker persists
+        /// so a later edit or retry can drain it.
         case failed(reason: String)
+        /// A local prerequisite isn't ready; mirrors ``Result/deferred(reason:)``.
         case deferred(reason: String)
     }
 
+    /// Terminal outcome the injected ``Publisher`` reports for one publish attempt. Every
+    /// non-`succeeded` case leaves the durable pending marker in place.
     public enum Result: Sendable, Equatable {
+        /// The deploy finished; `url` is the live site. Clears the pending marker — unless an
+        /// edit landed mid-publish, in which case the newer working tree is rescheduled.
         case succeeded(url: URL)
+        /// The pre-deploy security gate refused the deploy; `failureCount` is the number of
+        /// check failures it reported. Distinct from `failed` so the app can route it to the
+        /// security-block notification path instead of a generic error.
         case blocked(failureCount: Int)
+        /// The attempt failed with a user-presentable reason; the queue stays pending.
         case failed(reason: String)
         /// A local prerequisite such as the container runtime or API token is not ready. The
         /// durable queue remains pending and `retryPending()` may drain it later.
         case deferred(reason: String)
     }
 
+    /// Runs one complete publish of the current working tree and reports its terminal
+    /// ``Result``. The queue never inspects site content itself — this closure owns the whole
+    /// pipeline (build, security gate, deploy), which is what keeps the queue's persisted
+    /// state down to a single "still needs publishing" bit.
     public typealias Publisher = @Sendable () async -> Result
+    /// Receives each distinct ``State`` transition (duplicates are suppressed). Invoked from
+    /// the actor as transitions happen — hop to the main actor before touching UI.
     public typealias StateObserver = @Sendable (State) -> Void
     /// Debounce timer seam. Production always uses `Task.sleep`; tests can substitute a
     /// manually-triggered gate so the debounce "elapses" only when the test says so, instead of
@@ -40,6 +66,8 @@ public actor InvisiblePublishQueue {
         let lastEditedAt: Date
     }
 
+    /// Name of the durable pending-marker file, written under the site's app-owned `Config/`
+    /// directory (never inside the `Source/` git repo — see the type doc).
     public static let filename = "invisible-publish-queue.json"
 
     private let recordURL: URL
@@ -57,6 +85,17 @@ public actor InvisiblePublishQueue {
     private var debounceTask: Task<Void, Never>?
     private var publishTask: Task<Void, Never>?
 
+    /// Creates a queue for one site. Call `start(isOnline:)` to load any persisted pending
+    /// marker and begin scheduling.
+    ///
+    /// - Parameters:
+    ///   - configDirectory: The site's app-owned `Config/` directory; the pending marker is
+    ///     persisted here as ``InvisiblePublishQueue/filename``.
+    ///   - debounce: Idle window after the last edit before a publish begins.
+    ///   - publisher: The closure that performs an actual publish — see ``Publisher``.
+    ///   - onStateChange: Optional observer of state transitions — see ``StateObserver``.
+    ///   - now: Clock seam; tests substitute a fixed date to make `lastEditedAt` deterministic.
+    ///   - sleep: Debounce timer seam — see ``Sleep``.
     public init(
         configDirectory: URL,
         debounce: Duration = .seconds(3),
@@ -128,14 +167,20 @@ public actor InvisiblePublishQueue {
         beginPublish()
     }
 
+    /// The queue's current lifecycle state.
     public func currentState() -> State { state }
+    /// Whether the working tree still needs publishing — stays true while a publish is in
+    /// flight, until an attempt succeeds for the latest edit generation.
     public func hasPendingPublish() -> Bool { isPending }
 
+    /// Cancels the debounce and re-persists the pending marker for the next launch.
+    ///
+    /// Deliberately does *not* cancel an in-flight publish: a real deploy is intentionally
+    /// allowed to reach its terminal result, because cancelling the wrapper task would cancel
+    /// its child subprocess and leave remote state unclear.
     public func stop() {
         debounceTask?.cancel()
         debounceTask = nil
-        // A real deploy is intentionally allowed to reach its terminal result. Cancelling this
-        // wrapper task would otherwise cancel its child subprocess and leave remote state unclear.
         if isPending { persistRecord() }
     }
 

--- a/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/KnowledgeAugmentedAssistant.swift
@@ -11,15 +11,28 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
     private let base: any ConversationalAssistant
     private let index: SiteKnowledgeIndex
 
+    /// Wraps `base` so every call is preceded by a retrieval pass against `index`.
+    ///
+    /// - Parameters:
+    ///   - base: The backend all calls forward to after enrichment.
+    ///   - index: The per-site retrieval index searched before each turn.
     public init(base: any ConversationalAssistant, index: SiteKnowledgeIndex) {
         self.base = base
         self.index = index
     }
 
+    /// Forwards the base backend's capabilities unchanged — retrieval adds context to prompts,
+    /// not abilities to the backend.
     public nonisolated var capabilities: AssistantCapabilities {
         base.capabilities
     }
 
+    /// Streams a conversational turn with the prompt enriched by retrieved site context.
+    ///
+    /// When retrieval matched anything, a single ``AssistantEvent/citations(_:)`` event is
+    /// prepended before the base backend's own events, so the chat panel can render source
+    /// chips before the first token arrives. When nothing matched, the base stream is returned
+    /// untouched — no relay task, no extra hop.
     public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
         let (enriched, citations) = await enrichedContext(prompt, context: context)
         let baseStream = try await base.converse(prompt: enriched, context: context)
@@ -36,12 +49,19 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
         }
     }
 
+    /// Plain text generation with the same retrieval enrichment as
+    /// ``KnowledgeAugmentedAssistant/converse(prompt:context:)``. Citations are computed and
+    /// discarded: this stream carries only text chunks, with no event channel to surface them.
     public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
         let (enriched, _) = await enrichedContext(prompt, context: context)
         return try await base.generate(prompt: enriched, context: context)
     }
 
     #if compiler(>=6.4) && canImport(FoundationModels)
+    /// Guided generation with the same retrieval enrichment as the other entry points.
+    /// Gated with the rest of the FoundationModels surface (the `Generable` constraint only
+    /// exists on the Xcode-27 toolchain), matching the gate on the `ContentAssistant`
+    /// requirement it satisfies.
     public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,
@@ -56,10 +76,14 @@ public actor KnowledgeAugmentedAssistant: ConversationalAssistant {
     }
     #endif
 
+    /// Forwards cancellation to the base backend, which owns the live generation; the citation
+    /// relay stream ends when the base stream does.
     public func cancel() async {
         await base.cancel()
     }
 
+    /// Resets the base backend's session. Retrieval itself is stateless per turn, so there is
+    /// nothing local to clear.
     public func resetSession() async {
         await base.resetSession()
     }

--- a/Sources/AnglesiteCore/LANControlClient.swift
+++ b/Sources/AnglesiteCore/LANControlClient.swift
@@ -8,13 +8,18 @@ public struct LANRuntimeConfiguration: Sendable, Equatable {
     /// Default ports match the container guest convention (`ContainerizationControl`):
     /// `astro dev` on 4321, the Node MCP sidecar on 4399.
     public static let defaultPreviewPort = 4321
+    /// The container-guest convention's MCP sidecar port (4399) — see `defaultPreviewPort`.
     public static let defaultMCPPort = 4399
 
     /// Hostname or IP of the LAN runtime host, e.g. `mac-studio.local` or `192.168.64.1`.
     public let host: String
+    /// TCP port the host's `astro dev` preview listens on.
     public let previewPort: Int
+    /// TCP port the host's MCP sidecar listens on.
     public let mcpPort: Int
 
+    /// Creates a configuration for `host`, with both ports defaulting to the container-guest
+    /// convention so a standard `anglesite-lan-host` invocation needs only the hostname.
     public init(
         host: String,
         previewPort: Int = Self.defaultPreviewPort,
@@ -27,6 +32,8 @@ public struct LANRuntimeConfiguration: Sendable, Equatable {
 
     /// `nil` when `host` can't form a valid URL (empty, embedded whitespace, …).
     public var previewURL: URL? { url(port: previewPort, path: "/") }
+    /// The MCP Streamable-HTTP endpoint (`/mcp` path); `nil` under the same conditions as
+    /// `previewURL`.
     public var mcpURL: URL? { url(port: mcpPort, path: "/mcp") }
 
     private func url(port: Int, path: String) -> URL? {
@@ -51,12 +58,19 @@ public struct LANControlClient: SandboxControlClient {
     /// explicit stand-in so no real-looking repo URL shows up in logs or state.
     public static let unusedGitRemote = URL(string: "lan-runtime://unused")!
 
+    /// The host/port triple every session this client "starts" will point at.
     public let configuration: LANRuntimeConfiguration
 
+    /// Creates a client for the given LAN runtime configuration.
     public init(configuration: LANRuntimeConfiguration) {
         self.configuration = configuration
     }
 
+    /// Constructs the session's URL pair from the configuration — no RPC, no clone. The git
+    /// and token parameters are ignored; see the type doc for why.
+    ///
+    /// - Throws: ``SandboxControlError/startFailed(_:)`` when the configured host can't form
+    ///   valid URLs — the only way this client can fail.
     public func start(siteID: String, gitRemote: URL, gitRef: String, token: SessionToken) async throws -> SandboxSession {
         guard let previewURL = configuration.previewURL, let mcpURL = configuration.mcpURL else {
             throw SandboxControlError.startFailed("invalid LAN runtime host “\(configuration.host)”")

--- a/Sources/AnglesiteCore/LANHostServer.swift
+++ b/Sources/AnglesiteCore/LANHostServer.swift
@@ -1,14 +1,19 @@
 import Foundation
 
-/// Pure, testable logic backing the `anglesite-lan-host` CLI (`Sources/AnglesiteLANHost`) — the
-/// Mac-Studio-side standing process for #601 §2. Kept here rather than in the executable target
-/// per the `TokenOnboarding` precedent noted in CLAUDE.md: `swift test` can exercise this,
-/// `main.swift` (a hosted CLI entry point) cannot be unit-tested the same way.
+/// A setup failure the `anglesite-lan-host` CLI reports before starting any server process —
+/// each case names the path that failed resolution so the operator can fix the invocation.
 public enum LANHostServerError: Error, Equatable, CustomStringConvertible {
+    /// The `--site` path is neither an `.anglesite` package nor an Astro project directory
+    /// (no `Info.plist` + `Source/`, and no `package.json`).
     case siteNotFound(String)
+    /// The resolved project root has no `.git` directory. The LAN host serves a working copy
+    /// that guests treat as the site's source of truth, so it must be a clonable git repo.
     case notAGitRepo(String)
+    /// No `server/index.mjs` under the resolved plugin root — the MCP sidecar entry point is
+    /// missing; pass `--plugin-path` or set `ANGLESITE_PLUGIN_SRC`.
     case pluginServerNotFound(String)
 
+    /// Operator-facing message printed by the CLI: the failing path plus the fix.
     public var description: String {
         switch self {
         case .siteNotFound(let path):
@@ -21,6 +26,10 @@ public enum LANHostServerError: Error, Equatable, CustomStringConvertible {
     }
 }
 
+/// Pure, testable logic backing the `anglesite-lan-host` CLI (`Sources/AnglesiteLANHost`) — the
+/// Mac-Studio-side standing process for #601 §2. Kept here rather than in the executable target
+/// per the `TokenOnboarding` precedent noted in CLAUDE.md: `swift test` can exercise this,
+/// `main.swift` (a hosted CLI entry point) cannot be unit-tested the same way.
 public enum LANHostServer {
     /// Resolves a `--site` argument — either an `.anglesite` package directory (containing
     /// `Info.plist` + `Source/`) or a raw Astro project directory — to the Astro project root to

--- a/Sources/AnglesiteCore/LicenseCatalog.swift
+++ b/Sources/AnglesiteCore/LicenseCatalog.swift
@@ -10,17 +10,27 @@ import Foundation
 /// asserts on the user's behalf — see
 /// docs/superpowers/specs/2026-07-26-really-simple-licensing-spike.md §Q3.
 public enum LicenseCatalog {
+    /// One offered license: stable picker identity, display strings, and the app-side AI-use
+    /// classification (which is deliberately *not* part of what gets stored — see `ref`).
     public struct Entry: Sendable, Equatable, Hashable, Identifiable {
         /// Stable across releases — it is the SwiftUI picker tag, not display text.
         public let id: String
+        /// Display name shown in the picker, e.g. "CC BY 4.0".
         public let name: String
+        /// Canonical deed URL — the identity `entry(for:)` matches stored licenses on.
         public let url: String
         /// True when the license's grant unambiguously covers AI training and AI answers.
         public let permitsAIUse: Bool
 
+        /// The `LicenseRef` this entry stores and publishes — URL + name only. The
+        /// `permitsAIUse` classification stays app-side, because it is Anglesite's reading of
+        /// the license, not something to assert on the user's behalf (see the type doc).
         public var ref: LicenseRef { LicenseRef(url: url, name: name) }
     }
 
+    /// The offered licenses in picker order: CC0 first, then the CC 4.0 suite from most to
+    /// least permissive. Extending this list requires the same "unambiguous grant" test the
+    /// type doc describes before setting `permitsAIUse`.
     public static let entries: [Entry] = [
         Entry(id: "cc0-1.0", name: "CC0 1.0",
               url: "https://creativecommons.org/publicdomain/zero/1.0/", permitsAIUse: true),

--- a/Sources/AnglesiteCore/LicensingStore.swift
+++ b/Sources/AnglesiteCore/LicensingStore.swift
@@ -3,9 +3,15 @@ import Foundation
 /// A license the site can point at: a canonical URL plus a human-readable label. Mirrors
 /// `LicenseRef` in `Resources/Template/src/lib/licensing.ts`.
 public struct LicenseRef: Sendable, Equatable, Hashable {
+    /// Canonical license URL — the value the template emits into `href`/`rel="license"`, so it
+    /// must satisfy ``isSafeLicenseURL(_:)`` to be decoded or persisted.
     public var url: String
+    /// Human-readable label. Decoding falls back to `url` when a document omits or empties it.
     public var name: String
 
+    /// Memberwise init. Deliberately unvalidated — the safety guard runs at the trust
+    /// boundaries instead (`Codable` decode and ``LicensingStore/validate(_:)``), so in-memory
+    /// editing (e.g. a settings field mid-typing) isn't forced through it.
     public init(url: String, name: String) {
         self.url = url
         self.name = name
@@ -72,6 +78,9 @@ extension LicenseRef: Codable {
         case url, name
     }
 
+    /// Decode-and-validate in one step: a missing, empty, or unsafe `url` throws (see the
+    /// extension doc for why callers catch and degrade), and an absent or empty `name` falls
+    /// back to `url` so a decoded ref always has something displayable.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let url = try container.decode(String.self, forKey: .url)
@@ -84,6 +93,8 @@ extension LicenseRef: Codable {
         self.name = (name?.isEmpty == false) ? name! : url
     }
 
+    /// Always writes both keys — `name` even when it merely mirrors `url` — so the on-disk
+    /// document reads unambiguously without knowing the decode-time fallback rule.
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(url, forKey: .url)
@@ -94,9 +105,13 @@ extension LicenseRef: Codable {
 /// A per-purpose AI usage permission. `unset` means the site states no preference; it is never
 /// written to `licensing.json`, matching `UsagePermission` in `licensing.ts`.
 public enum UsagePermission: String, Sendable, Equatable, CaseIterable, Identifiable {
+    /// No preference stated — omitted from `licensing.json` entirely (see the type doc).
     case unset
+    /// Usage explicitly permitted.
     case yes
+    /// Usage explicitly denied.
     case no
+    /// `Identifiable` by case, so SwiftUI pickers can list `allCases` directly.
     public var id: Self { self }
 }
 
@@ -104,11 +119,18 @@ public enum UsagePermission: String, Sendable, Equatable, CaseIterable, Identifi
 /// named-agent blocklist are both derived from this by `scripts/edge-artifacts.ts`, so they cannot
 /// disagree with each other.
 public struct AIUsage: Sendable, Equatable {
+    /// Permission for traditional search indexing.
     public var search: UsagePermission
+    /// Permission for using the content as input to AI answers/inference.
     public var aiInput: UsagePermission
+    /// Permission for using the content to train AI models.
     public var aiTrain: UsagePermission
+    /// Whether the named-agent blocklist is emitted into `robots.txt`. Only honored when
+    /// ``mayBlockAICrawlers`` allows it — ``clamped`` enforces that on every load and save.
     public var blockAICrawlers: Bool
 
+    /// All parameters default to the most conservative state — no preference stated, no
+    /// blocklist — so a zero-argument `AIUsage()` equals a document with no `usage` key at all.
     public init(
         search: UsagePermission = .unset,
         aiInput: UsagePermission = .unset,
@@ -140,6 +162,9 @@ extension AIUsage: Codable {
         case search, aiInput, aiTrain, blockAICrawlers
     }
 
+    /// Lenient decode mirroring `normalizeUsage` in `licensing.ts`: an unrecognized or
+    /// wrong-typed permission degrades to `unset` rather than failing the document, and the
+    /// result is ``clamped`` so a hand-edited contradiction never survives a load.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         func permission(_ key: CodingKeys) -> UsagePermission {
@@ -157,6 +182,8 @@ extension AIUsage: Codable {
         self = clamped
     }
 
+    /// Encodes the ``clamped`` value and omits `unset` permissions — an absent key is how
+    /// "no preference" is expressed on disk, matching what the template reads back.
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         let usage = clamped
@@ -170,7 +197,9 @@ extension AIUsage: Codable {
 /// Every collection that can carry a license — the routed collections plus `blog`. Mirrors
 /// `LicensableCollection` in `licensing.ts`; the order here is the order the settings facet lists.
 public enum LicensableCollection: String, Sendable, Equatable, CaseIterable, Identifiable, Codable {
+    /// One case per licensable collection; the raw values are the `licensing.json` keys.
     case notes, articles, photos, albums, bookmarks, replies, likes, announcements, events, reviews, blog
+    /// `Identifiable` by case, so the settings facet can list `allCases` directly.
     public var id: Self { self }
 
     /// Collections whose entries are responses to, or quotations of, third-party work. A site
@@ -189,8 +218,13 @@ public enum LicensableCollection: String, Sendable, Equatable, CaseIterable, Ide
 /// absent) falls through to the site default or the non-asserting rule, while `assertNothing`
 /// (an explicit `null`) beats both.
 public enum CollectionLicenseRule: Sendable, Equatable, Hashable {
+    /// The key is absent: fall through to the site default (or the non-asserting default for
+    /// collections where ``LicensableCollection/assertsNothingByDefault`` is true).
     case inherit
+    /// An explicit `null` in `licensing.json`: assert no license, beating both the site
+    /// default and the non-asserting rule.
     case assertNothing
+    /// An explicit per-collection license.
     case license(LicenseRef)
 }
 
@@ -200,8 +234,12 @@ public struct LicensingPolicy: Sendable, Equatable {
     public var defaultLicense: LicenseRef?
     /// Only non-`inherit` rules are stored; an absent key *is* `inherit`.
     public var collections: [LicensableCollection: CollectionLicenseRule]
+    /// Site-wide AI usage permissions (#991).
     public var usage: AIUsage
 
+    /// The all-defaults form is the empty policy — assert nothing, inherit everywhere, no
+    /// usage preferences — the same state ``LicensingStore/load()`` reports for a site with no
+    /// `licensing.json` at all.
     public init(
         defaultLicense: LicenseRef? = nil,
         collections: [LicensableCollection: CollectionLicenseRule] = [:],
@@ -212,10 +250,14 @@ public struct LicensingPolicy: Sendable, Equatable {
         self.usage = usage
     }
 
+    /// The effective stored rule for `collection` — an absent key *is* `.inherit`, which is
+    /// why `collections` never stores that case.
     public func rule(for collection: LicensableCollection) -> CollectionLicenseRule {
         collections[collection] ?? .inherit
     }
 
+    /// Stores `rule`, removing the key entirely for `.inherit` so the "only non-`inherit`
+    /// rules are stored (and serialized)" invariant holds by construction.
     public mutating func setRule(_ rule: CollectionLicenseRule, for collection: LicensableCollection) {
         if rule == .inherit {
             collections.removeValue(forKey: collection)
@@ -240,6 +282,10 @@ extension LicensingPolicy: Codable {
         init?(intValue: Int) { return nil }
     }
 
+    /// Lenient decode mirroring `normalizePolicy` in `licensing.ts`: each malformed piece
+    /// degrades independently (nil default, empty collections, all-unset usage) instead of
+    /// failing the whole document. The inline comments below record each degrade's exact TS
+    /// counterpart and rationale — they are the contract, not incidental detail.
     public init(from decoder: any Decoder) throws {
         // A syntactically valid JSON document that isn't an object at the top level (a bare
         // string, number, bool, or array) degrades to the empty policy rather than throwing —
@@ -305,6 +351,9 @@ extension LicensingPolicy: Codable {
         self.init(defaultLicense: defaultLicense, collections: collections, usage: usage.clamped)
     }
 
+    /// Template-compatible encoding: `default` is always written (an explicit null states "all
+    /// rights reserved" out loud), only non-`inherit` collection rules appear, and collections
+    /// are emitted in `allCases` order so a save produces a stable diff in the site's git repo.
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         // Always written, including as an explicit null: `"default": null` is the scaffolded value
@@ -329,17 +378,23 @@ extension LicensingPolicy: Codable {
 /// `sourceDirectory` (the `Source/` git repo), not `Config/`, on the same reasoning as
 /// `RedirectsStore`: the policy is site content and travels with the repo.
 public struct LicensingStore: Sendable {
+    /// Why ``LicensingStore/validate(_:)`` (and therefore ``LicensingStore/save(_:)``) can
+    /// refuse to persist a policy.
     public enum ValidationError: Error, Equatable {
         /// A URL the template's own scheme guard would reject at render time. Refusing it here
         /// keeps it out of the file entirely.
         case unsafeLicenseURL(String)
     }
 
+    /// The policy document's path relative to the site's `Source/` directory — public so
+    /// callers and tests build the same path instead of duplicating the constant.
     public static let relativePath = "src/data/licensing.json"
 
     private let fileURL: URL
     private let fileManager: FileManager
 
+    /// `sourceDirectory` is the package's `Source/` git repo (see the type doc for why the
+    /// policy lives there, not in `Config/`); `fileManager` is injectable for tests.
     public init(sourceDirectory: URL, fileManager: FileManager = .default) {
         self.fileURL = sourceDirectory.appendingPathComponent(Self.relativePath)
         self.fileManager = fileManager
@@ -366,6 +421,9 @@ public struct LicensingStore: Sendable {
         return policy
     }
 
+    /// Normalizes (``normalized(_:)``), validates (``validate(_:)``), then writes atomically
+    /// with pretty-printed, key-sorted JSON so successive saves diff cleanly in the site's git
+    /// repo. Creates `src/data/` first, for a site scaffolded before the policy existed.
     public func save(_ policy: LicensingPolicy) throws {
         let policy = Self.normalized(policy)
         try Self.validate(policy)
@@ -377,6 +435,11 @@ public struct LicensingStore: Sendable {
         try data.write(to: fileURL, options: .atomic)
     }
 
+    /// Refuses any policy carrying a license URL that fails ``LicenseRef/isSafeLicenseURL(_:)``
+    /// — the write-path half of the sanitization story (the read path degrades silently in
+    /// decode; see `LicensingPolicy.init(from:)`). An empty-URL default is skipped rather than
+    /// rejected: it means "no license", which ``save(_:)`` normalizes away anyway.
+    /// - Throws: ``ValidationError/unsafeLicenseURL(_:)`` with the offending URL.
     public static func validate(_ policy: LicensingPolicy) throws {
         var refs: [LicenseRef] = []
         // An empty-URL default is "no license", the same as nil — not an unsafe URL to reject.

--- a/Sources/AnglesiteCore/LinkGraph.swift
+++ b/Sources/AnglesiteCore/LinkGraph.swift
@@ -6,8 +6,11 @@ public enum LinkGraph {
     /// A missing reciprocal link: `sourcePath` is the page that should add a link,
     /// `targetPath` is the page it should link back to.
     public struct ReciprocalGap: Sendable, Equatable, Identifiable {
+        /// Stable identity for SwiftUI lists: the `source→target` pair, unique per gap.
         public var id: String { "\(sourcePath)→\(targetPath)" }
+        /// Document path of the page that should add the link.
         public let sourcePath: String
+        /// Document path of the page it should link back to.
         public let targetPath: String
     }
 
@@ -155,9 +158,13 @@ public enum LinkGraph {
 
     /// A suggested internal link target with its semantic confidence score.
     public struct LinkSuggestion: Sendable, Equatable, Identifiable {
+        /// Stable identity for SwiftUI lists — the target's document path.
         public var id: String { path }
+        /// Document path of the suggested target (e.g. `src/pages/about.astro`).
         public let path: String
+        /// The target's title, when the knowledge index has one for it.
         public let title: String?
+        /// The served route to use as the inserted link's href (e.g. `/about`).
         public let route: String
         /// Normalized confidence in 0…1 (min-max over the candidate set).
         public let confidence: Float

--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -3,12 +3,18 @@ import Foundation
 /// Host-reachable endpoints a started local container exposes. Both are 127.0.0.1 URLs on
 /// OS-assigned ports, delivered by the host-side vsock→TCP proxy. Mirrors `SandboxSession`.
 public struct LocalContainerSession: Sendable, Equatable {
+    /// The guest Astro dev server's host-proxied endpoint — what the preview web view loads.
     public let previewURL: URL
+    /// The MCP sidecar's host-proxied Streamable-HTTP endpoint — what
+    /// ``MCPClient/connect(httpEndpoint:bearerToken:urlSession:initializeTimeout:clientName:clientVersion:)``
+    /// targets.
     public let mcpURL: URL
     /// The local `wrangler dev --local` endpoint, populated only when `startWorkersDev` has been
     /// called for this session (#708) — not part of the initial `start()` payload, since the
     /// workers-dev process is started conditionally, after boot, not during it.
     public let workersDevURL: URL?
+    /// `workersDevURL` defaults to nil because sessions are built by `start()`, before any
+    /// workers-dev process can exist.
     public init(previewURL: URL, mcpURL: URL, workersDevURL: URL? = nil) {
         self.previewURL = previewURL
         self.mcpURL = mcpURL
@@ -16,11 +22,19 @@ public struct LocalContainerSession: Sendable, Equatable {
     }
 }
 
+/// Failures a local-container boot can surface. Cases carry a plain `String` (not an
+/// underlying error) so the type stays `Equatable` and no `Containerization`/`Virtualization`
+/// type crosses this seam; `LocalContainerSiteRuntime.friendlyMessage(for:)` maps each case to
+/// owner-readable prose.
 public enum LocalContainerError: Error, Equatable {
-    case virtualizationUnavailable      // no entitlement / not Apple Silicon / macOS < 26
-    case imageUnavailable(String)       // bundled OCI layout missing or failed to import
-    case bootFailed(String)             // VM/container failed to boot
-    case cloneFailed(String)            // git clone of Source/ into the guest failed
+    /// No entitlement / not Apple Silicon / macOS < 26.
+    case virtualizationUnavailable
+    /// Bundled OCI layout missing or failed to import.
+    case imageUnavailable(String)
+    /// VM/container failed to boot.
+    case bootFailed(String)
+    /// git clone of `Source/` into the guest failed.
+    case cloneFailed(String)
 }
 
 /// Hydration precondition: a `LocalContainerControl.start()` implementation hard-depends on
@@ -69,9 +83,14 @@ public enum SourceRepoPrecondition {
 /// The captured output of a guest `exec` call. No `Containerization`/`Virtualization` types cross
 /// this boundary — only `String` and `Int32`.
 public struct ContainerExecResult: Sendable, Equatable {
+    /// The guest process's exit status.
     public let exitCode: Int32
+    /// The complete captured stdout — the process has already exited when this exists, so
+    /// callers can parse it whole (e.g. `persistEdit`'s base64 bundle transport).
     public let stdout: String
+    /// The complete captured stderr — the diagnostic half, surfaced in failure messages.
     public let stderr: String
+    /// Memberwise init — public so test fakes can fabricate results.
     public init(exitCode: Int32, stdout: String, stderr: String) {
         self.exitCode = exitCode
         self.stdout = stdout
@@ -89,6 +108,8 @@ public final class InteractiveExecHandle: Sendable {
     private let writeHandler: @Sendable (Data) async throws -> Void
     private let terminateHandler: @Sendable () async -> Void
 
+    /// Builds a handle from the two closures a conformer wires to its real (or fake) process —
+    /// see the type doc for why this is closure-backed rather than a protocol.
     public init(
         write: @escaping @Sendable (Data) async throws -> Void,
         terminate: @escaping @Sendable () async -> Void
@@ -128,6 +149,12 @@ public protocol LocalContainerControl: Sendable {
         ref: String,
         onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void
     ) async throws -> LocalContainerSession
+
+    /// Stops the named container and every guest process it hosts. Teardown paths typically
+    /// `try?` this — a stop that fails because the container is already gone isn't actionable.
+    /// Keyed by `siteID`, not by container instance: a stale caller can stop a newer container
+    /// booted under the same ID (see the superseded-attempt commentary in
+    /// `LocalContainerSiteRuntime.start`), so callers must guard against that themselves.
     func stop(siteID: String) async throws
 
     /// Pauses the running VM for `siteID` in place instead of tearing it down — the guest's
@@ -219,12 +246,20 @@ public protocol LocalContainerControl: Sendable {
 }
 
 extension LocalContainerControl {
+    /// Default no-op — per the requirement's doc, only `ContainerizationControl`'s
+    /// vmnet-backed network has shared state worth resetting; every other conformer inherits
+    /// this and does nothing.
     public func resetNetworking() async {}
 
+    /// Default for conformers without a real suspend/resume distinction: a plain stop. Only
+    /// runtimes that can actually pause a VM (the Containerization control, #1151) override
+    /// this with something cheaper to undo.
     public func suspend(siteID: String) async throws {
         try await stop(siteID: siteID)
     }
 
+    /// Default for conformers with no live process state to report (test fakes, the Podman
+    /// control): forwards to the state-less overload and never calls `onState`.
     public func startWorkersDev(
         siteID: String,
         workers: [WorkerDescriptor],

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -15,6 +15,9 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
 
     private let ref: String
     private let control: any LocalContainerControl
+    /// The `SiteRuntime` MCP seam: `start` connects this client to the booted container's
+    /// sidecar endpoint, `teardown` stops it. Public (unlike every other collaborator here)
+    /// because the edit pipeline reaches the sidecar's tools through it.
     public let mcpClient: MCPClient
     private let knowledgeIndex: SiteKnowledgeIndex?
     private let semanticRanker: SemanticRanker?
@@ -49,6 +52,12 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
     private var bootLogContinuation: AsyncStream<(String, LogCenter.Stream)>.Continuation?
     private var bootLogDrainTask: Task<Void, Never>?
 
+    /// Only `ref`, `control`, and `mcpClient` are required; every other parameter is a
+    /// collaborator with a production default. The closure parameters (`connect`,
+    /// `makeFileWatcher`, `importBundle`, `beginActivity`, `workerCatalog`) exist as test
+    /// seams so the runtime's lifecycle and supersession logic is exercisable without a real
+    /// container, MCP server, file system watcher, or libgit2 — `importBundle`'s default also
+    /// carries the platform split (in-process git import is Darwin-only).
     public init(
         ref: String,
         control: any LocalContainerControl,
@@ -89,6 +98,8 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
         self.statusCenter = statusCenter
     }
 
+    /// The current lifecycle state, read from the generation-tracked state machine that
+    /// serializes overlapping `start()`/`stop()` attempts.
     public var state: SiteRuntimeState { stateMachine.state }
 
     /// This runtime's own capability surface (#823) — `LocalContainerSiteRuntime` is the only
@@ -358,6 +369,9 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
         }
     }
 
+    /// Streams every subsequent state transition (the `SiteRuntime.observe()` requirement),
+    /// delegated to the state machine so superseded attempts' settles never appear — only
+    /// transitions that actually won their generation check are published.
     public func observe() -> AsyncStream<SiteRuntimeState> {
         stateMachine.observe()
     }

--- a/Sources/AnglesiteCore/LocalContainerSupport.swift
+++ b/Sources/AnglesiteCore/LocalContainerSupport.swift
@@ -6,20 +6,33 @@
 /// including ad-hoc Debug builds; no Apple approval or provisioning-profile grant is involved
 /// (verified 2026-07-07 via `scripts/run-container-probe.sh` under `codesign --sign -`).
 public enum LocalContainerSupport {
+    /// The gate's result. `unavailable` carries *every* failing precondition, not just the
+    /// first, so UI can tell the user the complete story in one pass.
     public enum Availability: Sendable, Equatable {
+        /// The local container runtime can run on this build/host.
         case available
+        /// It cannot; the reasons list every failed precondition, in declaration order.
         case unavailable([UnavailabilityReason])
 
+        /// Collapse to a Bool for callers that only branch and don't need to explain why.
         public var isAvailable: Bool {
             if case .available = self { true } else { false }
         }
     }
 
+    /// The individual preconditions the gate checks. `String` raw values so a reason can be
+    /// logged or compared stably across builds.
     public enum UnavailabilityReason: String, Sendable, Equatable, CaseIterable {
+        /// The host CPU is not arm64 — Apple Containerization requires Apple Silicon.
         case notAppleSilicon
+        /// The host OS predates macOS 26, the Apple-Containerization floor (see
+        /// ``LocalContainerSupport/hostOSIsSupported``).
         case unsupportedOS
+        /// The running binary's signature lacks `com.apple.security.virtualization` (see
+        /// ``LocalContainerSupport/hostHasVirtualizationEntitlement``).
         case missingVirtualizationEntitlement
 
+        /// A short human-readable explanation of the failed precondition.
         public var description: String {
             switch self {
             case .notAppleSilicon:
@@ -32,6 +45,9 @@ public enum LocalContainerSupport {
         }
     }
 
+    /// Boolean collapse of ``availability(isAppleSilicon:osIsSupported:hasVirtualizationEntitlement:)``
+    /// for callers that only branch. Same parameter story: defaults are the host probes,
+    /// overridable for tests and for the app's real entitlement probe.
     public static func isAvailable(
         isAppleSilicon: Bool = hostIsAppleSilicon,
         osIsSupported: Bool = hostOSIsSupported,
@@ -44,6 +60,11 @@ public enum LocalContainerSupport {
         ).isAvailable
     }
 
+    /// Evaluates every precondition rather than short-circuiting on the first failure, so the
+    /// result can present the complete list of blockers at once. Each parameter defaults to
+    /// this type's host probe and exists as an override seam — for tests, and (for the
+    /// entitlement) for the app target's real `AnglesiteContainer`-backed probe, since the
+    /// default here is conservatively false (see ``hostHasVirtualizationEntitlement``).
     public static func availability(
         isAppleSilicon: Bool = hostIsAppleSilicon,
         osIsSupported: Bool = hostOSIsSupported,

--- a/Sources/AnglesiteCore/LogCenter.swift
+++ b/Sources/AnglesiteCore/LogCenter.swift
@@ -16,18 +16,33 @@ public actor LogCenter {
     /// Shared instance used by `ProcessSupervisor` by default. Tests build their own.
     public static let shared = LogCenter()
 
+    /// Which pipe a line arrived on. Its own `CaseIterable` type (not a Bool) so filter UI can
+    /// enumerate the options, and so the distinction survives into export/filter APIs.
     public enum Stream: String, Sendable, Equatable, CaseIterable {
+        /// Standard output.
         case stdout
+        /// Standard error.
         case stderr
     }
 
+    /// One captured line of subprocess output plus its provenance.
     public struct LogLine: Sendable, Equatable, Identifiable {
+        /// Monotonic per-`LogCenter` sequence number — a stable `Identifiable` identity and an
+        /// ordering key that, unlike `timestamp`, never collides for lines appended in the
+        /// same instant.
         public let id: UInt64
+        /// When the line was appended (`append` defaults it to now).
         public let timestamp: Date
+        /// Which process/component emitted the line (e.g. `mcp`, `container:<siteID>`) — the
+        /// Debug pane's Source-picker key.
         public let source: String
+        /// The pipe the line came from.
         public let stream: Stream
+        /// The line's text.
         public let text: String
 
+        /// Memberwise init — public so tests and previews can fabricate lines without going
+        /// through a live `LogCenter`.
         public init(id: UInt64, timestamp: Date, source: String, stream: Stream, text: String) {
             self.id = id
             self.timestamp = timestamp
@@ -41,6 +56,9 @@ public actor LogCenter {
     /// method that finishes the underlying continuation — needed because `AsyncStream` iteration
     /// doesn't unblock on task cancellation alone; the producer side has to call `finish()`.
     public struct Subscription: Sendable {
+        /// The stream consumers `for await` over. Ends only when ``cancel()`` runs (or the
+        /// stream is otherwise terminated) — see the type doc for why task cancellation alone
+        /// is not enough.
         public let stream: AsyncStream<LogLine>
         private let continuation: AsyncStream<LogLine>.Continuation
 
@@ -56,12 +74,16 @@ public actor LogCenter {
         }
     }
 
+    /// Maximum number of lines the history ring retains for late subscribers; older lines are
+    /// evicted first.
     public let bufferCapacity: Int
 
     private var nextID: UInt64 = 0
     private var buffer: [LogLine] = []
     private var subscribers: [UUID: AsyncStream<LogLine>.Continuation] = [:]
 
+    /// `bufferCapacity` bounds the retained history (preconditioned positive); the default
+    /// trades a useful Debug-pane backlog against unbounded growth from a chatty subprocess.
     public init(bufferCapacity: Int = 5000) {
         precondition(bufferCapacity > 0, "bufferCapacity must be positive")
         self.bufferCapacity = bufferCapacity

--- a/Sources/AnglesiteCore/LogoAsset.swift
+++ b/Sources/AnglesiteCore/LogoAsset.swift
@@ -2,22 +2,37 @@ import Foundation
 
 /// Deterministic handling for an optional owner-supplied logo selected in the new-site wizard.
 public enum LogoAsset {
+    /// Where the copied logo lands inside the site. Astro serves `public/` verbatim at the
+    /// site root, which is what makes ``publicURLPath(for:)`` a valid served path.
     public static let assetDirectoryRelativePath = "public"
 
+    /// Why ``LogoAsset/install(from:siteName:siteDirectory:fileManager:)`` can fail; each case
+    /// carries the URL that was checked so the error is actionable.
     public enum InstallError: Error, Sendable {
+        /// The wizard-selected logo file no longer exists at the remembered URL.
         case sourceLogoNotFound(URL)
+        /// The scaffolded homepage (`src/pages/index.astro`) is missing, so there is nowhere
+        /// to insert the logo markup.
         case homepageNotFound(URL)
     }
 
+    /// Canonical destination file name: always `logo` plus the source's lowercased extension,
+    /// so installing a replacement logo overwrites the old file rather than accumulating one
+    /// per install.
     public static func fileName(for logoURL: URL) -> String {
         let ext = logoURL.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
         return ext.isEmpty ? "logo" : "logo.\(ext.lowercased())"
     }
 
+    /// The root-relative URL path the installed logo is served at (`public/` maps to `/`).
     public static func publicURLPath(for logoURL: URL) -> String {
         "/\(fileName(for: logoURL))"
     }
 
+    /// Inserts a `site-logo` `<img>` immediately after the template's hero open line.
+    /// Deterministic and idempotent by construction: it returns `source` unchanged when the
+    /// hero anchor is missing (a customized homepage the app shouldn't guess about) or a
+    /// `site-logo` image is already present, so re-running never duplicates markup.
     public static func insertLogo(into source: String, urlPath: String, alt: String) -> String {
         guard source.contains(HeroImage.heroOpenLine) else { return source }
         guard !source.contains(#"class="site-logo""#) else { return source }
@@ -25,6 +40,11 @@ public enum LogoAsset {
         return source.replacingOccurrences(of: HeroImage.heroOpenLine, with: HeroImage.heroOpenLine + "\n      " + img)
     }
 
+    /// Copies the logo into `public/` and patches the homepage to reference it, returning the
+    /// served URL path. Copy-then-patch ordering means a homepage failure never leaves markup
+    /// pointing at a file that was never installed; the homepage write is skipped when
+    /// ``insertLogo(into:urlPath:alt:)`` made no change, keeping a re-run diff-free.
+    /// - Throws: ``InstallError`` when the source logo or the homepage is missing.
     public static func install(from logoURL: URL, siteName: String,
                                siteDirectory: URL, fileManager: FileManager = .default) throws -> String {
         guard fileManager.fileExists(atPath: logoURL.path) else {

--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -11,7 +11,13 @@ import Foundation
 /// `onEdit` fires after every successful `.applied` reply with a non-nil `commit` — wired by
 /// `SiteWindow` to `ChatModel.recordEdit(_:)` so the chat panel surfaces each edit as a row.
 public struct MCPApplyEditRouter: EditRouter {
+    /// The seam that performs the MCP `tools/call`. Production binds it to
+    /// ``MCPClient/callTool(name:arguments:)``; tests inject a fake so the router's mapping
+    /// logic runs without a live MCP server.
     public typealias ToolCaller = @Sendable (_ name: String, _ arguments: JSONValue) async throws -> MCPClient.ToolCallResult
+    /// Synchronous hook fired only for `.applied` replies carrying a `commit` (see the type
+    /// doc — `SiteWindow` wires it to `ChatModel.recordEdit(_:)`). Contrast ``PostProcessor``,
+    /// which fires for every applied edit, commit or not.
     public typealias EditObserver = @Sendable (EditReply) -> Void
     /// Persists a successful runtime edit into the canonical site repository. Unlike
     /// ``PostProcessor``, this hook is awaited before the applied reply is returned: acknowledging
@@ -64,6 +70,12 @@ public struct MCPApplyEditRouter: EditRouter {
         self.postProcess = postProcess
     }
 
+    /// Sends `message` as an `apply_edit` tool call and maps every outcome — preview, applied,
+    /// failed, cancelled, or thrown — into an `EditReply`; this never throws, so the overlay
+    /// always gets a reply to render. Hook ordering is the load-bearing part: `persistEdit` is
+    /// awaited *before* the applied reply is returned (see ``EditPersister`` for why), and a
+    /// persistence failure downgrades the reply to `.failed` with `commit` nil; `onEdit` fires
+    /// only after persistence succeeded; `postProcess` is detached entirely.
     public func apply(_ message: EditMessage) async -> EditReply {
         // Pre-call cancellation checkpoint. In production this is belt-and-suspenders — the real
         // `toolCaller` routes through `MCPClient.callTool`, which checks cancellation itself and

--- a/Sources/AnglesiteCore/MCPClient.swift
+++ b/Sources/AnglesiteCore/MCPClient.swift
@@ -8,12 +8,20 @@ import FoundationNetworking
 /// Minimal JSON value used at the MCP boundary so request/response shapes stay `Sendable` and
 /// `Equatable` without forcing every caller to define a `Codable` model.
 public indirect enum JSONValue: Sendable, Equatable {
+    /// JSON `null`.
     case null
+    /// A JSON boolean.
     case bool(Bool)
+    /// A JSON number that arrived as an integer — see ``from(_:)`` for how the int/double
+    /// split is decided.
     case int(Int)
+    /// A JSON number that arrived with a floating-point representation.
     case double(Double)
+    /// A JSON string.
     case string(String)
+    /// A JSON array.
     case array([JSONValue])
+    /// A JSON object.
     case object([String: JSONValue])
 
     /// Convert to a `JSONSerialization`-friendly value tree.
@@ -81,37 +89,66 @@ public indirect enum JSONValue: Sendable, Equatable {
 /// wire (process pipes vs HTTP). For the stdio transport, protocol traffic also flows through
 /// `LogCenter`, so the Debug pane can see it.
 public actor MCPClient {
+    /// Failures the client layer itself produces (a server-reported JSON-RPC error surfaces as
+    /// ``rpcError(code:message:)``, passed through rather than reinterpreted).
     public enum MCPError: Error, Sendable, Equatable {
+        /// No transport is connected and handshaken — `start(...)`/`connect(...)` hasn't run,
+        /// failed, or a post-crash re-handshake didn't succeed.
         case notInitialized
+        /// `start(...)`/`connect(...)` was called while a transport is already up; call
+        /// ``MCPClient/stop()`` first.
         case alreadyRunning
+        /// The server replied with JSON the client can't interpret; carries a description of
+        /// what was missing.
         case invalidResponse(String)
+        /// The server answered with a JSON-RPC error object, forwarded verbatim.
         case rpcError(code: Int, message: String)
+        /// The stdio server process exited before the client finished becoming ready.
         case exitedBeforeReady(ProcessSupervisor.ExitReason)
+        /// No response arrived within the per-request deadline; the pending request is failed
+        /// so a caller never hangs on a wedged server.
         case timeout
         /// In-flight request failed because the server process crashed and is being restarted;
         /// the client re-runs `initialize` against the fresh process. Retry the call.
         case reconnecting
     }
 
+    /// One tool advertised by the server's `tools/list` response.
     public struct ToolDescriptor: Sendable, Equatable {
+        /// The tool's wire name — the value passed to ``MCPClient/callTool(name:arguments:)``.
         public let name: String
+        /// The server's human-readable description, when it provides one.
         public let description: String?
+        /// The tool's declared JSON-Schema input, kept as raw ``JSONValue`` rather than a
+        /// typed model — the app has no need to validate against it. `nil` when omitted.
         public let inputSchema: JSONValue?
     }
 
+    /// The result of a `tools/call`. MCP separates transport success from tool-level failure:
+    /// a failed tool still resolves normally here with ``isError`` true rather than throwing.
     public struct ToolCallResult: Sendable, Equatable {
+        /// The content items, in server order. Non-text items keep their `type` with a nil
+        /// `text` rather than being dropped.
         public let content: [Content]
+        /// MCP's tool-level failure flag — the RPC itself succeeded even when this is true;
+        /// consumers (e.g. `MCPApplyEditRouter`) branch on it to build a failure reply.
         public let isError: Bool
 
+        /// Memberwise init — public so tests can fabricate results without a live server.
         public init(content: [Content], isError: Bool) {
             self.content = content
             self.isError = isError
         }
 
+        /// One content item. Only `type` and `text` are decoded — the app consumes text
+        /// content exclusively, so richer content kinds are preserved as type-only stubs.
         public struct Content: Sendable, Equatable {
+            /// The MCP content type (e.g. `text`).
             public let type: String
+            /// The text payload for `text` content; nil for other kinds.
             public let text: String?
 
+            /// Memberwise init — public so tests can fabricate content items.
             public init(type: String, text: String?) {
                 self.type = type
                 self.text = text
@@ -134,11 +171,17 @@ public actor MCPClient {
     private var clientVersion: String = "0.1.0"
     private var initializeTimeout: TimeInterval = 10
 
+    /// `supervisor`/`logCenter` are retained for the stdio path only — `start(...)` needs them
+    /// to build a ``StdioTransport``. They're taken at construction even for an HTTP-only
+    /// client because the transport choice isn't known until `start`/`connect` is called.
     public init(supervisor: ProcessSupervisor, logCenter: LogCenter = .shared) {
         self.supervisor = supervisor
         self.logCenter = logCenter
     }
 
+    /// Whether a transport is currently held — set by a successful open, cleared by ``stop()``
+    /// (a failed `start`/`connect` tears down before throwing, so this never reads true for a
+    /// client whose startup failed).
     public var isRunning: Bool { transport != nil }
 
     /// Spawn the MCP server and run the `initialize` handshake. Returns once the server has
@@ -247,6 +290,9 @@ public actor MCPClient {
         }
     }
 
+    /// Fetches the server's tool catalog. Entries missing a `name` are dropped rather than
+    /// failing the whole list; a top-level shape without a `tools` array throws
+    /// ``MCPError/invalidResponse(_:)``.
     public func listTools() async throws -> [ToolDescriptor] {
         guard initialized else { throw MCPError.notInitialized }
         let result = try await sendRequest(method: "tools/list", params: .object([:]), timeout: 5)
@@ -263,6 +309,12 @@ public actor MCPClient {
         }
     }
 
+    /// Invokes a server tool and normalizes its result. Tool-level failure comes back as
+    /// ``ToolCallResult/isError``, not a throw — only client/transport-layer problems throw,
+    /// including ``MCPError/timeout`` after 30 seconds (deliberately longer than the other
+    /// calls' deadlines; tool work is open-ended in a way `initialize`/`tools/list` are not).
+    /// Cancellation is checked before sending so an already-cancelled task never reaches the
+    /// wire; a cancel while awaiting surfaces as `CancellationError`.
     public func callTool(name: String, arguments: JSONValue = .object([:])) async throws -> ToolCallResult {
         guard initialized else { throw MCPError.notInitialized }
         try Task.checkCancellation()   // pre-call guard: never send for an already-cancelled task
@@ -292,6 +344,8 @@ public actor MCPClient {
         return ToolCallResult(content: contents, isError: isError)
     }
 
+    /// Closes the transport and fails every still-pending request with
+    /// ``MCPError/notInitialized`` so no caller is left hanging. Safe to call when not running.
     public func stop() async {
         await teardown()
     }

--- a/Sources/AnglesiteCore/MTAStsPolicyAsset.swift
+++ b/Sources/AnglesiteCore/MTAStsPolicyAsset.swift
@@ -6,15 +6,25 @@ import Foundation
 /// (`mta-sts.<domain>`) needs a valid certificate and a host mapping at the deploy provider, so
 /// the UI names that prerequisite instead of pretending a TXT record alone enables MTA-STS.
 public enum MTAStsPolicyAsset {
+    /// The policy mode as the settings UI offers it. `disabled` is the app's off state (no
+    /// records generated at all); `testing`/`enforce` are RFC 8461's like-named modes.
     public enum Mode: String, Sendable, CaseIterable, Identifiable, Equatable {
+        /// No policy asserted — ``MTAStsPolicyAsset/dnsRecords(for:settings:)`` returns nothing.
         case disabled
+        /// Receiving MTAs report TLS failures but still deliver (RFC 8461 `testing`).
         case testing
+        /// Receiving MTAs must refuse delivery over an untrusted channel (RFC 8461 `enforce`).
         case enforce
 
+        /// `Identifiable` by case, for SwiftUI pickers over `allCases`.
         public var id: Self { self }
     }
 
+    /// The deterministic policy inputs as edited in the settings facet — persisted as
+    /// `.site-config` keys by ``MTAStsPolicyAsset/install(_:siteDirectory:)`` and read back by
+    /// ``MTAStsPolicyAsset/parseSettings(from:)``.
     public struct Settings: Sendable, Equatable {
+        /// The asserted policy mode; `disabled` suppresses DNS record generation entirely.
         public var mode: Mode
         /// Recipient/policy domain (without `_mta-sts.`); this is not necessarily the website host.
         public var domain: String
@@ -23,6 +33,8 @@ public enum MTAStsPolicyAsset {
         /// Optional RFC 8460 mailbox. A bare email is normalized to `mailto:` in the DNS record.
         public var reportMailbox: String
 
+        /// All-defaults init is the disabled/empty state — the same value
+        /// ``MTAStsPolicyAsset/parseSettings(from:)`` returns for a config with no MTA-STS keys.
         public init(mode: Mode = .disabled, domain: String = "", mxHosts: String = "", reportMailbox: String = "") {
             self.mode = mode
             self.domain = domain
@@ -31,16 +43,25 @@ public enum MTAStsPolicyAsset {
         }
     }
 
+    /// One TXT record the owner must create at their DNS provider — plain display data, not a
+    /// provider-API shape.
     public struct DNSRecord: Sendable, Equatable {
+        /// The fully-qualified record name (e.g. `_mta-sts.example.com`).
         public let name: String
+        /// The literal TXT record value.
         public let content: String
 
+        /// Memberwise init.
         public init(name: String, content: String) {
             self.name = name
             self.content = content
         }
     }
 
+    /// Reads the four MTA-STS/TLS-RPT keys back out of a `.site-config` document, reversing
+    /// ``install(_:siteDirectory:)``'s persistence format for display: the comma-separated MX
+    /// list becomes one host per line, and an unrecognized mode degrades to `disabled` rather
+    /// than failing.
     public static func parseSettings(from config: String) -> Settings {
         let mode = Mode(rawValue: SiteConfigFile.value(forKey: "MTA_STS_MODE", in: config) ?? "") ?? .disabled
         let domain = SiteConfigFile.value(forKey: "MTA_STS_DOMAIN", in: config) ?? ""
@@ -49,6 +70,10 @@ public enum MTAStsPolicyAsset {
         return Settings(mode: mode, domain: normalizedDomain(domain), mxHosts: hosts.replacingOccurrences(of: ",", with: "\n"), reportMailbox: reportMailbox)
     }
 
+    /// Upserts the four keys into the site's `.site-config`, normalizing every value on the
+    /// way in (``normalizedDomain(_:)``/``normalizedMXList(_:)``/``normalizedReportMailbox(_:)``)
+    /// so the template only ever reads canonical forms. Writes only when the document actually
+    /// changed, so a no-op save doesn't dirty the site's git repo.
     public static func install(_ settings: Settings, siteDirectory: URL) throws {
         let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
         let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
@@ -76,6 +101,9 @@ public enum MTAStsPolicyAsset {
         return records
     }
 
+    /// The first concrete (non-wildcard) host in `raw`, run through the same validation as MX
+    /// patterns — a policy domain must be a real name to hang `_mta-sts.` records off, and a
+    /// `*.` pattern can't be one. Empty when nothing qualifies.
     public static func normalizedDomain(_ raw: String) -> String {
         normalizedMXList(raw).first(where: { !$0.hasPrefix("*.") }) ?? ""
     }
@@ -97,6 +125,9 @@ public enum MTAStsPolicyAsset {
         return result
     }
 
+    /// Canonicalizes the TLS-RPT contact to a `mailto:` URI, accepting either a bare email or
+    /// an existing `mailto:` form. Anything else returns nil so a junk value never reaches the
+    /// generated DNS record.
     public static func normalizedReportMailbox(_ raw: String) -> String? {
         let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !value.isEmpty else { return nil }


### PR DESCRIPTION
## Summary

- Phase 6 of the doc-comment retrofit tracked in #1141: fourth alphabetical chunk of AnglesiteCore (40 files, `HTTPGitHubClient` … `MTAStsPolicyAsset`, ~340 doc comments) — GitHub/sandbox/HTTP transports, the harden plan/planner/executor, health model, the integration catalog/descriptor/plan/scaffolder/wizard, in-process backend and git, licensing store, link graph, local container control/runtime/support, LogCenter, the MCP client and apply-edit router, and the MTA-STS policy asset.
- Relocates `LANHostServer`'s misattached CLI doc block from its error enum onto the type it describes.
- Single-line enum `case` lists split so each case carries its rationale; raw values and `CaseIterable` order unchanged. Comments only otherwise — no behavior changes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` — clean.
- [x] `swift test --filter AnglesiteCoreTests` — 3,050 tests in 384 suites; 2 failures, both the known "FoundationModelAssistant" concurrent-`swift test` FM-contention flake (same two tests fail identically on unmodified checkouts — see #1148/#1152/#1153/#1154). `FoundationModelAssistant.swift` is not touched by this diff.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run separately; comments-only diff, target compiles during DocC symbol-graph extraction.
