### PR TITLE
ci: install Swift toolchain in Claude web session containers

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# SessionStart hook for Claude Code on the web.
+#
+# The Linux portable-target flow (see scripts/setup-dev-env.sh and
+# README.md#developing-on-linux) needs a Swift 6.3+ toolchain, installed via
+# swiftly, for `swift build`/`swift test` to work. Web session containers
+# don't ship one, so install it here.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+SWIFTLY_ENV="$HOME/.local/share/swiftly/env.sh"
+[ -f "$SWIFTLY_ENV" ] && . "$SWIFTLY_ENV"
+
+swift_version_ok() {
+  command -v swift >/dev/null 2>&1 || return 1
+  local version minor
+  version=$(swift --version 2>/dev/null | sed -n 's/^Swift version \([0-9.]*\).*/\1/p' | head -1)
+  minor=$(printf '%s' "${version:-0}" | awk -F. '{ printf "%d%02d", $1, $2 }')
+  [ "${minor:-0}" -ge 603 ]
+}
+
+if ! swift_version_ok; then
+  if ! command -v swiftly >/dev/null 2>&1; then
+    curl -fsSL -o /tmp/swiftly.tar.gz "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
+    tar zxf /tmp/swiftly.tar.gz -C /tmp
+    /tmp/swiftly init -y --no-modify-profile --skip-install
+    rm -f /tmp/swiftly.tar.gz /tmp/swiftly
+    . "$SWIFTLY_ENV"
+  fi
+  swiftly install latest -y
+fi
+
+# Persist swiftly's PATH for the rest of this session (env.sh itself is a
+# no-op re-source: it only prepends SWIFTLY_BIN_DIR if not already present).
+if [ -f "$SWIFTLY_ENV" ]; then
+  echo ". \"$SWIFTLY_ENV\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+# Distros shipping libxml2 >= 2.15 (e.g. Ubuntu 26.04) provide libxml2.so.16
+# with no libxml2.so.2 compat symlink, but the swift.org toolchain's
+# libFoundationXML links libxml2.so.2. Shim it with a user-level symlink (the
+# API subset FoundationXML uses survived the soname bump) — mirrors
+# scripts/setup-dev-env.sh's Linux path.
+if ! ldconfig -p 2>/dev/null | grep -qF 'libxml2.so.2 '; then
+  LIBXML2_NEW=$(ldconfig -p 2>/dev/null | awk '/libxml2\.so\.[0-9]+ /{ print $NF; exit }' || true)
+  if [ -n "$LIBXML2_NEW" ]; then
+    SHIM_DIR="$HOME/.local/lib/anglesite-shims"
+    mkdir -p "$SHIM_DIR"
+    ln -sf "$LIBXML2_NEW" "$SHIM_DIR/libxml2.so.2"
+    case ":${LD_LIBRARY_PATH:-}:" in
+      *":$SHIM_DIR:"*) ;;
+      *) echo "export LD_LIBRARY_PATH=\"$SHIM_DIR\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\"" >> "$CLAUDE_ENV_FILE" ;;
+    esac
+  fi
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -12,6 +12,8 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+: "${CLAUDE_ENV_FILE:?CLAUDE_ENV_FILE must be set}"
+
 SWIFTLY_ENV="$HOME/.local/share/swiftly/env.sh"
 [ -f "$SWIFTLY_ENV" ] && . "$SWIFTLY_ENV"
 
@@ -23,12 +25,36 @@ swift_version_ok() {
   [ "${minor:-0}" -ge 603 ]
 }
 
+# Verifies the downloaded swiftly tarball against swift.org's published PGP
+# signature (https://www.swift.org/install/linux/swiftly/), in an isolated
+# GNUPGHOME so this doesn't touch any real user keyring. Runs unattended on
+# every qualifying web session, unlike the manual install instructions this
+# mirrors, so skipping verification here would be a bigger risk than there.
+# Best-effort: if gpg isn't available, warn and fall through rather than
+# blocking session bootstrap on an optional tool.
+verify_swiftly_tarball() {
+  local tarball="$1" sig="$2"
+  if ! command -v gpg >/dev/null 2>&1; then
+    echo "warning: gpg not found — skipping swiftly signature verification" >&2
+    return 0
+  fi
+  local gpg_home
+  gpg_home=$(mktemp -d)
+  # shellcheck disable=SC2064 (expand gpg_home now, not at trap time)
+  trap "rm -rf '$gpg_home'" RETURN
+  curl -fsSL --compressed https://www.swift.org/keys/all-keys.asc \
+    | gpg --homedir "$gpg_home" --quiet --import -
+  gpg --homedir "$gpg_home" --quiet --verify "$sig" "$tarball"
+}
+
 if ! swift_version_ok; then
   if ! command -v swiftly >/dev/null 2>&1; then
     curl -fsSL -o /tmp/swiftly.tar.gz "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
+    curl -fsSL -o /tmp/swiftly.tar.gz.sig "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz.sig"
+    verify_swiftly_tarball /tmp/swiftly.tar.gz /tmp/swiftly.tar.gz.sig
     tar zxf /tmp/swiftly.tar.gz -C /tmp
     /tmp/swiftly init -y --no-modify-profile --skip-install
-    rm -f /tmp/swiftly.tar.gz /tmp/swiftly
+    rm -f /tmp/swiftly.tar.gz /tmp/swiftly.tar.gz.sig /tmp/swiftly
     . "$SWIFTLY_ENV"
   fi
   swiftly install latest -y

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,17 @@
       "mcp__computer-use__zoom",
       "mcp__computer-use__wait"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -94,9 +94,12 @@ Resources/Anglesite.help/**/*.helpindex
 *~
 
 # Claude Code harness state (worktrees, local state) — but share the
-# project permission allowlist so parallel agents prompt less
+# project permission allowlist and the SessionStart hook so parallel agents
+# and fresh web sessions both get a working Swift toolchain
 .claude/*
 !.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/**
 
 # Codex harness state (worktrees, agent scratch)
 .Codex/


### PR DESCRIPTION
## Summary

- Claude Code web session containers had no Swift toolchain installed, so `swift build`/`swift test` failed immediately — even though `.claude/settings.json` already allowlists those commands.
- Add a `SessionStart` hook (`.claude/hooks/session-start.sh`) that installs Swift 6.3+ via [swiftly](https://www.swift.org/install/linux/), mirroring `scripts/setup-dev-env.sh`'s Linux path (including the `libxml2.so.2` compat shim for newer distros), and persists the toolchain's `PATH` for the rest of the session via `$CLAUDE_ENV_FILE`. It's idempotent and only runs when `$CLAUDE_CODE_REMOTE=true`.
- `.claude/*` is normally gitignored as local harness state; added an exception for `.claude/hooks/` so this hook actually ships to sessions instead of staying local-only.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (ran `--filter AnglesiteSiteModelTests`, since only the portable targets build off-Darwin — 22/22 tests passed)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (macOS-only, not available in this Linux session)
- [x] Manual smoke: ran the hook directly (`CLAUDE_CODE_REMOTE=true CLAUDE_ENV_FILE=... ./.claude/hooks/session-start.sh`) in a container with no pre-installed Swift — it installed swiftly + Swift 6.3.3, then a second run correctly no-op'd the install and just re-exported `PATH`. Sourced the resulting `$CLAUDE_ENV_FILE` in a clean shell and confirmed `swift build --target AnglesiteSiteModel` and `swift test --filter AnglesiteSiteModelTests` both work.

---
_Generated by [Claude Code](https://claude.ai/code/session_017VbhqGnZKb5GHjwisVwTMa)_