### PR TITLE
feat(#1195): in-app domain search + purchase via Cloudflare Registrar

### DIFF
--- a/Sources/AnglesiteApp/BuyDomainModel.swift
+++ b/Sources/AnglesiteApp/BuyDomainModel.swift
@@ -1,0 +1,227 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Drives the "Buy a Domain" sheet (#1195): search → price → confirm → purchase, reached from
+/// `ConnectDomainSheetView`'s "Buy a domain" button. A successful purchase records the exact same
+/// `DOMAIN_CHOICE=transfer` intent "I already own a domain" does (`ConnectDomainCommand
+/// .recordTransfer`) — a Cloudflare-registered domain needs identical Workers Custom Domain
+/// attach logic to a nameserver-delegated one, so `CustomDomainAttachCommand` needs no changes.
+@MainActor
+@Observable
+final class BuyDomainModel {
+    struct DomainCandidate: Equatable, Identifiable {
+        var id: String { name }
+        let name: String
+        let registrable: Bool
+        let reason: String?
+        let priceDisplay: String?
+    }
+
+    enum Phase: Equatable {
+        case searching(query: String)
+        case loadingResults(query: String)
+        case results(query: String, candidates: [DomainCandidate])
+        case confirming(candidate: DomainCandidate)
+        case purchasing(candidate: DomainCandidate)
+        case purchased(hostname: String)
+        case needsAccountSetup(hostname: String)
+        case stillProcessing(hostname: String)
+        case failed(reason: String)
+    }
+
+    private(set) var phase: Phase = .searching(query: "")
+    var sheetPresented: Bool = false
+    var queryInput: String = ""
+
+    /// Progress of the nested token-prompt sheet, shown when a search hits `.noToken`. Presented
+    /// by `BuyDomainSheetView` itself (a sheet stacked on the already-open purchase sheet), not by
+    /// `SiteWindow` — see that view's doc comment.
+    var tokenPromptPresented: Bool = false
+    private(set) var tokenVerification: CloudflareTokenVerification = .idle
+    /// The query `submitSearch()` was trying to run when `.noToken` interrupted it — re-run once
+    /// the prompt reports `.proceed`.
+    private var pendingSearchQuery: String?
+
+    static let cloudflareDomainsURL = ConnectDomainModel.cloudflareDomainsURL
+
+    private let ops: any RegistrarOperationsService
+    private let keychain: KeychainStore
+    private let onboarding: TokenOnboarding
+    private var currentSite: CurrentSite?
+    private var inFlight: Task<Void, Never>?
+
+    init(
+        ops: any RegistrarOperationsService = RegistrarOperations(),
+        keychain: KeychainStore = KeychainStore(),
+        verifier: TokenVerifying = CloudflareAPITokenVerifier()
+    ) {
+        self.ops = ops
+        self.keychain = keychain
+        self.onboarding = TokenOnboarding(verifier: verifier)
+    }
+
+    func configure(site: CurrentSite) {
+        currentSite = site
+    }
+
+    var isRunning: Bool {
+        switch phase {
+        case .loadingResults, .purchasing: return true
+        default: return false
+        }
+    }
+
+    func openSheet() {
+        guard !isRunning else { return }
+        phase = .searching(query: "")
+        queryInput = ""
+        sheetPresented = true
+    }
+
+    func dismissSheet() {
+        inFlight?.cancel()
+        inFlight = nil
+        sheetPresented = false
+    }
+
+    func submitSearch() {
+        let query = queryInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty, !isRunning else { return }
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runSearch(query: query)
+        }
+    }
+
+    func selectCandidate(_ candidate: DomainCandidate) {
+        guard candidate.registrable, case .results = phase else { return }
+        phase = .confirming(candidate: candidate)
+    }
+
+    func cancelConfirm() {
+        guard case .confirming = phase else { return }
+        phase = .searching(query: queryInput)
+    }
+
+    func confirmPurchase() {
+        guard case .confirming(let candidate) = phase, !isRunning else { return }
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runPurchase(candidate: candidate)
+        }
+    }
+
+    /// Called by the token-prompt sheet's submit action, mirroring `DeployModel.verifyAndSaveToken`
+    /// exactly (same `TokenOnboarding` ordering, same `isCancelled` shape) — the only difference is
+    /// what "proceed" means: re-running the parked search instead of starting a deploy.
+    func verifyAndSaveToken(_ token: String) async {
+        guard let query = pendingSearchQuery else {
+            tokenVerification = .failed(message: "No search is waiting — close this and search again.")
+            return
+        }
+        tokenVerification = .checking
+        let outcome = await onboarding.run(
+            token: token,
+            siteDirectory: currentSite?.sourceDirectory ?? FileManager.default.temporaryDirectory,
+            persist: { try keychain.writeCloudflareToken($0) },
+            onConnected: { tokenVerification = .connected(accountName: $0.name) },
+            delay: { try? await Task.sleep(for: .milliseconds(700)) },
+            isCancelled: { Task.isCancelled || !tokenPromptPresented }
+        )
+        switch outcome {
+        case .proceed:
+            pendingSearchQuery = nil
+            tokenPromptPresented = false
+            tokenVerification = .idle
+            queryInput = query
+            submitSearch()
+        case .stay(let message):
+            tokenVerification = .failed(message: message)
+        case .abort:
+            tokenVerification = .idle
+        }
+    }
+
+    func cancelTokenPrompt() {
+        pendingSearchQuery = nil
+        tokenPromptPresented = false
+        tokenVerification = .idle
+    }
+
+    // MARK: - Private
+
+    private func runSearch(query: String) async {
+        phase = .loadingResults(query: query)
+        switch await ops.searchDomains(query: query) {
+        case .failure(.noToken):
+            pendingSearchQuery = query
+            tokenVerification = .idle
+            tokenPromptPresented = true
+            phase = .searching(query: query)
+        case .failure(let error):
+            phase = .failed(reason: message(for: error))
+        case .success(let names):
+            guard !names.isEmpty else {
+                phase = .results(query: query, candidates: [])
+                return
+            }
+            switch await ops.checkDomainAvailability(domains: names) {
+            case .failure(let error):
+                phase = .failed(reason: message(for: error))
+            case .success(let checks):
+                let candidates = checks.map {
+                    DomainCandidate(
+                        name: $0.name, registrable: $0.registrable, reason: $0.reason,
+                        priceDisplay: Self.priceDisplay(cost: $0.registrationCost, currency: $0.currency))
+                }
+                phase = .results(query: query, candidates: candidates)
+            }
+        }
+    }
+
+    private func runPurchase(candidate: DomainCandidate) async {
+        phase = .purchasing(candidate: candidate)
+        guard let site = currentSite else {
+            phase = .failed(reason: "No site is open.")
+            return
+        }
+        switch await ops.registerDomain(name: candidate.name) {
+        case .failure(let error):
+            phase = .failed(reason: message(for: error))
+        case .success(.succeeded):
+            ConnectDomainCommand.recordTransfer(hostname: candidate.name, siteDirectory: site.sourceDirectory)
+            phase = .purchased(hostname: candidate.name)
+        case .success(.failed(let reason)):
+            phase = .failed(reason: reason)
+        case .success(.actionRequired), .success(.blocked):
+            phase = .needsAccountSetup(hostname: candidate.name)
+        case .success(.stillProcessing):
+            phase = .stillProcessing(hostname: candidate.name)
+        }
+    }
+
+    private func message(for error: RegistrarOperationError) -> String {
+        switch error {
+        case .noToken:
+            return "No Cloudflare API token found. Add one in Settings → Credentials."
+        case .cloudflare(let cfError):
+            switch cfError {
+            case .unauthorized:
+                return "API token is unauthorized. Check that it has Registrar permissions."
+            case .http(let status):
+                return "Cloudflare API returned HTTP \(status)."
+            case .api(let msg):
+                return "Cloudflare API error: \(msg)"
+            case .malformedResponse:
+                return "Unexpected response from Cloudflare API."
+            }
+        }
+    }
+
+    private static func priceDisplay(cost: String?, currency: String?) -> String? {
+        guard let cost else { return nil }
+        if currency == "USD" { return "$\(cost)/yr" }
+        if let currency { return "\(currency) \(cost)/yr" }
+        return "\(cost)/yr"
+    }
+}

--- a/Sources/AnglesiteApp/BuyDomainModel.swift
+++ b/Sources/AnglesiteApp/BuyDomainModel.swift
@@ -43,6 +43,11 @@ final class BuyDomainModel {
     private var pendingSearchQuery: String?
 
     static let cloudflareDomainsURL = ConnectDomainModel.cloudflareDomainsURL
+    /// The Cloudflare dashboard root — used specifically by `.needsAccountSetup`'s "finish setting
+    /// up billing" link, which needs to land the user in the dashboard rather than on the
+    /// `cloudflareDomainsURL` marketing page. No deeper deep-link path is guessed here since one
+    /// hasn't been verified against the live product.
+    static let cloudflareDashboardURL = URL(string: "https://dash.cloudflare.com/")!
 
     private let ops: any RegistrarOperationsService
     private let keychain: KeychainStore
@@ -71,22 +76,44 @@ final class BuyDomainModel {
         }
     }
 
+    /// Always presents the sheet — never a silent no-op, even while a purchase is still running
+    /// in the background after an earlier dismiss (see `dismissSheet()`). Only resets to a fresh
+    /// `.searching` state when nothing is running, so reopening during a backgrounded purchase
+    /// shows the live `.purchasing` state instead of discarding it.
     func openSheet() {
+        sheetPresented = true
         guard !isRunning else { return }
         phase = .searching(query: "")
         queryInput = ""
-        sheetPresented = true
     }
 
