### PR TITLE
fix(#1184): keep ad-hoc Debug builds off the iCloud entitlement

### DIFF
--- a/Resources/Anglesite-Debug-iCloud.entitlements
+++ b/Resources/Anglesite-Debug-iCloud.entitlements
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- Opt-in Debug entitlements (#1038): identical to Anglesite-Debug.entitlements plus the
+	     iCloud capability. Apple requires a real provisioning profile for the iCloud entitlement
+	     even under Manual/ad-hoc code signing, so it can't live in the default Debug entitlements
+	     (that file must stay buildable with no Apple Developer account — see README.md /
+	     CONTRIBUTING.md). Contributors who have a real Team and want to exercise the iCloud
+	     Drive storage path (#865) locally: point ANGLESITE_DEBUG_ENTITLEMENTS at this file from
+	     xcconfig/Signing-Debug.local.xcconfig (see Signing-Debug.local.xcconfig.example). -->
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
@@ -18,17 +25,17 @@
 	<key>com.apple.security.virtualization</key>
 	<true/>
 
-	<!-- NO iCloud entitlement here (#1038): unlike this file's other capabilities, iCloud
-	     (com.apple.developer.icloud-container-identifiers / -services) requires Apple to issue
-	     a real provisioning profile even under Manual/ad-hoc code signing — Xcode refuses to
-	     build at all ("requires a provisioning profile") once it's present without a Team. This
-	     is the default, CI-safe Debug entitlements file (README.md / CONTRIBUTING.md promise a
-	     clone-and-build with no Apple Developer account), so it must stay without it.
-	     AppSettings.sitesRoot already treats a Debug build with no iCloud entitlement/provisioning
-	     the same as "iCloud unavailable" and falls back to `~/Sites/`. Contributors with a real
-	     Team who want to exercise the iCloud Drive storage path (#865) locally can opt in via
-	     Resources/Anglesite-Debug-iCloud.entitlements — see
-	     xcconfig/Signing-Debug.local.xcconfig.example. -->
+	<!-- iCloud Drive default site storage (#865): the "Anglesite" folder new/imported .anglesite
+	     packages save into by default. Container identifier must match AppSettings.sitesRoot's
+	     ubiquityContainerIdentifier and Info.plist's NSUbiquitousContainers key below. -->
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.io.dwk.anglesite</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
 
 	<!-- DEBUG-ONLY WORKAROUND for #775 — do not add to Resources/Anglesite.entitlements.
 	     macOS 27 seeds 26A5378n–26A5388g deny sandboxed processes the mach bootstrap

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -77,8 +77,11 @@ public final class AppSettings: @unchecked Sendable {
     private let ubiquityContainerResolver: UbiquityContainerResolving
 
     /// Must match the `com.apple.developer.icloud-container-identifiers` entry in
-    /// `Resources/Anglesite.entitlements` / `Resources/Anglesite-Debug.entitlements`, and the
-    /// `NSUbiquitousContainers` key in `Resources/Info.plist`.
+    /// `Resources/Anglesite.entitlements` and the `NSUbiquitousContainers` key in
+    /// `Resources/Info.plist`. The default `Resources/Anglesite-Debug.entitlements` deliberately
+    /// omits this entitlement (#1038 — it requires a real provisioning profile, breaking the
+    /// no-Apple-account Debug build); `Resources/Anglesite-Debug-iCloud.entitlements` is the
+    /// opt-in local variant that carries it.
     static let ubiquityContainerIdentifier = "iCloud.io.dwk.anglesite"
 
     private let ubiquityCacheLock = NSLock()

--- a/project.yml
+++ b/project.yml
@@ -85,7 +85,8 @@ targets:
     # Debug signing (CODE_SIGN_STYLE/IDENTITY/TEAM) comes from xcconfig/Signing-Debug.xcconfig
     # instead of inline settings below, so a personal Team set via Xcode's Signing &
     # Capabilities tab can persist across `xcodegen generate` — see that file for how to
-    # override it locally without editing this tracked config.
+    # override it locally without editing this tracked config. The same file also carries
+    # ANGLESITE_DEBUG_ENTITLEMENTS (#1038), which CODE_SIGN_ENTITLEMENTS below reads.
     configFiles:
       Debug: xcconfig/Signing-Debug.xcconfig
     settings:
@@ -118,7 +119,11 @@ targets:
           # #775 workaround: punch the com.apple.NetworkSharing mach look-up back
           # through the sandbox so container boots survive macOS 27 seeds
           # 26A5378n–26A5388g. Debug-only — never ships to MAS.
-          CODE_SIGN_ENTITLEMENTS: Resources/Anglesite-Debug.entitlements
+          # Indirected through an xcconfig variable (#1038, defaults to
+          # Resources/Anglesite-Debug.entitlements) rather than a literal path here, so
+          # xcconfig/Signing-Debug.local.xcconfig can opt a real-Team local build into
+          # Resources/Anglesite-Debug-iCloud.entitlements without editing this tracked file.
+          CODE_SIGN_ENTITLEMENTS: $(ANGLESITE_DEBUG_ENTITLEMENTS)
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Apple Distribution"

--- a/xcconfig/Signing-Debug.local.xcconfig.example
+++ b/xcconfig/Signing-Debug.local.xcconfig.example
@@ -5,3 +5,9 @@
 // Find your Team ID in Xcode: Settings > Accounts > (your Apple ID) > (team) > Team ID.
 CODE_SIGN_STYLE = Automatic
 DEVELOPMENT_TEAM = YOUR_TEAM_ID
+
+// Optional (#1038): only if you also want to exercise the iCloud Drive storage path
+// (#865) in local Debug builds. Requires a real Team above — Apple must issue a
+// provisioning profile for the iCloud capability, which ad-hoc signing can't self-grant.
+// Uncomment to opt in:
+// ANGLESITE_DEBUG_ENTITLEMENTS = Resources/Anglesite-Debug-iCloud.entitlements

--- a/xcconfig/Signing-Debug.xcconfig
+++ b/xcconfig/Signing-Debug.xcconfig
@@ -10,4 +10,11 @@ CODE_SIGN_STYLE = Manual
 CODE_SIGN_IDENTITY = -
 DEVELOPMENT_TEAM =
 
+// The Anglesite target's CODE_SIGN_ENTITLEMENTS (Debug config) reads this indirection
+// instead of a literal path in project.yml (#1038), so a local override below can point
+// at Resources/Anglesite-Debug-iCloud.entitlements without editing tracked files. Must
+// stay the no-iCloud file by default: iCloud requires a real provisioning profile even
+// under the ad-hoc signing above, which breaks the no-Apple-account Debug build promise.
+ANGLESITE_DEBUG_ENTITLEMENTS = Resources/Anglesite-Debug.entitlements
+
 #include? "Signing-Debug.local.xcconfig"


### PR DESCRIPTION
Closes #1184

## Summary

- Xcode requires a real provisioning profile for the iCloud capability (`com.apple.developer.icloud-container-identifiers` / `-services`) even under `CODE_SIGN_STYLE = Manual` / `CODE_SIGN_IDENTITY = -` (ad-hoc), so #865's iCloud entitlement addition broke the "clone and build without an Apple account" promise (README.md / CONTRIBUTING.md) — `Debug` builds now fail with `'Anglesite' requires a provisioning profile.`
- Removes the iCloud capability from the default, CI-safe `Resources/Anglesite-Debug.entitlements`. `AppSettings.sitesRoot` already treats "no iCloud entitlement/provisioning" as one of its documented fallback cases and drops to `~/Sites/`, so this is a no-op runtime change for the default ad-hoc build.
- Adds an opt-in `Resources/Anglesite-Debug-iCloud.entitlements`, wired through a new `ANGLESITE_DEBUG_ENTITLEMENTS` xcconfig variable (default: the no-iCloud file), so contributors with a real Apple Developer Team can still exercise the iCloud Drive storage path (#865) locally via `xcconfig/Signing-Debug.local.xcconfig`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — all suites pass except two pre-existing, unrelated `FoundationModelAssistantTests` failures (on-device model streaming session flake, not touched by this change).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — reproduced the original failure, then confirmed **BUILD SUCCEEDED** after the fix; verified via `codesign -d --entitlements` that the built app carries no iCloud entitlement.
- [x] `scripts/check-xcodeproj-sync.sh` passes.
- [x] Verified the opt-in path: a test `Signing-Debug.local.xcconfig` with a real Team + `ANGLESITE_DEBUG_ENTITLEMENTS = Resources/Anglesite-Debug-iCloud.entitlements` correctly resolves `CODE_SIGN_ENTITLEMENTS` (confirmed via `-showBuildSettings`).
- [ ] Manual smoke: not run (headless environment; no UI-visible change).