### PR TITLE
anglesite.json: deploy-time validation (declared-vs-live + scan envelope)

### DIFF
--- a/Resources/Template/scripts/anglesite-config.ts
+++ b/Resources/Template/scripts/anglesite-config.ts
@@ -65,6 +65,13 @@ export interface AnglesiteConfig {
   workers?: AnglesiteWorkersConfig;
 }
 
+/// Schema versions this build understands. Shared with `pre-deploy-check.ts`'s structural
+/// validation (#1173) so "version recognized" means the same thing in both places — this
+/// tolerant reader still defaults an unrecognized/missing version to `1` rather than rejecting
+/// it (see `readAnglesiteConfig`'s doc comment), but the pre-deploy check treats a declared,
+/// unrecognized version as a hard failure with a fix-it.
+export const ANGLESITE_CONFIG_RECOGNIZED_VERSIONS = new Set([1]);
+
 function defaultConfig(): AnglesiteConfig {
   return { version: 1 };
 }

--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -10,6 +10,7 @@ import {
   checkMTAStsPolicy,
   checkSecurityTxt,
   checkEmbedMedia,
+  checkAnglesiteConfig,
 } from "./pre-deploy-check";
 import { MTA_STS_MARKER, SECURITY_TXT_MARKER } from "./edge-artifacts";
 
@@ -472,4 +473,54 @@ test("checkEmbedMedia: an upper-case host in a CSS url() is flagged", () => {
 
 test("checkEmbedMedia: an upper-case host in href is still not flagged", () => {
   assert.deepEqual(checkEmbedMedia('<a href="https://PBS.TWIMG.COM/media/x.jpg">original</a>', "f.html"), []);
+});
+
+test("checkAnglesiteConfig: a missing file (null) is clean — no declarations yet", () => {
+  assert.deepEqual(checkAnglesiteConfig(null), []);
+});
+
+test("checkAnglesiteConfig: a well-formed, versioned file is clean", () => {
+  assert.deepEqual(checkAnglesiteConfig(JSON.stringify({ version: 1, domain: { hostname: "example.com" } })), []);
+});
+
+test("checkAnglesiteConfig: a file with no version field defaults to 1 and is clean", () => {
+  assert.deepEqual(checkAnglesiteConfig(JSON.stringify({ domain: { hostname: "example.com" } })), []);
+});
+
+test("checkAnglesiteConfig: invalid JSON is an error with a fix-it", () => {
+  const issues = checkAnglesiteConfig("{ not json");
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].severity, "error");
+  assert.equal(issues[0].category, "anglesite-config-invalid");
+  assert.match(issues[0].message, /not valid JSON/);
+  assert.ok(issues[0].remediation);
+});
+
+test("checkAnglesiteConfig: a JSON array root is an error", () => {
+  const issues = checkAnglesiteConfig("[1, 2, 3]");
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].message, /must contain a JSON object/);
+});
+
+test("checkAnglesiteConfig: a JSON primitive root is an error", () => {
+  const issues = checkAnglesiteConfig("42");
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].message, /must contain a JSON object/);
+});
+
+test("checkAnglesiteConfig: a non-numeric version is an error", () => {
+  const issues = checkAnglesiteConfig(JSON.stringify({ version: "1" }));
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].message, /"version" must be a number/);
+});
+
+test("checkAnglesiteConfig: an unrecognized version number is an error naming the supported set", () => {
+  const issues = checkAnglesiteConfig(JSON.stringify({ version: 99 }));
+  assert.equal(issues.length, 1);
+  assert.match(issues[0].message, /version 99/);
+  assert.match(issues[0].message, /supported: 1/);
+});
+
+test("checkAnglesiteConfig: unknown top-level keys are tolerated (hand-edit rule)", () => {
+  assert.deepEqual(checkAnglesiteConfig(JSON.stringify({ version: 1, somethingFromANewerApp: true })), []);
 });

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -7,6 +7,8 @@
  * - No exposed API tokens or secrets
  * - No third-party tracking scripts
  * - No Keystatic admin routes in production output
