### PR TITLE
fix: stop DomainConfigAuditModelTests reading real keychain

### DIFF
--- a/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
+++ b/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
@@ -56,6 +56,13 @@ private final class StubWriter: CloudflareWriting, @unchecked Sendable {
 
 @Suite(.serialized)
 struct DomainConfigAuditModelTests {
+    /// A per-case scratch service (see `KeychainStore`'s own doc comment) so these tests never
+    /// touch the developer's real login keychain — every test sets `CLOUDFLARE_API_TOKEN` below,
+    /// so `apiToken()` should never fall through to the keychain at all, but a scratch service
+    /// keeps the model's `try? keychain.readCloudflareToken()` call from racing a concurrent
+    /// keychain read/prompt in another worktree if it ever does.
+    private let keychain = KeychainStore(service: "io.dwk.anglesite.tests.domainConfigAudit." + UUID().uuidString)
+
     init() {
         setenv("CLOUDFLARE_API_TOKEN", "test-token", 1)
     }
@@ -75,7 +82,7 @@ struct DomainConfigAuditModelTests {
     func runAuditNoDomainDeclared() async throws {
         let (site, cleanup) = try tempSite()
         defer { cleanup() }
-        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter())
+        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter(), keychain: keychain)
         model.configure(site: site)
 
         model.runAudit()
@@ -94,7 +101,7 @@ struct DomainConfigAuditModelTests {
         let declared = DomainConfig(domain: .init(hostname: "example.com"))
         let (site, cleanup) = try tempSite(declaring: declared)
         defer { cleanup() }
-        let model = DomainConfigAuditModel(reader: StubReader(zoneID: nil), writer: StubWriter())
+        let model = DomainConfigAuditModel(reader: StubReader(zoneID: nil), writer: StubWriter(), keychain: keychain)
         model.configure(site: site)
 
         model.runAudit()
@@ -116,7 +123,7 @@ struct DomainConfigAuditModelTests {
         let (site, cleanup) = try tempSite(declaring: declared)
         defer { cleanup() }
         let reader = StubReader(zoneID: "z1", state: StubReader.cleanState, records: [])
-        let model = DomainConfigAuditModel(reader: reader, writer: StubWriter())
+        let model = DomainConfigAuditModel(reader: reader, writer: StubWriter(), keychain: keychain)
         model.configure(site: site)
 
         model.runAudit()
@@ -142,7 +149,7 @@ struct DomainConfigAuditModelTests {
         let (site, cleanup) = try tempSite(declaring: declared)
         defer { cleanup() }
         let writer = StubWriter()
-        let model = DomainConfigAuditModel(reader: StubReader(zoneID: "z1"), writer: writer)
+        let model = DomainConfigAuditModel(reader: StubReader(zoneID: "z1"), writer: writer, keychain: keychain)
         model.configure(site: site)
 
         model.runAudit()
@@ -162,7 +169,7 @@ struct DomainConfigAuditModelTests {
     @MainActor
     @Test("openSheet() resets phase")
     func openSheetResets() {
-        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter())
+        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter(), keychain: keychain)
         model.openSheet()
         #expect(model.sheetPresented == true)
         #expect(model.phase == .idle)
@@ -171,7 +178,7 @@ struct DomainConfigAuditModelTests {
     @MainActor
     @Test("dismissSheet() clears the presented flag")
     func dismissSheetClearsPresented() {
-        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter())
+        let model = DomainConfigAuditModel(reader: StubReader(), writer: StubWriter(), keychain: keychain)
         model.openSheet()
         model.dismissSheet()
         #expect(model.sheetPresented == false)


### PR DESCRIPTION
## Summary

- `DomainConfigAuditModelTests` constructed `DomainConfigAuditModel(reader:writer:)` without the `keychain:` parameter at every call site, so the suite always fell back to `DomainConfigAuditModel`'s default `KeychainStore()` — the developer's real login keychain.
- Every test in the suite already sets `CLOUDFLARE_API_TOKEN` in `init()`, so `apiToken()` should short-circuit before touching the keychain — but on the path where it doesn't (or under a concurrent keychain read/prompt from another agent/worktree), the suite's outcome depended on the host machine's stored secrets, producing an intermittent "zone isn't found" / `.failed(reason:)` failure unrelated to the code under test.
- This surfaced during the final review of #975: `swift test --package-path .` had a one-off failure in this suite unrelated to that branch's changes; re-running in isolation passed 6/6.
- Fix: inject a per-case scratch-service `KeychainStore` (the same convention `KeychainStoreTests` already uses — see its doc comment on `KeychainStore`) into all six `DomainConfigAuditModel` construction sites, so the suite never touches the real keychain or depends on what's stored in it.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — **could not run**: this session's environment is Linux with a Swift 6.3.3 toolchain, and `AnglesiteAppTests` (which contains this suite) only builds under `compiler(>=6.4) && canImport(Darwin)` (see `Package.swift`), so it isn't part of the portable SwiftPM target set on this platform. Verified the edited file with `swiftc -parse` (syntax-only) instead.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run, no Xcode/macOS available in this environment.
- [ ] Manual smoke: N/A (test-only change, no UI).

Please run `swift test --package-path . --filter DomainConfigAuditModelTests` on macOS to confirm before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz5xqvvruXcNdm4A683g5v)_