### PR TITLE
Investigate Flatpak/podman sandbox interaction (#567)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -495,6 +495,20 @@ if ProcessInfo.processInfo.environment["ANGLESITE_LINUX_SHELL"] == "1" {
         )
     )
     packageProducts.append(.executable(name: "anglesite-linux", targets: ["AnglesiteLinux"]))
+    // Depends on the AnglesiteLinux target itself (for @testable import), so it inherits the
+    // same GTK-toolchain requirement and only enters the graph under this same
+    // ANGLESITE_LINUX_SHELL=1 gate — but the tests it holds today (ShellModel.overlayCandidates,
+    // a pure function with no GTK/Adwaita touch points) need none of that to actually run; the
+    // gating is a build-graph consequence of testing the target, not a requirement of the tests
+    // themselves.
+    packageTargets.append(
+        .testTarget(
+            name: "AnglesiteLinuxTests",
+            dependencies: ["AnglesiteLinux"],
+            path: "Tests/AnglesiteLinuxTests",
+            swiftSettings: strictConcurrency
+        )
+    )
 }
 #endif
 

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -33,6 +33,7 @@ public struct PodmanContainerControl: LocalContainerControl {
     private let mcpCommand: String
     private let logCenter: LogCenter
     private let flatpakHostSpawn: Bool
+    private let flatpakSpawnExecutable: URL
 
     private static let previewPort = 4321
     private static let mcpPort = 4399
@@ -89,6 +90,11 @@ public struct PodmanContainerControl: LocalContainerControl {
     ///     detecting a Flatpak sandbox via the `FLATPAK_ID` env var Flatpak sets for every
     ///     sandboxed process; injectable so tests can force either path without depending on the
     ///     test runner's own environment.
+    ///   - flatpakSpawnExecutable: The `flatpak-spawn` binary `podmanInvocation(_:)` wraps podman
+    ///     calls in when `flatpakHostSpawn` is true. Defaults to the common path
+    ///     `/usr/bin/flatpak-spawn`, the same "injectable common-path default" shape as
+    ///     `podmanExecutable` — kept a separate parameter rather than hardcoded so tests (or a
+    ///     future non-standard install) can substitute it independently.
     public init(
         image: String = "localhost/anglesite-dev:latest",
         podmanExecutable: URL = URL(fileURLWithPath: "/usr/bin/podman"),
@@ -96,7 +102,8 @@ public struct PodmanContainerControl: LocalContainerControl {
         astroCommand: String = PodmanContainerControl.defaultAstroCommand,
         mcpCommand: String = PodmanContainerControl.defaultMCPCommand,
         logCenter: LogCenter = .shared,
-        flatpakHostSpawn: Bool = ProcessInfo.processInfo.environment["FLATPAK_ID"] != nil
+        flatpakHostSpawn: Bool = ProcessInfo.processInfo.environment["FLATPAK_ID"] != nil,
+        flatpakSpawnExecutable: URL = URL(fileURLWithPath: "/usr/bin/flatpak-spawn")
     ) {
         self.image = image
         self.podmanExecutable = podmanExecutable
@@ -106,6 +113,7 @@ public struct PodmanContainerControl: LocalContainerControl {
         self.mcpCommand = mcpCommand
         self.logCenter = logCenter
         self.flatpakHostSpawn = flatpakHostSpawn
+        self.flatpakSpawnExecutable = flatpakSpawnExecutable
     }
 
     /// Resolves the actual executable + argv for a podman invocation. Outside a Flatpak sandbox
@@ -119,7 +127,7 @@ public struct PodmanContainerControl: LocalContainerControl {
     /// document-portal path visibility) that still need live verification on a Flatpak build.
     func podmanInvocation(_ arguments: [String]) -> (executable: URL, arguments: [String]) {
         guard flatpakHostSpawn else { return (podmanExecutable, arguments) }
-        return (URL(fileURLWithPath: "/usr/bin/flatpak-spawn"), ["--host", podmanExecutable.path] + arguments)
+        return (flatpakSpawnExecutable, ["--host", podmanExecutable.path] + arguments)
     }
 
     /// Boots a fresh rootless-podman container for the site and returns its preview/MCP URLs.

--- a/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
+++ b/Sources/AnglesiteCore/Platform/PodmanContainerControl.swift
@@ -32,6 +32,7 @@ public struct PodmanContainerControl: LocalContainerControl {
     private let astroCommand: String
     private let mcpCommand: String
     private let logCenter: LogCenter
+    private let flatpakHostSpawn: Bool
 
     private static let previewPort = 4321
     private static let mcpPort = 4399
@@ -81,13 +82,21 @@ public struct PodmanContainerControl: LocalContainerControl {
     ///   - logCenter: The `LogCenter` that `execInteractive` launches stream through before each
     ///     call's source-filtered subscription forwards lines to its own `onOutput`. Production
     ///     uses `.shared`.
+    ///   - flatpakHostSpawn: Whether to route every podman invocation through
+    ///     `flatpak-spawn --host` instead of exec'ing `podmanExecutable` directly — see
+    ///     `podmanInvocation(_:)` and
+    ///     docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md §4. Defaults to
+    ///     detecting a Flatpak sandbox via the `FLATPAK_ID` env var Flatpak sets for every
+    ///     sandboxed process; injectable so tests can force either path without depending on the
+    ///     test runner's own environment.
     public init(
         image: String = "localhost/anglesite-dev:latest",
         podmanExecutable: URL = URL(fileURLWithPath: "/usr/bin/podman"),
         supervisor: ProcessSupervisor = .shared,
         astroCommand: String = PodmanContainerControl.defaultAstroCommand,
         mcpCommand: String = PodmanContainerControl.defaultMCPCommand,
-        logCenter: LogCenter = .shared
+        logCenter: LogCenter = .shared,
+        flatpakHostSpawn: Bool = ProcessInfo.processInfo.environment["FLATPAK_ID"] != nil
     ) {
         self.image = image
         self.podmanExecutable = podmanExecutable
@@ -96,6 +105,21 @@ public struct PodmanContainerControl: LocalContainerControl {
         self.astroCommand = astroCommand
         self.mcpCommand = mcpCommand
         self.logCenter = logCenter
+        self.flatpakHostSpawn = flatpakHostSpawn
+    }
+
+    /// Resolves the actual executable + argv for a podman invocation. Outside a Flatpak sandbox
+    /// this is a transparent passthrough. Inside one, `podmanExecutable` itself is unreachable —
+    /// bubblewrap's sandbox doesn't let the app exec arbitrary host binaries — so every call is
+    /// rewritten to run `flatpak-spawn --host <podmanExecutable> <arguments>`, which asks the
+    /// `org.freedesktop.Flatpak` host service (over the `--talk-name` D-Bus permission the
+    /// packaged app's manifest grants) to run the command unsandboxed. Podman itself is never
+    /// installed inside the sandbox — only the CLI invocation crosses the boundary. See the
+    /// investigation doc above for the options considered and the risks (conmon detach behavior,
+    /// document-portal path visibility) that still need live verification on a Flatpak build.
+    func podmanInvocation(_ arguments: [String]) -> (executable: URL, arguments: [String]) {
+        guard flatpakHostSpawn else { return (podmanExecutable, arguments) }
+        return (URL(fileURLWithPath: "/usr/bin/flatpak-spawn"), ["--host", podmanExecutable.path] + arguments)
     }
 
     /// Boots a fresh rootless-podman container for the site and returns its preview/MCP URLs.
@@ -137,15 +161,16 @@ public struct PodmanContainerControl: LocalContainerControl {
         //    (`exec`, `port`, `stop` — none of which daemonize) goes through `ProcessSupervisor`
         //    normally and is unaffected.
         do {
+            let invocation = podmanInvocation([
+                "run", "-d", "--rm", "--name", name,
+                "-v", "\(cloneSource.path):\(Self.repoSharePath):ro",
+                "-p", "127.0.0.1::\(Self.previewPort)",
+                "-p", "127.0.0.1::\(Self.mcpPort)",
+                image, "sleep", "infinity",
+            ])
             try Self.spawnDetachedPodmanRun(
-                podmanExecutable: podmanExecutable,
-                arguments: [
-                    "run", "-d", "--rm", "--name", name,
-                    "-v", "\(cloneSource.path):\(Self.repoSharePath):ro",
-                    "-p", "127.0.0.1::\(Self.previewPort)",
-                    "-p", "127.0.0.1::\(Self.mcpPort)",
-                    image, "sleep", "infinity",
-                ]
+                podmanExecutable: invocation.executable,
+                arguments: invocation.arguments
             )
         } catch let error as LocalContainerError {
             throw error
@@ -195,16 +220,18 @@ public struct PodmanContainerControl: LocalContainerControl {
 
         var handles: [ProcessSupervisor.Handle] = []
         do {
+            let astroInvocation = podmanInvocation(["exec", name, "sh", "-lc", astroCommand])
             let astroHandle = try await supervisor.launch(
-                source: "astro", executable: podmanExecutable,
-                arguments: ["exec", name, "sh", "-lc", astroCommand],
+                source: "astro", executable: astroInvocation.executable,
+                arguments: astroInvocation.arguments,
                 logCenter: bridgeLogCenter
             )
             handles.append(astroHandle)
 
+            let mcpInvocation = podmanInvocation(["exec", name, "sh", "-lc", mcpCommand])
             let mcpHandle = try await supervisor.launch(
-                source: "mcp", executable: podmanExecutable,
-                arguments: ["exec", name, "sh", "-lc", mcpCommand],
+                source: "mcp", executable: mcpInvocation.executable,
+                arguments: mcpInvocation.arguments,
                 logCenter: bridgeLogCenter
             )
             handles.append(mcpHandle)
@@ -303,7 +330,8 @@ public struct PodmanContainerControl: LocalContainerControl {
         }
         arguments.append(name)
         arguments += argv
-        let result = try await supervisor.run(executable: podmanExecutable, arguments: arguments)
+        let invocation = podmanInvocation(arguments)
+        let result = try await supervisor.run(executable: invocation.executable, arguments: invocation.arguments)
         if !result.stdout.isEmpty { onOutput(result.stdout, .stdout) }
         if !result.stderr.isEmpty { onOutput(result.stderr, .stderr) }
         return ContainerExecResult(exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr)
@@ -346,10 +374,11 @@ public struct PodmanContainerControl: LocalContainerControl {
             }
         }
 
+        let invocation = podmanInvocation(arguments)
         let handle = try await supervisor.launch(
             source: source,
-            executable: podmanExecutable,
-            arguments: arguments,
+            executable: invocation.executable,
+            arguments: invocation.arguments,
             attachStdin: true,
             logCenter: logCenter
         )
@@ -378,7 +407,8 @@ public struct PodmanContainerControl: LocalContainerControl {
     private func execOneShot(
         name: String, label: String, onOutput: @escaping @Sendable (String, LogCenter.Stream) -> Void, _ argv: [String]
     ) async throws {
-        let result = try await supervisor.run(executable: podmanExecutable, arguments: ["exec", name] + argv)
+        let invocation = podmanInvocation(["exec", name] + argv)
+        let result = try await supervisor.run(executable: invocation.executable, arguments: invocation.arguments)
         for line in result.stdout.split(separator: "\n", omittingEmptySubsequences: true) {
             onOutput("[\(label)] \(line)", .stdout)
         }
@@ -393,8 +423,9 @@ public struct PodmanContainerControl: LocalContainerControl {
     /// `podman port <name> <guestPort>/tcp` prints `0.0.0.0:PORT` (or `127.0.0.1:PORT`) for the
     /// OS-assigned host port podman published. Parses the trailing port number.
     private func resolvedHostPort(name: String, guestPort: Int) async throws -> Int {
+        let invocation = podmanInvocation(["port", name, "\(guestPort)/tcp"])
         let result = try await supervisor.run(
-            executable: podmanExecutable, arguments: ["port", name, "\(guestPort)/tcp"])
+            executable: invocation.executable, arguments: invocation.arguments)
         guard result.exitCode == 0 else {
             throw LocalContainerError.bootFailed("podman port lookup failed for \(guestPort): \(result.stderr)")
         }
@@ -416,7 +447,8 @@ public struct PodmanContainerControl: LocalContainerControl {
     }
 
     private func stopContainer(name: String) async {
-        _ = try? await supervisor.run(executable: podmanExecutable, arguments: ["stop", "-t", "5", name])
+        let invocation = podmanInvocation(["stop", "-t", "5", name])
+        _ = try? await supervisor.run(executable: invocation.executable, arguments: invocation.arguments)
     }
 
     /// Podman container names must start with an alphanumeric and contain only

--- a/Sources/AnglesiteLinux/ShellModel.swift
+++ b/Sources/AnglesiteLinux/ShellModel.swift
@@ -84,14 +84,17 @@ actor ShellModel {
     }
 
     /// The edit-overlay JS to inject into the preview. On macOS this rides the app bundle
-    /// (`AnglesiteOverlayBundle`); the Linux executable has no bundle yet (Flatpak packaging is
-    /// a separate #567 item), so resolution is: `ANGLESITE_OVERLAY_JS` env override first (dev
-    /// loop), then the repo-relative `scripts/build-overlay.sh` output beside the binary's cwd.
-    /// Missing overlay is non-fatal — the preview loads without edit affordances, matching
-    /// `WebViewBridge`'s behavior when the bundle wasn't produced.
+    /// (`AnglesiteOverlayBundle`); on Linux resolution tries, in order: `ANGLESITE_OVERLAY_JS`
+    /// env override (dev loop); `/app/share/anglesite/edit-overlay/overlay.js`, the path the
+    /// Flatpak manifest installs it to (`packaging/flatpak/io.dwk.anglesite.linux.yml` — see
+    /// docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md §7); then the
+    /// repo-relative `scripts/build-overlay.sh` output beside the binary's cwd, for an unpackaged
+    /// dev build run from the repo root. Missing overlay is non-fatal — the preview loads without
+    /// edit affordances, matching `WebViewBridge`'s behavior when the bundle wasn't produced.
     static func overlaySource(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         let candidates = [
             environment["ANGLESITE_OVERLAY_JS"],
+            "/app/share/anglesite/edit-overlay/overlay.js",
             "Resources/edit-overlay/overlay.js",
         ]
         for case let path? in candidates {

--- a/Sources/AnglesiteLinux/ShellModel.swift
+++ b/Sources/AnglesiteLinux/ShellModel.swift
@@ -88,12 +88,12 @@ actor ShellModel {
     /// env override (dev loop); `/app/share/anglesite/edit-overlay/overlay.js`, the path the
     /// Flatpak manifest installs it to (`packaging/flatpak/io.dwk.anglesite.linux.yml` — see
     /// docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md §7), tried only when
-    /// `FLATPAK_ID` indicates a Flatpak sandbox — same detection `PodmanContainerControl.
-    /// flatpakHostSpawn` uses, so a stray `/app` directory on a non-Flatpak Linux box can't
-    /// silently shadow the dev-relative fallback below it; then the repo-relative
-    /// `scripts/build-overlay.sh` output beside the binary's cwd, for an unpackaged dev build run
-    /// from the repo root. Missing overlay is non-fatal — the preview loads without edit
-    /// affordances, matching `WebViewBridge`'s behavior when the bundle wasn't produced. The
+    /// `FLATPAK_ID` indicates a Flatpak sandbox — same detection
+    /// `PodmanContainerControl.flatpakHostSpawn` uses, so a stray `/app` directory on a
+    /// non-Flatpak Linux box can't silently shadow the dev-relative fallback below it; then the
+    /// repo-relative `scripts/build-overlay.sh` output beside the binary's cwd, for an unpackaged
+    /// dev build run from the repo root. Missing overlay is non-fatal — the preview loads without
+    /// edit affordances, matching `WebViewBridge`'s behavior when the bundle wasn't produced. The
     /// ordering/gating itself lives in `overlayCandidates(environment:)`, a pure function kept
     /// separate from this one's file I/O so `Tests/AnglesiteLinuxTests` can exercise it directly.
     static func overlaySource(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {

--- a/Sources/AnglesiteLinux/ShellModel.swift
+++ b/Sources/AnglesiteLinux/ShellModel.swift
@@ -87,14 +87,17 @@ actor ShellModel {
     /// (`AnglesiteOverlayBundle`); on Linux resolution tries, in order: `ANGLESITE_OVERLAY_JS`
     /// env override (dev loop); `/app/share/anglesite/edit-overlay/overlay.js`, the path the
     /// Flatpak manifest installs it to (`packaging/flatpak/io.dwk.anglesite.linux.yml` — see
-    /// docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md §7); then the
-    /// repo-relative `scripts/build-overlay.sh` output beside the binary's cwd, for an unpackaged
-    /// dev build run from the repo root. Missing overlay is non-fatal — the preview loads without
-    /// edit affordances, matching `WebViewBridge`'s behavior when the bundle wasn't produced.
+    /// docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md §7), tried only when
+    /// `FLATPAK_ID` indicates a Flatpak sandbox — same detection `PodmanContainerControl.
+    /// flatpakHostSpawn` uses, so a stray `/app` directory on a non-Flatpak Linux box can't
+    /// silently shadow the dev-relative fallback below it; then the repo-relative
+    /// `scripts/build-overlay.sh` output beside the binary's cwd, for an unpackaged dev build run
+    /// from the repo root. Missing overlay is non-fatal — the preview loads without edit
+    /// affordances, matching `WebViewBridge`'s behavior when the bundle wasn't produced.
     static func overlaySource(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         let candidates = [
             environment["ANGLESITE_OVERLAY_JS"],
-            "/app/share/anglesite/edit-overlay/overlay.js",
+            environment["FLATPAK_ID"] != nil ? "/app/share/anglesite/edit-overlay/overlay.js" : nil,
             "Resources/edit-overlay/overlay.js",
         ]
         for case let path? in candidates {

--- a/Sources/AnglesiteLinux/ShellModel.swift
+++ b/Sources/AnglesiteLinux/ShellModel.swift
@@ -93,18 +93,27 @@ actor ShellModel {
     /// silently shadow the dev-relative fallback below it; then the repo-relative
     /// `scripts/build-overlay.sh` output beside the binary's cwd, for an unpackaged dev build run
     /// from the repo root. Missing overlay is non-fatal — the preview loads without edit
-    /// affordances, matching `WebViewBridge`'s behavior when the bundle wasn't produced.
+    /// affordances, matching `WebViewBridge`'s behavior when the bundle wasn't produced. The
+    /// ordering/gating itself lives in `overlayCandidates(environment:)`, a pure function kept
+    /// separate from this one's file I/O so `Tests/AnglesiteLinuxTests` can exercise it directly.
     static func overlaySource(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        let candidates = [
-            environment["ANGLESITE_OVERLAY_JS"],
-            environment["FLATPAK_ID"] != nil ? "/app/share/anglesite/edit-overlay/overlay.js" : nil,
-            "Resources/edit-overlay/overlay.js",
-        ]
-        for case let path? in candidates {
+        for path in overlayCandidates(environment: environment) {
             if let source = try? String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8) {
                 return source
             }
         }
         return nil
+    }
+
+    /// The ordered, filtered candidate paths `overlaySource` tries — see its doc comment for what
+    /// each one is and why it's ordered that way. Split out as its own pure function (no file
+    /// I/O) specifically so the ordering/gating logic is unit-testable without needing real files
+    /// on disk at absolute paths like `/app/share/...`.
+    static func overlayCandidates(environment: [String: String]) -> [String] {
+        [
+            environment["ANGLESITE_OVERLAY_JS"],
+            environment["FLATPAK_ID"] != nil ? "/app/share/anglesite/edit-overlay/overlay.js" : nil,
+            "Resources/edit-overlay/overlay.js",
+        ].compactMap { $0 }
     }
 }

--- a/Tests/AnglesiteCoreTests/PodmanContainerControlTests.swift
+++ b/Tests/AnglesiteCoreTests/PodmanContainerControlTests.swift
@@ -51,14 +51,15 @@ struct PodmanContainerControlTests {
         #expect(invocation.arguments == ["stop", "-t", "5", "anglesite-test"])
     }
 
-    @Test("inside a Flatpak sandbox, podman invocations route through flatpak-spawn --host")
+    @Test("inside a Flatpak sandbox, podman invocations route through the injected flatpak-spawn")
     func podmanInvocationRoutesThroughFlatpakSpawn() {
         let control = PodmanContainerControl(
             podmanExecutable: URL(fileURLWithPath: "/usr/bin/podman"),
-            flatpakHostSpawn: true
+            flatpakHostSpawn: true,
+            flatpakSpawnExecutable: URL(fileURLWithPath: "/some/other/prefix/bin/flatpak-spawn")
         )
         let invocation = control.podmanInvocation(["stop", "-t", "5", "anglesite-test"])
-        #expect(invocation.executable.path == "/usr/bin/flatpak-spawn")
+        #expect(invocation.executable.path == "/some/other/prefix/bin/flatpak-spawn")
         #expect(invocation.arguments == ["--host", "/usr/bin/podman", "stop", "-t", "5", "anglesite-test"])
     }
 }

--- a/Tests/AnglesiteCoreTests/PodmanContainerControlTests.swift
+++ b/Tests/AnglesiteCoreTests/PodmanContainerControlTests.swift
@@ -2,6 +2,7 @@
 // podman-driven containers are Linux-only (cross-platform port design §7).
 #if canImport(Glibc)
 import Testing
+import Foundation
 @testable import AnglesiteCore
 
 @Suite("PodmanContainerControl")
@@ -37,6 +38,28 @@ struct PodmanContainerControlTests {
     func parseHostPortInvalidInput() {
         #expect(PodmanContainerControl.parseHostPort(from: "") == nil)
         #expect(PodmanContainerControl.parseHostPort(from: "not-a-port-line\n") == nil)
+    }
+
+    @Test("outside a Flatpak sandbox, podman invocations exec podmanExecutable directly")
+    func podmanInvocationPassesThroughOutsideFlatpak() {
+        let control = PodmanContainerControl(
+            podmanExecutable: URL(fileURLWithPath: "/usr/bin/podman"),
+            flatpakHostSpawn: false
+        )
+        let invocation = control.podmanInvocation(["stop", "-t", "5", "anglesite-test"])
+        #expect(invocation.executable.path == "/usr/bin/podman")
+        #expect(invocation.arguments == ["stop", "-t", "5", "anglesite-test"])
+    }
+
+    @Test("inside a Flatpak sandbox, podman invocations route through flatpak-spawn --host")
+    func podmanInvocationRoutesThroughFlatpakSpawn() {
+        let control = PodmanContainerControl(
+            podmanExecutable: URL(fileURLWithPath: "/usr/bin/podman"),
+            flatpakHostSpawn: true
+        )
+        let invocation = control.podmanInvocation(["stop", "-t", "5", "anglesite-test"])
+        #expect(invocation.executable.path == "/usr/bin/flatpak-spawn")
+        #expect(invocation.arguments == ["--host", "/usr/bin/podman", "stop", "-t", "5", "anglesite-test"])
     }
 }
 #endif

--- a/Tests/AnglesiteLinuxTests/ShellModelOverlaySourceTests.swift
+++ b/Tests/AnglesiteLinuxTests/ShellModelOverlaySourceTests.swift
@@ -1,0 +1,44 @@
+// Unit tests for ShellModel.overlayCandidates — the pure, no-I/O half of overlaySource's
+// resolution logic (Flatpak packaging investigation, #567). Split into its own testTarget
+// because AnglesiteLinux is only in the package graph under ANGLESITE_LINUX_SHELL=1 (see
+// Package.swift's gating comment) — this file needs none of the GTK/Adwaita toolchain that
+// gate exists for, but @testable import AnglesiteLinux still pulls in the whole target.
+import Testing
+@testable import AnglesiteLinux
+
+@Suite("ShellModel.overlayCandidates")
+struct ShellModelOverlaySourceTests {
+    @Test("env override wins over every other candidate")
+    func envOverrideWinsFirst() {
+        let candidates = ShellModel.overlayCandidates(environment: [
+            "ANGLESITE_OVERLAY_JS": "/custom/overlay.js",
+            "FLATPAK_ID": "io.dwk.anglesite.linux",
+        ])
+        #expect(candidates.first == "/custom/overlay.js")
+    }
+
+    @Test("outside a Flatpak sandbox, the /app path is never a candidate")
+    func flatpakPathAbsentOutsideSandbox() {
+        let candidates = ShellModel.overlayCandidates(environment: [:])
+        #expect(!candidates.contains("/app/share/anglesite/edit-overlay/overlay.js"))
+        #expect(candidates == ["Resources/edit-overlay/overlay.js"])
+    }
+
+    @Test("inside a Flatpak sandbox, the /app path is tried before the dev-relative fallback")
+    func flatpakPathPrecedesDevFallback() {
+        let candidates = ShellModel.overlayCandidates(environment: ["FLATPAK_ID": "io.dwk.anglesite.linux"])
+        #expect(candidates == [
+            "/app/share/anglesite/edit-overlay/overlay.js",
+            "Resources/edit-overlay/overlay.js",
+        ])
+    }
+
+    static let nonOverridingEnvironments: [[String: String]] = [
+        [:], ["FLATPAK_ID": "x"], ["ANGLESITE_OVERLAY_JS": "/y"],
+    ]
+
+    @Test("the dev-relative fallback is always present, last", arguments: nonOverridingEnvironments)
+    func devFallbackAlwaysPresentLast(environment: [String: String]) {
+        #expect(ShellModel.overlayCandidates(environment: environment).last == "Resources/edit-overlay/overlay.js")
+    }
+}

--- a/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
+++ b/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
@@ -130,6 +130,24 @@ this is trusted.** If it doesn't hold, the fix is mechanical: apply the same raw
 `posix_spawn`+`waitpid` bypass to `flatpak-spawn` instead of `podman` directly — the code path
 already isolates this to `spawnDetachedPodmanRun`'s one caller.
 
+## 5b. Unverified risk: does interactive `exec` stdio survive `flatpak-spawn --host`?
+
+`execInteractive` launches `podman exec -i` as a long-running supervised process with
+`attachStdin: true` — the ACP-style path that keeps writing to the process's stdin after launch
+(`PodmanContainerControl.execInteractive`, and `InteractiveExecHandle.write`). Once routed through
+`podmanInvocation`, this becomes `flatpak-spawn --host podman exec -i ...`, which — unlike the
+one-shot `run -d`/`exec`/`port`/`stop` calls elsewhere in this file — depends on stdio staying
+live and bidirectional for the whole session, not just an exit code and captured output.
+
+`flatpak-spawn --host` proxies the child over a D-Bus call to `org.freedesktop.Flatpak` rather
+than being a direct local child process — a different I/O path than the one `ProcessSupervisor`
+was built against. Flatpak's own documentation says stdio is forwarded by default, so this should
+work, but per this doc's own standard for §5/§6 ("this is inference, not verification"), that
+claim hasn't been exercised here: no live Flatpak+podman environment was available to open an
+actual interactive `exec` session and confirm writes/reads round-trip correctly (latency, buffering,
+and EOF-on-terminate behavior are all plausible places a D-Bus-proxied pipe could diverge from a
+direct one). Added to the §9 verification checklist below.
+
 ## 6. Unverified risk: does the sandboxed app's picked-folder path resolve on the host?
 
 `AnglesiteLinuxApp`'s "Open Site…" button uses Adwaita's `.folderImporter`, which — like every
@@ -238,6 +256,9 @@ verification"). Before treating this design as load-bearing, a real Ubuntu/Fedor
    the Exit Criterion entirely if it fails).
 3. Confirm `podman run -d` boots promptly through `flatpak-spawn --host` (§5) rather than hanging.
 4. Confirm the overlay JS actually loads from `/app/share/anglesite/edit-overlay/overlay.js` (§7).
+5. Open an interactive `exec` session (the ACP-agent path, `PodmanContainerControl.
+   execInteractive`) and confirm stdin writes and stdout/stderr reads round-trip correctly through
+   `flatpak-spawn --host` for the life of the session, not just at launch/exit (§5b).
 
 None of this PR's Swift changes are behind a new feature flag — `flatpakHostSpawn` only activates
 when `FLATPAK_ID` is set, which is never true outside an actual Flatpak sandbox, so the existing

--- a/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
+++ b/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
@@ -169,26 +169,36 @@ picked path through `xdg-document-portal`'s FUSE filesystem, typically surfaced 
 
 `PodmanContainerControl.start()` then bind-mounts that path into the container:
 `-v "\(cloneSource.path):/run/anglesite-source:ro"`. Under `flatpak-spawn --host`, podman itself
-runs as a normal host process (outside the sandbox) — the question is whether the **document
-portal's FUSE path is visible to that host process** at all, since `xdg-document-portal` is itself
-a host/system service (not sandbox-namespace-scoped), so in principle a same-session host process
-should see the same `/run/user/$UID/doc/...` mount non-sandboxed processes already do. This is
-plausible but **not verified** here — no live Flatpak+podman environment was available to test the
-actual bind-mount succeeding end-to-end.
+runs as a normal host process, entirely outside any Flatpak sandbox — and that's specifically why
+the naive path is likely to fail, not just an open question: `xdg-document-portal`'s FUSE grants
+are recorded per **sandboxed app instance** (the identity a Flatpak sandbox presents to the
+portal), not per Unix UID. A `flatpak-spawn --host`-launched `podman` isn't running as that
+identity — it's a plain host process — so it's plausibly not the caller the grant was issued to,
+even though it's the same user and the sandboxed app itself can read the path fine. This is a
+reportedly common failure mode for exactly this "spawn-to-host, then hand the host process a
+document-portal path" shape (`EACCES`/`ENOENT` from the host-side process). **Not verified here**
+— no live Flatpak+podman environment was available to test the actual bind-mount — but treated as
+the *expected* outcome rather than a coin-flip, which changes the fallback ordering below.
 
-Two fallbacks if it doesn't hold, to try in this order when a real Flatpak build is verified:
+Two approaches to try when a real Flatpak build is verified, **in this priority order** (reversed
+from an earlier draft of this doc, which listed the narrower-grant option second only as a
+fallback "if plan A fails" — on reflection plan A has a real chance of failing this exact way on
+the very first live test, so it shouldn't be the thing tried first in production):
 
-1. Have the app resolve the **real** host path for a document-portal file via
-   `org.freedesktop.portal.Documents`'s host-path-resolution affordances (available to processes
-   with the right access) instead of passing the FUSE path to `podman -v`.
-2. If that's not viable, scope a narrower `--filesystem=` grant to a known Sites directory (e.g.
-   `xdg-data/anglesite/Sites:create`, mirroring how the macOS app defaults new sites into an
-   app-owned location) so at least the common "new site" path never needs the document portal's
-   FUSE indirection, while `.folderImporter`-picked sites elsewhere keep depending on (1).
+1. **Primary: resolve the real host path before handing it to podman.**
+   `org.freedesktop.portal.Documents`'s path-resolution affordances can return the actual host
+   filesystem path backing a document-portal grant (to a caller with the right access), rather
+   than the FUSE path. Have the app do that resolution itself and pass the resolved host path to
+   `podman -v`, instead of the FUSE path.
+2. **Fallback: a narrower `--filesystem=` grant for the common case.** If (1) isn't viable, scope
+   a grant to a known Sites directory (e.g. `xdg-data/anglesite/Sites:create`, mirroring how the
+   macOS app defaults new sites into an app-owned location) so at least the common "new site" path
+   never needs the document portal's FUSE indirection at all — `.folderImporter`-picked sites
+   elsewhere would still depend on (1) working.
 
-This risk is independent of §5 and should be tested first, since a failed bind-mount blocks the
-Exit Criterion entirely (open → edit → preview), while a `conmon`-detach hang is "boot is slow" at
-worst.
+This risk is independent of §5/§5b and should be tested first, since a failed bind-mount blocks
+the Exit Criterion entirely (open → edit → preview), while a `conmon`-detach hang or an
+interactive-exec stdio hiccup are "boot is slow" / "the ACP shell path is flaky" at worst.
 
 ## 7. Implemented: resource bundling + the manifest scaffold
 
@@ -239,7 +249,8 @@ non-fatal in every case, matching the existing behavior.
 Consistent with the design doc's own "Open questions (deferred, non-blocking)" framing for items
 that don't block the phase they're filed under:
 
-- **End-user dev-server image distribution.** `PodmanContainerControl` boots
+- **End-user dev-server image distribution**, tracked in
+  [#1291](https://github.com/Anglesite/Anglesite/issues/1291). `PodmanContainerControl` boots
   `localhost/anglesite-dev:latest`, which today only exists after a developer runs
   `scripts/build-podman-image.sh` against a sibling MCP-sidecar checkout
   (`scripts/lib/stage-dev-image-context.sh`). A Flathub end user has neither the sibling repo nor
@@ -248,16 +259,17 @@ that don't block the phase they're filed under:
   pipeline in `scripts/build-container-image.sh`, vs. vendoring a prebuilt OCI layout the way
   macOS's `Resources/container-image/` does) and is a large enough change to warrant its own
   tracked issue rather than folding it into this one silently.
-- **A Flatpak-based CI lane.** Package.swift's own comment names this as the blocker for
-  un-gating `AnglesiteLinux` from `ANGLESITE_LINUX_SHELL=1` in the default Linux CI leg. Building
-  one (and deciding whether it also becomes the `PodmanContainerControlTests`/`AnglesiteCoreTests`
-  Linux runner — see the CI-target gap noted in §4) is follow-up work once the manifest itself is
-  live-verified per §9's checklist.
-- **Actual Flathub submission and review.** Everything here targets a locally-buildable
-  `flatpak-builder` manifest, not a submitted-and-reviewed Flathub listing (icon art, screenshots,
-  a stable release/update channel, and Flathub's own manifest-review process — including likely
-  scrutiny of `--talk-name=org.freedesktop.Flatpak`'s breadth, see §3(b) — all still need to
-  happen).
+- **Live-verifying the manifest, a Flatpak-based CI lane, and actual Flathub submission**, tracked
+  in [#1293](https://github.com/Anglesite/Anglesite/issues/1293). Everything here targets a
+  locally-buildable `flatpak-builder` manifest, not a live-tested build or a
+  submitted-and-reviewed Flathub listing: §9's verification checklist (the bind-mount, the
+  `conmon`/`flatpak-spawn` interaction, interactive-exec stdio) still needs a real Ubuntu/Fedora
+  box; the CI lane Package.swift's own comment names as the blocker for un-gating `AnglesiteLinux`
+  from `ANGLESITE_LINUX_SHELL=1` (and deciding whether it also becomes the
+  `PodmanContainerControlTests`/`AnglesiteCoreTests` Linux runner — see the CI-target gap noted in
+  §4) still needs building; and Flathub's own manifest-review process (icon art, screenshots, a
+  stable release/update channel, and likely scrutiny of `--talk-name=org.freedesktop.Flatpak`'s
+  breadth, see §3(a)) hasn't started.
 
 ## 9. What still needs a real Flatpak/podman/GTK environment to verify
 
@@ -273,7 +285,9 @@ verification"). Before treating this design as load-bearing, a real Ubuntu/Fedor
    research in this doc, not confirmed against this repo's exact dependency pins).
 2. Run the installed Flatpak, open a `.anglesite` package via the folder picker, and confirm the
    bind-mount in §6 actually works end-to-end (this is the highest-priority unknown — it blocks
-   the Exit Criterion entirely if it fails).
+   the Exit Criterion entirely if it fails). Per §6's reprioritization, implement and test the
+   Documents-portal path-resolution approach (§6 option 1) first, not the FUSE path passed
+   straight through — it's the one expected to work, not just the one tried first for convenience.
 3. Confirm `podman run -d` boots promptly through `flatpak-spawn --host` (§5) rather than hanging.
 4. Confirm the overlay JS actually loads from `/app/share/anglesite/edit-overlay/overlay.js` (§7).
 5. Open an interactive `exec` session (the ACP-agent path, `PodmanContainerControl.

--- a/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
+++ b/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
@@ -282,7 +282,13 @@ verification"). Before treating this design as load-bearing, a real Ubuntu/Fedor
 1. `flatpak-builder --user --install --force-clean build-dir packaging/flatpak/io.dwk.anglesite.linux.yml`
    and confirm it actually builds (Swift SDK extension version, GNOME runtime version, and
    webkitgtk-6.0 pkg-config availability are all inferred from the adwaita-swift precedent and web
-   research in this doc, not confirmed against this repo's exact dependency pins).
+   research in this doc, not confirmed against this repo's exact dependency pins). The manifest's
+   `build-options.build-args: [--share=network]` (added after review — `flatpak-builder` sandboxes
+   the build step itself with no network by default, and `swift build` needs to fetch SwiftPM's
+   git-pinned dependencies) makes this **local verification** build possible, but it is not
+   Flathub-submittable as-is: a hermetic build needs those dependencies vendored ahead of time,
+   the same unresolved gap the overlay JS's npm dependencies already have (§7) — both tracked in
+   #1293, not solved here.
 2. Run the installed Flatpak, open a `.anglesite` package via the folder picker, and confirm the
    bind-mount in §6 actually works end-to-end (this is the highest-priority unknown — it blocks
    the Exit Criterion entirely if it fails). Per §6's reprioritization, implement and test the

--- a/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
+++ b/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
@@ -196,7 +196,12 @@ worst.
 `"Resources/edit-overlay/overlay.js"` — meaningless once the binary runs from `/app/bin/` inside a
 Flatpak install. It now tries, in order: `ANGLESITE_OVERLAY_JS` env override (dev loop unchanged);
 `/app/share/anglesite/edit-overlay/overlay.js` (the Flatpak-installed location, below); then the
-original cwd-relative path (unpackaged dev builds run from the repo root). A missing overlay stays
+original cwd-relative path (unpackaged dev builds run from the repo root). The ordering/gating
+logic is split out into a pure `overlayCandidates(environment:)` function (no file I/O), covered
+by a new `Tests/AnglesiteLinuxTests` target (`ShellModelOverlaySourceTests`) added alongside it —
+unlike `PodmanContainerControlTests` (§4), this target *does* actually run: it depends on
+`AnglesiteLinux`, so it's gated the same `ANGLESITE_LINUX_SHELL=1` way the shell itself is, but
+none of its test code touches GTK/Adwaita, only the environment-driven candidate list. A missing overlay stays
 non-fatal in every case, matching the existing behavior.
 
 `packaging/flatpak/` (new) holds:

--- a/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
+++ b/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
@@ -91,18 +91,27 @@ mechanical follow-up if it turns out to matter, not a redesign.
   nil` — `FLATPAK_ID` is the documented, stable env var Flatpak sets for every process running
   inside one of its sandboxes (also used by `flatpak-spawn` itself and countless sandboxed apps to
   self-detect). Injectable so tests can force either path.
+- `flatpakSpawnExecutable: URL`, defaulting to `/usr/bin/flatpak-spawn` — kept as its own
+  injectable parameter (the same "common-path default, overridable" shape as `podmanExecutable`)
+  rather than hardcoded inline, so tests exercise the actual injection seam instead of just
+  matching a coincidental default.
 - `podmanInvocation(_ arguments: [String]) -> (executable: URL, arguments: [String])` — the single
   seam every podman call now routes through. Outside a sandbox it's a passthrough
   (`podmanExecutable`, unchanged args). Inside one, it rewrites to
-  `(/usr/bin/flatpak-spawn, ["--host", podmanExecutable.path] + arguments)`.
+  `(flatpakSpawnExecutable, ["--host", podmanExecutable.path] + arguments)`.
 
 Every call site that used to pass `podmanExecutable` straight to `ProcessSupervisor.run`/`.launch`
 (the boot-time `spawnDetachedPodmanRun`, `exec`/`execInteractive`, `execOneShot`, `resolvedHostPort`,
 `stopContainer`) now resolves through `podmanInvocation` first. No call site needed its own
 sandbox-awareness — the rewrite is centralized. Two unit tests
 (`PodmanContainerControlTests.podmanInvocationPassesThroughOutsideFlatpak` /
-`...RoutesThroughFlatpakSpawn`) cover the pure argv rewrite; see §9 for why they don't yet run in
-CI (a pre-existing, unrelated gap this PR doesn't newly introduce).
+`...RoutesThroughFlatpakSpawn`) cover the pure argv rewrite, but **don't currently run in CI** —
+`AnglesiteCoreTests` isn't in `Package.swift`'s off-Darwin `portableTargets` filter, so the whole
+target (and this file's own `#if canImport(Glibc)` gate) never builds in either the Linux or
+macOS CI leg today. Pre-existing, not introduced by this PR (see §9) — tracked as a follow-up in
+[#1284](https://github.com/Anglesite/Anglesite/issues/1284) rather than left as only a PR-footnote
+disclosure, since it means `podmanInvocation`'s rewrite logic is currently unverified by any CI
+run, only reviewed by hand.
 
 The manifest (`packaging/flatpak/io.dwk.anglesite.linux.yml`, §7) grants exactly
 `--talk-name=org.freedesktop.Flatpak` for this — no `--filesystem=host`.
@@ -203,8 +212,14 @@ non-fatal in every case, matching the existing behavior.
   `--share=network` (the app itself, not just podman, needs a network namespace so its own
   WebKitGTK preview and HTTP client can reach podman's host-loopback-published ports — this is a
   functional requirement of a live-preview browser, not a sandboxing shortcut for a packaging
-  defect); installs `overlay.js` to `/app/share/anglesite/edit-overlay/overlay.js` (§ above); and
-  builds the `anglesite-linux` product instead of a generic template binary.
+  defect). Like `--talk-name=org.freedesktop.Flatpak` (§3(a)), this is a real, broader-than-
+  strictly-needed grant, not a free one: Flatpak has no loopback-only network permission, so
+  `--share=network` gives the sandboxed WebKitGTK/HTTP-client process unrestricted outbound
+  network access generally, not just reachability to `127.0.0.1:4321`/`4399`. Accepted for the
+  same reason as `--talk-name` — no narrower Flatpak primitive exists for this — and worth the
+  same Flathub-review scrutiny that permission gets (§9); installs `overlay.js` to
+  `/app/share/anglesite/edit-overlay/overlay.js` (§ above); and builds the `anglesite-linux`
+  product instead of a generic template binary.
 - `io.dwk.anglesite.linux.desktop` — reuses the app ID already chosen in code
   (`AdwaitaApp(id: "io.dwk.anglesite.linux")`, `AnglesiteLinuxApp.swift`), so no new identifier is
   introduced.

--- a/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
+++ b/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
@@ -1,0 +1,245 @@
+# Investigation: Flatpak packaging for `AnglesiteLinux`
+
+**Date:** 2026-08-06
+**Issue:** [#567 — Cross-platform P2: Linux MVP](https://github.com/Anglesite/Anglesite/issues/567), last checklist item
+**Resolves:** cross-platform port design §12 open question — "Flatpak sandbox vs.
+rootless-podman-from-Flatpak interaction (may require `flatpak-spawn` or a host-side helper;
+investigate at Linux MVP)"
+**Status:** Investigation complete; recommended design implemented in this PR for the
+sandbox/podman interaction and resource bundling. Manifest scaffold added but **not yet built or
+run** — no `flatpak-builder`/GTK toolchain is available in this environment (see §9). CI lane and
+end-user image distribution are explicitly deferred (§8).
+
+## 1. Where things stand
+
+`AnglesiteLinux` (`Sources/AnglesiteLinux/`) is a GTK4/libadwaita executable (via
+[adwaita-swift](https://codeberg.org/aparoksha/adwaita-swift)) with a WebKitGTK preview. It talks
+to `PodmanContainerControl` (`Sources/AnglesiteCore/Platform/PodmanContainerControl.swift`), which
+drives rootless podman **entirely as CLI subprocess invocations** through `ProcessSupervisor` (one
+exception: `podman run -d`, which bypasses `Process` for a `conmon`-hang workaround via raw
+`posix_spawn` — see that function's doc comment). There is no dependency anywhere on the podman
+REST/unix-socket API, which simplifies this investigation to a single question: **can the app exec
+`podman` at all from inside a Flatpak sandbox**, not "can it reach a socket."
+
+`AnglesiteLinux` is gated behind `ANGLESITE_LINUX_SHELL=1` in `Package.swift` and excluded from the
+default Linux CI leg (`swift:6.3.3-noble` lacks libadwaita ≥ 1.7 and webkitgtk-6.0 dev headers) —
+Package.swift's own comment names a Flatpak-based CI lane as the thing that unblocks that. This doc
+doesn't build that lane (§8); it resolves the sandbox-interaction design question a CI lane and a
+real manifest both depend on.
+
+## 2. Why this is hard: Flatpak's sandbox vs. a CLI-driven container runtime
+
+A Flatpak app runs inside `bubblewrap` (`bwrap`) — a private mount/PID/user namespace with no
+general ability to exec arbitrary host binaries. `podman` is not (and should not be) installed
+inside that sandbox: rootless podman itself creates user namespaces and manages `pasta`
+network-namespace plumbing, cgroups, and `$XDG_RUNTIME_DIR/containers` state that assume it's
+running as a normal host process for the user's session — nesting a second layer of user-namespace
+creation inside `bwrap`'s own is exactly the "rootless-in-rootless" problem Flatpak's sandbox is
+designed to prevent, and is not realistically viable for this app to take on.
+
+So the question is how a sandboxed `AnglesiteLinux` reaches the **host's** already-installed
+podman.
+
+## 3. Options considered
+
+**a. `flatpak-spawn --host` (recommended, implemented in this PR).** Flatpak ships a CLI,
+`flatpak-spawn`, that sandboxed apps can call to run a command outside the sandbox via the
+`org.freedesktop.Flatpak` D-Bus portal — the manifest declares `--talk-name=org.freedesktop.Flatpak`
+in `finish-args`, and the app runs `flatpak-spawn --host podman <args>` in place of `podman <args>`.
+This is the established pattern for exactly this class of problem: VS Code's Flatpak build uses it
+(directly or via the community `host-spawn` reimplementation) to let the Dev Containers extension
+reach host podman/docker, and it needs no `--filesystem=host` grant — the command crosses the
+sandbox boundary over D-Bus, not a widened filesystem view. Cost: `flatpak-spawn --host` can run
+*any* host command the manifest's `--talk-name` unlocks, not just `podman` — Flatpak has no
+built-in per-command allowlist for this yet ([flatpak/flatpak#5538](https://github.com/flatpak/flatpak/issues/5538)
+is an open feature request for one). That's a real, if usual-for-this-pattern, widening of what a
+compromised app process could do; noted here rather than glossed over.
+
+**b. Bundle a `podman-remote` client, expose the host's podman API socket.** VS Code's Flatpak
+ecosystem also has a companion extension (`com.visualstudio.code.tool.podman`) that ships
+`podman-remote` inside the sandbox and talks to the host's podman REST socket via a narrower
+filesystem grant (e.g. `--filesystem=xdg-run/podman:create`) instead of the broader "any host
+command" surface of (a). This is a **materially bigger change** for `PodmanContainerControl` than
+(a): its whole design is built around the plain CLI's argv shape (`podman run -d ...`, `podman exec
+... sh -lc ...`), and `podman-remote` doesn't support every one of those verbs identically (notably,
+detached long-running `exec` process management and the `conmon`-detach behavior this file already
+works around would need to be re-verified against the remote client's process model). It also
+requires the host to have `podman.socket` active (`systemctl --user enable --now podman.socket`),
+which rootless podman doesn't enable by default — an extra host-side setup step for every user,
+which the current CLI-driven design avoids entirely. Rejected **for this phase**: worth
+reconsidering only if Flathub review pushes back on `--talk-name=org.freedesktop.Flatpak`'s breadth
+(see the open item in §9).
+
+**c. A host-side systemd/D-Bus helper service, installed separately (deb/rpm/etc.).** Narrowest
+possible sandbox surface, but requires a second install step outside the Flatpak (`sudo apt install
+anglesite-helper` or similar) before the app works at all — directly against
+`docs/linux-assed-app-spec.md` §6's "do not tell users to weaken sandboxing... to compensate for
+packaging defects" *and* its adjacent expectation that the packaged app is the whole product
+surface. Rejected.
+
+**Decision: (a), `flatpak-spawn --host`.** It's the precedent other GUI-apps-that-drive-podman
+already use, requires no changes to `PodmanContainerControl`'s command construction beyond a
+prefix, and needs no additional host-side setup. The broader-permission cost in (a) is accepted for
+now and flagged for Flathub review (§9) rather than solved speculatively — narrowing to (b) is a
+mechanical follow-up if it turns out to matter, not a redesign.
+
+## 4. Implemented: routing podman invocations through `flatpak-spawn --host`
+
+`PodmanContainerControl` gained:
+
+- `flatpakHostSpawn: Bool`, defaulting to `ProcessInfo.processInfo.environment["FLATPAK_ID"] !=
+  nil` — `FLATPAK_ID` is the documented, stable env var Flatpak sets for every process running
+  inside one of its sandboxes (also used by `flatpak-spawn` itself and countless sandboxed apps to
+  self-detect). Injectable so tests can force either path.
+- `podmanInvocation(_ arguments: [String]) -> (executable: URL, arguments: [String])` — the single
+  seam every podman call now routes through. Outside a sandbox it's a passthrough
+  (`podmanExecutable`, unchanged args). Inside one, it rewrites to
+  `(/usr/bin/flatpak-spawn, ["--host", podmanExecutable.path] + arguments)`.
+
+Every call site that used to pass `podmanExecutable` straight to `ProcessSupervisor.run`/`.launch`
+(the boot-time `spawnDetachedPodmanRun`, `exec`/`execInteractive`, `execOneShot`, `resolvedHostPort`,
+`stopContainer`) now resolves through `podmanInvocation` first. No call site needed its own
+sandbox-awareness — the rewrite is centralized. Two unit tests
+(`PodmanContainerControlTests.podmanInvocationPassesThroughOutsideFlatpak` /
+`...RoutesThroughFlatpakSpawn`) cover the pure argv rewrite; see §9 for why they don't yet run in
+CI (a pre-existing, unrelated gap this PR doesn't newly introduce).
+
+The manifest (`packaging/flatpak/io.dwk.anglesite.linux.yml`, §7) grants exactly
+`--talk-name=org.freedesktop.Flatpak` for this — no `--filesystem=host`.
+
+## 5. Unverified risk: does the `conmon`-detach workaround survive `flatpak-spawn`?
+
+`start()`'s step 1 (`podman run -d`) deliberately bypasses `ProcessSupervisor`/Foundation's
+`Process` via raw `posix_spawn`+`waitpid`, because `conmon` (podman's forked monitor process,
+which outlives the `podman` CLI invocation) was empirically found to hang `Process.waitUntilExit()`
+on Linux. That workaround was verified against a **direct** `podman run -d` child process.
+
+Under Flatpak, the locally-spawned process is `flatpak-spawn`, not `podman` itself —
+`flatpak-spawn --host podman run -d ...` makes a D-Bus call to the host-side `org.freedesktop.Flatpak`
+service, which executes `podman run -d` as a child of a *different* process tree (the portal /
+session-helper), then streams that remote process's stdout/stderr/exit-status back to the local
+`flatpak-spawn` process, which exits once the **host podman CLI invocation** (not `conmon`) exits.
+This is architecturally the same "the daemonizing grandchild doesn't hold the exit-detecting
+process open" shape the current `posix_spawn` workaround exploits, since `flatpak-spawn` sits
+locally in exactly the position `podman` itself used to. It should carry over unchanged, but this
+is inference, not verification — the existing code's own convention is to say "verified
+empirically" only after testing against a real process tree, and this PR can't do that: no
+`flatpak`, `flatpak-builder`, `podman`, or GTK toolchain is available in the environment this
+investigation was written in (§9). **Needs a live check on a real Flatpak-packaged build before
+this is trusted.** If it doesn't hold, the fix is mechanical: apply the same raw
+`posix_spawn`+`waitpid` bypass to `flatpak-spawn` instead of `podman` directly — the code path
+already isolates this to `spawnDetachedPodmanRun`'s one caller.
+
+## 6. Unverified risk: does the sandboxed app's picked-folder path resolve on the host?
+
+`AnglesiteLinuxApp`'s "Open Site…" button uses Adwaita's `.folderImporter`, which — like every
+GTK4 file chooser running inside a Flatpak sandbox — transparently routes through the
+`org.freedesktop.portal.FileChooser` portal rather than a raw dialog, so no `--filesystem=host`
+grant is needed for the picker itself (this already matches `docs/linux-assed-app-spec.md` §4's
+portal expectation, no change needed). The portal grants the sandboxed process access to the
+picked path through `xdg-document-portal`'s FUSE filesystem, typically surfaced at
+`/run/user/$UID/doc/<id>/<name>` — a real path visible *inside* the sandbox.
+
+`PodmanContainerControl.start()` then bind-mounts that path into the container:
+`-v "\(cloneSource.path):/run/anglesite-source:ro"`. Under `flatpak-spawn --host`, podman itself
+runs as a normal host process (outside the sandbox) — the question is whether the **document
+portal's FUSE path is visible to that host process** at all, since `xdg-document-portal` is itself
+a host/system service (not sandbox-namespace-scoped), so in principle a same-session host process
+should see the same `/run/user/$UID/doc/...` mount non-sandboxed processes already do. This is
+plausible but **not verified** here — no live Flatpak+podman environment was available to test the
+actual bind-mount succeeding end-to-end.
+
+Two fallbacks if it doesn't hold, to try in this order when a real Flatpak build is verified:
+
+1. Have the app resolve the **real** host path for a document-portal file via
+   `org.freedesktop.portal.Documents`'s host-path-resolution affordances (available to processes
+   with the right access) instead of passing the FUSE path to `podman -v`.
+2. If that's not viable, scope a narrower `--filesystem=` grant to a known Sites directory (e.g.
+   `xdg-data/anglesite/Sites:create`, mirroring how the macOS app defaults new sites into an
+   app-owned location) so at least the common "new site" path never needs the document portal's
+   FUSE indirection, while `.folderImporter`-picked sites elsewhere keep depending on (1).
+
+This risk is independent of §5 and should be tested first, since a failed bind-mount blocks the
+Exit Criterion entirely (open → edit → preview), while a `conmon`-detach hang is "boot is slow" at
+worst.
+
+## 7. Implemented: resource bundling + the manifest scaffold
+
+`ShellModel.overlaySource` used to resolve the edit-overlay JS from a `cwd`-relative
+`"Resources/edit-overlay/overlay.js"` — meaningless once the binary runs from `/app/bin/` inside a
+Flatpak install. It now tries, in order: `ANGLESITE_OVERLAY_JS` env override (dev loop unchanged);
+`/app/share/anglesite/edit-overlay/overlay.js` (the Flatpak-installed location, below); then the
+original cwd-relative path (unpackaged dev builds run from the repo root). A missing overlay stays
+non-fatal in every case, matching the existing behavior.
+
+`packaging/flatpak/` (new) holds:
+
+- `io.dwk.anglesite.linux.yml` — the `flatpak-builder` manifest. Modeled directly on
+  [adwaita-swift's own template manifest](https://codeberg.org/aparoksha/adwaita-template/raw/branch/main/io.github.AparokshaUI.AdwaitaTemplate.json)
+  (`AparokshaUI/adwaita-swift`'s reference app), since it's a real, working precedent for this
+  exact stack (Swift + libadwaita via `adwaita-swift` + a GNOME runtime, built with
+  `swift build --static-swift-stdlib`). Confirmed `org.gnome.Platform` bundles WebKitGTK
+  (`libwebkitgtk-6.0`), so `org.gnome.Sdk` should carry the `webkitgtk-6.0` pkg-config dev files
+  `CWebKitGTK`'s system-library target needs — no separate WebKit module required. Differences
+  from the adwaita-swift template: adds `--talk-name=org.freedesktop.Flatpak` (§4) and
+  `--share=network` (the app itself, not just podman, needs a network namespace so its own
+  WebKitGTK preview and HTTP client can reach podman's host-loopback-published ports — this is a
+  functional requirement of a live-preview browser, not a sandboxing shortcut for a packaging
+  defect); installs `overlay.js` to `/app/share/anglesite/edit-overlay/overlay.js` (§ above); and
+  builds the `anglesite-linux` product instead of a generic template binary.
+- `io.dwk.anglesite.linux.desktop` — reuses the app ID already chosen in code
+  (`AdwaitaApp(id: "io.dwk.anglesite.linux")`, `AnglesiteLinuxApp.swift`), so no new identifier is
+  introduced.
+- `io.dwk.anglesite.linux.metainfo.xml` — minimal AppStream metadata (summary/description drawn
+  from `README.md`'s own framing, ISC license per `LICENSE`).
+- `icons/io.dwk.anglesite.linux.svg` — a placeholder lettermark, not final brand art (§9).
+- `README.md` — states the scaffold's unverified status up front and lists the manual steps a
+  GTK-provisioned Linux box needs to run to actually build and smoke-test it.
+
+## 8. Explicitly deferred (not attempted in this PR)
+
+Consistent with the design doc's own "Open questions (deferred, non-blocking)" framing for items
+that don't block the phase they're filed under:
+
+- **End-user dev-server image distribution.** `PodmanContainerControl` boots
+  `localhost/anglesite-dev:latest`, which today only exists after a developer runs
+  `scripts/build-podman-image.sh` against a sibling MCP-sidecar checkout
+  (`scripts/lib/stage-dev-image-context.sh`). A Flathub end user has neither the sibling repo nor
+  a reason to run a build script. Closing this gap needs its own design decision (pull a
+  registry-hosted image, mirroring the already-existing `ghcr.io/anglesite/anglesite-devserver`
+  pipeline in `scripts/build-container-image.sh`, vs. vendoring a prebuilt OCI layout the way
+  macOS's `Resources/container-image/` does) and is a large enough change to warrant its own
+  tracked issue rather than folding it into this one silently.
+- **A Flatpak-based CI lane.** Package.swift's own comment names this as the blocker for
+  un-gating `AnglesiteLinux` from `ANGLESITE_LINUX_SHELL=1` in the default Linux CI leg. Building
+  one (and deciding whether it also becomes the `PodmanContainerControlTests`/`AnglesiteCoreTests`
+  Linux runner — see the CI-target gap noted in §4) is follow-up work once the manifest itself is
+  live-verified per §9's checklist.
+- **Actual Flathub submission and review.** Everything here targets a locally-buildable
+  `flatpak-builder` manifest, not a submitted-and-reviewed Flathub listing (icon art, screenshots,
+  a stable release/update channel, and Flathub's own manifest-review process — including likely
+  scrutiny of `--talk-name=org.freedesktop.Flatpak`'s breadth, see §3(b) — all still need to
+  happen).
+
+## 9. What still needs a real Flatpak/podman/GTK environment to verify
+
+This investigation was written in a container with no `flatpak`, `flatpak-builder`, `podman`, or
+GTK4/libadwaita/webkitgtk dev headers available — the same constraint Package.swift's own comment
+already documents for `AnglesiteLinux` itself ("a GTK-provisioned Linux box is the real
+verification"). Before treating this design as load-bearing, a real Ubuntu/Fedora box with Flatpak
++ podman installed needs to:
+
+1. `flatpak-builder --user --install --force-clean build-dir packaging/flatpak/io.dwk.anglesite.linux.yml`
+   and confirm it actually builds (Swift SDK extension version, GNOME runtime version, and
+   webkitgtk-6.0 pkg-config availability are all inferred from the adwaita-swift precedent and web
+   research in this doc, not confirmed against this repo's exact dependency pins).
+2. Run the installed Flatpak, open a `.anglesite` package via the folder picker, and confirm the
+   bind-mount in §6 actually works end-to-end (this is the highest-priority unknown — it blocks
+   the Exit Criterion entirely if it fails).
+3. Confirm `podman run -d` boots promptly through `flatpak-spawn --host` (§5) rather than hanging.
+4. Confirm the overlay JS actually loads from `/app/share/anglesite/edit-overlay/overlay.js` (§7).
+
+None of this PR's Swift changes are behind a new feature flag — `flatpakHostSpawn` only activates
+when `FLATPAK_ID` is set, which is never true outside an actual Flatpak sandbox, so the existing
+non-Flatpak (bare Linux, direct `podman` on PATH) path is unchanged and already covered by
+`PodmanContainerControlIntegrationTests`.

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -31,23 +31,30 @@ written in.
    ```sh
    scripts/build-overlay.sh
    ```
-3. From the repo root:
+3. From the repo root (the manifest's `build-args: [--share=network]` lets this build resolve
+   SwiftPM's git-pinned dependencies — see the manifest's own comment; this makes local
+   verification builds work but is **not** Flathub-submittable as-is, see "Known gaps" below):
    ```sh
    flatpak-builder --user --install --force-clean \
      packaging/flatpak/build-dir packaging/flatpak/io.dwk.anglesite.linux.yml
    ```
 4. `flatpak run io.dwk.anglesite.linux`, open a `.anglesite` package via the folder picker, and
-   confirm the preview actually boots — this exercises the two unverified risks the investigation
-   doc calls out: whether the document-portal-picked path resolves for the host-side podman
-   bind-mount (§6), and whether `podman run -d` boots promptly through `flatpak-spawn --host`
-   rather than hanging (§5).
+   confirm the preview actually boots — this exercises the unverified risks the investigation doc
+   calls out: whether the document-portal-picked path resolves for the host-side podman
+   bind-mount (§6), whether `podman run -d` boots promptly through `flatpak-spawn --host` rather
+   than hanging (§5), and whether an interactive `exec` session's stdio survives the same D-Bus
+   proxy (§5b).
 
 ## Known gaps (see the investigation doc §8-9 for the full list)
 
 - No CI lane builds this manifest yet.
+- Not Flathub-submittable as-is: both the SwiftPM build step (`--share=network` in `build-options`,
+  needed to fetch git-pinned dependencies) and the overlay JS's npm dependencies (built outside
+  the sandboxed build step entirely, per step 2 above) need their dependencies vendored ahead of
+  time for a real hermetic Flathub build — tracked in #1293.
 - No path exists yet for an end user to obtain the `localhost/anglesite-dev:latest` image this
   app requires — today it's only produced by a developer running
-  `scripts/build-podman-image.sh` against a sibling checkout.
+  `scripts/build-podman-image.sh` against a sibling checkout — tracked in #1291.
 - No MIME-type association for `.anglesite` packages is registered (Linux has no direct
   equivalent of macOS's `io.dwk.anglesite.site` package UTI without a separate
   `shared-mime-info` XML registration) — "Open Site…" via the in-app folder picker works

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,56 @@
+# Flatpak packaging for AnglesiteLinux
+
+**Status: unverified scaffold.** This directory was added to resolve the cross-platform port
+design's [§12 open question](../../docs/superpowers/specs/2026-07-08-cross-platform-swift-port-design.md#12-open-questions-deferred-non-blocking)
+about the Flatpak sandbox / rootless-podman interaction — see
+[`docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md`](../../docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md)
+for the design rationale. It has **not** been built or run: no `flatpak`, `flatpak-builder`,
+`podman`, or GTK4/libadwaita/webkitgtk toolchain was available in the environment this was
+written in.
+
+## Files
+
+- `io.dwk.anglesite.linux.yml` — the `flatpak-builder` manifest.
+- `io.dwk.anglesite.linux.desktop` — desktop entry.
+- `io.dwk.anglesite.linux.metainfo.xml` — AppStream metadata (placeholder release entry).
+- `icons/io.dwk.anglesite.linux.svg` — placeholder app icon, not final brand art.
+
+## Before trusting this manifest, verify on a real Linux box
+
+1. Install Flatpak + `flatpak-builder`, and add Flathub for the `org.gnome.Platform`/
+   `org.gnome.Sdk` runtime and the `org.freedesktop.Sdk.Extension.swift6` extension:
+   ```sh
+   flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+   flatpak install flathub org.gnome.Platform//50 org.gnome.Sdk//50 org.freedesktop.Sdk.Extension.swift6
+   ```
+   Confirm the runtime/extension version numbers above are still current — they weren't verified
+   against a real install.
+2. Build the edit overlay first (the manifest installs its output, but doesn't build it —
+   building it needs npm, which a real Flathub-submittable build can't reach; see the manifest's
+   own comment on this):
+   ```sh
+   scripts/build-overlay.sh
+   ```
+3. From the repo root:
+   ```sh
+   flatpak-builder --user --install --force-clean \
+     packaging/flatpak/build-dir packaging/flatpak/io.dwk.anglesite.linux.yml
+   ```
+4. `flatpak run io.dwk.anglesite.linux`, open a `.anglesite` package via the folder picker, and
+   confirm the preview actually boots — this exercises the two unverified risks the investigation
+   doc calls out: whether the document-portal-picked path resolves for the host-side podman
+   bind-mount (§6), and whether `podman run -d` boots promptly through `flatpak-spawn --host`
+   rather than hanging (§5).
+
+## Known gaps (see the investigation doc §8-9 for the full list)
+
+- No CI lane builds this manifest yet.
+- No path exists yet for an end user to obtain the `localhost/anglesite-dev:latest` image this
+  app requires — today it's only produced by a developer running
+  `scripts/build-podman-image.sh` against a sibling checkout.
+- No MIME-type association for `.anglesite` packages is registered (Linux has no direct
+  equivalent of macOS's `io.dwk.anglesite.site` package UTI without a separate
+  `shared-mime-info` XML registration) — "Open Site…" via the in-app folder picker works
+  regardless; double-click-to-open from a file manager doesn't yet.
+- Icon is a placeholder, not final brand art.
+- Not submitted to Flathub — this is a locally-buildable manifest only.

--- a/packaging/flatpak/icons/io.dwk.anglesite.linux.svg
+++ b/packaging/flatpak/icons/io.dwk.anglesite.linux.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Placeholder app icon — not final brand art. See packaging/flatpak/README.md. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <rect x="4" y="4" width="120" height="120" rx="26" fill="#3584e4" />
+  <path d="M64 30 L96 92 L80 92 L73 78 L55 78 L48 92 L32 92 Z M64 50 L57 66 L71 66 Z"
+        fill="#ffffff" />
+</svg>

--- a/packaging/flatpak/io.dwk.anglesite.linux.desktop
+++ b/packaging/flatpak/io.dwk.anglesite.linux.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Anglesite
+GenericName=Website Editor
+Comment=Click-to-edit websites with a live preview
+Exec=anglesite-linux %f
+Icon=io.dwk.anglesite.linux
+Terminal=false
+Categories=Development;WebDevelopment;
+StartupNotify=true

--- a/packaging/flatpak/io.dwk.anglesite.linux.metainfo.xml
+++ b/packaging/flatpak/io.dwk.anglesite.linux.metainfo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.dwk.anglesite.linux</id>
+  <name>Anglesite</name>
+  <summary>Click-to-edit websites with a live preview</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>ISC</project_license>
+  <developer id="io.dwk">
+    <name>David W. Keith</name>
+  </developer>
+  <description>
+    <p>
+      Anglesite gives non-technical site owners a click-to-edit experience for their website.
+      Open a site, edit it directly in a live preview, and deploy — no code editor required.
+    </p>
+  </description>
+  <launchable type="desktop-id">io.dwk.anglesite.linux.desktop</launchable>
+  <url type="homepage">https://github.com/Anglesite/Anglesite</url>
+  <url type="bugtracker">https://github.com/Anglesite/Anglesite/issues</url>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <!--
+      Placeholder — this manifest is an unverified packaging scaffold (#567), not yet built,
+      tested, or released. Fill in a real <release> entry (version + date) once a Flatpak build
+      has been verified per docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md
+      §9 and is ready to ship.
+    -->
+    <release version="0.0.0" date="2026-08-06">
+      <description>
+        <p>Unreleased packaging scaffold — not yet built or verified.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/packaging/flatpak/io.dwk.anglesite.linux.yml
+++ b/packaging/flatpak/io.dwk.anglesite.linux.yml
@@ -29,7 +29,10 @@ finish-args:
   # The app's own WebKitGTK preview + HTTP client need to reach podman's host-loopback-published
   # preview/MCP ports — a functional requirement of a live-preview browser, not a workaround for
   # a packaging defect (docs/linux-assed-app-spec.md §6 forbids the latter). There's no
-  # loopback-only middle ground in Flatpak's network permission model.
+  # loopback-only middle ground in Flatpak's network permission model: this grants the sandboxed
+  # process unrestricted outbound network access generally, not just 127.0.0.1 reachability — a
+  # real, broader-than-strictly-needed cost accepted for the same reason as --talk-name below
+  # (investigation doc §3(a)), not an oversight.
   - --share=network
   # Lets `flatpak-spawn --host podman ...` run podman unsandboxed on the host — see the
   # investigation doc §3-4 for why this is the chosen design (over bundling a socket-talking

--- a/packaging/flatpak/io.dwk.anglesite.linux.yml
+++ b/packaging/flatpak/io.dwk.anglesite.linux.yml
@@ -46,6 +46,18 @@ finish-args:
 build-options:
   append-path: /usr/lib/sdk/swift6/bin
   prepend-ld-library-path: /usr/lib/sdk/swift6/lib
+  # flatpak-builder sandboxes the BUILD step itself with no network access by default (a Flathub
+  # hermeticity requirement) — but `swift build` below needs to resolve/fetch SwiftPM's git-pinned
+  # dependencies (adwaita-swift, plus whatever AnglesiteCore's graph pulls in) unless
+  # .build/checkouts is already populated from a prior unsandboxed build. Without this,
+  # `flatpak-builder --force-clean` (the command packaging/flatpak/README.md tells a verifier to
+  # run) fails on the first `swift build` invocation. --share=network here makes local
+  # verification builds actually work; it is NOT Flathub-submittable as-is — Flathub requires
+  # hermetic builds, so a real submission needs SwiftPM's dependencies vendored ahead of time the
+  # same way the overlay JS's npm dependencies do (see the build-commands comment below), which is
+  # exactly the kind of gap #1293 (live manifest verification + Flathub submission) tracks.
+  build-args:
+    - --share=network
 
 cleanup:
   - /include

--- a/packaging/flatpak/io.dwk.anglesite.linux.yml
+++ b/packaging/flatpak/io.dwk.anglesite.linux.yml
@@ -1,0 +1,101 @@
+# Flatpak manifest for the AnglesiteLinux shell (cross-platform port phase 2, #567).
+#
+# STATUS: scaffold, not yet built or run — see packaging/flatpak/README.md and
+# docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md §9 for the manual
+# verification steps a GTK-provisioned Linux box still needs to run before this is trusted.
+#
+# Modeled on adwaita-swift's own reference manifest for its template app
+# (https://codeberg.org/aparoksha/adwaita-template/raw/branch/main/io.github.AparokshaUI.AdwaitaTemplate.json)
+# — a real, working precedent for this exact stack (Swift + libadwaita via adwaita-swift on a
+# GNOME runtime). org.gnome.Platform bundles WebKitGTK (libwebkitgtk-6.0), so org.gnome.Sdk
+# should carry the webkitgtk-6.0 pkg-config dev files Sources/CWebKitGTK needs without an
+# additional WebKit build module — confirm this against the actual runtime version pinned below
+# when this manifest is first built for real.
+
+app-id: io.dwk.anglesite.linux
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.swift6
+command: anglesite-linux
+
+finish-args:
+  # Standard GTK4 GUI surface (matches adwaita-swift's own template manifest).
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  # The app's own WebKitGTK preview + HTTP client need to reach podman's host-loopback-published
+  # preview/MCP ports — a functional requirement of a live-preview browser, not a workaround for
+  # a packaging defect (docs/linux-assed-app-spec.md §6 forbids the latter). There's no
+  # loopback-only middle ground in Flatpak's network permission model.
+  - --share=network
+  # Lets `flatpak-spawn --host podman ...` run podman unsandboxed on the host — see the
+  # investigation doc §3-4 for why this is the chosen design (over bundling a socket-talking
+  # podman-remote client, or a separate host-side helper service) and the accepted cost (this
+  # permission allows spawning any host command the manifest grants, not just podman; Flatpak has
+  # no built-in per-command allowlist yet — flatpak/flatpak#5538). No --filesystem=host grant:
+  # the "Open Site…" folder picker already goes through the document portal (§6 of the
+  # investigation doc), which is the narrower, platform-correct mechanism.
+  - --talk-name=org.freedesktop.Flatpak
+
+build-options:
+  append-path: /usr/lib/sdk/swift6/bin
+  prepend-ld-library-path: /usr/lib/sdk/swift6/lib
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /man
+  - /share/doc
+  - /share/gtk-doc
+  - /share/man
+  - /share/pkgconfig
+  - '*.la'
+  - '*.a'
+
+modules:
+  - name: anglesite-linux
+    builddir: true
+    buildsystem: simple
+    sources:
+      - type: dir
+        # The manifest lives at packaging/flatpak/ inside the repo; flatpak-builder resolves
+        # relative source paths against the manifest's own directory, so this reaches the repo
+        # root where Package.swift lives.
+        path: ../..
+    build-commands:
+      # ANGLESITE_LINUX_SHELL=1 opts the AnglesiteLinux target into the package graph (Package.swift)
+      # — it's excluded by default because most build environments (including this repo's own
+      # Linux CI leg) lack the GTK/libadwaita/webkitgtk dev headers this module provides via the
+      # GNOME SDK.
+      - >-
+        ANGLESITE_LINUX_SHELL=1 swift build -c release --static-swift-stdlib
+        --product anglesite-linux
+      # SwiftPM's built binary name for an executable product can differ from the product name
+      # depending on toolchain version (it may match the underlying target name, "AnglesiteLinux",
+      # instead of the product name, "anglesite-linux") — this manifest hasn't been run against a
+      # real Swift 6 Flatpak SDK extension yet to confirm which. Installing whichever one exists
+      # keeps this build-command correct either way; if a future toolchain produces neither name
+      # this step fails loudly rather than silently installing a stale binary.
+      - >-
+        install -Dm755
+        "$(find .build/release -maxdepth 1 -type f \( -name anglesite-linux -o -name AnglesiteLinux \) | head -n1)"
+        /app/bin/anglesite-linux
+      # Assumes scripts/build-overlay.sh already ran against this checkout (it bundles
+      # JS/edit-overlay/ into Resources/edit-overlay/overlay.js — same output the macOS app
+      # bundle copies). A Flathub-submittable build can't reach npm during the sandboxed build
+      # step, so a real submission needs the overlay's node dependencies vendored ahead of time
+      # (e.g. via a flatpak-node-generator-produced sources list) — deferred along with the rest
+      # of actual Flathub submission (investigation doc §8).
+      - install -Dm644 Resources/edit-overlay/overlay.js /app/share/anglesite/edit-overlay/overlay.js
+      - >-
+        install -Dm644 packaging/flatpak/io.dwk.anglesite.linux.metainfo.xml
+        /app/share/metainfo/io.dwk.anglesite.linux.metainfo.xml
+      - >-
+        install -Dm644 packaging/flatpak/io.dwk.anglesite.linux.desktop
+        /app/share/applications/io.dwk.anglesite.linux.desktop
+      - >-
+        install -Dm644 packaging/flatpak/icons/io.dwk.anglesite.linux.svg
+        /app/share/icons/hicolor/scalable/apps/io.dwk.anglesite.linux.svg


### PR DESCRIPTION
Closes #567

## Summary

- Resolves the cross-platform port design's §12 open question ("Flatpak sandbox vs.
  rootless-podman-from-Flatpak interaction") — recommends `flatpak-spawn --host` over bundling a
  socket-talking `podman-remote` client or a separate host-side helper service, and implements it:
  `PodmanContainerControl` now routes every podman invocation through a new `podmanInvocation(_:)`
  seam that transparently rewrites to `flatpak-spawn --host podman ...` when running inside a
  Flatpak sandbox (detected via the `FLATPAK_ID` env var Flatpak sets for sandboxed processes; no
  behavior change outside one).
- Fixes `ShellModel.overlaySource`'s resource-path resolution to also check the Flatpak-installed
  location (`/app/share/anglesite/edit-overlay/overlay.js`), alongside the existing env override
  and cwd-relative dev fallback.
- Adds an unbuilt `flatpak-builder` manifest scaffold (`packaging/flatpak/`) modeled on
  adwaita-swift's own reference manifest for this exact stack (Swift + libadwaita on a GNOME
  runtime), plus desktop entry, AppStream metainfo, and a placeholder icon.
- Records the full investigation — options considered, the design decision, and two risks that
  still need a live Flatpak+podman+GTK environment to verify (the `conmon`-detach boot workaround
  under `flatpak-spawn`, and whether a document-portal-picked site path resolves for the host-side
  podman bind-mount) — in
  [`docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md`](https://github.com/Anglesite/Anglesite/blob/main/docs/superpowers/specs/2026-08-06-flatpak-packaging-investigation.md).

Deliberately **not** in scope here (see the doc's §8): a CI lane building the manifest, an
end-user path to the `localhost/anglesite-dev:latest` dev image (today only produced by a
developer's local build script), and actual Flathub submission. All three need their own
follow-up.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — **could not run**: no Swift toolchain is available in this
      session's environment. The two new unit tests
      (`PodmanContainerControlTests.podmanInvocationPassesThroughOutsideFlatpak` /
      `...RoutesThroughFlatpakSpawn`) were reviewed by hand for syntax correctness against the
      existing file's patterns, but are unverified by an actual compile. Also note: this whole
      test file (`PodmanContainerControlTests.swift`) is pre-existing dead code in the current
      package graph — `AnglesiteCoreTests` isn't in `Package.swift`'s `portableTargets` filter, so
      it's excluded from the package entirely on Linux, and the file's own `#if canImport(Glibc)`
      gate makes it compile to nothing on macOS. Not introduced by this PR; noted in the
      investigation doc §4.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` —
      **could not run**: macOS/Xcode only, unavailable in this Linux container session.
- [x] Manual smoke: not applicable — `AnglesiteLinux` needs a real GTK-provisioned Linux box with
      libadwaita ≥ 1.7 and webkitgtk-6.0 (Package.swift's own gating comment already documents
      this requirement), which this session doesn't have. The Flatpak manifest itself is
      explicitly unverified — see the investigation doc §9 for the manual verification checklist
      a real box still needs to run.
- [x] Manually reviewed the full diff of `PodmanContainerControl.swift` for balanced
      braces/syntax correctness given the lack of a compiler in this environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdaeJTLEgbzxGKLGN4NTWd)_