### PR TITLE
ci: vendor CWebKitGTK out of language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,17 @@ project.yml text eol=lf
 *.md text eol=lf
 *.sh text eol=lf
 
+# CWebKitGTK is a SwiftPM systemLibrary shim (a single header + modulemap
+# binding to the system webkitgtk-6.0/glib-unix pkg-config libraries) — not
+# buildable C/C++ source. Left un-vendored, GitHub's language detection counts
+# it as "C" present in the repo, which makes automatic code-scanning default
+# setup try to `autobuild` a nonexistent C build system and fail (fatal
+# `codeql database trace-command`/autobuild.sh error). codeql.yml's advanced
+# workflow (added alongside this shim in #1158 specifically to replace
+# default setup's build-mode guessing — see that file's Swift comment)
+# already omits cpp/c from its language matrix on purpose.
+Sources/CWebKitGTK/** linguist-vendored
+
 # Binary vendored/build assets — never diff, never normalize
 *.png binary
 *.icns binary


### PR DESCRIPTION
## Summary

- Fixes the reported `CodeQL Error: ... codeql database trace-command ... /codeql_databases/cpp ... Exit status 1 from command: [.../cpp/tools/autobuild.sh]` failure.
- Root cause: `Sources/CWebKitGTK/shim.h` (a header-only SwiftPM `systemLibrary` shim binding to `webkitgtk-6.0`/`glib-unix` via pkg-config, added in #1158 alongside `.github/workflows/codeql.yml`) is enough for GitHub's language detection to flag "C" as present in the repo. `codeql.yml`'s advanced workflow deliberately omits `cpp`/`c` from its own language matrix — there's no real C/C++ build system, just a header — but GitHub's separate automatic **default setup** still auto-detects the language and tries to `autobuild` it, which has nothing to build and fails immediately.
- Fix: mark `Sources/CWebKitGTK/**` `linguist-vendored` in `.gitattributes` so GitHub stops counting it toward the repo's language statistics/detection, keeping default setup's language list in sync with the advanced workflow's already-intentional exclusion.
- No Swift/JS/build-affecting changes — `.gitattributes` only.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — not run; change touches only `.gitattributes`, no Swift sources.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; no app-target changes.
- [x] Verified `Sources/CWebKitGTK/shim.h` is the only C/C++-classified file tracked in the repo (`git ls-files | grep -iE '\.(c|cc|cpp|cxx|h|hpp)$'`), and it's header-only with no build system, confirming it's the sole source of the phantom "cpp" language detection.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SGc46YHcNyQ4ddaN2CeENz)_