### PR TITLE
test(ci): isolate AuditCommandTests' subprocess supervisor

### DIFF
--- a/Tests/AnglesiteCoreTests/AuditCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/AuditCommandTests.swift
@@ -20,7 +20,14 @@ struct AuditCommandTests {
         }
     ) -> (AuditCommand, LogCenter) {
         let center = LogCenter()
+        // Isolated supervision, mirroring DeployExecutorTests.makeExecutor — HostAuditExecutor's
+        // default (`.shared`) would otherwise route this suite's real subprocess spawns through
+        // the same process-wide actor every other `.shared`-using suite contends on under
+        // `swift test --parallel`, which is exactly the kind of cross-suite scheduling pressure
+        // documented as a recurring CI flake source (see VsockTCPProxyTests' `.serialized` note).
+        let supervisor = ProcessSupervisor()
         let hostExecutor = HostAuditExecutor(
+            supervisor: supervisor,
             logCenter: center,
             resolveCommand: { step in
                 switch step {

--- a/Tests/AnglesiteCoreTests/VsockTCPProxyTests.swift
+++ b/Tests/AnglesiteCoreTests/VsockTCPProxyTests.swift
@@ -4,10 +4,14 @@ import Foundation
 
 /// `.serialized`: this suite drives real sockets and per-connection `DispatchIO`/`DispatchQueue`
 /// pumps. Under CI's full parallel test run (1087 tests across 163 suites on a resource-constrained
-/// macos-15 runner), the global GCD thread pool gets so oversubscribed that some of these tests'
-/// read/write handlers went unscheduled for 10+ seconds — the same 3 of 9 tests failed identically,
-/// with 0 bytes ever received, on two consecutive CI runs of an unmodified commit, while a local
-/// `swift test --filter VsockTCPProxyTests` run passes every test in under 200ms. Serializing this
+/// runner — originally observed on macos-15, and reproduced again after `build-test` moved to
+/// macos-26 (see AGENTS.md's "Swift lanes" note and PR #1264's CI history) — the contention tracks
+/// parallel test load, not a specific runner tier, so don't read this as macos-15-specific when
+/// investigating a future recurrence. The global GCD thread pool gets so oversubscribed that some
+/// of these tests' read/write handlers went unscheduled for 10+ seconds — the same 3 of 9 tests
+/// failed identically, with 0 bytes ever received, on two consecutive CI runs of an unmodified
+/// commit, while a local `swift test --filter VsockTCPProxyTests` run passes every test in under
+/// 200ms. Serializing this
 /// suite's own tests removes its largest source of internal GCD contention so it isn't competing
 /// with itself on top of the rest of the parallel test binary.
 ///


### PR DESCRIPTION
## Summary

- Follow-up to [PR #1264's CI status comment](https://github.com/Anglesite/Anglesite/pull/1264#issuecomment-5186833191): `build-test` failed repeatedly on that PR in `VsockTCPProxyTests` plus one-off hits on `AuditCommandTests` and `E2EServerReadinessTests` — all pre-existing, unrelated to that PR's `DomainConfigStore` change, and attributed to GCD thread-pool contention under `swift test --parallel`.
- `AuditCommandTests.makeCommand` built its `HostAuditExecutor` without overriding the `supervisor` parameter, so it silently defaulted to the process-wide `ProcessSupervisor.shared` actor — the same singleton ~20 other suites route real subprocess spawns through. `DeployExecutorTests` (`HostAuditExecutor`'s own sibling, per its doc comment) already isolates supervision with a fresh instance; this gives `AuditCommandTests` the same isolation so its subprocess launches aren't queued behind unrelated suites' spawns under a parallel test run.
- Corrects `VsockTCPProxyTests`' doc comment, which blamed the flake on the "macos-15 runner" — `build-test` has run on `macos-26` since PR #644/#646 (see `AGENTS.md` ▸ "Swift lanes"), and the same flake reproduced there during PR #1264, so the note now tracks parallel test load generally instead of pointing at a stale runner tier.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [ ] `swift test --package-path .` — **could not run**: no Swift toolchain in this remote execution environment (Linux container, no `swift`/`xcodebuild`). CI's `Linux (portable SwiftPM targets)` and `build-test` lanes should cover this.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — same toolchain limitation, could not run locally.
- [x] Manual code review: confirmed `HostAuditExecutor`'s `supervisor` parameter is injectable (used the same way `HostDeployExecutor`/`DeployExecutorTests` already do) and that `ProcessSupervisor` is an `actor`, so the only change in behavior is which actor instance `AuditCommandTests`' subprocess spawns route through — no production code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YbR9YCHKepxmoLysVA9HFa)_