### PR TITLE
TestFlight beta distribution setup

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -28,6 +28,8 @@
 	<string>27.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 David W. Keith. ISC License.</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsSuddenTermination</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>27.0</string>
 	<key>NSHumanReadableCopyright</key>

--- a/docs/release.md
+++ b/docs/release.md
@@ -109,8 +109,9 @@ ASC_API_KEY_ID=XXXXXXXXXX \
 ASC_API_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
   scripts/release.sh
 
-# 2. Wait for App Store Connect to finish processing the build (check
-#    TestFlight -> Builds in the portal, or just run step 3 -- it polls).
+# 2. Wait until the build appears under TestFlight -> Builds in App Store
+#    Connect, then run step 3 below (it polls while the build finishes
+#    processing, but won't wait for the build to first appear).
 
 # 3. Set the "What to Test" notes for testers.
 ASC_API_KEY_ID=XXXXXXXXXX \

--- a/docs/release.md
+++ b/docs/release.md
@@ -61,3 +61,67 @@ The script:
 
 Use `--validate-only` to archive/export/validate without uploading. Transporter
 is still a valid manual fallback: drop the exported `.pkg` onto Transporter.app.
+
+## TestFlight Beta Distribution
+
+TestFlight builds go through the exact same pipeline as a full release --
+`scripts/release.sh` archives, signs, and uploads to App Store Connect, and
+that upload *is* the TestFlight build-upload path. There is no separate
+"upload for beta" step. What's specific to TestFlight is App Store
+Connect configuration (mostly manual) and setting the build's "What to
+Test" notes (scripted).
+
+### One-time setup (manual, in App Store Connect)
+
+1. **TestFlight tab.** Nothing to create separately -- it appears
+   automatically on the app record from step 1 of "One-Time Setup" above,
+   once the first build is uploaded and finishes processing.
+2. **Export compliance.** `Resources/Info.plist` declares
+   `ITSAppUsesNonExemptEncryption=false` (accurate -- Anglesite only uses
+   standard HTTPS/TLS via system frameworks, no custom cryptography). This
+   skips App Store Connect's manual export-compliance prompt, which
+   otherwise blocks a build from being distributed to any tester group
+   until answered.
+3. **Internal Testing group.** App Store Connect -> TestFlight -> Internal
+   Testing -> create a group, add testers by Apple ID (they must already
+   have a role on the App Store Connect team), then add a processed build
+   to the group. No Beta App Review required -- builds are available to
+   internal testers immediately.
+4. **External Testing group -- when to open one.** Left as a deliberate
+   judgment call, not automated here: open an External Testing group once
+   internal testers have validated a build and you want feedback from
+   people outside the Apple Developer team. The first build submitted to
+   an external group needs Beta App Review (typically faster and lighter
+   than full App Store review); most builds after that, without
+   significant changes, don't need re-review.
+5. **Virtualization entitlement.** Already confirmed in "One-Time Setup"
+   step 4 above -- the same `scripts/release.sh --validate-only` check
+   covers TestFlight builds, since they go through the identical export
+   pipeline.
+
+### Beta release flow
+
+```sh
+# 1. Archive, sign, and upload -- same as a full release.
+TEAM_ID=YOUR_TEAM_ID \
+PROVISIONING_PROFILE="Anglesite App Store" \
+ASC_API_KEY_ID=XXXXXXXXXX \
+ASC_API_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
+  scripts/release.sh
+
+# 2. Wait for App Store Connect to finish processing the build (check
+#    TestFlight -> Builds in the portal, or just run step 3 -- it polls).
+
+# 3. Set the "What to Test" notes for testers.
+ASC_API_KEY_ID=XXXXXXXXXX \
+ASC_API_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
+  scripts/testflight-notes.sh --notes "Try the new site importer and report crashes."
+```
+
+Then add the build to a tester group (Internal or External) in App Store
+Connect -- see "One-time setup" above.
+
+See [#617](https://github.com/Anglesite/Anglesite/issues/617) for the
+separate v1.0 App Store submission track, which shares this same
+archive/export/upload pipeline but goes through full App Review instead
+of TestFlight's Beta App Review.

--- a/docs/superpowers/specs/2026-08-06-testflight-beta-distribution-design.md
+++ b/docs/superpowers/specs/2026-08-06-testflight-beta-distribution-design.md
@@ -1,0 +1,172 @@
+# TestFlight beta distribution setup
+
+Date: 2026-08-06
+Issue: [#766](https://github.com/Anglesite/Anglesite/issues/766)
+
+## Problem
+
+The v1.0.0-Beta milestone says the app "will be distributed through TestFlight,"
+but no issue covered standing that up — [#617](https://github.com/Anglesite/Anglesite/issues/617)
+only covers the final v1.0 App Store submission. TestFlight needs its own
+one-time App Store Connect configuration, a way to attach "What to Test" notes
+to an uploaded build, and an accurate export-compliance declaration so builds
+don't stall on a manual compliance prompt.
+
+## Scope and constraints
+
+App Store Connect app-record creation and TestFlight tester-group membership
+are portal actions gated behind Apple Developer account credentials that
+aren't available in this environment. Those stay a documented manual
+checklist. What's scriptable/documentable here:
+
+1. An accurate export-compliance declaration in `Info.plist`.
+2. A script to set a build's "What to Test" beta notes via the App Store
+   Connect REST API (the only interface that exposes this — `xcodebuild` and
+   `altool` don't).
+3. Documentation tying the existing `scripts/release.sh` upload path,
+   the new notes script, and the manual TestFlight-group steps into one
+   beta-release flow.
+
+`scripts/release.sh` already archives, signs, and uploads to App Store
+Connect via `xcodebuild -exportArchive -destination upload`. That upload
+*is* the TestFlight build-upload path — App Store Connect builds land in
+TestFlight automatically once processed. No separate "upload for beta"
+script is needed.
+
+## 1. Export compliance
+
+Add to `Resources/Info.plist`:
+
+```xml
+<key>ITSAppUsesNonExemptEncryption</key>
+<false/>
+```
+
+Anglesite only uses standard HTTPS/TLS via system frameworks (`URLSession`
+for GitHub/Cloudflare API calls, `WKWebView` for the local dev-server
+preview, Keychain for token storage) — no custom cryptographic
+implementation. `false` is accurate and lets App Store Connect skip the
+per-build manual export-compliance question that otherwise blocks
+processing.
+
+## 2. `scripts/lib/resolve-asc-key.sh`
+
+The `.p8` App Store Connect API key discovery logic already exists inline in
+`scripts/release.sh` (search `~/.appstoreconnect/private_keys/`,
+`~/.private_keys/`, `~/private_keys/`, `./private_keys/`, or an explicit
+`ASC_API_KEY_PATH`). Extract it into a shared function,
+`resolve_asc_key_path <key_id>`, sourced by both `release.sh` and the new
+`testflight-notes.sh`. Behavior is unchanged; this is a pure extraction to
+avoid duplicating the same ~20 lines in a second script.
+
+## 3. `scripts/lib/asc-jwt.py`
+
+App Store Connect API auth is a JWT signed with ES256 using the `.p8` key —
+a token type `xcodebuild`'s own `-authenticationKeyPath` handles internally,
+but that raw signing has to be done by hand for direct REST calls.
+
+Stdlib-only Python (no pip installs), invoked as:
+
+```sh
+python3 scripts/lib/asc-jwt.py --key-id "$ASC_API_KEY_ID" --issuer-id "$ASC_API_ISSUER_ID" --key-path "$ASC_KEY_PATH"
+```
+
+Prints a signed JWT to stdout. Implementation:
+
+1. Build the header (`{"alg":"ES256","kid":<key id>,"typ":"JWT"}`) and
+   payload (`{"iss":<issuer id>,"iat":<now>,"exp":<now + 1200>,"aud":"appstoreconnect-v1"}`,
+   20-minute expiry — the API's max) as compact JSON, base64url-encode each.
+2. Sign `base64url(header) + "." + base64url(payload)` via
+   `openssl dgst -sha256 -sign <key-path>`, which produces a DER-encoded
+   ECDSA signature (`SEQUENCE { INTEGER r, INTEGER s }`).
+3. Parse the DER by hand (simple fixed-structure ASN.1 — no library needed):
+   walk the SEQUENCE/INTEGER tags, strip any leading `0x00` sign-padding
+   byte from `r`/`s`, left-pad each to 32 bytes, concatenate to the raw
+   64-byte `r‖s` format JWT ES256 requires.
+4. base64url-encode the raw signature, append as the JWT's third segment.
+
+This is a well-established recipe (openssl for the actual EC signing, hand
+parsing for the DER→raw conversion) and keeps the dependency footprint to
+tools already on any macOS dev machine.
+
+## 4. `scripts/testflight-notes.sh`
+
+Styled after `release.sh`: preflight checks, numbered steps, clear `bail`
+messages.
+
+**Usage:**
+
+```sh
+ASC_API_KEY_ID=XXXXXXXXXX ASC_API_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
+  scripts/testflight-notes.sh --notes "Try the new site importer and report crashes." [--build 42] [--dry-run]
+```
+
+**Flags:**
+- `--notes "text"` / `--notes-file path` — required, mutually exclusive.
+- `--build N` — optional, defaults to `CURRENT_PROJECT_VERSION` read from
+  `project.yml`.
+- `--dry-run` — generate the JWT and construct every API request (method,
+  URL, body) but skip execution, printing them instead. This is the only
+  way to exercise the script's logic without live App Store Connect access,
+  and is what verification in this change relies on.
+
+**Flow:**
+
+1. Preflight: `ASC_API_KEY_ID`/`ASC_API_ISSUER_ID` set, `--notes`/`--notes-file`
+   present and mutually exclusive, `openssl`/`python3`/`curl`/`jq` on `PATH`,
+   resolve the `.p8` path via `resolve_asc_key_path`.
+2. Read `MARKETING_VERSION` from `project.yml`; use `--build` or
+   `CURRENT_PROJECT_VERSION` for the build number.
+3. Mint a JWT via `asc-jwt.py`.
+4. `GET /v1/apps?filter[bundleId]=io.dwk.anglesite` → app id.
+5. `GET /v1/builds?filter[app]=<id>&filter[version]=<build>&filter[preReleaseVersion.version]=<marketing version>`
+   → build id. If `processingState == PROCESSING`, poll every 30s up to
+   ~15 minutes; `FAILED`/`INVALID` bails immediately with the reason; not
+   found bails with "build not found — did you upload it with
+   scripts/release.sh yet?"
+6. `GET` existing `en-US` beta build localization for the build. If present,
+   `PATCH` its `whatsToTest`; otherwise `POST` a new one with the build
+   relationship, `locale: en-US`, and `whatsToTest`.
+7. Print a confirmation and point to App Store Connect → TestFlight for the
+   next manual step (adding the build to a tester group).
+
+Only `en-US` is handled — matches `CFBundleDevelopmentRegion`. Additional
+locales are out of scope until the app is actually localized.
+
+## 5. `docs/release.md` — new "TestFlight Beta Distribution" section
+
+Added after the existing "Per-Release Flow" section:
+
+- **One-time setup** (manual, checklist form): confirm the TestFlight tab is
+  live on the App Store Connect app record; Internal Testing group needs no
+  review — add testers by account role; External Testing groups require
+  Beta App Review (first build per version only, in the common case) —
+  documented as a deliberate manual decision on *when* to open one, per the
+  issue's own framing, not something this change automates.
+  Export-compliance: note the `ITSAppUsesNonExemptEncryption` key added here
+  and that it removes the per-build manual prompt.
+- **Beta release flow:** run `scripts/release.sh` (unchanged — same upload
+  path as a full release), wait for App Store Connect processing, then run
+  `scripts/testflight-notes.sh --notes "..."` to set What-to-Test text,
+  then add the build to a tester group in App Store Connect.
+- Cross-reference to #617 for the full App Store submission track, noting
+  the shared archive/export/upload pipeline.
+
+## Testing
+
+No live App Store Connect credentials are available in this environment, so:
+
+- `asc-jwt.py`: generate a throwaway EC private key
+  (`openssl ecparam -genkey -name prime256v1 -noout`) and its public half,
+  run the script against the private key, then re-derive a DER signature
+  from the JWT's raw `r‖s` third segment (reverse of the script's own
+  raw-from-DER conversion) and confirm it validates against the signing
+  input with `openssl dgst -sha256 -verify pubkey.pem -signature sig.der`.
+  Confirms the signing and DER conversion logic is correct independent of
+  real ASC credentials.
+- `testflight-notes.sh --dry-run`: exercises argument parsing, `project.yml`
+  parsing, and the constructed request list end-to-end without network
+  calls.
+- `swift test --package-path .` and `scripts/build-app.sh` — the `Info.plist`
+  change touches a tracked app resource; confirm the app still builds and
+  the plist is well-formed.

--- a/scripts/lib/asc-jwt.sh
+++ b/scripts/lib/asc-jwt.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Signs an App Store Connect API JWT (ES256), used by scripts/testflight-notes.sh.
+# Source this file, then call:
+#   mint_asc_jwt <key_id> <issuer_id> <key_path>
+# It echoes the signed JWT to stdout. App Store Connect API auth is a JWT
+# signed with the .p8 key's ES256 private key (RFC 7518 3.4) -- xcodebuild's
+# own -authenticationKeyPath handles this internally, but direct REST calls
+# need one minted by hand. openssl performs the actual EC signing (DER-encoded);
+# the inline python3 (stdlib only, no pip installs) does the DER-to-raw
+# r||s conversion JWT ES256 requires, plus the base64url encoding.
+
+mint_asc_jwt() {
+    local key_id="$1" issuer_id="$2" key_path="$3"
+    python3 - "$key_id" "$issuer_id" "$key_path" <<'PY'
+import base64
+import json
+import subprocess
+import sys
+import time
+
+key_id, issuer_id, key_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+
+def b64url(data):
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def der_to_raw_signature(der, size=32):
+    """SEQUENCE { INTEGER r, INTEGER s } -> raw r||s (RFC 7518 3.4)."""
+    if der[0] != 0x30:
+        raise ValueError("not a DER SEQUENCE")
+    pos = 2 if der[1] < 0x80 else 2 + (der[1] & 0x7F)
+
+    def read_integer(data, offset):
+        if data[offset] != 0x02:
+            raise ValueError("expected DER INTEGER")
+        length = data[offset + 1]
+        start = offset + 2
+        value = data[start:start + length].lstrip(b"\x00")
+        return value, start + length
+
+    r, pos = read_integer(der, pos)
+    s, pos = read_integer(der, pos)
+    return r.rjust(size, b"\x00") + s.rjust(size, b"\x00")
+
+
+now = int(time.time())
+header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+payload = {"iss": issuer_id, "iat": now, "exp": now + 1200, "aud": "appstoreconnect-v1"}
+signing_input = (
+    b64url(json.dumps(header, separators=(",", ":")).encode())
+    + "."
+    + b64url(json.dumps(payload, separators=(",", ":")).encode())
+)
+
+result = subprocess.run(
+    ["openssl", "dgst", "-sha256", "-sign", key_path],
+    input=signing_input.encode(),
+    capture_output=True,
+    check=True,
+)
+raw_signature = der_to_raw_signature(result.stdout)
+print(f"{signing_input}.{b64url(raw_signature)}")
+PY
+}

--- a/scripts/lib/resolve-asc-key.sh
+++ b/scripts/lib/resolve-asc-key.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Shared App Store Connect API key resolution, used by scripts/release.sh and
+# scripts/testflight-notes.sh. Source this file, then call:
+#   resolve_asc_key_path <key_id>
+# It echoes the absolute path to AuthKey_<key_id>.p8, honoring an explicit
+# ASC_API_KEY_PATH override or searching the standard private_keys
+# directories. Requires the sourcing script to define bail().
+
+resolve_asc_key_path() {
+    local key_id="$1" key_path=""
+    if [[ -n "${ASC_API_KEY_PATH:-}" ]]; then
+        [[ -f "$ASC_API_KEY_PATH" ]] || bail "ASC_API_KEY_PATH is set but no file exists at $ASC_API_KEY_PATH."
+        key_path="$ASC_API_KEY_PATH"
+    else
+        local dir
+        for dir in "$HOME/.appstoreconnect/private_keys" "$HOME/.private_keys" "$HOME/private_keys" "./private_keys"; do
+            if [[ -f "$dir/AuthKey_${key_id}.p8" ]]; then
+                key_path="$dir/AuthKey_${key_id}.p8"
+                break
+            fi
+        done
+        [[ -n "$key_path" ]] \
+            || bail "AuthKey_${key_id}.p8 not found in ~/.appstoreconnect/private_keys/ or ~/.private_keys/. Install the .p8 there or set ASC_API_KEY_PATH."
+    fi
+    # Callers (openssl, xcodebuild) need an absolute path; normalize.
+    echo "$(cd "$(dirname "$key_path")" && pwd)/$(basename "$key_path")"
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -57,6 +57,8 @@ done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=scripts/lib/resolve-asc-key.sh
+source "$SCRIPT_DIR/lib/resolve-asc-key.sh"
 BUILD_DIR="$REPO_ROOT/build"
 ARCHIVE_PATH="$BUILD_DIR/Anglesite.xcarchive"
 EXPORT_DIR="$BUILD_DIR/export-mas"
@@ -110,23 +112,8 @@ if [[ "$VALIDATE_ONLY" -eq 0 ]]; then
         || bail "ASC_API_KEY_ID is unset (needed for upload). Re-run with --validate-only to skip the upload step."
     [[ -n "${ASC_API_ISSUER_ID:-}" ]] \
         || bail "ASC_API_ISSUER_ID is unset (needed for upload). Re-run with --validate-only to skip the upload step."
-    # xcodebuild (unlike altool) needs the API key file path spelled out; search the
-    # standard private_keys locations unless ASC_API_KEY_PATH points at it directly.
-    if [[ -n "${ASC_API_KEY_PATH:-}" ]]; then
-        [[ -f "$ASC_API_KEY_PATH" ]] || bail "ASC_API_KEY_PATH is set but no file exists at $ASC_API_KEY_PATH."
-        ASC_KEY_PATH="$ASC_API_KEY_PATH"
-    else
-        for dir in "$HOME/.appstoreconnect/private_keys" "$HOME/.private_keys" "$HOME/private_keys" "./private_keys"; do
-            if [[ -f "$dir/AuthKey_${ASC_API_KEY_ID}.p8" ]]; then
-                ASC_KEY_PATH="$dir/AuthKey_${ASC_API_KEY_ID}.p8"
-                break
-            fi
-        done
-        [[ -n "$ASC_KEY_PATH" ]] \
-            || bail "AuthKey_${ASC_API_KEY_ID}.p8 not found in ~/.appstoreconnect/private_keys/ or ~/.private_keys/. Install the .p8 there or set ASC_API_KEY_PATH."
-    fi
-    # xcodebuild requires -authenticationKeyPath to be absolute; normalize.
-    ASC_KEY_PATH="$(cd "$(dirname "$ASC_KEY_PATH")" && pwd)/$(basename "$ASC_KEY_PATH")"
+    # xcodebuild (unlike altool) needs the API key file path spelled out.
+    ASC_KEY_PATH="$(resolve_asc_key_path "$ASC_API_KEY_ID")"
 fi
 
 echo "  team:        $TEAM_ID"

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Sets the "What to Test" beta notes on an already-uploaded App Store Connect
+# build, via the App Store Connect REST API (xcodebuild/altool have no CLI
+# flag for this -- TestFlight beta build localizations are API-only).
+#
+# scripts/release.sh uploads the build; App Store Connect builds land in
+# TestFlight automatically once processed, so there is no separate
+# "TestFlight upload" step. Run this after that upload finishes processing.
+#
+# Prerequisites: same App Store Connect API key as scripts/release.sh. See
+# docs/release.md "TestFlight Beta Distribution".
+#
+# Usage:
+#   ASC_API_KEY_ID=XXXXXXXXXX ASC_API_ISSUER_ID=00000000-0000-0000-0000-000000000000 \
+#     scripts/testflight-notes.sh --notes "Try the new site importer." [--build 42] [--dry-run]
+#
+#   --notes TEXT       "What to Test" text for the build (mutually exclusive
+#                       with --notes-file).
+#   --notes-file PATH  Read "What to Test" text from a file.
+#   --build N          Build number to target (default: CURRENT_PROJECT_VERSION
+#                       from project.yml).
+#   --dry-run          Mint the JWT and print every API request that would be
+#                       made, without sending any of them. No network access;
+#                       safe to run without live App Store Connect credentials.
+#
+# Env:
+#   ASC_API_KEY_ID        (required) App Store Connect API key id.
+#   ASC_API_ISSUER_ID     (required) App Store Connect API issuer id.
+#   ASC_API_KEY_PATH      (optional) Explicit path to AuthKey_<key id>.p8; see
+#                         scripts/lib/resolve-asc-key.sh for the default search.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUNDLE_ID="io.dwk.anglesite"
+LOCALE="en-US"
+API_BASE="https://api.appstoreconnect.apple.com/v1"
+
+bail() { printf 'error: %s\n' "$*" >&2; exit 1; }
+step() { printf '\n=== %s ===\n' "$*"; }
+
+# shellcheck source=scripts/lib/resolve-asc-key.sh
+source "$SCRIPT_DIR/lib/resolve-asc-key.sh"
+# shellcheck source=scripts/lib/asc-jwt.sh
+source "$SCRIPT_DIR/lib/asc-jwt.sh"
+
+NOTES=""
+NOTES_FILE=""
+BUILD_NUMBER=""
+DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --notes) NOTES="$2"; shift 2 ;;
+        --notes-file) NOTES_FILE="$2"; shift 2 ;;
+        --build) BUILD_NUMBER="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) sed -n '2,31p' "$0"; exit 0 ;;
+        *) bail "unknown argument '$1'" ;;
+    esac
+done
+
+# --- Preflight ---------------------------------------------------------------
+step "0/5 preflight"
+
+[[ -n "$NOTES" && -n "$NOTES_FILE" ]] && bail "--notes and --notes-file are mutually exclusive."
+[[ -z "$NOTES" && -z "$NOTES_FILE" ]] && bail "one of --notes or --notes-file is required."
+if [[ -n "$NOTES_FILE" ]]; then
+    [[ -f "$NOTES_FILE" ]] || bail "--notes-file '$NOTES_FILE' does not exist."
+    NOTES="$(cat "$NOTES_FILE")"
+fi
+[[ -n "$NOTES" ]] || bail "notes text is empty."
+
+[[ -n "${ASC_API_KEY_ID:-}" ]] || bail "ASC_API_KEY_ID is unset."
+[[ -n "${ASC_API_ISSUER_ID:-}" ]] || bail "ASC_API_ISSUER_ID is unset."
+
+for cmd in openssl python3 curl jq; do
+    command -v "$cmd" >/dev/null || bail "$cmd not on PATH."
+done
+
+ASC_KEY_PATH="$(resolve_asc_key_path "$ASC_API_KEY_ID")"
+
+if [[ -z "$BUILD_NUMBER" ]]; then
+    BUILD_NUMBER="$(awk -F': *' '/CURRENT_PROJECT_VERSION:/{print $2; exit}' "$REPO_ROOT/project.yml" | tr -d '"')"
+    [[ -n "$BUILD_NUMBER" ]] || bail "could not read CURRENT_PROJECT_VERSION from project.yml; pass --build explicitly."
+fi
+MARKETING_VERSION="$(awk -F': *' '/MARKETING_VERSION:/{print $2; exit}' "$REPO_ROOT/project.yml" | tr -d '"')"
+[[ -n "$MARKETING_VERSION" ]] || bail "could not read MARKETING_VERSION from project.yml."
+
+echo "  build:   $BUILD_NUMBER (marketing version $MARKETING_VERSION)"
+echo "  locale:  $LOCALE"
+echo "  mode:    $([[ "$DRY_RUN" -eq 1 ]] && echo 'dry-run (no network calls)' || echo 'live')"
+
+# --- Mint JWT ------------------------------------------------------------------
+step "1/5 mint App Store Connect API JWT"
+JWT="$(mint_asc_jwt "$ASC_API_KEY_ID" "$ASC_API_ISSUER_ID" "$ASC_KEY_PATH")"
+[[ -n "$JWT" ]] || bail "failed to mint JWT."
+echo "  minted."
+
+api_call() {
+    # api_call METHOD PATH [JSON_BODY]
+    local method="$1" path="$2" body="${3:-}"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "  [dry-run] $method $API_BASE$path" >&2
+        [[ -n "$body" ]] && echo "  [dry-run] body: $body" >&2
+        echo "{}"
+        return 0
+    fi
+    if [[ -n "$body" ]]; then
+        curl -sS -X "$method" "$API_BASE$path" \
+            -H "Authorization: Bearer $JWT" \
+            -H "Content-Type: application/json" \
+            -d "$body"
+    else
+        curl -sS -X "$method" "$API_BASE$path" \
+            -H "Authorization: Bearer $JWT"
+    fi
+}
+
+# --- Look up app id -------------------------------------------------------------
+step "2/5 look up app id for $BUNDLE_ID"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "  [dry-run] GET $API_BASE/apps?filter[bundleId]=$BUNDLE_ID"
+    APP_ID="DRYRUN_APP_ID"
+else
+    APP_RESPONSE="$(api_call GET "/apps?filter[bundleId]=$BUNDLE_ID")"
+    APP_ID="$(jq -r '.data[0].id // empty' <<<"$APP_RESPONSE")"
+    [[ -n "$APP_ID" ]] || bail "no app found for bundle id $BUNDLE_ID. Has the App Store Connect app record been created?"
+fi
+echo "  app id: $APP_ID"
+
+# --- Find and wait for the build -------------------------------------------------
+step "3/5 find build $BUILD_NUMBER (version $MARKETING_VERSION)"
+BUILD_PATH="/builds?filter[app]=$APP_ID&filter[version]=$BUILD_NUMBER&filter[preReleaseVersion.version]=$MARKETING_VERSION"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "  [dry-run] GET $API_BASE$BUILD_PATH"
+    BUILD_ID="DRYRUN_BUILD_ID"
+else
+    ATTEMPTS=30
+    BUILD_ID=""
+    for ((i = 1; i <= ATTEMPTS; i++)); do
+        BUILD_RESPONSE="$(api_call GET "$BUILD_PATH")"
+        BUILD_ID="$(jq -r '.data[0].id // empty' <<<"$BUILD_RESPONSE")"
+        [[ -n "$BUILD_ID" ]] || bail "no build found for version $MARKETING_VERSION build $BUILD_NUMBER. Has scripts/release.sh uploaded it yet?"
+        PROCESSING_STATE="$(jq -r '.data[0].attributes.processingState' <<<"$BUILD_RESPONSE")"
+        case "$PROCESSING_STATE" in
+            VALID) break ;;
+            FAILED|INVALID) bail "build $BUILD_NUMBER processing state is $PROCESSING_STATE -- check App Store Connect for details." ;;
+            *)
+                [[ "$i" -eq "$ATTEMPTS" ]] && bail "build $BUILD_NUMBER still $PROCESSING_STATE after $((ATTEMPTS * 30 / 60)) minutes; re-run once App Store Connect finishes processing it."
+                echo "  processing ($PROCESSING_STATE), waiting 30s... ($i/$ATTEMPTS)"
+                sleep 30
+                ;;
+        esac
+    done
+fi
+echo "  build id: $BUILD_ID"
+
+# --- Set What to Test -------------------------------------------------------------
+step "4/5 set What to Test ($LOCALE)"
+NOTES_JSON="$(jq -n --arg notes "$NOTES" '$notes')"
+LOCALIZATION_PATH="/betaBuildLocalizations?filter[build]=$BUILD_ID&filter[locale]=$LOCALE"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "  [dry-run] GET $API_BASE$LOCALIZATION_PATH"
+    echo "  [dry-run] would PATCH the existing localization, or POST a new one, with whatsToTest=$NOTES_JSON"
+else
+    LOC_RESPONSE="$(api_call GET "$LOCALIZATION_PATH")"
+    LOC_ID="$(jq -r '.data[0].id // empty' <<<"$LOC_RESPONSE")"
+    if [[ -n "$LOC_ID" ]]; then
+        BODY="$(jq -n --arg id "$LOC_ID" --argjson notes "$NOTES_JSON" \
+            '{data: {type: "betaBuildLocalizations", id: $id, attributes: {whatsToTest: $notes}}}')"
+        RESULT="$(api_call PATCH "/betaBuildLocalizations/$LOC_ID" "$BODY")"
+    else
+        BODY="$(jq -n --arg buildId "$BUILD_ID" --arg locale "$LOCALE" --argjson notes "$NOTES_JSON" \
+            '{data: {type: "betaBuildLocalizations", attributes: {locale: $locale, whatsToTest: $notes}, relationships: {build: {data: {type: "builds", id: $buildId}}}}}')"
+        RESULT="$(api_call POST "/betaBuildLocalizations" "$BODY")"
+    fi
+    jq -e '.data.id' <<<"$RESULT" >/dev/null || bail "failed to set What to Test: $(jq -c '.errors // .' <<<"$RESULT")"
+fi
+
+# --- Result -------------------------------------------------------------------
+step "5/5 result"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo ""
+    echo "Dry run complete -- no requests were sent."
+else
+    cat <<EOF
+
+What to Test set for build $BUILD_NUMBER ($LOCALE).
+
+Next step: add this build to a TestFlight tester group in App Store Connect.
+See docs/release.md "TestFlight Beta Distribution".
+EOF
+fi

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -108,12 +108,12 @@ api_call() {
         return 0
     fi
     if [[ -n "$body" ]]; then
-        curl -sS -X "$method" "$API_BASE$path" \
+        curl -sS -g -X "$method" "$API_BASE$path" \
             -H "Authorization: Bearer $JWT" \
             -H "Content-Type: application/json" \
             -d "$body"
     else
-        curl -sS -X "$method" "$API_BASE$path" \
+        curl -sS -g -X "$method" "$API_BASE$path" \
             -H "Authorization: Bearer $JWT"
     fi
 }
