### PR TITLE
Validate generated HTML for W3C markup conformance

### DIFF
--- a/Resources/Template/package.json
+++ b/Resources/Template/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "prebuild": "npx tsx scripts/well-known.ts check && npx tsx scripts/csp.ts && npx tsx scripts/edge-artifacts.ts",
-    "build": "astro check && astro build && npx tsx scripts/check-microformats.ts",
+    "build": "astro check && astro build && npx tsx scripts/check-microformats.ts && npx tsx scripts/validate-html.ts",
     "postbuild": "npx pagefind --site dist && npx tsx scripts/well-known.ts verify",
     "preview": "astro preview",
     "check": "npx tsx scripts/pre-deploy-check.ts",

--- a/Resources/Template/scripts/markup-validate.test.ts
+++ b/Resources/Template/scripts/markup-validate.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { validateMarkupHtml, validateDist } from "./markup-validate.ts";
@@ -55,4 +55,16 @@ test("validateDist: walks nested dist/ and aggregates problems across files", ()
 
 test("validateDist: returns no problems for an absent directory", () => {
   assert.deepEqual(validateDist(join(tmpdir(), "markup-validate-test-does-not-exist")), []);
+});
+
+test("validateDist: skips a dangling symlink instead of crashing the whole scan", () => {
+  const dir = mkdtempSync(join(tmpdir(), "markup-validate-test-"));
+  try {
+    writeFileSync(join(dir, "index.html"), GOOD);
+    symlinkSync(join(dir, "does-not-exist.html"), join(dir, "dangling.html"));
+
+    assert.deepEqual(validateDist(dir), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/Resources/Template/scripts/markup-validate.test.ts
+++ b/Resources/Template/scripts/markup-validate.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateMarkupHtml, validateDist } from "./markup-validate.ts";
+
+const GOOD = `<!DOCTYPE html><html lang="en"><head><title>Hello</title></head><body><h1>Hi</h1></body></html>`;
+
+test("validateMarkupHtml: passes conformant markup", () => {
+  assert.deepEqual(validateMarkupHtml(GOOD, "index.html"), []);
+});
+
+test("validateMarkupHtml: flags an empty <title>", () => {
+  const html = `<!DOCTYPE html><html><head><title></title></head><body></body></html>`;
+  const problems = validateMarkupHtml(html, "about/index.html");
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /^about\/index\.html:/);
+  assert.match(problems[0], /empty-title/);
+});
+
+test("validateMarkupHtml: flags unclosed/misnested elements", () => {
+  const html = `<!DOCTYPE html><html><head><title>T</title></head><body><div><span></div></span></body></html>`;
+  const problems = validateMarkupHtml(html, "index.html");
+  assert.ok(problems.length > 0);
+  assert.ok(problems.every((p) => /close-order/.test(p)));
+});
+
+test("validateMarkupHtml: flags duplicate ids", () => {
+  const html = `<!DOCTYPE html><html><head><title>T</title></head><body><div id="a"></div><div id="a"></div></body></html>`;
+  const problems = validateMarkupHtml(html, "index.html");
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /no-dup-id/);
+});
+
+test("validateMarkupHtml: does not flag missing alt text — that's a11y-validate's job", () => {
+  const html = `<!DOCTYPE html><html><head><title>T</title></head><body><img src="x.png"></body></html>`;
+  assert.deepEqual(validateMarkupHtml(html, "index.html"), []);
+});
+
+test("validateDist: walks nested dist/ and aggregates problems across files", () => {
+  const dir = mkdtempSync(join(tmpdir(), "markup-validate-test-"));
+  try {
+    mkdirSync(join(dir, "about"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), GOOD);
+    writeFileSync(join(dir, "about", "index.html"), `<!DOCTYPE html><html><head><title></title></head><body></body></html>`);
+
+    const problems = validateDist(dir);
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /^about\/index\.html:/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("validateDist: returns no problems for an absent directory", () => {
+  assert.deepEqual(validateDist(join(tmpdir(), "markup-validate-test-does-not-exist")), []);
+});

--- a/Resources/Template/scripts/markup-validate.ts
+++ b/Resources/Template/scripts/markup-validate.ts
@@ -62,7 +62,13 @@ function walkHtml(dir: string): string[] {
   }
   for (const name of names) {
     const full = join(dir, name);
-    if (statSync(full).isDirectory()) out.push(...walkHtml(full));
+    let isDirectory: boolean;
+    try {
+      isDirectory = statSync(full).isDirectory();
+    } catch {
+      continue; // dangling symlink or removed mid-walk — skip rather than crash the whole scan
+    }
+    if (isDirectory) out.push(...walkHtml(full));
     else if (extname(full) === ".html") out.push(full);
   }
   return out;

--- a/Resources/Template/scripts/markup-validate.ts
+++ b/Resources/Template/scripts/markup-validate.ts
@@ -1,0 +1,80 @@
+/**
+ * HTML5 / W3C markup conformance validation for built pages.
+ *
+ * Uses html-validate configured with a hand-picked rule set that maps to genuine markup
+ * validity problems (unclosed/misnested elements, invalid content models, duplicate ids,
+ * empty <title>, malformed character references, …) — the same class of defect the W3C/WHATWG
+ * Nu Html Checker (vnu) flags. Deliberately excludes html-validate's accessibility (`wcag/*`)
+ * and style/best-practice rules (`attr-case`, `no-inline-style`, `prefer-button`, …): those
+ * aren't markup *validity* issues, and accessibility is already `scripts/a11y-validate.ts`'s job
+ * — running both here too would just double-report the same findings under a different name.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+import { HtmlValidate } from "html-validate";
+
+const htmlValidate = new HtmlValidate({
+  rules: {
+    "doctype-html": "error",
+    "doctype-style": "error",
+    "close-order": "error",
+    "close-attr": "error",
+    "no-dup-attr": "error",
+    "no-dup-id": "error",
+    "element-permitted-content": "error",
+    "element-permitted-occurrences": "error",
+    "element-permitted-order": "error",
+    "element-permitted-parent": "error",
+    "element-required-ancestor": "error",
+    "element-required-content": "error",
+    "element-name": "error",
+    "void-content": "error",
+    "empty-title": "error",
+    "form-dup-name": "error",
+    "map-dup-name": "error",
+    "map-id-name": "error",
+    "unrecognized-char-ref": "error",
+    "no-raw-characters": "error",
+    "valid-id": ["error", { relaxed: false }],
+    "script-element": "error",
+    "script-type": "error",
+    "no-utf8-bom": "error",
+  },
+});
+
+/** Validate a single built page's markup. Returns human-readable problem strings — an empty
+ * array means the page's HTML is conformant for our purposes. */
+export function validateMarkupHtml(html: string, label: string): string[] {
+  const report = htmlValidate.validateStringSync(html);
+  return report.results.flatMap((result) =>
+    result.messages.map((msg) => `${label}: ${msg.message} (${msg.ruleId})`),
+  );
+}
+
+function walkHtml(dir: string): string[] {
+  const out: string[] = [];
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return out; // dir absent — not an error here
+  }
+  for (const name of names) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walkHtml(full));
+    else if (extname(full) === ".html") out.push(full);
+  }
+  return out;
+}
+
+/** Validate every built HTML page under `distDir`. Returns a flat list of human-readable
+ * problem strings across all pages — an empty array means the whole build is conformant. */
+export function validateDist(distDir: string): string[] {
+  const problems: string[] = [];
+  for (const file of walkHtml(distDir)) {
+    const label = file.slice(distDir.length + 1);
+    problems.push(...validateMarkupHtml(readFileSync(file, "utf8"), label));
+  }
+  return problems;
+}

--- a/Resources/Template/scripts/validate-html.ts
+++ b/Resources/Template/scripts/validate-html.ts
@@ -1,0 +1,11 @@
+import { validateDist } from "./markup-validate.ts";
+
+const distDir = process.argv[2] ?? "dist";
+const problems = validateDist(distDir);
+
+if (problems.length > 0) {
+  console.error(`✗ HTML markup validation failed (${problems.length} problem(s)):`);
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log("✓ HTML markup validation passed");

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -30,12 +30,16 @@ const { title, description, lang } = Astro.props;
 // Astro's built-in Markdown `layout:` frontmatter mechanism (a plain .md page under
 // src/pages/ that selects this layout via `layout: ../layouts/BaseLayout.astro`) passes
 // the page's frontmatter as a nested Astro.props.frontmatter object rather than spreading
-// it at the top level — so a `lang` set in such a page's frontmatter never reaches the
-// `lang` destructured above. Fall back to it here so those pages' overrides still apply.
-// Blog posts and typed content-collection entries pass `lang` as an explicit top-level
-// prop and are unaffected by this fallback.
-const frontmatterLang = (Astro.props as { frontmatter?: { lang?: string } }).frontmatter?.lang;
-const effectiveLang = lang || frontmatterLang || siteLang();
+// it at the top level — so `title`/`description`/`lang` set in such a page's frontmatter
+// never reach the top-level props destructured above (an empty <title> is invalid HTML5,
+// caught by scripts/validate-html.ts). Fall back to it here so those pages' values still
+// apply. Blog posts and typed content-collection entries pass these as explicit top-level
+// props and are unaffected by this fallback.
+const frontmatter = (Astro.props as { frontmatter?: { title?: string; description?: string; lang?: string } })
+  .frontmatter;
+const effectiveTitle = title || frontmatter?.title || "";
+const effectiveDescription = description || frontmatter?.description;
+const effectiveLang = lang || frontmatter?.lang || siteLang();
 const license = headLicense(Astro.props.license, siteLicense());
 // Read directly by route rather than threaded as a prop (#1093) — every page renders through
 // this one layout, so the check lives in exactly one place instead of every call site.
@@ -48,9 +52,9 @@ const noindex = isNoindexed(Astro.url.pathname, readRobotsConfig(process.cwd()))
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
-    {description && <meta name="description" content={description} />}
+    {effectiveDescription && <meta name="description" content={effectiveDescription} />}
     {noindex && <meta name="robots" content="noindex" />}
-    <title>{title}</title>
+    <title>{effectiveTitle}</title>
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />
     <link rel="alternate" type="application/atom+xml" title="Atom" href="/atom.xml" />
     <link rel="alternate" type="application/feed+json" title="JSON Feed" href="/feed.json" />


### PR DESCRIPTION
Closes #955

## Summary

- Add `scripts/validate-html.ts` (+ core `scripts/markup-validate.ts`), wired into `npm run build` right after `check-microformats.ts`, walking `dist/**/*.html` through `html-validate` — already a devDependency, so no new dependency is introduced — with a hand-picked rule set scoped to genuine markup validity (unclosed/misnested elements, duplicate ids, empty `<title>`, invalid content models, malformed character references, …), the same class of defect the W3C/WHATWG Nu Html Checker flags. Deliberately excludes `wcag/*` and style/best-practice rules — accessibility is already `scripts/a11y-validate.ts`'s job, and duplicating it here would just double-report the same findings under a different name.
- Fixes a real bug the new gate caught on its first run: `BaseLayout.astro` read `title`/`description` only off `Astro.props`, but Astro's Markdown `layout:` frontmatter mechanism passes page frontmatter as a nested `Astro.props.frontmatter` object — so `about.md` and `community/about.md` rendered an **empty `<title>`** (invalid HTML5) and no meta description. This extends the file's existing frontmatter-fallback pattern (previously applied only to `lang`, see the neighboring comment) to also cover `title` and `description`.
- Adds `scripts/markup-validate.test.ts` covering the new validator (conformant markup passes; empty title, unclosed elements, and duplicate ids are each flagged; missing `alt` text is *not* flagged, since that's `a11y-validate`'s job; `validateDist` walks nested directories and handles an absent `dist/`).

### Scope note

The issue also floats surfacing failures through `PreDeployCheck`/the health badge, but flags that as an open design question ("worth deciding explicitly whether this blocks a deploy or only warns"). This PR keeps to the concrete, decided part of the issue — a build-time gate mirroring `check-microformats.ts`'s existing convention (hard block, consistent with how mf2 validation already gates `build`) — and leaves the health-badge/pre-deploy integration as a follow-up once that product question is settled.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

Template-only change (`Resources/Template/`) — app-only per `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `npm run build` (from `Resources/Template/`) — full build, including the new `validate-html.ts` gate, passes cleanly against the template's own scaffolded content.
- [x] `npm run test:scripts` — 670 tests, 666 pass, 1 pre-existing unrelated failure (`scaffold.sh` requires `zsh`, not installed in this sandbox), 3 skipped. The 7 new `markup-validate.test.ts` tests all pass.
- [x] `npx astro check` — 0 errors, 0 warnings (pre-existing hints unrelated to this change).
- [ ] `swift test --package-path .` — **could not run**: no Swift toolchain available in this sandbox. Per `CLAUDE.md`, template changes should also run `swift test` since some Swift tests couple to template markup; I checked the relevant suites by hand (`IntegrationTemplateAssetsTests`, `TemplateScriptsManifest`-adjacent tests) and confirmed they assert only on anchor comments/markers preserved by this change, not on the destructured prop shape, so I don't expect a regression — but this suite should still be run in CI or by a reviewer with the toolchain available.
- Not applicable: no app-target UI changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFXUXz3UBjwVRfWjyNoU1v)_