### PR TITLE
docs(#1165): record SRI disposition for Cloudflare beacon

### DIFF
--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -251,6 +251,13 @@ export function checkMixedContent(content: string, file: string): Issue[] {
  * blocks the response on CORS before integrity is evaluated, so the resource
  * silently fails to load. Heuristic tag-level regex match; multi-line tag
  * attributes are not matched. One issue per offending tag.
+ *
+ * No allowlist: this intentionally also warns on auto-updating, unversioned CDN
+ * scripts (e.g. the Cloudflare Web Analytics beacon, legacy Google gtag.js) that
+ * can't carry a stable `integrity` hash without breaking on the vendor's next
+ * content rotation — for those, the warning firing is the expected, disposed
+ * outcome (Cloudflare beacon: #1165), not a gap to fix. Advisory only
+ * (`severity: "warning"`); doesn't block deploys unless `--strict` is passed.
  */
 export function checkSRI(content: string, file: string): Issue[] {
   const issues: Issue[] = [];

--- a/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
+++ b/Sources/AnglesiteCore/WebsiteAnalyticsAsset.swift
@@ -293,6 +293,13 @@ public enum WebsiteAnalyticsAsset {
         let customTag = settings.customHeadTag.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if !cloudflareToken.isEmpty {
+            // Deliberately no `integrity=`: the beacon URL is unversioned and Cloudflare
+            // rotates its content routinely, so a pinned hash would break analytics fleet-wide
+            // on the next rotation with no build-time signal. `pre-deploy-check.ts`'s
+            // `sri-missing` warning on this tag is expected, not a gap — the compensating
+            // control is the CSP `SCRIPT_ALLOW` scoping this method adds for
+            // `cloudflareCSPDomains` while the beacon is enabled. See #1165 for the full
+            // investigation and disposition.
             let beacon = cloudflareBeaconAttributeValue(token: cloudflareToken)
             lines.append(#"<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='\#(beacon)'></script>"#)
         }


### PR DESCRIPTION
Closes #1165

## Summary

- Documented, in a code comment at the Cloudflare Web Analytics beacon's render site (`WebsiteAnalyticsAsset.swift`), why the script is deliberately unpinned: the beacon URL is unversioned and rotates routinely, so `integrity=` would break analytics fleet-wide on the next rotation with no build-time signal — CSP `SCRIPT_ALLOW` scoping (#1013/#1149) is the compensating control.
- Extended `checkSRI()`'s doc comment in `Resources/Template/scripts/pre-deploy-check.ts` to note that the `sri-missing` warning firing on this (and similar auto-updating, unversioned CDN scripts like legacy Google gtag.js) is expected and disposed, not a gap, so a future audit or hook run doesn't re-litigate it.
- No behavior change — advisory-only, non-blocking warning still fires as before.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — not run (no Swift toolchain available in this environment); change is comment-only, no Swift logic touched.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (no Xcode available in this environment); change is comment-only, no Swift logic touched.
- [x] `npx tsx --test scripts/pre-deploy-check.test.ts` (from `Resources/Template/`) — 81/81 passing, confirming the `checkSRI()` doc-comment change didn't affect behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_017skfZttRwoHCiD7hHih79a)_