### PR TITLE
Potential fix for code scanning alert no. 23: Cleartext logging of sensitive information

### DIFF
--- a/Sources/AnglesiteCore/GitIdentity.swift
+++ b/Sources/AnglesiteCore/GitIdentity.swift
@@ -58,7 +58,7 @@ public enum GitIdentity {
         await LogCenter.shared.append(
             source: "git:identity", stream: .stderr,
             text: "No git identity resolved for this site — a sandboxed app can't read ~/.gitconfig. "
-                + "Committing as \(substitute.name) <\(substitute.email)>. To attribute commits to you, "
+                + "Using the app fallback identity for this commit. To attribute commits to you, "
                 + "set one in the site's Source/: `git config user.name \"You\"` and `git config user.email you@example.com`.")
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Anglesite/Anglesite/security/code-scanning/23](https://github.com/Anglesite/Anglesite/security/code-scanning/23)

The safest fix is to **stop logging raw identity fields** and keep only non-sensitive guidance.  
Best single fix without changing functional behavior: update `logSubstitution(_:)` so it still informs users that fallback identity was used and how to configure git identity, but **remove `\(substitute.name)` and `\(substitute.email)` from the message**.

Edit only `Sources/AnglesiteCore/GitIdentity.swift`, specifically the string built in `logSubstitution(_:)` (lines 60–62 in the snippet). No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
