### PR TITLE
fix: remove wall-clock flake in E2E readiness death test

### DIFF
--- a/Tests/AnglesiteCoreTests/E2EServerReadinessTests.swift
+++ b/Tests/AnglesiteCoreTests/E2EServerReadinessTests.swift
@@ -21,7 +21,6 @@ struct E2EServerReadinessTests {
             logCenter: logCenter
         )
 
-        let start = Date()
         do {
             try await E2EServer.awaitReady(
                 handle: handle,
@@ -36,11 +35,13 @@ struct E2EServerReadinessTests {
         } catch let error as E2EServer.ServerExited {
             #expect(error.stderr.contains(marker), "stderr should surface the real crash output")
             #expect(error.reason == .exited(code: 7))
+        } catch let error as E2EServer.ServerTimedOut {
+            // A 20s timeout budget alongside readiness that never completes means the only other
+            // possible outcome is waiting out the full budget instead of detecting the death — the
+            // failure mode this test guards against. Asserting the error type (rather than elapsed
+            // wall-clock time) proves the fast path won without being sensitive to runner load.
+            Issue.record("expected ServerExited from process death, but timed out waiting for readiness: \(error)")
         }
-        #expect(
-            Date().timeIntervalSince(start) < 10,
-            "should fail fast on process death, not wait out the timeout budget"
-        )
     }
 
     @Test("awaitReady returns cleanly when readiness wins against a still-alive server")


### PR DESCRIPTION
## Summary

- `E2EServerReadinessTests.deathSurfacesStderr` asserted `Date().timeIntervalSince(start) < 10` to prove the death-detection path "fails fast" instead of waiting out the full timeout budget — on a loaded macOS-26 CI runner this hit 10.6s and failed an unrelated docs-only PR's build-test lane (#1158, run 30609802483).
- Removed the wall-clock assertion and instead added an explicit `catch` for `E2EServer.ServerTimedOut` alongside the existing `ServerExited` catch. Since the readiness closure never completes and the timeout is 20s, the only two possible outcomes are `ServerExited` (death detected) or `ServerTimedOut` (budget exhausted) — so catching `ServerExited` already proves the fast path won, without any timing sensitivity to runner load.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --filter E2EServerReadinessTests` — all 3 tests pass
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (not run; no app-target code touched)