### PR TITLE
Track domain registrar and expiration/renewal date

### DIFF
--- a/Sources/AnglesiteApp/ConnectDomainModel.swift
+++ b/Sources/AnglesiteApp/ConnectDomainModel.swift
@@ -3,9 +3,11 @@ import AnglesiteCore
 
 /// Drives the "Connect a Domain" sheet (#1180): buy/transfer/later, reachable from the
 /// first-publish nudge in `DeployDrawerView` and permanently from `Website ▸ Connect a Domain…`.
-/// Every action is a synchronous local file write via `ConnectDomainCommand` — no network calls,
-/// unlike `HardenModel`/`DomainModel`. The actual Workers Custom Domain attach stays owned by
-/// `CustomDomainAttachCommand`, which already runs on every deploy.
+/// Every domain-declaration action is a synchronous local file write via `ConnectDomainCommand` —
+/// no network calls, unlike `HardenModel`/`DomainModel`. The actual Workers Custom Domain attach
+/// stays owned by `CustomDomainAttachCommand`, which already runs on every deploy. The one
+/// exception is registrar/expiration lookup (#1194): a passive, best-effort RDAP query that never
+/// blocks or gates anything else in this sheet.
 @MainActor
 @Observable
 final class ConnectDomainModel {
@@ -15,10 +17,26 @@ final class ConnectDomainModel {
         case connected(hostname: String)
     }
 
+    /// Registrar/expiration info for the connected hostname (#1194) — orthogonal to `phase` since
+    /// it loads and refreshes on its own schedule instead of gating the sheet's own flow.
+    enum RegistrarInfoState: Equatable {
+        case idle
+        case loading
+        case available(RDAPDomainInfo)
+        case unavailable
+    }
+
     private(set) var phase: Phase = .choosing
     var sheetPresented: Bool = false
     var hostnameInput: String = ""
+    private(set) var registrarInfo: RegistrarInfoState = .idle
+    /// `true` while an RDAP lookup is in flight — lets tests deterministically wait for the
+    /// background `Task` `loadRegistrarInfo` spawns to finish, the same role `DomainModel.isRunning`
+    /// plays for its own async work.
+    private(set) var isLookingUpRegistrarInfo: Bool = false
 
+    private let rdap: any RDAPLookupService
+    private var registrarLookupTask: Task<Void, Never>?
     private var currentSite: CurrentSite?
 
     /// The Cloudflare Domains marketing page — opened by the view layer's "Buy a domain" button,
@@ -27,18 +45,42 @@ final class ConnectDomainModel {
     /// `NSWorkspace.shared.open` out of the model layer).
     static let cloudflareDomainsURL = URL(string: "https://www.cloudflare.com/products/registrar/")!
 
+    /// `rdap` is injectable for tests; production callers take the default `RDAPClient`.
+    init(rdap: any RDAPLookupService = RDAPClient()) {
+        self.rdap = rdap
+    }
+
     /// Threaded from `SiteWindowModel.loadAndStart`, mirroring `DomainModel.configure(site:)`.
     func configure(site: CurrentSite) {
         currentSite = site
     }
 
+    /// Resets to `.choosing` unless `anglesite.json` already declares an owned (`transfer`)
+    /// hostname, in which case this jumps straight to `.connected` and kicks off a registrar
+    /// lookup — the only way to revisit a previously-connected domain's registrar/expiration info
+    /// (#1194). A `buy` declaration (no real hostname yet) or no declaration at all still starts
+    /// at `.choosing`, unchanged from #1180.
     func openSheet() {
-        phase = .choosing
         hostnameInput = ""
+        registrarLookupTask?.cancel()
+        registrarLookupTask = nil
+        isLookingUpRegistrarInfo = false
+        registrarInfo = .idle
+
+        if let site = currentSite,
+           let declared = try? DomainConfigStore(sourceDirectory: site.sourceDirectory).load(),
+           let hostname = declared.domain?.hostname, !hostname.isEmpty,
+           declared.domain?.choice == NewSiteDomainChoice.transfer.rawValue {
+            phase = .connected(hostname: hostname)
+            loadRegistrarInfo(hostname: hostname, sourceDirectory: site.sourceDirectory)
+        } else {
+            phase = .choosing
+        }
         sheetPresented = true
     }
 
     func dismissSheet() {
+        registrarLookupTask?.cancel()
         sheetPresented = false
     }
 
@@ -70,5 +112,47 @@ final class ConnectDomainModel {
         guard !hostname.isEmpty else { return }
         ConnectDomainCommand.recordTransfer(hostname: hostname, siteDirectory: site.sourceDirectory)
         phase = .connected(hostname: hostname)
+        loadRegistrarInfo(hostname: hostname, sourceDirectory: site.sourceDirectory)
+    }
+
+    // MARK: - Private
+
+    /// Seeds `registrarInfo` from whatever's already cached in `anglesite.json` (instant, no
+    /// spinner) and kicks off a fresh RDAP lookup in the background. A successful lookup updates
+    /// `registrarInfo` and persists into `anglesite.json`; a failed one only clears a `.loading`
+    /// placeholder to `.unavailable` — it never regresses an already-good cached value back to
+    /// nothing.
+    private func loadRegistrarInfo(hostname: String, sourceDirectory: URL) {
+        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
+        let declared = try? store.load()
+        if let cached = declared?.domain, cached.hostname == hostname,
+           cached.registrar != nil || cached.expiresAt != nil {
+            registrarInfo = .available(RDAPDomainInfo(registrar: cached.registrar, expiresAt: cached.expiresAt))
+        } else {
+            registrarInfo = .loading
+        }
+
+        isLookingUpRegistrarInfo = true
+        registrarLookupTask?.cancel()
+        registrarLookupTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await self.rdap.lookup(hostname: hostname)
+            self.isLookingUpRegistrarInfo = false
+            guard case .connected(let current) = self.phase, current == hostname else { return }
+            if let result, result.registrar != nil || result.expiresAt != nil {
+                self.registrarInfo = .available(result)
+                self.persistRegistrarInfo(result, hostname: hostname, sourceDirectory: sourceDirectory)
+            } else if case .loading = self.registrarInfo {
+                self.registrarInfo = .unavailable
+            }
+        }
+    }
+
+    private func persistRegistrarInfo(_ info: RDAPDomainInfo, hostname: String, sourceDirectory: URL) {
+        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
+        guard var config = try? store.load(), config.domain?.hostname == hostname else { return }
+        config.domain?.registrar = info.registrar
+        config.domain?.expiresAt = info.expiresAt
+        try? store.save(config)
     }
 }

--- a/Sources/AnglesiteApp/ConnectDomainModel.swift
+++ b/Sources/AnglesiteApp/ConnectDomainModel.swift
@@ -115,6 +115,18 @@ final class ConnectDomainModel {
         phase = .enteringHostname
     }
 
+    /// "Use a different domain" — from `.connected`, lets the owner correct a previously-declared
+    /// hostname (a typo, or switching domains entirely) instead of being stuck with only "Done"
+    /// (#1194 review round 3: the sheet had become a dead end once a transfer was declared). Seeds
+    /// `hostnameInput` with the currently-connected hostname so `submitTransfer()` reaches it
+    /// exactly the same way `beginTransfer()` does — it doesn't care how `.enteringHostname` was
+    /// reached.
+    func beginChangeDomain() {
+        guard case .connected(let hostname) = phase else { return }
+        hostnameInput = hostname
+        phase = .enteringHostname
+    }
+
     /// Submits the typed hostname. No format validation beyond non-empty/trim, matching
     /// `DomainModel.resolveAndLoad` — a malformed hostname simply won't resolve a Cloudflare zone
     /// on the next deploy, surfaced there exactly like today's `.notConnected` outcome.
