### PR TITLE
fix(#1182): propagate rename into untitled site's .site-config

### DIFF
--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -334,10 +334,12 @@ public actor SiteStore {
     }
 
     /// Set (or clear, with a nil/blank `name`) the owner-facing display-name override for the site
-    /// with `id`. Writes `Config/settings.plist`, then re-resolves the in-memory + persisted name
-    /// via `Site.make` (so a clear falls back to the marker name) and broadcasts the change so an
-    /// open window's title and the launcher list refresh live (#266). Returns the updated site, or
-    /// `nil` if `id` is unknown.
+    /// with `id`. For a non-clearing rename, first best-effort propagates the new name into
+    /// `Source/`'s `.site-config`/`wrangler.toml` via `UntitledSitePropagation` (only takes effect
+    /// pre-publish; #1182). Then writes `Config/settings.plist`, re-resolves the in-memory +
+    /// persisted name via `Site.make` (so a clear falls back to the marker name), and broadcasts
+    /// the change so an open window's title and the launcher list refresh live (#266). Returns the
+    /// updated site, or `nil` if `id` is unknown.
     @discardableResult
     public func setDisplayName(_ name: String?, for id: String) async throws -> Site? {
         guard let index = sites.firstIndex(where: { $0.id == id }) else { return nil }

--- a/Sources/AnglesiteCore/SiteStore.swift
+++ b/Sources/AnglesiteCore/SiteStore.swift
@@ -346,6 +346,17 @@ public actor SiteStore {
         let override = (trimmed?.isEmpty == false) ? trimmed : nil
 
         let package = AnglesitePackage(url: existing.packageURL)
+
+        // Best-effort, and run before the no-op guard below so a retry always re-attempts it —
+        // propagateIfUntitled is itself cheap and idempotent (#1182).
+        if let override {
+            UntitledSitePropagation.propagateIfUntitled(
+                newDisplayName: override,
+                siteDirectory: package.sourceURL,
+                fileManager: fileManager
+            )
+        }
+
         let config = SiteConfigStore(configDirectory: package.configURL, fileManager: fileManager)
         var settings = try await config.load()
         // Renaming to the current value (or clearing an already-empty override) changes nothing —

--- a/Sources/AnglesiteCore/UntitledSitePropagation.swift
+++ b/Sources/AnglesiteCore/UntitledSitePropagation.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Best-effort propagation of a site's display-name rename into its `.site-config` and
+/// `wrangler.toml`, but only while the site is still carrying its scaffold-time "Untitled"
+/// defaults and hasn't touched Cloudflare yet (#1182). Distinct from `WorkerNameRename`, which
+/// handles the post-deploy, collision-triggered rename flow and deliberately leaves `SITE_NAME`
+/// untouched — this is the pre-deploy counterpart that updates both `SITE_NAME` and
+/// `CF_PROJECT_NAME`.
+public enum UntitledSitePropagation {
+    /// Propagates `newDisplayName` into `SITE_NAME`/`CF_PROJECT_NAME` (and `wrangler.toml`'s
+    /// `name` line) when — and only when — the site at `siteDirectory` is still untouched since
+    /// scaffold: neither `CF_WORKER_DEPLOYED` nor `CF_WORKER_PROVISIONED` is set, `SITE_NAME`
+    /// still matches the scaffold-time "Untitled"/"Untitled N" pattern (`NewSiteWizardModel`'s
+    /// `untitledName`), and `CF_PROJECT_NAME` still equals the slug derived from that name (i.e.
+    /// nothing has hand-customized it). Silently does nothing otherwise, or if any file is
+    /// missing/unreadable/unwritable, or if the derived slug is invalid — a display-name rename
+    /// must never fail or throw because of this.
+    public static func propagateIfUntitled(
+        newDisplayName: String,
+        siteDirectory: URL,
+        fileManager: FileManager = .default
+    ) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        guard let config = try? String(contentsOf: configURL, encoding: .utf8) else { return }
+
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
+              SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil else { return }
+
+        guard let currentSiteName = SiteConfigFile.value(forKey: "SITE_NAME", in: config),
+              isUntitledPattern(currentSiteName) else { return }
+
+        guard let currentProjectName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config),
+              currentProjectName == SiteSlug.derive(from: currentSiteName) else { return }
+
+        let newSlug = SiteSlug.derive(from: newDisplayName)
+        guard WorkerComposition.isValidSiteName(newSlug) else { return }
+
+        let wranglerURL = siteDirectory.appendingPathComponent("wrangler.toml")
+        if let toml = try? String(contentsOf: wranglerURL, encoding: .utf8) {
+            var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            if let nameLineIndex = lines.firstIndex(where: { $0.hasPrefix("name = \"") }) {
+                lines[nameLineIndex] = "name = \"\(newSlug)\""
+                try? lines.joined(separator: "\n").write(to: wranglerURL, atomically: true, encoding: .utf8)
+            }
+        }
+
+        let updatedConfig = SiteConfigFile.upsert(
+            [("SITE_NAME", newDisplayName), ("CF_PROJECT_NAME", newSlug)],
+            into: config
+        )
+        try? updatedConfig.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Matches exactly the pattern `NewSiteWizardModel.untitledName` generates: `"Untitled"` or
+    /// `"Untitled "` followed by an integer.
+    private static func isUntitledPattern(_ name: String) -> Bool {
+        if name == "Untitled" { return true }
+        guard name.hasPrefix("Untitled ") else { return false }
+        let suffix = name.dropFirst("Untitled ".count)
+        return !suffix.isEmpty && suffix.allSatisfy(\.isNumber)
+    }
+}

--- a/Sources/AnglesiteCore/UntitledSitePropagation.swift
+++ b/Sources/AnglesiteCore/UntitledSitePropagation.swift
@@ -1,62 +1,62 @@
 import Foundation
 
 /// Best-effort propagation of a site's display-name rename into its `.site-config` and
-/// `wrangler.toml`, but only while the site is still carrying its scaffold-time "Untitled"
-/// defaults and hasn't touched Cloudflare yet (#1182). Distinct from `WorkerNameRename`, which
-/// handles the post-deploy, collision-triggered rename flow and deliberately leaves `SITE_NAME`
-/// untouched — this is the pre-deploy counterpart that updates both `SITE_NAME` and
-/// `CF_PROJECT_NAME`.
+/// `wrangler.toml`, for as long as the site hasn't touched Cloudflare yet (#1182). Distinct from
+/// `WorkerNameRename`, which handles the post-deploy, collision-triggered rename flow and
+/// deliberately leaves `SITE_NAME` untouched — this is the pre-deploy counterpart that keeps
+/// `SITE_NAME` and `CF_PROJECT_NAME` in sync with the display name shown in the UI, whether the
+/// site started out as the scaffold-time "Untitled" default or was scaffolded with a real name
+/// and renamed again before its first publish.
 public enum UntitledSitePropagation {
     /// Propagates `newDisplayName` into `SITE_NAME`/`CF_PROJECT_NAME` (and `wrangler.toml`'s
-    /// `name` line) when — and only when — the site at `siteDirectory` is still untouched since
-    /// scaffold: neither `CF_WORKER_DEPLOYED` nor `CF_WORKER_PROVISIONED` is set, `SITE_NAME`
-    /// still matches the scaffold-time "Untitled"/"Untitled N" pattern (`NewSiteWizardModel`'s
-    /// `untitledName`), and `CF_PROJECT_NAME` still equals the slug derived from that name (i.e.
-    /// nothing has hand-customized it). Silently does nothing otherwise, or if any file is
-    /// missing/unreadable/unwritable, or if the derived slug is invalid — a display-name rename
-    /// must never fail or throw because of this.
+    /// `name` line) when — and only when — the site at `siteDirectory` hasn't touched Cloudflare
+    /// yet (neither `CF_WORKER_DEPLOYED` nor `CF_WORKER_PROVISIONED` is set in `.site-config`)
+    /// and `CF_PROJECT_NAME` still equals the slug derived from the *current* `SITE_NAME` — i.e.
+    /// nothing has hand-customized the project name away from what the display name would
+    /// derive. Silently does nothing otherwise, or if any file is missing/unreadable/unwritable,
+    /// or if `newDisplayName` is blank once sanitized — a display-name rename must never fail or
+    /// throw because of this.
     public static func propagateIfUntitled(
         newDisplayName: String,
         siteDirectory: URL,
         fileManager: FileManager = .default
     ) {
         let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
-        guard let config = try? String(contentsOf: configURL, encoding: .utf8) else { return }
+        guard fileManager.fileExists(atPath: configURL.path),
+              let config = try? String(contentsOf: configURL, encoding: .utf8) else { return }
 
         guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
               SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil else { return }
 
         guard let currentSiteName = SiteConfigFile.value(forKey: "SITE_NAME", in: config),
-              isUntitledPattern(currentSiteName) else { return }
-
-        guard let currentProjectName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config),
+              let currentProjectName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config),
               currentProjectName == SiteSlug.derive(from: currentSiteName) else { return }
 
-        let newSlug = SiteSlug.derive(from: newDisplayName)
+        // .site-config only stores single-line `KEY=value` entries — take the first line only, so
+        // an embedded newline in newDisplayName (e.g. from a hand-edited plist string) can't
+        // inject extra lines into this git-tracked file.
+        let sanitizedName = (newDisplayName.components(separatedBy: .newlines).first ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sanitizedName.isEmpty else { return }
+
+        let newSlug = SiteSlug.derive(from: sanitizedName)
         guard WorkerComposition.isValidSiteName(newSlug) else { return }
 
-        let wranglerURL = siteDirectory.appendingPathComponent("wrangler.toml")
-        if let toml = try? String(contentsOf: wranglerURL, encoding: .utf8) {
-            var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-            if let nameLineIndex = lines.firstIndex(where: { $0.hasPrefix("name = \"") }) {
-                lines[nameLineIndex] = "name = \"\(newSlug)\""
-                try? lines.joined(separator: "\n").write(to: wranglerURL, atomically: true, encoding: .utf8)
-            }
-        }
-
+        // .site-config first: it's what DeployCoordinator.resolveWorkerSiteName actually reads at
+        // publish time, so if the wrangler.toml write below fails, the site still deploys under
+        // the new slug rather than silently keeping the stale one.
         let updatedConfig = SiteConfigFile.upsert(
-            [("SITE_NAME", newDisplayName), ("CF_PROJECT_NAME", newSlug)],
+            [("SITE_NAME", sanitizedName), ("CF_PROJECT_NAME", newSlug)],
             into: config
         )
         try? updatedConfig.write(to: configURL, atomically: true, encoding: .utf8)
-    }
 
-    /// Matches exactly the pattern `NewSiteWizardModel.untitledName` generates: `"Untitled"` or
-    /// `"Untitled "` followed by an integer.
-    private static func isUntitledPattern(_ name: String) -> Bool {
-        if name == "Untitled" { return true }
-        guard name.hasPrefix("Untitled ") else { return false }
-        let suffix = name.dropFirst("Untitled ".count)
-        return !suffix.isEmpty && suffix.allSatisfy(\.isNumber)
+        let wranglerURL = siteDirectory.appendingPathComponent("wrangler.toml")
+        guard fileManager.fileExists(atPath: wranglerURL.path),
+              let toml = try? String(contentsOf: wranglerURL, encoding: .utf8) else { return }
+        var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard let nameLineIndex = lines.firstIndex(where: { $0.hasPrefix("name = \"") }) else { return }
+        lines[nameLineIndex] = "name = \"\(newSlug)\""
+        try? lines.joined(separator: "\n").write(to: wranglerURL, atomically: true, encoding: .utf8)
     }
 }

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -360,6 +360,33 @@ final class SiteStoreTests {
         #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "untitled")
     }
 
+    @Test("setDisplayName re-attempts .site-config propagation on a repeat call even though the plist write is a no-op")
+    func setDisplayNameRetriesPropagationOnRepeatCall() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        try "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\n".write(
+            to: pkg.sourceURL.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+
+        // First call: settings.plist doesn't have the override yet, so it writes through
+        // normally and propagation succeeds.
+        _ = try await store.setDisplayName("Acme Bakery", for: site.id)
+
+        // Simulate a previous propagation attempt being reverted externally (e.g. a failed
+        // write, or a hand-edit), while the plist-level override stays "Acme Bakery" — so a
+        // naive no-op-on-same-name guard would skip retrying.
+        try "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\n".write(
+            to: pkg.sourceURL.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+
+        // Second call with the identical name: settings.plist is unchanged (a no-op at that
+        // layer), but propagation must still run and repair .site-config.
+        _ = try await store.setDisplayName("Acme Bakery", for: site.id)
+
+        let config = try String(contentsOf: pkg.sourceURL.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+    }
+
     @Test("setDisplayName is a no-op for an unknown id")
     func setDisplayNameUnknownIDNoOp() async throws {
         let store = SiteStore(persistenceURL: persistenceURL)

--- a/Tests/AnglesiteCoreTests/SiteStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteStoreTests.swift
@@ -326,6 +326,40 @@ final class SiteStoreTests {
         #expect(await store.find(id: site.id)?.name == "Alpha Production")
     }
 
+    @Test("setDisplayName propagates SITE_NAME/CF_PROJECT_NAME into an untitled site's .site-config and wrangler.toml")
+    func setDisplayNamePropagatesUntitledSiteConfig() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        try "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\n".write(
+            to: pkg.sourceURL.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        try #"name = "untitled""#.write(
+            to: pkg.sourceURL.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+
+        _ = try await store.setDisplayName("Acme Bakery", for: site.id)
+
+        let config = try String(contentsOf: pkg.sourceURL.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+        let toml = try String(contentsOf: pkg.sourceURL.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains(#"name = "acme-bakery""#))
+    }
+
+    @Test("setDisplayName does not propagate into .site-config once the site has deployed")
+    func setDisplayNameSkipsPropagationAfterDeploy() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        try "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nCF_WORKER_DEPLOYED=true\n".write(
+            to: pkg.sourceURL.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+
+        _ = try await store.setDisplayName("Acme Bakery", for: site.id)
+
+        let config = try String(contentsOf: pkg.sourceURL.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "untitled")
+    }
+
     @Test("setDisplayName is a no-op for an unknown id")
     func setDisplayNameUnknownIDNoOp() async throws {
         let store = SiteStore(persistenceURL: persistenceURL)

--- a/Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift
+++ b/Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift
@@ -38,6 +38,19 @@ struct UntitledSitePropagationTests {
         #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "my-blog")
     }
 
+    @Test("Propagates a second pre-publish rename too, as long as CF_PROJECT_NAME still matches the previous name's derived slug")
+    func propagatesSecondPrePublishRename() throws {
+        // Simulates: scaffold as "Untitled" -> rename to "My Blog" (first propagation already
+        // applied) -> rename again to "Dave's Blog", still before any deploy.
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=My Blog\nCF_PROJECT_NAME=my-blog\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Dave's Blog", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Dave's Blog")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "dave-s-blog")
+    }
+
     @Test("No-ops when CF_WORKER_DEPLOYED is already set")
     func noOpWhenDeployed() throws {
         let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nCF_WORKER_DEPLOYED=true\n")
@@ -57,17 +70,6 @@ struct UntitledSitePropagationTests {
 
         let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
-    }
-
-    @Test("No-ops when SITE_NAME was already customized away from the Untitled pattern")
-    func noOpWhenSiteNameCustomized() throws {
-        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=My Existing Site\nCF_PROJECT_NAME=my-existing-site\n")
-
-        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
-
-        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
-        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "My Existing Site")
-        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "my-existing-site")
     }
 
     @Test("No-ops when CF_PROJECT_NAME was hand-customized away from the derived slug")
@@ -99,5 +101,28 @@ struct UntitledSitePropagationTests {
         let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
         #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+    }
+
+    @Test("Sanitizes an embedded newline in the new display name to its first line, without injecting extra .site-config keys")
+    func sanitizesEmbeddedNewline() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery\nEVIL_KEY=1", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+        #expect(SiteConfigFile.value(forKey: "EVIL_KEY", in: config) == nil, "an embedded newline must not inject a new .site-config key")
+    }
+
+    @Test("No-ops when the sanitized display name is blank")
+    func noOpWhenSanitizedNameIsBlank() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "\n  \n", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "untitled")
     }
 }

--- a/Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift
+++ b/Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift
@@ -2,7 +2,13 @@ import Testing
 import Foundation
 @testable import AnglesiteCore
 
-struct UntitledSitePropagationTests {
+final class UntitledSitePropagationTests {
+    private var createdDirs: [URL] = []
+
+    deinit {
+        for dir in createdDirs { try? FileManager.default.removeItem(at: dir) }
+    }
+
     private func makeSiteDirectory(siteConfig: String, wranglerToml: String? = #"name = "untitled""#) -> URL {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -10,6 +16,7 @@ struct UntitledSitePropagationTests {
         if let wranglerToml {
             try! wranglerToml.write(to: dir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
         }
+        createdDirs.append(dir)
         return dir
     }
 
@@ -27,7 +34,7 @@ struct UntitledSitePropagationTests {
         #expect(toml.contains(#"name = "acme-bakery""#))
     }
 
-    @Test("Matches the 'Untitled N' pattern the chooser generates for repeat untitled sites")
+    @Test("Propagates for a virgin site still carrying the chooser's numbered 'Untitled N' default")
     func propagatesForNumberedUntitledSite() throws {
         let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled 3\nCF_PROJECT_NAME=untitled-3\n")
 
@@ -87,6 +94,7 @@ struct UntitledSitePropagationTests {
     func noOpWhenSiteConfigMissing() {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        createdDirs.append(dir)
 
         // Must not throw or crash.
         UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)

--- a/Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift
+++ b/Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct UntitledSitePropagationTests {
+    private func makeSiteDirectory(siteConfig: String, wranglerToml: String? = #"name = "untitled""#) -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try! siteConfig.write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        if let wranglerToml {
+            try! wranglerToml.write(to: dir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    @Test("Propagates SITE_NAME, CF_PROJECT_NAME, and wrangler.toml name for a virgin untitled site")
+    func propagatesForVirginUntitledSite() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nTAGLINE=hi\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+        #expect(SiteConfigFile.value(forKey: "TAGLINE", in: config) == "hi", "unrelated keys must survive")
+        let toml = try String(contentsOf: dir.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains(#"name = "acme-bakery""#))
+    }
+
+    @Test("Matches the 'Untitled N' pattern the chooser generates for repeat untitled sites")
+    func propagatesForNumberedUntitledSite() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled 3\nCF_PROJECT_NAME=untitled-3\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "My Blog", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "My Blog")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "my-blog")
+    }
+
+    @Test("No-ops when CF_WORKER_DEPLOYED is already set")
+    func noOpWhenDeployed() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nCF_WORKER_DEPLOYED=true\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "untitled")
+    }
+
+    @Test("No-ops when CF_WORKER_PROVISIONED is already set")
+    func noOpWhenProvisioned() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nCF_WORKER_PROVISIONED=true\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+    }
+
+    @Test("No-ops when SITE_NAME was already customized away from the Untitled pattern")
+    func noOpWhenSiteNameCustomized() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=My Existing Site\nCF_PROJECT_NAME=my-existing-site\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "My Existing Site")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "my-existing-site")
+    }
+
+    @Test("No-ops when CF_PROJECT_NAME was hand-customized away from the derived slug")
+    func noOpWhenProjectNameCustomized() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=custom-project-name\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "custom-project-name")
+    }
+
+    @Test("No-ops gracefully when .site-config is missing")
+    func noOpWhenSiteConfigMissing() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        // Must not throw or crash.
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+    }
+
+    @Test("Still updates .site-config when wrangler.toml is missing")
+    func updatesSiteConfigWhenWranglerMissing() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\n", wranglerToml: nil)
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+    }
+}

