### PR TITLE
anglesite.json: move worker activation intent to Source/ (with fallback)

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -538,6 +538,11 @@ final class DeployModel {
                 text: "Deactivating workers: \(activationPlan.removedIDs.sorted().joined(separator: ", "))"
             )
         }
+        if let notice = DeployCoordinator.activeWorkerIDsFallbackNotice(source: activationPlan.activeWorkerIDsSource) {
+            // Mirrors SiteOperations.deployWithWorkerComposition's identical notice — shared text
+            // via DeployCoordinator so the two paths can't drift (#708 review feedback's idiom).
+            await logCenter.append(source: "deploy:\(siteID)", stream: .stdout, text: notice)
+        }
         let workers = activationPlan.workers
         if let warning = WorkerActivation.missingDescriptorWarning(unresolvedIDs: activationPlan.unresolvedIDs) {
             // Mirrors SiteOperations.deployWithWorkerComposition's identical warning — shared

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -880,6 +880,11 @@ final class PlistEditorModel {
     /// of `Config/settings.plist` so concurrently written fields (e.g. a deploy updating
     /// `lastDeployedWorkerIDs`) aren't clobbered, then notifies the runtime so a live local
     /// wrangler-dev session restarts with the new active set (§7).
+    ///
+    /// Also write-throughs the new `activeWorkerIDs` into `Source/anglesite.json`'s `workers.active`
+    /// declaration (#1172, `DeployCoordinator.syncWorkerActivationToAnglesiteJSON`) — best-effort,
+    /// like every other `anglesite.json` write-through: a git-tracked-file write failure must never
+    /// turn an already-succeeded `Config/` toggle into a reported failure.
     func setWorkerActive(_ workerID: String, isOn: Bool) async {
         guard let configDirectory else { return }
         let store = SiteConfigStore(configDirectory: configDirectory)
@@ -893,6 +898,9 @@ final class PlistEditorModel {
             workersError = String(localized: "Couldn't save the worker change: \(error.localizedDescription)")
             return
         }
+        settings = await DeployCoordinator.syncWorkerActivationToAnglesiteJSON(
+            configStore: store, sourceDirectory: sourceDirectory, settings: settings
+        )
         workerSettings = settings
         workersError = nil
         for groupIndex in workerGroups.indices {

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -856,6 +856,12 @@ final class PlistEditorModel {
     /// (network fetch with cache/empty degradation inside `WorkerCatalogFetcher`), and per-
     /// component-tied-worker affected pages via `ImpactAnalysis` over the Site Graph snapshot.
     /// Called from the tab's `.task`, so it re-runs (and re-fetches) on each tab open.
+    ///
+    /// Displays the *resolved* active set (`DeployCoordinator.resolveActiveWorkerIDs`), not
+    /// `Config/`'s raw `activeWorkerIDs` (#1172 review follow-up): a hand-edited `anglesite.json`
+    /// declaration the deploy path is about to trust would otherwise be invisible here, leaving
+    /// the owner unable to see — or knowingly toggle off — a worker that's actually about to
+    /// deploy.
     func loadWorkers() async {
         guard let configDirectory else {
             workerGroups = []
@@ -865,7 +871,11 @@ final class PlistEditorModel {
         }
         isLoadingWorkers = true
         defer { isLoadingWorkers = false }
-        let settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+        var settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+        let (resolvedActiveWorkerIDs, _) = DeployCoordinator.resolveActiveWorkerIDs(
+            settings: settings, sourceDirectory: sourceDirectory
+        )
+        settings.activeWorkerIDs = resolvedActiveWorkerIDs
         workerSettings = settings
         workerLastDeployedIDs = settings.lastDeployedWorkerIDs ?? []
         let catalog = await workerCatalogProvider()
@@ -885,13 +895,17 @@ final class PlistEditorModel {
     /// declaration (#1172, `DeployCoordinator.syncWorkerActivationToAnglesiteJSON`) — best-effort,
     /// like every other `anglesite.json` write-through: a git-tracked-file write failure must never
     /// turn an already-succeeded `Config/` toggle into a reported failure.
+    ///
+    /// Toggles from `DeployCoordinator.toggledActiveWorkerIDs`'s resolved base, not `Config/`'s raw
+    /// `activeWorkerIDs` (#1172 review follow-up) — see that function's doc comment for why a plain
+    /// `Config/`-only toggle would silently drop a trusted hand edit to the declaration.
     func setWorkerActive(_ workerID: String, isOn: Bool) async {
         guard let configDirectory else { return }
         let store = SiteConfigStore(configDirectory: configDirectory)
         var settings = (try? await store.load()) ?? workerSettings
-        var ids = Set(settings.activeWorkerIDs ?? [])
-        if isOn { ids.insert(workerID) } else { ids.remove(workerID) }
-        settings.activeWorkerIDs = ids.sorted()
+        settings.activeWorkerIDs = DeployCoordinator.toggledActiveWorkerIDs(
+            workerID: workerID, isOn: isOn, settings: settings, sourceDirectory: sourceDirectory
+        )
         do {
             try await store.save(settings)
         } catch {

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -120,6 +120,29 @@ public enum DeployCoordinator {
         return "using Config/'s worker activation (\(why))"
     }
 
+    /// The full active-worker-id set after applying one Settings-tab toggle (#1172 review
+    /// follow-up), for `syncWorkerActivationToAnglesiteJSON` to write through unconditionally.
+    ///
+    /// Toggles from the *resolved* set (`resolveActiveWorkerIDs`), not `settings.activeWorkerIDs`
+    /// directly: `resolveActiveWorkerIDs` trusts a hand-edited `anglesite.json` declaration
+    /// whenever `Config/` hasn't drifted since the last sync, and `syncWorkerActivationToAnglesiteJSON`
+    /// overwrites `workers.active` wholesale with whatever it's given — so toggling from
+    /// `Config/`'s raw (narrower) value would silently drop any hand-added id the declaration was
+    /// trusted to deploy on the very next toggle. Deliberately NOT a union of the two sets: a
+    /// union can only add ids, so it would make deactivating an already-declared worker
+    /// impossible — every toggle-off would be immediately re-added by the id still sitting in the
+    /// declaration. Resolving to one base set and applying exactly one add/remove on top of it is
+    /// what makes both directions (a hand-added id survives; an explicit deactivation sticks) work
+    /// simultaneously.
+    public static func toggledActiveWorkerIDs(
+        workerID: String, isOn: Bool, settings: SiteSettings, sourceDirectory: URL
+    ) -> [String] {
+        let (resolved, _) = resolveActiveWorkerIDs(settings: settings, sourceDirectory: sourceDirectory)
+        var ids = Set(resolved ?? [])
+        if isOn { ids.insert(workerID) } else { ids.remove(workerID) }
+        return ids.sorted()
+    }
+
     /// Write-through for the Workers Settings tab toggle (#1172): mirrors `settings.activeWorkerIDs`
     /// into `Source/anglesite.json`'s `workers.active` declaration, then records the synced value
     /// back into `Config/settings.plist` so `resolveActiveWorkerIDs` can tell a successful sync

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -34,19 +34,111 @@ public enum DeployCoordinator {
         /// to surface `WorkerActivation.missingDescriptorWarning` for this (`DeployModel` logs it
         /// to the debug pane, mirroring `SiteOperations.deployWithWorkerComposition`).
         public let unresolvedIDs: Set<String>
+        /// Where the settings-activated ids in `effectiveActiveIDs` were resolved from (#1172) —
+        /// the caller decides whether to surface `activeWorkerIDsFallbackNotice` for this, the
+        /// same way it already does for `unresolvedIDs`.
+        public let activeWorkerIDsSource: ActiveWorkerIDsSource
 
         /// Memberwise initializer — plans are normally produced by
         /// ``DeployCoordinator/planWorkerActivation(siteID:siteDirectory:settings:catalog:contentGraph:)``;
         /// this exists so tests can construct one directly.
         public init(
             effectiveActiveIDs: Set<String>, removedIDs: Set<String>,
-            workers: [WorkerDescriptor], unresolvedIDs: Set<String>
+            workers: [WorkerDescriptor], unresolvedIDs: Set<String>,
+            activeWorkerIDsSource: ActiveWorkerIDsSource = .declared
         ) {
             self.effectiveActiveIDs = effectiveActiveIDs
             self.removedIDs = removedIDs
             self.workers = workers
             self.unresolvedIDs = unresolvedIDs
+            self.activeWorkerIDsSource = activeWorkerIDsSource
         }
+    }
+
+    /// Where `resolveActiveWorkerIDs` sourced the settings-activated worker-id set from (#1172).
+    public enum ActiveWorkerIDsSource: Sendable, Equatable {
+        /// `Source/anglesite.json`'s `workers.active` declaration — current and trusted.
+        case declared
+        /// `Config/settings.plist`'s `activeWorkerIDs` — used because the declaration couldn't be
+        /// trusted, per `reason`.
+        case configFallback(reason: FallbackReason)
+
+        public enum FallbackReason: Sendable, Equatable {
+            /// `anglesite.json` exists but isn't valid JSON matching the schema.
+            case unparsable
+            /// `anglesite.json` is absent, or exists with no `workers.active` declared yet.
+            case notDeclared
+            /// `workers.active` is declared, but `Config/`'s current `activeWorkerIDs` no longer
+            /// matches the snapshot recorded at the last successful sync — either the write-through
+            /// failed partway, or something wrote `Config/` directly without going through it.
+            case staleRelativeToConfig
+        }
+    }
+
+    /// Resolves the settings-activated worker-id set for a deploy (#1172): prefers
+    /// `Source/anglesite.json`'s `workers.active` declaration, falling back to `Config/`'s
+    /// `activeWorkerIDs` whenever the declaration can't be trusted — absent, unparsable, or stale
+    /// relative to `Config/`'s live state (owner decision: never fail or silently deploy a reduced
+    /// worker set just because the migration hasn't caught up yet; see the timing investigation doc
+    /// `docs/superpowers/specs/2026-07-31-worker-activation-timing-investigation.md` §7).
+    ///
+    /// "Stale" is a value comparison against `settings.activeWorkerIDsMigratedToAnglesiteJSON`, not
+    /// a file-mtime one — `anglesite.json` also holds `domain`/`dns`/`edge`/`email` sections that
+    /// change far more often than `workers.active`, so the whole-file mtime is a poor staleness
+    /// proxy (see the investigation doc §5). This also self-heals: the next successful
+    /// `syncWorkerActivationToAnglesiteJSON` call brings the recorded snapshot back in sync.
+    public static func resolveActiveWorkerIDs(
+        settings: SiteSettings, sourceDirectory: URL
+    ) -> (ids: [String]?, source: ActiveWorkerIDsSource) {
+        let domainConfig: DomainConfig
+        do {
+            domainConfig = try DomainConfigStore(sourceDirectory: sourceDirectory).load()
+        } catch {
+            return (settings.activeWorkerIDs, .configFallback(reason: .unparsable))
+        }
+        guard let declared = domainConfig.workers?.active else {
+            return (settings.activeWorkerIDs, .configFallback(reason: .notDeclared))
+        }
+        guard settings.activeWorkerIDsMigratedToAnglesiteJSON == settings.activeWorkerIDs else {
+            return (settings.activeWorkerIDs, .configFallback(reason: .staleRelativeToConfig))
+        }
+        return (declared, .declared)
+    }
+
+    /// The shared debug-pane notice text for a `configFallback` `ActiveWorkerIDsSource`, so the
+    /// wording can't drift between `DeployModel.swift` and `SiteOperations.swift` — mirrors
+    /// `WorkerActivation.missingDescriptorWarning`'s shared-text idiom (#708 review feedback).
+    /// `nil` when `source` is `.declared` — nothing to report.
+    public static func activeWorkerIDsFallbackNotice(source: ActiveWorkerIDsSource) -> String? {
+        guard case .configFallback(let reason) = source else { return nil }
+        let why: String
+        switch reason {
+        case .unparsable: why = "anglesite.json couldn't be parsed"
+        case .notDeclared: why = "anglesite.json has no declared worker activation yet"
+        case .staleRelativeToConfig: why = "anglesite.json's declared worker activation is behind Config/'s"
+        }
+        return "using Config/'s worker activation (\(why))"
+    }
+
+    /// Write-through for the Workers Settings tab toggle (#1172): mirrors `settings.activeWorkerIDs`
+    /// into `Source/anglesite.json`'s `workers.active` declaration, then records the synced value
+    /// back into `Config/settings.plist` so `resolveActiveWorkerIDs` can tell a successful sync
+    /// apart from a `Config/`-only write. Best-effort, like every other write-through call site
+    /// (`CustomDomainAttachCommand`, `HardenExecutor`, `EmailSetupExecutor`): a git-tracked-file
+    /// write failure must never block the Settings tab toggle the caller already committed to
+    /// `Config/` — it just leaves `resolveActiveWorkerIDs` on the `Config/` fallback until the next
+    /// successful call. Returns `settings` unchanged if the `anglesite.json` write fails.
+    public static func syncWorkerActivationToAnglesiteJSON(
+        configStore: SiteConfigStore, sourceDirectory: URL, settings: SiteSettings
+    ) async -> SiteSettings {
+        let domainStore = DomainConfigStore(sourceDirectory: sourceDirectory)
+        var domainConfig = (try? domainStore.load()) ?? DomainConfig()
+        domainConfig.workers = DomainConfig.Workers(active: settings.activeWorkerIDs)
+        guard (try? domainStore.save(domainConfig)) != nil else { return settings }
+        var updated = settings
+        updated.activeWorkerIDsMigratedToAnglesiteJSON = settings.activeWorkerIDs
+        try? await configStore.save(updated)
+        return updated
     }
 
     /// Builds a `SiteGraphExplorerSnapshot` for `siteID` only when `contentGraph` has actually
@@ -75,13 +167,19 @@ public enum DeployCoordinator {
         } else {
             snapshot = nil
         }
-        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: catalog, graph: snapshot)
+        let (resolvedActiveWorkerIDs, activeWorkerIDsSource) = resolveActiveWorkerIDs(
+            settings: settings, sourceDirectory: siteDirectory
+        )
+        var effectiveSettings = settings
+        effectiveSettings.activeWorkerIDs = resolvedActiveWorkerIDs
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: effectiveSettings, catalog: catalog, graph: snapshot)
         let removedIDs = WorkerActivation.removedIDs(previous: Set(settings.lastDeployedWorkerIDs ?? []), next: effectiveActiveIDs)
         let workers = WorkerActivation.activeDescriptors(catalog: catalog, activeIDs: effectiveActiveIDs)
         let unresolvedIDs = WorkerActivation.unresolvedActiveIDs(activeIDs: effectiveActiveIDs, resolved: workers)
         return WorkerActivationPlan(
             effectiveActiveIDs: effectiveActiveIDs, removedIDs: removedIDs,
-            workers: workers, unresolvedIDs: unresolvedIDs
+            workers: workers, unresolvedIDs: unresolvedIDs,
+            activeWorkerIDsSource: activeWorkerIDsSource
         )
     }
 

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -44,6 +44,14 @@ public struct SiteSettings: Sendable, Codable, Equatable {
     /// content.
     public var activeWorkerIDs: [String]?
 
+    /// The `activeWorkerIDs` snapshot that was last successfully written into `Source/anglesite.json`'s
+    /// `workers.active` declaration by `DeployCoordinator.syncWorkerActivationToAnglesiteJSON` (#1172).
+    /// `DeployCoordinator.resolveActiveWorkerIDs` compares this against the current `activeWorkerIDs`
+    /// above to tell "the declaration is current" apart from "`Config/` has moved on since the last
+    /// successful sync" (a failed write-through, or a write that bypassed it) — in the latter case it
+    /// falls back to `activeWorkerIDs` rather than trusting a declaration that may be behind.
+    public var activeWorkerIDsMigratedToAnglesiteJSON: [String]?
+
     /// The full effective active worker-id set (component-tied + settings-activated) as of the
     /// last successful deploy — the diff baseline `WorkerActivation.removedIDs` reports removals
     /// against (#709).
@@ -78,6 +86,7 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         blueskyPDSURL: String? = nil,
         deployedSourceBundleCommit: String? = nil,
         activeWorkerIDs: [String]? = nil,
+        activeWorkerIDsMigratedToAnglesiteJSON: [String]? = nil,
         lastDeployedWorkerIDs: [String]? = nil,
         provisionedWorkerResources: WorkerComposition.ProvisionedResources? = nil,
         webmentionReceivePaidPlanAcknowledged: Bool? = nil,
@@ -91,6 +100,7 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         self.blueskyPDSURL = blueskyPDSURL
         self.deployedSourceBundleCommit = deployedSourceBundleCommit
         self.activeWorkerIDs = activeWorkerIDs
+        self.activeWorkerIDsMigratedToAnglesiteJSON = activeWorkerIDsMigratedToAnglesiteJSON
         self.lastDeployedWorkerIDs = lastDeployedWorkerIDs
         self.provisionedWorkerResources = provisionedWorkerResources
         self.webmentionReceivePaidPlanAcknowledged = webmentionReceivePaidPlanAcknowledged

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -89,7 +89,21 @@ public struct SiteOperations: Sendable {
     ) async -> DeployCommand.Result {
         let configStore = SiteConfigStore(configDirectory: site.configDirectory)
         let settings = (try? await configStore.load()) ?? SiteSettings()
-        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: settings, catalog: [], graph: nil)
+        // Resolves through the same `Source/anglesite.json` declaration (falling back to `Config/`)
+        // as `DeployModel.runDeploy`'s `DeployCoordinator.planWorkerActivation` (#1172) — mirrors
+        // its call, since this path doesn't otherwise go through `planWorkerActivation` (it has no
+        // populated `SiteContentGraph` to build a snapshot from, see the comment above).
+        let (resolvedActiveWorkerIDs, activeWorkerIDsSource) = DeployCoordinator.resolveActiveWorkerIDs(
+            settings: settings, sourceDirectory: siteDirectory
+        )
+        var effectiveSettings = settings
+        effectiveSettings.activeWorkerIDs = resolvedActiveWorkerIDs
+        if let notice = DeployCoordinator.activeWorkerIDsFallbackNotice(source: activeWorkerIDsSource) {
+            // Mirrors DeployModel.runDeploy's identical notice — shared text via DeployCoordinator
+            // so the two paths can't drift (#708 review feedback's idiom).
+            await LogCenter.shared.append(source: "deploy:\(site.id)", stream: .stdout, text: notice)
+        }
+        let effectiveActiveIDs = WorkerActivation.effectiveActiveIDs(settings: effectiveSettings, catalog: [], graph: nil)
 
         // Dynamic-route claims (#746) and resource composition (#708) both need real descriptor
         // data, which the `catalog: []` activation call above deliberately doesn't have (matching

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -209,6 +209,145 @@ struct DeployCoordinatorTests {
         #expect(saved.displayName == "Keep Me")
     }
 
+    // MARK: - resolveActiveWorkerIDs (#1172)
+
+    @Test("with no anglesite.json, falls back to Config/'s activeWorkerIDs")
+    func resolveActiveWorkerIDsFallsBackWhenFileAbsent() throws {
+        let dir = try temporaryDirectory()
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"])
+
+        let resolved = DeployCoordinator.resolveActiveWorkerIDs(settings: settings, sourceDirectory: dir)
+
+        #expect(resolved.ids == ["indieauth"])
+        #expect(resolved.source == .configFallback(reason: .notDeclared))
+    }
+
+    @Test("with anglesite.json present but no workers section, falls back to Config/")
+    func resolveActiveWorkerIDsFallsBackWhenWorkersNotDeclared() throws {
+        let dir = try temporaryDirectory()
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(hostname: "example.com")))
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"])
+
+        let resolved = DeployCoordinator.resolveActiveWorkerIDs(settings: settings, sourceDirectory: dir)
+
+        #expect(resolved.ids == ["indieauth"])
+        #expect(resolved.source == .configFallback(reason: .notDeclared))
+    }
+
+    @Test("with anglesite.json unparsable, falls back to Config/")
+    func resolveActiveWorkerIDsFallsBackWhenUnparsable() throws {
+        let dir = try temporaryDirectory()
+        try "not json".write(to: dir.appendingPathComponent("anglesite.json"), atomically: true, encoding: .utf8)
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"])
+
+        let resolved = DeployCoordinator.resolveActiveWorkerIDs(settings: settings, sourceDirectory: dir)
+
+        #expect(resolved.ids == ["indieauth"])
+        #expect(resolved.source == .configFallback(reason: .unparsable))
+    }
+
+    @Test("with a declared set in sync with Config/'s recorded migration snapshot, the declaration wins")
+    func resolveActiveWorkerIDsUsesDeclaredWhenInSync() throws {
+        let dir = try temporaryDirectory()
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(workers: .init(active: ["websub"])))
+        let settings = SiteSettings(activeWorkerIDs: ["websub"], activeWorkerIDsMigratedToAnglesiteJSON: ["websub"])
+
+        let resolved = DeployCoordinator.resolveActiveWorkerIDs(settings: settings, sourceDirectory: dir)
+
+        #expect(resolved.ids == ["websub"])
+        #expect(resolved.source == .declared)
+    }
+
+    @Test("with Config/'s activeWorkerIDs changed since the last successful sync, falls back to Config/ as stale")
+    func resolveActiveWorkerIDsFallsBackWhenStaleRelativeToConfig() throws {
+        let dir = try temporaryDirectory()
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(workers: .init(active: ["websub"])))
+        // Config/'s activeWorkerIDs has moved on to ["indieauth"] since the recorded sync snapshot
+        // (["websub"]) — e.g. the write-through failed partway, or an older build wrote Config/
+        // directly.
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"], activeWorkerIDsMigratedToAnglesiteJSON: ["websub"])
+
+        let resolved = DeployCoordinator.resolveActiveWorkerIDs(settings: settings, sourceDirectory: dir)
+
+        #expect(resolved.ids == ["indieauth"])
+        #expect(resolved.source == .configFallback(reason: .staleRelativeToConfig))
+    }
+
+    // MARK: - syncWorkerActivationToAnglesiteJSON (#1172)
+
+    @Test("writes Config/'s activeWorkerIDs into anglesite.json's workers.active and records the sync snapshot")
+    func syncWorkerActivationWritesDeclarationAndRecordsSnapshot() async throws {
+        let dir = try temporaryDirectory()
+        let configStore = SiteConfigStore(configDirectory: dir)
+        let settings = SiteSettings(activeWorkerIDs: ["websub", "indieauth"])
+
+        let updated = await DeployCoordinator.syncWorkerActivationToAnglesiteJSON(
+            configStore: configStore, sourceDirectory: dir, settings: settings
+        )
+
+        #expect(updated.activeWorkerIDsMigratedToAnglesiteJSON == ["websub", "indieauth"])
+        let declared = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(declared.workers?.active == ["websub", "indieauth"])
+        // The returned settings were also persisted to Config/, not just returned.
+        let saved = try await configStore.load()
+        #expect(saved.activeWorkerIDsMigratedToAnglesiteJSON == ["websub", "indieauth"])
+    }
+
+    @Test("syncing preserves an existing anglesite.json's other declared sections")
+    func syncWorkerActivationPreservesOtherSections() async throws {
+        let dir = try temporaryDirectory()
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(hostname: "example.com")))
+        let configStore = SiteConfigStore(configDirectory: dir)
+        let settings = SiteSettings(activeWorkerIDs: ["websub"])
+
+        _ = await DeployCoordinator.syncWorkerActivationToAnglesiteJSON(
+            configStore: configStore, sourceDirectory: dir, settings: settings
+        )
+
+        let declared = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(declared.domain?.hostname == "example.com")
+        #expect(declared.workers?.active == ["websub"])
+    }
+
+    // MARK: - planWorkerActivation reads through anglesite.json (#1172)
+
+    @Test("planWorkerActivation prefers a synced anglesite.json declaration over Config/'s activeWorkerIDs")
+    func planWorkerActivationPrefersDeclaredWhenSynced() async throws {
+        let catalog = [
+            descriptor(id: "websub", binding: .settingsActivated),
+            descriptor(id: "indieauth", binding: .settingsActivated),
+        ]
+        let dir = try temporaryDirectory()
+        // A hand edit added "indieauth" to the file after the last successful sync — Config/'s
+        // own activeWorkerIDs ("websub") hasn't moved since that sync, so the declaration (not
+        // Config/'s raw value) is what should win.
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(workers: .init(active: ["websub", "indieauth"])))
+        let settings = SiteSettings(activeWorkerIDs: ["websub"], activeWorkerIDsMigratedToAnglesiteJSON: ["websub"])
+        let contentGraph = SiteContentGraph()
+
+        let plan = await DeployCoordinator.planWorkerActivation(
+            siteID: "site-1", siteDirectory: dir, settings: settings, catalog: catalog, contentGraph: contentGraph
+        )
+
+        #expect(plan.effectiveActiveIDs == ["indieauth", "websub"])
+        #expect(plan.activeWorkerIDsSource == .declared)
+    }
+
+    @Test("planWorkerActivation reports the fallback source when anglesite.json has no declaration")
+    func planWorkerActivationReportsFallbackSource() async throws {
+        let catalog = [descriptor(id: "indieauth", binding: .settingsActivated)]
+        let dir = try temporaryDirectory()
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"])
+        let contentGraph = SiteContentGraph()
+
+        let plan = await DeployCoordinator.planWorkerActivation(
+            siteID: "site-1", siteDirectory: dir, settings: settings, catalog: catalog, contentGraph: contentGraph
+        )
+
+        #expect(plan.effectiveActiveIDs == ["indieauth"])
+        #expect(plan.activeWorkerIDsSource == .configFallback(reason: .notDeclared))
+    }
+
     // MARK: - runPostDeploySequencing
 
     /// Not an actor: `runPostDeploySequencing` calls `onMilestone` synchronously and awaits

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -309,6 +309,62 @@ struct DeployCoordinatorTests {
         #expect(declared.workers?.active == ["websub"])
     }
 
+    // MARK: - toggledActiveWorkerIDs (#1172 review follow-up)
+
+    @Test("toggling on preserves a hand-added id that's only in the trusted declaration, not yet in Config/")
+    func toggledActiveWorkerIDsPreservesHandAddedDeclaredID() throws {
+        let dir = try temporaryDirectory()
+        // A hand edit added "newsletter" to the declaration; Config/'s own activeWorkerIDs and its
+        // migration snapshot are still both ["indieauth"] (untouched, so nothing looks stale) —
+        // resolveActiveWorkerIDs trusts the declaration in this state.
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(workers: .init(active: ["indieauth", "newsletter"])))
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"], activeWorkerIDsMigratedToAnglesiteJSON: ["indieauth"])
+
+        let ids = DeployCoordinator.toggledActiveWorkerIDs(
+            workerID: "websub", isOn: true, settings: settings, sourceDirectory: dir
+        )
+
+        #expect(ids == ["indieauth", "newsletter", "websub"])
+    }
+
+    @Test("toggling off a hand-added declared id actually removes it, rather than being resurrected")
+    func toggledActiveWorkerIDsCanRemoveAHandAddedDeclaredID() throws {
+        let dir = try temporaryDirectory()
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(workers: .init(active: ["indieauth", "newsletter"])))
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"], activeWorkerIDsMigratedToAnglesiteJSON: ["indieauth"])
+
+        let ids = DeployCoordinator.toggledActiveWorkerIDs(
+            workerID: "newsletter", isOn: false, settings: settings, sourceDirectory: dir
+        )
+
+        #expect(ids == ["indieauth"])
+    }
+
+    @Test("toggling off a normal (non-hand-edited) worker still deactivates it — guards against a naive union fix")
+    func toggledActiveWorkerIDsDeactivatesNormally() throws {
+        let dir = try temporaryDirectory()
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(workers: .init(active: ["indieauth", "websub"])))
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth", "websub"], activeWorkerIDsMigratedToAnglesiteJSON: ["indieauth", "websub"])
+
+        let ids = DeployCoordinator.toggledActiveWorkerIDs(
+            workerID: "websub", isOn: false, settings: settings, sourceDirectory: dir
+        )
+
+        #expect(ids == ["indieauth"])
+    }
+
+    @Test("with no anglesite.json declared, toggling behaves exactly as it did against Config/ alone")
+    func toggledActiveWorkerIDsFallsBackWhenNotDeclared() throws {
+        let dir = try temporaryDirectory()
+        let settings = SiteSettings(activeWorkerIDs: ["indieauth"])
+
+        let ids = DeployCoordinator.toggledActiveWorkerIDs(
+            workerID: "websub", isOn: true, settings: settings, sourceDirectory: dir
+        )
+
+        #expect(ids == ["indieauth", "websub"])
+    }
+
     // MARK: - planWorkerActivation reads through anglesite.json (#1172)
 
     @Test("planWorkerActivation prefers a synced anglesite.json declaration over Config/'s activeWorkerIDs")

