### PR TITLE
feat(#1071): replace new-site wizard with a template chooser

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -706,6 +706,9 @@
     "Choose Logo" : {
 
     },
+    "Choose a Template" : {
+
+    },
     "Choose a provider" : {
 
     },

--- a/Sources/AnglesiteApp/NewSiteWizard.swift
+++ b/Sources/AnglesiteApp/NewSiteWizard.swift
@@ -1,16 +1,12 @@
 import SwiftUI
 import AppKit
-import UniformTypeIdentifiers
 import AnglesiteCore
-#if canImport(ImagePlayground)
-import ImagePlayground
-#endif
 
-/// The New Site wizard sheet. Presented from SitesLauncherView; calls `onComplete(siteID)`
-/// when the site is scaffolded and registered.
+/// The New Site template chooser (#1071) — the iWork model: one question (which template),
+/// then the site scaffolds as "Untitled" into the default location and opens in the preview.
+/// Presented from SitesLauncherView; calls `onComplete(siteID)` when the site is scaffolded
+/// and registered.
 struct NewSiteWizard: View {
-    private static let cloudflareDomainsURL = URL(string: "https://www.cloudflare.com/products/registrar/")!
-
     @Bindable var model: NewSiteWizardModel
     let scaffolder: SiteScaffolder
     let onComplete: (String) -> Void
@@ -22,236 +18,39 @@ struct NewSiteWizard: View {
             Divider()
             footer
         }
-        .frame(width: 520, height: 460)
-        .modifier(ImagePlaygroundPresenter(model: model))
+        .frame(width: 560, height: 460)
     }
 
     @ViewBuilder private var content: some View {
         switch model.step {
-        case .details:  detailsStep
-        case .type:     typeStep
-        case .look:     lookStep
-        case .content:  contentStep
-        case .save:     saveStep
+        case .chooser:  chooserStep
         case .building: buildingStep
         }
     }
 
-    private var typeStep: some View {
+    private var chooserStep: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("What kind of website are you creating?").font(.title2.bold())
-            ForEach(SiteType.allCases, id: \.self) { type in
-                Button { model.choose(type: type) } label: {
-                    HStack {
-                        Image(systemName: type.symbol).frame(width: 24)
-                            .accessibilityHidden(true)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(type.label)
-                            Text(type.description)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer()
-                        if model.draft.siteType == type {
-                            Image(systemName: "checkmark").accessibilityHidden(true)
-                        }
-                    }.contentShape(Rectangle())
-                }
-                .buttonStyle(.plain).padding(.vertical, 4)
-                .accessibilityLabel("\(type.label). \(type.description)")
-                .accessibilityValue(model.draft.siteType == type ? "Selected" : "")
-            }
-        }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    private var detailsStep: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Create a website").font(.title2.bold())
-            Text("Website name").font(.headline)
-            TextField("My Website", text: $model.draft.name)
-            if let err = model.detailsError {
-                Text(err).font(.caption).foregroundStyle(.red)
-                    .accessibilityLabel("Error")
-                    .accessibilityValue(err)
-            }
-            Text("Domain").font(.headline).padding(.top, 8)
-            Picker("Domain", selection: $model.draft.domainChoice) {
-                Text("Buy a domain").tag(NewSiteDomainChoice.buy)
-                Text("Transfer an existing domain").tag(NewSiteDomainChoice.transfer)
-                Text("Set this up later").tag(NewSiteDomainChoice.later)
-            }
-            .pickerStyle(.radioGroup)
-            .labelsHidden()
-            domainChoiceDetails
-        }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    @ViewBuilder private var domainChoiceDetails: some View {
-        switch model.draft.domainChoice {
-        case .buy:
-            Link("Open Cloudflare Domains", destination: Self.cloudflareDomainsURL)
-                .font(.caption)
-        case .transfer:
-            TextField("example.com", text: $model.draft.domain)
-                .textFieldStyle(.roundedBorder)
-            Text("Enter the domain you already own.")
-                .font(.caption).foregroundStyle(.secondary)
-        case .later:
-            Text("Use a temporary Cloudflare Workers domain later, such as \(model.cloudflareDevPreview).")
-                .font(.caption).foregroundStyle(.secondary)
-        }
-    }
-
-    private var lookStep: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Pick a color scheme").font(.title2.bold())
+            Text("Choose a Template").font(.title2.bold())
             ScrollView {
-                VStack(alignment: .leading, spacing: 12) {
-                    customColorScheme
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))], spacing: 12) {
-                        ForEach(model.catalog.themes) { theme in
-                            Button { model.draft.themeID = theme.id } label: {
-                                VStack(alignment: .leading, spacing: 6) {
-                                    HStack(spacing: 0) {
-                                        ForEach(theme.swatch, id: \.self) { hex in
-                                            Color(hex: hex).frame(height: 28)
-                                        }
-                                    }.clipShape(RoundedRectangle(cornerRadius: 6))
-                                    .accessibilityHidden(true)
-                                    Text(theme.name).font(.subheadline.bold())
-                                    Text(theme.blurb).font(.caption2).foregroundStyle(.secondary).lineLimit(2)
-                                }
-                                .padding(8)
-                                .overlay(RoundedRectangle(cornerRadius: 8)
-                                    .stroke(model.draft.themeID == theme.id ? Color.accentColor : Color.clear, lineWidth: 2))
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityElement(children: .combine)
-                            .accessibilityValue(model.draft.themeID == theme.id ? "Selected" : "")
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))], spacing: 12) {
+                    ForEach(model.catalog.themes) { theme in
+                        Button { model.draft.themeID = theme.id } label: {
+                            ThemePreviewCard(theme: theme, isSelected: model.draft.themeID == theme.id)
+                                .contentShape(Rectangle())
                         }
+                        .buttonStyle(.plain)
+                        // Double-click = choose and create, the document-chooser convention.
+                        .simultaneousGesture(TapGesture(count: 2).onEnded {
+                            model.draft.themeID = theme.id
+                            create()
+                        })
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("\(theme.name). \(theme.blurb)")
+                        .accessibilityValue(model.draft.themeID == theme.id ? "Selected" : "")
                     }
                 }
             }
         }.padding(24)
