### PR TITLE
Potential fix for code scanning alert no. 24: Incomplete multi-character sanitization

### DIFF
--- a/Resources/Template/scripts/a11y-validate.ts
+++ b/Resources/Template/scripts/a11y-validate.ts
@@ -98,7 +98,9 @@ export function validateLinkText(html: string): A11yIssue[] {
 
   while ((match = linkRegex.exec(html)) !== null) {
     const attrs = match[1];
-    const text = match[2].replace(/<[^>]*>/g, "").trim();
+    const linkInnerHtml = match[2];
+    const parsed = new DOMParser().parseFromString(linkInnerHtml, "text/html");
+    const text = (parsed.body.textContent ?? "").trim();
     if (!text || /aria-label\s*=/.test(attrs)) continue;
 
     for (const pattern of GENERIC_LINK_PATTERNS) {


### PR DESCRIPTION
Potential fix for [https://github.com/Anglesite/Anglesite/security/code-scanning/24](https://github.com/Anglesite/Anglesite/security/code-scanning/24)

Use a robust HTML-to-text extraction method instead of regex tag stripping.

Best fix in this file/region: in `validateLinkText` (around line 101), replace:
- `match[2].replace(/<[^>]*>/g, "").trim()`

with:
- parse the captured link inner HTML via `DOMParser` and read `textContent`, then `trim()`.

This avoids incomplete multi-character sanitization and handles malformed/nested HTML more safely than regex replacement, while preserving existing functionality (extracting visible text for generic-link heuristics). No new imports are required in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