@@ -125,6 +125,7 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
     APP_ID="DRYRUN_APP_ID"
 else
     APP_RESPONSE="$(api_call GET "/apps?filter[bundleId]=$BUNDLE_ID")"
+    jq -e '.errors' <<<"$APP_RESPONSE" >/dev/null 2>&1 && bail "App Store Connect API error: $(jq -c '.errors' <<<"$APP_RESPONSE")"
     APP_ID="$(jq -r '.data[0].id // empty' <<<"$APP_RESPONSE")"
     [[ -n "$APP_ID" ]] || bail "no app found for bundle id $BUNDLE_ID. Has the App Store Connect app record been created?"
 fi
@@ -141,6 +142,7 @@ else
     BUILD_ID=""
     for ((i = 1; i <= ATTEMPTS; i++)); do
         BUILD_RESPONSE="$(api_call GET "$BUILD_PATH")"
+        jq -e '.errors' <<<"$BUILD_RESPONSE" >/dev/null 2>&1 && bail "App Store Connect API error: $(jq -c '.errors' <<<"$BUILD_RESPONSE")"
         BUILD_ID="$(jq -r '.data[0].id // empty' <<<"$BUILD_RESPONSE")"
         [[ -n "$BUILD_ID" ]] || bail "no build found for version $MARKETING_VERSION build $BUILD_NUMBER. Has scripts/release.sh uploaded it yet?"
         PROCESSING_STATE="$(jq -r '.data[0].attributes.processingState' <<<"$BUILD_RESPONSE")"


