### PR TITLE
test(#919): e2e-gate the worker toggle→restart path

### DIFF
--- a/Sources/AnglesiteContainerProbe/main.swift
+++ b/Sources/AnglesiteContainerProbe/main.swift
@@ -28,6 +28,11 @@ private struct PauseResumeProbeTimeout: Error {}
 //   workers-dev — mirrors ContainerizationControlTests.startsWorkersDevForActiveWorker: boot a
 //           container, start local wrangler-dev for one active (fixture) worker, poll its URL
 //           for a live HTTP response. The #708 local-runtime feature's own decision gate.
+//   worker-toggle — mirrors WorkerToggleEndToEndTests.toggleRestartsLocalWranglerDev: boots a
+//           LocalContainerSiteRuntime with an empty active-worker set, calls
+//           updateActiveWorkers to toggle a settings-activated worker on (asserting the state
+//           re-settles to .ready with a reachable workersDevURL), then toggles it back off
+//           (asserting workersDevURL returns to nil). The #919 decision gate.
 //   pause-resume — bare container + guest vsock echo listener, confirm a round trip, pause the
 //           VM, resume it, confirm a FRESH dial still reaches the listener, then EMPIRICALLY
 //           confirm the resume-before-stop ordering: a direct `container.stop()` call while still
@@ -39,7 +44,8 @@ struct AnglesiteContainerProbe {
     static func main() async {
         let args = CommandLine.arguments.dropFirst()
         guard let subcommand = args.first else {
-            FileHandle.standardError.write(Data("usage: anglesite-container-probe <echo|boot|workers-dev|pause-resume>\n".utf8))
+            FileHandle.standardError.write(
+                Data("usage: anglesite-container-probe <echo|boot|workers-dev|worker-toggle|pause-resume>\n".utf8))
             exit(2)
         }
 
@@ -51,11 +57,13 @@ struct AnglesiteContainerProbe {
             exitCode = await runBoot()
         case "workers-dev":
             exitCode = await runWorkersDev()
+        case "worker-toggle":
+            exitCode = await runWorkerToggle()
         case "pause-resume":
             exitCode = await runPauseResume()
         default:
             FileHandle.standardError.write(
-                Data("unknown subcommand '\(subcommand)' (expected echo|boot|workers-dev|pause-resume)\n".utf8))
+                Data("unknown subcommand '\(subcommand)' (expected echo|boot|workers-dev|worker-toggle|pause-resume)\n".utf8))
             exitCode = 2
         }
         exit(exitCode)
@@ -400,6 +408,105 @@ struct AnglesiteContainerProbe {
         return 0
     }
 
+    // MARK: - worker-toggle
+
+    /// Mirrors `WorkerToggleEndToEndTests.toggleRestartsLocalWranglerDev`: boots a
+    /// `LocalContainerSiteRuntime` (not the bare `ContainerizationControl` the other subcommands
+    /// exercise) with an empty active-worker set, calls `updateActiveWorkers` to toggle a
+    /// settings-activated fixture worker on, polls the returned `workersDevURL` for a live HTTP
+    /// response, then toggles it back off and confirms `workersDevURL` returns to nil. The #919
+    /// decision gate for the Workers tab's (#917) toggle→restart path.
+    private static func runWorkerToggle() async -> Int32 {
+        let siteID = "worker-toggle-probe"
+
+        let package: URL
+        do {
+            package = try makeThrowawayPackage()
+        } catch {
+            print("WORKER-TOGGLE: FAIL — could not create throwaway package: \(error)")
+            return 1
+        }
+        defer { try? FileManager.default.removeItem(at: package) }
+
+        let configStore = SiteConfigStore(configDirectory: AnglesitePackage(url: package).configURL)
+        do {
+            try await configStore.save(SiteSettings())
+        } catch {
+            print("WORKER-TOGGLE: FAIL — could not save initial (empty) settings: \(error)")
+            return 1
+        }
+
+        let workers = [WorkerDescriptor(
+            id: "indieauth", displayName: "IndieAuth", description: "probe fixture", group: "identity",
+            binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))]
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: ContainerizationControl(),
+            mcpClient: MCPClient(supervisor: .shared),
+            workerCatalog: { workers })
+
+        await runtime.start(siteID: siteID, siteDirectory: AnglesitePackage(url: package).sourceURL)
+        guard case .ready(_, _, let bootWorkersDevURL) = await runtime.state else {
+            print("WORKER-TOGGLE: FAIL — expected .ready after boot, got \(await runtime.state)")
+            await runtime.stop()
+            return 1
+        }
+        guard bootWorkersDevURL == nil else {
+            print("WORKER-TOGGLE: FAIL — expected a nil workersDevURL at boot (no active workers), got \(bootWorkersDevURL!)")
+            await runtime.stop()
+            return 1
+        }
+        print("WORKER-TOGGLE: boot with an empty active-worker set OK")
+
+        let activated = SiteSettings(activeWorkerIDs: ["indieauth"])
+        do {
+            try await configStore.save(activated)
+        } catch {
+            print("WORKER-TOGGLE: FAIL — could not save activated settings: \(error)")
+            await runtime.stop()
+            return 1
+        }
+        await runtime.updateActiveWorkers(activated)
+        guard case .ready(_, _, let activeWorkersDevURL) = await runtime.state, let workersDevURL = activeWorkersDevURL else {
+            print("WORKER-TOGGLE: FAIL — expected .ready with a non-nil workersDevURL after toggle-on, got \(await runtime.state)")
+            await runtime.stop()
+            return 1
+        }
+
+        let reachable = await pollForHTTPResponse(workersDevURL, timeout: .seconds(60))
+        guard reachable else {
+            print("WORKER-TOGGLE: FAIL — \(workersDevURL) never answered within the timeout after toggle-on")
+            await runtime.stop()
+            return 1
+        }
+        print("WORKER-TOGGLE: toggle-on restarted a reachable local wrangler-dev OK")
+
+        let deactivated = SiteSettings()
+        do {
+            try await configStore.save(deactivated)
+        } catch {
+            print("WORKER-TOGGLE: FAIL — could not save deactivated settings: \(error)")
+            await runtime.stop()
+            return 1
+        }
+        await runtime.updateActiveWorkers(deactivated)
+        guard case .ready(_, _, let stoppedWorkersDevURL) = await runtime.state else {
+            print("WORKER-TOGGLE: FAIL — expected .ready after toggle-off, got \(await runtime.state)")
+            await runtime.stop()
+            return 1
+        }
+        guard stoppedWorkersDevURL == nil else {
+            print("WORKER-TOGGLE: FAIL — expected a nil workersDevURL after toggle-off, got \(stoppedWorkersDevURL!)")
+            await runtime.stop()
+            return 1
+        }
+        print("WORKER-TOGGLE: toggle-off stopped local wrangler-dev OK")
+
+        print("GATE: PASS")
+        await runtime.stop()
+        return 0
+    }
+
     /// Polls `url` for any HTTP response (any status code is a pass — we only care that the
     /// guest dev server is accepting connections and speaking HTTP), bounded by `timeout`.
     private static func pollForHTTPResponse(_ url: URL, timeout: Duration) async -> Bool {
@@ -456,5 +563,52 @@ struct AnglesiteContainerProbe {
         try git(["add", "-A"])
         try git(["commit", "-q", "-m", "initial"])
         return dir
+    }
+
+    /// Create a throwaway `.anglesite` package for `worker-toggle`: `Source/` holds the same
+    /// minimal Astro project + initial commit as `makeThrowawayAstroRepo`, and `Config/` is where
+    /// `SiteConfigStore` persists the active-worker settings `LocalContainerSiteRuntime`'s
+    /// `updateActiveWorkers`/`startWorkersDevIfActive` re-read from disk. A bare repo (as
+    /// `makeThrowawayAstroRepo` returns) has no `Config/` sibling, so `worker-toggle` needs this
+    /// distinct helper rather than reusing that one directly.
+    private static func makeThrowawayPackage() throws -> URL {
+        let fm = FileManager.default
+        let package = fm.temporaryDirectory
+            .appendingPathComponent("anglesite-worker-toggle-probe-\(UUID().uuidString).anglesite", isDirectory: true)
+        let sourceURL = AnglesitePackage(url: package).sourceURL
+        try fm.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: AnglesitePackage(url: package).configURL, withIntermediateDirectories: true)
+
+        try """
+        {
+          "name": "anglesite-worker-toggle-probe",
+          "private": true,
+          "dependencies": { "astro": "*" }
+        }
+        """.write(to: sourceURL.appendingPathComponent("package.json"), atomically: true, encoding: .utf8)
+
+        let pages = sourceURL.appendingPathComponent("src/pages", isDirectory: true)
+        try fm.createDirectory(at: pages, withIntermediateDirectories: true)
+        try "<html><body><h1>Anglesite worker-toggle probe</h1></body></html>\n"
+            .write(to: pages.appendingPathComponent("index.astro"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = sourceURL
+            p.environment = ProcessInfo.processInfo.environment
+                .merging(["GIT_AUTHOR_NAME": "probe", "GIT_AUTHOR_EMAIL": "probe@anglesite.test",
+                          "GIT_COMMITTER_NAME": "probe", "GIT_COMMITTER_EMAIL": "probe@anglesite.test"]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                throw LocalContainerError.cloneFailed("git \(args.joined(separator: " ")) exited \(p.terminationStatus)")
+            }
+        }
+        try git(["init", "-q"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return package
     }
 }

--- a/Tests/AnglesiteContainerLocalTests/WorkerToggleEndToEndTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/WorkerToggleEndToEndTests.swift
@@ -1,0 +1,157 @@
+import Testing
+import Foundation
+import AnglesiteContainer
+import AnglesiteCore
+
+/// Local-only, entitlement-gated e2e test for the toggle→restart path a future Workers tab
+/// (#917) drives through `SiteRuntimeContainerCapability.updateActiveWorkers`. Owed from the
+/// #700 design doc §9 and #917 (#919): unit tests in `LocalContainerSiteRuntimeTests` cover the
+/// plumbing against a `FakeLocalContainerControl`, but nothing e2e-verifies that toggling a
+/// settings-activated worker on/off actually restarts/stops local `wrangler dev` inside a real
+/// booted container.
+///
+/// This whole *target* is excluded from CI's `swift test` (it's appended to `packageTargets` in
+/// Package.swift only when `ANGLESITE_CONTAINER_TESTS=1`), and this test body additionally
+/// requires `ANGLESITE_CONTAINER_E2E=1` so it is skipped unless explicitly run on an entitled
+/// Apple-Silicon Mac with the vendored boot artifacts present (mirrors
+/// `ContainerizationControlTests`'s gating).
+struct WorkerToggleEndToEndTests {
+    private var enabled: Bool { ProcessInfo.processInfo.environment["ANGLESITE_CONTAINER_E2E"] == "1" }
+
+    /// The single settings-activated fixture worker used throughout the suite (mirrors
+    /// `LocalContainerSiteRuntimeTests`'s "indieauth" fixture and the `workers-dev` probe's own).
+    private static let indieAuthCatalog: [WorkerDescriptor] = [
+        WorkerDescriptor(
+            id: "indieauth", displayName: "IndieAuth", description: "e2e fixture", group: "identity",
+            binding: .settingsActivated, resources: .init(needsD1: true, needsKV: true, needsR2: false))
+    ]
+
+    @Test("updateActiveWorkers toggles local wrangler-dev on and off for a running container")
+    func toggleRestartsLocalWranglerDev() async throws {
+        try #require(enabled, "set ANGLESITE_CONTAINER_E2E=1 on an entitled Apple-Silicon Mac")
+
+        let siteID = "worker-toggle-e2e"
+        let package = try makeThrowawayPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+
+        let configStore = SiteConfigStore(configDirectory: AnglesitePackage(url: package).configURL)
+        // Empty active-worker set at boot time, matching #919 step 1 ("boots a site with an empty
+        // active-worker set (no workersDevURL in the ready state)").
+        try await configStore.save(SiteSettings())
+
+        let control = ContainerizationControl()
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: control,
+            mcpClient: MCPClient(supervisor: .shared),
+            workerCatalog: { Self.indieAuthCatalog })
+        // Safety net: fires on any exit path (incl. a thrown #expect below) so a failed
+        // assertion doesn't leave the VM running. stop() is idempotent, so the awaited
+        // happy-path stop below is harmless after this.
+        defer { Task { await runtime.stop() } }
+
+        await runtime.start(siteID: siteID, siteDirectory: AnglesitePackage(url: package).sourceURL)
+
+        guard case .ready(_, _, let bootWorkersDevURL) = await runtime.state else {
+            Issue.record("expected .ready after boot, got \(await runtime.state)")
+            return
+        }
+        #expect(bootWorkersDevURL == nil, "no active workers were configured at boot")
+
+        // Step 2/3: activate the fixture worker via Settings and drive the toggle through
+        // updateActiveWorkers (the Workers tab's own call path) — assert the state re-settles to
+        // .ready with a non-nil workersDevURL and the local worker URL becomes reachable.
+        let activated = SiteSettings(activeWorkerIDs: ["indieauth"])
+        try await configStore.save(activated)
+        await runtime.updateActiveWorkers(activated)
+
+        guard case .ready(_, _, let activeWorkersDevURL) = await runtime.state else {
+            Issue.record("expected .ready after activating a worker, got \(await runtime.state)")
+            return
+        }
+        let workersDevURL = try #require(activeWorkersDevURL, "activating a worker should populate workersDevURL")
+
+        let reachable = await pollForHTTPResponse(workersDevURL, timeout: .seconds(60))
+        #expect(reachable, "local wrangler-dev never answered within the timeout after the toggle-on")
+
+        // Step 4: toggle back off and assert wrangler-dev stops (workersDevURL returns to nil).
+        let deactivated = SiteSettings()
+        try await configStore.save(deactivated)
+        await runtime.updateActiveWorkers(deactivated)
+
+        guard case .ready(_, _, let stoppedWorkersDevURL) = await runtime.state else {
+            Issue.record("expected .ready after deactivating the worker, got \(await runtime.state)")
+            return
+        }
+        #expect(stoppedWorkersDevURL == nil, "deactivating the worker should clear workersDevURL")
+
+        await runtime.stop()
+    }
+
+    /// Polls `url` for any HTTP response (any status code is a pass — we only care that the local
+    /// wrangler-dev endpoint is accepting connections and speaking HTTP), bounded by `timeout`.
+    /// Mirrors `ContainerizationControlTests.pollForHTTPResponse` — kept as a small,
+    /// self-contained duplicate here per that file's own precedent (no shared test-support target
+    /// for this local-only suite).
+    private func pollForHTTPResponse(_ url: URL, timeout: Duration) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            do {
+                let (_, response) = try await URLSession.shared.data(from: url)
+                if response is HTTPURLResponse { return true }
+            } catch {
+                // Not ready yet — wrangler-dev may still be starting up inside the guest.
+            }
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+        return false
+    }
+
+    /// Creates a throwaway `.anglesite` package: `Source/` holds a minimal Astro project with an
+    /// initial git commit (the `file://` repo `LocalContainerSiteRuntime.start` clones into the
+    /// guest), `Config/` is where `SiteConfigStore` persists the active-worker settings
+    /// `updateActiveWorkers`'s `startWorkersDevIfActive` re-reads from disk. Mirrors
+    /// `ContainerizationControlTests.makeThrowawayAstroRepo` plus
+    /// `LocalContainerSiteRuntimeTests.temporaryPackage`, combined since this suite needs both a
+    /// real bootable repo and a real on-disk settings store.
+    private func makeThrowawayPackage() throws -> URL {
+        let fm = FileManager.default
+        let package = fm.temporaryDirectory
+            .appendingPathComponent("WorkerToggleEndToEndTests-\(UUID().uuidString).anglesite", isDirectory: true)
+        let sourceURL = AnglesitePackage(url: package).sourceURL
+        try fm.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: AnglesitePackage(url: package).configURL, withIntermediateDirectories: true)
+
+        try """
+        {
+          "name": "anglesite-worker-toggle-e2e",
+          "private": true,
+          "dependencies": { "astro": "*" }
+        }
+        """.write(to: sourceURL.appendingPathComponent("package.json"), atomically: true, encoding: .utf8)
+
+        let pages = sourceURL.appendingPathComponent("src/pages", isDirectory: true)
+        try fm.createDirectory(at: pages, withIntermediateDirectories: true)
+        try "<html><body><h1>Anglesite worker-toggle e2e</h1></body></html>\n"
+            .write(to: pages.appendingPathComponent("index.astro"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = sourceURL
+            p.environment = ProcessInfo.processInfo.environment
+                .merging(["GIT_AUTHOR_NAME": "e2e", "GIT_AUTHOR_EMAIL": "e2e@anglesite.test",
+                          "GIT_COMMITTER_NAME": "e2e", "GIT_COMMITTER_EMAIL": "e2e@anglesite.test"]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                throw LocalContainerError.cloneFailed("git \(args.joined(separator: " ")) exited \(p.terminationStatus)")
+            }
+        }
+        try git(["init", "-q"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return package
+    }
+}

--- a/scripts/run-container-probe.sh
+++ b/scripts/run-container-probe.sh
@@ -11,10 +11,11 @@
 # process that really is entitled.
 #
 # Usage:
-#   scripts/run-container-probe.sh echo         # THE Task 4b decision gate (vsock round-trip)
-#   scripts/run-container-probe.sh boot         # Task 5's gate (full boot + preview HTTP poll)
-#   scripts/run-container-probe.sh workers-dev  # #708's gate (boot + local wrangler-dev HTTP poll)
-#   scripts/run-container-probe.sh pause-resume # suspend-on-close decision gate (vsock survives pause/resume)
+#   scripts/run-container-probe.sh echo          # THE Task 4b decision gate (vsock round-trip)
+#   scripts/run-container-probe.sh boot          # Task 5's gate (full boot + preview HTTP poll)
+#   scripts/run-container-probe.sh workers-dev   # #708's gate (boot + local wrangler-dev HTTP poll)
+#   scripts/run-container-probe.sh worker-toggle # #919's gate (updateActiveWorkers toggle restart)
+#   scripts/run-container-probe.sh pause-resume  # suspend-on-close decision gate (vsock survives pause/resume)
 #
 # The boot probe is also the #715 concurrent-vmnet regression gate. Before running it, use
 # `container network create anglesite-715-regression` to hold a second vmnet shared-mode network;
@@ -33,9 +34,9 @@ cd "${ROOT_DIR}"
 
 SUBCOMMAND="${1:-}"
 case "${SUBCOMMAND}" in
-    echo|boot|workers-dev|pause-resume) ;;
+    echo|boot|workers-dev|worker-toggle|pause-resume) ;;
     *)
