### PR TITLE
docs(#1141): retrofit doc comments, Core Preview-SiteContentGraph

### DIFF
--- a/Sources/AnglesiteCore/PreviewNavigation.swift
+++ b/Sources/AnglesiteCore/PreviewNavigation.swift
@@ -24,6 +24,10 @@ public enum PreviewNavigation {
     /// Query-parameter key the app appends to force `EsiInclude`'s dev-preview shim into the
     /// "unprocessed" state (spec §4a) — must match `esi-dev-shim.ts`'s `esiPreviewIsUnprocessed`.
     public static let esiPreviewQueryKey = "esiPreview"
+
+    /// The value paired with ``esiPreviewQueryKey`` to request the "unprocessed" state — must
+    /// also match `esi-dev-shim.ts`, which string-compares it when deciding whether to leave
+    /// `<esi:include>` tags unexpanded.
     public static let esiPreviewUnprocessedValue = "unprocessed"
 
     /// Appends (or replaces) the `esiPreview=unprocessed` query item on `url` when `unprocessed`

--- a/Sources/AnglesiteCore/PreviewZoom.swift
+++ b/Sources/AnglesiteCore/PreviewZoom.swift
@@ -12,7 +12,12 @@ public enum PreviewZoom {
     /// The 100% detent — View ▸ Actual Size (⌘0).
     public static let actualSize: Double = 1.0
 
+    /// The lowest detent — the floor `zoomOut(from:)` clamps to. Derived from ``levels`` so the
+    /// ladder stays the single source of truth.
     public static var minimum: Double { levels[0] }
+
+    /// The highest detent — the ceiling `zoomIn(from:)` clamps to. Derived from ``levels`` so the
+    /// ladder stays the single source of truth.
     public static var maximum: Double { levels[levels.count - 1] }
 
     /// Comparison slop so a level reproduced through floating-point arithmetic still counts as
@@ -31,10 +36,16 @@ public enum PreviewZoom {
         levels.last { $0 < level - tolerance } ?? minimum
     }
 
+    /// Whether View ▸ Zoom In should be enabled at `level` — `false` only at (or within
+    /// floating-point tolerance of) ``maximum``, so the menu item disables exactly when
+    /// ``zoomIn(from:)`` would be a no-op.
     public static func canZoomIn(from level: Double) -> Bool {
         level + tolerance < maximum
     }
 
+    /// Whether View ▸ Zoom Out should be enabled at `level` — `false` only at (or within
+    /// floating-point tolerance of) ``minimum``, so the menu item disables exactly when
+    /// ``zoomOut(from:)`` would be a no-op.
     public static func canZoomOut(from level: Double) -> Bool {
         level - tolerance > minimum
     }

--- a/Sources/AnglesiteCore/ProcessSupervisor.swift
+++ b/Sources/AnglesiteCore/ProcessSupervisor.swift
@@ -50,7 +50,11 @@ public actor ProcessSupervisor {
     /// `ProcessSupervisor.RestartPolicy.onCrash(...)` and `ProcessSupervisor.ExitReason` compile
     /// unchanged.
     public typealias RestartPolicy = AnglesiteCore.RestartPolicy
+    /// Source-compat re-export of ``ProcessExitReason`` — see ``RestartPolicy`` for why these
+    /// aliases exist.
     public typealias ExitReason = AnglesiteCore.ProcessExitReason
+    /// Source-compat re-export of the module-level `RespawnHandler` — see ``RestartPolicy`` for
+    /// why these aliases exist.
     public typealias RespawnHandler = AnglesiteCore.RespawnHandler
 
     /// `Handle.source` is preserved (the backend's opaque handle doesn't carry it), so map by `id`.
@@ -87,11 +91,20 @@ public actor ProcessSupervisor {
 
     // MARK: One-shot run
 
+    /// Captured outcome of a one-shot ``run(executable:arguments:environment:currentDirectoryURL:)``.
+    ///
+    /// A nonzero exit is *not* thrown — short-lived tools routinely use exit codes as answers
+    /// (e.g. `git diff --quiet`), so callers inspect ``exitCode`` themselves.
     public struct RunResult: Sendable, Equatable {
+        /// Everything the process wrote to stdout, decoded as UTF-8 (empty on decode failure).
         public let stdout: String
+        /// Everything the process wrote to stderr, decoded as UTF-8 (empty on decode failure).
         public let stderr: String
+        /// The process's exit status. `0` means success by convention; interpreting anything
+        /// else is the caller's job.
         public let exitCode: Int32
 
+        /// Memberwise initializer — public so tests and fake backends can fabricate results.
         public init(stdout: String, stderr: String, exitCode: Int32) {
             self.stdout = stdout
             self.stderr = stderr
@@ -99,8 +112,14 @@ public actor ProcessSupervisor {
         }
     }
 
+    /// Failures the supervisor surfaces to callers, translated from the backend's
+    /// ``SupervisorBackendError`` so call sites don't couple to the backend seam.
     public enum SupervisorError: Error, Sendable {
+        /// The process could not be spawned (missing executable, sandbox denial, backend
+        /// unavailable). The underlying error carries the backend's message.
         case spawnFailed(underlying: Error)
+        /// The ``Handle`` doesn't correspond to a live supervised process — it already exited
+        /// and was reaped, or was never launched by this supervisor instance.
         case unknownHandle
     }
 
@@ -138,12 +157,27 @@ public actor ProcessSupervisor {
 
     // MARK: Long-running launch
 
+    /// Opaque reference to a launched, supervised process.
+    ///
+    /// Deliberately carries no PID: under a ``RestartPolicy`` the underlying OS process can be
+    /// respawned (new PID) while the handle stays valid, so identity is the supervisor-assigned
+    /// ``id``, not anything the kernel hands out.
     public struct Handle: Sendable, Identifiable, Hashable {
+        /// Supervisor-assigned identity — shared with the backend's `SpawnedProcessHandle.id`,
+        /// which is how the facade maps between the two without extra bookkeeping.
         public let id: UUID
+        /// The log-source tag given to `launch(...)`, kept on the handle so callers can label
+        /// UI (debug pane sections, error messages) without a supervisor round-trip.
         public let source: String
     }
 
+    /// Wrapper for a launched process's stdin pipe, vended by ``stdinWriter(_:)``.
+    ///
+    /// Prefer ``writeStdin(_:_:)`` for routine writes — it stays on the backend and surfaces
+    /// errors; the raw handle exists for callers that need `FileHandle`-level control.
     public struct StdinHandle: Sendable {
+        /// The write end of the child's stdin pipe. Writing after the child exits raises
+        /// `EPIPE` rather than killing the app — see the supervisor's `SIGPIPE` handling.
         public let writer: FileHandle
     }
 
@@ -230,6 +264,9 @@ public actor ProcessSupervisor {
         }
     }
 
+    /// Whether the supervised process behind `handle` is currently alive. `false` for an unknown
+    /// handle as well as an exited process — callers polling for liveness don't need to
+    /// distinguish the two.
     public func isRunning(_ handle: Handle) async -> Bool {
         await backend.isRunning(backendHandle(for: handle))
     }

--- a/Sources/AnglesiteCore/ProjectConventions.swift
+++ b/Sources/AnglesiteCore/ProjectConventions.swift
@@ -3,46 +3,80 @@ import Foundation
 
 /// Where a `Learned` field's current value came from.
 public enum ConventionSource: Sendable, Codable, Equatable {
+    /// Computed by the extractor or enrichment pass. `confidence` is the share of evidence
+    /// agreeing with the value (0–1); `0` marks an unset default. Note the FM enricher writes
+    /// `confidence: 1` — signal checks must accept any positive confidence, not gate on
+    /// sample size (see `BrandVoiceGuidance.hasSignal`).
     case inferred(confidence: Double)
+    /// Explicitly set by the user (Style Guide inspector or brand-voice interview). Re-learning
+    /// never replaces it — see ``ProjectConventions/merging(overriddenFrom:)``.
     case userOverride
 }
 
 /// One inferred-or-overridden fact about a project's conventions. Re-learning never overwrites
 /// a `.userOverride` value — see `ProjectConventions.merging(overriddenFrom:)`.
 public struct Learned<Value: Sendable & Codable & Equatable>: Sendable, Codable, Equatable {
+    /// The current value of the fact, regardless of whether it was inferred or user-set.
     public var value: Value
+    /// Provenance of ``value`` — the merge invariant keys off this, not off the value itself.
     public var source: ConventionSource
     /// How many files this was inferred from, when known. `nil`/0 lets a future UI show a
     /// "low confidence" indicator instead of asserting a rule from too little evidence.
     public var sampleSize: Int?
 
+    /// Memberwise initializer. `sampleSize` defaults to `nil` because user overrides and
+    /// interview answers have no file-count evidence behind them.
     public init(value: Value, source: ConventionSource, sampleSize: Int? = nil) {
         self.value = value
         self.source = source
         self.sampleSize = sampleSize
     }
 
+    /// `true` when ``source`` is `.userOverride` — the predicate
+    /// ``ProjectConventions/merging(overriddenFrom:)`` uses to decide which fields survive a
+    /// background re-learn.
     public var isOverridden: Bool {
         if case .userOverride = source { return true }
         return false
     }
 }
 
+/// The dominant heading style the extractor detected across a site's markdown headings.
+/// A style is only asserted when ≥70% of sampled headings agree — anything less is `mixed`
+/// (see `ProjectConventionsExtractor`).
 public enum HeadingCapitalization: String, Sendable, Codable, Equatable, CaseIterable {
+    /// Most headings capitalize every significant word ("Getting Started With Anglesite").
     case titleCase
+    /// Most headings capitalize only the first word ("Getting started with anglesite").
     case sentenceCase
+    /// No style reached the confidence threshold — also the zero-evidence default, so
+    /// generation shouldn't impose either style.
     case mixed
 }
 
+/// The dominant file-naming style of a site's content/page slugs. Same ≥70% confidence
+/// threshold as ``HeadingCapitalization``.
 public enum SlugStyle: String, Sendable, Codable, Equatable, CaseIterable {
+    /// Lowercase words joined with hyphens (`my-first-post`).
     case kebabCase
+    /// Lowercase words joined with underscores (`my_first_post`).
     case snakeCase
+    /// No style reached the confidence threshold — also the zero-evidence default.
     case mixed
 }
 
+/// Prose-style facts about a site: how it capitalizes, sounds, and names things. The voice
+/// fields (`toneDescriptors`, `brandTerms`, `audience`, `avoidPhrases`) feed generation prompts
+/// via `BrandVoiceGuidance`.
 public struct WritingConventions: Sendable, Codable, Equatable {
+    /// Dominant heading style, inferred from markdown headings by the deterministic extractor.
     public var headingCapitalization: Learned<HeadingCapitalization>
+    /// Adjectives describing the site's voice (e.g. "warm", "technical"). Produced by the
+    /// throttled on-device enrichment pass, not the deterministic extractor — text stats alone
+    /// can't judge tone.
     public var toneDescriptors: Learned<[String]>
+    /// Product/brand names and site-specific terms generation should spell exactly as the site
+    /// does. Enrichment-produced, like ``toneDescriptors``.
     public var brandTerms: Learned<[String]>
     /// Who the site speaks to, in the owner's words. `""` = unset. Set by the brand-voice
     /// interview (#465); never inferred by the extractor.
@@ -50,6 +84,9 @@ public struct WritingConventions: Sendable, Codable, Equatable {
     /// Words/phrases generation must avoid. `[]` = unset. Set by the brand-voice interview.
     public var avoidPhrases: Learned<[String]>
 
+    /// Memberwise initializer. The interview-only fields (`audience`, `avoidPhrases`) default
+    /// to zero-confidence "unset" so extractor call sites that predate #465 don't have to
+    /// supply them.
     public init(
         headingCapitalization: Learned<HeadingCapitalization>,
         toneDescriptors: Learned<[String]>,
@@ -68,8 +105,8 @@ public struct WritingConventions: Sendable, Codable, Equatable {
         case headingCapitalization, toneDescriptors, brandTerms, audience, avoidPhrases
     }
 
-    // Pre-#465 conventions.json has no voice fields; default them instead of failing the decode
-    // (a decode failure would silently drop the user's whole learned state).
+    /// Pre-#465 conventions.json has no voice fields; default them instead of failing the decode
+    /// (a decode failure would silently drop the user's whole learned state).
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         headingCapitalization = try c.decode(Learned<HeadingCapitalization>.self, forKey: .headingCapitalization)
@@ -85,42 +122,63 @@ public struct WritingConventions: Sendable, Codable, Equatable {
 /// Read as ground truth from `src/content.config.ts` (Task 3) — not inferred, so no `Learned`
 /// wrapper and never user-overridable. Maps collection name to its declared field names.
 public struct FrontmatterConventions: Sendable, Codable, Equatable {
+    /// Collection name → declared field names, in schema order. Empty when the site has no
+    /// `content.config.ts` (or it couldn't be parsed).
     public var collections: [String: [String]]
 
+    /// Memberwise initializer.
     public init(collections: [String: [String]]) {
         self.collections = collections
     }
 }
 
+/// Which Astro components a site actually uses, so suggestions favor components the owner
+/// already reaches for.
 public struct ComponentConventions: Sendable, Codable, Equatable {
+    /// Component tag name → number of usages across `.astro` files. A count, not a preference —
+    /// which is why it's excluded from ``OverridableField``.
     public var usageCounts: Learned<[String: Int]>
 
+    /// Memberwise initializer.
     public init(usageCounts: Learned<[String: Int]>) {
         self.usageCounts = usageCounts
     }
 }
 
+/// Alt-text habits inferred from the site's existing images, used to make generated alt text
+/// (e.g. `AltTextGenerator`) match what the owner already writes.
 public struct ImageConventions: Sendable, Codable, Equatable {
+    /// Average character length of non-empty alt texts. `0` means no evidence yet.
     public var altTextAverageLength: Learned<Int>
+    /// Whether a majority of alt texts end with sentence punctuation — a stylistic choice
+    /// (screen-reader pause behavior) worth matching either way.
     public var altTextEndsWithPunctuation: Learned<Bool>
 
+    /// Memberwise initializer.
     public init(altTextAverageLength: Learned<Int>, altTextEndsWithPunctuation: Learned<Bool>) {
         self.altTextAverageLength = altTextAverageLength
         self.altTextEndsWithPunctuation = altTextEndsWithPunctuation
     }
 }
 
+/// File-naming facts, so newly scaffolded pages/posts get slugs shaped like the existing ones.
 public struct NamingConventions: Sendable, Codable, Equatable {
+    /// Dominant slug style across `src/content/` and `src/pages/` file names.
     public var slugStyle: Learned<SlugStyle>
 
+    /// Memberwise initializer.
     public init(slugStyle: Learned<SlugStyle>) {
         self.slugStyle = slugStyle
     }
 }
 
+/// SEO-relevant metadata habits inferred from existing frontmatter.
 public struct SEOConventions: Sendable, Codable, Equatable {
+    /// Average character length of non-empty frontmatter `description` values — a target for
+    /// generated meta descriptions. `0` means no evidence yet.
     public var metaDescriptionAverageLength: Learned<Int>
 
+    /// Memberwise initializer.
     public init(metaDescriptionAverageLength: Learned<Int>) {
         self.metaDescriptionAverageLength = metaDescriptionAverageLength
     }
@@ -129,14 +187,23 @@ public struct SEOConventions: Sendable, Codable, Equatable {
 /// One site's learned/edited project conventions. See the design doc for the taxonomy and the
 /// override-preserving merge invariant.
 public struct ProjectConventions: Sendable, Codable, Equatable {
+    /// Prose style and brand voice.
     public var writing: WritingConventions
+    /// Declared content-collection schemas — ground truth, never overridable.
     public var frontmatter: FrontmatterConventions
+    /// Component usage counts.
     public var components: ComponentConventions
+    /// Alt-text habits.
     public var images: ImageConventions
+    /// Slug/file-naming habits.
     public var naming: NamingConventions
+    /// Metadata habits.
     public var seo: SEOConventions
+    /// When the last full extraction ran, or `nil` if this value has never been learned from
+    /// disk (e.g. it's still ``empty`` or a seeded pre-restart snapshot).
     public var lastLearnedAt: Date?
 
+    /// Memberwise initializer.
     public init(
         writing: WritingConventions,
         frontmatter: FrontmatterConventions,
@@ -185,28 +252,46 @@ public struct ProjectConventions: Sendable, Codable, Equatable {
 /// (ground truth) and component usage counts (a count, not a preference) are intentionally
 /// excluded.
 public enum OverridableField: String, Sendable, Codable, CaseIterable {
+    /// ``WritingConventions/headingCapitalization``.
     case headingCapitalization
+    /// ``WritingConventions/toneDescriptors``.
     case toneDescriptors
+    /// ``WritingConventions/brandTerms``.
     case brandTerms
+    /// ``WritingConventions/audience``.
     case audience
+    /// ``WritingConventions/avoidPhrases``.
     case avoidPhrases
+    /// ``ImageConventions/altTextAverageLength``.
     case altTextAverageLength
+    /// ``ImageConventions/altTextEndsWithPunctuation``.
     case altTextEndsWithPunctuation
+    /// ``NamingConventions/slugStyle``.
     case slugStyle
+    /// ``SEOConventions/metaDescriptionAverageLength``.
     case metaDescriptionAverageLength
 }
 
 /// A typed value for one `OverridableField`. The case identifies the field; the payload is
 /// already the right type for it, so callers can't set a `String` onto an `Int` field.
 public enum OverrideValue: Sendable, Equatable {
+    /// New value for ``OverridableField/headingCapitalization``.
     case headingCapitalization(HeadingCapitalization)
+    /// New value for ``OverridableField/toneDescriptors``.
     case toneDescriptors([String])
+    /// New value for ``OverridableField/brandTerms``.
     case brandTerms([String])
+    /// New value for ``OverridableField/audience``.
     case audience(String)
+    /// New value for ``OverridableField/avoidPhrases``.
     case avoidPhrases([String])
+    /// New value for ``OverridableField/altTextAverageLength``.
     case altTextAverageLength(Int)
+    /// New value for ``OverridableField/altTextEndsWithPunctuation``.
     case altTextEndsWithPunctuation(Bool)
+    /// New value for ``OverridableField/slugStyle``.
     case slugStyle(SlugStyle)
+    /// New value for ``OverridableField/metaDescriptionAverageLength``.
     case metaDescriptionAverageLength(Int)
 }
 

--- a/Sources/AnglesiteCore/ProjectConventionsEngine.swift
+++ b/Sources/AnglesiteCore/ProjectConventionsEngine.swift
@@ -26,6 +26,14 @@ public actor ProjectConventionsEngine {
     private let now: @Sendable () -> Date
     private var lastEnrichedAt: [String: Date] = [:]
 
+    /// Creates an engine.
+    ///
+    /// - Parameters:
+    ///   - enrich: Model-backed tone/brand-term producer, or `nil` to run extraction-only
+    ///     (the reduced CI toolchain path — see ``ProjectConventionsEnricherFactory``).
+    ///   - enrichmentInterval: Minimum seconds between enrichment passes per site. The default
+    ///     (5 minutes) keeps the on-device model out of the hot file-watcher path.
+    ///   - now: Clock seam so tests can drive the throttle without real waiting.
     public init(
         enrich: ConventionsEnricher? = nil,
         enrichmentInterval: TimeInterval = 300,
@@ -36,6 +44,10 @@ public actor ProjectConventionsEngine {
         self.now = now
     }
 
+    /// Full rescan: walks `projectRoot`, re-extracts every convention, merges preserved user
+    /// overrides back in, and (throttle permitting, or always with `forceEnrichment`) runs the
+    /// tone/brand enrichment pass. Disk I/O happens off-actor at utility priority so a large
+    /// site doesn't stall callers.
     public func rebuild(siteID: String, projectRoot: URL, forceEnrichment: Bool = false) async {
         let files = await Task.detached(priority: .utility) {
             Self.scan(projectRoot: projectRoot)
@@ -45,6 +57,10 @@ public actor ProjectConventionsEngine {
         await maybeEnrich(siteID: siteID, siteDirectory: projectRoot, force: forceEnrichment)
     }
 
+    /// Incremental update for one changed file (the `SiteFileWatcher` path). Non-scanned
+    /// paths/extensions are ignored; an unreadable file is treated as a removal so a
+    /// delete-then-event race can't leave stale contents in the index. Never triggers
+    /// enrichment — that stays on the `rebuild` cadence.
     public func upsertFile(siteID: String, projectRoot: URL, relativePath: String) async {
         guard shouldScan(relativePath) else { return }
         let url = projectRoot.appendingPathComponent(relativePath)
@@ -59,6 +75,9 @@ public actor ProjectConventionsEngine {
         await recompute(siteID: siteID, projectRoot: projectRoot)
     }
 
+    /// Drops one file from the index and recomputes. No `projectRoot` here (mirrors
+    /// `SiteKnowledgeIndex.removeFile`), so frontmatter collections keep their last-known
+    /// reading until the next full `rebuild` re-reads them from disk.
     public func removeFile(siteID: String, relativePath: String) async {
         guard filesBySite[siteID]?.removeValue(forKey: relativePath) != nil else { return }
         // No projectRoot available here (mirrors SiteKnowledgeIndex.removeFile) — frontmatter
@@ -66,11 +85,17 @@ public actor ProjectConventionsEngine {
         await recompute(siteID: siteID, projectRoot: nil)
     }
 
+    /// Frees a closed site's in-memory state. Persistence is the caller's job (via
+    /// ``ProjectConventionsStore``) *before* unloading — anything not saved is gone, including
+    /// user overrides applied this session.
     public func unload(siteID: String) {
         conventionsBySite.removeValue(forKey: siteID)
         filesBySite.removeValue(forKey: siteID)
     }
 
+    /// The current in-memory conventions for a site, or `nil` if it was never seeded, rebuilt,
+    /// or overridden this session. Callers wanting a usable value regardless should fall back
+    /// to ``ProjectConventions/empty``.
     public func conventions(siteID: String) -> ProjectConventions? {
         conventionsBySite[siteID]
     }
@@ -83,12 +108,18 @@ public actor ProjectConventionsEngine {
         conventionsBySite[siteID] = conventions
     }
 
+    /// Applies a user override, flipping the field's source to `.userOverride` so later
+    /// rebuilds preserve it. Starts from ``ProjectConventions/empty`` when the site has no
+    /// state yet — an override must never be dropped just because learning hasn't run.
     public func applyOverride(siteID: String, value: OverrideValue) {
         var conventions = conventionsBySite[siteID] ?? .empty
         conventions.apply(value)
         conventionsBySite[siteID] = conventions
     }
 
+    /// Reverts one field to inferred; the current value stays in place until the next rebuild
+    /// recomputes it (see ``ProjectConventions/clearOverride(_:)``). No-op for an unknown site —
+    /// there's nothing to revert.
     public func clearOverride(siteID: String, field: OverridableField) {
         guard var conventions = conventionsBySite[siteID] else { return }
         conventions.clearOverride(field)

--- a/Sources/AnglesiteCore/ProjectConventionsEnricherFactory.swift
+++ b/Sources/AnglesiteCore/ProjectConventionsEnricherFactory.swift
@@ -6,6 +6,10 @@ import Foundation
 /// constructs `ProjectConventionsEngine` with whatever this returns, so the engine works
 /// identically (just without tone/brand enrichment) on the reduced CI toolchain.
 public enum ProjectConventionsEnricherFactory {
+    /// The production enricher: one on-device `FoundationModelAssistant` guided-generation call
+    /// producing `GeneratedProjectConventions` from a sample of the site's text. Returns `nil`
+    /// when the toolchain can't import `FoundationModels` (pre-Xcode-27 / reduced CI), which the
+    /// engine treats as "extraction only, no tone/brand fields".
     public static func makeDefault() -> ProjectConventionsEngine.ConventionsEnricher? {
         #if compiler(>=6.4) && canImport(FoundationModels)
         return { sampleText, context in

--- a/Sources/AnglesiteCore/ProjectConventionsExtractor.swift
+++ b/Sources/AnglesiteCore/ProjectConventionsExtractor.swift
@@ -7,16 +7,28 @@ import Foundation
 /// `.empty` zero-confidence default here — those come from the throttled FM enrichment pass
 /// added in Task 5.
 public enum ProjectConventionsExtractor {
+    /// A project file handed to the extractor as an in-memory path + contents snapshot, so
+    /// extraction stays pure (no filesystem access) and each heuristic is testable against
+    /// fixture strings.
     public struct ScannedFile: Sendable {
+        /// Project-relative path (e.g. `src/content/posts/my-trip.mdoc`). The prefix and
+        /// extension decide which conventions the file feeds — slugs come only from
+        /// `src/content/`/`src/pages/`, component counts only from `.astro` files.
         public let path: String
+        /// The file's full text contents.
         public let contents: String
 
+        /// Pairs a project-relative `path` with the file's `contents`.
         public init(path: String, contents: String) {
             self.path = path
             self.contents = contents
         }
     }
 
+    /// Runs every deterministic convention heuristic over `files` and composes the results into
+    /// one ``ProjectConventions`` value. Heuristics with no signal (no headings, no alt text, …)
+    /// yield zero-confidence values rather than guesses, so downstream guidance can tell
+    /// "learned" from "unknown" — see `BrandVoiceGuidance.hasSignal`.
     public static func extract(files: [ScannedFile]) -> ProjectConventions {
         var conventions = ProjectConventions.empty
         conventions.writing.headingCapitalization = headingCapitalizationConvention(files: files)

--- a/Sources/AnglesiteCore/ProjectConventionsStore.swift
+++ b/Sources/AnglesiteCore/ProjectConventionsStore.swift
@@ -11,6 +11,9 @@ public actor ProjectConventionsStore {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
+    /// Points the store at `<configDirectory>/conventions.json`. Encoding uses sorted keys and
+    /// ISO 8601 dates so successive saves of equal values are byte-identical (stable for
+    /// change-detection and debugging); `fileManager` is injectable for tests.
     public init(configDirectory: URL, fileManager: FileManager = .default) {
         self.fileURL = configDirectory.appendingPathComponent("conventions.json")
         self.fileManager = fileManager
@@ -23,11 +26,17 @@ public actor ProjectConventionsStore {
         self.decoder = decoder
     }
 
+    /// The stored conventions, or `nil` when the file is absent or undecodable. Both collapse
+    /// to `nil` deliberately: conventions are a derived cache, so a missing or stale-schema file
+    /// just means "re-extract from the site source" — never an error worth surfacing.
     public func load() -> ProjectConventions? {
         guard let data = try? Data(contentsOf: fileURL) else { return nil }
         return try? decoder.decode(ProjectConventions.self, from: data)
     }
 
+    /// Persists `conventions` atomically, creating the `Config/` directory if needed. Failures
+    /// are swallowed for the same reason ``load()`` returns `nil`: the file is a re-derivable
+    /// cache, and a failed write must never break the feature that triggered the extraction.
     public func save(_ conventions: ProjectConventions) {
         guard let data = try? encoder.encode(conventions) else { return }
         try? fileManager.createDirectory(

--- a/Sources/AnglesiteCore/ReceivedInteraction.swift
+++ b/Sources/AnglesiteCore/ReceivedInteraction.swift
@@ -14,17 +14,25 @@ import Foundation
 public struct ReceivedInteraction: Codable, Sendable, Equatable, Identifiable {
     /// Protocol source of the interaction.
     public enum ProtocolType: String, Codable, Sendable, Equatable {
+        /// Delivered to the site's Webmention endpoint (IndieWeb).
         case webmention
+        /// Delivered via ActivityPub (fediverse) federation.
         case activitypub
+        /// Created through the site's Micropub endpoint.
         case micropub
     }
 
     /// What kind of interaction this represents.
     public enum InteractionType: String, Codable, Sendable, Equatable {
+        /// A comment on the target — the only kind that renders threaded (``isComment``).
         case reply
+        /// A like/favourite of the target — rendered as a facepile avatar, not a comment.
         case like
+        /// A reshare/boost of the target — rendered as a facepile avatar, not a comment.
         case repost
+        /// The sender bookmarked the target.
         case bookmark
+        /// The source page links to the target without any more specific relation.
         case mention
 
         /// Whether this interaction renders as a threaded comment.
@@ -35,8 +43,11 @@ public struct ReceivedInteraction: Codable, Sendable, Equatable, Identifiable {
 
     /// Verification state of the interaction.
     public enum VerificationStatus: String, Codable, Sendable, Equatable {
+        /// The Worker fetched the source and confirmed it really links to the target.
         case verified
+        /// Verification hasn't completed yet.
         case pending
+        /// The source couldn't be verified — unreachable, or it no longer links to the target.
         case failed
     }
 
@@ -45,10 +56,15 @@ public struct ReceivedInteraction: Codable, Sendable, Equatable, Identifiable {
     /// This is not live-updated — if the sender changes their name/photo, the old values
     /// persist in the snapshot. This is standard IndieWeb practice.
     public struct Author: Codable, Sendable, Equatable {
+        /// Display name at verification time, if the source exposed one.
         public let name: String?
+        /// The author's profile URL, if the source exposed one.
         public let url: URL?
+        /// Avatar URL at verification time, if the source exposed one.
         public let photo: URL?
 
+        /// Creates a snapshot. Every field is optional because sources routinely omit author
+        /// metadata — a like from a bare URL is still a valid interaction.
         public init(name: String?, url: URL?, photo: URL?) {
             self.name = name
             self.url = url
@@ -83,10 +99,17 @@ public struct ReceivedInteraction: Codable, Sendable, Equatable, Identifiable {
     /// For example: `"data/interactions/wm-abc123.json"`
     public var gitPath: String { "data/interactions/\(id).json" }
 
+    /// Construction-time failures enforcing the type-level sanitisation contract.
     public enum ValidationError: Error, Sendable {
+        /// The given `id` contains characters outside `[A-Za-z0-9_-]`, which could otherwise
+        /// traverse paths through ``ReceivedInteraction/gitPath``.
         case invalidID(String)
     }
 
+    /// Creates an interaction, validating `id` against `[A-Za-z0-9_-]+` first — the sanitisation
+    /// contract that keeps ``gitPath`` path-traversal-safe (see the type-level doc).
+    ///
+    /// - Throws: ``ValidationError/invalidID(_:)`` when `id` contains any other character.
     public init(
         id: String,
         type: ProtocolType,

--- a/Sources/AnglesiteCore/RedirectsStore.swift
+++ b/Sources/AnglesiteCore/RedirectsStore.swift
@@ -9,17 +9,29 @@ import Foundation
 /// this type only owns the read/write/validate contract the app's Redirects UI and the delete
 /// flow use to produce that file.
 public struct RedirectsStore: Sendable {
+    /// One ordered redirect rule, as serialized in `redirects.json`.
     public struct RedirectEntry: Sendable, Equatable, Codable, Identifiable {
+        /// HTTP status the redirect responds with; raw values are the wire status codes, so
+        /// they round-trip through JSON unchanged.
         public enum Code: Int, Sendable, Codable, CaseIterable {
+            /// 301 — the move is permanent; browsers and crawlers may cache it indefinitely.
             case permanent = 301
+            /// 302 — temporary; clients keep re-checking the original URL.
             case temporary = 302
         }
 
+        /// Identity is the `source` path — ``RedirectsStore/validate(_:)`` rejects duplicate
+        /// sources, so it's unique within any saved list.
         public var id: String { source }
+        /// The site-absolute path being redirected away from; must start with `/`.
         public var source: String
+        /// Where the redirect goes: a site-absolute path or an absolute `http(s)://` URL.
         public var destination: String
+        /// The HTTP status to respond with.
         public var code: Code
 
+        /// Creates an entry. `code` defaults to permanent (301) — the right answer for the
+        /// common "page moved" case the Redirects UI serves.
         public init(source: String, destination: String, code: Code = .permanent) {
             self.source = source
             self.destination = destination
@@ -27,21 +39,33 @@ public struct RedirectsStore: Sendable {
         }
     }
 
+    /// Invariants ``RedirectsStore/validate(_:)`` enforces before anything reaches disk. Each case carries the
+    /// offending value(s) so the Redirects UI can point at the exact bad row.
     public enum ValidationError: Error, Equatable {
+        /// `source` isn't a site-absolute path starting with `/`.
         case sourceMustStartWithSlash(String)
+        /// Two entries share a `source` — only one rule can match a given path, and `source`
+        /// is also the entry's `Identifiable` identity.
         case duplicateSource(String)
         /// A direct cycle: either `source == destination`, or an existing entry's destination is
         /// this entry's source and vice versa. Deep chains (A→B→C) are not resolved or rejected —
         /// matches Cloudflare's own behavior of following each hop independently.
         case cycle(String, String)
+        /// `source` contains whitespace, which can't appear in a URL path.
         case sourceContainsWhitespace(String)
+        /// `destination` contains whitespace, which can't appear in a URL.
         case destinationContainsWhitespace(String)
+        /// `destination` is neither a site-absolute path nor an absolute `http(s)://` URL —
+        /// relative destinations would resolve differently per requesting page.
         case destinationMustBeAbsolutePathOrURL(String)
     }
 
     private let fileURL: URL
     private let fileManager: FileManager
 
+    /// Roots the store at `<sourceDirectory>/redirects.json` — inside the `Source/` git repo,
+    /// per the type-level rationale that redirects are site content, not app state.
+    /// `fileManager` is injectable for tests.
     public init(sourceDirectory: URL, fileManager: FileManager = .default) {
         self.fileURL = sourceDirectory.appendingPathComponent("redirects.json")
         self.fileManager = fileManager
@@ -55,6 +79,13 @@ public struct RedirectsStore: Sendable {
         return try JSONDecoder().decode([RedirectEntry].self, from: data)
     }
 
+    /// Validates, then writes the full entry list (pretty-printed, sorted keys, atomic — the
+    /// file is git-tracked and hand-readable, so diffs should stay minimal). Validation runs
+    /// here rather than only in the UI, so no code path can persist a file the template-side
+    /// build integration would choke on.
+    ///
+    /// - Throws: A ``ValidationError`` before touching disk, or the underlying encode/write
+    ///   error.
     public func save(_ entries: [RedirectEntry]) throws {
         try Self.validate(entries)
         let encoder = JSONEncoder()
@@ -63,6 +94,12 @@ public struct RedirectsStore: Sendable {
         try data.write(to: fileURL, options: .atomic)
     }
 
+    /// Checks the whole list's invariants: absolute sources, no whitespace, valid destinations,
+    /// no duplicate sources, no direct cycles. Static (and separate from ``save(_:)``) so the
+    /// Redirects UI can validate a draft list live without constructing a store or touching disk.
+    ///
+    /// - Throws: A ``ValidationError`` for the first violation found (per-entry rules are
+    ///   checked before the cycle pass).
     public static func validate(_ entries: [RedirectEntry]) throws {
         var seenSources = Set<String>()
         var destinationBySource: [String: String] = [:]

--- a/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
+++ b/Sources/AnglesiteCore/RemoteSandboxSiteRuntime.swift
@@ -7,6 +7,9 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
     private let gitRemote: URL
     private let gitRef: String
     private let control: any SandboxControlClient
+    /// The per-site MCP connection the edit pipeline routes through. `start` connects it to the
+    /// session's MCP tunnel URL with the freshly-minted bearer token, so consumers always talk to
+    /// the sandbox this runtime most recently booted.
     public let mcpClient: MCPClient
     private let mintToken: @Sendable () -> SessionToken
     private let connect: @Sendable (MCPClient, URL, SessionToken) async throws -> Void
@@ -14,6 +17,20 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
     private let stateMachine = SiteRuntimeStateMachine()
     private var activeSiteID: String?
 
+    /// Creates a runtime bound to one git remote+ref, with injectable token-minting and
+    /// MCP-connect steps.
+    ///
+    /// - Parameters:
+    ///   - gitRemote: The site's canonical `Source/` repository — the sandbox clones this, per
+    ///     "git is the source of truth" (#72); there is no local working copy on iOS.
+    ///   - gitRef: The ref the sandbox checks out from `gitRemote`.
+    ///   - control: The Control Worker RPC seam that boots/stops the sandbox session.
+    ///   - mcpClient: The client `connect` wires to the session's MCP tunnel; exposed as
+    ///     ``mcpClient`` for the edit pipeline.
+    ///   - mintToken: Test seam for the per-session bearer secret; defaults to
+    ///     ``SessionToken/mint()``.
+    ///   - connect: Test seam for the MCP-connect step, so tests can observe/fail the handshake
+    ///     without a real HTTP transport; defaults to `MCPClient.connect(httpEndpoint:bearerToken:)`.
     public init(
         gitRemote: URL,
         gitRef: String,
@@ -32,8 +49,12 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
         self.connect = connect
     }
 
+    /// The current lifecycle state, read from the shared `SiteRuntimeStateMachine` so it always
+    /// reflects the most recent (non-superseded) start/stop attempt.
     public var state: SiteRuntimeState { stateMachine.state }
 
+    /// Streams every ``SiteRuntimeState`` transition, starting with the current state — the UI's
+    /// single source for spinner/ready/failure rendering.
     public func observe() -> AsyncStream<SiteRuntimeState> {
         stateMachine.observe()
     }
@@ -61,6 +82,8 @@ public actor RemoteSandboxSiteRuntime: SiteRuntime {
         }
     }
 
+    /// Tears down the session and settles to `.idle` — unless a start()/stop() issued while this
+    /// one was suspended has superseded it, in which case the newer attempt owns the state.
     public func stop() async {
         let gen = stateMachine.beginAttempt()
         await teardown()

--- a/Sources/AnglesiteCore/RepoBootstrap.swift
+++ b/Sources/AnglesiteCore/RepoBootstrap.swift
@@ -14,13 +14,34 @@ import SwiftGit2
 /// (subprocess `gh`/`git`) elsewhere, where there's no sandbox to route around.
 /// `RepoCommandRunner` remains the seam `GHRepoProvider` and the off-Darwin preflight fallback use.
 public actor RepoBootstrap {
-    public enum Step: Sendable, Equatable { case checkingRemote, initializing, committing, creatingRepo, pushing }
+    /// The publish pipeline's phases, in execution order — carried by
+    /// ``RepoBootstrap/Event/progress(step:message:)`` so the UI can show which stage is running
+    /// rather than an opaque spinner.
+    public enum Step: Sendable, Equatable {
+        /// Reading `origin` to detect an already-published site (the idempotence check).
+        case checkingRemote
+        /// Creating a git repository in a directory that isn't one yet.
+        case initializing
+        /// Staging the working tree and creating the initial commit.
+        case committing
+        /// Creating the repository on GitHub via the `RepoProvider`.
+        case creatingRepo
+        /// Wiring `origin` and pushing the local history up.
+        case pushing
+    }
 
+    /// One update from the `publish` stream. Terminal events are ``published(_:)``,
+    /// ``needsAuth``, and ``failed(reason:)`` — the stream finishes right after emitting one.
     public enum Event: Sendable, Equatable {
+        /// A stage started (or completed, for `.pushing`); `message` is user-facing progress text.
         case progress(step: Step, message: String)
         /// Provider has no credentials. The UI presents a GitHub token prompt, then retries `publish`.
         case needsAuth
+        /// The site is on GitHub — either just pushed, or detected as already published (in which
+        /// case no other event precedes it).
         case published(RemoteRepo)
+        /// The pipeline stopped; `reason` is the user-facing explanation (a `RepoBootstrapError`'s
+        /// reason when the failure was anticipated, a raw error description otherwise).
         case failed(reason: String)
     }
 
@@ -28,6 +49,9 @@ public actor RepoBootstrap {
     private let run: RepoCommandRunner
     private let env = URL(fileURLWithPath: "/usr/bin/env")
 
+    /// Injection seam for tests: pass a fake ``RepoProvider`` and ``RepoCommandRunner`` to drive
+    /// the pipeline without touching GitHub or spawning processes. Production wiring comes from
+    /// ``live(supervisor:logCenter:)``.
     public init(provider: RepoProvider, run: @escaping RepoCommandRunner) {
         self.provider = provider
         self.run = run

--- a/Sources/AnglesiteCore/RepoBootstrapTypes.swift
+++ b/Sources/AnglesiteCore/RepoBootstrapTypes.swift
@@ -2,10 +2,16 @@ import Foundation
 
 /// A site's GitHub remote, derived from `origin`. Source of truth for "is this site published?".
 public struct RemoteRepo: Sendable, Equatable {
-    public let url: URL      // browser URL, e.g. https://github.com/owner/name
+    /// Browser URL, e.g. `https://github.com/owner/name` — always https, regardless of whether
+    /// the remote itself was an ssh URL.
+    public let url: URL
+    /// The GitHub account or organization owning the repository.
     public let owner: String
+    /// The repository name, with any `.git` suffix already stripped.
     public let name: String
 
+    /// Memberwise initializer; prefer ``parse(remoteURL:)``, which derives all three fields
+    /// consistently from a raw remote URL.
     public init(url: URL, owner: String, name: String) {
         self.url = url
         self.owner = owner
@@ -54,8 +60,13 @@ public struct RemoteRepo: Sendable, Equatable {
 
 /// User-facing failure from the bootstrap pipeline.
 public struct RepoBootstrapError: LocalizedError, Equatable, Sendable {
+    /// The user-facing explanation — written for the site owner (what went wrong and what to do),
+    /// not as a git diagnostic. Surfaced verbatim via `RepoBootstrap.Event.failed`.
     public let reason: String
+    /// Wraps a user-facing failure message.
     public init(reason: String) { self.reason = reason }
+    /// `LocalizedError` conformance so `error.localizedDescription` shows `reason` rather than a
+    /// generic "operation couldn't be completed".
     public var errorDescription: String? { reason }
 }
 
@@ -77,13 +88,21 @@ public struct GHRepoProvider: RepoProvider {
     private let run: RepoCommandRunner
     private let env = URL(fileURLWithPath: "/usr/bin/env")
 
+    /// Creates a provider that runs `gh`/`git` through the given runner — injectable so tests can
+    /// script subprocess results without spawning anything.
     public init(run: @escaping RepoCommandRunner) { self.run = run }
 
+    /// True when `gh auth status` exits 0 — i.e. the user's own `gh` login is usable. No token is
+    /// read or stored app-side.
     public func isAuthenticated() async -> Bool {
         guard let r = try? await run(env, ["gh", "auth", "status"], nil) else { return false }
         return r.exitCode == 0
     }
 
+    /// `gh repo create --source … --push` in one shot, then reads `origin` back as the source of
+    /// truth rather than parsing `gh`'s human-oriented output. Throws ``RepoBootstrapError`` with
+    /// the first non-empty stderr line so the owner sees `gh`'s own explanation (name taken,
+    /// scope missing, …).
     public func createAndPush(name: String, isPrivate: Bool, source: URL) async throws -> RemoteRepo {
         let visibility = isPrivate ? "--private" : "--public"
         // `--` terminates flag parsing, so `name` (the positional) must come last, after all flags —

--- a/Sources/AnglesiteCore/RepoRelocator.swift
+++ b/Sources/AnglesiteCore/RepoRelocator.swift
@@ -18,6 +18,8 @@ public enum RepoRelocator {
     /// `gitdir:` pointer content, relative from `Source/` to `Config/repo.nosync/`.
     static let gitfileContents = "gitdir: ../Config/repo.nosync\n"
 
+    /// What ``migrate(package:fileManager:)`` found and did. Distinguishing the no-op cases lets
+    /// callers (and tests) verify heal-on-open really was a no-op rather than silently redoing work.
     public enum MigrationResult: Sendable, Equatable {
         /// Moved an embedded `Source/.git` directory to `Config/repo.nosync/` and wrote the
         /// gitfile, or completed an interrupted prior migration (repo already relocated, gitfile
@@ -31,6 +33,8 @@ public enum RepoRelocator {
         case noRepository
     }
 
+    /// The states ``migrate(package:fileManager:)`` refuses to resolve automatically — both are
+    /// "a human (or a later sync phase) must decide" situations, never data-loss candidates.
     public enum RelocationError: Error, Equatable, Sendable, LocalizedError {
         /// `Source/.git` is a gitfile, but its target `Config/repo.nosync/` doesn't exist on this
         /// Mac. This is the "fresh peer" case — a package synced in from iCloud before its live
@@ -41,6 +45,8 @@ public enum RepoRelocator {
         /// `RepoRelocator` refuses to resolve automatically rather than risk discarding history.
         case conflictingRepositories(embedded: URL, live: URL)
 
+        /// Owner-facing wording: phrased around consequences to the site ("history hasn't arrived
+        /// yet"), not git mechanics, per the app's advise-don't-delegate rule.
         public var errorDescription: String? {
             switch self {
             case .danglingGitfile(let url):

--- a/Sources/AnglesiteCore/RepurposePlatformSpecs.swift
+++ b/Sources/AnglesiteCore/RepurposePlatformSpecs.swift
@@ -3,13 +3,20 @@ import Foundation
 /// Per-platform constraints for repurposed posts — the repurpose skill's table as Swift data.
 /// Char limits are enforced in Swift (spec §5.3), never trusted to the model.
 public struct PlatformPostSpec: Sendable, Equatable {
+    /// Display name of the platform, used verbatim in the chat reply and generation prompts.
     public let platform: String
+    /// Hard character ceiling, enforced deterministically via ``RepurposePlatformSpecs/fits(_:spec:)``
+    /// — an over-limit variant is rejected, not trimmed by the model.
     public let charLimit: Int
     /// Whether the post should end with the canonical post URL (Instagram strips links).
     public let includesURL: Bool
+    /// Whether hashtags are idiomatic on this platform (they read as spam on Facebook/Nextdoor).
     public let allowsHashtags: Bool
+    /// Free-form tone/format guidance fed into the generation prompt for this platform.
     public let styleHint: String
 
+    /// Memberwise initializer — public so tests (and any future user-configurable platform list)
+    /// can build specs beyond the built-in ``RepurposePlatformSpecs/all`` table.
     public init(platform: String, charLimit: Int, includesURL: Bool, allowsHashtags: Bool, styleHint: String) {
         self.platform = platform
         self.charLimit = charLimit
@@ -19,7 +26,10 @@ public struct PlatformPostSpec: Sendable, Equatable {
     }
 }
 
+/// The built-in platform table the repurpose feature targets (#465). Kept as Swift data (not
+/// model output or user config) so the char limits below are always the ones actually enforced.
 public enum RepurposePlatformSpecs {
+    /// Every platform a post is repurposed for, in the order variants appear in the chat reply.
     public static let all: [PlatformPostSpec] = [
         PlatformPostSpec(platform: "Instagram", charLimit: 2200, includesURL: false, allowsHashtags: true,
                          styleHint: "engaging caption; mention 'link in bio'; end with a handful of relevant hashtags"),
@@ -35,6 +45,8 @@ public enum RepurposePlatformSpecs {
                          styleHint: "punchy single post"),
     ]
 
+    /// The deterministic length gate (spec §5.3): character count against ``PlatformPostSpec/charLimit``,
+    /// in Swift, so a model that ignores its length instruction can't ship an over-limit post.
     public static func fits(_ text: String, spec: PlatformPostSpec) -> Bool {
         text.count <= spec.charLimit
     }

--- a/Sources/AnglesiteCore/RepurposePostTool.swift
+++ b/Sources/AnglesiteCore/RepurposePostTool.swift
@@ -5,6 +5,9 @@ public enum RepurposeReply {
     /// Prepended to the reply when the site has no configured domain — links would be wrong.
     public static let missingDomainWarning = "Note: this site has no domain configured, so links below use example.com — set your domain before posting."
 
+    /// Renders the variants as one copy-pasteable chat reply. Per-platform failures are shown
+    /// inline rather than dropped, and the framing reiterates that Anglesite never posts on the
+    /// owner's behalf — publishing stays a human act (the POSSE model, #465).
     public static func text(postTitle: String, variants: [PlatformPostVariant]) -> String {
         var lines = ["Platform posts for \"\(postTitle)\" — copy-paste what you like (Anglesite never posts for you):", ""]
         for v in variants {
@@ -28,12 +31,20 @@ import FoundationModels
 
 /// Chat front-door for repurposing one post into per-platform variants (#465).
 public struct RepurposePostTool: Tool, Sendable {
+    /// Stable wire name, kept as a static so registration/telemetry sites can reference it
+    /// without constructing the tool.
     public static let toolName = "repurposePost"
+    /// `Tool` conformance: the name the model calls this tool by.
     public let name = RepurposePostTool.toolName
+    /// `Tool` conformance: model-facing usage guidance. The "do not search first" instruction
+    /// exists because models otherwise chain a content search before calling, and a stale/empty
+    /// search result talks them out of a call that would have succeeded.
     public let description = "Turn one published blog post into ready-to-paste social posts for each platform (Instagram, Facebook, Google Business, Nextdoor, X, Bluesky), respecting each platform's length rules. If the user gives you a slug, call this directly with it — do not search for the post first; this tool reads the post from disk and will find it even if a prior search came back empty."
 
+    /// Model-generated arguments; the `@Guide` text is what steers the model, this is just its shape.
     @Generable
     public struct Arguments {
+        /// The post's content-collection slug (filename without extension).
         @Guide(description: "The post's slug, e.g. 'coast-trip' for src/content/posts/coast-trip.mdoc.")
         public var slug: String
     }
@@ -43,6 +54,9 @@ public struct RepurposePostTool: Tool, Sendable {
     private let siteID: String
     private let siteDirectory: URL
 
+    /// Creates the tool. `repurposer` is a protocol seam so tests exercise the tool without
+    /// on-device inference; `conventionsStore` is optional because a site may not have learned
+    /// conventions yet — the brand-voice preamble degrades to defaults rather than blocking.
     public init(repurposer: any PostRepurposing, conventionsStore: ProjectConventionsStore?,
                 siteID: String, siteDirectory: URL) {
         self.repurposer = repurposer
@@ -51,6 +65,11 @@ public struct RepurposePostTool: Tool, Sendable {
         self.siteDirectory = siteDirectory
     }
 
+    /// Loads the post from disk, resolves the site's domain from `.site-config`, and renders
+    /// every platform variant as one copy-pasteable reply. With no domain configured, links fall
+    /// back to example.com behind an explicit warning — never silently wrong URLs. Failures are
+    /// conversational strings, not thrown errors: a throw would surface to the model, not the
+    /// owner.
     public func call(arguments: Arguments) async throws -> String {
         guard let post = PostSource.load(slug: arguments.slug, sourceDirectory: siteDirectory) else {
             return "I couldn't find a post with the slug \"\(arguments.slug)\"."
@@ -75,21 +94,36 @@ public struct RepurposePostTool: Tool, Sendable {
 /// Deterministic POSSE write-back (#465): records published-copy URLs into the post's
 /// `syndication:` frontmatter. No FM involved.
 public struct SaveSyndicationTool: Tool, Sendable {
+    /// Stable wire name, kept as a static so registration/telemetry sites can reference it
+    /// without constructing the tool.
     public static let toolName = "saveSyndication"
+    /// `Tool` conformance: the name the model calls this tool by.
     public let name = SaveSyndicationTool.toolName
+    /// `Tool` conformance: model-facing usage guidance. "Call after the owner has posted" is
+    /// load-bearing — publishing itself stays a human act (the POSSE model, #465); this tool
+    /// only records the trail.
     public let description = "Record the published social-post URLs on a blog post's syndication list (POSSE trail). Call after the owner has posted and shared the URLs."
 
+    /// Model-generated arguments; the `@Guide` text is what steers the model, this is just
+    /// its shape.
     @Generable
     public struct Arguments {
+        /// The post's content-collection slug (filename without extension).
         @Guide(description: "The post's slug.")
         public var slug: String
+        /// The published URLs, comma-separated; split leniently on the model's behalf via
+        /// `BrandVoiceInterview.list`.
         @Guide(description: "The published URLs, comma-separated.")
         public var urls: String
     }
 
     private let siteDirectory: URL
+    /// Creates the tool for one site's `Source/` tree.
     public init(siteDirectory: URL) { self.siteDirectory = siteDirectory }
 
+    /// Appends the URLs to the post's `syndication:` frontmatter on disk (via
+    /// `SyndicationFrontmatter.adding`). Replies — including failures — are conversational
+    /// strings rather than thrown errors, because they reach the owner through the model.
     public func call(arguments: Arguments) async throws -> String {
         guard let post = PostSource.load(slug: arguments.slug, sourceDirectory: siteDirectory) else {
             return "I couldn't find a post with the slug \"\(arguments.slug)\"."

--- a/Sources/AnglesiteCore/RetrievedCitation.swift
+++ b/Sources/AnglesiteCore/RetrievedCitation.swift
@@ -3,13 +3,21 @@ import Foundation
 /// A lightweight value type representing one file cited during RAG retrieval. Carries enough
 /// for the chat UI to render a chip and navigate to the file without reaching back into the index.
 public struct RetrievedCitation: Sendable, Equatable, Identifiable {
+    /// The cited document's stable id in the knowledge index.
     public let id: String
+    /// Project-relative path of the cited file — what chip navigation opens.
     public let path: String
+    /// What kind of document was cited (page, post, …), copied from the index entry.
     public let kind: SiteKnowledgeIndex.Document.Kind
+    /// Human-readable title, when the document has one; the UI falls back to ``path``.
     public let title: String?
+    /// Line span of the matched chunk within the file, when retrieval was chunk-scoped —
+    /// lets navigation land on the relevant passage, not just the file.
     public let lineRange: ClosedRange<Int>?
+    /// Retrieval relevance score, kept for ordering and debugging rather than display.
     public let score: Double
 
+    /// Memberwise creation, for tests and callers that already hold the fields.
     public init(id: String, path: String, kind: SiteKnowledgeIndex.Document.Kind, title: String?, lineRange: ClosedRange<Int>?, score: Double) {
         self.id = id
         self.path = path
@@ -19,6 +27,9 @@ public struct RetrievedCitation: Sendable, Equatable, Identifiable {
         self.score = score
     }
 
+    /// Projects a ``SiteKnowledgeIndex/SearchResult`` down to just the citation fields — the
+    /// point of this type: the chat UI keeps the chip metadata without retaining the indexed
+    /// document content behind it.
     public init(_ result: SiteKnowledgeIndex.SearchResult) {
         self.init(
             id: result.document.id,

--- a/Sources/AnglesiteCore/ReviewCopyTool.swift
+++ b/Sources/AnglesiteCore/ReviewCopyTool.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Pure chat rendering of a `CopyEditReport`, non-gated for CI tests. `capped` is non-nil when
 /// a site-wide audit was truncated to the tool's chunk budget (no silent caps — spec §6).
 public enum ReviewCopyReply {
+    /// Renders the report as one chat reply: findings as severity-tagged bullets with their
+    /// suggested rewrites, plus explicit lines for skipped routes and any cap — the reply always
+    /// discloses what wasn't reviewed (no silent caps — spec §6).
     public static func text(for report: CopyEditReport, capped: Int?) -> String {
         if let unavailableMessage = report.unavailableMessage {
             return unavailableMessage
@@ -43,13 +46,25 @@ import FoundationModels
 /// site-wide pass capped at `maxSiteChunks` chunks (a chat turn shouldn't run for minutes — the
 /// GUI report is the uncapped surface, and the cap is always disclosed in the reply).
 public struct ReviewCopyTool: Tool, Sendable {
+    /// Stable wire name, kept as a static so registration/telemetry sites can reference it
+    /// without constructing the tool.
     public static let toolName = "reviewCopy"
+    /// Chunk budget for a site-wide chat audit — bounds a chat turn's latency. The GUI report
+    /// is the uncapped surface, and hitting this cap is always disclosed in the reply.
     public static let maxSiteChunks = 8
+    /// `Tool` conformance: the name the model calls this tool by.
     public let name = ReviewCopyTool.toolName
+    /// `Tool` conformance: model-facing usage guidance. The "do not search first" instruction
+    /// exists because models otherwise chain a content search before calling, and a stale/empty
+    /// search result talks them out of a call that would have succeeded.
     public let description = "Review the site's written copy for clarity, tone, calls to action, and jargon. Pass a route (like '/about') for one page, or omit it to review the site. If the user gives you a route, call this directly with it — do not search for the page first; this tool reads pages from disk and will find them even if a prior search came back empty."
 
+    /// Model-generated arguments; the `@Guide` text is what steers the model, this is just
+    /// its shape.
     @Generable
     public struct Arguments {
+        /// Page route to audit (e.g. `/about`); `nil` or empty audits the whole site under
+        /// the chunk cap.
         @Guide(description: "Page route to review (e.g. '/about'). Omit to review the whole site.")
         public var route: String?
     }
@@ -59,6 +74,9 @@ public struct ReviewCopyTool: Tool, Sendable {
     private let siteID: String
     private let siteDirectory: URL
 
+    /// Creates the tool. `auditor` is a protocol seam so tests exercise the tool without
+    /// on-device inference; `conventionsStore` is optional because a site may not have learned
+    /// conventions yet — the brand-voice preamble degrades to defaults rather than blocking.
     public init(auditor: any CopyEditAuditing, conventionsStore: ProjectConventionsStore?,
                 siteID: String, siteDirectory: URL) {
         self.auditor = auditor
@@ -67,6 +85,10 @@ public struct ReviewCopyTool: Tool, Sendable {
         self.siteDirectory = siteDirectory
     }
 
+    /// Chunks the site from disk, narrows to the requested route (or applies the site-wide
+    /// cap), runs the audit with the brand-voice preamble, and renders the report via
+    /// `ReviewCopyReply`. "Couldn't find" outcomes are conversational strings, not thrown
+    /// errors — a throw would surface to the model, not the owner.
     public func call(arguments: Arguments) async throws -> String {
         var chunks = SiteContentChunker.chunks(sourceDirectory: siteDirectory)
         var capped: Int? = nil

--- a/Sources/AnglesiteCore/RouteCoverageScanner.swift
+++ b/Sources/AnglesiteCore/RouteCoverageScanner.swift
@@ -5,6 +5,17 @@ import Foundation
 /// covering it. Pure `SiteContentGraph`/`RedirectsStore` diffing — no JS/plugin involvement,
 /// unlike the rest of `PreDeployCheck`'s checks.
 public enum RouteCoverageScanner {
+    /// Returns one orphaned-route warning per previously-published route that is neither still
+    /// published nor covered by a redirect. Warnings, not failures — removing a page can be
+    /// intentional, so the owner decides (the remediation text offers both paths).
+    ///
+    /// - Parameters:
+    ///   - currentRoutes: The route set about to be deployed.
+    ///   - previousRoutes: The snapshot from the last deploy. `nil` (no snapshot yet — first
+    ///     deploy, or pre-snapshot sites) returns `[]`: with no baseline there is nothing to
+    ///     diff, and warning on every route would teach owners to ignore the check.
+    ///   - redirectSources: `source` paths from `redirects.json`; a vanished route with a
+    ///     matching redirect is covered, not orphaned.
     public static func scan(
         currentRoutes: [String],
         previousRoutes: [String]?,

--- a/Sources/AnglesiteCore/SandboxControlClient.swift
+++ b/Sources/AnglesiteCore/SandboxControlClient.swift
@@ -3,33 +3,50 @@ import Foundation
 /// The two tunnel URLs a started remote session exposes: the preview (auth-proxy port) and the
 /// in-container MCP server. Both are `*.trycloudflare.com` quick-tunnel URLs.
 public struct SandboxSession: Sendable, Equatable {
+    /// URL of the auth-proxied dev-server preview the WKWebView loads.
     public let previewURL: URL
+    /// URL of the in-container MCP server (HTTP/Streamable transport).
     public let mcpURL: URL
+    /// Wraps the two tunnel URLs the Control Worker returned from `start`.
     public init(previewURL: URL, mcpURL: URL) {
         self.previewURL = previewURL
         self.mcpURL = mcpURL
     }
 }
 
+/// Reachability snapshot of a remote session's two endpoints. Tracked per-endpoint because the
+/// preview proxy and the MCP server come up independently — the UI can show partial progress
+/// instead of one opaque spinner.
 public struct SandboxStatus: Sendable, Equatable {
+    /// The site whose sandbox was probed.
     public let siteID: String
+    /// Whether the in-guest preview proxy answered the probe.
     public let previewReady: Bool
+    /// Whether the in-container MCP endpoint answered the probe.
     public let mcpReady: Bool
 
+    /// Memberwise creation from the Control Worker's status response.
     public init(siteID: String, previewReady: Bool, mcpReady: Bool) {
         self.siteID = siteID
         self.previewReady = previewReady
         self.mcpReady = mcpReady
     }
 
+    /// Fully usable: both endpoints are reachable.
     public var isReady: Bool { previewReady && mcpReady }
 }
 
+/// Failures from the Control Worker seam, categorized by what the caller should do next
+/// (onboard, re-auth, retry, surface) rather than by transport detail.
 public enum SandboxControlError: Error, Equatable {
-    case notProvisioned          // no Control Worker / token on file → route to onboarding
-    case unauthorized            // token rejected by the Worker
-    case unreachable(String)     // network / DNS
-    case startFailed(String)     // Worker reported a boot/clone/hydrate failure
+    /// No Control Worker / token on file → route to onboarding.
+    case notProvisioned
+    /// Token rejected by the Worker.
+    case unauthorized
+    /// Network / DNS failure reaching the Worker.
+    case unreachable(String)
+    /// Worker reported a boot/clone/hydrate failure.
+    case startFailed(String)
 }
 
 /// Typed wrapper over the user's Control Worker RPCs. The HTTPS impl (`HTTPSandboxControlClient`)

--- a/Sources/AnglesiteCore/SaveBrandVoiceTool.swift
+++ b/Sources/AnglesiteCore/SaveBrandVoiceTool.swift
@@ -2,6 +2,11 @@ import Foundation
 
 /// Pure reply strings for the brand-voice tool, non-gated for CI tests.
 public enum SaveBrandVoiceReply {
+    /// The tool's user-visible reply, listing exactly which answer categories were captured so
+    /// the owner can spot (and correct) a field the model dropped during the interview. When
+    /// every field is empty it returns the "didn't save" message instead — mirroring the
+    /// ``BrandVoiceWriter/hasContent(_:)`` guard the tool applies before writing, so the reply
+    /// never claims a save that didn't happen.
     public static func confirmation(for answers: BrandVoiceAnswers) -> String {
         var saved: [String] = []
         if !answers.audience.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { saved.append("audience") }
@@ -26,18 +31,32 @@ import FoundationModels
 /// engine `ProjectConventionsModel`'s Style Guide sheet writes through — so a chat-driven save
 /// can't be silently reverted by a later GUI override write persisting a stale engine snapshot.
 public struct SaveBrandVoiceTool: Tool, Sendable {
+    /// The tool's stable name. Exposed statically so callers (e.g. `FoundationModelAssistant`'s
+    /// `.started` event) can report the attached tools without constructing an instance.
     public static let toolName = "saveBrandVoice"
+    /// `Tool` conformance — always ``SaveBrandVoiceTool/toolName``.
     public let name = SaveBrandVoiceTool.toolName
+    /// The tool card the model reads. Front-loads the interview protocol (one question at a
+    /// time, four specific questions) because the on-device model has no other channel for
+    /// learning how this tool expects to be driven.
     public let description = "Save the site's brand voice after interviewing the owner. Before calling, ask the owner (one question at a time): who the site speaks to, three personality words for the tone, brand/product terms with exact capitalization, and words or phrases to avoid."
 
+    /// The interview answers as the model collected them. Every field is optional so a partial
+    /// interview still saves what was gathered instead of failing outright.
     @Generable
     public struct Arguments {
+        /// Who the site speaks to, in the owner's own words. `nil`/empty saves nothing for
+        /// this field.
         @Guide(description: "Who the site speaks to, in the owner's words.")
         public var audience: String?
+        /// Comma-separated personality words; split by `BrandVoiceInterview.list` before saving.
         @Guide(description: "About three personality words, comma-separated (e.g. 'warm, expert, playful').")
         public var toneWords: String?
+        /// Comma-separated brand/product terms, capitalization preserved exactly — the point of
+        /// collecting them is to stop copy suggestions from re-casing them.
         @Guide(description: "Brand/product terms with their exact capitalization, comma-separated.")
         public var brandTerms: String?
+        /// Comma-separated words or phrases the owner never wants used.
         @Guide(description: "Words or phrases the owner never wants used, comma-separated.")
         public var avoidPhrases: String?
     }
@@ -46,12 +65,19 @@ public struct SaveBrandVoiceTool: Tool, Sendable {
     private let store: ProjectConventionsStore
     private let siteID: String
 
+    /// Binds the tool to one site's conventions engine and store. Pass the *shared* engine —
+    /// the same instance `ProjectConventionsModel`'s Style Guide sheet uses — or a chat-driven
+    /// save can be silently reverted by a later GUI write persisting a stale engine snapshot
+    /// (see the type doc).
     public init(engine: ProjectConventionsEngine, store: ProjectConventionsStore, siteID: String) {
         self.engine = engine
         self.store = store
         self.siteID = siteID
     }
 
+    /// Saves the collected answers (only when at least one field has content) and returns the
+    /// ``SaveBrandVoiceReply/confirmation(for:)`` string, so the reply's saved-category list and
+    /// the write are derived from the same normalized ``BrandVoiceAnswers`` and can't disagree.
     public func call(arguments: Arguments) async throws -> String {
         let answers = BrandVoiceAnswers(
             audience: arguments.audience ?? "",

--- a/Sources/AnglesiteCore/SearchContentTool.swift
+++ b/Sources/AnglesiteCore/SearchContentTool.swift
@@ -12,11 +12,19 @@ public struct SearchContentTool: Tool, Sendable {
     /// The tool's stable name. Exposed statically so callers (e.g. `FoundationModelAssistant`'s
     /// `.started` event) can report the attached tools without constructing an instance.
     public static let toolName = "searchContent"
+    /// `Tool` conformance — always ``SearchContentTool/toolName``.
     public let name = SearchContentTool.toolName
+    /// The tool card the model reads. Deliberately warns that this is a convenience lookup, not
+    /// the source of truth: without that framing the model treats a search miss as proof the
+    /// content doesn't exist and refuses to call slug/route-based tools it could have used
+    /// directly.
     public let description = "Search the current site's pages and posts by title, route, slug, tag, or collection. This is a convenience lookup, not the source of truth: if you already know a post's slug or a page's route (e.g. the user stated it), call the tool for that slug/route directly instead of searching first — a search miss does not prove the content doesn't exist."
 
+    /// The model-supplied search input.
     @Generable
     public struct Arguments {
+        /// Free-text query matched against page/post metadata (title, route, slug, tag,
+        /// collection) — not body text; that's `SearchKnowledgeTool`'s job.
         @Guide(description: "What to search for — words from a page title, route, post slug, tag, or collection.")
         public var query: String
     }
@@ -28,11 +36,17 @@ public struct SearchContentTool: Tool, Sendable {
     private let contentGraph: SiteContentGraph
     private let siteID: String
 
+    /// Binds the tool to one site's content graph; the model never supplies (and so can never
+    /// misdirect) the site it searches.
     public init(contentGraph: SiteContentGraph, siteID: String) {
         self.contentGraph = contentGraph
         self.siteID = siteID
     }
 
+    /// Runs the search and returns one `PAGE`/`POST` line per hit. Empty results distinguish an
+    /// index that's loaded (miss is reliable) from one that isn't (miss proves nothing), so the
+    /// model doesn't conclude content is missing just because indexing hasn't run. Output is
+    /// capped via `fairBudget` with an explicit per-category truncation trailer — never silent.
     public func call(arguments: Arguments) async throws -> String {
         let query = arguments.query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {

--- a/Sources/AnglesiteCore/SearchKnowledgeTool.swift
+++ b/Sources/AnglesiteCore/SearchKnowledgeTool.swift
@@ -10,12 +10,20 @@ import os
 /// index. Complements ``SearchContentTool``: content graph search finds known pages/posts by
 /// metadata, while this searches file contents across pages, components, layouts, config, and copy.
 public struct SearchKnowledgeTool: Tool, Sendable {
+    /// The tool's stable name. Exposed statically so callers (e.g. `FoundationModelAssistant`'s
+    /// `.started` event) can report the attached tools without constructing an instance.
     public static let toolName = "searchKnowledge"
+    /// `Tool` conformance — always ``SearchKnowledgeTool/toolName``.
     public let name = SearchKnowledgeTool.toolName
+    /// The tool card the model reads: nudges it to ground answers and edits in retrieved
+    /// project context rather than guessing at file contents.
     public let description = "Search the current Astro project for relevant files and excerpts before answering or editing."
 
+    /// The model-supplied search input.
     @Generable
     public struct Arguments {
+        /// Free-text query matched against file *contents* (pages, components, layouts, config,
+        /// copy) — metadata lookup by title/route/slug is ``SearchContentTool``'s job.
         @Guide(description: "Natural-language query or keywords to search for in the current project.")
         public var query: String
     }
@@ -26,12 +34,19 @@ public struct SearchKnowledgeTool: Tool, Sendable {
     private let siteID: String
     private let ranker: SemanticRanker?
 
+    /// Binds the tool to one site's knowledge index. Pass a ``SemanticRanker`` to rerank the
+    /// lexical candidate pool by blended lexical+semantic score; `nil` keeps pure lexical
+    /// ranking (the tool degrades to that at call time anyway when the ranker has no vectors).
     public init(index: SiteKnowledgeIndex, siteID: String, ranker: SemanticRanker? = nil) {
         self.index = index
         self.siteID = siteID
         self.ranker = ranker
     }
 
+    /// Returns up to six results, each a `KIND path:line - title` header plus a lexical excerpt.
+    /// With a ranker, a wider lexical pool is reranked by ``SemanticRanker/blend(lexical:semantic:semanticWeight:)``
+    /// so an on-topic-but-weak-keyword doc can surface — but a doc with zero lexical overlap
+    /// never does, because this tool's contract is *cited* excerpts (see the body comment).
     public func call(arguments: Arguments) async throws -> String {
         let query = arguments.query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {

--- a/Sources/AnglesiteCore/SecurityAudit.swift
+++ b/Sources/AnglesiteCore/SecurityAudit.swift
@@ -2,6 +2,19 @@
 /// no I/O — it never fixes anything. Findings reuse the shared `AuditReport.Finding`
 /// model (`category: .security`).
 public enum SecurityAudit {
+    /// Grades a zone snapshot against Anglesite's baseline: DNSSEC, origin TLS validation
+    /// (Full-strict), HTTPS enforcement, HSTS lifetime, bot mitigation, CAA, mail-spoofing
+    /// lockdown, ECH, and client-side script monitoring.
+    ///
+    /// - Parameters:
+    ///   - state: The read-only Cloudflare zone snapshot to grade.
+    ///   - expectsMail: Whether the domain legitimately sends mail. When `false`, a missing
+    ///     `v=spf1 -all` / DMARC `p=reject` lockdown is flagged — a non-sending domain without
+    ///     them is trivially spoofable. When `true`, SPF/DMARC checks are skipped entirely:
+    ///     the mail setup flow owns that DNS, and flagging its records here would produce
+    ///     remediation advice that breaks the owner's mail.
+    /// - Returns: Findings (all `category: .security`); empty when the zone already meets the
+    ///   baseline.
     public static func evaluate(_ state: CloudflareZoneState, expectsMail: Bool) -> [AuditReport.Finding] {
         var findings: [AuditReport.Finding] = []
         func add(_ severity: AuditReport.Finding.Severity, _ title: String, _ detail: String, _ remediation: String) {

--- a/Sources/AnglesiteCore/SecurityReportingAsset.swift
+++ b/Sources/AnglesiteCore/SecurityReportingAsset.swift
@@ -10,24 +10,38 @@ import Foundation
 public enum SecurityReportingAsset {
     /// Mirrors the template's `SecurityTxtMode`.
     public enum Mode: String, Sendable, CaseIterable, Identifiable, Equatable {
+        /// The template generates `security.txt` from the configured contacts on each build.
         case generated
+        /// The owner hand-maintains `security.txt`; the template (and the app's settings UI)
+        /// leave the published file alone.
         case manual
+        /// No `security.txt` is published at all — the owner has opted out.
         case disabled
 
+        /// `Identifiable` by case so SwiftUI pickers can bind `allCases` directly.
         public var id: Self { self }
     }
 
+    /// The editable pair the Website Settings ▸ Security Reports UI binds to — one value type
+    /// so save/dirty comparisons cover both keys at once.
     public struct Settings: Sendable, Equatable {
         /// Preference-ordered contacts, one per line in the UI; comma-joined in `.site-config`.
         public var contacts: String
+        /// How (or whether) the template publishes `security.txt` on the next build.
         public var mode: Mode
 
+        /// Defaults mirror a site with nothing configured: no contacts, nothing published
+        /// until the owner opts in.
         public init(contacts: String = "", mode: Mode = .disabled) {
             self.contacts = contacts
             self.mode = mode
         }
     }
 
+    /// Reads this type's two `.site-config` keys out of a raw config string. Deliberately
+    /// tolerant: an unset or unrecognized mode is inferred from whether a contact exists at all
+    /// (matching the template's `resolveSecurityTxtMode`), so a site scaffolded before
+    /// `SECURITY_TXT_MODE` existed never reads as having turned `security.txt` off.
     public static func parseSettings(from config: String) -> Settings {
         let stored = SiteConfigFile.value(forKey: "SECURITY_CONTACT", in: config) ?? ""
         // An unset or unrecognized mode mirrors the template's `resolveSecurityTxtMode`: infer
@@ -38,6 +52,10 @@ public enum SecurityReportingAsset {
         return Settings(contacts: decodeStored(stored).joined(separator: "\n"), mode: mode)
     }
 
+    /// Upserts both keys into the site's `.site-config`, normalizing contact shape (but not
+    /// validity — see the type doc) on the way through. Skips the write entirely when the
+    /// result is byte-identical, so re-saving an untouched settings sheet never dirties the
+    /// site's git working tree.
     public static func install(_ settings: Settings, siteDirectory: URL) throws {
         let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
         let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""

--- a/Sources/AnglesiteCore/SecurityTxtAuditRunner.swift
+++ b/Sources/AnglesiteCore/SecurityTxtAuditRunner.swift
@@ -11,6 +11,7 @@ import Foundation
 /// isn't available. A hint that resolves to "not applicable" costs nothing, whereas skipping it
 /// silently would hide the feature from exactly the owners it targets.
 public struct SecurityTxtAuditRunner: AuditRunner {
+    /// ``AuditRunner`` conformance — these findings file under the report's security section.
     public let category: AuditReport.Finding.Category = .security
 
     private let gitRunner: BackupCommand.GitRunner
@@ -22,6 +23,12 @@ public struct SecurityTxtAuditRunner: AuditRunner {
         self.gitRunner = gitRunner
     }
 
+    /// Emits at most one `.info` finding, and only when every condition holds: the site's
+    /// `origin` is GitHub, `security.txt` is in `.generated` mode, and the repo's advisory form
+    /// isn't already among the contacts. Every other state returns empty rather than a softer
+    /// finding — for a manual or disabled `security.txt` the hint's own remediation wouldn't
+    /// apply, so showing it would be wrong, not just unhelpful. `executor`, `logCenter`, and
+    /// `source` go unused: this runner spawns nothing (see the type doc).
     public func run(
         siteDirectory: URL,
         executor: any AuditExecutor,

--- a/Sources/AnglesiteCore/SemanticIndexCache.swift
+++ b/Sources/AnglesiteCore/SemanticIndexCache.swift
@@ -5,12 +5,24 @@ import Foundation
 /// itself stays in-memory (see #329). Invalidation is by `contentHash` (caller-checked) and by
 /// `dimension` (checked here on load).
 public struct SemanticIndexCache: Sendable {
+    /// One document's persisted embedding plus the metadata needed to invalidate it without
+    /// re-embedding.
     public struct Entry: Codable, Equatable, Sendable {
+        /// The knowledge-index document id this vector belongs to.
         public let docID: String
+        /// Hash of the embedded text at write time. A mismatch means the document changed and
+        /// the vector is stale — checked by the caller (`SemanticRanker.sync`), not by
+        /// ``SemanticIndexCache/load(expectedDimension:)``.
         public let contentHash: String
+        /// The embedding provider's vector dimension at write time. Load-time invalidation key:
+        /// vectors from providers of different dimensions aren't comparable, so a dimension
+        /// change silently retires the old entries.
         public let dimension: Int
+        /// The embedding itself.
         public let vector: [Float]
 
+        /// Memberwise initializer; see the stored properties for the invalidation semantics of
+        /// each field.
         public init(docID: String, contentHash: String, dimension: Int, vector: [Float]) {
             self.docID = docID
             self.contentHash = contentHash
@@ -21,6 +33,8 @@ public struct SemanticIndexCache: Sendable {
 
     private let fileURL: URL
 
+    /// Binds the cache to one site's file. Nothing is read or created here — I/O happens only
+    /// in ``load(expectedDimension:)`` and ``save(_:)``, so constructing a cache is free.
     public init(fileURL: URL) {
         self.fileURL = fileURL
     }

--- a/Sources/AnglesiteCore/SemanticRanker.swift
+++ b/Sources/AnglesiteCore/SemanticRanker.swift
@@ -14,6 +14,14 @@ public actor SemanticRanker {
     /// `[siteID: [docID: Stored]]`.
     private var vectorsBySite: [String: [String: Stored]] = [:]
 
+    /// Creates a ranker over the given embedding provider.
+    ///
+    /// - Parameters:
+    ///   - provider: Source of document/query vectors; its `dimension` doubles as the cache
+    ///     invalidation key (see ``SemanticIndexCache``).
+    ///   - cache: Cold-start persistence, seeded on the first ``sync(siteID:documents:)`` of a
+    ///     site and rewritten after every mutation. Pass `nil` to keep vectors purely in-memory —
+    ///     production's v0 wiring, pending the off-actor writer noted in `persist`.
     public init(provider: EmbeddingProvider, cache: SemanticIndexCache?) {
         self.provider = provider
         self.cache = cache
@@ -91,8 +99,11 @@ public actor SemanticRanker {
 
     /// A document scored against a query, where `score` is cosine similarity in -1…1.
     public struct Ranked: Sendable, Equatable {
+        /// The matched document's id in ``SiteKnowledgeIndex``.
         public let docID: String
+        /// Cosine similarity against the query vector (-1…1); higher is more similar.
         public let score: Float
+        /// Memberwise initializer (public so tests and callers can build expected results).
         public init(docID: String, score: Float) {
             self.docID = docID
             self.score = score

--- a/Sources/AnglesiteCore/SessionToken.swift
+++ b/Sources/AnglesiteCore/SessionToken.swift
@@ -3,8 +3,12 @@ import Foundation
 /// A per-session bearer secret minted by the app and validated in-container (auth-proxy + MCP
 /// sidecar). Opaque; symmetric compare. The value is a secret — never log it (see `KeychainStore`).
 public struct SessionToken: Sendable, Equatable, CustomStringConvertible {
+    /// The raw secret, for symmetric compare and for handing to the container side. Never log
+    /// or interpolate it — ``description`` is redacted for exactly that reason.
     public let value: String
 
+    /// Wraps an existing secret (e.g. one read back from the environment on the container
+    /// side); use ``mint()`` to create a fresh one.
     public init(value: String) { self.value = value }
 
     /// 32 cryptographically-random bytes, hex-encoded (64 chars).

--- a/Sources/AnglesiteCore/SetupIntegrationTool.swift
+++ b/Sources/AnglesiteCore/SetupIntegrationTool.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// Pure, non-gated helpers for the FM tool, so the parse/reply logic is unit-testable on CI.
 public enum SetupIntegrationArguments {
+    /// Parses the model's `key=value,key=value` config string into ``Answers``. Lenient by
+    /// design — malformed pairs are skipped rather than failing the call, because the planning
+    /// layer already reports missing/invalid fields with a better, user-facing message.
     public static func parseConfig(_ raw: String?) -> Answers {
         guard let raw, !raw.isEmpty else { return [:] }
         var out: Answers = [:]
@@ -13,6 +16,9 @@ public enum SetupIntegrationArguments {
         return out
     }
 
+    /// Maps the model's free-text integration type onto a known `IntegrationID`, or `nil` for
+    /// anything unrecognized — the tool answers that with the menu of valid options instead of
+    /// guessing.
     public static func id(for type: String) -> IntegrationID? { IntegrationID(rawValue: type) }
 
     /// Turn a plan result into a chat reply: re-prompt on missing field, else a confirm-before-apply summary.
@@ -66,29 +72,51 @@ public enum SetupIntegrationArguments {
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
+/// Chat front-door for the integration wizard. Plans first, applies only on a second call with
+/// `apply: true` — the plan/confirm/apply split keeps a single model call from mutating the
+/// site before the owner has said yes.
 public struct SetupIntegrationTool: Tool, Sendable {
+    /// Stable wire name, kept as a static so registration/telemetry sites can reference it
+    /// without constructing the tool.
     public static let toolName = "setupIntegration"
+    /// `Tool` conformance: the name the model calls this tool by.
     public let name = SetupIntegrationTool.toolName
+    /// `Tool` conformance: model-facing usage guidance, including the confirm-before-apply
+    /// contract.
     public let description = "Set up a website integration (booking, contact form, donations, giscus comments, or newsletter). Returns a plan to confirm before applying."
 
+    /// Model-generated arguments; the `@Guide` text is what steers the model, this is just
+    /// its shape.
     @Generable
     public struct Arguments {
+        /// Which integration to add, matched against `IntegrationID` raw values.
         @Guide(description: "Integration to add: 'booking', 'contact', 'donations', 'giscus', or 'newsletter'.")
         public var integrationType: String
+        /// Provider id for integrations offering a choice; merged into the answers under the
+        /// `"provider"` key.
         @Guide(description: "Provider id when the integration needs one (e.g. 'cal', 'calendly', 'stripe').")
         public var provider: String?
+        /// Field values as comma-separated `key=value` pairs, parsed leniently by
+        /// `SetupIntegrationArguments.parseConfig`.
         @Guide(description: "Field values as key=value pairs, comma-separated (e.g. 'username=jane,style=inline').")
         public var config: String?
+        /// The confirm-before-apply gate: `true` only after the owner has confirmed the plan;
+        /// anything else re-plans without touching the site.
         @Guide(description: "Set to true ONLY after the user has confirmed they want these changes applied.")
         public var apply: Bool?
     }
 
     private let service: any IntegrationOperationsService
     private let siteID: String
+    /// Creates the tool over the injected operations service (the seam tests fake) for one site.
     public init(service: any IntegrationOperationsService, siteID: String) {
         self.service = service; self.siteID = siteID
     }
 
+    /// Plans the integration and replies with a confirm-before-apply summary; applies only when
+    /// `apply == true`. Re-planning before every apply is deliberate — the plan is recomputed
+    /// from the latest answers, so a stale earlier plan can never be the one applied. Failures
+    /// are conversational strings (re-prompts), not thrown errors.
     public func call(arguments: Arguments) async throws -> String {
         guard let id = SetupIntegrationArguments.id(for: arguments.integrationType) else {
             return "I can set up booking, a contact form, donations, giscus comments, or a newsletter. Which one?"

--- a/Sources/AnglesiteCore/SetupThemeTool.swift
+++ b/Sources/AnglesiteCore/SetupThemeTool.swift
@@ -4,6 +4,12 @@ import Foundation
 /// Pure, non-gated helpers so parse/reply logic is unit-testable on CI, mirroring
 /// `SetupIntegrationArguments`.
 public enum SetupThemeArguments {
+    /// Maps a ``DesignApplyService`` apply result to the chat reply the FM tool returns.
+    ///
+    /// Failures are worded for the site owner, not the developer: no error types, no file-system
+    /// vocabulary. The partial-write case names the files that were already updated because
+    /// ``DesignApplyError/writeFailed(message:partiallyWritten:)`` carries that list precisely so the
+    /// reply can warn that the site is in a mixed state until a retry.
     public static func reply(for result: Result<AppliedDesign, DesignApplyError>, themeName: String) -> String {
         switch result {
         case .success:
@@ -25,13 +31,27 @@ public enum SetupThemeArguments {
 #if compiler(>=6.4) && canImport(FoundationModels)
 import FoundationModels
 
+/// FoundationModels tool letting the on-device assistant apply a built-in theme by id.
+///
+/// Gated to the Xcode-27 toolchain *and* `canImport(FoundationModels)` (see
+/// `SetupIntegrationTool` for the rationale) — which is why everything unit-testable lives in
+/// the non-gated `SetupThemeArguments` / `DesignApplyService` instead of here.
 public struct SetupThemeTool: Tool, Sendable {
+    /// The tool's wire name — a `static` mirror of `name` so call sites (transcript
+    /// inspection, logging) can match tool invocations without constructing the tool.
     public static let toolName = "setupTheme"
+    /// `Tool` conformance: the name the model calls this tool by.
     public let name = SetupThemeTool.toolName
+    /// `Tool` conformance: the prompt-visible description the model uses to decide when to
+    /// call this tool.
     public let description = "Apply one of the built-in visual themes to the current site."
 
+    /// The model-generated argument payload for a `setupTheme` call.
     @Generable
     public struct Arguments {
+        /// The catalog id of the theme to apply. An id the catalog doesn't recognize is not an
+        /// error — ``SetupThemeTool/call(arguments:)`` answers with the list of available
+        /// themes so the model can retry.
         @Guide(description: "The theme id to apply, e.g. 'warm', 'classic', 'bold'.")
         public var themeID: String
     }
@@ -43,11 +63,17 @@ public struct SetupThemeTool: Tool, Sendable {
     /// and the conversation context only ever hands tools the already-resolved source directory.)
     private let sourceDirectory: URL
 
+    /// Creates the tool bound to one site's theme catalog and resolved `Source/` directory
+    /// (see the `sourceDirectory` note above for why it's a `URL`, not a package).
     public init(catalog: ThemeCatalog, sourceDirectory: URL) {
         self.catalog = catalog
         self.sourceDirectory = sourceDirectory
     }
 
+    /// Resolves the requested theme and applies it via `DesignApplyService`, always returning
+    /// a user-facing chat reply rather than throwing: an unrecognized id gets a corrective
+    /// reply listing the available themes, and apply failures are worded by
+    /// `SetupThemeArguments.reply(for:themeName:)`.
     public func call(arguments: Arguments) async throws -> String {
         guard let theme = catalog.theme(id: arguments.themeID) else {
             let names = catalog.themes.map(\.name).joined(separator: ", ")

--- a/Sources/AnglesiteCore/SharedInstanceCache.swift
+++ b/Sources/AnglesiteCore/SharedInstanceCache.swift
@@ -21,6 +21,9 @@ public final class SharedInstanceCache<Value: Sendable>: @unchecked Sendable {
     private let lock = NSLock()
     private var instances: [String: Value] = [:]
 
+    /// Creates an empty cache. Consumers typically hold it as a `static let` — the "one
+    /// instance per key" guarantee is only as wide as the scope everyone shares the cache in,
+    /// so a per-caller cache would defeat the point.
     public init() {}
 
     /// Returns the cached instance for `key`, constructing and caching it via `make` if absent.

--- a/Sources/AnglesiteCore/SiriReadiness.swift
+++ b/Sources/AnglesiteCore/SiriReadiness.swift
@@ -4,21 +4,38 @@ import Observation
 /// Severity of a single capability check. `unsupported` means "not available in this
 /// build/OS yet" (a truthful absence, not a failure the user caused).
 public enum ReadinessLevel: String, Sendable, Equatable, CaseIterable {
+    /// The capability is present and working.
     case ok
+    /// Usable but degraded, or waiting on something (a user action, a download) to reach
+    /// full capability.
     case warning
+    /// The capability is broken in a way that blocks Siri workflows — usually with a
+    /// remediation the user can act on.
     case failure
+    /// Truthfully absent in this build/OS/hardware; not the user's fault and not
+    /// remediable, so it must not be styled as an error.
     case unsupported
 }
 
 /// The result of one probe. Concrete `detail` (what the probe found), with optional
 /// user-actionable `remediation`.
 public struct ReadinessFinding: Identifiable, Sendable, Equatable {
+    /// Stable identifier, echoing the producing probe's ``ReadinessProbe/id`` so findings can
+    /// be correlated across rechecks.
     public let id: String
+    /// User-facing check title. Carried on the finding rather than the probe — see
+    /// ``ReadinessProbe`` for why.
     public let title: String
+    /// Severity of what the probe found.
     public let level: ReadinessLevel
+    /// What the probe concretely observed, phrased for the user.
     public let detail: String
+    /// A user-actionable next step, or `nil` when there is nothing for the user to do
+    /// (an ok finding, or an ``ReadinessLevel/unsupported`` one).
     public let remediation: String?
 
+    /// Creates a finding. `remediation` defaults to `nil` for findings that need no user
+    /// action.
     public init(id: String, title: String, level: ReadinessLevel, detail: String, remediation: String? = nil) {
         self.id = id
         self.title = title
@@ -34,7 +51,11 @@ public struct ReadinessFinding: Identifiable, Sendable, Equatable {
 /// The user-facing title is carried by the `ReadinessFinding` each probe returns, so it is not
 /// part of the protocol surface — consumers read `finding.title`, never `probe.title`.
 public protocol ReadinessProbe: Sendable {
+    /// Stable identifier for this check, echoed into the returned finding's
+    /// ``ReadinessFinding/id``.
     var id: String { get }
+    /// Runs the check. Must not throw — encode any failure as a finding with a failing
+    /// ``ReadinessFinding/level`` so the readiness surface always has something to show.
     func check() async -> ReadinessFinding
 }
 
@@ -44,11 +65,17 @@ public protocol ReadinessProbe: Sendable {
 @MainActor
 @Observable
 public final class SiriReadinessModel: Identifiable {
-    // Identity lets the readiness sheet bind via `.sheet(item:)`.
+    /// Identity lets the readiness sheet bind via `.sheet(item:)`.
     public nonisolated var id: ObjectIdentifier { ObjectIdentifier(self) }
 
+    /// Findings from the most recent *completed* run, in probe order (probes run serially, so
+    /// the surface's row order is deterministic). Empty until the first ``recheck()`` commits;
+    /// a cancelled or superseded run never publishes partial results.
     public private(set) var findings: [ReadinessFinding] = []
+    /// Whether a run is in flight — drives the surface's progress indicator. Only the run
+    /// that owns the current generation may clear it (see `cancelled(_:)`).
     public private(set) var isChecking: Bool = false
+    /// When the last completed run committed, from the injected clock; `nil` until then.
     public private(set) var lastChecked: Date?
 
     @ObservationIgnored private let probes: [any ReadinessProbe]
@@ -58,6 +85,8 @@ public final class SiriReadinessModel: Identifiable {
     /// replaced me" (clear the spinner) from "a newer run superseded me" (leave its spinner alone).
     @ObservationIgnored private var generation = 0
 
+    /// Creates the model with its probe set fixed for the model's lifetime. `now` is
+    /// injectable so tests can pin ``lastChecked`` to a deterministic clock.
     public init(probes: [any ReadinessProbe], now: @escaping @Sendable () -> Date = { Date() }) {
         self.probes = probes
         self.now = now

--- a/Sources/AnglesiteCore/SiriReadinessSiteProbes.swift
+++ b/Sources/AnglesiteCore/SiriReadinessSiteProbes.swift
@@ -4,16 +4,23 @@ import Foundation
 /// search/status intents read). Empty is a warning, not a failure — the user just needs to
 /// open the site.
 public struct ContentGraphProbe: ReadinessProbe {
+    /// Stable probe id, echoed into the finding.
     public let id = "site.graph"
+    /// User-facing check title, carried into every finding this probe returns.
     public let title = "Site content index"
     private let siteID: String
     private let graph: SiteContentGraph
 
+    /// Creates the probe for one site's slice of the shared content graph.
     public init(siteID: String, graph: SiteContentGraph) {
         self.siteID = siteID
         self.graph = graph
     }
 
+    /// Counts the site's pages, posts, and images in the graph. Any content at all is ok;
+    /// an empty result warns with "open the site" remediation, because the graph is only
+    /// populated when a site window opens — emptiness here usually means "not scanned yet",
+    /// not "the site has no content".
     public func check() async -> ReadinessFinding {
         let pages = await graph.pages(for: siteID).count
         let posts = await graph.posts(for: siteID).count

--- a/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
+++ b/Sources/AnglesiteCore/SiriReadinessSystemProbes.swift
@@ -8,11 +8,15 @@ import FoundationModels
 /// Confirms the running OS meets Anglesite's macOS floor. Version is injectable so the
 /// mapping is testable without spoofing the process environment.
 public struct OSRuntimeProbe: ReadinessProbe {
+    /// Stable probe id, echoed into the finding.
     public let id = "os.runtime"
+    /// User-facing check title, carried into every finding this probe returns.
     public let title = "macOS runtime"
     private let version: OperatingSystemVersion
     private let minimumMajor: Int
 
+    /// Creates the probe. The defaults check the live process against Anglesite's macOS 27
+    /// floor; tests inject `version` to exercise the mapping without spoofing the host OS.
     public init(
         version: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
         minimumMajor: Int = 27
@@ -21,6 +25,9 @@ public struct OSRuntimeProbe: ReadinessProbe {
         self.minimumMajor = minimumMajor
     }
 
+    /// Passes when the major version meets the floor; otherwise fails with a Software Update
+    /// remediation. Only the major version gates — minor/patch appear in the detail text for
+    /// honesty, not in the comparison.
     public func check() async -> ReadinessFinding {
         // Include the patch so a user on e.g. 26.9.5 doesn't see a misleading "26.9 is below…".
         let running = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
@@ -37,24 +44,37 @@ public struct OSRuntimeProbe: ReadinessProbe {
 /// Normalized Foundation Models availability, decoupled from the SDK enum so the probe
 /// mapping is testable without the framework.
 public enum FoundationModelsAvailability: Sendable, Equatable {
+    /// The on-device model can serve requests now.
     case available
+    /// The user has Apple Intelligence turned off — remediable in System Settings.
     case appleIntelligenceNotEnabled
+    /// Eligible device, but the model is still downloading or preparing — transient.
     case modelNotReady
+    /// This hardware can't run the model; no remediation exists.
     case deviceNotEligible
+    /// Availability couldn't be classified; carries the SDK's own description so the finding
+    /// can still say something concrete.
     case unknown(String)
 }
 
 /// Reports whether Apple's on-device language model is usable. Availability is injected so
 /// tests never touch the live model; the live source reads `SystemLanguageModel` (no inference).
 public struct FoundationModelsProbe: ReadinessProbe {
+    /// Stable probe id, echoed into the finding.
     public let id = "foundation.models"
+    /// User-facing check title, carried into every finding this probe returns.
     public let title = "Apple Foundation Models"
     private let availability: @Sendable () -> FoundationModelsAvailability
 
+    /// Creates the probe with an injected availability source. Production passes
+    /// `LiveFoundationModelsAvailability.current`; tests pass a closure returning a fixed case.
     public init(availability: @escaping @Sendable () -> FoundationModelsAvailability) {
         self.availability = availability
     }
 
+    /// Maps availability onto a finding. Transient/remediable states are warnings with a
+    /// remediation; ineligible hardware is `.unsupported` rather than a failure, because
+    /// there's nothing the owner can do about it.
     public func check() async -> ReadinessFinding {
         switch availability() {
         case .available:
@@ -81,6 +101,9 @@ public struct FoundationModelsProbe: ReadinessProbe {
 /// Live availability source. Reads `SystemLanguageModel.default.availability` (no inference).
 /// Case names below must match the `FoundationModels` SDK; `@unknown default` absorbs drift.
 public enum LiveFoundationModelsAvailability {
+    /// The current availability, or `.unknown` when the framework isn't present at build time
+    /// (older toolchain, or a platform without FoundationModels). Reads availability only —
+    /// never triggers inference or a model download.
     public static func current() -> FoundationModelsAvailability {
         #if compiler(>=6.4) && canImport(FoundationModels)
         switch SystemLanguageModel.default.availability {

--- a/Sources/AnglesiteCore/SiteAccess.swift
+++ b/Sources/AnglesiteCore/SiteAccess.swift
@@ -10,6 +10,9 @@ import Foundation
 /// - Package tests / non-app callers without `ANGLESITE_MAS`: pass `site.sourceDirectory`
 ///   straight through.
 public enum SiteAccess {
+    /// Failures acquiring scoped access. Cases carry ready-to-show messages because the callers
+    /// (background App Intents) have no window UI to elaborate — the string is the whole story
+    /// the user gets.
     public enum AccessError: Error, Sendable, Equatable {
         /// No security-scoped bookmark for this site. Carries a user-facing message.
         case noGrant(String)

--- a/Sources/AnglesiteCore/SiteConfigFile.swift
+++ b/Sources/AnglesiteCore/SiteConfigFile.swift
@@ -1,9 +1,20 @@
 // Sources/AnglesiteCore/SiteConfigFile.swift
 import Foundation
 
+/// Line-level editing of `.site-config` — the template-owned `KEY=value` file in `Source/`
+/// (distinct from the app-owned `Config/` stores). Pure string transforms over file contents;
+/// callers own the actual read/write, so the same helpers serve app flows and tests. Note the
+/// app records a site's domain under the `DOMAIN` key (not `SITE_DOMAIN`) — resolve hosts via
+/// `WebsiteAnalyticsAsset.bestHost` rather than reading either key directly.
 public enum SiteConfigFile {
+    /// The `.site-config` key holding the comma-separated third-party script-origin allowlist
+    /// the template folds into its Content-Security-Policy.
     public static let cspKey = "SCRIPT_ALLOW"
 
+    /// Replaces or appends `KEY=value` lines while preserving unrelated lines and their order,
+    /// so a hand-edited file survives round-trips (git is the source of truth — the file must
+    /// stay editable outside the app). Normalizes CRLF to LF and guarantees exactly one
+    /// trailing newline on non-empty output.
     public static func upsert(_ entries: [(key: String, value: String)], into contents: String) -> String {
         // Normalize CRLF to LF so stray \r don't appear in split lines or output.
         let contents = contents.replacingOccurrences(of: "\r\n", with: "\n")
@@ -20,6 +31,9 @@ public enum SiteConfigFile {
         return lines.isEmpty ? "" : lines.joined(separator: "\n") + "\n"
     }
 
+    /// Merges `domains` into the existing ``cspKey`` list, deduplicating while preserving the
+    /// existing order — so re-running an integration setup never grows the CSP allowlist with
+    /// repeated entries.
     public static func addCSPDomains(_ domains: [String], into contents: String) -> String {
         let existing = cspDomains(in: contents)
         var merged = existing

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -66,6 +66,9 @@ public struct SiteSettings: Sendable, Codable, Equatable {
     /// site: `AnnouncedPostSync` no-ops without it, so this field is inert until #907 ships.
     public var communityOutboxURL: URL?
 
+    /// Memberwise creation. Every parameter defaults to `nil`, matching the type-level
+    /// forward-compat rule that all fields stay optional — `SiteSettings()` is the canonical
+    /// "no settings yet" value ``SiteConfigStore/load()`` falls back to.
     public init(
         displayName: String? = nil,
         inboxCaptureAccountID: String? = nil,
@@ -104,6 +107,9 @@ public actor SiteConfigStore {
     private let fileURL: URL
     private let fileManager: FileManager
 
+    /// Points the store at `<configDirectory>/settings.plist` — the package's app-owned
+    /// `Config/` directory, never the git-tracked `Source/`. `fileManager` is injectable for
+    /// tests.
     public init(configDirectory: URL, fileManager: FileManager = .default) {
         self.fileURL = configDirectory.appendingPathComponent("settings.plist")
         self.fileManager = fileManager

--- a/Sources/AnglesiteCore/SiteContentChunker.swift
+++ b/Sources/AnglesiteCore/SiteContentChunker.swift
@@ -3,13 +3,21 @@ import Foundation
 /// One page/post of a site reduced to capped plain text for a single FM call (#465). `filePath`
 /// is project-relative (e.g. `src/pages/about.astro`) so findings can be applied back to disk.
 public struct ContentChunk: Sendable, Equatable, Identifiable {
+    /// Identity is the file path — the chunker emits exactly one chunk per source file.
     public var id: String { filePath }
+    /// The public route the file renders at (see `SiteContentChunker.route(forRelativePath:)`).
     public let route: String
+    /// Frontmatter `title`, when the file declares one.
     public let title: String?
+    /// Project-relative source path — the write-back target when a finding is applied to disk.
     public let filePath: String
+    /// The extracted text, hard-capped so a single FM call fits the on-device window.
     public let text: String
+    /// Whether ``text`` was cut at the cap — carried so downstream replies can disclose
+    /// partial coverage instead of silently trimming.
     public let truncated: Bool
 
+    /// Memberwise creation, used by the chunker and by test fixtures.
     public init(route: String, title: String?, filePath: String, text: String, truncated: Bool) {
         self.route = route
         self.title = title
@@ -30,6 +38,11 @@ public enum SiteContentChunker {
     static let contentExtensions: Set<String> = ["md", "mdoc"]
     static let pageExtensions: Set<String> = ["astro", "md", "mdoc"]
 
+    /// Enumerates `src/content` (markdown/mdoc) and `src/pages` (plus `.astro`) under
+    /// `sourceDirectory`, yielding one capped ``ContentChunk`` per content file, sorted by
+    /// route so prompt order — and therefore FM output — is deterministic across runs.
+    /// Unreadable or empty files are skipped, not errors: a half-saved file mid-edit must not
+    /// fail a whole-site audit.
     public static func chunks(sourceDirectory: URL, fileManager: FileManager = .default) -> [ContentChunk] {
         var chunks: [ContentChunk] = []
         for (subdir, extensions) in [("src/content", contentExtensions), ("src/pages", pageExtensions)] {
@@ -119,6 +132,8 @@ public enum SiteContentChunker {
         return collapsed(text)
     }
 
+    /// Truncates to ``maxChunkCharacters`` (appending an ellipsis) and reports whether it did —
+    /// the flag is what lets replies disclose partial coverage rather than trim silently.
     public static func capped(_ text: String) -> (text: String, truncated: Bool) {
         guard text.count > maxChunkCharacters else { return (text, false) }
         return (String(text.prefix(maxChunkCharacters)) + "…", true)

--- a/Sources/AnglesiteCore/SiteContentGraph.swift
+++ b/Sources/AnglesiteCore/SiteContentGraph.swift
@@ -14,14 +14,23 @@ import Foundation
 /// `SpotlightIndexer.reindex(_:)` "trust whatever the source publishes at moment of read"
 /// pattern.
 public actor SiteContentGraph {
+    /// One routed page entry (an Astro page file), keyed by route.
     public struct Page: Sendable, Equatable, Identifiable {
-        public let id: String          // "{siteID}:page:{route}"
+        /// `"{siteID}:page:{route}"` — site-qualified so multiple open sites coexist in one graph.
+        public let id: String
+        /// The owning site's stable UUID string.
         public let siteID: String
+        /// The public route the page renders at (e.g. `/about`).
         public let route: String
+        /// Project-relative source path within `Source/`.
         public let filePath: String
+        /// Frontmatter-derived title, when the scanner found one.
         public let title: String?
+        /// The source file's modification date at scan time — the staleness signal indexers
+        /// diff against.
         public let lastModified: Date
 
+        /// Memberwise creation; callers (the content scanner) compose `id` themselves.
         public init(
             id: String,
             siteID: String,
@@ -39,18 +48,32 @@ public actor SiteContentGraph {
         }
     }
 
+    /// One content-collection post entry, carrying the frontmatter facets (draft state,
+    /// publish date, tags) the navigator and search filter on.
     public struct Post: Sendable, Equatable, Identifiable {
-        public let id: String          // "{siteID}:post:{slug}"
+        /// `"{siteID}:post:{slug}"` — site-qualified so multiple open sites coexist in one graph.
+        public let id: String
+        /// The owning site's stable UUID string.
         public let siteID: String
+        /// The content collection the post belongs to (e.g. `posts`).
         public let collection: String
+        /// Filename-derived slug, unique within its collection.
         public let slug: String
+        /// The post's frontmatter title.
         public let title: String
+        /// Whether the post is marked draft in frontmatter (excluded from published builds).
         public let draft: Bool
+        /// Frontmatter publish date, when set.
         public let publishDate: Date?
+        /// Frontmatter tags; empty when none.
         public let tags: [String]
+        /// Project-relative source path within `Source/`.
         public let filePath: String
+        /// The source file's modification date at scan time — the staleness signal indexers
+        /// diff against.
         public let lastModified: Date
 
+        /// Memberwise creation; callers (the content scanner) compose `id` themselves.
         public init(
             id: String,
             siteID: String,
@@ -76,18 +99,29 @@ public actor SiteContentGraph {
         }
     }
 
+    /// One image asset entry, including reverse usage references (``usedOnPages``) so callers
+    /// can tell an in-use image from a dead asset.
     public struct Image: Sendable, Equatable, Identifiable {
-        public let id: String          // "{siteID}:image:{relativePath}"
+        /// `"{siteID}:image:{relativePath}"` — site-qualified so multiple open sites coexist
+        /// in one graph.
+        public let id: String
+        /// The owning site's stable UUID string.
         public let siteID: String
+        /// Path relative to the project root.
         public let relativePath: String
+        /// Base file name, for display and search.
         public let fileName: String
+        /// Size in bytes, when the scanner could stat the file.
         public let byteSize: Int64?
         /// Project-relative source paths that reference this image, sorted. Populated by
         /// `ContentScanner.scanImages` from `DeadAssetScanner.referencedPaths(projectRoot:)`
         /// (#140/#553) — `DeadAssetScanner` is the canonical usage authority for this field.
         public let usedOnPages: [String]
+        /// The asset file's modification date at scan time — the staleness signal indexers
+        /// diff against.
         public let lastModified: Date
 
+        /// Memberwise creation; callers (the content scanner) compose `id` themselves.
         public init(
             id: String,
             siteID: String,
@@ -107,6 +141,9 @@ public actor SiteContentGraph {
         }
     }
 
+    /// The single awaited change hook (see the type-level "Change handler" note). Receives only
+    /// the affected siteID — the subscriber reads pages/posts/images back from the graph itself,
+    /// keeping emits cheap.
     public typealias ChangeHandler = @Sendable (String) async -> Void
 
     private var pages: [String: Page] = [:]
@@ -138,6 +175,8 @@ public actor SiteContentGraph {
     /// sites' scans never interfere with each other's fencing.
     private var scanGenerations: [String: Int] = [:]
 
+    /// Creates an empty graph — per the type-level contract, cold start holds nothing until the
+    /// first ``load(siteID:pages:posts:images:generation:)``.
     public init() {}
 
     /// Claims a new scan generation for `siteID`. Call this *before* starting a filesystem
@@ -155,6 +194,8 @@ public actor SiteContentGraph {
         return next
     }
 
+    /// Installs (or clears, with `nil`) the single awaited change hook, replacing any previous
+    /// one — single-subscriber by design; UI observers use ``changeStream()`` instead.
     public func setChangeHandler(_ handler: ChangeHandler?) {
         changeHandler = handler
     }
@@ -238,32 +279,42 @@ public actor SiteContentGraph {
         populatedSiteIDs.contains(siteID)
     }
 
+    /// All page entries for `siteID`, in no guaranteed order — callers sort for display.
     public func pages(for siteID: String) -> [Page] {
         pages.values.filter { $0.siteID == siteID }
     }
 
+    /// All post entries for `siteID`, in no guaranteed order — callers sort for display.
     public func posts(for siteID: String) -> [Post] {
         posts.values.filter { $0.siteID == siteID }
     }
 
+    /// All image entries for `siteID`, in no guaranteed order — callers sort for display.
     public func images(for siteID: String) -> [Image] {
         images.values.filter { $0.siteID == siteID }
     }
 
     // MARK: - Incremental upsert
 
+    /// Inserts or replaces one page entry. Emits a change only when the value actually differs
+    /// — the `Equatable` suppression that keeps file-watch echo events from re-triggering
+    /// subscribers for nothing.
     public func upsertPage(_ page: Page) async {
         if pages[page.id] == page { return }
         pages[page.id] = page
         await emitChange(page.siteID)
     }
 
+    /// Inserts or replaces one post entry; same equal-value emit suppression as
+    /// ``upsertPage(_:)``.
     public func upsertPost(_ post: Post) async {
         if posts[post.id] == post { return }
         posts[post.id] = post
         await emitChange(post.siteID)
     }
 
+    /// Inserts or replaces one image entry; same equal-value emit suppression as
+    /// ``upsertPage(_:)``.
     public func upsertImage(_ image: Image) async {
         if images[image.id] == image { return }
         images[image.id] = image
@@ -280,11 +331,15 @@ public actor SiteContentGraph {
         await emitChange(removed.siteID)
     }
 
+    /// Removes the post with the given id; same silent no-op-on-unknown contract (and
+    /// rationale) as ``removePage(id:)``.
     public func removePost(id: String) async {
         guard let removed = posts.removeValue(forKey: id) else { return }
         await emitChange(removed.siteID)
     }
 
+    /// Removes the image with the given id; same silent no-op-on-unknown contract (and
+    /// rationale) as ``removePage(id:)``.
     public func removeImage(id: String) async {
         guard let removed = images.removeValue(forKey: id) else { return }
         await emitChange(removed.siteID)
@@ -311,8 +366,11 @@ public actor SiteContentGraph {
 
     // MARK: - Queries (single)
 
+    /// The page with this exact id, or `nil` if the graph doesn't hold it.
     public func page(id: String) -> Page? { pages[id] }
+    /// The post with this exact id, or `nil` if the graph doesn't hold it.
     public func post(id: String) -> Post? { posts[id] }
+    /// The image with this exact id, or `nil` if the graph doesn't hold it.
     public func image(id: String) -> Image? { images[id] }
 
     // MARK: - Batched id lookup
@@ -323,7 +381,9 @@ public actor SiteContentGraph {
     /// ids after a multi-pick. Takes an ordered `[String]` (not a `Set`) to preserve the
     /// input-order contract the entity queries' tests assert.
     public func pages(ids: [String]) -> [Page] { ids.compactMap { pages[$0] } }
+    /// Same single-hop, input-order, skip-unknown contract as ``pages(ids:)``.
     public func posts(ids: [String]) -> [Post] { ids.compactMap { posts[$0] } }
+    /// Same single-hop, input-order, skip-unknown contract as ``pages(ids:)``.
     public func images(ids: [String]) -> [Image] { ids.compactMap { images[$0] } }
 
     // MARK: - Search


### PR DESCRIPTION
## Summary

- Phase 9 of the doc-comment retrofit tracked in #1141: the `PreviewNavigation` … `SiteContentGraph` chunk of AnglesiteCore (40 files, ~330 doc comments) — preview navigation/zoom, ProcessSupervisor, the project conventions engine/extractor/store, received interactions, the redirects store, the repurpose/review/setup/suggest FoundationModels tools, route coverage scanner, sandbox control client, Siri readiness probes, site access/config file/config store, the content chunker, and SiteContentGraph.
- Single-line enum `case` lists split so each case carries its rationale; raw values and `CaseIterable` order unchanged. Comments only — no behavior changes.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` — clean (run after rebasing onto current `main`).
- [x] `swift test --filter AnglesiteCoreTests` — 3,058 tests in 385 suites; 2 failures, both the known "FoundationModelAssistant" concurrent-`swift test` FM-contention flake (same two tests fail identically on unmodified checkouts — see the sibling #1141 PRs). `FoundationModelAssistant.swift` is not touched by this diff.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run separately; comments-only diff, target compiles during DocC symbol-graph extraction.