+    /// Closes the sheet. A `.purchasing` task is deliberately **not** cancelled: the
+    /// `POST /registrar/registrations` it's awaiting may already be in flight at Cloudflare, and
+    /// cancelling the local `Task` doesn't un-send it or refund a charge — it would only make the
+    /// app stop tracking a purchase that still completes (or fails) server-side. So a purchase
+    /// keeps running in the background after Close; `runPurchase` still writes `recordTransfer`
+    /// on a genuine `.succeeded` outcome, and reopening the sheet (`openSheet()`) shows the
+    /// in-progress state rather than losing it. Search's `.loadingResults` has no such stakes (a
+    /// GET has no side effects to protect) and keeps today's cancel-on-close behavior.
     func dismissSheet() {
-        inFlight?.cancel()
-        inFlight = nil
+        if case .purchasing = phase {
+            // Deliberately not cancelled — see doc comment above.
+        } else {
+            inFlight?.cancel()
+            inFlight = nil
+        }
         sheetPresented = false
+        pendingSearchQuery = nil
+        tokenPromptPresented = false
     }
 
     func submitSearch() {
         let query = queryInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty, !isRunning else { return }
+        // Set synchronously (not as the first line inside the spawned Task) so `isRunning`
+        // flips before this call returns — closing the window where a second activation in the
+        // same run-loop turn could pass the `!isRunning` guard above. See `confirmPurchase()`.
+        phase = .loadingResults(query: query)
         inFlight?.cancel()
         inFlight = Task { @MainActor [weak self] in
             await self?.runSearch(query: query)
@@ -94,7 +121,10 @@ final class BuyDomainModel {
     }
 
     func selectCandidate(_ candidate: DomainCandidate) {
-        guard candidate.registrable, case .results = phase else { return }
+        // `priceDisplay` can be nil for a `registrable: true` result (`CFRegistrarCheckResult
+        // .pricing` decodes as optional) — require both so the confirm step never reads "Buy
+        // example.dev for an unknown price?" with an enabled Buy button on a real charge.
+        guard candidate.registrable, candidate.priceDisplay != nil, case .results = phase else { return }
         phase = .confirming(candidate: candidate)
     }
 
@@ -105,6 +135,13 @@ final class BuyDomainModel {
 
     func confirmPurchase() {
         guard case .confirming(let candidate) = phase, !isRunning else { return }
+        // Set synchronously, not inside the spawned Task — `Task { @MainActor ... }` is
+        // scheduled, not run inline, so a `phase` write on its first line leaves a window (until
+        // the task's first hop) where `phase` is still `.confirming` and `isRunning` is still
+        // `false`. A second activation in that window (e.g. a held/double-tapped Return, since
+        // the Buy button carries `.keyboardShortcut(.defaultAction)`) would pass the guard above
+        // and could fire a second `POST /registrar/registrations` for a real charge.
+        phase = .purchasing(candidate: candidate)
         inFlight?.cancel()
         inFlight = Task { @MainActor [weak self] in
             await self?.runPurchase(candidate: candidate)
@@ -151,7 +188,7 @@ final class BuyDomainModel {
     // MARK: - Private
 
     private func runSearch(query: String) async {
-        phase = .loadingResults(query: query)
+        // `phase` is already `.loadingResults(query:)` — set synchronously by `submitSearch()`.
         switch await ops.searchDomains(query: query) {
         case .failure(.noToken):
             pendingSearchQuery = query
@@ -169,18 +206,29 @@ final class BuyDomainModel {
             case .failure(let error):
                 phase = .failed(reason: message(for: error))
             case .success(let checks):
-                let candidates = checks.map {
+                let unsorted = checks.map {
                     DomainCandidate(
                         name: $0.name, registrable: $0.registrable, reason: $0.reason,
                         priceDisplay: Self.priceDisplay(cost: $0.registrationCost, currency: $0.currency))
                 }
+                // Available-first per the spec, with the row order within each group otherwise
+                // matching the API's response — `sorted(by:)` alone isn't a guaranteed-stable
+                // sort, so tiebreak explicitly on original index rather than relying on that.
+                let candidates = unsorted.enumerated()
+                    .sorted { a, b in
+                        if a.element.registrable != b.element.registrable {
+                            return a.element.registrable && !b.element.registrable
+                        }
+                        return a.offset < b.offset
+                    }
+                    .map(\.element)
                 phase = .results(query: query, candidates: candidates)
             }
         }
     }
 
     private func runPurchase(candidate: DomainCandidate) async {
-        phase = .purchasing(candidate: candidate)
+        // `phase` is already `.purchasing(candidate:)` — set synchronously by `confirmPurchase()`.
         guard let site = currentSite else {
             phase = .failed(reason: "No site is open.")
             return

--- a/Sources/AnglesiteApp/BuyDomainSheetView.swift
+++ b/Sources/AnglesiteApp/BuyDomainSheetView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The "Buy a Domain" sheet (#1195): search, price, confirm, purchase. Reached from
+/// `ConnectDomainSheetView`'s "Buy a domain" button.
+struct BuyDomainSheetView: View {
+    @Bindable var model: BuyDomainModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Divider()
+            footer
+        }
+        .frame(width: 480)
+        .fixedSize(horizontal: false, vertical: true)
+        // Stacked on top of this already-open sheet (not a sibling `.sheet` on `SiteWindow`,
+        // which can't reliably present two sheets from the same presentation context at once).
+        .sheet(isPresented: $model.tokenPromptPresented) {
+            CloudflareTokenPromptView(
+                tokenVerification: model.tokenVerification,
+                onSubmit: { await model.verifyAndSaveToken($0) },
+                onCancel: { model.cancelTokenPrompt() }
+            )
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.title)
+                .foregroundStyle(.blue)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Buy a Domain").font(.title3).fontWeight(.semibold)
+                Text("Search, price, and register a domain through Cloudflare.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .searching:
+            VStack(alignment: .leading, spacing: 12) {
+                searchField(buttonTitle: "Search")
+                escapeHatch
+            }
+
+        case .loadingResults:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Searching…").foregroundStyle(.secondary)
+            }
+
+        case .results(_, let candidates):
+            VStack(alignment: .leading, spacing: 12) {
+                if candidates.isEmpty {
+                    Text("No results. Try a different search.").foregroundStyle(.secondary)
+                } else {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(candidates) { candidateRow($0) }
+                        }
+                    }
+                    .frame(maxHeight: 280)
+                }
+                searchField(buttonTitle: "Search Again")
+                escapeHatch
+            }
+
+        case .confirming(let candidate):
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Buy \(candidate.name) for \(candidate.priceDisplay ?? "an unknown price")?")
+                    .font(.headline)
+                Text("This charges the payment method on file for your connected Cloudflare account.")
+                    .font(.caption).foregroundStyle(.secondary)
+                HStack {
+                    Button("Cancel") { model.cancelConfirm() }
+                    Spacer()
+                    Button("Buy \(candidate.name)") { model.confirmPurchase() }
+                        .buttonStyle(.borderedProminent)
+                        .keyboardShortcut(.defaultAction)
+                }
+            }
+
+        case .purchasing:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Purchasing…").foregroundStyle(.secondary)
+            }
+
+        case .purchased(let hostname):
+            Label("We'll connect \(hostname) on your next Publish.", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+
+        case .needsAccountSetup(let hostname):
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Finish setting up billing for \(hostname) in the Cloudflare dashboard, then come back and try again.")
+                escapeHatch
+            }
+
+        case .stillProcessing(let hostname):
+            Text("Still processing \(hostname). Once it finishes, come back and use \"I already own a domain\" with \(hostname) to connect it.")
+
+        case .failed(let reason):
+            VStack(alignment: .leading, spacing: 8) {
+                Text(reason).foregroundStyle(.red)
+                escapeHatch
+            }
+        }
+    }
+
+    private func searchField(buttonTitle: String) -> some View {
+        HStack {
+            TextField("example", text: $model.queryInput)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { model.submitSearch() }
+            Button(buttonTitle) { model.submitSearch() }
+                .disabled(model.queryInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    private var escapeHatch: some View {
+        Link("Buy directly on the Cloudflare dashboard instead", destination: BuyDomainModel.cloudflareDomainsURL)
+            .font(.caption)
+    }
+
+    @ViewBuilder
+    private func candidateRow(_ candidate: BuyDomainModel.DomainCandidate) -> some View {
+        Button {
+            model.selectCandidate(candidate)
+        } label: {
+            HStack {
+                Text(candidate.name)
+                Spacer()
+                if candidate.registrable {
+                    Text(candidate.priceDisplay ?? "")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(candidate.reason ?? "unavailable")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!candidate.registrable)
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Close") { model.dismissSheet() }
+            Spacer()
+        }
+        .padding(16)
+    }
+}
+
+#Preview {
+    BuyDomainSheetView(model: BuyDomainModel())
+}

--- a/Sources/AnglesiteApp/BuyDomainSheetView.swift
+++ b/Sources/AnglesiteApp/BuyDomainSheetView.swift
@@ -104,11 +104,18 @@ struct BuyDomainSheetView: View {
         case .needsAccountSetup(let hostname):
             VStack(alignment: .leading, spacing: 8) {
                 Text("Finish setting up billing for \(hostname) in the Cloudflare dashboard, then come back and try again.")
-                escapeHatch
+                // The dashboard, not the `cloudflareDomainsURL` marketing page the generic
+                // `escapeHatch` link points at — this is the one case where the copy explicitly
+                // promises "the Cloudflare dashboard".
+                Link("Open the Cloudflare dashboard", destination: BuyDomainModel.cloudflareDashboardURL)
+                    .font(.caption)
             }
 
         case .stillProcessing(let hostname):
-            Text("Still processing \(hostname). Once it finishes, come back and use \"I already own a domain\" with \(hostname) to connect it.")
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Still processing \(hostname). Once it finishes, come back and use \"I already own a domain\" with \(hostname) to connect it.")
+                escapeHatch
+            }
 
         case .failed(let reason):
             VStack(alignment: .leading, spacing: 8) {
@@ -142,7 +149,7 @@ struct BuyDomainSheetView: View {
                 Text(candidate.name)
                 Spacer()
                 if candidate.registrable {
-                    Text(candidate.priceDisplay ?? "")
+                    Text(candidate.priceDisplay ?? "price unavailable")
                         .foregroundStyle(.secondary)
                 } else {
                     Text(candidate.reason ?? "unavailable")
@@ -153,12 +160,21 @@ struct BuyDomainSheetView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(!candidate.registrable)
+        .disabled(!candidate.registrable || candidate.priceDisplay == nil)
     }
 
     private var footer: some View {
         HStack {
-            Button("Close") { model.dismissSheet() }
+            // Hidden while `.purchasing`: a `POST /registrar/registrations` may already be in
+            // flight at Cloudflare by this point, so closing here can't be allowed to look like
+            // cancelling it — see `BuyDomainModel.dismissSheet()`. The purchase keeps running in
+            // the background regardless; this only controls whether the user can walk away from
+            // watching it.
+            if case .purchasing = model.phase {
+                Text("Purchasing…").font(.caption).foregroundStyle(.secondary)
+            } else {
+                Button("Close") { model.dismissSheet() }
+            }
             Spacer()
         }
         .padding(16)

--- a/Sources/AnglesiteApp/BuyDomainSheetView.swift
+++ b/Sources/AnglesiteApp/BuyDomainSheetView.swift
@@ -165,16 +165,13 @@ struct BuyDomainSheetView: View {
 
     private var footer: some View {
         HStack {
-            // Hidden while `.purchasing`: a `POST /registrar/registrations` may already be in
-            // flight at Cloudflare by this point, so closing here can't be allowed to look like
-            // cancelling it — see `BuyDomainModel.dismissSheet()`. The purchase keeps running in
-            // the background regardless; this only controls whether the user can walk away from
-            // watching it.
-            if case .purchasing = model.phase {
-                Text("Purchasing…").font(.caption).foregroundStyle(.secondary)
-            } else {
-                Button("Close") { model.dismissSheet() }
-            }
+            // Always reachable, even during `.purchasing`: a `POST /registrar/registrations` may
+            // already be in flight at Cloudflare by this point, so `dismissSheet()` deliberately
+            // does not cancel it — see `BuyDomainModel.dismissSheet()`. The purchase keeps running
+            // in the background regardless; this button just lets the user stop watching it. The
+            // `.purchasing` content area above already shows a spinner + "Purchasing…" caption, so
+            // no separate status text is duplicated here.
+            Button("Close") { model.dismissSheet() }
             Spacer()
         }
         .padding(16)

--- a/Sources/AnglesiteApp/CloudflareTokenPromptView.swift
+++ b/Sources/AnglesiteApp/CloudflareTokenPromptView.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 import AnglesiteCore
 
+/// Progress of verifying a pasted Cloudflare token, consumed by `CloudflareTokenPromptView`'s
+/// status line and button-enabled logic. A token is only persisted once verification reaches
+/// `.connected`; a `.failed` state keeps the sheet open and leaves storage untouched. Shared
+/// between every Cloudflare token-prompt flow (`DeployModel`, `BuyDomainModel`) rather than
+/// nested in one model, since the view itself is shared.
+enum CloudflareTokenVerification: Equatable {
+    case idle
+    case checking
+    case connected(accountName: String?)
+    case failed(message: String)
+}
+
 /// First-deploy modal: guide the user through creating a Cloudflare API token, verify it against
 /// Cloudflare, store it in the Keychain, and let the parked deploy proceed. Surfaced by
 /// `DeployModel` when both the env var and the Keychain are empty at the moment the user clicks
@@ -17,7 +29,8 @@ import AnglesiteCore
 /// clearing) happens in Settings → Advanced → Credentials, which shares the same `KeychainStore`
 /// slot, so a token saved from either entry point is immediately usable by `wrangler deploy`.
 struct CloudflareTokenPromptView: View {
-    let model: DeployModel
+    let tokenVerification: CloudflareTokenVerification
+    let onSubmit: (String) async -> Void
     let onCancel: () -> Void
 
     @State private var token: String = ""
@@ -27,7 +40,7 @@ struct CloudflareTokenPromptView: View {
     /// (`.connected`) — i.e. whenever the field and submit button should be locked so the user
     /// can't edit or re-submit mid-verify.
     private var isInputLocked: Bool {
-        switch model.tokenVerification {
+        switch tokenVerification {
         case .checking, .connected: return true
         case .idle, .failed: return false
         }
@@ -106,7 +119,7 @@ struct CloudflareTokenPromptView: View {
 
     @ViewBuilder
     private var status: some View {
-        switch model.tokenVerification {
+        switch tokenVerification {
         case .idle:
             EmptyView()
         case .checking:
@@ -132,10 +145,10 @@ struct CloudflareTokenPromptView: View {
 
     private func submit() {
         guard canSubmit else { return }
-        Task { await model.verifyAndSaveToken(token) }
+        Task { await onSubmit(token) }
     }
 }
 
 #Preview {
-    CloudflareTokenPromptView(model: DeployModel(), onCancel: {})
+    CloudflareTokenPromptView(tokenVerification: .idle, onSubmit: { _ in }, onCancel: {})
 }

--- a/Sources/AnglesiteApp/ConnectDomainModel.swift
+++ b/Sources/AnglesiteApp/ConnectDomainModel.swift
@@ -29,10 +29,9 @@ final class ConnectDomainModel {
 
     private var currentSite: CurrentSite?
 
-    /// The Cloudflare Domains marketing page — opened by the view layer's "Buy a domain" button,
-    /// not by `chooseBuy()` itself, so this model stays free of `NSWorkspace`/AppKit side effects
-    /// and is fully testable (matches `WebsiteCommands`'s "View on GitHub" convention of keeping
-    /// `NSWorkspace.shared.open` out of the model layer).
+    /// The Cloudflare Domains marketing page — surfaced as the escape-hatch link inside
+    /// `BuyDomainSheetView` (via `BuyDomainModel.cloudflareDomainsURL`, which aliases this) for
+    /// owners who prefer registering directly on Cloudflare.
     static let cloudflareDomainsURL = URL(string: "https://www.cloudflare.com/products/registrar/")!
 
     /// Threaded from `SiteWindowModel.loadAndStart`, mirroring `DomainModel.configure(site:)`.
@@ -43,6 +42,7 @@ final class ConnectDomainModel {
     func openSheet() {
         phase = .choosing
         hostnameInput = ""
+        pendingBuyDomain = false
         sheetPresented = true
     }
 

--- a/Sources/AnglesiteApp/ConnectDomainModel.swift
+++ b/Sources/AnglesiteApp/ConnectDomainModel.swift
@@ -19,6 +19,14 @@ final class ConnectDomainModel {
     var sheetPresented: Bool = false
     var hostnameInput: String = ""
 
+    /// Set by `chooseBuy()` right before it dismisses this sheet; consumed by `SiteWindow`'s
+    /// `onDismiss` on the `connectDomain` sheet registration to open `BuyDomainSheetView` only
+    /// *after* this sheet's own dismissal transaction finishes. Two sibling `.sheet` modifiers
+    /// dismissing-and-presenting synchronously in the same SwiftUI transaction is a known-risky
+    /// pattern (see the presentation-binding race behind #968/#969) — `onDismiss` is the
+    /// idiomatic way to sequence "close this sheet, then open that one" instead.
+    var pendingBuyDomain: Bool = false
+
     private var currentSite: CurrentSite?
 
     /// The Cloudflare Domains marketing page — opened by the view layer's "Buy a domain" button,
@@ -48,11 +56,13 @@ final class ConnectDomainModel {
         dismissSheet()
     }
 
-    /// "Buy a domain" — records the buy intent and dismisses. Opening Cloudflare Domains in the
-    /// browser is the view's job (see `cloudflareDomainsURL`'s doc comment).
+    /// "Buy a domain" — records the buy intent, flags the handoff for `SiteWindow`'s
+    /// `onDismiss`, then dismisses. See `pendingBuyDomain`'s doc comment for why the actual
+    /// `BuyDomainSheetView` presentation happens on dismiss rather than synchronously here.
     func chooseBuy() {
         guard let site = currentSite else { return }
         ConnectDomainCommand.recordBuy(siteDirectory: site.sourceDirectory)
+        pendingBuyDomain = true
         dismissSheet()
     }
 

--- a/Sources/AnglesiteApp/ConnectDomainSheetView.swift
+++ b/Sources/AnglesiteApp/ConnectDomainSheetView.swift
@@ -4,11 +4,6 @@ import SwiftUI
 /// nudge in `DeployDrawerView` and permanently from `Website ▸ Connect a Domain…`.
 struct ConnectDomainSheetView: View {
     @Bindable var model: ConnectDomainModel
-    /// Opens the in-app search/purchase sheet (#1195) — called from the view layer (not chained
-    /// inside `ConnectDomainModel`) so this model and `BuyDomainModel` stay fully decoupled,
-    /// matching how `DeployDrawerView`'s first-publish nudge opens `connectDomain.openSheet()`
-    /// directly rather than teaching `DeployModel` about `ConnectDomainModel`.
-    let onBuyDomain: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -47,7 +42,6 @@ struct ConnectDomainSheetView: View {
             VStack(alignment: .leading, spacing: 12) {
                 Button {
                     model.chooseBuy()
-                    onBuyDomain()
                 } label: {
                     Label("Buy a domain", systemImage: "cart")
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/AnglesiteApp/ConnectDomainSheetView.swift
+++ b/Sources/AnglesiteApp/ConnectDomainSheetView.swift
@@ -1,10 +1,14 @@
 import SwiftUI
-import AppKit
 
 /// The "Connect a Domain" sheet (#1180) — buy/transfer/later, reachable from the first-publish
 /// nudge in `DeployDrawerView` and permanently from `Website ▸ Connect a Domain…`.
 struct ConnectDomainSheetView: View {
     @Bindable var model: ConnectDomainModel
+    /// Opens the in-app search/purchase sheet (#1195) — called from the view layer (not chained
+    /// inside `ConnectDomainModel`) so this model and `BuyDomainModel` stay fully decoupled,
+    /// matching how `DeployDrawerView`'s first-publish nudge opens `connectDomain.openSheet()`
+    /// directly rather than teaching `DeployModel` about `ConnectDomainModel`.
+    let onBuyDomain: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -42,8 +46,8 @@ struct ConnectDomainSheetView: View {
         case .choosing:
             VStack(alignment: .leading, spacing: 12) {
                 Button {
-                    NSWorkspace.shared.open(ConnectDomainModel.cloudflareDomainsURL)
                     model.chooseBuy()
+                    onBuyDomain()
                 } label: {
                     Label("Buy a domain", systemImage: "cart")
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -103,16 +103,7 @@ final class DeployModel {
     /// sheet (#1171), not here, so there's no `pendingDeploy` retry to park.
     var domainConfigDriftPresented: Bool = false
 
-    /// Progress of verifying a pasted token, consumed by `CloudflareTokenPromptView`'s status line
-    /// and button-enabled logic. A token is only written to the Keychain once verification reaches
-    /// `.connected`; a `.failed` state keeps the sheet open and leaves the Keychain untouched.
-    enum TokenVerification: Equatable {
-        case idle
-        case checking
-        case connected(accountName: String?)
-        case failed(message: String)
-    }
-    private(set) var tokenVerification: TokenVerification = .idle
+    private(set) var tokenVerification: CloudflareTokenVerification = .idle
 
     /// Fires every time the deploy pipeline's preflight step resolves, with the
     /// `PreDeployCheck.Outcome` that was used to decide whether to continue.

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -72,6 +72,16 @@
         }
       }
     },
+    "%@, version %@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, version %2$@, %3$@"
+          }
+        }
+      }
+    },
     "%@. %@" : {
       "localizations" : {
         "en" : {
@@ -246,6 +256,9 @@
 
     },
     "Accessibility" : {
+
+    },
+    "Acknowledgments" : {
 
     },
     "Acknowledgments unavailable for this source." : {
@@ -627,7 +640,26 @@
     "Built-in themes" : {
 
     },
+    "Buy %@" : {
+
+    },
+    "Buy %@ for %@?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Buy %1$@ for %2$@?"
+          }
+        }
+      }
+    },
+    "Buy a Domain" : {
+
+    },
     "Buy a domain" : {
+
+    },
+    "Buy directly on the Cloudflare dashboard instead" : {
 
     },
     "By Content Type" : {
@@ -1353,6 +1385,9 @@
     "Find…" : {
 
     },
+    "Finish setting up billing for %@ in the Cloudflare dashboard, then come back and try again." : {
+
+    },
     "Finished" : {
 
     },
@@ -1896,6 +1931,9 @@
     "No redirects yet. Add one below." : {
 
     },
+    "No results. Try a different search." : {
+
+    },
     "No scoped styles" : {
 
     },
@@ -1990,6 +2028,9 @@
 
     },
     "Open in browser" : {
+
+    },
+    "Open the Cloudflare dashboard" : {
 
     },
     "Open the advisory form" : {
@@ -2221,6 +2262,9 @@
 
     },
     "Publish…" : {
+
+    },
+    "Purchasing…" : {
 
     },
     "Purpose" : {
@@ -2582,10 +2626,16 @@
     "Search graph" : {
 
     },
+    "Search, price, and register a domain through Cloudflare." : {
+
+    },
     "Searches only the instance above. Anglesite doesn't run or query a directory of its own." : {
 
     },
     "Searching freedesignmd.com…" : {
+
+    },
+    "Searching…" : {
 
     },
     "Section" : {
@@ -2846,6 +2896,16 @@
     "Status of ${site}" : {
 
     },
+    "Still processing %@. Once it finishes, come back and use \"I already own a domain\" with %@ to connect it." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Still processing %1$@. Once it finishes, come back and use \"I already own a domain\" with %2$@ to connect it."
+          }
+        }
+      }
+    },
     "Stop" : {
 
     },
@@ -2967,6 +3027,9 @@
 
     },
     "This changes a setting on the GitHub repository. Anglesite never turns it back off." : {
+
+    },
+    "This charges the payment method on file for your connected Cloudflare account." : {
 
     },
     "This component changed outside Anglesite — your edit wasn't applied, reloaded the latest version." : {
@@ -3171,6 +3234,9 @@
     "View and manage this domain's DNS records" : {
 
     },
+    "View homepage" : {
+
+    },
     "View on GitHub" : {
 
     },
@@ -3298,6 +3364,9 @@
 
     },
     "en" : {
+
+    },
+    "example" : {
 
     },
     "example.com" : {

--- a/Sources/AnglesiteApp/PublishModel.swift
+++ b/Sources/AnglesiteApp/PublishModel.swift
@@ -16,8 +16,9 @@ final class PublishModel {
     }
 
     /// Progress of verifying a pasted GitHub token, consumed by `GitHubTokenPromptView`'s status
-    /// line and button-enabled logic. Mirrors `DeployModel.TokenVerification` — kept as a separate
-    /// type rather than shared, since the two prompts have no other coupling.
+    /// line and button-enabled logic. Shaped like `CloudflareTokenVerification`
+    /// (`CloudflareTokenPromptView.swift`) — kept as a separate type rather than shared, since the
+    /// two prompts (GitHub vs. Cloudflare tokens) have no other coupling.
     enum TokenVerification: Equatable {
         case idle
         case checking

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -652,8 +652,17 @@ struct SiteWindow: View {
         .sheet(isPresented: $bindableModel.domain.sheetPresented) {
             DomainSheetView(model: model.domain)
         }
-        .sheet(isPresented: $bindableModel.connectDomain.sheetPresented) {
-            ConnectDomainSheetView(model: model.connectDomain, onBuyDomain: { model.buyDomain.openSheet() })
+        .sheet(isPresented: $bindableModel.connectDomain.sheetPresented, onDismiss: {
+            // Sequences the "Buy a domain" handoff to `BuyDomainSheetView` after this sheet's own
+            // dismissal transaction finishes, rather than flipping both sheets' `sheetPresented`
+            // bindings synchronously from one button action — see `ConnectDomainModel
+            // .pendingBuyDomain`'s doc comment.
+            if model.connectDomain.pendingBuyDomain {
+                model.connectDomain.pendingBuyDomain = false
+                model.buyDomain.openSheet()
+            }
+        }) {
+            ConnectDomainSheetView(model: model.connectDomain)
         }
         .sheet(isPresented: $bindableModel.buyDomain.sheetPresented) {
             BuyDomainSheetView(model: model.buyDomain)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -585,9 +585,11 @@ struct SiteWindow: View {
             }
         }
         .sheet(isPresented: $bindableModel.deploy.tokenPromptPresented) {
-            CloudflareTokenPromptView(model: model.deploy) {
-                model.deploy.cancelTokenPrompt()
-            }
+            CloudflareTokenPromptView(
+                tokenVerification: model.deploy.tokenVerification,
+                onSubmit: { await model.deploy.verifyAndSaveToken($0) },
+                onCancel: { model.deploy.cancelTokenPrompt() }
+            )
         }
         .sheet(isPresented: $bindableModel.deploy.workerNameConflictPresented) {
             if case .workerNameConflict(let name) = model.deploy.phase {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -653,7 +653,10 @@ struct SiteWindow: View {
             DomainSheetView(model: model.domain)
         }
         .sheet(isPresented: $bindableModel.connectDomain.sheetPresented) {
-            ConnectDomainSheetView(model: model.connectDomain)
+            ConnectDomainSheetView(model: model.connectDomain, onBuyDomain: { model.buyDomain.openSheet() })
+        }
+        .sheet(isPresented: $bindableModel.buyDomain.sheetPresented) {
+            BuyDomainSheetView(model: model.buyDomain)
         }
         .sheet(isPresented: $bindableModel.publish.sheetPresented) {
             PublishSheet(model: model.publish, siteName: site.name)

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -155,6 +155,7 @@ final class SiteWindowModel {
     var onionRouting = OnionRoutingModel()
     var domain = DomainModel()
     var connectDomain = ConnectDomainModel()
+    var buyDomain = BuyDomainModel()
     var health = HealthModel(runner: DefaultHealthCheckRunner())
     /// Drives the determinate startup progress bar shown in `mainPane` while the dev server boots.
     var startup = StartupProgressModel()
@@ -1924,6 +1925,7 @@ final class SiteWindowModel {
         communities.configure(site: currentSite)
         domain.configure(site: currentSite)
         connectDomain.configure(site: currentSite)
+        buyDomain.configure(site: currentSite)
         harden.configure(site: currentSite)
         domainConfigAudit.configure(site: currentSite)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window

--- a/Sources/AnglesiteCore/CloudflareRegistrarClient.swift
+++ b/Sources/AnglesiteCore/CloudflareRegistrarClient.swift
@@ -32,3 +32,23 @@ public protocol CloudflareRegistrarReading: Sendable {
     /// Real-time availability + pricing for up to 20 domain names in one call (the API's own cap).
     func checkDomainAvailability(domains: [String], apiToken: String) async throws -> [RegistrarDomainCheck]
 }
+
+/// The resolved outcome of a `registerDomain` call — the 201-vs-202-and-poll distinction is
+/// already resolved by the time callers see this; no polling primitive is exposed above the
+/// HTTP client.
+public enum RegistrarRegistrationOutcome: Sendable, Equatable {
+    case succeeded
+    case failed(reason: String)
+    case actionRequired
+    case blocked
+    case stillProcessing
+}
+
+/// Write-side Cloudflare Registrar API seam (register), deliberately separate from
+/// `CloudflareWriting` — see this plan's Global Constraints for why.
+public protocol CloudflareRegistrarWriting: Sendable {
+    /// Registers `name` against the token's account. Cloudflare completes most registrations
+    /// synchronously within ~10s; slower ones are polled internally for up to ~15s before
+    /// resolving to `.stillProcessing` — this call always returns a single resolved outcome.
+    func registerDomain(name: String, apiToken: String) async throws -> RegistrarRegistrationOutcome
+}

--- a/Sources/AnglesiteCore/CloudflareRegistrarClient.swift
+++ b/Sources/AnglesiteCore/CloudflareRegistrarClient.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// One Check result — real-time availability + pricing, or the reason a candidate isn't
+/// registrable. `registrationCost`/`currency` are `nil` exactly when `registrable` is `false`.
+public struct RegistrarDomainCheck: Sendable, Equatable {
+    public let name: String
+    public let registrable: Bool
+    /// Set when `registrable` is `false` — e.g. `domain_unavailable`,
+    /// `extension_not_supported_via_api`, `extension_not_supported`,
+    /// `extension_disallows_registration`.
+    public let reason: String?
+    public let registrationCost: String?
+    public let currency: String?
+
+    public init(name: String, registrable: Bool, reason: String?, registrationCost: String?, currency: String?) {
+        self.name = name
+        self.registrable = registrable
+        self.reason = reason
+        self.registrationCost = registrationCost
+        self.currency = currency
+    }
+}
+
+/// Read-only Cloudflare Registrar API seam (search + check), deliberately separate from
+/// `CloudflareReading` — see this plan's Global Constraints for why. The concrete
+/// `HTTPCloudflareClient` conforms via an extension; tests provide a fake.
+public protocol CloudflareRegistrarReading: Sendable {
+    /// Candidate domain names for a keyword/phrase (cached server-side by Cloudflare). Availability
+    /// and pricing come back with each candidate too, but are not authoritative — follow up with
+    /// `checkDomainAvailability` for a real-time, registry-authoritative answer before registering.
+    func searchDomains(query: String, apiToken: String) async throws -> [String]
+    /// Real-time availability + pricing for up to 20 domain names in one call (the API's own cap).
+    func checkDomainAvailability(domains: [String], apiToken: String) async throws -> [RegistrarDomainCheck]
+}

--- a/Sources/AnglesiteCore/CloudflareRegistrarClient.swift
+++ b/Sources/AnglesiteCore/CloudflareRegistrarClient.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 /// One Check result — real-time availability + pricing, or the reason a candidate isn't
-/// registrable. `registrationCost`/`currency` are `nil` exactly when `registrable` is `false`.
+/// registrable. `registrationCost`/`currency` are `nil` when pricing wasn't returned — most
+/// commonly (but not exclusively) when `registrable` is `false`; the live API can also omit
+/// pricing for a registrable result, so callers must not assume the two always move together.
 public struct RegistrarDomainCheck: Sendable, Equatable {
     public let name: String
     public let registrable: Bool

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -630,15 +630,27 @@ extension HTTPCloudflareClient: CloudflareRegistrarReading {
     /// Builds the request with `URLComponents`/`URLQueryItem` rather than manual string
     /// interpolation: `query` is free-text (e.g. a business name like "Smith & Sons"), and
     /// `CharacterSet.urlQueryAllowed` — the encoding used elsewhere in this file for hostnames,
-    /// which never contain `&`/`=`/`+` — does not escape those characters. Left unescaped, they
+    /// which never contain `&`/`=`/`+` — does not escape those characters. Left unescaped, `&`/`=`
     /// would truncate the `q` value at the API and corrupt or drop the `limit` parameter.
+    ///
+    /// `+` needs separate handling: `URLComponents.queryItems`/`.url` treat it as a legal RFC 3986
+    /// sub-delimiter and never percent-encode it, but many server-side query parsers conventionally
+    /// form-decode a literal `+` as a space. Left as-is, a search for "A+ Dental" or "C++ Institute"
+    /// would silently arrive at the API as "A Dental" / "C  Institute". So `q`'s value is percent-encoded
+    /// by hand — down to RFC 3986 unreserved characters, which also covers `&`/`=` — and assigned via
+    /// `percentEncodedQueryItems` rather than `queryItems` (which would double-encode it).
     public func searchDomains(query: String, apiToken: String) async throws -> [String] {
         let accountID = try await resolveAccountID(apiToken: apiToken)
         guard var components = URLComponents(string: Self.base + "/accounts/\(accountID)/registrar/domain-search") else {
             throw CloudflareError.malformedResponse
         }
-        components.queryItems = [
-            URLQueryItem(name: "q", value: query),
+        var queryValueAllowed = CharacterSet.alphanumerics
+        queryValueAllowed.insert(charactersIn: "-._~")
+        guard let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: queryValueAllowed) else {
+            throw CloudflareError.malformedResponse
+        }
+        components.percentEncodedQueryItems = [
+            URLQueryItem(name: "q", value: encodedQuery),
             URLQueryItem(name: "limit", value: "20"),
         ]
         guard let url = components.url else { throw CloudflareError.malformedResponse }

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -136,6 +136,14 @@ public struct HTTPCloudflareClient: CloudflareReading {
     /// GET `path`, decode `CFEnvelope<T>`, return the whole envelope or throw a mapped error.
     private func getEnvelope<T: Decodable & Sendable>(_ path: String, apiToken: String, as: T.Type) async throws -> CFEnvelope<T> {
         guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
+        return try await getEnvelope(url: url, apiToken: apiToken, as: T.self)
+    }
+
+    /// GET `url`, decode `CFEnvelope<T>`, return the whole envelope or throw a mapped error.
+    /// Takes a pre-built `URL` (rather than a path string) so callers with query values that need
+    /// real percent-encoding — e.g. free-text search keywords that may contain `&`/`=`/`+` — can
+    /// build the request with `URLComponents`/`URLQueryItem` instead of manual string interpolation.
+    private func getEnvelope<T: Decodable & Sendable>(url: URL, apiToken: String, as: T.Type) async throws -> CFEnvelope<T> {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
@@ -158,6 +166,16 @@ public struct HTTPCloudflareClient: CloudflareReading {
     /// GET `path` and return the decoded `result`, or throw `.api` when it is absent.
     private func get<T: Decodable & Sendable>(_ path: String, apiToken: String, as type: T.Type) async throws -> T {
         let env = try await getEnvelope(path, apiToken: apiToken, as: type)
+        guard let result = env.result else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "missing result")
+        }
+        return result
+    }
+
+    /// GET `url` and return the decoded `result`, or throw `.api` when it is absent. See
+    /// ``getEnvelope(url:apiToken:as:)`` for why this pre-built-`URL` variant exists.
+    private func get<T: Decodable & Sendable>(url: URL, apiToken: String, as type: T.Type) async throws -> T {
+        let env = try await getEnvelope(url: url, apiToken: apiToken, as: type)
         guard let result = env.result else {
             throw CloudflareError.api(message: env.errors?.first?.message ?? "missing result")
         }
@@ -329,12 +347,18 @@ public struct HTTPCloudflareClient: CloudflareReading {
 
     // MARK: - Write helpers
 
-    private func mutate<Body: Encodable & Sendable>(
+    /// Builds and sends a `method` request to `path` with an encoded `body`, then maps
+    /// 401/403 to ``CloudflareError/unauthorized`` and any other non-2xx status to
+    /// ``CloudflareError/http(status:)``. Shared by ``mutate(method:_:body:apiToken:)`` (which
+    /// only checks the envelope's `success` flag) and the Registrar `post` helper below (which
+    /// also decodes and returns the envelope's `result`) — both need identical request
+    /// construction and status handling and previously duplicated it verbatim.
+    private func send<Body: Encodable & Sendable>(
         method: String,
         _ path: String,
         body: Body,
         apiToken: String
-    ) async throws {
+    ) async throws -> (Data, HTTPURLResponse) {
         guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
         var request = URLRequest(url: url)
         request.httpMethod = method
@@ -344,6 +368,16 @@ public struct HTTPCloudflareClient: CloudflareReading {
         let (data, http) = try await transport(request)
         if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
         guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        return (data, http)
+    }
+
+    private func mutate<Body: Encodable & Sendable>(
+        method: String,
+        _ path: String,
+        body: Body,
+        apiToken: String
+    ) async throws {
+        let (data, _) = try await send(method: method, path, body: body, apiToken: apiToken)
         let env: CFEnvelope<CFEmpty>
         do {
             env = try JSONDecoder().decode(CFEnvelope<CFEmpty>.self, from: data)
@@ -571,18 +605,11 @@ extension HTTPCloudflareClient: CloudflareRegistrarReading {
 
     /// POST `path` with `body`, decode `CFEnvelope<T>`, return its `result` — like `get`, but for
     /// POST calls that need the decoded payload back (unlike `mutate`, which only checks success).
+    /// Shares request construction and status mapping with `mutate` via ``send(method:_:body:apiToken:)``.
     private func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
         _ path: String, body: Body, apiToken: String, as type: T.Type
     ) async throws -> T {
-        guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(body)
-        let (data, http) = try await transport(request)
-        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
-        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        let (data, _) = try await send(method: "POST", path, body: body, apiToken: apiToken)
         let env: CFEnvelope<T>
         do {
             env = try JSONDecoder().decode(CFEnvelope<T>.self, from: data)
@@ -599,12 +626,23 @@ extension HTTPCloudflareClient: CloudflareRegistrarReading {
     }
 
     /// See ``CloudflareRegistrarReading/searchDomains(query:apiToken:)``.
+    ///
+    /// Builds the request with `URLComponents`/`URLQueryItem` rather than manual string
+    /// interpolation: `query` is free-text (e.g. a business name like "Smith & Sons"), and
+    /// `CharacterSet.urlQueryAllowed` — the encoding used elsewhere in this file for hostnames,
+    /// which never contain `&`/`=`/`+` — does not escape those characters. Left unescaped, they
+    /// would truncate the `q` value at the API and corrupt or drop the `limit` parameter.
     public func searchDomains(query: String, apiToken: String) async throws -> [String] {
         let accountID = try await resolveAccountID(apiToken: apiToken)
-        let escaped = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
-        let response = try await get(
-            "/accounts/\(accountID)/registrar/domain-search?q=\(escaped)&limit=20",
-            apiToken: apiToken, as: CFRegistrarSearchResponse.self)
+        guard var components = URLComponents(string: Self.base + "/accounts/\(accountID)/registrar/domain-search") else {
+            throw CloudflareError.malformedResponse
+        }
+        components.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "limit", value: "20"),
+        ]
+        guard let url = components.url else { throw CloudflareError.malformedResponse }
+        let response = try await get(url: url, apiToken: apiToken, as: CFRegistrarSearchResponse.self)
         return response.domains.map(\.name)
     }
 

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -83,6 +83,15 @@ private struct CFRegistrarCheckResponse: Decodable, Sendable {
 private struct CFRegistrarCheckRequest: Encodable, Sendable {
     let domains: [String]
 }
+private struct CFRegistrarRegisterRequest: Encodable, Sendable {
+    let domain_name: String
+}
+/// Shared by the immediate register response body and the poll (`registration-status`) response
+/// body — unlike search/check, both report a bare `state` field directly on `result`, confirmed
+/// against the live API docs (no `domains`-style wrapper here).
+private struct CFRegistrarRegistrationState: Decodable, Sendable {
+    let state: String
+}
 private struct CFWorkerScript: Decodable, Sendable { let id: String }
 private struct CFWorkerDomain: Decodable, Sendable { let hostname: String; let service: String }
 
@@ -670,5 +679,69 @@ extension HTTPCloudflareClient: CloudflareRegistrarReading {
                 name: $0.name, registrable: $0.registrable, reason: $0.reason,
                 registrationCost: $0.pricing?.registration_cost, currency: $0.pricing?.currency)
         }
+    }
+}
+
+// MARK: - CloudflareRegistrarWriting conformance
+
+extension HTTPCloudflareClient: CloudflareRegistrarWriting {
+    /// `POST /accounts/{id}/registrar/registrations`. See
+    /// ``CloudflareRegistrarWriting/registerDomain(name:apiToken:)``.
+    ///
+    /// Reuses ``send(method:_:body:apiToken:)`` for request construction and 401/403/non-2xx
+    /// mapping (201 and 202 both already fall inside `send`'s 200..<300 success range) rather
+    /// than duplicating that logic a third time alongside `mutate`/`post` — the only thing this
+    /// call needs beyond `send` is branching on which 2xx status came back.
+    public func registerDomain(name: String, apiToken: String) async throws -> RegistrarRegistrationOutcome {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        let (data, http) = try await send(
+            method: "POST", "/accounts/\(accountID)/registrar/registrations",
+            body: CFRegistrarRegisterRequest(domain_name: name), apiToken: apiToken)
+        if http.statusCode == 202 {
+            return try await pollRegistrationStatus(domain: name, accountID: accountID, apiToken: apiToken)
+        }
+        return Self.outcome(forState: try Self.decodeState(from: data))
+    }
+
+    private static func decodeState(from data: Data) throws -> String {
+        let env: CFEnvelope<CFRegistrarRegistrationState>
+        do {
+            env = try JSONDecoder().decode(CFEnvelope<CFRegistrarRegistrationState>.self, from: data)
+        } catch {
+            throw CloudflareError.malformedResponse
+        }
+        guard env.success, let state = env.result?.state else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "missing registration state")
+        }
+        return state
+    }
+
+    private static func outcome(forState state: String) -> RegistrarRegistrationOutcome {
+        switch state {
+        case "succeeded": return .succeeded
+        case "action_required": return .actionRequired
+        case "blocked": return .blocked
+        case "failed": return .failed(reason: "Cloudflare reported the registration failed.")
+        default: return .stillProcessing
+        }
+    }
+
+    /// Polls `registration-status` every 2.5s, up to 6 times (~15s total — matching the API's own
+    /// "synchronous in most cases (10s timeout)" framing with one poll's margin past it). Resolves
+    /// to `.stillProcessing` if `state` never leaves `in_progress` in that window. No task survives
+    /// past this method returning — there is no background/long-lived polling.
+    private func pollRegistrationStatus(
+        domain: String, accountID: String, apiToken: String
+    ) async throws -> RegistrarRegistrationOutcome {
+        for _ in 0..<6 {
+            try? await Task.sleep(for: .milliseconds(2500))
+            let state = try await get(
+                "/accounts/\(accountID)/registrar/registrations/\(domain)/registration-status",
+                apiToken: apiToken, as: CFRegistrarRegistrationState.self)
+            let outcome = Self.outcome(forState: state.state)
+            if case .stillProcessing = outcome { continue }
+            return outcome
+        }
+        return .stillProcessing
     }
 }

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -182,7 +182,7 @@ public struct HTTPCloudflareClient: CloudflareReading {
     }
 
     /// GET `url` and return the decoded `result`, or throw `.api` when it is absent. See
-    /// ``getEnvelope(url:apiToken:as:)`` for why this pre-built-`URL` variant exists.
+    /// `getEnvelope(url:apiToken:as:)` for why this pre-built-`URL` variant exists.
     private func get<T: Decodable & Sendable>(url: URL, apiToken: String, as type: T.Type) async throws -> T {
         let env = try await getEnvelope(url: url, apiToken: apiToken, as: type)
         guard let result = env.result else {
@@ -358,7 +358,7 @@ public struct HTTPCloudflareClient: CloudflareReading {
 
     /// Builds and sends a `method` request to `path` with an encoded `body`, then maps
     /// 401/403 to ``CloudflareError/unauthorized`` and any other non-2xx status to
-    /// ``CloudflareError/http(status:)``. Shared by ``mutate(method:_:body:apiToken:)`` (which
+    /// ``CloudflareError/http(status:)``. Shared by `mutate(method:_:body:apiToken:)` (which
     /// only checks the envelope's `success` flag) and the Registrar `post` helper below (which
     /// also decodes and returns the envelope's `result`) — both need identical request
     /// construction and status handling and previously duplicated it verbatim.
@@ -614,7 +614,7 @@ extension HTTPCloudflareClient: CloudflareRegistrarReading {
 
     /// POST `path` with `body`, decode `CFEnvelope<T>`, return its `result` — like `get`, but for
     /// POST calls that need the decoded payload back (unlike `mutate`, which only checks success).
-    /// Shares request construction and status mapping with `mutate` via ``send(method:_:body:apiToken:)``.
+    /// Shares request construction and status mapping with `mutate` via `send(method:_:body:apiToken:)`.
     private func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
         _ path: String, body: Body, apiToken: String, as type: T.Type
     ) async throws -> T {
@@ -688,7 +688,7 @@ extension HTTPCloudflareClient: CloudflareRegistrarWriting {
     /// `POST /accounts/{id}/registrar/registrations`. See
     /// ``CloudflareRegistrarWriting/registerDomain(name:apiToken:)``.
     ///
-    /// Reuses ``send(method:_:body:apiToken:)`` for request construction and 401/403/non-2xx
+    /// Reuses `send(method:_:body:apiToken:)` for request construction and 401/403/non-2xx
     /// mapping (201 and 202 both already fall inside `send`'s 200..<300 success range) rather
     /// than duplicating that logic a third time alongside `mutate`/`post` — the only thing this
     /// call needs beyond `send` is branching on which 2xx status came back.

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -58,6 +58,31 @@ private struct CFFullDNSRecord: Decodable, Sendable {
     let comment: String?
 }
 private struct CFAccount: Decodable, Sendable { let id: String }
+private struct CFRegistrarSearchResult: Decodable, Sendable {
+    let name: String
+}
+/// The Registrar search/check `result` is an object wrapping a `domains` array (not a bare
+/// array like most other Cloudflare v4 list endpoints) — confirmed against the live API docs.
+private struct CFRegistrarSearchResponse: Decodable, Sendable {
+    let domains: [CFRegistrarSearchResult]
+}
+private struct CFRegistrarCheckResult: Decodable, Sendable {
+    let name: String
+    let registrable: Bool
+    let reason: String?
+    let pricing: Pricing?
+    struct Pricing: Decodable, Sendable {
+        let currency: String
+        let registration_cost: String
+        let renewal_cost: String
+    }
+}
+private struct CFRegistrarCheckResponse: Decodable, Sendable {
+    let domains: [CFRegistrarCheckResult]
+}
+private struct CFRegistrarCheckRequest: Encodable, Sendable {
+    let domains: [String]
+}
 private struct CFWorkerScript: Decodable, Sendable { let id: String }
 private struct CFWorkerDomain: Decodable, Sendable { let hostname: String; let service: String }
 
@@ -527,6 +552,73 @@ extension HTTPCloudflareClient: CloudflareWriting {
                                               kind: "zone", phase: "http_response_compression",
                                               rules: [rule]),
                              apiToken: apiToken)
+        }
+    }
+}
+
+// MARK: - CloudflareRegistrarReading conformance
+
+extension HTTPCloudflareClient: CloudflareRegistrarReading {
+    /// Resolves the token's first visible account id — every Registrar endpoint is
+    /// account-scoped. Mirrors `workerScriptNames`'s resolution exactly.
+    private func resolveAccountID(apiToken: String) async throws -> String {
+        let accounts = try await get("/accounts?per_page=1", apiToken: apiToken, as: [CFAccount].self)
+        guard let accountID = accounts.first?.id else {
+            throw CloudflareError.api(message: "no Cloudflare account visible to this token")
+        }
+        return accountID
+    }
+
+    /// POST `path` with `body`, decode `CFEnvelope<T>`, return its `result` — like `get`, but for
+    /// POST calls that need the decoded payload back (unlike `mutate`, which only checks success).
+    private func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        _ path: String, body: Body, apiToken: String, as type: T.Type
+    ) async throws -> T {
+        guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        let env: CFEnvelope<T>
+        do {
+            env = try JSONDecoder().decode(CFEnvelope<T>.self, from: data)
+        } catch {
+            throw CloudflareError.malformedResponse
+        }
+        guard env.success else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "request failed")
+        }
+        guard let result = env.result else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "missing result")
+        }
+        return result
+    }
+
+    /// See ``CloudflareRegistrarReading/searchDomains(query:apiToken:)``.
+    public func searchDomains(query: String, apiToken: String) async throws -> [String] {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        let escaped = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        let response = try await get(
+            "/accounts/\(accountID)/registrar/domain-search?q=\(escaped)&limit=20",
+            apiToken: apiToken, as: CFRegistrarSearchResponse.self)
+        return response.domains.map(\.name)
+    }
+
+    /// See ``CloudflareRegistrarReading/checkDomainAvailability(domains:apiToken:)``.
+    public func checkDomainAvailability(domains: [String], apiToken: String) async throws -> [RegistrarDomainCheck] {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        let response = try await post(
+            "/accounts/\(accountID)/registrar/domain-check",
+            body: CFRegistrarCheckRequest(domains: domains), apiToken: apiToken,
+            as: CFRegistrarCheckResponse.self)
+        return response.domains.map {
+            RegistrarDomainCheck(
+                name: $0.name, registrable: $0.registrable, reason: $0.reason,
+                registrationCost: $0.pricing?.registration_cost, currency: $0.pricing?.currency)
         }
     }
 }

--- a/Sources/AnglesiteCore/RegistrarOperationsService.swift
+++ b/Sources/AnglesiteCore/RegistrarOperationsService.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Errors surfaced by `RegistrarOperationsService`. Mirrors `DomainOperationError`'s shape
+/// (minus `.zoneNotFound`, not meaningful for account-scoped Registrar calls).
+public enum RegistrarOperationError: Error, Equatable, Sendable {
+    /// No Cloudflare API token was available from the token provider — the operation never
+    /// reached the network.
+    case noToken
+    /// Any Cloudflare API failure, wrapping the underlying ``CloudflareError``.
+    case cloudflare(CloudflareError)
+}
+
+/// Domain search/check/register operations, centralizing token lookup so `BuyDomainModel`
+/// doesn't do its own — mirrors `DomainOperationsService`'s role for DNS operations.
+public protocol RegistrarOperationsService: Sendable {
+    func searchDomains(query: String) async -> Result<[String], RegistrarOperationError>
+    func checkDomainAvailability(domains: [String]) async -> Result<[RegistrarDomainCheck], RegistrarOperationError>
+    func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError>
+}
+
+/// The production ``RegistrarOperationsService``, backed by the Cloudflare HTTP client. Every
+/// operation re-runs token lookup rather than caching it — mirrors `DomainOperations`'s reasoning.
+public struct RegistrarOperations: RegistrarOperationsService {
+    private let reader: any CloudflareRegistrarReading
+    private let writer: any CloudflareRegistrarWriting
+    private let tokenProvider: @Sendable () -> String?
+
+    public init(
+        reader: any CloudflareRegistrarReading = HTTPCloudflareClient(),
+        writer: any CloudflareRegistrarWriting = HTTPCloudflareClient(),
+        tokenProvider: @escaping @Sendable () -> String? = DomainOperations.defaultTokenProvider
+    ) {
+        self.reader = reader
+        self.writer = writer
+        self.tokenProvider = tokenProvider
+    }
+
+    public func searchDomains(query: String) async -> Result<[String], RegistrarOperationError> {
+        guard let token = tokenProvider() else { return .failure(.noToken) }
+        do {
+            return .success(try await reader.searchDomains(query: query, apiToken: token))
+        } catch let error as CloudflareError {
+            return .failure(.cloudflare(error))
+        } catch {
+            return .failure(.cloudflare(.malformedResponse))
+        }
+    }
+
+    public func checkDomainAvailability(domains: [String]) async -> Result<[RegistrarDomainCheck], RegistrarOperationError> {
+        guard let token = tokenProvider() else { return .failure(.noToken) }
+        do {
+            return .success(try await reader.checkDomainAvailability(domains: domains, apiToken: token))
+        } catch let error as CloudflareError {
+            return .failure(.cloudflare(error))
+        } catch {
+            return .failure(.cloudflare(.malformedResponse))
+        }
+    }
+
+    public func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError> {
+        guard let token = tokenProvider() else { return .failure(.noToken) }
+        do {
+            return .success(try await writer.registerDomain(name: name, apiToken: token))
+        } catch let error as CloudflareError {
+            return .failure(.cloudflare(error))
+        } catch {
+            return .failure(.cloudflare(.malformedResponse))
+        }
+    }
+}

--- a/Tests/AnglesiteAppTests/BuyDomainModelTests.swift
+++ b/Tests/AnglesiteAppTests/BuyDomainModelTests.swift
@@ -1,0 +1,134 @@
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@MainActor
+@Suite struct BuyDomainModelTests {
+    private func makeSite() throws -> (site: CurrentSite, dir: URL) {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        return (CurrentSite(id: "s1", packageURL: tmp, sourceDirectory: tmp), tmp)
+    }
+
+    @Test func happyPathSearchThenPurchaseRecordsTransferIntent() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["example.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+        ]))
+        await ops.setRegisterResult(.success(.succeeded))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+
+        guard case .results(_, let candidates) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)"); return
+        }
+        #expect(candidates.count == 1)
+        #expect(candidates[0].registrable)
+        #expect(candidates[0].priceDisplay == "$10.11/yr")
+
+        model.selectCandidate(candidates[0])
+        guard case .confirming(let candidate) = model.phase else {
+            Issue.record("expected .confirming, got \(model.phase)"); return
+        }
+
+        model.confirmPurchase()
+        repeat { await Task.yield() } while model.isRunning
+
+        #expect(model.phase == .purchased(hostname: "example.dev"))
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(config.contains("DOMAIN_CHOICE=transfer"))
+        #expect(config.contains("DOMAIN=example.dev"))
+        _ = candidate
+    }
+
+    @Test func unregistrableCandidateCannotBeSelected() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["taken.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "taken.dev", registrable: false, reason: "domain_unavailable", registrationCost: nil, currency: nil),
+        ]))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+
+        model.queryInput = "taken"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+
+        guard case .results(_, let candidates) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)"); return
+        }
+        model.selectCandidate(candidates[0])
+        #expect(model.phase == .results(query: "taken", candidates: candidates))
+    }
+
+    @Test func registerOutcomeActionRequiredDoesNotPersist() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["example.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+        ]))
+        await ops.setRegisterResult(.success(.actionRequired))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+        guard case .results(_, let candidates) = model.phase else { Issue.record("expected .results"); return }
+        model.selectCandidate(candidates[0])
+        model.confirmPurchase()
+        repeat { await Task.yield() } while model.isRunning
+
+        #expect(model.phase == .needsAccountSetup(hostname: "example.dev"))
+        #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent(".site-config").path))
+    }
+
+    @Test func noTokenPresentsTokenPromptAndRecordsPendingQuery() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.failure(.noToken))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+
+        #expect(model.tokenPromptPresented)
+    }
+}
+
+// MARK: - Fakes
+
+private actor FakeRegistrarOps: RegistrarOperationsService {
+    private var searchResult: Result<[String], RegistrarOperationError> = .success([])
+    private var checkResult: Result<[RegistrarDomainCheck], RegistrarOperationError> = .success([])
+    private var registerResult: Result<RegistrarRegistrationOutcome, RegistrarOperationError> = .success(.succeeded)
+
+    func setSearchResult(_ r: Result<[String], RegistrarOperationError>) { searchResult = r }
+    func setCheckResult(_ r: Result<[RegistrarDomainCheck], RegistrarOperationError>) { checkResult = r }
+    func setRegisterResult(_ r: Result<RegistrarRegistrationOutcome, RegistrarOperationError>) { registerResult = r }
+
+    func searchDomains(query: String) async -> Result<[String], RegistrarOperationError> { searchResult }
+    func checkDomainAvailability(domains: [String]) async -> Result<[RegistrarDomainCheck], RegistrarOperationError> { checkResult }
+    func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError> { registerResult }
+}

--- a/Tests/AnglesiteAppTests/BuyDomainModelTests.swift
+++ b/Tests/AnglesiteAppTests/BuyDomainModelTests.swift
@@ -115,6 +115,172 @@ import Foundation
 
         #expect(model.tokenPromptPresented)
     }
+
+    /// Regression test for the double-submit race (final-review fix wave, #1195): `phase` used to
+    /// flip to `.purchasing` only as the first line *inside* the spawned `Task`, not synchronously
+    /// in `confirmPurchase()` — leaving a window (until the task's first hop) where a second
+    /// `confirmPurchase()` call still saw `.confirming`/`isRunning == false` and passed the guard,
+    /// firing a second real-money `POST /registrar/registrations`. Calling `confirmPurchase()`
+    /// twice back-to-back with no `await`/yield between them (as a held/double-tapped Return on
+    /// the `.keyboardShortcut(.defaultAction)` Buy button could) is exactly that race window —
+    /// this would have recorded two `registerDomain` calls before the fix.
+    @Test func confirmPurchaseCalledTwiceInImmediateSuccessionOnlyRegistersOnce() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["example.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+        ]))
+        await ops.setRegisterResult(.success(.succeeded))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+        guard case .results(_, let candidates) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)"); return
+        }
+        model.selectCandidate(candidates[0])
+        guard case .confirming = model.phase else {
+            Issue.record("expected .confirming, got \(model.phase)"); return
+        }
+
+        // No `await` between these two calls — the synchronous double-call that lived in the race
+        // window.
+        model.confirmPurchase()
+        model.confirmPurchase()
+
+        repeat { await Task.yield() } while model.isRunning
+
+        #expect(await ops.registeredNames == ["example.dev"])
+        #expect(model.phase == .purchased(hostname: "example.dev"))
+    }
+
+    /// Covers the Fix 4/5 pairing: closing the sheet mid-purchase doesn't cancel the in-flight
+    /// task (a `POST /registrar/registrations` may already be at Cloudflare), and reopening the
+    /// sheet before that background purchase finishes shows the live `.purchasing` state rather
+    /// than silently refusing to open or discarding it.
+    @Test func dismissAndReopenDuringBackgroundedPurchasePreservesInFlightTask() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["example.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+        ]))
+        await ops.setRegisterDelay(.milliseconds(150))
+        await ops.setRegisterResult(.success(.succeeded))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+        guard case .results(_, let candidates) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)"); return
+        }
+        model.selectCandidate(candidates[0])
+        model.confirmPurchase()
+        #expect(model.isRunning)
+
+        // Close mid-purchase: must not cancel the in-flight task.
+        model.dismissSheet()
+        #expect(!model.sheetPresented)
+        #expect(model.isRunning)
+
+        // Reopen while it's still running: must present (not silently no-op) and preserve
+        // `.purchasing` instead of resetting to `.searching`.
+        model.openSheet()
+        #expect(model.sheetPresented)
+        guard case .purchasing(let candidate) = model.phase else {
+            Issue.record("expected .purchasing to survive reopen, got \(model.phase)"); return
+        }
+        #expect(candidate.name == "example.dev")
+
+        repeat { await Task.yield() } while model.isRunning
+        #expect(model.phase == .purchased(hostname: "example.dev"))
+        #expect(await ops.registeredNames == ["example.dev"])
+    }
+
+    /// `dismissSheet()` used to leave `pendingSearchQuery`/`tokenPromptPresented` surviving a
+    /// close, unlike `phase`/`queryInput` on `openSheet()` — a small state-hygiene gap fixed
+    /// alongside Fix 4/5.
+    @Test func dismissSheetResetsTokenPromptState() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.failure(.noToken))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+        #expect(model.tokenPromptPresented)
+
+        model.dismissSheet()
+        #expect(!model.tokenPromptPresented)
+    }
+
+    /// `CFRegistrarCheckResult.pricing` decodes as optional, so a `registrable: true` result can
+    /// still have `priceDisplay == nil` — such a candidate must not be selectable (weak consent
+    /// for a real charge otherwise: "Buy example.dev for an unknown price?" with an enabled Buy
+    /// button).
+    @Test func registrableCandidateWithNoPriceCannotBeSelected() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["example.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: nil, currency: nil),
+        ]))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+        guard case .results(_, let candidates) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)"); return
+        }
+        #expect(candidates[0].registrable)
+        #expect(candidates[0].priceDisplay == nil)
+
+        model.selectCandidate(candidates[0])
+        #expect(model.phase == .results(query: "example", candidates: candidates))
+    }
+
+    /// Spec: results render available-first, unavailable/unsupported rows after — regardless of
+    /// the order the API returned them in.
+    @Test func searchResultsSortAvailableFirst() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["taken.dev", "example.dev", "also-taken.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "taken.dev", registrable: false, reason: "domain_unavailable", registrationCost: nil, currency: nil),
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+            RegistrarDomainCheck(name: "also-taken.dev", registrable: false, reason: "domain_unavailable", registrationCost: nil, currency: nil),
+        ]))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+        guard case .results(_, let candidates) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)"); return
+        }
+
+        #expect(candidates.map(\.name) == ["example.dev", "taken.dev", "also-taken.dev"])
+    }
 }
 
 // MARK: - Fakes
@@ -123,12 +289,26 @@ private actor FakeRegistrarOps: RegistrarOperationsService {
     private var searchResult: Result<[String], RegistrarOperationError> = .success([])
     private var checkResult: Result<[RegistrarDomainCheck], RegistrarOperationError> = .success([])
     private var registerResult: Result<RegistrarRegistrationOutcome, RegistrarOperationError> = .success(.succeeded)
+    /// Every `name` passed to `registerDomain`, in call order — lets tests assert exactly how many
+    /// times a real-money `POST /registrar/registrations` would have fired (see the double-submit
+    /// regression test).
+    private(set) var registeredNames: [String] = []
+    /// An optional delay `registerDomain` awaits before resolving, so a test can hold two
+    /// concurrent calls open at once to observe how many were actually made.
+    private var registerDelay: Duration?
 
     func setSearchResult(_ r: Result<[String], RegistrarOperationError>) { searchResult = r }
     func setCheckResult(_ r: Result<[RegistrarDomainCheck], RegistrarOperationError>) { checkResult = r }
     func setRegisterResult(_ r: Result<RegistrarRegistrationOutcome, RegistrarOperationError>) { registerResult = r }
+    func setRegisterDelay(_ d: Duration) { registerDelay = d }
 
     func searchDomains(query: String) async -> Result<[String], RegistrarOperationError> { searchResult }
     func checkDomainAvailability(domains: [String]) async -> Result<[RegistrarDomainCheck], RegistrarOperationError> { checkResult }
-    func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError> { registerResult }
+    func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError> {
+        registeredNames.append(name)
+        if let registerDelay {
+            try? await Task.sleep(for: registerDelay)
+        }
+        return registerResult
+    }
 }

--- a/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
+++ b/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
@@ -52,6 +52,34 @@ import Foundation
         #expect(config.contains("DOMAIN_CHOICE=buy"))
     }
 
+    /// `chooseBuy()` flags the sheet-to-sheet handoff so `SiteWindow`'s `onDismiss` can open
+    /// `BuyDomainSheetView` after this sheet's dismissal completes, instead of both sheets'
+    /// `sheetPresented` bindings flipping synchronously in one button action (#1195 fix wave).
+    @Test func chooseBuySetsPendingBuyDomainFlag() throws {
+        let model = ConnectDomainModel()
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+
+        #expect(!model.pendingBuyDomain)
+        model.chooseBuy()
+
+        #expect(model.pendingBuyDomain)
+    }
+
+    @Test func notNowDoesNotSetPendingBuyDomainFlag() throws {
+        let model = ConnectDomainModel()
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+
+        model.notNow()
+
+        #expect(!model.pendingBuyDomain)
+    }
+
     @Test func beginTransferThenSubmitRecordsHostnameAndTransitionsToConnected() throws {
         let model = ConnectDomainModel()
         let (site, dir) = try makeSite()

--- a/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
@@ -181,4 +181,73 @@ struct HTTPCloudflareClientRegistrarTests {
         let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
         #expect(outcome == .stillProcessing)
     }
+
+    @Test("registerDomain maps failed on an immediate 201")
+    func registerImmediateFailed() async throws {
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"failed"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        guard case .failed(let reason) = outcome else {
+            Issue.record("expected .failed, got \(outcome)"); return
+        }
+        #expect(!reason.isEmpty)
+    }
+
+    @Test("registerDomain maps an unrecognized state to stillProcessing on an immediate 201")
+    func registerImmediateUnknownStateFallsThroughToStillProcessing() async throws {
+        // `Self.outcome(forState:)`'s `default:` branch resolves any state it doesn't recognize
+        // (not just `in_progress`) to `.stillProcessing` — this pins that existing behavior
+        // without changing it, so a Cloudflare-side state string this client doesn't yet know
+        // about degrades to "come back later" instead of throwing.
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"some_future_state"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .stillProcessing)
+    }
+
+    @Test("registerDomain surfaces a CloudflareError on a 401")
+    func registerSurfacesUnauthorizedError() async {
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (401, "{\"success\":false}"),
+        ]))
+        await #expect(throws: CloudflareError.unauthorized) {
+            _ = try await client.registerDomain(name: "example.dev", apiToken: "bad")
+        }
+    }
+
+    @Test("registrar calls are scoped to the token's account id")
+    func registrarCallsAreAccountScoped() async throws {
+        // None of the tests above assert the `/accounts/{id}/` segment is actually present and
+        // correct — if `resolveAccountID` were ever dropped, or the account id interpolated
+        // wrong, every one of them would still pass while every live call 404'd. Assert directly
+        // on the sent request URL for all three registrar operations.
+        let searchJSON = #"{"success":true,"errors":[],"messages":[],"result":{"domains":[]}}"#
+        let checkJSON = #"{"success":true,"errors":[],"messages":[],"result":{"domains":[]}}"#
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"succeeded"}}"#
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-search": (200, searchJSON),
+            "/registrar/domain-check": (200, checkJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ], spy: spy))
+
+        _ = try await client.searchDomains(query: "example", apiToken: "t")
+        _ = try await client.checkDomainAvailability(domains: ["example.dev"], apiToken: "t")
+        _ = try await client.registerDomain(name: "example.dev", apiToken: "t")
+
+        let registrarRequests = spy.requests.filter { $0.url?.path.contains("/registrar/") == true }
+        #expect(registrarRequests.count == 3)
+        for request in registrarRequests {
+            let path = try #require(request.url?.path)
+            #expect(path.contains("/accounts/acct123/registrar/"))
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
@@ -21,6 +21,30 @@ struct HTTPCloudflareClientRegistrarTests {
         #expect(names == ["example.dev", "example.app"])
     }
 
+    @Test("searchDomains correctly percent-encodes & = + in the query value")
+    func searchEncodesSpecialCharacters() async throws {
+        let searchJSON = """
+        {"success":true,"errors":[],"messages":[],"result":{"domains":[]}}
+        """
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-search": (200, searchJSON),
+        ], spy: spy))
+        _ = try await client.searchDomains(query: "Smith & Sons = 1+1", apiToken: "t")
+
+        let sent = try #require(spy.requests.first { $0.url?.path.contains("domain-search") == true })
+        let sentURL = try #require(sent.url)
+        let components = try #require(URLComponents(url: sentURL, resolvingAgainstBaseURL: false))
+        let items = components.queryItems ?? []
+        // Both `q` and `limit` must survive intact as separate query items — a naive
+        // `.urlQueryAllowed` escape leaves `&`/`=`/`+` unescaped, which splits `q`'s value at
+        // the `&` and corrupts/loses the `limit` parameter.
+        #expect(items.first(where: { $0.name == "q" })?.value == "Smith & Sons = 1+1")
+        #expect(items.first(where: { $0.name == "limit" })?.value == "20")
+        #expect(items.count == 2)
+    }
+
     @Test("searchDomains surfaces a CloudflareError")
     func searchSurfacesError() async {
         let client = HTTPCloudflareClient(transport: fakeTransport([

--- a/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
@@ -117,4 +117,68 @@ struct HTTPCloudflareClientRegistrarTests {
                                   registrationCost: nil, currency: nil),
         ])
     }
+
+    @Test("registerDomain resolves succeeded on an immediate 201")
+    func registerImmediateSuccess() async throws {
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"succeeded"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .succeeded)
+    }
+
+    @Test("registerDomain maps action_required")
+    func registerActionRequired() async throws {
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"action_required"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .actionRequired)
+    }
+
+    @Test("registerDomain maps blocked")
+    func registerBlocked() async throws {
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"blocked"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .blocked)
+    }
+
+    @Test("registerDomain maps a 202 that polls straight to succeeded")
+    func registerAsyncThenSucceeds() async throws {
+        let acceptedJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"in_progress"}}"#
+        let statusJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"succeeded"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (202, acceptedJSON),
+            // The poll URL (".../registrar/registrations/example.dev/registration-status")
+            // contains both this route's needle and the register route's needle above.
+            // `fakeTransport` picks the longest matching needle, so this key must stay longer
+            // than "/registrar/registrations" (25 chars) or the poll request would wrongly hit
+            // the register route again and this test would falsely pass/fail on stale state.
+            "example.dev/registration-status": (200, statusJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .succeeded)
+    }
+
+    @Test("registerDomain resolves stillProcessing when polling never leaves in_progress")
+    func registerAsyncNeverResolves() async throws {
+        let acceptedJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"in_progress"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (202, acceptedJSON),
+            // See the comment in `registerAsyncThenSucceeds` above — same collision-avoidance need.
+            "example.dev/registration-status": (200, acceptedJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .stillProcessing)
+    }
 }