@@ -137,9 +149,14 @@ final class ConnectDomainModel {
     private func loadRegistrarInfo(hostname: String, sourceDirectory: URL) {
         let store = DomainConfigStore(sourceDirectory: sourceDirectory)
         let declared = try? store.load()
-        if let cached = declared?.domain, cached.hostname == hostname,
-           cached.registrar != nil || cached.expiresAt != nil {
-            registrarInfo = .available(RDAPDomainInfo(registrar: cached.registrar, expiresAt: cached.expiresAt))
+        if let cached = declared?.domain, cached.hostname == hostname {
+            let registrar = Self.nonBlank(cached.registrar)
+            let expiresAt = Self.nonBlank(cached.expiresAt)
+            if registrar != nil || expiresAt != nil {
+                registrarInfo = .available(RDAPDomainInfo(registrar: registrar, expiresAt: expiresAt))
+            } else {
+                registrarInfo = .loading
+            }
         } else {
             registrarInfo = .loading
         }
@@ -164,6 +181,14 @@ final class ConnectDomainModel {
                 self.registrarInfo = .unavailable
             }
         }
+    }
+
+    /// Normalizes `DomainIntentRecorder`'s explicit-`""` "clear the stale value" marker (#1194
+    /// review round 3) back to `nil` — a freshly-cleared registrar/expiration reads the same as
+    /// "no cached value yet" (`.loading`), not as a blank display line.
+    private static func nonBlank(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
     }
 
     private func persistRegistrarInfo(_ info: RDAPDomainInfo, hostname: String, sourceDirectory: URL) {

--- a/Sources/AnglesiteApp/ConnectDomainModel.swift
+++ b/Sources/AnglesiteApp/ConnectDomainModel.swift
@@ -38,6 +38,16 @@ final class ConnectDomainModel {
     private let rdap: any RDAPLookupService
     private var registrarLookupTask: Task<Void, Never>?
     private var currentSite: CurrentSite?
+    /// Bumped every time `loadRegistrarInfo` starts a new lookup, and captured locally before the
+    /// `Task` spawns. `registrarLookupTask?.cancel()` alone can't stop a stale lookup from
+    /// eventually resuming — `RDAPLookupService.lookup(hostname:)` is non-throwing and doesn't
+    /// participate in cooperative cancellation — so a superseded task's continuation would
+    /// otherwise still be able to overwrite `registrarInfo`/`anglesite.json` or clobber
+    /// `isLookingUpRegistrarInfo` after a newer lookup already finished. Comparing the captured
+    /// generation against this property before every mutation makes a stale task's completion a
+    /// complete no-op once superseded (reopening the sheet before the first lookup resolves, or a
+    /// double-tap on submit, both spawn two lookups for the same hostname).
+    private var registrarLookupGeneration = 0
 
     /// The Cloudflare Domains marketing page — opened by the view layer's "Buy a domain" button,
     /// not by `chooseBuy()` itself, so this model stays free of `NSWorkspace`/AppKit side effects
@@ -81,6 +91,8 @@ final class ConnectDomainModel {
 
     func dismissSheet() {
         registrarLookupTask?.cancel()
+        registrarLookupTask = nil
+        isLookingUpRegistrarInfo = false
         sheetPresented = false
     }
 
@@ -134,9 +146,15 @@ final class ConnectDomainModel {
 
         isLookingUpRegistrarInfo = true
         registrarLookupTask?.cancel()
+        registrarLookupGeneration += 1
+        let generation = registrarLookupGeneration
         registrarLookupTask = Task { @MainActor [weak self] in
             guard let self else { return }
             let result = await self.rdap.lookup(hostname: hostname)
+            // A newer lookup superseded this one (reopen-before-resolve, or a double submit) —
+            // this task's completion is a no-op, including the `isLookingUpRegistrarInfo` write,
+            // so it can't clear a flag the newer task already set.
+            guard generation == self.registrarLookupGeneration else { return }
             self.isLookingUpRegistrarInfo = false
             guard case .connected(let current) = self.phase, current == hostname else { return }
             if let result, result.registrar != nil || result.expiresAt != nil {

--- a/Sources/AnglesiteApp/ConnectDomainSheetView.swift
+++ b/Sources/AnglesiteApp/ConnectDomainSheetView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import Foundation
 
 /// The "Connect a Domain" sheet (#1180) — buy/transfer/later, reachable from the first-publish
 /// nudge in `DeployDrawerView` and permanently from `Website ▸ Connect a Domain…`.
@@ -74,9 +75,45 @@ struct ConnectDomainSheetView: View {
             }
 
         case .connected(let hostname):
-            Label("We'll connect \(hostname) on your next Publish.", systemImage: "checkmark.circle.fill")
-                .foregroundStyle(.green)
+            VStack(alignment: .leading, spacing: 8) {
+                Label("We'll connect \(hostname) on your next Publish.", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                registrarInfoView
+            }
         }
+    }
+
+    @ViewBuilder
+    private var registrarInfoView: some View {
+        switch model.registrarInfo {
+        case .idle, .unavailable:
+            EmptyView()
+        case .loading:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Looking up registrar info…")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        case .available(let info):
+            VStack(alignment: .leading, spacing: 2) {
+                if let registrar = info.registrar {
+                    Text("Registrar: \(registrar)")
+                }
+                if let expiresAt = info.expiresAt {
+                    Text("Expires \(Self.formattedExpiration(expiresAt))")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Formats a raw RDAP ISO 8601 `eventDate` for display; falls back to the raw string if it
+    /// doesn't parse (an RDAP server returning something non-standard shouldn't blank the field).
+    private static func formattedExpiration(_ raw: String) -> String {
+        guard let date = ISO8601DateFormatter().date(from: raw) else { return raw }
+        return date.formatted(date: .abbreviated, time: .omitted)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/ConnectDomainSheetView.swift
+++ b/Sources/AnglesiteApp/ConnectDomainSheetView.swift
@@ -79,6 +79,10 @@ struct ConnectDomainSheetView: View {
                 Label("We'll connect \(hostname) on your next Publish.", systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)
                 registrarInfoView
+                Button("Use a different domain") { model.beginChangeDomain() }
+                    .font(.caption)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -111,9 +115,18 @@ struct ConnectDomainSheetView: View {
 
     /// Formats a raw RDAP ISO 8601 `eventDate` for display; falls back to the raw string if it
     /// doesn't parse (an RDAP server returning something non-standard shouldn't blank the field).
+    /// Tries a second, fractional-seconds formatter before giving up — some RDAP servers include
+    /// fractional seconds (e.g. `2027-08-13T04:00:00.000Z`), which the default formatter rejects.
     private static func formattedExpiration(_ raw: String) -> String {
-        guard let date = ISO8601DateFormatter().date(from: raw) else { return raw }
-        return date.formatted(date: .abbreviated, time: .omitted)
+        if let date = ISO8601DateFormatter().date(from: raw) {
+            return date.formatted(date: .abbreviated, time: .omitted)
+        }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: raw) {
+            return date.formatted(date: .abbreviated, time: .omitted)
+        }
+        return raw
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/ConnectDomainSheetView.swift
+++ b/Sources/AnglesiteApp/ConnectDomainSheetView.swift
@@ -80,9 +80,8 @@ struct ConnectDomainSheetView: View {
                     .foregroundStyle(.green)
                 registrarInfoView
                 Button("Use a different domain") { model.beginChangeDomain() }
+                    .buttonStyle(.link)
                     .font(.caption)
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -72,6 +72,16 @@
         }
       }
     },
+    "%@, version %@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, version %2$@, %3$@"
+          }
+        }
+      }
+    },
     "%@. %@" : {
       "localizations" : {
         "en" : {
@@ -246,6 +256,9 @@
 
     },
     "Accessibility" : {
+
+    },
+    "Acknowledgments" : {
 
     },
     "Acknowledgments unavailable for this source." : {
@@ -1263,6 +1276,9 @@
     "Events" : {
 
     },
+    "Expires %@" : {
+
+    },
     "Explain" : {
 
     },
@@ -1714,6 +1730,9 @@
 
     },
     "Logs…" : {
+
+    },
+    "Looking up registrar info…" : {
 
     },
     "Lower numbers are preferred mail servers, e.g. 10." : {
@@ -2284,6 +2303,9 @@
 
     },
     "Regenerate…" : {
+
+    },
+    "Registrar: %@" : {
 
     },
     "Related Pages" : {
@@ -3135,6 +3157,9 @@
     "Use Selection for Find" : {
 
     },
+    "Use a different domain" : {
+
+    },
     "Use a temporary Cloudflare Pages domain later, such as %@." : {
 
     },
@@ -3169,6 +3194,9 @@
 
     },
     "View and manage this domain's DNS records" : {
+
+    },
+    "View homepage" : {
 
     },
     "View on GitHub" : {

--- a/Sources/AnglesiteCore/DomainConfig.swift
+++ b/Sources/AnglesiteCore/DomainConfig.swift
@@ -47,11 +47,22 @@ public struct DomainConfig: Equatable, Sendable {
         /// the reader instead of failing the whole document to decode.
         public var choice: String?
         public var attach: Bool?
+        /// The domain's registrar name, from an RDAP lookup (`RDAPClient`, #1194). `nil` until a
+        /// lookup has succeeded at least once.
+        public var registrar: String?
+        /// The domain's expiration date, as the raw ISO 8601 `eventDate` string RDAP returned —
+        /// unparsed, like every other value in this struct; callers format it for display.
+        public var expiresAt: String?
 
-        public init(hostname: String? = nil, choice: String? = nil, attach: Bool? = nil) {
+        public init(
+            hostname: String? = nil, choice: String? = nil, attach: Bool? = nil,
+            registrar: String? = nil, expiresAt: String? = nil
+        ) {
             self.hostname = hostname
             self.choice = choice
             self.attach = attach
+            self.registrar = registrar
+            self.expiresAt = expiresAt
         }
     }
 

--- a/Sources/AnglesiteCore/DomainIntentRecorder.swift
+++ b/Sources/AnglesiteCore/DomainIntentRecorder.swift
@@ -11,11 +11,20 @@ public enum DomainIntentRecorder {
     /// `CF_DOMAIN_ATTACHED`, written separately (`CustomDomainAttachCommand.persistAttached`) once
     /// attach actually succeeds. Best-effort — a write failure here must never surface as an
     /// error to the caller (matches `CustomDomainAttachCommand`'s existing posture).
+    ///
+    /// Writes `registrar`/`expiresAt` as explicit `""` rather than `nil` for the same reason
+    /// `recordBuyIntent` writes `hostname: ""` below: `DomainConfigStore.save`'s merge can't
+    /// express deletion, so a `nil` here would leave a *previous* domain's cached registrar/
+    /// expiration sitting under the *new* hostname (#1194 review round 3) — `ConnectDomainModel`
+    /// would then seed its display straight from that stale, now-mismatched value. An explicit
+    /// `""` does get encoded and so does overwrite the merge; `ConnectDomainModel.loadRegistrarInfo`
+    /// normalizes a blank string back to `nil` at the read boundary.
     public static func recordTransferIntent(hostname: String, siteDirectory: URL) {
         let store = DomainConfigStore(sourceDirectory: siteDirectory)
         var config = (try? store.load()) ?? DomainConfig()
         config.domain = DomainConfig.Domain(
-            hostname: hostname, choice: NewSiteDomainChoice.transfer.rawValue, attach: true)
+            hostname: hostname, choice: NewSiteDomainChoice.transfer.rawValue, attach: true,
+            registrar: "", expiresAt: "")
         try? store.save(config)
     }
 
@@ -30,12 +39,16 @@ public enum DomainIntentRecorder {
     /// a previously-declared hostname (from a prior `recordTransferIntent`, e.g. the owner
     /// reopening the sheet and switching from "I already own a domain" to "Buy a domain") would
     /// survive untouched in `anglesite.json`. An explicit `""` does get encoded and so does
-    /// overwrite the merge.
+    /// overwrite the merge. `registrar`/`expiresAt` get the same explicit-`""` treatment for the
+    /// same reason (see `recordTransferIntent`'s doc comment) — a buy declaration has no hostname
+    /// to look up a registrar for, so any registrar/expiration cached under a previous transfer
+    /// declaration must not survive into this one.
     public static func recordBuyIntent(siteDirectory: URL) {
         let store = DomainConfigStore(sourceDirectory: siteDirectory)
         var config = (try? store.load()) ?? DomainConfig()
         config.domain = DomainConfig.Domain(
-            hostname: "", choice: NewSiteDomainChoice.buy.rawValue, attach: false)
+            hostname: "", choice: NewSiteDomainChoice.buy.rawValue, attach: false,
+            registrar: "", expiresAt: "")
         try? store.save(config)
     }
 }

--- a/Sources/AnglesiteCore/RDAPClient.swift
+++ b/Sources/AnglesiteCore/RDAPClient.swift
@@ -24,7 +24,6 @@ public struct RDAPDomainInfo: Equatable, Sendable {
     /// - Parameters:
     ///   - registrar: The domain's registrar name, or `nil` if unknown.
     ///   - expiresAt: The raw ISO 8601 expiration event date, or `nil` if unknown.
-    /// - Returns: A new `RDAPDomainInfo` value.
     public init(registrar: String?, expiresAt: String?) {
         self.registrar = registrar
         self.expiresAt = expiresAt

--- a/Sources/AnglesiteCore/RDAPClient.swift
+++ b/Sources/AnglesiteCore/RDAPClient.swift
@@ -4,15 +4,27 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+// OSLog is Darwin-only; AnglesiteCore is part of the Linux-portable target set (Package.swift,
+// cross-platform port design §9/§10), so logging falls back to stderr off-Darwin — mirrors
+// `WorkerCatalogFetcher.logDegradation`.
+#if canImport(OSLog)
+import OSLog
+#endif
 
 /// Registrar name and expiration date for one domain, from an RDAP lookup (`RDAPClient`, #1194).
 public struct RDAPDomainInfo: Equatable, Sendable {
+    /// The domain's registrar name, from the RDAP response's `registrar`-role entity's jCard `fn`
+    /// property. `nil` if the response had no registrar entity.
     public let registrar: String?
     /// Raw RDAP `eventDate` string (ISO 8601) for the domain's expiration event, unparsed — every
     /// other value in `DomainConfig.Domain` is stored as a plain string too; callers format it
     /// for display.
     public let expiresAt: String?
 
+    /// - Parameters:
+    ///   - registrar: The domain's registrar name, or `nil` if unknown.
+    ///   - expiresAt: The raw ISO 8601 expiration event date, or `nil` if unknown.
+    /// - Returns: A new `RDAPDomainInfo` value.
     public init(registrar: String?, expiresAt: String?) {
         self.registrar = registrar
         self.expiresAt = expiresAt
@@ -22,6 +34,13 @@ public struct RDAPDomainInfo: Equatable, Sendable {
 /// Looks up a domain's registrar and expiration date. A protocol seam so `ConnectDomainModel`
 /// tests can inject a fake instead of hitting the network — mirrors `DomainOperationsService`.
 public protocol RDAPLookupService: Sendable {
+    /// Looks up the registrar and expiration date for `hostname`.
+    ///
+    /// - Parameter hostname: The fully-qualified domain name to look up (e.g. `"example.com"`).
+    /// - Returns: The domain's registrar/expiration info, or `nil` if the lookup failed or found
+    ///   nothing usable — implementations are expected to degrade every failure mode to `nil`
+    ///   rather than throwing (see ``RDAPClient/lookup(hostname:)`` for the production
+    ///   implementation's full list of degradation cases).
     func lookup(hostname: String) async -> RDAPDomainInfo?
 }
 
@@ -34,6 +53,28 @@ public protocol RDAPLookupService: Sendable {
 /// `expiration` event or `registrar` entity) degrades to `nil` — this is advisory metadata for the
 /// Connect Domain sheet (#1180), never a blocking requirement.
 public actor RDAPClient: RDAPLookupService {
+    #if canImport(OSLog)
+    private static let logger = Logger(subsystem: "io.dwk.anglesite", category: "RDAPClient")
+    #endif
+
+    /// Degraded-path logging, portable off-Darwin (no OSLog on Linux — cross-platform port design
+    /// §9/§10). Mirrors `WorkerCatalogFetcher.logDegradation` — every failure branch below logs
+    /// enough context (which URL, what was malformed) to diagnose without logging response bodies
+    /// (#1194 review: every RDAP failure was previously silent to both user and developer).
+    private static func logDegradation(_ message: String) {
+        #if canImport(OSLog)
+        logger.error("\(message, privacy: .public)")
+        #else
+        FileHandle.standardError.write(Data("[RDAPClient] \(message)\n".utf8))
+        #endif
+    }
+
+    /// How long a cached bootstrap registry is trusted before a fresh fetch is attempted again.
+    /// IANA's `dns.json` changes rarely, so a day is generous — this avoids re-downloading it on
+    /// every sheet open (#1194 review: the design doc's stated caching rationale wasn't actually
+    /// achieved by the original always-fetch-first implementation).
+    private static let bootstrapCacheTTL: TimeInterval = 24 * 60 * 60
+
     private let bootstrapURL: URL
     private let cacheURL: URL
     private let session: URLSession
@@ -70,24 +111,72 @@ public actor RDAPClient: RDAPLookupService {
             .appendingPathComponent("rdap-bootstrap-cache.json")
     }
 
+    /// Looks up `hostname`'s registrar and expiration date via RDAP: resolves the RDAP server for
+    /// its TLD from IANA's bootstrap registry (caching the registry for up to 24h), then queries
+    /// that server directly for the domain.
+    ///
+    /// - Parameter hostname: The fully-qualified domain name to look up (e.g. `"example.com"`);
+    ///   surrounding whitespace is trimmed and the value is lowercased before use.
+    /// - Returns: The domain's registrar/expiration info, or `nil` on any failure (unknown TLD,
+    ///   network error, malformed response, or no matching registrar/expiration data) — see this
+    ///   type's doc comment for the full list of degradation cases, each of which logs via
+    ///   `logDegradation(_:)` before returning `nil`.
     public func lookup(hostname: String) async -> RDAPDomainInfo? {
         let host = hostname.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard let tld = host.split(separator: ".").last.map(String.init), !tld.isEmpty else { return nil }
+        guard let tld = host.split(separator: ".").last.map(String.init), !tld.isEmpty else {
+            Self.logDegradation("hostname \"\(host)\" has no TLD to resolve an RDAP server for")
+            return nil
+        }
         guard let bootstrapData = await rdapServerData() else { return nil }
         guard let base = Self.rdapServer(forTLD: tld, bootstrapData: bootstrapData) else { return nil }
         return await fetchDomainInfo(base: base, hostname: host)
     }
 
-    /// Fetches the bootstrap registry and caches it on success; falls back to the cache on any
-    /// failure (network error or non-2xx). Returns `nil` only when there's neither a fresh fetch
-    /// nor a usable cache.
+    /// Returns the bootstrap registry, preferring a still-fresh cache over the network entirely
+    /// (see `bootstrapCacheTTL`). Otherwise fetches over the network and caches it on success;
+    /// falls back to a stale cache on any failure (network error or non-2xx). Returns `nil` only
+    /// when there's neither a fresh fetch nor any usable cache.
     private func rdapServerData() async -> Data? {
-        if let (data, response) = try? await session.data(from: bootstrapURL),
-           let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) {
-            try? writeCache(data)
-            return data
+        if let fresh = freshCachedBootstrapData() {
+            return fresh
         }
+        do {
+            let (data, response) = try await session.data(from: bootstrapURL)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                Self.logDegradation("bootstrap registry fetch from \(bootstrapURL) returned a non-2xx response")
+                return staleCachedBootstrapData()
+            }
+            do {
+                try writeCache(data)
+            } catch {
+                Self.logDegradation("bootstrap registry cache write to \(cacheURL.path) failed: \(error)")
+            }
+            return data
+        } catch {
+            Self.logDegradation("bootstrap registry fetch from \(bootstrapURL) failed: \(error)")
+            return staleCachedBootstrapData()
+        }
+    }
+
+    /// The cached bootstrap registry if it exists and is younger than `bootstrapCacheTTL` —
+    /// skips the network entirely. `nil` if there's no cache, the cache is stale, or the cache
+    /// file can't be read despite fresh-looking attributes (falls through to a live fetch in that
+    /// last case, same as a missing cache).
+    private func freshCachedBootstrapData() -> Data? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: cacheURL.path),
+              let modified = attributes[.modificationDate] as? Date,
+              Date().timeIntervalSince(modified) < Self.bootstrapCacheTTL
+        else { return nil }
         return try? Data(contentsOf: cacheURL)
+    }
+
+    private func staleCachedBootstrapData() -> Data? {
+        do {
+            return try Data(contentsOf: cacheURL)
+        } catch {
+            Self.logDegradation("bootstrap registry cache read from \(cacheURL.path) failed: \(error)")
+            return nil
+        }
     }
 
     private func writeCache(_ data: Data) throws {
@@ -98,32 +187,64 @@ public actor RDAPClient: RDAPLookupService {
 
     /// Finds the RDAP base URL that serves `tld`, per the bootstrap registry's
     /// `services: [[tlds, urls], ...]` shape (RFC 9224) — parsed with `JSONValue` rather than a
-    /// `Decodable` struct since each entry is itself a heterogeneous nested array.
+    /// `Decodable` struct since each entry is itself a heterogeneous nested array. Prefers an
+    /// `https` URL among the candidates for the matched TLD (RFC 9224 says https SHOULD be
+    /// preferred), falling back to the first parseable URL otherwise — some TLDs list `http://`
+    /// first, which App Transport Security blocks, previously causing a silent `nil`.
     private static func rdapServer(forTLD tld: String, bootstrapData: Data) -> URL? {
         guard let any = try? JSONSerialization.jsonObject(with: bootstrapData),
               case .object(let fields)? = JSONValue.from(any),
               case .array(let services)? = fields["services"]
-        else { return nil }
+        else {
+            logDegradation("bootstrap registry data was not valid JSON or had no services array")
+            return nil
+        }
         for case .array(let entry) in services where entry.count >= 2 {
             guard case .array(let tlds) = entry[0], case .array(let urls) = entry[1] else { continue }
             guard tlds.contains(.string(tld)) else { continue }
-            for case .string(let urlString) in urls {
-                if let url = URL(string: urlString) { return url }
+            let candidates: [URL] = urls.compactMap {
+                guard case .string(let urlString) = $0 else { return nil }
+                return URL(string: urlString)
             }
+            if let https = candidates.first(where: { $0.scheme == "https" }) {
+                return https
+            }
+            if let first = candidates.first {
+                return first
+            }
+            logDegradation("bootstrap registry entry for .\(tld) had no parseable RDAP server URL")
+            return nil
         }
+        logDegradation("bootstrap registry has no RDAP server entry for .\(tld)")
         return nil
     }
 
     private func fetchDomainInfo(base: URL, hostname: String) async -> RDAPDomainInfo? {
         let url = base.appendingPathComponent("domain").appendingPathComponent(hostname)
-        guard let (data, response) = try? await session.data(from: url),
-              let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
-              let any = try? JSONSerialization.jsonObject(with: data),
+        let data: Data
+        do {
+            let (responseData, response) = try await session.data(from: url)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                Self.logDegradation("domain lookup at \(url) returned a non-2xx response")
+                return nil
+            }
+            data = responseData
+        } catch {
+            Self.logDegradation("domain lookup at \(url) failed: \(error)")
+            return nil
+        }
+        guard let any = try? JSONSerialization.jsonObject(with: data),
               case .object(let fields)? = JSONValue.from(any)
-        else { return nil }
+        else {
+            Self.logDegradation("domain lookup response from \(url) was not valid JSON")
+            return nil
+        }
         let registrar = Self.registrarName(fields: fields)
         let expiresAt = Self.expirationDate(fields: fields)
-        guard registrar != nil || expiresAt != nil else { return nil }
+        guard registrar != nil || expiresAt != nil else {
+            Self.logDegradation("domain lookup response from \(url) had no registrar or expiration event")
+            return nil
+        }
         return RDAPDomainInfo(registrar: registrar, expiresAt: expiresAt)
     }
 

--- a/Sources/AnglesiteCore/RDAPClient.swift
+++ b/Sources/AnglesiteCore/RDAPClient.swift
@@ -1,0 +1,165 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Registrar name and expiration date for one domain, from an RDAP lookup (`RDAPClient`, #1194).
+public struct RDAPDomainInfo: Equatable, Sendable {
+    public let registrar: String?
+    /// Raw RDAP `eventDate` string (ISO 8601) for the domain's expiration event, unparsed — every
+    /// other value in `DomainConfig.Domain` is stored as a plain string too; callers format it
+    /// for display.
+    public let expiresAt: String?
+
+    public init(registrar: String?, expiresAt: String?) {
+        self.registrar = registrar
+        self.expiresAt = expiresAt
+    }
+}
+
+/// Looks up a domain's registrar and expiration date. A protocol seam so `ConnectDomainModel`
+/// tests can inject a fake instead of hitting the network — mirrors `DomainOperationsService`.
+public protocol RDAPLookupService: Sendable {
+    func lookup(hostname: String) async -> RDAPDomainInfo?
+}
+
+/// Production `RDAPLookupService`: looks up a domain's registrar and expiration date via RDAP
+/// (RFC 7480/9082/9083, the standardized WHOIS successor) — no API key needed (#1194). Resolves
+/// the RDAP server for the hostname's TLD from IANA's bootstrap registry (RFC 9224), then queries
+/// that server directly for the domain.
+///
+/// Every failure mode (unknown TLD, network error, non-2xx response, malformed JSON, no matching
+/// `expiration` event or `registrar` entity) degrades to `nil` — this is advisory metadata for the
+/// Connect Domain sheet (#1180), never a blocking requirement.
+public actor RDAPClient: RDAPLookupService {
+    private let bootstrapURL: URL
+    private let cacheURL: URL
+    private let session: URLSession
+    private let fileManager: FileManager
+
+    /// All parameters are injectable for tests; production callers take the defaults.
+    public init(
+        bootstrapURL: URL = RDAPClient.productionBootstrapURL,
+        cacheURL: URL = RDAPClient.defaultCacheURL(),
+        session: URLSession = .shared,
+        fileManager: FileManager = .default
+    ) {
+        self.bootstrapURL = bootstrapURL
+        self.cacheURL = cacheURL
+        self.session = session
+        self.fileManager = fileManager
+    }
+
+    /// IANA's RDAP bootstrap registry for the DNS (domain name) space (RFC 9224).
+    public static let productionBootstrapURL = URL(string: "https://data.iana.org/rdap/dns.json")!
+
+    /// `~/Library/Application Support/Anglesite/rdap-bootstrap-cache.json` — mirrors
+    /// `WorkerCatalogFetcher.defaultCacheURL`'s convention.
+    public static func defaultCacheURL(fileManager: FileManager = .default) -> URL {
+        let support = (try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fileManager.portableHomeDirectory
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return support
+            .appendingPathComponent("Anglesite", isDirectory: true)
+            .appendingPathComponent("rdap-bootstrap-cache.json")
+    }
+
+    public func lookup(hostname: String) async -> RDAPDomainInfo? {
+        let host = hostname.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let tld = host.split(separator: ".").last.map(String.init), !tld.isEmpty else { return nil }
+        guard let bootstrapData = await rdapServerData() else { return nil }
+        guard let base = Self.rdapServer(forTLD: tld, bootstrapData: bootstrapData) else { return nil }
+        return await fetchDomainInfo(base: base, hostname: host)
+    }
+
+    /// Fetches the bootstrap registry and caches it on success; falls back to the cache on any
+    /// failure (network error or non-2xx). Returns `nil` only when there's neither a fresh fetch
+    /// nor a usable cache.
+    private func rdapServerData() async -> Data? {
+        if let (data, response) = try? await session.data(from: bootstrapURL),
+           let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) {
+            try? writeCache(data)
+            return data
+        }
+        return try? Data(contentsOf: cacheURL)
+    }
+
+    private func writeCache(_ data: Data) throws {
+        try fileManager.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: cacheURL, options: [.atomic])
+    }
+
+    /// Finds the RDAP base URL that serves `tld`, per the bootstrap registry's
+    /// `services: [[tlds, urls], ...]` shape (RFC 9224) — parsed with `JSONValue` rather than a
+    /// `Decodable` struct since each entry is itself a heterogeneous nested array.
+    private static func rdapServer(forTLD tld: String, bootstrapData: Data) -> URL? {
+        guard let any = try? JSONSerialization.jsonObject(with: bootstrapData),
+              case .object(let fields)? = JSONValue.from(any),
+              case .array(let services)? = fields["services"]
+        else { return nil }
+        for case .array(let entry) in services where entry.count >= 2 {
+            guard case .array(let tlds) = entry[0], case .array(let urls) = entry[1] else { continue }
+            guard tlds.contains(.string(tld)) else { continue }
+            for case .string(let urlString) in urls {
+                if let url = URL(string: urlString) { return url }
+            }
+        }
+        return nil
+    }
+
+    private func fetchDomainInfo(base: URL, hostname: String) async -> RDAPDomainInfo? {
+        let url = base.appendingPathComponent("domain").appendingPathComponent(hostname)
+        guard let (data, response) = try? await session.data(from: url),
+              let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let any = try? JSONSerialization.jsonObject(with: data),
+              case .object(let fields)? = JSONValue.from(any)
+        else { return nil }
+        let registrar = Self.registrarName(fields: fields)
+        let expiresAt = Self.expirationDate(fields: fields)
+        guard registrar != nil || expiresAt != nil else { return nil }
+        return RDAPDomainInfo(registrar: registrar, expiresAt: expiresAt)
+    }
+
+    /// The `expiration` event's `eventDate`, from the response's top-level `events` array
+    /// (RFC 9083 §4.5).
+    private static func expirationDate(fields: [String: JSONValue]) -> String? {
+        guard case .array(let events)? = fields["events"] else { return nil }
+        for case .object(let event) in events {
+            if case .string("expiration")? = event["eventAction"],
+               case .string(let date)? = event["eventDate"] {
+                return date
+            }
+        }
+        return nil
+    }
+
+    /// The `registrar`-role entity's formatted name, from its jCard `vcardArray` (RFC 9083 §5.1,
+    /// RFC 7095).
+    private static func registrarName(fields: [String: JSONValue]) -> String? {
+        guard case .array(let entities)? = fields["entities"] else { return nil }
+        for case .object(let entity) in entities {
+            guard case .array(let roles)? = entity["roles"], roles.contains(.string("registrar")) else { continue }
+            if let name = fn(fromVCard: entity["vcardArray"]) { return name }
+        }
+        return nil
+    }
+
+    /// Extracts the `fn` (formatted name) property from a jCard array:
+    /// `["vcard", [["version", {}, "text", "4.0"], ["fn", {}, "text", "Example Registrar"]]]`.
+    private static func fn(fromVCard vcard: JSONValue?) -> String? {
+        guard case .array(let outer)? = vcard, outer.count >= 2, case .array(let properties) = outer[1] else { return nil }
+        for case .array(let field) in properties where field.count >= 4 {
+            if case .string("fn") = field[0], case .string(let value) = field[3] {
+                return value
+            }
+        }
+        return nil
+    }
+}

--- a/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
+++ b/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
@@ -9,6 +9,27 @@ private actor FakeRDAPLookupService: RDAPLookupService {
     func lookup(hostname: String) async -> RDAPDomainInfo? { result }
 }
 
+/// A `RDAPLookupService` whose calls suspend until the test explicitly resolves them, in whatever
+/// order the test chooses — used to exercise overlapping/superseded lookups (race-condition
+/// coverage for #1194 review round 2) where resolution order doesn't match call order.
+private actor ControllableRDAPLookupService: RDAPLookupService {
+    private var continuations: [CheckedContinuation<RDAPDomainInfo?, Never>] = []
+
+    func lookup(hostname: String) async -> RDAPDomainInfo? {
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    /// Number of `lookup` calls received so far (in call order), for tests to poll against.
+    func callCount() -> Int { continuations.count }
+
+    /// Resolves the `index`-th call (0-based, in call order) with `result`.
+    func resolve(callIndex index: Int, with result: RDAPDomainInfo?) {
+        continuations[index].resume(returning: result)
+    }
+}
+
 @MainActor
 @Suite struct ConnectDomainModelTests {
     private func makeSite() throws -> (site: CurrentSite, dir: URL) {
@@ -167,5 +188,47 @@ private actor FakeRDAPLookupService: RDAPLookupService {
 
         #expect(model.registrarInfo == .available(
             RDAPDomainInfo(registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
+    }
+
+    /// Reopening the sheet before the first RDAP lookup resolves spawns a second, overlapping
+    /// lookup for the same hostname (review round 2 finding on #1194). The stale first lookup must
+    /// not win the race for `registrarInfo`/the persisted `anglesite.json` write, and it must not
+    /// clobber `isLookingUpRegistrarInfo` after the newer lookup already cleared it.
+    @Test func reopeningBeforeFirstLookupResolvesKeepsNewerResult() async throws {
+        let fake = ControllableRDAPLookupService()
+        let model = ConnectDomainModel(rdap: fake)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+
+        // First lookup: opened via the hostname-entry flow, kicks off call #0.
+        model.openSheet()
+        model.beginTransfer()
+        model.hostnameInput = "example.com"
+        model.submitTransfer()
+        while await fake.callCount() < 1 { await Task.yield() }
+
+        // Dismiss and reopen before call #0 resolves — the still-declared "transfer" hostname
+        // takes the sheet straight back to `.connected` and kicks off a second, overlapping
+        // lookup (call #1) for the same hostname.
+        model.dismissSheet()
+        model.openSheet()
+        #expect(model.phase == .connected(hostname: "example.com"))
+        while await fake.callCount() < 2 { await Task.yield() }
+
+        // Resolve the newer call first, then the stale one — the stale completion must be a
+        // complete no-op once superseded.
+        let newer = RDAPDomainInfo(registrar: "Newer Registrar", expiresAt: "2029-01-01T00:00:00Z")
+        let stale = RDAPDomainInfo(registrar: "Stale Registrar", expiresAt: "2020-01-01T00:00:00Z")
+        await fake.resolve(callIndex: 1, with: newer)
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+        await fake.resolve(callIndex: 0, with: stale)
+        for _ in 0..<10 { await Task.yield() }
+
+        #expect(model.registrarInfo == .available(newer))
+        #expect(!model.isLookingUpRegistrarInfo)
+        let saved = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(saved.domain?.registrar == "Newer Registrar")
+        #expect(saved.domain?.expiresAt == "2029-01-01T00:00:00Z")
     }
 }

--- a/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
+++ b/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
@@ -3,6 +3,12 @@ import Foundation
 @testable import AnglesiteAppCore
 @testable import AnglesiteCore
 
+private actor FakeRDAPLookupService: RDAPLookupService {
+    private let result: RDAPDomainInfo?
+    init(result: RDAPDomainInfo?) { self.result = result }
+    func lookup(hostname: String) async -> RDAPDomainInfo? { result }
+}
+
 @MainActor
 @Suite struct ConnectDomainModelTests {
     private func makeSite() throws -> (site: CurrentSite, dir: URL) {
@@ -84,5 +90,82 @@ import Foundation
 
         #expect(model.phase == .enteringHostname)
         #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent(".site-config").path))
+    }
+
+    @Test func openSheetJumpsToConnectedWhenTransferAlreadyDeclared() throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(
+            DomainConfig(domain: .init(hostname: "example.com", choice: "transfer", attach: true)))
+
+        model.openSheet()
+
+        #expect(model.phase == .connected(hostname: "example.com"))
+        #expect(model.sheetPresented)
+    }
+
+    @Test func openSheetStaysAtChoosingWhenChoiceIsBuy() throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(
+            DomainConfig(domain: .init(hostname: "", choice: "buy", attach: false)))
+
+        model.openSheet()
+
+        #expect(model.phase == .choosing)
+    }
+
+    @Test func openSheetSeedsRegistrarInfoFromCachedAnglesiteJSON() throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(
+            hostname: "example.com", choice: "transfer", attach: true,
+            registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
+
+        model.openSheet()
+
+        #expect(model.registrarInfo == .available(
+            RDAPDomainInfo(registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
+    }
+
+    @Test func submitTransferPersistsFreshRegistrarLookup() async throws {
+        let fake = FakeRDAPLookupService(result: RDAPDomainInfo(registrar: "Namecheap", expiresAt: "2028-01-01T00:00:00Z"))
+        let model = ConnectDomainModel(rdap: fake)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.beginTransfer()
+        model.hostnameInput = "example.com"
+        model.submitTransfer()
+
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+
+        #expect(model.registrarInfo == .available(RDAPDomainInfo(registrar: "Namecheap", expiresAt: "2028-01-01T00:00:00Z")))
+        let saved = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(saved.domain?.registrar == "Namecheap")
+        #expect(saved.domain?.expiresAt == "2028-01-01T00:00:00Z")
+    }
+
+    @Test func failedLookupDoesNotClobberCachedRegistrarInfo() async throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(
+            hostname: "example.com", choice: "transfer", attach: true,
+            registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
+
+        model.openSheet()
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+
+        #expect(model.registrarInfo == .available(
+            RDAPDomainInfo(registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
     }
 }

--- a/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
+++ b/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
@@ -39,7 +39,7 @@ private actor ControllableRDAPLookupService: RDAPLookupService {
     }
 
     @Test func openSheetResetsToChoosingPhase() throws {
-        let model = ConnectDomainModel()
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
         let (site, dir) = try makeSite()
         defer { try? FileManager.default.removeItem(at: dir) }
         model.configure(site: site)
@@ -53,7 +53,7 @@ private actor ControllableRDAPLookupService: RDAPLookupService {
     }
 
     @Test func notNowDismissesWithoutWritingSiteConfig() throws {
-        let model = ConnectDomainModel()
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
         let (site, dir) = try makeSite()
         defer { try? FileManager.default.removeItem(at: dir) }
         model.configure(site: site)
@@ -66,7 +66,7 @@ private actor ControllableRDAPLookupService: RDAPLookupService {
     }
 
     @Test func chooseBuyRecordsIntentAndDismisses() throws {
-        let model = ConnectDomainModel()
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
         let (site, dir) = try makeSite()
         defer { try? FileManager.default.removeItem(at: dir) }
         model.configure(site: site)
@@ -80,7 +80,7 @@ private actor ControllableRDAPLookupService: RDAPLookupService {
     }
 
     @Test func beginTransferThenSubmitRecordsHostnameAndTransitionsToConnected() throws {
-        let model = ConnectDomainModel()
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
         let (site, dir) = try makeSite()
         defer { try? FileManager.default.removeItem(at: dir) }
         model.configure(site: site)
@@ -99,7 +99,7 @@ private actor ControllableRDAPLookupService: RDAPLookupService {
     }
 
     @Test func submitTransferWithEmptyHostnameIsANoOp() throws {
-        let model = ConnectDomainModel()
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
         let (site, dir) = try makeSite()
         defer { try? FileManager.default.removeItem(at: dir) }
         model.configure(site: site)
@@ -230,5 +230,78 @@ private actor ControllableRDAPLookupService: RDAPLookupService {
         let saved = try DomainConfigStore(sourceDirectory: dir).load()
         #expect(saved.domain?.registrar == "Newer Registrar")
         #expect(saved.domain?.expiresAt == "2029-01-01T00:00:00Z")
+    }
+
+    /// #1194 review round 3, finding 1: once `.connected`, the sheet had no way back to
+    /// `.enteringHostname` — an owner who typo'd a hostname was stuck. `beginChangeDomain()` is the
+    /// fix; it must seed `hostnameInput` with the current hostname so re-submitting a corrected
+    /// value doesn't require retyping from scratch.
+    @Test func beginChangeDomainSeedsHostnameAndTransitionsToEnteringHostname() throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(
+            DomainConfig(domain: .init(hostname: "example.com", choice: "transfer", attach: true)))
+        model.openSheet()
+        #expect(model.phase == .connected(hostname: "example.com"))
+
+        model.beginChangeDomain()
+
+        #expect(model.phase == .enteringHostname)
+        #expect(model.hostnameInput == "example.com")
+    }
+
+    @Test func beginChangeDomainIsANoOpOutsideConnectedPhase() throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        #expect(model.phase == .choosing)
+
+        model.beginChangeDomain()
+
+        #expect(model.phase == .choosing)
+        #expect(model.hostnameInput.isEmpty)
+    }
+
+    /// #1194 review round 3, finding 2: `recordTransferIntent` used to leave a previous hostname's
+    /// cached registrar/expiration sitting on disk, un-cleared, under the freshly-declared
+    /// hostname — so reopening (or the fresh submit itself, before any new lookup resolves) could
+    /// display the *old* domain's registrar as if it belonged to the *new* one.
+    @Test func changingDomainClearsStaleRegistrarInfoForNewHostname() async throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(
+            hostname: "old.example.com", choice: "transfer", attach: true,
+            registrar: "Old Registrar, LLC", expiresAt: "2020-01-01T00:00:00Z")))
+
+        model.openSheet()
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+        #expect(model.registrarInfo == .available(
+            RDAPDomainInfo(registrar: "Old Registrar, LLC", expiresAt: "2020-01-01T00:00:00Z")))
+
+        model.beginChangeDomain()
+        #expect(model.hostnameInput == "old.example.com")
+        model.hostnameInput = "new.example.com"
+        model.submitTransfer()
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+
+        #expect(model.phase == .connected(hostname: "new.example.com"))
+        #expect(model.registrarInfo == .unavailable)
+
+        // Reopening the sheet must not resurrect the old registrar under the new hostname either.
+        model.dismissSheet()
+        model.openSheet()
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+        #expect(model.registrarInfo == .unavailable)
+
+        let saved = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(saved.domain?.hostname == "new.example.com")
+        #expect(saved.domain?.registrar != "Old Registrar, LLC")
+        #expect(saved.domain?.expiresAt != "2020-01-01T00:00:00Z")
     }
 }

--- a/Tests/AnglesiteCoreTests/ConnectDomainCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/ConnectDomainCommandTests.swift
@@ -23,10 +23,12 @@ struct ConnectDomainCommandTests {
         #expect(!config.contains("DOMAIN="))
 
         let domainConfig = try DomainConfigStore(sourceDirectory: dir).load()
-        // hostname is an explicit "" rather than nil — see DomainIntentRecorder.recordBuyIntent's
-        // doc comment: a nil Optional is omitted by JSON encoding entirely, so it can't overwrite
-        // a hostname declared by a prior recordTransfer via DomainConfigStore's merge-save.
-        #expect(domainConfig.domain == DomainConfig.Domain(hostname: "", choice: "buy", attach: false))
+        // hostname/registrar/expiresAt are explicit "" rather than nil — see
+        // DomainIntentRecorder.recordBuyIntent's doc comment: a nil Optional is omitted by JSON
+        // encoding entirely, so it can't overwrite values declared by a prior recordTransfer via
+        // DomainConfigStore's merge-save.
+        #expect(domainConfig.domain == DomainConfig.Domain(
+            hostname: "", choice: "buy", attach: false, registrar: "", expiresAt: ""))
     }
 
     @Test("recordTransfer writes DOMAIN_CHOICE/DOMAIN to .site-config and a transfer intent to anglesite.json")
@@ -41,7 +43,8 @@ struct ConnectDomainCommandTests {
         #expect(config.contains("DOMAIN=example.com"))
 
         let domainConfig = try DomainConfigStore(sourceDirectory: dir).load()
-        #expect(domainConfig.domain == DomainConfig.Domain(hostname: "example.com", choice: "transfer", attach: true))
+        #expect(domainConfig.domain == DomainConfig.Domain(
+            hostname: "example.com", choice: "transfer", attach: true, registrar: "", expiresAt: ""))
     }
 
     @Test("recordTransfer overwrites a previous hostname rather than duplicating the DOMAIN line")

--- a/Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift
@@ -26,7 +26,9 @@ struct DomainConfigStoreTests {
         let store = DomainConfigStore(sourceDirectory: dir)
         let config = DomainConfig(
             version: 1,
-            domain: .init(hostname: "example.com", choice: "transfer", attach: true),
+            domain: .init(
+                hostname: "example.com", choice: "transfer", attach: true,
+                registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z"),
             dns: .init(managedRecords: [
                 .init(type: "MX", name: "@", content: "mx01.mail.icloud.com", priority: 10, purpose: "email:icloud"),
             ]),

--- a/Tests/AnglesiteCoreTests/DomainIntentRecorderTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainIntentRecorderTests.swift
@@ -19,7 +19,11 @@ struct DomainIntentRecorderTests {
         DomainIntentRecorder.recordTransferIntent(hostname: "example.com", siteDirectory: dir)
 
         let config = try DomainConfigStore(sourceDirectory: dir).load()
-        #expect(config.domain == DomainConfig.Domain(hostname: "example.com", choice: "transfer", attach: true))
+        // registrar/expiresAt are explicit "" rather than nil (see the method's doc comment) so
+        // this call also overwrites any registrar/expiration cached under a previously-declared
+        // hostname.
+        #expect(config.domain == DomainConfig.Domain(
+            hostname: "example.com", choice: "transfer", attach: true, registrar: "", expiresAt: ""))
     }
 
     @Test("recordBuyIntent writes an empty-string-hostname buy declaration")
@@ -30,10 +34,12 @@ struct DomainIntentRecorderTests {
         DomainIntentRecorder.recordBuyIntent(siteDirectory: dir)
 
         let config = try DomainConfigStore(sourceDirectory: dir).load()
-        // hostname is an explicit "" rather than nil so this call overwrites (rather than
-        // leaves untouched) a hostname declared by a prior recordTransferIntent — see the
-        // method's doc comment for why nil can't express that under DomainConfigStore's merge-save.
-        #expect(config.domain == DomainConfig.Domain(hostname: "", choice: "buy", attach: false))
+        // hostname/registrar/expiresAt are explicit "" rather than nil so this call overwrites
+        // (rather than leaves untouched) values declared by a prior recordTransferIntent — see
+        // the method's doc comment for why nil can't express that under DomainConfigStore's
+        // merge-save.
+        #expect(config.domain == DomainConfig.Domain(
+            hostname: "", choice: "buy", attach: false, registrar: "", expiresAt: ""))
     }
 
     @Test("recordBuyIntent after a prior recordTransferIntent clears the hostname")
@@ -47,5 +53,44 @@ struct DomainIntentRecorderTests {
         let config = try DomainConfigStore(sourceDirectory: dir).load()
         #expect(config.domain?.choice == "buy")
         #expect(config.domain?.hostname != "old.example.com")
+    }
+
+    /// #1194 review round 3, finding 2: a prior domain's cached registrar/expiration must not
+    /// survive under a freshly-declared hostname — `DomainConfigStore.save`'s merge otherwise
+    /// preserves an omitted (`nil`) field from whatever's already on disk, so a *new*
+    /// `recordTransferIntent` call with no registrar/expiresAt of its own would leave the *old*
+    /// domain's values sitting there, now mismatched with the new hostname.
+    @Test("recordTransferIntent for a new hostname clears a previously-cached registrar/expiresAt")
+    func recordTransferIntentClearsStaleRegistrarAndExpiresAt() throws {
+        let dir = try makeSiteDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(
+            hostname: "old.example.com", choice: "transfer", attach: true,
+            registrar: "Old Registrar, LLC", expiresAt: "2020-01-01T00:00:00Z")))
+
+        DomainIntentRecorder.recordTransferIntent(hostname: "new.example.com", siteDirectory: dir)
+
+        let config = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(config.domain?.hostname == "new.example.com")
+        #expect(config.domain?.registrar != "Old Registrar, LLC")
+        #expect(config.domain?.expiresAt != "2020-01-01T00:00:00Z")
+    }
+
+    /// Same carryover risk as above, but via the buy path: switching from a previously-declared
+    /// transfer (with cached registrar info) to "Buy a domain" must not leave that registrar info
+    /// behind under the now-empty hostname.
+    @Test("recordBuyIntent after a prior recordTransferIntent clears registrar/expiresAt")
+    func recordBuyIntentClearsStaleRegistrarAndExpiresAt() throws {
+        let dir = try makeSiteDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(
+            hostname: "old.example.com", choice: "transfer", attach: true,
+            registrar: "Old Registrar, LLC", expiresAt: "2020-01-01T00:00:00Z")))
+
+        DomainIntentRecorder.recordBuyIntent(siteDirectory: dir)
+
+        let config = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(config.domain?.registrar != "Old Registrar, LLC")
+        #expect(config.domain?.expiresAt != "2020-01-01T00:00:00Z")
     }
 }

--- a/Tests/AnglesiteCoreTests/RDAPClientTests.swift
+++ b/Tests/AnglesiteCoreTests/RDAPClientTests.swift
@@ -11,12 +11,17 @@ private final class RDAPStubURLProtocol: URLProtocol, @unchecked Sendable {
     struct Stub { let statusCode: Int; let body: String }
     nonisolated(unsafe) static var responses: [String: Stub] = [:]
     nonisolated(unsafe) static var failingURLs: Set<String> = []
+    /// Every URL actually requested through this protocol, in request order — lets tests prove a
+    /// fetch was *skipped* entirely (e.g. the bootstrap-cache TTL short-circuit), not just that it
+    /// happened to return the right answer.
+    nonisolated(unsafe) static var requestedURLs: [String] = []
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
         let key = request.url?.absoluteString ?? ""
+        Self.requestedURLs.append(key)
         if Self.failingURLs.contains(key) {
             client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
             return
@@ -38,6 +43,7 @@ private final class RDAPStubURLProtocol: URLProtocol, @unchecked Sendable {
     static func reset() {
         responses = [:]
         failingURLs = []
+        requestedURLs = []
     }
 
     static func makeSession() -> URLSession {
@@ -177,5 +183,51 @@ private final class RDAPStubURLProtocol: URLProtocol, @unchecked Sendable {
     @Test("productionBootstrapURL points at IANA's RDAP bootstrap registry")
     func productionBootstrapURLIsIANA() {
         #expect(RDAPClient.productionBootstrapURL == URL(string: "https://data.iana.org/rdap/dns.json")!)
+    }
+
+    /// #1194 review round 3, finding 6: a fresh (<24h old) cached bootstrap registry must be used
+    /// directly, with no network fetch at all — not merely "the fetch fails over to the same
+    /// cache and produces the right answer," which the pre-fix always-fetch-first implementation
+    /// already did. `RDAPStubURLProtocol.requestedURLs` distinguishes the two.
+    @Test("skips the bootstrap network fetch entirely when the cache is fresh")
+    func skipsNetworkFetchWhenBootstrapCacheIsFresh() async throws {
+        RDAPStubURLProtocol.reset()
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(bootstrapJSON.utf8).write(to: cacheURL)
+        // Deliberately no stub registered for bootstrapURL — if the client attempted the fetch
+        // anyway, it would hit the protocol's "no stub" branch (a hard failure), not silently
+        // succeed, so this test would fail loudly rather than passing by accident.
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: domainJSON)
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info?.registrar == "Example Registrar, LLC")
+        #expect(!RDAPStubURLProtocol.requestedURLs.contains(bootstrapURL.absoluteString))
+    }
+
+    /// #1194 review round 3, bundled trivial fix: RFC 9224 says https SHOULD be preferred, and some
+    /// TLDs list `http://` first — App Transport Security would block that and silently produce a
+    /// `nil` lookup. This bootstrap entry deliberately lists `http://` first to prove the https
+    /// entry is chosen instead.
+    @Test("prefers an https RDAP server URL over an http one for the same TLD")
+    func prefersHTTPSRDAPServerURL() async throws {
+        RDAPStubURLProtocol.reset()
+        let httpFirstBootstrapJSON = """
+        {"services":[[["com"],["http://insecure.example.invalid/rdap-com/","https://example.invalid/rdap-com/"]]]}
+        """
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: httpFirstBootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: domainJSON)
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        // If the client had used the http:// URL listed first, it would have requested an
+        // unstubbed domain endpoint under insecure.example.invalid and gotten nil back instead.
+        #expect(info?.registrar == "Example Registrar, LLC")
     }
 }

--- a/Tests/AnglesiteCoreTests/RDAPClientTests.swift
+++ b/Tests/AnglesiteCoreTests/RDAPClientTests.swift
@@ -1,0 +1,181 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Routes each request to a canned status/body keyed by exact URL string, so `RDAPClient`'s
+/// two-hop fetch (bootstrap registry, then the domain-specific RDAP server) can be exercised
+/// without a real network call. Unlike `WorkerCatalogStubURLProtocol` (which returns one fixed
+/// response for every request), `RDAPClient` makes two *different* requests per lookup, so the
+/// stub needs to distinguish them.
+private final class RDAPStubURLProtocol: URLProtocol, @unchecked Sendable {
+    struct Stub { let statusCode: Int; let body: String }
+    nonisolated(unsafe) static var responses: [String: Stub] = [:]
+    nonisolated(unsafe) static var failingURLs: Set<String> = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let key = request.url?.absoluteString ?? ""
+        if Self.failingURLs.contains(key) {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+        guard let stub = Self.responses[key] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: stub.statusCode, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(stub.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        responses = [:]
+        failingURLs = []
+    }
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RDAPStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: tests share RDAPStubURLProtocol's mutable static response table, which would race
+// under Swift Testing's default parallel execution.
+@Suite(.serialized) struct RDAPClientTests {
+    private let bootstrapURL = URL(string: "https://example.invalid/rdap/dns.json")!
+    private let domainURL = "https://example.invalid/rdap-com/domain/example.com"
+
+    private let bootstrapJSON = """
+    {"services":[[["com","net"],["https://example.invalid/rdap-com/"]],[["org"],["https://example.invalid/rdap-org/"]]]}
+    """
+    private let domainJSON = """
+    {
+      "events":[
+        {"eventAction":"registration","eventDate":"1995-08-14T04:00:00Z"},
+        {"eventAction":"expiration","eventDate":"2027-08-13T04:00:00Z"}
+      ],
+      "entities":[
+        {"roles":["registrar"],"vcardArray":["vcard",[["version",{},"text","4.0"],["fn",{},"text","Example Registrar, LLC"]]]}
+      ]
+    }
+    """
+
+    private func tempCacheURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("rdap-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("rdap-bootstrap-cache.json")
+    }
+
+    @Test("looks up registrar and expiration for a known TLD")
+    func looksUpRegistrarAndExpiration() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: domainJSON)
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "Example.com")
+
+        #expect(info?.registrar == "Example Registrar, LLC")
+        #expect(info?.expiresAt == "2027-08-13T04:00:00Z")
+    }
+
+    @Test("returns nil for a TLD absent from the bootstrap registry")
+    func returnsNilForUnknownTLD() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.zzz")
+
+        #expect(info == nil)
+    }
+
+    @Test("returns nil when the domain lookup responds with a non-2xx status")
+    func returnsNilOnBadDomainStatus() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 404, body: "not found")
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info == nil)
+    }
+
+    @Test("falls back to the cached bootstrap registry when the live fetch fails")
+    func fallsBackToCachedBootstrapOnFetchFailure() async throws {
+        RDAPStubURLProtocol.reset()
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(bootstrapJSON.utf8).write(to: cacheURL)
+
+        RDAPStubURLProtocol.failingURLs = [bootstrapURL.absoluteString]
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: domainJSON)
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info?.registrar == "Example Registrar, LLC")
+    }
+
+    @Test("returns nil when the bootstrap fetch fails and there is no cache")
+    func returnsNilWhenNoCacheAndFetchFails() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.failingURLs = [bootstrapURL.absoluteString]
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info == nil)
+    }
+
+    @Test("caches the bootstrap registry to disk on a successful fetch")
+    func cachesBootstrapOnSuccess() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: domainJSON)
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        _ = await client.lookup(hostname: "example.com")
+
+        #expect(FileManager.default.fileExists(atPath: cacheURL.path))
+    }
+
+    @Test("returns nil when the domain response has neither a registrar nor an expiration date")
+    func returnsNilWhenNoUsefulData() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: "{}")
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info == nil)
+    }
+
+    @Test("productionBootstrapURL points at IANA's RDAP bootstrap registry")
+    func productionBootstrapURLIsIANA() {
+        #expect(RDAPClient.productionBootstrapURL == URL(string: "https://data.iana.org/rdap/dns.json")!)
+    }
+}

