### PR TITLE
Serialize concurrent domain config saves to prevent lost updates

### DIFF
--- a/Sources/AnglesiteCore/DomainConfigStore.swift
+++ b/Sources/AnglesiteCore/DomainConfigStore.swift
@@ -1,10 +1,15 @@
 import Foundation
 
-/// Global actor that serializes access to `anglesite.json` to prevent concurrent writes from
+/// Per-file-path locks that serialize access to `anglesite.json` to prevent concurrent writes from
 /// dropping updates (#1189). Multiple producers (DomainOperations, HardenExecutor,
 /// CustomDomainAttachCommand, EmailSetupExecutor, and others) may call `DomainConfigStore.save()`
-/// concurrently; this actor ensures the read-modify-write sequence is atomic.
-nonisolated(unsafe) private let domainConfigFileLock = NSLock()
+/// concurrently; locks ensure the read-modify-write sequence is atomic. Scoped per file path so
+/// concurrent saves to different sites' configs don't block each other.
+/// Note: Uses `NSLock` (OS-thread blocking) rather than Swift `actor` (cooperative suspension),
+/// which is acceptable here due to the short critical section. An actor-based store may be
+/// reconsidered if contention becomes a concern (#1189).
+private var domainConfigFileLocks: [String: NSLock] = [:]
+private let domainConfigFileLocksMutex = NSLock()
 
 /// Reads/writes `Source/anglesite.json` (#1169) — the git-tracked declared-intent file for a
 /// site's domain, DNS, edge hardening, email, and Worker configuration. Rooted at
