### PR TITLE
anglesite.json: drift audit + reconcile UI (declared vs live)

### DIFF
--- a/Sources/AnglesiteApp/DomainConfigAuditModel.swift
+++ b/Sources/AnglesiteApp/DomainConfigAuditModel.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+import AnglesiteCore
+
+/// App-layer glue for the #1171 drift audit: reads the site's declared `Source/anglesite.json`,
+/// resolves its declared domain against live Cloudflare state, and offers one-click reconciliation
+/// for the unambiguous app-owned drift `DomainConfigAudit` finds — mirroring `HardenModel`'s
+/// resolve → plan → apply → re-audit shape (investigation doc §5.5: "remediation reuses the
+/// Harden idiom"). Unlike `HardenModel`, the domain comes from the declaration itself, not a
+/// text field: there's nothing useful to audit without one.
+@MainActor
+@Observable
+final class DomainConfigAuditModel {
+    enum Phase: Equatable {
+        case idle
+        case auditing(domain: String)
+        case results(findings: [DomainConfigAudit.Finding], plan: DomainConfigReconcilePlan, domain: String, zoneID: String)
+        case reconciling(domain: String)
+        case succeeded(result: ReconcileResult)
+        case failed(reason: String)
+    }
+
+    struct ReconcileResult: Equatable {
+        let appliedCount: Int
+        let failedItems: [FailedItem]
+        let postAuditFindings: [DomainConfigAudit.Finding]
+        let auditError: String?
+
+        struct FailedItem: Equatable {
+            let description: String
+            let error: String
+        }
+    }
+
+    private(set) var phase: Phase = .idle
+    var sheetPresented: Bool = false
+
+    private let reader: any CloudflareReading
+    private let writer: any CloudflareWriting
+    private let keychain: KeychainStore
+    private var inFlight: Task<Void, Never>?
+
+    private var currentSite: CurrentSite?
+
+    init(
+        reader: any CloudflareReading = HTTPCloudflareClient(),
+        writer: any CloudflareWriting = HTTPCloudflareClient(),
+        keychain: KeychainStore = KeychainStore()
+    ) {
+        self.reader = reader
+        self.writer = writer
+        self.keychain = keychain
+    }
+
+    /// Threaded from `SiteWindowModel.loadAndStart`, mirroring `HardenModel.configure(site:)`.
+    func configure(site: CurrentSite) {
+        currentSite = site
+    }
+
+    var isRunning: Bool {
+        switch phase {
+        case .auditing, .reconciling: return true
+        default: return false
+        }
+    }
+
+    func openSheet() {
+        guard !isRunning else { return }
+        phase = .idle
+        sheetPresented = true
+    }
+
+    func retryFromFailed() {
+        guard !isRunning else { return }
+        phase = .idle
+    }
+
+    /// Validates synchronously (site open, declared domain present, token available) and, only
+    /// once that succeeds, flips `phase` to `.auditing` *before* spawning the network task — so a
+    /// caller that immediately checks `isRunning` (a synchronous poll loop, e.g. in tests) always
+    /// observes the running state rather than racing the task's own first `phase` write.
+    func runAudit() {
+        guard !isRunning else { return }
+        guard let site = currentSite else {
+            phase = .failed(reason: "No site is open.")
+            return
+        }
+
+        let declared: DomainConfig
+        do {
+            declared = try DomainConfigStore(sourceDirectory: site.sourceDirectory).load()
+        } catch {
+            phase = .failed(reason: "anglesite.json couldn't be read: \(error.localizedDescription)")
+            return
+        }
+        guard let domain = declared.domain?.hostname, !domain.isEmpty else {
+            phase = .failed(reason: "No domain is declared in anglesite.json yet. Attach a domain first.")
+            return
+        }
+        guard let token = apiToken() else {
+            phase = .failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials.")
+            return
+        }
+
+        phase = .auditing(domain: domain)
+
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.performAudit(declared: declared, domain: domain, token: token)
+        }
+    }
+
+    /// Same synchronous-then-async split as ``runAudit()``, for the same reason.
+    func reconcile() {
+        guard case .results(_, let plan, let domain, let zoneID) = phase, !plan.isEmpty else { return }
+        guard let site = currentSite else {
+            phase = .failed(reason: "No site is open.")
+            return
+        }
+        guard let token = apiToken() else {
+            phase = .failed(reason: "No Cloudflare API token found.")
+            return
+        }
+        let declared = (try? DomainConfigStore(sourceDirectory: site.sourceDirectory).load()) ?? DomainConfig()
+
+        phase = .reconciling(domain: domain)
+
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.performReconcile(plan: plan, domain: domain, zoneID: zoneID, declared: declared, token: token)
+        }
+    }
+
+    func dismissSheet() {
+        inFlight?.cancel()
+        inFlight = nil
+        sheetPresented = false
+        phase = .idle
+    }
+
+    // MARK: - Private
+
+    private func apiToken() -> String? {
+        if let env = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"], !env.isEmpty {
+            return env
+        }
+        return try? keychain.readCloudflareToken()
+    }
+
+    private func performAudit(declared: DomainConfig, domain: String, token: String) async {
+        do {
+            guard let zoneID = try await reader.resolveZoneID(domain: domain, apiToken: token) else {
+                phase = .failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission.")
+                return
+            }
+
+            let state = try await reader.zoneState(zoneID: zoneID, domain: domain, apiToken: token)
+            let records = try await reader.listDNSRecords(zoneID: zoneID, apiToken: token)
+            let findings = DomainConfigAudit.evaluate(
+                declared: declared, live: state, liveDNSRecords: records, domain: domain)
+            let planItems = findings.compactMap { finding -> DomainConfigReconcileItem? in
+                guard case .autoApply(let item) = finding.remediation else { return nil }
+                return item
+            }
+            phase = .results(
+                findings: findings, plan: DomainConfigReconcilePlan(items: planItems),
+                domain: domain, zoneID: zoneID)
+        } catch let error as CloudflareError {
+            phase = .failed(reason: cloudflareErrorMessage(error, domain: domain))
+        } catch {
+            phase = .failed(reason: "Failed to read zone state: \(error.localizedDescription)")
+        }
+    }
+
+    private func performReconcile(
+        plan: DomainConfigReconcilePlan, domain: String, zoneID: String, declared: DomainConfig, token: String
+    ) async {
+        let reconciler = DomainConfigReconciler(reader: reader, writer: writer)
+        let result = await reconciler.execute(
+            plan: plan, zoneID: zoneID, domain: domain, apiToken: token, declared: declared)
+
+        phase = .succeeded(result: ReconcileResult(
+            appliedCount: result.appliedCount,
+            failedItems: result.failedItems.map { .init(description: $0.item.description, error: $0.error) },
+            postAuditFindings: result.postAuditFindings,
+            auditError: result.auditError
+        ))
+    }
+
+    private func cloudflareErrorMessage(_ error: CloudflareError, domain: String) -> String {
+        switch error {
+        case .unauthorized:
+            return "API token is unauthorized. Check that it has Zone Read and DNS Read permissions."
+        case .http(let status):
+            return "Cloudflare API returned HTTP \(status)."
+        case .api(let message):
+            return "Cloudflare API error: \(message)"
+        case .malformedResponse:
+            return "Unexpected response from Cloudflare API."
+        }
+    }
+}

