### PR TITLE
Email Setup wizard + Experiment Results front-doors (#769)

### DIFF
--- a/Sources/AnglesiteApp/DomainModel.swift
+++ b/Sources/AnglesiteApp/DomainModel.swift
@@ -50,6 +50,10 @@ final class DomainModel {
     private(set) var phase: Phase = .idle
     var sheetPresented: Bool = false
     var domainInput: String = ""
+    /// Set by `openEmailSetup()`, read by `SiteWindow`'s domain-sheet `onDismiss` to sequence
+    /// the Email Setup wizard's presentation after this sheet finishes dismissing — same
+    /// handoff pattern as `ConnectDomainModel.pendingBuyDomain`.
+    var pendingEmailSetup: Bool = false
 
     private let ops: any DomainOperationsService
     private var inFlight: Task<Void, Never>?
@@ -86,6 +90,13 @@ final class DomainModel {
         inFlight = nil
         sheetPresented = false
         phase = .idle
+    }
+
+    /// The "Set up Email…" affordance in the loaded record list (#769): closes this sheet and
+    /// flags the handoff so `SiteWindow` opens the Email Setup wizard once dismissal finishes.
+    func openEmailSetup() {
+        pendingEmailSetup = true
+        dismissSheet()
     }
 
     /// Like `openSheet()` but preserves `domainInput` — matches `HardenModel.retryFromFailed()`,

--- a/Sources/AnglesiteApp/DomainSheetView.swift
+++ b/Sources/AnglesiteApp/DomainSheetView.swift
@@ -145,6 +145,12 @@ struct DomainSheetView: View {
                 } label: {
                     Label("Add Google verification", systemImage: "checkmark.seal")
                 }
+                Button {
+                    model.openEmailSetup()
+                } label: {
+                    Label("Set up email", systemImage: "envelope")
+                }
+                .help("Recommend an email provider and pre-fill its DNS records")
                 Spacer()
                 Button {
                     model.refresh()

--- a/Sources/AnglesiteApp/EmailSetupModel.swift
+++ b/Sources/AnglesiteApp/EmailSetupModel.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Email Setup wizard (#769): walks the owner through
+/// `EmailSetupPlanner`'s Apple-first decision tree, reconciles the resulting DNS plan against
+/// any SPF record the zone already has, and applies it via `EmailSetupExecutor`. Fresh-per-open,
+/// same lifecycle as `CopyEditReportModel`/`SocialPlanModel` — not a persistent zone-editing
+/// model like `DomainModel`.
+@Observable @MainActor
+final class EmailSetupModel: Identifiable {
+    let id = UUID()
+    let siteID: String
+    let sourceDirectory: URL
+
+    enum Step {
+        case ecosystem
+        case appleTier
+        /// Recommendation shown, owner fills in domain + DMARC report address and can switch to
+        /// an alternative provider before building the plan.
+        case details
+        case buildingPlan
+        case review(plan: EmailSetupPlanner.DNSPlan, spfWasMerged: Bool)
+        case applying
+        case result(EmailSetupExecutor.Result)
+    }
+
+    private(set) var step: Step = .ecosystem
+    private var ecosystem: EmailSetupPlanner.Ecosystem?
+    var appleTier: EmailSetupPlanner.AppleTier = .personal
+    var domain: String
+    var dmarcReportEmail: String = ""
+    private(set) var recommendation: EmailSetupPlanner.Recommendation?
+    var selectedProvider: EmailSetupPlanner.Provider?
+
+    private let ops: any DomainOperationsService
+    private var inFlight: Task<Void, Never>?
+
+    /// `domain` prefills from the site's declared `anglesite.json` hostname (empty if none yet);
+    /// the owner can still edit it before building a plan.
+    init(
+        siteID: String, sourceDirectory: URL, domain: String,
+        ops: any DomainOperationsService = DomainOperations()
+    ) {
+        self.siteID = siteID
+        self.sourceDirectory = sourceDirectory
+        self.domain = domain
+        self.ops = ops
+    }
+
+    var isRunning: Bool {
+        switch step {
+        case .buildingPlan, .applying: return true
+        default: return false
+        }
+    }
+
+    var availableProviders: [EmailSetupPlanner.Provider] {
+        guard let recommendation else { return [] }
+        return [recommendation.provider] + recommendation.alternatives
+    }
+
+    func choose(ecosystem: EmailSetupPlanner.Ecosystem) {
+        self.ecosystem = ecosystem
+        switch ecosystem {
+        case .apple:
+            step = .appleTier
+        case .mixedOrOther:
+            recommendation = EmailSetupPlanner.recommend(ecosystem: .mixedOrOther)
+            selectedProvider = recommendation?.provider
+            step = .details
+        }
+    }
+
+    func choose(appleTier: EmailSetupPlanner.AppleTier) {
+        self.appleTier = appleTier
+        recommendation = EmailSetupPlanner.recommend(ecosystem: .apple, appleTier: appleTier)
+        selectedProvider = recommendation?.provider
+        step = .details
+    }
+
+    func selectProvider(_ provider: EmailSetupPlanner.Provider) {
+        selectedProvider = provider
+    }
+
+    /// Backs up one step from `.details`/`.appleTier` — mirrors a wizard's Back button rather
+    /// than dismissing outright.
+    func back() {
+        switch step {
+        case .appleTier:
+            step = .ecosystem
+        case .details:
+            step = ecosystem == .apple ? .appleTier : .ecosystem
+        default:
+            break
+        }
+    }
+
+    func buildPlan() {
+        guard let provider = selectedProvider, !isRunning else { return }
+        let trimmedDomain = domain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let trimmedEmail = dmarcReportEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDomain.isEmpty, !trimmedEmail.isEmpty else { return }
+        inFlight?.cancel()
+        domain = trimmedDomain
+        dmarcReportEmail = trimmedEmail
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runBuildPlan(provider: provider, domain: trimmedDomain, dmarcReportEmail: trimmedEmail)
+        }
+    }
+
+    func apply() {
+        guard case .review(let plan, _) = step, !isRunning else { return }
+        let domain = self.domain
+        let dmarcReportEmail = self.dmarcReportEmail
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runApply(plan: plan, domain: domain, dmarcReportEmail: dmarcReportEmail)
+        }
+    }
+
+    // MARK: - Private
+
+    private func runBuildPlan(provider: EmailSetupPlanner.Provider, domain: String, dmarcReportEmail: String) async {
+        step = .buildingPlan
+        let basePlan = EmailSetupPlanner.dnsPlan(for: provider, domain: domain, dmarcReportEmail: dmarcReportEmail)
+        var existingSPF: String?
+        if case .success(let records) = await ops.listRecords(domain: domain) {
+            existingSPF = records.first {
+                $0.type == "TXT" && $0.name.caseInsensitiveCompare(domain) == .orderedSame
+                    && $0.content.lowercased().hasPrefix("v=spf1")
+            }?.content
+        }
+        let reconciled = EmailSetupPlanner.reconcilingExistingSPF(in: basePlan, existingSPFRecordContent: existingSPF)
+        step = .review(plan: reconciled, spfWasMerged: reconciled != basePlan)
+    }
+
+    private func runApply(plan: EmailSetupPlanner.DNSPlan, domain: String, dmarcReportEmail: String) async {
+        step = .applying
+        let executor = EmailSetupExecutor(ops: ops)
+        let result = await executor.apply(
+            plan: plan, domain: domain, dmarcReportEmail: dmarcReportEmail, sourceDirectory: sourceDirectory)
+        step = .result(result)
+    }
+}

--- a/Sources/AnglesiteApp/EmailSetupSheetView.swift
+++ b/Sources/AnglesiteApp/EmailSetupSheetView.swift
@@ -1,0 +1,261 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Wizard UI for `EmailSetupModel` (#769) — Apple-first ecosystem question, provider
+/// recommendation + domain/DMARC details, a review of the exact DNS records (with any SPF merge
+/// called out), then apply. Structural template: header/content/footer split, same as
+/// `DomainSheetView`.
+struct EmailSetupSheetView: View {
+    @Bindable var model: EmailSetupModel
+    /// Dismisses the sheet — `SiteWindow` nils `SiteWindowModel.emailSetupModel` here, same as
+    /// `copyEditModel`'s "Done" button.
+    var onDone: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            footer
+        }
+        .frame(minWidth: 560, idealWidth: 640, minHeight: 460, idealHeight: 560)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            statusIcon
+            VStack(alignment: .leading, spacing: 1) {
+                Text(headerTitle).font(.headline)
+                if let subtitle = headerSubtitle {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch model.step {
+        case .buildingPlan, .applying:
+            ProgressView().controlSize(.small)
+        case .result(let result):
+            Image(systemName: result.failures.isEmpty ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(result.failures.isEmpty ? .green : .yellow)
+                .font(.title3)
+        default:
+            Image(systemName: "envelope").font(.title3)
+        }
+    }
+
+    private var headerTitle: String {
+        switch model.step {
+        case .ecosystem: return "Set Up Business Email"
+        case .appleTier: return "Personal or business?"
+        case .details: return "Email provider details"
+        case .buildingPlan: return "Checking existing DNS records…"
+        case .review(let plan, _): return "Review \(plan.provider.displayName) setup"
+        case .applying: return "Adding DNS records…"
+        case .result(let result):
+            return "Added \(result.addedCount) record\(result.addedCount == 1 ? "" : "s")"
+        }
+    }
+
+    private var headerSubtitle: String? {
+        switch model.step {
+        case .review(_, let spfWasMerged) where spfWasMerged:
+            return "Your existing SPF record will be updated to include this provider — not duplicated."
+        case .result(let result) where !result.failures.isEmpty:
+            return "\(result.failures.count) record\(result.failures.count == 1 ? "" : "s") couldn't be added."
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.step {
+        case .ecosystem:
+            ecosystemStep
+        case .appleTier:
+            appleTierStep
+        case .details:
+            detailsStep
+        case .buildingPlan:
+            progressView("Reading existing DNS records…")
+        case .review(let plan, _):
+            reviewStep(plan)
+        case .applying:
+            progressView("Adding DNS records…")
+        case .result(let result):
+            resultStep(result)
+        }
+    }
+
+    private func progressView(_ text: String) -> some View {
+        VStack(spacing: 8) {
+            ProgressView()
+            Text(text).font(.callout).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var ecosystemStep: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "envelope.badge").font(.system(size: 40)).foregroundStyle(.secondary)
+            Text("Do you use Apple devices (iPhone, Mac) for this business?")
+                .font(.headline).multilineTextAlignment(.center).frame(maxWidth: 420)
+            HStack(spacing: 12) {
+                Button("Yes, mostly Apple") { model.choose(ecosystem: .apple) }
+                    .buttonStyle(.borderedProminent)
+                Button("No, mixed or other devices") { model.choose(ecosystem: .mixedOrOther) }
+            }
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    private var appleTierStep: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Text("Is this email for you personally, or for a registered business?")
+                .font(.headline).multilineTextAlignment(.center).frame(maxWidth: 420)
+            HStack(spacing: 12) {
+                Button("Just me") { model.choose(appleTier: .personal) }
+                    .buttonStyle(.borderedProminent)
+                Button("Registered business") { model.choose(appleTier: .registeredBusiness) }
+            }
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    private var detailsStep: some View {
+        Form {
+            if let recommendation = model.recommendation {
+                Section {
+                    Picker("Provider", selection: Binding(
+                        get: { model.selectedProvider ?? recommendation.provider },
+                        set: { model.selectProvider($0) }
+                    )) {
+                        ForEach(model.availableProviders, id: \.self) { provider in
+                            Text(provider.displayName).tag(provider)
+                        }
+                    }
+                    Text(recommendation.reason).font(.caption).foregroundStyle(.secondary)
+                    if let provider = model.selectedProvider {
+                        Text(provider.costSummary).font(.caption).foregroundStyle(.secondary)
+                    }
+                } header: {
+                    Text("Recommended provider")
+                }
+            }
+            Section {
+                TextField("example.com", text: $model.domain)
+                TextField("owner@example.com", text: $model.dmarcReportEmail)
+            } header: {
+                Text("Domain & DMARC reports")
+            } footer: {
+                Text("DMARC reports go to this address so you'll hear about delivery problems.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(16)
+    }
+
+    private func reviewStep(_ plan: EmailSetupPlanner.DNSPlan) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("DNS records to add").font(.subheadline.weight(.semibold))
+                    ForEach(Array(plan.records.enumerated()), id: \.offset) { _, record in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(EmailSetupPlanner.explanation(forRecordType: record.type, name: record.name))
+                                .font(.callout)
+                            Text("\(record.type) \(record.name) → \(record.content)"
+                                + (record.priority.map { " (priority \($0))" } ?? ""))
+                                .font(.caption.monospaced()).foregroundStyle(.secondary).textSelection(.enabled)
+                        }
+                        .padding(10)
+                        .background(Color.secondary.opacity(0.06))
+                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    }
+                }
+                if !plan.manualSteps.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("You'll need to add these yourself").font(.subheadline.weight(.semibold))
+                        ForEach(Array(plan.manualSteps.enumerated()), id: \.offset) { _, step in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(step.title).font(.callout.weight(.medium))
+                                Text(step.instructions).font(.caption).foregroundStyle(.secondary)
+                            }
+                            .padding(10)
+                            .background(Color.orange.opacity(0.08))
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private func resultStep(_ result: EmailSetupExecutor.Result) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                if !result.failures.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(Array(result.failures.enumerated()), id: \.offset) { _, failure in
+                            Text("\(failure.record.type) \(failure.record.name): couldn't be added.")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                Text("Finish setup in your email provider's dashboard for any manual steps shown earlier, then your email will start working once DNS propagates (usually within a few hours).")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .padding(16)
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            switch model.step {
+            case .appleTier, .details:
+                Button("Back") { model.back() }
+            default:
+                EmptyView()
+            }
+            Spacer()
+            switch model.step {
+            case .details:
+                Button("Continue") { model.buildPlan() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(model.domain.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || model.dmarcReportEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            case .review:
+                Button("Add DNS Records") { model.apply() }
+                    .buttonStyle(.borderedProminent)
+            case .result:
+                Button("Done") { onDone() }.keyboardShortcut(.defaultAction)
+            case .buildingPlan, .applying:
+                EmptyView()
+            default:
+                Button("Cancel") { onDone() }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}

--- a/Sources/AnglesiteApp/ExperimentStatsModel.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsModel.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Experiment Results sheet (#769): a manual-entry front door onto `ExperimentStats`.
+/// The retired Claude Code plugin's edge A/B machinery (cookie-based variant assignment, an
+/// analytics pipeline reporting impressions/conversions back to the app) was never rebuilt after
+/// #466 — see `ExperimentStats`' doc comment and the follow-up (#1270) — so this sheet takes the
+/// two variants' counts as owner-typed input (read off whatever analytics the owner already has)
+/// rather than reading them from a stored experiment config. Fresh-per-open, same lifecycle as
+/// `CopyEditReportModel`.
+@Observable @MainActor
+final class ExperimentStatsModel: Identifiable {
+    let id = UUID()
+    let siteID: String
+
+    var experimentName: String = ""
+    var controlName: String = "Original"
+    var controlImpressions: Int = 0
+    var controlConversions: Int = 0
+    var treatmentName: String = "Variant"
+    var treatmentImpressions: Int = 0
+    var treatmentConversions: Int = 0
+
+    private(set) var result: ExperimentStats.Result?
+    private(set) var hasSufficientData = false
+    private(set) var sampleRatioMismatch = false
+
+    let suggestions = ExperimentStats.suggestionPlaybook
+
+    init(siteID: String) {
+        self.siteID = siteID
+    }
+
+    /// Both variants need at least one visitor before there's anything to analyze —
+    /// `ExperimentStats.Variant`'s own clamping already handles zero/negative conversions.
+    var canAnalyze: Bool {
+        controlImpressions > 0 && treatmentImpressions > 0
+    }
+
+    func analyze() {
+        guard canAnalyze else { return }
+        let control = ExperimentStats.Variant(
+            name: controlName.isEmpty ? "Original" : controlName,
+            impressions: controlImpressions, conversions: controlConversions)
+        let treatment = ExperimentStats.Variant(
+            name: treatmentName.isEmpty ? "Variant" : treatmentName,
+            impressions: treatmentImpressions, conversions: treatmentConversions)
+        result = ExperimentStats.analyze(control: control, treatment: treatment)
+        hasSufficientData = ExperimentStats.hasSufficientData(control: control, treatment: treatment)
+        sampleRatioMismatch = ExperimentStats.hasSampleRatioMismatch(control: control, treatment: treatment)
+    }
+
+    var summary: String? {
+        guard let result else { return nil }
+        return ExperimentStats.formatSummary(
+            experimentName: experimentName.isEmpty ? "Experiment" : experimentName, result: result)
+    }
+
+    /// Clears the result so the owner can revise counts and re-analyze — doesn't reset the
+    /// entered counts themselves.
+    func editAgain() {
+        result = nil
+    }
+}

--- a/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
+++ b/Sources/AnglesiteApp/ExperimentStatsSheetView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import AnglesiteCore
+
+/// UI for `ExperimentStatsModel` (#769): owner types in each variant's impression/conversion
+/// counts, gets `ExperimentStats`' exact Bayesian analysis back in plain language, plus the
+/// default test-idea playbook for owners who haven't started a test yet.
+struct ExperimentStatsSheetView: View {
+    @Bindable var model: ExperimentStatsModel
+    var onDone: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Experiment") {
+                    TextField("What are you testing? (optional)", text: $model.experimentName)
+                }
+                variantSection(
+                    title: "Original (control)", name: $model.controlName,
+                    impressions: $model.controlImpressions, conversions: $model.controlConversions)
+                variantSection(
+                    title: "Variant (treatment)", name: $model.treatmentName,
+                    impressions: $model.treatmentImpressions, conversions: $model.treatmentConversions)
+
+                Section {
+                    Button("Analyze") {
+                        model.analyze()
+                    }
+                    .disabled(!model.canAnalyze)
+                }
+
+                if let result = model.result {
+                    resultSection(result)
+                }
+
+                Section("Test ideas") {
+                    ForEach(model.suggestions, id: \.title) { suggestion in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(suggestion.title).font(.callout.weight(.medium))
+                            Text(suggestion.rationale).font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle("Experiment Results")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { onDone() }
+                }
+            }
+        }
+        .frame(minWidth: 520, idealWidth: 560, minHeight: 480, idealHeight: 620)
+    }
+
+    private func variantSection(
+        title: String, name: Binding<String>, impressions: Binding<Int>, conversions: Binding<Int>
+    ) -> some View {
+        Section(title) {
+            TextField("Name", text: name)
+            TextField("Visitors", value: impressions, format: .number)
+            TextField("Conversions", value: conversions, format: .number)
+        }
+    }
+
+    private func resultSection(_ result: ExperimentStats.Result) -> some View {
+        Section("Result") {
+            if let summary = model.summary {
+                Text(summary).font(.callout).textSelection(.enabled)
+            }
+            LabeledContent("Control rate", value: percent(result.controlRate))
+            LabeledContent("Variant rate", value: percent(result.treatmentRate))
+            LabeledContent("Probability variant wins", value: percent(result.probabilityTreatmentBeatsControl))
+            if !model.hasSufficientData {
+                Label(
+                    "Not enough traffic yet — the retired skill's rule of thumb is 30+ days or 500+ visitors per variant before trusting an inconclusive result.",
+                    systemImage: "clock")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+            if model.sampleRatioMismatch {
+                Label(
+                    "The traffic split looks off from what you'd expect — check your test setup before trusting these numbers.",
+                    systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption).foregroundStyle(.orange)
+            }
+            Button("Edit and re-analyze") { model.editAgain() }
+        }
+    }
+
+    private func percent(_ value: Double) -> String {
+        String(format: "%.1f%%", value * 100)
+    }
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -27,6 +27,16 @@
         }
       }
     },
+    "%@ %@: couldn't be added." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@: couldn't be added."
+          }
+        }
+      }
+    },
     "%@ already permits this use. Crawlers reading both your license and these signals will see them disagree." : {
 
     },
@@ -285,6 +295,9 @@
     "Add Bluesky verification" : {
 
     },
+    "Add DNS Records" : {
+
+    },
     "Add Google verification" : {
 
     },
@@ -400,6 +413,9 @@
 
     },
     "Analytics…" : {
+
+    },
+    "Analyze" : {
 
     },
     "Anglesite Debug" : {
@@ -936,6 +952,12 @@
     "Continue" : {
 
     },
+    "Control rate" : {
+
+    },
+    "Conversions" : {
+
+    },
     "Copied" : {
 
     },
@@ -1073,6 +1095,12 @@
     "Custom…" : {
 
     },
+    "DMARC reports go to this address so you'll hear about delivery problems." : {
+
+    },
+    "DNS records to add" : {
+
+    },
     "Dashboard" : {
 
     },
@@ -1199,7 +1227,13 @@
     "Distribute Objects" : {
 
     },
+    "Do you use Apple devices (iPhone, Mac) for this business?" : {
+
+    },
     "Domain" : {
+
+    },
+    "Domain & DMARC reports" : {
 
     },
     "Domain Config" : {
@@ -1232,6 +1266,9 @@
     "Edit Header" : {
 
     },
+    "Edit and re-analyze" : {
+
+    },
     "Editing" : {
 
     },
@@ -1239,6 +1276,9 @@
 
     },
     "Edit…" : {
+
+    },
+    "Email Setup…" : {
 
     },
     "Embed" : {
@@ -1296,6 +1336,12 @@
 
     },
     "Events" : {
+
+    },
+    "Experiment" : {
+
+    },
+    "Experiment Results…" : {
 
     },
     "Expires %@" : {
@@ -1392,6 +1438,9 @@
 
     },
     "Finish setting up billing for %@ in the Cloudflare dashboard, then come back and try again." : {
+
+    },
+    "Finish setup in your email provider's dashboard for any manual steps shown earlier, then your email will start working once DNS propagates (usually within a few hours)." : {
 
     },
     "Finished" : {
@@ -1628,10 +1677,16 @@
     "Instance, e.g. lemmy.world" : {
 
     },
+    "Is this email for you personally, or for a registered business?" : {
+
+    },
     "Join" : {
 
     },
     "Just a few" : {
+
+    },
+    "Just me" : {
 
     },
     "Justify" : {
@@ -1952,10 +2007,16 @@
     "No website details" : {
 
     },
+    "No, mixed or other devices" : {
+
+    },
     "None" : {
 
     },
     "Not Set" : {
+
+    },
+    "Not enough traffic yet — the retired skill's rule of thumb is 30+ days or 500+ visitors per variant before trusting an inconclusive result." : {
 
     },
     "Not now" : {
@@ -2210,6 +2271,9 @@
     "Privacy & Analytics…" : {
 
     },
+    "Probability variant wins" : {
+
+    },
     "Production Logs" : {
 
     },
@@ -2315,6 +2379,9 @@
     "Recheck Readiness" : {
 
     },
+    "Recommended provider" : {
+
+    },
     "Record Audio…" : {
 
     },
@@ -2337,6 +2404,9 @@
 
     },
     "Regenerate…" : {
+
+    },
+    "Registered business" : {
 
     },
     "Registrar: %@" : {
@@ -2716,6 +2786,9 @@
     "Set up a third-party integration for this site" : {
 
     },
+    "Set up email" : {
+
+    },
     "Sets a display name just for Anglesite. Leave blank to use the site's built-in name." : {
 
     },
@@ -2996,6 +3069,9 @@
     "Temporary (302)" : {
 
     },
+    "Test ideas" : {
+
+    },
     "Testing" : {
 
     },
@@ -3027,6 +3103,9 @@
 
     },
     "The preview is paused for %@. Start the dev server to resume." : {
+
+    },
+    "The traffic split looks off from what you'd expect — check your test setup before trusting these numbers." : {
 
     },
     "The worker catalog couldn't be loaded. Check your network connection and reopen this tab." : {
@@ -3246,6 +3325,9 @@
     "Valid" : {
 
     },
+    "Variant rate" : {
+
+    },
     "Vertically" : {
 
     },
@@ -3262,6 +3344,9 @@
 
     },
     "View on GitHub" : {
+
+    },
+    "Visitors" : {
 
     },
     "Vulnerability Reports" : {
@@ -3306,6 +3391,9 @@
     "What are you selling?" : {
 
     },
+    "What are you testing? (optional)" : {
+
+    },
     "What kind of website are you creating?" : {
 
     },
@@ -3343,6 +3431,12 @@
 
     },
     "Writing" : {
+
+    },
+    "Yes, mostly Apple" : {
+
+    },
+    "You'll need to add these yourself" : {
 
     },
     "Your declared domain configuration (anglesite.json) doesn't match what's live on Cloudflare. Review and reconcile before deploying again." : {
@@ -3418,6 +3512,9 @@
 
     },
     "optional" : {
+
+    },
+    "owner@example.com" : {
 
     },
     "paste token" : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -647,7 +647,15 @@ struct SiteWindow: View {
                 ProjectStyleGuideView(model: styleGuide, siteName: site.name)
             }
         }
-        .sheet(isPresented: $bindableModel.domain.sheetPresented) {
+        .sheet(isPresented: $bindableModel.domain.sheetPresented, onDismiss: {
+            // Sequences the "Set up email" handoff to `EmailSetupSheetView` after this sheet's
+            // own dismissal transaction finishes — same pattern as the Connect Domain → Buy
+            // Domain handoff just below.
+            if model.domain.pendingEmailSetup {
+                model.domain.pendingEmailSetup = false
+                model.presentEmailSetup()
+            }
+        }) {
             DomainSheetView(model: model.domain)
         }
         .sheet(isPresented: $bindableModel.connectDomain.sheetPresented, onDismiss: {
@@ -779,6 +787,12 @@ struct SiteWindow: View {
         }
         .sheet(item: $bindableModel.repurposeModel) { repurposeModel in
             RepurposeView(model: repurposeModel)
+        }
+        .sheet(item: $bindableModel.emailSetupModel) { setupModel in
+            EmailSetupSheetView(model: setupModel, onDone: { model.emailSetupModel = nil })
+        }
+        .sheet(item: $bindableModel.experimentStatsModel) { statsModel in
+            ExperimentStatsSheetView(model: statsModel, onDone: { model.experimentStatsModel = nil })
         }
         .sheet(item: $bindableModel.designInterviewModel) { interviewModel in
             NavigationStack {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -112,7 +112,9 @@ final class SiteWindowModel {
     var designInterviewModel: DesignInterviewModel?
     /// Non-nil ⟺ the Email Setup wizard is presented (`.sheet(item:)`), same fresh-construction-
     /// from-`site` pattern as `copyEditModel`/`socialPlanModel` (#769). Reachable both from
-    /// Website ▸ Assistant ▸ Email Setup… and from the "Set up email" button in the Domain sheet.
+    /// Website ▸ Email Setup… (grouped with Domain/Connect a Domain — it writes DNS records,
+    /// same as those two, not a content-assistant tool) and from the "Set up email" button in
+    /// the Domain sheet.
     var emailSetupModel: EmailSetupModel?
     /// Non-nil ⟺ the Experiment Results sheet is presented (`.sheet(item:)`), same fresh-
     /// construction-from-`site` pattern as `copyEditModel`/`emailSetupModel` (#769).

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -110,6 +110,13 @@ final class SiteWindowModel {
     /// Non-nil ⟺ the Design Interview sheet is presented (`.sheet(item:)`), same fresh-
     /// construction-from-`site` pattern as `copyEditModel`/`socialPlanModel`/`repurposeModel` (#631).
     var designInterviewModel: DesignInterviewModel?
+    /// Non-nil ⟺ the Email Setup wizard is presented (`.sheet(item:)`), same fresh-construction-
+    /// from-`site` pattern as `copyEditModel`/`socialPlanModel` (#769). Reachable both from
+    /// Website ▸ Assistant ▸ Email Setup… and from the "Set up email" button in the Domain sheet.
+    var emailSetupModel: EmailSetupModel?
+    /// Non-nil ⟺ the Experiment Results sheet is presented (`.sheet(item:)`), same fresh-
+    /// construction-from-`site` pattern as `copyEditModel`/`emailSetupModel` (#769).
+    var experimentStatsModel: ExperimentStatsModel?
     /// The window's `UndoManager`, published down from `SiteWindow`'s
     /// `@Environment(\.undoManager)` so applied edits register for Edit ▸ Undo (#527). Weak +
     /// `@ObservationIgnored`: the window owns it and it isn't render state. Forwarded on set
@@ -505,6 +512,27 @@ final class SiteWindowModel {
         )
     }
 
+    var canOpenEmailSetup: Bool { site != nil }
+
+    /// Presents the Email Setup wizard (#769), same fresh-construction pattern as
+    /// `presentCopyEdit`. Prefills the domain field from `anglesite.json`'s declared hostname
+    /// when the owner has already gone through Domain/Connect a Domain; leaves it blank
+    /// otherwise (the wizard itself doesn't require the site to be attached to a domain yet).
+    func presentEmailSetup() {
+        guard emailSetupModel == nil, let site else { return }
+        let hostname = try? DomainConfigStore(sourceDirectory: site.sourceDirectory).load().domain?.hostname
+        emailSetupModel = EmailSetupModel(siteID: site.id, sourceDirectory: site.sourceDirectory, domain: hostname ?? "")
+    }
+
+    var canOpenExperimentStats: Bool { site != nil }
+
+    /// Presents the Experiment Results sheet (#769), same fresh-construction pattern as
+    /// `presentCopyEdit`.
+    func presentExperimentStats() {
+        guard experimentStatsModel == nil, let site else { return }
+        experimentStatsModel = ExperimentStatsModel(siteID: site.id)
+    }
+
     /// Presents the Repurpose Post sheet (#465), same pattern as `presentCopyEdit`/`presentSocialPlan`.
     func presentRepurpose(slug: String) {
         guard repurposeModel == nil, let site else { return }
@@ -589,6 +617,8 @@ final class SiteWindowModel {
         copyEditModel = nil
         socialPlanModel = nil
         repurposeModel = nil
+        emailSetupModel = nil
+        experimentStatsModel = nil
         navigator?.stop()
         navigator = nil
         graphExplorer.stop()

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -79,6 +79,9 @@ struct WebsiteCommands: Commands {
             Button("Connect a Domain…") { model?.connectDomain.openSheet() }
                 .disabled(model?.site == nil)
 
+            Button("Email Setup…") { model?.presentEmailSetup() }
+                .disabled(model?.canOpenEmailSetup != true)
+
             Button("Add Integration…") { model?.openIntegrationWizard() }
                 .disabled(model?.canOpenIntegrationWizard != true)
 
@@ -94,6 +97,9 @@ struct WebsiteCommands: Commands {
 
                 Button("Design Interview…") { model?.presentDesignInterview() }
                     .disabled(model?.canOpenDesignInterview != true)
+
+                Button("Experiment Results…") { model?.presentExperimentStats() }
+                    .disabled(model?.canOpenExperimentStats != true)
             }
 
             Menu("GitHub") {

--- a/Sources/AnglesiteCore/EmailSetupPlanner.swift
+++ b/Sources/AnglesiteCore/EmailSetupPlanner.swift
@@ -34,7 +34,7 @@ public enum EmailSetupPlanner {
     /// The closed set of email providers the planner knows DNS records for — the providers
     /// from the retired skill's reference doc, no more. Raw values are stable kebab-case
     /// identifiers, safe to persist or put in URLs.
-    public enum Provider: String, Sendable, CaseIterable, Equatable {
+    public enum Provider: String, Sendable, CaseIterable, Equatable, Hashable {
         /// iCloud+ Custom Email Domain — the Apple personal-tier pick.
         case icloudPlus = "icloud-plus"
         /// Apple Business Essentials — the Apple registered-business pick. Same mail
@@ -295,6 +295,31 @@ public enum EmailSetupPlanner {
         guard !mechanisms.contains(include) else { return existing }
         mechanisms.insert(include, at: 1)
         return mechanisms.joined(separator: " ")
+    }
+
+    /// Folds a provider's `include:` mechanism into the domain's *existing* SPF record instead
+    /// of adding `plan`'s own SPF TXT record verbatim — the wizard-facing counterpart to
+    /// ``mergedSPF(existing:adding:)``, used when the owner already has an SPF record (from a
+    /// prior provider, or another service like a marketing tool) that this plan would otherwise
+    /// duplicate. Returns `plan` unchanged when it has no SPF record of its own, or when the
+    /// merge produces the same content the plan already had (no existing record, or the
+    /// existing record already includes this provider's mechanism).
+    ///
+    /// - Parameters:
+    ///   - plan: The plan from ``dnsPlan(for:domain:dmarcReportEmail:)``.
+    ///   - existingSPFRecordContent: The domain's current apex SPF TXT record content, or `nil`
+    ///     if it has none.
+    public static func reconcilingExistingSPF(in plan: DNSPlan, existingSPFRecordContent: String?) -> DNSPlan {
+        guard let index = plan.records.firstIndex(where: {
+            $0.type == "TXT" && $0.name == "@" && $0.content.lowercased().hasPrefix("v=spf1")
+        }) else {
+            return plan
+        }
+        let merged = mergedSPF(existing: existingSPFRecordContent, adding: plan.provider.spfInclude)
+        guard merged != plan.records[index].content else { return plan }
+        var records = plan.records
+        records[index] = RecordTemplate(type: "TXT", name: "@", content: merged)
+        return DNSPlan(provider: plan.provider, records: records, manualSteps: plan.manualSteps)
     }
 
     // MARK: - Owner-facing education

--- a/Sources/AnglesiteCore/ExperimentStats.swift
+++ b/Sources/AnglesiteCore/ExperimentStats.swift
@@ -17,6 +17,11 @@ import Glibc
 /// upgrade: instead of Monte Carlo simulation, `probabilityTreatmentBeatsControl` uses the
 /// exact closed form for Beta-Binomial posteriors (Evan Miller's formula), so results are
 /// reproducible bit-for-bit across runs and platforms.
+///
+/// Front-doors: the Experiment Results sheet (`ExperimentStatsSheetView`) and
+/// `AnalyzeExperimentIntent` (#769) take each variant's counts as owner-typed input rather than
+/// reading them from a stored experiment config — there's no edge-side variant assignment or
+/// analytics pipeline to source them from yet. That's tracked separately as #1270.
 public enum ExperimentStats {
     // MARK: - Inputs / outputs
 

--- a/Sources/AnglesiteIntents/ExperimentIntents.swift
+++ b/Sources/AnglesiteIntents/ExperimentIntents.swift
@@ -1,0 +1,82 @@
+import AppIntents
+import AnglesiteCore
+import Foundation
+
+/// Siri/Shortcuts front-door for `ExperimentStats` (#769) — "How is my test going?". Pure
+/// computation, no site/network dependency: the retired plugin's edge A/B machinery (variant
+/// assignment, an analytics pipeline reporting counts back to the app) was never rebuilt after
+/// #466 (follow-up: #1270), so — like the Experiment Results sheet (`ExperimentStatsSheetView`) —
+/// this intent takes each variant's impression/conversion counts as parameters rather than
+/// reading them from a stored experiment config.
+///
+/// Not registered in AnglesiteShortcuts: same phrase-budget reasoning as `ReviewCopyIntent` (the
+/// 10-phrase cap is already spent) — stays discoverable via the Shortcuts app.
+public struct AnalyzeExperimentIntent: AppIntent {
+    /// Action name in the Shortcuts library.
+    public static let title: LocalizedStringResource = "Analyze Experiment"
+    /// Shortcuts-editor blurb.
+    public static let description = IntentDescription(
+        "Compare two variants' visitor and conversion counts and report whether either is winning.")
+
+    /// Optional label for the dialog, e.g. "Hero headline test". Purely cosmetic.
+    @Parameter(title: "Experiment Name", default: "")
+    public var experimentName: String
+    @Parameter(title: "Original Name", default: "Original")
+    public var controlName: String
+    @Parameter(title: "Original Visitors") public var controlImpressions: Int
+    @Parameter(title: "Original Conversions") public var controlConversions: Int
+    @Parameter(title: "Variant Name", default: "Variant")
+    public var treatmentName: String
+    @Parameter(title: "Variant Visitors") public var treatmentImpressions: Int
+    @Parameter(title: "Variant Conversions") public var treatmentConversions: Int
+
+    /// Required by the AppIntents runtime; parameters are populated after init.
+    public init() {}
+
+    /// Shortcuts-editor sentence: "Analyze (name) with (control) vs (variant)".
+    public static var parameterSummary: some ParameterSummary {
+        Summary("Analyze \(\.$experimentName)") {
+            \.$controlName
+            \.$controlImpressions
+            \.$controlConversions
+            \.$treatmentName
+            \.$treatmentImpressions
+            \.$treatmentConversions
+        }
+    }
+
+    /// No side effects and nothing to confirm — reads no state, writes nothing.
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        .result(dialog: IntentDialog(stringLiteral: run()))
+    }
+
+    private func run() -> String {
+        let control = ExperimentStats.Variant(
+            name: controlName.isEmpty ? "Original" : controlName,
+            impressions: controlImpressions, conversions: controlConversions)
+        let treatment = ExperimentStats.Variant(
+            name: treatmentName.isEmpty ? "Variant" : treatmentName,
+            impressions: treatmentImpressions, conversions: treatmentConversions)
+        let result = ExperimentStats.analyze(control: control, treatment: treatment)
+        let name = experimentName.isEmpty ? "This experiment" : experimentName
+        var reply = ExperimentStats.formatSummary(experimentName: name, result: result)
+        if !ExperimentStats.hasSufficientData(control: control, treatment: treatment) {
+            reply += "\nNot much traffic yet — the usual rule of thumb is 30+ days or 500+ visitors per variant."
+        }
+        if ExperimentStats.hasSampleRatioMismatch(control: control, treatment: treatment) {
+            reply += "\nThe traffic split looks off from what you'd expect — check your test setup."
+        }
+        return reply
+    }
+}
+
+// MARK: - Test-only helpers
+
+extension AnalyzeExperimentIntent {
+    /// Drives `perform`'s dialog logic directly, bypassing the AppIntents runtime — see
+    /// `ReviewCopyIntent.performForTesting()`. Safe here since `run()` has no runtime
+    /// dependency at all (no `@Dependency`, no confirmation).
+    func performForTesting() -> String {
+        run()
+    }
+}

--- a/Tests/AnglesiteAppTests/EmailSetupModelTests.swift
+++ b/Tests/AnglesiteAppTests/EmailSetupModelTests.swift
@@ -1,0 +1,121 @@
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@MainActor
+@Suite struct EmailSetupModelTests {
+    private actor FakeOps: DomainOperationsService {
+        var existingRecords: [DNSRecord]
+        var addedTypes: [String] = []
+        var addedPurposes: [String?] = []
+
+        init(existingRecords: [DNSRecord] = []) {
+            self.existingRecords = existingRecords
+        }
+
+        func listRecords(domain: String) async -> Result<[DNSRecord], DomainOperationError> {
+            .success(existingRecords)
+        }
+        func addRecord(
+            domain: String, type: String, name: String, content: String, ttl: Int, priority: Int?,
+            purpose: String?, sourceDirectory: URL?
+        ) async -> Result<Void, DomainOperationError> {
+            addedTypes.append(type)
+            addedPurposes.append(purpose)
+            return .success(())
+        }
+        func deleteRecord(
+            domain: String, recordID: String, type: String?, name: String?, content: String?,
+            sourceDirectory: URL?
+        ) async -> Result<Void, DomainOperationError> { .success(()) }
+    }
+
+    private func tempDirectory() throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        return tmp
+    }
+
+    @Test func mixedEcosystemGoesStraightToDetailsWithFastmailRecommended() {
+        let model = EmailSetupModel(siteID: "s1", sourceDirectory: URL(fileURLWithPath: "/tmp"), domain: "", ops: FakeOps())
+        model.choose(ecosystem: .mixedOrOther)
+        guard case .details = model.step else {
+            Issue.record("expected .details, got \(model.step)")
+            return
+        }
+        #expect(model.recommendation?.provider == .fastmail)
+        #expect(model.selectedProvider == .fastmail)
+    }
+
+    @Test func appleEcosystemAsksTierFirst() {
+        let model = EmailSetupModel(siteID: "s1", sourceDirectory: URL(fileURLWithPath: "/tmp"), domain: "", ops: FakeOps())
+        model.choose(ecosystem: .apple)
+        guard case .appleTier = model.step else {
+            Issue.record("expected .appleTier, got \(model.step)")
+            return
+        }
+        model.choose(appleTier: .registeredBusiness)
+        #expect(model.recommendation?.provider == .appleBusiness)
+        guard case .details = model.step else {
+            Issue.record("expected .details, got \(model.step)")
+            return
+        }
+    }
+
+    @Test func buildPlanMergesExistingSPFFromAnotherProvider() async throws {
+        let existing = DNSRecord(
+            id: "r1", type: "TXT", name: "example.com",
+            content: "v=spf1 include:_spf.mx.cloudflare.net ~all", ttl: 1, proxied: false)
+        let ops = FakeOps(existingRecords: [existing])
+        let model = EmailSetupModel(siteID: "s1", sourceDirectory: try tempDirectory(), domain: "example.com", ops: ops)
+        model.choose(ecosystem: .apple)
+        model.choose(appleTier: .personal)
+        model.dmarcReportEmail = "owner@example.com"
+        model.buildPlan()
+        repeat { await Task.yield() } while model.isRunning
+
+        guard case .review(let plan, let spfWasMerged) = model.step else {
+            Issue.record("expected .review, got \(model.step)")
+            return
+        }
+        #expect(spfWasMerged)
+        let spf = plan.records.first { $0.type == "TXT" && $0.name == "@" }
+        #expect(spf?.content == "v=spf1 include:icloud.com include:_spf.mx.cloudflare.net ~all")
+    }
+
+    @Test func buildPlanLeavesPlanAloneWhenNoExistingSPF() async throws {
+        let ops = FakeOps()
+        let model = EmailSetupModel(siteID: "s1", sourceDirectory: try tempDirectory(), domain: "example.com", ops: ops)
+        model.choose(ecosystem: .mixedOrOther)
+        model.dmarcReportEmail = "owner@example.com"
+        model.buildPlan()
+        repeat { await Task.yield() } while model.isRunning
+
+        guard case .review(_, let spfWasMerged) = model.step else {
+            Issue.record("expected .review, got \(model.step)")
+            return
+        }
+        #expect(!spfWasMerged)
+    }
+
+    @Test func applyAddsEveryRecordAndReportsResult() async throws {
+        let ops = FakeOps()
+        let model = EmailSetupModel(siteID: "s1", sourceDirectory: try tempDirectory(), domain: "example.com", ops: ops)
+        model.choose(ecosystem: .mixedOrOther)
+        model.dmarcReportEmail = "owner@example.com"
+        model.buildPlan()
+        repeat { await Task.yield() } while model.isRunning
+
+        model.apply()
+        repeat { await Task.yield() } while model.isRunning
+
+        guard case .result(let result) = model.step else {
+            Issue.record("expected .result, got \(model.step)")
+            return
+        }
+        #expect(result.failures.isEmpty)
+        #expect(result.addedCount == (await ops.addedTypes).count)
+        #expect((await ops.addedPurposes).allSatisfy { $0 == "email:fastmail" })
+    }
+}

--- a/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ExperimentStatsModelTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@MainActor
+@Suite struct ExperimentStatsModelTests {
+    @Test func canAnalyzeOnlyOnceBothVariantsHaveVisitors() {
+        let model = ExperimentStatsModel(siteID: "s1")
+        #expect(!model.canAnalyze)
+        model.controlImpressions = 1000
+        model.controlConversions = 50
+        #expect(!model.canAnalyze)
+        model.treatmentImpressions = 1000
+        model.treatmentConversions = 120
+        #expect(model.canAnalyze)
+    }
+
+    @Test func analyzeProducesAResultAndSummary() {
+        let model = ExperimentStatsModel(siteID: "s1")
+        model.experimentName = "Hero headline"
+        model.controlImpressions = 1000
+        model.controlConversions = 50
+        model.treatmentImpressions = 1000
+        model.treatmentConversions = 120
+        model.analyze()
+        #expect(model.result != nil)
+        #expect(model.summary?.contains("Hero headline") == true)
+    }
+
+    @Test func editAgainClearsTheResultButKeepsCounts() {
+        let model = ExperimentStatsModel(siteID: "s1")
+        model.controlImpressions = 1000
+        model.controlConversions = 50
+        model.treatmentImpressions = 1000
+        model.treatmentConversions = 120
+        model.analyze()
+        #expect(model.result != nil)
+        model.editAgain()
+        #expect(model.result == nil)
+        #expect(model.controlImpressions == 1000)
+    }
+
+    @Test func suggestionPlaybookIsAlwaysAvailable() {
+        let model = ExperimentStatsModel(siteID: "s1")
+        #expect(!model.suggestions.isEmpty)
+        #expect(model.suggestions == ExperimentStats.suggestionPlaybook)
+    }
+}

--- a/Tests/AnglesiteCoreTests/EmailSetupPlannerTests.swift
+++ b/Tests/AnglesiteCoreTests/EmailSetupPlannerTests.swift
@@ -108,6 +108,32 @@ import Foundation
         #expect(merged == "v=spf1 include:zoho.com ~all")
     }
 
+    // MARK: - Existing-SPF reconciliation (wizard-facing)
+
+    @Test func reconcilingExistingSPFLeavesPlanAloneWhenNoExistingRecord() {
+        let plan = EmailSetupPlanner.dnsPlan(for: .fastmail, domain: "example.com", dmarcReportEmail: "o@example.com")
+        let reconciled = EmailSetupPlanner.reconcilingExistingSPF(in: plan, existingSPFRecordContent: nil)
+        #expect(reconciled == plan)
+    }
+
+    @Test func reconcilingExistingSPFMergesIntoAnotherProvidersRecord() {
+        let plan = EmailSetupPlanner.dnsPlan(for: .icloudPlus, domain: "example.com", dmarcReportEmail: "o@example.com")
+        let reconciled = EmailSetupPlanner.reconcilingExistingSPF(
+            in: plan, existingSPFRecordContent: "v=spf1 include:_spf.mx.cloudflare.net ~all")
+        let spf = reconciled.records.first { $0.type == "TXT" && $0.name == "@" }
+        #expect(spf?.content == "v=spf1 include:icloud.com include:_spf.mx.cloudflare.net ~all")
+        // Every other record (MX, manual steps) is untouched.
+        #expect(reconciled.records.filter { $0.type == "MX" } == plan.records.filter { $0.type == "MX" })
+        #expect(reconciled.manualSteps == plan.manualSteps)
+    }
+
+    @Test func reconcilingExistingSPFIsIdempotentWhenIncludeAlreadyPresent() {
+        let plan = EmailSetupPlanner.dnsPlan(for: .zohoMail, domain: "example.com", dmarcReportEmail: "o@example.com")
+        let reconciled = EmailSetupPlanner.reconcilingExistingSPF(
+            in: plan, existingSPFRecordContent: "v=spf1 include:zoho.com ~all")
+        #expect(reconciled == plan)
+    }
+
     // MARK: - Owner-facing copy
 
     @Test func explanationsUseSkillLanguage() {

--- a/Tests/AnglesiteIntentsTests/ExperimentIntentsTests.swift
+++ b/Tests/AnglesiteIntentsTests/ExperimentIntentsTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import Foundation
+@testable import AnglesiteIntents
+import AnglesiteCore
+
+extension AppIntentsTests {
+    @Suite("ExperimentIntents")
+    struct ExperimentIntentsTests {
+        @Test("AnalyzeExperimentIntent reports a treatment win")
+        func reportsTreatmentWin() {
+            var intent = AnalyzeExperimentIntent()
+            intent.experimentName = "Hero headline"
+            intent.controlName = "Original"
+            intent.controlImpressions = 1000
+            intent.controlConversions = 50
+            intent.treatmentName = "New headline"
+            intent.treatmentImpressions = 1000
+            intent.treatmentConversions = 120
+            let dialog = intent.performForTesting()
+            #expect(dialog.contains("Hero headline"))
+            #expect(dialog.contains("New headline"))
+            #expect(dialog.contains("outperforming"))
+        }
+
+        @Test("AnalyzeExperimentIntent flags insufficient data")
+        func flagsInsufficientData() {
+            var intent = AnalyzeExperimentIntent()
+            intent.experimentName = ""
+            intent.controlName = "Original"
+            intent.controlImpressions = 10
+            intent.controlConversions = 1
+            intent.treatmentName = "Variant"
+            intent.treatmentImpressions = 10
+            intent.treatmentConversions = 1
+            let dialog = intent.performForTesting()
+            #expect(dialog.contains("Not much traffic yet"))
+        }
+
+        @Test("AnalyzeExperimentIntent flags a sample ratio mismatch")
+        func flagsSampleRatioMismatch() {
+            var intent = AnalyzeExperimentIntent()
+            intent.experimentName = "Skewed test"
+            intent.controlName = "Original"
+            intent.controlImpressions = 9000
+            intent.controlConversions = 450
+            intent.treatmentName = "Variant"
+            intent.treatmentImpressions = 1000
+            intent.treatmentConversions = 60
+            let dialog = intent.performForTesting()
+            #expect(dialog.contains("traffic split looks off"))
+        }
+    }
+}


### PR DESCRIPTION
Closes #769

## Summary

- Add the **Email Setup wizard** (`EmailSetupModel`/`EmailSetupSheetView`): walks the owner through `EmailSetupPlanner`'s Apple-first decision tree, reconciles the resulting DNS plan against any SPF record the zone already has (new `EmailSetupPlanner.reconcilingExistingSPF`), and applies it through `EmailSetupExecutor`. Reachable from Website ▸ Assistant ▸ Email Setup… and from a new "Set up email" button in the Domain sheet.
- Add the **Experiment Results sheet** (`ExperimentStatsModel`/`ExperimentStatsSheetView`) and `AnalyzeExperimentIntent` (Siri/Shortcuts) for `ExperimentStats`. Since no edge A/B variant-assignment or analytics pipeline exists in this repo (confirmed by investigation — see below), both take each variant's visitor/conversion counts as owner-typed input rather than reading a stored experiment config.
- Filed #1270 as a follow-up for the edge A/B machinery + persisted experiment config needed for the full propose/configure/promote lifecycle #769 originally described — that's new template + edge infrastructure and warrants its own design pass per `CONTRIBUTING.md`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — **could not run**: this environment has no Swift toolchain installed (`swift`/`swiftc`/`xcodebuild` all absent). New/changed Swift files were reviewed by hand for compile-correctness and matched against existing patterns in the repo (`DomainModel`/`DomainSheetView`, `CopyEditReportModel`, `ContentHelpIntents.swift`'s intent shapes) since I could not build locally.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — same limitation; please have CI confirm.
- [x] New unit tests added: `EmailSetupPlannerTests` (SPF reconciliation), `EmailSetupModelTests`, `ExperimentStatsModelTests`, `ExperimentIntentsTests` — none of these could be executed locally either, for the same reason.
- [ ] Manual smoke (UI-touching): not performed — no macOS/Xcode environment available in this session.

I'm flagging the unrun checks explicitly per `CLAUDE.md` rather than claiming they passed; please treat CI as the first real compile/test signal on this PR and let me know if anything needs fixing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NA7pQV5cyWs5oP6rSBG5s3)_