### PR TITLE
ci(#864): add iOS app target build lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,83 @@ jobs:
       - name: Build (release)
         run: swift build -c release
 
+  ios-build:
+    name: iOS app target (AnglesiteMobile)
+    # #864: no other lane ever actually compiles an iOS app target. xcodeproj-sync (macos-15)
+    # only checks source-file membership in the generated project — its own header says
+    # explicitly that it "deliberately does NOT run a full xcodebuild" — and every other
+    # xcodebuild-based lane (build-test, concurrency-tsan, appintents-schema) builds only the
+    # macOS `Anglesite`/`AnglesiteIntents` schemes. This lane closes that gap by actually
+    # building the `AnglesiteMobile` target (Package.swift's `.iOS("27.0")` platform entry +
+    # the project.yml target both already exist — PR #886) for the iOS Simulator SDK, so an
+    # iOS-incompatible change to AnglesiteCore/AnglesiteBridge/AnglesiteIOS (the modules this
+    # target links) fails CI instead of surfacing only on a contributor's local build.
+    # macos-26, matching build-test's rationale: the newest available Xcode carries the most
+    # complete iOS 27 SDK.
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
+    runs-on: macos-26
+    timeout-minutes: 15
+    env:
+      # Keep in sync with the xcodeproj-sync/appintents-schema lanes above (and MIN_XCODEGEN in
+      # check-xcodeproj-sync.sh).
+      XCODEGEN_VERSION: 2.45.4
+      XCODEGEN_SHA256: 090ec29491aad50aec10631bf6e62253fed733c50f3aab0f5ffc86bc170bdbef
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Select latest available Xcode
+        # Same toolchain rationale as build-test: CLAUDE.md mandates Xcode 27+, and this
+        # target's iOS deploymentTarget (project.yml) is "27.0".
+        id: xcode
+        run: |
+          set -euo pipefail
+          ls -d /Applications/Xcode*.app 2>/dev/null | sort -V
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | grep -vE '/Xcode_26\.3(\.app|\.[0-9]+\.app)$' | tail -1)
+          echo "Selecting: $LATEST"
+          sudo xcode-select -s "$LATEST"
+          echo "version=$(basename "$LATEST")" >> "$GITHUB_OUTPUT"
+
+      - name: Show toolchain versions
+        run: |
+          swift --version
+          xcodebuild -version
+
+      - name: Install XcodeGen (pinned)
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" -o /tmp/xcodegen.zip
+          echo "${XCODEGEN_SHA256}  /tmp/xcodegen.zip" | shasum -a 256 --check
+          unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
+          test -x /tmp/xcodegen-dist/xcodegen/bin/xcodegen \
+            || { echo "error: xcodegen binary not found at expected path after unzip — check zip layout" >&2; exit 1; }
+          echo "/tmp/xcodegen-dist/xcodegen/bin" >> "$GITHUB_PATH"
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      # See the linux-build-test cache step for the key-scheme rationale. A distinct namespace
+      # (`swiftpm-ios-...`) from the macOS lanes above: an iOS Simulator SDK build produces
+      # different object files than a macOS build of the same sources, so sharing a cache key
+      # would just churn without ever hitting.
+      - name: Cache SwiftPM build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build
+          key: swiftpm-ios-v1-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-${{ github.sha }}
+          restore-keys: |
+            swiftpm-ios-v1-${{ steps.xcode.outputs.version }}-${{ hashFiles('Package.resolved') }}-
+            swiftpm-ios-v1-${{ steps.xcode.outputs.version }}-
+
+      - name: Build AnglesiteMobile (iOS Simulator)
+        # Matches the invocation PR #886 verified manually ("BUILD SUCCEEDED") when the target
+        # was first added; this lane is what makes that verification continuous. Ad-hoc Debug
+        # signing (xcconfig/Signing-Debug.xcconfig) is already CI-safe — no extra
+        # CODE_SIGNING_ALLOWED override needed.
+        run: |
+          xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile \
+            -configuration Debug -destination 'generic/platform=iOS Simulator' build
+
   concurrency-tsan:
     name: Concurrency suites (ThreadSanitizer)
     # macos-26 for the same OS-runtime reason as build-test: this lane runs Swift concurrency