+ * - `anglesite.json` (if present) parses, is a JSON object, and declares a recognized schema
+ *   version (#1173) — structural only; stays network-free, no declared-vs-live comparison here
  *
  * Usage: npx tsx scripts/pre-deploy-check.ts [--json] [--strict]
  *
@@ -23,12 +25,17 @@ import { fileURLToPath } from "node:url";
 import { parseAllowedDomains } from "./csp";
 import { readConfigFromString } from "./config";
 import { isMTAStsMarkerOwned, isSecurityTxtMarkerOwned, normalizeMTAStsMX, resolveMTAStsMode, resolveSecurityTxtMode } from "./edge-artifacts";
+import { ANGLESITE_CONFIG_RECOGNIZED_VERSIONS } from "./anglesite-config";
 
 interface Issue {
   severity: "error" | "warning";
   category: string;
   message: string;
   file?: string;
+  /// The scan's suggested fix, when it has one — mirrors `PreDeployCheck.ScanFailure`/
+  /// `ScanWarning`'s optional `remediation` field on the Swift side (#742/#1173). No existing
+  /// check populates this yet; `checkAnglesiteConfig` is the first producer.
+  remediation?: string;
 }
 
 interface ScanReport {
@@ -43,6 +50,7 @@ const STRICT_MODE = process.argv.includes("--strict");
 const DIST_DIR = join(process.cwd(), "dist");
 const HEADERS_FILE = join(DIST_DIR, "_headers");
 const CONFIG_FILE = join(process.cwd(), ".site-config");
+const ANGLESITE_CONFIG_FILE = join(process.cwd(), "anglesite.json");
 
 const PII_PATTERNS = [
   { name: "email", pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g },
@@ -522,8 +530,78 @@ export function checkMTAStsPolicy(content: string | null, configContent: string)
   return issues;
 }
 
+/**
+ * Structural validation of `Source/anglesite.json` (#1173): the file parses as JSON, is a JSON
+ * object, and declares a recognized schema version. Deliberately shallow — per-section field
+ * validation is `DomainConfigStore`'s job (Swift-side, #1169) and the #1171 drift audit's; this
+ * check exists only to fail loudly on a hand-edit that broke the file outright, since
+ * `readAnglesiteConfig`'s tolerant reader would otherwise silently fall back to defaults and the
+ * owner's declarations would vanish with no signal. `raw` is `null` when the file doesn't exist
+ * — the normal "no declarations yet" case, not an issue. Returns at most one issue: each
+ * structural problem is a prerequisite for checking the next (can't validate a version that
+ * didn't parse), so there's nothing to gain from accumulating more than one.
+ */
+export function checkAnglesiteConfig(raw: string | null): Issue[] {
+  const file = "anglesite.json";
+  if (raw === null) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return [{
+      severity: "error",
+      category: "anglesite-config-invalid",
+      message: `anglesite.json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      file,
+      remediation: "Fix the JSON syntax, or delete the file to reset your domain configuration declarations.",
+    }];
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return [{
+      severity: "error",
+      category: "anglesite-config-invalid",
+      message: "anglesite.json must contain a JSON object.",
+      file,
+      remediation: "Wrap the file's contents in a single JSON object (\"{ ... }\"), or delete it to reset your domain configuration declarations.",
+    }];
+  }
+
+  const config = parsed as Record<string, unknown>;
+  if ("version" in config && typeof config.version !== "number") {
+    return [{
+      severity: "error",
+      category: "anglesite-config-invalid",
+      message: `anglesite.json's "version" must be a number (found ${typeof config.version}).`,
+      file,
+      remediation: "Fix the \"version\" field, or remove it to default to the current schema version.",
+    }];
+  }
+
+  const version = typeof config.version === "number" ? config.version : 1;
+  if (!ANGLESITE_CONFIG_RECOGNIZED_VERSIONS.has(version)) {
+    return [{
+      severity: "error",
+      category: "anglesite-config-invalid",
+      message: `anglesite.json declares version ${version}, which this build doesn't recognize (supported: ${[...ANGLESITE_CONFIG_RECOGNIZED_VERSIONS].join(", ")}).`,
+      file,
+      remediation: "Update Anglesite to a version that supports this schema, or hand-edit \"version\" back to a supported value.",
+    }];
+  }
+
+  return [];
+}
+
 async function scan(): Promise<Issue[]> {
   const issues: Issue[] = [];
+
+  // Independent of dist/ — anglesite.json lives at the site root, so this runs even when
+  // there's nothing built yet to scan below.
+  const anglesiteConfigContent = await readFile(ANGLESITE_CONFIG_FILE, "utf-8").catch(
+    (e: NodeJS.ErrnoException) => (e.code === "ENOENT" ? null : Promise.reject(e)),
+  );
+  issues.push(...checkAnglesiteConfig(anglesiteConfigContent));
 
   try {
     await stat(DIST_DIR);

--- a/Sources/AnglesiteApp/BlockedDeploySheetView.swift
+++ b/Sources/AnglesiteApp/BlockedDeploySheetView.swift
@@ -104,6 +104,7 @@ private struct FailureCard: View {
         case .cspMisconfigured: return "shield.slash"
         case .embedMediaHotlink: return "photo.badge.exclamationmark"
         case .wellKnownCollision: return "exclamationmark.lock"
+        case .anglesiteConfigInvalid: return "doc.badge.gearshape"
         case .other: return "exclamationmark.triangle"
         }
     }
@@ -119,6 +120,7 @@ private struct FailureCard: View {
         case .cspMisconfigured: return "CSP misconfigured"
         case .embedMediaHotlink: return "Hotlinked embed media"
         case .wellKnownCollision: return "/.well-known/ collision"
+        case .anglesiteConfigInvalid: return "anglesite.json invalid"
         case .other: return "Other"
         }
     }

--- a/Sources/AnglesiteApp/CompletionNotificationHub.swift
+++ b/Sources/AnglesiteApp/CompletionNotificationHub.swift
@@ -66,6 +66,15 @@ enum CompletionNotificationHub {
                 // separately) carries the actionable info, and the deploy is parked rather than
                 // finished.
                 DockProgressController.shared.clear(token: dockToken)
+            case .domainConfigDrift(let findings):
+                // Unlike `.workerNameConflict`, this deploy isn't parked for an in-app retry — it
+                // just stopped, like `.blocked` — so it does get a completion notice.
+                DockProgressController.shared.clear(token: dockToken)
+                postNotice(siteID: siteID) { name in
+                    CompletionNoticeBuilder.deploy(
+                        siteName: name, siteID: siteID, outcome: .domainConfigDrift(findingCount: findings.count)
+                    )
+                }
             }
         }
         deploy.onMilestone = { siteID, progress in

--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -110,7 +110,7 @@ struct DeployDrawerView: View {
             Image(systemName: "exclamationmark.octagon.fill")
                 .foregroundStyle(.red).font(.title3)
                 .accessibilityHidden(true)
-        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded:
+        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded, .domainConfigDrift:
             Image(systemName: "shippingbox").font(.title3)
                 .accessibilityHidden(true)
         }
@@ -121,7 +121,7 @@ struct DeployDrawerView: View {
         case .running: return "Deploying \(siteName)…"
         case .succeeded(let url, _): return url.absoluteString
         case .failed: return "Deploy failed"
-        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded: return siteName
+        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded, .domainConfigDrift: return siteName
         }
     }
 
@@ -240,15 +240,15 @@ struct DeployDrawerView: View {
     }
 
     /// Collapses the app-target `DeployModel.Phase` onto the announceable substrate the decider