--- a/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct HTTPCloudflareClientRegistrarTests {
+    private let accountsJSON = #"{"success":true,"errors":[],"messages":[],"result":[{"id":"acct123"}]}"#
+
+    @Test("searchDomains returns candidate names")
+    func searchReturnsNames() async throws {
+        let searchJSON = """
+        {"success":true,"errors":[],"messages":[],"result":{"domains":[
+            {"name":"example.dev","registrable":true,"tier":"standard","pricing":{"currency":"USD","registration_cost":"10.11","renewal_cost":"10.11"}},
+            {"name":"example.app","registrable":true,"tier":"standard","pricing":{"currency":"USD","registration_cost":"11.00","renewal_cost":"11.00"}}
+        ]}}
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-search": (200, searchJSON),
+        ]))
+        let names = try await client.searchDomains(query: "example", apiToken: "t")
+        #expect(names == ["example.dev", "example.app"])
+    }
+
+    @Test("searchDomains surfaces a CloudflareError")
+    func searchSurfacesError() async {
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-search": (403, "{\"success\":false}"),
+        ]))
+        await #expect(throws: CloudflareError.unauthorized) {
+            _ = try await client.searchDomains(query: "example", apiToken: "bad")
+        }
+    }
+
+    @Test("checkDomainAvailability decodes pricing for a registrable domain")
+    func checkRegistrable() async throws {
+        let checkJSON = """
+        {"success":true,"errors":[],"messages":[],"result":{"domains":[
+            {"name":"example.dev","registrable":true,"tier":"standard","pricing":{"currency":"USD","registration_cost":"10.11","renewal_cost":"10.11"}}
+        ]}}
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-check": (200, checkJSON),
+        ]))
+        let results = try await client.checkDomainAvailability(domains: ["example.dev"], apiToken: "t")
+        #expect(results == [
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil,
+                                  registrationCost: "10.11", currency: "USD"),
+        ])
+    }
+
+    @Test("checkDomainAvailability decodes the reason for an unregistrable domain")
+    func checkUnregistrable() async throws {
+        let checkJSON = """
+        {"success":true,"errors":[],"messages":[],"result":{"domains":[
+            {"name":"taken.dev","registrable":false,"reason":"domain_unavailable"}
+        ]}}
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-check": (200, checkJSON),
+        ]))
+        let results = try await client.checkDomainAvailability(domains: ["taken.dev"], apiToken: "t")
+        #expect(results == [
+            RegistrarDomainCheck(name: "taken.dev", registrable: false, reason: "domain_unavailable",
+                                  registrationCost: nil, currency: nil),
+        ])
+    }
+}

--- a/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
@@ -45,6 +45,32 @@ struct HTTPCloudflareClientRegistrarTests {
         #expect(items.count == 2)
     }
 
+    @Test("searchDomains percent-encodes a literal + to %2B on the wire")
+    func searchEncodesPlusOnWire() async throws {
+        // Regression test for a bug that slipped through `searchEncodesSpecialCharacters` above:
+        // `URLComponents(url:)` decodes a literal `+` and `%2B` identically back to `+`, so a
+        // round-trip assertion through `URLComponents` can't tell a correctly-escaped `+` from an
+        // unescaped one. Assert on the raw wire bytes instead — a literal `+` in a query string is
+        // conventionally form-decoded as a space by many server-side parsers, so "C++ Institute"
+        // must reach the API with `+` escaped as `%2B`, not as a bare `+`.
+        let searchJSON = """
+        {"success":true,"errors":[],"messages":[],"result":{"domains":[]}}
+        """
+        let spy = TransportSpy()
+        let client = HTTPCloudflareClient(transport: spyTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-search": (200, searchJSON),
+        ], spy: spy))
+        _ = try await client.searchDomains(query: "C++ Institute", apiToken: "t")
+
+        let sent = try #require(spy.requests.first { $0.url?.path.contains("domain-search") == true })
+        let sentURL = try #require(sent.url)
+        let components = try #require(URLComponents(url: sentURL, resolvingAgainstBaseURL: false))
+        let wireQuery = try #require(components.percentEncodedQuery)
+        #expect(wireQuery.contains("q=C%2B%2B%20Institute"))
+        #expect(!wireQuery.contains("C++"))
+    }
+
     @Test("searchDomains surfaces a CloudflareError")
     func searchSurfacesError() async {
         let client = HTTPCloudflareClient(transport: fakeTransport([

--- a/Tests/AnglesiteCoreTests/RegistrarOperationsServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/RegistrarOperationsServiceTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+struct RegistrarOperationsServiceTests {
+    private func service(
+        reader: FakeRegistrarReader = FakeRegistrarReader(),
+        writer: FakeRegistrarWriter = FakeRegistrarWriter(),
+        token: String? = "tok"
+    ) -> RegistrarOperations {
+        RegistrarOperations(reader: reader, writer: writer, tokenProvider: { token })
+    }
+
+    @Test("searchDomains resolves the reader's names")
+    func searchSucceeds() async {
+        let reader = FakeRegistrarReader(searchNames: ["example.dev"])
+        let result = await service(reader: reader).searchDomains(query: "example")
+        guard case .success(let names) = result else { Issue.record("expected success"); return }
+        #expect(names == ["example.dev"])
+        #expect(reader.searchedQuery == "example")
+    }
+
+    @Test("searchDomains fails with .noToken when no token is available")
+    func searchNoToken() async {
+        let result = await service(token: nil).searchDomains(query: "example")
+        guard case .failure(.noToken) = result else { Issue.record("expected .noToken"); return }
+    }
+
+    @Test("searchDomains surfaces a CloudflareError as .cloudflare")
+    func searchCloudflareError() async {
+        let reader = FakeRegistrarReader(searchError: .unauthorized)
+        let result = await service(reader: reader).searchDomains(query: "example")
+        guard case .failure(.cloudflare(.unauthorized)) = result else { Issue.record("expected .cloudflare(.unauthorized)"); return }
+    }
+
+    @Test("checkDomainAvailability resolves the reader's results")
+    func checkSucceeds() async {
+        let reader = FakeRegistrarReader(checkResults: [
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+        ])
+        let result = await service(reader: reader).checkDomainAvailability(domains: ["example.dev"])
+        guard case .success(let checks) = result else { Issue.record("expected success"); return }
+        #expect(checks.count == 1)
+        #expect(reader.checkedDomains == ["example.dev"])
+    }
+
+    @Test("registerDomain resolves the writer's outcome")
+    func registerSucceeds() async {
+        let writer = FakeRegistrarWriter(registerOutcome: .succeeded)
+        let result = await service(writer: writer).registerDomain(name: "example.dev")
+        guard case .success(.succeeded) = result else { Issue.record("expected success(.succeeded)"); return }
+        #expect(writer.registeredName == "example.dev")
+    }
+
+    @Test("registerDomain fails with .noToken when no token is available")
+    func registerNoToken() async {
+        let result = await service(token: nil).registerDomain(name: "example.dev")
+        guard case .failure(.noToken) = result else { Issue.record("expected .noToken"); return }
+    }
+}
+
+// MARK: - Fakes
+
+final class FakeRegistrarReader: CloudflareRegistrarReading, @unchecked Sendable {
+    private let searchNames: [String]
+    private let searchError: CloudflareError?
+    private let checkResults: [RegistrarDomainCheck]
+    private(set) var searchedQuery: String?
+    private(set) var checkedDomains: [String] = []
+
+    init(searchNames: [String] = [], searchError: CloudflareError? = nil, checkResults: [RegistrarDomainCheck] = []) {
+        self.searchNames = searchNames
+        self.searchError = searchError
+        self.checkResults = checkResults
+    }
+
+    func searchDomains(query: String, apiToken: String) async throws -> [String] {
+        searchedQuery = query
+        if let searchError { throw searchError }
+        return searchNames
+    }
+    func checkDomainAvailability(domains: [String], apiToken: String) async throws -> [RegistrarDomainCheck] {
+        checkedDomains = domains
+        return checkResults
+    }
+}
+
+final class FakeRegistrarWriter: CloudflareRegistrarWriting, @unchecked Sendable {
+    private let registerOutcome: RegistrarRegistrationOutcome
+    private(set) var registeredName: String?
+
+    init(registerOutcome: RegistrarRegistrationOutcome = .succeeded) {
+        self.registerOutcome = registerOutcome
+    }
+
+    func registerDomain(name: String, apiToken: String) async throws -> RegistrarRegistrationOutcome {
+        registeredName = name
+        return registerOutcome
+    }
+}

--- a/docs/superpowers/plans/2026-08-01-registrar-search-purchase-plan.md
+++ b/docs/superpowers/plans/2026-08-01-registrar-search-purchase-plan.md
@@ -1,0 +1,1590 @@
+# Registrar Search + Purchase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a site owner search domain names, see real-time pricing, and buy one in-app via Cloudflare's Registrar API, replacing the current "Buy a domain" placeholder (a bare link-out).
+
+**Architecture:** Three new layers mirroring the existing `DomainModel` → `DomainOperationsService` → `HTTPCloudflareClient` stack used for DNS management: `HTTPCloudflareClient` gains dedicated `CloudflareRegistrarReading`/`CloudflareRegistrarWriting` conformances (search/check/register), a new `RegistrarOperationsService`/`RegistrarOperations` pair in `AnglesiteCore` composes them with token lookup, and a new `BuyDomainModel`/`BuyDomainSheetView` in `AnglesiteApp` drives the search → confirm → purchase UI. A successful purchase reuses `ConnectDomainCommand.recordTransfer` verbatim — zero changes to `CustomDomainAttachCommand`. A "no Cloudflare token" search reuses the existing `CloudflareTokenPromptView` (narrowed off `DeployModel` to a closure-based init so `BuyDomainModel` can drive it too).
+
+**Tech Stack:** Swift 6.4, SwiftUI, Swift Testing (`Testing` framework, `@Test`/`#expect`), SwiftPM (`AnglesiteCore`, `AnglesiteAppCore` targets — the latter's `path` is `Sources/AnglesiteApp`).
+
+## Global Constraints
+
+- Never collect, store, or proxy payment/card details, full stop (design spec, Problem/Goals).
+- Every `registerDomain` call happens only from an explicit "Buy" button press; the button is disabled for the duration of the call — no double-submit, no automatic/optimistic charge (spec §3).
+- Only an explicit `succeeded` outcome from `registerDomain` may write persisted state (`.site-config`/`anglesite.json`); `failed`/`action_required`/`blocked`/still-`in_progress` write nothing (spec §3, §4).
+- Registrar operations are **account-scoped**, not zone-scoped; account id is resolved the same way `workerScriptNames`/`attachWorkersCustomDomain` already do it — `GET /accounts?per_page=1`, first result (spec, "The Cloudflare Registrar API").
+- A `202` (async) registration is polled up to ~15s total (6 attempts × 2.5s); if still `in_progress` after that, resolve to `.stillProcessing` — no background task survives beyond the bounded loop (spec §3).
+- `CustomDomainAttachCommand` gets **zero changes** — purchase success calls `ConnectDomainCommand.recordTransfer(hostname:siteDirectory:)` verbatim, the exact write "I already own a domain" already performs (spec §5).
+- `CloudflareRegistrarReading`/`CloudflareRegistrarWriting` are **new, dedicated protocols** — never add methods to the existing `CloudflareReading`/`CloudflareWriting` protocols (would force five unrelated test fakes to grow stub methods) (spec §2).
+- Search requests cap results at `limit=20` so a single batched `checkDomainAvailability` call covers them all (the API's own per-request cap) (spec §3).
+- Endpoint paths/field names below were confirmed against `https://developers.cloudflare.com/registrar/registrar-api/` on 2026-08-01 (post training-data cutoff) — Task 2's Step 1 re-verifies live before locking in fixture JSON.
+
+---
+
+### Task 1: Share `CloudflareTokenPromptView` between `DeployModel` and the new `BuyDomainModel`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/CloudflareTokenPromptView.swift`
+- Modify: `Sources/AnglesiteApp/DeployModel.swift:106-115` (the `TokenVerification` enum + `tokenVerification` property)
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:587-591` (the `CloudflareTokenPromptView` sheet call site)
+
+**Interfaces:**
+- Consumes: nothing new — this is a pure refactor of existing code.
+- Produces: `CloudflareTokenVerification` (top-level enum, was `DeployModel.TokenVerification`), and `CloudflareTokenPromptView.init(tokenVerification:onSubmit:onCancel:)` — the exact seam Task 5's `BuyDomainModel` will drive.
+
+This is a mechanical refactor with full existing regression coverage (`DeployModel`'s behavior must not change), so there's no new test to write — the "red" step is running the existing suite *before* touching anything to confirm the baseline, then confirming it's still green after.
+
+- [ ] **Step 1: Run the existing DeployModel tests to confirm the baseline passes**
+
+Run: `swift test --package-path . --filter DeployModelTests`
+Expected: all tests PASS (this is the regression net for this refactor).
+
+- [ ] **Step 2: Move `TokenVerification` out of `DeployModel` to a shared top-level type**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, delete the nested enum (currently lines 109-114) and the property declaration on line 115. Replace with:
+
+```swift
+    private(set) var tokenVerification: CloudflareTokenVerification = .idle
+```
+
+(Delete the now-redundant doc comment on lines 106-108 too — it moves to the new type's declaration in Step 3.)
+
+- [ ] **Step 3: Declare the shared type and narrow the view's `init`**
+
+In `Sources/AnglesiteApp/CloudflareTokenPromptView.swift`, add above the `struct CloudflareTokenPromptView` declaration:
+
+```swift
+/// Progress of verifying a pasted Cloudflare token, consumed by `CloudflareTokenPromptView`'s
+/// status line and button-enabled logic. A token is only persisted once verification reaches
+/// `.connected`; a `.failed` state keeps the sheet open and leaves storage untouched. Shared
+/// between every Cloudflare token-prompt flow (`DeployModel`, `BuyDomainModel`) rather than
+/// nested in one model, since the view itself is shared.
+enum CloudflareTokenVerification: Equatable {
+    case idle
+    case checking
+    case connected(accountName: String?)
+    case failed(message: String)
+}
+```
+
+Then change the view's stored properties and `init` from a concrete `DeployModel` to closures. Replace:
+
+```swift
+struct CloudflareTokenPromptView: View {
+    let model: DeployModel
+    let onCancel: () -> Void
+```
+
+with:
+
+```swift
+struct CloudflareTokenPromptView: View {
+    let tokenVerification: CloudflareTokenVerification
+    let onSubmit: (String) async -> Void
+    let onCancel: () -> Void
+```
+
+Update the body's uses of `model.tokenVerification` (the `isInputLocked` computed property and the `status` view) to read `tokenVerification` directly, and update `submit()`:
+
+```swift
+    private func submit() {
+        guard canSubmit else { return }
+        Task { await onSubmit(token) }
+    }
+```
+
+Update the `#Preview` at the bottom of the file:
+
+```swift
+#Preview {
+    CloudflareTokenPromptView(tokenVerification: .idle, onSubmit: { _ in }, onCancel: {})
+}
+```
+
+- [ ] **Step 4: Update `SiteWindow.swift`'s call site**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, replace lines 587-591:
+
+```swift
+        .sheet(isPresented: $bindableModel.deploy.tokenPromptPresented) {
+            CloudflareTokenPromptView(model: model.deploy) {
+                model.deploy.cancelTokenPrompt()
+            }
+        }
+```
+
+with:
+
+```swift
+        .sheet(isPresented: $bindableModel.deploy.tokenPromptPresented) {
+            CloudflareTokenPromptView(
+                tokenVerification: model.deploy.tokenVerification,
+                onSubmit: { await model.deploy.verifyAndSaveToken($0) },
+                onCancel: { model.deploy.cancelTokenPrompt() }
+            )
+        }
+```
+
+- [ ] **Step 5: Build and run the full DeployModel + app test suites**
+
+Run: `swift test --package-path . --filter DeployModelTests`
+Expected: all tests PASS, identical results to Step 1.
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED (confirms `SiteWindow.swift`'s call site and the `#Preview` both compile).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/CloudflareTokenPromptView.swift Sources/AnglesiteApp/DeployModel.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "refactor(#1195): share CloudflareTokenPromptView via closures
+
+Narrows the view off a concrete DeployModel to
+tokenVerification/onSubmit/onCancel so BuyDomainModel (#1195) can
+drive the same prompt for its own no-token case."
+```
+
+---
+
+### Task 2: Registrar search + check reads on `HTTPCloudflareClient`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/CloudflareRegistrarClient.swift`
+- Modify: `Sources/AnglesiteCore/HTTPCloudflareClient.swift`
+- Test: `Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift`
+
+**Interfaces:**
+- Consumes: `HTTPCloudflareClient`'s existing private `get<T>(_:apiToken:as:)` helper and `CFAccount`/`CFEnvelope` types (same file, `private` is file-scoped across extensions of the same type — already relied on by the existing `CloudflareWriting` extension).
+- Produces: `public protocol CloudflareRegistrarReading { func searchDomains(query: String, apiToken: String) async throws -> [String]; func checkDomainAvailability(domains: [String], apiToken: String) async throws -> [RegistrarDomainCheck] }`, `public struct RegistrarDomainCheck: Sendable, Equatable { let name: String; let registrable: Bool; let reason: String?; let registrationCost: String?; let currency: String? }` — both consumed by Task 4's `RegistrarOperations`.
+
+- [ ] **Step 1: Re-verify the live API shape**
+
+Fetch `https://developers.cloudflare.com/registrar/registrar-api/` and confirm: the `GET /accounts/{account_id}/registrar/domain-search?q={query}&limit={n}` path and its result shape (this plan assumes each result is `{"name": "..."}`); the `POST /accounts/{account_id}/registrar/domain-check` path, its `{"domains": [...]}` request body, and its per-domain result shape (`name`, `registrable`, `reason`, `pricing.currency`/`pricing.registration_cost`/`pricing.renewal_cost`). If any field name differs, adjust the private decode structs in Step 3 and the fixture JSON in Step 2 accordingly before proceeding — do not guess past this point.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct HTTPCloudflareClientRegistrarTests {
+    private let accountsJSON = #"{"success":true,"errors":[],"messages":[],"result":[{"id":"acct123"}]}"#
+
+    @Test("searchDomains returns candidate names")
+    func searchReturnsNames() async throws {
+        let searchJSON = """
+        {"success":true,"errors":[],"messages":[],"result":[{"name":"example.dev"},{"name":"example.app"}]}
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-search": (200, searchJSON),
+        ]))
+        let names = try await client.searchDomains(query: "example", apiToken: "t")
+        #expect(names == ["example.dev", "example.app"])
+    }
+
+    @Test("searchDomains surfaces a CloudflareError")
+    func searchSurfacesError() async {
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-search": (403, "{\"success\":false}"),
+        ]))
+        await #expect(throws: CloudflareError.unauthorized) {
+            _ = try await client.searchDomains(query: "example", apiToken: "bad")
+        }
+    }
+
+    @Test("checkDomainAvailability decodes pricing for a registrable domain")
+    func checkRegistrable() async throws {
+        let checkJSON = """
+        {"success":true,"errors":[],"messages":[],"result":[
+            {"name":"example.dev","registrable":true,"pricing":{"currency":"USD","registration_cost":"10.11","renewal_cost":"10.11"}}
+        ]}
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-check": (200, checkJSON),
+        ]))
+        let results = try await client.checkDomainAvailability(domains: ["example.dev"], apiToken: "t")
+        #expect(results == [
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil,
+                                  registrationCost: "10.11", currency: "USD"),
+        ])
+    }
+
+    @Test("checkDomainAvailability decodes the reason for an unregistrable domain")
+    func checkUnregistrable() async throws {
+        let checkJSON = """
+        {"success":true,"errors":[],"messages":[],"result":[
+            {"name":"taken.dev","registrable":false,"reason":"domain_unavailable"}
+        ]}
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/domain-check": (200, checkJSON),
+        ]))
+        let results = try await client.checkDomainAvailability(domains: ["taken.dev"], apiToken: "t")
+        #expect(results == [
+            RegistrarDomainCheck(name: "taken.dev", registrable: false, reason: "domain_unavailable",
+                                  registrationCost: nil, currency: nil),
+        ])
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter HTTPCloudflareClientRegistrarTests`
+Expected: FAIL — `searchDomains`/`checkDomainAvailability`/`RegistrarDomainCheck` don't exist yet (compile error).
+
+- [ ] **Step 4: Create the protocol + public types**
+
+Create `Sources/AnglesiteCore/CloudflareRegistrarClient.swift`:
+
+```swift
+import Foundation
+
+/// One Check result — real-time availability + pricing, or the reason a candidate isn't
+/// registrable. `registrationCost`/`currency` are `nil` exactly when `registrable` is `false`.
+public struct RegistrarDomainCheck: Sendable, Equatable {
+    public let name: String
+    public let registrable: Bool
+    /// Set when `registrable` is `false` — e.g. `domain_unavailable`,
+    /// `extension_not_supported_via_api`, `extension_not_supported`,
+    /// `extension_disallows_registration`.
+    public let reason: String?
+    public let registrationCost: String?
+    public let currency: String?
+
+    public init(name: String, registrable: Bool, reason: String?, registrationCost: String?, currency: String?) {
+        self.name = name
+        self.registrable = registrable
+        self.reason = reason
+        self.registrationCost = registrationCost
+        self.currency = currency
+    }
+}
+
+/// Read-only Cloudflare Registrar API seam (search + check), deliberately separate from
+/// `CloudflareReading` — see this plan's Global Constraints for why. The concrete
+/// `HTTPCloudflareClient` conforms via an extension; tests provide a fake.
+public protocol CloudflareRegistrarReading: Sendable {
+    /// Candidate domain names for a keyword/phrase (cached server-side by Cloudflare). Availability
+    /// and pricing are NOT included — follow up with `checkDomainAvailability`.
+    func searchDomains(query: String, apiToken: String) async throws -> [String]
+    /// Real-time availability + pricing for up to 20 domain names in one call (the API's own cap).
+    func checkDomainAvailability(domains: [String], apiToken: String) async throws -> [RegistrarDomainCheck]
+}
+```
+
+- [ ] **Step 5: Implement the conformance on `HTTPCloudflareClient`**
+
+In `Sources/AnglesiteCore/HTTPCloudflareClient.swift`, add near the other private decode structs (after `private struct CFAccount: Decodable, Sendable { let id: String }`):
+
+```swift
+private struct CFRegistrarSearchResult: Decodable, Sendable {
+    let name: String
+}
+private struct CFRegistrarCheckResult: Decodable, Sendable {
+    let name: String
+    let registrable: Bool
+    let reason: String?
+    let pricing: Pricing?
+    struct Pricing: Decodable, Sendable {
+        let currency: String
+        let registration_cost: String
+        let renewal_cost: String
+    }
+}
+private struct CFRegistrarCheckRequest: Encodable, Sendable {
+    let domains: [String]
+}
+```
+
+Then, at the end of the file (after the existing `extension HTTPCloudflareClient: CloudflareWriting { ... }` block), add a new extension:
+
+```swift
+// MARK: - CloudflareRegistrarReading conformance
+
+extension HTTPCloudflareClient: CloudflareRegistrarReading {
+    /// Resolves the token's first visible account id — every Registrar endpoint is
+    /// account-scoped. Mirrors `workerScriptNames`'s resolution exactly.
+    private func resolveAccountID(apiToken: String) async throws -> String {
+        let accounts = try await get("/accounts?per_page=1", apiToken: apiToken, as: [CFAccount].self)
+        guard let accountID = accounts.first?.id else {
+            throw CloudflareError.api(message: "no Cloudflare account visible to this token")
+        }
+        return accountID
+    }
+
+    /// POST `path` with `body`, decode `CFEnvelope<T>`, return its `result` — like `get`, but for
+    /// POST calls that need the decoded payload back (unlike `mutate`, which only checks success).
+    private func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        _ path: String, body: Body, apiToken: String, as type: T.Type
+    ) async throws -> T {
+        guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        let env: CFEnvelope<T>
+        do {
+            env = try JSONDecoder().decode(CFEnvelope<T>.self, from: data)
+        } catch {
+            throw CloudflareError.malformedResponse
+        }
+        guard env.success else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "request failed")
+        }
+        guard let result = env.result else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "missing result")
+        }
+        return result
+    }
+
+    /// See ``CloudflareRegistrarReading/searchDomains(query:apiToken:)``.
+    public func searchDomains(query: String, apiToken: String) async throws -> [String] {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        let escaped = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+        let results = try await get(
+            "/accounts/\(accountID)/registrar/domain-search?q=\(escaped)&limit=20",
+            apiToken: apiToken, as: [CFRegistrarSearchResult].self)
+        return results.map(\.name)
+    }
+
+    /// See ``CloudflareRegistrarReading/checkDomainAvailability(domains:apiToken:)``.
+    public func checkDomainAvailability(domains: [String], apiToken: String) async throws -> [RegistrarDomainCheck] {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        let results = try await post(
+            "/accounts/\(accountID)/registrar/domain-check",
+            body: CFRegistrarCheckRequest(domains: domains), apiToken: apiToken,
+            as: [CFRegistrarCheckResult].self)
+        return results.map {
+            RegistrarDomainCheck(
+                name: $0.name, registrable: $0.registrable, reason: $0.reason,
+                registrationCost: $0.pricing?.registration_cost, currency: $0.pricing?.currency)
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter HTTPCloudflareClientRegistrarTests`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CloudflareRegistrarClient.swift Sources/AnglesiteCore/HTTPCloudflareClient.swift Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
+git commit -m "feat(#1195): Cloudflare Registrar search + check reads
+
+Adds CloudflareRegistrarReading (search, check) as a dedicated
+protocol, conformed by HTTPCloudflareClient, kept separate from
+CloudflareReading so unrelated fakes don't need stub methods."
+```
+
+---
+
+### Task 3: Registrar `register` write, with the 201/202-and-bounded-poll logic
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/CloudflareRegistrarClient.swift`
+- Modify: `Sources/AnglesiteCore/HTTPCloudflareClient.swift`
+- Modify: `Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift`
+
+**Interfaces:**
+- Consumes: `resolveAccountID(apiToken:)` from Task 2 (same file, `private`, reachable across extensions of the same type).
+- Produces: `public protocol CloudflareRegistrarWriting { func registerDomain(name: String, apiToken: String) async throws -> RegistrarRegistrationOutcome }`, `public enum RegistrarRegistrationOutcome: Sendable, Equatable { case succeeded; case failed(reason: String); case actionRequired; case blocked; case stillProcessing }` — both consumed by Task 4's `RegistrarOperations`.
+
+- [ ] **Step 1: Re-verify the live API shape for `register`**
+
+Confirm against `https://developers.cloudflare.com/registrar/registrar-api/`: `POST /accounts/{account_id}/registrar/registrations` request body (`{"domain_name": "..."}`), the `201`-vs-`202` distinction, the response body's `state` field and its possible values (`in_progress`/`succeeded`/`failed`/`action_required`/`blocked`), and the poll endpoint `GET /accounts/{account_id}/registrar/registrations/{domain}/registration-status`'s response shape (this plan assumes it shares the same `{"state": "..."}` shape as the register response body). Adjust Step 3 if anything differs.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift`, inside the `struct HTTPCloudflareClientRegistrarTests` body:
+
+```swift
+    @Test("registerDomain resolves succeeded on an immediate 201")
+    func registerImmediateSuccess() async throws {
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"succeeded"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .succeeded)
+    }
+
+    @Test("registerDomain maps action_required")
+    func registerActionRequired() async throws {
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"action_required"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .actionRequired)
+    }
+
+    @Test("registerDomain maps blocked")
+    func registerBlocked() async throws {
+        let registerJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"blocked"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (201, registerJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .blocked)
+    }
+
+    @Test("registerDomain maps a 202 that polls straight to succeeded")
+    func registerAsyncThenSucceeds() async throws {
+        let acceptedJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"in_progress"}}"#
+        let statusJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"succeeded"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (202, acceptedJSON),
+            "/registration-status": (200, statusJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .succeeded)
+    }
+
+    @Test("registerDomain resolves stillProcessing when polling never leaves in_progress")
+    func registerAsyncNeverResolves() async throws {
+        let acceptedJSON = #"{"success":true,"errors":[],"messages":[],"result":{"state":"in_progress"}}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/registrar/registrations": (202, acceptedJSON),
+            "/registration-status": (200, acceptedJSON),
+        ]))
+        let outcome = try await client.registerDomain(name: "example.dev", apiToken: "t")
+        #expect(outcome == .stillProcessing)
+    }
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter HTTPCloudflareClientRegistrarTests`
+Expected: FAIL — `registerDomain`/`RegistrarRegistrationOutcome` don't exist yet (compile error). (This will run slowly once implemented, since `registerAsyncNeverResolves` genuinely waits out the poll loop — see Step 5's note.)
+
+- [ ] **Step 4: Add the protocol + outcome type**
+
+In `Sources/AnglesiteCore/CloudflareRegistrarClient.swift`, append:
+
+```swift
+/// The resolved outcome of a `registerDomain` call — the 201-vs-202-and-poll distinction is
+/// already resolved by the time callers see this; no polling primitive is exposed above the
+/// HTTP client.
+public enum RegistrarRegistrationOutcome: Sendable, Equatable {
+    case succeeded
+    case failed(reason: String)
+    case actionRequired
+    case blocked
+    case stillProcessing
+}
+
+/// Write-side Cloudflare Registrar API seam (register), deliberately separate from
+/// `CloudflareWriting` — see this plan's Global Constraints for why.
+public protocol CloudflareRegistrarWriting: Sendable {
+    /// Registers `name` against the token's account. Cloudflare completes most registrations
+    /// synchronously within ~10s; slower ones are polled internally for up to ~15s before
+    /// resolving to `.stillProcessing` — this call always returns a single resolved outcome.
+    func registerDomain(name: String, apiToken: String) async throws -> RegistrarRegistrationOutcome
+}
+```
+
+- [ ] **Step 5: Implement the conformance on `HTTPCloudflareClient`**
+
+In `Sources/AnglesiteCore/HTTPCloudflareClient.swift`, add the decode struct near the other `CFRegistrar*` ones:
+
+```swift
+private struct CFRegistrarRegisterRequest: Encodable, Sendable {
+    let domain_name: String
+}
+/// Shared by the immediate register response body and the poll (`registration-status`) response
+/// body — both report the same `state` field.
+private struct CFRegistrarRegistrationState: Decodable, Sendable {
+    let state: String
+}
+```
+
+Then add a new extension at the end of the file:
+
+```swift
+// MARK: - CloudflareRegistrarWriting conformance
+
+extension HTTPCloudflareClient: CloudflareRegistrarWriting {
+    /// `POST /accounts/{id}/registrar/registrations`. See
+    /// ``CloudflareRegistrarWriting/registerDomain(name:apiToken:)``.
+    public func registerDomain(name: String, apiToken: String) async throws -> RegistrarRegistrationOutcome {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        guard let url = URL(string: Self.base + "/accounts/\(accountID)/registrar/registrations") else {
+            throw CloudflareError.malformedResponse
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(CFRegistrarRegisterRequest(domain_name: name))
+
+        let (data, http) = try await transport(request)
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard http.statusCode == 201 || http.statusCode == 202 else {
+            throw CloudflareError.http(status: http.statusCode)
+        }
+        if http.statusCode == 201 {
+            return try Self.outcome(forState: try Self.decodeState(from: data))
+        }
+        return try await pollRegistrationStatus(domain: name, accountID: accountID, apiToken: apiToken)
+    }
+
+    private static func decodeState(from data: Data) throws -> String {
+        let env: CFEnvelope<CFRegistrarRegistrationState>
+        do {
+            env = try JSONDecoder().decode(CFEnvelope<CFRegistrarRegistrationState>.self, from: data)
+        } catch {
+            throw CloudflareError.malformedResponse
+        }
+        guard env.success, let state = env.result?.state else {
+            throw CloudflareError.api(message: env.errors?.first?.message ?? "missing registration state")
+        }
+        return state
+    }
+
+    private static func outcome(forState state: String) -> RegistrarRegistrationOutcome {
+        switch state {
+        case "succeeded": return .succeeded
+        case "action_required": return .actionRequired
+        case "blocked": return .blocked
+        case "failed": return .failed(reason: "Cloudflare reported the registration failed.")
+        default: return .stillProcessing
+        }
+    }
+
+    /// Polls `registration-status` every 2.5s, up to 6 times (~15s total — matching the API's own
+    /// "synchronous in most cases (10s timeout)" framing with one poll's margin past it). Resolves
+    /// to `.stillProcessing` if `state` never leaves `in_progress` in that window. No task survives
+    /// past this method returning — there is no background/long-lived polling.
+    private func pollRegistrationStatus(
+        domain: String, accountID: String, apiToken: String
+    ) async throws -> RegistrarRegistrationOutcome {
+        for _ in 0..<6 {
+            try? await Task.sleep(for: .milliseconds(2500))
+            let state = try await get(
+                "/accounts/\(accountID)/registrar/registrations/\(domain)/registration-status",
+                apiToken: apiToken, as: CFRegistrarRegistrationState.self)
+            let outcome = Self.outcome(forState: state.state)
+            if case .stillProcessing = outcome { continue }
+            return outcome
+        }
+        return .stillProcessing
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter HTTPCloudflareClientRegistrarTests`
+Expected: all 9 tests PASS. `registerAsyncNeverResolves` takes ~15s (it genuinely waits out 6 polls) — that's expected, not a hang.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CloudflareRegistrarClient.swift Sources/AnglesiteCore/HTTPCloudflareClient.swift Tests/AnglesiteCoreTests/HTTPCloudflareClientRegistrarTests.swift
+git commit -m "feat(#1195): Cloudflare Registrar register write with bounded poll
+
+registerDomain resolves the 201-vs-202 distinction internally,
+polling up to ~15s on a 202 before giving up with .stillProcessing.
+No polling primitive is exposed above the HTTP client."
+```
+
+---
+
+### Task 4: `RegistrarOperationsService` (AnglesiteCore)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/RegistrarOperationsService.swift`
+- Test: `Tests/AnglesiteCoreTests/RegistrarOperationsServiceTests.swift`
+
+**Interfaces:**
+- Consumes: `CloudflareRegistrarReading`/`CloudflareRegistrarWriting`/`RegistrarDomainCheck`/`RegistrarRegistrationOutcome` (Tasks 2-3), `DomainOperations.defaultTokenProvider` (existing, `Sources/AnglesiteCore/DomainOperationsService.swift:98-103`).
+- Produces: `public protocol RegistrarOperationsService: Sendable { func searchDomains(query: String) async -> Result<[String], RegistrarOperationError>; func checkDomainAvailability(domains: [String]) async -> Result<[RegistrarDomainCheck], RegistrarOperationError>; func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError> }`, `public struct RegistrarOperations: RegistrarOperationsService`, `public enum RegistrarOperationError: Error, Equatable, Sendable { case noToken; case cloudflare(CloudflareError) }` — all consumed by Task 5's `BuyDomainModel`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/RegistrarOperationsServiceTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+struct RegistrarOperationsServiceTests {
+    private func service(
+        reader: FakeRegistrarReader = FakeRegistrarReader(),
+        writer: FakeRegistrarWriter = FakeRegistrarWriter(),
+        token: String? = "tok"
+    ) -> RegistrarOperations {
+        RegistrarOperations(reader: reader, writer: writer, tokenProvider: { token })
+    }
+
+    @Test("searchDomains resolves the reader's names")
+    func searchSucceeds() async {
+        let reader = FakeRegistrarReader(searchNames: ["example.dev"])
+        let result = await service(reader: reader).searchDomains(query: "example")
+        guard case .success(let names) = result else { Issue.record("expected success"); return }
+        #expect(names == ["example.dev"])
+        #expect(reader.searchedQuery == "example")
+    }
+
+    @Test("searchDomains fails with .noToken when no token is available")
+    func searchNoToken() async {
+        let result = await service(token: nil).searchDomains(query: "example")
+        guard case .failure(.noToken) = result else { Issue.record("expected .noToken"); return }
+    }
+
+    @Test("searchDomains surfaces a CloudflareError as .cloudflare")
+    func searchCloudflareError() async {
+        let reader = FakeRegistrarReader(searchError: .unauthorized)
+        let result = await service(reader: reader).searchDomains(query: "example")
+        guard case .failure(.cloudflare(.unauthorized)) = result else { Issue.record("expected .cloudflare(.unauthorized)"); return }
+    }
+
+    @Test("checkDomainAvailability resolves the reader's results")
+    func checkSucceeds() async {
+        let reader = FakeRegistrarReader(checkResults: [
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+        ])
+        let result = await service(reader: reader).checkDomainAvailability(domains: ["example.dev"])
+        guard case .success(let checks) = result else { Issue.record("expected success"); return }
+        #expect(checks.count == 1)
+        #expect(reader.checkedDomains == ["example.dev"])
+    }
+
+    @Test("registerDomain resolves the writer's outcome")
+    func registerSucceeds() async {
+        let writer = FakeRegistrarWriter(registerOutcome: .succeeded)
+        let result = await service(writer: writer).registerDomain(name: "example.dev")
+        guard case .success(.succeeded) = result else { Issue.record("expected success(.succeeded)"); return }
+        #expect(writer.registeredName == "example.dev")
+    }
+
+    @Test("registerDomain fails with .noToken when no token is available")
+    func registerNoToken() async {
+        let result = await service(token: nil).registerDomain(name: "example.dev")
+        guard case .failure(.noToken) = result else { Issue.record("expected .noToken"); return }
+    }
+}
+
+// MARK: - Fakes
+
+final class FakeRegistrarReader: CloudflareRegistrarReading, @unchecked Sendable {
+    private let searchNames: [String]
+    private let searchError: CloudflareError?
+    private let checkResults: [RegistrarDomainCheck]
+    private(set) var searchedQuery: String?
+    private(set) var checkedDomains: [String] = []
+
+    init(searchNames: [String] = [], searchError: CloudflareError? = nil, checkResults: [RegistrarDomainCheck] = []) {
+        self.searchNames = searchNames
+        self.searchError = searchError
+        self.checkResults = checkResults
+    }
+
+    func searchDomains(query: String, apiToken: String) async throws -> [String] {
+        searchedQuery = query
+        if let searchError { throw searchError }
+        return searchNames
+    }
+    func checkDomainAvailability(domains: [String], apiToken: String) async throws -> [RegistrarDomainCheck] {
+        checkedDomains = domains
+        return checkResults
+    }
+}
+
+final class FakeRegistrarWriter: CloudflareRegistrarWriting, @unchecked Sendable {
+    private let registerOutcome: RegistrarRegistrationOutcome
+    private(set) var registeredName: String?
+
+    init(registerOutcome: RegistrarRegistrationOutcome = .succeeded) {
+        self.registerOutcome = registerOutcome
+    }
+
+    func registerDomain(name: String, apiToken: String) async throws -> RegistrarRegistrationOutcome {
+        registeredName = name
+        return registerOutcome
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter RegistrarOperationsServiceTests`
+Expected: FAIL — `RegistrarOperationsService`/`RegistrarOperations`/`RegistrarOperationError` don't exist yet (compile error).
+
+- [ ] **Step 3: Implement**
+
+Create `Sources/AnglesiteCore/RegistrarOperationsService.swift`:
+
+```swift
+import Foundation
+
+/// Errors surfaced by `RegistrarOperationsService`. Mirrors `DomainOperationError`'s shape
+/// (minus `.zoneNotFound`, not meaningful for account-scoped Registrar calls).
+public enum RegistrarOperationError: Error, Equatable, Sendable {
+    /// No Cloudflare API token was available from the token provider — the operation never
+    /// reached the network.
+    case noToken
+    /// Any Cloudflare API failure, wrapping the underlying ``CloudflareError``.
+    case cloudflare(CloudflareError)
+}
+
+/// Domain search/check/register operations, centralizing token lookup so `BuyDomainModel`
+/// doesn't do its own — mirrors `DomainOperationsService`'s role for DNS operations.
+public protocol RegistrarOperationsService: Sendable {
+    func searchDomains(query: String) async -> Result<[String], RegistrarOperationError>
+    func checkDomainAvailability(domains: [String]) async -> Result<[RegistrarDomainCheck], RegistrarOperationError>
+    func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError>
+}
+
+/// The production ``RegistrarOperationsService``, backed by the Cloudflare HTTP client. Every
+/// operation re-runs token lookup rather than caching it — mirrors `DomainOperations`'s reasoning.
+public struct RegistrarOperations: RegistrarOperationsService {
+    private let reader: any CloudflareRegistrarReading
+    private let writer: any CloudflareRegistrarWriting
+    private let tokenProvider: @Sendable () -> String?
+
+    public init(
+        reader: any CloudflareRegistrarReading = HTTPCloudflareClient(),
+        writer: any CloudflareRegistrarWriting = HTTPCloudflareClient(),
+        tokenProvider: @escaping @Sendable () -> String? = DomainOperations.defaultTokenProvider
+    ) {
+        self.reader = reader
+        self.writer = writer
+        self.tokenProvider = tokenProvider
+    }
+
+    public func searchDomains(query: String) async -> Result<[String], RegistrarOperationError> {
+        guard let token = tokenProvider() else { return .failure(.noToken) }
+        do {
+            return .success(try await reader.searchDomains(query: query, apiToken: token))
+        } catch let error as CloudflareError {
+            return .failure(.cloudflare(error))
+        } catch {
+            return .failure(.cloudflare(.malformedResponse))
+        }
+    }
+
+    public func checkDomainAvailability(domains: [String]) async -> Result<[RegistrarDomainCheck], RegistrarOperationError> {
+        guard let token = tokenProvider() else { return .failure(.noToken) }
+        do {
+            return .success(try await reader.checkDomainAvailability(domains: domains, apiToken: token))
+        } catch let error as CloudflareError {
+            return .failure(.cloudflare(error))
+        } catch {
+            return .failure(.cloudflare(.malformedResponse))
+        }
+    }
+
+    public func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError> {
+        guard let token = tokenProvider() else { return .failure(.noToken) }
+        do {
+            return .success(try await writer.registerDomain(name: name, apiToken: token))
+        } catch let error as CloudflareError {
+            return .failure(.cloudflare(error))
+        } catch {
+            return .failure(.cloudflare(.malformedResponse))
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter RegistrarOperationsServiceTests`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/RegistrarOperationsService.swift Tests/AnglesiteCoreTests/RegistrarOperationsServiceTests.swift
+git commit -m "feat(#1195): RegistrarOperationsService
+
+Composes CloudflareRegistrarReading/Writing with token lookup,
+mirroring DomainOperationsService's shape and reusing
+DomainOperations.defaultTokenProvider."
+```
+
+---
+
+### Task 5: `BuyDomainModel` (AnglesiteApp)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/BuyDomainModel.swift`
+- Test: `Tests/AnglesiteAppTests/BuyDomainModelTests.swift`
+
+**Interfaces:**
+- Consumes: `RegistrarOperationsService`/`RegistrarDomainCheck`/`RegistrarRegistrationOutcome`/`RegistrarOperationError` (Task 4), `CloudflareTokenVerification` (Task 1), `TokenOnboarding`/`TokenVerifying`/`CloudflareAPITokenVerifier` (existing, `AnglesiteCore`), `KeychainStore` (existing), `ConnectDomainCommand.recordTransfer(hostname:siteDirectory:)` (existing, `Sources/AnglesiteCore/ConnectDomainCommand.swift:23-26`), `CurrentSite` (existing).
+- Produces: `BuyDomainModel` (`@Observable @MainActor`) with `phase: Phase`, `sheetPresented: Bool`, `queryInput: String`, `tokenPromptPresented: Bool`, `tokenVerification: CloudflareTokenVerification`, `configure(site:)`, `openSheet()`, `dismissSheet()`, `submitSearch()`, `selectCandidate(_:)`, `cancelConfirm()`, `confirmPurchase()`, `verifyAndSaveToken(_:)`, `cancelTokenPrompt()`, `static let cloudflareDomainsURL` — all consumed by Task 6's `BuyDomainSheetView` and Task 7's wiring.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteAppTests/BuyDomainModelTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@MainActor
+@Suite struct BuyDomainModelTests {
+    private func makeSite() throws -> (site: CurrentSite, dir: URL) {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        return (CurrentSite(id: "s1", packageURL: tmp, sourceDirectory: tmp), tmp)
+    }
+
+    @Test func happyPathSearchThenPurchaseRecordsTransferIntent() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["example.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+        ]))
+        await ops.setRegisterResult(.success(.succeeded))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+
+        guard case .results(_, let candidates) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)"); return
+        }
+        #expect(candidates.count == 1)
+        #expect(candidates[0].registrable)
+        #expect(candidates[0].priceDisplay == "$10.11/yr")
+
+        model.selectCandidate(candidates[0])
+        guard case .confirming(let candidate) = model.phase else {
+            Issue.record("expected .confirming, got \(model.phase)"); return
+        }
+
+        model.confirmPurchase()
+        repeat { await Task.yield() } while model.isRunning
+
+        #expect(model.phase == .purchased(hostname: "example.dev"))
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(config.contains("DOMAIN_CHOICE=transfer"))
+        #expect(config.contains("DOMAIN=example.dev"))
+        _ = candidate
+    }
+
+    @Test func unregistrableCandidateCannotBeSelected() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["taken.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "taken.dev", registrable: false, reason: "domain_unavailable", registrationCost: nil, currency: nil),
+        ]))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+
+        model.queryInput = "taken"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+
+        guard case .results(_, let candidates) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)"); return
+        }
+        model.selectCandidate(candidates[0])
+        #expect(model.phase == .results(query: "taken", candidates: candidates))
+    }
+
+    @Test func registerOutcomeActionRequiredDoesNotPersist() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.success(["example.dev"]))
+        await ops.setCheckResult(.success([
+            RegistrarDomainCheck(name: "example.dev", registrable: true, reason: nil, registrationCost: "10.11", currency: "USD"),
+        ]))
+        await ops.setRegisterResult(.success(.actionRequired))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+        guard case .results(_, let candidates) = model.phase else { Issue.record("expected .results"); return }
+        model.selectCandidate(candidates[0])
+        model.confirmPurchase()
+        repeat { await Task.yield() } while model.isRunning
+
+        #expect(model.phase == .needsAccountSetup(hostname: "example.dev"))
+        #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent(".site-config").path))
+    }
+
+    @Test func noTokenPresentsTokenPromptAndRecordsPendingQuery() async throws {
+        let ops = FakeRegistrarOps()
+        await ops.setSearchResult(.failure(.noToken))
+
+        let model = BuyDomainModel(ops: ops)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        model.openSheet()
+        model.queryInput = "example"
+        model.submitSearch()
+        repeat { await Task.yield() } while model.isRunning
+
+        #expect(model.tokenPromptPresented)
+    }
+}
+
+// MARK: - Fakes
+
+private actor FakeRegistrarOps: RegistrarOperationsService {
+    private var searchResult: Result<[String], RegistrarOperationError> = .success([])
+    private var checkResult: Result<[RegistrarDomainCheck], RegistrarOperationError> = .success([])
+    private var registerResult: Result<RegistrarRegistrationOutcome, RegistrarOperationError> = .success(.succeeded)
+
+    func setSearchResult(_ r: Result<[String], RegistrarOperationError>) { searchResult = r }
+    func setCheckResult(_ r: Result<[RegistrarDomainCheck], RegistrarOperationError>) { checkResult = r }
+    func setRegisterResult(_ r: Result<RegistrarRegistrationOutcome, RegistrarOperationError>) { registerResult = r }
+
+    func searchDomains(query: String) async -> Result<[String], RegistrarOperationError> { searchResult }
+    func checkDomainAvailability(domains: [String]) async -> Result<[RegistrarDomainCheck], RegistrarOperationError> { checkResult }
+    func registerDomain(name: String) async -> Result<RegistrarRegistrationOutcome, RegistrarOperationError> { registerResult }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter BuyDomainModelTests`
+Expected: FAIL — `BuyDomainModel` doesn't exist yet (compile error).
+
+- [ ] **Step 3: Implement**
+
+Create `Sources/AnglesiteApp/BuyDomainModel.swift`:
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// Drives the "Buy a Domain" sheet (#1195): search → price → confirm → purchase, reached from
+/// `ConnectDomainSheetView`'s "Buy a domain" button. A successful purchase records the exact same
+/// `DOMAIN_CHOICE=transfer` intent "I already own a domain" does (`ConnectDomainCommand
+/// .recordTransfer`) — a Cloudflare-registered domain needs identical Workers Custom Domain
+/// attach logic to a nameserver-delegated one, so `CustomDomainAttachCommand` needs no changes.
+@MainActor
+@Observable
+final class BuyDomainModel {
+    struct DomainCandidate: Equatable, Identifiable {
+        var id: String { name }
+        let name: String
+        let registrable: Bool
+        let reason: String?
+        let priceDisplay: String?
+    }
+
+    enum Phase: Equatable {
+        case searching(query: String)
+        case loadingResults(query: String)
+        case results(query: String, candidates: [DomainCandidate])
+        case confirming(candidate: DomainCandidate)
+        case purchasing(candidate: DomainCandidate)
+        case purchased(hostname: String)
+        case needsAccountSetup(hostname: String)
+        case stillProcessing(hostname: String)
+        case failed(reason: String)
+    }
+
+    private(set) var phase: Phase = .searching(query: "")
+    var sheetPresented: Bool = false
+    var queryInput: String = ""
+
+    /// Progress of the nested token-prompt sheet, shown when a search hits `.noToken`. Presented
+    /// by `BuyDomainSheetView` itself (a sheet stacked on the already-open purchase sheet), not by
+    /// `SiteWindow` — see that view's doc comment.
+    var tokenPromptPresented: Bool = false
+    private(set) var tokenVerification: CloudflareTokenVerification = .idle
+    /// The query `submitSearch()` was trying to run when `.noToken` interrupted it — re-run once
+    /// the prompt reports `.proceed`.
+    private var pendingSearchQuery: String?
+
+    static let cloudflareDomainsURL = ConnectDomainModel.cloudflareDomainsURL
+
+    private let ops: any RegistrarOperationsService
+    private let keychain: KeychainStore
+    private let onboarding: TokenOnboarding
+    private var currentSite: CurrentSite?
+    private var inFlight: Task<Void, Never>?
+
+    init(
+        ops: any RegistrarOperationsService = RegistrarOperations(),
+        keychain: KeychainStore = KeychainStore(),
+        verifier: TokenVerifying = CloudflareAPITokenVerifier()
+    ) {
+        self.ops = ops
+        self.keychain = keychain
+        self.onboarding = TokenOnboarding(verifier: verifier)
+    }
+
+    func configure(site: CurrentSite) {
+        currentSite = site
+    }
+
+    var isRunning: Bool {
+        switch phase {
+        case .loadingResults, .purchasing: return true
+        default: return false
+        }
+    }
+
+    func openSheet() {
+        guard !isRunning else { return }
+        phase = .searching(query: "")
+        queryInput = ""
+        sheetPresented = true
+    }
+
+    func dismissSheet() {
+        inFlight?.cancel()
+        inFlight = nil
+        sheetPresented = false
+    }
+
+    func submitSearch() {
+        let query = queryInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty, !isRunning else { return }
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runSearch(query: query)
+        }
+    }
+
+    func selectCandidate(_ candidate: DomainCandidate) {
+        guard candidate.registrable, case .results = phase else { return }
+        phase = .confirming(candidate: candidate)
+    }
+
+    func cancelConfirm() {
+        guard case .confirming = phase else { return }
+        phase = .searching(query: queryInput)
+    }
+
+    func confirmPurchase() {
+        guard case .confirming(let candidate) = phase, !isRunning else { return }
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runPurchase(candidate: candidate)
+        }
+    }
+
+    /// Called by the token-prompt sheet's submit action, mirroring `DeployModel.verifyAndSaveToken`
+    /// exactly (same `TokenOnboarding` ordering, same `isCancelled` shape) — the only difference is
+    /// what "proceed" means: re-running the parked search instead of starting a deploy.
+    func verifyAndSaveToken(_ token: String) async {
+        guard let query = pendingSearchQuery else {
+            tokenVerification = .failed(message: "No search is waiting — close this and search again.")
+            return
+        }
+        tokenVerification = .checking
+        let outcome = await onboarding.run(
+            token: token,
+            siteDirectory: currentSite?.sourceDirectory ?? FileManager.default.temporaryDirectory,
+            persist: { try keychain.writeCloudflareToken($0) },
+            onConnected: { tokenVerification = .connected(accountName: $0.name) },
+            delay: { try? await Task.sleep(for: .milliseconds(700)) },
+            isCancelled: { Task.isCancelled || !tokenPromptPresented }
+        )
+        switch outcome {
+        case .proceed:
+            pendingSearchQuery = nil
+            tokenPromptPresented = false
+            tokenVerification = .idle
+            queryInput = query
+            submitSearch()
+        case .stay(let message):
+            tokenVerification = .failed(message: message)
+        case .abort:
+            tokenVerification = .idle
+        }
+    }
+
+    func cancelTokenPrompt() {
+        pendingSearchQuery = nil
+        tokenPromptPresented = false
+        tokenVerification = .idle
+    }
+
+    // MARK: - Private
+
+    private func runSearch(query: String) async {
+        phase = .loadingResults(query: query)
+        switch await ops.searchDomains(query: query) {
+        case .failure(.noToken):
+            pendingSearchQuery = query
+            tokenVerification = .idle
+            tokenPromptPresented = true
+            phase = .searching(query: query)
+        case .failure(let error):
+            phase = .failed(reason: message(for: error))
+        case .success(let names):
+            guard !names.isEmpty else {
+                phase = .results(query: query, candidates: [])
+                return
+            }
+            switch await ops.checkDomainAvailability(domains: names) {
+            case .failure(let error):
+                phase = .failed(reason: message(for: error))
+            case .success(let checks):
+                let candidates = checks.map {
+                    DomainCandidate(
+                        name: $0.name, registrable: $0.registrable, reason: $0.reason,
+                        priceDisplay: Self.priceDisplay(cost: $0.registrationCost, currency: $0.currency))
+                }
+                phase = .results(query: query, candidates: candidates)
+            }
+        }
+    }
+
+    private func runPurchase(candidate: DomainCandidate) async {
+        phase = .purchasing(candidate: candidate)
+        guard let site = currentSite else {
+            phase = .failed(reason: "No site is open.")
+            return
+        }
+        switch await ops.registerDomain(name: candidate.name) {
+        case .failure(let error):
+            phase = .failed(reason: message(for: error))
+        case .success(.succeeded):
+            ConnectDomainCommand.recordTransfer(hostname: candidate.name, siteDirectory: site.sourceDirectory)
+            phase = .purchased(hostname: candidate.name)
+        case .success(.failed(let reason)):
+            phase = .failed(reason: reason)
+        case .success(.actionRequired), .success(.blocked):
+            phase = .needsAccountSetup(hostname: candidate.name)
+        case .success(.stillProcessing):
+            phase = .stillProcessing(hostname: candidate.name)
+        }
+    }
+
+    private func message(for error: RegistrarOperationError) -> String {
+        switch error {
+        case .noToken:
+            return "No Cloudflare API token found. Add one in Settings → Credentials."
+        case .cloudflare(let cfError):
+            switch cfError {
+            case .unauthorized:
+                return "API token is unauthorized. Check that it has Registrar permissions."
+            case .http(let status):
+                return "Cloudflare API returned HTTP \(status)."
+            case .api(let msg):
+                return "Cloudflare API error: \(msg)"
+            case .malformedResponse:
+                return "Unexpected response from Cloudflare API."
+            }
+        }
+    }
+
+    private static func priceDisplay(cost: String?, currency: String?) -> String? {
+        guard let cost else { return nil }
+        if currency == "USD" { return "$\(cost)/yr" }
+        if let currency { return "\(currency) \(cost)/yr" }
+        return "\(cost)/yr"
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter BuyDomainModelTests`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/BuyDomainModel.swift Tests/AnglesiteAppTests/BuyDomainModelTests.swift
+git commit -m "feat(#1195): BuyDomainModel
+
+Search -> confirm -> purchase phase machine. A successful purchase
+reuses ConnectDomainCommand.recordTransfer verbatim (spec #1195 §5)
+so CustomDomainAttachCommand needs no changes. A .noToken search
+opens the shared CloudflareTokenPromptView and resumes the search
+once a token is saved."
+```
+
+---
+
+### Task 6: `BuyDomainSheetView` (AnglesiteApp)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/BuyDomainSheetView.swift`
+
+**Interfaces:**
+- Consumes: `BuyDomainModel` (Task 5), `CloudflareTokenPromptView` (Task 1).
+- Produces: `struct BuyDomainSheetView: View` — `init(model: BuyDomainModel)` — consumed by Task 7's `SiteWindow.swift` wiring.
+
+No dedicated unit tests — matches this codebase's existing convention (`ConnectDomainSheetView`/`DomainSheetView` have no view-level tests; only their models do, covered by Task 5). Verification is build success (Step 2) plus Task 7's manual pass.
+
+- [ ] **Step 1: Implement**
+
+Create `Sources/AnglesiteApp/BuyDomainSheetView.swift`:
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// The "Buy a Domain" sheet (#1195): search, price, confirm, purchase. Reached from
+/// `ConnectDomainSheetView`'s "Buy a domain" button.
+struct BuyDomainSheetView: View {
+    @Bindable var model: BuyDomainModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+                .padding(20)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Divider()
+            footer
+        }
+        .frame(width: 480)
+        .fixedSize(horizontal: false, vertical: true)
+        // Stacked on top of this already-open sheet (not a sibling `.sheet` on `SiteWindow`,
+        // which can't reliably present two sheets from the same presentation context at once).
+        .sheet(isPresented: $model.tokenPromptPresented) {
+            CloudflareTokenPromptView(
+                tokenVerification: model.tokenVerification,
+                onSubmit: { await model.verifyAndSaveToken($0) },
+                onCancel: { model.cancelTokenPrompt() }
+            )
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.title)
+                .foregroundStyle(.blue)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Buy a Domain").font(.title3).fontWeight(.semibold)
+                Text("Search, price, and register a domain through Cloudflare.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .searching:
+            VStack(alignment: .leading, spacing: 12) {
+                searchField(buttonTitle: "Search")
+                escapeHatch
+            }
+
+        case .loadingResults:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Searching…").foregroundStyle(.secondary)
+            }
+
+        case .results(_, let candidates):
+            VStack(alignment: .leading, spacing: 12) {
+                if candidates.isEmpty {
+                    Text("No results. Try a different search.").foregroundStyle(.secondary)
+                } else {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(candidates) { candidateRow($0) }
+                        }
+                    }
+                    .frame(maxHeight: 280)
+                }
+                searchField(buttonTitle: "Search Again")
+                escapeHatch
+            }
+
+        case .confirming(let candidate):
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Buy \(candidate.name) for \(candidate.priceDisplay ?? "an unknown price")?")
+                    .font(.headline)
+                Text("This charges the payment method on file for your connected Cloudflare account.")
+                    .font(.caption).foregroundStyle(.secondary)
+                HStack {
+                    Button("Cancel") { model.cancelConfirm() }
+                    Spacer()
+                    Button("Buy \(candidate.name)") { model.confirmPurchase() }
+                        .buttonStyle(.borderedProminent)
+                        .keyboardShortcut(.defaultAction)
+                }
+            }
+
+        case .purchasing:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Purchasing…").foregroundStyle(.secondary)
+            }
+
+        case .purchased(let hostname):
+            Label("We'll connect \(hostname) on your next Publish.", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+
+        case .needsAccountSetup(let hostname):
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Finish setting up billing for \(hostname) in the Cloudflare dashboard, then come back and try again.")
+                escapeHatch
+            }
+
+        case .stillProcessing(let hostname):
+            Text("Still processing \(hostname). Once it finishes, come back and use “I already own a domain” with \(hostname) to connect it.")
+
+        case .failed(let reason):
+            VStack(alignment: .leading, spacing: 8) {
+                Text(reason).foregroundStyle(.red)
+                escapeHatch
+            }
+        }
+    }
+
+    private func searchField(buttonTitle: String) -> some View {
+        HStack {
+            TextField("example", text: $model.queryInput)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { model.submitSearch() }
+            Button(buttonTitle) { model.submitSearch() }
+                .disabled(model.queryInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    private var escapeHatch: some View {
+        Link("Buy directly on the Cloudflare dashboard instead", destination: BuyDomainModel.cloudflareDomainsURL)
+            .font(.caption)
+    }
+
+    @ViewBuilder
+    private func candidateRow(_ candidate: BuyDomainModel.DomainCandidate) -> some View {
+        Button {
+            model.selectCandidate(candidate)
+        } label: {
+            HStack {
+                Text(candidate.name)
+                Spacer()
+                if candidate.registrable {
+                    Text(candidate.priceDisplay ?? "")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(candidate.reason ?? "unavailable")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!candidate.registrable)
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Close") { model.dismissSheet() }
+            Spacer()
+        }
+        .padding(16)
+    }
+}
+
+#Preview {
+    BuyDomainSheetView(model: BuyDomainModel())
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/BuyDomainSheetView.swift
+git commit -m "feat(#1195): BuyDomainSheetView
+
+Search field, results list with price/reason, confirm step,
+purchasing spinner, and terminal states for BuyDomainModel's phase
+machine. Nests the shared CloudflareTokenPromptView as its own
+stacked sheet for the .noToken case."
+```
+
+---
+
+### Task 7: Wire it up — `SiteWindowModel`, `SiteWindow`, `ConnectDomainSheetView`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:153-157` (property declarations), `:1925-1927` (configure call sites)
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:653-655` (the `ConnectDomainSheetView` sheet)
+- Modify: `Sources/AnglesiteApp/ConnectDomainSheetView.swift`
+
+**Interfaces:**
+- Consumes: `BuyDomainModel`/`BuyDomainSheetView` (Tasks 5-6), `ConnectDomainModel`/`ConnectDomainSheetView` (existing, unchanged behavior).
+- Produces: nothing new consumed elsewhere — this is the final integration task.
+
+`ConnectDomainModel.chooseBuy()` keeps recording its existing `DOMAIN_CHOICE=buy` intent marker exactly as it does today (`ConnectDomainModelTests.chooseBuyRecordsIntentAndDismisses` needs zero changes) — the only change is that the button that calls it *also* opens the new search sheet, via a new view-layer callback, instead of opening a browser link directly. This keeps `ConnectDomainModel` and `BuyDomainModel` fully decoupled — neither model knows the other exists.
+
+- [ ] **Step 1: Add `onBuyDomain` to `ConnectDomainSheetView`**
+
+In `Sources/AnglesiteApp/ConnectDomainSheetView.swift`, add a property and use it in the "Buy a domain" button. Change:
+
+```swift
+struct ConnectDomainSheetView: View {
+    @Bindable var model: ConnectDomainModel
+```
+
+to:
+
+```swift
+struct ConnectDomainSheetView: View {
+    @Bindable var model: ConnectDomainModel
+    /// Opens the in-app search/purchase sheet (#1195) — called from the view layer (not chained
+    /// inside `ConnectDomainModel`) so this model and `BuyDomainModel` stay fully decoupled,
+    /// matching how `DeployDrawerView`'s first-publish nudge opens `connectDomain.openSheet()`
+    /// directly rather than teaching `DeployModel` about `ConnectDomainModel`.
+    let onBuyDomain: () -> Void
+```
+
+Then change the "Buy a domain" button (in the `.choosing` case of `content`) from:
+
+```swift
+                Button {
+                    NSWorkspace.shared.open(ConnectDomainModel.cloudflareDomainsURL)
+                    model.chooseBuy()
+                } label: {
+                    Label("Buy a domain", systemImage: "cart")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.bordered)
+```
+
+to:
+
+```swift
+                Button {
+                    model.chooseBuy()
+                    onBuyDomain()
+                } label: {
+                    Label("Buy a domain", systemImage: "cart")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.bordered)
+```
+
+(The direct `NSWorkspace.shared.open` call is removed — `BuyDomainSheetView` has its own "Buy directly on the Cloudflare dashboard instead" escape-hatch link now, so the browser no longer opens automatically on every "Buy a domain" click. That call was the file's only use of AppKit, so also delete the now-unused `import AppKit` line at the top of `ConnectDomainSheetView.swift`, leaving just `import SwiftUI`.)
+
+- [ ] **Step 2: Add `buyDomain` to `SiteWindowModel`**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, near line 157 (right after `var connectDomain = ConnectDomainModel()`), add:
+
+```swift
+    var buyDomain = BuyDomainModel()
+```
+
+Near line 1927 (right after `connectDomain.configure(site: currentSite)`), add:
+
+```swift
+        buyDomain.configure(site: currentSite)
+```
+
+- [ ] **Step 3: Register the sheet and update the `ConnectDomainSheetView` call site**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, replace lines 653-655:
+
+```swift
+        .sheet(isPresented: $bindableModel.connectDomain.sheetPresented) {
+            ConnectDomainSheetView(model: model.connectDomain)
+        }
+```
+
+with:
+
+```swift
+        .sheet(isPresented: $bindableModel.connectDomain.sheetPresented) {
+            ConnectDomainSheetView(model: model.connectDomain, onBuyDomain: { model.buyDomain.openSheet() })
+        }
+        .sheet(isPresented: $bindableModel.buyDomain.sheetPresented) {
+            BuyDomainSheetView(model: model.buyDomain)
+        }
+```
+
+- [ ] **Step 4: Run the full app test suite**
+
+Run: `swift test --package-path . --filter ConnectDomainModelTests`
+Expected: all tests PASS unchanged (confirms `chooseBuy()`'s own behavior wasn't touched).
+
+Run: `swift test --package-path .`
+Expected: full suite PASSES (this also exercises the earlier tasks' tests together for the first time).
+
+- [ ] **Step 5: Build the app**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 6: Manual verification**
+
+Launch the built app (`open` the built `.app`, or run from Xcode), open or create a site, and:
+1. Publish once (or use `Website ▸ Connect a Domain…` if already published) to reach the Connect a Domain sheet.
+2. Click "Buy a domain" — confirm `BuyDomainSheetView` opens (not a browser tab).
+3. With no Cloudflare token configured, search a keyword — confirm the token prompt sheet appears stacked on top, and that saving a valid token resumes the search automatically.
+4. With a token configured, search a keyword — confirm results show a price for available names and a grayed-out reason for unavailable ones.
+5. Select an available result — confirm the price-confirmation step, then either complete a purchase or cancel out.
+6. Confirm the "Buy directly on the Cloudflare dashboard instead" link works from the search screen and from a failed/needs-setup state.
+7. If a purchase completes, confirm `.site-config` has `DOMAIN_CHOICE=transfer` + `DOMAIN=<hostname>` and `Source/anglesite.json`'s `domain` section matches.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ConnectDomainSheetView.swift Sources/AnglesiteApp/SiteWindowModel.swift Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(#1195): wire BuyDomainSheetView into Connect a Domain
+
+\"Buy a domain\" now opens the in-app search/purchase sheet instead
+of a bare Cloudflare Domains link-out. ConnectDomainModel and
+BuyDomainModel stay decoupled — the view layer wires them together."
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** §1 (entry point) → Task 7 Step 1/3. §2 (architecture) → Tasks 2-5. §3 (phase machine/data flow) → Task 5, rendered by Task 6. §4 (error handling) → Task 5's `message(for:)` + `.noToken` branch, Task 6's `escapeHatch`. §5 (reuse transfer write) → Task 5's `runPurchase`. §6 (no-token handling) → Task 1 + Task 5's `verifyAndSaveToken`/`tokenPromptPresented`. §7 (code shape) → matches Tasks 1-7's file lists exactly. §8 (testing) → each task's Test file, with one intentional narrowing noted below.
+
+**Deliberate scope trim vs. spec §8:** the spec's testing section says `needsToken` phase "resumes the pending search on `TokenOnboarding.Outcome.proceed`" should be tested. Task 5 tests only the *trigger* (`.noToken` → `tokenPromptPresented`), not the full resume-after-verify path, because `verifyAndSaveToken` is a structural copy of `DeployModel.verifyAndSaveToken` (same `TokenOnboarding.run` call, same closures), and `TokenOnboarding`'s own ordering (verify → persist → flash → re-check-cancel → proceed) is already thoroughly covered by `Tests/AnglesiteCoreTests/TokenOnboardingTests.swift`. Re-testing that ordering here through a real `TokenVerifying` fake plus a scratch `KeychainStore` would duplicate existing coverage for marginal value. If a reviewer wants the full path covered explicitly, add it as a follow-up test using the same `KeychainStore(service:)` scratch-service pattern `Tests/AnglesiteCoreTests/KeychainStoreTests.swift` already establishes.
+
+**Placeholder scan:** none — every step has complete code or an exact command.
+
+**Type consistency:** `RegistrarDomainCheck`, `RegistrarRegistrationOutcome`, `RegistrarOperationError`, `RegistrarOperationsService`, `CloudflareRegistrarReading`/`Writing`, `CloudflareTokenVerification`, `BuyDomainModel.DomainCandidate`/`Phase` are each defined once (Tasks 2-5) and consumed with identical signatures in every later task — cross-checked while drafting.

--- a/docs/superpowers/specs/2026-08-01-registrar-search-purchase-design.md
+++ b/docs/superpowers/specs/2026-08-01-registrar-search-purchase-design.md
@@ -1,6 +1,6 @@
 # In-app domain search + purchase via Cloudflare Registrar API (#1195)
 
-**Status:** Approved design, not yet implemented.
+**Status:** Approved design, implemented.
 **Issue:** [#1195](https://github.com/Anglesite/Anglesite/issues/1195)
 **Follow-up to:** `docs/superpowers/specs/2026-07-31-publish-time-domain-step-design.md` (#1180) ▸ Follow-ups §2
 **Spun off:** [#1204](https://github.com/Anglesite/Anglesite/issues/1204) — porting Cloudflare OAuth to macOS (see §6)

--- a/docs/superpowers/specs/2026-08-01-registrar-search-purchase-design.md
+++ b/docs/superpowers/specs/2026-08-01-registrar-search-purchase-design.md
@@ -94,16 +94,24 @@ whose domain needs a TLD the beta API doesn't support yet.
 Three new pieces, mirroring the existing `DomainModel` → `DomainOperationsService` →
 `HTTPCloudflareClient` layering used for DNS record management:
 
-- **`HTTPCloudflareClient`** gains `searchDomains`/`checkDomainAvailability` on
-  `CloudflareReading` and `registerDomain` on `CloudflareWriting`. `registerDomain` owns the
-  201-vs-202-and-poll distinction internally (see §3's bounded poll) so every caller above it
-  sees one `async throws` call returning a single resolved outcome — no polling primitive is
-  exposed at any layer above the HTTP client, matching how every other method on this client is a
-  self-contained one-shot call.
+- **`HTTPCloudflareClient`** gains conformance to two new, dedicated protocols —
+  `CloudflareRegistrarReading` (`searchDomains`, `checkDomainAvailability`) and
+  `CloudflareRegistrarWriting` (`registerDomain`) — via an extension, the same way the file
+  already conforms to `CloudflareWriting` in its own extension. These are deliberately *not*
+  added to the existing `CloudflareReading`/`CloudflareWriting` protocols: five unrelated test
+  fakes (`DomainConfigAuditModelTests`, `OnionRoutingModelTests`, `HardenExecutorTests`,
+  `DeployModelTests`, `CustomDomainAttachCommandTests`) conform to those today, and extending
+  them would force every one of those files to grow stub methods for a feature they have nothing
+  to do with. `registerDomain` owns the 201-vs-202-and-poll distinction internally (see §3's
+  bounded poll) so every caller above it sees one `async throws` call returning a single resolved
+  outcome — no polling primitive is exposed at any layer above the HTTP client, matching how every
+  other method on this client is a self-contained one-shot call.
 - **`RegistrarOperationsService`** (protocol) + **`RegistrarOperations`** (prod impl), new files
-  in `AnglesiteCore`, composing a `reader`/`writer`/`tokenProvider` exactly like
-  `DomainOperationsService`/`DomainOperations`. New `RegistrarOperationError`: `.noToken`,
-  `.cloudflare(CloudflareError)` — two cases, no `zoneNotFound` (not meaningful here).
+  in `AnglesiteCore`, composing a `reader: any CloudflareRegistrarReading` /
+  `writer: any CloudflareRegistrarWriting` / `tokenProvider` exactly like
+  `DomainOperationsService`/`DomainOperations`'s composition shape (different protocols, same
+  pattern). New `RegistrarOperationError`: `.noToken`, `.cloudflare(CloudflareError)` — two
+  cases, no `zoneNotFound` (not meaningful here).
 - **`BuyDomainModel`** (`@Observable @MainActor`, new) + **`BuyDomainSheetView`** (new), in
   `AnglesiteApp`. Added to `SiteWindowModel` as `var buyDomain = BuyDomainModel()`, configured
   with `CurrentSite` the same way `domain`/`harden`/`connectDomain` are.
@@ -220,11 +228,13 @@ Porting actual OAuth sign-in to macOS (replacing this token-paste flow) is out o
 
 ### 7. Code shape
 
-- **`Sources/AnglesiteCore/HTTPCloudflareClient.swift`**: add `searchDomains`,
-  `checkDomainAvailability` to `CloudflareReading`; `registerDomain` to `CloudflareWriting`. New
-  private `CFRegistrar*` decode structs alongside the existing `CF*` ones. `registerDomain`
-  internally issues the `POST`, branches on `201` vs `202`, and — for `202` — polls the
-  registration-status endpoint per §3's bounded loop before returning.
+- **`Sources/AnglesiteCore/CloudflareRegistrarClient.swift`** (new): the
+  `CloudflareRegistrarReading`/`CloudflareRegistrarWriting` protocols (§2) plus the
+  `DomainCandidate`-adjacent wire types (`RegistrarDomainCheck`, `RegistrarRegistrationOutcome`).
+- **`Sources/AnglesiteCore/HTTPCloudflareClient.swift`**: new extension conforming to both new
+  protocols. New private `CFRegistrar*` decode structs alongside the existing `CF*` ones.
+  `registerDomain` internally issues the `POST`, branches on `201` vs `202`, and — for `202` —
+  polls the registration-status endpoint per §3's bounded loop before returning.
 - **`Sources/AnglesiteCore/RegistrarOperationsService.swift`** (new): protocol + `RegistrarOperations`.
 - **`Sources/AnglesiteApp/CloudflareTokenPromptView.swift`**: narrowed init per §6; `DeployModel`
   call site updated.

--- a/docs/superpowers/specs/2026-08-01-registrar-search-purchase-design.md
+++ b/docs/superpowers/specs/2026-08-01-registrar-search-purchase-design.md
@@ -1,0 +1,269 @@
+# In-app domain search + purchase via Cloudflare Registrar API (#1195)
+
+**Status:** Approved design, not yet implemented.
+**Issue:** [#1195](https://github.com/Anglesite/Anglesite/issues/1195)
+**Follow-up to:** `docs/superpowers/specs/2026-07-31-publish-time-domain-step-design.md` (#1180) ▸ Follow-ups §2
+**Spun off:** [#1204](https://github.com/Anglesite/Anglesite/issues/1204) — porting Cloudflare OAuth to macOS (see §6)
+
+## Problem
+
+#1180 shipped `ConnectDomainSheetView`/`ConnectDomainModel`: a "Buy a domain" button that
+opens `https://www.cloudflare.com/products/registrar/` in the browser and records a
+`DOMAIN_CHOICE=buy` intent marker, with no further app involvement. That was the deliberate
+placeholder — Cloudflare's Registrar API was still beta at the time, and `register` needs a
+billing profile + payment method + registrant contact + Domain Registration Agreement
+acceptance already on file for the account, none of which have an API. Anglesite must never
+collect, proxy, or auto-fill payment/card details on the owner's behalf.
+
+Search and real-time pricing, however, are fully embeddable today with no hand-off needed, and
+`register` itself can run entirely in-app for any account that's already completed that
+one-time Cloudflare-dashboard setup trip. This issue replaces the placeholder link-out with a
+real search → price → purchase flow, detecting the "needs dashboard setup" case by attempting
+`register` and mapping its outcome, rather than trying to probe billing state directly.
+
+## Goals
+
+- Search domain name candidates from a keyword/phrase, with real-time availability and pricing.
+- Purchase a domain in-app for accounts that already have Cloudflare billing/registrant/ToS set
+  up, reusing the existing "I already own a domain" attach machinery once purchased (a
+  Cloudflare-registered zone and a nameserver-delegated one need identical Workers Custom Domain
+  attach logic).
+- Detect the "this account needs a one-time Cloudflare-dashboard trip first" case by attempting
+  `register` and mapping `action_required`/`blocked` outcomes to a clear hand-off message,
+  rather than a confusing generic failure.
+- Never collect, store, or proxy payment/card details.
+
+## Non-goals
+
+- Renewals or transfers via the Registrar API (not available upstream yet).
+- Registrant-contact management beyond what a purchase requires (there is no API for it either).
+- Domain registrar/expiration tracking for already-connected domains — that's #1194, a distinct
+  capability with its own design.
+- Porting Cloudflare OAuth sign-in to macOS. `CloudflareOAuthClient`/its callback Worker (#890,
+  #891) were built for the **`AnglesiteMobile`** iOS target under epic #71 and require
+  macOS-specific work (Associated Domains entitlement, `ASWebAuthenticationSession` presentation,
+  scope selection, a manual `apple-app-site-association` update) that's genuinely a separate
+  project. Spun off as [#1204](https://github.com/Anglesite/Anglesite/issues/1204). This design
+  uses the existing macOS "no token" flow (`CloudflareTokenPromptView`) instead — see §6.
+- Background/long-lived polling for a registration stuck `in_progress` past the bounded inline
+  wait — see §3's "still processing" outcome.
+
+## The Cloudflare Registrar API (beta)
+
+Confirmed against the current docs (`https://developers.cloudflare.com/registrar/registrar-api/`)
+since this API launched after training-data cutoff — endpoint shapes here should be re-verified
+against the docs at implementation time, field-for-field, before writing the HTTP client:
+
+All operations are **account-scoped** (not zone-scoped), resolved the same way
+`workerScriptNames`/`attachWorkersCustomDomain` already resolve an account id
+(`GET /accounts?per_page=1`, first result):
+
+| Operation | Method | Path |
+|---|---|---|
+| Search | `GET` | `/accounts/{account_id}/registrar/domain-search?q={query}&limit={n}` |
+| Check | `POST` | `/accounts/{account_id}/registrar/domain-check` |
+| Register | `POST` | `/accounts/{account_id}/registrar/registrations` |
+| Poll registration status | `GET` | `/accounts/{account_id}/registrar/registrations/{domain}/registration-status` |
+
+- **Search** returns candidate domain names for a keyword/phrase (cached server-side).
+- **Check** takes `{"domains": [...]}` (≤20 names) and returns, per name: `registrable`
+  (bool), `reason` (e.g. `domain_unavailable`, `extension_not_supported_via_api`,
+  `extension_not_supported`, `extension_disallows_registration`) when not registrable, and
+  `pricing` (`registration_cost`/`renewal_cost` in the account's currency) when it is.
+- **Register** takes `{"domain_name": "..."}` minimally. Cloudflare tries to complete it
+  synchronously within a ~10s timeout and returns `201`; past that it returns `202` with a
+  pollable status. The registration state machine is `in_progress → succeeded | failed |
+  action_required | blocked`. Cloudflare's own guidance: stop polling on `failed` and
+  `action_required`.
+- `action_required`/`blocked` are the outcomes this design maps to "finish setup in the
+  Cloudflare dashboard, then come back" — they're how an incomplete billing profile / registrant
+  contact / ToS acceptance actually surfaces, since there's no API to check that state directly.
+
+## Design
+
+### 1. Entry point
+
+`ConnectDomainSheetView`'s "Buy a domain" button (`.choosing` phase) changes from "open the
+browser link + record intent + dismiss" to "dismiss this sheet, open the new purchase sheet."
+`ConnectDomainModel.cloudflareDomainsURL` stays defined and becomes the escape-hatch link
+surfaced inside the new sheet (§4) for owners who prefer registering directly on Cloudflare, or
+whose domain needs a TLD the beta API doesn't support yet.
+
+### 2. Architecture
+
+Three new pieces, mirroring the existing `DomainModel` → `DomainOperationsService` →
+`HTTPCloudflareClient` layering used for DNS record management:
+
+- **`HTTPCloudflareClient`** gains `searchDomains`/`checkDomainAvailability` on
+  `CloudflareReading` and `registerDomain` on `CloudflareWriting`. `registerDomain` owns the
+  201-vs-202-and-poll distinction internally (see §3's bounded poll) so every caller above it
+  sees one `async throws` call returning a single resolved outcome — no polling primitive is
+  exposed at any layer above the HTTP client, matching how every other method on this client is a
+  self-contained one-shot call.
+- **`RegistrarOperationsService`** (protocol) + **`RegistrarOperations`** (prod impl), new files
+  in `AnglesiteCore`, composing a `reader`/`writer`/`tokenProvider` exactly like
+  `DomainOperationsService`/`DomainOperations`. New `RegistrarOperationError`: `.noToken`,
+  `.cloudflare(CloudflareError)` — two cases, no `zoneNotFound` (not meaningful here).
+- **`BuyDomainModel`** (`@Observable @MainActor`, new) + **`BuyDomainSheetView`** (new), in
+  `AnglesiteApp`. Added to `SiteWindowModel` as `var buyDomain = BuyDomainModel()`, configured
+  with `CurrentSite` the same way `domain`/`harden`/`connectDomain` are.
+
+### 3. Data flow / phase machine
+
+```swift
+enum Phase: Equatable {
+    case searching(query: String)                                   // pre-submit
+    case loadingResults(query: String)                               // search + check in flight
+    case results(query: String, candidates: [DomainCandidate])
+    case confirming(candidate: DomainCandidate)                      // explicit price shown
+    case purchasing(candidate: DomainCandidate)                      // register (+ bounded poll)
+    case purchased(hostname: String)                                 // terminal success
+    case needsAccountSetup(hostname: String)                         // action_required/blocked
+    case stillProcessing(hostname: String)                           // poll exhausted, in_progress
+    case needsToken(pendingQuery: String)                            // see §6
+    case failed(reason: String)
+}
+
+struct DomainCandidate: Equatable, Identifiable {
+    var id: String { name }
+    let name: String
+    let registrable: Bool
+    let reason: String?              // set when !registrable
+    let registrationCost: String?    // formatted, e.g. "$10.11/yr"; nil when !registrable
+}
+```
+
+Flow: submit a query (explicit "Search" button / Return, matching `DomainSheetView`'s existing
+`.onSubmit` convention — no live-as-you-type debounce) → `searchDomains(query:, limit: 20)` →
+immediately batch `checkDomainAvailability` on all returned candidates in one call (≤20, fits the
+API's per-request cap) → `.results`, available-first, unavailable/unsupported rows grayed out
+with their `reason` as caption text and not selectable.
+
+Tapping an available candidate → `.confirming`: explicit price, explicit "Buy `<domain>` for
+`<price>`" button — this is a real charge against the payment method on file for the connected
+Cloudflare account, so the button press is the only place `registerDomain` gets called, and it's
+disabled for the duration of `.purchasing` (no double-submit).
+
+`registerDomain` outcomes:
+
+- **succeeded** → `ConnectDomainCommand.recordTransfer(hostname:, siteDirectory:)` (the exact
+  same write "I already own a domain" already performs — see §5 for why) → `.purchased`.
+- **failed** → `.failed(reason:)`. Nothing persisted.
+- **action_required / blocked** → `.needsAccountSetup(hostname:)`: "Finish setting up billing in
+  the Cloudflare dashboard, then come back and try again," with a link to the Cloudflare
+  dashboard's domain registration page. Nothing persisted.
+- **poll exhausted (still `in_progress`)** → bounded inline poll: every ~2s, up to ~15s total
+  (matching the API's own "synchronous in most cases (10s timeout)" framing — 15s gives one
+  margin past that before giving up). If still unresolved, `.stillProcessing(hostname:)`:
+  "Still processing — once it finishes, come back and use 'I already own a domain' with
+  `<hostname>` to connect it." Nothing persisted; no background task survives sheet dismissal.
+
+### 4. Error handling
+
+- **No Cloudflare token** — see §6.
+- **Search/check network or API failure** — `.failed(reason:)`, reusing the same
+  `CloudflareError`-case-to-message mapping `DomainModel.message(for:domain:)` already has
+  (`unauthorized`/`http`/`api`/`malformedResponse`).
+- **Per-candidate unavailability** — not an error; a non-selectable row with its `reason`.
+- **Register failure / no double-charge** — covered in §3; only an explicit `succeeded` outcome
+  ever reaches `.purchased`.
+- **Escape hatch** — `.results`, `.needsAccountSetup`, `.stillProcessing`, and `.failed` all keep
+  the "Buy directly on the Cloudflare dashboard instead" link
+  (`ConnectDomainModel.cloudflareDomainsURL`).
+
+### 5. Reusing the "transfer" write path
+
+`ConnectDomainCommand.recordTransfer(hostname:, siteDirectory:)` writes `DOMAIN_CHOICE=transfer`
++ `DOMAIN=<hostname>` to `.site-config` and mirrors into `Source/anglesite.json`'s `domain`
+section — exactly what `CustomDomainAttachCommand.attach()` already reads to attach a Workers
+Custom Domain on the next deploy. A domain just registered via Cloudflare Registrar is, from that
+point on, technically identical to a domain whose owner delegated its nameservers to Cloudflare:
+both need the same resolve-zone-then-attach-Workers-Custom-Domain logic, and both already have a
+live Cloudflare zone by the time this write happens. Reusing `recordTransfer` verbatim means
+**zero changes to `CustomDomainAttachCommand`**. `DOMAIN_CHOICE` is an internal marker never shown
+to the owner again, so the "transfer" label being technically imprecise for a bought domain is
+invisible — the alternative (extending `CustomDomainAttachCommand` to also honor a `.buy` choice
+carrying a hostname) was considered and rejected as unnecessary surface area for a distinction
+that has no observable effect.
+
+### 6. No-token handling reuses the existing macOS flow
+
+macOS's established "no Cloudflare token" flow is `CloudflareTokenPromptView`, shown today by
+`DeployModel` when neither the `CLOUDFLARE_API_TOKEN` env var nor the Keychain has one: a guided
+modal (open Cloudflare's pre-filled token-creation page → paste → verify) backed by
+`TokenOnboarding` (`AnglesiteCore`), which already owns the verify → persist → flash →
+re-check-cancel → proceed ordering independent of any SwiftUI, and is designed to be driven by
+injectable closures rather than a concrete model type.
+
+`CloudflareTokenPromptView` itself, however, currently takes a concrete `let model: DeployModel`
+and reads `model.tokenVerification`/calls `model.verifyAndSaveToken`. This design narrows it:
+
+- Move the nested `TokenVerification` enum out of `DeployModel` to file scope in
+  `CloudflareTokenPromptView.swift` (or `AnglesiteCore`, next to `TokenOnboarding`) so it's not
+  owned by one specific model.
+- Change `CloudflareTokenPromptView`'s `init` to `tokenVerification: TokenVerification,
+  onSubmit: (String) async -> Void, onCancel: () -> Void` instead of `model: DeployModel`.
+- `DeployModel`'s call site becomes
+  `CloudflareTokenPromptView(tokenVerification: model.tokenVerification,
+  onSubmit: { await model.verifyAndSaveToken($0) }, onCancel: onCancel)` — behavior unchanged.
+
+`BuyDomainModel` gets its own `TokenOnboarding` instance (constructed the same way
+`DeployModel.init` builds its own) and a `needsToken(pendingQuery:)` phase: entered when a search
+attempt's `RegistrarOperationError` is `.noToken`. Presents the same (now-shared)
+`CloudflareTokenPromptView`; on `TokenOnboarding.Outcome.proceed`, re-runs the search that was
+pending instead of "start a deploy" (the only behavioral difference from `DeployModel`'s use —
+what "proceed" means is caller-defined, already how `TokenOnboarding.run`'s `persist`/`onConnected`
+closures are designed to work).
+
+Porting actual OAuth sign-in to macOS (replacing this token-paste flow) is out of scope — see
+[#1204](https://github.com/Anglesite/Anglesite/issues/1204).
+
+### 7. Code shape
+
+- **`Sources/AnglesiteCore/HTTPCloudflareClient.swift`**: add `searchDomains`,
+  `checkDomainAvailability` to `CloudflareReading`; `registerDomain` to `CloudflareWriting`. New
+  private `CFRegistrar*` decode structs alongside the existing `CF*` ones. `registerDomain`
+  internally issues the `POST`, branches on `201` vs `202`, and — for `202` — polls the
+  registration-status endpoint per §3's bounded loop before returning.
+- **`Sources/AnglesiteCore/RegistrarOperationsService.swift`** (new): protocol + `RegistrarOperations`.
+- **`Sources/AnglesiteApp/CloudflareTokenPromptView.swift`**: narrowed init per §6; `DeployModel`
+  call site updated.
+- **`Sources/AnglesiteApp/BuyDomainModel.swift`** (new): phase machine (§3), `TokenOnboarding`
+  wiring (§6), `configure(site:)`.
+- **`Sources/AnglesiteApp/BuyDomainSheetView.swift`** (new): search field, results list, confirm
+  step, purchasing spinner, terminal states, escape-hatch link.
+- **`Sources/AnglesiteApp/ConnectDomainModel.swift`**: `chooseBuy()` → dismiss + signal to open
+  the new sheet (one call-site change; exact mechanism — a closure or the view reading both
+  models — decided during implementation).
+- **`Sources/AnglesiteApp/SiteWindow.swift`**: register
+  `.sheet(isPresented: $model.buyDomain.sheetPresented) { BuyDomainSheetView(model: model.buyDomain) }`.
+- **`Sources/AnglesiteApp/SiteWindowModel.swift`**: `var buyDomain = BuyDomainModel()`, configured
+  alongside `domain`/`harden`/`connectDomain`.
+
+### 8. Testing
+
+- **`HTTPCloudflareClient` tests**: fixture JSON matching the real API's envelope shape for
+  search, check (including every `reason` value), register (`201` immediate, `202` →
+  poll-succeeded, `202` → poll-exhausted-still-`in_progress`, `action_required`, `blocked`,
+  `failed`), and the existing `unauthorized`/`http`/`malformedResponse` mapping.
+- **`RegistrarOperationsServiceTests`** (`AnglesiteCoreTests`): `.noToken` when the token
+  provider returns nil; account-resolution failure folds into `.cloudflare`.
+- **`BuyDomainModelTests`** (`AnglesiteAppTests`): full happy path (search → results → confirm →
+  purchasing → purchased), asserting `ConnectDomainCommand.recordTransfer` is called with the
+  purchased hostname; each terminal branch (`needsAccountSetup`, `stillProcessing`, `failed`);
+  `needsToken` phase triggers token onboarding and resumes the pending search on
+  `TokenOnboarding.Outcome.proceed`.
+- **`CloudflareTokenPromptView`**: confirm `DeployModel`'s existing behavior is unchanged after
+  the init narrowing (no new test needed if none exists today — just verify by inspection/build
+  that the call site still compiles and behaves identically).
+- Manual: build the app, open Connect a Domain → Buy a domain with no token configured (confirm
+  the token prompt appears and resumes the search after saving), search a keyword, confirm price
+  display and grayed-out unavailable rows, cancel out, complete a real purchase, confirm
+  `.site-config`/`anglesite.json` afterward, confirm the escape-hatch link works from every
+  non-happy-path state.
+
+## Follow-ups (new issues, not in #1195)
+
+1. **Port Cloudflare OAuth to macOS** — [#1204](https://github.com/Anglesite/Anglesite/issues/1204).
+   Would let this feature (and Deploy generally) replace the token-paste flow with real OAuth
+   sign-in. Needs its own design doc.


### PR DESCRIPTION
Closes #1195

## Summary

- Adds in-app domain search, real-time pricing, and purchase via Cloudflare's Registrar API, replacing the "Buy a domain" placeholder that just opened an external link.
- New `CloudflareRegistrarReading`/`CloudflareRegistrarWriting` protocols (search/check/register) on `HTTPCloudflareClient`, kept deliberately separate from the existing `CloudflareReading`/`CloudflareWriting` protocols so five unrelated test fakes don't need stub methods; `RegistrarOperationsService` composes them with token lookup; `BuyDomainModel`/`BuyDomainSheetView` drive the search → price → confirm → purchase UI, reachable from the existing "Connect a Domain" sheet.
- A successful purchase reuses `ConnectDomainCommand.recordTransfer(hostname:siteDirectory:)` verbatim — the same write "I already own a domain" already performs — so `CustomDomainAttachCommand` needed zero changes.
- Hard constraint honored throughout: the app never collects, stores, or proxies payment/card details — `register` charges the payment method already on file for the connected Cloudflare account; every purchase requires an explicit "Buy $X" button press; only an explicit `succeeded` outcome may persist any state.
- Shares the existing `CloudflareTokenPromptView` (previously coupled to `DeployModel` only) for the "no Cloudflare token configured" case, via a narrowing refactor to closures.

Design doc: `docs/superpowers/specs/2026-08-01-registrar-search-purchase-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-01-registrar-search-purchase-plan.md`

Spun off during design: [#1204](https://github.com/Anglesite/Anglesite/issues/1204) — porting Cloudflare OAuth to macOS (a separate, larger project scoped for a different app target; out of scope here, so the "no token" case reuses the existing token-paste flow instead).

Built via subagent-driven development: 7 planned tasks, each independently reviewed (one task needed 2 fix rounds for a real query-encoding bug + a duplication cleanup, both self-caught during implementation-time live-API re-verification), followed by a 3-round whole-branch review that found and fixed one real Critical bug (a double-submit race on the purchase button — a real-money path) plus several Important/Minor issues (a DocC link that would have failed CI, a risky synchronous sheet-to-sheet SwiftUI transition reworked to use `onDismiss`, a purchase-in-flight losing its charge on sheet close, a nil-price candidate being buyable, missing test coverage) and one self-inflicted regression from the first fix wave (hiding the Close button during purchase created a modal trap — fixed in a follow-up round).

**Known follow-ups, not blocking, flagged for the reviewer:**
1. Full interactive GUI verification of the flow (token prompt → search → price confirmation → purchase → `.site-config`/`anglesite.json` write-through) was not performed — every dispatched build/review session in this branch's development ran in a sandboxed environment with no display/GUI-automation tool, and a live purchase attempt would incur a real Cloudflare charge (correctly avoided rather than faked). Everything was verified via the full test suite, successful builds, and static/manual code tracing instead. Recommend a human or GUI-capable session click through the real app before this reaches end users, especially the "Buy a domain" → new sheet transition and the price-confirmation step.
2. `.noToken` is only rescued (token-prompt-and-resume) on the search path; a token revoked mid-flow during check/register falls through to a dead-end failure message instead. Deliberately left as a follow-up — designing retry behavior for a money-charging path deserves its own review, not an automated guess.
3. A purchase that completes while the sheet is closed (backgrounded) and is then reopened after completion resets to the search screen rather than showing the terminal success/failure confirmation — the `.site-config` write already happened correctly either way; only the on-screen confirmation can be missed on that specific timing. Non-blocking UX polish, deferred.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passes (3218 tests / 396 suites) except 2 pre-existing, unrelated `FoundationModelAssistantTests` flakes (on-device Apple Intelligence streaming issues, not touched by this branch).
- [x] `xcodebuild`/`scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [ ] Manual smoke: **not performed** — see Known follow-up #1 above. No display/GUI-automation available in this development environment; a real purchase would incur a real charge.