--- a/docs/superpowers/plans/2026-07-31-untitled-site-rename-propagation.md
+++ b/docs/superpowers/plans/2026-07-31-untitled-site-rename-propagation.md
@@ -1,0 +1,355 @@
+# Untitled Site Rename Propagation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a site still carrying its scaffold-time "Untitled" defaults is renamed via `SiteStore.setDisplayName`, propagate the new name into `.site-config`'s `SITE_NAME`/`CF_PROJECT_NAME` and `wrangler.toml`'s `name` line — so first publish lands under the renamed project slug instead of `untitled`.
+
+**Architecture:** A new best-effort `AnglesiteCore` helper, `UntitledSitePropagation.propagateIfUntitled`, guarded to fire only when the site is still virgin (no `CF_WORKER_DEPLOYED`/`CF_WORKER_PROVISIONED`) and still carrying untouched "Untitled" defaults. `SiteStore.setDisplayName` calls it before its existing plist no-op check.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`import Testing`, `@testable import AnglesiteCore`), SwiftPM (`swift test --package-path .`).
+
+## Global Constraints
+
+- Conventional commit subjects, ≤72 characters, reference `#1182` (e.g. `feat(#1182): ...`).
+- No new dependencies.
+- All file writes in the new helper are best-effort (`try?`) — this must never throw or block a rename.
+- Follow existing code style: `WorkerNameRename.swift` and `SiteConfigFile.swift` are the closest precedents: doc comments explain *why*, not *what*.
+
+---
+
+### Task 1: `UntitledSitePropagation` helper + unit tests
+
+**Files:**
+- Create: `Sources/AnglesiteCore/UntitledSitePropagation.swift`
+- Test: `Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift`
+
+**Interfaces:**
+- Consumes: `SiteConfigFile.value(forKey:in:) -> String?`, `SiteConfigFile.upsert(_:into:) -> String` (`Sources/AnglesiteCore/SiteConfigFile.swift`); `SiteSlug.derive(from:) -> String` (`Sources/AnglesiteCore/NewSiteDraft.swift`); `WorkerComposition.isValidSiteName(_:) -> Bool` (`Sources/AnglesiteCore/WorkerComposition.swift`, internal, same module); `WebsiteAnalyticsAsset.configRelativePath` (`Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift`, `= ".site-config"`).
+- Produces: `public enum UntitledSitePropagation { public static func propagateIfUntitled(newDisplayName: String, siteDirectory: URL, fileManager: FileManager = .default) }` — consumed by Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct UntitledSitePropagationTests {
+    private func makeSiteDirectory(siteConfig: String, wranglerToml: String? = #"name = "untitled""#) -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try! siteConfig.write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        if let wranglerToml {
+            try! wranglerToml.write(to: dir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    @Test("Propagates SITE_NAME, CF_PROJECT_NAME, and wrangler.toml name for a virgin untitled site")
+    func propagatesForVirginUntitledSite() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nTAGLINE=hi\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+        #expect(SiteConfigFile.value(forKey: "TAGLINE", in: config) == "hi", "unrelated keys must survive")
+        let toml = try String(contentsOf: dir.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains(#"name = "acme-bakery""#))
+    }
+
+    @Test("Matches the 'Untitled N' pattern the chooser generates for repeat untitled sites")
+    func propagatesForNumberedUntitledSite() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled 3\nCF_PROJECT_NAME=untitled-3\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "My Blog", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "My Blog")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "my-blog")
+    }
+
+    @Test("No-ops when CF_WORKER_DEPLOYED is already set")
+    func noOpWhenDeployed() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nCF_WORKER_DEPLOYED=true\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "untitled")
+    }
+
+    @Test("No-ops when CF_WORKER_PROVISIONED is already set")
+    func noOpWhenProvisioned() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nCF_WORKER_PROVISIONED=true\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+    }
+
+    @Test("No-ops when SITE_NAME was already customized away from the Untitled pattern")
+    func noOpWhenSiteNameCustomized() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=My Existing Site\nCF_PROJECT_NAME=my-existing-site\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "My Existing Site")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "my-existing-site")
+    }
+
+    @Test("No-ops when CF_PROJECT_NAME was hand-customized away from the derived slug")
+    func noOpWhenProjectNameCustomized() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=custom-project-name\n")
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "custom-project-name")
+    }
+
+    @Test("No-ops gracefully when .site-config is missing")
+    func noOpWhenSiteConfigMissing() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        // Must not throw or crash.
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+    }
+
+    @Test("Still updates .site-config when wrangler.toml is missing")
+    func updatesSiteConfigWhenWranglerMissing() throws {
+        let dir = makeSiteDirectory(siteConfig: "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\n", wranglerToml: nil)
+
+        UntitledSitePropagation.propagateIfUntitled(newDisplayName: "Acme Bakery", siteDirectory: dir)
+
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail with "cannot find 'UntitledSitePropagation' in scope"**
+
+Run: `swift test --package-path . --filter UntitledSitePropagationTests 2>&1 | tail -30`
+Expected: FAIL — compile error, `UntitledSitePropagation` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/UntitledSitePropagation.swift`:
+
+```swift
+import Foundation
+
+/// Best-effort propagation of a site's display-name rename into its `.site-config` and
+/// `wrangler.toml`, but only while the site is still carrying its scaffold-time "Untitled"
+/// defaults and hasn't touched Cloudflare yet (#1182). Distinct from `WorkerNameRename`, which
+/// handles the post-deploy, collision-triggered rename flow and deliberately leaves `SITE_NAME`
+/// untouched — this is the pre-deploy counterpart that updates both `SITE_NAME` and
+/// `CF_PROJECT_NAME`.
+public enum UntitledSitePropagation {
+    /// Propagates `newDisplayName` into `SITE_NAME`/`CF_PROJECT_NAME` (and `wrangler.toml`'s
+    /// `name` line) when — and only when — the site at `siteDirectory` is still untouched since
+    /// scaffold: neither `CF_WORKER_DEPLOYED` nor `CF_WORKER_PROVISIONED` is set, `SITE_NAME`
+    /// still matches the scaffold-time "Untitled"/"Untitled N" pattern (`NewSiteWizardModel`'s
+    /// `untitledName`), and `CF_PROJECT_NAME` still equals the slug derived from that name (i.e.
+    /// nothing has hand-customized it). Silently does nothing otherwise, or if any file is
+    /// missing/unreadable/unwritable, or if the derived slug is invalid — a display-name rename
+    /// must never fail or throw because of this.
+    public static func propagateIfUntitled(
+        newDisplayName: String,
+        siteDirectory: URL,
+        fileManager: FileManager = .default
+    ) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        guard let config = try? String(contentsOf: configURL, encoding: .utf8) else { return }
+
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
+              SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil else { return }
+
+        guard let currentSiteName = SiteConfigFile.value(forKey: "SITE_NAME", in: config),
+              isUntitledPattern(currentSiteName) else { return }
+
+        guard let currentProjectName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config),
+              currentProjectName == SiteSlug.derive(from: currentSiteName) else { return }
+
+        let newSlug = SiteSlug.derive(from: newDisplayName)
+        guard WorkerComposition.isValidSiteName(newSlug) else { return }
+
+        let wranglerURL = siteDirectory.appendingPathComponent("wrangler.toml")
+        if let toml = try? String(contentsOf: wranglerURL, encoding: .utf8) {
+            var lines = toml.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            if let nameLineIndex = lines.firstIndex(where: { $0.hasPrefix("name = \"") }) {
+                lines[nameLineIndex] = "name = \"\(newSlug)\""
+                try? lines.joined(separator: "\n").write(to: wranglerURL, atomically: true, encoding: .utf8)
+            }
+        }
+
+        let updatedConfig = SiteConfigFile.upsert(
+            [("SITE_NAME", newDisplayName), ("CF_PROJECT_NAME", newSlug)],
+            into: config
+        )
+        try? updatedConfig.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Matches exactly the pattern `NewSiteWizardModel.untitledName` generates: `"Untitled"` or
+    /// `"Untitled "` followed by an integer.
+    private static func isUntitledPattern(_ name: String) -> Bool {
+        if name == "Untitled" { return true }
+        guard name.hasPrefix("Untitled ") else { return false }
+        let suffix = name.dropFirst("Untitled ".count)
+        return !suffix.isEmpty && suffix.allSatisfy(\.isNumber)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter UntitledSitePropagationTests 2>&1 | tail -30`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/UntitledSitePropagation.swift Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift
+git commit -m "feat(#1182): add UntitledSitePropagation helper"
+```
+
+---
+
+### Task 2: Wire into `SiteStore.setDisplayName` + end-to-end test
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteStore.swift:341-364`
+- Test: `Tests/AnglesiteCoreTests/SiteStoreTests.swift` (append near the existing `setDisplayName` tests, after `setDisplayNameNoOpWhenUnchanged` around line 320)
+
+**Interfaces:**
+- Consumes: `UntitledSitePropagation.propagateIfUntitled(newDisplayName:siteDirectory:fileManager:)` from Task 1; `AnglesitePackage.sourceURL` (`Sources/AnglesiteSiteModel/AnglesitePackage.swift:33`).
+- Produces: no new public API — behavioral change to existing `SiteStore.setDisplayName`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/SiteStoreTests.swift`, directly after the existing `setDisplayNameNoOpWhenUnchanged` test (around line 320, before the `setDisplayNameUnknownIDNoOp` test):
+
+```swift
+    @Test("setDisplayName propagates SITE_NAME/CF_PROJECT_NAME into an untitled site's .site-config and wrangler.toml")
+    func setDisplayNamePropagatesUntitledSiteConfig() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        try "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\n".write(
+            to: pkg.sourceURL.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        try #"name = "untitled""#.write(
+            to: pkg.sourceURL.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+
+        _ = try await store.setDisplayName("Acme Bakery", for: site.id)
+
+        let config = try String(contentsOf: pkg.sourceURL.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Acme Bakery")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "acme-bakery")
+        let toml = try String(contentsOf: pkg.sourceURL.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains(#"name = "acme-bakery""#))
+    }
+
+    @Test("setDisplayName does not propagate into .site-config once the site has deployed")
+    func setDisplayNameSkipsPropagationAfterDeploy() async throws {
+        let pkg = try makeValidPackage(named: "alpha")
+        try "SITE_NAME=Untitled\nCF_PROJECT_NAME=untitled\nCF_WORKER_DEPLOYED=true\n".write(
+            to: pkg.sourceURL.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        let store = SiteStore(persistenceURL: persistenceURL)
+        let site = try await store.record(pkg)
+
+        _ = try await store.setDisplayName("Acme Bakery", for: site.id)
+
+        let config = try String(contentsOf: pkg.sourceURL.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "SITE_NAME", in: config) == "Untitled")
+        #expect(SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config) == "untitled")
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter SiteStoreTests 2>&1 | tail -40`
+Expected: FAIL — `setDisplayNamePropagatesUntitledSiteConfig` fails because `.site-config` still has `SITE_NAME=Untitled` (propagation not wired up yet). `setDisplayNameSkipsPropagationAfterDeploy` passes trivially (nothing to skip yet), which is fine — it will still guard the behavior once Step 3 lands.
+
+- [ ] **Step 3: Wire the call into `setDisplayName`**
+
+In `Sources/AnglesiteCore/SiteStore.swift`, replace the `setDisplayName` method (currently lines 341-364):
+
+```swift
+    @discardableResult
+    public func setDisplayName(_ name: String?, for id: String) async throws -> Site? {
+        guard let index = sites.firstIndex(where: { $0.id == id }) else { return nil }
+        let existing = sites[index]
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let override = (trimmed?.isEmpty == false) ? trimmed : nil
+
+        let package = AnglesitePackage(url: existing.packageURL)
+
+        // Best-effort, and run before the no-op guard below so a retry always re-attempts it —
+        // propagateIfUntitled is itself cheap and idempotent (#1182).
+        if let override {
+            UntitledSitePropagation.propagateIfUntitled(
+                newDisplayName: override,
+                siteDirectory: package.sourceURL,
+                fileManager: fileManager
+            )
+        }
+
+        let config = SiteConfigStore(configDirectory: package.configURL, fileManager: fileManager)
+        var settings = try await config.load()
+        // Renaming to the current value (or clearing an already-empty override) changes nothing —
+        // skip the disk write, the re-make, and the change broadcast.
+        guard settings.displayName != override else { return existing }
+        settings.displayName = override
+        try await config.save(settings)
+
+        var updated = try Site.make(package: package, fileManager: fileManager)
+        updated.lastSeen = existing.lastSeen
+        updated.bookmarkData = existing.bookmarkData
+        sites[index] = updated
+        try persist()
+        await emitChange()
+        return updated
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter SiteStoreTests 2>&1 | tail -40`
+Expected: PASS — all `SiteStoreTests` tests green, including the two new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SiteStore.swift Tests/AnglesiteCoreTests/SiteStoreTests.swift
+git commit -m "feat(#1182): propagate rename into untitled site's .site-config"
+```
+
+---
+
+### Task 3: Full test suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full AnglesiteCore + AnglesiteSiteModel + AnglesiteBridge test suite**
+
+Run: `swift test --package-path . 2>&1 | tail -60`
+Expected: All tests pass, including pre-existing `WorkerNameRenameTests`, `SiteScaffolderTests`, `DeployCoordinatorTests`, `SiteOperationsTests` (none of these touch the new code path, but confirm nothing regressed).
+
+- [ ] **Step 2: If `swift test` hangs with no output**
+
+A stale SwiftPM process may be holding the `.build` lock. Check with `pgrep -fl swift-test` and kill the orphan process, then re-run Step 1.
+
+- [ ] **Step 3: Confirm no unrelated files changed**
+
+Run: `git status`
+Expected: only `Sources/AnglesiteCore/UntitledSitePropagation.swift`, `Sources/AnglesiteCore/SiteStore.swift`, `Tests/AnglesiteCoreTests/UntitledSitePropagationTests.swift`, `Tests/AnglesiteCoreTests/SiteStoreTests.swift`, and the design doc/plan doc already committed earlier in this session.

--- a/docs/superpowers/specs/2026-07-31-untitled-site-rename-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-31-untitled-site-rename-propagation-design.md
@@ -26,16 +26,19 @@ A new `AnglesiteCore` type, `UntitledSitePropagation.propagateIfUntitled(newDisp
 
 **Guard conditions** (all must hold, else silent no-op):
 
-1. Neither `CF_WORKER_DEPLOYED` nor `CF_WORKER_PROVISIONED` is present in `.site-config` — no Cloudflare resources (D1/KV/R2, all named from the current project slug in `WorkerComposition.generateWranglerToml`) exist yet to break.
-2. `SITE_NAME` still matches the scaffold-time pattern: exactly `"Untitled"` or `"Untitled N"` (matching `NewSiteWizardModel.untitledName`'s output).
-3. `CF_PROJECT_NAME` still equals `SiteSlug.derive(from: SITE_NAME)` — nothing has hand-customized the project name since scaffold.
+1. Neither `CF_WORKER_DEPLOYED` nor `CF_WORKER_PROVISIONED` is present in `.site-config` — no Cloudflare resources (D1/KV/R2, all named from the current project slug in `WorkerComposition.generateWranglerToml`) exist yet to break. Same virginity test `DeployCommand.checkWorkerNameConflict` already uses.
+2. `CF_PROJECT_NAME` still equals `SiteSlug.derive(from: SITE_NAME)` — nothing has hand-customized the project name away from what the current display name would derive.
 
-**On pass:** derive `newSlug = SiteSlug.derive(from: newDisplayName)`, validate with `WorkerComposition.isValidSiteName`, then best-effort:
+**Revision (post-review):** an earlier draft of this guard also required `SITE_NAME` to still literally match the scaffold-time `"Untitled"`/`"Untitled N"` pattern, so only the *very first* rename away from that default would propagate — a second pre-publish rename (e.g. "Untitled" → "My Blog" → "Dave's Blog") silently stopped working, a muted recurrence of the bug this change fixes. The final review caught it; the literal-Untitled check was dropped, so every pre-publish rename keeps `CF_PROJECT_NAME` in sync now, not just the first.
 
+**On pass:** sanitize `newDisplayName` to its first line (`.components(separatedBy: .newlines).first`), trimmed, bailing if blank — `.site-config` is a git-tracked, externally-editable file and `SiteConfigFile.upsert` does no escaping, so an unsanitized multi-line name could inject arbitrary `KEY=value` lines (caught in review; `SiteScaffolder`'s own `SITE_NAME` writer already guards this the same way). Derive `newSlug = SiteSlug.derive(from: sanitizedName)`, validate with `WorkerComposition.isValidSiteName`, then best-effort:
+
+- `SiteConfigFile.upsert` both `SITE_NAME` and `CF_PROJECT_NAME` in `.site-config` — written **first**, since it's what `DeployCoordinator.resolveWorkerSiteName` actually reads at publish time, so a subsequent `wrangler.toml` write failure is self-correcting rather than authoritative.
 - Rewrite `wrangler.toml`'s `name = "..."` line (same line-level, non-regenerating approach as `WorkerNameRename.apply`, to avoid dropping provisioned feature config — though by guard #1 there shouldn't be any yet).
-- `SiteConfigFile.upsert` both `SITE_NAME` and `CF_PROJECT_NAME` in `.site-config`.
 
 All writes are `try?`. Renaming a site's display name is a frequent, low-stakes action (a text field commit) and must never fail because this propagation couldn't complete — mirrors the best-effort idiom already used by `DeployCoordinator.syncWorkerActivationToAnglesiteJSON`.
+
+**Known blind spot (accepted, not fixed):** the virginity check only looks at `.site-config`'s own `CF_WORKER_DEPLOYED`/`CF_WORKER_PROVISIONED` markers. Since "git is the source of truth", a site's `Source/` repo can be cloned and `wrangler deploy`'d entirely outside the app, which never sets those markers — the app still reads such a site as virgin. An in-app rename would then silently re-slug `CF_PROJECT_NAME`, and because the new slug is free on the account, the existing collision check finds nothing wrong; the next in-app deploy lands on a new worker rather than the live one. This blind spot already exists elsewhere in the app's virginity handling and isn't introduced by this change, but it is newly reachable from a plain text-field rename rather than an explicit deploy action. Not worth a code change for this issue; noted for whoever next touches virginity detection.
 
 ### Call site: `SiteStore.setDisplayName`
 
@@ -50,5 +53,5 @@ Call `UntitledSitePropagation.propagateIfUntitled` for a real (non-clearing) ren
 
 ## Testing
 
-- New `UntitledSitePropagationTests.swift`: fires and rewrites both files when virgin + untitled; no-ops when `CF_WORKER_DEPLOYED`/`CF_WORKER_PROVISIONED` present; no-ops when `SITE_NAME` was already customized; no-ops when `CF_PROJECT_NAME` was hand-customized away from its derived value; no-ops gracefully when `wrangler.toml`/`.site-config` is missing.
+- New `UntitledSitePropagationTests.swift`: fires and rewrites both files when virgin + untitled; fires again on a second pre-publish rename; no-ops when `CF_WORKER_DEPLOYED`/`CF_WORKER_PROVISIONED` present; no-ops when `CF_PROJECT_NAME` was hand-customized away from its derived value; sanitizes an embedded newline instead of injecting a `.site-config` key; no-ops when the sanitized name is blank; no-ops gracefully when `wrangler.toml`/`.site-config` is missing.
 - Extend `SiteStoreTests.swift`'s `setDisplayName` coverage with an end-to-end case: scaffold an untitled site, rename it, assert `.site-config` now has the new `SITE_NAME`/`CF_PROJECT_NAME` and `wrangler.toml` has the new `name`.

--- a/docs/superpowers/specs/2026-07-31-untitled-site-rename-propagation-design.md
+++ b/docs/superpowers/specs/2026-07-31-untitled-site-rename-propagation-design.md
@@ -1,0 +1,54 @@
+# Propagate site rename into SITE_NAME/CF_PROJECT_NAME for untitled sites
+
+Issue: [#1182](https://github.com/Anglesite/Anglesite/issues/1182). Follow-up to [#1071](https://github.com/Anglesite/Anglesite/issues/1071) / [#1183](https://github.com/Anglesite/Anglesite/pull/1183) (the new-site chooser that scaffolds every site as "Untitled").
+
+## Problem
+
+The template chooser scaffolds every new site with `SITE_NAME=Untitled` and `CF_PROJECT_NAME=untitled` in `.site-config` (`SiteScaffolder.appendSiteConfig`). `SiteStore.setDisplayName` — the only path that renames a site today — writes just a `Config/settings.plist` display-name override; it never touches `.site-config` or `wrangler.toml`. Consequences:
+
+- First publish lands at `untitled.<account>.workers.dev` even after the owner renamed the site in the UI, because `DeployCoordinator.resolveWorkerSiteName` deliberately prefers an already-stored `CF_PROJECT_NAME` over re-deriving from the display name (the #740 precedence rule — never re-derive over an established name).
+- `IntegrationPlanner` and `BrandVoiceGuidance` read `SITE_NAME` from `.site-config` and substitute the literal string "Untitled" into PWA manifests and brand-voice prompts.
+
+## Decision: propagate at rename time, not at first publish
+
+Two seams were considered:
+
+1. **Rename-time** (chosen): hook `SiteStore.setDisplayName`. Single call site, and safe by construction — a virgin site (no Cloudflare resources provisioned yet) can have its project slug changed freely.
+2. **First-publish**: hook `DeployCommand` right before `persistWorkerProvisioned`. Would catch every case regardless of when the rename happened, but the worker-name resolution logic is duplicated between `DeployCoordinator` (GUI) and `SiteOperations` (headless/Intents) — both would need the same fix.
+
+Rename-time was chosen for its single seam and because it covers the realistic flow (owners rename the jarring "Untitled" placeholder well before their first deploy). A site renamed *after* it has already deployed under "untitled" is a different, already-handled case: `WorkerNameRename` (collision-triggered, explicit user action via the conflict sheet) is the existing mechanism for changing a project name post-deploy, and it intentionally leaves `SITE_NAME` untouched. A first-publish safety net is explicitly deferred, not part of this change.
+
+## Design
+
+### New helper: `UntitledSitePropagation`
+
+A new `AnglesiteCore` type, `UntitledSitePropagation.propagateIfUntitled(newDisplayName:siteDirectory:fileManager:)`. Sibling to `WorkerNameRename`, not built on top of it — `WorkerNameRename` is the post-deploy, collision-triggered flow (its own test asserts `SITE_NAME` is left alone); this is a distinct pre-deploy flow that updates both `SITE_NAME` and `CF_PROJECT_NAME`.
+
+**Guard conditions** (all must hold, else silent no-op):
+
+1. Neither `CF_WORKER_DEPLOYED` nor `CF_WORKER_PROVISIONED` is present in `.site-config` — no Cloudflare resources (D1/KV/R2, all named from the current project slug in `WorkerComposition.generateWranglerToml`) exist yet to break.
+2. `SITE_NAME` still matches the scaffold-time pattern: exactly `"Untitled"` or `"Untitled N"` (matching `NewSiteWizardModel.untitledName`'s output).
+3. `CF_PROJECT_NAME` still equals `SiteSlug.derive(from: SITE_NAME)` — nothing has hand-customized the project name since scaffold.
+
+**On pass:** derive `newSlug = SiteSlug.derive(from: newDisplayName)`, validate with `WorkerComposition.isValidSiteName`, then best-effort:
+
+- Rewrite `wrangler.toml`'s `name = "..."` line (same line-level, non-regenerating approach as `WorkerNameRename.apply`, to avoid dropping provisioned feature config — though by guard #1 there shouldn't be any yet).
+- `SiteConfigFile.upsert` both `SITE_NAME` and `CF_PROJECT_NAME` in `.site-config`.
+
+All writes are `try?`. Renaming a site's display name is a frequent, low-stakes action (a text field commit) and must never fail because this propagation couldn't complete — mirrors the best-effort idiom already used by `DeployCoordinator.syncWorkerActivationToAnglesiteJSON`.
+
+### Call site: `SiteStore.setDisplayName`
+
+Call `UntitledSitePropagation.propagateIfUntitled` for a real (non-clearing) rename, **before** the existing `guard settings.displayName != override else { return existing }` no-op check — not after. Today that guard would skip propagation entirely on a repeat call with the same name (e.g., if a previous attempt silently failed to write `.site-config` for some reason). Since the guards inside `propagateIfUntitled` make it cheap and idempotent, attempting it on every call is safe and self-healing.
+
+### Out of scope
+
+- `anglesite.json` has no site-name field today; not adding one here (`DomainConfig`'s schema stays as-is).
+- `WorkerDashboardLinks`' existing use of a display-name-derived slug instead of `CF_PROJECT_NAME` for dashboard/analytics links — a separate, pre-existing bug (already wrong after any #740 collision-rename too).
+- `IntegrationPlanner`'s duplicate hand-rolled `SITE_NAME` parser (vs. `SiteConfigFile.value`) — pre-existing duplication, unrelated to this fix.
+- A first-publish safety net for sites renamed after their first deploy.
+
+## Testing
+
+- New `UntitledSitePropagationTests.swift`: fires and rewrites both files when virgin + untitled; no-ops when `CF_WORKER_DEPLOYED`/`CF_WORKER_PROVISIONED` present; no-ops when `SITE_NAME` was already customized; no-ops when `CF_PROJECT_NAME` was hand-customized away from its derived value; no-ops gracefully when `wrangler.toml`/`.site-config` is missing.
+- Extend `SiteStoreTests.swift`'s `setDisplayName` coverage with an end-to-end case: scaffold an untitled site, rename it, assert `.site-config` now has the new `SITE_NAME`/`CF_PROJECT_NAME` and `wrangler.toml` has the new `name`.


### PR DESCRIPTION
Closes #1182

## Summary

- Adds `UntitledSitePropagation.propagateIfUntitled`, a best-effort `AnglesiteCore` helper that keeps `.site-config`'s `SITE_NAME`/`CF_PROJECT_NAME` and `wrangler.toml`'s `name` line in sync with a site's display name, for as long as the site hasn't touched Cloudflare yet (no `CF_WORKER_DEPLOYED`/`CF_WORKER_PROVISIONED`) and nothing has hand-customized `CF_PROJECT_NAME` away from its derived slug.
- Wires it into `SiteStore.setDisplayName`, so first publish now lands under the renamed project slug instead of `untitled.<account>.workers.dev`, even across multiple pre-publish renames.
- Sanitizes the display name to a single line before writing it into the git-tracked `.site-config`, so an embedded newline can't inject arbitrary `KEY=value` lines.

Design doc: `docs/superpowers/specs/2026-07-31-untitled-site-rename-propagation-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-31-untitled-site-rename-propagation.md`

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 3186/3186 relevant tests pass. The only 2 failures are pre-existing, unrelated `FoundationModelAssistantTests` on-device streaming flakiness (confirmed present unchanged on `main`), not touched by this change.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds.
- [ ] Manual smoke (if UI-touching): not UI-touching (`SiteStore`/`.site-config` only, no view changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)