### PR TITLE
feat(#975): wire security badge's View-all button to Settings tab

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -3322,6 +3322,9 @@
     "View" : {
 
     },
+    "View all in Security Reports" : {
+
+    },
     "View and manage this domain's DNS records" : {
 
     },

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -7,6 +7,11 @@ import AnglesiteCore
 final class PlistEditorModel {
     let file: FileRef
     let sourceDirectory: URL
+    /// Set by `SiteWindowModel.openWebsiteSettings(landOn:)` (#975 follow-up: the security-reports
+    /// toolbar badge's "View all in Security Reports" button) to request a tab switch from outside
+    /// `PlistEditorView`. The view applies it and clears it back to `nil` — see its
+    /// `onChange(of: model.requestedTab)`.
+    var requestedTab: SettingsTab?
     private let initialWebsiteTitle: String
     private let analyticsProvider: any CloudflareWebAnalyticsProviding
     private let customAnalyticsValidator: any CustomAnalyticsHTMLValidating

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -2,32 +2,35 @@ import AppKit
 import SwiftUI
 import AnglesiteCore
 
+/// Website Settings' tab identity (#975 follow-up: internal, not `private`, so
+/// `SiteWindowModel.openWebsiteSettings(landOn:)` and `PlistEditorModel.requestedTab` — both in
+/// this module — can name a tab to land on from outside this view).
+enum SettingsTab: String, CaseIterable, Identifiable {
+    case website = "Website"
+    case analytics = "Analytics"
+    case redirects = "Redirects"
+    case licensing = "Licensing"
+    case emailSecurity = "Email Security"
+    case securityReports = "Security Reports"
+    case workers = "Workers"
+    var id: Self { self }
+
+    var symbolName: String {
+        switch self {
+        case .website: return "globe"
+        case .analytics: return "chart.bar.xaxis"
+        case .redirects: return "arrow.triangle.turn.up.right.diamond.fill"
+        case .licensing: return "checkmark.seal"
+        case .emailSecurity: return "envelope.badge.shield.half.filled"
+        case .securityReports: return "doc.text.magnifyingglass"
+        case .workers: return "bolt.fill"
+        }
+    }
+}
+
 struct PlistEditorView: View {
     @Bindable var model: PlistEditorModel
     let onWebsiteTitleSaved: (String) -> Void
-
-    private enum SettingsTab: String, CaseIterable, Identifiable {
-        case website = "Website"
-        case analytics = "Analytics"
-        case redirects = "Redirects"
-        case licensing = "Licensing"
-        case emailSecurity = "Email Security"
-        case securityReports = "Security Reports"
-        case workers = "Workers"
-        var id: Self { self }
-
-        var symbolName: String {
-            switch self {
-            case .website: return "globe"
-            case .analytics: return "chart.bar.xaxis"
-            case .redirects: return "arrow.triangle.turn.up.right.diamond.fill"
-            case .licensing: return "checkmark.seal"
-            case .emailSecurity: return "envelope.badge.shield.half.filled"
-            case .securityReports: return "doc.text.magnifyingglass"
-            case .workers: return "bolt.fill"
-            }
-        }
-    }
 
     @Environment(\.controlActiveState) private var controlActiveState
     @State private var selectedTab: SettingsTab = .website
@@ -44,6 +47,15 @@ struct PlistEditorView: View {
             content
         }
         .task(id: model.file.id) { await model.load() }
+        // `initial: true` so this also applies a request already set before this view was ever
+        // rendered (`openWebsiteSettings(landOn:)` on a not-yet-open editor) — not just one set
+        // while the view is already live (the badge's button clicked while Settings is already
+        // showing some other tab). `.onChange` alone would only catch the latter.
+        .onChange(of: model.requestedTab, initial: true) { _, requestedTab in
+            guard let requestedTab else { return }
+            selectedTab = requestedTab
+            model.requestedTab = nil
+        }
         .onChange(of: titleFocused) { wasFocused, isFocused in
             if wasFocused && !isFocused {
                 Task { await saveWebsiteTitle() }

--- a/Sources/AnglesiteApp/SecurityReportsBadgeView.swift
+++ b/Sources/AnglesiteApp/SecurityReportsBadgeView.swift
@@ -9,6 +9,9 @@ import AnglesiteCore
 struct SecurityReportsBadgeView: View {
     @Bindable var model: SecurityReportsModel
     let onRecheck: () -> Void
+    /// Opens Website Settings ▸ Security Reports (design doc §4: "its popover is a summary, not
+    /// the full view") — the popover's "View all in Security Reports" button.
+    let onViewAll: () -> Void
 
     @State private var popoverPresented = false
     @Environment(\.accessibilityDifferentiateWithoutColor) private var differentiateWithoutColor
@@ -100,6 +103,26 @@ struct SecurityReportsBadgeView: View {
                               text: String(localized: "\(alert.packageName): dependency alert"))
                 }
             }
+            Divider()
+            // Full-width, its own row: the popover is only 320pt wide, and this label is long
+            // enough that sharing a row with "Recheck" (as `HealthBadgeView`'s "Ask
+            // Assistant"/"Recheck" footer does) would crowd both. The trailing chevron marks it
+            // as a disclosure into another surface, matching the design doc's "the popover is a
+            // summary, not the full view" — Website Settings ▸ Security Reports is where the
+            // per-item actions actually live.
+            Button {
+                popoverPresented = false
+                onViewAll()
+            } label: {
+                HStack {
+                    Text("View all in Security Reports")
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .controlSize(.small)
             Divider()
             HStack {
                 Spacer()

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -353,7 +353,8 @@ struct SiteWindow: View {
             ToolbarItem(id: SiteToolbarItemID.securityReports.rawValue, placement: .primaryAction) {
                 SecurityReportsBadgeView(
                     model: model.securityReports,
-                    onRecheck: { model.recheckSecurityReports() }
+                    onRecheck: { model.recheckSecurityReports() },
+                    onViewAll: { model.openWebsiteSettings(landOn: .securityReports) }
                 )
             }
 

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -203,6 +203,12 @@ final class SiteWindowModel {
     /// when the delete actually succeeded. Never break an inbound URL a user didn't choose to
     /// abandon (#584).
     var pendingRedirectOfferRoute: String?
+    /// Carries a requested `SettingsTab` across `openFile`'s async model-construction `Task` for
+    /// `openWebsiteSettings(landOn:)` (#975 follow-up: the security-reports badge's "View all in
+    /// Security Reports" button), the same "record a request, the target consumes and clears it"
+    /// shape as `pendingRedirectOfferRoute` above. Unused when Website Settings is already open —
+    /// that case sets `PlistEditorModel.requestedTab` directly instead, see `openWebsiteSettings`.
+    private var pendingWebsiteSettingsTab: SettingsTab?
     /// Editor/inspector state closed by a delete, keyed by the deleted file's relative path, so a
     /// ⌘Z restore of that file can put it back (#675). Written by every path that closes surfaces
     /// for a delete (`confirmDelete()` and `applyContentUndo`'s delete branch) and removed the
@@ -760,6 +766,31 @@ final class SiteWindowModel {
         }
     }
 
+    /// The Info.plist `FileRef` that `.websiteSettings` navigator selection and
+    /// `openWebsiteSettings(landOn:)` both open — the same file the slice-1 interim note above
+    /// describes. `nil` when there's no open site or the package layout can't locate Info.plist.
+    private func websiteSettingsFileRef() -> FileRef? {
+        guard let site else { return nil }
+        let layout = SiteFileTree.layout(for: site.packageURL)
+        guard let infoPlist = layout.infoPlist else { return nil }
+        return FileRef(url: infoPlist, group: .metadata, name: "Info.plist")
+    }
+
+    /// Opens Website Settings landed on `tab` — the security-reports toolbar badge's "View all in
+    /// Security Reports" button (#975 follow-up) calls this so the popover's summary has a route
+    /// into the tab that's the actual triage surface. If the settings editor is already open,
+    /// the request lands directly on its live `PlistEditorModel`; otherwise it's stashed in
+    /// `pendingWebsiteSettingsTab` for `openFile`'s async model-construction `Task` to consume.
+    func openWebsiteSettings(landOn tab: SettingsTab) {
+        guard let file = websiteSettingsFileRef() else { return }
+        if case .plist(let plistEditorModel) = activeEditor, activeEditorFile?.id == file.id {
+            plistEditorModel.requestedTab = tab
+        } else {
+            pendingWebsiteSettingsTab = tab
+        }
+        openFile(file)
+    }
+
     func openPreviewInBrowser() {
         guard let url = preview.readyURL else { return }
         NSWorkspace.shared.open(url)
@@ -1033,10 +1064,8 @@ final class SiteWindowModel {
             // Slice-1 interim: the website row opens the package Info.plist — exactly what the
             // old sidebar Metadata row opened. The full Website Settings surface is slice 2
             // (spec §7, docs/superpowers/specs/2026-07-13-website-design-window-cleanup-design.md).
-            guard let site else { return }
-            let layout = SiteFileTree.layout(for: site.packageURL)
-            guard let infoPlist = layout.infoPlist else { return }
-            openFile(FileRef(url: infoPlist, group: .metadata, name: "Info.plist"))
+            guard let file = websiteSettingsFileRef() else { return }
+            openFile(file)
         case .directory(let collection, let route):
             // #714 slice 3 (§6): a directory shows its route in the preview and its properties
             // (type, entries, feeds, template) in the inspector's collection context.
@@ -1171,6 +1200,10 @@ final class SiteWindowModel {
                     dependencySyncOffers: dependencySyncOffers,
                     onOpenDependencyFix: { [weak self] offer in self?.presentDependencyFixSheet(offer) }
                 ))
+                if let tab = pendingWebsiteSettingsTab, case .plist(let plistEditorModel) = activeEditor {
+                    pendingWebsiteSettingsTab = nil
+                    plistEditorModel.requestedTab = tab
+                }
             }
             // Same mitigation as Graph/Cleanup/Reader/Followers/Communities (#1126): give a
             // presented inspector's dismissal its own transaction before the pane rebuild below,

--- a/Tests/AnglesiteAppTests/SiteWindowModelWebsiteSettingsNavigationTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelWebsiteSettingsNavigationTests.swift
@@ -1,0 +1,102 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// Wiring tests for `SiteWindowModel.openWebsiteSettings(landOn:)` (#975 follow-up): the
+/// security-reports toolbar badge's "View all in Security Reports" button needs a route into
+/// Website Settings ▸ Security Reports, per the design doc's "its popover is a summary, not the
+/// full view" call-out. Covers both the cold-open path (nothing open yet, so the request has to
+/// survive `openFile`'s async model-construction `Task` via `pendingWebsiteSettingsTab`) and the
+/// already-open path (the request lands directly on the live `PlistEditorModel` instead of
+/// rebuilding it) — see `SiteWindowModel.websiteSettingsFileRef()`/`openWebsiteSettings(landOn:)`.
+@Suite("SiteWindowModel website settings navigation (#975 follow-up)")
+@MainActor
+struct SiteWindowModelWebsiteSettingsNavigationTests {
+    private func makeModel() -> SiteWindowModel {
+        SiteWindowModel(
+            contentGraph: SiteContentGraph(),
+            knowledgeIndex: SiteKnowledgeIndex(),
+            semanticRanker: nil,
+            conventionsEngine: ProjectConventionsEngine(),
+            runtimeFactory: NeverStartedSiteRuntimeFactory(),
+            contentIndexerStore: ContentIndexerStore()
+        )
+    }
+
+    /// Same shape as `SiteWindowModelTests.makeSitePackage(named:)` — a real `.anglesite` package
+    /// skeleton on disk, since `openWebsiteSettings(landOn:)` resolves Info.plist through
+    /// `SiteFileTree.layout(for:)`, which needs an actual package to find.
+    private func makeSitePackage(named name: String = "Test") throws -> (root: URL, packageURL: URL, package: AnglesitePackage) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("site-window-website-settings-nav-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let packageURL = root.appendingPathComponent("\(name).anglesite", isDirectory: true)
+        let (package, _) = try AnglesitePackage.createSkeleton(at: packageURL, displayName: name)
+        return (root, packageURL, package)
+    }
+
+    @Test("opens Website Settings and requests the given tab when nothing is open yet")
+    func coldOpenRequestsTab() async throws {
+        let (root, packageURL, package) = try makeSitePackage()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = makeModel()
+        model.site = SiteStore.Site(
+            id: "site-a", name: "Test", packageURL: packageURL,
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil)
+
+        model.openWebsiteSettings(landOn: .securityReports)
+
+        // Same suspension-point shape as `applyNavigatorSelectionWebsiteSettingsOpensInfoPlist`
+        // in `SiteWindowModelTests`: `openFile` builds the `.plist` editor from inside its own
+        // `Task`, so poll rather than assert inline.
+        while model.activeEditor == nil { await Task.yield() }
+        guard case .plist(let plistModel) = model.activeEditor else {
+            Issue.record("expected the Info.plist to open as a .plist editor")
+            return
+        }
+        #expect(plistModel.file.url == package.infoPlistURL)
+        #expect(plistModel.requestedTab == .securityReports)
+        #expect(model.mainPaneMode == .editor(plistModel.file))
+    }
+
+    @Test("lands the request on the live PlistEditorModel instead of rebuilding it when already open")
+    func reusesLiveModelWhenAlreadyOpen() async throws {
+        let (root, packageURL, package) = try makeSitePackage()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = makeModel()
+        model.site = SiteStore.Site(
+            id: "site-a", name: "Test", packageURL: packageURL,
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil)
+
+        model.openWebsiteSettings(landOn: .website)
+        while model.activeEditor == nil { await Task.yield() }
+        guard case .plist(let firstModel) = model.activeEditor else {
+            Issue.record("expected the Info.plist to open as a .plist editor")
+            return
+        }
+        #expect(firstModel.requestedTab == .website)
+
+        // Navigate away, then request Security Reports from the badge — the scenario this
+        // wiring exists for: the pane isn't showing Website Settings right now, but the editor
+        // model is still alive underneath.
+        model.mainPaneMode = .preview
+        model.openWebsiteSettings(landOn: .securityReports)
+
+        guard case .plist(let secondModel) = model.activeEditor else {
+            Issue.record("expected the .plist editor to still be active")
+            return
+        }
+        #expect(secondModel === firstModel)
+        #expect(secondModel.requestedTab == .securityReports)
+        #expect(model.mainPaneMode == .editor(secondModel.file))
+    }
+
+    @Test("without an open site does nothing")
+    func noSiteIsNoOp() {
+        let model = makeModel()
+        model.openWebsiteSettings(landOn: .securityReports)
+        #expect(model.activeEditor == nil)
+        #expect(model.mainPaneMode == .preview)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SiteWindowModel.openWebsiteSettings(landOn:)` and an externally-settable `PlistEditorModel.requestedTab` so something outside `PlistEditorView` (whose `selectedTab` was `@State private`) can request a specific Website Settings tab — the cross-view routing seam #1304's final whole-branch review flagged as missing.
- Wires the security-reports toolbar badge's popover with a "View all in Security Reports" button that opens Website Settings and lands on the Security Reports tab, per the design doc §4 ("its popover is a summary, not the full view... that tab, not the popover, is the actual triage surface with per-item actions").
- Adds `SiteWindowModelWebsiteSettingsNavigationTests`, covering both the cold-open path (nothing open yet — the request survives `openFile`'s async model-construction `Task`) and the already-open path (the request lands directly on the live `PlistEditorModel` instead of rebuilding it).
- Severity was already shown on the popover's advisory/alert rows (`reportRow`), so no change was needed there.

**Depends on #1304** (branch `claude/issue-975-2b5594`) — `SecurityReportsBadgeView`/`PlistEditorView`'s Security Reports tab don't exist on `main` yet, so this PR is based on that still-open branch rather than `main`. Please merge #1304 first (or merge this into it) rather than merging this PR standalone against `main`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [ ] `swift test --package-path .` — this Claude Code on the web session runs on Linux with no Xcode, and this repo's `Package.swift` gates `AnglesiteAppCore`/`AnglesiteAppTests` (which contain every file this PR touches, including the new test) behind `canImport(Darwin)`. This session's manifest only resolves a reduced portable target set (`AnglesiteSiteModelTests`, `AnglesiteBridgeCoreTests`, `AnglesiteQuickLookSupportTests` — 37 tests, all passing) — confirmed the same reduced set resolves on an unmodified checkout, so this is a pre-existing environment limitation, not something this diff caused. The new `SiteWindowModelWebsiteSettingsNavigationTests` needs a macOS session to actually run.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; no Xcode/macOS available in this session.
- [x] `scripts/check-localization-catalog.sh` — passes; added the one missing catalog key ("View all in Security Reports") by hand since the real Xcode IDE merge isn't available here — please review the `Localizable.xcstrings` diff.
- [ ] Manual smoke (UI-touching): not performed — no macOS/Xcode available in this session. The popover's new "View all in Security Reports" row and the tab-switch on click need a real run before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A5dUZpmBNxJvQqmJLeVi2b)_