### PR TITLE
refactor(#1187): centralize DNS record purpose vocabulary

### DIFF
--- a/Sources/AnglesiteApp/DomainModel.swift
+++ b/Sources/AnglesiteApp/DomainModel.swift
@@ -14,8 +14,8 @@ final class DomainModel {
             var purpose: String? {
                 switch self {
                 case .generic: return nil
-                case .bluesky: return "verification:bluesky"
-                case .google: return "verification:google"
+                case .bluesky: return DomainRecordPurpose.Verification.bluesky
+                case .google: return DomainRecordPurpose.Verification.google
                 }
             }
         }

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -739,7 +739,7 @@ final class PlistEditorModel {
                     mtaStsError = "A TXT record already exists for \(record.name) with different content. Update it in Website → Manage Domain, then try again."
                     return
                 }
-                switch await domainOperations.addRecord(domain: domain, type: "TXT", name: record.name, content: record.content, ttl: 1, priority: nil, purpose: "email:mta-sts", sourceDirectory: sourceDirectory) {
+                switch await domainOperations.addRecord(domain: domain, type: "TXT", name: record.name, content: record.content, ttl: 1, priority: nil, purpose: DomainRecordPurpose.Email.mtaSTS, sourceDirectory: sourceDirectory) {
                 case .success:
                     continue
                 case .failure(let error):

--- a/Sources/AnglesiteCore/DomainOperationsService.swift
+++ b/Sources/AnglesiteCore/DomainOperationsService.swift
@@ -30,10 +30,11 @@ public protocol DomainOperationsService: Sendable {
     /// `priority` is required by MX records (lower = higher priority mail server) and ignored
     /// by every other record type — `nil` for non-MX records.
     ///
-    /// `purpose` is a namespaced tag (e.g. `"email:icloud"`, `"verification:bluesky"`) mirrored
-    /// into the live record's Cloudflare `comment` field as `"anglesite:<purpose>"` and, when
-    /// `sourceDirectory` is non-nil, appended to `Source/anglesite.json`'s `dns.managedRecords`
-    /// (#1170) — both nil for a generic owner-added record with no specific purpose.
+    /// `purpose` is a namespaced tag (e.g. `"email:icloud-plus"`, `"verification:bluesky"` — see
+    /// ``DomainRecordPurpose`` for the known vocabulary) mirrored into the live record's
+    /// Cloudflare `comment` field as `"anglesite:<purpose>"` and, when `sourceDirectory` is
+    /// non-nil, appended to `Source/anglesite.json`'s `dns.managedRecords` (#1170) — both nil for
+    /// a generic owner-added record with no specific purpose.
     /// `sourceDirectory` is nil for callers with no local site context (Siri/Shortcuts intents),
     /// which skip the write-through entirely rather than failing.
     func addRecord(

--- a/Sources/AnglesiteCore/DomainRecordPurpose.swift
+++ b/Sources/AnglesiteCore/DomainRecordPurpose.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// The known `purpose` tag vocabulary for `DomainOperationsService.addRecord` (#1170): a
+/// namespaced `type:subtype` string written to `anglesite.json`'s `dns.managedRecords` entries
+/// and mirrored into the live Cloudflare record's `anglesite:<purpose>` comment. One source of
+/// truth for these strings so the call sites and future consumers (e.g. slice 3's / #1095
+/// reconciliation parsing) can't drift apart (#1187).
+public enum DomainRecordPurpose {
+    public enum Verification {
+        public static let bluesky = "verification:bluesky"
+        public static let google = "verification:google"
+    }
+
+    public enum Email {
+        public static let mtaSTS = "email:mta-sts"
+
+        /// `"email:<provider.rawValue>"` for a completed `EmailSetupPlanner` provider choice.
+        public static func provider(_ provider: EmailSetupPlanner.Provider) -> String {
+            "email:\(provider.rawValue)"
+        }
+    }
+
+    public enum Security {
+        public static let caa = "security:caa"
+        public static let nullMX = "security:null-mx"
+        public static let spfReject = "security:spf-reject"
+        public static let dmarcReject = "security:dmarc-reject"
+    }
+}

--- a/Sources/AnglesiteCore/EmailSetupExecutor.swift
+++ b/Sources/AnglesiteCore/EmailSetupExecutor.swift
@@ -51,7 +51,7 @@ public struct EmailSetupExecutor: Sendable {
     ) async -> Result {
         var added = 0
         var failures: [RecordFailure] = []
-        let purpose = "email:\(plan.provider.rawValue)"
+        let purpose = DomainRecordPurpose.Email.provider(plan.provider)
 
         for record in plan.records {
             let result = await ops.addRecord(

--- a/Sources/AnglesiteCore/HardenExecutor.swift
+++ b/Sources/AnglesiteCore/HardenExecutor.swift
@@ -114,7 +114,7 @@ public struct HardenExecutor: Sendable {
                 zoneID: zoneID,
                 record: DNSRecordPayload(type: "CAA", name: domain,
                                          content: "0 issue \"\(ca)\"",
-                                         comment: "anglesite:security:caa"),
+                                         comment: "anglesite:\(DomainRecordPurpose.Security.caa)"),
                 apiToken: apiToken)
         case .enableAlwaysUseHTTPS:
             try await writer.setAlwaysUseHTTPS(zoneID: zoneID, enabled: true, apiToken: apiToken)
@@ -127,20 +127,20 @@ public struct HardenExecutor: Sendable {
             try await writer.addDNSRecord(
                 zoneID: zoneID,
                 record: DNSRecordPayload(type: "MX", name: domain, content: ".", priority: 0,
-                                         comment: "anglesite:security:null-mx"),
+                                         comment: "anglesite:\(DomainRecordPurpose.Security.nullMX)"),
                 apiToken: apiToken)
         case .addSPFRejectAll:
             try await writer.addDNSRecord(
                 zoneID: zoneID,
                 record: DNSRecordPayload(type: "TXT", name: domain, content: "v=spf1 -all",
-                                         comment: "anglesite:security:spf-reject"),
+                                         comment: "anglesite:\(DomainRecordPurpose.Security.spfReject)"),
                 apiToken: apiToken)
         case .addDMARCReject:
             try await writer.addDNSRecord(
                 zoneID: zoneID,
                 record: DNSRecordPayload(type: "TXT", name: "_dmarc.\(domain)",
                                          content: "v=DMARC1; p=reject",
-                                         comment: "anglesite:security:dmarc-reject"),
+                                         comment: "anglesite:\(DomainRecordPurpose.Security.dmarcReject)"),
                 apiToken: apiToken)
         case .addWAFRule(let desc, let expr, let action):
             try await writer.createWAFCustomRule(


### PR DESCRIPTION
Closes #1187

## Summary

- Adds `DomainRecordPurpose` (`Sources/AnglesiteCore/DomainRecordPurpose.swift`) as the single source of truth for the `verification:`/`email:`/`security:` purpose-tag vocabulary written to `anglesite.json`'s `dns.managedRecords` entries and mirrored into Cloudflare record comments.
- Replaces the four inline raw-string call sites (`DomainModel.Draft.Context.purpose`, `PlistEditorModel`'s MTA-STS publish, `EmailSetupExecutor`, `HardenExecutor`'s four record-comment sites) with references to the new type.
- Fixes `DomainOperationsService.addRecord`'s doc comment, which cited `"email:icloud"` as an example purpose — no real `EmailSetupPlanner.Provider` raw value emits that; the real values are `icloud-plus`, `apple-business`, `fastmail`, `google-workspace`, `proton-mail`, `zoho-mail`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` (pre-existing `FoundationModelAssistant` streaming failures unrelated to this change; no Domain/Harden/EmailSetup failures)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [ ] Manual smoke (if UI-touching): not needed — no UI behavior change, purely a string-constant refactor