--- a/Sources/AnglesiteApp/DomainConfigAuditSheetView.swift
+++ b/Sources/AnglesiteApp/DomainConfigAuditSheetView.swift
@@ -1,0 +1,278 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The #1171 drift audit + reconcile UI: shows declared `anglesite.json` vs live Cloudflare drift,
+/// grouped by how each finding should be resolved (investigation doc §5.5's "app advises" rule —
+/// auto-apply unambiguous app-owned drift, ask a consequences-phrased question for contested
+/// state, surface untracked records for awareness only). Structurally mirrors `HardenSheetView`'s
+/// header/content/footer shape and its plan-preview → apply → re-audit result view.
+struct DomainConfigAuditSheetView: View {
+    @Bindable var model: DomainConfigAuditModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            footer
+        }
+        .frame(minWidth: 560, idealWidth: 640, minHeight: 400, idealHeight: 540)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            statusIcon
+            VStack(alignment: .leading, spacing: 1) {
+                Text(headerTitle).font(.headline)
+                if let subtitle = headerSubtitle {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch model.phase {
+        case .idle:
+            Image(systemName: "arrow.triangle.2.circlepath").font(.title3)
+        case .auditing, .reconciling:
+            ProgressView().controlSize(.small)
+        case .results(let findings, _, _, _):
+            Image(systemName: findings.isEmpty ? "checkmark.circle.fill" : "arrow.triangle.2.circlepath.circle.fill")
+                .foregroundStyle(findings.isEmpty ? .green : .blue)
+                .font(.title3)
+        case .succeeded(let result):
+            Image(systemName: result.failedItems.isEmpty ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(result.failedItems.isEmpty ? .green : .yellow)
+                .font(.title3)
+        case .failed:
+            Image(systemName: "xmark.circle.fill")
+                .foregroundStyle(.red).font(.title3)
+        }
+    }
+
+    private var headerTitle: String {
+        switch model.phase {
+        case .idle:
+            return "Domain Config Audit"
+        case .auditing(let domain):
+            return "Comparing anglesite.json to \(domain)…"
+        case .results(let findings, _, let domain, _):
+            if findings.isEmpty { return "\(domain) matches anglesite.json" }
+            return "\(findings.count) drift finding\(findings.count == 1 ? "" : "s") for \(domain)"
+        case .reconciling(let domain):
+            return "Reconciling \(domain)…"
+        case .succeeded(let result):
+            if result.failedItems.isEmpty {
+                return "\(result.appliedCount) change\(result.appliedCount == 1 ? "" : "s") applied"
+            }
+            return "\(result.appliedCount) applied, \(result.failedItems.count) failed"
+        case .failed:
+            return "Domain config audit failed"
+        }
+    }
+
+    private var headerSubtitle: String? {
+        switch model.phase {
+        case .results:
+            return "Review the drift below. Auto-fixable changes can be applied with one click."
+        case .succeeded(let result):
+            if let err = result.auditError {
+                return "Post-apply audit failed: \(err)"
+            }
+            let findings = result.postAuditFindings.count
+            if findings == 0 { return "Post-apply audit: no remaining drift." }
+            return "Post-apply audit: \(findings) remaining finding\(findings == 1 ? "" : "s")."
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .idle:
+            idleView
+        case .auditing:
+            VStack(spacing: 8) {
+                ProgressView()
+                Text("Reading anglesite.json and the live Cloudflare zone…")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .results(let findings, let plan, _, _):
+            resultsView(findings: findings, plan: plan)
+        case .reconciling:
+            VStack(spacing: 8) {
+                ProgressView()
+                Text("Applying reconciliation changes…")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .succeeded(let result):
+            succeededView(result)
+        case .failed(let reason):
+            VStack(spacing: 12) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red).font(.largeTitle)
+                Text(reason)
+                    .font(.callout).foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 440)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var idleView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+            Text("Check for domain config drift")
+                .font(.headline)
+            Text("Compares this site's declared anglesite.json (domain, managed DNS records, edge hardening) against what's actually live on Cloudflare.")
+                .font(.callout).foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private func resultsView(findings: [DomainConfigAudit.Finding], plan: DomainConfigReconcilePlan) -> some View {
+        if findings.isEmpty {
+            VStack(spacing: 8) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green).font(.largeTitle)
+                Text("No drift found.").font(.headline)
+                Text("The live Cloudflare zone matches everything declared in anglesite.json.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 14) {
+                    let autoApply = findings.filter { if case .autoApply = $0.remediation { return true }; return false }
+                    let ownerQuestions = findings.filter { if case .ownerQuestion = $0.remediation { return true }; return false }
+                    let informational = findings.filter { if case .informational = $0.remediation { return true }; return false }
+
+                    if !autoApply.isEmpty {
+                        findingSection(title: "Can be fixed automatically", findings: autoApply, tint: .blue)
+                    }
+                    if !ownerQuestions.isEmpty {
+                        findingSection(title: "Needs your decision", findings: ownerQuestions, tint: .orange)
+                    }
+                    if !informational.isEmpty {
+                        findingSection(title: "For your awareness", findings: informational, tint: .secondary)
+                    }
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    private func findingSection(title: String, findings: [DomainConfigAudit.Finding], tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.subheadline.weight(.semibold))
+            ForEach(findings) { finding in
+                findingRow(finding, tint: tint)
+            }
+        }
+    }
+
+    private func findingRow(_ finding: DomainConfigAudit.Finding, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(finding.title).font(.callout.weight(.medium))
+            Text(finding.detail).font(.callout).foregroundStyle(.secondary)
+            if case .ownerQuestion(let question) = finding.remediation {
+                Text(question).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(tint.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    @ViewBuilder
+    private func succeededView(_ result: DomainConfigAuditModel.ReconcileResult) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 14) {
+                if result.appliedCount > 0 {
+                    Label("\(result.appliedCount) change\(result.appliedCount == 1 ? "" : "s") applied successfully.", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.callout)
+                }
+
+                if !result.failedItems.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Failed").font(.subheadline.weight(.semibold))
+                        ForEach(Array(result.failedItems.enumerated()), id: \.offset) { _, item in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(item.description).font(.callout.weight(.medium))
+                                Text(item.error).font(.caption).foregroundStyle(.red)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                            .background(Color.red.opacity(0.06))
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        }
+                    }
+                }
+
+                if !result.postAuditFindings.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Remaining drift").font(.subheadline.weight(.semibold))
+                        ForEach(result.postAuditFindings) { finding in
+                            findingRow(finding, tint: .secondary)
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            switch model.phase {
+            case .idle:
+                Button("Check Domain Config") { model.runAudit() }
+                    .buttonStyle(.borderedProminent)
+            case .results(_, let plan, _, _) where !plan.isEmpty:
+                Button("Apply \(plan.items.count) change\(plan.items.count == 1 ? "" : "s")") {
+                    model.reconcile()
+                }
+                .buttonStyle(.borderedProminent)
+            case .failed:
+                Button("Try again") {
+                    model.retryFromFailed()
+                }
+            default:
+                EmptyView()
+            }
+            Spacer()
+            Button("Close") {
+                model.dismissSheet()
+            }
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -468,6 +468,9 @@
     "Applying hardening changes…" : {
 
     },
+    "Applying reconciliation changes…" : {
+
+    },
     "Applying…" : {
 
     },
@@ -678,7 +681,16 @@
     "Check ${site}" : {
 
     },
+    "Check Domain Config" : {
+
+    },
+    "Check for domain config drift" : {
+
+    },
     "Check whether Siri workflows are ready for this site" : {
+
+    },
+    "Checking Domain Config…" : {
 
     },
     "Checking token…" : {
@@ -806,6 +818,9 @@
 
     },
     "Communities…" : {
+
+    },
+    "Compares this site's declared anglesite.json (domain, managed DNS records, edge hardening) against what's actually live on Cloudflare." : {
 
     },
     "Complete Sign In" : {
@@ -1129,6 +1144,9 @@
 
     },
     "Domain" : {
+
+    },
+    "Domain Config" : {
 
     },
     "Domain…" : {
@@ -1818,6 +1836,9 @@
     "No copy issues found across %lld pages — nice work." : {
 
     },
+    "No drift found." : {
+
+    },
     "No entries yet — follow a feed above to get started." : {
 
     },
@@ -2190,6 +2211,9 @@
     "Reading %@ zone settings from Cloudflare…" : {
 
     },
+    "Reading anglesite.json and the live Cloudflare zone…" : {
+
+    },
     "Receiving webmentions and pushing feed updates to subscribers both work asynchronously using Cloudflare Queues, which aren't available on the Workers Free plan. Continuing will create the Queues these features need on your connected Cloudflare account." : {
 
     },
@@ -2248,6 +2272,9 @@
 
     },
     "Remaining audit findings" : {
+
+    },
+    "Remaining drift" : {
 
     },
     "Remove" : {
@@ -2868,6 +2895,9 @@
 
     },
     "The license offered for your content. Anglesite never picks one for you — until you choose, your site says all rights reserved." : {
+
+    },
+    "The live Cloudflare zone matches everything declared in anglesite.json." : {
 
     },
     "The pre-deploy scan found issues that need fixing before this site can ship." : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -404,6 +404,23 @@ struct SiteWindow: View {
             }
             .defaultCustomization(.hidden)
 
+            ToolbarItem(id: SiteToolbarItemID.domainConfigAudit.rawValue, placement: .primaryAction) {
+                Button {
+                    model.domainConfigAudit.openSheet()
+                } label: {
+                    if model.domainConfigAudit.isRunning {
+                        Label("Checking Domain Config…", systemImage: "arrow.triangle.2.circlepath")
+                    } else {
+                        Label("Domain Config", systemImage: "arrow.triangle.2.circlepath")
+                    }
+                }
+                .disabled(!model.canRunDomainConfigAudit)
+                .help(site.isValid
+                      ? "Compare anglesite.json's declared domain/DNS/edge config against live Cloudflare state"
+                      : "Site is missing required files")
+            }
+            .defaultCustomization(.hidden)
+
             ToolbarItem(id: SiteToolbarItemID.onionRouting.rawValue, placement: .primaryAction) {
                 Button {
                     model.onionRouting.openSheet()
@@ -597,6 +614,9 @@ struct SiteWindow: View {
         }
         .sheet(isPresented: $bindableModel.sync.resolutionSheetPresented) {
             SyncConflictResolutionSheetView(model: model.sync, siteName: site.name)
+        }
+        .sheet(isPresented: $bindableModel.domainConfigAudit.sheetPresented) {
+            DomainConfigAuditSheetView(model: model.domainConfigAudit)
         }
         .sheet(isPresented: $bindableModel.harden.sheetPresented) {
             HardenSheetView(model: model.harden)

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -151,6 +151,7 @@ final class SiteWindowModel {
     /// fediverse Group actors and read a per-group timeline.
     var communities = CommunitiesModel()
     var harden = HardenModel()
+    var domainConfigAudit = DomainConfigAuditModel()
     var onionRouting = OnionRoutingModel()
     var domain = DomainModel()
     var health = HealthModel(runner: DefaultHealthCheckRunner())
@@ -635,6 +636,7 @@ final class SiteWindowModel {
     var canRunBackup: Bool { site?.isValid == true && !siteOperationRunning }
     var canRunAudit: Bool { site?.isValid == true && !siteOperationRunning && preview.canDeploy }
     var canRunHarden: Bool { site?.isValid == true && !harden.isRunning }
+    var canRunDomainConfigAudit: Bool { site?.isValid == true && !domainConfigAudit.isRunning }
     var canRunOnionRouting: Bool { site?.isValid == true && !onionRouting.isRunning }
     var canRecheckHealth: Bool { site != nil }
     var canOpenDomain: Bool { site != nil && !domain.isRunning }
@@ -1921,6 +1923,7 @@ final class SiteWindowModel {
         communities.configure(site: currentSite)
         domain.configure(site: currentSite)
         harden.configure(site: currentSite)
+        domainConfigAudit.configure(site: currentSite)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)

--- a/Sources/AnglesiteCore/CloudflareReading.swift
+++ b/Sources/AnglesiteCore/CloudflareReading.swift
@@ -40,14 +40,20 @@ public struct DNSRecord: Sendable, Equatable, Identifiable {
     /// Whether traffic for this record routes through Cloudflare's proxy (the orange cloud).
     /// Read-side only — `DNSRecordPayload` deliberately doesn't carry it.
     public let proxied: Bool
+    /// Cloudflare's free-text `comment` field, as read back. When it starts with `"anglesite:"`
+    /// the app stamped it (`DNSRecordPayload.comment`, #1170); `DomainConfigAudit` (#1171) uses
+    /// it to join this live record to its declared `anglesite.json` counterpart. `nil` when the
+    /// record has no comment.
+    public let comment: String?
     /// Memberwise initializer; the HTTP client and test fixtures build records directly.
-    public init(id: String, type: String, name: String, content: String, ttl: Int, proxied: Bool) {
+    public init(id: String, type: String, name: String, content: String, ttl: Int, proxied: Bool, comment: String? = nil) {
         self.id = id
         self.type = type
         self.name = name
         self.content = content
         self.ttl = ttl
         self.proxied = proxied
+        self.comment = comment
     }
 }
 

--- a/Sources/AnglesiteCore/DomainConfigAudit.swift
+++ b/Sources/AnglesiteCore/DomainConfigAudit.swift
@@ -1,0 +1,203 @@
+/// Pure evaluator: diffs a site's declared `Source/anglesite.json` (`DomainConfig`, #1169)
+/// against its live Cloudflare state (`CloudflareZoneState` + `listDNSRecords`, #406) and reports
+/// drift. Read-only, no I/O — mirrors `SecurityAudit`'s idiom, extended to also grade DNS records
+/// (`SecurityAudit` only grades the narrow CAA/MX/SPF/DMARC subset `CloudflareZoneState` carries).
+///
+/// Managed DNS records are joined to their live counterpart via the `anglesite:<purpose>` record
+/// `comment` stamp (#1170, investigation doc §5.3) — never by content alone, since content is
+/// exactly what can drift. A live record with no `anglesite:` comment is never inspected: it's
+/// external by definition and the abort-don't-clobber posture falls out of not touching it.
+public enum DomainConfigAudit {
+    /// One piece of drift between declared and live state.
+    public struct Finding: Sendable, Equatable, Identifiable {
+        public enum Category: String, Sendable, Equatable {
+            case dns
+            case edge
+        }
+
+        /// How this finding should be resolved, per the "app advises" rule (investigation doc
+        /// §5.5): unambiguous app-owned drift auto-applies; contested state asks the owner a
+        /// question phrased about consequences to their site, never about git/diffs; some
+        /// findings (an untracked live record the app once created but no longer declares) are
+        /// surfaced with no action at all — the app was never told to touch it.
+        public enum Remediation: Sendable, Equatable {
+            /// Safe to apply without asking — resolves to one `DomainConfigReconcileItem`.
+            case autoApply(DomainConfigReconcileItem)
+            /// Needs the owner's call; the string is the consequences-phrased question to show.
+            case ownerQuestion(String)
+            /// Surfaced for awareness only; no action is offered.
+            case informational
+        }
+
+        public let category: Category
+        public let title: String
+        public let detail: String
+        public let remediation: Remediation
+
+        /// Memberwise initializer.
+        public init(category: Category, title: String, detail: String, remediation: Remediation) {
+            self.category = category
+            self.title = title
+            self.detail = detail
+            self.remediation = remediation
+        }
+
+        /// Content-derived identity, matching `AuditReport.Finding`'s rationale: the same drift
+        /// keeps the same id across re-audits so a SwiftUI list updates rows in place.
+        public var id: String { "\(category.rawValue):\(title):\(detail)" }
+    }
+
+    /// Grades declared `anglesite.json` state against a fresh Cloudflare read.
+    ///
+    /// - Parameters:
+    ///   - declared: The site's `Source/anglesite.json`, as loaded by `DomainConfigStore`.
+    ///   - live: The zone's security-relevant edge/DNS state (graded fields only).
+    ///   - liveDNSRecords: The zone's full DNS record listing (for the managed-record join,
+    ///     which needs the `comment` field `CloudflareZoneState` doesn't carry).
+    ///   - domain: The zone's apex hostname, to expand a declared record's zone-relative `name`
+    ///     (`"@"`, `"_atproto"`) into the fully-qualified form live records report.
+    /// - Returns: Findings in declared-record, then declared-edge-field order; empty when nothing
+    ///   has drifted.
+    public static func evaluate(
+        declared: DomainConfig,
+        live: CloudflareZoneState,
+        liveDNSRecords: [DNSRecord],
+        domain: String
+    ) -> [Finding] {
+        evaluateDNS(declared: declared, liveDNSRecords: liveDNSRecords, domain: domain)
+            + evaluateEdge(declared: declared, live: live)
+    }
+
+    // MARK: - DNS
+
+    private static func evaluateDNS(
+        declared: DomainConfig, liveDNSRecords: [DNSRecord], domain: String
+    ) -> [Finding] {
+        var findings: [Finding] = []
+        var matchedLiveIDs = Set<String>()
+
+        for record in declared.dns?.managedRecords ?? [] {
+            let fqName = fullyQualifiedName(record.name, domain: domain)
+            let expectedComment = record.purpose.map { "anglesite:\($0)" }
+            let candidates = liveDNSRecords.filter {
+                expectedComment != nil
+                    ? $0.comment == expectedComment
+                    : $0.type.caseInsensitiveCompare(record.type) == .orderedSame
+                        && $0.name.caseInsensitiveCompare(fqName) == .orderedSame
+            }
+            candidates.forEach { matchedLiveIDs.insert($0.id) }
+
+            // MX is multi-valued and shared with the owner's other mail setup, unlike every other
+            // record type here — adding our declared MX alongside an untagged (not app-managed)
+            // one already live could silently split mail delivery between two providers, so this
+            // is the one case that must ask rather than auto-apply.
+            if record.type.caseInsensitiveCompare("MX") == .orderedSame,
+               let conflicting = liveDNSRecords.first(where: {
+                   $0.type.caseInsensitiveCompare("MX") == .orderedSame
+                       && $0.name.caseInsensitiveCompare(fqName) == .orderedSame
+                       && !isAnglesiteTagged($0)
+               }) {
+                matchedLiveIDs.insert(conflicting.id)
+                findings.append(.init(
+                    category: .dns,
+                    title: "Existing mail record may conflict",
+                    detail: "Declared MX record \(record.content) for \(record.name) wasn't reconciled because an untracked MX record (\(conflicting.content)) is already live.",
+                    remediation: .ownerQuestion(
+                        "Your domain already has a mail (MX) record pointing to \(conflicting.content) that Anglesite didn't set up. Adding Anglesite's declared record for \(record.content) alongside it could disrupt your existing mail delivery. Keep the existing record and leave this alone?")))
+                continue
+            }
+
+            guard let liveMatch = candidates.first else {
+                findings.append(.init(
+                    category: .dns,
+                    title: "Missing managed DNS record",
+                    detail: "\(record.type) record \(record.name) is declared but not live.",
+                    remediation: .autoApply(.createManagedRecord(record))))
+                continue
+            }
+
+            if liveMatch.content != record.content {
+                findings.append(.init(
+                    category: .dns,
+                    title: "Managed DNS record content drifted",
+                    detail: "\(record.type) record \(record.name) is declared as \(record.content) but live as \(liveMatch.content).",
+                    remediation: .autoApply(.replaceManagedRecord(staleRecordID: liveMatch.id, declared: record))))
+            }
+        }
+
+        for live in liveDNSRecords where isAnglesiteTagged(live) && !matchedLiveIDs.contains(live.id) {
+            findings.append(.init(
+                category: .dns,
+                title: "Untracked Anglesite-managed record",
+                detail: "\(live.type) record \(live.name) is tagged \(live.comment ?? "") but anglesite.json no longer declares it.",
+                remediation: .informational))
+        }
+
+        return findings
+    }
+
+    private static func isAnglesiteTagged(_ record: DNSRecord) -> Bool {
+        record.comment?.hasPrefix("anglesite:") == true
+    }
+
+    /// Inverse of `DomainOperationsService`'s private `relativeName` — expands a declared
+    /// zone-relative name (`"@"` for the apex) into the fully-qualified form `listDNSRecords`
+    /// reports.
+    private static func fullyQualifiedName(_ name: String, domain: String) -> String {
+        name == "@" ? domain : "\(name).\(domain)"
+    }
+
+    // MARK: - Edge
+
+    private static func evaluateEdge(declared: DomainConfig, live: CloudflareZoneState) -> [Finding] {
+        guard let edge = declared.edge else { return [] }
+        var findings: [Finding] = []
+
+        if edge.dnssec == true, !live.dnssecActive {
+            findings.append(.init(
+                category: .edge, title: "DNSSEC is not active",
+                detail: "Declared but not applied on the live zone.",
+                remediation: .autoApply(.hardenEdge(.enableDNSSEC))))
+        }
+        if edge.alwaysUseHTTPS == true, !live.alwaysUseHTTPS {
+            findings.append(.init(
+                category: .edge, title: "Always Use HTTPS is off",
+                detail: "Declared but not applied on the live zone.",
+                remediation: .autoApply(.hardenEdge(.enableAlwaysUseHTTPS))))
+        }
+        if let declaredHSTS = edge.hsts {
+            let maxAge = declaredHSTS.maxAge ?? 31_536_000
+            let includeSubdomains = declaredHSTS.includeSubdomains ?? true
+            let preload = declaredHSTS.preload ?? false
+            let matchesLive = live.hsts.map {
+                $0.maxAge == maxAge && $0.includeSubdomains == includeSubdomains && $0.preload == preload
+            } ?? false
+            if !matchesLive {
+                findings.append(.init(
+                    category: .edge, title: "HSTS doesn't match the declared configuration",
+                    detail: "Declared but not applied on the live zone.",
+                    remediation: .autoApply(.hardenEdge(
+                        .enableHSTS(maxAge: maxAge, includeSubdomains: includeSubdomains, preload: preload)))))
+            }
+        }
+        if edge.cloudflare?.botFightMode == true, !live.botFightMode {
+            findings.append(.init(
+                category: .edge, title: "Bot Fight Mode is off",
+                detail: "Declared but not applied on the live zone.",
+                remediation: .autoApply(.hardenEdge(.enableBotFightMode))))
+        }
+        for rule in edge.cloudflare?.wafRules ?? [] {
+            let isLive = live.wafCustomRules.contains {
+                $0.description.caseInsensitiveCompare(rule.description) == .orderedSame
+            }
+            guard !isLive else { continue }
+            findings.append(.init(
+                category: .edge, title: "Declared WAF rule missing",
+                detail: "\(rule.description) is declared but not live.",
+                remediation: .autoApply(.hardenEdge(
+                    .addWAFRule(description: rule.description, expression: rule.expression, action: rule.action)))))
+        }
+
+        return findings
+    }
+}

--- a/Sources/AnglesiteCore/DomainConfigReconcilePlan.swift
+++ b/Sources/AnglesiteCore/DomainConfigReconcilePlan.swift
@@ -1,0 +1,50 @@
+/// One drift-correcting action `DomainConfigReconciler` can apply. Produced only for findings
+/// `DomainConfigAudit` classified as unambiguous app-owned drift (#1171) — never for
+/// `.ownerQuestion`/`.informational` findings, which the reconcile plan never includes.
+public enum DomainConfigReconcileItem: Sendable, Equatable, CustomStringConvertible {
+    /// Create a declared managed DNS record that has no live counterpart at all.
+    case createManagedRecord(DomainConfig.DNSRecord)
+    /// Delete the stale live record (by Cloudflare record id) and recreate it with the declared
+    /// content — Cloudflare's write API has no update-in-place, so a content drift is a
+    /// delete-then-recreate rather than a patch.
+    case replaceManagedRecord(staleRecordID: String, declared: DomainConfig.DNSRecord)
+    /// Reapply one declared edge-hardening setting via the same vocabulary `HardenExecutor`
+    /// already knows how to apply.
+    case hardenEdge(HardenPlanItem)
+
+    /// One diff-style `+`-prefixed preview line, matching `HardenPlanItem.description`'s idiom —
+    /// `DomainConfigReconcilePlan.summary` joins these into the opt-in preview the owner approves.
+    public var description: String {
+        switch self {
+        case .createManagedRecord(let record):
+            return "+ Create \(record.type) record \(record.name): \(record.content)"
+        case .replaceManagedRecord(_, let declared):
+            return "+ Replace \(declared.type) record \(declared.name) with: \(declared.content)"
+        case .hardenEdge(let item):
+            return item.description
+        }
+    }
+}
+
+/// A computed set of drift-correcting changes, ready for preview and opt-in application —
+/// the `DomainConfigAudit` counterpart to `HardenPlan` (investigation doc §5.5: "remediation
+/// reuses the Harden idiom").
+public struct DomainConfigReconcilePlan: Sendable, Equatable {
+    /// The changes to apply, in emission order — also the order `summary` previews them and
+    /// `DomainConfigReconciler` applies them.
+    public let items: [DomainConfigReconcileItem]
+    /// True when there is no unambiguous app-owned drift to correct.
+    public var isEmpty: Bool { items.isEmpty }
+
+    /// Creates a plan. Normally produced via `DomainConfigAudit.evaluate(...).reconcilePlan`;
+    /// direct construction is for tests.
+    public init(items: [DomainConfigReconcileItem]) {
+        self.items = items
+    }
+
+    /// Human-readable preview shown before the owner opts in.
+    public var summary: String {
+        if items.isEmpty { return "No drift to reconcile." }
+        return items.map(\.description).joined(separator: "\n")
+    }
+}

--- a/Sources/AnglesiteCore/DomainConfigReconciler.swift
+++ b/Sources/AnglesiteCore/DomainConfigReconciler.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Applies a `DomainConfigReconcilePlan` (unambiguous app-owned drift only — never contested
+/// state) via the Cloudflare write API, then re-reads state and re-runs `DomainConfigAudit`. The
+/// `DomainConfigAudit` counterpart to `HardenExecutor`, whose apply → re-read → re-audit shape it
+/// reuses directly for `.hardenEdge` items (investigation doc §5.5: "remediation reuses the
+/// Harden idiom"). Per-item failures do not abort the remaining items.
+public struct DomainConfigReconciler: Sendable {
+    private let reader: any CloudflareReading
+    private let writer: any CloudflareWriting
+
+    /// Creates a reconciler. Reader and writer are separate seams, matching `HardenExecutor`.
+    public init(reader: any CloudflareReading, writer: any CloudflareWriting) {
+        self.reader = reader
+        self.writer = writer
+    }
+
+    /// One plan item that failed to apply, paired with why — mirrors `HardenExecutor.ItemFailure`.
+    public struct ItemFailure: Sendable {
+        public let item: DomainConfigReconcileItem
+        public let error: String
+        public init(item: DomainConfigReconcileItem, error: String) {
+            self.item = item
+            self.error = error
+        }
+    }
+
+    /// The outcome of one ``execute(plan:zoneID:domain:apiToken:declared:)`` run.
+    public struct Result: Sendable {
+        public let appliedCount: Int
+        public let failedItems: [ItemFailure]
+        /// Findings from re-auditing declared vs the fresh post-apply live state. Empty either
+        /// means the audit is clean *or* the re-read failed — check ``auditError`` first.
+        public let postAuditFindings: [DomainConfigAudit.Finding]
+        public let auditError: String?
+
+        public init(appliedCount: Int, failedItems: [ItemFailure],
+                    postAuditFindings: [DomainConfigAudit.Finding], auditError: String? = nil) {
+            self.appliedCount = appliedCount
+            self.failedItems = failedItems
+            self.postAuditFindings = postAuditFindings
+            self.auditError = auditError
+        }
+    }
+
+    /// Applies every item in `plan`, then re-reads the zone (state + DNS records) and re-audits
+    /// `declared` against it so the caller shows the actual resulting drift, not an optimistic
+    /// prediction. DNS items (`.createManagedRecord`/`.replaceManagedRecord`) apply directly
+    /// against the writer; `.hardenEdge` items are batched into a `HardenPlan` and delegated to
+    /// `HardenExecutor.execute`, so edge-setting application logic lives in exactly one place.
+    public func execute(
+        plan: DomainConfigReconcilePlan,
+        zoneID: String,
+        domain: String,
+        apiToken: String,
+        declared: DomainConfig
+    ) async -> Result {
+        var applied = 0
+        var failures: [ItemFailure] = []
+        var edgeItems: [HardenPlanItem] = []
+
+        for item in plan.items {
+            switch item {
+            case .createManagedRecord(let record):
+                do {
+                    try await writer.addDNSRecord(zoneID: zoneID, record: payload(for: record), apiToken: apiToken)
+                    applied += 1
+                } catch {
+                    failures.append(.init(item: item, error: "\(error)"))
+                }
+            case .replaceManagedRecord(let staleRecordID, let record):
+                do {
+                    try await writer.deleteDNSRecord(zoneID: zoneID, recordID: staleRecordID, apiToken: apiToken)
+                    try await writer.addDNSRecord(zoneID: zoneID, record: payload(for: record), apiToken: apiToken)
+                    applied += 1
+                } catch {
+                    failures.append(.init(item: item, error: "\(error)"))
+                }
+            case .hardenEdge(let hardenItem):
+                edgeItems.append(hardenItem)
+            }
+        }
+
+        if !edgeItems.isEmpty {
+            let hardenResult = await HardenExecutor(reader: reader, writer: writer).execute(
+                plan: HardenPlan(items: edgeItems), zoneID: zoneID, domain: domain, apiToken: apiToken)
+            applied += hardenResult.appliedCount
+            failures += hardenResult.failedItems.map {
+                .init(item: .hardenEdge($0.item), error: $0.error)
+            }
+        }
+
+        let findings: [DomainConfigAudit.Finding]
+        var auditErr: String?
+        do {
+            let freshState = try await reader.zoneState(zoneID: zoneID, domain: domain, apiToken: apiToken)
+            let freshRecords = try await reader.listDNSRecords(zoneID: zoneID, apiToken: apiToken)
+            findings = DomainConfigAudit.evaluate(
+                declared: declared, live: freshState, liveDNSRecords: freshRecords, domain: domain)
+        } catch {
+            findings = []
+            auditErr = "\(error)"
+        }
+
+        return Result(appliedCount: applied, failedItems: failures,
+                      postAuditFindings: findings, auditError: auditErr)
+    }
+
+    private func payload(for record: DomainConfig.DNSRecord) -> DNSRecordPayload {
+        DNSRecordPayload(
+            type: record.type, name: record.name, content: record.content,
+            priority: record.priority, comment: record.purpose.map { "anglesite:\($0)" })
+    }
+}

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -55,6 +55,7 @@ private struct CFFullDNSRecord: Decodable, Sendable {
     let content: String
     let ttl: Int
     let proxied: Bool?
+    let comment: String?
 }
 private struct CFAccount: Decodable, Sendable { let id: String }
 private struct CFWorkerScript: Decodable, Sendable { let id: String }
@@ -284,7 +285,7 @@ public struct HTTPCloudflareClient: CloudflareReading {
         let raw = try await paginated("/zones/\(zoneID)/dns_records?per_page=100", apiToken: apiToken, as: CFFullDNSRecord.self)
         return raw.map {
             DNSRecord(id: $0.id, type: $0.type, name: $0.name, content: $0.content,
-                      ttl: $0.ttl, proxied: $0.proxied ?? false)
+                      ttl: $0.ttl, proxied: $0.proxied ?? false, comment: $0.comment)
         }
     }
 

--- a/Sources/AnglesiteCore/SiteToolbarItemID.swift
+++ b/Sources/AnglesiteCore/SiteToolbarItemID.swift
@@ -15,6 +15,8 @@ public enum SiteToolbarItemID: String, CaseIterable, Sendable {
     case audit
     case openInBrowser
     case harden
+    /// Domain config drift audit + reconcile (#1171): declared `anglesite.json` vs live Cloudflare.
+    case domainConfigAudit
     case onionRouting
     case domain
     case integration

--- a/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
+++ b/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+private final class StubReader: CloudflareReading, @unchecked Sendable {
+    private let zoneID: String?
+    private let state: CloudflareZoneState
+    private let records: [DNSRecord]
+    private(set) var resolvedDomain: String?
+    private(set) var listedZoneID: String?
+
+    init(zoneID: String? = "z1", state: CloudflareZoneState = StubReader.cleanState, records: [DNSRecord] = []) {
+        self.zoneID = zoneID
+        self.state = state
+        self.records = records
+    }
+
+    static let cleanState = CloudflareZoneState(
+        dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true,
+        hsts: nil, caaRecords: [], mxRecords: [], spfRecords: [], dmarcRecords: [])
+
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String? {
+        resolvedDomain = domain
+        return zoneID
+    }
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState { state }
+    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] {
+        listedZoneID = zoneID
+        return records
+    }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
+}
+
+private final class StubWriter: CloudflareWriting, @unchecked Sendable {
+    private(set) var addedRecords: [DNSRecordPayload] = []
+
+    func enableDNSSEC(zoneID: String, apiToken: String) async throws {}
+    func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool, apiToken: String) async throws {}
+    func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws {
+        addedRecords.append(record)
+    }
+    func deleteDNSRecord(zoneID: String, recordID: String, apiToken: String) async throws {}
+    func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {}
+    func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
+    func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func attachWorkersCustomDomain(hostname: String, workerScriptName: String, apiToken: String) async throws -> CustomDomainAttachResult {
+        .attached
+    }
+}
+
+@Suite(.serialized)
+struct DomainConfigAuditModelTests {
+    init() {
+        setenv("CLOUDFLARE_API_TOKEN", "test-token", 1)
+    }
+
+    private func tempSite(declaring config: DomainConfig? = nil) throws -> (CurrentSite, () -> Void) {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        if let config {
+            try DomainConfigStore(sourceDirectory: tmp).save(config)
+        }
+        let site = CurrentSite(id: "s1", packageURL: tmp, sourceDirectory: tmp)
+        return (site, { try? FileManager.default.removeItem(at: tmp) })
+    }
+
+    @MainActor
+    @Test("runAudit() surfaces a clear error when no domain is declared")
+    func runAuditNoDomainDeclared() async throws {
+        let (site, cleanup) = try tempSite()
+        defer { cleanup() }
+        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter())
+        model.configure(site: site)
+
+        model.runAudit()
+        while model.isRunning { await Task.yield() }
+
+        guard case .failed(let reason) = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        #expect(reason.contains("domain"))
+    }
+
+    @MainActor
+    @Test("runAudit() surfaces a clear error when the zone isn't found")
+    func runAuditZoneNotFound() async throws {
+        let declared = DomainConfig(domain: .init(hostname: "example.com"))
+        let (site, cleanup) = try tempSite(declaring: declared)
+        defer { cleanup() }
+        let model = DomainConfigAuditModel(reader: StubReader(zoneID: nil), writer: StubWriter())
+        model.configure(site: site)
+
+        model.runAudit()
+        while model.isRunning { await Task.yield() }
+
+        guard case .failed(let reason) = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        #expect(reason.contains("example.com"))
+    }
+
+    @MainActor
+    @Test("runAudit() computes findings against the declared config and resolved zone")
+    func runAuditComputesFindings() async throws {
+        let record = DomainConfig.DNSRecord(
+            type: "TXT", name: "_atproto", content: "did=did:plc:abc", purpose: "verification:bluesky")
+        let declared = DomainConfig(domain: .init(hostname: "example.com"), dns: .init(managedRecords: [record]))
+        let (site, cleanup) = try tempSite(declaring: declared)
+        defer { cleanup() }
+        let reader = StubReader(zoneID: "z1", state: StubReader.cleanState, records: [])
+        let model = DomainConfigAuditModel(reader: reader, writer: StubWriter())
+        model.configure(site: site)
+
+        model.runAudit()
+        while model.isRunning { await Task.yield() }
+
+        guard case .results(let findings, let plan, let domain, let zoneID) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)")
+            return
+        }
+        #expect(reader.resolvedDomain == "example.com")
+        #expect(domain == "example.com")
+        #expect(zoneID == "z1")
+        #expect(findings.count == 1)
+        #expect(plan.items == [.createManagedRecord(record)])
+    }
+
+    @MainActor
+    @Test("reconcile() delegates to DomainConfigReconciler and reports the applied plan")
+    func reconcileAppliesPlan() async throws {
+        let record = DomainConfig.DNSRecord(
+            type: "TXT", name: "_atproto", content: "did=did:plc:abc", purpose: "verification:bluesky")
+        let declared = DomainConfig(domain: .init(hostname: "example.com"), dns: .init(managedRecords: [record]))
+        let (site, cleanup) = try tempSite(declaring: declared)
+        defer { cleanup() }
+        let writer = StubWriter()
+        let model = DomainConfigAuditModel(reader: StubReader(zoneID: "z1"), writer: writer)
+        model.configure(site: site)
+
+        model.runAudit()
+        while model.isRunning { await Task.yield() }
+
+        model.reconcile()
+        while model.isRunning { await Task.yield() }
+
+        guard case .succeeded(let result) = model.phase else {
+            Issue.record("expected .succeeded, got \(model.phase)")
+            return
+        }
+        #expect(result.appliedCount == 1)
+        #expect(writer.addedRecords.first?.content == "did=did:plc:abc")
+    }
+
+    @MainActor
+    @Test("openSheet() resets phase")
+    func openSheetResets() {
+        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter())
+        model.openSheet()
+        #expect(model.sheetPresented == true)
+        #expect(model.phase == .idle)
+    }
+
+    @MainActor
+    @Test("dismissSheet() clears the presented flag")
+    func dismissSheetClearsPresented() {
+        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter())
+        model.openSheet()
+        model.dismissSheet()
+        #expect(model.sheetPresented == false)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DomainConfigAuditTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainConfigAuditTests.swift
@@ -1,0 +1,212 @@
+import Testing
+@testable import AnglesiteCore
+
+struct DomainConfigAuditTests {
+    private let domain = "example.com"
+
+    private func cleanZoneState(
+        dnssecActive: Bool = true,
+        alwaysUseHTTPS: Bool = true,
+        hsts: CloudflareZoneState.HSTS? = .init(maxAge: 31_536_000, includeSubdomains: true, preload: false),
+        botFightMode: Bool = true,
+        wafCustomRules: [CloudflareZoneState.WAFCustomRule] = []
+    ) -> CloudflareZoneState {
+        CloudflareZoneState(
+            dnssecActive: dnssecActive, sslMode: "strict", alwaysUseHTTPS: alwaysUseHTTPS,
+            hsts: hsts, caaRecords: [], mxRecords: [], spfRecords: [], dmarcRecords: [],
+            botFightMode: botFightMode, wafCustomRules: wafCustomRules)
+    }
+
+    @Test("no drift when declared is empty and nothing is tagged live")
+    func noDriftOnEmptyDeclared() {
+        let findings = DomainConfigAudit.evaluate(
+            declared: DomainConfig(), live: cleanZoneState(), liveDNSRecords: [], domain: domain)
+        #expect(findings.isEmpty)
+    }
+
+    @Test("flags a missing managed DNS record as auto-applicable")
+    func missingManagedRecordIsAutoApplicable() {
+        let declaredRecord = DomainConfig.DNSRecord(
+            type: "TXT", name: "_atproto", content: "did=did:plc:abc", purpose: "verification:bluesky")
+        let declared = DomainConfig(dns: .init(managedRecords: [declaredRecord]))
+
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(), liveDNSRecords: [], domain: domain)
+
+        #expect(findings.count == 1)
+        #expect(findings[0].category == .dns)
+        #expect(findings[0].remediation == .autoApply(.createManagedRecord(declaredRecord)))
+    }
+
+    @Test("in-sync managed record produces no finding")
+    func inSyncManagedRecordProducesNoFinding() {
+        let declaredRecord = DomainConfig.DNSRecord(
+            type: "TXT", name: "_atproto", content: "did=did:plc:abc", purpose: "verification:bluesky")
+        let declared = DomainConfig(dns: .init(managedRecords: [declaredRecord]))
+        let live = [DNSRecord(id: "r1", type: "TXT", name: "_atproto.example.com",
+                              content: "did=did:plc:abc", ttl: 1, proxied: false,
+                              comment: "anglesite:verification:bluesky")]
+
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(), liveDNSRecords: live, domain: domain)
+
+        #expect(findings.isEmpty)
+    }
+
+    @Test("flags drifted content on a managed non-MX record as auto-applicable")
+    func driftedNonMXRecordIsAutoApplicable() {
+        let declaredRecord = DomainConfig.DNSRecord(
+            type: "TXT", name: "_atproto", content: "did=did:plc:NEW", purpose: "verification:bluesky")
+        let declared = DomainConfig(dns: .init(managedRecords: [declaredRecord]))
+        let staleLive = DNSRecord(id: "r1", type: "TXT", name: "_atproto.example.com",
+                                  content: "did=did:plc:OLD", ttl: 1, proxied: false,
+                                  comment: "anglesite:verification:bluesky")
+
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(), liveDNSRecords: [staleLive], domain: domain)
+
+        #expect(findings.count == 1)
+        #expect(findings[0].category == .dns)
+        #expect(findings[0].remediation == .autoApply(
+            .replaceManagedRecord(staleRecordID: "r1", declared: declaredRecord)))
+    }
+
+    @Test("flags an MX conflict with an untagged live record as an owner question, not auto-apply")
+    func mxConflictWithUntaggedRecordIsOwnerQuestion() {
+        let declaredRecord = DomainConfig.DNSRecord(
+            type: "MX", name: "@", content: "mx01.mail.icloud.com", priority: 10, purpose: "email:icloud")
+        let declared = DomainConfig(dns: .init(managedRecords: [declaredRecord]))
+        let untaggedLiveMX = DNSRecord(id: "r1", type: "MX", name: "example.com",
+                                       content: "aspmx.l.google.com", ttl: 1, proxied: false, comment: nil)
+
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(), liveDNSRecords: [untaggedLiveMX], domain: domain)
+
+        #expect(findings.count == 1)
+        guard case .ownerQuestion(let question) = findings[0].remediation else {
+            Issue.record("expected an owner question, got \(findings[0].remediation)")
+            return
+        }
+        #expect(question.contains("mail"))
+    }
+
+    @Test("auto-applies a missing MX record when no untagged live MX record exists")
+    func missingMXRecordAutoAppliesWithNoConflict() {
+        let declaredRecord = DomainConfig.DNSRecord(
+            type: "MX", name: "@", content: "mx01.mail.icloud.com", priority: 10, purpose: "email:icloud")
+        let declared = DomainConfig(dns: .init(managedRecords: [declaredRecord]))
+
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(), liveDNSRecords: [], domain: domain)
+
+        #expect(findings.count == 1)
+        #expect(findings[0].remediation == .autoApply(.createManagedRecord(declaredRecord)))
+    }
+
+    @Test("ignores untagged live records with no declared counterpart entirely")
+    func ignoresUntaggedLiveRecords() {
+        let untagged = DNSRecord(id: "r1", type: "A", name: "example.com", content: "192.0.2.1",
+                                 ttl: 300, proxied: true, comment: nil)
+        let findings = DomainConfigAudit.evaluate(
+            declared: DomainConfig(), live: cleanZoneState(), liveDNSRecords: [untagged], domain: domain)
+        #expect(findings.isEmpty)
+    }
+
+    @Test("flags an orphaned anglesite-tagged live record with no declared counterpart as informational")
+    func orphanedTaggedRecordIsInformational() {
+        let orphan = DNSRecord(id: "r1", type: "TXT", name: "_atproto.example.com",
+                               content: "did=did:plc:abc", ttl: 1, proxied: false,
+                               comment: "anglesite:verification:bluesky")
+        let findings = DomainConfigAudit.evaluate(
+            declared: DomainConfig(), live: cleanZoneState(), liveDNSRecords: [orphan], domain: domain)
+
+        #expect(findings.count == 1)
+        #expect(findings[0].category == .dns)
+        #expect(findings[0].remediation == .informational)
+    }
+
+    @Test("flags missing DNSSEC as auto-applicable edge drift")
+    func missingDNSSECIsAutoApplicable() {
+        let declared = DomainConfig(edge: .init(dnssec: true))
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(dnssecActive: false), liveDNSRecords: [], domain: domain)
+
+        #expect(findings.count == 1)
+        #expect(findings[0].category == .edge)
+        #expect(findings[0].remediation == .autoApply(.hardenEdge(.enableDNSSEC)))
+    }
+
+    @Test("flags missing Always Use HTTPS as auto-applicable edge drift")
+    func missingAlwaysUseHTTPSIsAutoApplicable() {
+        let declared = DomainConfig(edge: .init(alwaysUseHTTPS: true))
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(alwaysUseHTTPS: false), liveDNSRecords: [], domain: domain)
+
+        #expect(findings.contains(.init(category: .edge, title: "Always Use HTTPS is off",
+                                        detail: "Declared but not applied on the live zone.",
+                                        remediation: .autoApply(.hardenEdge(.enableAlwaysUseHTTPS)))))
+    }
+
+    @Test("flags mismatched declared HSTS as auto-applicable edge drift")
+    func mismatchedHSTSIsAutoApplicable() {
+        let declaredHSTS = DomainConfig.Edge.HSTS(maxAge: 31_536_000, includeSubdomains: true, preload: false)
+        let declared = DomainConfig(edge: .init(hsts: declaredHSTS))
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(hsts: nil), liveDNSRecords: [], domain: domain)
+
+        #expect(findings.count == 1)
+        #expect(findings[0].remediation == .autoApply(.hardenEdge(
+            .enableHSTS(maxAge: 31_536_000, includeSubdomains: true, preload: false))))
+    }
+
+    @Test("declared HSTS matching live produces no finding")
+    func matchingHSTSProducesNoFinding() {
+        let declaredHSTS = DomainConfig.Edge.HSTS(maxAge: 31_536_000, includeSubdomains: true, preload: false)
+        let declared = DomainConfig(edge: .init(hsts: declaredHSTS))
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(), liveDNSRecords: [], domain: domain)
+        #expect(findings.isEmpty)
+    }
+
+    @Test("flags missing Bot Fight Mode as auto-applicable edge drift")
+    func missingBotFightModeIsAutoApplicable() {
+        let declared = DomainConfig(edge: .init(cloudflare: .init(botFightMode: true)))
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(botFightMode: false), liveDNSRecords: [], domain: domain)
+
+        #expect(findings.count == 1)
+        #expect(findings[0].remediation == .autoApply(.hardenEdge(.enableBotFightMode)))
+    }
+
+    @Test("flags a missing declared WAF rule as auto-applicable")
+    func missingWAFRuleIsAutoApplicable() {
+        let rule = DomainConfig.Edge.WAFRule(description: "Block dotfiles", expression: "(x)", action: "block")
+        let declared = DomainConfig(edge: .init(cloudflare: .init(wafRules: [rule])))
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: cleanZoneState(), liveDNSRecords: [], domain: domain)
+
+        #expect(findings.count == 1)
+        #expect(findings[0].remediation == .autoApply(.hardenEdge(
+            .addWAFRule(description: "Block dotfiles", expression: "(x)", action: "block"))))
+    }
+
+    @Test("declared WAF rule already live produces no finding")
+    func matchingWAFRuleProducesNoFinding() {
+        let rule = DomainConfig.Edge.WAFRule(description: "Block dotfiles", expression: "(x)", action: "block")
+        let declared = DomainConfig(edge: .init(cloudflare: .init(wafRules: [rule])))
+        let live = cleanZoneState(wafCustomRules: [
+            .init(description: "Block dotfiles", expression: "(x)", action: "block"),
+        ])
+        let findings = DomainConfigAudit.evaluate(
+            declared: declared, live: live, liveDNSRecords: [], domain: domain)
+        #expect(findings.isEmpty)
+    }
+
+    @Test("no edge findings when nothing is declared, regardless of live state")
+    func noEdgeFindingsWhenNothingDeclared() {
+        let findings = DomainConfigAudit.evaluate(
+            declared: DomainConfig(), live: cleanZoneState(dnssecActive: false, alwaysUseHTTPS: false),
+            liveDNSRecords: [], domain: domain)
+        #expect(findings.isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DomainConfigReconcilerTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainConfigReconcilerTests.swift
@@ -1,0 +1,124 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct DomainConfigReconcilerTests {
+    @Test("an empty plan produces zero applied, no failures, and re-audits")
+    func emptyPlanNoOps() async {
+        let reader = MockCloudflareReader()
+        let writer = MockCloudflareWriter()
+        let reconciler = DomainConfigReconciler(reader: reader, writer: writer)
+        let result = await reconciler.execute(
+            plan: DomainConfigReconcilePlan(items: []),
+            zoneID: "z", domain: "example.com", apiToken: "t", declared: DomainConfig())
+        #expect(result.appliedCount == 0)
+        #expect(result.failedItems.isEmpty)
+        #expect(writer.calls.isEmpty)
+    }
+
+    @Test("createManagedRecord calls addDNSRecord with the declared content and a namespaced comment")
+    func createManagedRecordAddsWithComment() async {
+        let writer = MockCloudflareWriter()
+        let reconciler = DomainConfigReconciler(reader: MockCloudflareReader(), writer: writer)
+        let record = DomainConfig.DNSRecord(
+            type: "TXT", name: "_atproto", content: "did=did:plc:abc", purpose: "verification:bluesky")
+        let result = await reconciler.execute(
+            plan: DomainConfigReconcilePlan(items: [.createManagedRecord(record)]),
+            zoneID: "z", domain: "example.com", apiToken: "t", declared: DomainConfig())
+
+        #expect(result.appliedCount == 1)
+        #expect(result.failedItems.isEmpty)
+        let added = writer.addedRecords.first
+        #expect(added?.type == "TXT")
+        #expect(added?.name == "_atproto")
+        #expect(added?.content == "did=did:plc:abc")
+        #expect(added?.comment == "anglesite:verification:bluesky")
+    }
+
+    @Test("createManagedRecord with no purpose adds with no comment")
+    func createManagedRecordWithNoPurposeAddsWithNoComment() async {
+        let writer = MockCloudflareWriter()
+        let reconciler = DomainConfigReconciler(reader: MockCloudflareReader(), writer: writer)
+        let record = DomainConfig.DNSRecord(type: "A", name: "@", content: "192.0.2.1")
+        _ = await reconciler.execute(
+            plan: DomainConfigReconcilePlan(items: [.createManagedRecord(record)]),
+            zoneID: "z", domain: "example.com", apiToken: "t", declared: DomainConfig())
+        #expect(writer.addedRecords.first?.comment == nil)
+    }
+
+    @Test("replaceManagedRecord deletes the stale record then creates the declared one")
+    func replaceManagedRecordDeletesThenCreates() async {
+        let writer = MockCloudflareWriter()
+        let reconciler = DomainConfigReconciler(reader: MockCloudflareReader(), writer: writer)
+        let record = DomainConfig.DNSRecord(
+            type: "TXT", name: "_atproto", content: "did=did:plc:NEW", purpose: "verification:bluesky")
+        let result = await reconciler.execute(
+            plan: DomainConfigReconcilePlan(items: [.replaceManagedRecord(staleRecordID: "stale1", declared: record)]),
+            zoneID: "z", domain: "example.com", apiToken: "t", declared: DomainConfig())
+
+        #expect(result.appliedCount == 1)
+        #expect(writer.calls.contains("deleteDNSRecord:stale1"))
+        #expect(writer.addedRecords.first?.content == "did=did:plc:NEW")
+        #expect(writer.addedRecords.first?.comment == "anglesite:verification:bluesky")
+    }
+
+    @Test("hardenEdge items apply via the writer, same as HardenExecutor")
+    func hardenEdgeItemsApplyViaWriter() async {
+        let writer = MockCloudflareWriter()
+        let reconciler = DomainConfigReconciler(reader: MockCloudflareReader(), writer: writer)
+        let result = await reconciler.execute(
+            plan: DomainConfigReconcilePlan(items: [.hardenEdge(.enableDNSSEC), .hardenEdge(.enableBotFightMode)]),
+            zoneID: "z", domain: "example.com", apiToken: "t", declared: DomainConfig())
+
+        #expect(result.appliedCount == 2)
+        #expect(writer.calls.contains("enableDNSSEC"))
+        #expect(writer.calls.contains("setBotFightMode"))
+    }
+
+    @Test("a per-item failure does not abort remaining items")
+    func perItemFailureResilience() async {
+        let writer = MockCloudflareWriter()
+        writer.failOn = "enableDNSSEC"
+        let reconciler = DomainConfigReconciler(reader: MockCloudflareReader(), writer: writer)
+        let record = DomainConfig.DNSRecord(type: "A", name: "@", content: "192.0.2.1")
+        let result = await reconciler.execute(
+            plan: DomainConfigReconcilePlan(items: [.hardenEdge(.enableDNSSEC), .createManagedRecord(record)]),
+            zoneID: "z", domain: "example.com", apiToken: "t", declared: DomainConfig())
+
+        #expect(result.appliedCount == 1)
+        #expect(result.failedItems.count == 1)
+        #expect(result.failedItems[0].item == .hardenEdge(.enableDNSSEC))
+    }
+
+    @Test("post-audit findings are recomputed against fresh live state")
+    func postAuditFindingsRecomputed() async {
+        let reader = MockCloudflareReader()
+        reader.dnsRecords = []
+        let writer = MockCloudflareWriter()
+        let reconciler = DomainConfigReconciler(reader: reader, writer: writer)
+        let stillMissing = DomainConfig.DNSRecord(
+            type: "TXT", name: "_atproto", content: "did=did:plc:abc", purpose: "verification:bluesky")
+        let declared = DomainConfig(dns: .init(managedRecords: [stillMissing]))
+
+        let result = await reconciler.execute(
+            plan: DomainConfigReconcilePlan(items: []),
+            zoneID: "z", domain: "example.com", apiToken: "t", declared: declared)
+
+        #expect(result.postAuditFindings.contains { $0.title == "Missing managed DNS record" })
+        #expect(result.auditError == nil)
+    }
+
+    @Test("reader failure during re-audit yields empty post-audit findings and populates auditError")
+    func readerFailureDuringReauditYieldsError() async {
+        let reader = MockCloudflareReader()
+        reader.shouldFail = true
+        let reconciler = DomainConfigReconciler(reader: reader, writer: MockCloudflareWriter())
+        let result = await reconciler.execute(
+            plan: DomainConfigReconcilePlan(items: [.hardenEdge(.enableDNSSEC)]),
+            zoneID: "z", domain: "example.com", apiToken: "t", declared: DomainConfig())
+
+        #expect(result.appliedCount == 1)
+        #expect(result.postAuditFindings.isEmpty)
+        #expect(result.auditError != nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DomainDNSClientTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainDNSClientTests.swift
@@ -36,6 +36,30 @@ struct DomainDNSClientTests {
         #expect(records.map(\.id) == ["rec1", "rec2"])
     }
 
+    @Test("listDNSRecords decodes the comment field")
+    func listDecodesComment() async throws {
+        let json = """
+        {"success":true,"errors":[],"result":[
+            {"id":"rec1","type":"MX","name":"example.com","content":"mx01.mail.icloud.com","ttl":1,"proxied":false,"comment":"anglesite:email:icloud"}
+        ]}
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport(["/dns_records?per_page=100": (200, json)]))
+        let records = try await client.listDNSRecords(zoneID: zoneID, apiToken: token)
+        #expect(records.first?.comment == "anglesite:email:icloud")
+    }
+
+    @Test("listDNSRecords defaults comment to nil when absent")
+    func listDefaultsCommentToNil() async throws {
+        let json = """
+        {"success":true,"errors":[],"result":[
+            {"id":"rec1","type":"A","name":"example.com","content":"192.0.2.1","ttl":300,"proxied":true}
+        ]}
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport(["/dns_records?per_page=100": (200, json)]))
+        let records = try await client.listDNSRecords(zoneID: zoneID, apiToken: token)
+        #expect(records.first?.comment == nil)
+    }
+
     @Test("listDNSRecords defaults proxied to false when absent")
     func listDefaultsProxied() async throws {
         let json = """

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -192,6 +192,9 @@ struct HardenExecutorTests {
 final class MockCloudflareReader: CloudflareReading, @unchecked Sendable {
     private let state: CloudflareZoneState
     var shouldFail = false
+    /// Configurable result for `listDNSRecords` — defaults empty; set before `execute` to feed a
+    /// reconciler's post-apply re-audit a specific live record set (`DomainConfigReconcilerTests`).
+    var dnsRecords: [DNSRecord] = []
 
     init(state: CloudflareZoneState = CloudflareZoneState(
         dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true,
@@ -208,7 +211,10 @@ final class MockCloudflareReader: CloudflareReading, @unchecked Sendable {
         if shouldFail { throw CloudflareError.malformedResponse }
         return state
     }
-    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] { [] }
+    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] {
+        if shouldFail { throw CloudflareError.malformedResponse }
+        return dnsRecords
+    }
     func workerScriptNames(apiToken: String) async throws -> [String] { [] }
 }
 

--- a/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
@@ -14,6 +14,7 @@ struct SiteToolbarItemIDTests {
             "audit",
             "openInBrowser",
             "harden",
+            "domainConfigAudit",
             "onionRouting",
             "domain",
             "integration",


### PR DESCRIPTION
Closes #1171

## Summary

- Slice 3 of 5 for #1095 (investigation doc, PR #1168) — stacked on #1186 (slice 2, write-through, not yet merged), which builds on #1178 (slice 1, schema + stores, merged).
- `DomainConfigAudit` (AnglesiteCore): pure evaluator that diffs a site's declared `Source/anglesite.json` against a fresh Cloudflare read (`CloudflareZoneState` + `listDNSRecords`). DNS records are joined to their live counterpart via the `anglesite:<purpose>` record `comment` stamp #1170 already applies — a live record with no `anglesite:` comment is never inspected. Findings classify their own remediation per the "app advises" rule: unambiguous app-owned drift (a missing/drifted managed record, a missing/drifted edge hardening setting, a missing declared WAF rule) auto-applies; an MX record that would land alongside an untracked live MX record asks the owner instead, phrased about consequences to their mail delivery, never about git/diffs; an `anglesite:`-tagged live record with no declared counterpart is surfaced for awareness only, with no action offered.
- `DomainConfigReconcilePlan`/`DomainConfigReconcileItem` (AnglesiteCore): the drift-audit counterpart to `HardenPlan`/`HardenPlanItem`, reusing `HardenPlanItem` directly for edge remediation so there's exactly one vocabulary for "apply this hardening setting."
- `DomainConfigReconciler` (AnglesiteCore): applies a reconcile plan — DNS create/replace items go straight through the Cloudflare writer; `.hardenEdge` items are batched into a `HardenPlan` and delegated to `HardenExecutor.execute`, so edge-setting application logic lives in exactly one place. Re-reads live state afterward and re-runs `DomainConfigAudit`, matching `HardenExecutor`'s apply → re-read → re-audit shape (investigation doc §5.5: "remediation reuses the Harden idiom").
- `DomainConfigAuditModel`/`DomainConfigAuditSheetView` (AnglesiteApp): a new "Domain Config" toolbar item (palette-only, next to Harden) that reads the declared domain straight out of `anglesite.json` — no text field, unlike Harden — and drives resolve → audit → reconcile → re-audit. The sheet groups findings into "Can be fixed automatically," "Needs your decision," and "For your awareness."
- `DNSRecord` (the read-side `CloudflareReading.listDNSRecords` shape) gains a `comment` field, since the declared-vs-live join needs it and #1170 never added one to the read side (only the write payload carries `comment`).

**Scope notes worth reviewer awareness:**
- MX priority isn't compared: `DNSRecord` (live/read-side) has no `priority` field, so a declared MX record's `priority` can silently drift undetected. Not fixable without widening the read model, which felt out of scope here.
- The MX-conflict-is-an-owner-question rule only fires while evaluating a *declared* MX record (missing or drifted) — it doesn't proactively scan for untracked MX records the app has no declared interest in. That's intentional: an owner's independent mail setup with nothing declared in `anglesite.json` isn't drift at all.
- Reconciling a "content drifted" DNS record is delete-then-recreate, not a patch — Cloudflare's write API in this codebase has no update-in-place seam.
- No interactive per-question UI flow for `.ownerQuestion` findings yet (accept/decline a specific reconciliation) — they're surfaced as text only. Wiring a real decision path is left for a follow-up; this slice's scope was "audit + remediation surfaces," and remediation here is the auto-apply path only.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passing (3149/3151; only the 2 pre-existing, unrelated `FoundationModelAssistantTests` on-device streaming flakes, present before this branch — see PR #1186's own test plan for the same note).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — could not run in this environment: fails with "requires a provisioning profile" (signing/provisioning limitation in this sandbox, unrelated to this change — same failure PR #1178/#1186 documented). Every app-target file this PR touches (`DomainConfigAuditModel.swift`, `DomainConfigAuditSheetView.swift`, `SiteWindow.swift`, `SiteWindowModel.swift`) compiles via `swift build`/`swift test` through the `AnglesiteAppCore`/`AnglesiteApp` SwiftPM targets. Since the app target itself can't build here, `Localizable.xcstrings` could not be re-synced for this sheet's new user-visible strings — flagging for whoever next has an interactive Xcode session, same as prior slices' documented limitation.
- [ ] Manual smoke: not run (no interactive Xcode/simulator session in this environment).