### PR TITLE
refactor(#975): unify GitHub-remote resolution into GitRemoteResolver

### DIFF
--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -722,9 +722,7 @@ final class PlistEditorModel {
     }
 
     private func currentRemoteRepo() async -> RemoteRepo? {
-        guard let result = try? await gitRunner(sourceDirectory, ["remote", "get-url", "origin"]),
-              result.exitCode == 0 else { return nil }
-        return RemoteRepo.parse(remoteURL: result.stdout)
+        await GitRemoteResolver.origin(in: sourceDirectory, runner: gitRunner)
     }
 
     private func repoSecurityMessage(for error: any Error) -> String {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -701,15 +701,13 @@ final class SiteWindowModel {
         health.recheck(siteID: site.id, siteDirectory: site.sourceDirectory)
     }
 
-    /// Resolves this site's GitHub origin via the injected `gitRunner`, mirroring
-    /// `PlistEditorModel.currentRemoteRepo()` — a separate small lookup rather than a shared
-    /// dependency, consistent with how `PublishModel` already resolves the same fact its own way
-    /// via `RepoBootstrap`. `nil` for no remote, a non-GitHub remote, or a failed git call.
+    /// Resolves this site's GitHub origin via the injected `gitRunner`, sharing
+    /// `GitRemoteResolver.origin(in:runner:)` with `PlistEditorModel.currentRemoteRepo()` — see
+    /// that type's doc comment for why `PublishModel`'s `RepoBootstrap`-based resolution stays
+    /// separate. `nil` for no remote, a non-GitHub remote, or a failed git call.
     private func currentGitHubRemote() async -> RemoteRepo? {
         guard let site else { return nil }
-        guard let result = try? await gitRunner(site.sourceDirectory, ["remote", "get-url", "origin"]),
-              result.exitCode == 0 else { return nil }
-        return RemoteRepo.parse(remoteURL: result.stdout)
+        return await GitRemoteResolver.origin(in: site.sourceDirectory, runner: gitRunner)
     }
 
     /// Kicks off a `securityReports` check and returns the settling `Task` so callers (and

--- a/Sources/AnglesiteCore/GitRemoteResolver.swift
+++ b/Sources/AnglesiteCore/GitRemoteResolver.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Shared "read `origin` and parse it as a GitHub `RemoteRepo`" lookup. Extracted from
+/// `PlistEditorModel.currentRemoteRepo()` and `SiteWindowModel.currentGitHubRemote()`, which had
+/// each grown byte-for-byte identical copies of this (flagged in #975's final whole-branch
+/// review). Both keep their own `gitRunner` init parameter as the test-injection seam and just
+/// call through to this instead of re-implementing the lookup.
+///
+/// `RepoBootstrap.remote(of:)` (used by `PublishModel`) intentionally stays separate rather than
+/// also routing through here: on Darwin it reads `origin` via direct in-process SwiftGit2 as one
+/// step of `RepoBootstrap`'s own actor-owned `publish()` pipeline (the idempotence check that lets
+/// an already-published site short-circuit straight to `.published`), and off-Darwin it uses
+/// `RepoCommandRunner` (`executable`/`args`/`cwd`) — a different shape than `BackupCommand.GitRunner`
+/// (`siteDirectory`/`arguments`). Unifying it here would mean either widening this helper's
+/// contract to cover both runner shapes or changing what `RepoBootstrap` injects, for a lookup
+/// that's a one-line implementation detail of a much larger create-and-push pipeline rather than a
+/// standalone resolution `PlistEditorModel`/`SiteWindowModel` also need.
+public enum GitRemoteResolver {
+    /// Runs `git remote get-url origin` in `siteDirectory` via `runner` and parses the result.
+    /// `nil` for no remote, a non-GitHub remote, or a failed git call.
+    public static func origin(
+        in siteDirectory: URL,
+        runner: BackupCommand.GitRunner
+    ) async -> RemoteRepo? {
+        guard let result = try? await runner(siteDirectory, ["remote", "get-url", "origin"]),
+              result.exitCode == 0 else { return nil }
+        return RemoteRepo.parse(remoteURL: result.stdout)
+    }
+}

--- a/Tests/AnglesiteCoreTests/GitRemoteResolverTests.swift
+++ b/Tests/AnglesiteCoreTests/GitRemoteResolverTests.swift
@@ -1,0 +1,41 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests for `GitRemoteResolver.origin(in:runner:)` — the shared "read `origin`, parse as
+/// `RemoteRepo`" lookup extracted from `PlistEditorModel`/`SiteWindowModel`'s previously
+/// duplicated copies (#975 final review). `RemoteRepo.parse(remoteURL:)`'s own parsing rules are
+/// covered by `RemoteRepoTests`; these exercise the runner-plumbing wrapper around it.
+@Suite struct GitRemoteResolverTests {
+    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    @Test func parsesGitHubOriginFromSuccessfulRunner() async {
+        let repo = await GitRemoteResolver.origin(in: tmpDir, runner: { siteDirectory, args in
+            #expect(siteDirectory == self.tmpDir)
+            #expect(args == ["remote", "get-url", "origin"])
+            return .init(stdout: "https://github.com/acme/my-site.git\n", stderr: "", exitCode: 0)
+        })
+        #expect(repo?.owner == "acme")
+        #expect(repo?.name == "my-site")
+    }
+
+    @Test func nilOnNonZeroExit() async {
+        let repo = await GitRemoteResolver.origin(in: tmpDir, runner: { _, _ in
+            .init(stdout: "", stderr: "fatal: No such remote 'origin'", exitCode: 128)
+        })
+        #expect(repo == nil)
+    }
+
+    @Test func nilWhenRunnerThrows() async {
+        struct Boom: Error {}
+        let repo = await GitRemoteResolver.origin(in: tmpDir, runner: { _, _ in throw Boom() })
+        #expect(repo == nil)
+    }
+
+    @Test func nilForNonGitHubRemote() async {
+        let repo = await GitRemoteResolver.origin(in: tmpDir, runner: { _, _ in
+            .init(stdout: "https://gitlab.com/acme/my-site.git", stderr: "", exitCode: 0)
+        })
+        #expect(repo == nil)
+    }
+}


### PR DESCRIPTION
**Stacked on #1304** — this branch starts from `claude/issue-975-2b5594` (PR #1304's head), because the duplication it fixes only exists on that branch. Base is set to `claude/issue-975-2b5594` rather than `main` so the diff shown here is just this follow-up; retarget to `main` once #1304 merges.

## Summary

- `PlistEditorModel.currentRemoteRepo()` and `SiteWindowModel.currentGitHubRemote()` (added by #1304's Task 7) each independently ran `git remote get-url origin` and parsed it with `RemoteRepo.parse(remoteURL:)` — byte-for-byte identical apart from `SiteWindowModel`'s `guard let site` unwrap. Flagged as a "worth a follow-up" finding in #1304's final whole-branch review.
- Extracted a shared `AnglesiteCore.GitRemoteResolver.origin(in:runner:)` helper; both models now call it instead of re-implementing the lookup, while keeping their own `gitRunner` init parameter as the test-injection seam.
- Investigated unifying `PublishModel`'s `RepoBootstrap.remote(of:)` onto the same helper too, and left it separate: on Darwin it reads `origin` via direct in-process SwiftGit2 as one step of `RepoBootstrap`'s own actor-owned `publish()` pipeline (the idempotence check for an already-published site), and off-Darwin it takes a differently-shaped `RepoCommandRunner` (`executable`/`args`/`cwd`) rather than `BackupCommand.GitRunner` (`siteDirectory`/`arguments`). Documented the reasoning on `GitRemoteResolver` itself rather than forcing a merge.
- Added `GitRemoteResolverTests` covering the new helper directly (success parse, non-zero exit, thrown error, non-GitHub host).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — Linux only builds/runs the portable target subset (`AnglesiteSiteModel(Tests)`, `AnglesiteQuickLookSupport(Tests)`, `AnglesiteCore`, `AnglesiteBridgeCore(Tests)`); `AnglesiteCoreTests` and `AnglesiteAppTests` (including `PlistEditorModelSecurityReportsSectionTests`, `PlistEditorModelSecurityReportsTests`, `SiteWindowModelSecurityReportsTests`) are Darwin-only per `Package.swift` and could not run in this environment. `swift build --package-path .` does compile `AnglesiteCore` (including the new `GitRemoteResolver.swift`) cleanly on Linux.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (no Xcode/macOS in this environment).
- [ ] Manual smoke: not applicable — no UI change, pure internal refactor.

**Please run the full macOS `swift test` (especially the three test files named above) and the Xcode build before merging** — this session could only verify the change by careful reading plus a Linux-side `AnglesiteCore` compile.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USTLbfgh1L6SmJsewA46sD)_