### PR TITLE
fix(#1010): mark required URL rows in New Collection sheet

### DIFF
--- a/Sources/AnglesiteApp/NewContentSheets.swift
+++ b/Sources/AnglesiteApp/NewContentSheets.swift
@@ -203,10 +203,13 @@ struct NewCollectionEntrySheet: View {
                                 "Title", text: $title,
                                 prompt: selectedDescriptor?.titleIsRequired == true ? nil : Text("optional"))
                         }
-                        // Field names match the inspector's labels in `TypedEntryForm`.
+                        // Field names match the inspector's labels in `TypedEntryForm`, including
+                        // the " *" required suffix — every field here is schema-required (#916),
+                        // and without it an untouched reply/like row gives no sign anything's
+                        // missing before Create refuses to enable (#1010).
                         ForEach(requiredURLFields, id: \.name) { field in
                             TextField(
-                                field.name,
+                                field.name + (field.required ? " *" : ""),
                                 text: urlBinding(field.name),
                                 prompt: Text(verbatim: "https://example.com/post"))
                         }


### PR DESCRIPTION
Closes #1010

## Summary

- Add the `" *"` required-field suffix (already used by `TypedEntryForm`) to the required `.url` field rows in `NewCollectionEntrySheet`, so a reply/like row — which has no title field to anchor on — signals it's required instead of leaving a disabled Create button unexplained.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` (306/306 in the app-target-adjacent suites pass; 2 unrelated pre-existing failures in `FoundationModelAssistant`'s on-device streaming tests, unaffected by this change)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — BUILD SUCCEEDED
- [ ] Manual smoke (if UI-touching): not run in this headless session — recommend opening New Collection Entry for a `reply`/`like` type and confirming the URL field now reads "likeOf *" / "inReplyTo *"