### PR TITLE
docs(#1141): retrofit doc comments, Core TokenOnboarding-XPC

### DIFF
--- a/Sources/AnglesiteCore/TokenOnboarding.swift
+++ b/Sources/AnglesiteCore/TokenOnboarding.swift
@@ -13,6 +13,8 @@ import Foundation
 /// still runs on CI's older runners.
 @MainActor
 public struct TokenOnboarding {
+    /// What the caller should do after a run — the three-way split exists so the view-model can
+    /// distinguish "keep the sheet open" from "close it silently" without re-deriving state.
     public enum Outcome: Equatable {
         /// Token verified and persisted — the caller should start the parked deploy.
         case proceed(CloudflareAccount)
@@ -24,6 +26,7 @@ public struct TokenOnboarding {
 
     private let verifier: TokenVerifying
 
+    /// Creates the flow with an injectable verifier so tests can stub the network round-trip.
     public init(verifier: TokenVerifying) {
         self.verifier = verifier
     }

--- a/Sources/AnglesiteCore/TypedContentEditor.swift
+++ b/Sources/AnglesiteCore/TypedContentEditor.swift
@@ -8,24 +8,45 @@ import Foundation
 /// `FrontmatterDocument`'s verbatim preservation keeps untouched keys and the body intact. Pure,
 /// no I/O.
 public enum TypedContentEditor {
+    /// A decoded, editor-facing field value — one case per shape a form control binds to, not one
+    /// per `ContentTypeField.Kind` (several kinds share a shape: `.string`/`.text`/`.url`/`.image`
+    /// are all `.text`). Equality at this level is what makes ``TypedContentEditor/write(_:into:descriptor:)``'s
+    /// changed-fields-only diff format-preserving.
     public enum FieldValue: Equatable, Sendable {
+        /// Free text — backs string-like kinds and the markdown body alike.
         case text(String)
+        /// A boolean toggle.
         case flag(Bool)
+        /// A date; `nil` means cleared/unset, which serializes back as an empty scalar rather than
+        /// being dropped.
         case date(Date?)
+        /// A number; `nil` means cleared/unset, mirroring `date`'s empty-scalar round-trip.
         case number(Double?)
+        /// An ordered list of strings (string-array and image-array kinds).
         case list([String])
+        /// Rows of an object-array field, each row keyed by member-field name.
         case records([[String: FieldValue]])
     }
 
+    /// The full set of per-field values for one document, keyed by field name.
+    ///
+    /// A thin wrapper over a dictionary rather than a bare `[String: FieldValue]` so the editor's
+    /// binding surface stays a single value type the form can diff with `==`.
     public struct Values: Equatable, Sendable {
         private var dict: [String: FieldValue]
+        /// Creates a value set, empty by default so an editor can start blank and fill in per field.
         public init(_ dict: [String: FieldValue] = [:]) { self.dict = dict }
+        /// Accesses the value for a field by name; `nil` means the field isn't present in this set
+        /// (distinct from a present-but-empty value like `.text("")`).
         public subscript(_ name: String) -> FieldValue? {
             get { dict[name] }
             set { dict[name] = newValue }
         }
     }
 
+    /// The empty/cleared value a field of the given kind starts with when the document doesn't
+    /// define it — so every descriptor field always has a bindable value and the form never has to
+    /// handle a missing key.
     public static func defaultValue(for kind: ContentTypeField.Kind) -> FieldValue {
         switch kind {
         case .string, .text, .markdown, .url, .image: return .text("")
@@ -37,6 +58,10 @@ public enum TypedContentEditor {
         }
     }
 
+    /// Decodes a content file's frontmatter + body into per-field values for the descriptor.
+    ///
+    /// Fields absent from the file come back as ``defaultValue(for:)`` rather than being omitted,
+    /// so the result always covers every descriptor field.
     public static func read(_ contents: String, descriptor: ContentTypeDescriptor) -> Values {
         read(from: FrontmatterDocument.parse(contents), descriptor: descriptor)
     }
@@ -59,6 +84,12 @@ public enum TypedContentEditor {
         return out
     }
 
+    /// Applies edited values back onto the original file contents and returns the new serialization.
+    ///
+    /// Only fields whose decoded value actually differs from what's on disk are rewritten — that
+    /// changed-fields-only diff is what lets `FrontmatterDocument`'s verbatim preservation keep
+    /// untouched keys, comments, and non-canonical formatting (e.g. a date-only `publishDate`)
+    /// byte-identical.
     public static func write(_ values: Values, into contents: String, descriptor: ContentTypeDescriptor) -> String {
         var doc = FrontmatterDocument.parse(contents)
         // Derive `current` from the already-parsed `doc` (no second parse). Comparison stays at the

--- a/Sources/AnglesiteCore/UTType+Anglesite.swift
+++ b/Sources/AnglesiteCore/UTType+Anglesite.swift
@@ -26,7 +26,11 @@ public extension UTType {
     /// filename extension, and no cross-process/Launch Services resolution (Finder, Quick Look,
     /// Spotlight) involved, which is what Info.plist registration is for.
     static let anglesiteComponentDragItem = UTType(exportedAs: "io.dwk.anglesite.component-drag-item")
+    /// Drag payload for palette items dragged into the Component Editor outline — in-process only,
+    /// unregistered by design (see `anglesiteComponentDragItem` above for why).
     static let anglesitePaletteDragPayload = UTType(exportedAs: "io.dwk.anglesite.palette-drag-payload")
+    /// Drag payload for reordering existing nodes within the Component Editor outline — in-process
+    /// only, unregistered by design (see `anglesiteComponentDragItem` above for why).
     static let anglesiteOutlineDragPayload = UTType(exportedAs: "io.dwk.anglesite.outline-drag-payload")
 }
 #endif

--- a/Sources/AnglesiteCore/UnavailableSiteRuntime.swift
+++ b/Sources/AnglesiteCore/UnavailableSiteRuntime.swift
@@ -5,23 +5,32 @@ import Foundation
 /// instead of silently spawning the old host subprocess runtime.
 public actor UnavailableSiteRuntime: SiteRuntime {
     private let reason: String
+    /// A never-started client, present only to satisfy ``SiteRuntime`` — nothing in this runtime
+    /// ever connects it, since no site process exists to talk to.
     public let mcpClient: MCPClient
     private let stateMachine = SiteRuntimeStateMachine()
 
+    /// Creates the placeholder runtime with the human-readable `reason` that will surface as the
+    /// failed preview state's message when a site is opened.
     public init(reason: String, mcpClient: MCPClient = MCPClient(supervisor: .shared)) {
         self.reason = reason
         self.mcpClient = mcpClient
     }
 
+    /// Immediately fails: transitions straight to `.failed` with the configured reason instead of
+    /// starting anything, so the UI shows *why* no runtime is available.
     public func start(siteID: String, siteDirectory: URL) async {
         stateMachine.setState(.failed(siteID: siteID, message: reason))
     }
 
+    /// Resets to `.idle`; stops the (never-started) client for symmetry with real runtimes.
     public func stop() async {
         await mcpClient.stop()
         stateMachine.setState(.idle)
     }
 
+    /// Streams state changes exactly like a real runtime, so `PreviewModel` observes the failure
+    /// through the same seam it uses everywhere else.
     public func observe() -> AsyncStream<SiteRuntimeState> {
         stateMachine.observe()
     }

--- a/Sources/AnglesiteCore/UndoCommand.swift
+++ b/Sources/AnglesiteCore/UndoCommand.swift
@@ -7,16 +7,26 @@ import Foundation
 /// generic failure with a reason+detail pair. The chat panel presents a warn-and-confirm
 /// sheet on `.workingTreeModified` and retries with `force: true` if the owner confirms.
 public struct UndoCommand: Sendable {
+    /// The tool-call seam: `(toolName, arguments) → result`. Injectable so tests exercise the
+    /// reply-parsing logic without a live MCP connection.
     public typealias Caller = @Sendable (_ name: String, _ arguments: JSONValue) async throws -> MCPClient.ToolCallResult
 
+    /// The three outcomes the chat panel actually branches on — anything the server reports that
+    /// isn't a success or a working-tree conflict collapses into `.failed`.
     public enum UndoResult: Sendable, Equatable {
+        /// The undo landed; `newCommit` is the branch's new head SHA, which becomes the anchor for
+        /// the next undo.
         case success(newCommit: String)
+        /// The working tree has uncommitted drift in `files` — the caller warns the owner and may
+        /// retry with `force: true` to discard it.
         case workingTreeModified(files: [String])
+        /// Any other failure (transport error, malformed reply, or a server-reported reason).
         case failed(reason: String, detail: String)
     }
 
     private let caller: Caller
 
+    /// Test hookup — inject a fake ``Caller`` to script the server's replies.
     public init(caller: @escaping Caller) {
         self.caller = caller
     }
@@ -30,6 +40,9 @@ public struct UndoCommand: Sendable {
         }
     }
 
+    /// Asks the plugin to undo the edit at `commit`, classifying the JSON reply into an
+    /// ``UndoResult``. Never throws — every failure mode (including a transport error or a reply
+    /// that isn't valid JSON) is folded into `.failed` so the UI has exactly one error path.
     public func undo(commit: String, force: Bool) async -> UndoResult {
         let args: JSONValue = .object([
             "commit": .string(commit),

--- a/Sources/AnglesiteCore/VersionStore.swift
+++ b/Sources/AnglesiteCore/VersionStore.swift
@@ -34,6 +34,8 @@ public final class ConflictVersionHandle: @unchecked Sendable, Equatable {
     public let contentURL: URL
     private let markResolvedAction: @Sendable () -> Void
 
+    /// Creates a handle. `markResolved` captures the underlying `NSFileVersion` (or a test stub),
+    /// which is why the handle never needs to re-locate the version itself.
     public init(id: String, contentURL: URL, markResolved: @escaping @Sendable () -> Void) {
         self.id = id
         self.contentURL = contentURL
@@ -45,6 +47,8 @@ public final class ConflictVersionHandle: @unchecked Sendable, Equatable {
     /// in has fully converged, never on a partial or conflicted result.
     public func markResolved() { markResolvedAction() }
 
+    /// Identity is `id` + `contentURL` only — the `markResolved` closure can't be compared, and
+    /// two handles pointing at the same conflict copy should compare equal in tests regardless.
     public static func == (lhs: ConflictVersionHandle, rhs: ConflictVersionHandle) -> Bool {
         lhs.id == rhs.id && lhs.contentURL == rhs.contentURL
     }
@@ -63,6 +67,10 @@ public final class ConflictVersionHandle: @unchecked Sendable, Equatable {
 /// Real conflict versions can't be manufactured in CI, so both phases fake this seam in tests
 /// instead of exercising real iCloud.
 public protocol VersionStore: Sendable {
+    /// Ensures the *current* version of `url` is fully present on local disk, waiting up to
+    /// `timeout` for iCloud to download an evicted item. Never throws — the three-way
+    /// `VersionMaterialization` result is the whole contract, so callers must handle `.timedOut`
+    /// explicitly rather than catching an error.
     func materialize(at url: URL, timeout: TimeInterval) async -> VersionMaterialization
 
     /// Enumerates `url`'s unresolved NSFileVersion conflict versions — the peer writes iCloud
@@ -77,10 +85,15 @@ public struct UbiquitousVersionStore: VersionStore {
     /// How often to re-check the downloading status while waiting.
     private let pollInterval: TimeInterval
 
+    /// Creates the store. `pollInterval` is injectable mainly so tests can tighten the wait loop;
+    /// the 0.2 s default balances responsiveness against spamming resource-value reads.
     public init(pollInterval: TimeInterval = 0.2) {
         self.pollInterval = pollInterval
     }
 
+    /// Polls the item's ubiquitous downloading status until it reaches `.current` or `timeout`
+    /// elapses, kicking off the download first when the item is evicted. A non-ubiquitous URL
+    /// (plain local file, unit-test temp dir) short-circuits to `.alreadyLocal`.
     public func materialize(at url: URL, timeout: TimeInterval) async -> VersionMaterialization {
         guard let status = Self.downloadingStatus(of: url), status != .current else {
             // Not a ubiquitous item at all (plain local file, resource values unavailable — e.g.
@@ -101,6 +114,9 @@ public struct UbiquitousVersionStore: VersionStore {
         try? url.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]).ubiquitousItemDownloadingStatus
     }
 
+    /// Wraps each of `NSFileVersion.unresolvedConflictVersionsOfItem(at:)`'s results in a handle
+    /// whose `markResolved` flips that version's `isResolved` — the index-based `peer-<n>` id is
+    /// only a stable label for logs and ref namespaces within this one enumeration.
     public func conflictVersions(of url: URL) async -> [ConflictVersionHandle] {
         guard let versions = NSFileVersion.unresolvedConflictVersionsOfItem(at: url) else { return [] }
         return versions.enumerated().map { index, version in

--- a/Sources/AnglesiteCore/VisibleElementMessage.swift
+++ b/Sources/AnglesiteCore/VisibleElementMessage.swift
@@ -13,20 +13,38 @@ public struct VisibleElement: Sendable, Equatable {
     /// Per-tab stable id. Sourced from `data-anglesite-id` when present, otherwise a generated
     /// `v-…` string the JS layer keeps stable across reports via an internal WeakMap.
     public let id: String
+    /// Lowercased HTML tag name — the cheapest signal for kind-of-element filtering ("this image"
+    /// vs "this heading") before any selector work happens.
     public let tag: String
+    /// The structured `ElementInfo` metadata (always a JSON object; the decoder enforces this) —
+    /// kept opaque here so the plugin's `server/selector.mjs` remains the only selector builder.
     public let selector: JSONValue
+    /// Viewport-relative bounding box, used for Siri's "this one" hit-testing.
     public let rect: Rect
+    /// Trimmed visible text content, when the element has any — a disambiguation hint, not a
+    /// faithful copy of the DOM.
     public let text: String?
+    /// The element's resolved `src` (images/media), when present.
     public let src: String?
+    /// The element's ARIA role, when the JS layer could determine one.
     public let role: String?
+    /// The page path the element was observed on — lets the provider scope entities to the page
+    /// the preview is actually showing.
     public let pagePath: String?
 
+    /// A viewport-coordinate bounding box. A minimal value type rather than `CGRect` so this
+    /// message stays Foundation-only and portable off-Darwin.
     public struct Rect: Sendable, Equatable {
+        /// Left edge, in CSS pixels relative to the viewport.
         public let x: Double
+        /// Top edge, in CSS pixels relative to the viewport.
         public let y: Double
+        /// Width in CSS pixels.
         public let width: Double
+        /// Height in CSS pixels.
         public let height: Double
 
+        /// Creates a rect from the four viewport-relative components.
         public init(x: Double, y: Double, width: Double, height: Double) {
             self.x = x
             self.y = y
@@ -35,6 +53,8 @@ public struct VisibleElement: Sendable, Equatable {
         }
     }
 
+    /// Memberwise creation, with the optional disambiguation hints defaulting to `nil` so tests
+    /// and alternate producers only spell out what they care about.
     public init(
         id: String,
         tag: String,
@@ -58,19 +78,32 @@ public struct VisibleElement: Sendable, Equatable {
 
 /// The full `anglesite:visible-elements` payload — type tag plus the element list.
 public struct VisibleElementReport: Sendable, Equatable {
+    /// The `type` discriminator the JS reporter stamps on every payload; ``decode(from:)`` rejects
+    /// anything else so one script handler can route multiple message families.
     public static let messageType = "anglesite:visible-elements"
 
+    /// The elements visible at report time, in the order the JS layer enumerated them.
     public let elements: [VisibleElement]
 
+    /// Wraps an element list — used by tests and by ``decode(from:)`` on success.
     public init(elements: [VisibleElement]) {
         self.elements = elements
     }
 
+    /// Report-level decode failure shape. Each case pins down *where* a malformed payload went
+    /// wrong, because a bare "bad message" from the JS boundary is undebuggable.
     public enum DecodeError: Error, Sendable, Equatable {
+        /// The body wasn't a dictionary at all.
         case notAnObject
+        /// A required top-level key was absent.
         case missingField(String)
+        /// A top-level key was present but had the wrong type.
         case wrongType(field: String, expected: String)
+        /// The `type` tag didn't match ``VisibleElementReport/messageType`` — the message belongs
+        /// to another family.
         case unknownType(String)
+        /// One element in the batch failed to decode; the whole report is rejected rather than
+        /// silently dropping the bad element, so the JS bug surfaces instead of hiding.
         case malformedElement(index: Int, error: VisibleElement.DecodeError)
     }
 
@@ -106,8 +139,11 @@ extension VisibleElement {
     /// `Type.DecodeError` pairing `EditMessage` uses), and surfaced from the report's
     /// `DecodeError.malformedElement(index:error:)` case when one element in a batch fails.
     public enum DecodeError: Error, Sendable, Equatable {
+        /// The element payload wasn't a dictionary.
         case notAnObject
+        /// A required element key was absent.
         case missingField(String)
+        /// An element key was present but had the wrong type.
         case wrongType(field: String, expected: String)
     }
 

--- a/Sources/AnglesiteCore/VsockTCPProxy.swift
+++ b/Sources/AnglesiteCore/VsockTCPProxy.swift
@@ -32,6 +32,9 @@ public actor VsockTCPProxy {
     private var acceptSource: DispatchSourceRead?
     private var connections: [ProxyConnection] = []
 
+    /// Creates a proxy for one guest port. The diagnostic closures default to no-ops so callers
+    /// that don't care about the failure-stage breakdown (tests, simple tools) stay one-liners,
+    /// while the runtime wires them into the debug pane.
     public init(
         guestPort: UInt32,
         dial: @escaping VsockDialer,
@@ -88,6 +91,8 @@ public actor VsockTCPProxy {
         return URL(string: "http://127.0.0.1:\(port)")!
     }
 
+    /// Tears down the listener and every live spliced connection. Safe to call more than once —
+    /// a straggling accept-handler invocation after cancel is absorbed by the fd guards below.
     public func stop() {
         // cancel() is async wrt GCD delivery, so one more handler invocation may fire after this;
         // accept() on the closed fd returns EBADF (<0), which the handler's `guard conn >= 0` catches cleanly.

--- a/Sources/AnglesiteCore/WCAGContrast.swift
+++ b/Sources/AnglesiteCore/WCAGContrast.swift
@@ -3,12 +3,19 @@ import Foundation
 /// WCAG 2.2 contrast-ratio utilities, ported 1:1 from the plugin's `scripts/contrast.ts`.
 /// Pure, no I/O.
 public struct RGBColor: Sendable, Equatable {
+    /// Red channel, 0–255.
     public let r: Int
+    /// Green channel, 0–255.
     public let g: Int
+    /// Blue channel, 0–255.
     public let b: Int
+    /// Creates a color from 0–255 channel values. Not range-checked here — clamping happens at
+    /// the serialization edge (`suggestReadable`'s hex output) instead.
     public init(r: Int, g: Int, b: Int) { self.r = r; self.g = g; self.b = b }
 }
 
+/// Namespace for the WCAG 2.2 contrast math — kept a caseless enum so the port from the plugin's
+/// `scripts/contrast.ts` stays a set of pure static functions with no state to drift.
 public enum WCAGContrast {
     /// Parses a hex color (`#rgb` or `#rrggbb`, leading `#` optional). Returns `nil` for invalid input.
     public static func hexToRGB(_ hex: String) -> RGBColor? {
@@ -42,7 +49,11 @@ public enum WCAGContrast {
         return (lighter + 0.05) / (darker + 0.05)
     }
 
+    /// Whether the pair meets WCAG AA for normal-size text (ratio ≥ 4.5:1). A parse failure yields
+    /// `NaN`, and `NaN >= 4.5` is `false` — unparseable colors fail closed.
     public static func meetsAA(fg: String, bg: String) -> Bool { contrastRatio(fg, bg) >= 4.5 }
+    /// Whether the pair meets WCAG AA for large text (ratio ≥ 3:1); fails closed on parse errors
+    /// like ``meetsAA(fg:bg:)``.
     public static func meetsAALarge(fg: String, bg: String) -> Bool { contrastRatio(fg, bg) >= 3 }
 
     private static func toHex(_ rgb: RGBColor) -> String {

--- a/Sources/AnglesiteCore/WebSubPublishPing.swift
+++ b/Sources/AnglesiteCore/WebSubPublishPing.swift
@@ -18,17 +18,27 @@ import FoundationNetworking
 /// as the webmention-send and POSSE passes it runs alongside in
 /// `DeployCoordinator.runPostDeploySequencing`.
 public struct WebSubPublishPing: Sendable {
+    /// Injectable HTTP seam so tests can stub hub responses without a network. Returning
+    /// `HTTPURLResponse` (not `URLResponse`) keeps the "was this even HTTP?" check inside the
+    /// transport, so `notify` only reasons about status codes.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     /// The feed paths the hub serves as topics. Must mirror the template's
     /// `worker/worker.ts` `WEBSUB_TOPIC_PATHS` — a ping for any other path is a 400.
     public static let topicPaths = ["/rss.xml", "/atom.xml", "/feed.json"]
 
+    /// The result of pinging the hub for one feed topic. Reported instead of thrown so a partial
+    /// failure (one feed rejected, two accepted) stays visible per-topic rather than collapsing
+    /// into a single error for the whole pass.
     public struct Outcome: Equatable, Sendable {
+        /// The full topic URL that was pinged (`<origin><feed path>`).
         public let topic: String
+        /// Whether the hub answered with a 2xx.
         public let accepted: Bool
+        /// Failure detail (HTTP status + body, or the transport error) — `nil` on success.
         public let detail: String?
 
+        /// Creates an outcome; `detail` defaults to `nil` for the accepted case.
         public init(topic: String, accepted: Bool, detail: String? = nil) {
             self.topic = topic
             self.accepted = accepted
@@ -38,6 +48,7 @@ public struct WebSubPublishPing: Sendable {
 
     private let transport: Transport
 
+    /// Creates a pinger; pass a custom `transport` in tests to stub the hub without a network.
     public init(transport: @escaping Transport = WebSubPublishPing.defaultTransport) {
         self.transport = transport
     }
@@ -129,6 +140,10 @@ public struct WebSubPublishPing: Sendable {
         return URLSession(configuration: config)
     }()
 
+    /// Production transport: a dedicated ephemeral `URLSession` with the tight per-request
+    /// timeout above (not `URLSession.shared`, whose ~60s default could stall a deploy's
+    /// post-processing on an unreachable hub). A non-HTTP response is surfaced as
+    /// `URLError.badServerResponse` rather than silently coerced.
     public static let defaultTransport: Transport = { request in
         let (data, response) = try await defaultSession.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }

--- a/Sources/AnglesiteCore/WebmentionInboxD1Client.swift
+++ b/Sources/AnglesiteCore/WebmentionInboxD1Client.swift
@@ -23,15 +23,27 @@ public struct WebmentionInboxD1Client: Sendable {
     /// (`author.name` -> `authorName`, etc.) since this is a SQL projection, not a JSON decode of
     /// that type. Dates are epoch milliseconds, matching the column types.
     public struct Mention: Sendable, Equatable {
+        /// Stable row id (upstream's FNV-1a hash of source+target) — rows without one are
+        /// skipped at decode, so this is non-optional here even though the column predates it.
         public let id: String
+        /// URL of the page that mentioned us.
         public let source: String
+        /// URL on this site that was mentioned.
         public let target: String
+        /// When the Worker verified the mention, in epoch milliseconds (the column's native unit).
         public let verifiedAt: Int
+        /// Microformats interaction class (`like`, `repost`, `reply`, …) — `nil` on rows written
+        /// before the mf2-enrichment pass landed upstream.
         public let interactionType: String?
+        /// Author display name from the source page's h-card, when enrichment ran.
         public let authorName: String?
+        /// Author profile URL from the source page's h-card, when enrichment ran.
         public let authorURL: String?
+        /// Author avatar URL from the source page's h-card, when enrichment ran.
         public let authorPhoto: String?
+        /// Excerpted mention content (reply text), when enrichment ran.
         public let content: String?
+        /// Source page's declared publication date in epoch milliseconds, when enrichment ran.
         public let publishedAt: Int?
     }
 
@@ -76,6 +88,10 @@ public struct WebmentionInboxD1Client: Sendable {
     private let apiToken: String
     private let transport: CloudflareTransport
 
+    /// Creates a client for one site's inbox database. The token is passed in directly (no
+    /// Keychain coupling — the caller owns credential resolution, matching `InboxKVClient`);
+    /// `baseURL` and `transport` are injectable so tests can point at a stub instead of the
+    /// live Cloudflare API.
     public init(
         accountID: String,
         databaseID: String,

--- a/Sources/AnglesiteCore/WebmentionSendCommand.swift
+++ b/Sources/AnglesiteCore/WebmentionSendCommand.swift
@@ -22,6 +22,9 @@ public actor WebmentionSendCommand {
     /// not appended, on every call for that site).
     private var inFlight: [String: Task<Void, Never>] = [:]
 
+    /// Creates the orchestrator. Everything is injectable — transport, log sink, and clock — so
+    /// tests can script endpoint discovery/POST responses and assert on the persisted timestamps
+    /// without network or wall-clock time.
     public init(
         transport: @escaping WebmentionEndpointDiscovery.Transport = WebmentionSendCommand.defaultTransport,
         logCenter: LogCenter = .shared,

--- a/Sources/AnglesiteCore/WebmentionSender.swift
+++ b/Sources/AnglesiteCore/WebmentionSender.swift
@@ -5,8 +5,14 @@ import FoundationNetworking
 
 /// Outcome of one webmention send attempt for a single (source, target) pair.
 public enum WebmentionSendOutcome: Equatable, Sendable {
+    /// The endpoint accepted the mention (2xx). `statusCode` distinguishes a synchronous 200 from
+    /// an async-processing 201/202, both of which count as sent.
     case sent(endpoint: URL, statusCode: Int)
+    /// The target declares no webmention endpoint — a normal outcome (most of the web doesn't),
+    /// distinct from failure so callers can skip quietly rather than log an error.
     case noEndpointDiscovered
+    /// Discovery or the POST failed; `reason` is human-readable for the log pane. The pair stays
+    /// unrecorded, so the next send pass retries it for free.
     case requestFailed(reason: String)
 }
 
@@ -15,6 +21,9 @@ public enum WebmentionSendOutcome: Equatable, Sendable {
 /// a caller that doesn't record a `.requestFailed` pair as sent gets a free retry on its next
 /// pass (see `WebmentionSendCommand`).
 public enum WebmentionSender {
+    /// Discovers `target`'s endpoint and POSTs the form-encoded pair, folding every failure mode
+    /// into a ``WebmentionSendOutcome`` instead of throwing — the caller treats each pair as
+    /// independent best-effort work and only needs a value to log/record.
     public static func send(
         source: URL,
         target: URL,

--- a/Sources/AnglesiteCore/WebmentionSentLog.swift
+++ b/Sources/AnglesiteCore/WebmentionSentLog.swift
@@ -3,9 +3,13 @@ import Foundation
 /// A `(source, target)` webmention pair — the unit `WebmentionSentLog` tracks and
 /// `WebmentionSendCommand` sends.
 public struct WebmentionTargetPair: Equatable, Sendable {
+    /// The just-published page on the owner's site that mentions the target.
     public let source: URL
+    /// The external URL being notified.
     public let target: URL
 
+    /// Creates a pair; identity is exact URL equality (no normalization), matching how the sent
+    /// log keys pairs.
     public init(source: URL, target: URL) {
         self.source = source
         self.target = target
@@ -18,11 +22,18 @@ public struct WebmentionTargetPair: Equatable, Sendable {
 /// skip pairs it already notified on a prior deploy, instead of re-pinging every target's
 /// endpoint on every redeploy.
 public struct WebmentionSentLog: Equatable, Sendable {
+    /// One successfully-sent pair plus when it was sent — the timestamp is diagnostic (nothing
+    /// currently expires entries; the pair alone decides dedup).
     public struct Entry: Codable, Equatable, Sendable {
+        /// The owner-site page that carried the mention.
         public let source: URL
+        /// The external URL that was notified.
         public let target: URL
+        /// When the send succeeded (ISO 8601 on disk).
         public let sentAt: Date
 
+        /// Memberwise creation — normally reached via ``WebmentionSentLog/recording(_:now:)``
+        /// rather than directly.
         public init(source: URL, target: URL, sentAt: Date) {
             self.source = source
             self.target = target
@@ -30,12 +41,15 @@ public struct WebmentionSentLog: Equatable, Sendable {
         }
     }
 
+    /// Every pair recorded as sent, in recording order. Append-only via ``recording(_:now:)``.
     public let sent: [Entry]
 
+    /// Creates a log; the empty default is the "fresh site, nothing sent yet" starting state.
     public init(sent: [Entry] = []) {
         self.sent = sent
     }
 
+    /// On-disk filename inside the site's `Config/` directory.
     public static let filename = "webmention-sent.json"
 
     private struct Envelope: Codable {
@@ -52,6 +66,8 @@ public struct WebmentionSentLog: Equatable, Sendable {
         return WebmentionSentLog(sent: envelope.sent)
     }
 
+    /// Writes the log atomically. Losing this file is safe — the worst case is re-sending
+    /// webmentions the targets already received, which the protocol treats as an update.
     public func save(to configDirectory: URL) throws {
         let url = configDirectory.appendingPathComponent(Self.filename)
         let encoder = JSONEncoder()

--- a/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
+++ b/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
@@ -1,26 +1,46 @@
 import Foundation
 
+/// Manages the analytics `<script>` block in a site's base layout, plus the `.site-config` keys
+/// that go with it. The layout itself is the source of truth: settings are re-parsed from the
+/// marker-delimited HTML block on every read rather than stored separately, so an owner (or git)
+/// editing the layout by hand can never drift out of sync with what the app shows.
 public enum WebsiteAnalyticsAsset {
+    /// The two analytics inputs the settings UI edits: a Cloudflare Web Analytics token, and a
+    /// free-form custom `<head>` snippet for any other provider.
     public struct Settings: Sendable, Equatable {
+        /// The Cloudflare Web Analytics beacon token; empty means Cloudflare analytics is off.
         public var cloudflareToken: String
+        /// Owner-supplied `<head>` HTML for a non-Cloudflare provider. Validated by
+        /// ``WebsiteAnalyticsAsset/customHeadTagValidationMessage(_:)`` before install, since a
+        /// malformed snippet here would corrupt the layout for every page.
         public var customHeadTag: String
 
+        /// Creates settings; both fields default empty so `Settings()` means "analytics off".
         public init(cloudflareToken: String = "", customHeadTag: String = "") {
             self.cloudflareToken = cloudflareToken
             self.customHeadTag = customHeadTag
         }
 
+        /// True when neither field has non-whitespace content — the signal to *remove* the managed
+        /// block from the layout rather than write an empty one.
         public var isEmpty: Bool {
             cloudflareToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 && customHeadTag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }
 
+    /// Failures ``WebsiteAnalyticsAsset/install(_:siteDirectory:fileManager:)`` can throw — each
+    /// carries enough context for a user-facing message, since these surface directly in the
+    /// settings UI.
     public enum InstallError: LocalizedError, Sendable {
+        /// The base layout file doesn't exist where the template puts it.
         case layoutNotFound(URL)
+        /// The layout has no `</head>` to insert before — the block would have nowhere to live.
         case headCloseTagNotFound(URL)
+        /// The custom HTML failed validation; the associated string is the user-facing reason.
         case invalidCustomHTML(String)
 
+        /// User-facing message for each failure, shown as-is in the settings sheet.
         public var errorDescription: String? {
             switch self {
             case .layoutNotFound(let url):
@@ -33,8 +53,13 @@ public enum WebsiteAnalyticsAsset {
         }
     }
 
+    /// Where the template keeps the base layout the analytics block is patched into.
     public static let layoutRelativePath = "src/layouts/BaseLayout.astro"
+    /// The template-owned config file (lives in `Source/`, unlike app-owned `Config/` state) that
+    /// carries the token and CSP domains for the pre-deploy check.
     public static let configRelativePath = ".site-config"
+    /// Deep link into the Cloudflare dashboard's Web Analytics page (`:account` is resolved by
+    /// Cloudflare to the signed-in account), for the "get a token" affordance in settings.
     public static let dashboardURL = URL(string: "https://dash.cloudflare.com/?to=/:account/web-analytics")!
 
     /// CSP origins the Cloudflare Web Analytics beacon needs: the script host and the
@@ -48,6 +73,8 @@ public enum WebsiteAnalyticsAsset {
     private static let customStart = "<!-- anglesite:custom-analytics-start -->"
     private static let customEnd = "<!-- anglesite:custom-analytics-end -->"
 
+    /// Recovers the current settings from the layout's managed block — the read half of the
+    /// layout-is-source-of-truth design. Absent markers simply yield empty settings.
     public static func parseSettings(from source: String) -> Settings {
         Settings(
             cloudflareToken: cloudflareToken(in: source) ?? "",
@@ -55,6 +82,10 @@ public enum WebsiteAnalyticsAsset {
         )
     }
 
+    /// Rewrites the layout source with the managed block matching `settings`: replaces an existing
+    /// block in place (removing it entirely when settings are empty), otherwise inserts before
+    /// `</head>`. Pure — returns `source` unchanged when there's nowhere to insert, so the caller
+    /// decides whether a missing `</head>` is an error (see ``install(_:siteDirectory:fileManager:)``).
     public static func apply(_ settings: Settings, to source: String) -> String {
         let block = renderBlock(settings)
         if let existing = analyticsBlockRange(in: source) {
@@ -72,6 +103,10 @@ public enum WebsiteAnalyticsAsset {
         return patched
     }
 
+    /// The I/O entry point: validates the custom HTML, patches the layout (migrating any legacy
+    /// hand-installed Google tag into the managed block), and upserts the token plus any custom
+    /// script domains into `.site-config` — the CSP domains keep the pre-deploy check from
+    /// blocking the very script this feature just installed. Writes only on actual change.
     public static func install(_ settings: Settings, siteDirectory: URL, fileManager: FileManager = .default) throws {
         if let validationMessage = customHeadTagValidationMessage(settings.customHeadTag) {
             throw InstallError.invalidCustomHTML(validationMessage)
@@ -110,6 +145,10 @@ public enum WebsiteAnalyticsAsset {
         }
     }
 
+    /// The canonical way to resolve a site's host from its `.site-config`. The app writes the
+    /// `DOMAIN` key; `SITE_DOMAIN` is only accepted as a legacy fallback — resolve hosts through
+    /// this method rather than reading either key directly, so every caller agrees on the
+    /// precedence.
     public static func bestHost(from config: String, fallback: String) -> String {
         let domain = configValue("DOMAIN", in: config)
             ?? configValue("SITE_DOMAIN", in: config)
@@ -117,6 +156,9 @@ public enum WebsiteAnalyticsAsset {
         return domain.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Extracts the external hosts of any `<script src="https://…">` tags in the custom HTML, so
+    /// ``install(_:siteDirectory:fileManager:)`` can add them to the site's CSP allowlist. Sorted
+    /// and deduplicated for a deterministic `.site-config` diff.
     public static func customScriptDomains(from html: String) -> [String] {
         guard let regex = try? NSRegularExpression(pattern: #"<script[^>]+src=["']https?://([^/"']+)"#, options: [.caseInsensitive]) else {
             return []
@@ -129,6 +171,10 @@ public enum WebsiteAnalyticsAsset {
         return Array(Set(domains)).sorted()
     }
 
+    /// Returns a user-facing rejection message for custom head HTML, or `nil` when it's safe to
+    /// install. The checks are structural, not a full HTML parse: an unfinished comment, dangling
+    /// tag, unclosed `<script>`, or an embedded copy of Anglesite's own marker comments would each
+    /// break the marker-based block parsing (or swallow the rest of the layout's `<head>`).
     public static func customHeadTagValidationMessage(_ html: String) -> String? {
         let snippet = html.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !snippet.isEmpty else { return nil }
@@ -153,6 +199,8 @@ public enum WebsiteAnalyticsAsset {
         return nil
     }
 
+    /// Reads one `KEY=value` line from `.site-config` contents; `nil` when the key is absent.
+    /// Line-oriented on purpose — the file is a simple env-style format, not a parsed grammar.
     public static func configValue(_ key: String, in config: String) -> String? {
         for line in config.split(separator: "\n", omittingEmptySubsequences: false) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
@@ -162,12 +210,17 @@ public enum WebsiteAnalyticsAsset {
         return nil
     }
 
+    /// Loads `.site-config`'s raw contents; a missing file reads as empty rather than throwing,
+    /// since a fresh site legitimately has no config yet.
     public static func loadConfig(siteDirectory: URL, fileManager: FileManager = .default) throws -> String {
         let configURL = siteDirectory.appendingPathComponent(configRelativePath)
         guard fileManager.fileExists(atPath: configURL.path) else { return "" }
         return try String(contentsOf: configURL, encoding: .utf8)
     }
 
+    /// Like ``parseSettings(from:)``, but falls back to `.site-config`'s `CF_WEB_ANALYTICS_TOKEN`
+    /// when the layout block carries no token — covering a site whose config was written before
+    /// the layout was patched (or whose layout was edited by hand).
     public static func parseSettings(layoutSource: String, config: String) -> Settings {
         var settings = parseSettings(from: layoutSource)
         if settings.cloudflareToken.isEmpty, let token = configValue("CF_WEB_ANALYTICS_TOKEN", in: config) {
@@ -176,6 +229,8 @@ public enum WebsiteAnalyticsAsset {
         return settings
     }
 
+    /// Assigns a token with whitespace trimmed — the one normalization point, so a pasted token
+    /// with a stray newline doesn't end up verbatim in the beacon attribute and config file.
     public static func setCloudflareToken(_ token: String, in settings: inout Settings) {
         settings.cloudflareToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -202,12 +257,18 @@ public enum WebsiteAnalyticsAsset {
         }
     }
 
+    /// ``parseSettings(layoutSource:config:)`` plus legacy migration: a hand-installed Google
+    /// gtag.js snippet found outside the managed block is surfaced as the custom head tag (unless
+    /// one is already set), so opening settings on an older site shows what's actually installed
+    /// instead of pretending analytics is off.
     public static func parseMigratingLegacySettings(layoutSource: String, config: String) -> Settings {
         var settings = parseSettings(layoutSource: layoutSource, config: config)
         migrateLegacyGoogle(from: layoutSource, into: &settings)
         return settings
     }
 
+    /// Removes a legacy hand-installed gtag.js pair (async loader + inline config) from the layout
+    /// so the migrated copy inside the managed block doesn't leave the tag firing twice.
     public static func stripLegacyGoogle(from source: String) -> String {
         var output = source
         if let asyncRange = output.range(of: #"\n?\s*<script async src="https://www\.googletagmanager\.com/gtag/js\?id=[^"]+"></script>"#, options: .regularExpression) {
@@ -219,6 +280,9 @@ public enum WebsiteAnalyticsAsset {
         return output
     }
 
+    /// ``apply(_:to:)`` after ``stripLegacyGoogle(from:)`` — the write half of legacy migration,
+    /// used by ``install(_:siteDirectory:fileManager:)`` so one save both adopts and de-duplicates
+    /// an old hand-installed tag.
     public static func applyMigratingLegacy(_ settings: Settings, to source: String) -> String {
         apply(settings, to: stripLegacyGoogle(from: source))
     }

--- a/Sources/AnglesiteCore/WebsiteIconAsset.swift
+++ b/Sources/AnglesiteCore/WebsiteIconAsset.swift
@@ -2,19 +2,32 @@ import Foundation
 
 /// Deterministic website icon links and metadata for an Anglesite site's public assets.
 public enum WebsiteIconAsset {
+    /// Astro's static-assets directory, where all icon files land (served from the site root).
     public static let publicDirectoryRelativePath = "public"
+    /// The template's base layout — the one `<head>` every page shares, so patching it once
+    /// covers the whole site.
     public static let layoutRelativePath = "src/layouts/BaseLayout.astro"
+    /// Legacy-format favicon, still the widest-compatibility fallback (`sizes="any"`).
     public static let faviconICOName = "favicon.ico"
+    /// PNG favicon for browsers that prefer it over ICO.
     public static let faviconPNGName = "favicon.png"
+    /// Home-screen icon for iOS/iPadOS Safari.
     public static let appleTouchIconName = "apple-touch-icon.png"
+    /// PWA manifest icon at 192×192 — the minimum Android install-prompt size.
     public static let icon192Name = "icon-192.png"
+    /// PWA manifest icon at 512×512 — used for splash screens and high-density launchers.
     public static let icon512Name = "icon-512.png"
+    /// The web-app manifest filename referenced from ``headLinks``.
     public static let manifestName = "site.webmanifest"
 
+    /// Failures ``WebsiteIconAsset/patchLayout(in:fileManager:)`` can throw.
     public enum InstallError: Error, Sendable {
+        /// The base layout file doesn't exist where the template puts it.
         case layoutNotFound(URL)
     }
 
+    /// The exact `<link>` block inserted after `<head>` — fixed root-relative paths matching the
+    /// filenames above, so the layout never needs regenerating when icon *content* changes.
     public static let headLinks = """
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="icon" type="image/png" href="/favicon.png" />
@@ -22,6 +35,9 @@ public enum WebsiteIconAsset {
         <link rel="manifest" href="/site.webmanifest" />
     """
 
+    /// Inserts ``headLinks`` right after `<head>`, idempotently: an existing favicon or manifest
+    /// href (from a prior install, or hand-authored) leaves the source untouched rather than
+    /// duplicating links. Pure — the file write lives in ``patchLayout(in:fileManager:)``.
     public static func insertHeadLinks(into source: String) -> String {
         guard !source.contains(#"href="/favicon.ico""#),
               !source.contains(#"href="/site.webmanifest""#) else {
@@ -34,6 +50,8 @@ public enum WebsiteIconAsset {
         return patched
     }
 
+    /// Applies ``insertHeadLinks(into:)`` to the site's base layout on disk, writing only when
+    /// the insertion actually changed something (no spurious mtime churn / git noise).
     public static func patchLayout(in siteDirectory: URL, fileManager: FileManager = .default) throws {
         let layoutURL = siteDirectory.appendingPathComponent(layoutRelativePath)
         guard fileManager.fileExists(atPath: layoutURL.path) else {
@@ -46,6 +64,8 @@ public enum WebsiteIconAsset {
         }
     }
 
+    /// Renders the `site.webmanifest` JSON for the two PWA icons. Sorted keys keep the output
+    /// byte-stable across runs, so re-installing icons doesn't dirty the site's git repo.
     public static func manifestData(siteName: String) throws -> Data {
         let manifest: [String: Any] = [
             "name": siteName,
@@ -67,6 +87,8 @@ public enum WebsiteIconAsset {
         return try JSONSerialization.data(withJSONObject: manifest, options: [.prettyPrinted, .sortedKeys])
     }
 
+    /// Every file the icon install writes into `public/`, whether or not it exists yet — the
+    /// single list uninstall/inspection logic should iterate instead of re-deriving filenames.
     public static func installedIconURLs(in siteDirectory: URL) -> [URL] {
         let publicDir = siteDirectory.appendingPathComponent(publicDirectoryRelativePath, isDirectory: true)
         return [
@@ -79,6 +101,8 @@ public enum WebsiteIconAsset {
         ].map { publicDir.appendingPathComponent($0) }
     }
 
+    /// True when *any* icon artifact exists — deliberately not "all", so a partially-completed
+    /// install still reads as installed and a re-run overwrites rather than duplicates.
     public static func hasInstalledIcons(in siteDirectory: URL, fileManager: FileManager = .default) -> Bool {
         installedIconURLs(in: siteDirectory).contains { fileManager.fileExists(atPath: $0.path) }
     }

--- a/Sources/AnglesiteCore/WellKnownClaimManifest.swift
+++ b/Sources/AnglesiteCore/WellKnownClaimManifest.swift
@@ -8,7 +8,10 @@ import Foundation
 
 /// Whether a claim matches one exact path or every path under a prefix.
 public enum WellKnownPathMatch: String, Sendable, Codable, Equatable {
+    /// The claim covers only the path itself.
     case exact
+    /// The claim covers the path and everything nested under it (e.g. an ACME challenge
+    /// directory whose token filenames can't be known in advance).
     case prefix
 }
 
@@ -16,8 +19,12 @@ public enum WellKnownPathMatch: String, Sendable, Codable, Equatable {
 /// `.well-known` path — e.g. a hosting provider's managed-TLS ACME challenge handler. Never
 /// carries credentials, tokens, or runtime bindings.
 public struct RuntimeOwnedPathClaim: Sendable, Codable, Equatable, Identifiable {
+    /// URL scheme a claim applies under — modeled explicitly because ACME's HTTP-01 challenge is
+    /// specified over plain `http`, so "https-only" cannot be assumed for every claim.
     public enum Scheme: String, Sendable, Codable, Equatable {
+        /// Plain HTTP (port 80 by default).
         case http
+        /// HTTPS (port 443 by default) — the default for new claims.
         case https
     }
 
@@ -27,6 +34,7 @@ public struct RuntimeOwnedPathClaim: Sendable, Codable, Equatable, Identifiable 
     public var owner: String
     /// The `.well-known` path segment (or prefix) this claim covers, no leading slash.
     public var path: String
+    /// Whether `path` is claimed exactly or as a prefix.
     public var match: WellKnownPathMatch
     /// Schemes this claim applies under.
     public var schemes: Set<Scheme>
@@ -34,8 +42,11 @@ public struct RuntimeOwnedPathClaim: Sendable, Codable, Equatable, Identifiable 
     public var port: Int?
     /// Human-readable capability/provenance description, e.g. "RFC 8555 managed-TLS ownership".
     public var capability: String
+    /// Link to the specification that grants this ownership (e.g. RFC 8555), when there is one.
     public var specificationURL: URL?
 
+    /// Memberwise creation; `schemes` defaults to https-only and `port` to the scheme default,
+    /// matching the common managed-TLS case.
     public init(
         id: String,
         owner: String,
@@ -61,10 +72,18 @@ public struct RuntimeOwnedPathClaim: Sendable, Codable, Equatable, Identifiable 
 /// inventory) and hands to a runtime's build step. Only the fields a runtime needs to detect a
 /// fresh on-disk collision cross this seam — never raw site settings or credentials.
 public struct WellKnownClaimManifest: Sendable, Codable, Equatable {
+    /// One claim as the build step sees it — a deliberately narrowed projection of the inventory
+    /// row (`WellKnownEndpointDescriptor`), because only these fields are needed to detect and
+    /// report an on-disk collision.
     public struct Entry: Sendable, Codable, Equatable, Identifiable {
+        /// Stable identifier carried over from the inventory row, so a build-step finding can be
+        /// traced back to the exact claim.
         public var id: String
+        /// The `.well-known`-relative path (or prefix), no leading slash.
         public var path: String
+        /// Whether `path` is claimed exactly or as a prefix.
         public var match: WellKnownPathMatch
+        /// The claiming feature/generator/runtime id, for naming the other party in a collision.
         public var owner: String
         /// The claim's delivery class, as the raw value of
         /// `WellKnownEndpointDescriptor.Delivery` (`AnglesiteCore` owns that enum; this contract
@@ -75,6 +94,8 @@ public struct WellKnownClaimManifest: Sendable, Codable, Equatable {
         /// manifest still parses.
         public var delivery: String
 
+        /// Memberwise creation; `delivery` defaults to `"userStatic"` to match the decoder's
+        /// backward-compatible fallback.
         public init(id: String, path: String, match: WellKnownPathMatch, owner: String, delivery: String = "userStatic") {
             self.id = id
             self.path = path
@@ -83,6 +104,8 @@ public struct WellKnownClaimManifest: Sendable, Codable, Equatable {
             self.delivery = delivery
         }
 
+        /// Hand-written only to make `delivery` optional on the wire — an older producer's
+        /// manifest (pre-`delivery`) must keep parsing as `"userStatic"`.
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             id = try container.decode(String.self, forKey: .id)
@@ -93,8 +116,11 @@ public struct WellKnownClaimManifest: Sendable, Codable, Equatable {
         }
     }
 
+    /// The full claim set the build step must check new artifacts against.
     public var entries: [Entry]
 
+    /// Creates a manifest; the empty default is a valid "no claims yet" manifest, not an error
+    /// state.
     public init(entries: [Entry] = []) {
         self.entries = entries
     }
@@ -111,10 +137,15 @@ public struct WellKnownClaimManifest: Sendable, Codable, Equatable {
 
 /// What a build step observed on disk after receiving a `WellKnownClaimManifest`.
 public struct WellKnownBuildSeamResult: Sendable, Codable, Equatable {
+    /// One build-step observation worth reporting — a collision, a rejected file, or anything
+    /// else the step wants surfaced host-side.
     public struct Finding: Sendable, Codable, Equatable {
+        /// The `.well-known`-relative path the finding is about, or `nil` for a step-wide note.
         public var path: String?
+        /// Human-readable description, surfaced verbatim in host-side diagnostics.
         public var message: String
 
+        /// Memberwise creation; `path` defaults to `nil` for findings not tied to one file.
         public init(path: String? = nil, message: String) {
             self.path = path
             self.message = message
@@ -129,14 +160,19 @@ public struct WellKnownBuildSeamResult: Sendable, Codable, Equatable {
     /// did not exist when it scanned — without this, every generated `security.txt`/`mta-sts.txt`
     /// would read as an unclaimed artifact on a first deploy.
     public var generatedArtifacts: [String]
+    /// Whatever the build step chose to report beyond the artifact lists.
     public var findings: [Finding]
 
+    /// Memberwise creation; all-empty defaults are the same shape a malformed result degrades to
+    /// (see ``parsing(_:)``).
     public init(observedArtifacts: [String] = [], generatedArtifacts: [String] = [], findings: [Finding] = []) {
         self.observedArtifacts = observedArtifacts
         self.generatedArtifacts = generatedArtifacts
         self.findings = findings
     }
 
+    /// Hand-written so every field is optional on the wire — a build step that predates a field
+    /// (or omits an empty list) still produces a valid result.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         observedArtifacts = try container.decodeIfPresent([String].self, forKey: .observedArtifacts) ?? []
@@ -166,5 +202,8 @@ public enum WellKnownBuildSeamOutcome: Sendable, Equatable {
     case unsupported
     /// The build was cancelled before it produced a result.
     case cancelled
+    /// The build ran; carries the step result plus whatever the build step reported — the only
+    /// case from which a ``WellKnownBuildSeamResult`` can be obtained, which is what forces
+    /// callers to handle `.unsupported`/`.cancelled` honestly.
     case completed(DeployStepResult, WellKnownBuildSeamResult)
 }

--- a/Sources/AnglesiteCore/WellKnownInventory.swift
+++ b/Sources/AnglesiteCore/WellKnownInventory.swift
@@ -12,6 +12,8 @@ import Foundation
 /// `.well-known/` prefix) — e.g. `"security.txt"`, `"webfinger"`, `"acme-challenge/"` — matching
 /// `WellKnownClaimManifest.Entry.path`'s convention.
 public struct WellKnownEndpointDescriptor: Sendable, Codable, Equatable, Identifiable {
+    /// The four delivery-owner classes the design doc defines — *how* an endpoint gets served
+    /// decides which collision and verification rules apply to it.
     public enum Delivery: String, Sendable, Codable, Equatable {
         /// A committed file in `Source/public/.well-known/` with no recognized Anglesite marker.
         case userStatic
@@ -27,11 +29,18 @@ public struct WellKnownEndpointDescriptor: Sendable, Codable, Equatable, Identif
     /// IANA Well-Known URI registry status, or `.custom` for anything else (including "not
     /// registered at all" and "registration unknown to this descriptor").
     public enum Registration: Sendable, Codable, Equatable {
+        /// Permanently registered in the IANA Well-Known URIs registry.
         case permanent
+        /// Provisionally registered with IANA.
         case provisional
+        /// Registered but deprecated — inventoried, not endorsed.
         case deprecated
+        /// Anything else, carrying the raw string so an unrecognized future status round-trips
+        /// instead of failing to decode.
         case custom(String)
 
+        /// Hand-written to decode unknown strings as `.custom` — a raw-value enum would throw on
+        /// a status this build doesn't know, making the inventory brittle against registry churn.
         public init(from decoder: Decoder) throws {
             let raw = try decoder.singleValueContainer().decode(String.self)
             switch raw {
@@ -42,6 +51,7 @@ public struct WellKnownEndpointDescriptor: Sendable, Codable, Equatable, Identif
             }
         }
 
+        /// Encodes as the plain status string, so `.custom(raw)` round-trips byte-identically.
         public func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             switch self {
@@ -53,19 +63,30 @@ public struct WellKnownEndpointDescriptor: Sendable, Codable, Equatable, Identif
         }
     }
 
+    /// Stable identifier, unique within one assembled inventory.
     public var id: String
+    /// Path relative to `.well-known/` — see the type doc for the exact convention.
     public var suffix: String
+    /// Whether `suffix` is claimed exactly or as a prefix.
     public var match: WellKnownPathMatch
+    /// Which delivery-owner class serves this endpoint.
     public var delivery: Delivery
     /// Stable feature, generator, or runtime id — e.g. `"generator:security-txt"`,
     /// `"webfinger"` (a `WorkerDescriptor.id`), or a `RuntimeOwnedPathClaim.owner`.
     public var owner: String
+    /// IANA registry status for this well-known URI.
     public var registration: Registration
+    /// Link to the governing specification, when known.
     public var specificationURL: URL?
     /// `nil` means inventory-only: Anglesite makes no conformance claim for this endpoint.
     public var validatorID: String?
+    /// Whether this endpoint binds domain authority (e.g. an ACME challenge proves control of the
+    /// host) — flagged so authority-carrying paths can be treated more strictly than plain
+    /// metadata documents.
     public var authorityBinding: Bool
 
+    /// Memberwise creation; the optional/`false` defaults describe a plain inventory row with no
+    /// spec link, no conformance claim, and no authority binding.
     public init(
         id: String,
         suffix: String,
@@ -99,9 +120,13 @@ public enum WellKnownInventory {
 
     /// One party attributed to a collision, for naming both remediation sources in an error.
     public struct Claimant: Sendable, Equatable, Hashable {
+        /// The claiming feature/generator/runtime id.
         public let owner: String
+        /// How the claimant delivers its endpoint — included so a collision message can tell
+        /// static-vs-dynamic apart without a second lookup.
         public let delivery: WellKnownEndpointDescriptor.Delivery
 
+        /// Memberwise creation.
         public init(owner: String, delivery: WellKnownEndpointDescriptor.Delivery) {
             self.owner = owner
             self.delivery = delivery
@@ -112,9 +137,12 @@ public enum WellKnownInventory {
     /// artifact, or an unexpected artifact. Never blocks assembly by itself; callers decide how to
     /// surface these (e.g. as `PreDeployCheck.ScanWarning`/`ScanFailure`).
     public struct Finding: Sendable, Equatable {
+        /// The `.well-known`-relative path the finding is about, or `nil` for a scan-wide note.
         public var path: String?
+        /// Human-readable description, surfaced verbatim to the caller's warning channel.
         public var message: String
 
+        /// Memberwise creation; `path` defaults to `nil` for findings not tied to one file.
         public init(path: String? = nil, message: String) {
             self.path = path
             self.message = message
@@ -133,6 +161,8 @@ public enum WellKnownInventory {
         /// exact/prefix and prefix/prefix collisions.
         case overlappingClaims(path: String, claimant: Claimant, otherPath: String, other: Claimant)
 
+        /// The design-doc-mandated error text: every message names the exact path and every
+        /// claimant (owner + delivery class), so the owner knows both sides of the conflict.
         public var description: String {
             switch self {
             case .duplicateClaim(let path, let claimants):

--- a/Sources/AnglesiteCore/WorkerCatalog.swift
+++ b/Sources/AnglesiteCore/WorkerCatalog.swift
@@ -5,13 +5,19 @@ import Foundation
 /// (design doc §3): whatever the manifest lists is what the Workers tab shows and what deploy
 /// composition can activate.
 public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
+    /// Stable worker id from the manifest (e.g. also referenced by `requires` and conformance
+    /// reports) — the identity everything else keys on.
     public let id: String
+    /// Human-readable name shown in the Workers tab.
     public let displayName: String
+    /// Manifest-supplied description shown alongside the toggle.
     public let description: String
     /// Free-text grouping key the Workers tab sections by (e.g. `"social"`, `"storage"`) — never
     /// enumerated in Swift, since the manifest owns the set of groups.
     public let group: String
+    /// How this worker becomes active — see ``Binding``.
     public let binding: Binding
+    /// The Cloudflare resources this worker needs provisioned — see ``Resources``.
     public let resources: Resources
     /// Generic HTTP route claims this worker's handler serves (#746). Optional so catalogs
     /// published before the route-claim schema extension still decode; `nil` (or `[]`) means the
@@ -27,6 +33,9 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
     /// the ids it names, provided they're present in the catalog.
     public let requires: [String]?
 
+    /// Memberwise creation (mainly for tests/fixtures — production descriptors come from
+    /// `WorkerCatalogReader.parse`). The optional fields default `nil`, matching what an older
+    /// published catalog decodes to.
     public init(
         id: String,
         displayName: String,
@@ -51,7 +60,10 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
     /// active state is always recomputed from Site Graph Explorer's `ImpactAnalysis` against
     /// `componentIDs` (design doc §4). `settingsActivated` workers are toggled in the Workers tab.
     public enum Binding: Sendable, Equatable, Codable {
+        /// Active exactly when one of `componentIDs` is in use on the site — recomputed, never
+        /// user-toggled.
         case componentTied(componentIDs: [String])
+        /// Active when the owner turns it on in the Workers tab.
         case settingsActivated
 
         private enum CodingKeys: String, CodingKey {
@@ -59,6 +71,9 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
             case componentIDs
         }
 
+        /// Hand-written to decode the manifest's tagged `{"kind": …}` object form. An unknown
+        /// `kind` throws — a binding style this build doesn't understand must not be silently
+        /// coerced into a toggleable worker.
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             let kind = try container.decode(String.self, forKey: .kind)
@@ -74,6 +89,7 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
             }
         }
 
+        /// Encodes the same tagged `{"kind": …}` object shape the decoder accepts.
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             switch self {
@@ -98,10 +114,14 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
     /// no provisioning flag yet and are ignored here — adopting their fidelity is future work,
     /// not silently claimed. Encoding always emits the object form.
     public struct Resources: Sendable, Equatable, Codable {
+        /// Whether the worker needs a D1 database binding.
         public let needsD1: Bool
+        /// Whether the worker needs a KV namespace binding.
         public let needsKV: Bool
+        /// Whether the worker needs an R2 bucket binding.
         public let needsR2: Bool
 
+        /// Memberwise creation, used by fixtures and by the dual-shape decoder below.
         public init(needsD1: Bool, needsKV: Bool, needsR2: Bool) {
             self.needsD1 = needsD1
             self.needsKV = needsKV
@@ -118,6 +138,9 @@ public struct WorkerDescriptor: Sendable, Equatable, Codable, Identifiable {
             let type: String
         }
 
+        /// Decodes both published shapes (see the type doc): tries the catalog's array-of-typed-
+        /// bindings form first, then falls back to the object form used by fixtures and older
+        /// caches.
         public init(from decoder: Decoder) throws {
             if var entries = try? decoder.unkeyedContainer() {
                 var d1 = false, kv = false, r2 = false
@@ -168,7 +191,10 @@ public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
     /// approves child paths (RFC 8615's ACME-style delegation) — enforced by
     /// `WorkerRouteClaims.validate` requiring `specificationURL` on prefix claims.
     public enum Match: String, Sendable, Codable {
+        /// Matches only the declared path.
         case exact
+        /// Also matches descendants — restricted to specification-approved delegation (see the
+        /// enum doc above).
         case prefix
     }
 
@@ -178,6 +204,7 @@ public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
     /// catalog's published convention (`spec/catalog.md`: "a prefix path ends with `/`") — is
     /// stripped on construction so this always holds the app's own slash-less canonical form.
     public let path: String
+    /// How requests bind to `path` — see ``Match``.
     public let match: Match
     /// Uppercase HTTP methods the handler serves. `HEAD` must be declared explicitly to be
     /// supported and requires a paired `GET` (the dispatcher serves HEAD by mirroring GET's
@@ -198,6 +225,9 @@ public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
     /// can approve child paths); recommended for exact claims.
     public let specificationURL: URL?
 
+    /// Memberwise creation. Normalizes `path` on the way in (a prefix claim's trailing slash is
+    /// stripped — see `normalizedPrefixPath`), so a claim constructed in Swift and one decoded
+    /// from the catalog always compare equal.
     public init(
         path: String,
         match: Match,
@@ -220,6 +250,10 @@ public struct WorkerRouteClaim: Sendable, Equatable, Hashable, Codable {
         case path, match, methods, handler, validatorID, authorityBinding, specificationURL
     }
 
+    /// Hand-written for two backward-compatibility reasons: the optional fields
+    /// (`validatorID`/`authorityBinding`/`specificationURL`) must stay optional on the wire so
+    /// older published catalogs keep decoding, and `path` gets the same prefix-slash
+    /// normalization the memberwise initializer applies.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let decodedPath = try container.decode(String.self, forKey: .path)

--- a/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
+++ b/Sources/AnglesiteCore/WorkerCatalogFetcher.swift
@@ -10,7 +10,10 @@ import FoundationNetworking
 import OSLog
 #endif
 
+/// Internal failure signal for the fetch path — never escapes `WorkerCatalogFetcher.catalog()`,
+/// which degrades to cache/empty instead of throwing; public only so tests can construct it.
 public enum WorkerCatalogFetchError: Error, Sendable, Equatable {
+    /// The HTTP fetch didn't produce a usable 2xx response; the string names the URL for the log.
     case fetchFailed(String)
 }
 
@@ -38,6 +41,9 @@ public actor WorkerCatalogFetcher {
     private let session: URLSession
     private let fileManager: FileManager
 
+    /// Creates a fetcher. `catalogURL` is deliberately required (pass ``productionCatalogURL`` in
+    /// production) so tests point at a local fixture server; cache location, session, and file
+    /// manager default to production values.
     public init(
         catalogURL: URL,
         cacheURL: URL = WorkerCatalogFetcher.defaultCacheURL(),

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -9,7 +9,11 @@ import Foundation
 /// Cloudflare resource identifiers once provisioning has created the backing stores.
 public enum WorkerComposition {
 
+    /// Ways `generateWranglerToml` can refuse to generate — both exist to keep unvalidated input
+    /// out of the generated file.
     public enum ConfigError: Error, Sendable {
+        /// `siteName` contains characters outside `[A-Za-z0-9_-]` — it's interpolated into TOML
+        /// and used as the Cloudflare project name, so anything else is rejected up front.
         case invalidSiteName(String)
         /// A route claim reached TOML generation without passing `WorkerRouteClaims` validation
         /// (callers derive claims via `WorkerRouteClaims.activeClaims`, which validates; this is
@@ -91,9 +95,19 @@ public enum WorkerComposition {
         charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
     )
 
+    /// The Cloudflare resource identifiers/names provisioning has created for a site. Every field
+    /// is optional: `nil` means "not provisioned yet", and TOML generation emits a placeholder (or
+    /// deterministic name) instead of failing — so config can be generated before, during, and
+    /// after provisioning without a separate schema per phase.
     public struct ProvisionedResources: Sendable, Equatable, Codable {
+        /// The shared per-site D1 database's Cloudflare id — an *id* (unlike the queue/R2 names)
+        /// because wrangler.toml's `[[d1_databases]]` blocks reference databases by id.
         public var d1DatabaseID: String?
+        /// The `SOCIAL_KV` namespace's Cloudflare id — an id for the same reason as
+        /// `d1DatabaseID`.
         public var kvNamespaceID: String?
+        /// The R2 bucket name backing Micropub's `MEDIA` binding — a deterministic name
+        /// (`\(siteName)-media`), not an id: wrangler references buckets by name.
         public var r2BucketName: String?
         /// The Cloudflare Queue name backing `@dwk/webmention`'s async verify step. Like
         /// `r2BucketName`, this is a deterministic name (`\(siteName)-webmention`), not an id —
@@ -116,6 +130,7 @@ public enum WorkerComposition {
         /// (Micropub's `MEDIA` bucket) since the two hold semantically different content.
         public var podBlobsR2BucketName: String?
 
+        /// Memberwise creation; the all-`nil` default is the pre-provisioning state.
         public init(
             d1DatabaseID: String? = nil, kvNamespaceID: String? = nil, r2BucketName: String? = nil,
             queueName: String? = nil, websubQueueName: String? = nil, microsubQueueName: String? = nil,

--- a/Sources/AnglesiteCore/WorkerNameRename.swift
+++ b/Sources/AnglesiteCore/WorkerNameRename.swift
@@ -9,9 +9,16 @@ import Foundation
 /// regenerate would silently drop any social-feature config a user provisioned (via
 /// `SocialWorkerProvisionCommand`) before their first deploy.
 public enum WorkerNameRename {
+    /// Ways ``WorkerNameRename/apply(newName:siteDirectory:fileManager:)`` can refuse — all
+    /// thrown before any write, so a failed rename never leaves the two files half-updated.
     public enum RenameError: Error, Equatable, Sendable {
+        /// `newName` doesn't satisfy `WorkerComposition`'s `[A-Za-z0-9_-]+` constraint.
         case invalidName(String)
+        /// No `wrangler.toml` at the site root — the site was never scaffolded for deploy, so
+        /// there is nothing to rename.
         case wranglerConfigMissing
+        /// `wrangler.toml` exists but has no `name = "..."` line to rewrite — surfaced rather
+        /// than appending one, since a hand-edited file shouldn't be silently restructured.
         case nameLineNotFound
     }
 

--- a/Sources/AnglesiteCore/WorkerRouteClaims.swift
+++ b/Sources/AnglesiteCore/WorkerRouteClaims.swift
@@ -13,24 +13,37 @@ public enum WorkerRouteClaims {
     /// A validated claim attributed to the worker (catalog descriptor id) that declared it —
     /// the attribution #744 needs to name both owners in a collision report.
     public struct OwnedClaim: Sendable, Equatable, Hashable {
+        /// The catalog descriptor id (`WorkerDescriptor.id`) that declared the claim.
         public let owner: String
+        /// The validated claim itself.
         public let claim: WorkerRouteClaim
 
+        /// Memberwise creation — normally produced by ``WorkerRouteClaims/activeClaims(catalog:activeIDs:)``,
+        /// which validates before attributing.
         public init(owner: String, claim: WorkerRouteClaim) {
             self.owner = owner
             self.claim = claim
         }
     }
 
+    /// Why a claim (or claim set) was rejected — every case carries the owning worker id(s), so
+    /// a manifest error names the package to fix rather than just the path.
     public enum ValidationError: Error, Equatable, CustomStringConvertible {
+        /// The claim's path failed syntactic/safety validation; `reason` says exactly why.
         case invalidPath(owner: String, path: String, reason: String)
+        /// The claim's method list is empty, unknown, duplicated, or declares HEAD without GET.
         case invalidMethods(owner: String, path: String, reason: String)
         /// A `prefix` claim with no governing `specificationURL` — only a protocol specification
         /// can approve child paths (RFC 8615), so an undeclared prefix claim is rejected.
         case undeclaredPrefix(owner: String, path: String)
+        /// Two or more active claims with the same path *and* match kind — identical coverage.
         case duplicateClaim(path: String, owners: [String])
+        /// An active claim falls inside another active prefix claim's coverage — no delegation or
+        /// precedence exists to resolve it.
         case overlappingClaims(path: String, owner: String, otherPath: String, otherOwner: String)
 
+        /// Human-readable rejection text, quoting the worker(s) and path(s) so it can surface in
+        /// deploy diagnostics unedited.
         public var description: String {
             switch self {
             case .invalidPath(let owner, let path, let reason):

--- a/Sources/AnglesiteCore/WorkersConformance.swift
+++ b/Sources/AnglesiteCore/WorkersConformance.swift
@@ -47,6 +47,8 @@ public struct WorkersConformanceStatus: Sendable, Equatable {
         case storage
     }
 
+    /// The `@dwk/*` packages each phase's activation is gated on — the app-side mirror of the
+    /// release plan, kept as data (not logic) so ``gateStatus(for:)`` stays a pure lookup.
     public static let phaseRequirements: [Phase: [String]] = [
         .v2: ["@dwk/webmention", "@dwk/indieauth"],
         .v3: ["@dwk/micropub", "@dwk/webmention", "@dwk/websub"],

--- a/Sources/AnglesiteCore/WorkersConformanceFetcher.swift
+++ b/Sources/AnglesiteCore/WorkersConformanceFetcher.swift
@@ -10,7 +10,10 @@ import FoundationNetworking
 import OSLog
 #endif
 
+/// Internal failure signal for the fetch path — never escapes `WorkersConformanceFetcher.status()`,
+/// which degrades to cache/empty instead of throwing; public only so tests can construct it.
 public enum WorkersConformanceFetchError: Error, Sendable, Equatable {
+    /// The HTTP fetch didn't produce a usable 2xx response; the string names the URL for the log.
     case fetchFailed(String)
 }
 
@@ -39,6 +42,9 @@ public actor WorkersConformanceFetcher {
     private let session: URLSession
     private let fileManager: FileManager
 
+    /// Creates a fetcher. `statusURL` is deliberately required (pass ``productionStatusURL`` in
+    /// production) so tests point at a local fixture server; cache location, session, and file
+    /// manager default to production values.
     public init(
         statusURL: URL,
         cacheURL: URL = WorkersConformanceFetcher.defaultCacheURL(),

--- a/Sources/AnglesiteCore/WorkersDevStatusCenter.swift
+++ b/Sources/AnglesiteCore/WorkersDevStatusCenter.swift
@@ -5,28 +5,43 @@ import Foundation
 /// separate from `WorkersDevStatus` below because the supervisor doesn't know the proxied URL;
 /// `LocalContainerSiteRuntime` composes the two.
 public enum WorkersDevProcessState: Sendable, Equatable {
+    /// The wrangler-dev process is up.
     case running
+    /// The supervisor is relaunching after a crash; `attempt` counts restarts for backoff/UI.
     case restarting(attempt: Int)
+    /// The process exited and the supervisor isn't bringing it back (deliberate stop).
     case stopped
+    /// The supervisor gave up; `reason` is the diagnostic surfaced to the Debug Pane.
     case failed(reason: String)
 }
 
 /// One site's local wrangler-dev session status as shown in the Debug Pane (#699).
 public enum WorkersDevStatus: Sendable, Equatable {
+    /// The session is being brought up — shown before the supervisor reports anything.
     case starting
     /// `url` is nil only in the brief window between the supervisor reporting `.running` and
     /// `startWorkersDev` returning the proxied URL.
     case running(url: URL?)
+    /// The supervisor is relaunching after a crash; `attempt` mirrors
+    /// `WorkersDevProcessState.restarting`.
     case restarting(attempt: Int)
+    /// The session is dead; `reason` is shown in the Debug Pane row.
     case failed(reason: String)
 }
 
+/// One Debug Pane row: a site's wrangler-dev session and its current status.
 public struct WorkersDevSession: Sendable, Equatable, Identifiable {
+    /// `Identifiable` conformance — a site has at most one dev session, so `siteID` is the row
+    /// identity.
     public var id: String { siteID }
+    /// The owning site's stable id.
     public let siteID: String
+    /// The site's display name, denormalized into the row so the Debug Pane needs no site lookup.
     public let displayName: String
+    /// The session's current status.
     public let status: WorkersDevStatus
 
+    /// Memberwise creation — normally produced by `WorkersDevStatusCenter.update`.
     public init(siteID: String, displayName: String, status: WorkersDevStatus) {
         self.siteID = siteID
         self.displayName = displayName
@@ -46,6 +61,8 @@ public actor WorkersDevStatusCenter {
     /// Handle returned by `subscribe()` — same contract as `LogCenter.Subscription`: `cancel()`
     /// finishes the continuation so a `for await` consumer unblocks.
     public struct Subscription: Sendable {
+        /// The full ordered session snapshot, re-yielded on every change (see the actor doc for
+        /// why snapshots rather than deltas).
         public let stream: AsyncStream<[WorkersDevSession]>
         private let continuation: AsyncStream<[WorkersDevSession]>.Continuation
 
@@ -64,13 +81,19 @@ public actor WorkersDevStatusCenter {
     private var sessions: [String: WorkersDevSession] = [:]
     private var subscribers: [UUID: AsyncStream<[WorkersDevSession]>.Continuation] = [:]
 
+    /// Creates an empty center — public so tests get isolated instances instead of sharing
+    /// ``shared``'s state.
     public init() {}
 
+    /// Publishes a site's latest session state (insert-or-replace) and broadcasts the new
+    /// snapshot to every subscriber.
     public func update(siteID: String, displayName: String, status: WorkersDevStatus) {
         sessions[siteID] = WorkersDevSession(siteID: siteID, displayName: displayName, status: status)
         broadcast()
     }
 
+    /// Drops a site's row (e.g. its window closed) and broadcasts — a no-op, with no broadcast,
+    /// when the site had no session, so repeated teardown paths don't spam subscribers.
     public func remove(siteID: String) {
         guard sessions.removeValue(forKey: siteID) != nil else { return }
         broadcast()

--- a/Sources/AnglesiteCore/XPC/SpawnTypes.swift
+++ b/Sources/AnglesiteCore/XPC/SpawnTypes.swift
@@ -12,15 +12,24 @@ import Foundation
 /// grant for that folder (per-`SiteWindow`) so the spawned child inherits access — nothing
 /// bookmark-related crosses a process boundary.
 public struct SpawnSpec: Sendable, Codable, Equatable {
+    /// Absolute path to the binary to launch — always resolved by the caller, never `PATH`-looked
+    /// up by the backend.
     public let executable: URL
+    /// Arguments passed as-is (no shell involved, so no quoting/injection concerns).
     public let arguments: [String]
+    /// Environment for the child, or `nil` to inherit the app's.
     public let environment: [String: String]?
+    /// The child's cwd, or `nil` to inherit. See the type doc for why this is a plain path rather
+    /// than a security-scoped bookmark.
     public let workingDirectory: URL?
     /// When `true`, the spawned process gets a writable stdin pipe (MCP JSON-RPC framing needs this).
     public let stdinPipe: Bool
     /// Tag used by `LogCenter` when streaming stdout/stderr — e.g. `"container:<siteID>"`.
     public let logSource: String
 
+    /// Memberwise creation. `logSource` is deliberately non-defaulted — every spawn must name a
+    /// log tag, because subprocess output silently vanishing is the failure mode the "logs are
+    /// sacred" rule exists to prevent.
     public init(
         executable: URL,
         arguments: [String] = [],
@@ -40,10 +49,15 @@ public struct SpawnSpec: Sendable, Codable, Equatable {
 
 /// Result of a one-shot `runOneShot` call.
 public struct ProcessResult: Sendable, Codable, Equatable {
+    /// The child's complete stdout, as raw bytes — decoding (and whether to) is the caller's call.
     public let stdout: Data
+    /// The child's complete stderr, kept separate from stdout so error text is attributable.
     public let stderr: Data
+    /// The child's exit code; 0 means success by Unix convention, but interpretation is the
+    /// caller's.
     public let exitCode: Int32
 
+    /// Memberwise creation.
     public init(stdout: Data, stderr: Data, exitCode: Int32) {
         self.stdout = stdout
         self.stderr = stderr
@@ -54,18 +68,30 @@ public struct ProcessResult: Sendable, Codable, Equatable {
 /// Opaque token identifying a long-lived spawned process. The backend maps this to whatever
 /// it tracks internally (a `Process` for InProcess, a pid + connection for XPC).
 public struct SpawnedProcessHandle: Sendable, Codable, Equatable, Hashable {
+    /// The backend's own stable identity for the process — the part that stays unique even if the
+    /// OS reuses `pid`.
     public let id: UUID
+    /// The OS process id, for diagnostics/logs; not a safe lookup key on its own (pids recycle).
     public let pid: Int32
 
+    /// Creates a handle; `id` defaults to a fresh UUID so backends don't have to invent one.
     public init(id: UUID = UUID(), pid: Int32) {
         self.id = id
         self.pid = pid
     }
 }
 
+/// Failures a `SupervisorBackend` can surface — shared across backends so callers handle one
+/// error vocabulary regardless of how the process was actually spawned.
 public enum SupervisorBackendError: Error, Sendable {
+    /// The process could not be launched; the string carries the underlying OS error.
     case spawnFailed(String)
+    /// The given `SpawnedProcessHandle` doesn't map to anything this backend is tracking —
+    /// typically the process already exited and was reaped.
     case unknownHandle
+    /// A security-scoped bookmark for the working directory couldn't be resolved (a remnant of
+    /// the retired XPC-helper path, where bookmarks crossed the process boundary).
     case bookmarkResolutionFailed(String)
+    /// The backend itself isn't usable in this configuration; the string says why.
     case backendUnavailable(String)
 }


### PR DESCRIPTION
## Summary

- Phase 10 — the final alphabetical chunk of the doc-comment retrofit tracked in #1141 (27 files, `TokenOnboarding` … `XPC/SpawnTypes`, ~230 doc comments) — token onboarding, typed content editor, UTTypes, undo command, version store, visible-element messages, the vsock proxy, WCAG contrast, webmention send/log, the website analytics and icon assets (`bestHost` documented as the canonical host resolver: `DOMAIN` app-written, `SITE_DOMAIN` legacy-only), the well-known claim manifest/inventory, the `@dwk/workers` catalog types (decoders documented as the backward-compatible seam CONTRIBUTING requires), worker composition/rename/route claims, workers conformance, the workers-dev status center, and the XPC spawn types.
- Comments only — no behavior changes. With this and the sibling #1141 PRs, every explicit public/open declaration in the SwiftPM library targets carries a doc comment; a small follow-up will mop up symbols only DocC's coverage data can see (protocol requirements in files that had no other gaps).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` — clean (run after rebasing onto current `main`).
- [x] `swift test --filter AnglesiteCoreTests` — 3,058 tests in 385 suites; 2 failures, both the known "FoundationModelAssistant" concurrent-`swift test` FM-contention flake (same two tests fail identically on unmodified checkouts — see the sibling #1141 PRs). `FoundationModelAssistant.swift` is not touched by this diff.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run separately; comments-only diff, target compiles during DocC symbol-graph extraction.