-    /// understands. `idle`, `blocked`, and `workerNameConflict` are all pre-output states →
-    /// `.inactive`.
+    /// understands. `idle`, `blocked`, `workerNameConflict`, `webmentionPaidPlanConfirmationNeeded`,
+    /// and `domainConfigDrift` are all pre-output states → `.inactive`.
     private func activity(for phase: DeployModel.Phase) -> LiveRegionAnnouncer.DeployActivity {
         switch phase {
         case .running: return .running(site: siteName)
         case .succeeded(let url, _): return .succeeded(url: url.absoluteString)
         case .failed(let reason, let exit):
             return .failed(reason: exit.map { "\(reason) (exit \($0))" } ?? reason)
-        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded: return .inactive
+        case .idle, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded, .domainConfigDrift: return .inactive
         }
     }
 
@@ -258,7 +258,7 @@ struct DeployDrawerView: View {
     private var canCopyLog: Bool {
         switch model.phase {
         case .succeeded, .failed: return true
-        case .idle, .running, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded: return false
+        case .idle, .running, .blocked, .workerNameConflict, .webmentionPaidPlanConfirmationNeeded, .domainConfigDrift: return false
         }
     }
 

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -26,6 +26,7 @@ final class DeployModel {
         case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning])
         case workerNameConflict(name: String)
         case webmentionPaidPlanConfirmationNeeded
+        case domainConfigDrift(findings: [DomainConfigAudit.Finding])
     }
 
     private(set) var phase: Phase = .idle
@@ -81,6 +82,11 @@ final class DeployModel {
     /// transfer domain is already attached to a *different* Worker. Dismiss-only; doesn't block
     /// the drawer or further deploys, since wrangler already succeeded by the time this runs.
     var domainConflictPresented: Bool = false
+    /// Bound to a `.sheet` in `SiteWindow` for the `.domainConfigDrift` outcome (#1173) — the
+    /// site's declared `anglesite.json` domain has drifted from its live Cloudflare state.
+    /// Dismiss-only, like `blockedPresented`: remediation happens in the Domain Config Audit
+    /// sheet (#1171), not here, so there's no `pendingDeploy` retry to park.
+    var domainConfigDriftPresented: Bool = false
 
     /// Progress of verifying a pasted token, consumed by `CloudflareTokenPromptView`'s status line
     /// and button-enabled logic. A token is only written to the Keychain once verification reaches
@@ -199,6 +205,7 @@ final class DeployModel {
     /// the user can act, since the background run's own reset/outcome always presents as `false`.
     private var awaitingUserAction: Bool {
         workerNameConflictPresented || webmentionPaidPlanConfirmationPresented || blockedPresented
+            || domainConfigDriftPresented
     }
 
     /// Renders the captured log lines as plain text for the "Copy log" affordance on failure.
@@ -290,6 +297,8 @@ final class DeployModel {
             return .blocked(failureCount: failures.count)
         case .workerNameConflict(let name):
             return .failed(reason: "Worker name \"\(name)\" is already in use on your Cloudflare account — rename it in the app and deploy again.")
+        case .domainConfigDrift(let findings):
+            return .failed(reason: "\(findings.count) declared domain configuration item(s) don't match your live Cloudflare setup — review the Domain Config Audit in the app and deploy again.")
         case .failed(let reason, _):
             return .failed(reason: reason)
         }
@@ -395,6 +404,13 @@ final class DeployModel {
         domainConflictPresented = false
     }
 
+    /// Dismisses the domain-config-drift sheet (#1173). Like `dismissDomainConflict`, this only
+    /// clears the informational sheet — reconciling the drift happens in the Domain Config Audit
+    /// sheet, which the sheet's "Review" button opens directly (wired in `SiteWindow`).
+    func dismissDomainConfigDrift() {
+        domainConfigDriftPresented = false
+    }
+
     /// Called by the paid-plan confirmation sheet's "Enable & retry" button. Persists the
     /// acknowledgment into `SiteSettings` (so future deploys never re-prompt) and retries the
     /// parked deploy — `runDeploy` re-reads settings and passes `acknowledgesPaidPlan: true`
@@ -477,6 +493,7 @@ final class DeployModel {
         drawerPresented = presentation == .foreground
         blockedPresented = false
         domainConflictPresented = false
+        domainConfigDriftPresented = false
 
         let sources = DeployCoordinator.deployLogSources(siteID: siteID)
 
@@ -805,6 +822,15 @@ final class DeployModel {
             workerNameConflictError = nil
             workerNameConflictPresented = presentation == .foreground
             webmentionPaidPlanConfirmationPresented = false
+        case .domainConfigDrift(let findings):
+            transition(siteID: siteID, to: .domainConfigDrift(findings: findings))
+            // Same reasoning as `.blocked`: the modal sheet carries the actionable info, and
+            // reconciling happens in the Domain Config Audit sheet, not by retrying this deploy
+            // directly — no `pendingDeploy` park.
+            drawerPresented = false
+            workerNameConflictPresented = false
+            webmentionPaidPlanConfirmationPresented = false
+            domainConfigDriftPresented = presentation == .foreground
         }
         return result
     }

--- a/Sources/AnglesiteApp/DomainConfigDriftSheetView.swift
+++ b/Sources/AnglesiteApp/DomainConfigDriftSheetView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Sheet shown when the deploy pipeline's declared-vs-live check (#1173) finds drift between
+/// `Source/anglesite.json` and the site's live Cloudflare state. Informs, doesn't remediate
+/// in-app — the "Review in Domain Config Audit" button hands off to the #1171 audit sheet, where
+/// findings are actually reconciled. Dismiss-only otherwise, like `DomainConflictSheetView`;
+/// there's no rename-and-retry action here, so no `pendingDeploy` park.
+struct DomainConfigDriftSheetView: View {
+    let findings: [DomainConfigAudit.Finding]
+    let onReview: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(findings) { finding in
+                        FindingCard(finding: finding)
+                    }
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            Divider()
+            HStack {
+                Button("Dismiss", action: onDismiss)
+                Spacer()
+                Button("Review in Domain Config Audit", action: onReview)
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            }
+            .padding(16)
+        }
+        .frame(width: 560, height: 420)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.title)
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Deploy blocked — domain config drift").font(.title3).fontWeight(.semibold)
+                Text("Your declared domain configuration (anglesite.json) doesn't match what's live on Cloudflare. Review and reconcile before deploying again.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(16)
+    }
+}
+
+private struct FindingCard: View {
+    let finding: DomainConfigAudit.Finding
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: categoryIcon)
+                    .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+                Text(finding.title)
+                    .font(.subheadline).fontWeight(.semibold)
+            }
+            Text(finding.detail).font(.callout)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(NSColor.controlBackgroundColor))
+        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(.orange.opacity(0.25)))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var categoryIcon: String {
+        switch finding.category {
+        case .dns: return "network"
+        case .edge: return "shield.lefthalf.filled"
+        }
+    }
+}
+
+#Preview {
+    DomainConfigDriftSheetView(
+        findings: [
+            DomainConfigAudit.Finding(
+                category: .dns, title: "Missing managed DNS record",
+                detail: "MX record @ is declared but not live.",
+                remediation: .autoApply(.createManagedRecord(
+                    DomainConfig.DNSRecord(type: "MX", name: "@", content: "mx.example.com")))
+            )
+        ],
+        onReview: {}, onDismiss: {}
+    )
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -820,6 +820,9 @@
     "Communities…" : {
 
     },
