### PR TITLE
docs(#1141): retrofit doc comments, Core SiteFileTree-ThemeCatalog

### DIFF
--- a/Sources/AnglesiteCore/SiteFileTree.swift
+++ b/Sources/AnglesiteCore/SiteFileTree.swift
@@ -8,15 +8,34 @@ import AnglesiteSiteModel
 /// Roots are resolved adaptively: an `.anglesite` package (#242) exposes `Source/` and `Config/`;
 /// a plain directory (the current pre-package layout) is treated as the project root directly.
 public enum FileGroup: String, Sendable, CaseIterable {
-    case pages, posts, collections, components, styles, metadata
+    /// Content pages — populated from ``SiteContentGraph``, never by `SiteFileTree.scan`.
+    case pages
+    /// Collection posts — populated from ``SiteContentGraph``, never by `SiteFileTree.scan`.
+    case posts
+    /// Content collections — populated from ``SiteContentGraph``, never by `SiteFileTree.scan`.
+    case collections
+    /// Layouts and components under `src/layouts` and `src/components`.
+    case components
+    /// Stylesheets under `src/styles`.
+    case styles
+    /// App-owned per-site state: everything in the package's `Config/` plus its `Info.plist` marker.
+    case metadata
 }
 
+/// One file the Site Navigator lists, tagged with the group it was found under.
 public struct FileRef: Sendable, Equatable, Identifiable {
+    /// Identity is the file's absolute POSIX path, so refs to the same file compare equal
+    /// across rescans and SwiftUI list diffing stays stable.
     public var id: String { url.path(percentEncoded: false) }
+    /// Absolute location of the file on disk.
     public let url: URL
+    /// The navigator group this file was discovered under.
     public let group: FileGroup
+    /// Display name — the file's last path component.
     public let name: String
 
+    /// Memberwise initializer; `name` is passed rather than derived so callers (and tests) can
+    /// label synthetic entries like the package `Info.plist` marker explicitly.
     public init(url: URL, group: FileGroup, name: String) {
         self.url = url
         self.group = group
@@ -24,10 +43,19 @@ public struct FileRef: Sendable, Equatable, Identifiable {
     }
 }
 
+/// The scanner behind the Site Navigator's file-backed groups (see ``FileGroup``'s per-case
+/// notes for which groups it covers) and the feed-route prober the preview uses (#714).
 public enum SiteFileTree {
+    /// The resolved on-disk roots for a site, abstracting over whether it is an `.anglesite`
+    /// package (#242) or a plain pre-package directory.
     public struct Layout: Sendable, Equatable {
+        /// Where the Astro project lives — the package's `Source/`, or the site root itself for
+        /// a plain directory.
         public let sourceDir: URL
+        /// The package's app-owned `Config/` directory; `nil` for a plain directory, which has
+        /// no app-owned state beside the project.
         public let configDir: URL?
+        /// The package's `Info.plist` identity marker; `nil` for a plain directory.
         public let infoPlist: URL?
     }
 
@@ -35,6 +63,9 @@ public enum SiteFileTree {
     private static let excludedDirNames: Set<String> = ["node_modules", "dist", ".astro", ".git"]
     private static let excludedFileNames: Set<String> = [".DS_Store"]
 
+    /// Resolves `siteRoot` adaptively: an `.anglesite` package exposes its `Source/`/`Config/`
+    /// split; anything else is treated as a plain project root directly, so pre-package sites
+    /// keep working without a migration.
     public static func layout(for siteRoot: URL, fileManager: FileManager = .default) -> Layout {
         if AnglesitePackage.isPackage(at: siteRoot, fileManager: fileManager) {
             let pkg = AnglesitePackage(url: siteRoot)
@@ -43,6 +74,9 @@ public enum SiteFileTree {
         return Layout(sourceDir: siteRoot, configDir: nil, infoPlist: nil)
     }
 
+    /// Scans the Components, Styles, and Metadata groups (the only groups this scanner owns —
+    /// see ``FileGroup``). A group with no files is omitted from the result rather than mapped
+    /// to an empty array, so the navigator can hide empty sections with a plain key check.
     public static func scan(siteRoot: URL, fileManager: FileManager = .default) -> [FileGroup: [FileRef]] {
         let layout = layout(for: siteRoot, fileManager: fileManager)
         var result: [FileGroup: [FileRef]] = [:]
@@ -94,16 +128,28 @@ public enum SiteFileTree {
     /// One feed route a collection ships — `/notes/rss.xml` etc. `Kind.rawValue` is the route's
     /// filename so probe path and preview route can't drift apart.
     public struct DetectedFeed: Sendable, Equatable, Identifiable {
+        /// The feed formats the template can materialize. Each raw value is the route's exact
+        /// filename, which is also what `detectedFeeds` probes for on disk (as `<rawValue>.ts`).
         public enum Kind: String, Sendable, CaseIterable {
+            /// RSS 2.0 — `rss.xml`.
             case rss = "rss.xml"
+            /// Atom — `atom.xml`.
             case atom = "atom.xml"
+            /// JSON Feed — `feed.json`.
             case json = "feed.json"
         }
+        /// Which feed format this route serves.
         public let kind: Kind
+        /// The content collection the feed belongs to (e.g. `notes`).
         public let collection: String
+        /// The site-relative feed route, derived from `collection` and `kind` so it can't drift
+        /// from the on-disk probe path.
         public var route: String { "/\(collection)/\(kind.rawValue)" }
+        /// Identity is the route — one feed per (collection, kind) pair.
         public var id: String { route }
 
+        /// Memberwise initializer; `route` is always derived, never stored, so a feed can't be
+        /// constructed with a route that disagrees with its parts.
         public init(kind: Kind, collection: String) {
             self.kind = kind
             self.collection = collection

--- a/Sources/AnglesiteCore/SiteFileWatcher.swift
+++ b/Sources/AnglesiteCore/SiteFileWatcher.swift
@@ -30,6 +30,21 @@ public enum SiteIndexPaths {
 /// without spinning a runtime. Portable — reindexing has no platform-specific code; only the
 /// watcher that feeds it (`Platform/SiteFileWatching.swift`) does.
 public enum KnowledgeReindex {
+    /// Reconciles one change batch against the index (and optional ranker): a bulk/coalesced
+    /// batch triggers a full rebuild + ranker re-sync, while a per-file batch upserts or removes
+    /// each unique in-tree path according to its current on-disk existence.
+    ///
+    /// - Parameters:
+    ///   - batch: The coalesced watcher output. `needsFullRescan` means per-file granularity was
+    ///     lost, so the whole site is rebuilt rather than guessing what changed.
+    ///   - index: The lexical index to mutate.
+    ///   - ranker: The semantic half to keep in lockstep (#383); `nil` skips vector maintenance
+    ///     entirely (e.g. hosts without embedding support).
+    ///   - siteID: The site whose documents are keyed in both stores.
+    ///   - projectRoot: Root that watcher paths are relativized against; out-of-tree paths are
+    ///     dropped.
+    ///   - fileExists: Existence probe, injectable so tests can simulate deletes without
+    ///     touching the filesystem. A missing file means "remove", not "skip".
     public static func apply(
         _ batch: FileChangeBatch,
         to index: SiteKnowledgeIndex,

--- a/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
+++ b/Sources/AnglesiteCore/SiteGraphAugmentedAssistant.swift
@@ -24,6 +24,13 @@ public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
     private let base: any ConversationalAssistant
     private let snapshotProvider: @Sendable () async -> SiteGraphExplorerSnapshot
 
+    /// Wraps `base` with graph grounding.
+    ///
+    /// - Parameters:
+    ///   - base: The assistant that actually answers; this decorator only rewrites its prompt
+    ///     and prepends citations.
+    ///   - snapshotProvider: Queried fresh on every turn (not captured once) so the grounding
+    ///     always reflects the current graph, even as the explorer rebuilds it behind us.
     public init(
         base: any ConversationalAssistant,
         snapshotProvider: @escaping @Sendable () async -> SiteGraphExplorerSnapshot
@@ -32,10 +39,15 @@ public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
         self.snapshotProvider = snapshotProvider
     }
 
+    /// Passes through the wrapped assistant's capabilities unchanged — grounding rewrites
+    /// prompts, it doesn't add or remove what the backend can do.
     public nonisolated var capabilities: AssistantCapabilities {
         base.capabilities
     }
 
+    /// Streams the wrapped assistant's conversation over a graph-enriched prompt, prepending a
+    /// single `.citations` event for the matched nodes' files. When no node matches the
+    /// question, the base stream is returned untouched — unrelated chat turns pay nothing.
     public func converse(prompt: String, context: AssistantContext) async throws -> AsyncStream<AssistantEvent> {
         let (enriched, citations) = await enrichedContext(prompt)
         let baseStream = try await base.converse(prompt: enriched, context: context)
@@ -59,12 +71,17 @@ public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
         }
     }
 
+    /// One-shot generation over the same graph-enriched prompt. Citations are discarded — the
+    /// plain text stream has no event channel to carry them, and generate callers (e.g. inline
+    /// rewrite) have no citations UI anyway.
     public func generate(prompt: String, context: AssistantContext) async throws -> AsyncThrowingStream<String, Error> {
         let (enriched, _) = await enrichedContext(prompt)
         return try await base.generate(prompt: enriched, context: context)
     }
 
     #if compiler(>=6.4) && canImport(FoundationModels)
+    /// Structured generation over the graph-enriched prompt; the `Generable` decoding itself is
+    /// entirely the wrapped assistant's job. Citations are discarded, as in `generate`.
     public func generateStructured<T: Generable & Sendable>(
         prompt: String,
         context: AssistantContext,
@@ -75,10 +92,15 @@ public actor SiteGraphAugmentedAssistant: ConversationalAssistant {
     }
     #endif
 
+    /// Forwards cancellation to the wrapped assistant — the decorator holds no in-flight work of
+    /// its own (enrichment is synchronous once the snapshot arrives), so there is nothing else to
+    /// stop.
     public func cancel() async {
         await base.cancel()
     }
 
+    /// Forwards the session reset to the wrapped assistant. Grounding is recomputed per turn from
+    /// `snapshotProvider`, so this decorator carries no session state of its own to clear.
     public func resetSession() async {
         await base.resetSession()
     }

--- a/Sources/AnglesiteCore/SiteGraphExplorer.swift
+++ b/Sources/AnglesiteCore/SiteGraphExplorer.swift
@@ -1,35 +1,79 @@
 import Foundation
 
+/// What a ``SiteGraphNode`` represents in the Astro project. Case order is meaningful: it is the
+/// display rank ``SiteGraphExplorer/build(projectRoot:siteID:pages:posts:images:fileManager:)``
+/// sorts the snapshot's nodes by (via `allCases`), so pages lead and styles trail in the
+/// explorer's list.
 public enum SiteGraphNodeKind: String, Sendable, CaseIterable, Identifiable {
+    /// A routable page under `src/pages/`.
     case page
+    /// A layout under `src/layouts/` — reached via ``SiteGraphEdgeKind/usesLayout`` edges.
     case layout
+    /// A reusable component under `src/components/`.
     case component
+    /// A content collection (e.g. `src/content/posts`) — a grouping with no file of its own, so
+    /// its node has a `nil` `filePath`.
     case collection
+    /// One entry inside a content collection (a markdown post, note, etc.).
     case contentEntry
+    /// An image or other static asset, whether under `src/` or `public/`.
     case asset
+    /// A stylesheet under `src/styles/`.
     case style
 
+    /// `Identifiable` via the raw value so SwiftUI lists and pickers can key on the kind directly.
     public var id: String { rawValue }
 }
 
+/// The relationship a ``SiteGraphEdge`` records, source → target. Distinguished so
+/// `ImpactAnalysis` and the explorer UI can weigh a layout dependency differently from a plain
+/// import or an asset reference.
 public enum SiteGraphEdgeKind: String, Sendable, CaseIterable, Identifiable {
+    /// Source imports the target (static `import`/`export … from` or dynamic `import()`).
     case imports
+    /// Source renders through the target layout — via an import whose target is a
+    /// ``SiteGraphNodeKind/layout``, or a markdown frontmatter `layout:` field (#309).
     case usesLayout
+    /// Source references the target asset (`src=`/`href=` attribute, CSS `url()`, or an import
+    /// resolving to an asset file).
     case referencesAsset
+    /// A collection node contains the target content entry.
     case contains
 
+    /// `Identifiable` via the raw value so SwiftUI lists and pickers can key on the kind directly.
     public var id: String { rawValue }
 }
 
+/// One file, content entry, or collection in the Site Graph Explorer's dependency graph. A plain
+/// value: nodes are built once per snapshot by ``SiteGraphExplorer`` and never mutated, so the
+/// UI, ``ImpactAnalysis``, and ``SiteGraphAugmentedAssistant`` can all share them freely.
 public struct SiteGraphNode: Sendable, Equatable, Identifiable {
+    /// Stable identity within one site's graph. Reuses `SiteContentGraph` IDs for pages/posts/
+    /// images so selection survives a rebuild; synthesized (`<siteID>:file:<path>`,
+    /// `<siteID>:collection:<name>`) for nodes only this explorer discovers.
     public let id: String
+    /// What the node represents — drives its icon, its sort rank, and which edge kinds point at it.
     public let kind: SiteGraphNodeKind
+    /// Human-readable name shown in the explorer: a page's title, a file's name, a collection's
+    /// name. Never empty (falls back to the route or filename).
     public let title: String
+    /// Secondary display line (a route, a relative path, a `collection/slug` pair) — purely
+    /// informational, distinct from `filePath` which is machine-resolvable.
     public let detail: String?
+    /// Project-relative POSIX path of the backing file, or `nil` for nodes with no single file
+    /// (a ``SiteGraphNodeKind/collection``) — which is why citations and "open file" actions must
+    /// treat it as optional.
     public let filePath: String?
+    /// The public URL path this node renders at, when it is routable (pages and content entries);
+    /// `nil` for everything that only exists at build time.
     public let route: String?
+    /// Incoming-edge count, precomputed by ``SiteGraphExplorer`` so list rows can show "used by
+    /// N" without each walking the full edge set.
     public let referencedByCount: Int
 
+    /// Memberwise initializer. `referencedByCount` defaults to `0` because only
+    /// ``SiteGraphExplorer``'s final pass knows the real count — intermediate construction (and
+    /// most tests) build nodes before edges exist.
     public init(
         id: String,
         kind: SiteGraphNodeKind,
@@ -49,12 +93,21 @@ public struct SiteGraphNode: Sendable, Equatable, Identifiable {
     }
 }
 
+/// A directed dependency between two ``SiteGraphNode``s: source depends on target.
 public struct SiteGraphEdge: Sendable, Equatable, Identifiable {
+    /// Derived as `"<sourceID>-><targetID>:<kind>"` — deterministic, so the same dependency
+    /// discovered twice (e.g. an asset referenced from two attributes in one file) collapses to
+    /// one edge when keyed by `id`, which is exactly how ``SiteGraphExplorer`` dedups.
     public let id: String
+    /// The depending node's ``SiteGraphNode/id``.
     public let sourceID: String
+    /// The depended-upon node's ``SiteGraphNode/id``.
     public let targetID: String
+    /// The relationship this edge records — see ``SiteGraphEdgeKind``.
     public let kind: SiteGraphEdgeKind
 
+    /// Builds the edge, deriving ``id`` from the three inputs — there is no way to supply an
+    /// arbitrary id, keeping the dedup-by-id invariant above unbreakable.
     public init(sourceID: String, targetID: String, kind: SiteGraphEdgeKind) {
         self.sourceID = sourceID
         self.targetID = targetID
@@ -63,16 +116,27 @@ public struct SiteGraphEdge: Sendable, Equatable, Identifiable {
     }
 }
 
+/// An immutable snapshot of one site's whole dependency graph. `Equatable` so observers (the
+/// explorer UI, chat grounding) can cheaply skip work when a rebuild produced an identical graph.
 public struct SiteGraphExplorerSnapshot: Sendable, Equatable {
+    /// All nodes, in the builder's stable order (by kind rank, then localized title) — consumers
+    /// can render directly without re-sorting.
     public let nodes: [SiteGraphNode]
+    /// All edges, sorted by ``SiteGraphEdge/id`` for deterministic equality across rebuilds.
     public let edges: [SiteGraphEdge]
 
+    /// Memberwise initializer; performs no validation, so callers (tests especially) can build
+    /// arbitrary graphs, including edges whose endpoints aren't in `nodes`.
     public init(nodes: [SiteGraphNode], edges: [SiteGraphEdge]) {
         self.nodes = nodes
         self.edges = edges
     }
 }
 
+/// Builds the Site Graph Explorer's dependency graph for an Astro project by static analysis —
+/// no dev server or Astro build involved, so it works on any checkout, at the cost of the
+/// heuristics being lexical (regex/prefix-based import, `src=`/`href=`, and `url()` scanning)
+/// rather than a real module resolution.
 public enum SiteGraphExplorer {
     private static let sourceExtensions: Set<String> = [
         ".astro", ".md", ".mdx", ".markdown", ".js", ".jsx", ".ts", ".tsx", ".css"
@@ -92,6 +156,28 @@ public enum SiteGraphExplorer {
         options: [.caseInsensitive]
     )
 
+    /// Builds a full graph snapshot from the already-parsed content model plus a fresh disk scan.
+    ///
+    /// Seeding from ``SiteContentGraph``'s pages/posts/images (rather than re-deriving them from
+    /// disk) keeps node IDs identical to the rest of the app, so selection and navigation carry
+    /// over; the walk then only adds what the content graph doesn't track — layouts, components,
+    /// styles, and stray assets. Every node's `referencedByCount` is filled in from the final
+    /// edge set in a last pass, which is why nodes are rebuilt at the end.
+    ///
+    /// Synchronous and file-system-bound: it reads every source file's text to extract imports
+    /// and asset references, so call it off the main actor for non-trivial sites.
+    ///
+    /// - Parameters:
+    ///   - projectRoot: The site's Astro project root (the package's `Source/` directory).
+    ///   - siteID: Namespaces synthesized node IDs so snapshots from different sites can never
+    ///     collide.
+    ///   - pages: The content model's routable pages, adopted as ``SiteGraphNodeKind/page`` nodes.
+    ///   - posts: The content model's collection entries; their collections become synthetic
+    ///     ``SiteGraphNodeKind/collection`` nodes with ``SiteGraphEdgeKind/contains`` edges.
+    ///   - images: The content model's known images, adopted as ``SiteGraphNodeKind/asset`` nodes.
+    ///   - fileManager: Injectable for tests that stage fixture trees.
+    /// - Returns: A deterministic snapshot — stable node and edge ordering — for cheap
+    ///   equality-based change detection.
     public static func build(
         projectRoot: URL,
         siteID: String,

--- a/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
+++ b/Sources/AnglesiteCore/SiteGraphNodeExplainer.swift
@@ -20,6 +20,9 @@ public protocol SiteGraphNodeExplaining: Sendable {
 /// FoundationModels means "no backend exists" (hide the feature), distinct from the runtime
 /// ``AssistantError/unavailable(_:)`` ("backend exists, Apple Intelligence is off").
 public enum SiteGraphExplainerFactory {
+    /// `FoundationModelSiteGraphExplainer` on a FoundationModels-capable toolchain, `nil`
+    /// otherwise. Callers treat `nil` as "hide the Explain button entirely" — see the enum doc
+    /// for how that differs from the runtime unavailable error.
     public static func makeDefault() -> (any SiteGraphNodeExplaining)? {
         #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelSiteGraphExplainer()
@@ -61,6 +64,17 @@ public enum SiteGraphExplainPrompt {
         return facts
     }
 
+    /// The complete explain prompt: a non-developer-audience instruction preamble wrapping the
+    /// deterministic fact list for `node`. Instructs the model to synthesize (not restate) the
+    /// facts and to invent nothing beyond them — the grounding contract described on the enum.
+    ///
+    /// - Parameters:
+    ///   - node: The node being explained.
+    ///   - impact: The node's precomputed ``ImpactAnalysis/Report``; its groups become the
+    ///     "editing it would affect …" facts.
+    ///   - dependsOn: The node's one-hop outgoing neighbors (deduplicated internally — a
+    ///     neighbor reachable via several edge kinds is listed once).
+    ///   - referencedBy: The node's one-hop incoming neighbors, deduplicated the same way.
     public static func prompt(
         node: SiteGraphNode,
         impact: ImpactAnalysis.Report,
@@ -141,8 +155,13 @@ public enum SiteGraphExplainPrompt {
 /// without Apple Intelligence throws ``AssistantError/unavailable(_:)`` from `generate` before
 /// the stream opens — surfaced by the UI as its "unavailable" state, never a cloud fallback.
 public struct FoundationModelSiteGraphExplainer: SiteGraphNodeExplaining {
+    /// Stateless — each `explain` call builds its own ``FoundationModelAssistant``, so there is
+    /// nothing to configure here.
     public init() {}
 
+    /// Streams an on-device (`.onDevice` tier, never Private Cloud Compute) explanation for a
+    /// prompt built by ``SiteGraphExplainPrompt``. `siteID`/`siteDirectory` only populate the
+    /// ``AssistantContext``; the prompt already carries every fact the model may use.
     public func explain(prompt: String, siteID: String, siteDirectory: URL) async throws -> AsyncThrowingStream<String, Error> {
         try await FoundationModelAssistant(tier: .onDevice).generate(
             prompt: prompt,

--- a/Sources/AnglesiteCore/SiteIndieAuthClient.swift
+++ b/Sources/AnglesiteCore/SiteIndieAuthClient.swift
@@ -22,8 +22,15 @@ import CryptoKit
 /// the user copy it back into the app rather than standing up a real loopback HTTP server to
 /// capture it automatically. Neither URL is a secret (PKCE public clients have none).
 public enum SiteIndieAuthLoopback {
+    /// Fixed (not ephemeral) port so `clientID` and `redirectURI` are stable constants the
+    /// authorization server sees identically across sign-ins — nothing ever binds to it (see the
+    /// enum doc).
     public static let redirectPort: UInt16 = 51789
+    /// The loopback-origin `client_id`. IndieAuth client IDs are URLs; a loopback origin is the
+    /// one kind that needs no pre-registration with the site's server.
     public static let clientID = URL(string: "http://127.0.0.1:51789/")!
+    /// Where the browser is redirected with `code`/`state` after approval. Same origin as
+    /// ``clientID``, which is what `@dwk/indieauth`'s `redirectUriPolicy` requires.
     public static let redirectURI = URL(string: "http://127.0.0.1:51789/callback")!
 
     /// The scopes `@dwk/microsub` needs: read the timeline, manage channels, follow/unfollow
@@ -46,6 +53,9 @@ struct IndieAuthMetadata: Decodable, Sendable {
     }
 }
 
+/// Everything that can go wrong across the ``SiteIndieAuthClient`` flow — discovery, callback
+/// validation, and token exchange. `Equatable` so tests and UI mapping can match on exact cases
+/// rather than string-compare descriptions.
 public enum SiteIndieAuthError: Error, Equatable, Sendable {
     /// Discovery document couldn't be fetched or decoded.
     case discoveryUnavailable(String)
@@ -69,6 +79,9 @@ public enum SiteIndieAuthError: Error, Equatable, Sendable {
 /// URL comes back — pasted back by the user, not captured automatically (see
 /// `SiteIndieAuthLoopback`'s doc comment for why).
 public struct SiteIndieAuthRequest: Sendable {
+    /// The fully-built authorization URL to open in the system browser. The only public member —
+    /// `state`, the PKCE verifier, and the endpoints stay internal so callers can't leak or
+    /// tamper with them; they only hand the whole request back to the completion APIs.
     public let authorizeURL: URL
     let state: String
     let codeVerifier: String
@@ -80,10 +93,20 @@ public struct SiteIndieAuthRequest: Sendable {
 /// The token response from a site's own `/token` endpoint (`@dwk/indieauth`'s DPoP-bound access
 /// token, see `token.ts`'s `signAccessToken`).
 public struct SiteIndieAuthToken: Sendable, Equatable {
+    /// The bearer credential itself — DPoP-bound, so it is only usable together with proofs
+    /// signed by the same key pair that ran the exchange.
     public let accessToken: String
+    /// The server's `token_type` (`DPoP` here, not `Bearer`) — echoed into the
+    /// `Authorization` scheme on resource requests.
     public let tokenType: String
+    /// The space-separated scopes actually granted, which may be narrower than what
+    /// ``SiteIndieAuthLoopback/microsubScope`` asked for.
     public let scope: String
+    /// The authenticated user's canonical URL — IndieAuth's identity claim, the whole point of
+    /// the flow.
     public let me: String
+    /// Lifetime in seconds; optional because IndieAuth servers aren't required to report it, and
+    /// this client doesn't refresh — an expired token just fails and re-runs sign-in.
     public let expiresIn: Int?
 
     enum CodingKeys: String, CodingKey {
@@ -109,10 +132,14 @@ extension SiteIndieAuthToken: Decodable {}
 /// (`MicrosubReaderModel`), kept out of this type so it stays fully unit-testable without
 /// networking beyond the injected `Transport`. Mirrors `CloudflareOAuthClient`'s seam.
 public struct SiteIndieAuthClient: Sendable {
+    /// The single seam all network traffic (discovery + token exchange) flows through, so tests
+    /// exercise the full flow with canned responses and zero real networking.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     private let transport: Transport
 
+    /// Defaults to ``defaultTransport`` (plain `URLSession`); inject a fake to unit-test the
+    /// flow.
     public init(transport: @escaping Transport = SiteIndieAuthClient.defaultTransport) {
         self.transport = transport
     }

--- a/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
+++ b/Sources/AnglesiteCore/SiteKnowledgeIndex.swift
@@ -6,43 +6,93 @@ import Foundation
 /// metadata (frontmatter, headings, internal links), and ranks file excerpts against a user query.
 /// That gives assistant features citation-ready project context without a network embedding service.
 public actor SiteKnowledgeIndex {
+    /// One indexed project file: the extracted metadata plus a capped excerpt of its text. This
+    /// is everything scoring needs, so search never re-reads the file from disk.
     public struct Document: Sendable, Equatable, Identifiable {
+        /// Stable identity in ``SiteKnowledgeIndex/documentID(siteID:relativePath:)``'s format —
+        /// derive it there, never reconstruct the string by hand.
         public let id: String
+        /// The owning site, since one shared index instance holds documents for every open site.
         public let siteID: String
+        /// Project-relative POSIX path — doubles as the citation path shown to the user.
         public let path: String
+        /// Coarse role classification (see ``Kind``), used both for search-result weighting and
+        /// for callers' kind filters.
         public let kind: Kind
+        /// The frontmatter `title:` when present, else the first heading; `nil` for files with
+        /// neither (config, styles, scripts).
         public let title: String?
+        /// The parsed frontmatter block. Kept structured (not flattened to text) so consumers
+        /// beyond search — e.g. content tooling — can read individual fields.
         public let frontmatter: [String: FrontmatterValue]
+        /// Up to the first 12 markdown/HTML headings — enough for relevance signal without
+        /// storing a full outline.
         public let headings: [String]
+        /// Site-internal link targets (`/…`, `./…`, `../…`) found in the body, deduplicated and
+        /// sorted; external URLs are deliberately excluded.
         public let internalLinks: [String]
+        /// The frontmatter-stripped body, truncated to the index's excerpt cap — the text
+        /// snippets are extracted from at search time.
         public let excerptText: String
+        /// File modification time when scanned (epoch on failure) — lets consumers detect
+        /// staleness against the file on disk.
         public let lastModified: Date
 
+        /// A document's coarse role, derived from its path prefix and extension. Distinguished
+        /// because search boosts owner-facing content (pages/posts) over plumbing, and callers
+        /// scope queries by kind via ``SiteKnowledgeIndex/SearchOptions``.
         public enum Kind: String, Sendable, Equatable, CaseIterable {
+            /// A routable page under `src/pages/`.
             case page
+            /// A post-like entry (`src/content/posts/`, `src/content/notes/`) — split from
+            /// ``content`` so blog-focused queries can target just these.
             case post
+            /// A component under `src/components/`.
             case component
+            /// A layout under `src/layouts/`.
             case layout
+            /// Any other content-collection entry under `src/content/`.
             case content
+            /// Project configuration (`package.json`, `astro.config.mjs`, JSON/YAML/TOML files).
             case config
+            /// A CSS stylesheet.
             case style
+            /// A JS/TS source file outside the categories above.
             case script
+            /// Indexed text that fits no other category.
             case other
         }
     }
 
+    /// One search hit: the matched document plus the specific excerpt that matched.
     public struct SearchResult: Sendable, Equatable, Identifiable {
+        /// The document id suffixed with the excerpt's starting line — unique even if a future
+        /// change surfaces multiple excerpts per document in one result list.
         public let id: String
+        /// The matched document, carried whole so result UIs can show title/path/kind without a
+        /// second index lookup.
         public let document: Document
+        /// Lexical relevance score; meaningful only for ordering within one query, not across
+        /// queries.
         public let score: Double
+        /// A few trimmed lines around the first matching line, capped so a prompt assembled from
+        /// several results stays small.
         public let excerpt: String
+        /// 1-based line range of the excerpt in the source file — what citation UIs display and
+        /// jump to. `nil` only when no range could be determined.
         public let lineRange: ClosedRange<Int>?
     }
 
+    /// Query knobs for ``SiteKnowledgeIndex/search(siteID:query:options:)``.
     public struct SearchOptions: Sendable, Equatable {
+        /// Maximum results returned; clamped to at least 1 at init so a caller can't accidentally
+        /// ask for zero and read "no matches" from a valid query.
         public let limit: Int
+        /// Restrict matches to these document kinds; `nil` searches everything.
         public let kinds: Set<Document.Kind>?
 
+        /// The default (8 results, all kinds) suits prompt-context retrieval; tighten `kinds` for
+        /// purpose-built lookups.
         public init(limit: Int = 8, kinds: Set<Document.Kind>? = nil) {
             self.limit = max(1, limit)
             self.kinds = kinds
@@ -52,6 +102,8 @@ public actor SiteKnowledgeIndex {
     private var documentsBySite: [String: [String: Document]] = [:]
     private static let maxExcerptCharacters = 8_192
 
+    /// Starts empty; the index is in-memory only, so each launch (and each site open) must
+    /// `rebuild` before searching.
     public init() {}
 
     /// Rebuilds the site's index from disk. Missing directories and unreadable files are skipped.
@@ -62,14 +114,21 @@ public actor SiteKnowledgeIndex {
         documentsBySite[siteID] = Dictionary(uniqueKeysWithValues: documents.map { ($0.path, $0) })
     }
 
+    /// Drops every document for a closed site, so a long-lived shared index doesn't hold excerpt
+    /// text for sites no longer open.
     public func unload(siteID: String) {
         documentsBySite[siteID] = nil
     }
 
+    /// All indexed documents for a site, sorted by path for deterministic iteration; empty when
+    /// the site was never rebuilt (or was unloaded).
     public func documents(siteID: String) -> [Document] {
         (documentsBySite[siteID] ?? [:]).values.sorted { $0.path < $1.path }
     }
 
+    /// Incrementally re-indexes one changed file — the file-watcher path, so a single edit
+    /// doesn't trigger a full `rebuild`. A file that no longer exists (or is no longer indexable)
+    /// is removed instead, so callers can route both "changed" and "unsure" events here.
     public func upsertFile(siteID: String, projectRoot: URL, relativePath: String) async {
         let scanned = await Task.detached(priority: .utility) {
             Self.document(siteID: siteID, projectRoot: projectRoot, relativePath: relativePath)
@@ -83,6 +142,7 @@ public actor SiteKnowledgeIndex {
         documentsBySite[siteID] = siteDocs
     }
 
+    /// Drops one file's document on deletion. No-op if the path was never indexed.
     public func removeFile(siteID: String, relativePath: String) {
         documentsBySite[siteID]?[relativePath] = nil
     }
@@ -99,6 +159,10 @@ public actor SiteKnowledgeIndex {
         "\(siteID):knowledge:\(relativePath)"
     }
 
+    /// Ranks indexed documents against a free-text query — lexical term/phrase matching over
+    /// path, title, headings, frontmatter, links, and body (see the actor doc for why not
+    /// embeddings). Ties break by path so identical scores order deterministically. Empty when
+    /// the query has no usable terms or the site isn't indexed.
     public func search(siteID: String, query: String, options: SearchOptions = .init()) -> [SearchResult] {
         let terms = Self.queryTerms(query)
         guard !terms.isEmpty else { return [] }
@@ -130,6 +194,10 @@ public actor SiteKnowledgeIndex {
         .map { $0 }
     }
 
+    /// Search results rendered as a ready-to-inject prompt block — `[path:lines]`-labelled
+    /// excerpts under a short instruction to cite file paths, matching the citation contract the
+    /// assistant decorators rely on. `nil` (rather than an empty block) when nothing matched, so
+    /// callers skip enrichment entirely for unrelated prompts.
     public func formattedContext(siteID: String, query: String, limit: Int = 6) -> String? {
         let results = search(siteID: siteID, query: query, options: .init(limit: limit))
         guard !results.isEmpty else { return nil }

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -22,6 +22,9 @@ public struct SiteOperations: Sendable {
     /// cache file `WorkerCatalogFetcher.cachedCatalog` reads from.
     private let cachedWorkerCatalog: @Sendable () -> [WorkerDescriptor]
 
+    /// Production entry point: live commands, the shared registry, and real security-scoped
+    /// access. Tests use the internal initializer instead, which additionally injects the
+    /// scoped-access hop and the cached worker catalog.
     public init(factory: CommandFactory = LiveCommandFactory(), store: SiteStore = .shared) {
         self.init(
             factory: factory,
@@ -51,6 +54,9 @@ public struct SiteOperations: Sendable {
 
     // MARK: Operations
 
+    /// Headless deploy with the same worker composition as the GUI Deploy button (see
+    /// `deployWithWorkerComposition` below). Never throws: access and lookup failures are folded
+    /// into `DeployCommand.Result.failed`, per the type's one-Result-per-operation contract.
     public func deploy(site: SiteStore.Site, onProgress: ProgressHandler? = nil) async -> DeployCommand.Result {
         do {
             return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
@@ -140,6 +146,8 @@ public struct SiteOperations: Sendable {
         return provisionResult.asDeployCommandResult
     }
 
+    /// Runs the site's backup inside scoped access; access and lookup failures fold into
+    /// `BackupCommand.Result.failed` rather than throwing.
     public func backup(site: SiteStore.Site, onProgress: ProgressHandler? = nil) async -> BackupCommand.Result {
         do {
             return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
@@ -152,6 +160,8 @@ public struct SiteOperations: Sendable {
         }
     }
 
+    /// Runs the site's audit inside scoped access; access and lookup failures fold into
+    /// `AuditCommand.Result.failed` (with an empty log tail, since no subprocess ever ran).
     public func audit(site: SiteStore.Site, onProgress: ProgressHandler? = nil) async -> AuditCommand.Result {
         do {
             return try await SiteAccess.withScopedAccess(to: site, in: store) { url in
@@ -181,6 +191,9 @@ public struct SiteOperations: Sendable {
         ),
     ]
 
+    /// Provisions the fixed V-2 starter pack (`v2StarterWorkers` above) for a site — the
+    /// one-button "turn on social basics" operation, deliberately independent of the site's
+    /// catalog-driven active-worker set.
     public func provisionSocialWorker(site: SiteStore.Site) async -> SocialWorkerProvisionCommand.Result {
         do {
             return try await socialWorkerAccess(site, store) { url in
@@ -200,6 +213,8 @@ public struct SiteOperations: Sendable {
 
     // MARK: Dialog mapping (pure)
 
+    /// Maps a deploy result onto the sentence Siri/Shortcuts speaks or shows. Pure and static so
+    /// intent tests can assert exact strings without running any operation.
     public static func dialog(forDeploy result: DeployCommand.Result) -> String {
         switch result {
         case .succeeded(let url, _):
@@ -215,6 +230,7 @@ public struct SiteOperations: Sendable {
         }
     }
 
+    /// Backup counterpart to `dialog(forDeploy:)` — pure result-to-sentence mapping.
     public static func dialog(forBackup result: BackupCommand.Result) -> String {
         switch result {
         case .succeeded(let sha, _, let remote):
@@ -226,6 +242,7 @@ public struct SiteOperations: Sendable {
         }
     }
 
+    /// Audit counterpart to `dialog(forDeploy:)` — summarizes finding counts by severity.
     public static func dialog(forAudit result: AuditCommand.Result) -> String {
         switch result {
         case .succeeded(let report, _):
@@ -238,6 +255,9 @@ public struct SiteOperations: Sendable {
         }
     }
 
+    /// Social-worker-provision counterpart to `dialog(forDeploy:)`. Always appends the
+    /// provisioned-resource suffix, including on failure — resources (D1/KV/R2) created before
+    /// the failure survive it, and the owner should know they exist.
     public static func dialog(forSocialWorkerProvision result: SocialWorkerProvisionCommand.Result) -> String {
         switch result {
         case .succeeded(let url, let resources, _):

--- a/Sources/AnglesiteCore/SiteOperationsService.swift
+++ b/Sources/AnglesiteCore/SiteOperationsService.swift
@@ -7,16 +7,27 @@ import Foundation
 /// with `AppDependencyManager.shared` to drive intent suites; see the AnglesiteIntents
 /// test target.
 public protocol SiteOperationsService: Sendable {
+    /// Resolves a site id (as carried by `SiteEntity`) to the registry's site, or `nil` when it
+    /// is unknown — the intent's "site not found" path.
     func site(id: String) async -> SiteStore.Site?
+    /// Deploys the site. Never throws: failures arrive as the result's own `.failed` case so
+    /// intents map exactly one result type to dialog.
     func deploy(site: SiteStore.Site, onProgress: ProgressHandler?) async -> DeployCommand.Result
+    /// Backs up the site, with the same never-throws result contract as `deploy`.
     func backup(site: SiteStore.Site, onProgress: ProgressHandler?) async -> BackupCommand.Result
+    /// Audits the site, with the same never-throws result contract as `deploy`.
     func audit(site: SiteStore.Site, onProgress: ProgressHandler?) async -> AuditCommand.Result
+    /// Provisions the V-2 social starter workers for the site; no progress hook, matching the
+    /// underlying command (see ``SiteOperations``).
     func provisionSocialWorker(site: SiteStore.Site) async -> SocialWorkerProvisionCommand.Result
 }
 
 public extension SiteOperationsService {
+    /// Progress-free convenience for callers with no progress UI; forwards `onProgress: nil`.
     func deploy(site: SiteStore.Site) async -> DeployCommand.Result { await deploy(site: site, onProgress: nil) }
+    /// Progress-free convenience for callers with no progress UI; forwards `onProgress: nil`.
     func backup(site: SiteStore.Site) async -> BackupCommand.Result { await backup(site: site, onProgress: nil) }
+    /// Progress-free convenience for callers with no progress UI; forwards `onProgress: nil`.
     func audit(site: SiteStore.Site) async -> AuditCommand.Result { await audit(site: site, onProgress: nil) }
 }
 

--- a/Sources/AnglesiteCore/SiteRuntime.swift
+++ b/Sources/AnglesiteCore/SiteRuntime.swift
@@ -2,7 +2,10 @@ import Foundation
 
 /// The lifecycle state of one site's live preview, independent of where it runs.
 public enum SiteRuntimeState: Sendable, Equatable {
+    /// No site is running — the initial state, and where `stop()` settles.
     case idle
+    /// Boot in progress (container start, hydration, dev-server launch). Carries the site ID so
+    /// observers can drop transitions belonging to a superseded site.
     case starting(siteID: String)
     /// `workersDevURL` is the local `wrangler dev --local` endpoint, present only when the site's
     /// effective active-worker set was non-empty at start time (#708) — `nil` for a static-only
@@ -17,10 +20,15 @@ public enum SiteRuntimeState: Sendable, Equatable {
 
 /// Failures that prevent a runtime edit from becoming durable in the canonical `Source/` repo.
 public enum SiteRuntimePersistenceError: LocalizedError, Sendable, Equatable {
+    /// The edit server returned no (or a malformed) commit SHA, so there is nothing verifiable to
+    /// sync back — better to fail than to guess at which guest state to persist.
     case missingOrInvalidCommit
+    /// The runtime stopped (or was superseded) between the edit and the persistence hop.
     case runtimeNotRunning
+    /// The guest-to-host sync itself failed; the message is the underlying tool's own output.
     case syncFailed(String)
 
+    /// Owner-facing message per case; the Debug pane carries the full underlying output.
     public var errorDescription: String? {
         switch self {
         case .missingOrInvalidCommit:
@@ -72,7 +80,12 @@ public protocol SiteRuntimeContainerCapability: AnyObject, Sendable {
 ///
 /// `mcpClient` is the substrate-agnostic MCP seam for the running container endpoint.
 public protocol SiteRuntime: Actor {
+    /// Boots `siteID`'s preview from `siteDirectory` (the package's `Source/`), tearing down any
+    /// previously running site first — one runtime never hosts two sites. Never throws: it
+    /// settles to `.ready` or `.failed`, observable via `observe()`, so every caller handles
+    /// failure through the same state channel.
     func start(siteID: String, siteDirectory: URL) async
+    /// Tears down the running site (if any) and settles to `.idle`. Safe to call redundantly.
     func stop() async
 
     /// Pauses this site's runtime instead of fully stopping it, when the substrate supports it —
@@ -83,7 +96,13 @@ public protocol SiteRuntime: Actor {
     /// those behaves exactly as it does today.
     func suspend() async
 
+    /// Streams every ``SiteRuntimeState`` transition, replaying the current state to each new
+    /// subscriber first — an observer attached after `.ready` still learns the URL.
+    /// Deliberately non-`async` so UI code can subscribe without hopping onto the runtime actor
+    /// (see `SiteRuntimeStateMachine` for the implementation consequence).
     func observe() -> AsyncStream<SiteRuntimeState>
+    /// The per-site MCP connection the edit pipeline and annotation feed route through —
+    /// substrate-agnostic: the transport underneath differs per conformer, the client doesn't.
     var mcpClient: MCPClient { get }
     /// The container-only capability surface (deploy execution context, network reset, edit
     /// persistence) — `nil` unless this runtime is a local Apple-Containerization runtime. See

--- a/Sources/AnglesiteCore/SiteRuntimeStateMachine.swift
+++ b/Sources/AnglesiteCore/SiteRuntimeStateMachine.swift
@@ -37,6 +37,7 @@ public final class SiteRuntimeStateMachine: @unchecked Sendable {
     private var observers: [UUID: AsyncStream<SiteRuntimeState>.Continuation] = [:]
     private var generation = 0
 
+    /// Starts at `.idle`, generation 0 — each owning runtime creates exactly one at init.
     public init() {}
 
     /// The current lifecycle state.

--- a/Sources/AnglesiteCore/SiteScaffolder.swift
+++ b/Sources/AnglesiteCore/SiteScaffolder.swift
@@ -5,10 +5,21 @@ import AnglesiteSiteModel
 /// goes through the injected `CommandRunner` (production: `ProcessSupervisor.shared.run`).
 public actor SiteScaffolder {
 
+    /// Progress events from the pipeline, in emission order. The milestone cases mark a step
+    /// *starting* (the wizard's progress list checks them off as they arrive); `warning` reports
+    /// a non-fatal problem within a step without stopping the pipeline, while `failed` is
+    /// terminal — the stream finishes after it, as it does after `done`.
     public enum ScaffoldStep: Sendable, Equatable {
+        /// Milestone steps: package skeleton, template copy, theme, homepage/content writes,
+        /// dependency install (delegated to the runtime), and registry recording.
         case creatingFolder, copyingTemplate, applyingTheme, writingContent, installing, registering
+        /// A step partially failed but the site is still viable (e.g. theme not applied, git init
+        /// skipped); `step` names the milestone it happened within.
         case warning(step: String, message: String)
+        /// A fatal failure in `step`; nothing after it ran, and no site was registered.
         case failed(step: String, message: String)
+        /// The pipeline finished and the package is registered; `siteID` is the recorded site's
+        /// registry ID, ready to open.
         case done(siteID: String)
     }
 
@@ -52,6 +63,10 @@ public actor SiteScaffolder {
         self.appVersion = appVersion
     }
 
+    /// Runs the whole pipeline for the wizard's finished draft, streaming ``ScaffoldStep``s as it
+    /// goes. `nonisolated` and immediately returning: the stream is the only result channel —
+    /// success is `.done`, failure `.failed`, and the stream finishes after either — so the
+    /// wizard binds its progress UI to this without awaiting the actor.
     public nonisolated func scaffold(_ draft: NewSiteDraft) -> AsyncStream<ScaffoldStep> {
         AsyncStream<ScaffoldStep>(bufferingPolicy: .unbounded) { continuation in
             Task {

--- a/Sources/AnglesiteCore/SiteSearchDestination.swift
+++ b/Sources/AnglesiteCore/SiteSearchDestination.swift
@@ -14,6 +14,9 @@ public enum SiteSearchDestination: Equatable, Sendable {
     /// Open this file (path relative to the site's `Source/`) in the editor.
     case file(path: String, group: FileGroup)
 
+    /// Resolves a search hit's fields to a destination, preferring navigator selection over a
+    /// raw file open whenever the hit's route matches a row the navigator actually shows.
+    ///
     /// - Parameters:
     ///   - kind: The matched document's kind, used to pick the destination's `FileGroup` when it
     ///     falls back to `.file`.
@@ -37,6 +40,8 @@ public enum SiteSearchDestination: Equatable, Sendable {
         return .file(path: path, group: group(for: kind))
     }
 
+    /// Convenience over ``resolve(kind:route:path:navigatorRouteIDs:)`` taking a
+    /// ``SiteSearchIndex/Hit`` directly, so call sites can't mismatch a hit's fields.
     public static func resolve(
         hit: SiteSearchIndex.Hit,
         navigatorRouteIDs: [String: String]

--- a/Sources/AnglesiteCore/SiteSearchIndex.swift
+++ b/Sources/AnglesiteCore/SiteSearchIndex.swift
@@ -58,13 +58,29 @@ enum ContentRouteResolver {
 /// no state of its own: every call reads the live index, so results always reflect whatever the
 /// file-watcher pipeline (`KnowledgeReindex`) has most recently applied.
 public enum SiteSearchIndex {
+    /// One ranked search result, flattened to exactly what a suggestions row needs to render and
+    /// activate — no reference back to the index or the underlying document, so the UI layer
+    /// never holds live index state.
     public struct Hit: Sendable, Equatable, Identifiable {
+        /// The indexed document's id — stable across searches, so SwiftUI row identity survives
+        /// re-querying as the user types.
         public let id: String
+        /// The matched document's kind, which drives the row's icon and the
+        /// ``SiteSearchDestination`` fallback grouping.
         public let kind: SiteKnowledgeIndex.Document.Kind
+        /// The document's title, when it has one — `nil` for files with no frontmatter title,
+        /// where the row falls back to showing the path.
         public let title: String?
+        /// The navigable route serving this document, if convention suggests one. Best-effort
+        /// (see `ContentRouteResolver`): non-nil does not guarantee the URL resolves, so
+        /// consumers should treat it as a candidate, not a promise.
         public let route: String?
+        /// Path relative to the site's `Source/` — always present, so every hit has at least a
+        /// file-open destination even when `route` is `nil`.
         public let path: String
+        /// The index's match excerpt, for showing the user *why* this row matched.
         public let matchContext: String
+        /// The index's lexical relevance score; hits arrive already sorted by it, descending.
         public let score: Double
     }
 

--- a/Sources/AnglesiteCore/SiteSearchScope.swift
+++ b/Sources/AnglesiteCore/SiteSearchScope.swift
@@ -11,12 +11,20 @@ import Foundation
 /// Raw values are persisted with the window's scene state, so they're API in the same sense
 /// `SiteToolbarItemID`'s are: renaming one silently resets every user's chosen scope.
 public enum SiteSearchScope: String, CaseIterable, Sendable, Identifiable {
+    /// No kind filter — searches every indexed document, including kinds no narrower scope names.
     case all
+    /// Standalone pages (`src/pages/`).
     case pages
+    /// Collection entries — both post-shaped collections and other content collections, since
+    /// both read as "a piece of writing" in the scope bar.
     case posts
+    /// Components and layouts together — the navigator's Components group already holds both,
+    /// so the scope bar matches the user's existing mental model.
     case components
+    /// Stylesheets.
     case styles
 
+    /// `Identifiable` conformance via the raw value, which is already unique and persisted.
     public var id: String { rawValue }
 
     /// The document kinds this scope searches, or `nil` for no filter.

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -16,6 +16,10 @@ public actor SiteStore {
     /// Process-wide shared instance.
     public static let shared = SiteStore()
 
+    /// One recents-registry entry: a known `.anglesite` package plus the cached state the
+    /// launcher, Open Recent, and Spotlight need to render it without touching disk. Identity
+    /// is the package's marker UUID, not its path — the entry survives the package being moved
+    /// or renamed (#242).
     public struct Site: Sendable, Codable, Equatable, Identifiable {
         /// The package's stable marker UUID (string). Path-independent — survives moves (#242).
         public let id: String
@@ -25,8 +29,16 @@ public actor SiteStore {
         public var name: String
         /// The `.anglesite` package directory.
         public let packageURL: URL
+        /// Whether `Source/` passed the project sentinels on the last check. Cached (not live):
+        /// refreshed by `load()` and `record(_:)`, so it can go stale between launches if files
+        /// change outside the app.
         public var isValid: Bool
+        /// The sentinel paths missing from `Source/` when `isValid` is `false` — lets the
+        /// launcher say *what's* broken instead of just flagging the site. Empty when
+        /// `needsReauthorization` is set, because the check couldn't actually run (#776).
         public var missingSentinels: [String]
+        /// When this site was last opened or recorded — the most-recently-used sort key for the
+        /// launcher, Open Recent, and the Dock menu.
         public var lastSeen: Date
         /// Security-scoped bookmark for `packageURL`. One grant covers the whole package, so
         /// Source/ and Config/ are both reachable under it.
@@ -45,6 +57,9 @@ public actor SiteStore {
         /// App-owned per-site config dir (settings, chat history, cache).
         public var configDirectory: URL { AnglesitePackage(url: packageURL).configURL }
 
+        /// Memberwise initializer. Prefer ``make(package:fileManager:)`` for entries built from
+        /// a real package on disk — it derives identity, name, and validity from the marker
+        /// instead of trusting caller-supplied values.
         public init(
             id: String,
             name: String,
@@ -122,8 +137,13 @@ public actor SiteStore {
         }
     }
 
+    /// Why a URL can't join the registry as a site. Part of the store's public error vocabulary
+    /// for callers that vet a candidate location before recording it.
     public enum StoreError: Error, Sendable {
+        /// The URL doesn't point at a directory at all.
         case notADirectory(URL)
+        /// The directory exists but its `Source/` tree fails the project sentinels; the payload
+        /// lists which sentinel paths are missing, mirroring `Site.missingSentinels`.
         case invalidProject(URL, missing: [String])
     }
 
@@ -135,12 +155,18 @@ public actor SiteStore {
 
     private let fileManager: FileManager
     private let persistenceURL: URL
+    /// The in-memory registry, most-recently-used first. Empty until `load()` runs; read-only
+    /// from outside — every mutation goes through the actor's methods so persistence and change
+    /// broadcasts can't be skipped.
     private(set) public var sites: [Site] = []
     private var changeHandler: ChangeHandler?
 
     /// Continuations for the UI-observer broadcast, keyed by a per-subscription `UUID`.
     private var changeStreamContinuations: [UUID: AsyncStream<[Site]>.Continuation] = [:]
 
+    /// Creates a store bound to a `recents.json` location. Does not load it — call `load()`
+    /// once the caller is ready to render.
+    ///
     /// - Parameters:
     ///   - persistenceURL: where to read/write `recents.json`. Defaults to
     ///     `~/Library/Application Support/Anglesite/recents.json`. Tests should pass a temp URL.
@@ -339,6 +365,12 @@ public actor SiteStore {
 
     // MARK: - Change notification
 
+    /// A per-subscriber stream of registry snapshots for UI observers (launcher, Open Recent).
+    /// Unlike the single-subscriber ``ChangeHandler``, any number of these can be live at once.
+    /// Yields the current list immediately on subscription (so a late-arriving view isn't blank
+    /// until the next mutation) and buffers only the newest snapshot — a slow consumer sees the
+    /// latest state, never a backlog of stale intermediates. `nonisolated` so SwiftUI `.task`
+    /// modifiers can subscribe without first hopping onto the actor.
     public nonisolated func changeStream() -> AsyncStream<[Site]> {
         let id = UUID()
         return AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in

--- a/Sources/AnglesiteCore/SiteURLTree.swift
+++ b/Sources/AnglesiteCore/SiteURLTree.swift
@@ -4,26 +4,41 @@ import Foundation
 /// pages — never source files. Images, CSS, JS, components, and feed routes are excluded by
 /// construction because only page/entry routes enter the builder.
 public struct URLTreeNode: Identifiable, Sendable, Equatable {
+    /// What a row represents, which decides its icon, context menu, and ``target``.
     public enum Kind: Sendable, Equatable {
+        /// The pinned first row for the site itself — activates website settings, not a route.
         case website
+        /// The home page (`/`), pinned ahead of its top-level siblings.
         case home
+        /// Any other single page or collection entry.
         case page
+        /// A URL directory. `collection` names the content collection whose entries live here
+        /// (`nil` for a directory of plain nested pages); `hasFeed` marks collections that
+        /// publish a feed, so the row can badge it.
         case directory(collection: String?, hasFeed: Bool)
     }
-    // Graph entity id for leaves — the rename/context-menu machinery resolves rows via
-    // graph.page(id:)/post(id:), so routes can't serve as leaf ids.
+    /// Graph entity id for leaves — the rename/context-menu machinery resolves rows via
+    /// `graph.page(id:)`/`post(id:)`, so routes can't serve as leaf ids.
     public let id: String
+    /// Row label: the page/entry title where one exists, falling back to its route.
     public let title: String
+    /// The visitor-facing URL path this row represents (directories keep a trailing slash).
     public let route: String
+    /// What the row represents — see ``Kind``.
     public let kind: Kind
     /// nil for leaves so `List`/`OutlineGroup` hides the disclosure chevron.
     public let children: [URLTreeNode]?
 
+    /// Memberwise initializer; `buildSiteURLTree(websiteTitle:pages:posts:feedCollections:contentTypes:)`
+    /// is the production constructor — direct use is for tests and previews.
     public init(id: String, title: String, route: String, kind: Kind, children: [URLTreeNode]?) {
         self.id = id; self.title = title; self.route = route; self.kind = kind
         self.children = children
     }
 
+    /// The navigation this row performs when activated, folding ``Kind`` into the shared
+    /// ``NavigatorTarget`` vocabulary so URL-tree rows and file-tree rows drive the window
+    /// through one selection path.
     public var target: NavigatorTarget {
         switch kind {
         case .website: return .websiteSettings

--- a/Sources/AnglesiteCore/SocialCalendarMarkdown.swift
+++ b/Sources/AnglesiteCore/SocialCalendarMarkdown.swift
@@ -23,6 +23,10 @@ public enum SocialCalendarMarkdown {
             .replacingOccurrences(of: "\r", with: " ")
     }
 
+    /// Renders the plan as the full `social-calendar.md` document: platform cadence table,
+    /// per-platform bios (a missing bio is marked, never silently skipped), content pillars,
+    /// then one table per week. Pure string building — pair with ``write(markdown:sourceDirectory:fileManager:)``
+    /// to put it on disk, and keep the two separate so tests can assert on output without I/O.
     public static func render(plan: SocialMediaPlan, siteName: String) -> String {
         var out: [String] = []
         out.append("# Social media plan for \(siteName)")

--- a/Sources/AnglesiteCore/SocialMediaPlan.swift
+++ b/Sources/AnglesiteCore/SocialMediaPlan.swift
@@ -1,19 +1,34 @@
 import Foundation
 
+/// One content pillar — a recurring theme the calendar's posts rotate through. The pillar names
+/// are the join key between plan sections: ``SocialCalendarEntry/pillar`` refers back to
+/// ``name``, which is why the week-generation prompt insists on using the names exactly.
 public struct SocialPillar: Sendable, Equatable {
+    /// Short pillar label (e.g. "Behind the scenes"), referenced verbatim by calendar entries.
     public let name: String
+    /// One-sentence description of what the pillar covers, used to brief week generation.
     public let detail: String
+    /// Memberwise initializer — the FM-generated pillar is converted to this plain value at the
+    /// planner boundary so the plan model stays toolchain-ungated.
     public init(name: String, detail: String) {
         self.name = name
         self.detail = detail
     }
 }
 
+/// One planned post in the calendar. All-string fields by design: the model generates the plan
+/// (spec §5.2), and deterministic Swift renders it without interpreting day names or platform
+/// labels beyond display.
 public struct SocialCalendarEntry: Sendable, Equatable {
+    /// Weekday label for the post (model-generated text, not a parsed date).
     public let day: String
+    /// Which platform the post targets — one of the plan's recommended platform names.
     public let platform: String
+    /// The ``SocialPillar/name`` this post belongs to.
     public let pillar: String
+    /// The post idea itself — the one model-authored creative field per entry.
     public let idea: String
+    /// Memberwise initializer, mirroring ``SocialPillar``'s boundary role.
     public init(day: String, platform: String, pillar: String, idea: String) {
         self.day = day
         self.platform = platform
@@ -22,9 +37,15 @@ public struct SocialCalendarEntry: Sendable, Equatable {
     }
 }
 
+/// One week of the calendar. The date comes from deterministic Swift (``SocialWeekDates``), never
+/// from the model — only `entries` is generated content.
 public struct SocialCalendarWeek: Sendable, Equatable {
+    /// The week's first day, computed by ``SocialWeekDates/startDates(from:count:)``.
     public let startDate: Date
+    /// The week's planned posts. A failed generation drops the whole week rather than shipping a
+    /// partial one (see ``SocialMediaPlanning``'s degradation policy).
     public let entries: [SocialCalendarEntry]
+    /// Memberwise initializer, mirroring ``SocialPillar``'s boundary role.
     public init(startDate: Date, entries: [SocialCalendarEntry]) {
         self.startDate = startDate
         self.entries = entries
@@ -35,12 +56,23 @@ public struct SocialCalendarWeek: Sendable, Equatable {
 /// the file format (spec §5.2). `bios` is keyed by platform name; a missing key means that
 /// bio couldn't be generated within its limit.
 public struct SocialMediaPlan: Sendable, Equatable {
+    /// The owner-declared business type the plan was generated for; `nil` when unknown, which
+    /// falls back to the generic platform recommendation.
     public let businessType: String?
+    /// The recommended platforms (deterministic, from ``SocialPlatformCatalog``) the bios and
+    /// calendar entries are keyed against.
     public let platforms: [SocialPlatformProfile]
+    /// Generated profile bios keyed by platform name — see the type doc for the missing-key
+    /// contract.
     public let bios: [String: String]
+    /// The generated content pillars; never empty in a non-`nil` plan (pillar failure aborts the
+    /// whole plan — see ``SocialMediaPlanning``).
     public let pillars: [SocialPillar]
+    /// The generated calendar weeks; may hold fewer weeks than requested when individual weeks
+    /// failed and were dropped.
     public let weeks: [SocialCalendarWeek]
 
+    /// Memberwise initializer — assembled by the planner, or directly by tests and renderers.
     public init(businessType: String?, platforms: [SocialPlatformProfile], bios: [String: String],
                 pillars: [SocialPillar], weeks: [SocialCalendarWeek]) {
         self.businessType = businessType

--- a/Sources/AnglesiteCore/SocialMediaPlanner.swift
+++ b/Sources/AnglesiteCore/SocialMediaPlanner.swift
@@ -5,11 +5,27 @@ import Foundation
 /// can't fit its platform limit after one retry is omitted (the renderer marks it), a failed
 /// week is dropped.
 public protocol SocialMediaPlanning: Sendable {
+    /// Generates a full ``SocialMediaPlan``, or `nil` when the backbone (pillars) couldn't be
+    /// generated — never throws, so callers only distinguish "plan" from "no plan".
+    ///
+    /// - Parameters:
+    ///   - siteName: The site's display name, woven into every prompt.
+    ///   - businessType: Owner-declared business type; also drives the deterministic platform
+    ///     recommendation (``SocialPlatformCatalog``). `nil` falls back to the generic set.
+    ///   - preamble: Optional brand-voice preamble prepended to each prompt; `nil` omits it.
+    ///   - weeks: How many calendar weeks to request; fewer may come back (failed weeks drop).
+    ///   - startDate: The first week's start; later weeks step deterministically from it.
+    ///   - siteID: Populates the `AssistantContext` for the generation calls.
+    ///   - siteDirectory: Likewise context-only — the planner reads no site files itself.
     func plan(siteName: String, businessType: String?, preamble: String?, weeks: Int,
               startDate: Date, siteID: String, siteDirectory: URL) async -> SocialMediaPlan?
 }
 
+/// Chooses the planner for the current toolchain — same pattern as `SiteGraphExplainerFactory`:
+/// non-gated so callers can default their dependency without importing FoundationModels.
 public enum SocialMediaPlannerFactory {
+    /// `FoundationModelSocialMediaPlanner` on a FoundationModels-capable toolchain, `nil`
+    /// otherwise — `nil` means "no backend exists on this build", so hide the feature.
     public static func makeDefault() -> (any SocialMediaPlanning)? {
         #if compiler(>=6.4) && canImport(FoundationModels)
         return FoundationModelSocialMediaPlanner()
@@ -24,9 +40,18 @@ public enum SocialMediaPlannerFactory {
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
+/// Apple-Intelligence-backed planner: structured generation via the `.privateCloudCompute` tier
+/// (creative multi-part output wants the larger model; PCC keeps it within the no-external-APIs
+/// policy, #459). Structure stays deterministic — platforms, week dates, and assembly are Swift;
+/// the model only fills content.
 public struct FoundationModelSocialMediaPlanner: SocialMediaPlanning {
+    /// Stateless — each `plan` call builds its own assistant, so there is nothing to configure.
     public init() {}
 
+    /// Implements ``SocialMediaPlanning/plan(siteName:businessType:preamble:weeks:startDate:siteID:siteDirectory:)``:
+    /// pillars first (abort to `nil` on failure), then per-platform bios and per-week calendar
+    /// chunks, each degrading individually per the protocol's policy. Also `nil` when no
+    /// assistant backend is available on this host.
     public func plan(siteName: String, businessType: String?, preamble: String?, weeks: Int,
                      startDate: Date, siteID: String, siteDirectory: URL) async -> SocialMediaPlan? {
         guard let assistant = ContentAssistantFactory.make(tier: .privateCloudCompute) else { return nil }

--- a/Sources/AnglesiteCore/SocialPlanPrompt.swift
+++ b/Sources/AnglesiteCore/SocialPlanPrompt.swift
@@ -4,6 +4,9 @@ import Foundation
 /// is one call per week (chunk-first): each call carries only the platform cadence and pillar
 /// facts, comfortably inside the on-device window.
 public enum SocialPlanPrompt {
+    /// Prompt for one platform's profile bio. States the platform's character limit as a hard
+    /// limit up front — the planner still verifies the count and retries once, because the model
+    /// can't be trusted to count characters (see the planner's no-silent-truncation policy).
     public static func bio(platform: SocialPlatformProfile, siteName: String,
                            businessType: String?, preamble: String?) -> String {
         joined(preamble, """
@@ -13,6 +16,8 @@ public enum SocialPlanPrompt {
         """)
     }
 
+    /// Prompt for the 3–5 content pillars, encoding the 80/20 value-vs-promotion rule so the
+    /// generated plan doesn't read as pure advertising.
     public static func pillars(siteName: String, businessType: String?, preamble: String?) -> String {
         joined(preamble, """
         Propose 3 to 5 social media content pillars for \(siteName)\(businessDescription(businessType)). \
@@ -21,6 +26,9 @@ public enum SocialPlanPrompt {
         """)
     }
 
+    /// Prompt for one calendar week (`index` is zero-based; the prompt says "week N+1"). Carries
+    /// the platform cadences and the already-generated pillars as facts, and requires pillar
+    /// names verbatim so entries join back to ``SocialPillar/name``.
     public static func week(index: Int, platforms: [SocialPlatformProfile], pillars: [SocialPillar],
                             businessType: String?, preamble: String?) -> String {
         let platformFacts = platforms
@@ -56,6 +64,9 @@ public enum SocialPlanPrompt {
 
 /// Pure 7-day week-start math, gregorian/UTC — deterministic regardless of the user's calendar.
 public enum SocialWeekDates {
+    /// `count` week-start dates at exact 7-day (in seconds) intervals from `start` — no calendar
+    /// or time-zone lookup, so DST shifts the wall-clock time rather than the interval, which is
+    /// fine for labeling calendar weeks. Negative `count` yields `[]`.
     public static func startDates(from start: Date, count: Int) -> [Date] {
         (0..<max(0, count)).map { start.addingTimeInterval(TimeInterval($0) * 7 * 86_400) }
     }

--- a/Sources/AnglesiteCore/SocialPlatformCatalog.swift
+++ b/Sources/AnglesiteCore/SocialPlatformCatalog.swift
@@ -4,11 +4,20 @@ import Foundation
 /// skill's business-type→platform table (v1: a representative subset; enriching from the SMB
 /// guides is a tracked follow-up). Cadence is posts per week.
 public struct SocialPlatformProfile: Sendable, Equatable {
+    /// Display name of the platform — also the key ``SocialMediaPlan/bios`` and calendar entries
+    /// join on.
     public let platform: String
+    /// The platform's profile-bio character limit, enforced deterministically by the planner (one
+    /// retry, then omit) rather than trusted to the model.
     public let bioCharLimit: Int
+    /// Recommended posting cadence, stated as a fact in the week-generation prompt.
     public let postsPerWeek: Int
+    /// One-line platform character note (audience/format), included in prompts so generated
+    /// copy fits the platform's register.
     public let note: String
 
+    /// Memberwise initializer — public mainly so tests and future catalog sources can build
+    /// profiles beyond the built-in table.
     public init(platform: String, bioCharLimit: Int, postsPerWeek: Int, note: String) {
         self.platform = platform
         self.bioCharLimit = bioCharLimit
@@ -17,6 +26,9 @@ public struct SocialPlatformProfile: Sendable, Equatable {
     }
 }
 
+/// The built-in business-type→platform lookup table (see ``SocialPlatformProfile`` for its
+/// provenance). Deterministic on purpose: which platforms a business should be on is a
+/// known-answer question, so it never goes through the model.
 public enum SocialPlatformCatalog {
     static let instagram = SocialPlatformProfile(platform: "Instagram", bioCharLimit: 150, postsPerWeek: 4, note: "visual-first; photos and reels")
     static let facebook = SocialPlatformProfile(platform: "Facebook", bioCharLimit: 255, postsPerWeek: 3, note: "community updates and events")
@@ -24,6 +36,10 @@ public enum SocialPlatformCatalog {
     static let nextdoor = SocialPlatformProfile(platform: "Nextdoor", bioCharLimit: 500, postsPerWeek: 1, note: "neighborhood word of mouth")
     static let bluesky = SocialPlatformProfile(platform: "Bluesky", bioCharLimit: 256, postsPerWeek: 3, note: "conversational, link-friendly")
 
+    /// The recommended platform set for a business type (matched case-insensitively against the
+    /// wizard's business-type identifiers). Unknown or `nil` types get the generic
+    /// Facebook/Instagram/Google Business trio rather than an empty set — every owner gets a
+    /// usable plan.
     public static func recommended(businessType: String?) -> [SocialPlatformProfile] {
         switch businessType?.lowercased() {
         case "restaurant", "cafe", "bakery", "food-truck":

--- a/Sources/AnglesiteCore/SocialPublishPlan.swift
+++ b/Sources/AnglesiteCore/SocialPublishPlan.swift
@@ -6,12 +6,25 @@ import Foundation
 /// the deploy pipeline a deterministic contract: for each publishable content entry, compute the
 /// canonical source URL, outbound Webmention targets, and requested POSSE destinations.
 public enum SocialPublishPlan {
+    /// One publishable content entry's outbound-social work. Only entries with at least one
+    /// Webmention or POSSE target become entries at all — content with nothing to send is left
+    /// out of the plan entirely.
     public struct Entry: Equatable, Sendable {
+        /// Project-relative POSIX path of the source markdown file, for display and tracing.
         public let sourceFile: String
+        /// The entry's public URL on the deployed site — the Webmention `source` every outbound
+        /// send will claim. Derived from the collection path and slug, since planning runs
+        /// without a built site to consult.
         public let canonicalURL: URL
+        /// External `http(s)` URLs this entry links to (reply/bookmark/like/repost frontmatter
+        /// plus body links), deduplicated, sorted, and with same-host links excluded — a site
+        /// never webmentions itself.
         public let webmentionTargets: [URL]
+        /// Syndication destinations requested in frontmatter (`posse`/`syndicateTo`), kept as
+        /// raw strings because destination identifiers belong to the (not-yet-shipped) sender.
         public let posseTargets: [String]
 
+        /// Memberwise initializer, public for tests and future senders to construct fixtures.
         public init(
             sourceFile: String,
             canonicalURL: URL,
@@ -25,19 +38,31 @@ public enum SocialPublishPlan {
         }
     }
 
+    /// The whole site's outbound-social plan for one deploy — deterministic for a given content
+    /// tree, so the deploy pipeline can diff/summarize it before anything is actually sent.
     public struct Plan: Equatable, Sendable {
+        /// The plan's entries, sorted by source file for stable output.
         public let entries: [Entry]
 
+        /// Memberwise initializer, public for tests and future senders to construct fixtures.
         public init(entries: [Entry]) {
             self.entries = entries
         }
 
+        /// `true` when this deploy has no outbound social work at all — the common case, letting
+        /// the pipeline skip the whole feature silently.
         public var isEmpty: Bool { entries.isEmpty }
+        /// Total outbound Webmention sends across all entries, for summary UI.
         public var webmentionCount: Int { entries.reduce(0) { $0 + $1.webmentionTargets.count } }
+        /// Total requested POSSE syndications across all entries, for summary UI.
         public var posseCount: Int { entries.reduce(0) { $0 + $1.posseTargets.count } }
     }
 
+    /// Input errors that make planning impossible (as opposed to per-file problems, which just
+    /// skip the file).
     public enum PlanningError: Error, Equatable, Sendable {
+        /// The site base URL has no host or a non-`http(s)` scheme, so canonical URLs and the
+        /// self-link exclusion can't be computed; carries the offending URL string.
         case invalidSiteBase(String)
     }
 

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -10,8 +10,14 @@ import Foundation
 /// `@dwk/*` packages are stable, that file is the only protocol-specific piece that needs to
 /// grow imports and route handlers.
 public actor SocialWorkerProvisionCommand {
+    /// Outcome of one `provision()` run. Every case carries the `resources` provisioned so far
+    /// because provisioning is incremental and resumable: a failure partway through must not lose
+    /// the D1/KV/R2/Queue ids already created, or a retry would re-create them against wrangler.
     public enum Result: Sendable, Equatable {
+        /// Provisioning and the downstream deploy both completed; `url` is the live Worker URL.
         case succeeded(url: URL, resources: WorkerComposition.ProvisionedResources, duration: TimeInterval)
+        /// The pre-deploy security gate (``PreDeployCheck``) refused the deploy. Resources were
+        /// still provisioned — the gate runs at the deploy stage, after resource creation.
         case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning], resources: WorkerComposition.ProvisionedResources)
         /// The candidate Worker name is already in use on the connected Cloudflare account by a
         /// project this site's own local config doesn't already claim as its own (`.site-config`'s
@@ -31,10 +37,17 @@ public actor SocialWorkerProvisionCommand {
         /// one acknowledgment covers every Queue-backed feature — it's the same account-level
         /// plan fact.)
         case webmentionPaidPlanConfirmationNeeded(resources: WorkerComposition.ProvisionedResources)
+        /// A wrangler call, secret push, or the downstream deploy failed. `exitCode` is `nil` when
+        /// the process couldn't run at all (as opposed to running and exiting non-zero).
         case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
     }
 
+    /// Re-exported from ``DeployCommand`` so both commands share one token-resolution seam
+    /// (Keychain in production, injected values in tests).
     public typealias TokenSource = DeployCommand.TokenSource
+    /// Runs one `wrangler <arguments>` invocation with `siteDirectory` as cwd, tagged with
+    /// `source` for the debug pane. Injected so tests can fake wrangler without a container; the
+    /// production conformer routes through the site's container runtime.
     public typealias CommandRunner = @Sendable (
         _ siteDirectory: URL,
         _ arguments: [String],
@@ -68,6 +81,10 @@ public actor SocialWorkerProvisionCommand {
     /// hashing pepper. Defaults to the real Keychain via `SolidOidcKeyProvisioning`; tests inject
     /// a fake, mirroring `KeyPairSource`/`SolidOidcSigningKeySource`.
     public typealias WebdavPepperSource = @Sendable (_ siteID: String) throws -> String
+    /// The final publish step, once every resource and secret is in place — production is
+    /// `DeployCommand.deploy` (build, pre-deploy security scan, wrangler deploy). Injected so
+    /// `DeployModel` can thread its own progress/preflight callbacks, and so tests can stub the
+    /// deploy without a Cloudflare account.
     public typealias Deployer = @Sendable (
         _ token: String,
         _ siteID: String,
@@ -75,6 +92,9 @@ public actor SocialWorkerProvisionCommand {
         _ wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim]
     ) async -> DeployCommand.Result
 
+    /// The Cloudflare API token seam this command was constructed with. `nonisolated` (and
+    /// public) so callers can reuse the exact same token source for related calls without
+    /// hopping onto the actor.
     public nonisolated let tokenSource: TokenSource
     private let runner: CommandRunner
     private let keyPairSource: KeyPairSource
@@ -84,6 +104,8 @@ public actor SocialWorkerProvisionCommand {
     private let deployer: Deployer
     private let workerScriptNamesSource: DeployCommand.WorkerScriptNamesSource
 
+    /// Creates a provisioner. Every dependency defaults to its production conformer; tests (and
+    /// `DeployModel`, which threads its own runner/deployer) override only the seams they need.
     public init(
         tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
         runner: @escaping CommandRunner = SocialWorkerProvisionCommand.defaultRunner,
@@ -108,6 +130,11 @@ public actor SocialWorkerProvisionCommand {
         self.workerScriptNamesSource = workerScriptNamesSource
     }
 
+    /// Provisions every Cloudflare resource the active workers need (D1, KV, R2, Queues,
+    /// secrets), regenerates `wrangler.toml`, then hands off to `deployer` to build, scan, and
+    /// publish. Idempotent and resumable: each resource is created only if not already known
+    /// (from `knownResources` or a prior `wrangler.toml`), and config is persisted after every
+    /// successful step so a failure partway through never loses ids already created.
     public func provision(
         siteID: String,
         siteDirectory: URL,
@@ -653,36 +680,48 @@ public actor SocialWorkerProvisionCommand {
         return nil
     }
 
+    /// Host-side wrangler is retired (#70 — no host Node runtime): this default fails with a
+    /// logged explanation and exit code 127 rather than spawning anything. Real provisioning
+    /// injects a container-backed runner (`ContainerCommandRunner`).
     public static let defaultRunner: CommandRunner = { siteDirectory, arguments, environment, source in
         let reason = HostNodeRetirement.reason("social worker provisioning")
         await LogCenter.shared.append(source: source, stream: .stderr, text: reason)
         return ProcessSupervisor.RunResult(stdout: reason, stderr: "", exitCode: 127)
     }
 
+    /// Same host-Node retirement stance as ``defaultRunner``, for the secret-push seam: fails
+    /// with a logged explanation instead of spawning; production injects
+    /// `ContainerCommandRunner.secretRunner`.
     public static let defaultSecretRunner: SecretRunner = { siteDirectory, name, value, environment, source in
         let reason = HostNodeRetirement.reason("social worker secret provisioning")
         await LogCenter.shared.append(source: source, stream: .stderr, text: reason)
         return ProcessSupervisor.RunResult(stdout: reason, stderr: "", exitCode: 127)
     }
 
+    /// Production ``KeyPairSource``: the real per-site ActivityPub secrets, generated once and
+    /// persisted in the platform secret store (Keychain on macOS).
     public static let defaultKeyPairSource: KeyPairSource = { siteID in
         try ActivityPubKeyProvisioning.secrets(siteID: siteID, secretStore: PlatformSecretStore.make())
     }
 
+    /// Production ``SolidOidcSigningKeySource``: the real per-site ES256 signing key from the
+    /// platform secret store, generated on first use.
     public static let defaultSolidOidcSigningKeySource: SolidOidcSigningKeySource = { siteID in
         try SolidOidcKeyProvisioning.signingKeyJWK(siteID: siteID, secretStore: PlatformSecretStore.make())
     }
 
+    /// Production ``WebdavPepperSource``: the real per-site WebDAV hashing pepper from the
+    /// platform secret store, generated on first use.
     public static let defaultWebdavPepperSource: WebdavPepperSource = { siteID in
         try SolidOidcKeyProvisioning.webdavPepper(siteID: siteID, secretStore: PlatformSecretStore.make())
     }
 
-    // Calls `DeployCommand.deploy` with `configDirectory` still defaulted (route-coverage
-    // scanning skipped, #530), but now forwards `wellKnownDynamicClaims` through to #744's
-    // pre-build /.well-known/ collision check (#934) — `provision`'s caller supplies whatever
-    // active dynamic-route claims it computed (empty if it didn't, matching prior behavior).
-    // `DeployModel.runDeploy` still constructs its own deployer closure (for `configDirectory`/
-    // `onPreflight`/`onProgress`, which this default has no equivalent for).
+    /// Calls `DeployCommand.deploy` with `configDirectory` still defaulted (route-coverage
+    /// scanning skipped, #530), but now forwards `wellKnownDynamicClaims` through to #744's
+    /// pre-build /.well-known/ collision check (#934) — `provision`'s caller supplies whatever
+    /// active dynamic-route claims it computed (empty if it didn't, matching prior behavior).
+    /// `DeployModel.runDeploy` still constructs its own deployer closure (for `configDirectory`/
+    /// `onPreflight`/`onProgress`, which this default has no equivalent for).
     public static let defaultDeployer: Deployer = { token, siteID, siteDirectory, wellKnownDynamicClaims in
         await DeployCommand(tokenSource: { token }).deploy(
             siteID: siteID, siteDirectory: siteDirectory, wellKnownDynamicClaims: wellKnownDynamicClaims)

--- a/Sources/AnglesiteCore/SolidOidcKeyProvisioning.swift
+++ b/Sources/AnglesiteCore/SolidOidcKeyProvisioning.swift
@@ -15,8 +15,14 @@ import CryptoKit
 /// access token `@dwk/solid-pod` has already accepted the corresponding JWKS entry for (mirrors
 /// `ActivityPubKeyProvisioning`'s "never regenerate" rationale for its own signing key).
 public enum SolidOidcKeyProvisioning {
+    /// Failures generating secret material. Both cases mean *no* secret was persisted — a caller
+    /// can safely retry, since nothing partial is ever written to the `SecretStore`.
     public enum Error: Swift.Error {
+        /// The platform's secure random source refused to produce bytes (the associated string
+        /// carries the underlying `SecRandomCopyBytes` status for the log).
         case keyGenerationFailed(String)
+        /// Built without CryptoKit/Security (non-Darwin) — this provisioning path requires the
+        /// platform crypto stack, and there is deliberately no weaker fallback for key material.
         case unsupportedPlatform
     }
 

--- a/Sources/AnglesiteCore/SourceBundleStatus.swift
+++ b/Sources/AnglesiteCore/SourceBundleStatus.swift
@@ -17,6 +17,11 @@ public enum SourceBundleStatus: Sendable, Equatable {
     /// `Source/` has commits after the last uploaded bundle.
     case dirty(uploadedCommit: String, currentCommit: String)
 
+    /// Computes the status for one site by reading `.site-config` and asking git for `HEAD`.
+    /// Deliberately quiet on every failure path: an unreadable config or a `rev-parse` that
+    /// doesn't run reports `.notConfigured`/`.upToDate` rather than an error — this check only
+    /// exists to *offer* a "redeploy your source bundle" nudge, so a wrong-but-calm answer beats
+    /// alarming the owner over a diagnostic the deploy itself will surface properly.
     public static func check(siteDirectory: URL, settings: SiteSettings) async -> SourceBundleStatus {
         let configURL = siteDirectory.appendingPathComponent(".site-config")
         let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""

--- a/Sources/AnglesiteCore/StartupProgressEstimator.swift
+++ b/Sources/AnglesiteCore/StartupProgressEstimator.swift
@@ -3,11 +3,18 @@ import Foundation
 /// The coarse milestone a dev-server startup is currently at. Drives both the progress bar's fill
 /// range and the curated message shown beneath it.
 public enum StartupPhase: String, Sendable, Equatable, CaseIterable {
+    /// No startup in progress (initial state, or reset after the runtime went back to idle).
     case idle
+    /// The runtime reported `.starting` — the dev-server process is being spawned.
     case launching
+    /// First astro stdout arrived: the process is alive and Astro/Vite is doing its build work.
     case building
+    /// The dev server printed its ready URL; the preview WebView is connecting to it.
     case connecting
+    /// The runtime reported `.ready` — the bar jumps to full.
     case ready
+    /// Startup failed before reaching `.ready`. A crash *after* `.ready` never lands here — that
+    /// is a runtime concern the error pane owns, not a startup one.
     case failed
 
     /// Forward-only ordering. The estimator only ever advances to a higher-ranked active phase.
@@ -37,6 +44,8 @@ public enum StartupPhase: String, Sendable, Equatable, CaseIterable {
         }
     }
 
+    /// The curated status line shown beneath the progress bar while this phase is active. Empty
+    /// for the non-active phases — the bar isn't shown then, so there's nothing to caption.
     public var message: String {
         switch self {
         case .idle, .failed, .ready: return ""
@@ -71,7 +80,11 @@ public enum StartupPhase: String, Sendable, Equatable, CaseIterable {
 /// phase the fraction approaches — but never reaches — that phase's cap, so the bar keeps inching
 /// on overrun and only a genuine anchor completes a segment. `.ready` jumps to `1.0`.
 public struct StartupProgressEstimator: Sendable, Equatable {
+    /// The current milestone. Advances forward-only through the active phases; only a runtime
+    /// `.failed`/`.idle` signal resets it.
     public private(set) var phase: StartupPhase = .idle
+    /// Determinate progress in `0...1`, monotonic within a startup — it never moves backward, so
+    /// the bar never visibly regresses even when signals arrive out of the expected cadence.
     public private(set) var fraction: Double = 0
 
     private let profile: StartupProfile
@@ -83,12 +96,19 @@ public struct StartupProgressEstimator: Sendable, Equatable {
     private static let easeK = 2.5
     private static let fractionEpsilon = 0.0001
 
+    /// Creates an estimator paced by `profile` — typically the last successful startup's measured
+    /// timings (``StartupTimingStore``), so the smooth fill matches how long *this site* usually
+    /// takes rather than a one-size-fits-all guess.
     public init(profile: StartupProfile = .default) {
         self.profile = profile
     }
 
+    /// The current phase's curated status line (see ``StartupPhase/message``).
     public var message: String { phase.message }
 
+    /// `true` while a startup is genuinely in flight (launching/building/connecting) — the window
+    /// in which the caller should keep `tick`ing and feeding log lines. `false` for the terminal
+    /// and idle states, where every ingest/tick becomes a no-op.
     public var isActive: Bool {
         phase == .launching || phase == .building || phase == .connecting
     }

--- a/Sources/AnglesiteCore/StartupTiming.swift
+++ b/Sources/AnglesiteCore/StartupTiming.swift
@@ -4,10 +4,17 @@ import Foundation
 /// startup progress bar between milestone anchors. One segment per gap in the milestone sequence
 /// launching → building → connecting → ready.
 public struct StartupProfile: Sendable, Equatable, Codable {
+    /// Seconds from process spawn to the first astro stdout line.
     public var launchingToBuilding: TimeInterval
+    /// Seconds from the first astro stdout line to the dev server printing its ready URL —
+    /// typically the longest segment (the Astro/Vite build).
     public var buildingToConnecting: TimeInterval
+    /// Seconds from the ready URL appearing to the runtime reporting `.ready`.
     public var connectingToReady: TimeInterval
 
+    /// Creates a profile from three measured (or estimated) segment durations. Not validated
+    /// here — readers gate on ``isPlausible`` instead, so a degenerate measurement can still be
+    /// constructed, inspected, and then rejected at the persistence boundary.
     public init(launchingToBuilding: TimeInterval, buildingToConnecting: TimeInterval, connectingToReady: TimeInterval) {
         self.launchingToBuilding = launchingToBuilding
         self.buildingToConnecting = buildingToConnecting
@@ -41,6 +48,8 @@ public final class StartupTimingStore: @unchecked Sendable {
 
     private let defaults: UserDefaults
 
+    /// Creates a store over `defaults`. Injectable so tests can use a scratch suite instead of
+    /// polluting (or depending on) `UserDefaults.standard`.
     public init(defaults: UserDefaults) {
         self.defaults = defaults
     }

--- a/Sources/AnglesiteCore/StdioTransport.swift
+++ b/Sources/AnglesiteCore/StdioTransport.swift
@@ -22,6 +22,12 @@ public actor StdioTransport: MCPTransport {
     private let stream: AsyncStream<JSONValue>
     private let continuation: AsyncStream<JSONValue>.Continuation
 
+    /// Creates a transport that will spawn `executable` under `supervisor` when opened. `source`
+    /// is the ``LogCenter`` tag the child's output is filed under — it doubles as the filter key
+    /// `inbound()` uses to pick this process's stdout lines out of the shared log stream, so it
+    /// must be unique per transport. `onReconnect` fires after every supervised respawn (never for
+    /// the initial launch), giving `MCPClient` its hook to re-run the MCP handshake against the
+    /// fresh process.
     public init(
         supervisor: ProcessSupervisor,
         logCenter: LogCenter,
@@ -45,6 +51,9 @@ public actor StdioTransport: MCPTransport {
         (self.stream, self.continuation) = AsyncStream<JSONValue>.makeStream(bufferingPolicy: .unbounded)
     }
 
+    /// Launches the supervised child with a stdin pipe attached and starts forwarding its stdout
+    /// into the inbound stream. The log subscription is opened *before* the launch so no early
+    /// output can slip past the forwarder.
     public func open() async throws {
         let sub = await logCenter.subscribe()
         self.subscription = sub
@@ -74,6 +83,10 @@ public actor StdioTransport: MCPTransport {
         }
     }
 
+    /// Writes `message` to the child's stdin as one newline-terminated JSON line. Both "not yet
+    /// opened" and "the write itself failed" surface as `MCPClient.MCPError.notInitialized` — from
+    /// the client's perspective either way means "no usable connection; re-handshake", and the
+    /// respawn path's `onReconnect` is what restores it.
     public func send(_ message: JSONValue) async throws {
         guard let handle else { throw MCPClient.MCPError.notInitialized }
         var data = try JSONSerialization.data(withJSONObject: message.rawValue, options: [])
@@ -85,8 +98,14 @@ public actor StdioTransport: MCPTransport {
         }
     }
 
+    /// The single backing stream of parsed stdout frames. Created in `init` (not `open()`), so a
+    /// caller may start iterating before the process is even launched; `nonisolated` because it
+    /// only hands out an immutable stored property.
     public nonisolated func inbound() -> AsyncStream<JSONValue> { stream }
 
+    /// Stops forwarding, terminates the child (SIGTERM with a 2 s SIGKILL escalation), waits for
+    /// its exit, and finishes the inbound stream — in that order, so no consumer sees the stream
+    /// end while the process could still emit frames.
     public func close() async {
         forwardTask?.cancel()
         forwardTask = nil

--- a/Sources/AnglesiteCore/SuddenTerminationController.swift
+++ b/Sources/AnglesiteCore/SuddenTerminationController.swift
@@ -7,6 +7,9 @@ import os
 /// Anglesite. Callers retain the returned lease for exactly as long as their critical state exists;
 /// releasing (or deinitializing) the last lease re-enables sudden termination.
 public final class SuddenTerminationController: @unchecked Sendable {
+    /// The process-wide instance backed by the real `ProcessInfo` sudden-termination counter.
+    /// Use this in app code — a second instance would keep its own lease count and could
+    /// re-enable sudden termination while another instance still holds leases.
     public static let shared = SuddenTerminationController()
 #if canImport(os)
     private static let logger = Logger(
@@ -15,6 +18,9 @@ public final class SuddenTerminationController: @unchecked Sendable {
     )
 #endif
 
+    /// One held reference to "don't suddenly terminate yet." Releasing is idempotent and also
+    /// happens automatically on `deinit`, so a lease dropped on an error path (or captured by a
+    /// cancelled task) can never permanently pin sudden termination off.
     public final class Lease: @unchecked Sendable {
         private let lock = NSLock()
         private var controller: SuddenTerminationController?
@@ -42,6 +48,8 @@ public final class SuddenTerminationController: @unchecked Sendable {
     private let enable: @Sendable () -> Void
     private var leaseCount = 0
 
+    /// Creates a controller wired to the real `ProcessInfo` disable/enable calls (no-ops off
+    /// macOS). Prefer ``shared`` in app code — see its note on why a second instance is unsafe.
     public convenience init() {
         self.init(
             disable: { SuddenTerminationController.disableProcessSuddenTermination() },
@@ -59,10 +67,15 @@ public final class SuddenTerminationController: @unchecked Sendable {
         self.enable = enable
     }
 
+    /// The number of currently outstanding leases — exposed for tests asserting the balancing
+    /// invariant; sudden termination is disabled exactly while this is non-zero.
     public var activeLeaseCount: Int {
         lock.withLock { leaseCount }
     }
 
+    /// Takes out a lease, disabling sudden termination if this is the first outstanding one.
+    /// Hold the returned ``Lease`` for exactly as long as the critical state exists — its
+    /// `release()` (or `deinit`) balances this call.
     public func acquire() -> Lease {
         lock.lock()
         if leaseCount == 0 {

--- a/Sources/AnglesiteCore/SuggestLinksTool.swift
+++ b/Sources/AnglesiteCore/SuggestLinksTool.swift
@@ -9,12 +9,20 @@ import os
 /// Foundation Models tool that suggests internal pages to link to from a given page. Uses
 /// semantic similarity (``SemanticRanker/related(siteID:toDocID:limit:)``) filtered by existing links (``LinkGraph``).
 public struct SuggestLinksTool: Tool, Sendable {
+    /// Stable tool identifier, exposed as a static so callers (transcript inspection, tool
+    /// gating) can reference it without constructing an instance.
     public static let toolName = "suggestLinks"
+    /// `Tool` conformance: the name the model calls this tool by.
     public let name = SuggestLinksTool.toolName
+    /// `Tool` conformance: tells the model when to invoke this tool — the trigger phrasing
+    /// ("improving internal linking or related content") is model-facing prompt text, not UI copy.
     public let description = "Suggest internal pages to link to from a given page. Use when the user asks about improving internal linking or related content."
 
+    /// The model-generated arguments for one call; the `@Guide` description steers the model
+    /// toward the site-relative path form the knowledge index keys documents by.
     @Generable
     public struct Arguments {
+        /// Relative file path of the page to suggest links for (e.g. `src/pages/about.astro`).
         @Guide(description: "The relative file path of the page to suggest links for, e.g. 'src/pages/about.astro'.")
         public var path: String
     }
@@ -25,12 +33,19 @@ public struct SuggestLinksTool: Tool, Sendable {
     private let siteID: String
     private let ranker: SemanticRanker?
 
+    /// Creates the tool for one site. `ranker` is optional because the on-device embedding model
+    /// may be unavailable (device eligibility, model download state) — without it the tool
+    /// degrades to an honest "unavailable" reply rather than guessing at relevance.
     public init(index: SiteKnowledgeIndex, siteID: String, ranker: SemanticRanker? = nil) {
         self.index = index
         self.siteID = siteID
         self.ranker = ranker
     }
 
+    /// `Tool` conformance: resolves the page, ranks semantically related documents, filters out
+    /// pages already linked (via `LinkGraph`), and returns a numbered Markdown list. Always
+    /// returns model-readable prose — bad input (empty/unknown path) or a missing ranker is
+    /// reported as a plain sentence the model can relay, never thrown.
     public func call(arguments: Arguments) async throws -> String {
         let path = arguments.path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !path.isEmpty else { return "Provide a file path (e.g. src/pages/about.astro)." }

--- a/Sources/AnglesiteCore/SupervisorBackend.swift
+++ b/Sources/AnglesiteCore/SupervisorBackend.swift
@@ -10,6 +10,7 @@ import Foundation
 /// concern doesn't belong in a `Codable` spec. `ProcessSupervisor` re-exposes this via a typealias
 /// so existing call sites (`ProcessSupervisor.RestartPolicy.onCrash(...)`) keep compiling.
 public enum RestartPolicy: Sendable, Equatable {
+    /// One life: any exit — clean or crash — ends supervision.
     case never
     /// Restart on non-zero exit only (clean exit code 0 always stops). Capped at `maxAttempts`
     /// consecutive failures, with `baseBackoff * 2^(attempt-1)` between retries.
@@ -82,14 +83,17 @@ public protocol SupervisorBackend: Sendable {
 /// iOS thin client is remote-only and selects `RemoteSandboxSiteRuntime`, so nothing reaches this
 /// in normal operation.
 public struct UnavailableProcessBackend: SupervisorBackend {
+    /// Stateless — nothing to configure; every operation reports unavailability.
     public init() {}
 
     private static let message = "Subprocess spawning is unavailable on this platform."
 
+    /// Always throws `SupervisorBackendError.spawnFailed` — no process ever runs here.
     public func runOneShot(_ spec: SpawnSpec) async throws -> ProcessResult {
         throw SupervisorBackendError.spawnFailed(Self.message)
     }
 
+    /// Always throws `SupervisorBackendError.spawnFailed` — no process ever runs here.
     public func launch(
         _ spec: SpawnSpec,
         restartPolicy: RestartPolicy,
@@ -99,17 +103,24 @@ public struct UnavailableProcessBackend: SupervisorBackend {
         throw SupervisorBackendError.spawnFailed(Self.message)
     }
 
+    /// Returns `.terminated` immediately — matching the protocol's unknown-handle contract,
+    /// since no handle from this backend can exist.
     public func waitForExit(_ handle: SpawnedProcessHandle) async -> ProcessExitReason { .terminated }
 
+    /// Always `false` — nothing can be running.
     public func isRunning(_ handle: SpawnedProcessHandle) async -> Bool { false }
 
+    /// No-op — there is never anything to terminate.
     public func terminate(_ handle: SpawnedProcessHandle, timeout: TimeInterval) async {}
 
+    /// No-op — there is never anything to shut down.
     public func shutdownAll(timeout: TimeInterval) async {}
 
+    /// Always throws `SupervisorBackendError.spawnFailed` — no stdin pipe can exist here.
     public func writeStdin(_ handle: SpawnedProcessHandle, _ bytes: Data) async throws {
         throw SupervisorBackendError.spawnFailed(Self.message)
     }
 
+    /// Always `nil` — the protocol's contract for a backend that can't expose a live descriptor.
     public func stdinHandle(_ handle: SpawnedProcessHandle) async -> FileHandle? { nil }
 }

--- a/Sources/AnglesiteCore/SyncArtifact.swift
+++ b/Sources/AnglesiteCore/SyncArtifact.swift
@@ -6,9 +6,14 @@ import Foundation
 /// shape `git show-ref`/`git bundle list-heads` produce. For an annotated tag, `oid` is the tag
 /// object's own id, not the peeled commit — matching stock git's own bundle/show-ref convention.
 public struct SyncArtifactRef: Sendable, Equatable, Hashable, Codable {
+    /// The ref's direct target as a 40-hex SHA-1 (an annotated tag's own object id, not the
+    /// peeled commit — see the type doc).
     public let oid: String
+    /// Full ref name (`refs/heads/<n>`, `refs/tags/<n>`, or the literal `HEAD`).
     public let name: String
 
+    /// Creates a ref record. No validation — the codecs that produce these are the ones that
+    /// enforce the `<40-hex> <name>` shape on parse.
     public init(oid: String, name: String) {
         self.oid = oid
         self.name = name
@@ -44,6 +49,9 @@ public enum SyncArtifactError: Error, Equatable, Sendable, LocalizedError {
     /// A filesystem operation (read/write/temp-file swap) failed.
     case io(String)
 
+    /// Diagnostic phrasing per case — lower-case sentences that read naturally when a caller
+    /// prefixes its own context ("couldn't sync: …"). These name bundle/packfile specifics for
+    /// the debug pane; `SyncEngine` wraps them in owner-facing language before surfacing.
     public var errorDescription: String? {
         switch self {
         case .notFound(let url):

--- a/Sources/AnglesiteCore/SyncConflictResolver.swift
+++ b/Sources/AnglesiteCore/SyncConflictResolver.swift
@@ -20,7 +20,9 @@ import AnglesiteSiteModel
 public actor SyncConflictResolver {
     /// Which side's content to keep for one conflicted path.
     public enum Choice: Sendable, Equatable {
+        /// Keep this Mac's version (the conflict's `ourOID` side).
         case keepMine
+        /// Keep the synced version from the other Mac (the conflict's `theirOID` side).
         case keepTheirs
     }
 
@@ -28,19 +30,34 @@ public actor SyncConflictResolver {
     /// `nil` text means that side deleted the path, or the blob is binary/too large to preview
     /// (200 KB cap — plenty for template source files, not for images).
     public struct ConflictedFile: Sendable, Equatable, Identifiable {
+        /// `Identifiable` via the path — paths are unique within one conflict, and stable ids
+        /// keep SwiftUI list rows from resetting as the user works through the sheet.
         public var id: String { path }
+        /// The conflicted path, relative to `Source/`.
         public let path: String
+        /// This Mac's version of the file, or `nil` when deleted/binary/too large (see type doc).
         public let oursText: String?
+        /// The other Mac's version of the file, or `nil` when deleted/binary/too large (see type doc).
         public let theirsText: String?
     }
 
+    /// Why a `resolve` call couldn't commit. Messages are lower-case fragments meant to be
+    /// wrapped by the caller's own owner-facing sentence.
     public enum ResolveError: Error, Equatable, CustomStringConvertible {
+        /// `package.sourceURL` didn't open as a git repository.
         case repositoryUnavailable
+        /// The recorded conflict's `ourOID`/`theirOID` strings don't parse as commit ids.
         case invalidConflict
+        /// One or more conflicted paths were given no `Choice` — a partial resolution can't
+        /// produce a valid tree, so nothing was committed.
         case missingChoices(paths: [String])
+        /// After applying every choice the replayed merge index still reports conflicts —
+        /// committing would bake unresolved state into history, so nothing was committed.
         case stillConflicted
+        /// A libgit2 call failed; the payload carries libgit2's own message for the debug pane.
         case libgit2(String)
 
+        /// Human-readable summary of the failure, used directly in error surfaces.
         public var description: String {
             switch self {
             case .repositoryUnavailable: return "this site's git repository couldn't be opened."
@@ -52,6 +69,8 @@ public actor SyncConflictResolver {
         }
     }
 
+    /// Stateless apart from actor serialization — the actor wrapper exists to serialize libgit2
+    /// access (not thread-safe here), not to hold configuration.
     public init() {}
 
     /// Reads both sides' content for every path in `conflict.conflictedPaths`, for display in the

--- a/Sources/AnglesiteCore/SyncEngine.swift
+++ b/Sources/AnglesiteCore/SyncEngine.swift
@@ -38,9 +38,12 @@ public actor SyncEngine {
 
     // MARK: - Results
 
+    /// Outcome of one `push()`. Distinguishes "nothing to do" from "wrote the artifact" so
+    /// callers can avoid logging/status churn on the overwhelmingly common no-op case.
     public enum PushResult: Sendable, Equatable {
         /// The artifact already reflected the repo's heads — nothing written, no iCloud churn.
         case unchanged
+        /// A fresh artifact was verified and swapped into place; `refs` is what it now carries.
         case pushed(refs: [SyncArtifactRef])
         /// A prior `pull()` hit a textual merge conflict on this branch (`SyncConflict`) that
         /// hasn't been acknowledged resolved yet (`acknowledgeConflictResolved(package:)`) —
@@ -48,11 +51,19 @@ public actor SyncEngine {
         /// incoming bundles keep fetching. Not an error: the caller should surface the pending
         /// conflict (`pendingConflict(package:)`) rather than retry.
         case pausedForConflict(branch: String)
+        /// The push couldn't complete; `reason` is already owner-readable prose.
         case failed(reason: String)
     }
 
+    /// Outcome of one `pull()` — one case per distinct way local history can relate to the
+    /// artifact's, so callers (``SyncScheduler``, the status UI) never have to re-derive what
+    /// happened from repo state.
     public enum PullResult: Sendable, Equatable {
+        /// The artifact carries nothing this repo doesn't already have (including "artifact
+        /// doesn't carry the current branch at all").
         case upToDate
+        /// The current branch was strictly behind and moved forward to the artifact's tip
+        /// (`from`/`to` are full commit ids, for logging).
         case fastForwarded(branch: String, from: String, to: String)
         /// This Mac's branch is ahead of the artifact — nothing to pull; call `push()`.
         case localAhead(branch: String)
@@ -75,6 +86,7 @@ public actor SyncEngine {
         case bootstrapped(branch: String)
         /// The artifact is evicted and iCloud didn't finish downloading it within the timeout.
         case waitingForICloud
+        /// The pull couldn't complete; `reason` is already owner-readable prose.
         case failed(reason: String)
     }
 
@@ -84,6 +96,7 @@ public actor SyncEngine {
     /// at detecting, persisting, and reporting it (`pendingConflict(package:)`), and clearing the
     /// pause once the caller says it's resolved (`acknowledgeConflictResolved(package:)`).
     public struct SyncConflict: Sendable, Equatable, Codable {
+        /// The local branch whose merge conflicted — the branch whose pushes pause.
         public let branch: String
         /// Paths git flagged with textual conflicts in the failed three-way merge.
         public let conflictedPaths: [String]
@@ -108,6 +121,10 @@ public actor SyncEngine {
     private let versionStore: any VersionStore
     private let materializeTimeout: TimeInterval
 
+    /// Creates an engine. Both seams default to production (git-bundle codec, NSFileVersion-
+    /// backed store); tests inject fakes to run without iCloud. `materializeTimeout` bounds how
+    /// long push/pull wait for iCloud to download an evicted artifact before giving up with a
+    /// "waiting" result instead of blocking the caller indefinitely.
     public init(
         artifact: any SyncArtifact = BundleArtifact(),
         versionStore: any VersionStore = UbiquitousVersionStore(),

--- a/Sources/AnglesiteCore/SyncScheduler.swift
+++ b/Sources/AnglesiteCore/SyncScheduler.swift
@@ -8,9 +8,16 @@ import AnglesiteSiteModel
 /// the testable logic into AnglesiteCore" instruction, mirroring how `TokenOnboarding` was
 /// extracted from `DeployModel`).
 public protocol SyncEngineProtocol: Sendable {
+    /// Mirrors ``SyncEngine/pull(package:)`` — bring the repo up to date from the artifact.
     func pull(package: AnglesitePackage) async -> SyncEngine.PullResult
+    /// Mirrors ``SyncEngine/push(package:)`` — mirror the repo's heads into the artifact.
     func push(package: AnglesitePackage) async -> SyncEngine.PushResult
+    /// Mirrors ``SyncEngine/pendingConflict(package:)`` — the unresolved conflict, if any.
+    /// Synchronous (a plain file read) so status logic can call it mid-transition.
     func pendingConflict(package: AnglesitePackage) -> SyncEngine.SyncConflict?
+    /// Mirrors ``SyncEngine/acknowledgeConflictResolved(package:)`` — lift the push pause.
+    /// `async` here (unlike the engine's own synchronous method) because a protocol requirement
+    /// satisfied by an actor method must be awaitable.
     func acknowledgeConflictResolved(package: AnglesitePackage) async
 }
 
@@ -37,14 +44,24 @@ public actor SyncScheduler {
     /// for iCloud / needs attention"). `.idle` is the initial state before the first `siteOpened()`
     /// — a package this scheduler has never touched, including one that was never eligible.
     public enum Status: Sendable, Equatable {
+        /// No sync activity yet — the state before the first `siteOpened()` (see the enum doc).
         case idle
+        /// A pull or push is in flight.
         case syncing
+        /// The last pull/push completed cleanly; the date is when (from the injected clock), so
+        /// the UI can render "synced N minutes ago".
         case synced(Date)
+        /// The artifact is evicted and iCloud hasn't finished downloading it yet.
         case waitingForICloud
+        /// A merge conflict needs the owner's decision; syncing this branch is paused until
+        /// `conflictResolved()` runs.
         case needsAttention(SyncEngine.SyncConflict)
+        /// The last pull/push failed; `reason` is already owner-readable prose.
         case failed(reason: String)
     }
 
+    /// Observes every status *change* (transitions to the same status are swallowed) — the
+    /// scheduler's only output channel to the app layer, so `SiteWindow` never has to poll.
     public typealias StatusObserver = @Sendable (Status) -> Void
     /// Debounce timer seam — mirrors `InvisiblePublishQueue.Sleep`: production always sleeps for
     /// real, tests substitute a manually-released gate so debounce assertions don't race a live
@@ -67,6 +84,10 @@ public actor SyncScheduler {
     private var pushDebounceTask: Task<Void, Never>?
     private var pushTask: Task<Void, Never>?
 
+    /// Creates a scheduler for one open site window. `now` and `sleep` are injectable clock
+    /// seams so debounce behavior tests neither race a live timer nor hit the macOS 26 CI
+    /// zero-duration `Task.sleep` allocator crash (see `schedulePush`). Construct one only for a
+    /// package that actually lives in iCloud Drive — see the type doc's idle guarantee.
     public init(
         package: AnglesitePackage,
         engine: any SyncEngineProtocol,
@@ -83,6 +104,8 @@ public actor SyncScheduler {
         self.sleep = sleep
     }
 
+    /// The current status, for a caller that attaches after transitions already happened (the
+    /// observer only sees changes from here on).
     public func currentStatus() -> Status { status }
 
     // MARK: - Pull triggers

--- a/Sources/AnglesiteCore/SyndicationFrontmatter.swift
+++ b/Sources/AnglesiteCore/SyndicationFrontmatter.swift
@@ -7,6 +7,13 @@ import Foundation
 /// edits is exactly what the canonical reader (`Frontmatter.parse`) sees; only the line-level
 /// splicing — which must preserve the file's existing formatting — lives here.
 public enum SyndicationFrontmatter {
+    /// Splices `urls` into the post's top-level `syndication:` list, preserving the file's
+    /// existing formatting (including CRLF line endings) and deduplicating against items already
+    /// recorded in block, inline-array, or bare-scalar form. Returns `contents` unchanged when
+    /// there is nothing new to add, so callers can write the result back unconditionally without
+    /// churning the file. A file with no (or an unterminated) frontmatter fence gets one
+    /// synthesized around the new block — otherwise the canonical reader (`Frontmatter.parse`)
+    /// would never see the URLs.
     public static func adding(urls: [String], to contents: String) -> String {
         let newURLs = urls.map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
         guard !newURLs.isEmpty else { return contents }

--- a/Sources/AnglesiteCore/TemplateRuntime.swift
+++ b/Sources/AnglesiteCore/TemplateRuntime.swift
@@ -9,15 +9,28 @@ import Foundation
 /// The Settings → Advanced → Template path override lets template authors point a running app at
 /// a working copy without rebuilding.
 public enum TemplateRuntime {
+    /// The outcome of one template lookup — the location *and* its provenance, so callers can
+    /// log or display which copy of the template a site is actually using (a dev override
+    /// silently shadowing the bundle would otherwise be invisible).
     public struct Resolution: Sendable, Equatable {
+        /// Where the template came from, in the priority order ``TemplateRuntime/resolve(settings:bundle:)`` tries.
         public enum Source: Sendable, Equatable {
+            /// The Settings → Advanced template path override — a template author's working
+            /// copy, honored ahead of the bundled copy so edits show up without rebuilding.
             case override(URL)
+            /// The committed template shipped in the app bundle (`Resources/Template/`) — the
+            /// normal case for every end user.
             case bundled(URL)
+            /// Neither candidate held a valid template (broken install, or a stale override
+            /// with no bundled fallback) — callers must surface this, not scaffold from nothing.
             case missing
         }
 
+        /// Which candidate won (or that none did).
         public let source: Source
 
+        /// The resolved template root, or `nil` when no valid template was found — the
+        /// provenance-free accessor for callers that only need a working directory.
         public var url: URL? {
             switch source {
             case .override(let url), .bundled(let url): return url
@@ -25,6 +38,8 @@ public enum TemplateRuntime {
             }
         }
 
+        /// Human-readable provenance ("override: …" / "bundled: …" / "not found") for logs and
+        /// diagnostics.
         public var description: String {
             switch source {
             case .override(let url): return "override: \(url.path)"
@@ -34,6 +49,11 @@ public enum TemplateRuntime {
         }
     }
 
+    /// Resolves the template root, preferring a *valid* Settings override over the bundled copy.
+    /// An override that no longer passes ``isTemplateDirectory(_:)`` (moved, deleted, or never a
+    /// template) is skipped in favor of the bundle rather than treated as an error — a stale dev
+    /// override must never break template resolution for a working app. Both parameters default
+    /// to the live app values; they're injectable for tests.
     public static func resolve(settings: AppSettings = .shared, bundle: Bundle = .main) -> Resolution {
         if let override = settings.templatePathOverride, isTemplateDirectory(override) {
             return Resolution(source: .override(override))
@@ -44,6 +64,9 @@ public enum TemplateRuntime {
         return Resolution(source: .missing)
     }
 
+    /// The `Template/` directory inside the bundle's resources, or `nil` when the bundle has no
+    /// such directory at all. This only checks existence-as-directory; ``resolve(settings:bundle:)``
+    /// separately validates that it actually *is* the template via ``isTemplateDirectory(_:)``.
     public static func bundledURL(in bundle: Bundle = .main) -> URL? {
         guard let resourceURL = bundle.resourceURL else { return nil }
         let candidate = resourceURL.appendingPathComponent("Template", isDirectory: true)

--- a/Sources/AnglesiteCore/TemplateScriptsBaseline.swift
+++ b/Sources/AnglesiteCore/TemplateScriptsBaseline.swift
@@ -6,6 +6,8 @@ import Foundation
 /// `Source/` — see the `.anglesite` package model), mirroring `Config/dependency-baseline.json`'s
 /// placement rationale.
 public struct TemplateScriptsBaseline: Codable, Equatable, Sendable {
+    /// The baseline record for one app-owned `scripts/` file: the last reconciled template
+    /// content hash, plus (when set) a divergence the owner already declined.
     public struct Entry: Codable, Equatable, Sendable {
         /// Hash (`VectorMath.stableHash`) of the template content this file was last
         /// successfully reconciled against — at scaffold time, at a prior silent refresh, or
@@ -16,16 +18,25 @@ public struct TemplateScriptsBaseline: Codable, Equatable, Sendable {
         /// changes again past this point.
         public var acknowledgedTemplateHash: String?
 
+        /// Creates an entry; the default `nil` acknowledgement is the normal freshly-reconciled
+        /// state — an acknowledgement only appears after the owner declines an update.
         public init(baselineHash: String, acknowledgedTemplateHash: String? = nil) {
             self.baselineHash = baselineHash
             self.acknowledgedTemplateHash = acknowledgedTemplateHash
         }
     }
 
+    /// The baseline's filename inside `Config/` — public so tests and diagnostics can locate the
+    /// file without duplicating the string.
     public static let filename = "template-scripts-baseline.json"
 
+    /// One ``Entry`` per app-owned file, keyed by template-relative path (e.g.
+    /// `scripts/pre-deploy-check.ts`). A missing key means the file was never reconciled — the
+    /// checker backfills it on first encounter.
     public var files: [String: Entry]
 
+    /// Creates a baseline; the empty default is the never-recorded state ``load(from:)`` also
+    /// falls back to.
     public init(files: [String: Entry] = [:]) {
         self.files = files
     }
@@ -40,6 +51,9 @@ public struct TemplateScriptsBaseline: Codable, Equatable, Sendable {
         return decoded
     }
 
+    /// Writes the baseline atomically into `configDirectory` — unlike ``load(from:)`` this does
+    /// throw, since silently losing a just-reconciled baseline would re-prompt the owner about
+    /// divergences they already resolved.
     public func save(to configDirectory: URL) throws {
         let url = configDirectory.appendingPathComponent(Self.filename)
         let data = try JSONEncoder().encode(self)

--- a/Sources/AnglesiteCore/TemplateScriptsSync.swift
+++ b/Sources/AnglesiteCore/TemplateScriptsSync.swift
@@ -6,6 +6,8 @@ public enum TemplateScriptsSyncAction: Sendable, Equatable {
     /// The site's file is unmodified since its last known-good baseline, and the template moved on.
     case refresh(relativePath: String)
 
+    /// The affected file's template-relative path, regardless of case — both actions target
+    /// exactly one path, so callers can group/sort a plan without switching.
     public var relativePath: String {
         switch self {
         case .create(let path), .refresh(let path): return path
@@ -17,10 +19,16 @@ public enum TemplateScriptsSyncAction: Sendable, Equatable {
 /// content the owner customized from — the one case this mechanism can't silently resolve
 /// (design doc §Divergence UX).
 public struct TemplateScriptsDivergence: Sendable, Equatable, Identifiable {
+    /// `Identifiable` via the path — at most one divergence per file per check pass, and stable
+    /// ids keep the divergence sheet's SwiftUI rows from resetting between passes.
     public var id: String { relativePath }
+    /// The divergent file's template-relative path.
     public let relativePath: String
+    /// Hash of the template's current content — recorded so a "keep my version" decision can
+    /// remember exactly which template revision was declined (and re-ask only when it changes).
     public let templateHash: String
 
+    /// Creates a divergence record; normally only `TemplateScriptsSyncChecker` does.
     public init(relativePath: String, templateHash: String) {
         self.relativePath = relativePath
         self.templateHash = templateHash
@@ -29,9 +37,14 @@ public struct TemplateScriptsDivergence: Sendable, Equatable, Identifiable {
 
 /// The full result of one `TemplateScriptsSyncChecker.check` pass.
 public struct TemplateScriptsSyncPlan: Sendable, Equatable {
+    /// Actions safe to apply silently, immediately, without asking the owner — the app knows the
+    /// right answer for these (#1053).
     public let toApply: [TemplateScriptsSyncAction]
+    /// Files needing an owner decision — each is surfaced through the divergence UX, never
+    /// auto-resolved.
     public let divergences: [TemplateScriptsDivergence]
 
+    /// Creates a plan; the all-empty default is the nothing-to-do result.
     public init(toApply: [TemplateScriptsSyncAction] = [], divergences: [TemplateScriptsDivergence] = []) {
         self.toApply = toApply
         self.divergences = divergences

--- a/Sources/AnglesiteCore/TemplateScriptsSyncApplier.swift
+++ b/Sources/AnglesiteCore/TemplateScriptsSyncApplier.swift
@@ -5,11 +5,19 @@ import Foundation
 /// call unconditionally and immediately), and `resolve` for a single divergence the owner has made
 /// a decision about.
 public enum TemplateScriptsSyncApplier {
+    /// Why an apply/resolve stopped. Both cases name the file so the caller can say which one —
+    /// and, for `applyQueued`, everything written before it keeps its baseline (see that method).
     public enum ApplyError: Error, Equatable {
+        /// The template's own copy couldn't be read — the bundled template is missing or
+        /// unreadable, so there's nothing correct to write.
         case templateReadFailed(relativePath: String)
+        /// The site-side write failed (permissions, disk); the baseline was not updated for this
+        /// file, so the next check pass will retry it.
         case writeFailed(relativePath: String)
     }
 
+    /// The owner's answer to one `TemplateScriptsDivergence` — the only decision this mechanism
+    /// ever delegates to the owner (everything else is applied silently, #1053).
     public enum DivergenceDecision: Sendable, Equatable {
         /// Overwrite the owner's version with the template's (git-recoverable; design doc's
         /// resolution that `Source/` being a real git repo is sufficient recovery — no extra
@@ -19,6 +27,11 @@ public enum TemplateScriptsSyncApplier {
         case keepMine
     }
 
+    /// Writes each queued create/refresh into `sourceDirectory` and records the new baseline
+    /// hash after every successful write — so a mid-batch failure leaves every file already
+    /// written with its matching baseline entry intact (nothing gets re-flagged as divergent on
+    /// the next pass). Throws on the first file that can't be read from the template or written
+    /// to the site; earlier writes stand.
     public static func applyQueued(
         _ actions: [TemplateScriptsSyncAction],
         sourceDirectory: URL,
@@ -52,6 +65,10 @@ public enum TemplateScriptsSyncApplier {
         }
     }
 
+    /// Carries out the owner's decision for one divergence: `.update` overwrites the site's file
+    /// with the template's and re-baselines it (git-recoverable — `Source/` is a real repo);
+    /// `.keepMine` touches nothing under `Source/` and records the declined template hash so the
+    /// same divergence isn't re-asked until the template file changes again.
     public static func resolve(
         _ divergence: TemplateScriptsDivergence,
         decision: DivergenceDecision,

--- a/Sources/AnglesiteCore/TemplateScriptsSyncChecker.swift
+++ b/Sources/AnglesiteCore/TemplateScriptsSyncChecker.swift
@@ -26,6 +26,13 @@ public enum TemplateScriptsSyncChecker {
         #endif
     }
 
+    /// Compares every app-owned template `scripts/` file against the site's copy and the
+    /// recorded baseline, classifying each as silently appliable (missing, or unmodified-but-
+    /// stale) vs. a divergence needing the owner (customized *and* the template moved on).
+    /// Side effects are `Config/`-only: matching or first-encounter files get their baseline
+    /// entries recorded/backfilled here (design doc's legacy-site trade-off — a first
+    /// encounter's current content is assumed untouched). An unreadable site file is skipped
+    /// and logged, never overwritten. Returns the plan; never throws.
     public static func check(
         sourceDirectory: URL,
         configDirectory: URL,

--- a/Sources/AnglesiteCore/ThemeApplier.swift
+++ b/Sources/AnglesiteCore/ThemeApplier.swift
@@ -4,8 +4,17 @@ import Foundation
 /// `--<key>` custom properties the theme provides. Properties without a matching theme key
 /// (spacing, radius, shadows, type scale) are left untouched. Pure + idempotent.
 public enum ThemeApplier {
-    public enum ApplyError: Error, Sendable { case cssNotFound(URL) }
+    /// Failure modes for the file-writing overload.
+    public enum ApplyError: Error, Sendable {
+        /// `src/styles/global.css` doesn't exist at the expected path — the site isn't a
+        /// recognizable template layout, so nothing is written rather than creating a stray file.
+        case cssNotFound(URL)
+    }
 
+    /// The pure string transform: rewrites each `--<key>` declaration's value in `css` to the
+    /// theme's. Split out from the file overload so it's testable without a filesystem. Assumes
+    /// one declaration per line ending in `;` (true of all template-generated `global.css`
+    /// files); unknown theme keys and unmatched properties pass through untouched.
     public static func apply(_ theme: Theme, toCSS css: String) -> String {
         var result = css
         for (key, value) in theme.cssVars {
@@ -27,6 +36,10 @@ public enum ThemeApplier {
         return result
     }
 
+    /// Rewrites `siteDirectory`'s `src/styles/global.css` in place via ``apply(_:toCSS:)``.
+    /// Throws ``ApplyError/cssNotFound(_:)`` rather than creating the file — a missing
+    /// `global.css` means this isn't a template-shaped site, and writing one wouldn't be loaded
+    /// by anything.
     public static func apply(_ theme: Theme, siteDirectory: URL, fileManager: FileManager = .default) throws {
         let cssURL = siteDirectory.appendingPathComponent("src/styles/global.css")
         guard fileManager.fileExists(atPath: cssURL.path) else {

--- a/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
+++ b/Sources/AnglesiteCore/ThemeApplyWizardModel.swift
@@ -13,23 +13,62 @@ import FoundationNetworking
 /// wizard-state machine rather than one per source.
 @MainActor @Observable
 public final class ThemeApplyWizardModel: Identifiable {
-    public enum Step: Int, CaseIterable { case pickSource, pickBuiltIn, browseFreedesignmd, review, applying }
-    public enum Source: Equatable { case builtIn, freedesignmd }
+    /// The wizard's pages. `Int`-raw so step order is explicit; only one of
+    /// `pickBuiltIn`/`browseFreedesignmd` is ever visited in a given run, per the chosen source.
+    public enum Step: Int, CaseIterable {
+        /// Choose between the built-in gallery and freedesignmd.com.
+        case pickSource
+        /// Built-in path: pick a theme from the catalog.
+        case pickBuiltIn
+        /// freedesignmd path: pick a design system from the ranked candidates.
+        case browseFreedesignmd
+        /// Confirm the selection before writing anything.
+        case review
+        /// The apply is running (or finished — check ``ThemeApplyWizardModel/applyResult``); no
+        /// further navigation.
+        case applying
+    }
+    /// Which design source the owner chose on the first step.
+    public enum Source: Equatable {
+        /// A theme bundled with the app's template (`ThemeCatalog`).
+        case builtIn
+        /// A design system fetched from freedesignmd.com.
+        case freedesignmd
+    }
 
+    /// Stable identity for SwiftUI sheet/window presentation of one wizard run.
     public let id = UUID()
+    /// The page currently shown; mutate via ``advance()``/``back()`` so the source-dependent
+    /// branching stays in one place.
     public var step: Step = .pickSource
+    /// The chosen source; `nil` until the first step is answered (which is what gates Continue).
     public var source: Source?
+    /// The chosen built-in theme's id, when `source == .builtIn`.
     public var selectedBuiltInID: String?
+    /// The ranked freedesignmd systems to offer (top 10 by business-type keyword match), loaded
+    /// when the owner picks the freedesignmd source. Empty until then — or on fetch failure, in
+    /// which case ``fetchError`` says why.
     public var freedesignmdCandidates: [FreedesignmdSystem] = []
+    /// The chosen freedesignmd system's slug, when `source == .freedesignmd`.
     public var selectedFreedesignmdSlug: String?
+    /// The site's business type, used to rank freedesignmd candidates by keyword relevance.
     public var businessType: String
+    /// Terminal outcome of ``apply()`` — `nil` while the wizard is still in progress. Setter is
+    /// internal: only the wizard's own apply flow may decide the outcome.
     public internal(set) var applyResult: Result<AppliedDesign, DesignApplyError>?
+    /// Owner-readable message when fetching the freedesignmd catalog failed — kept separate from
+    /// ``applyResult`` because a fetch failure is recoverable (go back, retry, or pick a
+    /// built-in theme), not a terminal outcome.
     public internal(set) var fetchError: String?
 
+    /// The built-in theme catalog to offer — held by the model so the gallery view and
+    /// ``selectedBuiltInTheme`` resolve against the same catalog instance.
     public let catalog: ThemeCatalog
     private let package: AnglesitePackage
     private let session: URLSession
 
+    /// Creates one wizard run for `package`. `session` is injectable so tests can stub the
+    /// freedesignmd fetches without network access.
     public init(
         catalog: ThemeCatalog, businessType: String, package: AnglesitePackage, session: URLSession = .shared
     ) {
@@ -39,10 +78,14 @@ public final class ThemeApplyWizardModel: Identifiable {
         self.session = session
     }
 
+    /// The full ``Theme`` for ``selectedBuiltInID``, resolved against ``catalog`` — `nil` when
+    /// nothing is selected or the id isn't in the catalog.
     public var selectedBuiltInTheme: Theme? {
         selectedBuiltInID.flatMap(catalog.theme(id:))
     }
 
+    /// Whether the current step has what it needs to advance — drives the Continue button's
+    /// enablement so the view never encodes per-step validation itself.
     public var canContinue: Bool {
         switch step {
         case .pickSource: return source != nil
@@ -53,6 +96,9 @@ public final class ThemeApplyWizardModel: Identifiable {
         }
     }
 
+    /// Moves to the next step for the chosen source (a no-op when ``canContinue`` is false or
+    /// the wizard is already at review/applying). `async` because entering the freedesignmd
+    /// branch kicks off the candidate fetch as part of the same transition.
     public func advance() async {
         guard canContinue else { return }
         switch step {
@@ -66,6 +112,8 @@ public final class ThemeApplyWizardModel: Identifiable {
         }
     }
 
+    /// Moves to the previous step, retracing the source-dependent branch. Deliberately inert on
+    /// the first step and while applying — an in-flight apply can't be backed out of.
     public func back() {
         switch step {
         case .pickBuiltIn, .browseFreedesignmd: step = .pickSource
@@ -83,6 +131,12 @@ public final class ThemeApplyWizardModel: Identifiable {
         }
     }
 
+    /// Runs the terminal apply for whichever source/selection the wizard holds, landing the
+    /// outcome in ``applyResult``. A built-in theme writes its CSS vars via `DesignApplyService`;
+    /// the freedesignmd path currently records only the system's description as brand rationale
+    /// (its CSS-token translation is deliberately stubbed — see the inline note). A missing
+    /// selection becomes a failure result rather than a trap, since the UI's enablement guards
+    /// could be bypassed programmatically.
     public func apply() async {
         step = .applying
         switch source {

--- a/Sources/AnglesiteCore/ThemeCatalog.swift
+++ b/Sources/AnglesiteCore/ThemeCatalog.swift
@@ -2,12 +2,23 @@ import Foundation
 
 /// One built-in visual theme, decoded from `Resources/Template/scripts/themes.json`.
 public struct Theme: Sendable, Identifiable, Equatable {
-    public let id: String                    // theme id, e.g. "warm"
-    public let name: String                  // displayName
-    public let blurb: String                 // description
-    public let swatch: [String]              // [color-primary, color-accent] for the gallery
-    public let cssVars: [String: String]     // vars: custom-property name (no leading --) -> value
+    /// Theme id, e.g. "warm" — the stable key persisted in settings and matched by
+    /// `ThemeCatalog.theme(id:)`.
+    public let id: String
+    /// The JSON record's `displayName` — what the gallery shows.
+    public let name: String
+    /// The JSON record's `description` — one-line gallery copy, also reused as the brand
+    /// summary when the theme is applied.
+    public let blurb: String
+    /// `[color-primary, color-accent]` for the gallery's color-chip preview (fewer entries if a
+    /// theme omits one).
+    public let swatch: [String]
+    /// The record's `vars`: custom-property name (no leading `--`) → value, exactly what
+    /// `ThemeApplier` rewrites into `global.css`.
+    public let cssVars: [String: String]
 
+    /// Memberwise creation — normally themes come from ``ThemeCatalog/parse(themesJSON:)``, but
+    /// tests build them directly.
     public init(id: String, name: String, blurb: String, swatch: [String], cssVars: [String: String]) {
         self.id = id; self.name = name; self.blurb = blurb; self.swatch = swatch; self.cssVars = cssVars
     }
@@ -15,9 +26,14 @@ public struct Theme: Sendable, Identifiable, Equatable {
 
 /// The 8 built-in themes plus the wizard's default-by-site-type mapping.
 public struct ThemeCatalog: Sendable {
+    /// All themes in the shared JSON's order — order matters: the first entry is the fallback
+    /// default (see ``defaultThemeID(for:)``).
     public let themes: [Theme]
+    /// Wraps an already-decoded theme list; production loads via ``load(templateURL:)``.
     public init(themes: [Theme]) { self.themes = themes }
 
+    /// The theme with the given id, or `nil` — lookup by id rather than index so persisted theme
+    /// choices survive catalog reordering.
     public func theme(id: String) -> Theme? { themes.first { $0.id == id } }
 
     /// App-side default theme per broad site type. Falls back to the first available theme


### PR DESCRIPTION
## Summary

- Phase 8 of the doc-comment retrofit tracked in #1141: sixth-to-seventh alphabetical chunk of AnglesiteCore (45 files, `SiteFileTree` … `ThemeCatalog`, ~380 doc comments) — the site graph explorer/explainers, IndieAuth client, knowledge index, site operations/runtime/scaffolder, social media planning and publishing, the #875/#877 sync machinery (engine, artifacts, conflict resolver, scheduler), template-scripts sync, themes, and the supervisor backend.
- Resolved on top of current `main`: keeps #1151's new `SiteRuntime.suspend()` requirement and its doc while adding this chunk's `observe()` doc alongside it.
- Single-line enum `case` lists split so each case carries its rationale; raw values and `CaseIterable` order unchanged. Comments only — no behavior changes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` — clean (run after rebasing onto current `main`).
- [x] `swift test --filter AnglesiteCoreTests` — 3,058 tests in 385 suites; 2 failures, both the known "FoundationModelAssistant" concurrent-`swift test` FM-contention flake (same two tests fail identically on unmodified checkouts — see the sibling #1141 PRs). `FoundationModelAssistant.swift` is not touched by this diff.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run separately; comments-only diff, target compiles during DocC symbol-graph extraction.