@@ -660,6 +737,7 @@ jobs:
       - help-book-links
       - linux-build-test
       - build-test
+      - ios-build
       - concurrency-tsan
       - docs-docc
       - xcodeproj-sync


### PR DESCRIPTION
Closes #864

## Summary

- Adds an `ios-build` CI lane (`.github/workflows/ci.yml`) that actually compiles the
  `AnglesiteMobile` iOS app target for the iOS Simulator SDK — the one real gap left in #864's
  checklist. `xcodeproj-sync` only checks source-file membership in the generated project (its
  own header says it "deliberately does NOT run a full xcodebuild"), and every other
  `xcodebuild`-based lane (`build-test`, `concurrency-tsan`, `appintents-schema`) builds only the
  macOS `Anglesite`/`AnglesiteIntents` schemes, so nothing in CI ever exercised an iOS build path
  before this.
- The other checklist items were already satisfied on `main` before this PR: `Package.swift`'s
  `.iOS("27.0")` platform entry and the `AnglesiteMobile` `project.yml` target both landed in
  #886 (#71's iOS thin-client scaffold), which also manually verified the exact `xcodebuild`
  invocation this lane now runs continuously.
- Ran the target-by-target module audit the issue asks for (no Xcode available in this
  environment, so source-level instead of a real build): `AnglesiteCore`, `AnglesiteBridge`, and
  `AnglesiteIOS` have no *unguarded* macOS-only paths. Every AppKit-only code path is already
  scoped — `PreviewPrinting.swift` and `InProcessBackend.swift` are whole-file
  `#if os(macOS)`/`#if !os(iOS)`, `WebViewBridge.enableWritingTools`'s `writingToolsBehavior`
  setter is `#if os(macOS)`-gated, and `AnglesiteIOS` itself is whole-file `#if os(iOS)`. The one
  dependency-level thing worth a note: `SwiftGit2` links into `AnglesiteCore` under
  `#if canImport(Darwin)` (which includes iOS) — confirmed the pinned fork declares `.iOS("15.5")`
  and builds `Clibgit2` from source, so this is fine, just not literally "off-macOS" as the
  neighboring comment says.

## Design note (not resolved by this PR)

The 2026-07-21 Micropub-client design this issue elaborates (linked from the issue body) says the
iOS app's bundle ID should reuse `io.dwk.anglesite` (the Mac target's own ID) for Apple's
universal-purchase mechanism. `AnglesiteMobile` (added by #886, a separate #71 effort predating
this design) actually uses `io.dwk.anglesite.ios`. I left this alone rather than renaming it or
adding a second app target: the 2026-08-03 Anywhere-runtime spec (`docs/superpowers/specs/
2026-08-03-anywhere-runtime-webrtc-design.md` §4) explicitly treats `AnglesiteMobile`'s existing
scaffold as the one that continues forward ("not deleted by this re-base... the P4 plan owns the
runtime-selection policy and any pruning of that scaffold"), so a bundle-ID change reads as a
product decision for whichever plan actually ships the posting-client UI (#868/#869), not
something to fold into this scaffolding-only issue.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML.
- [ ] `swift test --package-path .` — not run; no Swift source changed, CI workflow config only.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not
      runnable in this Linux environment (no Xcode); the new lane's `AnglesiteMobile` invocation
      matches what #886 already verified manually ("BUILD SUCCEEDED"), and will now run on every
      PR via `ios-build`.
- [x] Source-level iOS-readiness audit of `AnglesiteCore`/`AnglesiteBridge`/`AnglesiteIOS` (see
      Summary) — no unguarded macOS-only paths found.
- [ ] Manual smoke (if UI-touching): n/a — no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrsAnvMDJe4EdN9otYtweu)_