### PR TITLE
fix(#989): drop duplicate Edit ▸ Delete menu item

### DIFF
--- a/Sources/AnglesiteApp/AnglesiteApp.swift
+++ b/Sources/AnglesiteApp/AnglesiteApp.swift
@@ -219,7 +219,8 @@ struct AnglesiteApp: App {
             }
 
             NewContentCommands()
-            // Edit ▸ Delete ⌘⌫ / Duplicate ⌘D for the focused window's Navigator selection (#516).
+            // Edit ▸ Duplicate ⌘D / Publish / Unpublish for the focused window's Navigator
+            // selection (#516). Delete is deliberately not here — see NavigatorEditCommands (#989).
             NavigatorEditCommands()
             // Edit-menu skeleton: selection walkers, annotations, Find ▸ (menu-bar spec §2.3).
             EditMenuSkeletonCommands()

--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -15,12 +15,14 @@ struct NewContentActions {
     let newComponent: @MainActor () -> Void
 }
 
-/// Delete/Duplicate/Publish/Unpublish acting on the Navigator's current selection (#516, #798).
-/// Each action is `nil` when there is no selection, or the selection doesn't support that verb
-/// (`SiteNavigatorModel.canDelete`/`canDuplicate`/`canPublish`/`canUnpublish`) — that's what lets
-/// the Edit-menu items enable/disable correctly without the menu needing to know Navigator internals.
+/// Duplicate/Publish/Unpublish acting on the Navigator's current selection (#516, #798). Each
+/// action is `nil` when there is no selection, or the selection doesn't support that verb
+/// (`SiteNavigatorModel.canDuplicate`/`canPublish`/`canUnpublish`) — that's what lets the
+/// Edit-menu items enable/disable correctly without the menu needing to know Navigator internals.
+/// Delete has no field here (#989) — it's driven entirely by `SiteNavigatorView`'s
+/// `.onDeleteCommand`, which is also what AppKit's standard Edit ▸ Delete menu item invokes; a
+/// second Commands-level Delete button here would just re-create the duplicate-item bug.
 struct NavigatorSelectionActions {
-    let delete: (@MainActor () -> Void)?
     let duplicate: (@MainActor () -> Void)?
     let publish: (@MainActor () -> Void)?
     let unpublish: (@MainActor () -> Void)?
@@ -89,20 +91,17 @@ struct NewContentCommands: Commands {
     }
 }
 
-/// Edit ▸ Delete (⌘⌫) / Duplicate (⌘D) / Publish / Unpublish for the focused window's Navigator
-/// selection (#516, #798). Placed in the Edit menu next to Cut/Copy/Paste — the macOS convention
-/// for selection-scoped destructive/duplicate actions — rather than the File menu.
+/// Edit ▸ Duplicate (⌘D) / Publish / Unpublish for the focused window's Navigator selection
+/// (#516, #798). Placed in the Edit menu next to Cut/Copy/Paste — the macOS convention for
+/// selection-scoped duplicate/destructive actions — rather than the File menu. Delete is
+/// deliberately not a Commands item here (#989): AppKit's standard Edit ▸ Delete already appears
+/// in this group and is wired to the same action via `SiteNavigatorView`'s `.onDeleteCommand`, so
+/// a second one just duplicated it with no distinguishing label.
 struct NavigatorEditCommands: Commands {
     @FocusedValue(\.navigatorSelectionActions) private var actions
 
     var body: some Commands {
         CommandGroup(after: .pasteboard) {
-            Button("Delete") {
-                actions?.delete?()
-            }
-            .keyboardShortcut(.delete, modifiers: [.command])
-            .disabled(actions?.delete == nil)
-
             Button("Duplicate") {
                 actions?.duplicate?()
             }

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -21,7 +21,11 @@ struct SiteNavigatorView: View {
         .listStyle(.sidebar)
         // Bare Delete key deletes the selection, matching Xcode/Mail/Notes sidebar convention
         // (#674). `deletableSelection()` is nil during inline-rename, so Delete edits the text
-        // field there instead — same guard the Return-to-rename affordance above uses.
+        // field there instead — same guard the Return-to-rename affordance above uses. This is
+        // also the ONLY Commands-level wiring for content delete (#989): `.onDeleteCommand` is
+        // what AppKit's standard Edit ▸ Delete menu item invokes too, so it doubles as that item's
+        // handler — a separate Commands `Button("Delete")` alongside it just renders as a second,
+        // indistinguishable "Delete" row.
         .onDeleteCommand {
             if let item = model.deletableSelection() {
                 onDeleteRequested(item)
@@ -46,6 +50,18 @@ struct SiteNavigatorView: View {
             // Disabled while editing: otherwise this default-button shortcut swallows Return
             // before the focused TextField's onSubmit, so commits never fire (#299 review).
             .disabled(model.editingItemID != nil)
+        }
+        .background {
+            // ⌘⌫ as a second key equivalent for the same delete action (#989) — a view-level key
+            // command, not a Commands-scene item, so it doesn't add another Edit-menu row.
+            Button("") {
+                if let item = model.deletableSelection() {
+                    onDeleteRequested(item)
+                }
+            }
+            .keyboardShortcut(.delete, modifiers: [.command])
+            .hidden()
+            .accessibilityHidden(true)
         }
         .alert(
             "Rename failed",

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -1059,23 +1059,14 @@ struct SiteWindow: View {
             .background(Color(NSColor.windowBackgroundColor))
     }
 
-    /// Builds the Edit-menu Delete/Duplicate actions for the current Navigator selection, or nil
-    /// when there's no site or no selection. `delete`/`duplicate` are individually nil when the
-    /// selected row isn't a page/post (`canDelete`/`canDuplicate`), which is what disables the
-    /// individual menu items rather than hiding the whole group.
+    /// Builds the Edit-menu Duplicate/Publish/Unpublish actions for the current Navigator
+    /// selection, or nil when there's no site or no selection. Each is individually nil when the
+    /// selected row doesn't support that verb (`canDuplicate`/`canPublish`/`canUnpublish`), which
+    /// is what disables the individual menu items rather than hiding the whole group. Delete has
+    /// no action built here (#989) — see `NavigatorSelectionActions`.
     private func navigatorSelectionActions(for model: SiteWindowModel) -> NavigatorSelectionActions? {
         guard model.site != nil, let navigator = model.navigator, let id = navigator.selection else {
             return nil
-        }
-        let deleteAction: (() -> Void)?
-        if navigator.canDelete(id) {
-            deleteAction = {
-                guard let item = navigator.item(for: id) else { return }
-                contentDeleteTitle = "Delete “\(item.title)”?"
-                model.deleteConfirmation = item
-            }
-        } else {
-            deleteAction = nil
         }
         let duplicateAction: (() -> Void)?
         if navigator.canDuplicate(id) {
@@ -1102,6 +1093,6 @@ struct SiteWindow: View {
             unpublishAction = nil
         }
         return NavigatorSelectionActions(
-            delete: deleteAction, duplicate: duplicateAction, publish: publishAction, unpublish: unpublishAction)
+            duplicate: duplicateAction, publish: publishAction, unpublish: unpublishAction)
     }
 }


### PR DESCRIPTION
Closes #989

## Summary

- `NavigatorEditCommands`'s custom `Button("Delete")` (⌘⌫) duplicated AppKit's standard Edit ▸ Delete menu item, which `SiteNavigatorView`'s `.onDeleteCommand` (#674) already wires to the exact same delete-confirmation action — both items were fully functional and did the identical thing, just via two different key equivalents, with no distinguishing label between them.
- Removed the custom Commands-level Delete button (and the now-dead `delete` field it depended on), leaving AppKit's standard item as the sole Edit ▸ Delete entry.
- Preserved the ⌘⌫ shortcut by moving it to an invisible view-level key command in `SiteNavigatorView` — the same pattern this file already uses for its Return-to-rename shortcut — so no keyboard behavior is lost, only the confusing duplicate menu row.
- The "related ordering wart" flagged in the issue (`EditMenuSkeletonCommands`'s Deselect All/Select Parent landing below Publish/Unpublish instead of adjacent to Select All) is left out of scope: fixing it fully to match the menu-bar spec's exact §2.3 order would require restructuring which items live in which `CommandGroup`, which is a bigger, separately-verifiable change than this focused bug fix.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passed (378 tests); two unrelated timing-sensitive suites (`DomainConfigAuditModelTests`, `ComponentEditorModelDraftStateTests`) flaked under concurrent-agent load in one run and were confirmed green re-run in isolation.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — builds clean.
- [ ] Manual smoke: not run — this environment's `computer-use` access to the built app was denied (no interactive user available to approve the permission dialog), so I could not visually confirm the Edit menu now shows a single Delete item. Root cause and fix were verified through static analysis of `SwiftUI`'s `.onDeleteCommand` responder-chain wiring and by confirming both the removed and retained delete paths call the identical `NavigatorSelectionActions`/`onDeleteRequested` logic. Recommend a quick manual check (select a page in the Navigator, open Edit menu) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)