+    "Compare anglesite.json's declared domain/DNS/edge config against live Cloudflare state" : {
+
+    },
     "Compares this site's declared anglesite.json (domain, managed DNS records, edge hardening) against what's actually live on Cloudflare." : {
 
     },
@@ -1060,6 +1063,9 @@
 
     },
     "Deploy blocked" : {
+
+    },
+    "Deploy blocked — domain config drift" : {
 
     },
     "Deploy readiness" : {
@@ -2438,6 +2444,9 @@
     "Review copy on ${site}" : {
 
     },
+    "Review in Domain Config Audit" : {
+
+    },
     "Reviewing your site's copy, page by page…" : {
 
     },
@@ -3208,6 +3217,9 @@
 
     },
     "Writing" : {
+
+    },
+    "Your declared domain configuration (anglesite.json) doesn't match what's live on Cloudflare. Review and reconcile before deploying again." : {
 
     },
     "Your website was created with warnings. You can open it anyway and fix it from the website window." : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -605,6 +605,18 @@ struct SiteWindow: View {
                 model.deploy.cancelWebmentionPaidPlanConfirmation()
             }
         }
+        .sheet(isPresented: $bindableModel.deploy.domainConfigDriftPresented) {
+            if case .domainConfigDrift(let findings) = model.deploy.phase {
+                DomainConfigDriftSheetView(
+                    findings: findings,
+                    onReview: {
+                        model.deploy.dismissDomainConfigDrift()
+                        model.domainConfigAudit.openSheet()
+                    },
+                    onDismiss: { model.deploy.dismissDomainConfigDrift() }
+                )
+            }
+        }
         .sheet(isPresented: $bindableModel.audit.sheetPresented) {
             AuditSheetView(
                 model: model.audit,

--- a/Sources/AnglesiteCore/CompletionNotice.swift
+++ b/Sources/AnglesiteCore/CompletionNotice.swift
@@ -57,6 +57,11 @@ public enum CompletionNoticeBuilder {
         /// Pre-deploy security scan blocked the deploy; `failureCount` is the number of
         /// must-fix findings.
         case blocked(failureCount: Int)
+        /// Declared `anglesite.json` domain config drifted from live Cloudflare state (#1173);
+        /// `findingCount` is the number of drift findings. Distinguished from `.failed` for the
+        /// same reason as `.blocked` — this is the deploy pipeline's own validation catching a
+        /// real problem, not an error.
+        case domainConfigDrift(findingCount: Int)
     }
 
     /// Builds the deploy notice. All three outcomes share one identifier (`deploy.<siteID>`) so
@@ -84,6 +89,14 @@ public enum CompletionNoticeBuilder {
                 title: "Deploy Blocked",
                 subtitle: siteName,
                 body: "Pre-deploy check found \(failureCount) \(noun) that must be fixed before deploying.",
+                siteID: siteID, identifier: identifier, isFailure: true
+            )
+        case .domainConfigDrift(let findingCount):
+            let noun = findingCount == 1 ? "item" : "items"
+            return CompletionNotice(
+                title: "Deploy Blocked",
+                subtitle: siteName,
+                body: "\(findingCount) declared domain configuration \(noun) don't match your live Cloudflare setup. Review the Domain Config Audit, then deploy again.",
                 siteID: siteID, identifier: identifier, isFailure: true
             )
         }

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -46,6 +46,13 @@ public actor DeployCommand {
         /// `wrangler deploy` take over an unrelated (or stale) Worker. Carries the taken name for
         /// the UI's rename prompt (#740).
         case workerNameConflict(name: String)
+        /// The site declares a `Source/anglesite.json` domain (#1169) whose live Cloudflare state
+        /// has drifted from it (#1171) — refusing to ship against a domain/DNS/edge configuration
+        /// the app no longer knows is accurate. Carries the findings so the UI can summarize them
+        /// and point at the Domain Config Audit flow, where the owner reviews and reconciles
+        /// before redeploying (investigation doc §5.5 — deploy-time validation is a cheap check,
+        /// not a second remediation surface).
+        case domainConfigDrift(findings: [DomainConfigAudit.Finding])
         /// `exitCode` is `nil` for pre-spawn refusals (no token, no wrangler) and for spawn
         /// failures; otherwise it's the failing subprocess's exit code (including `0` for the
         /// "wrangler exited cleanly but we couldn't find a URL" case).
@@ -90,6 +97,14 @@ public actor DeployCommand {
     /// inject a fake list or a throwing closure.
     public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
 
+    /// Grades a declared `Source/anglesite.json` domain against live Cloudflare state and returns
+    /// any drift (#1171's `DomainConfigAudit.evaluate`, given a fresh zone read). Production
+    /// callers use `DeployCommand.defaultDomainConfigDriftSource`; tests inject a canned findings
+    /// list or a throwing closure — same rationale as `WorkerScriptNamesSource`.
+    public typealias DomainConfigDriftSource = @Sendable (
+        _ declared: DomainConfig, _ hostname: String, _ apiToken: String
+    ) async throws -> [DomainConfigAudit.Finding]
+
     /// The token seam this command was constructed with. Exposed so `DeployModel.runDeploy` can
     /// forward the exact same seam into companion commands (e.g. `SocialWorkerProvisionCommand`)
     /// instead of letting them silently default to the production implementation and diverge
@@ -104,22 +119,28 @@ public actor DeployCommand {
     /// Exposed like `tokenSource`/`workerScriptNamesSource` so `DeployModel.runDeploy` can forward
     /// the exact same seam into a container-path `DeployCommand` it constructs on the fly (#1077).
     public nonisolated let customDomainAttachCommand: CustomDomainAttachCommand
+    /// Exposed like the other seams above so callers building a parallel `DeployCommand` (e.g.
+    /// `SocialWorkerProvisionCommand`'s `defaultDeployer`) forward the same one rather than
+    /// silently defaulting to production and diverging from a test's injected fake.
+    public nonisolated let domainConfigDriftSource: DomainConfigDriftSource
     private let executor: any DeployExecutor
 
-    /// All four dependencies are injectable seams with production defaults, so tests can drive a
-    /// full deploy — token gate, name-conflict check, every step — with a literal token, a
-    /// canned script-name list, and a scripted executor, never touching the network or spawning
-    /// a process.
+    /// All five dependencies are injectable seams with production defaults, so tests can drive a
+    /// full deploy — token gate, name-conflict check, domain-config-drift check, every step —
+    /// with a literal token, a canned script-name list, and a scripted executor, never touching
+    /// the network or spawning a process.
     public init(
         tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
         workerScriptNamesSource: @escaping WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,
         customDomainAttachCommand: CustomDomainAttachCommand = CustomDomainAttachCommand(),
-        executor: any DeployExecutor = HostDeployExecutor()
+        executor: any DeployExecutor = HostDeployExecutor(),
+        domainConfigDriftSource: @escaping DomainConfigDriftSource = DeployCommand.defaultDomainConfigDriftSource
     ) {
         self.tokenSource = tokenSource
         self.workerScriptNamesSource = workerScriptNamesSource
         self.customDomainAttachCommand = customDomainAttachCommand
         self.executor = executor
+        self.domainConfigDriftSource = domainConfigDriftSource
     }
 
     /// Run a deploy for `siteID`. Returns once wrangler has exited (or before, if pre-spawn
@@ -162,6 +183,12 @@ public actor DeployCommand {
             siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
         ) {
             return conflict
+        }
+
+        if let drift = await Self.checkDomainConfigDrift(
+            siteDirectory: siteDirectory, apiToken: token, domainConfigDriftSource: domainConfigDriftSource
+        ) {
+            return drift
         }
 
         // Curated environment for the non-secret steps: a safe subset of the host process env,
@@ -557,6 +584,25 @@ public actor DeployCommand {
         return .workerNameConflict(name: candidateName)
     }
 
+    /// Grades the site's declared `anglesite.json` domain against live Cloudflare state (#1173).
+    /// Returns `.domainConfigDrift` when the audit finds any drift, or `nil` when the check
+    /// doesn't apply (no `anglesite.json`, or no declared `domain.hostname` — nothing to compare
+    /// against live state) or can't be confirmed. A read/decode error and a thrown/failed
+    /// `domainConfigDriftSource` both fail open — same posture as `checkWorkerNameConflict`, since
+    /// a transient Cloudflare API hiccup here must never block an otherwise-good deploy.
+    static func checkDomainConfigDrift(
+        siteDirectory: URL,
+        apiToken: String,
+        domainConfigDriftSource: DomainConfigDriftSource
+    ) async -> Result? {
+        guard let declared = try? DomainConfigStore(sourceDirectory: siteDirectory).load(),
+              let hostname = declared.domain?.hostname, !hostname.isEmpty
+        else { return nil }
+        guard let findings = try? await domainConfigDriftSource(declared, hostname, apiToken), !findings.isEmpty
+        else { return nil }
+        return .domainConfigDrift(findings: findings)
+    }
+
     // MARK: Host environment curation
 
     /// Keys that a host-path build or preflight step legitimately needs. The allowlist is
@@ -631,6 +677,20 @@ public actor DeployCommand {
     /// `HTTPCloudflareClient`.
     public static let defaultWorkerScriptNames: WorkerScriptNamesSource = { apiToken in
         try await HTTPCloudflareClient().workerScriptNames(apiToken: apiToken)
+    }
+
+    /// Default `DomainConfigDriftSource` for production: resolves the declared hostname's zone,
+    /// reads its live edge state and DNS records via `HTTPCloudflareClient`, then grades them with
+    /// `DomainConfigAudit.evaluate` — the same three calls `DomainConfigAuditModel.performAudit`
+    /// makes App-side, just without the SwiftUI-facing `Phase` machinery. A zone that can't be
+    /// resolved (not yet attached, or a Cloudflare read failure) returns no findings rather than
+    /// throwing — nothing to compare declared state against yet, not drift.
+    public static let defaultDomainConfigDriftSource: DomainConfigDriftSource = { declared, hostname, apiToken in
+        let reader: any CloudflareReading = HTTPCloudflareClient()
+        guard let zoneID = try await reader.resolveZoneID(domain: hostname, apiToken: apiToken) else { return [] }
+        let state = try await reader.zoneState(zoneID: zoneID, domain: hostname, apiToken: apiToken)
+        let records = try await reader.listDNSRecords(zoneID: zoneID, apiToken: apiToken)
+        return DomainConfigAudit.evaluate(declared: declared, live: state, liveDNSRecords: records, domain: hostname)
     }
 
     /// Default `PreflightChecker`: host-side preflight was retired with embedded Node. Container

--- a/Sources/AnglesiteCore/PreDeployCheck.swift
+++ b/Sources/AnglesiteCore/PreDeployCheck.swift
@@ -65,6 +65,12 @@ public actor PreDeployCheck {
             /// Swift-side before build, the same way `RouteCoverageScanner`'s `.orphanedRoute`
             /// is computed Swift-side rather than emitted by the TS scan script.
             case wellKnownCollision = "well-known-collision"
+            /// `Source/anglesite.json` exists but doesn't parse, isn't a JSON object, or declares
+            /// a schema version this build doesn't recognize (#1173) — a structural problem
+            /// `Resources/Template/scripts/pre-deploy-check.ts`'s `checkAnglesiteConfig` computes
+            /// network-free, distinct from the deploy-time declared-vs-live check
+            /// (`DeployCommand.Result.domainConfigDrift`).
+            case anglesiteConfigInvalid = "anglesite-config-invalid"
             /// Any category code this build doesn't recognize yet — decoding falls back here
             /// instead of throwing, so a future/typo'd category can't crash the whole scan (#742).
             case other = "other"

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -239,6 +239,10 @@ public struct SiteOperations: Sendable {
             return "Deploy blocked by the pre-deploy security scan (\(count) \(noun)). Resolve these in Anglesite first."
         case .workerNameConflict(let name):
             return "Deploy blocked: the Worker name \"\(name)\" is already in use on your Cloudflare account. Rename the site's Worker in Anglesite and try again."
+        case .domainConfigDrift(let findings):
+            let count = findings.count
+            let noun = count == 1 ? "item" : "items"
+            return "Deploy blocked: \(count) declared domain configuration \(noun) don't match your live Cloudflare setup. Review and reconcile in Anglesite's Domain Config Audit, then try again."
         case .failed(let reason, _):
             return "Deploy failed: \(reason)"
         }
@@ -282,6 +286,10 @@ public struct SiteOperations: Sendable {
             return "Social Worker provisioning blocked by the pre-deploy security scan (\(count) \(noun)).\(resourceSuffix(resources))"
         case .workerNameConflict(let name, let resources):
             return "Social Worker provisioning blocked: the Worker name \"\(name)\" is already in use on your Cloudflare account. Rename the site's Worker in Anglesite and try again.\(resourceSuffix(resources))"
+        case .domainConfigDrift(let findings, let resources):
+            let count = findings.count
+            let noun = count == 1 ? "item" : "items"
+            return "Social Worker provisioning blocked: \(count) declared domain configuration \(noun) don't match your live Cloudflare setup. Review and reconcile in Anglesite's Domain Config Audit, then try again.\(resourceSuffix(resources))"
         case .webmentionPaidPlanConfirmationNeeded(let resources):
             return "Social Worker provisioning paused: inbound Webmention and WebSub require the Cloudflare Workers Paid plan. Confirm this in Anglesite's deploy sheet and try again.\(resourceSuffix(resources))"
         case .failed(let reason, _, let resources):

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -37,6 +37,10 @@ public actor SocialWorkerProvisionCommand {
         /// one acknowledgment covers every Queue-backed feature — it's the same account-level
         /// plan fact.)
         case webmentionPaidPlanConfirmationNeeded(resources: WorkerComposition.ProvisionedResources)
+        /// Mirrors `DeployCommand.Result.domainConfigDrift` (#1173) — the downstream deploy's
+        /// declared-vs-live check found drift. Resources provisioned before the deploy stage
+        /// still ride along, same as `.blocked`.
+        case domainConfigDrift(findings: [DomainConfigAudit.Finding], resources: WorkerComposition.ProvisionedResources)
         /// A wrangler call, secret push, or the downstream deploy failed. `exitCode` is `nil` when
         /// the process couldn't run at all (as opposed to running and exiting non-zero).
         case failed(reason: String, exitCode: Int32?, resources: WorkerComposition.ProvisionedResources)
@@ -492,6 +496,8 @@ public actor SocialWorkerProvisionCommand {
             return .blocked(failures: failures, warnings: warnings, resources: resources)
         case .workerNameConflict(let name):
             return .workerNameConflict(name: name, resources: resources)
+        case .domainConfigDrift(let findings):
+            return .domainConfigDrift(findings: findings, resources: resources)
         case .failed(let reason, let exitCode):
             return .failed(reason: reason, exitCode: exitCode, resources: resources)
         }
@@ -741,6 +747,8 @@ extension SocialWorkerProvisionCommand.Result {
             return .blocked(failures: failures, warnings: warnings)
         case .workerNameConflict(let name, _):
             return .workerNameConflict(name: name)
+        case .domainConfigDrift(let findings, _):
+            return .domainConfigDrift(findings: findings)
         case .webmentionPaidPlanConfirmationNeeded:
             // `DeployCommand.Result` has no equivalent case yet — callers that go through this
             // convenience mapping (rather than reading `SocialWorkerProvisionCommand.Result`

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -134,6 +134,39 @@ struct DeployModelTests {
         #expect(model.workerNameConflictPresented)
     }
 
+    @Test("Domain config drift blocks the deploy and presents the drift sheet (#1173)")
+    func domainConfigDriftBlocksAndPresents() async {
+        let executor = GatedDeployExecutor()
+        // Never reached — drift short-circuits before the build step — but present so a
+        // regression that skips the gate doesn't hang the test on the gated continuation.
+        await executor.resumeBuild()
+        let finding = DomainConfigAudit.Finding(
+            category: .dns, title: "Missing managed DNS record", detail: "detail", remediation: .informational)
+        let command = DeployCommand(
+            tokenSource: { "test-token" },
+            executor: executor,
+            domainConfigDriftSource: { _, _, _ in [finding] }
+        )
+        let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
+        let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        var config = DomainConfig()
+        config.domain = DomainConfig.Domain(hostname: "example.com")
+        try! DomainConfigStore(sourceDirectory: siteDir).save(config)
+
+        model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
+        while model.isRunning { await Task.yield() }
+
+        guard case .domainConfigDrift(let findings) = model.phase else {
+            Issue.record("expected .domainConfigDrift, got \(model.phase)"); return
+        }
+        #expect(findings == [finding])
+        #expect(model.domainConfigDriftPresented)
+
+        model.dismissDomainConfigDrift()
+        #expect(!model.domainConfigDriftPresented)
+    }
+
     @Test("Renaming and retrying rewrites wrangler.toml/.site-config and re-deploys under the new name")
     func renameAndRetrySucceedsUnderNewName() async {
         let executor = GatedDeployExecutor()

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -775,6 +775,94 @@ struct DeployCommandTests {
         guard case .succeeded = result else { Issue.record("expected .succeeded (fail open), got \(result)"); return }
     }
 
+    // MARK: Domain config drift (#1173)
+
+    /// Writes `anglesite.json` declaring only `domain.hostname` (nothing else — the drift source
+    /// closure supplies canned findings directly, so no DNS/edge sections are needed).
+    private func makeSiteDirectory(declaredHostname: String?) -> URL {
+        let dir = makeSiteDirectory()
+        if let declaredHostname {
+            var config = DomainConfig()
+            config.domain = DomainConfig.Domain(hostname: declaredHostname)
+            try? DomainConfigStore(sourceDirectory: dir).save(config)
+        }
+        return dir
+    }
+
+    private func makeFinding(title: String = "Missing managed DNS record") -> DomainConfigAudit.Finding {
+        DomainConfigAudit.Finding(
+            category: .dns, title: title, detail: "detail", remediation: .informational)
+    }
+
+    @Test("Drift found for a declared domain returns .domainConfigDrift before any step runs")
+    func declaredDomainWithDriftReturnsDomainConfigDrift() async {
+        let siteDir = makeSiteDirectory(declaredHostname: "example.com")
+        let exec = FakeExecutor().onRun(.build, { Issue.record("build must not run when domain config drift is found") })
+        let finding = makeFinding()
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            executor: exec,
+            domainConfigDriftSource: { _, _, _ in [finding] }
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .domainConfigDrift(let findings) = result else {
+            Issue.record("expected .domainConfigDrift, got \(result)"); return
+        }
+        #expect(findings == [finding])
+        #expect(!exec.ran(.build))
+    }
+
+    @Test("No drift for a declared domain proceeds to build")
+    func declaredDomainWithNoDriftProceeds() async {
+        let siteDir = makeSiteDirectory(declaredHostname: "example.com")
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            executor: exec,
+            domainConfigDriftSource: { _, _, _ in [] }
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+    }
+
+    @Test("No declared domain skips the check entirely (fail open, source never called)")
+    func noDeclaredDomainSkipsDriftCheck() async {
+        let siteDir = makeSiteDirectory(declaredHostname: nil)
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            executor: exec,
+            domainConfigDriftSource: { _, _, _ in
+                Issue.record("must not be called when no domain is declared")
+                return []
+            }
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
+    }
+
+    @Test("A thrown error from domainConfigDriftSource fails open and proceeds to build")
+    func domainConfigDriftSourceErrorFailsOpen() async {
+        let siteDir = makeSiteDirectory(declaredHostname: "example.com")
+        let exec = FakeExecutor()
+            .set(.build, exitCode: 0, output: "")
+            .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
+            .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
+        let cmd = DeployCommand(
+            tokenSource: { "tok" },
+            executor: exec,
+            domainConfigDriftSource: { _, _, _ in throw CloudflareError.http(status: 500) }
+        )
+        let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
+        guard case .succeeded = result else { Issue.record("expected .succeeded (fail open), got \(result)"); return }
+    }
+
     @Test("Finds the URL when wrangler uses current Uploaded/Deployed wording instead of Published")
     func findsURLWithUploadedDeployedWording() async {
         // Current wrangler (4.x) no longer prints a "Published" line — it prints separate

--- a/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
+++ b/Tests/AnglesiteCoreTests/PreDeployCheckTests.swift
@@ -53,7 +53,7 @@ struct PreDeployCheckTests {
         #expect(failures[0].remediation?.contains("PII_EMAIL_ALLOW") == true)
     }
 
-    @Test("Parses all eight concrete failure categories") func parsesAllEightConcreteFailureCategories() async {
+    @Test("Parses all nine concrete failure categories") func parsesAllNineConcreteFailureCategories() async {
         let json = """
         {
           "version": 1,
@@ -66,7 +66,8 @@ struct PreDeployCheckTests {
             {"category": "third-party-script", "message": "m", "file": "a", "remediation": "r"},
             {"category": "keystatic-route", "message": "m", "file": "a", "remediation": "r"},
             {"category": "csp-misconfigured", "message": "m", "file": "a", "remediation": "r"},
-            {"category": "embed-media-hotlink", "message": "m", "file": "a", "remediation": "r"}
+            {"category": "embed-media-hotlink", "message": "m", "file": "a", "remediation": "r"},
+            {"category": "anglesite-config-invalid", "message": "m", "file": "a", "remediation": "r"}
           ],
           "warnings": []
         }
@@ -77,12 +78,13 @@ struct PreDeployCheckTests {
             Issue.record("expected .blocked")
             return
         }
-        // Every concrete ScanFailure.Category case except `.other`, which has its own dedicated
-        // test (`unknownCategoryDecodesToOther`) covering the forward-compatible fallback.
+        // Every concrete ScanFailure.Category case the JS scan script can emit, except `.other`
+        // (its own dedicated test, `unknownCategoryDecodesToOther`, covers the forward-compatible
+        // fallback) and `.wellKnownCollision` (Swift-computed, never JSON-decoded from the script).
         #expect(
             Set(failures.map(\.category)) == Set([
                 .piiEmail, .piiPhone, .piiSSN, .exposedToken, .thirdPartyScript, .keystaticRoute, .cspMisconfigured,
-                .embedMediaHotlink,
+                .embedMediaHotlink, .anglesiteConfigInvalid,
             ])
         )
     }

--- a/docs/anglesite-json-schema.md
+++ b/docs/anglesite-json-schema.md
@@ -125,8 +125,31 @@ field inside a section it does — are preserved when the app rewrites this file
 a field written by a newer Anglesite version, survives being loaded and re-saved by an older one.
 
 The app-side store fails to load a malformed or type-mismatched file with a specific `DecodingError`.
-The template's build-time reader handles parsing and shape mismatches more gracefully: it warns via
-`console.warn` and continues with defaults, so a hand-edit error never breaks a deploy.
+The template's build-time reader (`readAnglesiteConfig`, consumed mid-build) handles parsing and
+shape mismatches more gracefully: it warns via `console.warn` and continues with defaults, so a
+hand-edit error never breaks the build itself. The pre-deploy check (below) is stricter, precisely
+because a silently-defaulted declaration at *that* point would mean the rest of the deploy — including
+the declared-vs-live check — runs against the wrong assumptions.
+
+## Deploy-time validation (#1173)
+
+Two independent checks run before `wrangler deploy`, closing the gap `DeployCoordinator.resolveSiteURL`
+used to document bluntly: a configured domain "is never verified to be live."
+
+- **Structural (template-side, network-free).** `pre-deploy-check.ts`'s `checkAnglesiteConfig`
+  re-parses `anglesite.json` strictly: it must be valid JSON, a JSON object, and declare a
+  recognized `version` (unlike `readAnglesiteConfig`, an unrecognized or malformed value here is a
+  build-blocking failure with a fix-it, category `anglesite-config-invalid`, in the same versioned
+  scan envelope every other pre-deploy check reports through). A missing file is not an error —
+  the normal "no declarations yet" case. Unknown top-level keys are still tolerated (the hand-edit
+  rule); this check only rejects fields it understands but finds malformed.
+- **Declared-vs-live (app-side, one Cloudflare read).** `DeployCommand` grades the declared
+  `domain`/`dns`/`edge` sections against a fresh Cloudflare zone read via the same
+  `DomainConfigAudit.evaluate` the Domain Config Audit sheet uses (#1171). Any drift blocks the
+  deploy (`DeployCommand.Result.domainConfigDrift`) with a sheet pointing at that audit sheet to
+  reconcile — remediation happens there, not as a deploy-time side effect. A site with no declared
+  `domain.hostname`, or a Cloudflare read that fails outright, skips this check (fails open) rather
+  than blocking an otherwise-good deploy on a transient API hiccup.
 
 There's currently no way for the app to "un-declare" something it previously wrote. A field or
 section the app has declared stays in the file even after a later app action stops setting it —


### PR DESCRIPTION
Closes #1173

Stacked on #1192 (slice 4, #1172) — this PR's diff will shrink to just its own commit once #1192 merges to `main`. Retarget to `main` at that point.

## Summary

- **App-side declared-vs-live check.** `DeployCommand` gains `checkDomainConfigDrift`, in the same pre-build slot `checkWorkerNameConflict` occupies: if the site declares a `Source/anglesite.json` `domain.hostname`, it grades that declaration against a fresh Cloudflare read via the existing `DomainConfigAudit.evaluate` (#1171) and short-circuits the deploy with a new `.domainConfigDrift(findings:)` result on any drift. Fails open (no declared domain, or a Cloudflare read error) so this never blocks an otherwise-good deploy. `DeployModel` surfaces it as a dismiss-only sheet (`DomainConfigDriftSheetView`) with a "Review in Domain Config Audit" button that opens the existing #1171 audit sheet — remediation happens there, not as a deploy-time side effect.
- **Template-side structural check.** `pre-deploy-check.ts` gains `checkAnglesiteConfig`, a network-free check that `anglesite.json` (if present) parses as JSON, is a JSON object, and declares a recognized schema version — folded into the existing versioned scan envelope (#742) under a new `anglesite-config-invalid` category. Unlike the tolerant build-time reader (`readAnglesiteConfig`), this fails loudly with a fix-it on a broken hand edit; unknown top-level keys are still tolerated.
- Plumbed the new `DeployCommand.Result` case through every exhaustive consumer (`SocialWorkerProvisionCommand`, `SiteOperations` dialog strings, `CompletionNotificationHub`/`CompletionNotice`, `DeployDrawerView`, `DeployModel`), and added the matching `PreDeployCheck.ScanFailure.Category` case + `BlockedDeploySheetView` icon/label.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 3169/3169 in AnglesiteCoreTests modulo 1 pre-existing, unrelated on-device `FoundationModelAssistantTests` streaming flake present before this branch (confirmed by re-running that suite in isolation); all AnglesiteApp-side suites pass, including new `DeployCommandTests`/`DeployModelTests` coverage for the drift check.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [x] `scripts/check-localization-catalog.sh` — passes; synced `Localizable.xcstrings` for the new sheet's strings (scoped to this worktree's own `BUILD_DIR`, reviewed the diff).
- [x] Template: `npm test` (tsx --test + both vitest configs) — 664+35 passing (2 pre-existing skips), plus new `checkAnglesiteConfig` unit tests in `pre-deploy-check.test.ts`; `npx tsc --noEmit` and `npx oxlint` clean on the touched files.
- [ ] Manual smoke: not run (no interactive Xcode/simulator session in this environment) — declaring a domain in `anglesite.json` that doesn't match live Cloudflare state, then deploying, would be the smoke path for the new sheet.