### PR TITLE
Fail loudly when validate-html scans zero pages

### DIFF
--- a/Resources/Template/scripts/markup-validate.test.ts
+++ b/Resources/Template/scripts/markup-validate.test.ts
@@ -53,8 +53,23 @@ test("validateDist: walks nested dist/ and aggregates problems across files", ()
   }
 });
 
-test("validateDist: returns no problems for an absent directory", () => {
-  assert.deepEqual(validateDist(join(tmpdir(), "markup-validate-test-does-not-exist")), []);
+test("validateDist: fails loudly on an absent directory instead of a vacuous pass", () => {
+  const dir = join(tmpdir(), "markup-validate-test-does-not-exist");
+  const problems = validateDist(dir);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /no \.html files found/);
+});
+
+test("validateDist: fails loudly on a directory with zero .html files", () => {
+  const dir = mkdtempSync(join(tmpdir(), "markup-validate-test-"));
+  try {
+    writeFileSync(join(dir, "styles.css"), "body { color: red; }");
+    const problems = validateDist(dir);
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /no \.html files found/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("validateDist: skips a dangling symlink instead of crashing the whole scan", () => {

--- a/Resources/Template/scripts/markup-validate.ts
+++ b/Resources/Template/scripts/markup-validate.ts
@@ -8,6 +8,10 @@
  * and style/best-practice rules (`attr-case`, `no-inline-style`, `prefer-button`, …): those
  * aren't markup *validity* issues, and accessibility is already `scripts/a11y-validate.ts`'s job
  * — running both here too would just double-report the same findings under a different name.
+ *
+ * `validateDist` also guards against a fail-open-on-empty vacuous pass: scanning zero HTML files
+ * (a missing/empty `dist/`, or a wrong `distDir` argument) is itself reported as a problem rather
+ * than silently returning no findings.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -75,10 +79,26 @@ function walkHtml(dir: string): string[] {
 }
 
 /** Validate every built HTML page under `distDir`. Returns a flat list of human-readable
- * problem strings across all pages — an empty array means the whole build is conformant. */
+ * problem strings across all pages — an empty array means the whole build is conformant.
+ *
+ * A missing `distDir` or a `distDir` with zero `.html` files is itself reported as a problem
+ * rather than silently returning `[]`: this script only ever runs chained after `astro build`
+ * (`npm run build`), so by the time it runs `dist/` must exist and hold pages — scanning zero
+ * files means something upstream is broken (a misconfigured `outDir`, a build that silently
+ * produced nothing, or `validate-html.ts` invoked with the wrong `distDir` argument), and a
+ * vacuous "0 problems found" pass would hide exactly that (the fail-open-on-empty failure mode
+ * #957/PR #1275 independently fixes for the conformance-suite gate).
+ */
 export function validateDist(distDir: string): string[] {
+  const files = walkHtml(distDir);
+  if (files.length === 0) {
+    return [
+      `${distDir}: no .html files found — nothing was validated (missing/empty dist/, or the wrong distDir argument)`,
+    ];
+  }
+
   const problems: string[] = [];
-  for (const file of walkHtml(distDir)) {
+  for (const file of files) {
     const label = file.slice(distDir.length + 1);
     problems.push(...validateMarkupHtml(readFileSync(file, "utf8"), label));
   }

--- a/Resources/Template/scripts/markup-validate.ts
+++ b/Resources/Template/scripts/markup-validate.ts
@@ -62,7 +62,7 @@ function walkHtml(dir: string): string[] {
   try {
     names = readdirSync(dir);
   } catch {
-    return out; // dir absent — not an error here
+    return out; // dir absent — validateDist turns the resulting empty list into an error
   }
   for (const name of names) {
     const full = join(dir, name);


### PR DESCRIPTION
Follow-up to #1276 (merged), addressing post-merge review feedback that arrived after that PR had already merged.

## Summary

- `markup-validate.ts`'s `validateDist` treated "zero HTML files scanned" the same as "zero problems found" — a missing/empty `dist/`, a misconfigured `outDir`, or `validate-html.ts` invoked with the wrong `distDir` argument would all print `✓ HTML markup validation passed` and exit 0, a vacuous pass rather than a loud failure. This is the same fail-open-on-empty shape #957/PR #1275 independently fixes for the conformance-suite gate.
- `validateDist` now reports a problem (and `validate-html.ts` exits 1) when it scans zero `.html` files, instead of silently returning no findings. Since this script only ever runs chained after `astro build` in `npm run build`, by the time it runs `dist/` must exist and hold pages — scanning zero means something upstream broke.
- Added two tests: an absent directory and a directory with only non-HTML files both now assert the loud failure instead of a silent pass. All 9 tests in `markup-validate.test.ts` pass; full `npm run build` still passes cleanly against the template's real scaffolded content (31 pages, exit 0).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

Template-only change (`Resources/Template/`) — app-only per `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `npm run build` (from `Resources/Template/`) — passes cleanly, including the strengthened `validate-html.ts` gate, against the template's own scaffolded content.
- [x] `npx tsx --test scripts/markup-validate.test.ts` — 9/9 pass.
- [ ] `swift test --package-path .` — could not run in this sandbox (no Swift toolchain available). This change is TypeScript-only (`Resources/Template/scripts/`), so I don't expect Swift-side impact, but flagging per `CLAUDE.md`'s "if you touch `Resources/Template/`, run `swift test` too."
- Not applicable: no app-target UI changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SFXUXz3UBjwVRfWjyNoU1v)_