-    }
-
-    private var customColorScheme: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Button { model.draft.themeID = CustomTheme.id } label: {
-                HStack(alignment: .top, spacing: 10) {
-                    HStack(spacing: 0) {
-                        Color(hex: model.draft.customPrimaryColor)
-                        Color(hex: model.draft.customAccentColor)
-                    }
-                    .frame(width: 64, height: 32)
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                    .accessibilityHidden(true)
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Custom").font(.subheadline.bold())
-                        Text("Choose your own colors and add a logo.")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    if model.draft.themeID == CustomTheme.id {
-                        Image(systemName: "checkmark").accessibilityHidden(true)
-                    }
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .padding(8)
-            .overlay(RoundedRectangle(cornerRadius: 8)
-                .stroke(model.draft.themeID == CustomTheme.id ? Color.accentColor : Color.clear, lineWidth: 2))
-            .accessibilityLabel("Custom. Choose your own colors and add a logo.")
-            .accessibilityValue(model.draft.themeID == CustomTheme.id ? "Selected" : "")
-
-            if model.draft.themeID == CustomTheme.id {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        ColorPicker("Primary color", selection: colorBinding(\.customPrimaryColor), supportsOpacity: false)
-                        ColorPicker("Accent color", selection: colorBinding(\.customAccentColor), supportsOpacity: false)
-                    }
-                    HStack {
-                        Button {
-                            chooseLogo()
-                        } label: {
-                            Label(model.draft.logoURL == nil ? "Upload Logo\u{2026}" : "Change Logo\u{2026}",
-                                  systemImage: "photo.badge.plus")
-                        }
-                        if let logoURL = model.draft.logoURL {
-                            Text(logoURL.lastPathComponent)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                            Button("Remove") { model.draft.logoURL = nil }
-                        }
-                    }
-                }
-                .padding(.horizontal, 8)
-                .padding(.bottom, 4)
-            }
-        }
-    }
-
-    private var contentStep: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("First words").font(.title2.bold())
-            Text("Homepage headline").font(.headline)
-            TextField("Welcome to \u{2026}", text: $model.draft.headline)
-            Text("Short description (optional)").font(.headline).padding(.top, 8)
-            TextField("What this website is about, in a sentence", text: $model.draft.blurb)
-            heroImageSection
-        }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    private var saveStep: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Save your website").font(.title2.bold())
-            Text("Choose where to save the local .anglesite file.")
-                .font(.caption).foregroundStyle(.secondary)
-        }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    /// Optional Image Playground hero image (#92). Hidden entirely when Apple Intelligence /
-    /// Image Playground isn't available on this device — sites work fine without it.
-    @ViewBuilder private var heroImageSection: some View {
-        if isImagePlaygroundAvailable {
-            Divider().padding(.vertical, 4)
-            Text("Hero image (optional)").font(.headline)
-            TextField("Abstract shapes in my brand colors, no text", text: $model.draft.heroImagePrompt)
-            if model.hasHeroImage {
-                HStack(spacing: 8) {
-                    Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
-                        .accessibilityHidden(true)
-                    Text("Hero image ready").font(.callout)
-                    Spacer()
-                    Button("Regenerate\u{2026}") { model.showingImagePlayground = true }
-                    Button("Remove") { model.setHeroImage(nil) }
-                }
-            } else {
-                Button {
-                    model.showingImagePlayground = true
-                } label: {
-                    Label("Generate hero image\u{2026}", systemImage: "wand.and.stars")
-                }
-                Text("Uses Apple Intelligence on your device. No content leaves your Mac without your say-so.")
-                    .font(.caption).foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    /// True only when the Image Playground sheet can actually present (Apple Intelligence enabled,
-    /// OS new enough). Compiled-out / false on platforms without the framework.
-    private var isImagePlaygroundAvailable: Bool {
-        #if canImport(ImagePlayground)
-        if #available(macOS 26.0, *) {
-            return ImagePlaygroundViewController.isAvailable
-        }
-        #endif
-        return false
     }
 
     private var buildingStep: some View {
@@ -280,7 +79,7 @@ struct NewSiteWizard: View {
         case .creatingFolder: return "\u{2705} Created the website file"
         case .copyingTemplate: return "\u{2705} Copied the template"
         case .applyingTheme: return "\u{2705} Applied your theme"
-        case .writingContent: return "\u{2705} Wrote your words"
+        case .writingContent: return "\u{2705} Prepared the starter content"
         case .installing: return "\u{23F3} Installing\u{2026}"
         case .registering: return "\u{2705} Registering"
         case .warning(_, let m): return "\u{26A0}\u{FE0F} \(m)"
@@ -296,7 +95,7 @@ struct NewSiteWizard: View {
         case .creatingFolder:    return "Created the website file"
         case .copyingTemplate:   return "Copied the template"
         case .applyingTheme:     return "Applied your theme"
-        case .writingContent:    return "Wrote your words"
+        case .writingContent:    return "Prepared the starter content"
         case .installing:        return "Installing…"
         case .registering:       return "Registering"
         case .warning(_, let m): return "Warning: \(m)"
@@ -307,23 +106,14 @@ struct NewSiteWizard: View {
 
     @ViewBuilder private var footer: some View {
         HStack {
-            if model.step != .details && model.step != .building {
-                Button("Back") { model.back() }
-            }
             Spacer()
             // No Cancel once building starts: the scaffold pipeline isn't cancellable and
             // always reaches .done or .failed (failure shows Close below), so cancelling
             // mid-build would leak the in-flight work and the MAS security scope.
-            if model.step != .building {
+            if model.step == .chooser {
                 Button("Cancel") { onCancel() }
-            }
-            if model.step == .save {
-                Button("Save Website\u{2026}") {
-                    saveWebsite()
-                }.keyboardShortcut(.defaultAction).disabled(!model.canContinue)
-            } else if model.step != .building {
-                Button("Continue") { model.advance() }
-                    .keyboardShortcut(.defaultAction).disabled(!model.canContinue)
+                Button("Create") { create() }
+                    .keyboardShortcut(.defaultAction).disabled(!model.canCreate)
             } else if let id = model.completedSiteID, model.hasWarnings {
                 Button("Open Website Anyway") { onComplete(id) }.keyboardShortcut(.defaultAction)
             } else if model.completedSiteID == nil && model.fatal != nil {
@@ -332,81 +122,59 @@ struct NewSiteWizard: View {
         }.padding(.horizontal, 16).padding(.vertical, 10)
     }
 
-    @MainActor private func saveWebsite() {
-        let panel = NSSavePanel()
-        panel.title = String(localized: "Save Your Website")
-        panel.prompt = String(localized: "Save")
-        panel.allowedContentTypes = [.anglesiteSite]
-        panel.canCreateDirectories = true
-        panel.directoryURL = model.draft.saveDirectory ?? model.defaultSaveDirectory
-        panel.nameFieldStringValue = model.draft.saveFileName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            ? model.defaultSaveFileName
-            : model.draft.saveFileName
-        if panel.runModal() == .OK {
-            guard let url = panel.url else { return }
-            model.draft.saveDirectory = url.deletingLastPathComponent()
-            model.draft.saveFileName = url.lastPathComponent
-            // Auto-open only on a clean build; with warnings, stay put so the owner sees them (#229).
-            Task {
-                _ = await model.build(using: scaffolder)
-                if model.didCompleteCleanly, let id = model.completedSiteID { onComplete(id) }
-            }
-        }
-    }
-
-    @MainActor private func chooseLogo() {
-        let panel = NSOpenPanel()
-        panel.title = String(localized: "Choose Logo")
-        panel.prompt = String(localized: "Choose")
-        panel.allowedContentTypes = [.image]
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        if panel.runModal() == .OK {
-            model.draft.logoURL = panel.url
-            model.draft.themeID = CustomTheme.id
-        }
-    }
-
-    private func colorBinding(_ keyPath: WritableKeyPath<NewSiteDraft, String>) -> Binding<Color> {
-        Binding {
-            Color(hex: model.draft[keyPath: keyPath])
-        } set: { newColor in
-            model.draft[keyPath: keyPath] = newColor.hexString ?? model.draft[keyPath: keyPath]
-            model.draft.themeID = CustomTheme.id
+    private func create() {
+        guard model.canCreate else { return }
+        // Auto-open only on a clean build; with warnings, stay put so the owner sees them (#229).
+        Task {
+            _ = await model.build(using: scaffolder)
+            if model.didCompleteCleanly, let id = model.completedSiteID { onComplete(id) }
         }
     }
 }
 
-/// Presents the Image Playground sheet for the wizard's hero-image action (#92).
-///
-/// Isolated in a `ViewModifier` so the availability `#if`/`#available` gating lives in one place
-/// and `NewSiteWizard.body` stays clean. On platforms without the framework (or older OSes), this
-/// is an inert pass-through and the button that drives `showingImagePlayground` is never shown.
-private struct ImagePlaygroundPresenter: ViewModifier {
-    @Bindable var model: NewSiteWizardModel
+/// One template card: a miniature page mock (nav bar, hero block, text lines) drawn from the
+/// theme's own palette, so each card previews a page rather than a bare swatch strip (#1071).
+private struct ThemePreviewCard: View {
+    let theme: Theme
+    let isSelected: Bool
 
-    func body(content: Content) -> some View {
-        #if canImport(ImagePlayground)
-        if #available(macOS 26.0, *) {
-            content.imagePlaygroundSheet(
-                isPresented: $model.showingImagePlayground,
-                concepts: model.heroImageConcepts.map { ImagePlaygroundConcept.text($0) }
-            ) { url in
-                // Image Playground hands back a URL to the generated image in a temporary
-                // location; stash it on the draft so the scaffolder copies it into the site.
-                model.setHeroImage(url)
+    private var primary: Color { Color(hex: theme.cssVars["color-primary"] ?? "#333333") }
+    private var accent: Color { Color(hex: theme.cssVars["color-accent"] ?? "#888888") }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 4) {
+                    Circle().fill(accent).frame(width: 6, height: 6)
+                    Capsule().fill(Color.white.opacity(0.9)).frame(width: 34, height: 4)
+                    Spacer()
+                }
+                .padding(6)
+                .background(primary)
+                RoundedRectangle(cornerRadius: 2).fill(accent.opacity(0.85)).frame(height: 22)
+                    .padding(.horizontal, 6)
+                Capsule().fill(Color.primary.opacity(0.5)).frame(width: 70, height: 4)
+                    .padding(.horizontal, 6)
+                Capsule().fill(Color.primary.opacity(0.25)).frame(height: 3)
+                    .padding(.horizontal, 6)
+                Capsule().fill(Color.primary.opacity(0.25)).frame(width: 90, height: 3)
+                    .padding(.horizontal, 6).padding(.bottom, 8)
             }
-        } else {
-            content
+            .background(Color(NSColor.textBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(Color.primary.opacity(0.1)))
+            .accessibilityHidden(true)
+            Text(theme.name).font(.subheadline.bold())
+            Text(theme.blurb).font(.caption2).foregroundStyle(.secondary).lineLimit(2)
         }
-        #else
-        content
-        #endif
+        .padding(8)
+        .overlay(RoundedRectangle(cornerRadius: 8)
+            .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2))
     }
 }
 
-/// Minimal hex -> Color for theme swatches (#rrggbb).
+/// Minimal hex -> Color for theme cards (#rrggbb). Also used by ThemeApplyWizard — keep it
+/// here (module-internal) when refactoring this file.
 extension Color {
     init(hex: String) {
         let h = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
@@ -416,17 +184,5 @@ extension Color {
                      red: Double((rgb >> 16) & 0xFF) / 255,
                      green: Double((rgb >> 8) & 0xFF) / 255,
                      blue: Double(rgb & 0xFF) / 255)
-    }
-
-    var hexString: String? {
-        guard let color = NSColor(self).usingColorSpace(.sRGB) ?? NSColor(self).usingColorSpace(.deviceRGB) else { return nil }
-        let red = Self.clampedByte(color.redComponent)
-        let green = Self.clampedByte(color.greenComponent)
-        let blue = Self.clampedByte(color.blueComponent)
-        return String(format: "#%02x%02x%02x", red, green, blue)
-    }
-
-    private static func clampedByte(_ component: CGFloat) -> Int {
-        min(255, max(0, Int(round(component * 255))))
     }
 }

--- a/Sources/AnglesiteApp/NewSiteWizard.swift
+++ b/Sources/AnglesiteApp/NewSiteWizard.swift
@@ -19,6 +19,8 @@ struct NewSiteWizard: View {
             footer
         }
         .frame(width: 560, height: 460)
+        // The scaffold pipeline isn't cancellable — block Esc/interactive dismissal once it starts.
+        .interactiveDismissDisabled(model.step == .building)
     }
 
     @ViewBuilder private var content: some View {
@@ -112,6 +114,7 @@ struct NewSiteWizard: View {
             // mid-build would leak the in-flight work and the MAS security scope.
             if model.step == .chooser {
                 Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
                 Button("Create") { create() }
                     .keyboardShortcut(.defaultAction).disabled(!model.canCreate)
             } else if let id = model.completedSiteID, model.hasWarnings {

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -443,7 +443,13 @@ struct SitesLauncherView: View {
         let knownSites = await SiteStore.shared.sites
         let takenSlugs = Set(knownSites.map { SiteSlug.derive(from: $0.name) })
 
-        let model = NewSiteWizardModel(catalog: catalog, defaultSaveDirectory: sitesRoot, slugTaken: { takenSlugs.contains($0) })
+        // "Untitled N" availability (#1071): taken if it collides with a registered site's slug
+        // OR a package already on disk in the sites root (registered or not) — silent save must
+        // never clobber an existing folder.
+        let model = NewSiteWizardModel(catalog: catalog, isNameTaken: { name in
+            takenSlugs.contains(SiteSlug.derive(from: name))
+                || FileManager.default.fileExists(atPath: sitesRoot.appendingPathComponent("\(name).anglesite").path)
+        })
 
         let scaffolder = SiteScaffolder(
             sitesRoot: sitesRoot,

--- a/Sources/AnglesiteCore/NewSiteWizardModel.swift
+++ b/Sources/AnglesiteCore/NewSiteWizardModel.swift
@@ -1,37 +1,31 @@
 import Foundation
 import Observation
 
-/// Observable state machine behind the New Site wizard: step navigation, draft validation,
-/// and scaffold progress. All wizard rules (what "can continue" means per step, when the
-/// name collides, when the finished site may open) live here rather than in the views, so
-/// they can be unit-tested without SwiftUI.
+/// Observable state behind the New Site template chooser (#1071): theme selection, Untitled
+/// naming, and scaffold progress. All rules (when Create is enabled, what the site is named,
+/// when the finished site may open) live here rather than in the views, so they can be
+/// unit-tested without SwiftUI.
+///
+/// The chooser deliberately asks exactly one question — which template — the iWork model.
+/// Name ("Untitled"), save location (the sites root), domain (deferred to publish), and
+/// homepage content (the template's placeholder copy) are all defaulted, not asked.
 @MainActor
 @Observable
 public final class NewSiteWizardModel {
-    /// The wizard's pages, in presentation order — ``NewSiteWizardModel/advance()`` /
-    /// ``NewSiteWizardModel/back()`` walk the raw values, so case order here *is* the wizard flow.
+    /// The chooser's two states; ``NewSiteWizardModel/build(using:)`` is the only transition.
     public enum Step: Int, CaseIterable {
-        /// Name + domain choice — the only step with hard validation (``NewSiteWizardModel/detailsError``).
-        case details
-        /// Broad site category (``SiteType``); picking one re-seeds the default theme.
-        case type
-        /// Theme selection, including the ``CustomTheme`` own-colors escape hatch.
-        case look
-        /// Optional homepage content (headline, blurb, hero image) — skippable.
-        case content
-        /// Save location and package file name.
-        case save
-        /// Terminal step while ``NewSiteWizardModel/build(using:)`` runs; `canContinue` is
+        /// The template grid — the only step with user input.
+        case chooser
+        /// Terminal step while ``NewSiteWizardModel/build(using:)`` runs; ``canCreate`` is
         /// always `false` here.
         case building
     }
 
-    /// The step currently shown. Mutated only via ``advance()``/``back()`` and ``build(using:)``.
-    public var step: Step = .details
-    /// The accumulating answers; a plain value handed to the scaffolder unchanged at build time.
-    public var draft = NewSiteDraft(siteType: .business, name: "")
-    /// Drives the Image Playground sheet presentation in the Content step (#92).
-    public var showingImagePlayground = false
+    /// The step currently shown. Mutated only by ``build(using:)``.
+    public private(set) var step: Step = .chooser
+    /// The answers handed to the scaffolder at build time. Only ``NewSiteDraft/themeID`` is
+    /// user-set (via the grid); everything else keeps the Untitled defaults from init.
+    public var draft: NewSiteDraft
     /// Every ``SiteScaffolder/ScaffoldStep`` emitted so far, in order — the Building step's
     /// live checklist. Append-only; never trimmed, so warnings stay visible after completion.
     public private(set) var progress: [SiteScaffolder.ScaffoldStep] = []
@@ -42,134 +36,61 @@ public final class NewSiteWizardModel {
     /// failure). Gate opening the site on ``didCompleteCleanly``, not just this being non-nil.
     public private(set) var completedSiteID: String?
 
-    /// Themes offered in the Look step; also supplies the per-type default seeded by
-    /// ``choose(type:)`` and the initializer.
+    /// Themes shown in the grid; the first entry is pre-selected (no site type exists to drive
+    /// the per-type default table).
     public let catalog: ThemeCatalog
-    /// Pre-selected save location for the Save step (typically `~/Sites/`); `nil` lets the
-    /// save panel fall back to its own default.
-    public let defaultSaveDirectory: URL?
-    private let slugTaken: @Sendable (String) -> Bool
 
-    /// Creates the model and seeds the draft's theme with the catalog default for the initial
-    /// site type, so the Look step never starts with nothing selected.
+    /// Creates the model with a fully-defaulted Untitled draft.
     ///
     /// - Parameters:
-    ///   - catalog: Themes for the Look step and the per-type default seeding.
-    ///   - defaultSaveDirectory: Pre-selected save location for the Save step; `nil` defers
-    ///     to the save panel's own default.
-    ///   - slugTaken: Injected collision check against the recents registry — the model
-    ///     deliberately doesn't know about `SiteStore`, keeping it testable with a plain
-    ///     closure.
-    public init(catalog: ThemeCatalog, defaultSaveDirectory: URL? = nil, slugTaken: @escaping @Sendable (String) -> Bool) {
+    ///   - catalog: Themes for the grid; its first entry seeds ``NewSiteDraft/themeID``.
+    ///   - isNameTaken: Availability check for a candidate display name (e.g. "Untitled 2").
+    ///     The caller decides what "taken" means — the launcher checks both the recents
+    ///     registry and the sites root on disk. Non-escaping: consulted only here, at init.
+    public init(catalog: ThemeCatalog, isNameTaken: (String) -> Bool) {
         self.catalog = catalog
-        self.defaultSaveDirectory = defaultSaveDirectory
-        self.slugTaken = slugTaken
-        // Seed a default theme for the initial type.
-        draft.themeID = catalog.defaultThemeID(for: draft.siteType)
+        let name = Self.untitledName(isTaken: isNameTaken)
+        // headline "" on purpose (overriding NewSiteDraft's default of `name`): the scaffolder
+        // skips the homepage write for a contentless draft, leaving the template's placeholder
+        // copy for the owner to edit in the preview (#1071).
+        var draft = NewSiteDraft(siteType: .blank, name: name,
+                                 saveFileName: "\(name).anglesite", headline: "")
+        draft.themeID = catalog.themes.first?.id ?? ""
+        self.draft = draft
     }
 
-    /// The folder slug the current name would produce (``SiteSlug/derive(from:)``), shown live
-    /// in the Details step so owners see the URL-ish identity their name implies before committing.
-    public var slugPreview: String { SiteSlug.derive(from: draft.name) }
+    /// First free name in "Untitled", "Untitled 2", "Untitled 3", … — the Mac document
+    /// convention. Not localized: AnglesiteCore has no string catalog (app-target only).
+    static func untitledName(isTaken: (String) -> Bool) -> String {
+        for n in 1...9999 {
+            let candidate = n == 1 ? "Untitled" : "Untitled \(n)"
+            if !isTaken(candidate) { return candidate }
+        }
+        // 9999 collisions means something is systematically wrong; fall back to a unique name
+        // rather than looping forever.
+        return "Untitled \(UUID().uuidString.prefix(8))"
+    }
 
-    /// Default `.anglesite` package file name derived from the slug; used verbatim when the
-    /// owner leaves the Save step's name field empty (see ``build(using:)``).
-    public var defaultSaveFileName: String { "\(slugPreview).anglesite" }
+    /// Gate for the chooser's Create button (and double-click): a real catalog theme is
+    /// selected and no build is running.
+    public var canCreate: Bool {
+        step == .chooser && catalog.theme(id: draft.themeID) != nil
+    }
 
     /// Non-fatal build warnings (e.g. a failed install), surfaced so a failure isn't hidden behind a dead-end preview (#229).
     public var warnings: [String] {
         progress.compactMap { if case .warning(_, let message) = $0 { return message } else { return nil } }
     }
 
-    /// Convenience over ``warnings`` for the wizard's "finished with warnings" branch.
+    /// Convenience over ``warnings`` for the chooser's "finished with warnings" branch.
     public var hasWarnings: Bool { !warnings.isEmpty }
 
-    /// Site registered with no warnings — only then may the wizard open it immediately (else it stays put so warnings are read) (#229).
+    /// Site registered with no warnings — only then may the chooser open it immediately (else it stays put so warnings are read) (#229).
     public var didCompleteCleanly: Bool { completedSiteID != nil && !hasWarnings }
-
-    /// Owner-facing validation message for the Details step, or `nil` when there's nothing to
-    /// show. An empty name is deliberately *not* an error — it's merely "incomplete" (Continue
-    /// stays disabled via ``canContinue``), so the owner isn't scolded before they've typed
-    /// anything. The only real error is a slug collision with an existing site.
-    public var detailsError: String? {
-        let name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
-        if name.isEmpty { return nil }              // empty is "incomplete", not an error to show
-        if slugTaken(slugPreview) { return "A site named \u{201C}\(slugPreview)\u{201D} already exists." }
-        return nil
-    }
-
-    /// The `workers.dev` hostname the site will get before a custom domain is attached, shown
-    /// in the Details step so "decide later" still promises a concrete public address.
-    public var cloudflareDevPreview: String {
-        "\(slugPreview).workers.dev"
-    }
-
-    /// Per-step gate for the wizard's Continue button. Notably: `.content` is always passable
-    /// (content is optional), `.building` never is (the build owns navigation from there), and
-    /// `.details` additionally requires a valid domain only when the owner chose to transfer one.
-    public var canContinue: Bool {
-        switch step {
-        case .details:
-            return !draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                && detailsError == nil
-                && (draft.domainChoice != .transfer || Self.isValidDomain(draft.domain))
-        case .type:    return true
-        case .look:    return draft.themeID == CustomTheme.id || catalog.theme(id: draft.themeID) != nil
-        case .content: return true                  // content is optional
-        case .save:    return true
-        case .building: return false
-        }
-    }
-
-    /// Records the site-type choice and re-seeds the type's default theme — unless the owner
-    /// already picked custom colors, which survive a type change on purpose (an explicit
-    /// aesthetic choice shouldn't be silently discarded by browsing types).
-    public func choose(type: SiteType) {
-        draft.siteType = type
-        if draft.themeID != CustomTheme.id {
-            draft.themeID = catalog.defaultThemeID(for: type)
-        }
-    }
-
-    /// Syntactic hostname check for the domain-transfer field: at least one dot, no whitespace,
-    /// and RFC-952/1123-shaped labels (≤63 chars, no leading/trailing hyphen). Deliberately
-    /// *not* a registrability or DNS check — the wizard only needs to catch typos before the
-    /// deploy flow takes over.
-    public static func isValidDomain(_ domain: String) -> Bool {
-        let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.contains("."),
-              trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
-              trimmed.range(of: #"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$"#,
-                            options: .regularExpression) != nil
-        else { return false }
-        return true
-    }
-
-    /// Image Playground generation concepts for the current draft (#92).
-    public var heroImageConcepts: [String] {
-        HeroImage.concepts(name: draft.name, siteType: draft.siteType, tagline: draft.tagline, imageDescription: draft.heroImagePrompt)
-    }
-
-    /// Whether a hero image has been generated and staged for scaffolding.
-    public var hasHeroImage: Bool { draft.heroImageURL != nil }
-
-    /// Store the URL of an image generated by Image Playground (or clear it).
-    public func setHeroImage(_ url: URL?) { draft.heroImageURL = url }
-
-    /// Moves to the next ``Step`` in declaration order; a no-op at the last step (no wrap-around).
-    public func advance() { if let next = Step(rawValue: step.rawValue + 1) { step = next } }
-    /// Moves to the previous ``Step``; a no-op at the first step.
-    public func back() { if let prev = Step(rawValue: step.rawValue - 1) { step = prev } }
 
     /// Runs the scaffolder, accumulating progress. Returns the new site id on success.
     public func build(using scaffolder: SiteScaffolder) async -> String? {
         step = .building
-        if draft.saveFileName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            draft.saveFileName = defaultSaveFileName
-        }
-        if draft.headline.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            draft.headline = draft.name
-        }
         for await s in scaffolder.scaffold(draft) {
             progress.append(s)
             if case .failed = s { fatal = s }

--- a/Sources/AnglesiteCore/SiteScaffolder.swift
+++ b/Sources/AnglesiteCore/SiteScaffolder.swift
@@ -141,14 +141,20 @@ public actor SiteScaffolder {
             emit(.warning(step: "applyingTheme", message: "No themes available; left default look."))
         }
 
-        // 4. Homepage (non-fatal)
+        // 4. Homepage (non-fatal). Skipped when the draft has no content at all — the chooser
+        // flow (#1071) ships the template's placeholder copy for the owner to edit in the
+        // preview; intents/AI paths that supply real words still get them written.
         emit(.writingContent)
         let metadataDescription = draft.tagline.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? draft.blurb
             : draft.tagline
-        do { try HomepageWriter.write(headline: draft.headline, blurb: draft.blurb,
-                                      tagline: metadataDescription, siteDirectory: siteDir, fileManager: fileManager) }
-        catch { emit(.warning(step: "writingContent", message: humanize(error))) }
+        let hasHomepageContent = !draft.headline.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !draft.blurb.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if hasHomepageContent {
+            do { try HomepageWriter.write(headline: draft.headline, blurb: draft.blurb,
+                                          tagline: metadataDescription, siteDirectory: siteDir, fileManager: fileManager) }
+            catch { emit(.warning(step: "writingContent", message: humanize(error))) }
+        }
 
         var logoPublicPath: String?
         if let logo = draft.logoURL {
@@ -210,13 +216,15 @@ public actor SiteScaffolder {
     /// Append owner answers without clobbering existing lines (e.g. ANGLESITE_VERSION).
     private func appendSiteConfig(_ draft: NewSiteDraft, logoPublicPath: String?,
                                   metadataDescription: String, siteDir: URL, cfProjectName: String) throws {
-        var values: [(String, String)] = [
-            ("SITE_NAME", draft.name),
-            ("SITE_TYPE", draft.siteType.rawValue),
+        var values: [(String, String)] = [("SITE_NAME", draft.name)]
+        // `.blank` is the chooser flow's "no answer" (#1071) — nothing reads SITE_TYPE back,
+        // so an unasked question writes no key rather than a fake answer.
+        if draft.siteType != .blank { values.append(("SITE_TYPE", draft.siteType.rawValue)) }
+        values.append(contentsOf: [
             ("DOMAIN_CHOICE", draft.domainChoice.rawValue),
             ("CF_PROJECT_NAME", cfProjectName),
             ("LANG", hostLanguage()),
-        ]
+        ])
         if draft.domainChoice == .transfer && !draft.domain.isEmpty { values.append(("DOMAIN", draft.domain)) }
         if draft.themeID == CustomTheme.id {
             values.append(contentsOf: [

--- a/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
@@ -10,65 +10,38 @@ final class NewSiteWizardModelTests: XCTestCase {
         ])
     }
 
-    func testPickingTypeSetsDefaultTheme() {
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
-        m.choose(type: .blog)               // default for .blog is "warm"
-        XCTAssertEqual(m.draft.themeID, "warm")
+    // MARK: Chooser state (#1071)
+
+    func testStartsOnChooserWithFirstThemeAndUntitledDraft() {
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
+        XCTAssertEqual(m.step, .chooser)
+        XCTAssertEqual(m.draft.themeID, "classic")     // catalog order, not a per-type default
+        XCTAssertEqual(m.draft.name, "Untitled")
+        XCTAssertEqual(m.draft.saveFileName, "Untitled.anglesite")
+        XCTAssertEqual(m.draft.siteType, .blank)
+        XCTAssertEqual(m.draft.domainChoice, .later)   // deferred to publish (#1071)
+        XCTAssertEqual(m.draft.headline, "")           // template placeholder stays
+        XCTAssertTrue(m.canCreate)
     }
 
-    func testPickingTypeDoesNotReplaceCustomTheme() {
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
-        m.draft.themeID = CustomTheme.id
-        m.choose(type: .blog)
-        XCTAssertEqual(m.draft.themeID, CustomTheme.id)
+    func testUntitledNameSkipsTakenNames() {
+        let m = NewSiteWizardModel(catalog: catalog(),
+                                   isNameTaken: { ["Untitled", "Untitled 2"].contains($0) })
+        XCTAssertEqual(m.draft.name, "Untitled 3")
+        XCTAssertEqual(m.draft.saveFileName, "Untitled 3.anglesite")
     }
 
-    func testStartsWithUniversalWebsiteIdentityStep() {
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
-        XCTAssertEqual(m.step, .details)
-        XCTAssertFalse(m.canContinue)
+    func testCanCreateRequiresACatalogTheme() {
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
+        m.draft.themeID = "no-such-theme"
+        XCTAssertFalse(m.canCreate)
+        m.draft.themeID = "warm"
+        XCTAssertTrue(m.canCreate)
     }
 
-    func testCannotContinuePastDetailsWithEmptyOrTakenName() {
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { $0 == "taken" })
-        m.step = .details
-        m.draft.name = ""
-        XCTAssertFalse(m.canContinue)
-        m.draft.name = "Taken"              // slug "taken"
-        XCTAssertFalse(m.canContinue)
-        XCTAssertNotNil(m.detailsError)
-        m.draft.name = "Fresh One"
-        XCTAssertTrue(m.canContinue)
-    }
-
-    func testTransferDomainRequiresDomainValue() {
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
-        m.step = .details
-        m.draft.name = "Fresh One"
-        m.draft.domainChoice = .transfer
-        m.draft.domain = ""
-        XCTAssertFalse(m.canContinue)
-        m.draft.domain = "not a domain"
-        XCTAssertFalse(m.canContinue)
-        m.draft.domain = "localhost"
-        XCTAssertFalse(m.canContinue)
-        m.draft.domain = "example.com"
-        XCTAssertTrue(m.canContinue)
-    }
-
-    func testLookStepAcceptsCustomTheme() {
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
-        m.step = .look
-        m.draft.themeID = CustomTheme.id
-        XCTAssertTrue(m.canContinue)
-    }
-
-    func testSlugPreviewTracksName() {
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
-        m.draft.name = "My Cool Site"
-        XCTAssertEqual(m.slugPreview, "my-cool-site")
-        XCTAssertEqual(m.defaultSaveFileName, "my-cool-site.anglesite")
-        XCTAssertEqual(m.cloudflareDevPreview, "my-cool-site.workers.dev")
+    func testEmptyCatalogCannotCreate() {
+        let m = NewSiteWizardModel(catalog: ThemeCatalog(themes: []), isNameTaken: { _ in false })
+        XCTAssertFalse(m.canCreate)
     }
 
     // MARK: Build warnings (#229)
@@ -99,16 +72,23 @@ final class NewSiteWizardModelTests: XCTestCase {
     }
 
     func testFreshModelHasNoWarningsAndIsNotCompletedCleanly() {
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
         XCTAssertFalse(m.hasWarnings)
         XCTAssertTrue(m.warnings.isEmpty)
         XCTAssertFalse(m.didCompleteCleanly)
     }
 
+    func testBuildEntersBuildingStepAndDisablesCreate() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
+        _ = await m.build(using: warningScaffolder(root: root))
+        XCTAssertEqual(m.step, .building)
+        XCTAssertFalse(m.canCreate)
+    }
+
     func testBuildWithWarningSurfacesWarningAndBlocksCleanCompletion() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        let m = NewSiteWizardModel(catalog: catalog(), slugTaken: { _ in false })
-        m.draft.name = "Warn Site"
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
 
         let id = await m.build(using: warningScaffolder(root: root))
 

--- a/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
@@ -132,6 +132,30 @@ final class SiteScaffolderTests: XCTestCase {
         XCTAssertFalse(cfg.contains("EVIL=1"))
     }
 
+    /// The chooser flow (#1071) hands over a fully-defaulted Untitled draft: blank type, no
+    /// headline/blurb. The template's placeholder homepage must survive untouched, and
+    /// `.site-config` must defer the domain (`later`) and omit `SITE_TYPE` entirely.
+    func testChooserDraftKeepsTemplatePlaceholderAndOmitsSiteType() async throws {
+        let root = tmpDir()
+        let scaffolder = makeScaffolder(root: root)
+        let draft = NewSiteDraft(siteType: .blank, name: "Untitled",
+                                 saveFileName: "Untitled.anglesite",
+                                 themeID: "classic", headline: "")
+        for await _ in scaffolder.scaffold(draft) {}
+
+        let pkgURL = root.appendingPathComponent("Untitled.anglesite")
+        // Homepage untouched: exactly the placeholder the fake scaffold.sh wrote.
+        let home = try String(contentsOf: pkgURL.appendingPathComponent("Source/src/pages/index.astro"), encoding: .utf8)
+        XCTAssertEqual(home, "<section class=\"hero\">\n  <h1>Welcome</h1>\n</section>")
+
+        let cfg = try String(contentsOf: pkgURL.appendingPathComponent("Source/.site-config"), encoding: .utf8)
+        XCTAssertTrue(cfg.contains("SITE_NAME=Untitled"))
+        XCTAssertTrue(cfg.contains("CF_PROJECT_NAME=untitled"))
+        XCTAssertTrue(cfg.contains("DOMAIN_CHOICE=later"))
+        XCTAssertFalse(cfg.contains("SITE_TYPE="))
+        XCTAssertFalse(cfg.contains("TAGLINE="))
+    }
+
     func testCustomColorSchemeAndLogoAreApplied() async throws {
         let root = tmpDir()
         let logo = root.appendingPathComponent("brand.PNG")

--- a/docs/qa/e2e-acceptance-2-new-website.md
+++ b/docs/qa/e2e-acceptance-2-new-website.md
@@ -1,24 +1,24 @@
 # E2E Acceptance — Part 2: Create a New Website
 
 **Sequence:** Part 2 of 4 — requires Part 1's exit state (running app, empty launcher).
-**Scope:** File ▸ New ▸ Site through a live previewing site window: wizard, scaffold on disk, container boot, first render.
+**Scope:** File ▸ New ▸ Site through a live previewing site window: template chooser, scaffold on disk, container boot, first render.
 
 ## Purpose
 
-Verify a user can create a `.anglesite` package end-to-end: the wizard collects name/type/look/content, the scaffold lands a complete git-initialized `Source/` **with a real initial commit** (#697), the site registers in recents, and the container runtime boots to a live preview of the owner's homepage without further user action.
+Verify a user can create a `.anglesite` package end-to-end: the chooser asks exactly one question (which template), the scaffold lands a complete git-initialized `Source/` **with a real initial commit** (#697) named "Untitled" in the sites root, the site registers in recents, and the container runtime boots to a live preview of the owner's homepage without further user action.
 
 ## Preconditions
 
 - Part 1 passed. Container artifacts provisioned and build entitled (overview doc) — otherwise every case from 7 on fails by design.
-- Test inputs used throughout: site name **"QA Bakery"**, type **business**, a non-default built-in theme, headline **"Fresh bread daily"**, domain choice **"Set this up later"**.
+- Test inputs used throughout: a non-default built-in theme picked in the chooser. There is no name/type/content/domain input — the site is created as **"Untitled"** (#1071).
 
 ## Acceptance Matrix
 
 | # | Case | Result | Notes |
 |---|---|---|---|
 | 1 | Wizard entry points |  |  |
-| 2 | Wizard steps, labels, validation |  |  |
-| 3 | Sandbox grant + save panel defaults |  |  |
+| 2 | Chooser, labels, selection |  |  |
+| 3 | Sandbox grant + silent save location |  |  |
 | 4 | Building checklist completes clean |  |  |
 | 5 | Package layout + marker on disk |  |  |
 | 6 | Git repo with initial commit (#697) |  |  |
@@ -39,43 +39,40 @@ All three routes present the same wizard sheet on the launcher window:
 - Dock menu **"New Site"**.
 - Launcher **Add Site → "Create new site…"**.
 
-### 2. Wizard steps, labels, validation
+### 2. Chooser, labels, selection
 
-Walk the six steps (fixed ~520×460 sheet; footer **Back / Cancel / Continue**):
+One screen (fixed ~560×460 sheet; footer **Cancel / Create**):
 
-- **Details** ("Create a website"): "Website name" field; domain radio group **"Buy a domain"** / **"Transfer an existing domain"** / **"Set this up later"**. Selecting "Set this up later" shows the temporary-domain explanation. Continue is disabled until the name is non-empty and the slug untaken; Transfer additionally requires a valid domain.
-  - *Fixed (#703):* the "later" copy now promises a `<slug>.workers.dev` address, matching the actual deploy target. Record the exact copy shown.
-- **Type** ("What kind of website are you creating?"): one card per site type; **business** is the default.
-- **Look** ("Pick a color scheme"): built-in theme grid plus a **Custom** card (primary/accent colors, "Upload Logo…"). Pick a non-default theme so case 8 can verify it applied.
-- **Content** ("First words"): "Homepage headline", optional short description; "Generate hero image…" appears only when Image Playground is available.
-- **Save**: leads to the save panel (case 3).
-- **Building**: case 4.
+- Title **"Choose a Template"**; a grid of theme cards, each a miniature page mock in the
+  theme's colors with name + description. The first catalog theme is pre-selected.
+- Single click selects (accent ring); **double-click creates immediately**.
+- **Create** is the default button (Return). No name field, no domain question, no site-type
+  step, no content step, no save panel (#1071).
+- Cancel must dismiss with nothing on disk.
 
-Cancel at any pre-build step must dismiss with nothing on disk.
-
-### 3. Sandbox grant + save panel defaults
+### 3. Sandbox grant + silent save location
 
 Expected:
 
 - First creation on a sandboxed build usually does **not** raise a "Grant Access" open panel — the app's own iCloud container needs no such grant. The panel only appears when iCloud is unavailable and the site root falls back to `~/Sites/`; in that case granting proceeds and it must not re-prompt for subsequent sites in the same root.
-- The save panel ("Save Your Website", prompt "Save") defaults to the Sites root (the iCloud "Anglesite" folder, or `~/Sites/` if iCloud is unavailable, unless overridden) with filename **`qa-bakery.anglesite`**, and creates the directory if missing.
+- The package lands at `Untitled.anglesite` in the sites root with no panel shown; a second run in the same session lands `Untitled 2.anglesite`.
 
 ### 4. Building checklist completes clean
 
-Expected, in order, all check off: created the website file → copied the template → applied your theme → wrote your words → installing → registering → done. On a clean build the wizard dismisses itself and the site window opens.
+Expected, in order, all check off: created the website file → copied the template → applied your theme → prepared the starter content → installing → registering → done. On a clean build the wizard dismisses itself and the site window opens.
 
 - Warnings (⚠️ rows, e.g. "git init skipped", "Dependency baseline not saved") keep the wizard open with "…something above needs attention" and an **"Open Website Anyway"** button — record any warning verbatim; a clean run should have none.
-- Failures at *create folder*, *copy template*, or *register* are fatal and must roll back the half-written package (verify no orphan `qa-bakery.anglesite` remains after a forced failure, if simulated).
+- Failures at *create folder*, *copy template*, or *register* are fatal and must roll back the half-written package (verify no orphan `Untitled.anglesite` remains after a forced failure, if simulated).
 
 ### 5. Package layout + marker on disk
 
 (Substitute your iCloud "Anglesite" folder for `~/Sites/` below if iCloud is available on the test machine.)
 
-Inspect `~/Sites/qa-bakery.anglesite/`:
+Inspect `~/Sites/Untitled.anglesite/`:
 
-- `Info.plist` marker with format version 1, a stable site UUID, display name "QA Bakery", created date.
+- `Info.plist` marker with format version 1, a stable site UUID, display name "Untitled", created date.
 - `Source/` — the Astro project: `package.json` (name `anglesite-site`), `astro.config.ts`, `src/`, `public/`, `scripts/`, `worker/`, `.site-config`.
-- `.site-config` contains the wizard answers: `SITE_NAME`, `SITE_TYPE`, `DOMAIN_CHOICE`, `THEME`, `TAGLINE`, and the real `ANGLESITE_VERSION` (not the `1.0.0` placeholder).
+- `.site-config` contains: `SITE_NAME=Untitled`, `DOMAIN_CHOICE=later`, `THEME`, `CF_PROJECT_NAME=untitled`, and the real `ANGLESITE_VERSION` (not the `1.0.0` placeholder); **must not contain** `SITE_TYPE` or `TAGLINE`.
 - `Config/` exists beside `Source/` with the dependency baseline; `Config/` is **not** inside the git repo.
 - Excluded from the copy: `scripts/scaffold.sh`, `scripts/themes.ts`, `*.test.ts`, `integrations/`, `node_modules/`.
 - When the package landed in the iCloud folder, any sync indicator (toolbar/inspector) showing this site as iCloud-sync-eligible is **expected, not a regression**: since #865 new sites are created inside the iCloud container, so `ICloudSyncEligibility` (#881) is now true by default rather than only for deliberately-relocated sites.
@@ -85,8 +82,8 @@ Inspect `~/Sites/qa-bakery.anglesite/`:
 In `Source/`:
 
 ```sh
-git -C ~/Sites/qa-bakery.anglesite/Source log --oneline
-git -C ~/Sites/qa-bakery.anglesite/Source status --porcelain
+git -C ~/Sites/Untitled.anglesite/Source log --oneline
+git -C ~/Sites/Untitled.anglesite/Source status --porcelain
 ```
 
 Expected:
@@ -99,7 +96,7 @@ Expected:
 
 Expected without any user action after the wizard:
 
-- The "QA Bakery" window opens (launcher dismisses) and the preview pane enters `.starting`: **"Starting dev server for QA Bakery…"** with a determinate progress bar walking "Starting dev server…" → "Building site…" → "Connecting to preview…", plus an ungated **"Show Logs"** affordance that opens the Debug window.
+- The "Untitled" window opens (launcher dismisses) and the preview pane enters `.starting`: **"Starting dev server for Untitled…"** with a determinate progress bar walking "Starting dev server…" → "Building site…" → "Connecting to preview…", plus an ungated **"Show Logs"** affordance that opens the Debug window.
 - Debug logs show the container path: image import, VM boot, guest `git clone` of `Source/`, `npm install`, `astro dev`, MCP sidecar, vsock proxies. Record cold-start wall-clock time (first boot includes `npm install` — minutes is normal; a silent stall in "Building site…" beyond ~10 min is a fail).
 - The preview URL is loopback (`http://127.0.0.1:<os-assigned port>`) — never a guest IP.
 
@@ -107,14 +104,14 @@ Expected without any user action after the wizard:
 
 Expected once ready:
 
-- Homepage shows headline **"Fresh bread daily"** (not the template default "Welcome"); the chosen theme's colors are visibly applied.
+- Homepage shows the **template placeholder** ("Welcome" hero — the owner edits it in the preview); the chosen theme's colors are visibly applied.
 - `/about` renders the business-profile page; `/blog/` renders the empty state ("No posts yet…" with an RSS link); `/rss.xml` returns a feed.
 - The window's subtitle shows the live preview URL.
 
 ### 9. Recents, window chrome, Finder behavior
 
 - The site appears in the launcher list (green check), **File ▸ Open Recent**, and the Dock menu.
-- Window title is "QA Bakery". Note whether a title-bar proxy icon appears (not currently wired — evidence for #680).
+- Window title is "Untitled". Note whether a title-bar proxy icon appears (not currently wired — evidence for #680).
 - In Finder the package is a single opaque document ("Anglesite Site"); double-clicking it opens/focuses the site in Anglesite. `cd`, `git`, and an external editor still descend into `Source/` normally.
 - Quit and relaunch the app: the last-opened site auto-opens (MRU), skipping the launcher.
 
@@ -124,13 +121,13 @@ Close the site window; within a few seconds no `com.apple.Virtualization` proces
 
 ### 11. Negative: duplicate name / cancelled grant
 
-- Re-run the wizard with the name "QA Bakery" → Details step shows `A site named "qa-bakery" already exists.` and Continue stays disabled.
+- Create two sites in a row without renaming → the second lands as **Untitled 2** (`Untitled 2.anglesite`), no clobber, no error. Also verify an *unregistered* `Untitled.anglesite` folder already sitting in the sites root is skipped the same way.
 - (Fresh sandbox state) Cancel the Grant Access panel → the wizard aborts without creating anything; record whether the abort is communicated or silent.
 
 ### 12. Negative: unprovisioned runtime messaging
 
-On a build without vendored container artifacts (or with them deliberately removed), opening the site must settle to the failed pane — ⚠️ **"Can't preview QA Bakery"** with the missing artifacts named, **Retry** and **Show Logs**, and **no host-subprocess fallback** (no host Node/npm processes spawned).
+On a build without vendored container artifacts (or with them deliberately removed), opening the site must settle to the failed pane — ⚠️ **"Can't preview Untitled"** with the missing artifacts named, **Retry** and **Show Logs**, and **no host-subprocess fallback** (no host Node/npm processes spawned).
 
 ## Exit state for Part 3
 
-"QA Bakery" open with a ready preview; git log shows the single initial commit.
+"Untitled" open with a ready preview; git log shows the single initial commit.

--- a/docs/qa/e2e-acceptance-2-new-website.md
+++ b/docs/qa/e2e-acceptance-2-new-website.md
@@ -16,7 +16,7 @@ Verify a user can create a `.anglesite` package end-to-end: the chooser asks exa
 
 | # | Case | Result | Notes |
 |---|---|---|---|
-| 1 | Wizard entry points |  |  |
+| 1 | Chooser entry points |  |  |
 | 2 | Chooser, labels, selection |  |  |
 | 3 | Sandbox grant + silent save location |  |  |
 | 4 | Building checklist completes clean |  |  |
@@ -26,14 +26,14 @@ Verify a user can create a `.anglesite` package end-to-end: the chooser asks exa
 | 8 | Preview renders the owner's homepage |  |  |
 | 9 | Recents, window chrome, Finder behavior |  |  |
 | 10 | Window close tears down the runtime |  |  |
-| 11 | Negative: duplicate name / cancelled grant |  |  |
+| 11 | Negative: Untitled numbering / cancelled grant |  |  |
 | 12 | Negative: unprovisioned runtime messaging |  |  |
 
 ## Test Cases
 
-### 1. Wizard entry points
+### 1. Chooser entry points
 
-All three routes present the same wizard sheet on the launcher window:
+All three routes present the same template-chooser sheet on the launcher window:
 
 - **File ▸ New ▸ "Site"** (⇧⌘N) — note ⌘N is New Page, not New Site.
 - Dock menu **"New Site"**.
@@ -59,9 +59,9 @@ Expected:
 
 ### 4. Building checklist completes clean
 
-Expected, in order, all check off: created the website file → copied the template → applied your theme → prepared the starter content → installing → registering → done. On a clean build the wizard dismisses itself and the site window opens.
+Expected, in order, all check off: created the website file → copied the template → applied your theme → prepared the starter content → installing → registering → done. On a clean build the chooser dismisses itself and the site window opens.
 
-- Warnings (⚠️ rows, e.g. "git init skipped", "Dependency baseline not saved") keep the wizard open with "…something above needs attention" and an **"Open Website Anyway"** button — record any warning verbatim; a clean run should have none.
+- Warnings (⚠️ rows, e.g. "git init skipped", "Dependency baseline not saved") keep the chooser open with "…something above needs attention" and an **"Open Website Anyway"** button — record any warning verbatim; a clean run should have none.
 - Failures at *create folder*, *copy template*, or *register* are fatal and must roll back the half-written package (verify no orphan `Untitled.anglesite` remains after a forced failure, if simulated).
 
 ### 5. Package layout + marker on disk
@@ -94,7 +94,7 @@ Expected:
 
 ### 7. Site window opens; dev server auto-boots
 
-Expected without any user action after the wizard:
+Expected without any user action after the chooser:
 
 - The "Untitled" window opens (launcher dismisses) and the preview pane enters `.starting`: **"Starting dev server for Untitled…"** with a determinate progress bar walking "Starting dev server…" → "Building site…" → "Connecting to preview…", plus an ungated **"Show Logs"** affordance that opens the Debug window.
 - Debug logs show the container path: image import, VM boot, guest `git clone` of `Source/`, `npm install`, `astro dev`, MCP sidecar, vsock proxies. Record cold-start wall-clock time (first boot includes `npm install` — minutes is normal; a silent stall in "Building site…" beyond ~10 min is a fail).
@@ -119,10 +119,10 @@ Expected once ready:
 
 Close the site window; within a few seconds no `com.apple.Virtualization` process remains, both vsock proxies are gone, and per-site ext4 artifacts are removed or accounted for (same bar as the container smoke doc).
 
-### 11. Negative: duplicate name / cancelled grant
+### 11. Negative: Untitled numbering / cancelled grant
 
 - Create two sites in a row without renaming → the second lands as **Untitled 2** (`Untitled 2.anglesite`), no clobber, no error. Also verify an *unregistered* `Untitled.anglesite` folder already sitting in the sites root is skipped the same way.
-- (Fresh sandbox state) Cancel the Grant Access panel → the wizard aborts without creating anything; record whether the abort is communicated or silent.
+- (Fresh sandbox state) Cancel the Grant Access panel → the chooser aborts without creating anything; record whether the abort is communicated or silent.
 
 ### 12. Negative: unprovisioned runtime messaging
 

--- a/docs/superpowers/plans/2026-07-31-new-site-chooser.md
+++ b/docs/superpowers/plans/2026-07-31-new-site-chooser.md
@@ -1,0 +1,774 @@
+# New Site Template Chooser Implementation Plan (#1071)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the six-step New Site wizard to a single Pages-style template chooser: pick a theme card → site scaffolds as "Untitled" into the default location → preview opens. Spec: `docs/superpowers/specs/2026-07-31-new-site-chooser-design.md`.
+
+**Architecture:** `NewSiteWizardModel` (AnglesiteCore) loses its step machine and validation, keeping only `chooser → building`; it derives an Untitled name at init. `SiteScaffolder` learns to skip the homepage write when the draft has no content and to omit `SITE_TYPE` for blank drafts. `NewSiteWizard` (AnglesiteApp) becomes a theme-card grid. `SitesLauncherView` supplies a name-availability closure (registry + disk).
+
+**Tech Stack:** Swift 6.4 / SwiftUI (macOS 27+), XCTest (AnglesiteCoreTests is an XCTest holdout — do not convert to Swift Testing), XcodeGen.
+
+## Global Constraints
+
+- Worktree: run `xcodegen generate` before any app build; `Anglesite.xcodeproj` is gitignored (CLAUDE.md ▸ Worktrees).
+- Build the app with `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`, never raw `xcodebuild`.
+- `swift test` needs `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` (CommandLineTools swift is too old). `--filter` still compiles the whole package.
+- Do **not** modify `Resources/Template/` — the template's existing placeholder content ("Welcome" hero, about/blog pages) is the post-chooser starting content. Placeholder copy improvements belong to the ported-themes follow-up epic.
+- No new dependencies. Conventional commits, subject ≤72 chars, issue number in subject.
+- User-visible strings changed in `Sources/AnglesiteApp` require the String Catalog sync (Task 5) per CONTRIBUTING.md — CLI builds don't merge `.xcstrings`.
+- Serialize full `swift test` runs (never two concurrent — FoundationModels suites hang under contention).
+- If the app build fails at "Check container resources", rsync `Resources/container-image`, `Resources/container-kernel`, `Resources/container-initfs` from the main checkout into the worktree.
+
+---
+
+### Task 1: Collapse `NewSiteWizardModel` to chooser → building
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/NewSiteWizardModel.swift` (full rewrite below)
+- Test: `Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift` (full rewrite below)
+
+**Interfaces:**
+- Consumes: `ThemeCatalog`, `NewSiteDraft`, `SiteScaffolder` (all unchanged in this task).
+- Produces (Tasks 3–4 rely on these exact members): `init(catalog: ThemeCatalog, isNameTaken: (String) -> Bool)` (closure receives a candidate display name like `"Untitled 2"`, is **non-escaping**, used only during init); `step: Step` with `enum Step { case chooser, building }`; `draft: NewSiteDraft`; `canCreate: Bool`; `build(using:) async -> String?`; unchanged: `progress`, `fatal`, `completedSiteID`, `warnings`, `hasWarnings`, `didCompleteCleanly`, `catalog`.
+- **Removed** (Task 3 must not reference them): `defaultSaveDirectory`, `slugTaken` param, `advance()`, `back()`, `canContinue`, `choose(type:)`, `detailsError`, `slugPreview`, `defaultSaveFileName`, `cloudflareDevPreview`, `isValidDomain`, `showingImagePlayground`, `heroImageConcepts`, `hasHeroImage`, `setHeroImage(_:)`.
+
+- [ ] **Step 1: Rewrite the test file with the new expectations**
+
+Replace the entire contents of `Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift` with:
+
+```swift
+import XCTest
+@testable import AnglesiteCore
+
+@MainActor
+final class NewSiteWizardModelTests: XCTestCase {
+    private func catalog() -> ThemeCatalog {
+        ThemeCatalog(themes: [
+            Theme(id: "classic", name: "Classic", blurb: "", swatch: [], cssVars: [:]),
+            Theme(id: "warm", name: "Warm", blurb: "", swatch: [], cssVars: [:]),
+        ])
+    }
+
+    // MARK: Chooser state (#1071)
+
+    func testStartsOnChooserWithFirstThemeAndUntitledDraft() {
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
+        XCTAssertEqual(m.step, .chooser)
+        XCTAssertEqual(m.draft.themeID, "classic")     // catalog order, not a per-type default
+        XCTAssertEqual(m.draft.name, "Untitled")
+        XCTAssertEqual(m.draft.saveFileName, "Untitled.anglesite")
+        XCTAssertEqual(m.draft.siteType, .blank)
+        XCTAssertEqual(m.draft.domainChoice, .later)   // deferred to publish (#1071)
+        XCTAssertEqual(m.draft.headline, "")           // template placeholder stays
+        XCTAssertTrue(m.canCreate)
+    }
+
+    func testUntitledNameSkipsTakenNames() {
+        let m = NewSiteWizardModel(catalog: catalog(),
+                                   isNameTaken: { ["Untitled", "Untitled 2"].contains($0) })
+        XCTAssertEqual(m.draft.name, "Untitled 3")
+        XCTAssertEqual(m.draft.saveFileName, "Untitled 3.anglesite")
+    }
+
+    func testCanCreateRequiresACatalogTheme() {
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
+        m.draft.themeID = "no-such-theme"
+        XCTAssertFalse(m.canCreate)
+        m.draft.themeID = "warm"
+        XCTAssertTrue(m.canCreate)
+    }
+
+    func testEmptyCatalogCannotCreate() {
+        let m = NewSiteWizardModel(catalog: ThemeCatalog(themes: []), isNameTaken: { _ in false })
+        XCTAssertFalse(m.canCreate)
+    }
+
+    // MARK: Build warnings (#229)
+
+    /// A scaffolder whose `scaffold.sh` writes the template files the appliers expect, then emits a
+    /// non-fatal `git init` warning.
+    private func warningScaffolder(root: URL) -> SiteScaffolder {
+        SiteScaffolder(
+            sitesRoot: root,
+            templateURL: URL(fileURLWithPath: "/template"),
+            catalog: catalog(),
+            run: { _, args, cwd in
+                if args.contains(where: { $0.hasSuffix("scaffold.sh") }), let cwd {
+                    let css = cwd.appendingPathComponent("src/styles/global.css")
+                    let astro = cwd.appendingPathComponent("src/pages/index.astro")
+                    try? FileManager.default.createDirectory(at: css.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? FileManager.default.createDirectory(at: astro.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? ":root { --color-primary: #2563eb; }".write(to: css, atomically: true, encoding: .utf8)
+                    try? "<h1>Welcome</h1>".write(to: astro, atomically: true, encoding: .utf8)
+                    try? "ANGLESITE_VERSION=1.0.0".write(to: cwd.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+                }
+                return ProcessSupervisor.RunResult(stdout: "", stderr: "", exitCode: 0)
+            },
+            gitInit: { _ in throw CocoaError(.fileWriteUnknown) },
+            gitCommit: { _ in },
+            register: { pkg in SiteStore.Site(id: pkg.url.path, name: pkg.url.lastPathComponent, packageURL: pkg.url, isValid: true, missingSentinels: []) }
+        )
+    }
+
+    func testFreshModelHasNoWarningsAndIsNotCompletedCleanly() {
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
+        XCTAssertFalse(m.hasWarnings)
+        XCTAssertTrue(m.warnings.isEmpty)
+        XCTAssertFalse(m.didCompleteCleanly)
+    }
+
+    func testBuildEntersBuildingStepAndDisablesCreate() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
+        _ = await m.build(using: warningScaffolder(root: root))
+        XCTAssertEqual(m.step, .building)
+        XCTAssertFalse(m.canCreate)
+    }
+
+    func testBuildWithWarningSurfacesWarningAndBlocksCleanCompletion() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let m = NewSiteWizardModel(catalog: catalog(), isNameTaken: { _ in false })
+
+        let id = await m.build(using: warningScaffolder(root: root))
+
+        XCTAssertNotNil(id)                       // the site was still registered
+        XCTAssertTrue(m.hasWarnings)              // …but with a non-fatal warning
+        // Assert on the stable step identifier, not the (rephrasable) message text.
+        XCTAssertTrue(m.progress.contains {
+            if case .warning(let step, _) = $0 { return step == "copyingTemplate" } else { return false }
+        })
+        XCTAssertFalse(m.didCompleteCleanly)      // so the wizard must NOT auto-open
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /path/to/worktree
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter NewSiteWizardModelTests 2>&1 | tail -20
+```
+
+Expected: **compile failure** — `NewSiteWizardModel` has no `isNameTaken:` initializer, no `.chooser` case, no `canCreate`.
+
+- [ ] **Step 3: Rewrite the model**
+
+Replace the entire contents of `Sources/AnglesiteCore/NewSiteWizardModel.swift` with:
+
+```swift
+import Foundation
+import Observation
+
+/// Observable state behind the New Site template chooser (#1071): theme selection, Untitled
+/// naming, and scaffold progress. All rules (when Create is enabled, what the site is named,
+/// when the finished site may open) live here rather than in the views, so they can be
+/// unit-tested without SwiftUI.
+///
+/// The chooser deliberately asks exactly one question — which template — the iWork model.
+/// Name ("Untitled"), save location (the sites root), domain (deferred to publish), and
+/// homepage content (the template's placeholder copy) are all defaulted, not asked.
+@MainActor
+@Observable
+public final class NewSiteWizardModel {
+    /// The chooser's two states; ``NewSiteWizardModel/build(using:)`` is the only transition.
+    public enum Step: Int, CaseIterable {
+        /// The template grid — the only step with user input.
+        case chooser
+        /// Terminal step while ``NewSiteWizardModel/build(using:)`` runs; ``canCreate`` is
+        /// always `false` here.
+        case building
+    }
+
+    /// The step currently shown. Mutated only by ``build(using:)``.
+    public private(set) var step: Step = .chooser
+    /// The answers handed to the scaffolder at build time. Only ``NewSiteDraft/themeID`` is
+    /// user-set (via the grid); everything else keeps the Untitled defaults from init.
+    public var draft: NewSiteDraft
+    /// Every ``SiteScaffolder/ScaffoldStep`` emitted so far, in order — the Building step's
+    /// live checklist. Append-only; never trimmed, so warnings stay visible after completion.
+    public private(set) var progress: [SiteScaffolder.ScaffoldStep] = []
+    /// The `.failed` step, if any — kept separately from ``progress`` so the UI can branch on
+    /// "the build died" without re-scanning the whole stream.
+    public private(set) var fatal: SiteScaffolder.ScaffoldStep?
+    /// The new site's registered id once scaffolding reaches `.done`; `nil` until then (or on
+    /// failure). Gate opening the site on ``didCompleteCleanly``, not just this being non-nil.
+    public private(set) var completedSiteID: String?
+
+    /// Themes shown in the grid; the first entry is pre-selected (no site type exists to drive
+    /// the per-type default table).
+    public let catalog: ThemeCatalog
+
+    /// Creates the model with a fully-defaulted Untitled draft.
+    ///
+    /// - Parameters:
+    ///   - catalog: Themes for the grid; its first entry seeds ``NewSiteDraft/themeID``.
+    ///   - isNameTaken: Availability check for a candidate display name (e.g. "Untitled 2").
+    ///     The caller decides what "taken" means — the launcher checks both the recents
+    ///     registry and the sites root on disk. Non-escaping: consulted only here, at init.
+    public init(catalog: ThemeCatalog, isNameTaken: (String) -> Bool) {
+        self.catalog = catalog
+        let name = Self.untitledName(isTaken: isNameTaken)
+        // headline "" on purpose (overriding NewSiteDraft's default of `name`): the scaffolder
+        // skips the homepage write for a contentless draft, leaving the template's placeholder
+        // copy for the owner to edit in the preview (#1071).
+        var draft = NewSiteDraft(siteType: .blank, name: name,
+                                 saveFileName: "\(name).anglesite", headline: "")
+        draft.themeID = catalog.themes.first?.id ?? ""
+        self.draft = draft
+    }
+
+    /// First free name in "Untitled", "Untitled 2", "Untitled 3", … — the Mac document
+    /// convention. Not localized: AnglesiteCore has no string catalog (app-target only).
+    static func untitledName(isTaken: (String) -> Bool) -> String {
+        for n in 1...9999 {
+            let candidate = n == 1 ? "Untitled" : "Untitled \(n)"
+            if !isTaken(candidate) { return candidate }
+        }
+        // 9999 collisions means something is systematically wrong; fall back to a unique name
+        // rather than looping forever.
+        return "Untitled \(UUID().uuidString.prefix(8))"
+    }
+
+    /// Gate for the chooser's Create button (and double-click): a real catalog theme is
+    /// selected and no build is running.
+    public var canCreate: Bool {
+        step == .chooser && catalog.theme(id: draft.themeID) != nil
+    }
+
+    /// Non-fatal build warnings (e.g. a failed install), surfaced so a failure isn't hidden behind a dead-end preview (#229).
+    public var warnings: [String] {
+        progress.compactMap { if case .warning(_, let message) = $0 { return message } else { return nil } }
+    }
+
+    /// Convenience over ``warnings`` for the chooser's "finished with warnings" branch.
+    public var hasWarnings: Bool { !warnings.isEmpty }
+
+    /// Site registered with no warnings — only then may the chooser open it immediately (else it stays put so warnings are read) (#229).
+    public var didCompleteCleanly: Bool { completedSiteID != nil && !hasWarnings }
+
+    /// Runs the scaffolder, accumulating progress. Returns the new site id on success.
+    public func build(using scaffolder: SiteScaffolder) async -> String? {
+        step = .building
+        for await s in scaffolder.scaffold(draft) {
+            progress.append(s)
+            if case .failed = s { fatal = s }
+            if case .done(let id) = s { completedSiteID = id }
+        }
+        return completedSiteID
+    }
+}
+```
+
+Note `step` became `private(set)` — nothing outside the model sets it anymore. If the old tests' `m.step = .details` pattern sneaks back, that's a compile error, which is correct.
+
+- [ ] **Step 4: Run the model tests — expect the package build to fail in dependents, not the model**
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter NewSiteWizardModelTests 2>&1 | tail -20
+```
+
+`Sources/AnglesiteApp` is **not** a SwiftPM target, so the package still compiles; only the app target (Tasks 3–4) references the removed members. Expected: PASS (all tests in `NewSiteWizardModelTests`).
+
+If other package targets fail to compile (e.g. an intents file referencing a removed member), fix the call site in this task — grep first:
+
+```bash
+grep -rn "slugTaken\|canContinue\|choose(type:\|detailsError\|cloudflareDevPreview\|defaultSaveDirectory" Sources/AnglesiteCore Sources/AnglesiteIntents Sources/AnglesiteSiteModel Sources/AnglesiteBridge
+```
+
+Expected: no hits outside `NewSiteWizardModel.swift` (verified at planning time — the only consumers are `Sources/AnglesiteApp/NewSiteWizard.swift` and `SitesLauncherView.swift`, handled in Tasks 3–4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NewSiteWizardModel.swift Tests/AnglesiteCoreTests/NewSiteWizardModelTests.swift
+git commit -m "feat(#1071): collapse NewSiteWizardModel to chooser step machine"
+```
+
+---
+
+### Task 2: Scaffolder skips homepage write and SITE_TYPE for chooser drafts
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteScaffolder.swift:144-151` (homepage write) and `:211-235` (`appendSiteConfig`)
+- Test: `Tests/AnglesiteCoreTests/SiteScaffolderTests.swift` (add one test)
+
+**Interfaces:**
+- Consumes: `NewSiteDraft` with `siteType == .blank`, empty `headline`/`blurb` (produced by Task 1's init).
+- Produces: on-disk behavior only — `Source/src/pages/index.astro` untouched and no `SITE_TYPE=` line in `.site-config` for such drafts. No API changes.
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `Tests/AnglesiteCoreTests/SiteScaffolderTests.swift` (inside the class, after `testSiteConfigValuesAreSanitizedAndBlurbBackfillsTagline`):
+
+```swift
+    /// The chooser flow (#1071) hands over a fully-defaulted Untitled draft: blank type, no
+    /// headline/blurb. The template's placeholder homepage must survive untouched, and
+    /// `.site-config` must defer the domain (`later`) and omit `SITE_TYPE` entirely.
+    func testChooserDraftKeepsTemplatePlaceholderAndOmitsSiteType() async throws {
+        let root = tmpDir()
+        let scaffolder = makeScaffolder(root: root)
+        let draft = NewSiteDraft(siteType: .blank, name: "Untitled",
+                                 saveFileName: "Untitled.anglesite",
+                                 themeID: "classic", headline: "")
+        for await _ in scaffolder.scaffold(draft) {}
+
+        let pkgURL = root.appendingPathComponent("Untitled.anglesite")
+        // Homepage untouched: exactly the placeholder the fake scaffold.sh wrote.
+        let home = try String(contentsOf: pkgURL.appendingPathComponent("Source/src/pages/index.astro"), encoding: .utf8)
+        XCTAssertEqual(home, "<section class=\"hero\">\n  <h1>Welcome</h1>\n</section>")
+
+        let cfg = try String(contentsOf: pkgURL.appendingPathComponent("Source/.site-config"), encoding: .utf8)
+        XCTAssertTrue(cfg.contains("SITE_NAME=Untitled"))
+        XCTAssertTrue(cfg.contains("CF_PROJECT_NAME=untitled"))
+        XCTAssertTrue(cfg.contains("DOMAIN_CHOICE=later"))
+        XCTAssertFalse(cfg.contains("SITE_TYPE="))
+        XCTAssertFalse(cfg.contains("TAGLINE="))
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter SiteScaffolderTests.testChooserDraftKeepsTemplatePlaceholderAndOmitsSiteType 2>&1 | tail -10
+```
+
+Expected: FAIL — `index.astro` was rewritten by `HomepageWriter` (empty `<h1></h1>`), and `cfg` contains `SITE_TYPE=blank`.
+
+- [ ] **Step 3: Implement the two skips**
+
+In `Sources/AnglesiteCore/SiteScaffolder.swift`, replace the homepage block (currently lines 144–151):
+
+```swift
+        // 4. Homepage (non-fatal). Skipped when the draft has no content at all — the chooser
+        // flow (#1071) ships the template's placeholder copy for the owner to edit in the
+        // preview; intents/AI paths that supply real words still get them written.
+        emit(.writingContent)
+        let metadataDescription = draft.tagline.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? draft.blurb
+            : draft.tagline
+        let hasHomepageContent = !draft.headline.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !draft.blurb.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if hasHomepageContent {
+            do { try HomepageWriter.write(headline: draft.headline, blurb: draft.blurb,
+                                          tagline: metadataDescription, siteDirectory: siteDir, fileManager: fileManager) }
+            catch { emit(.warning(step: "writingContent", message: humanize(error))) }
+        }
+```
+
+And in `appendSiteConfig` (currently lines 211–235), replace the fixed `values` array head:
+
+```swift
+        var values: [(String, String)] = [("SITE_NAME", draft.name)]
+        // `.blank` is the chooser flow's "no answer" (#1071) — nothing reads SITE_TYPE back,
+        // so an unasked question writes no key rather than a fake answer.
+        if draft.siteType != .blank { values.append(("SITE_TYPE", draft.siteType.rawValue)) }
+        values.append(contentsOf: [
+            ("DOMAIN_CHOICE", draft.domainChoice.rawValue),
+            ("CF_PROJECT_NAME", cfProjectName),
+            ("LANG", hostLanguage()),
+        ])
+```
+
+(The rest of `appendSiteConfig` — DOMAIN, THEME/COLOR_*, TAGLINE, LOGO — is unchanged.)
+
+- [ ] **Step 4: Run the scaffolder + wizard-model suites**
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . --filter "SiteScaffolderTests|SiteScaffolderPackageTests|NewSiteWizardModelTests|HomepageWriterTests" 2>&1 | tail -10
+```
+
+Expected: PASS. `testHappyPathEmitsStepsInOrderAndRegisters` still passes because `makeDraft()` uses `.business` with a headline — both skips are inert for it. A pre-existing site type `.blank` draft was never constructed by production code before, so no behavior regresses.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteScaffolder.swift Tests/AnglesiteCoreTests/SiteScaffolderTests.swift
+git commit -m "feat(#1071): skip homepage write and SITE_TYPE for chooser drafts"
+```
+
+---
+
+### Task 3: Rebuild the wizard UI as the template chooser
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/NewSiteWizard.swift` (full rewrite below)
+- Modify: `Sources/AnglesiteApp/SitesLauncherView.swift:441-446` (model construction)
+
+There are no unit tests for the app target (it isn't hosted on CI — CLAUDE.md ▸ Build); verification is the Debug build compiling plus Task 6's manual smoke. Model logic was tested in Task 1.
+
+**Interfaces:**
+- Consumes: Task 1's `NewSiteWizardModel` surface (`init(catalog:isNameTaken:)`, `.chooser`/`.building`, `canCreate`, `build(using:)`, `progress`, `fatal`, `completedSiteID`, `hasWarnings`), `Theme` (`name`, `blurb`, `cssVars`), `SiteSlug.derive(from:)`.
+- Produces: `NewSiteWizard(model:scaffolder:onComplete:onCancel:)` — the same view signature `SitesLauncherView`'s sheet already uses, so the sheet call site (lines 83–106) is untouched.
+
+- [ ] **Step 1: Rewrite `NewSiteWizard.swift`**
+
+Replace the entire contents of `Sources/AnglesiteApp/NewSiteWizard.swift` with:
+
+```swift
+import SwiftUI
+import AppKit
+import AnglesiteCore
+
+/// The New Site template chooser (#1071) — the iWork model: one question (which template),
+/// then the site scaffolds as "Untitled" into the default location and opens in the preview.
+/// Presented from SitesLauncherView; calls `onComplete(siteID)` when the site is scaffolded
+/// and registered.
+struct NewSiteWizard: View {
+    @Bindable var model: NewSiteWizardModel
+    let scaffolder: SiteScaffolder
+    let onComplete: (String) -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            content
+            Divider()
+            footer
+        }
+        .frame(width: 560, height: 460)
+    }
+
+    @ViewBuilder private var content: some View {
+        switch model.step {
+        case .chooser:  chooserStep
+        case .building: buildingStep
+        }
+    }
+
+    private var chooserStep: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Choose a Template").font(.title2.bold())
+            ScrollView {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))], spacing: 12) {
+                    ForEach(model.catalog.themes) { theme in
+                        Button { model.draft.themeID = theme.id } label: {
+                            ThemePreviewCard(theme: theme, isSelected: model.draft.themeID == theme.id)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        // Double-click = choose and create, the document-chooser convention.
+                        .simultaneousGesture(TapGesture(count: 2).onEnded {
+                            model.draft.themeID = theme.id
+                            create()
+                        })
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("\(theme.name). \(theme.blurb)")
+                        .accessibilityValue(model.draft.themeID == theme.id ? "Selected" : "")
+                    }
+                }
+            }
+        }.padding(24)
+    }
+
+    private var buildingStep: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Building your website\u{2026}").font(.title2.bold())
+            ForEach(Array(model.progress.enumerated()), id: \.offset) { _, s in
+                Text(label(for: s)).font(.callout)
+                    // The visible label leads with an emoji status glyph; give VoiceOver clean text.
+                    .accessibilityLabel(accessibilityLabel(for: s))
+            }
+            if case .failed(_, let msg) = model.fatal {
+                Text(msg).font(.caption).foregroundStyle(.red).textSelection(.enabled)
+                    .accessibilityLabel("Build failed")
+                    .accessibilityValue(msg)
+            }
+            if model.completedSiteID != nil && model.hasWarnings {
+                Text("Your website was created, but something above needs attention before it can preview. You can open it anyway and fix it from the website window.")
+                    .font(.caption).foregroundStyle(.secondary).textSelection(.enabled)
+                    .accessibilityLabel("Your website was created with warnings. You can open it anyway and fix it from the website window.")
+            }
+        }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func label(for step: SiteScaffolder.ScaffoldStep) -> String {
+        switch step {
+        case .creatingFolder: return "\u{2705} Created the website file"
+        case .copyingTemplate: return "\u{2705} Copied the template"
+        case .applyingTheme: return "\u{2705} Applied your theme"
+        case .writingContent: return "\u{2705} Prepared the starter content"
+        case .installing: return "\u{23F3} Installing\u{2026}"
+        case .registering: return "\u{2705} Registering"
+        case .warning(_, let m): return "\u{26A0}\u{FE0F} \(m)"
+        case .failed(_, let m): return "\u{274C} \(m)"
+        case .done: return "\u{2705} Done"
+        }
+    }
+
+    /// Emoji-free version of `label(for:)` for VoiceOver, which would otherwise read the status
+    /// glyph as "check mark", "hourglass", etc. before the actual message.
+    private func accessibilityLabel(for step: SiteScaffolder.ScaffoldStep) -> String {
+        switch step {
+        case .creatingFolder:    return "Created the website file"
+        case .copyingTemplate:   return "Copied the template"
+        case .applyingTheme:     return "Applied your theme"
+        case .writingContent:    return "Prepared the starter content"
+        case .installing:        return "Installing…"
+        case .registering:       return "Registering"
+        case .warning(_, let m): return "Warning: \(m)"
+        case .failed(_, let m):  return "Failed: \(m)"
+        case .done:              return "Done"
+        }
+    }
+
+    @ViewBuilder private var footer: some View {
+        HStack {
+            Spacer()
+            // No Cancel once building starts: the scaffold pipeline isn't cancellable and
+            // always reaches .done or .failed (failure shows Close below), so cancelling
+            // mid-build would leak the in-flight work and the MAS security scope.
+            if model.step == .chooser {
+                Button("Cancel") { onCancel() }
+                Button("Create") { create() }
+                    .keyboardShortcut(.defaultAction).disabled(!model.canCreate)
+            } else if let id = model.completedSiteID, model.hasWarnings {
+                Button("Open Website Anyway") { onComplete(id) }.keyboardShortcut(.defaultAction)
+            } else if model.completedSiteID == nil && model.fatal != nil {
+                Button("Close") { onCancel() }
+            }
+        }.padding(.horizontal, 16).padding(.vertical, 10)
+    }
+
+    private func create() {
+        guard model.canCreate else { return }
+        // Auto-open only on a clean build; with warnings, stay put so the owner sees them (#229).
+        Task {
+            _ = await model.build(using: scaffolder)
+            if model.didCompleteCleanly, let id = model.completedSiteID { onComplete(id) }
+        }
+    }
+}
+
+/// One template card: a miniature page mock (nav bar, hero block, text lines) drawn from the
+/// theme's own palette, so each card previews a page rather than a bare swatch strip (#1071).
+private struct ThemePreviewCard: View {
+    let theme: Theme
+    let isSelected: Bool
+
+    private var primary: Color { Color(hex: theme.cssVars["color-primary"] ?? "#333333") }
+    private var accent: Color { Color(hex: theme.cssVars["color-accent"] ?? "#888888") }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 4) {
+                    Circle().fill(accent).frame(width: 6, height: 6)
+                    Capsule().fill(Color.white.opacity(0.9)).frame(width: 34, height: 4)
+                    Spacer()
+                }
+                .padding(6)
+                .background(primary)
+                RoundedRectangle(cornerRadius: 2).fill(accent.opacity(0.85)).frame(height: 22)
+                    .padding(.horizontal, 6)
+                Capsule().fill(Color.primary.opacity(0.5)).frame(width: 70, height: 4)
+                    .padding(.horizontal, 6)
+                Capsule().fill(Color.primary.opacity(0.25)).frame(height: 3)
+                    .padding(.horizontal, 6)
+                Capsule().fill(Color.primary.opacity(0.25)).frame(width: 90, height: 3)
+                    .padding(.horizontal, 6).padding(.bottom, 8)
+            }
+            .background(Color(NSColor.textBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(Color.primary.opacity(0.1)))
+            .accessibilityHidden(true)
+            Text(theme.name).font(.subheadline.bold())
+            Text(theme.blurb).font(.caption2).foregroundStyle(.secondary).lineLimit(2)
+        }
+        .padding(8)
+        .overlay(RoundedRectangle(cornerRadius: 8)
+            .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2))
+    }
+}
+
+/// Minimal hex -> Color for theme cards (#rrggbb). Also used by ThemeApplyWizard — keep it
+/// here (module-internal) when refactoring this file.
+extension Color {
+    init(hex: String) {
+        let h = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        var rgb: UInt64 = 0
+        Scanner(string: h).scanHexInt64(&rgb)
+        self = Color(.sRGB,
+                     red: Double((rgb >> 16) & 0xFF) / 255,
+                     green: Double((rgb >> 8) & 0xFF) / 255,
+                     blue: Double(rgb & 0xFF) / 255)
+    }
+}
+```
+
+Deliberately gone (removed, not moved): `ImagePlaygroundPresenter` and the `ImagePlayground` import, `detailsStep`, `typeStep`, `lookStep`, `contentStep`, `saveStep`, `customColorScheme`, `heroImageSection`, `isImagePlaygroundAvailable`, `saveWebsite()`, `chooseLogo()`, `colorBinding(_:)`, `cloudflareDomainsURL`, and the `Color.hexString` accessor (its only consumer was `colorBinding`; verified at planning time — `ThemeApplyWizard.swift` uses only `Color(hex:)`).
+
+- [ ] **Step 2: Update the launcher's model construction**
+
+In `Sources/AnglesiteApp/SitesLauncherView.swift`, replace (currently lines 441–446):
+
+```swift
+        // Load persisted registry to derive taken slugs; no scan needed (registry = source of truth).
+        try? await SiteStore.shared.load()
+        let knownSites = await SiteStore.shared.sites
+        let takenSlugs = Set(knownSites.map { SiteSlug.derive(from: $0.name) })
+
+        let model = NewSiteWizardModel(catalog: catalog, defaultSaveDirectory: sitesRoot, slugTaken: { takenSlugs.contains($0) })
+```
+
+with:
+
+```swift
+        // Load persisted registry to derive taken slugs; no scan needed (registry = source of truth).
+        try? await SiteStore.shared.load()
+        let knownSites = await SiteStore.shared.sites
+        let takenSlugs = Set(knownSites.map { SiteSlug.derive(from: $0.name) })
+
+        // "Untitled N" availability (#1071): taken if it collides with a registered site's slug
+        // OR a package already on disk in the sites root (registered or not) — silent save must
+        // never clobber an existing folder.
+        let model = NewSiteWizardModel(catalog: catalog, isNameTaken: { name in
+            takenSlugs.contains(SiteSlug.derive(from: name))
+                || FileManager.default.fileExists(atPath: sitesRoot.appendingPathComponent("\(name).anglesite").path)
+        })
+```
+
+- [ ] **Step 3: Build the app**
+
+```bash
+cd /path/to/worktree
+xcodegen generate
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -5
+```
+
+Expected: `BUILD SUCCEEDED`. Any "cannot find … in scope" error here means a leftover reference to a removed model member — fix the reference, don't re-add the member.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/NewSiteWizard.swift Sources/AnglesiteApp/SitesLauncherView.swift
+git commit -m "feat(#1071): replace new-site wizard with template chooser"
+```
+
+---
+
+### Task 4: Full package test run
+
+**Files:** none (verification gate).
+
+- [ ] **Step 1: Run the whole SwiftPM suite** (serialize — no concurrent `swift test` on this machine)
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path . 2>&1 | tail -15
+```
+
+Expected: all suites pass. Known trap: if it hangs with no output, check `pgrep -fl swift-test` for an orphan holding the `.build` lock. If `AnglesiteIntentsTests` or FoundationModels suites fail flakily, re-run once alone before investigating (see memory: FM contention).
+
+- [ ] **Step 2: No commit** — this task produces no changes; failures route back to the task that broke them.
+
+---
+
+### Task 5: String Catalog sync
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/Localizable.xcstrings` (generated sync — review, don't hand-edit)
+
+New user-visible strings ("Choose a Template", "Create", "Prepared the starter content") were added and many removed; CLI builds don't merge the catalog (CONTRIBUTING.md ▸ "Commit String Catalog updates").
+
+- [ ] **Step 1: Build, then sync scoped to THIS worktree's BUILD_DIR**
+
+```bash
+cd /path/to/worktree
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+BUILD_DIR=$(xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug -showBuildSettings 2>/dev/null | awk '/ BUILD_DIR =/{print $3}')
+xcrun xcstringstool sync Sources/AnglesiteApp/Localizable.xcstrings \
+  --stringsdata $(find "$(dirname "$BUILD_DIR")/Intermediates.noindex/Anglesite.build/Debug/Anglesite.build/Objects-normal/arm64" -name "*.stringsdata") \
+  --skip-marking-strings-stale
+```
+
+Never glob `~/Library/Developer/Xcode/DerivedData/Anglesite-*` — sibling worktrees pollute it. Always `--skip-marking-strings-stale`.
+
+- [ ] **Step 2: Review the diff**
+
+```bash
+git diff --stat Sources/AnglesiteApp/Localizable.xcstrings
+git diff Sources/AnglesiteApp/Localizable.xcstrings | head -80
+```
+
+Expected: **added** keys only from this change ("Choose a Template", "Create", "Prepared the starter content", the combined accessibility strings). Removed wizard strings ("Website name", "Pick a color scheme", …) will *remain* in the catalog (the `--skip-marking-strings-stale` trade-off) — that's expected; do not hand-delete them. If the diff contains keys from unrelated in-flight branches, discard and re-run scoped to this worktree's `BUILD_DIR`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/Localizable.xcstrings
+git commit -m "chore(#1071): sync string catalog for template chooser"
+```
+
+---
+
+### Task 6: Update the QA acceptance doc + manual smoke
+
+**Files:**
+- Modify: `docs/qa/e2e-acceptance-2-new-website.md`
+
+- [ ] **Step 1: Rewrite the wizard-specific sections**
+
+Apply these edits (leave cases 5–12's container/git/runtime content intact except where noted):
+
+1. **Scope line (line 4):** replace with
+   `**Scope:** File ▸ New ▸ Site through a live previewing site window: template chooser, scaffold on disk, container boot, first render.`
+2. **Purpose (line 8):** replace the first clause with
+   `Verify a user can create a \`.anglesite\` package end-to-end: the chooser asks exactly one question (which template), the scaffold lands a complete git-initialized \`Source/\` **with a real initial commit** (#697) named "Untitled" in the sites root, …` (keep the rest).
+3. **Preconditions test inputs (line 13):** replace with
+   `- Test inputs used throughout: a non-default built-in theme picked in the chooser. There is no name/type/content/domain input — the site is created as **"Untitled"** (#1071).`
+4. **Case 2** (retitle "Chooser, labels, selection"): replace the six-step walk with:
+
+   ```markdown
+   ### 2. Chooser, labels, selection
+
+   One screen (fixed ~560×460 sheet; footer **Cancel / Create**):
+
+   - Title **"Choose a Template"**; a grid of theme cards, each a miniature page mock in the
+     theme's colors with name + description. The first catalog theme is pre-selected.
+   - Single click selects (accent ring); **double-click creates immediately**.
+   - **Create** is the default button (Return). No name field, no domain question, no site-type
+     step, no content step, no save panel (#1071).
+   - Cancel must dismiss with nothing on disk.
+   ```
+5. **Case 3** (retitle "Sandbox grant + silent save location"): drop the save-panel paragraph; keep the grant expectations and state the package lands at `Untitled.anglesite` in the sites root with no panel shown; a second run in the same session lands `Untitled 2.anglesite`.
+6. **Case 4:** update the checklist copy: `created the website file → copied the template → applied your theme → prepared the starter content → installing → registering → done`.
+7. **Case 5:** substitute `Untitled.anglesite` for `qa-bakery.anglesite`; display name "Untitled"; `.site-config` line becomes: contains `SITE_NAME=Untitled`, `DOMAIN_CHOICE=later`, `THEME`, `CF_PROJECT_NAME=untitled`, and the real `ANGLESITE_VERSION`; **must not contain** `SITE_TYPE` or `TAGLINE`.
+8. **Case 6/7/8/9/10/12:** substitute "Untitled" / `Untitled.anglesite` for "QA Bakery" / `qa-bakery.anglesite` throughout. Case 8's homepage expectation becomes: homepage shows the **template placeholder** ("Welcome" hero — the owner edits it in the preview); the chosen theme's colors are visibly applied; `/about`, `/blog/`, `/rss.xml` expectations unchanged.
+9. **Case 11:** replace the duplicate-name bullet with:
+   `- Create two sites in a row without renaming → the second lands as **Untitled 2** (\`Untitled 2.anglesite\`), no clobber, no error. Also verify an *unregistered* \`Untitled.anglesite\` folder already sitting in the sites root is skipped the same way.`
+   (keep the cancelled-grant bullet).
+10. **Exit state:** `"Untitled" open with a ready preview; git log shows the single initial commit.`
+
+- [ ] **Step 2: Manual smoke (app already built in Task 5)**
+
+Launch the built app, then: Add Site → Create new site… → chooser appears → double-click a non-first theme → Building checklist runs → site window opens with the template placeholder homepage in the chosen theme's colors. Then create a second site → it lands as "Untitled 2". Record both results in the PR body's test plan. If a live run isn't possible in the execution environment, state that explicitly in the PR body instead of claiming it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/qa/e2e-acceptance-2-new-website.md
+git commit -m "docs(#1071): update new-website QA doc for template chooser"
+```
+
+---
+
+### Task 7: File the three follow-up issues
+
+**Files:** none (gh only). The spec's Follow-ups section promises these; file them so the PR body can reference real numbers.
+
+- [ ] **Step 1: Create the issues**
+
+```bash
+gh issue create --title "Epic: curated Astro theme ports for the template chooser" --body "Follow-up to #1071 (see docs/superpowers/specs/2026-07-31-new-site-chooser-design.md ▸ Follow-ups). Curate MIT-licensed Astro themes and port each into the existing template chassis (Resources/Template) as layout/component/style packs — one dependency tree, same scripts/.site-config/writer structure. Adds the chooser's category sidebar (Business, Personal, Blog, Portfolio, Organization, Blank) and records site type from category choice. Rejected alternatives (decision log): live astro.build catalog scaffolding and sibling-template vendoring — unreviewed dependency trees and broken structural assumptions (HomepageWriter, ThemeApplier, edit overlay, template-coupled tests)."
+
+gh issue create --title "Publish-time domain setup step (buy/transfer/later)" --body "Follow-up to #1071: onboarding no longer asks the domain question (DOMAIN_CHOICE=later is always written). Add a first-publish affordance to buy/transfer/defer a domain, feeding the existing CustomDomainAttachCommand path. See docs/superpowers/specs/2026-07-31-new-site-chooser-design.md ▸ Follow-ups."
+
+gh issue create --title "Give ThemeApplyWizard a UI entry point (Website menu)" --body "Follow-up to #1071: ThemeApplyWizard (built-in + freedesignmd theme apply, Sources/AnglesiteApp/ThemeApplyWizard.swift) shipped with no UI entry point — reachable only via App Intent and the FM chat tool. Wire it into the Website menu so post-create restyling is discoverable; with the chooser now the only onboarding question, this is the owner's path to richer restyling. See docs/superpowers/specs/2026-07-31-new-site-chooser-design.md ▸ Follow-ups."
+```
+
+- [ ] **Step 2: Record the created issue numbers** for the PR body (the PR should mention them under Design notes).
+
+---
+
+## Completion
+
+After all tasks: re-check changed files against `CONTRIBUTING.md` (subject lengths, PR template with **Summary / Paired PR check / Test plan** — this change is app-only, no paired sidecar PR), then use superpowers:finishing-a-development-branch. The PR body must include `Closes #1071`.

--- a/docs/superpowers/specs/2026-07-31-new-site-chooser-design.md
+++ b/docs/superpowers/specs/2026-07-31-new-site-chooser-design.md
@@ -1,0 +1,121 @@
+# New Site window redesign: template chooser only (#1071)
+
+**Status:** Approved design, not yet implemented.
+**Issue:** [#1071](https://github.com/Anglesite/Anglesite/issues/1071)
+**Supersedes the flow shipped from:** `docs/superpowers/specs/2026-05-29-new-site-onboarding-design.md`
+
+## Problem
+
+The current new-site wizard asks six steps' worth of questions before the owner
+ever sees their site: name + domain (buy/transfer/later), site type, color
+scheme, headline/blurb/hero image, and a save panel. Almost none of that is
+needed to show a preview. The domain answer in particular is pure deploy-time
+configuration — its only consumers (`CustomDomainAttachCommand`,
+`DeployCoordinator`) run *after* a successful deploy and already treat
+"set up later" as a clean skip.
+
+The model to follow is iWork: Pages asks exactly one question — which template —
+then opens the document untitled, auto-saved, full of editable placeholder
+content. Everything else happens later, and publish-time concerns (DNS,
+license, tokens) gate publish, not creation.
+
+## Goals
+
+- One pre-preview question: pick a template.
+- Site opens in the live preview seconds after the choice, named "Untitled",
+  saved to the default location without a panel.
+- Deploy-time configuration (domain, tokens, license) stays where it already
+  lives: at publish.
+
+## Non-goals
+
+- Porting third-party Astro themes into the chassis (follow-up epic; see
+  Follow-ups).
+- A category sidebar in the chooser (arrives with the ported-themes epic).
+- A publish-time "connect a domain" step (follow-up issue).
+- Changing the deploy path, token onboarding, pre-deploy gate, or licensing UI.
+
+## Design
+
+### 1. Flow
+
+Add Site / File ▸ New ▸ Site / Dock menu all open a single **template
+chooser** (Pages-style): a flat grid of the 8 built-in themes
+(`Resources/Template/scripts/themes.json`) rendered as preview cards, with the
+catalog's first theme pre-selected (deterministic — no site type exists to
+drive the per-type default table). Double-click a card, or select + **Create** →
+the chooser dismisses, scaffolding runs (existing Building progress UI —
+feedback, not a question), and the site window opens on the live preview.
+
+Removed entirely from onboarding: website name, domain choice, site type,
+headline/blurb/hero-image, and the save panel.
+
+### 2. Naming and save
+
+- The package is created as `Untitled.anglesite` (collision-suffixed
+  `Untitled 2.anglesite`, …) directly in the default save location — the
+  iCloud Drive "Anglesite" folder (#865), `~/Sites` fallback.
+- Rename later via the existing launcher/window affordances (Mac document
+  convention). Slug and `CF_PROJECT_NAME` derive from the name as today;
+  worker-name collisions at deploy are already handled by the
+  rename-and-retry sheet (`WorkerNameRename`).
+
+### 3. Content
+
+No content questions. The template ships with good placeholder content — the
+template *is* the content prompt — and the owner edits it in the live preview.
+`HomepageWriter`'s wizard-driven customization is bypassed in this flow; it
+remains available to intents/AI paths that supply real content.
+
+### 4. Deferral to publish
+
+- `.site-config` gets `DOMAIN_CHOICE=later` — the value the deploy path
+  already treats as a no-op skip. No `SITE_TYPE` is written (the AI features
+  that want a business type — design interview, brand voice — already handle
+  its absence by asking when needed).
+- First publish goes to `<slug>.workers.dev` exactly as today. Unchanged
+  deferred gates: Cloudflare/GitHub token prompts at first deploy/publish,
+  the un-bypassable `pre-deploy-check.ts` security gate, licensing in site
+  settings.
+
+### 5. Code shape
+
+- `Sources/AnglesiteCore/NewSiteWizardModel.swift`: `Step` collapses to
+  `chooser → building`. Details/Type/Content/Save steps, their validation,
+  and their state go away.
+- `Sources/AnglesiteCore/NewSiteDraft.swift`: `SiteType` stays (intents/AI
+  still use it) but defaults to blank/none for this flow; domain and content
+  fields are no longer populated by the wizard.
+- `Sources/AnglesiteApp/NewSiteWizard.swift`: becomes the chooser view. Theme
+  cards upgrade from color swatches to static rendered thumbnails generated
+  from the theme palette (no dev server involved).
+- Entry points (`SitesLauncherView`, `FocusedSite`, Dock menu,
+  `WindowRouter`), the `SiteScaffolder` pipeline, and `.site-config` writing
+  survive with fewer inputs. Untitled-name collision suffixing lands beside
+  the existing slug-collision logic.
+
+### 6. Testing
+
+- Model tests: collapsed step machine, Untitled collision-suffix naming,
+  `.site-config` output (`DOMAIN_CHOICE=later`, no `SITE_TYPE`).
+- Update `docs/qa/e2e-acceptance-2-new-website.md` to the new flow.
+- `swift test --package-path .` and the app build per `CONTRIBUTING.md`
+  (template untouched, but wizard strings change — sync the String Catalog).
+
+## Follow-ups (new issues, not in #1071)
+
+1. **Ported-themes epic** — curate MIT-licensed Astro themes (from the
+   astro.build catalog ecosystem) and port each into the existing template
+   chassis as layout/component/style packs (one dependency tree, same
+   scripts/`.site-config`/writer structure). Adds the category sidebar
+   (Business, Personal, Blog, Portfolio, Organization, Blank) and records
+   site type from category choice. Decision log: live-catalog scaffolding
+   and sibling-template vendoring were rejected — unreviewed dependency
+   trees and broken structural assumptions (`HomepageWriter`,
+   `ThemeApplier`, edit overlay, template-coupled tests).
+2. **Publish-time domain step** — a first-publish "connect a domain
+   (buy/transfer/later)" affordance, replacing the question onboarding no
+   longer asks.
+3. **`ThemeApplyWizard` entry point** — the shipped freedesignmd/built-in
+   theme wizard is currently unreachable from the UI; wire it into the
+   Website menu so post-create restyling is discoverable.


### PR DESCRIPTION
Closes #1071

## Summary

- Collapses the six-step New Site wizard (name+domain / type / color scheme / content / save panel / building) to a single Pages-style **template chooser**: pick a theme card → the site scaffolds as **"Untitled"** (auto-numbered) into the default sites root and opens straight into the live preview. Design: `docs/superpowers/specs/2026-07-31-new-site-chooser-design.md`.
- Deploy-time configuration stays at publish, where it already lives: `.site-config` is written with `DOMAIN_CHOICE=later` (the value the deploy path treats as a clean skip), `SITE_TYPE` is omitted for unasked blank drafts, and `HomepageWriter` is skipped for contentless drafts so the template's placeholder copy survives for in-preview editing.
- Updates the Part-2 QA acceptance doc to the chooser flow and syncs the String Catalog (one new key, "Choose a Template").

Follow-ups filed from the spec + final review: #1179 (curated Astro theme ports epic), #1180 (publish-time domain step), #1181 (ThemeApplyWizard UI entry point), #1182 (propagate rename into `SITE_NAME`/`CF_PROJECT_NAME` for untitled sites — the one behavioral gap the chooser introduces, since every site is now born "Untitled").

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` — green twice, including new `NewSiteWizardModelTests` (chooser state machine, Untitled collision numbering) and `SiteScaffolderTests.testChooserDraftKeepsTemplatePlaceholderAndOmitsSiteType`. Known exception: `FoundationModelAssistantTests`' two live-Apple-Intelligence tests fail on this machine ("Session ended without producing a response") — reproduced in isolation, environmental, untouched by this branch.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — compiles/links with `CODE_SIGNING_ALLOWED=NO`; `scripts/build-app.sh` signing currently fails in this worktree from a pre-existing provisioning issue (being fixed separately).
- [ ] Manual smoke (if UI-touching): **not run** — headless session; the updated `docs/qa/e2e-acceptance-2-new-website.md` Part 2 covers the chooser flow (create → "Untitled" → preview; second create → "Untitled 2").

## Design notes

- Chooser cards render a miniature page mock from each theme's palette (no dev server); first catalog theme pre-selected; double-click creates; Esc cancels; interactive dismissal blocked while building.
- The removed Custom-colors/logo and hero-image (Image Playground) steps move to post-create paths (#1181 tracks discoverability).