### PR TITLE
fix(#956): make site language configurable, not hardcoded en

### DIFF
--- a/Resources/Template/scripts/config.test.ts
+++ b/Resources/Template/scripts/config.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { asBookingProvider, asDonationsProvider, asContactProvider, readConfigFromString } from "./config";
+import { asBookingProvider, asDonationsProvider, asContactProvider, readConfigFromString, resolveLang } from "./config";
 
 test("asBookingProvider: passes through recognized providers", () => {
   assert.equal(asBookingProvider("cal"), "cal");
@@ -61,4 +61,19 @@ test("readConfigFromString: reads COPYRIGHT_HOLDER", () => {
 
 test("readConfigFromString: COPYRIGHT_HOLDER is undefined when absent", () => {
   assert.equal(readConfigFromString("SITE_NAME=Acme\n", "COPYRIGHT_HOLDER"), undefined);
+});
+
+// BaseLayout.astro sets <html lang> from this (#956, WCAG 2.2 SC 3.1.1).
+test("readConfigFromString: reads LANG", () => {
+  assert.equal(readConfigFromString("SITE_NAME=Acme\nLANG=fr-CA\n", "LANG"), "fr-CA");
+});
+
+test("resolveLang: passes through a configured tag", () => {
+  assert.equal(resolveLang("fr-CA"), "fr-CA");
+});
+
+test("resolveLang: falls back to en when unset or blank", () => {
+  assert.equal(resolveLang(undefined), "en");
+  assert.equal(resolveLang(""), "en");
+  assert.equal(resolveLang("   "), "en");
 });

--- a/Resources/Template/scripts/config.ts
+++ b/Resources/Template/scripts/config.ts
@@ -38,6 +38,20 @@ export function readConfig(
   return loadDefaultConfig()[key];
 }
 
+/** Applies the "en" fallback used by {@link siteLang}; split out so the default is unit-testable
+ * without touching disk. */
+export function resolveLang(value: string | undefined): string {
+  return value?.trim() || "en";
+}
+
+/**
+ * The site's BCP 47 language tag for `<html lang>` (WCAG 2.2 SC 3.1.1). Falls back to "en" for a
+ * site scaffolded before this key existed, or with `LANG` cleared by hand.
+ */
+export function siteLang(): string {
+  return resolveLang(readConfig("LANG"));
+}
+
 // Config values are free-form strings, but the booking/donation widgets accept a
 // closed set of provider literals. These narrow at runtime so an unrecognized
 // `.site-config` value (e.g. a typo) becomes `undefined` — which the widgets

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -2,7 +2,7 @@
 import "../styles/global.css";
 import Hcard from "../components/Hcard.astro";
 import Rights from "../components/Rights.astro";
-import { readConfig } from "../../scripts/config";
+import { readConfig, siteLang } from "../../scripts/config";
 import { siteLicense } from "../lib/licensing-data.ts";
 import { headLicense, type LicenseRef } from "../lib/licensing.ts";
 import { readRobotsConfig, isNoindexed } from "../lib/robots-config.ts";
@@ -27,7 +27,7 @@ const noindex = isNoindexed(Astro.url.pathname, readRobotsConfig(process.cwd()))
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={siteLang()}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -197,6 +197,9 @@
     "@media %@" : {
 
     },
+    "A BCP 47 language tag, e.g. \"en\", \"fr-CA\", \"es\". Screen readers and search engines use this to pronounce and index your content correctly." : {
+
+    },
     "A custom token named “Anglesite” should be pre-filled with all permissions Anglesite uses. If it isn’t, add at least the “Edit Cloudflare Workers” template’s permissions so deploying works — Anglesite will ask again when a feature needs more access. Click **Continue to summary**." : {
 
     },
@@ -1576,6 +1579,9 @@
 
     },
     "LAN site runtime" : {
+
+    },
+    "Language" : {
 
     },
     "Language & Region…" : {
@@ -3196,6 +3202,9 @@
 
     },
     "edited" : {
+
+    },
+    "en" : {
 
     },
     "example.com" : {

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -31,6 +31,10 @@ final class PlistEditorModel {
         }
     }
     private(set) var savedAnalyticsSettings = WebsiteAnalyticsAsset.Settings()
+    var langSettings = SiteLanguageAsset.Settings()
+    private(set) var savedLangSettings = SiteLanguageAsset.Settings()
+    private(set) var langError: String?
+    private(set) var isSavingLang = false
     var redirectEntries: [RedirectsStore.RedirectEntry] = []
     private(set) var savedRedirectEntries: [RedirectsStore.RedirectEntry] = []
     private(set) var redirectsError: String?
@@ -127,6 +131,7 @@ final class PlistEditorModel {
 
     var isDirty: Bool { entries != savedEntries && loadError == nil && !isLoading }
     var isAnalyticsDirty: Bool { analyticsSettings != savedAnalyticsSettings && loadError == nil && !isLoading }
+    var isLangDirty: Bool { langSettings != savedLangSettings && loadError == nil && !isLoading }
     var isRedirectsDirty: Bool { redirectEntries != savedRedirectEntries && loadError == nil && !isLoading }
     var isLicensingDirty: Bool { licensingPolicy != savedLicensingPolicy && loadError == nil && !isLoading }
     var isMtaStsDirty: Bool { mtaStsSettings != savedMtaStsSettings && loadError == nil && !isLoading }
@@ -242,6 +247,10 @@ final class PlistEditorModel {
                 licensingError = "Couldn't load existing licensing.json — it may be corrupted or hand-edited. Fix it externally or your next save will discard it. (\(error.localizedDescription))"
                 licensingLoadFailed = true
             }
+            let lang = SiteLanguageAsset.parseSettings(from: config)
+            langSettings = lang
+            savedLangSettings = lang
+            langError = nil
             let mtaSts = MTAStsPolicyAsset.parseSettings(from: config)
             mtaStsSettings = mtaSts
             savedMtaStsSettings = mtaSts
@@ -296,6 +305,9 @@ final class PlistEditorModel {
         }
         if isAnalyticsDirty {
             guard await saveAnalytics() else { return false }
+        }
+        if isLangDirty {
+            guard await saveLang() else { return false }
         }
         if isRedirectsDirty {
             guard await saveRedirects() else { return false }
@@ -441,6 +453,28 @@ final class PlistEditorModel {
             return false
         } catch {
             licensingError = "Couldn't save content licensing: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    @discardableResult
+    func saveLang() async -> Bool {
+        guard isLangDirty else { return true }
+        guard !isSavingLang else { return false }
+        isSavingLang = true
+        langError = nil
+        defer { isSavingLang = false }
+        let sourceDirectory = sourceDirectory
+        let settings = SiteLanguageAsset.Settings(lang: langSettings.lang)
+        do {
+            try await Task.detached(priority: .userInitiated) {
+                try SiteLanguageAsset.install(settings, siteDirectory: sourceDirectory)
+            }.value
+            langSettings = settings
+            savedLangSettings = settings
+            return true
+        } catch {
+            langError = "Couldn't save website language: \(error.localizedDescription)"
             return false
         }
     }
@@ -952,6 +986,7 @@ final class PlistEditorModel {
         [
             DirtyFacet(isDirty: isDirty, isSaving: isSaving) { await self.save() },
             DirtyFacet(isDirty: isAnalyticsDirty, isSaving: isSavingAnalytics) { await self.saveAnalytics() },
+            DirtyFacet(isDirty: isLangDirty, isSaving: isSavingLang) { await self.saveLang() },
             DirtyFacet(isDirty: isRedirectsDirty, isSaving: isSavingRedirects) { await self.saveRedirects() },
             DirtyFacet(isDirty: isLicensingDirty, isSaving: isSavingLicensing) { await self.saveLicensing() },
             DirtyFacet(isDirty: isMtaStsDirty, isSaving: isSavingMtaSts) { await self.saveMtaSts() },

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -35,6 +35,7 @@ struct PlistEditorView: View {
     @State private var isConfirmingEnablePVR = false
     @State private var isConfirmingEnablePVRForConfiguredRepo = false
     @FocusState private var titleFocused: Bool
+    @FocusState private var languageFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -46,6 +47,11 @@ struct PlistEditorView: View {
         .onChange(of: titleFocused) { wasFocused, isFocused in
             if wasFocused && !isFocused {
                 Task { await saveWebsiteTitle() }
+            }
+        }
+        .onChange(of: languageFocused) { wasFocused, isFocused in
+            if wasFocused && !isFocused {
+                Task { await model.saveLang() }
             }
         }
         .onChange(of: selectedTab) { oldValue, _ in
@@ -158,6 +164,11 @@ struct PlistEditorView: View {
                             .foregroundStyle(.orange)
                             .font(.callout)
                     }
+                    if selectedTab != .website, let langError = model.langError {
+                        Label(langError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.callout)
+                    }
                     if selectedTab != .redirects, let redirectsError = model.redirectsError {
                         Label(redirectsError, systemImage: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
@@ -213,6 +224,19 @@ struct PlistEditorView: View {
                             .focused($titleFocused)
                             .onSubmit { Task { await saveWebsiteTitle() } }
                             .frame(minWidth: 220)
+                    }
+                    GridRow {
+                        Text("Language")
+                            .frame(minWidth: 160, alignment: .leading)
+                        VStack(alignment: .leading, spacing: 2) {
+                            TextField("en", text: $model.langSettings.lang)
+                                .focused($languageFocused)
+                                .onSubmit { Task { await model.saveLang() } }
+                                .frame(minWidth: 220)
+                            Text("A BCP 47 language tag, e.g. \"en\", \"fr-CA\", \"es\". Screen readers and search engines use this to pronounce and index your content correctly.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                     GridRow {
                         Text("Icons")

--- a/Sources/AnglesiteCore/DependencySync.swift
+++ b/Sources/AnglesiteCore/DependencySync.swift
@@ -8,7 +8,8 @@ public struct DependencyUpdateOffer: Sendable, Equatable {
     /// The bundled template's newer range that replaces `currentRange` if the offer is accepted.
     public let offeredRange: String
 
-    /// Memberwise initializer — offers are normally produced by ``DependencySync/diff(site:baseline:template:)``;
+    /// Memberwise initializer — offers are normally produced by
+    /// ``DependencySync/diff(site:baseline:template:templateDevDependencyNames:)``;
     /// this exists so tests (and previews) can construct them directly.
     public init(name: String, currentRange: String, offeredRange: String) {
         self.name = name

--- a/Sources/AnglesiteCore/SiteLanguageAsset.swift
+++ b/Sources/AnglesiteCore/SiteLanguageAsset.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The site-settings representation of the BCP 47 language tag `BaseLayout.astro` uses for
+/// `<html lang>` (#956, WCAG 2.2 SC 3.1.1 "Language of Page").
+///
+/// Owns exactly one `.site-config` key — `LANG`. Unset (or blank) reads back as `"en"`, matching
+/// the template's own `resolveLang` fallback in `scripts/config.ts`, so a site scaffolded before
+/// this key existed still renders a valid (if incorrect-for-non-English-content) language.
+public enum SiteLanguageAsset {
+    /// The `.site-config` key this type owns.
+    public static let configKey = "LANG"
+
+    /// The editable value the Website Settings ▸ Website tab binds to.
+    public struct Settings: Sendable, Equatable {
+        /// A BCP 47 language tag, e.g. `"en"`, `"fr-CA"`, `"es"`. Never empty — construction and
+        /// `parseSettings` both apply the `"en"` fallback.
+        public var lang: String
+
+        /// Defaults to `"en"`, matching a site with nothing configured.
+        public init(lang: String = "en") {
+            self.lang = lang.trimmingCharacters(in: .whitespaces).isEmpty ? "en" : lang
+        }
+    }
+
+    /// Reads `LANG` out of a raw `.site-config` string, falling back to `"en"` when unset or
+    /// blank — mirrors the template's `resolveLang` in `scripts/config.ts` so the app's settings
+    /// UI and the built site never disagree about the effective language.
+    public static func parseSettings(from config: String) -> Settings {
+        Settings(lang: SiteConfigFile.value(forKey: configKey, in: config) ?? "en")
+    }
+
+    /// Upserts `LANG` into the site's `.site-config`. Skips the write when the result is
+    /// byte-identical, so re-saving an untouched settings sheet never dirties the site's git
+    /// working tree.
+    public static func install(_ settings: Settings, siteDirectory: URL) throws {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let updated = SiteConfigFile.upsert([(configKey, settings.lang)], into: config)
+        guard updated != config else { return }
+        try updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// The host system's current language as a BCP 47 tag, e.g. `"en-US"` — the default a newly
+    /// scaffolded site's `LANG` is stamped with (`SiteScaffolder`). Built from `languageCode` +
+    /// `region` directly rather than `Locale.Language.minimalIdentifier`, which drops the region
+    /// whenever it considers it redundant (e.g. "en_US" minimizes to just "en") — a real BCP 47
+    /// tag, not the shortest unambiguous one, is what a screen reader or search engine expects in
+    /// `<html lang>`. Falls back to `"en"` if the host locale has no language code at all
+    /// (unexpected, but `Locale.Language.languageCode` is optional-returning API).
+    public static func hostLanguageTag(locale: Locale = .current) -> String {
+        let language = locale.language
+        guard let code = language.languageCode?.identifier else { return "en" }
+        guard let region = language.region?.identifier else { return code }
+        return "\(code)-\(region)"
+    }
+}

--- a/Sources/AnglesiteCore/SiteScaffolder.swift
+++ b/Sources/AnglesiteCore/SiteScaffolder.swift
@@ -42,16 +42,20 @@ public actor SiteScaffolder {
     private let register: Register
     private let fileManager: FileManager
     private let appVersion: @Sendable () -> String?
+    private let hostLanguage: @Sendable () -> String
 
     /// `catalog` (not a fixed theme) so the owner's Look-step choice resolves at pipeline time
     /// from `draft.themeID`. `appVersion` defaults to `AppVersion.current()` (i.e. `Bundle.main`);
     /// tests inject a fixed string since `Bundle.main` inside `swift test` is the test runner and
-    /// has no `CFBundleShortVersionString`.
+    /// has no `CFBundleShortVersionString`. `hostLanguage` defaults to
+    /// `SiteLanguageAsset.hostLanguageTag()` (i.e. `Locale.current`); tests inject a fixed tag
+    /// since the host locale running `swift test` varies by machine (#956).
     public init(sitesRoot: URL, templateURL: URL, catalog: ThemeCatalog,
                 run: @escaping CommandRunner, gitInit: @escaping GitInit,
                 gitCommit: @escaping GitCommit,
                 register: @escaping Register, fileManager: FileManager = .default,
-                appVersion: @escaping @Sendable () -> String? = { AppVersion.current() }) {
+                appVersion: @escaping @Sendable () -> String? = { AppVersion.current() },
+                hostLanguage: @escaping @Sendable () -> String = { SiteLanguageAsset.hostLanguageTag() }) {
         self.sitesRoot = sitesRoot
         self.templateURL = templateURL
         self.catalog = catalog
@@ -61,6 +65,7 @@ public actor SiteScaffolder {
         self.register = register
         self.fileManager = fileManager
         self.appVersion = appVersion
+        self.hostLanguage = hostLanguage
     }
 
     /// Runs the whole pipeline for the wizard's finished draft, streaming ``ScaffoldStep``s as it
@@ -210,6 +215,7 @@ public actor SiteScaffolder {
             ("SITE_TYPE", draft.siteType.rawValue),
             ("DOMAIN_CHOICE", draft.domainChoice.rawValue),
             ("CF_PROJECT_NAME", cfProjectName),
+            ("LANG", hostLanguage()),
         ]
         if draft.domainChoice == .transfer && !draft.domain.isEmpty { values.append(("DOMAIN", draft.domain)) }
         if draft.themeID == CustomTheme.id {

--- a/Tests/AnglesiteAppTests/PlistEditorModelLangTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelLangTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@Suite("PlistEditorModel Language (#956)")
+@MainActor
+struct PlistEditorModelLangTests {
+    private static let emptyPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict/></plist>
+        """
+
+    private func makeModel(config: String? = nil) throws -> PlistEditorModel {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("PlistEditorModelLangTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let plistURL = directory.appendingPathComponent("Info.plist")
+        try Self.emptyPlist.write(to: plistURL, atomically: true, encoding: .utf8)
+        if let config { try config.write(to: directory.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8) }
+        return PlistEditorModel(file: FileRef(url: plistURL, group: .metadata, name: "Info.plist"), websiteTitle: "Test Site", sourceDirectory: directory)
+    }
+
+    @Test("loads the language from .site-config")
+    func load() async throws {
+        let model = try makeModel(config: "LANG=fr-CA\n")
+        await model.load()
+        #expect(model.langSettings == .init(lang: "fr-CA"))
+        #expect(!model.isLangDirty)
+    }
+
+    @Test("a site scaffolded before LANG existed loads as en")
+    func loadDefaultsToEnglish() async throws {
+        let model = try makeModel(config: "SITE_NAME=Acme\n")
+        await model.load()
+        #expect(model.langSettings == .init(lang: "en"))
+    }
+
+    @Test("saves a dirty language facet and includes it in aggregate saves")
+    func save() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.langSettings = .init(lang: "es")
+        #expect(model.isLangDirty)
+        #expect(model.hasAnyUnsavedEdits)
+        await model.saveAllDirty()
+        #expect(!model.isLangDirty)
+        let config = try String(contentsOf: model.sourceDirectory.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteLanguageAsset.parseSettings(from: config) == model.langSettings)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteLanguageAssetTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteLanguageAssetTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("SiteLanguageAsset (#956)")
+struct SiteLanguageAssetTests {
+    @Test("parses LANG out of .site-config")
+    func parseSettings() {
+        let settings = SiteLanguageAsset.parseSettings(from: "SITE_NAME=Acme\nLANG=fr-CA\n")
+        #expect(settings == .init(lang: "fr-CA"))
+    }
+
+    @Test("an unset LANG falls back to en")
+    func parseSettingsFallsBackToEnglish() {
+        #expect(SiteLanguageAsset.parseSettings(from: "").lang == "en")
+        #expect(SiteLanguageAsset.parseSettings(from: "SITE_NAME=Acme\n").lang == "en")
+    }
+
+    @Test("Settings.init rejects a blank tag in favor of the en fallback")
+    func settingsInitRejectsBlank() {
+        #expect(SiteLanguageAsset.Settings(lang: "").lang == "en")
+        #expect(SiteLanguageAsset.Settings(lang: "   ").lang == "en")
+    }
+
+    @Test("install writes LANG and skips a no-op rewrite")
+    func install() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try SiteLanguageAsset.install(.init(lang: "es"), siteDirectory: dir)
+        let configURL = dir.appendingPathComponent(".site-config")
+        let written = try String(contentsOf: configURL, encoding: .utf8)
+        #expect(written.contains("LANG=es"))
+
+        // Re-installing the same value must not touch the file's modification date — the write
+        // is skipped outright when the upserted content is byte-identical.
+        let before = try FileManager.default.attributesOfItem(atPath: configURL.path)[.modificationDate] as? Date
+        try SiteLanguageAsset.install(.init(lang: "es"), siteDirectory: dir)
+        let after = try FileManager.default.attributesOfItem(atPath: configURL.path)[.modificationDate] as? Date
+        #expect(before == after)
+    }
+
+    @Test("hostLanguageTag reads a BCP 47 tag off the given locale")
+    func hostLanguageTag() {
+        #expect(SiteLanguageAsset.hostLanguageTag(locale: Locale(identifier: "fr_CA")) == "fr-CA")
+        #expect(SiteLanguageAsset.hostLanguageTag(locale: Locale(identifier: "en_US")) == "en-US")
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -226,6 +226,26 @@ final class SiteScaffolderTests: XCTestCase {
         XCTAssertNotEqual(stampedVersion, "1.0.0")  // no longer the scaffold.sh placeholder
     }
 
+    /// #956: a newly scaffolded site's `<html lang>` must default to the owner's actual
+    /// language, not a hardcoded "en" — `hostLanguage` is injected here since the real host
+    /// locale running `swift test` varies by machine.
+    func testHappyPathStampsLangFromHostLanguage() async throws {
+        let root = tmpDir()
+        let scaffolder = SiteScaffolder(
+            sitesRoot: root, templateURL: URL(fileURLWithPath: "/template"), catalog: ThemeCatalog(themes: [theme]),
+            run: fakeRunner(calls: CallRecorder()),
+            gitInit: { _ in },
+            gitCommit: { _ in },
+            register: { pkg in try SiteStore.Site.make(package: pkg) },
+            hostLanguage: { "fr-CA" }
+        )
+        for await _ in scaffolder.scaffold(makeDraft()) {}
+
+        let pkgURL = root.appendingPathComponent("acme-co.anglesite")
+        let cfg = try String(contentsOf: pkgURL.appendingPathComponent("Source/.site-config"), encoding: .utf8)
+        XCTAssertTrue(cfg.contains("LANG=fr-CA"))
+    }
+
     func testMissingTemplatePackageJSONWarnsButStillRegisters() async throws {
         // makeScaffolder's default templateURL ("/template") has no package.json,
         // so reading it for the dependency baseline fails — this must surface as a


### PR DESCRIPTION
Closes #956

## Summary

- `BaseLayout.astro`'s `<html lang>` now reads a `LANG` `.site-config` key via a new `siteLang()` helper (falls back to `"en"`) instead of hardcoding `en` — fixes WCAG 2.2 SC 3.1.1 "Language of Page" for non-English sites.
- `SiteScaffolder` stamps `LANG` from the host locale (`SiteLanguageAsset.hostLanguageTag()`, injectable for tests) when a site is created, so new sites default to the owner's actual language.
- The Website Settings ▸ Website tab gains a "Language" field (BCP 47 tag, e.g. `en`, `fr-CA`) so an owner can override the default, wired through the existing dirty/save-facet pattern (`SiteLanguageAsset`, mirroring `MTAStsPolicyAsset`/`SecurityReportingAsset`).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP message schema changes — this is a `.site-config` key plus template/app-side plumbing only.

## Test plan

- [x] `swift test --package-path .` — full suite passes (309/309 in the app/core test run I filtered, and the full run of 3091 tests has 2 pre-existing, unrelated failures in `FoundationModelAssistantTests` — on-device FoundationModels streaming tests that fail in this environment regardless of this change).
- [x] `npx tsx --test scripts/config.test.ts` (from `Resources/Template/`) — 13/13 pass, including new `LANG`/`resolveLang` cases.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — could not run in this worktree: it requires a locally-configured Apple Developer Team (`xcconfig/Signing-Debug.local.xcconfig`, gitignored) that isn't set up here. `swift build --package-path .` (which builds the `AnglesiteAppCore` SwiftPM target containing the actual `PlistEditorModel`/`PlistEditorView` changes) succeeds cleanly.
- [x] Manual smoke: not run (no interactive Xcode session in this environment) — the settings-editor UI change is a single `TextField` + caption following the existing "Title" field pattern in the same `Grid`, load/save/dirty-tracking covered by `PlistEditorModelLangTests`.