@@ -42,7 +47,7 @@ public struct DomainConfigStore: Sendable {
     /// Writes `config`, merging it over whatever is already on disk so unknown keys survive.
     /// Pretty-printed and sorted (matching `RedirectsStore`/`RobotsConfigStore`) so re-saving
     /// unchanged content produces a minimal git diff. The read-modify-write sequence is protected
-    /// by a lock to ensure atomicity when multiple producers call `save()` concurrently (#1189).
+    /// by a per-file lock to ensure atomicity when multiple producers call `save()` concurrently (#1189).
     ///
     /// This merge cannot distinguish "this field is unknown to the current app version" from
     /// "this field is known but the caller passed `nil` for it" — both look identical to `merge`
@@ -66,8 +71,21 @@ public struct DomainConfigStore: Sendable {
     /// as any other non-object value. A hand-added array element, or an unknown field inside one,
     /// does not survive a save that touches the containing array.
     public func save(_ config: DomainConfig) throws {
-        domainConfigFileLock.lock()
-        defer { domainConfigFileLock.unlock() }
+        let filePath = fileURL.path
+        let lock: NSLock
+
+        domainConfigFileLocksMutex.lock()
+        if let existingLock = domainConfigFileLocks[filePath] {
+            lock = existingLock
+        } else {
+            let newLock = NSLock()
+            domainConfigFileLocks[filePath] = newLock
+            lock = newLock
+        }
+        domainConfigFileLocksMutex.unlock()
+
+        lock.lock()
+        defer { lock.unlock() }
 
         let newData = try JSONEncoder().encode(config)
         var newFields = Self.objectFields(fromJSONData: newData)

--- a/Sources/AnglesiteCore/DomainConfigStore.swift
+++ b/Sources/AnglesiteCore/DomainConfigStore.swift
@@ -8,8 +8,7 @@ import Foundation
 /// Note: Uses `NSLock` (OS-thread blocking) rather than Swift `actor` (cooperative suspension),
 /// which is acceptable here due to the short critical section. An actor-based store may be
 /// reconsidered if contention becomes a concern (#1189).
-private var domainConfigFileLocks: [String: NSLock] = [:]
-private let domainConfigFileLocksMutex = NSLock()
+private static let fileLocks = SharedInstanceCache<NSLock>()
 
 /// Reads/writes `Source/anglesite.json` (#1169) — the git-tracked declared-intent file for a
 /// site's domain, DNS, edge hardening, email, and Worker configuration. Rooted at
@@ -71,19 +70,7 @@ public struct DomainConfigStore: Sendable {
     /// as any other non-object value. A hand-added array element, or an unknown field inside one,
     /// does not survive a save that touches the containing array.
     public func save(_ config: DomainConfig) throws {
-        let filePath = fileURL.path
-        let lock: NSLock
-
-        domainConfigFileLocksMutex.lock()
-        if let existingLock = domainConfigFileLocks[filePath] {
-            lock = existingLock
-        } else {
-            let newLock = NSLock()
-            domainConfigFileLocks[filePath] = newLock
-            lock = newLock
-        }
-        domainConfigFileLocksMutex.unlock()
-
+        let lock = Self.fileLocks.instance(forKey: fileURL.path) { NSLock() }
         lock.lock()
         defer { lock.unlock() }
 

--- a/Sources/AnglesiteCore/DomainConfigStore.swift
+++ b/Sources/AnglesiteCore/DomainConfigStore.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+/// Global actor that serializes access to `anglesite.json` to prevent concurrent writes from
+/// dropping updates (#1189). Multiple producers (DomainOperations, HardenExecutor,
+/// CustomDomainAttachCommand, EmailSetupExecutor, and others) may call `DomainConfigStore.save()`
+/// concurrently; this actor ensures the read-modify-write sequence is atomic.
+nonisolated(unsafe) private let domainConfigFileLock = NSLock()
+
 /// Reads/writes `Source/anglesite.json` (#1169) — the git-tracked declared-intent file for a
 /// site's domain, DNS, edge hardening, email, and Worker configuration. Rooted at
 /// `sourceDirectory` (the `Source/` git repo), not `Config/`, following `RedirectsStore`:
@@ -35,8 +41,8 @@ public struct DomainConfigStore: Sendable {
 
     /// Writes `config`, merging it over whatever is already on disk so unknown keys survive.
     /// Pretty-printed and sorted (matching `RedirectsStore`/`RobotsConfigStore`) so re-saving
-    /// unchanged content produces a minimal git diff, and atomic so a crash mid-write can never
-    /// leave a truncated `anglesite.json` behind.
+    /// unchanged content produces a minimal git diff. The read-modify-write sequence is protected
+    /// by a lock to ensure atomicity when multiple producers call `save()` concurrently (#1189).
     ///
     /// This merge cannot distinguish "this field is unknown to the current app version" from
     /// "this field is known but the caller passed `nil` for it" — both look identical to `merge`
@@ -60,6 +66,9 @@ public struct DomainConfigStore: Sendable {
     /// as any other non-object value. A hand-added array element, or an unknown field inside one,
     /// does not survive a save that touches the containing array.
     public func save(_ config: DomainConfig) throws {
+        domainConfigFileLock.lock()
+        defer { domainConfigFileLock.unlock() }
+
         let newData = try JSONEncoder().encode(config)
         var newFields = Self.objectFields(fromJSONData: newData)
 

--- a/Sources/AnglesiteCore/DomainConfigStore.swift
+++ b/Sources/AnglesiteCore/DomainConfigStore.swift
@@ -1,15 +1,5 @@
 import Foundation
 
-/// Per-file-path locks that serialize access to `anglesite.json` to prevent concurrent writes from
-/// dropping updates (#1189). Multiple producers (DomainOperations, HardenExecutor,
-/// CustomDomainAttachCommand, EmailSetupExecutor, and others) may call `DomainConfigStore.save()`
-/// concurrently; locks ensure the read-modify-write sequence is atomic. Scoped per file path so
-/// concurrent saves to different sites' configs don't block each other.
-/// Note: Uses `NSLock` (OS-thread blocking) rather than Swift `actor` (cooperative suspension),
-/// which is acceptable here due to the short critical section. An actor-based store may be
-/// reconsidered if contention becomes a concern (#1189).
-private static let fileLocks = SharedInstanceCache<NSLock>()
-
 /// Reads/writes `Source/anglesite.json` (#1169) — the git-tracked declared-intent file for a
 /// site's domain, DNS, edge hardening, email, and Worker configuration. Rooted at
 /// `sourceDirectory` (the `Source/` git repo), not `Config/`, following `RedirectsStore`:
@@ -22,6 +12,16 @@ private static let fileLocks = SharedInstanceCache<NSLock>()
 /// exact fields `DomainConfig` declares are ever overwritten; everything else in the existing
 /// file rides along untouched.
 public struct DomainConfigStore: Sendable {
+    /// Per-file-path locks that serialize access to `anglesite.json` to prevent concurrent writes from
+    /// dropping updates (#1189). Multiple producers (DomainOperations, HardenExecutor,
+    /// CustomDomainAttachCommand, EmailSetupExecutor, and others) may call `save()`
+    /// concurrently; locks ensure the read-modify-write sequence is atomic. Scoped per file path so
+    /// concurrent saves to different sites' configs don't block each other.
+    /// Note: Uses `NSLock` (OS-thread blocking) rather than Swift `actor` (cooperative suspension),
+    /// which is acceptable here due to the short critical section. An actor-based store may be
+    /// reconsidered if contention becomes a concern (#1189).
+    private static let fileLocks = SharedInstanceCache<NSLock>()
+
     private let fileURL: URL
     private let fileManager: FileManager
 

--- a/Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift
@@ -158,4 +158,81 @@ struct DomainConfigStoreTests {
         #expect(reloaded.dns?.managedRecords?.count == 1)
         #expect(reloaded.dns?.managedRecords?.first?.type == "MX")
     }
+
+    @Test("concurrent saves from multiple producers merge updates without losing data (#1189)")
+    func concurrentSavesMergeUpdates() throws {
+        let dir = try tempSourceDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = DomainConfigStore(sourceDirectory: dir)
+
+        let initialConfig = DomainConfig(
+            domain: .init(hostname: "example.com"),
+            dns: .init(managedRecords: [
+                .init(type: "MX", name: "@", content: "mx01.mail.icloud.com", priority: 10, purpose: "email:icloud"),
+            ])
+        )
+        try store.save(initialConfig)
+
+        let group = DispatchGroup()
+        var saveErrors: [Error] = []
+        let errorLock = NSLock()
+
+        // Simulate concurrent producers: email setup and DNS modifications
+        group.enter()
+        DispatchQueue.global().async {
+            defer { group.leave() }
+            do {
+                let emailConfig = DomainConfig(
+                    email: .init(provider: "icloud", dmarcReportEmail: "postmaster@example.com")
+                )
+                try store.save(emailConfig)
+            } catch {
+                errorLock.lock()
+                saveErrors.append(error)
+                errorLock.unlock()
+            }
+        }
+
+        group.enter()
+        DispatchQueue.global().async {
+            defer { group.leave() }
+            do {
+                let edgeConfig = DomainConfig(
+                    edge: .init(dnssec: true, alwaysUseHTTPS: true)
+                )
+                try store.save(edgeConfig)
+            } catch {
+                errorLock.lock()
+                saveErrors.append(error)
+                errorLock.unlock()
+            }
+        }
+
+        group.enter()
+        DispatchQueue.global().async {
+            defer { group.leave() }
+            do {
+                let workersConfig = DomainConfig(
+                    workers: .init(active: ["webmention-receive"])
+                )
+                try store.save(workersConfig)
+            } catch {
+                errorLock.lock()
+                saveErrors.append(error)
+                errorLock.unlock()
+            }
+        }
+
+        group.wait()
+        #expect(saveErrors.isEmpty, "No errors during concurrent saves")
+
+        let final = try store.load()
+        // Verify all sections from all concurrent producers were saved
+        #expect(final.domain?.hostname == "example.com", "Initial domain config preserved")
+        #expect(final.dns?.managedRecords?.count == 1, "Initial DNS records preserved")
+        #expect(final.dns?.managedRecords?.first?.type == "MX", "DNS record type preserved")
+        #expect(final.email?.provider == "icloud", "Email config from concurrent save")
+        #expect(final.edge?.dnssec == true, "Edge config from concurrent save")
+        #expect(final.workers?.active == ["webmention-receive"], "Workers config from concurrent save")
+    }
 }


### PR DESCRIPTION
Closes #1189

## Summary

- Multiple producers (`DomainOperations`, `HardenExecutor`, `CustomDomainAttachCommand`, `EmailSetupExecutor`) can call `DomainConfigStore.save()` concurrently, causing a lost-update race condition where the read-then-write pattern was not atomic.
- Added `NSLock` to serialize access to `anglesite.json` during the load-modify-write sequence, ensuring atomicity.
- Added a concurrent write test that verifies multiple producers save different sections simultaneously without losing updates.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [x] This change **does not need a paired PR** — it's an internal concurrency fix to the config file handling with no MCP schema changes.

## Test plan

- [ ] `swift test --package-path .` — Run the new concurrent write test and existing config store tests
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — Verify the app builds with the locking mechanism in place
- Manual testing: Concurrent domain operations (e.g., deploy while editing DNS records) should preserve all updates without silent data loss

---
_Generated by [Claude Code](https://claude.ai/code/session_01RA4tXjqFA51PFcdnP36Dk8)_