### PR TITLE
refactor(#1188): unify anglesite.json write-through producers

### DIFF
--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -154,10 +154,10 @@ public enum DeployCoordinator {
     public static func syncWorkerActivationToAnglesiteJSON(
         configStore: SiteConfigStore, sourceDirectory: URL, settings: SiteSettings
     ) async -> SiteSettings {
-        let domainStore = DomainConfigStore(sourceDirectory: sourceDirectory)
-        var domainConfig = (try? domainStore.load()) ?? DomainConfig()
-        domainConfig.workers = DomainConfig.Workers(active: settings.activeWorkerIDs)
-        guard (try? domainStore.save(domainConfig)) != nil else { return settings }
+        let saved = DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+            config.workers = DomainConfig.Workers(active: settings.activeWorkerIDs)
+        }
+        guard saved else { return settings }
         var updated = settings
         updated.activeWorkerIDsMigratedToAnglesiteJSON = settings.activeWorkerIDs
         try? await configStore.save(updated)

--- a/Sources/AnglesiteCore/DomainConfigStore+Update.swift
+++ b/Sources/AnglesiteCore/DomainConfigStore+Update.swift
@@ -18,6 +18,15 @@ extension DomainConfigStore {
     /// never turn that success into a reported failure. Returns whether the save succeeded so a
     /// caller that does need to know (e.g. to decide whether a *second* write elsewhere should also
     /// happen) can check it; every current best-effort caller ignores it via `@discardableResult`.
+    ///
+    /// **Not atomic across the whole load-mutate-save sequence** (#1255): `load()` and `save()` are
+    /// still two separate calls here, so two concurrent `update()` calls that both mutate the *same*
+    /// top-level section can each `load()` a stale snapshot before either `save()`s, silently
+    /// dropping whichever one saves first — the #1189/#1253 lock only protects `save()`'s own
+    /// read-merge-write, not this gap. Not currently reachable by any producer routed through here
+    /// (no two same-section write-throughs fire concurrently today); #1255 tracks closing it once
+    /// #1253's lock lands, by moving this sequence into `DomainConfigStore.swift` itself so it can
+    /// hold that lock across the full load+mutate+save.
     @discardableResult
     public static func update(
         sourceDirectory: URL, _ mutate: (inout DomainConfig) -> Void

--- a/Sources/AnglesiteCore/DomainConfigStore+Update.swift
+++ b/Sources/AnglesiteCore/DomainConfigStore+Update.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Shared load/mutate/save shape for `Source/anglesite.json` write-through producers (#1188).
+/// `DomainOperations.writeThroughAdd`/`writeThroughRemove`, `HardenExecutor.writeThroughEdge`,
+/// `DomainIntentRecorder.recordTransferIntent`/`recordBuyIntent`, `EmailSetupExecutor.apply`, and
+/// `DeployCoordinator.syncWorkerActivationToAnglesiteJSON` each independently hand-rolled "load the
+/// current `DomainConfig`, mutate one section, best-effort save" — this collapses that into one
+/// place so the shape can't drift further across producers, and gives the next one a single
+/// pattern to route through. Kept in its own file (not `DomainConfigStore.swift`'s existing body),
+/// matching #1170's own constraint of not touching that file.
+extension DomainConfigStore {
+    /// Loads the current config for `sourceDirectory` (falling back to an empty `DomainConfig` if
+    /// the file is absent or fails to decode — mirrors every existing call site's `(try? …) ??
+    /// DomainConfig()` fallback), applies `mutate` in place, and saves the result.
+    ///
+    /// The save is best-effort by default: most callers are finishing up after an already-succeeded
+    /// network call, where a disk failure here (full disk, permissions, a hand-corrupted file) must
+    /// never turn that success into a reported failure. Returns whether the save succeeded so a
+    /// caller that does need to know (e.g. to decide whether a *second* write elsewhere should also
+    /// happen) can check it; every current best-effort caller ignores it via `@discardableResult`.
+    @discardableResult
+    public static func update(
+        sourceDirectory: URL, _ mutate: (inout DomainConfig) -> Void
+    ) -> Bool {
+        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
+        var config = (try? store.load()) ?? DomainConfig()
+        mutate(&config)
+        return (try? store.save(config)) != nil
+    }
+}

--- a/Sources/AnglesiteCore/DomainIntentRecorder.swift
+++ b/Sources/AnglesiteCore/DomainIntentRecorder.swift
@@ -20,12 +20,11 @@ public enum DomainIntentRecorder {
     /// `""` does get encoded and so does overwrite the merge; `ConnectDomainModel.loadRegistrarInfo`
     /// normalizes a blank string back to `nil` at the read boundary.
     public static func recordTransferIntent(hostname: String, siteDirectory: URL) {
-        let store = DomainConfigStore(sourceDirectory: siteDirectory)
-        var config = (try? store.load()) ?? DomainConfig()
-        config.domain = DomainConfig.Domain(
-            hostname: hostname, choice: NewSiteDomainChoice.transfer.rawValue, attach: true,
-            registrar: "", expiresAt: "")
-        try? store.save(config)
+        DomainConfigStore.update(sourceDirectory: siteDirectory) { config in
+            config.domain = DomainConfig.Domain(
+                hostname: hostname, choice: NewSiteDomainChoice.transfer.rawValue, attach: true,
+                registrar: "", expiresAt: "")
+        }
     }
 
     /// Declares a buy-a-domain intent: no hostname exists yet, so `attach` is `false` — there is
@@ -44,11 +43,10 @@ public enum DomainIntentRecorder {
     /// to look up a registrar for, so any registrar/expiration cached under a previous transfer
     /// declaration must not survive into this one.
     public static func recordBuyIntent(siteDirectory: URL) {
-        let store = DomainConfigStore(sourceDirectory: siteDirectory)
-        var config = (try? store.load()) ?? DomainConfig()
-        config.domain = DomainConfig.Domain(
-            hostname: "", choice: NewSiteDomainChoice.buy.rawValue, attach: false,
-            registrar: "", expiresAt: "")
-        try? store.save(config)
+        DomainConfigStore.update(sourceDirectory: siteDirectory) { config in
+            config.domain = DomainConfig.Domain(
+                hostname: "", choice: NewSiteDomainChoice.buy.rawValue, attach: false,
+                registrar: "", expiresAt: "")
+        }
     }
 }

--- a/Sources/AnglesiteCore/DomainOperationsService.swift
+++ b/Sources/AnglesiteCore/DomainOperationsService.swift
@@ -210,21 +210,19 @@ public struct DomainOperations: DomainOperationsService {
         type: String, name: String, content: String, priority: Int?, purpose: String?, domain: String,
         sourceDirectory: URL
     ) {
-        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
-        let current = (try? store.load()) ?? DomainConfig()
-        let updated = current.addingManagedDNSRecord(
-            .init(type: type, name: relativeName(name, domain: domain), content: content,
-                  priority: priority, purpose: purpose))
-        try? store.save(updated)
+        DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+            config = config.addingManagedDNSRecord(
+                .init(type: type, name: relativeName(name, domain: domain), content: content,
+                      priority: priority, purpose: purpose))
+        }
     }
 
     private static func writeThroughRemove(
         type: String, name: String, content: String, domain: String, sourceDirectory: URL
     ) {
-        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
-        let current = (try? store.load()) ?? DomainConfig()
-        let updated = current.removingManagedDNSRecord(
-            type: type, name: relativeName(name, domain: domain), content: content)
-        try? store.save(updated)
+        DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+            config = config.removingManagedDNSRecord(
+                type: type, name: relativeName(name, domain: domain), content: content)
+        }
     }
 }

--- a/Sources/AnglesiteCore/EmailSetupExecutor.swift
+++ b/Sources/AnglesiteCore/EmailSetupExecutor.swift
@@ -66,10 +66,9 @@ public struct EmailSetupExecutor: Sendable {
         }
 
         if let sourceDirectory {
-            let store = DomainConfigStore(sourceDirectory: sourceDirectory)
-            var config = (try? store.load()) ?? DomainConfig()
-            config.email = DomainConfig.Email(provider: plan.provider.rawValue, dmarcReportEmail: dmarcReportEmail)
-            try? store.save(config)
+            DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+                config.email = DomainConfig.Email(provider: plan.provider.rawValue, dmarcReportEmail: dmarcReportEmail)
+            }
         }
 
         return Result(addedCount: added, failures: failures)

--- a/Sources/AnglesiteCore/HardenExecutor.swift
+++ b/Sources/AnglesiteCore/HardenExecutor.swift
@@ -167,38 +167,37 @@ public struct HardenExecutor: Sendable {
     /// Harden's own DNS writes is left to a follow-up.
     private static func writeThroughEdge(_ items: [HardenPlanItem], sourceDirectory: URL) {
         guard !items.isEmpty else { return }
-        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
-        var config = (try? store.load()) ?? DomainConfig()
-        var edge = config.edge ?? DomainConfig.Edge()
-        var cloudflareEdge = edge.cloudflare ?? DomainConfig.Edge.CloudflareEdge()
-        var newWAFRules: [DomainConfig.Edge.WAFRule] = []
+        DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+            var edge = config.edge ?? DomainConfig.Edge()
+            var cloudflareEdge = edge.cloudflare ?? DomainConfig.Edge.CloudflareEdge()
+            var newWAFRules: [DomainConfig.Edge.WAFRule] = []
 
-        for item in items {
-            switch item {
-            case .enableDNSSEC:
-                edge.dnssec = true
-            case .enableAlwaysUseHTTPS:
-                edge.alwaysUseHTTPS = true
-            case .enableHSTS(let maxAge, let subs, let preload):
-                edge.hsts = .init(maxAge: maxAge, includeSubdomains: subs, preload: preload)
-            case .enableBotFightMode:
-                cloudflareEdge.botFightMode = true
-            case .addWAFRule(let desc, let expr, let action):
-                newWAFRules.append(.init(description: desc, expression: expr, action: action))
-            case .addCAARecord, .addNullMX, .addSPFRejectAll, .addDMARCReject,
-                 .enableSpeedBrain, .enableZstandardCompression, .enableECH, .enablePageShieldMonitoring:
-                break
+            for item in items {
+                switch item {
+                case .enableDNSSEC:
+                    edge.dnssec = true
+                case .enableAlwaysUseHTTPS:
+                    edge.alwaysUseHTTPS = true
+                case .enableHSTS(let maxAge, let subs, let preload):
+                    edge.hsts = .init(maxAge: maxAge, includeSubdomains: subs, preload: preload)
+                case .enableBotFightMode:
+                    cloudflareEdge.botFightMode = true
+                case .addWAFRule(let desc, let expr, let action):
+                    newWAFRules.append(.init(description: desc, expression: expr, action: action))
+                case .addCAARecord, .addNullMX, .addSPFRejectAll, .addDMARCReject,
+                     .enableSpeedBrain, .enableZstandardCompression, .enableECH, .enablePageShieldMonitoring:
+                    break
+                }
             }
-        }
 
-        if !newWAFRules.isEmpty {
-            cloudflareEdge.wafRules = DomainConfig.Edge.CloudflareEdge.accumulatingWAFRules(
-                newWAFRules, onto: cloudflareEdge.wafRules ?? [])
+            if !newWAFRules.isEmpty {
+                cloudflareEdge.wafRules = DomainConfig.Edge.CloudflareEdge.accumulatingWAFRules(
+                    newWAFRules, onto: cloudflareEdge.wafRules ?? [])
+            }
+            if cloudflareEdge.botFightMode != nil || cloudflareEdge.wafRules != nil {
+                edge.cloudflare = cloudflareEdge
+            }
+            config.edge = edge
         }
-        if cloudflareEdge.botFightMode != nil || cloudflareEdge.wafRules != nil {
-            edge.cloudflare = cloudflareEdge
-        }
-        config.edge = edge
-        try? store.save(config)
     }
 }

--- a/Tests/AnglesiteCoreTests/DomainConfigStoreUpdateTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainConfigStoreUpdateTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("DomainConfigStore.update")
+struct DomainConfigStoreUpdateTests {
+    private func tempSourceDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DomainConfigStoreUpdateTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("mutates a default config when no file exists yet, and saves it")
+    func mutatesDefaultConfigWhenMissing() throws {
+        let dir = try tempSourceDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let saved = DomainConfigStore.update(sourceDirectory: dir) { config in
+            config.domain = DomainConfig.Domain(hostname: "example.com")
+        }
+
+        #expect(saved)
+        let reloaded = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(reloaded.domain?.hostname == "example.com")
+    }
+
+    @Test("mutates the currently-saved config rather than starting fresh")
+    func mutatesExistingConfig() throws {
+        let dir = try tempSourceDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = DomainConfigStore(sourceDirectory: dir)
+        try store.save(DomainConfig(email: .init(provider: "icloud", dmarcReportEmail: "postmaster@example.com")))
+
+        DomainConfigStore.update(sourceDirectory: dir) { config in
+            config.domain = DomainConfig.Domain(hostname: "example.com")
+        }
+
+        let reloaded = try store.load()
+        #expect(reloaded.domain?.hostname == "example.com")
+        #expect(reloaded.email?.provider == "icloud", "update() must not clobber sections it didn't touch")
+    }
+
+    @Test("falls back to a default config when the on-disk file is malformed, rather than throwing")
+    func fallsBackToDefaultOnMalformedFile() throws {
+        let dir = try tempSourceDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try "not json {".write(
+            to: dir.appendingPathComponent("anglesite.json"), atomically: true, encoding: .utf8)
+
+        let saved = DomainConfigStore.update(sourceDirectory: dir) { config in
+            config.domain = DomainConfig.Domain(hostname: "example.com")
+        }
+
+        #expect(saved)
+        let reloaded = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(reloaded.domain?.hostname == "example.com")
+    }
+
+    @Test("returns false when the save fails, without throwing")
+    func returnsFalseOnSaveFailure() throws {
+        let missingDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DomainConfigStoreUpdateTests-missing-\(UUID().uuidString)", isDirectory: true)
+
+        let saved = DomainConfigStore.update(sourceDirectory: missingDir) { config in
+            config.domain = DomainConfig.Domain(hostname: "example.com")
+        }
+
+        #expect(!saved)
+    }
+}


### PR DESCRIPTION
Closes #1188

## Summary

- Add `DomainConfigStore.update(sourceDirectory:_:)` — a shared "load current `DomainConfig` (best-effort, falling back to a default), mutate it, best-effort save" helper — in a new `DomainConfigStore+Update.swift` file, per #1170's own constraint of not touching `DomainConfigStore.swift`'s existing body.
- Route all five current write-through producers through it, replacing each one's hand-rolled copy of the same three-line shape: `DomainOperations.writeThroughAdd`/`writeThroughRemove`, `HardenExecutor.writeThroughEdge`, `DomainIntentRecorder.recordTransferIntent`/`recordBuyIntent`, `EmailSetupExecutor.apply`'s inline write-through, and `DeployCoordinator.syncWorkerActivationToAnglesiteJSON` (the "fifth producer" the issue anticipated arriving via #1095's worker-activation slice — it had already landed by the time I picked this up, so I folded it in too rather than leaving a fresh producer un-migrated).
- `update(_:)` is `@discardableResult` and returns whether the save succeeded: every best-effort caller ignores it, but `DeployCoordinator` needs the signal (it only records the `Config/` sync snapshot after a successful `anglesite.json` write), so the helper covers both shapes without a second variant.
- Added `DomainConfigStoreUpdateTests.swift` covering the helper directly (missing file, existing file, malformed file, save failure).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — **could not run**: this session's container has no Swift toolchain installed (`swift`/`swiftc` not found) and no container runtime (`docker`/`podman` daemon unreachable) to fall back to. Changes were reviewed by hand for syntax/type correctness against the existing call sites and test suite; please run this in CI/locally before merge.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **could not run**, same reason (this change only touches `AnglesiteCore`, no app-target code).
- [ ] Manual smoke: not applicable — no UI-visible change; behavior of all five producers is preserved (same fallback-to-default-on-load-failure, same best-effort-swallow-save-failure posture except `DeployCoordinator`, which already checked the save result before this change and still does).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LaWETcbMAmxB2TPHwVHLcV)_