### PR TITLE
fix(#1108): scope objectSpan to true top-level keys

### DIFF
--- a/Sources/AnglesiteCore/PackageJSONDependencies.swift
+++ b/Sources/AnglesiteCore/PackageJSONDependencies.swift
@@ -110,16 +110,22 @@ public enum PackageJSONDependencies {
     }
 
     /// Finds the `{ ... }` span (braces inclusive) of the object value for a
-    /// top-level `"key": { ... }` entry, or `nil` if the key isn't present or
-    /// isn't followed by an object. Brace-depth tracking skips over quoted
-    /// string content (respecting `\"` escapes) so a version range or other
-    /// string value can never be mistaken for a structural brace.
+    /// top-level `"key": { ... }` entry, or `nil` if the key isn't present at
+    /// the root of the document or isn't followed by an object. Brace-depth
+    /// tracking skips over quoted string content (respecting `\"` escapes) so
+    /// a version range or other string value can never be mistaken for a
+    /// structural brace. Candidate matches of `"key": {` are checked against
+    /// their enclosing brace depth so a nested object that happens to reuse
+    /// the same key name (e.g. an `"overrides": { "dependencies": {...} }`
+    /// block) is skipped in favor of the real top-level one.
     private static func objectSpan(forKey key: String, in text: String) -> Range<String.Index>? {
         let escapedKey = NSRegularExpression.escapedPattern(for: key)
         guard let keyRegex = try? NSRegularExpression(pattern: "\"\(escapedKey)\"\\s*:\\s*\\{") else { return nil }
         let fullRange = NSRange(text.startIndex..<text.endIndex, in: text)
-        guard let match = keyRegex.firstMatch(in: text, range: fullRange),
-              let matchRange = Range(match.range, in: text)
+        let candidates = keyRegex.matches(in: text, range: fullRange)
+        guard let matchRange = candidates.lazy
+            .compactMap({ Range($0.range, in: text) })
+            .first(where: { enclosingBraceDepth(in: text, upTo: $0.lowerBound) == 1 })
         else { return nil }
 
         let objectStart = text.index(before: matchRange.upperBound)  // the `{` itself
@@ -150,5 +156,37 @@ public enum PackageJSONDependencies {
             index = text.index(after: index)
         }
         return nil  // unbalanced braces — malformed input, no span to offer
+    }
+
+    /// The brace-nesting depth at `index`, counting only unclosed `{` seen so
+    /// far (a root document's own top-level keys sit at depth 1, just inside
+    /// its opening `{`). Quoted string content is skipped (respecting `\"`
+    /// escapes) so braces inside a string value are never mistaken for
+    /// structural ones.
+    private static func enclosingBraceDepth(in text: String, upTo index: String.Index) -> Int {
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var cursor = text.startIndex
+        while cursor < index {
+            let char = text[cursor]
+            if inString {
+                if escaped {
+                    escaped = false
+                } else if char == "\\" {
+                    escaped = true
+                } else if char == "\"" {
+                    inString = false
+                }
+            } else if char == "\"" {
+                inString = true
+            } else if char == "{" {
+                depth += 1
+            } else if char == "}" {
+                depth -= 1
+            }
+            cursor = text.index(after: cursor)
+        }
+        return depth
     }
 }

--- a/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
+++ b/Tests/AnglesiteCoreTests/PackageJSONDependenciesTests.swift
@@ -164,6 +164,61 @@ import Testing
         #expect(PackageJSONDependencies.applyAdditions([], to: Self.fixture) == Self.fixture)
     }
 
+    @Test func applyOperatesOnlyOnTheTopLevelDependenciesSectionNotANestedOneWithTheSameKeyName() {
+        // A nested object reusing "dependencies" as a key name (e.g. npm's
+        // "overrides" field) appears *before* the real top-level section here,
+        // so a naive first-match-anywhere search would find it instead of the
+        // real one.
+        let textWithNestedCollision = """
+        {
+          "name": "anglesite-site",
+          "overrides": {
+            "dependencies": {
+              "astro": "^1.2.3"
+            }
+          },
+          "dependencies": {
+            "astro": "^5.0.0"
+          },
+          "devDependencies": {
+            "typescript": "^5.9.3"
+          }
+        }
+        """
+        let offers = [DependencyUpdateOffer(name: "astro", currentRange: "^5.0.0", offeredRange: "^6.4.8")]
+        let updated = PackageJSONDependencies.apply(offers, to: textWithNestedCollision)
+        #expect(updated.contains("\"dependencies\": {\n    \"astro\": \"^6.4.8\"\n  }"))
+        // The nested "overrides.dependencies" object is a different key entirely — untouched.
+        #expect(updated.contains("\"overrides\": {\n    \"dependencies\": {\n      \"astro\": \"^1.2.3\"\n    }\n  }"))
+    }
+
+    @Test func applyAdditionsOperatesOnlyOnTheTopLevelDevDependenciesSectionNotANestedOneWithTheSameKeyName() {
+        // Same collision risk as `apply`, but higher-impact: an insertion into
+        // the wrong nested object succeeds silently — no error, no test
+        // failure — and would keep landing there on every future offer.
+        let textWithNestedCollision = """
+        {
+          "name": "anglesite-site",
+          "overrides": {
+            "devDependencies": {
+              "typescript": "^4.0.0"
+            }
+          },
+          "dependencies": {
+            "astro": "^5.0.0"
+          },
+          "devDependencies": {
+            "typescript": "^5.9.3"
+          }
+        }
+        """
+        let offers = [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)]
+        let updated = PackageJSONDependencies.applyAdditions(offers, to: textWithNestedCollision)
+        #expect(updated.contains("\"devDependencies\": {\n    \"html-validate\": \"^11.6.0\",\n    \"typescript\": \"^5.9.3\"\n  }"))
+        // The nested "overrides.devDependencies" object is untouched — no insertion there.
+        #expect(updated.contains("\"overrides\": {\n    \"devDependencies\": {\n      \"typescript\": \"^4.0.0\"\n    }\n  }"))
+    }
+
     @Test func applyAdditionsSkipsAnOfferWhoseNameAlreadyExistsInTheTargetSection() {
         // "astro" is already a key in `dependencies` in the fixture. Inserting it
         // again would produce two `"astro": ...` keys in the same JSON object —


### PR DESCRIPTION
## Summary

- `objectSpan(forKey:in:)` in `PackageJSONDependencies` matched `"key": {` anywhere in the text via `firstMatch`, not just at the document root — so a nested object reusing `"dependencies"`/`"devDependencies"` as a key name (e.g. a hypothetical `"overrides": { "dependencies": {...} }` block) could be matched instead of the real top-level section.
- Candidate matches are now filtered by enclosing brace depth, so only a true root-level `"key": { ... }` is ever used.
- Adds regression tests for both `apply` and `applyAdditions` covering a package.json with a nested collision, confirming each operates on the real top-level section and leaves the nested one untouched.

Follow-up to the `objectSpan` scoping noted during #1164's final review — deliberately deferred out of that branch since the bug predates it and is shared by the untouched `apply` function too.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (`PackageJSONDependenciesTests` suite: 19/19 passing, including the two new regression tests; full-package run has 2 pre-existing/unrelated `FoundationModelAssistant` on-device flakes — "Session ended without producing a response" — not touched by this change)
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke: not applicable — non-UI logic-only change