### PR TITLE
refactor(#1155): consolidate AppKit-storm 300ms sleeps

### DIFF
--- a/Sources/AnglesiteApp/AppKitConstraintStormMitigation.swift
+++ b/Sources/AnglesiteApp/AppKitConstraintStormMitigation.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Single source for the fixed-duration sleep that guards against macOS 27 beta's AppKit
+/// constraint-update storm (#1126 class): coalescing an inspector/sheet dismissal transaction
+/// with a following main-pane rebuild, toolbar re-layout, or inspector presentation into the
+/// same synchronous step sends AppKit's layout engine into a runaway `-updateConstraints` loop
+/// that hangs the window and then crashes the app. Giving the first transaction its own run-loop
+/// turn before starting the second avoids it. Call sites: `SiteWindowModel
+/// .clearInspectorThenSwitchPane`, `SiteWindowModel.openFile`'s post-pane-swap delay before the
+/// Component Editor inspector presents (#1139), `SiteSearchFieldModifier.focusSearchField`, and
+/// `SiteWindowModel.loadAndStart`'s dependency-sheet-to-scripts-sheet handoff.
+///
+/// ## Why this is still a fixed sleep, not a condition wait
+///
+/// #1155 asked whether a deterministic completion signal — tied to the actual AppKit
+/// layout/constraint pass rather than a guessed duration — could replace this. Investigated and
+/// ruled out for now:
+///
+/// - **`CATransaction.setCompletionBlock`**: fires once a Core Animation transaction's layer
+///   changes (including any animations declared within it) have committed. But the crash-log
+///   stack traces (#1126, #1139) show a runaway **Auto Layout** `-updateConstraints` cycle driven
+///   by `NSWindow`'s own display pass, not a Core Animation transaction our code opens — there's
+///   nothing for us to attach a completion block to that's guaranteed to enclose AppKit's internal
+///   constraint pass.
+/// - **`withAnimation(_:completionCriteria:completion:)`**: tracks completion of a SwiftUI
+///   transaction *we* declare with an explicit animation. The state mutations at every call site
+///   here (`inspectorContext = nil`, `inspectorPresented.wrappedValue = false`, …) are plain,
+///   non-animated assignments — SwiftUI's `.inspector(isPresented:)` transition and the
+///   corresponding AppKit split-view layout work are framework-internal, not something an
+///   `withAnimation` block around our own mutation observes.
+/// - **`NSWindow.didUpdateNotification`-based quiescence polling**: plausible in principle (wait
+///   for N consecutive "window updated" passes with no further pending constraint invalidation,
+///   capped by a timeout), but it needs a reference to the site window's `NSWindow`, which
+///   `SiteWindowModel` and `SiteSearchFieldModifier` don't currently have — plumbing one through
+///   would be new machinery in a crash-workaround path with no way to manually verify it against
+///   the actual macOS 27 beta storm in this environment (headless: no windowed session to trigger
+///   the AppKit layout race in). Swapping a working, empirically-tuned mitigation for an unverified
+///   one risks reintroducing the crash. Worth revisiting with real hardware access; not attempted
+///   here.
+///
+/// So the fix for #1155 is consolidation, not a new mechanism: one named duration and one call
+/// site instead of four independent magic numbers that could drift out of sync.
+enum AppKitConstraintStormMitigation {
+    /// Empirically chosen (#1126/#1131/#1132/#1139) — long enough in practice to let AppKit's
+    /// dismissal/layout transaction settle before the next state mutation triggers its own, short
+    /// enough not to read as a stall. Not derived from a measured worst-case; see the type doc for
+    /// why this isn't condition-based.
+    static let settleDelay: Duration = .milliseconds(300)
+
+    /// Suspends for `settleDelay`, giving a just-triggered AppKit transaction (inspector/sheet
+    /// dismissal, pane rebuild) a run-loop turn to settle before the caller's next state mutation.
+    /// Never throws — cancellation just ends the wait early, which is fine here since callers
+    /// don't have follow-up cleanup contingent on the full delay elapsing.
+    static func settle() async {
+        try? await Task.sleep(for: settleDelay)
+    }
+}

--- a/Sources/AnglesiteApp/SiteSearchField.swift
+++ b/Sources/AnglesiteApp/SiteSearchField.swift
@@ -73,7 +73,8 @@ struct SiteSearchFieldModifier: ViewModifier {
                     // that, coalesced with a still-presented window inspector, hits the same
                     // macOS 27 beta AppKit constraint-update storm as the pane-switch case
                     // (#1126). Dismiss the inspector and give its own dismissal transaction a
-                    // moment to settle first, same mitigation as
+                    // moment to settle first, same mitigation
+                    // (`AppKitConstraintStormMitigation`) as
                     // `SiteWindowModel.clearInspectorThenSwitchPane`; skipped entirely when
                     // there's no inspector presented to collide with.
                     guard inspectorPresented.wrappedValue else {
@@ -82,7 +83,7 @@ struct SiteSearchFieldModifier: ViewModifier {
                     }
                     inspectorPresented.wrappedValue = false
                     Task {
-                        try? await Task.sleep(for: .milliseconds(300))
+                        await AppKitConstraintStormMitigation.settle()
                         searchFieldFocused = true
                     }
                 }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -384,10 +384,8 @@ final class SiteWindowModel {
     /// to false) and swapping `mainPaneMode` right after — sent macOS 27 beta's AppKit layout
     /// engine into an unrecoverable constraint-update storm that hung the window and then
     /// crashed the app (#1126), most reliably via Graph but not exclusive to it. Same class of
-    /// problem, same mitigation, as the sheet-dismissal delay in `loadAndStart()` below: a
-    /// single `Task.yield()` only defers to the next run-loop tick, which isn't necessarily
-    /// enough for AppKit's own dismiss animation, so a short sleep is used instead — skipped
-    /// entirely when there was no inspector to dismiss.
+    /// problem, same mitigation (`AppKitConstraintStormMitigation`), as the sheet-dismissal delay
+    /// in `loadAndStart()` below — skipped entirely when there was no inspector to dismiss.
     ///
     /// For Graph/Cleanup/Reader/Followers/Communities the inspector has no companion to reopen,
     /// so clearing it here is the whole story. `openFile` also routes through here — a component
@@ -404,7 +402,7 @@ final class SiteWindowModel {
         inspectorContext = nil
         collectionInspection = nil
         if wasInspecting {
-            try? await Task.sleep(for: .milliseconds(300))
+            await AppKitConstraintStormMitigation.settle()
         }
         mainPaneMode = mode
     }
@@ -1108,7 +1106,7 @@ final class SiteWindowModel {
                 // conditioned on `wasInspecting` because the storm trigger here is the pane
                 // rebuild + inspector *presentation* landing together, which happens regardless
                 // of whether an inspector was already up.
-                try? await Task.sleep(for: .milliseconds(300))
+                await AppKitConstraintStormMitigation.settle()
             }
             await ensureComponentEditorLoaded()
         }
@@ -1795,15 +1793,14 @@ final class SiteWindowModel {
         // requests its own presentation — back-to-back `.sheet(item:)` presentations in the same
         // synchronous continuation-resumption stack risk a silently-failed second presentation,
         // which (with `.interactiveDismissDisabled()` on both sheets) would leave this method's
-        // `CheckedContinuation` unresumed forever. This is a best-effort mitigation, not a
-        // structural guarantee — a single `Task.yield()` only defers to the next run-loop tick,
-        // which is enough for the state change but not necessarily for AppKit's own dismiss
-        // animation, so a short sleep is used instead. A real guarantee would mean gating on the
-        // first sheet's actual `onDisappear`, which isn't done here; accepted as low-risk because
-        // this path only triggers when a single site-open queues both a dependency offer and a
-        // script divergence at once (an app-upgrade edge case) — narrow enough that a manual QA
-        // pass covering it (see this PR's test plan) is the practical verification, not a proof.
-        try? await Task.sleep(for: .milliseconds(300))
+        // `CheckedContinuation` unresumed forever. Same mitigation, same class of problem, as
+        // `clearInspectorThenSwitchPane` above (`AppKitConstraintStormMitigation`) — a real
+        // guarantee would mean gating on the first sheet's actual `onDisappear`, which isn't done
+        // here; accepted as low-risk because this path only triggers when a single site-open
+        // queues both a dependency offer and a script divergence at once (an app-upgrade edge
+        // case) — narrow enough that a manual QA pass covering it (see this PR's test plan) is the
+        // practical verification, not a proof.
+        await AppKitConstraintStormMitigation.settle()
         if let templateURL = TemplateRuntime.resolve().url {
             let plan = TemplateScriptsSyncChecker.check(
                 sourceDirectory: resolved.sourceDirectory,


### PR DESCRIPTION
Closes #1155

## Summary

- Investigated whether a deterministic AppKit layout/constraint-settle signal (`CATransaction` completion, `withAnimation(completionCriteria:completion:)`, `NSWindow.didUpdateNotification` quiescence polling) could replace the fixed 300ms sleeps guarding the #1126-class constraint-update storm — none are safely wireable and verifiable here without live macOS 27 beta GUI access; findings are documented in the new helper's doc comment.
- Consolidated the four independent `try? await Task.sleep(for: .milliseconds(300))` copies (`SiteWindowModel.clearInspectorThenSwitchPane`, `openFile`'s post-pane-swap delay before the Component Editor inspector presents (#1139), `loadAndStart`'s dependency-sheet-to-scripts-sheet handoff, `SiteSearchFieldModifier.focusSearchField`) into one named constant and helper (`AppKitConstraintStormMitigation`), so a future fifth trigger site reuses it instead of adding another magic number.
- No behavior change — same duration, same conditional-skip logic at each call site, just deduplicated.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — full suite passes except two pre-existing, unrelated `FoundationModelAssistantTests` on-device streaming flakes ("Session ended without producing a response"), in a target this PR doesn't touch.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — builds clean.
- [ ] Manual smoke (if UI-touching): not verified interactively — same timing-dependent macOS 27 beta AppKit behavior noted in the original #1131/#1132 mitigation PRs' test plans; this PR only refactors where the sleep lives, not its duration or trigger conditions, so the existing manual-verification gap is unchanged, not newly introduced.