### PR TITLE
fix(#1245): fast-forward pull must force-checkout the working tree

### DIFF
--- a/Sources/AnglesiteCore/SyncEngine.swift
+++ b/Sources/AnglesiteCore/SyncEngine.swift
@@ -748,8 +748,22 @@ public actor SyncEngine {
     }
 
     /// Force-updates `branchRefName` to `oid`, then checks out HEAD (which already points at that
-    /// branch symbolically) with a safe strategy — the fast-forward's working-tree update. Safe
-    /// to call only once the caller has confirmed a clean working tree.
+    /// branch symbolically) — the fast-forward's working-tree update. Safe to call only once the
+    /// caller has confirmed a clean working tree.
+    ///
+    /// The strategy must be `.force`, not `.safe` (#1245). `Repository.checkout(strategy:)` calls
+    /// libgit2's `git_checkout_head`, whose `baseline` defaults to HEAD — and by this point the ref
+    /// move above has already pointed HEAD at the target. A file the peer changed therefore differs
+    /// from that baseline, so libgit2 classifies it as a *local modification*: `.safe` preserves it
+    /// and the peer's edit is silently dropped, leaving history advanced but `Source/` stale.
+    /// `.recreateMissing` masks this for added files (they're absent, so they're recreated), which
+    /// is why it went unnoticed until a test asserted content rather than mere presence.
+    /// `.force` takes the target as definitive, matching `reconcileDivergence`'s post-merge
+    /// checkout and `SyncConflictResolver`'s.
+    ///
+    /// Nothing of the owner's can be lost to `.force` here: `pull()` snapshots a dirty tree into a
+    /// commit before reconciling, and a fast-forward only runs when the branch is not ahead — so
+    /// the working tree is clean by the time this is reached.
     private static func fastForward(repo: Repository, branchRefName: String, to oid: OID) -> Result<Void, EngineError> {
         var targetOID = oid.oid
         var createdRef: OpaquePointer?
@@ -760,7 +774,7 @@ public actor SyncEngine {
         guard result == GIT_OK.rawValue else {
             return .failure("couldn't update \(branchRefName): \(lastErrorMessage())")
         }
-        guard case .success = repo.checkout(strategy: [.safe, .recreateMissing]) else {
+        guard case .success = repo.checkout(strategy: [.force, .recreateMissing]) else {
             return .failure("checkout failed after moving \(branchRefName)")
         }
         return .success(())

--- a/Tests/AnglesiteCoreTests/SyncConflictResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/SyncConflictResolverTests.swift
@@ -240,27 +240,16 @@ import SwiftGit2
         #expect(engineA.pendingConflict(package: a) == nil)
         #expect(engineB.pendingConflict(package: b) == nil)
 
-        // The resolving Mac holds the chosen content (QA §2 pass criteria).
+        // Both Macs hold the identical chosen content (QA §2 pass criteria).
+        //
+        // Asserting the peer's *content*, not just its refs, is the point: this is the assertion
+        // that caught #1245, where the peer's HEAD reached the resolution commit while `Source/`
+        // kept the pre-merge text. Ref convergence alone would have passed throughout that bug.
+        let aContent = try String(contentsOf: a.sourceURL.appendingPathComponent("file0.txt"), encoding: .utf8)
         let bContent = try String(contentsOf: b.sourceURL.appendingPathComponent("file0.txt"), encoding: .utf8)
         #expect(bContent == "b-version")
-
-        // The peer's *content* is deliberately NOT asserted here, because today it would fail: this
-        // test found a real bug in `SyncEngine.fastForward`, tracked separately. The peer's ref and
-        // HEAD both reach the resolution commit (asserted above, and those pass), but its working
-        // tree keeps the stale content — `fastForward` force-moves the branch ref and only then
-        // calls `repo.checkout(strategy: [.safe, .recreateMissing])`, by which point HEAD is already
-        // the target. `.recreateMissing` still restores files that are *absent*, which is why every
-        // pre-existing fast-forward test passes: `fastForwardPull` and `bothPeersConverge` only ever
-        // assert `fileExists` on newly-added paths. Overwriting an existing file's content is the
-        // uncovered case, and it silently doesn't happen.
-        //
-        // For a site owner that means editing an existing page on one Mac, pulling on the other, and
-        // watching git history advance while `Source/` still serves the old content — QA §1.4's exact
-        // scenario. The fix belongs with the engine, alongside a `fastForwardPull` case that pins
-        // working-tree *content* rather than mere file presence; add the assertion below back then:
-        //
-        //     #expect(try String(contentsOf: a.sourceURL.appending(path: "file0.txt"),
-        //                       encoding: .utf8) == "b-version")
+        #expect(aContent == "b-version")
+        #expect(bContent == aContent)
     }
 }
 #endif

--- a/Tests/AnglesiteCoreTests/SyncEngineTests.swift
+++ b/Tests/AnglesiteCoreTests/SyncEngineTests.swift
@@ -226,6 +226,97 @@ import SwiftGit2
         #expect(FileManager.default.fileExists(atPath: b.sourceURL.appendingPathComponent("file1.txt").path))
     }
 
+    /// QA §1.4 / #1245: the peer must end up with the *content* of the fast-forwarded history, not
+    /// merely its refs.
+    ///
+    /// The regression this pins is narrow and was invisible for a long time: every other
+    /// fast-forward assertion in this file checks `fileExists` on a newly **added** path, and an
+    /// added path is absent from the peer's working tree, so `.recreateMissing` restores it no
+    /// matter what the checkout strategy is. Rewriting an **existing** tracked file is the case
+    /// that actually exercises the update, and under the old `.safe` strategy it silently did
+    /// nothing — history advanced while `Source/` still served the old page.
+    @Test("a fast-forward pull rewrites an existing file's content, not just added files")
+    func fastForwardPullUpdatesExistingFileContent() async throws {
+        let a = try await makeGitPackage(name: "A15", commits: 1)
+        let engineA = SyncEngine()
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture push failed"); return
+        }
+
+        let b = try makeFreshPeerPackage(mirroring: a, name: "B15")
+        let engineB = SyncEngine()
+        guard case .bootstrapped = await engineB.pull(package: b) else {
+            Issue.record("fixture bootstrap failed"); return
+        }
+
+        // A rewrites a file that already exists on both sides, rather than adding a new one.
+        try "rewritten by A".write(
+            to: a.sourceURL.appendingPathComponent("file0.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: a.sourceURL)
+        try await git(["commit", "-m", "rewrite file0"], in: a.sourceURL)
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture second push failed"); return
+        }
+        try copyArtifact(from: a, to: b)
+
+        let aHead = try await headOID(in: a.sourceURL)
+        let result = await engineB.pull(package: b)
+        guard case .fastForwarded(_, _, let to) = result else {
+            Issue.record("expected .fastForwarded, got \(result)"); return
+        }
+        #expect(to == aHead)
+        #expect(try await headOID(in: b.sourceURL) == aHead)
+
+        let content = try String(
+            contentsOf: b.sourceURL.appendingPathComponent("file0.txt"), encoding: .utf8)
+        #expect(content == "rewritten by A", "the peer's working tree must match the history it fast-forwarded to")
+    }
+
+    /// #1245 sibling path: the same content check against the *merge* branch of reconciliation,
+    /// which shares `fastForward`'s move-then-checkout shape. It has always used `.force`, so this
+    /// is expected to pass unchanged — it's here so the two paths can't drift apart silently, since
+    /// the merge path's own tests likewise only ever assert on newly-added files.
+    @Test("a merging pull rewrites an existing file the other Mac changed")
+    func mergePullUpdatesExistingFileContent() async throws {
+        let a = try await makeGitPackage(name: "A16", commits: 1)
+        let engineA = SyncEngine()
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture push failed"); return
+        }
+
+        let b = try makeFreshPeerPackage(mirroring: a, name: "B16")
+        let engineB = SyncEngine()
+        guard case .bootstrapped = await engineB.pull(package: b) else {
+            Issue.record("fixture bootstrap failed"); return
+        }
+
+        // A rewrites the shared file; B commits an unrelated addition, so the histories diverge and
+        // reconciliation takes the three-way-merge branch rather than fast-forwarding.
+        try "rewritten by A".write(
+            to: a.sourceURL.appendingPathComponent("file0.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: a.sourceURL)
+        try await git(["commit", "-m", "rewrite file0"], in: a.sourceURL)
+        guard case .pushed = await engineA.push(package: a) else {
+            Issue.record("fixture second push failed"); return
+        }
+        try copyArtifact(from: a, to: b)
+
+        try "b's own work".write(
+            to: b.sourceURL.appendingPathComponent("b-only.txt"), atomically: true, encoding: .utf8)
+        try await git(["add", "-A"], in: b.sourceURL)
+        try await git(["commit", "-m", "b's addition"], in: b.sourceURL)
+
+        let result = await engineB.pull(package: b)
+        guard case .merged = result else {
+            Issue.record("expected .merged, got \(result)"); return
+        }
+
+        let content = try String(
+            contentsOf: b.sourceURL.appendingPathComponent("file0.txt"), encoding: .utf8)
+        #expect(content == "rewritten by A", "the merge result must reach the working tree, not just the index")
+        #expect(FileManager.default.fileExists(atPath: b.sourceURL.appendingPathComponent("b-only.txt").path))
+    }
+
     @Test("pull reports upToDate when local and artifact history already match")
     func upToDatePull() async throws {
         let a = try await makeGitPackage(name: "A2", commits: 1)

--- a/docs/qa/2026-07-27-icloud-sync-manual-qa.md
+++ b/docs/qa/2026-07-27-icloud-sync-manual-qa.md
@@ -75,8 +75,10 @@ Baseline case: edit on Mac A, close, edit on Mac B — no true concurrency.
 > `Synced` state carries, and `nonUpToDatePullResultsReportSynced` pins that a fast-forward pull
 > settles on `Synced` with no banner (1.3–1.4). `SyncEngineTests.fastForwardPull`,
 > `freshPeerBootstraps`, and `bothPeersConverge` cover the engine-side handoff on real fixture
-> repos. What stays manual: that iCloud actually propagates `source.bundle` between two Macs, and
-> how long that takes.
+> repos, and `fastForwardPullUpdatesExistingFileContent` pins step 1.4's real payload — that a
+> rewritten **existing** page reaches the other Mac's `Source/`, not merely its git history (#1245).
+> What stays manual: that iCloud actually propagates `source.bundle` between two Macs, and how long
+> that takes.
 
 | Step | Action | Expected outcome |
 |---|---|---|
@@ -100,10 +102,7 @@ time.
 > only once converged, so a resolved conflict can't re-surface as a banner).
 > `SyncConflictResolverTests.loadsBothSides`/`resolveKeepMine`/`resolveKeepTheirs` cover the sheet's
 > data layer (2.5, 2.7) and `peerConvergesAfterResolution` covers the other Mac converging (2.8) —
-> its *history* only. That test found a live bug: the peer's ref and HEAD reach the resolution
-> commit but its working tree keeps the stale content, so **2.8's "converges to the same resolved
-> content" is currently expected to fail by hand** until the engine fix lands. Check it deliberately
-> rather than skimming past it.
+> including its working-tree *content*, not just its refs, which is the assertion that caught #1245.
 > `SyncSchedulerTests.conflictResolvedRepullsAndClears` covers leaving `needs attention` (2.7).
 > What stays manual: iCloud actually minting `NSFileVersion` conflict versions from two real
 > concurrent writes (2.2–2.3 — the tests hand-build those handles), the sheet and banner as


### PR DESCRIPTION
Closes #1245

## Summary

- A fast-forward pull advanced `HEAD` but **never rewrote an existing file's content**. Edit an existing page on one Mac, pull on the other: git history moves while `Source/` keeps serving the old page — silently, with no error, conflict, or banner. That's QA §1.4 verbatim, and it also broke §2.8's "converges to the same resolved content".
- `SyncEngine.fastForward` now checks out with `[.force, .recreateMissing]` instead of `[.safe, .recreateMissing]`, matching the two sibling call sites.
- Adds the content-level regression coverage whose absence let this survive, and restores the assertion in `peerConvergesAfterResolution` that found it.

### Root cause

`Repository.checkout(strategy:)` in [our SwiftGit2 fork](https://github.com/Anglesite/SwiftGit2/blob/main/Sources/SwiftGit2/Repository.swift) calls libgit2's `git_checkout_head`, and libgit2's `baseline` **defaults to HEAD**. `fastForward` force-moves the branch ref *before* checking out, so by then HEAD already points at the target. A file the peer changed therefore differs from that baseline, and libgit2 classifies it as a **local modification** — which `.safe` is specifically designed to preserve. The peer's edit is dropped on the floor.

`.recreateMissing` masked it for **added** files: an absent file is recreated regardless of strategy. That is exactly why it went unnoticed — every pre-existing fast-forward assertion checks `fileExists` on a newly-added path:

- `fastForwardPull` → `#expect(fileExists(... "file1.txt"))`
- `bothPeersConverge` → `#expect(fileExists(... "a-only.txt"))`, `"b-only.txt"`

Rewriting an existing tracked file was never asserted, and that's the only case that exercises the update.

### Why `.force` is safe here

No owner data can be lost. `pull()` snapshots a dirty working tree into a commit before reconciling, and a fast-forward only runs when the branch is **not ahead** — so the tree is clean by the time `fastForward` is reached. This is the same reasoning the post-merge checkout in `reconcileDivergence` already relies on, which has always used `.force`.

### Tests

- `fastForwardPullUpdatesExistingFileContent` — rewrites a **tracked** file and asserts it reaches the peer's working tree. Fails on the old `.safe` strategy.
- `mergePullUpdatesExistingFileContent` — pins the same property on the merge path, which shares the move-then-checkout shape and whose own tests likewise only asserted added files. Expected to pass unchanged; it's there so the two paths can't drift apart silently.
- `peerConvergesAfterResolution` — content assertions restored (they were removed in #1244 with the bug documented in place).
- QA doc: §2's "expected to fail by hand" warning removed, and §1 now credits the new test with pinning step 1.4's real payload.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [ ] `swift test --package-path .`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke (if UI-touching): two-Mac QA §1.4 — edit an existing page on one Mac, confirm the other's `Source/` updates, not just its history.

> [!NOTE]
> As with #1244, this was authored in a Linux container with no Swift toolchain, so the boxes above are unchecked because they could not be run — CI is the first compile. The root cause here was confirmed by reading the SwiftGit2 fork's `checkout` implementation directly rather than inferred, and `fastForwardPullUpdatesExistingFileContent` is designed to fail against the old strategy, so a green run is meaningful evidence the fix works rather than merely compiling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJcKyqZUTNWCSWThLMKw3m)_