--- a/docs/superpowers/plans/2026-08-01-domain-registrar-tracking.md
+++ b/docs/superpowers/plans/2026-08-01-domain-registrar-tracking.md
@@ -1,0 +1,891 @@
+# Domain Registrar/Expiration Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Look up a connected domain's registrar and expiration date via RDAP, persist it into `Source/anglesite.json`, and surface it in the Connect Domain sheet.
+
+**Architecture:** A new `RDAPClient` actor in `AnglesiteCore` resolves the right RDAP server per TLD from IANA's bootstrap registry, queries it for a domain's registrar/expiration, and degrades to `nil` on any failure. `ConnectDomainModel` (`AnglesiteApp`, #1180) is extended to detect an already-declared domain on `openSheet()`, run the lookup in the background, show cached results instantly, and persist fresh ones back into `anglesite.json` via the existing `DomainConfigStore`.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Test`/`@Suite`), `URLSession` + a stub `URLProtocol` for network tests, SwiftUI.
+
+## Global Constraints
+
+- Design doc: `docs/superpowers/specs/2026-08-01-domain-registrar-tracking-design.md` — read it first if anything below is ambiguous.
+- Conventional commits, subject line ≤72 characters, reference `#1194`.
+- No new third-party dependencies — `RDAPClient` uses only `Foundation`/`URLSession` and the existing `JSONValue` type (`Sources/AnglesiteCore/MCPClient.swift`).
+- Every new/changed public type in `AnglesiteCore`/`AnglesiteApp` needs a doc comment per `docs/comment-style-guide.md` (state the non-obvious *why*, not the *what*).
+- `RDAPClient.lookup(hostname:)` must never throw and must degrade to `nil` on any failure (network error, non-2xx, malformed JSON, unknown TLD, no useful data) — this is advisory metadata, never blocking.
+- Don't touch `CustomDomainAttachCommand`'s attach logic, `DeployCommand`'s pipeline, or `.notConnected`/`conflict` handling in `DeployDrawerView` — out of scope per the design doc's non-goals.
+
+---
+
+### Task 1: Extend `DomainConfig.Domain` with `registrar`/`expiresAt`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DomainConfig.swift:43-56`
+- Test: `Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift:24-41` (`saveLoadRoundTrips`)
+
+**Interfaces:**
+- Produces: `DomainConfig.Domain.registrar: String?`, `DomainConfig.Domain.expiresAt: String?`, and the corresponding `init` parameters (both default `nil`) — every later task constructs/reads `Domain` through these.
+
+- [ ] **Step 1: Write the failing test**
+
+Edit `Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift`, in `saveLoadRoundTrips()`, change the `domain:` line from:
+
+```swift
+            domain: .init(hostname: "example.com", choice: "transfer", attach: true),
+```
+
+to:
+
+```swift
+            domain: .init(
+                hostname: "example.com", choice: "transfer", attach: true,
+                registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z"),
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter DomainConfigStoreTests 2>&1 | tail -40`
+Expected: FAIL to build — `extra argument 'registrar' in call` (the `Domain.init` doesn't accept it yet).
+
+- [ ] **Step 3: Implement the schema change**
+
+In `Sources/AnglesiteCore/DomainConfig.swift`, replace the `Domain` struct (lines 43-56):
+
+```swift
+    public struct Domain: Codable, Equatable, Sendable {
+        public var hostname: String?
+        /// `"buy" | "transfer" | "later"` — kept as an open string (not a closed `enum`) so an
+        /// unrecognized value from a future app version or a hand edit degrades gracefully for
+        /// the reader instead of failing the whole document to decode.
+        public var choice: String?
+        public var attach: Bool?
+        /// The domain's registrar name, from an RDAP lookup (`RDAPClient`, #1194). `nil` until a
+        /// lookup has succeeded at least once.
+        public var registrar: String?
+        /// The domain's expiration date, as the raw ISO 8601 `eventDate` string RDAP returned —
+        /// unparsed, like every other value in this struct; callers format it for display.
+        public var expiresAt: String?
+
+        public init(
+            hostname: String? = nil, choice: String? = nil, attach: Bool? = nil,
+            registrar: String? = nil, expiresAt: String? = nil
+        ) {
+            self.hostname = hostname
+            self.choice = choice
+            self.attach = attach
+            self.registrar = registrar
+            self.expiresAt = expiresAt
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter DomainConfigStoreTests 2>&1 | tail -40`
+Expected: PASS — all `DomainConfigStoreTests` tests green, including the updated round-trip.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DomainConfig.swift Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift
+git commit -m "feat(#1194): add registrar/expiresAt to DomainConfig.Domain"
+```
+
+---
+
+### Task 2: RDAP lookup client (`AnglesiteCore`)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/RDAPClient.swift`
+- Test: `Tests/AnglesiteCoreTests/RDAPClientTests.swift`
+
+**Interfaces:**
+- Consumes: `JSONValue` (`Sources/AnglesiteCore/MCPClient.swift`) — cases `.object([String: JSONValue])`, `.array([JSONValue])`, `.string(String)`, and `static func from(_ value: Any) -> JSONValue?`.
+- Produces: `public struct RDAPDomainInfo: Equatable, Sendable { let registrar: String?; let expiresAt: String? }` (public memberwise `init(registrar:expiresAt:)`), `public protocol RDAPLookupService: Sendable { func lookup(hostname: String) async -> RDAPDomainInfo? }`, `public actor RDAPClient: RDAPLookupService` with `init(bootstrapURL: URL = RDAPClient.productionBootstrapURL, cacheURL: URL = RDAPClient.defaultCacheURL(), session: URLSession = .shared, fileManager: FileManager = .default)`, `static let productionBootstrapURL: URL`, `static func defaultCacheURL(fileManager: FileManager = .default) -> URL`. Task 3 (`ConnectDomainModel`) consumes all of these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/RDAPClientTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Routes each request to a canned status/body keyed by exact URL string, so `RDAPClient`'s
+/// two-hop fetch (bootstrap registry, then the domain-specific RDAP server) can be exercised
+/// without a real network call. Unlike `WorkerCatalogStubURLProtocol` (which returns one fixed
+/// response for every request), `RDAPClient` makes two *different* requests per lookup, so the
+/// stub needs to distinguish them.
+private final class RDAPStubURLProtocol: URLProtocol, @unchecked Sendable {
+    struct Stub { let statusCode: Int; let body: String }
+    nonisolated(unsafe) static var responses: [String: Stub] = [:]
+    nonisolated(unsafe) static var failingURLs: Set<String> = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let key = request.url?.absoluteString ?? ""
+        if Self.failingURLs.contains(key) {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+        guard let stub = Self.responses[key] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: stub.statusCode, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(stub.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        responses = [:]
+        failingURLs = []
+    }
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RDAPStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: tests share RDAPStubURLProtocol's mutable static response table, which would race
+// under Swift Testing's default parallel execution.
+@Suite(.serialized) struct RDAPClientTests {
+    private let bootstrapURL = URL(string: "https://example.invalid/rdap/dns.json")!
+    private let domainURL = "https://example.invalid/rdap-com/domain/example.com"
+
+    private let bootstrapJSON = """
+    {"services":[[["com","net"],["https://example.invalid/rdap-com/"]],[["org"],["https://example.invalid/rdap-org/"]]]}
+    """
+    private let domainJSON = """
+    {
+      "events":[
+        {"eventAction":"registration","eventDate":"1995-08-14T04:00:00Z"},
+        {"eventAction":"expiration","eventDate":"2027-08-13T04:00:00Z"}
+      ],
+      "entities":[
+        {"roles":["registrar"],"vcardArray":["vcard",[["version",{},"text","4.0"],["fn",{},"text","Example Registrar, LLC"]]]}
+      ]
+    }
+    """
+
+    private func tempCacheURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("rdap-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("rdap-bootstrap-cache.json")
+    }
+
+    @Test("looks up registrar and expiration for a known TLD")
+    func looksUpRegistrarAndExpiration() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: domainJSON)
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "Example.com")
+
+        #expect(info?.registrar == "Example Registrar, LLC")
+        #expect(info?.expiresAt == "2027-08-13T04:00:00Z")
+    }
+
+    @Test("returns nil for a TLD absent from the bootstrap registry")
+    func returnsNilForUnknownTLD() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.zzz")
+
+        #expect(info == nil)
+    }
+
+    @Test("returns nil when the domain lookup responds with a non-2xx status")
+    func returnsNilOnBadDomainStatus() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 404, body: "not found")
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info == nil)
+    }
+
+    @Test("falls back to the cached bootstrap registry when the live fetch fails")
+    func fallsBackToCachedBootstrapOnFetchFailure() async throws {
+        RDAPStubURLProtocol.reset()
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(bootstrapJSON.utf8).write(to: cacheURL)
+
+        RDAPStubURLProtocol.failingURLs = [bootstrapURL.absoluteString]
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: domainJSON)
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info?.registrar == "Example Registrar, LLC")
+    }
+
+    @Test("returns nil when the bootstrap fetch fails and there is no cache")
+    func returnsNilWhenNoCacheAndFetchFails() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.failingURLs = [bootstrapURL.absoluteString]
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info == nil)
+    }
+
+    @Test("caches the bootstrap registry to disk on a successful fetch")
+    func cachesBootstrapOnSuccess() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: domainJSON)
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        _ = await client.lookup(hostname: "example.com")
+
+        #expect(FileManager.default.fileExists(atPath: cacheURL.path))
+    }
+
+    @Test("returns nil when the domain response has neither a registrar nor an expiration date")
+    func returnsNilWhenNoUsefulData() async throws {
+        RDAPStubURLProtocol.reset()
+        RDAPStubURLProtocol.responses[bootstrapURL.absoluteString] = .init(statusCode: 200, body: bootstrapJSON)
+        RDAPStubURLProtocol.responses[domainURL] = .init(statusCode: 200, body: "{}")
+        let cacheURL = tempCacheURL()
+        defer { try? FileManager.default.removeItem(at: cacheURL.deletingLastPathComponent()) }
+
+        let client = RDAPClient(bootstrapURL: bootstrapURL, cacheURL: cacheURL, session: RDAPStubURLProtocol.makeSession())
+        let info = await client.lookup(hostname: "example.com")
+
+        #expect(info == nil)
+    }
+
+    @Test("productionBootstrapURL points at IANA's RDAP bootstrap registry")
+    func productionBootstrapURLIsIANA() {
+        #expect(RDAPClient.productionBootstrapURL == URL(string: "https://data.iana.org/rdap/dns.json")!)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter RDAPClientTests 2>&1 | tail -40`
+Expected: FAIL to build — `cannot find type 'RDAPClient' in scope` (nothing implemented yet).
+
+- [ ] **Step 3: Implement `RDAPClient`**
+
+Create `Sources/AnglesiteCore/RDAPClient.swift`:
+
+```swift
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Registrar name and expiration date for one domain, from an RDAP lookup (`RDAPClient`, #1194).
+public struct RDAPDomainInfo: Equatable, Sendable {
+    public let registrar: String?
+    /// Raw RDAP `eventDate` string (ISO 8601) for the domain's expiration event, unparsed — every
+    /// other value in `DomainConfig.Domain` is stored as a plain string too; callers format it
+    /// for display.
+    public let expiresAt: String?
+
+    public init(registrar: String?, expiresAt: String?) {
+        self.registrar = registrar
+        self.expiresAt = expiresAt
+    }
+}
+
+/// Looks up a domain's registrar and expiration date. A protocol seam so `ConnectDomainModel`
+/// tests can inject a fake instead of hitting the network — mirrors `DomainOperationsService`.
+public protocol RDAPLookupService: Sendable {
+    func lookup(hostname: String) async -> RDAPDomainInfo?
+}
+
+/// Production `RDAPLookupService`: looks up a domain's registrar and expiration date via RDAP
+/// (RFC 7480/9082/9083, the standardized WHOIS successor) — no API key needed (#1194). Resolves
+/// the RDAP server for the hostname's TLD from IANA's bootstrap registry (RFC 9224), then queries
+/// that server directly for the domain.
+///
+/// Every failure mode (unknown TLD, network error, non-2xx response, malformed JSON, no matching
+/// `expiration` event or `registrar` entity) degrades to `nil` — this is advisory metadata for the
+/// Connect Domain sheet (#1180), never a blocking requirement.
+public actor RDAPClient: RDAPLookupService {
+    private let bootstrapURL: URL
+    private let cacheURL: URL
+    private let session: URLSession
+    private let fileManager: FileManager
+
+    /// All parameters are injectable for tests; production callers take the defaults.
+    public init(
+        bootstrapURL: URL = RDAPClient.productionBootstrapURL,
+        cacheURL: URL = RDAPClient.defaultCacheURL(),
+        session: URLSession = .shared,
+        fileManager: FileManager = .default
+    ) {
+        self.bootstrapURL = bootstrapURL
+        self.cacheURL = cacheURL
+        self.session = session
+        self.fileManager = fileManager
+    }
+
+    /// IANA's RDAP bootstrap registry for the DNS (domain name) space (RFC 9224).
+    public static let productionBootstrapURL = URL(string: "https://data.iana.org/rdap/dns.json")!
+
+    /// `~/Library/Application Support/Anglesite/rdap-bootstrap-cache.json` — mirrors
+    /// `WorkerCatalogFetcher.defaultCacheURL`'s convention.
+    public static func defaultCacheURL(fileManager: FileManager = .default) -> URL {
+        let support = (try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? fileManager.portableHomeDirectory
+            .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return support
+            .appendingPathComponent("Anglesite", isDirectory: true)
+            .appendingPathComponent("rdap-bootstrap-cache.json")
+    }
+
+    public func lookup(hostname: String) async -> RDAPDomainInfo? {
+        let host = hostname.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let tld = host.split(separator: ".").last.map(String.init), !tld.isEmpty else { return nil }
+        guard let bootstrapData = await rdapServerData() else { return nil }
+        guard let base = Self.rdapServer(forTLD: tld, bootstrapData: bootstrapData) else { return nil }
+        return await fetchDomainInfo(base: base, hostname: host)
+    }
+
+    /// Fetches the bootstrap registry and caches it on success; falls back to the cache on any
+    /// failure (network error or non-2xx). Returns `nil` only when there's neither a fresh fetch
+    /// nor a usable cache.
+    private func rdapServerData() async -> Data? {
+        if let (data, response) = try? await session.data(from: bootstrapURL),
+           let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) {
+            try? writeCache(data)
+            return data
+        }
+        return try? Data(contentsOf: cacheURL)
+    }
+
+    private func writeCache(_ data: Data) throws {
+        try fileManager.createDirectory(
+            at: cacheURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: cacheURL, options: [.atomic])
+    }
+
+    /// Finds the RDAP base URL that serves `tld`, per the bootstrap registry's
+    /// `services: [[tlds, urls], ...]` shape (RFC 9224) — parsed with `JSONValue` rather than a
+    /// `Decodable` struct since each entry is itself a heterogeneous nested array.
+    private static func rdapServer(forTLD tld: String, bootstrapData: Data) -> URL? {
+        guard let any = try? JSONSerialization.jsonObject(with: bootstrapData),
+              case .object(let fields)? = JSONValue.from(any),
+              case .array(let services)? = fields["services"]
+        else { return nil }
+        for case .array(let entry) in services where entry.count >= 2 {
+            guard case .array(let tlds) = entry[0], case .array(let urls) = entry[1] else { continue }
+            guard tlds.contains(.string(tld)) else { continue }
+            for case .string(let urlString) in urls {
+                if let url = URL(string: urlString) { return url }
+            }
+        }
+        return nil
+    }
+
+    private func fetchDomainInfo(base: URL, hostname: String) async -> RDAPDomainInfo? {
+        let url = base.appendingPathComponent("domain").appendingPathComponent(hostname)
+        guard let (data, response) = try? await session.data(from: url),
+              let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let any = try? JSONSerialization.jsonObject(with: data),
+              case .object(let fields)? = JSONValue.from(any)
+        else { return nil }
+        let registrar = Self.registrarName(fields: fields)
+        let expiresAt = Self.expirationDate(fields: fields)
+        guard registrar != nil || expiresAt != nil else { return nil }
+        return RDAPDomainInfo(registrar: registrar, expiresAt: expiresAt)
+    }
+
+    /// The `expiration` event's `eventDate`, from the response's top-level `events` array
+    /// (RFC 9083 §4.5).
+    private static func expirationDate(fields: [String: JSONValue]) -> String? {
+        guard case .array(let events)? = fields["events"] else { return nil }
+        for case .object(let event) in events {
+            if case .string("expiration")? = event["eventAction"],
+               case .string(let date)? = event["eventDate"] {
+                return date
+            }
+        }
+        return nil
+    }
+
+    /// The `registrar`-role entity's formatted name, from its jCard `vcardArray` (RFC 9083 §5.1,
+    /// RFC 7095).
+    private static func registrarName(fields: [String: JSONValue]) -> String? {
+        guard case .array(let entities)? = fields["entities"] else { return nil }
+        for case .object(let entity) in entities {
+            guard case .array(let roles)? = entity["roles"], roles.contains(.string("registrar")) else { continue }
+            if let name = fn(fromVCard: entity["vcardArray"]) { return name }
+        }
+        return nil
+    }
+
+    /// Extracts the `fn` (formatted name) property from a jCard array:
+    /// `["vcard", [["version", {}, "text", "4.0"], ["fn", {}, "text", "Example Registrar"]]]`.
+    private static func fn(fromVCard vcard: JSONValue?) -> String? {
+        guard case .array(let outer)? = vcard, outer.count >= 2, case .array(let properties) = outer[1] else { return nil }
+        for case .array(let field) in properties where field.count >= 4 {
+            if case .string("fn") = field[0], case .string(let value) = field[3] {
+                return value
+            }
+        }
+        return nil
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter RDAPClientTests 2>&1 | tail -60`
+Expected: PASS — all 8 `RDAPClientTests` tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/RDAPClient.swift Tests/AnglesiteCoreTests/RDAPClientTests.swift
+git commit -m "feat(#1194): add RDAPClient for registrar/expiration lookup"
+```
+
+---
+
+### Task 3: Wire registrar lookup into `ConnectDomainModel`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ConnectDomainModel.swift` (full rewrite, ~120 lines)
+- Test: `Tests/AnglesiteAppTests/ConnectDomainModelTests.swift` (append new tests + a fake)
+
+**Interfaces:**
+- Consumes: `RDAPLookupService`, `RDAPClient`, `RDAPDomainInfo` (Task 2); `DomainConfigStore`, `DomainConfig`, `DomainConfig.Domain`, `NewSiteDomainChoice.transfer` (existing `AnglesiteCore`).
+- Produces: `ConnectDomainModel.RegistrarInfoState` (`.idle`/`.loading`/`.available(RDAPDomainInfo)`/`.unavailable`), `ConnectDomainModel.registrarInfo: RegistrarInfoState` (read-only), `ConnectDomainModel.isLookingUpRegistrarInfo: Bool` (read-only, for tests to await the background lookup), `ConnectDomainModel.init(rdap: any RDAPLookupService = RDAPClient())`. Task 4 (the view) consumes `registrarInfo`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/AnglesiteAppTests/ConnectDomainModelTests.swift`, add a fake right after the imports (before `@MainActor @Suite struct ConnectDomainModelTests {`):
+
+```swift
+private actor FakeRDAPLookupService: RDAPLookupService {
+    private let result: RDAPDomainInfo?
+    init(result: RDAPDomainInfo?) { self.result = result }
+    func lookup(hostname: String) async -> RDAPDomainInfo? { result }
+}
+```
+
+Then append these tests inside the `ConnectDomainModelTests` struct, after the existing `submitTransferWithEmptyHostnameIsANoOp` test:
+
+```swift
+    @Test func openSheetJumpsToConnectedWhenTransferAlreadyDeclared() throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(
+            DomainConfig(domain: .init(hostname: "example.com", choice: "transfer", attach: true)))
+
+        model.openSheet()
+
+        #expect(model.phase == .connected(hostname: "example.com"))
+        #expect(model.sheetPresented)
+    }
+
+    @Test func openSheetStaysAtChoosingWhenChoiceIsBuy() throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(
+            DomainConfig(domain: .init(hostname: "", choice: "buy", attach: false)))
+
+        model.openSheet()
+
+        #expect(model.phase == .choosing)
+    }
+
+    @Test func openSheetSeedsRegistrarInfoFromCachedAnglesiteJSON() throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(
+            hostname: "example.com", choice: "transfer", attach: true,
+            registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
+
+        model.openSheet()
+
+        #expect(model.registrarInfo == .available(
+            RDAPDomainInfo(registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
+    }
+
+    @Test func submitTransferPersistsFreshRegistrarLookup() async throws {
+        let fake = FakeRDAPLookupService(result: RDAPDomainInfo(registrar: "Namecheap", expiresAt: "2028-01-01T00:00:00Z"))
+        let model = ConnectDomainModel(rdap: fake)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.beginTransfer()
+        model.hostnameInput = "example.com"
+        model.submitTransfer()
+
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+
+        #expect(model.registrarInfo == .available(RDAPDomainInfo(registrar: "Namecheap", expiresAt: "2028-01-01T00:00:00Z")))
+        let saved = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(saved.domain?.registrar == "Namecheap")
+        #expect(saved.domain?.expiresAt == "2028-01-01T00:00:00Z")
+    }
+
+    @Test func failedLookupDoesNotClobberCachedRegistrarInfo() async throws {
+        let model = ConnectDomainModel(rdap: FakeRDAPLookupService(result: nil))
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(DomainConfig(domain: .init(
+            hostname: "example.com", choice: "transfer", attach: true,
+            registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
+
+        model.openSheet()
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+
+        #expect(model.registrarInfo == .available(
+            RDAPDomainInfo(registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z")))
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter ConnectDomainModelTests 2>&1 | tail -60`
+Expected: FAIL to build — `argument passed to call that takes no arguments` (`ConnectDomainModel(rdap:)`) and `value of type 'ConnectDomainModel' has no member 'registrarInfo'`/`'isLookingUpRegistrarInfo'`.
+
+- [ ] **Step 3: Implement the model changes**
+
+Replace the full contents of `Sources/AnglesiteApp/ConnectDomainModel.swift`:
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// Drives the "Connect a Domain" sheet (#1180): buy/transfer/later, reachable from the
+/// first-publish nudge in `DeployDrawerView` and permanently from `Website ▸ Connect a Domain…`.
+/// Every domain-declaration action is a synchronous local file write via `ConnectDomainCommand` —
+/// no network calls, unlike `HardenModel`/`DomainModel`. The actual Workers Custom Domain attach
+/// stays owned by `CustomDomainAttachCommand`, which already runs on every deploy. The one
+/// exception is registrar/expiration lookup (#1194): a passive, best-effort RDAP query that never
+/// blocks or gates anything else in this sheet.
+@MainActor
+@Observable
+final class ConnectDomainModel {
+    enum Phase: Equatable {
+        case choosing
+        case enteringHostname
+        case connected(hostname: String)
+    }
+
+    /// Registrar/expiration info for the connected hostname (#1194) — orthogonal to `phase` since
+    /// it loads and refreshes on its own schedule instead of gating the sheet's own flow.
+    enum RegistrarInfoState: Equatable {
+        case idle
+        case loading
+        case available(RDAPDomainInfo)
+        case unavailable
+    }
+
+    private(set) var phase: Phase = .choosing
+    var sheetPresented: Bool = false
+    var hostnameInput: String = ""
+    private(set) var registrarInfo: RegistrarInfoState = .idle
+    /// `true` while an RDAP lookup is in flight — lets tests deterministically wait for the
+    /// background `Task` `loadRegistrarInfo` spawns to finish, the same role `DomainModel.isRunning`
+    /// plays for its own async work.
+    private(set) var isLookingUpRegistrarInfo: Bool = false
+
+    private let rdap: any RDAPLookupService
+    private var registrarLookupTask: Task<Void, Never>?
+    private var currentSite: CurrentSite?
+
+    /// The Cloudflare Domains marketing page — opened by the view layer's "Buy a domain" button,
+    /// not by `chooseBuy()` itself, so this model stays free of `NSWorkspace`/AppKit side effects
+    /// and is fully testable (matches `WebsiteCommands`'s "View on GitHub" convention of keeping
+    /// `NSWorkspace.shared.open` out of the model layer).
+    static let cloudflareDomainsURL = URL(string: "https://www.cloudflare.com/products/registrar/")!
+
+    /// `rdap` is injectable for tests; production callers take the default `RDAPClient`.
+    init(rdap: any RDAPLookupService = RDAPClient()) {
+        self.rdap = rdap
+    }
+
+    /// Threaded from `SiteWindowModel.loadAndStart`, mirroring `DomainModel.configure(site:)`.
+    func configure(site: CurrentSite) {
+        currentSite = site
+    }
+
+    /// Resets to `.choosing` unless `anglesite.json` already declares an owned (`transfer`)
+    /// hostname, in which case this jumps straight to `.connected` and kicks off a registrar
+    /// lookup — the only way to revisit a previously-connected domain's registrar/expiration info
+    /// (#1194). A `buy` declaration (no real hostname yet) or no declaration at all still starts
+    /// at `.choosing`, unchanged from #1180.
+    func openSheet() {
+        hostnameInput = ""
+        registrarLookupTask?.cancel()
+        registrarLookupTask = nil
+        isLookingUpRegistrarInfo = false
+        registrarInfo = .idle
+
+        if let site = currentSite,
+           let declared = try? DomainConfigStore(sourceDirectory: site.sourceDirectory).load(),
+           let hostname = declared.domain?.hostname, !hostname.isEmpty,
+           declared.domain?.choice == NewSiteDomainChoice.transfer.rawValue {
+            phase = .connected(hostname: hostname)
+            loadRegistrarInfo(hostname: hostname, sourceDirectory: site.sourceDirectory)
+        } else {
+            phase = .choosing
+        }
+        sheetPresented = true
+    }
+
+    func dismissSheet() {
+        registrarLookupTask?.cancel()
+        sheetPresented = false
+    }
+
+    /// "Not now" — dismisses without writing anything. `DOMAIN_CHOICE` stays whatever it already
+    /// was (`later` by default), so this is a true no-op.
+    func notNow() {
+        dismissSheet()
+    }
+
+    /// "Buy a domain" — records the buy intent and dismisses. Opening Cloudflare Domains in the
+    /// browser is the view's job (see `cloudflareDomainsURL`'s doc comment).
+    func chooseBuy() {
+        guard let site = currentSite else { return }
+        ConnectDomainCommand.recordBuy(siteDirectory: site.sourceDirectory)
+        dismissSheet()
+    }
+
+    /// "I already own a domain" — reveals the hostname field.
+    func beginTransfer() {
+        phase = .enteringHostname
+    }
+
+    /// Submits the typed hostname. No format validation beyond non-empty/trim, matching
+    /// `DomainModel.resolveAndLoad` — a malformed hostname simply won't resolve a Cloudflare zone
+    /// on the next deploy, surfaced there exactly like today's `.notConnected` outcome.
+    func submitTransfer() {
+        guard case .enteringHostname = phase, let site = currentSite else { return }
+        let hostname = hostnameInput.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !hostname.isEmpty else { return }
+        ConnectDomainCommand.recordTransfer(hostname: hostname, siteDirectory: site.sourceDirectory)
+        phase = .connected(hostname: hostname)
+        loadRegistrarInfo(hostname: hostname, sourceDirectory: site.sourceDirectory)
+    }
+
+    // MARK: - Private
+
+    /// Seeds `registrarInfo` from whatever's already cached in `anglesite.json` (instant, no
+    /// spinner) and kicks off a fresh RDAP lookup in the background. A successful lookup updates
+    /// `registrarInfo` and persists into `anglesite.json`; a failed one only clears a `.loading`
+    /// placeholder to `.unavailable` — it never regresses an already-good cached value back to
+    /// nothing.
+    private func loadRegistrarInfo(hostname: String, sourceDirectory: URL) {
+        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
+        let declared = try? store.load()
+        if let cached = declared?.domain, cached.hostname == hostname,
+           cached.registrar != nil || cached.expiresAt != nil {
+            registrarInfo = .available(RDAPDomainInfo(registrar: cached.registrar, expiresAt: cached.expiresAt))
+        } else {
+            registrarInfo = .loading
+        }
+
+        isLookingUpRegistrarInfo = true
+        registrarLookupTask?.cancel()
+        registrarLookupTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await self.rdap.lookup(hostname: hostname)
+            self.isLookingUpRegistrarInfo = false
+            guard case .connected(let current) = self.phase, current == hostname else { return }
+            if let result, result.registrar != nil || result.expiresAt != nil {
+                self.registrarInfo = .available(result)
+                self.persistRegistrarInfo(result, hostname: hostname, sourceDirectory: sourceDirectory)
+            } else if case .loading = self.registrarInfo {
+                self.registrarInfo = .unavailable
+            }
+        }
+    }
+
+    private func persistRegistrarInfo(_ info: RDAPDomainInfo, hostname: String, sourceDirectory: URL) {
+        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
+        guard var config = try? store.load(), config.domain?.hostname == hostname else { return }
+        config.domain?.registrar = info.registrar
+        config.domain?.expiresAt = info.expiresAt
+        try? store.save(config)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ConnectDomainModelTests 2>&1 | tail -80`
+Expected: PASS — all `ConnectDomainModelTests` tests green, including the 5 new ones and the 5 pre-existing ones (`openSheetResetsToChoosingPhase` still passes since it declares no domain, so it still lands on `.choosing`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ConnectDomainModel.swift Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
+git commit -m "feat(#1194): look up and persist registrar info in ConnectDomainModel"
+```
+
+---
+
+### Task 4: Display registrar/expiration in `ConnectDomainSheetView`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ConnectDomainSheetView.swift`
+
+**Interfaces:**
+- Consumes: `ConnectDomainModel.registrarInfo: RegistrarInfoState`, `RDAPDomainInfo.registrar`/`.expiresAt` (Task 3).
+
+There is no unit test target for SwiftUI view bodies in this codebase (`DomainConfigAuditSheetView`, `DomainSheetView`, etc. have no corresponding `*ViewTests.swift`) — this task is verified by building and a manual check in Task 5.
+
+- [ ] **Step 1: Add the registrar info view**
+
+In `Sources/AnglesiteApp/ConnectDomainSheetView.swift`, add `import Foundation` after `import AppKit`:
+
+```swift
+import SwiftUI
+import AppKit
+import Foundation
+```
+
+Replace the `.connected` case inside `content` (currently a single `Label`):
+
+```swift
+        case .connected(let hostname):
+            Label("We'll connect \(hostname) on your next Publish.", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+```
+
+with:
+
+```swift
+        case .connected(let hostname):
+            VStack(alignment: .leading, spacing: 8) {
+                Label("We'll connect \(hostname) on your next Publish.", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                registrarInfoView
+            }
+```
+
+Then add these two private members after `content` (before `progressView`/`footer`, i.e. right after the `content` computed property's closing brace):
+
+```swift
+    @ViewBuilder
+    private var registrarInfoView: some View {
+        switch model.registrarInfo {
+        case .idle, .unavailable:
+            EmptyView()
+        case .loading:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Looking up registrar info…")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        case .available(let info):
+            VStack(alignment: .leading, spacing: 2) {
+                if let registrar = info.registrar {
+                    Text("Registrar: \(registrar)")
+                }
+                if let expiresAt = info.expiresAt {
+                    Text("Expires \(Self.formattedExpiration(expiresAt))")
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Formats a raw RDAP ISO 8601 `eventDate` for display; falls back to the raw string if it
+    /// doesn't parse (an RDAP server returning something non-standard shouldn't blank the field).
+    private static func formattedExpiration(_ raw: String) -> String {
+        guard let date = ISO8601DateFormatter().date(from: raw) else { return raw }
+        return date.formatted(date: .abbreviated, time: .omitted)
+    }
+```
+
+- [ ] **Step 2: Build the app target**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -60`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ConnectDomainSheetView.swift
+git commit -m "feat(#1194): show registrar and expiration in Connect Domain sheet"
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full SwiftPM test suite**
+
+Run: `swift test --package-path . 2>&1 | tail -80`
+Expected: All tests pass, including the pre-existing `ConnectDomainCommandTests`, `DomainConfigAuditModelTests`, `CustomDomainAttachCommandTests` (none touch the new code path, but confirm nothing regressed).
+
+If it hangs with no output: a stale SwiftPM process may be holding the `.build` lock — check `pgrep -fl swift-test`, kill the orphan, and re-run.
+
+- [ ] **Step 2: Rebuild the app target**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build 2>&1 | tail -60`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Manual check (requires a Cloudflare API token already configured)**
+
+1. Launch the built app, open or create a site.
+2. `Website ▸ Connect a Domain…` ▸ "I already own a domain" ▸ enter a real domain you control ▸ Connect.
+3. Confirm "Registrar: …" / "Expires …" appear under the confirmation message within a few seconds.
+4. Check `Source/anglesite.json` for that site — confirm `domain.registrar` and `domain.expiresAt` are populated.
+5. Quit and relaunch the app, reopen the same site, `Website ▸ Connect a Domain…` again — confirm the sheet shows the cached registrar/expiration immediately (no spinner) before/without needing network.
+
+- [ ] **Step 4: Confirm no unrelated files changed**
+
+Run: `git status`
+Expected: only `Sources/AnglesiteCore/DomainConfig.swift`, `Sources/AnglesiteCore/RDAPClient.swift`, `Sources/AnglesiteApp/ConnectDomainModel.swift`, `Sources/AnglesiteApp/ConnectDomainSheetView.swift`, `Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift`, `Tests/AnglesiteCoreTests/RDAPClientTests.swift`, `Tests/AnglesiteAppTests/ConnectDomainModelTests.swift`, and the design/plan docs already committed this session.

--- a/docs/superpowers/specs/2026-08-01-domain-registrar-tracking-design.md
+++ b/docs/superpowers/specs/2026-08-01-domain-registrar-tracking-design.md
@@ -1,0 +1,194 @@
+# Domain registrar and expiration/renewal tracking (#1194)
+
+**Status:** Approved design, not yet implemented.
+**Issue:** [#1194](https://github.com/Anglesite/Anglesite/issues/1194)
+**Follow-up to:** `docs/superpowers/specs/2026-07-31-publish-time-domain-step-design.md` (#1180) ▸ Follow-ups §1
+
+## Problem
+
+Anglesite doesn't currently know a connected domain's registrar or when it
+expires or renews. Cloudflare's own Registrar API (`TokenCapabilities.registrar`,
+`CloudflareCapabilityProber`) only covers domains bought *through* Cloudflare —
+a domain that stays at its original registrar (the common "I already own a
+domain" path added by #1180) needs a separate, registrar-agnostic lookup.
+
+## Goals
+
+- Look up a connected domain's registrar name and expiration date via RDAP
+  (the standardized WHOIS successor, RFC 7480/9082/9083/9224) — no API key,
+  no Cloudflare token needed.
+- Persist the result into `Source/anglesite.json`'s `domain` section so it
+  survives across app launches and is visible to anyone reading the file
+  directly.
+- Surface it somewhere the owner will actually see it, reachable on demand
+  (not just once).
+
+## Non-goals
+
+- Renewal reminders/notifications — deserves its own design once the
+  underlying data is being tracked (this issue's explicit non-goal).
+- Any registrar API integration beyond read-only RDAP lookups — no
+  auto-renew, no registrar account linking, no purchase flow (that's
+  [#1195](https://github.com/Anglesite/Anglesite/issues/1195), a distinct
+  fast-follow with its own billing/ToS constraints).
+- Changing `CustomDomainAttachCommand`'s attach logic, `DeployCommand`'s
+  pipeline, or the `.notConnected`/`conflict` handling in `DeployDrawerView`
+  — this only adds a passive, informational lookup layered on top of the
+  domain that's already declared.
+- A general "site settings" screen — no such surface exists yet; this reuses
+  the existing Connect Domain sheet instead of inventing a new one.
+
+## Design
+
+### 1. RDAP lookup (`AnglesiteCore`)
+
+**`RDAPDomainInfo`** — a small `Equatable, Sendable` struct:
+
+```swift
+public struct RDAPDomainInfo: Equatable, Sendable {
+    public let registrar: String?
+    /// Raw RDAP `eventDate` string (ISO 8601) for the expiration event, unparsed —
+    /// consistent with every other value in `DomainConfig.Domain` being a plain string.
+    public let expiresAt: String?
+}
+```
+
+**`RDAPLookupService`** (protocol) / **`RDAPClient`** (production actor) — mirrors
+the `DomainOperationsService`/`DomainOperations` shape so `ConnectDomainModel`
+tests can inject a fake:
+
+```swift
+public protocol RDAPLookupService: Sendable {
+    func lookup(hostname: String) async -> RDAPDomainInfo?
+}
+
+public actor RDAPClient: RDAPLookupService {
+    public init(bootstrapURL: URL = RDAPClient.productionBootstrapURL, session: URLSession = .shared)
+    public func lookup(hostname: String) async -> RDAPDomainInfo?
+}
+```
+
+Two-hop flow inside `lookup(hostname:)`:
+
+1. Fetch IANA's RDAP bootstrap registry (`https://data.iana.org/rdap/dns.json`),
+   which maps each TLD to the RDAP base URL(s) that serve it. Disk-cached
+   (fetch → cache → fall back to cache → fall back to giving up, matching
+   `WorkerCatalogFetcher`'s degrade path) since it's a few hundred KB and
+   changes rarely — avoids a 2-hop fetch every time the sheet opens.
+2. Take the hostname's TLD, find its RDAP base URL in the bootstrap data, and
+   GET `{base}domain/{hostname}`.
+3. Parse the response for the `expiration` event's `eventDate` and the
+   `registrar`-role entity's `fn` (formatted name) from its jCard
+   `vcardArray`.
+
+Both the bootstrap registry (an array of `[tlds, urls]` pairs — an awkward
+shape for a normal `Decodable` struct) and the domain record (registrar name
+is buried in a jCard array) are parsed with the existing `JSONValue` type
+(`MCPClient.swift`), the same tool `DomainConfigStore` already uses for
+arbitrary/heterogeneous JSON, rather than new `Decodable` structs.
+
+Every failure mode — unknown TLD, network error, non-2xx response, malformed
+JSON, no matching `expiration` event or `registrar` entity — degrades to
+`nil`. `lookup(hostname:)` never throws; this is advisory metadata, never a
+blocking requirement.
+
+### 2. Persistence
+
+Extend `DomainConfig.Domain` (`Sources/AnglesiteCore/DomainConfig.swift`) with
+two new optional fields, matching every other field in this struct:
+
+```swift
+public struct Domain: Codable, Equatable, Sendable {
+    public var hostname: String?
+    public var choice: String?
+    public var attach: Bool?
+    public var registrar: String?
+    public var expiresAt: String?
+    // ...
+}
+```
+
+`DomainConfigStore`'s existing merge-save handles the round trip (including
+unknown-key preservation) with no changes needed there.
+
+### 3. Where it surfaces: the Connect Domain sheet
+
+Today, `ConnectDomainModel.openSheet()` (#1180) unconditionally resets to
+`.choosing`, even when `anglesite.json` already declares a hostname. That
+means there is currently no way to *revisit* a connected domain through this
+sheet — which is exactly the gap this feature needs closed, since
+registrar/expiration data is only useful if the owner can check back on it
+later. This design changes `openSheet()`'s entry behavior:
+
+- If `anglesite.json`'s `domain.hostname` is non-empty **and**
+  `domain.choice == "transfer"`, `openSheet()` goes straight to
+  `.connected(hostname:)` instead of `.choosing`.
+- Otherwise (no domain, or `choice == "buy"`), behavior is unchanged —
+  `.choosing`, exactly as #1180 shipped it.
+
+This is the only behavioral change to `ConnectDomainModel` outside of the new
+registrar-info state below. Nothing about `chooseBuy()`, `beginTransfer()`,
+`submitTransfer()`, `notNow()`, or the actual attach pipeline changes.
+
+**New model state**, alongside `phase` (not folded into the `Phase` enum,
+since it's an orthogonal, independently-loading concern):
+
+```swift
+enum RegistrarInfoState: Equatable {
+    case idle
+    case loading
+    case available(RDAPDomainInfo)
+    case unavailable
+}
+private(set) var registrarInfo: RegistrarInfoState = .idle
+private let rdap: any RDAPLookupService
+```
+
+A private `loadRegistrarInfo(hostname:site:)` is called from both places that
+land on `.connected`: `submitTransfer()` (a fresh declaration) and the
+`openSheet()` branch above (revisiting an existing one). It:
+
+1. Seeds `registrarInfo` from whatever's already cached in `anglesite.json`
+   (`.available(...)`) if present, so reopening the sheet shows last-known
+   data instantly with no spinner; otherwise `.loading`.
+2. Kicks off `rdap.lookup(hostname:)` in the background.
+3. On success, updates `registrarInfo = .available(...)` and persists the
+   result into `anglesite.json` via `DomainConfigStore` (guarded on the
+   loaded config's `domain.hostname` still matching — a stale write can't
+   land if the owner has since changed the domain).
+4. On failure (`nil` result), only flips to `.unavailable` if `registrarInfo`
+   was still `.loading` — a transient failure never regresses a
+   previously-good cached value back to nothing.
+5. Guards on `phase` still being `.connected(hostname:)` for the same
+   hostname before applying the result — a stale task from a dismissed sheet
+   or a different hostname is a no-op.
+
+**View** (`ConnectDomainSheetView`): under the existing `.connected` case's
+"We'll connect `<hostname>` on your next Publish." message, one or two
+secondary-text lines render the registrar/expiration state — e.g.
+*"Registrar: Namecheap"* / *"Expires March 15, 2027"* (parsed from the raw
+ISO 8601 string for display; falls back to the raw string if parsing fails).
+`.loading` shows a small inline spinner + "Looking up registrar info…";
+`.idle`/`.unavailable` render nothing extra.
+
+### 4. Testing
+
+- **`RDAPClientTests`** (`AnglesiteCoreTests`): bootstrap-registry TLD
+  matching against a fixture `dns.json`; registrar name + expiration date
+  extraction from a fixture RDAP domain response; `nil` on an unknown TLD,
+  non-2xx response, and malformed JSON; cache fallback when the live
+  bootstrap fetch fails.
+- **`ConnectDomainModelTests`** additions: `openSheet()` on a site with an
+  already-declared transfer hostname lands on `.connected` (not `.choosing`)
+  and seeds `registrarInfo` from the cached `anglesite.json` values;
+  `openSheet()` on a site with `choice == "buy"` or no domain still lands on
+  `.choosing` (regression guard for the existing behavior); a successful
+  lookup persists `registrar`/`expiresAt` into `anglesite.json`; a failed
+  lookup leaves a previously-cached value in place rather than clearing it.
+- **`DomainConfigStoreTests`** or `DomainConfigTests` additions if needed:
+  round-trip encode/decode of the two new `Domain` fields, including
+  unknown-key preservation when an older-schema file is merged.
+- Manual: connect a real domain via the sheet, confirm registrar/expiration
+  appear after the lookup completes and persist into `anglesite.json`; quit
+  and relaunch the app, reopen the sheet, confirm the cached values appear
+  immediately.


### PR DESCRIPTION
Closes #1194

## Summary

- Add an RDAP lookup (`RDAPClient`, `AnglesiteCore`) that resolves a domain's registrar name and expiration date via IANA's bootstrap registry + the matching RDAP server — no API key needed, degrades to `nil` on any failure, disk-caches the bootstrap registry for 24h.
- Persist the result into `Source/anglesite.json`'s `domain` section (`DomainConfig.Domain.registrar`/`.expiresAt`).
- Surface it in the existing "Connect a Domain" sheet (#1180): reopening the sheet for an already-declared domain now shows registrar/expiration instead of always resetting to the buy/transfer chooser, and a new "Use a different domain" action restores the ability to correct a previously-declared hostname.

Design doc: `docs/superpowers/specs/2026-08-01-domain-registrar-tracking-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-01-domain-registrar-tracking.md`

Built with subagent-driven development: 4 planned tasks (each independently reviewed) plus a final whole-branch review that caught and fixed cross-task issues — a race between overlapping registrar lookups, a dead-end in the Connect Domain sheet once a domain was declared, and stale registrar data surviving a hostname change.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite green except pre-existing, unrelated `FoundationModelAssistantTests` failures (on-device model streaming, not touched by this PR).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds.
- [ ] Manual smoke (UI-touching): not performed — this was built in an automated session with no configured Cloudflare API token. Before merge, please connect a real domain via `Website ▸ Connect a Domain…` and confirm registrar/expiration appear and persist into `anglesite.json`, and that reopening the sheet later still shows the cached values.