-        echo "usage: $(basename "$0") <echo|boot|workers-dev|pause-resume>" >&2
+        echo "usage: $(basename "$0") <echo|boot|workers-dev|worker-toggle|pause-resume>" >&2
         exit 2
         ;;
 esac


### PR DESCRIPTION
Closes #919

## Summary

- Adds a Swift Testing case (`WorkerToggleEndToEndTests`) to `AnglesiteContainerLocalTests` that boots a `LocalContainerSiteRuntime` with an empty active-worker set, calls `updateActiveWorkers` to toggle a settings-activated fixture worker on, asserts the state re-settles to `.ready` with a reachable `workersDevURL`, then toggles it back off and asserts `workersDevURL` returns to nil.
- Adds a matching `worker-toggle` subcommand to `anglesite-container-probe` (and `scripts/run-container-probe.sh`) so the gate is actually runnable entitled — `swift test`'s own runner can't carry `com.apple.security.virtualization`, mirroring how `workers-dev` already works.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (default lane, unaffected)
- [x] `ANGLESITE_CONTAINER_TESTS=1 swift test --package-path . --filter WorkerToggleEndToEndTests` (compiles; body `#require`-skips without `ANGLESITE_CONTAINER_E2E=1`, matching every sibling live case in this target)
- [x] `ANGLESITE_CONTAINER_TESTS=1 swift build --package-path . --product anglesite-container-probe` (new `worker-toggle` subcommand builds)
- [ ] `scripts/run-container-probe.sh worker-toggle` on an entitled Apple-Silicon Mac with vendored boot artifacts — not run in this environment (no entitled/provisioned host); this is the actual live decision gate, see #919's own note that it "couldn't run in the implementing environment — needs the entitled probe"
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; no app-target (`Sources/AnglesiteApp`) files touched