--- a/docs/anglesite-json-schema.md
+++ b/docs/anglesite-json-schema.md
@@ -111,6 +111,13 @@ hasn't touched that setting (which is different from the app having explicitly t
 |---|---|---|
 | `active` | array of string | The catalog IDs of the Workers the owner has activated for this site, e.g. `["webmention-receive", "micropub"]`. |
 
+The Workers Settings tab toggle writes this array here (in addition to the app-private
+`Config/settings.plist` it always wrote), and deploy reads it from here — falling back to
+`Config/`'s copy if this file is missing, unparsable, or hasn't caught up with a `Config/` change
+yet, so a deploy never fails or silently activates the wrong set just because the two haven't
+synced. A hand edit to `active` takes effect on the next deploy once the app's own copy in
+`Config/` matches it again (e.g. after the next toggle in the Workers tab).
+
 ## Compatibility
 
 Unknown keys — either a whole section this version of Anglesite doesn't recognize, or an extra

--- a/docs/superpowers/specs/2026-07-31-worker-activation-timing-investigation.md
+++ b/docs/superpowers/specs/2026-07-31-worker-activation-timing-investigation.md
@@ -1,0 +1,153 @@
+# Investigation: timing hazards for moving worker activation to `Source/anglesite.json`
+
+**Date:** 2026-07-31
+**Issue:** [#1172 — anglesite.json: move worker activation intent to Source/ (with fallback)](https://github.com/Anglesite/Anglesite/issues/1172)
+**Status:** Investigation complete, informs the implementation in the same PR
+
+Per the owner decision recorded in the parent investigation doc
+(`docs/superpowers/specs/2026-07-31-domain-config-in-git-investigation.md` §7.3): "investigate
+timing issues further during implementation and keep a fallback to the current `Config/`-based
+behavior." This doc records that investigation before describing the wiring it justifies.
+
+## 1. Where `activeWorkerIDs` lives and is touched today
+
+`SiteSettings.activeWorkerIDs` (`Sources/AnglesiteCore/SiteConfigStore.swift:45`) is read and
+written through `SiteConfigStore`, an actor scoped to `Config/settings.plist`. Every call site
+constructs its **own** `SiteConfigStore` instance — the actor provides no cross-instance
+serialization, so two concurrent read-modify-write cycles against the same file race the plist
+directly:
+
+- Reads: `WorkerActivation.effectiveActiveIDs` callers — `DeployModel.swift:527-528`,
+  `SiteOperations.swift:90-91`, `PlistEditorModel.swift:868-870`.
+- Writes: `PlistEditorModel.setWorkerActive` (`PlistEditorModel.swift:889-891`, the Workers
+  Settings tab toggle), `DeployCoordinator.persistProvisionedResources`
+  (`DeployCoordinator.swift:149-159`, the GUI post-deploy write), `SiteOperations.swift:139-144`
+  (the headless post-deploy write).
+
+`provisionedWorkerResources` (`SiteConfigStore.swift:56`) is the contrast case: it stays in
+`Config/` permanently (account-scoped resource identity, #709), never moves to `anglesite.json`.
+
+## 2. GUI deploy path (`DeployModel.runDeploy`)
+
+1. `DeployModel.swift:527-528` — **one** snapshot read of `Config/settings.plist`, held for the
+   entire deploy (build + provision + Cloudflare calls: real wall-clock seconds-to-minutes).
+2. `DeployCoordinator.planWorkerActivation` computes the effective set from that snapshot.
+3. `SocialWorkerProvisionCommand.provision` writes the host `Source/wrangler.toml` at several
+   points, culminating in `WorkerComposition.generateWranglerToml`
+   (`SocialWorkerProvisionCommand.swift:543`).
+4. When a container runtime is active, `ContainerDeployExecutor.run` re-syncs that host
+   `wrangler.toml` into the guest's boot-time clone immediately before the `.wrangler` step
+   (`DeployExecutor.swift:158-178`, the #1084 fix) — an explicit acknowledgment that the guest's
+   one-time `git clone` (`ContainerizationControl.swift:100-125`) is otherwise stale for any
+   uncommitted host write.
+5. `DeployCoordinator.persistProvisionedResources` (`DeployCoordinator.swift:149-159`) builds its
+   update from the **step-1 snapshot**, not a fresh read, and saves.
+
+Steps 1 and 5 are two independent, unsynchronized plist read/writes separated by the whole
+deploy. Nothing locks `Config/settings.plist` between them today, and this doc doesn't change
+that — it only adds a second file (`Source/anglesite.json`) with the same shape of hazard.
+
+## 3. Headless deploy path (`SiteOperations.deployWithWorkerComposition`)
+
+Runs **on the host**, inside `SiteAccess.withScopedAccess` (`SiteOperations.swift:87-147`) — it
+reads `Config/settings.plist` directly (`SiteOperations.swift:90-91`), the same as the GUI path.
+It is *not* the "container can't see `Config/`" case; that gap is structural, not this call
+site's problem. What it *does* lack is a populated `SiteContentGraph` (headless — no window open
+to build one) and a fresh worker-catalog fetch, so it resolves `WorkerDescriptor` data from
+`WorkerCatalogFetcher.cachedCatalog()` (PR #829) rather than the network. That workaround is about
+catalog **descriptor** data (bindings/routes), not the activation-id source `#1172` moves — the
+two are orthogonal, and this change doesn't touch the catalog-cache workaround.
+
+The genuinely `Config/`-blind boundary is the container **guest**: its `git clone` of `Source/`
+happens once at boot (`ContainerizationControl.swift:100-125`) and never sees `Config/` at all.
+Today this doesn't cause a bug because the **host** always computes activation and pushes the
+result (`wrangler.toml`) across the boundary (§2 step 4) — the guest never independently resolves
+`activeWorkerIDs`. Moving the declared source into `Source/anglesite.json` doesn't change *who*
+resolves activation (still the host, in both deploy paths); it changes *which file* the host reads
+it from, so that a future genuinely-remote trigger (no local Mac host in the loop at all) has a
+chance of working, since `anglesite.json` is the one activation-relevant file already inside the
+git clone the remote side would have.
+
+## 4. Workers Settings tab toggle (`PlistEditorModel.setWorkerActive`)
+
+`PlistEditorModel.swift:883-905` does a read-modify-write of `Config/settings.plist`, saves
+immediately, then calls `onActiveWorkersChanged(settings)`
+(`SiteWindowModel.swift:1077-1079` → `PreviewModel.activeWorkersChanged`,
+`PreviewModel.swift:504-506`) which **only** restarts a live local `wrangler-dev` preview session
+(`PreviewModel.swift:501-503`, "No-op for non-container runtimes"). It does not touch
+`wrangler.toml` and does not trigger a redeploy — the next real deploy re-reads `Config/` fresh at
+`DeployModel.swift:527-528`.
+
+## 5. Existing staleness idiom
+
+`FileDocumentIO.externalChange(at:lastKnownModificationDate:...)`
+(`Sources/AnglesiteCore/FileDocumentIO.swift:45-70`) is the codebase's one "is disk newer than my
+baseline" primitive — a strict `current > last` mtime comparison, with a documented HFS+
+1-second-granularity caveat. **Neither `SiteConfigStore` nor `DomainConfigStore` has any
+staleness logic today** — `DomainConfigStore.save` only guards the `version` field from being
+lowered by a merge (§ "Unlike every other field, `version`..."), which is schema-version
+protection, not a freshness check.
+
+Reusing raw file mtimes for this fallback would be misleading: `anglesite.json` also holds
+`domain`/`dns`/`edge`/`email` sections that change far more often than `workers.active` (a DNS
+record add touches the same file), so the whole-file mtime is a poor proxy for "is the `workers`
+declaration itself current." A value comparison against a recorded sync marker is used instead
+(§7) — no clock/mtime-granularity dependency, and it self-heals on the next successful
+write-through.
+
+## 6. Concrete hazard scenarios
+
+**a. GUI deploy vs. headless deploy running concurrently.** Both paths independently
+read-then-await-then-write `Config/settings.plist` through unsynchronized `SiteConfigStore`
+instances (§1). Whichever finishes last silently overwrites the other's
+`lastDeployedWorkerIDs`/`provisionedWorkerResources`. Pre-existing hazard, unrelated to this
+slice's `workers.active` move — noted for completeness, not addressed here.
+
+**b. Mid-deploy Workers-tab toggle.** `persistProvisionedResources` derives its update from the
+deploy's pre-deploy snapshot. A `setWorkerActive` toggle that lands between the snapshot and the
+post-deploy save gets its `activeWorkerIDs` write silently reverted the moment the deploy's
+success handler persists — even though the toggle already reported success to the owner.
+Pre-existing; moving the declared source to `anglesite.json` doesn't fix this (a deploy still
+plans from a point-in-time resolution), but it also doesn't make it worse, since the resolution
+in §7 is computed once per deploy exactly like today's `Config/` read is.
+
+**c. Stale container clone.** Not reachable today (§3) because the host always resolves
+activation and pushes `wrangler.toml` across. It becomes reachable only if a *future* deploy
+trigger reads `anglesite.json` from inside the guest's own clone rather than being told by a live
+host — out of scope for this slice, which keeps activation resolution host-side in both existing
+deploy paths.
+
+**d. `wrangler.toml` regen racing a hand edit of `anglesite.json`.** `DomainConfigStore.save` does
+an unlocked read-merge-write of the whole file. An owner's hand edit to `workers.active` and a
+concurrent write-through (Settings tab toggle, or the deploy-time sync in §7) each read-merge-write
+independently; whichever saves second wins for the `workers` key. This is the general
+`DomainConfigStore` concurrent-writer hazard already implicit in #1169/#1170/#1171 — not
+introduced by this slice — and is why the fallback (§7) treats a `Config/`/`anglesite.json`
+mismatch as "trust `Config/`, don't fail and don't silently deploy a reduced set" rather than
+trying to resolve the conflict.
+
+## 7. Resulting design (implemented in this PR)
+
+- **Resolution is a value comparison, not a timestamp one.** `SiteSettings` gains
+  `activeWorkerIDsMigratedToAnglesiteJSON: [String]?` — the `Config/` value that was successfully
+  written into `anglesite.json`'s `workers.active` the last time the write-through ran. At deploy
+  time, `DeployCoordinator.resolveActiveWorkerIDs` prefers the `anglesite.json` declaration only
+  when: the file parses, `workers.active` is declared, AND `Config/`'s *current* `activeWorkerIDs`
+  still equals that recorded snapshot. Any other case (unparsable file, never declared, or
+  `Config/` has moved since the last successful sync — write-through failed, or something wrote
+  `Config/` directly without going through it) falls back to `Config/`, matching the issue's
+  "absent, unparsable, or older than the `Config/` state it migrated from" wording without
+  depending on filesystem mtimes (avoids the HFS+ granularity caveat in §5, and self-heals on the
+  next successful write-through rather than requiring manual recovery).
+- **Write-through happens at toggle time**, not deploy time:
+  `DeployCoordinator.syncWorkerActivationToAnglesiteJSON` runs inside
+  `PlistEditorModel.setWorkerActive`, mirroring `CustomDomainAttachCommand.persistDomainIntent`'s
+  load-modify-save-best-effort shape. `Config/` is written first (existing behavior, unchanged);
+  the `anglesite.json` write and the sync-marker update are both best-effort (`try?`) so a
+  git-tracked-file write failure (e.g. `Source/` unwritable) never blocks the toggle the owner
+  already saw succeed — it just leaves the resolver on the `Config/` fallback until the next
+  successful toggle.
+- **Both deploy paths resolve through the same function.** `DeployCoordinator.planWorkerActivation`
+  calls `resolveActiveWorkerIDs` before computing `WorkerActivation.effectiveActiveIDs`, so
+  `DeployModel.runDeploy` and `SiteOperations.deployWithWorkerComposition` can't drift (same
+  mirrored-warning idiom #708/#744 already established for `missingDescriptorWarning`).


### PR DESCRIPTION
Closes #1172

## Summary

- Slice 4 of 5 for #1095 (investigation doc, PR #1168), stacked on the now-merged #1169/#1170/#1171 (PRs #1178/#1186/#1190). Per the owner decision recorded in that doc (§7.3), this starts with a timing-hazard investigation before any wiring — written up in `docs/superpowers/specs/2026-07-31-worker-activation-timing-investigation.md`. Key finding: the host (not the container guest) always resolves worker activation today, in both the GUI and headless deploy paths, so moving the declared source to `Source/anglesite.json` doesn't change *who* resolves activation, only *which file* it reads from.
- `DeployCoordinator.resolveActiveWorkerIDs` (AnglesiteCore): prefers `Source/anglesite.json`'s `workers.active` declaration, falling back to `Config/settings.plist`'s `activeWorkerIDs` whenever the declaration can't be trusted — absent, unparsable, or **stale relative to `Config/`'s live state**. Staleness is a value comparison against a new `SiteSettings.activeWorkerIDsMigratedToAnglesiteJSON` snapshot field, not a file-mtime one (the investigation doc explains why mtime is a poor proxy here — `anglesite.json` also holds `domain`/`dns`/`edge`/`email` sections that change far more often than `workers.active`). This never fails or silently deploys a reduced worker set — it just falls back.
- `DeployCoordinator.syncWorkerActivationToAnglesiteJSON`: the write-through, called from the Workers Settings tab toggle (`PlistEditorModel.setWorkerActive`) right after its existing `Config/` save. Best-effort (`try?`), mirroring `CustomDomainAttachCommand.persistDomainIntent`'s shape — a git-tracked-file write failure never blocks the toggle the owner already saw succeed.
- Both deploy paths resolve through the same function: `DeployCoordinator.planWorkerActivation` (GUI, via `DeployModel.runDeploy`) and `SiteOperations.deployWithWorkerComposition` (headless/App Intents) now both call `resolveActiveWorkerIDs` and log the same shared fallback-notice text when they fall back, mirroring the existing `missingDescriptorWarning` mirrored-warning idiom (#708 review feedback).
- `Config/settings.plist.activeWorkerIDs` is unchanged and still written on every toggle — this is the "fallback" the owner asked for, not a full migration; it stops being the primary source only once the declaration is trusted.
- Schema doc (`docs/anglesite-json-schema.md`) gets a short note on the write-through/fallback behavior for anyone hand-editing `workers.active`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passing (3165/3165 in AnglesiteCoreTests modulo 2 pre-existing, unrelated `FoundationModelAssistantTests` on-device streaming flakes present before this branch; 324/324 in the AnglesiteApp-side suites).
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [x] `scripts/check-localization-catalog.sh` — passes (no new user-facing strings; the new fallback notice is debug-pane/log-only, unlocalized like the existing `missingDescriptorWarning`).
- [ ] Manual smoke: not run (no interactive Xcode/simulator session in this environment) — toggling a worker in the Workers Settings tab and confirming `Source/anglesite.json`'s `workers.active` updates, then a deploy reading it, would be the smoke path.