### PR TITLE
Offer new template dependencies to existing sites

### DIFF
--- a/Sources/AnglesiteApp/DependencyUpdateModel.swift
+++ b/Sources/AnglesiteApp/DependencyUpdateModel.swift
@@ -2,16 +2,17 @@ import Foundation
 import AnglesiteCore
 
 /// Thin, `Identifiable` model driving the dependency-update-offer sheet
-/// (spec §5). Holds the already-computed offers and forwards the user's
-/// decision — no comparison/diff logic lives here, that's all in
-/// `AnglesiteCore` (`DependencySyncChecker`/`DependencySyncApplier`).
+/// (spec §5, #1108). Holds the already-computed offers (bumps and new-package
+/// additions) and forwards the user's decision — no comparison/diff logic
+/// lives here, that's all in `AnglesiteCore`
+/// (`DependencySyncChecker`/`DependencySyncApplier`).
 @MainActor
 final class DependencyUpdateModel: Identifiable {
     nonisolated let id = UUID()
-    let offers: [DependencyUpdateOffer]
+    let offers: DependencySyncOffers
     private let onDecision: (_ accepted: Bool) -> Void
 
-    init(offers: [DependencyUpdateOffer], onDecision: @escaping (_ accepted: Bool) -> Void) {
+    init(offers: DependencySyncOffers, onDecision: @escaping (_ accepted: Bool) -> Void) {
         self.offers = offers
         self.onDecision = onDecision
     }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1014,6 +1014,9 @@
     "Delete failed" : {
 
     },
+    "Dependency Updates" : {
+
+    },
     "Dependency Updates Available" : {
 
     },
@@ -1714,6 +1717,9 @@
 
     },
     "New Component…" : {
+
+    },
+    "New Dependencies" : {
 
     },
     "New Inventory…" : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -644,10 +644,28 @@ struct SiteWindow: View {
         }
         .sheet(item: $bindableModel.dependencyUpdateModel) { updateModel in
             NavigationStack {
-                List(updateModel.offers, id: \.name) { offer in
-                    LabeledContent(offer.name) {
-                        Text("\(offer.currentRange) → \(offer.offeredRange)")
-                            .font(.system(.body, design: .monospaced))
+                List {
+                    if !updateModel.offers.updates.isEmpty {
+                        Section("Dependency Updates") {
+                            ForEach(updateModel.offers.updates, id: \.name) { offer in
+                                LabeledContent(offer.name) {
+                                    Text("\(offer.currentRange) → \(offer.offeredRange)")
+                                        .font(.system(.body, design: .monospaced))
+                                }
+                            }
+                        }
+                    }
+                    if !updateModel.offers.additions.isEmpty {
+                        Section("New Dependencies") {
+                            ForEach(updateModel.offers.additions, id: \.name) { offer in
+                                LabeledContent {
+                                    Text(offer.offeredRange)
+                                        .font(.system(.body, design: .monospaced))
+                                } label: {
+                                    Label(offer.name, systemImage: "plus.circle")
+                                }
+                            }
+                        }
                     }
                 }
                 .navigationTitle("Dependency Updates Available")

--- a/Sources/AnglesiteCore/DependencySync.swift
+++ b/Sources/AnglesiteCore/DependencySync.swift
@@ -32,9 +32,7 @@ public struct DependencyAdditionOffer: Sendable, Equatable {
 
 /// The full result of a `DependencySync.diff` call: version bumps for packages
 /// the site already has, and new packages the template has that the site
-/// doesn't. `diff` itself doesn't return this yet (see #1108 Task 2) — this
-/// type exists now so `PackageJSONDependencies.applyAdditions` can consume
-/// `DependencyAdditionOffer` independently.
+/// doesn't.
 public struct DependencySyncOffers: Sendable, Equatable {
     public let updates: [DependencyUpdateOffer]
     public let additions: [DependencyAdditionOffer]
@@ -48,9 +46,12 @@ public struct DependencySyncOffers: Sendable, Equatable {
 }
 
 /// Three-way comparison between a site's dependencies, an optional scaffold-time
-/// baseline snapshot, and the app's current bundled template (spec §3). Only ever
-/// offers a version bump for a package present in both the site and the template —
-/// never adds or removes a package name.
+/// baseline snapshot, and the app's current bundled template (spec §3, #1108).
+/// Offers a version bump for a package present in both the site and the
+/// template, and offers to add a package the template has that the site is
+/// missing (unless the baseline shows the site is known to have had — and so
+/// deliberately removed — that package before). Never offers to remove a
+/// package the template no longer has.
 public enum DependencySync {
     public static func diff(
         site: [String: String],

--- a/Sources/AnglesiteCore/DependencySync.swift
+++ b/Sources/AnglesiteCore/DependencySync.swift
@@ -55,11 +55,25 @@ public enum DependencySync {
     public static func diff(
         site: [String: String],
         baseline: [String: String]?,
-        template: [String: String]
-    ) -> [DependencyUpdateOffer] {
-        var offers: [DependencyUpdateOffer] = []
+        template: [String: String],
+        templateDevDependencyNames: Set<String> = []
+    ) -> DependencySyncOffers {
+        var updates: [DependencyUpdateOffer] = []
+        var additions: [DependencyAdditionOffer] = []
         for (name, templateRange) in template.sorted(by: { $0.key < $1.key }) {
-            guard let siteRange = site[name] else { continue }
+            guard let siteRange = site[name] else {
+                // Not in the site at all: a candidate for an addition offer,
+                // gated by whether the site is known to have deliberately
+                // removed it before (#1108).
+                if let baseline {
+                    guard baseline[name] == nil else { continue }
+                }
+                // else: no baseline at all -> legacy direct-diff fallback, same
+                // risk tolerance as the bump path below.
+                let section: DependencySection = templateDevDependencyNames.contains(name) ? .devDependencies : .dependencies
+                additions.append(DependencyAdditionOffer(name: name, offeredRange: templateRange, section: section))
+                continue
+            }
             guard DependencyVersionComparator.isNewer(templateRange, than: siteRange) == true else { continue }
             if let baseline {
                 // 3-way case: only offer when the site never touched this package
@@ -67,8 +81,8 @@ public enum DependencySync {
                 guard let baselineRange = baseline[name], baselineRange == siteRange else { continue }
             }
             // else: no baseline at all -> legacy direct-diff fallback (spec §3).
-            offers.append(DependencyUpdateOffer(name: name, currentRange: siteRange, offeredRange: templateRange))
+            updates.append(DependencyUpdateOffer(name: name, currentRange: siteRange, offeredRange: templateRange))
         }
-        return offers
+        return DependencySyncOffers(updates: updates, additions: additions)
     }
 }

--- a/Sources/AnglesiteCore/DependencySync.swift
+++ b/Sources/AnglesiteCore/DependencySync.swift
@@ -11,6 +11,42 @@ public struct DependencyUpdateOffer: Sendable, Equatable {
     }
 }
 
+/// Which `package.json` section a dependency belongs (or would be added) to.
+public enum DependencySection: Sendable, Equatable {
+    case dependencies
+    case devDependencies
+}
+
+/// One offered new package the template has that the site does not.
+public struct DependencyAdditionOffer: Sendable, Equatable {
+    public let name: String
+    public let offeredRange: String
+    public let section: DependencySection
+
+    public init(name: String, offeredRange: String, section: DependencySection) {
+        self.name = name
+        self.offeredRange = offeredRange
+        self.section = section
+    }
+}
+
+/// The full result of a `DependencySync.diff` call: version bumps for packages
+/// the site already has, and new packages the template has that the site
+/// doesn't. `diff` itself doesn't return this yet (see #1108 Task 2) — this
+/// type exists now so `PackageJSONDependencies.applyAdditions` can consume
+/// `DependencyAdditionOffer` independently.
+public struct DependencySyncOffers: Sendable, Equatable {
+    public let updates: [DependencyUpdateOffer]
+    public let additions: [DependencyAdditionOffer]
+
+    public init(updates: [DependencyUpdateOffer] = [], additions: [DependencyAdditionOffer] = []) {
+        self.updates = updates
+        self.additions = additions
+    }
+
+    public var isEmpty: Bool { updates.isEmpty && additions.isEmpty }
+}
+
 /// Three-way comparison between a site's dependencies, an optional scaffold-time
 /// baseline snapshot, and the app's current bundled template (spec §3). Only ever
 /// offers a version bump for a package present in both the site and the template —

--- a/Sources/AnglesiteCore/DependencySyncApplier.swift
+++ b/Sources/AnglesiteCore/DependencySyncApplier.swift
@@ -58,18 +58,19 @@ public enum DependencySyncApplier {
         // silently withhold future bump offers for every other dependency the
         // site has.
         var newBaseline = DependencyBaseline.load(from: configDirectory) ?? landed
-        // Only baseline an update/addition that actually landed in `updatedText`.
-        // For an update, "landed" means the merged range now equals the offered
-        // range (the stronger check — a bump target already existed, so its value
-        // should have visibly changed). For an addition, "landed" means the name
-        // is now present at all (existence check — a fresh insertion has no prior
-        // value to compare against). Baselining an offer that silently no-opped
-        // would make `DependencySync.diff`'s gates think it already landed and
-        // withhold it forever, with no way for the user to ever see or recover it.
+        // Only baseline an update/addition that actually landed in `updatedText`:
+        // the merged range now equals the offered range. Applies equally to both
+        // kinds — `applyAdditions` also silently skips an offer whose name is
+        // already present in the target section (see its own doc comment), so an
+        // addition's mere presence in `landed` doesn't prove *this* offer wrote
+        // it; only an exact range match does. Baselining an offer that silently
+        // no-opped would make `DependencySync.diff`'s gates think it already
+        // landed and withhold it forever, with no way for the user to ever see or
+        // recover it.
         for offer in offers.updates where landed[offer.name] == offer.offeredRange {
             newBaseline[offer.name] = offer.offeredRange
         }
-        for offer in offers.additions where landed[offer.name] != nil {
+        for offer in offers.additions where landed[offer.name] == offer.offeredRange {
             newBaseline[offer.name] = offer.offeredRange
         }
         try? DependencyBaseline.save(newBaseline, to: configDirectory)

--- a/Sources/AnglesiteCore/DependencySyncApplier.swift
+++ b/Sources/AnglesiteCore/DependencySyncApplier.swift
@@ -37,7 +37,18 @@ public enum DependencySyncApplier {
 
         var newBaseline = DependencyBaseline.load(from: configDirectory) ?? [:]
         for offer in offers.updates { newBaseline[offer.name] = offer.offeredRange }
-        for offer in offers.additions { newBaseline[offer.name] = offer.offeredRange }
+        // Only baseline an addition that actually landed in `updatedText` —
+        // `applyAdditions` silently skips an offer whose target section doesn't
+        // exist in the site's package.json, and baselining it anyway would make
+        // `DependencySync.diff`'s "site is known to have had this before" gate
+        // withhold the offer forever, with no way for the user to ever see or
+        // recover it.
+        if let landedSections = try? PackageJSONDependencies.extractSections(from: updatedText) {
+            for offer in offers.additions
+            where landedSections.dependencies[offer.name] != nil || landedSections.devDependencies[offer.name] != nil {
+                newBaseline[offer.name] = offer.offeredRange
+            }
+        }
         try? DependencyBaseline.save(newBaseline, to: configDirectory)
 
         let siteConfigURL = sourceDirectory.appendingPathComponent(".site-config")

--- a/Sources/AnglesiteCore/DependencySyncApplier.swift
+++ b/Sources/AnglesiteCore/DependencySyncApplier.swift
@@ -27,6 +27,19 @@ public enum DependencySyncApplier {
         }
         var updatedText = PackageJSONDependencies.apply(offers.updates, to: originalText)
         updatedText = PackageJSONDependencies.applyAdditions(offers.additions, to: updatedText)
+
+        // Re-parse once and reuse the result for everything below. This both
+        // gates the write against ever landing corrupted JSON on disk (`applyAdditions`
+        // does text insertion, not just in-place substitution, so a bug there could
+        // in principle produce invalid output) and tells us which offers actually
+        // landed — `PackageJSONDependencies.apply`/`.applyAdditions` are both
+        // best-effort and silently no-op an offer whose target name/section isn't
+        // found in the site's package.json.
+        guard let landedSections = try? PackageJSONDependencies.extractSections(from: updatedText) else {
+            throw ApplyError.writeFailed
+        }
+        let landed = landedSections.dependencies.merging(landedSections.devDependencies) { _, new in new }
+
         do {
             try updatedText.write(to: packageJSONURL, atomically: true, encoding: .utf8)
         } catch {
@@ -35,19 +48,29 @@ public enum DependencySyncApplier {
 
         try? FileManager.default.removeItem(at: sourceDirectory.appendingPathComponent("package-lock.json"))
 
-        var newBaseline = DependencyBaseline.load(from: configDirectory) ?? [:]
-        for offer in offers.updates { newBaseline[offer.name] = offer.offeredRange }
-        // Only baseline an addition that actually landed in `updatedText` —
-        // `applyAdditions` silently skips an offer whose target section doesn't
-        // exist in the site's package.json, and baselining it anyway would make
-        // `DependencySync.diff`'s "site is known to have had this before" gate
-        // withhold the offer forever, with no way for the user to ever see or
-        // recover it.
-        if let landedSections = try? PackageJSONDependencies.extractSections(from: updatedText) {
-            for offer in offers.additions
-            where landedSections.dependencies[offer.name] != nil || landedSections.devDependencies[offer.name] != nil {
-                newBaseline[offer.name] = offer.offeredRange
-            }
+        // Seed from every dependency in the freshly-written package.json when the
+        // site has no baseline yet (legacy sites scaffolded before the baseline
+        // mechanism existed, or sites created via File > Import) — mirrors what
+        // `SiteScaffolder` writes at scaffold time (the full template dependency
+        // set, not just what changed). Without this, a site's baseline would end
+        // up containing only the name(s) from *this* accepted offer, and
+        // `DependencySync.diff`'s `guard let baselineRange = baseline[name]` would
+        // silently withhold future bump offers for every other dependency the
+        // site has.
+        var newBaseline = DependencyBaseline.load(from: configDirectory) ?? landed
+        // Only baseline an update/addition that actually landed in `updatedText`.
+        // For an update, "landed" means the merged range now equals the offered
+        // range (the stronger check — a bump target already existed, so its value
+        // should have visibly changed). For an addition, "landed" means the name
+        // is now present at all (existence check — a fresh insertion has no prior
+        // value to compare against). Baselining an offer that silently no-opped
+        // would make `DependencySync.diff`'s gates think it already landed and
+        // withhold it forever, with no way for the user to ever see or recover it.
+        for offer in offers.updates where landed[offer.name] == offer.offeredRange {
+            newBaseline[offer.name] = offer.offeredRange
+        }
+        for offer in offers.additions where landed[offer.name] != nil {
+            newBaseline[offer.name] = offer.offeredRange
         }
         try? DependencyBaseline.save(newBaseline, to: configDirectory)
 

--- a/Sources/AnglesiteCore/DependencySyncApplier.swift
+++ b/Sources/AnglesiteCore/DependencySyncApplier.swift
@@ -1,12 +1,14 @@
 import Foundation
 
-/// Applies an accepted dependency-sync update (spec §6): rewrites `package.json`'s
-/// version ranges, deletes the now-stale `package-lock.json` (so the next preview
-/// boot's existing `hydrate.sh` regenerates one via its normal `npm install` path —
-/// no new container-exec machinery), refreshes the baseline, and bumps the
-/// `ANGLESITE_VERSION` stamp. The lockfile delete, baseline save, and version bump
-/// are best-effort (`try?`) once the package.json rewrite itself has succeeded —
-/// none of them are things the user's file-open flow should hard-fail on.
+/// Applies an accepted dependency-sync decision (spec §6, #1108): rewrites
+/// `package.json`'s version ranges and inserts any accepted new-dependency
+/// entries, deletes the now-stale `package-lock.json` (so the next preview
+/// boot's existing `hydrate.sh` regenerates one via its normal `npm install`
+/// path — no new container-exec machinery), refreshes the baseline for both
+/// updates and additions, and bumps the `ANGLESITE_VERSION` stamp. The
+/// lockfile delete, baseline save, and version bump are best-effort (`try?`)
+/// once the package.json rewrite itself has succeeded — none of them are
+/// things the user's file-open flow should hard-fail on.
 public enum DependencySyncApplier {
     public enum ApplyError: Error, Equatable {
         case readFailed
@@ -14,7 +16,7 @@ public enum DependencySyncApplier {
     }
 
     public static func apply(
-        _ offers: [DependencyUpdateOffer],
+        _ offers: DependencySyncOffers,
         sourceDirectory: URL,
         configDirectory: URL,
         runningAppVersion: String
@@ -23,7 +25,8 @@ public enum DependencySyncApplier {
         guard let originalText = try? String(contentsOf: packageJSONURL, encoding: .utf8) else {
             throw ApplyError.readFailed
         }
-        let updatedText = PackageJSONDependencies.apply(offers, to: originalText)
+        var updatedText = PackageJSONDependencies.apply(offers.updates, to: originalText)
+        updatedText = PackageJSONDependencies.applyAdditions(offers.additions, to: updatedText)
         do {
             try updatedText.write(to: packageJSONURL, atomically: true, encoding: .utf8)
         } catch {
@@ -33,7 +36,8 @@ public enum DependencySyncApplier {
         try? FileManager.default.removeItem(at: sourceDirectory.appendingPathComponent("package-lock.json"))
 
         var newBaseline = DependencyBaseline.load(from: configDirectory) ?? [:]
-        for offer in offers { newBaseline[offer.name] = offer.offeredRange }
+        for offer in offers.updates { newBaseline[offer.name] = offer.offeredRange }
+        for offer in offers.additions { newBaseline[offer.name] = offer.offeredRange }
         try? DependencyBaseline.save(newBaseline, to: configDirectory)
 
         let siteConfigURL = sourceDirectory.appendingPathComponent(".site-config")

--- a/Sources/AnglesiteCore/DependencySyncChecker.swift
+++ b/Sources/AnglesiteCore/DependencySyncChecker.swift
@@ -10,12 +10,12 @@ public enum DependencySyncChecker {
         configDirectory: URL,
         templateDirectory: URL,
         runningAppVersion: String
-    ) -> [DependencyUpdateOffer] {
+    ) -> DependencySyncOffers {
         let siteConfigURL = sourceDirectory.appendingPathComponent(".site-config")
         if let siteConfigContents = try? String(contentsOf: siteConfigURL, encoding: .utf8),
            let stampedVersion = SiteConfigFile.value(forKey: "ANGLESITE_VERSION", in: siteConfigContents),
            stampedVersion == runningAppVersion {
-            return []
+            return DependencySyncOffers()
         }
 
         guard let sitePackageText = try? String(
@@ -23,10 +23,18 @@ public enum DependencySyncChecker {
               let siteDeps = try? PackageJSONDependencies.extract(from: sitePackageText),
               let templatePackageText = try? String(
                 contentsOf: templateDirectory.appendingPathComponent("package.json"), encoding: .utf8),
-              let templateDeps = try? PackageJSONDependencies.extract(from: templatePackageText)
-        else { return [] }
+              let templateSections = try? PackageJSONDependencies.extractSections(from: templatePackageText)
+        else { return DependencySyncOffers() }
+
+        var templateDeps = templateSections.dependencies
+        templateDeps.merge(templateSections.devDependencies) { _, new in new }
 
         let baseline = DependencyBaseline.load(from: configDirectory)
-        return DependencySync.diff(site: siteDeps, baseline: baseline, template: templateDeps)
+        return DependencySync.diff(
+            site: siteDeps,
+            baseline: baseline,
+            template: templateDeps,
+            templateDevDependencyNames: Set(templateSections.devDependencies.keys)
+        )
     }
 }

--- a/Sources/AnglesiteCore/PackageJSONDependencies.swift
+++ b/Sources/AnglesiteCore/PackageJSONDependencies.swift
@@ -86,7 +86,7 @@ public enum PackageJSONDependencies {
                 // Non-empty section: prepend as a new first entry, copying the
                 // whitespace that currently precedes the existing first entry.
                 let indent = String(result[afterBrace..<firstContent])
-                result.insert(contentsOf: "\(indent)\(entry),\(indent)", at: afterBrace)
+                result.insert(contentsOf: "\(indent)\(entry),", at: afterBrace)
             } else {
                 // Empty section (`{}` or `{ }`): no existing indentation to copy.
                 result.replaceSubrange(afterBrace..<firstContent, with: "\n  \(entry)\n")

--- a/Sources/AnglesiteCore/PackageJSONDependencies.swift
+++ b/Sources/AnglesiteCore/PackageJSONDependencies.swift
@@ -67,12 +67,26 @@ public enum PackageJSONDependencies {
     /// indentation of whatever currently comes first in that section. An
     /// offer whose target section doesn't exist in `text` at all is silently
     /// skipped — this mutates existing structure, it never fabricates a new
-    /// top-level section.
+    /// top-level section. An offer whose name is *already* a key in the
+    /// target section is also silently skipped — inserting it anyway would
+    /// produce a second `"name": ...` key in the same JSON object, which is
+    /// semantically broken even though most parsers (including
+    /// `JSONSerialization`) tolerate it by keeping only the last value. This
+    /// shouldn't be reachable through the real `DependencySync.diff` ->
+    /// `DependencySyncApplier` path (diff only offers additions for names
+    /// absent from the site), but this function is public and should stay
+    /// safe against a stale or already-present offer regardless of caller
+    /// discipline.
     public static func applyAdditions(_ offers: [DependencyAdditionOffer], to text: String) -> String {
         var result = text
         for offer in offers {
             let key = offer.section == .devDependencies ? "devDependencies" : "dependencies"
             guard let span = objectSpan(forKey: key, in: result) else { continue }
+            let escapedExistingName = NSRegularExpression.escapedPattern(for: offer.name)
+            if let existsRegex = try? NSRegularExpression(pattern: "\"\(escapedExistingName)\"\\s*:"),
+               existsRegex.firstMatch(in: result, range: NSRange(span, in: result)) != nil {
+                continue
+            }
             let openBrace = span.lowerBound
             let afterBrace = result.index(after: openBrace)
             var firstContent = afterBrace

--- a/Sources/AnglesiteCore/PackageJSONDependencies.swift
+++ b/Sources/AnglesiteCore/PackageJSONDependencies.swift
@@ -86,7 +86,7 @@ public enum PackageJSONDependencies {
                 // Non-empty section: prepend as a new first entry, copying the
                 // whitespace that currently precedes the existing first entry.
                 let indent = String(result[afterBrace..<firstContent])
-                result.insert(contentsOf: "\(entry),\(indent)", at: afterBrace)
+                result.insert(contentsOf: "\(indent)\(entry),\(indent)", at: afterBrace)
             } else {
                 // Empty section (`{}` or `{ }`): no existing indentation to copy.
                 result.replaceSubrange(afterBrace..<firstContent, with: "\n  \(entry)\n")

--- a/Sources/AnglesiteCore/PackageJSONDependencies.swift
+++ b/Sources/AnglesiteCore/PackageJSONDependencies.swift
@@ -10,20 +10,25 @@ public enum PackageJSONDependencies {
         case invalidJSON
     }
 
-    /// The union of `dependencies` and `devDependencies` (name -> version range).
-    /// If a name appears in both sections, `devDependencies` wins (checked second).
-    public static func extract(from text: String) throws -> [String: String] {
+    /// `dependencies` and `devDependencies`, kept separate (unlike `extract`,
+    /// which merges them). Used where the caller needs to know which section a
+    /// package belongs to, not just its version range.
+    public static func extractSections(from text: String) throws -> (dependencies: [String: String], devDependencies: [String: String]) {
         guard let data = text.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data),
               let object = json as? [String: Any]
         else { throw ExtractionError.invalidJSON }
-        var result: [String: String] = [:]
-        if let deps = object["dependencies"] as? [String: String] {
-            result.merge(deps) { _, new in new }
-        }
-        if let devDeps = object["devDependencies"] as? [String: String] {
-            result.merge(devDeps) { _, new in new }
-        }
+        let deps = object["dependencies"] as? [String: String] ?? [:]
+        let devDeps = object["devDependencies"] as? [String: String] ?? [:]
+        return (dependencies: deps, devDependencies: devDeps)
+    }
+
+    /// The union of `dependencies` and `devDependencies` (name -> version range).
+    /// If a name appears in both sections, `devDependencies` wins (checked second).
+    public static func extract(from text: String) throws -> [String: String] {
+        let sections = try extractSections(from: text)
+        var result = sections.dependencies
+        result.merge(sections.devDependencies) { _, new in new }
         return result
     }
 
@@ -52,6 +57,39 @@ public enum PackageJSONDependencies {
                 guard let span = objectSpan(forKey: key, in: result) else { continue }
                 let nsRange = NSRange(span, in: result)
                 result = regex.stringByReplacingMatches(in: result, range: nsRange, withTemplate: template)
+            }
+        }
+        return result
+    }
+
+    /// Inserts each offer's `"name": "range"` as a new first entry in its
+    /// target `dependencies`/`devDependencies` section, copying the
+    /// indentation of whatever currently comes first in that section. An
+    /// offer whose target section doesn't exist in `text` at all is silently
+    /// skipped — this mutates existing structure, it never fabricates a new
+    /// top-level section.
+    public static func applyAdditions(_ offers: [DependencyAdditionOffer], to text: String) -> String {
+        var result = text
+        for offer in offers {
+            let key = offer.section == .devDependencies ? "devDependencies" : "dependencies"
+            guard let span = objectSpan(forKey: key, in: result) else { continue }
+            let openBrace = span.lowerBound
+            let afterBrace = result.index(after: openBrace)
+            var firstContent = afterBrace
+            while firstContent < span.upperBound, result[firstContent].isWhitespace {
+                firstContent = result.index(after: firstContent)
+            }
+            let escapedName = offer.name.replacingOccurrences(of: "\"", with: "\\\"")
+            let escapedRange = offer.offeredRange.replacingOccurrences(of: "\"", with: "\\\"")
+            let entry = "\"\(escapedName)\": \"\(escapedRange)\""
+            if result[firstContent] != "}" {
+                // Non-empty section: prepend as a new first entry, copying the
+                // whitespace that currently precedes the existing first entry.
+                let indent = String(result[afterBrace..<firstContent])
+                result.insert(contentsOf: "\(entry),\(indent)", at: afterBrace)
+            } else {
+                // Empty section (`{}` or `{ }`): no existing indentation to copy.
+                result.replaceSubrange(afterBrace..<firstContent, with: "\n  \(entry)\n")
             }
         }
         return result

--- a/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
@@ -66,6 +66,36 @@ import Foundation
         #expect(SiteConfigFile.value(forKey: "ANGLESITE_VERSION", in: siteConfig) == "1.4.0")
     }
 
+    @Test func withholdsTheBaselineForAnAdditionThatDidNotLandBecauseItsSectionIsMissing() throws {
+        // No `devDependencies` key at all -> `PackageJSONDependencies.applyAdditions`
+        // silently drops a `.devDependencies`-targeted offer (Task 1 behavior,
+        // unchanged here). Baselining it anyway would make the next `diff` call
+        // think the site already has it and withhold the offer forever, with no
+        // way for the user to ever see or accept it (#1108 review).
+        let root = tmpDir()
+        let source = root.appendingPathComponent("Source")
+        let config = root.appendingPathComponent("Config")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        try """
+        { "dependencies": { "astro": "^5.0.0" } }
+        """.write(to: source.appendingPathComponent("package.json"), atomically: true, encoding: .utf8)
+        try "ANGLESITE_VERSION=1.2.0\n".write(to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        let offers = DependencySyncOffers(
+            updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")],
+            additions: [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)]
+        )
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+
+        let updated = try String(contentsOf: source.appendingPathComponent("package.json"), encoding: .utf8)
+        #expect(!updated.contains("html-validate"))
+
+        let baseline = DependencyBaseline.load(from: config)
+        #expect(baseline?["astro"] == "^6.4.8")
+        #expect(baseline?["html-validate"] == nil)
+    }
+
     @Test func throwsReadFailedWhenPackageJSONIsMissing() throws {
         let root = tmpDir()
         let source = root.appendingPathComponent("Source")

--- a/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
@@ -96,6 +96,59 @@ import Foundation
         #expect(baseline?["html-validate"] == nil)
     }
 
+    @Test func withholdsTheBaselineForAnUpdateThatDidNotLandBecauseItsNameIsAbsent() throws {
+        // "does-not-exist" isn't a key in the site's package.json at all, so
+        // `PackageJSONDependencies.apply` silently no-ops on that offer (by
+        // design — it never adds anything). Baselining it anyway would claim the
+        // site is at the new range while package.json never changed, and
+        // `DependencySync.diff`'s `baselineRange == siteRange` bump gate would then
+        // fail forever, permanently suppressing that package's future bump offers
+        // (#1108 review).
+        let (source, config) = try makeSourceAndConfig()
+        let offers = DependencySyncOffers(updates: [
+            DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8"),
+            DependencyUpdateOffer(name: "does-not-exist", currentRange: "^1.0.0", offeredRange: "^2.0.0"),
+        ])
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+
+        let updated = try String(contentsOf: source.appendingPathComponent("package.json"), encoding: .utf8)
+        #expect(!updated.contains("does-not-exist"))
+
+        let baseline = DependencyBaseline.load(from: config)
+        #expect(baseline?["astro"] == "^6.4.8")
+        #expect(baseline?["does-not-exist"] == nil)
+    }
+
+    @Test func seedsTheFullBaselineFromExistingDependenciesWhenNoBaselineFileExisted() throws {
+        // A legacy/imported site with no baseline file at all must not end up
+        // with a baseline containing only the just-accepted offer's name(s) —
+        // that would silently disable future bump offers for every other
+        // dependency the site has, since `DependencySync.diff`'s bump path
+        // requires `guard let baselineRange = baseline[name]` to succeed
+        // (#1108 review). Mirrors `SiteScaffolder`'s scaffold-time baseline seed.
+        let root = tmpDir()
+        let source = root.appendingPathComponent("Source")
+        let config = root.appendingPathComponent("Config")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        try """
+        {
+          "dependencies": { "astro": "^5.0.0", "@astrojs/rss": "^4.0.0" },
+          "devDependencies": { "typescript": "^5.9.3" }
+        }
+        """.write(to: source.appendingPathComponent("package.json"), atomically: true, encoding: .utf8)
+        try "ANGLESITE_VERSION=1.2.0\n".write(to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        // Deliberately no DependencyBaseline.save call — no baseline file exists.
+
+        let offers = DependencySyncOffers(updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+
+        let baseline = DependencyBaseline.load(from: config)
+        #expect(baseline?["astro"] == "^6.4.8")
+        #expect(baseline?["@astrojs/rss"] == "^4.0.0")
+        #expect(baseline?["typescript"] == "^5.9.3")
+    }
+
     @Test func throwsReadFailedWhenPackageJSONIsMissing() throws {
         let root = tmpDir()
         let source = root.appendingPathComponent("Source")

--- a/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
@@ -149,6 +149,32 @@ import Foundation
         #expect(baseline?["typescript"] == "^5.9.3")
     }
 
+    @Test func withholdsTheBaselineForAStaleAdditionSkippedBecauseItsNameAlreadyExists() throws {
+        // "astro" is already in the site's package.json at ^5.0.0, and the
+        // baseline already agrees (^5.0.0) — an established site, not a legacy
+        // one, so the no-baseline seed path (tested separately above) can't mask
+        // this. A stale addition offer for "astro" at ^6.0.0 reaches
+        // `applyAdditions`, which correctly skips it (PackageJSONDependencies's
+        // duplicate-key guard) — but `landed["astro"]` is still non-nil (it's the
+        // site's pre-existing ^5.0.0), so an existence-only check would wrongly
+        // baseline the offer's ^6.0.0 anyway, permanently withholding a real bump
+        // offer for "astro" thereafter. Only an exact-range match proves this
+        // offer landed (#1108 review, round 2).
+        let (source, config) = try makeSourceAndConfig()
+        try DependencyBaseline.save(["astro": "^5.0.0"], to: config)
+        let offers = DependencySyncOffers(
+            additions: [DependencyAdditionOffer(name: "astro", offeredRange: "^6.0.0", section: .dependencies)]
+        )
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+
+        let updated = try String(contentsOf: source.appendingPathComponent("package.json"), encoding: .utf8)
+        #expect(updated.contains("\"astro\": \"^5.0.0\""))
+        #expect(!updated.contains("^6.0.0"))
+
+        let baseline = DependencyBaseline.load(from: config)
+        #expect(baseline?["astro"] == "^5.0.0")
+    }
+
     @Test func throwsReadFailedWhenPackageJSONIsMissing() throws {
         let root = tmpDir()
         let source = root.appendingPathComponent("Source")

--- a/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
@@ -10,7 +10,7 @@ import Foundation
     }
 
     private static let packageJSON = """
-    { "dependencies": { "astro": "^5.0.0" } }
+    { "dependencies": { "astro": "^5.0.0" }, "devDependencies": {} }
     """
 
     private func makeSourceAndConfig() throws -> (source: URL, config: URL) {
@@ -27,29 +27,40 @@ import Foundation
 
     @Test func rewritesPackageJSONWithTheAcceptedRange() throws {
         let (source, config) = try makeSourceAndConfig()
-        let offers = [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")]
+        let offers = DependencySyncOffers(updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
         try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
         let updated = try String(contentsOf: source.appendingPathComponent("package.json"), encoding: .utf8)
         #expect(updated.contains("\"astro\": \"^6.4.8\""))
     }
 
+    @Test func writesAnAcceptedAdditionIntoTheCorrectSection() throws {
+        let (source, config) = try makeSourceAndConfig()
+        let offers = DependencySyncOffers(additions: [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)])
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+        let updated = try String(contentsOf: source.appendingPathComponent("package.json"), encoding: .utf8)
+        #expect(updated.contains("\"html-validate\": \"^11.6.0\""))
+    }
+
     @Test func deletesTheStaleLockfile() throws {
         let (source, config) = try makeSourceAndConfig()
-        let offers = [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")]
+        let offers = DependencySyncOffers(updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
         try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
         #expect(!FileManager.default.fileExists(atPath: source.appendingPathComponent("package-lock.json").path))
     }
 
-    @Test func savesTheNewBaselineWithTheAcceptedRanges() throws {
+    @Test func savesTheNewBaselineWithBothAcceptedUpdatesAndAdditions() throws {
         let (source, config) = try makeSourceAndConfig()
-        let offers = [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")]
+        let offers = DependencySyncOffers(
+            updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")],
+            additions: [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)]
+        )
         try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
-        #expect(DependencyBaseline.load(from: config) == ["astro": "^6.4.8"])
+        #expect(DependencyBaseline.load(from: config) == ["astro": "^6.4.8", "html-validate": "^11.6.0"])
     }
 
     @Test func bumpsTheAnglesiteVersionStamp() throws {
         let (source, config) = try makeSourceAndConfig()
-        let offers = [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")]
+        let offers = DependencySyncOffers(updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
         try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
         let siteConfig = try String(contentsOf: source.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(SiteConfigFile.value(forKey: "ANGLESITE_VERSION", in: siteConfig) == "1.4.0")
@@ -62,7 +73,7 @@ import Foundation
         try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
         #expect(throws: DependencySyncApplier.ApplyError.readFailed) {
-            try DependencySyncApplier.apply([], sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+            try DependencySyncApplier.apply(DependencySyncOffers(), sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
         }
     }
 }

--- a/Tests/AnglesiteCoreTests/DependencySyncCheckerTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencySyncCheckerTests.swift
@@ -67,7 +67,7 @@ import Foundation
             sourceDirectory: source, configDirectory: config, templateDirectory: template,
             runningAppVersion: "1.4.0"
         )
-        #expect(offers == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
     }
 
     @Test func fallsThroughWhenThereIsNoSiteConfigAtAll() throws {
@@ -77,7 +77,7 @@ import Foundation
             sourceDirectory: source, configDirectory: config, templateDirectory: template,
             runningAppVersion: "1.4.0"
         )
-        #expect(offers == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
     }
 
     @Test func returnsEmptyRatherThanThrowingWhenPackageJSONIsMissing() throws {
@@ -92,5 +92,23 @@ import Foundation
             runningAppVersion: "1.4.0"
         )
         #expect(offers.isEmpty)
+    }
+
+    @Test func surfacesANewTemplateDevDependencyAsAnAdditionOffer() throws {
+        let (source, config) = try makeSite(
+            siteConfig: "ANGLESITE_VERSION=1.2.0\n",
+            packageJSON: """
+            { "dependencies": { "astro": "^6.4.8" }, "devDependencies": {} }
+            """,
+            baseline: ["astro": "^6.4.8"]
+        )
+        let template = try makeTemplate(packageJSON: """
+        { "dependencies": { "astro": "^6.4.8" }, "devDependencies": { "html-validate": "^11.6.0" } }
+        """)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.additions == [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)])
     }
 }

--- a/Tests/AnglesiteCoreTests/DependencySyncTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencySyncTests.swift
@@ -8,7 +8,7 @@ import Testing
             baseline: ["astro": "^5.0.0"],
             template: ["astro": "^6.4.8"]
         )
-        #expect(offers == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
     }
 
     @Test func leavesAUserCustomizedPackageAlone() {
@@ -36,16 +36,7 @@ import Testing
             baseline: nil,
             template: ["astro": "^6.4.8"]
         )
-        #expect(offers == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
-    }
-
-    @Test func neverOffersToAddAPackageTheSiteDoesNotHave() {
-        let offers = DependencySync.diff(
-            site: [:],
-            baseline: [:],
-            template: ["astro-embed": "^0.13.0"]
-        )
-        #expect(offers.isEmpty)
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
     }
 
     @Test func neverOffersToRemoveAPackageTheTemplateNoLongerHas() {
@@ -72,9 +63,63 @@ import Testing
             baseline: ["astro": "^5.0.0", "tsx": "^3.0.0"],
             template: ["astro": "^6.4.8", "tsx": "^4.0.0"]
         )
-        #expect(offers == [
+        #expect(offers.updates == [
             DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8"),
             DependencyUpdateOffer(name: "tsx", currentRange: "^3.0.0", offeredRange: "^4.0.0"),
+        ])
+    }
+
+    @Test func offersToAddANewPackageWhenBaselineHasNoRecordOfIt() {
+        // Baseline present but never saw this name -> nothing of the owner's to
+        // have deliberately removed, safe to offer (#1108).
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: [:],
+            template: ["astro-embed": "^0.13.0"]
+        )
+        #expect(offers.additions == [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)])
+        #expect(offers.updates.isEmpty)
+    }
+
+    @Test func offersToAddANewPackageWhenThereIsNoBaselineAtAll() {
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: nil,
+            template: ["html-validate": "^11.6.0"]
+        )
+        #expect(offers.additions == [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .dependencies)])
+    }
+
+    @Test func withholdsAnAdditionForAPackageTheSiteDeliberatelyRemoved() {
+        // Baseline shows the site had this package before (e.g. a prior accepted
+        // addition offer) -> its current absence is the owner's own doing.
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: ["astro-embed": "^0.13.0"],
+            template: ["astro-embed": "^0.14.0"]
+        )
+        #expect(offers.additions.isEmpty)
+    }
+
+    @Test func tagsAnAdditionAsADevDependencyWhenTheTemplateHasItThere() {
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: [:],
+            template: ["html-validate": "^11.6.0"],
+            templateDevDependencyNames: ["html-validate"]
+        )
+        #expect(offers.additions == [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)])
+    }
+
+    @Test func handlesMultipleAdditionsSortedByName() {
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: [:],
+            template: ["html-validate": "^11.6.0", "astro-embed": "^0.13.0"]
+        )
+        #expect(offers.additions == [
+            DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies),
+            DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .dependencies),
         ])
     }
 }

--- a/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
@@ -163,4 +163,16 @@ import Testing
     @Test func applyAdditionsWithNoOffersReturnsTheTextUnchanged() {
         #expect(PackageJSONDependencies.applyAdditions([], to: Self.fixture) == Self.fixture)
     }
+
+    @Test func applyAdditionsSkipsAnOfferWhoseNameAlreadyExistsInTheTargetSection() {
+        // "astro" is already a key in `dependencies` in the fixture. Inserting it
+        // again would produce two `"astro": ...` keys in the same JSON object —
+        // parseable (last one wins) but semantically corrupted, and this function
+        // is public so it must defend against a stale/duplicate offer regardless
+        // of caller discipline (#1108 review).
+        let offers = [DependencyAdditionOffer(name: "astro", offeredRange: "^99.0.0", section: .dependencies)]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
+        #expect(updated.components(separatedBy: "\"astro\"").count - 1 == 1)
+        #expect(!updated.contains("^99.0.0"))
+    }
 }

--- a/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
@@ -110,15 +110,15 @@ import Testing
     @Test func applyAdditionsInsertsANewEntryMatchingExistingIndentation() {
         let offers = [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)]
         let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
-        #expect(updated.contains("\"dependencies\": {\n    \"astro-embed\": \"^0.13.0\",\n    \"@astrojs/rss\": \"^4.0.0\",\n    \"astro\": \"^5.0.0\"\n  }"))
+        #expect(updated.contains("\"dependencies\": {\n  \"astro-embed\": \"^0.13.0\",\n  \"@astrojs/rss\": \"^4.0.0\",\n  \"astro\": \"^5.0.0\"\n}"))
     }
 
     @Test func applyAdditionsTargetsTheDevDependenciesSectionWhenSpecified() {
         let offers = [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)]
         let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
-        #expect(updated.contains("\"devDependencies\": {\n    \"html-validate\": \"^11.6.0\",\n    \"typescript\": \"^5.9.3\"\n  }"))
+        #expect(updated.contains("\"devDependencies\": {\n  \"html-validate\": \"^11.6.0\",\n  \"typescript\": \"^5.9.3\"\n}"))
         // dependencies section untouched
-        #expect(updated.contains("\"dependencies\": {\n    \"@astrojs/rss\": \"^4.0.0\",\n    \"astro\": \"^5.0.0\"\n  }"))
+        #expect(updated.contains("\"dependencies\": {\n  \"@astrojs/rss\": \"^4.0.0\",\n  \"astro\": \"^5.0.0\"\n}"))
     }
 
     @Test func applyAdditionsUsesADefaultIndentForAnEmptySection() {

--- a/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
@@ -110,15 +110,15 @@ import Testing
     @Test func applyAdditionsInsertsANewEntryMatchingExistingIndentation() {
         let offers = [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)]
         let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
-        #expect(updated.contains("\"dependencies\": {\n  \"astro-embed\": \"^0.13.0\",\n  \"@astrojs/rss\": \"^4.0.0\",\n  \"astro\": \"^5.0.0\"\n}"))
+        #expect(updated.contains("\"dependencies\": {\n    \"astro-embed\": \"^0.13.0\",\n    \"@astrojs/rss\": \"^4.0.0\",\n    \"astro\": \"^5.0.0\"\n  }"))
     }
 
     @Test func applyAdditionsTargetsTheDevDependenciesSectionWhenSpecified() {
         let offers = [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)]
         let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
-        #expect(updated.contains("\"devDependencies\": {\n  \"html-validate\": \"^11.6.0\",\n  \"typescript\": \"^5.9.3\"\n}"))
+        #expect(updated.contains("\"devDependencies\": {\n    \"html-validate\": \"^11.6.0\",\n    \"typescript\": \"^5.9.3\"\n  }"))
         // dependencies section untouched
-        #expect(updated.contains("\"dependencies\": {\n  \"@astrojs/rss\": \"^4.0.0\",\n  \"astro\": \"^5.0.0\"\n}"))
+        #expect(updated.contains("\"dependencies\": {\n    \"@astrojs/rss\": \"^4.0.0\",\n    \"astro\": \"^5.0.0\"\n  }"))
     }
 
     @Test func applyAdditionsUsesADefaultIndentForAnEmptySection() {

--- a/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
@@ -94,4 +94,73 @@ import Testing
         #expect(occurrences == 2)
         #expect(!updated.contains("^1.0.0"))
     }
+
+    @Test func extractSectionsKeepsDependenciesAndDevDependenciesSeparate() throws {
+        let sections = try PackageJSONDependencies.extractSections(from: Self.fixture)
+        #expect(sections.dependencies == ["@astrojs/rss": "^4.0.0", "astro": "^5.0.0"])
+        #expect(sections.devDependencies == ["typescript": "^5.9.3"])
+    }
+
+    @Test func extractSectionsThrowsOnInvalidJSON() {
+        #expect(throws: PackageJSONDependencies.ExtractionError.self) {
+            _ = try PackageJSONDependencies.extractSections(from: "not json")
+        }
+    }
+
+    @Test func applyAdditionsInsertsANewEntryMatchingExistingIndentation() {
+        let offers = [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
+        #expect(updated.contains("\"dependencies\": {\n    \"astro-embed\": \"^0.13.0\",\n    \"@astrojs/rss\": \"^4.0.0\",\n    \"astro\": \"^5.0.0\"\n  }"))
+    }
+
+    @Test func applyAdditionsTargetsTheDevDependenciesSectionWhenSpecified() {
+        let offers = [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
+        #expect(updated.contains("\"devDependencies\": {\n    \"html-validate\": \"^11.6.0\",\n    \"typescript\": \"^5.9.3\"\n  }"))
+        // dependencies section untouched
+        #expect(updated.contains("\"dependencies\": {\n    \"@astrojs/rss\": \"^4.0.0\",\n    \"astro\": \"^5.0.0\"\n  }"))
+    }
+
+    @Test func applyAdditionsUsesADefaultIndentForAnEmptySection() {
+        let text = """
+        {
+          "dependencies": {}
+        }
+        """
+        let offers = [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: text)
+        #expect(updated.contains("\"dependencies\": {\n  \"astro-embed\": \"^0.13.0\"\n}"))
+    }
+
+    @Test func applyAdditionsSkipsWhenTheTargetSectionIsAbsent() {
+        let text = """
+        {
+          "name": "anglesite-site"
+        }
+        """
+        let offers = [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)]
+        #expect(PackageJSONDependencies.applyAdditions(offers, to: text) == text)
+    }
+
+    @Test func applyAdditionsHandlesMultipleOffersToTheSameSection() {
+        let text = """
+        {
+          "dependencies": {
+            "astro": "^5.0.0"
+          }
+        }
+        """
+        let offers = [
+            DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies),
+            DependencyAdditionOffer(name: "@tgwf/co2", offeredRange: "^0.19.0", section: .dependencies),
+        ]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: text)
+        #expect(updated.contains("\"astro-embed\": \"^0.13.0\""))
+        #expect(updated.contains("\"@tgwf/co2\": \"^0.19.0\""))
+        #expect(updated.contains("\"astro\": \"^5.0.0\""))
+    }
+
+    @Test func applyAdditionsWithNoOffersReturnsTheTextUnchanged() {
+        #expect(PackageJSONDependencies.applyAdditions([], to: Self.fixture) == Self.fixture)
+    }
 }

--- a/docs/superpowers/plans/2026-07-30-template-dependency-additions.md
+++ b/docs/superpowers/plans/2026-07-30-template-dependency-additions.md
@@ -1,0 +1,873 @@
+# Template Dependency Additions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `DependencySync` so a template package that's new (present in the template, absent from the site) can be offered and installed into an existing site, not just version-bumped.
+
+**Architecture:** `DependencySync.diff` gains a second output — addition offers alongside today's update offers, bundled in a new `DependencySyncOffers` struct. `PackageJSONDependencies` gains a section-aware extractor and an `applyAdditions` writer. `DependencySyncChecker`/`DependencySyncApplier` and the app's dependency-update sheet thread the new type through; the sheet UI gains a second, visually distinct section for additions.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Suite`/`@Test`), SwiftUI.
+
+## Global Constraints
+
+- Swift/SwiftUI with Apple frameworks only — no new third-party dependencies (CONTRIBUTING.md ▸ "Code guidelines").
+- Conventional commit subjects ≤72 characters, referencing `#1108` (CONTRIBUTING.md ▸ "Commits and pull requests").
+- `DependencySync.diff` never removes a package name the template dropped — unchanged invariant, do not touch that behavior.
+- This is an app-only change (no MCP message schema touched) — no paired sidecar PR needed.
+- **Compilation is atomic across the whole SwiftPM package.** `Sources/AnglesiteApp` is built as the `AnglesiteAppCore` SwiftPM target (`Package.swift:232`, gated `#if compiler(>=6.4) && canImport(Darwin)`), so `swift test --package-path .` compiles `SiteWindowModel.swift`/`SiteWindow.swift`/`DependencyUpdateModel.swift` too, not just `AnglesiteCore`. `swift test --filter` only restricts what *runs*, not what *compiles* — a broken file anywhere in the package blocks every suite. Task boundaries below are drawn so each task's final commit leaves the whole package compiling; do not split a task further without re-checking this.
+- Run `swift test --package-path .` before considering any task done; run `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` before considering the whole plan done.
+- Full design reference: [`docs/superpowers/specs/2026-07-30-template-dependency-additions-design.md`](../specs/2026-07-30-template-dependency-additions-design.md).
+
+---
+
+### Task 1: New offer types + `PackageJSONDependencies` additions
+
+This task only *adds* new types and new functions — it does not change any existing function's signature or behavior, so it's safe to land on its own: nothing calls the new code yet, and everything that currently compiles keeps compiling.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DependencySync.swift` (add types only — `diff` itself is untouched until Task 2)
+- Modify: `Sources/AnglesiteCore/PackageJSONDependencies.swift`
+- Test: `Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift`
+
+**Interfaces:**
+- Produces: `public enum DependencySection: Sendable, Equatable { case dependencies, devDependencies }`
+- Produces: `public struct DependencyAdditionOffer: Sendable, Equatable { public let name: String; public let offeredRange: String; public let section: DependencySection; public init(name:offeredRange:section:) }`
+- Produces: `public struct DependencySyncOffers: Sendable, Equatable { public let updates: [DependencyUpdateOffer]; public let additions: [DependencyAdditionOffer]; public init(updates: [DependencyUpdateOffer] = [], additions: [DependencyAdditionOffer] = []); public var isEmpty: Bool }` (not consumed by `diff` until Task 2)
+- Produces: `public static func extractSections(from text: String) throws -> (dependencies: [String: String], devDependencies: [String: String])`
+- Produces: `public static func applyAdditions(_ offers: [DependencyAdditionOffer], to text: String) -> String`
+- `public static func extract(from text: String) throws -> [String: String]` keeps its existing signature and behavior (devDependencies wins on name collision), reimplemented in terms of `extractSections`.
+
+- [ ] **Step 1: Add the new offer types to `DependencySync.swift`**
+
+In `Sources/AnglesiteCore/DependencySync.swift`, find:
+
+```swift
+/// One offered version-range bump for a single package.
+public struct DependencyUpdateOffer: Sendable, Equatable {
+    public let name: String
+    public let currentRange: String
+    public let offeredRange: String
+
+    public init(name: String, currentRange: String, offeredRange: String) {
+        self.name = name
+        self.currentRange = currentRange
+        self.offeredRange = offeredRange
+    }
+}
+
+/// Three-way comparison between a site's dependencies, an optional scaffold-time
+```
+
+Replace it with (inserting the three new types between `DependencyUpdateOffer` and the doc comment on `DependencySync`):
+
+```swift
+/// One offered version-range bump for a single package.
+public struct DependencyUpdateOffer: Sendable, Equatable {
+    public let name: String
+    public let currentRange: String
+    public let offeredRange: String
+
+    public init(name: String, currentRange: String, offeredRange: String) {
+        self.name = name
+        self.currentRange = currentRange
+        self.offeredRange = offeredRange
+    }
+}
+
+/// Which `package.json` section a dependency belongs (or would be added) to.
+public enum DependencySection: Sendable, Equatable {
+    case dependencies
+    case devDependencies
+}
+
+/// One offered new package the template has that the site does not.
+public struct DependencyAdditionOffer: Sendable, Equatable {
+    public let name: String
+    public let offeredRange: String
+    public let section: DependencySection
+
+    public init(name: String, offeredRange: String, section: DependencySection) {
+        self.name = name
+        self.offeredRange = offeredRange
+        self.section = section
+    }
+}
+
+/// The full result of a `DependencySync.diff` call: version bumps for packages
+/// the site already has, and new packages the template has that the site
+/// doesn't. `diff` itself doesn't return this yet (see #1108 Task 2) — this
+/// type exists now so `PackageJSONDependencies.applyAdditions` can consume
+/// `DependencyAdditionOffer` independently.
+public struct DependencySyncOffers: Sendable, Equatable {
+    public let updates: [DependencyUpdateOffer]
+    public let additions: [DependencyAdditionOffer]
+
+    public init(updates: [DependencyUpdateOffer] = [], additions: [DependencyAdditionOffer] = []) {
+        self.updates = updates
+        self.additions = additions
+    }
+
+    public var isEmpty: Bool { updates.isEmpty && additions.isEmpty }
+}
+
+/// Three-way comparison between a site's dependencies, an optional scaffold-time
+```
+
+Leave the rest of the file (the `DependencySync` enum and its `diff` function) completely unchanged for now.
+
+- [ ] **Step 2: Run the full test suite to confirm nothing broke**
+
+Run: `swift test --package-path .`
+Expected: PASS — every existing suite is green (these are pure additions; nothing references the new types yet).
+
+- [ ] **Step 3: Write the failing tests for `PackageJSONDependencies`**
+
+Add these test cases to the end of the `PackageJSONDependenciesTests` suite in `Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift` (inside the closing `}` of the existing suite, after `applyUpdatesAPackageNamePresentInBothSections`):
+
+```swift
+    @Test func extractSectionsKeepsDependenciesAndDevDependenciesSeparate() throws {
+        let sections = try PackageJSONDependencies.extractSections(from: Self.fixture)
+        #expect(sections.dependencies == ["@astrojs/rss": "^4.0.0", "astro": "^5.0.0"])
+        #expect(sections.devDependencies == ["typescript": "^5.9.3"])
+    }
+
+    @Test func extractSectionsThrowsOnInvalidJSON() {
+        #expect(throws: PackageJSONDependencies.ExtractionError.self) {
+            _ = try PackageJSONDependencies.extractSections(from: "not json")
+        }
+    }
+
+    @Test func applyAdditionsInsertsANewEntryMatchingExistingIndentation() {
+        let offers = [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
+        #expect(updated.contains("\"dependencies\": {\n    \"astro-embed\": \"^0.13.0\",\n    \"@astrojs/rss\": \"^4.0.0\",\n    \"astro\": \"^5.0.0\"\n  }"))
+    }
+
+    @Test func applyAdditionsTargetsTheDevDependenciesSectionWhenSpecified() {
+        let offers = [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: Self.fixture)
+        #expect(updated.contains("\"devDependencies\": {\n    \"html-validate\": \"^11.6.0\",\n    \"typescript\": \"^5.9.3\"\n  }"))
+        // dependencies section untouched
+        #expect(updated.contains("\"dependencies\": {\n    \"@astrojs/rss\": \"^4.0.0\",\n    \"astro\": \"^5.0.0\"\n  }"))
+    }
+
+    @Test func applyAdditionsUsesADefaultIndentForAnEmptySection() {
+        let text = """
+        {
+          "dependencies": {}
+        }
+        """
+        let offers = [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: text)
+        #expect(updated.contains("\"dependencies\": {\n  \"astro-embed\": \"^0.13.0\"\n}"))
+    }
+
+    @Test func applyAdditionsSkipsWhenTheTargetSectionIsAbsent() {
+        let text = """
+        {
+          "name": "anglesite-site"
+        }
+        """
+        let offers = [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)]
+        #expect(PackageJSONDependencies.applyAdditions(offers, to: text) == text)
+    }
+
+    @Test func applyAdditionsHandlesMultipleOffersToTheSameSection() {
+        let text = """
+        {
+          "dependencies": {
+            "astro": "^5.0.0"
+          }
+        }
+        """
+        let offers = [
+            DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies),
+            DependencyAdditionOffer(name: "@tgwf/co2", offeredRange: "^0.19.0", section: .dependencies),
+        ]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: text)
+        #expect(updated.contains("\"astro-embed\": \"^0.13.0\""))
+        #expect(updated.contains("\"@tgwf/co2\": \"^0.19.0\""))
+        #expect(updated.contains("\"astro\": \"^5.0.0\""))
+    }
+
+    @Test func applyAdditionsWithNoOffersReturnsTheTextUnchanged() {
+        #expect(PackageJSONDependencies.applyAdditions([], to: Self.fixture) == Self.fixture)
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they fail to compile**
+
+Run: `swift test --package-path . --filter PackageJSONDependenciesTests`
+Expected: FAIL to build — `extractSections` and `applyAdditions` don't exist yet.
+
+- [ ] **Step 5: Implement `extractSections` and `applyAdditions`**
+
+In `Sources/AnglesiteCore/PackageJSONDependencies.swift`, replace the existing `extract(from:)` method with this pair (keeping everything else — `ExtractionError`, `apply`, `objectSpan` — unchanged):
+
+```swift
+    /// `dependencies` and `devDependencies`, kept separate (unlike `extract`,
+    /// which merges them). Used where the caller needs to know which section a
+    /// package belongs to, not just its version range.
+    public static func extractSections(from text: String) throws -> (dependencies: [String: String], devDependencies: [String: String]) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data),
+              let object = json as? [String: Any]
+        else { throw ExtractionError.invalidJSON }
+        let deps = object["dependencies"] as? [String: String] ?? [:]
+        let devDeps = object["devDependencies"] as? [String: String] ?? [:]
+        return (dependencies: deps, devDependencies: devDeps)
+    }
+
+    /// The union of `dependencies` and `devDependencies` (name -> version range).
+    /// If a name appears in both sections, `devDependencies` wins (checked second).
+    public static func extract(from text: String) throws -> [String: String] {
+        let sections = try extractSections(from: text)
+        var result = sections.dependencies
+        result.merge(sections.devDependencies) { _, new in new }
+        return result
+    }
+```
+
+Then add `applyAdditions` immediately after the existing `apply(_:to:)` method (before the private `objectSpan` helper):
+
+```swift
+    /// Inserts each offer's `"name": "range"` as a new first entry in its
+    /// target `dependencies`/`devDependencies` section, copying the
+    /// indentation of whatever currently comes first in that section. An
+    /// offer whose target section doesn't exist in `text` at all is silently
+    /// skipped — this mutates existing structure, it never fabricates a new
+    /// top-level section.
+    public static func applyAdditions(_ offers: [DependencyAdditionOffer], to text: String) -> String {
+        var result = text
+        for offer in offers {
+            let key = offer.section == .devDependencies ? "devDependencies" : "dependencies"
+            guard let span = objectSpan(forKey: key, in: result) else { continue }
+            let openBrace = span.lowerBound
+            let afterBrace = result.index(after: openBrace)
+            var firstContent = afterBrace
+            while firstContent < span.upperBound, result[firstContent].isWhitespace {
+                firstContent = result.index(after: firstContent)
+            }
+            let escapedName = offer.name.replacingOccurrences(of: "\"", with: "\\\"")
+            let escapedRange = offer.offeredRange.replacingOccurrences(of: "\"", with: "\\\"")
+            let entry = "\"\(escapedName)\": \"\(escapedRange)\""
+            if result[firstContent] != "}" {
+                // Non-empty section: prepend as a new first entry, copying the
+                // whitespace that currently precedes the existing first entry.
+                let indent = String(result[afterBrace..<firstContent])
+                result.insert(contentsOf: "\(entry),\(indent)", at: afterBrace)
+            } else {
+                // Empty section (`{}` or `{ }`): no existing indentation to copy.
+                result.replaceSubrange(afterBrace..<firstContent, with: "\n  \(entry)\n")
+            }
+        }
+        return result
+    }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter PackageJSONDependenciesTests`
+Expected: PASS — all tests (existing + new) green.
+
+- [ ] **Step 7: Run the full suite once more and commit**
+
+Run: `swift test --package-path .`
+Expected: PASS — whole package still compiles and passes.
+
+```bash
+git add Sources/AnglesiteCore/DependencySync.swift Sources/AnglesiteCore/PackageJSONDependencies.swift Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
+git commit -m "feat(#1108): add addition-offer types and package.json writer"
+```
+
+---
+
+### Task 2: Wire additions through diff → checker → applier → sheet UI
+
+This is the atomic core of the feature. `DependencySync.diff`'s return type changes from `[DependencyUpdateOffer]` to `DependencySyncOffers`, and every one of its callers — `DependencySyncChecker`, `DependencySyncApplier`, `DependencyUpdateModel`, and the `SiteWindow.swift` sheet — depends on that change to keep compiling. They must land together in this one task; there is no smaller slice that leaves the package building (see the Global Constraints note above). `Sources/AnglesiteApp/SiteWindowModel.swift` needs **no changes** — its local `offers` variable's type follows automatically from `DependencySyncChecker.check`'s new return type, and it's passed straight through to `DependencyUpdateModel.init` and `DependencySyncApplier.apply` unchanged.
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DependencySync.swift` (the `diff` function body)
+- Modify: `Sources/AnglesiteCore/DependencySyncChecker.swift`
+- Modify: `Sources/AnglesiteCore/DependencySyncApplier.swift`
+- Modify: `Sources/AnglesiteApp/DependencyUpdateModel.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift` (around line 645)
+- Test: `Tests/AnglesiteCoreTests/DependencySyncTests.swift`
+- Test: `Tests/AnglesiteCoreTests/DependencySyncCheckerTests.swift`
+- Test: `Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift`
+
+**Interfaces:**
+- Consumes: `DependencySection`, `DependencyAdditionOffer`, `DependencySyncOffers`, `PackageJSONDependencies.extractSections`/`applyAdditions` (Task 1)
+- Produces: `public static func diff(site: [String: String], baseline: [String: String]?, template: [String: String], templateDevDependencyNames: Set<String> = []) -> DependencySyncOffers`
+- Produces: `public static func check(sourceDirectory: URL, configDirectory: URL, templateDirectory: URL, runningAppVersion: String) -> DependencySyncOffers` (same name/parameters as today, new return type)
+- Produces: `public static func apply(_ offers: DependencySyncOffers, sourceDirectory: URL, configDirectory: URL, runningAppVersion: String) throws` (same name/parameters as today except the first parameter's type)
+- Produces: `DependencyUpdateModel.offers: DependencySyncOffers` (was `[DependencyUpdateOffer]`)
+
+- [ ] **Step 1: Write the failing tests for `DependencySync.diff`**
+
+Replace the entire contents of `Tests/AnglesiteCoreTests/DependencySyncTests.swift` with:
+
+```swift
+import Testing
+@testable import AnglesiteCore
+
+@Suite struct DependencySyncTests {
+    @Test func offersABumpWhenSiteMatchesBaselineButTemplateMovedForward() {
+        let offers = DependencySync.diff(
+            site: ["astro": "^5.0.0"],
+            baseline: ["astro": "^5.0.0"],
+            template: ["astro": "^6.4.8"]
+        )
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+    }
+
+    @Test func leavesAUserCustomizedPackageAlone() {
+        // Site's range no longer matches the baseline -> the user edited it deliberately.
+        let offers = DependencySync.diff(
+            site: ["astro": "^5.1.0"],
+            baseline: ["astro": "^5.0.0"],
+            template: ["astro": "^6.4.8"]
+        )
+        #expect(offers.isEmpty)
+    }
+
+    @Test func doesNothingWhenSiteBaselineAndTemplateAllAgree() {
+        let offers = DependencySync.diff(
+            site: ["astro": "^6.4.8"],
+            baseline: ["astro": "^6.4.8"],
+            template: ["astro": "^6.4.8"]
+        )
+        #expect(offers.isEmpty)
+    }
+
+    @Test func legacySiteWithNoBaselineFallsBackToADirectDiff() {
+        let offers = DependencySync.diff(
+            site: ["astro": "^5.0.0"],
+            baseline: nil,
+            template: ["astro": "^6.4.8"]
+        )
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+    }
+
+    @Test func neverOffersToRemoveAPackageTheTemplateNoLongerHas() {
+        let offers = DependencySync.diff(
+            site: ["some-deprecated-package": "^1.0.0"],
+            baseline: ["some-deprecated-package": "^1.0.0"],
+            template: [:]
+        )
+        #expect(offers.isEmpty)
+    }
+
+    @Test func skipsAnIncomparableVersionRatherThanGuessing() {
+        let offers = DependencySync.diff(
+            site: ["astro": "workspace:*"],
+            baseline: ["astro": "workspace:*"],
+            template: ["astro": "^6.4.8"]
+        )
+        #expect(offers.isEmpty)
+    }
+
+    @Test func handlesMultiplePackagesSortedByName() {
+        let offers = DependencySync.diff(
+            site: ["astro": "^5.0.0", "tsx": "^3.0.0"],
+            baseline: ["astro": "^5.0.0", "tsx": "^3.0.0"],
+            template: ["astro": "^6.4.8", "tsx": "^4.0.0"]
+        )
+        #expect(offers.updates == [
+            DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8"),
+            DependencyUpdateOffer(name: "tsx", currentRange: "^3.0.0", offeredRange: "^4.0.0"),
+        ])
+    }
+
+    @Test func offersToAddANewPackageWhenBaselineHasNoRecordOfIt() {
+        // Baseline present but never saw this name -> nothing of the owner's to
+        // have deliberately removed, safe to offer (#1108).
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: [:],
+            template: ["astro-embed": "^0.13.0"]
+        )
+        #expect(offers.additions == [DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies)])
+        #expect(offers.updates.isEmpty)
+    }
+
+    @Test func offersToAddANewPackageWhenThereIsNoBaselineAtAll() {
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: nil,
+            template: ["html-validate": "^11.6.0"]
+        )
+        #expect(offers.additions == [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .dependencies)])
+    }
+
+    @Test func withholdsAnAdditionForAPackageTheSiteDeliberatelyRemoved() {
+        // Baseline shows the site had this package before (e.g. a prior accepted
+        // addition offer) -> its current absence is the owner's own doing.
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: ["astro-embed": "^0.13.0"],
+            template: ["astro-embed": "^0.14.0"]
+        )
+        #expect(offers.additions.isEmpty)
+    }
+
+    @Test func tagsAnAdditionAsADevDependencyWhenTheTemplateHasItThere() {
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: [:],
+            template: ["html-validate": "^11.6.0"],
+            templateDevDependencyNames: ["html-validate"]
+        )
+        #expect(offers.additions == [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)])
+    }
+
+    @Test func handlesMultipleAdditionsSortedByName() {
+        let offers = DependencySync.diff(
+            site: [:],
+            baseline: [:],
+            template: ["html-validate": "^11.6.0", "astro-embed": "^0.13.0"]
+        )
+        #expect(offers.additions == [
+            DependencyAdditionOffer(name: "astro-embed", offeredRange: "^0.13.0", section: .dependencies),
+            DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .dependencies),
+        ])
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing tests for `DependencySyncChecker`**
+
+In `Tests/AnglesiteCoreTests/DependencySyncCheckerTests.swift`, replace the four existing `@Test` methods (`fastPathSkipsEverythingWhenStampedVersionMatchesRunningVersion` through `returnsEmptyRatherThanThrowingWhenPackageJSONIsMissing`) and add a fifth, leaving the helpers (`tmpDir`, `writeFile`, `makeSite`, `makeTemplate`) and fixtures (`stalePackageJSON`, `currentTemplatePackageJSON`) unchanged:
+
+```swift
+    @Test func fastPathSkipsEverythingWhenStampedVersionMatchesRunningVersion() throws {
+        let (source, config) = try makeSite(
+            siteConfig: "ANGLESITE_VERSION=1.4.0\n",
+            packageJSON: Self.stalePackageJSON,  // deliberately stale, to prove the fast path never looks
+            baseline: nil
+        )
+        let template = try makeTemplate(packageJSON: Self.currentTemplatePackageJSON)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.isEmpty)
+    }
+
+    @Test func fallsThroughToTheRealDiffWhenStampedVersionDiffers() throws {
+        let (source, config) = try makeSite(
+            siteConfig: "ANGLESITE_VERSION=1.2.0\n",
+            packageJSON: Self.stalePackageJSON,
+            baseline: ["astro": "^5.0.0"]
+        )
+        let template = try makeTemplate(packageJSON: Self.currentTemplatePackageJSON)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+    }
+
+    @Test func fallsThroughWhenThereIsNoSiteConfigAtAll() throws {
+        let (source, config) = try makeSite(siteConfig: nil, packageJSON: Self.stalePackageJSON, baseline: nil)
+        let template = try makeTemplate(packageJSON: Self.currentTemplatePackageJSON)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+    }
+
+    @Test func returnsEmptyRatherThanThrowingWhenPackageJSONIsMissing() throws {
+        let root = tmpDir()
+        let source = root.appendingPathComponent("Source")
+        let config = root.appendingPathComponent("Config")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        let template = try makeTemplate(packageJSON: Self.currentTemplatePackageJSON)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.isEmpty)
+    }
+
+    @Test func surfacesANewTemplateDevDependencyAsAnAdditionOffer() throws {
+        let (source, config) = try makeSite(
+            siteConfig: "ANGLESITE_VERSION=1.2.0\n",
+            packageJSON: """
+            { "dependencies": { "astro": "^6.4.8" }, "devDependencies": {} }
+            """,
+            baseline: ["astro": "^6.4.8"]
+        )
+        let template = try makeTemplate(packageJSON: """
+        { "dependencies": { "astro": "^6.4.8" }, "devDependencies": { "html-validate": "^11.6.0" } }
+        """)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.additions == [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)])
+    }
+```
+
+- [ ] **Step 3: Write the failing tests for `DependencySyncApplier`**
+
+Replace the entire contents of `Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift` with:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct DependencySyncApplierTests {
+    private func tmpDir() -> URL {
+        let d = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    private static let packageJSON = """
+    { "dependencies": { "astro": "^5.0.0" }, "devDependencies": {} }
+    """
+
+    private func makeSourceAndConfig() throws -> (source: URL, config: URL) {
+        let root = tmpDir()
+        let source = root.appendingPathComponent("Source")
+        let config = root.appendingPathComponent("Config")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        try Self.packageJSON.write(to: source.appendingPathComponent("package.json"), atomically: true, encoding: .utf8)
+        try "old lockfile contents".write(to: source.appendingPathComponent("package-lock.json"), atomically: true, encoding: .utf8)
+        try "ANGLESITE_VERSION=1.2.0\n".write(to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        return (source, config)
+    }
+
+    @Test func rewritesPackageJSONWithTheAcceptedRange() throws {
+        let (source, config) = try makeSourceAndConfig()
+        let offers = DependencySyncOffers(updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+        let updated = try String(contentsOf: source.appendingPathComponent("package.json"), encoding: .utf8)
+        #expect(updated.contains("\"astro\": \"^6.4.8\""))
+    }
+
+    @Test func writesAnAcceptedAdditionIntoTheCorrectSection() throws {
+        let (source, config) = try makeSourceAndConfig()
+        let offers = DependencySyncOffers(additions: [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)])
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+        let updated = try String(contentsOf: source.appendingPathComponent("package.json"), encoding: .utf8)
+        #expect(updated.contains("\"html-validate\": \"^11.6.0\""))
+    }
+
+    @Test func deletesTheStaleLockfile() throws {
+        let (source, config) = try makeSourceAndConfig()
+        let offers = DependencySyncOffers(updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+        #expect(!FileManager.default.fileExists(atPath: source.appendingPathComponent("package-lock.json").path))
+    }
+
+    @Test func savesTheNewBaselineWithBothAcceptedUpdatesAndAdditions() throws {
+        let (source, config) = try makeSourceAndConfig()
+        let offers = DependencySyncOffers(
+            updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")],
+            additions: [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)]
+        )
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+        #expect(DependencyBaseline.load(from: config) == ["astro": "^6.4.8", "html-validate": "^11.6.0"])
+    }
+
+    @Test func bumpsTheAnglesiteVersionStamp() throws {
+        let (source, config) = try makeSourceAndConfig()
+        let offers = DependencySyncOffers(updates: [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")])
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+        let siteConfig = try String(contentsOf: source.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "ANGLESITE_VERSION", in: siteConfig) == "1.4.0")
+    }
+
+    @Test func throwsReadFailedWhenPackageJSONIsMissing() throws {
+        let root = tmpDir()
+        let source = root.appendingPathComponent("Source")
+        let config = root.appendingPathComponent("Config")
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        #expect(throws: DependencySyncApplier.ApplyError.readFailed) {
+            try DependencySyncApplier.apply(DependencySyncOffers(), sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they fail to build**
+
+Run: `swift test --package-path .`
+Expected: FAIL to build. `DependencySync.diff` still returns `[DependencyUpdateOffer]`, `DependencySyncChecker.check`/`DependencySyncApplier.apply` haven't changed, so none of the `.updates`/`.additions` accessors or the new `DependencySyncOffers`-typed calls compile. (A plain `swift test`, not `--filter`, is deliberate here — the goal is to see the whole package fail together, matching how it will need to succeed together in Step 6.)
+
+- [ ] **Step 5: Implement the four source files together**
+
+In `Sources/AnglesiteCore/DependencySync.swift`, replace the `diff` function's body (leave the doc comment above `DependencySync` and everything from Task 1 alone):
+
+```swift
+public enum DependencySync {
+    public static func diff(
+        site: [String: String],
+        baseline: [String: String]?,
+        template: [String: String],
+        templateDevDependencyNames: Set<String> = []
+    ) -> DependencySyncOffers {
+        var updates: [DependencyUpdateOffer] = []
+        var additions: [DependencyAdditionOffer] = []
+        for (name, templateRange) in template.sorted(by: { $0.key < $1.key }) {
+            guard let siteRange = site[name] else {
+                // Not in the site at all: a candidate for an addition offer,
+                // gated by whether the site is known to have deliberately
+                // removed it before (#1108).
+                if let baseline {
+                    guard baseline[name] == nil else { continue }
+                }
+                // else: no baseline at all -> legacy direct-diff fallback, same
+                // risk tolerance as the bump path below.
+                let section: DependencySection = templateDevDependencyNames.contains(name) ? .devDependencies : .dependencies
+                additions.append(DependencyAdditionOffer(name: name, offeredRange: templateRange, section: section))
+                continue
+            }
+            guard DependencyVersionComparator.isNewer(templateRange, than: siteRange) == true else { continue }
+            if let baseline {
+                // 3-way case: only offer when the site never touched this package
+                // since it was scaffolded (its range still matches the baseline).
+                guard let baselineRange = baseline[name], baselineRange == siteRange else { continue }
+            }
+            // else: no baseline at all -> legacy direct-diff fallback (spec §3).
+            updates.append(DependencyUpdateOffer(name: name, currentRange: siteRange, offeredRange: templateRange))
+        }
+        return DependencySyncOffers(updates: updates, additions: additions)
+    }
+}
+```
+
+Replace the entire contents of `Sources/AnglesiteCore/DependencySyncChecker.swift`:
+
+```swift
+import Foundation
+
+/// Top-level entry point for the dependency-sync feature: the fast-path gate
+/// (spec §3.1) plus the full 3-way diff, wired together. Never throws — any
+/// unreadable/malformed input degrades to "nothing to offer" (spec §7), since
+/// this is a diagnostic convenience feature that must never block a site opening.
+public enum DependencySyncChecker {
+    public static func check(
+        sourceDirectory: URL,
+        configDirectory: URL,
+        templateDirectory: URL,
+        runningAppVersion: String
+    ) -> DependencySyncOffers {
+        let siteConfigURL = sourceDirectory.appendingPathComponent(".site-config")
+        if let siteConfigContents = try? String(contentsOf: siteConfigURL, encoding: .utf8),
+           let stampedVersion = SiteConfigFile.value(forKey: "ANGLESITE_VERSION", in: siteConfigContents),
+           stampedVersion == runningAppVersion {
+            return DependencySyncOffers()
+        }
+
+        guard let sitePackageText = try? String(
+                contentsOf: sourceDirectory.appendingPathComponent("package.json"), encoding: .utf8),
+              let siteDeps = try? PackageJSONDependencies.extract(from: sitePackageText),
+              let templatePackageText = try? String(
+                contentsOf: templateDirectory.appendingPathComponent("package.json"), encoding: .utf8),
+              let templateSections = try? PackageJSONDependencies.extractSections(from: templatePackageText)
+        else { return DependencySyncOffers() }
+
+        var templateDeps = templateSections.dependencies
+        templateDeps.merge(templateSections.devDependencies) { _, new in new }
+
+        let baseline = DependencyBaseline.load(from: configDirectory)
+        return DependencySync.diff(
+            site: siteDeps,
+            baseline: baseline,
+            template: templateDeps,
+            templateDevDependencyNames: Set(templateSections.devDependencies.keys)
+        )
+    }
+}
+```
+
+Replace the entire contents of `Sources/AnglesiteCore/DependencySyncApplier.swift`:
+
+```swift
+import Foundation
+
+/// Applies an accepted dependency-sync decision (spec §6, #1108): rewrites
+/// `package.json`'s version ranges and inserts any accepted new-dependency
+/// entries, deletes the now-stale `package-lock.json` (so the next preview
+/// boot's existing `hydrate.sh` regenerates one via its normal `npm install`
+/// path — no new container-exec machinery), refreshes the baseline for both
+/// updates and additions, and bumps the `ANGLESITE_VERSION` stamp. The
+/// lockfile delete, baseline save, and version bump are best-effort (`try?`)
+/// once the package.json rewrite itself has succeeded — none of them are
+/// things the user's file-open flow should hard-fail on.
+public enum DependencySyncApplier {
+    public enum ApplyError: Error, Equatable {
+        case readFailed
+        case writeFailed
+    }
+
+    public static func apply(
+        _ offers: DependencySyncOffers,
+        sourceDirectory: URL,
+        configDirectory: URL,
+        runningAppVersion: String
+    ) throws {
+        let packageJSONURL = sourceDirectory.appendingPathComponent("package.json")
+        guard let originalText = try? String(contentsOf: packageJSONURL, encoding: .utf8) else {
+            throw ApplyError.readFailed
+        }
+        var updatedText = PackageJSONDependencies.apply(offers.updates, to: originalText)
+        updatedText = PackageJSONDependencies.applyAdditions(offers.additions, to: updatedText)
+        do {
+            try updatedText.write(to: packageJSONURL, atomically: true, encoding: .utf8)
+        } catch {
+            throw ApplyError.writeFailed
+        }
+
+        try? FileManager.default.removeItem(at: sourceDirectory.appendingPathComponent("package-lock.json"))
+
+        var newBaseline = DependencyBaseline.load(from: configDirectory) ?? [:]
+        for offer in offers.updates { newBaseline[offer.name] = offer.offeredRange }
+        for offer in offers.additions { newBaseline[offer.name] = offer.offeredRange }
+        try? DependencyBaseline.save(newBaseline, to: configDirectory)
+
+        let siteConfigURL = sourceDirectory.appendingPathComponent(".site-config")
+        let existingConfig = (try? String(contentsOf: siteConfigURL, encoding: .utf8)) ?? ""
+        let updatedConfig = SiteConfigFile.upsert([("ANGLESITE_VERSION", runningAppVersion)], into: existingConfig)
+        try? updatedConfig.write(to: siteConfigURL, atomically: true, encoding: .utf8)
+    }
+}
+```
+
+Replace the entire contents of `Sources/AnglesiteApp/DependencyUpdateModel.swift`:
+
+```swift
+import Foundation
+import AnglesiteCore
+
+/// Thin, `Identifiable` model driving the dependency-update-offer sheet
+/// (spec §5, #1108). Holds the already-computed offers (bumps and new-package
+/// additions) and forwards the user's decision — no comparison/diff logic
+/// lives here, that's all in `AnglesiteCore`
+/// (`DependencySyncChecker`/`DependencySyncApplier`).
+@MainActor
+final class DependencyUpdateModel: Identifiable {
+    nonisolated let id = UUID()
+    let offers: DependencySyncOffers
+    private let onDecision: (_ accepted: Bool) -> Void
+
+    init(offers: DependencySyncOffers, onDecision: @escaping (_ accepted: Bool) -> Void) {
+        self.offers = offers
+        self.onDecision = onDecision
+    }
+
+    func update() { onDecision(true) }
+    func skip() { onDecision(false) }
+}
+```
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, find this block (around line 645):
+
+```swift
+        .sheet(item: $bindableModel.dependencyUpdateModel) { updateModel in
+            NavigationStack {
+                List(updateModel.offers, id: \.name) { offer in
+                    LabeledContent(offer.name) {
+                        Text("\(offer.currentRange) → \(offer.offeredRange)")
+                            .font(.system(.body, design: .monospaced))
+                    }
+                }
+                .navigationTitle("Dependency Updates Available")
+```
+
+Replace it with:
+
+```swift
+        .sheet(item: $bindableModel.dependencyUpdateModel) { updateModel in
+            NavigationStack {
+                List {
+                    if !updateModel.offers.updates.isEmpty {
+                        Section("Dependency Updates") {
+                            ForEach(updateModel.offers.updates, id: \.name) { offer in
+                                LabeledContent(offer.name) {
+                                    Text("\(offer.currentRange) → \(offer.offeredRange)")
+                                        .font(.system(.body, design: .monospaced))
+                                }
+                            }
+                        }
+                    }
+                    if !updateModel.offers.additions.isEmpty {
+                        Section("New Dependencies") {
+                            ForEach(updateModel.offers.additions, id: \.name) { offer in
+                                LabeledContent {
+                                    Text(offer.offeredRange)
+                                        .font(.system(.body, design: .monospaced))
+                                } label: {
+                                    Label(offer.name, systemImage: "plus.circle")
+                                }
+                            }
+                        }
+                    }
+                }
+                .navigationTitle("Dependency Updates Available")
+```
+
+The rest of the `.sheet` block (the `.toolbar` with Skip/Update, `.frame`, `.interactiveDismissDisabled()`) is unchanged — leave it exactly as-is. Do not touch `Sources/AnglesiteApp/SiteWindowModel.swift` at all in this task.
+
+- [ ] **Step 6: Run the full test suite to verify everything passes**
+
+Run: `swift test --package-path .`
+Expected: PASS — every suite green, including `AnglesiteAppTests` (compiling `AnglesiteAppCore`, which now includes the updated `SiteWindow.swift`/`DependencyUpdateModel.swift`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DependencySync.swift Sources/AnglesiteCore/DependencySyncChecker.swift Sources/AnglesiteCore/DependencySyncApplier.swift Sources/AnglesiteApp/DependencyUpdateModel.swift Sources/AnglesiteApp/SiteWindow.swift Tests/AnglesiteCoreTests/DependencySyncTests.swift Tests/AnglesiteCoreTests/DependencySyncCheckerTests.swift Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
+git commit -m "feat(#1108): offer and apply new template dependencies"
+```
+
+---
+
+### Task 3: Full verification and String Catalog sync
+
+**Files:**
+- Modify (conditionally): `Sources/AnglesiteApp/Localizable.xcstrings`
+
+This task adds two new user-visible strings ("Dependency Updates" and "New Dependencies" section headers) via a CLI-only build, which per CONTRIBUTING.md does not auto-merge into the String Catalog. This step performs that merge manually and runs the full verification suite CONTRIBUTING.md requires before a PR.
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: All suites pass.
+
+- [ ] **Step 2: Build the app and sync the String Catalog**
+
+```bash
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+BUILD_DIR=$(xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug -showBuildSettings 2>/dev/null | awk '/ BUILD_DIR =/{print $3}')
+xcrun xcstringstool sync Sources/AnglesiteApp/Localizable.xcstrings \
+  --stringsdata $(find "$(dirname "$BUILD_DIR")/Intermediates.noindex/Anglesite.build/Debug/Anglesite.build/Objects-normal/arm64" -name "*.stringsdata") \
+  --skip-marking-strings-stale
+```
+
+Expected: `** BUILD SUCCEEDED **`, then the sync command completes without error.
+
+- [ ] **Step 3: Review the catalog diff**
+
+Run: `git diff Sources/AnglesiteApp/Localizable.xcstrings`
+Expected: Only new entries for "Dependency Updates" and "New Dependencies". If the diff contains keys you didn't add or touch, re-derive `BUILD_DIR` (it must be scoped to this worktree, not a glob across `~/Library/Developer/Xcode/DerivedData/Anglesite-*` — see CONTRIBUTING.md's warning) and re-run Step 2 rather than committing it.
+
+- [ ] **Step 4: Commit the catalog update (only if the diff is clean)**
+
+```bash
+git add Sources/AnglesiteApp/Localizable.xcstrings
+git commit -m "chore(#1108): sync string catalog for dependency-sync UI"
+```
+
+- [ ] **Step 5: Run the localization CI backstop locally**
+
+Run: `scripts/check-localization-catalog.sh`
+Expected: Passes (no unmatched literals reported for the new strings).

--- a/docs/superpowers/specs/2026-07-30-template-dependency-additions-design.md
+++ b/docs/superpowers/specs/2026-07-30-template-dependency-additions-design.md
@@ -1,0 +1,156 @@
+# Offering new template dependencies to existing sites
+
+**Date:** 2026-07-30
+**Status:** Approved — ready for an implementation plan
+**Issue:** [#1108 — Template dependency additions never reach existing sites (DependencySync)](https://github.com/Anglesite/Anglesite/issues/1108)
+
+## Problem
+
+`DependencySync.diff` (`Sources/AnglesiteCore/DependencySync.swift`) only ever offers a version
+bump for a package present in **both** the site and the template — it never adds a package name.
+When the bundled template gains a genuinely new dependency (as #958 did with `html-validate`,
+required by the restored `Website ▸ Audit` accessibility check), every site scaffolded before that
+change never picks it up: `TemplateScriptsSyncChecker` happily copies the new script files in (file
+sync handles additions fine), but the script's `import` throws at module load because the package
+was never installed. The audit silently reports "skipped" instead of running.
+
+`TemplateScriptsSyncChecker` already solves the file half of this. This spec solves the dependency
+half, generalizing past `html-validate` to any future template dependency addition.
+
+## Scope
+
+In scope: detecting a template package missing from a site's `package.json`, offering to add it
+(name + version range + correct `dependencies`/`devDependencies` section), and writing that
+addition when accepted — reusing the existing `npm install` follow-through
+(`preview.isUpdatingDependencies = true`) the version-bump path already triggers.
+
+Out of scope: removing a package the template no longer has (unchanged — `DependencySync` still
+never removes anything); per-offer accept/reject granularity (see "UI" below); anything about
+`TemplateScriptsSyncChecker` itself (already correct, referenced only for consistency).
+
+## Data model
+
+Add `DependencyAdditionOffer` alongside the existing `DependencyUpdateOffer`:
+
+```swift
+public struct DependencyAdditionOffer: Sendable, Equatable {
+    public let name: String
+    public let offeredRange: String
+    public let section: DependencySection  // .dependencies or .devDependencies
+}
+
+public enum DependencySection: Sendable, Equatable {
+    case dependencies
+    case devDependencies
+}
+```
+
+Bundle both offer kinds into one result type, replacing the bare `[DependencyUpdateOffer]` that
+`DependencySync.diff` and `DependencySyncChecker.check` return today:
+
+```swift
+public struct DependencySyncOffers: Sendable, Equatable {
+    public let updates: [DependencyUpdateOffer]
+    public let additions: [DependencyAdditionOffer]
+    public var isEmpty: Bool { updates.isEmpty && additions.isEmpty }
+}
+```
+
+## Diff logic (`DependencySync.diff`)
+
+The existing version-bump loop is untouched. A second loop handles additions: for each template
+package absent from `site`, offer it *unless* the site is known to have deliberately removed it
+before. "Known" comes from the same three-way baseline already used for bumps:
+
+- **No baseline file at all** → offer unconditionally. This matches the existing bump behavior's
+  "legacy direct-diff fallback" — a site with no baseline has no history to consult, so the feature
+  accepts the same risk it already accepts for bumps.
+- **Baseline present, no entry for this package name** → the site has never had this package in any
+  snapshot the app took, so there's nothing to have deliberately removed. Offer it.
+- **Baseline present, has an entry for this package name** (the site had it at some point — either
+  scaffolded with it, or it was added via a prior accepted addition offer — and no longer does) →
+  the absence is the site owner's own doing. Don't re-offer. This mirrors the existing "leaves a
+  user-customized package alone" rule for bumps, applied to the addition/removal case instead of
+  the version-range case.
+
+`diff` needs to know which section a candidate addition belongs to. Rather than deepen `diff`'s
+signature with a structured template-sections type, it takes one more flat parameter:
+
+```swift
+public static func diff(
+    site: [String: String],
+    baseline: [String: String]?,
+    template: [String: String],
+    templateDevDependencyNames: Set<String> = []
+) -> DependencySyncOffers
+```
+
+This keeps `diff` a pure function over plain dictionaries/sets, consistent with its current style,
+rather than coupling it to `PackageJSONDependencies`' parsing types.
+
+## Parsing (`PackageJSONDependencies`)
+
+Add `extractSections(from:) -> (dependencies: [String: String], devDependencies: [String: String])`
+and rewrite the existing `extract(from:)` to derive from it (merge, `devDependencies` wins on
+collision — same documented behavior as today, no test changes needed for `extract` itself).
+`DependencySyncChecker` calls `extractSections` on the template's `package.json` text to build the
+`templateDevDependencyNames` set passed into `diff`.
+
+## Writing additions (`PackageJSONDependencies.applyAdditions`)
+
+A new function parallel to today's `apply` (which only rewrites existing "name": "range" pairs):
+
+```swift
+public static func applyAdditions(_ offers: [DependencyAdditionOffer], to text: String) -> String
+```
+
+For each offer, it locates the target section's `{ ... }` span using the existing `objectSpan`
+helper and inserts `"name": "range",` as a new first entry:
+
+- If the section already has entries, the inserted line copies the indentation whitespace that
+  currently precedes the first entry, so the new line matches the file's existing formatting.
+- If the section is empty (`{}`), it inserts with a 2-space default indent (this repo's established
+  JSON style, e.g. `Resources/Template/package.json`).
+- If the target section is missing from the site's `package.json` entirely, that addition is
+  skipped — no top-level section is fabricated. This is a defensive fallback only (every site
+  scaffolded from the template has both sections); silently doing nothing is consistent with
+  `DependencySyncChecker`'s existing "never block a site opening" contract.
+
+Like `apply`, spans are recomputed against the current mutated text on each iteration rather than
+computed once up front, since an earlier insertion shifts the indices a later one would need.
+
+## Applying (`DependencySyncApplier`)
+
+`apply` takes a `DependencySyncOffers` instead of `[DependencyUpdateOffer]`. It runs the existing
+`PackageJSONDependencies.apply` (bumps) followed by the new `applyAdditions`, then records the
+*resulting* range for every offer — both updates and additions — into `DependencyBaseline`, exactly
+as it does for bumps today. Recording additions into the baseline is what makes the "deliberate
+removal" rule above work for packages added through this feature. Everything else in `apply`
+(lockfile delete, `ANGLESITE_VERSION` stamp bump) is unchanged.
+
+## UI (`SiteWindow.swift` / `DependencyUpdateModel`)
+
+`DependencyUpdateModel` holds a `DependencySyncOffers` instead of `[DependencyUpdateOffer]`. The
+sheet's single `List` gains a second `Section` — "New Dependencies," shown only when
+`offers.additions` is non-empty — alongside the existing "Dependency Updates" section (also only
+shown when non-empty). Each addition row shows the package name and offered range with a small
+visual marker (e.g. a `Label` with a `plus.circle` system image) distinguishing it from a bump row,
+satisfying the issue's "distinct offer type/UI treatment" ask without changing the interaction
+model.
+
+Skip/Update stay exactly as they are: one decision, applied to every offer (updates and additions
+together) at once. No per-row accept/reject — confirmed as the preferred shape over a per-row
+checkbox UI or a separate second confirmation sheet.
+
+## Testing
+
+- `DependencySyncTests`: new cases for the addition loop — offers when there's no baseline, offers
+  when the baseline has no entry for the name, withholds when the baseline has an entry but the
+  site doesn't have the package, correct section tagging via `templateDevDependencyNames`. Existing
+  bump tests are unaffected (same loop, same logic).
+- `PackageJSONDependenciesTests`: new cases for `applyAdditions` — inserting into a non-empty
+  section (indentation matches), an empty section (default indent), a missing section (no-op), and
+  multiple simultaneous additions.
+- `DependencySyncApplierTests` / `DependencySyncCheckerTests`: updated for the new
+  `DependencySyncOffers`-based signatures; new coverage confirming an accepted addition both writes
+  the package.json and is recorded into the baseline.


### PR DESCRIPTION
Closes #1108

## Summary

- `DependencySync.diff` now offers new template dependencies (e.g. `html-validate`, added by #958) to existing sites, not just version bumps for packages the site already has — gated by the same three-way baseline logic already used for bumps, so a package the site deliberately removed is never re-offered.
- `PackageJSONDependencies` gains `extractSections`/`applyAdditions` to parse and surgically insert new `dependencies`/`devDependencies` entries, matching the file's existing indentation and never fabricating a missing section.
- The dependency-update sheet gets a second "New Dependencies" section, visually distinct from the existing "Dependency Updates" bump list, reusing the same Skip/Update decision and `npm install` follow-through.
- Design spec and implementation plan are committed under `docs/superpowers/specs/` and `docs/superpowers/plans/` for reference.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 3047 tests / 380 suites, only the 2 known pre-existing `FoundationModelAssistantTests` on-device flakes ("Session ended without producing a response"), unrelated to this change.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — BUILD SUCCEEDED.
- [x] String Catalog synced for the two new UI strings ("Dependency Updates", "New Dependencies" section headers); `scripts/check-localization-catalog.sh` passes.
- [ ] Manual smoke: not performed in this headless session — worth a manual check that the sheet renders both sections correctly when a site has both bump and addition offers pending.