### PR DESCRIPTION
Closes #766

## Summary

- Add an export-compliance declaration (`ITSAppUsesNonExemptEncryption`) to `Resources/Info.plist` so builds don't stall on App Store Connect's manual export-compliance prompt.
- Add `scripts/testflight-notes.sh` (plus two small sourced libraries, `scripts/lib/resolve-asc-key.sh` and `scripts/lib/asc-jwt.sh`) to set a build's TestFlight "What to Test" beta notes via the App Store Connect REST API — the only interface that exposes this, since `xcodebuild`/`altool` have no flag for it. `scripts/release.sh`'s existing upload already *is* the TestFlight build-upload path; no separate upload step was needed.
- Document the TestFlight beta flow in `docs/release.md`: the App Store Connect steps that stay manual (app record, tester groups, Beta App Review) as a checklist, plus the scripted flow.

App Store Connect app-record creation and TestFlight tester-group membership are out of scope by design — those are portal-only actions with no CLI/API path suitable for this repo's tooling.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [ ] Manual smoke (if UI-touching): N/A — no UI changes.

## Verification notes

No live App Store Connect credentials exist in this development environment, so `scripts/testflight-notes.sh` was verified with `--dry-run` (mints a real JWT, prints every API request it would make, sends none) against a throwaway EC test key, plus a real cryptographic round-trip check of the JWT signing/DER-conversion logic in `scripts/lib/asc-jwt.sh` (`openssl dgst -verify` → `Verified OK`). A final whole-branch review caught and fixed one live-path bug this dry-run testing couldn't reach on its own: curl was glob-parsing the `filter[...]` query params and would have failed before any network request (`curl -g` now fixes this) — see commit `b43b72f5`.

Design spec: `docs/superpowers/specs/2026-08-06-testflight-beta-distribution-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-06-testflight-beta-distribution.md`