### PR TITLE
Standard.site 1: record types + post-deploy publish pass

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -129,6 +129,7 @@ final class DeployModel {
 
     private let command: DeployCommand
     private let webmentionCommand: WebmentionSendCommand
+    private let standardSitePublishCommand: StandardSitePublishCommand
     private let posseCommand: POSSESyndicationCommand
     private let websubPing: WebSubPublishPing
     private let activityPubOutboxBackfill: ActivityPubOutboxBackfill
@@ -172,6 +173,7 @@ final class DeployModel {
     init(
         command: DeployCommand = DeployCommand(),
         webmentionCommand: WebmentionSendCommand = WebmentionSendCommand(),
+        standardSitePublishCommand: StandardSitePublishCommand = StandardSitePublishCommand(),
         posseCommand: POSSESyndicationCommand = POSSESyndicationCommand(),
         websubPing: WebSubPublishPing = WebSubPublishPing(),
         activityPubOutboxBackfill: ActivityPubOutboxBackfill = ActivityPubOutboxBackfill(),
@@ -189,6 +191,7 @@ final class DeployModel {
     ) {
         self.command = command
         self.webmentionCommand = webmentionCommand
+        self.standardSitePublishCommand = standardSitePublishCommand
         self.posseCommand = posseCommand
         self.websubPing = websubPing
         self.activityPubOutboxBackfill = activityPubOutboxBackfill
@@ -784,6 +787,12 @@ final class DeployModel {
                     guard let self else { return }
                     await self.webmentionCommand.send(
                         siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory, siteBase: url
+                    )
+                },
+                publishStandardSite: { [weak self] in
+                    guard let self else { return }
+                    await self.standardSitePublishCommand.publish(
+                        siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory
                     )
                 },
                 syndicate: { [weak self] in

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -279,21 +279,28 @@ public enum DeployCoordinator {
         try? await configStore.save(updated)
     }
 
-    /// Runs the four post-deploy passes — webmention-send, POSSE-syndication, WebSub publish-ping,
-    /// and ActivityPub outbox backfill (`sendWebmentions`, `syndicate`, `notifySubscribers`, and
-    /// `backfillActivityPubOutbox` below) — in the fixed order the deploy pipeline has always used:
-    /// Astro's build (already complete by the time this runs) regenerates the site's RSS/Atom/JSON
-    /// feeds, so webmention discovery is ordered after the deployed canonical pages exist, and each
-    /// subsequent pass is ordered after the ones before it (see each parameter's own doc comment for
-    /// why). `onMilestone` fires immediately before each pass so a UI caller can surface progress
+    /// Runs the five post-deploy passes — webmention-send, Standard.site record publish,
+    /// POSSE-syndication, WebSub publish-ping, and ActivityPub outbox backfill (`sendWebmentions`,
+    /// `publishStandardSite`, `syndicate`, `notifySubscribers`, and `backfillActivityPubOutbox`
+    /// below) — in the fixed order the deploy pipeline has always used: Astro's build (already
+    /// complete by the time this runs) regenerates the site's RSS/Atom/JSON feeds, so webmention
+    /// discovery is ordered after the deployed canonical pages exist, and each subsequent pass is
+    /// ordered after the ones before it (see each parameter's own doc comment for why).
+    /// `onMilestone` fires immediately before each pass so a UI caller can surface progress
     /// (`DeployModel` wires it to the Dock-tile progress bar, #526) — the milestone always fires even
     /// if the caller-supplied closure for that pass turns out to be a no-op (e.g. no pending
-    /// webmention targets). All four passes are awaited sequentially, never concurrently, matching
-    /// the historical behavior; none of the four closures is expected to throw (the real commands
+    /// webmention targets). All five passes are awaited sequentially, never concurrently, matching
+    /// the historical behavior; none of the five closures is expected to throw (the real commands
     /// they wrap are documented best-effort and never throw).
     public static func runPostDeploySequencing(
         onMilestone: (OperationProgress) -> Void,
         sendWebmentions: () async -> Void,
+        /// Standard.site record publish pass (#1231, see ``StandardSitePublishCommand``). Ordered
+        /// after webmentions, before POSSE: the site's `site.standard.publication`/
+        /// `site.standard.document` records should exist by the time the POSSE cross-post lands
+        /// so Bluesky's preview enhancement sees them. Best-effort and never throws, like every
+        /// other step here. Callers without a Standard.site pass configured pass a no-op.
+        publishStandardSite: () async -> Void = {},
         syndicate: () async -> Void,
         /// WebSub publish pings (#361): tells the site's own hub the feeds changed so it fans
         /// the update out to subscribers. Ordered before the ActivityPub backfill below — the
@@ -308,6 +315,8 @@ public enum DeployCoordinator {
     ) async {
         onMilestone(.deployWebmentions)
         await sendWebmentions()
+        onMilestone(.deployStandardSitePublishing)
+        await publishStandardSite()
         onMilestone(.deploySyndicating)
         await syndicate()
         onMilestone(.deployNotifyingSubscribers)

--- a/Sources/AnglesiteCore/OperationProgress.swift
+++ b/Sources/AnglesiteCore/OperationProgress.swift
@@ -59,6 +59,12 @@ public extension OperationProgress {
     static let deployFinalizing = OperationProgress(kind: .deploy, phase: "finalizing", label: "Finishing up…")
     /// Post-deploy: sending outbound webmentions for newly-live content.
     static let deployWebmentions = OperationProgress(kind: .deploy, phase: "webmentions", label: "Sending webmentions…")
+    /// Post-deploy: Standard.site record publish pass (see ``StandardSitePublishCommand``).
+    /// Ordered after webmentions, before POSSE — the site's Atmosphere records should exist by
+    /// the time the POSSE cross-post lands so Bluesky's preview enhancement sees them.
+    static let deployStandardSitePublishing = OperationProgress(
+        kind: .deploy, phase: "standardSitePublishing", label: "Publishing to the Atmosphere…"
+    )
     /// Post-deploy: direct POSSE syndication pass (see ``POSSESyndicationCommand``).
     static let deploySyndicating = OperationProgress(kind: .deploy, phase: "syndicating", label: "Syndicating posts…")
     /// Post-deploy: WebSub ping so feed subscribers learn about the update promptly.

--- a/Sources/AnglesiteCore/POSSEClients.swift
+++ b/Sources/AnglesiteCore/POSSEClients.swift
@@ -229,7 +229,62 @@ public enum AtprotoPutRecordClient {
         public let uri: String
     }
 
-    /// Creates a session, then writes `record` to `collection` at `rkey` in the account's own repo.
+    /// An authenticated PDS session, reusable across multiple ``putRecord(collection:rkey:record:pdsURL:session:transport:)``
+    /// calls — callers writing a batch of records (e.g. ``StandardSitePublishCommand``) should
+    /// call ``createSession(credentials:transport:)`` once per run rather than once per record,
+    /// since every call is a fresh app-password login against the PDS.
+    public struct Session: Equatable, Sendable {
+        public let did: String
+        let accessJwt: String
+    }
+
+    /// Logs into `credentials.pdsURL` via `com.atproto.server.createSession`. Reuse the returned
+    /// ``Session`` across every ``putRecord(collection:rkey:record:pdsURL:session:transport:)``
+    /// call in a batch instead of calling ``put(collection:rkey:record:credentials:transport:)``
+    /// per record — that convenience method logs in fresh every time.
+    ///
+    /// - Throws: ``POSSEClientError`` for a bad endpoint, non-2xx status, or undecodable body.
+    public static func createSession(
+        credentials: POSSECredentials.Bluesky,
+        transport: POSSEHTTPTransport
+    ) async throws -> Session {
+        let session: SessionResponse = try await jsonRequest(
+            path: "/xrpc/com.atproto.server.createSession",
+            baseURL: credentials.pdsURL,
+            body: SessionRequest(identifier: credentials.identifier, password: credentials.appPassword),
+            bearer: nil,
+            transport: transport
+        )
+        return Session(did: session.did, accessJwt: session.accessJwt)
+    }
+
+    /// Writes `record` to `collection` at `rkey` in `session`'s repo, using an already-authenticated
+    /// ``Session`` (see ``createSession(credentials:transport:)``) — no login per call.
+    ///
+    /// - Throws: ``POSSEClientError`` for a bad endpoint, non-2xx status, or undecodable body.
+    public static func putRecord<Record: Encodable>(
+        collection: String,
+        rkey: String,
+        record: Record,
+        pdsURL: URL,
+        session: Session,
+        transport: POSSEHTTPTransport
+    ) async throws -> Result {
+        let body = PutRecordRequest(repo: session.did, collection: collection, rkey: rkey, record: record)
+        let response: PutRecordResponse = try await jsonRequest(
+            path: "/xrpc/com.atproto.repo.putRecord",
+            baseURL: pdsURL,
+            body: body,
+            bearer: session.accessJwt,
+            transport: transport
+        )
+        return Result(did: session.did, uri: response.uri)
+    }
+
+    /// Convenience for a single record write: ``createSession(credentials:transport:)`` followed by
+    /// ``putRecord(collection:rkey:record:pdsURL:session:transport:)``. Writing more than one record
+    /// in the same run (e.g. a publication plus its documents) should call those two directly and
+    /// reuse the session instead — this logs in fresh every time it's called.
     ///
     /// - Throws: ``POSSEClientError`` for a bad endpoint, non-2xx status, or undecodable body.
     public static func put<Record: Encodable>(
@@ -239,22 +294,11 @@ public enum AtprotoPutRecordClient {
         credentials: POSSECredentials.Bluesky,
         transport: POSSEHTTPTransport
     ) async throws -> Result {
-        let session: SessionResponse = try await jsonRequest(
-            path: "/xrpc/com.atproto.server.createSession",
-            baseURL: credentials.pdsURL,
-            body: SessionRequest(identifier: credentials.identifier, password: credentials.appPassword),
-            bearer: nil,
-            transport: transport
+        let session = try await createSession(credentials: credentials, transport: transport)
+        return try await putRecord(
+            collection: collection, rkey: rkey, record: record,
+            pdsURL: credentials.pdsURL, session: session, transport: transport
         )
-        let body = PutRecordRequest(repo: session.did, collection: collection, rkey: rkey, record: record)
-        let response: PutRecordResponse = try await jsonRequest(
-            path: "/xrpc/com.atproto.repo.putRecord",
-            baseURL: credentials.pdsURL,
-            body: body,
-            bearer: session.accessJwt,
-            transport: transport
-        )
-        return Result(did: session.did, uri: response.uri)
     }
 
     private static func jsonRequest<Body: Encodable, Response: Decodable>(

--- a/Sources/AnglesiteCore/POSSEClients.swift
+++ b/Sources/AnglesiteCore/POSSEClients.swift
@@ -206,6 +206,83 @@ public enum BlueskyPOSSEClient {
     }
 }
 
+/// Writes arbitrary records to a Bluesky-compatible PDS over `com.atproto.repo.putRecord` —
+/// create-or-update, unlike `BlueskyPOSSEClient`'s `createRecord`. Used by
+/// `StandardSitePublishCommand` for `site.standard.publication`/`site.standard.document`: with a
+/// caller-supplied deterministic `rkey` (see ``POSSEStableKey``), re-publishing after any crash or
+/// content edit converges on the same record instead of erroring or duplicating, so there's no
+/// 409-conflict special case to handle the way `BlueskyPOSSEClient.post` does.
+public enum AtprotoPutRecordClient {
+    private struct SessionRequest: Encodable { let identifier: String; let password: String }
+    private struct SessionResponse: Decodable { let accessJwt: String; let did: String }
+    private struct PutRecordRequest<Record: Encodable>: Encodable {
+        let repo: String
+        let collection: String
+        let rkey: String
+        let record: Record
+    }
+    private struct PutRecordResponse: Decodable { let uri: String }
+
+    /// The repo DID the record was written under, and the record's resulting at-URI.
+    public struct Result: Equatable, Sendable {
+        public let did: String
+        public let uri: String
+    }
+
+    /// Creates a session, then writes `record` to `collection` at `rkey` in the account's own repo.
+    ///
+    /// - Throws: ``POSSEClientError`` for a bad endpoint, non-2xx status, or undecodable body.
+    public static func put<Record: Encodable>(
+        collection: String,
+        rkey: String,
+        record: Record,
+        credentials: POSSECredentials.Bluesky,
+        transport: POSSEHTTPTransport
+    ) async throws -> Result {
+        let session: SessionResponse = try await jsonRequest(
+            path: "/xrpc/com.atproto.server.createSession",
+            baseURL: credentials.pdsURL,
+            body: SessionRequest(identifier: credentials.identifier, password: credentials.appPassword),
+            bearer: nil,
+            transport: transport
+        )
+        let body = PutRecordRequest(repo: session.did, collection: collection, rkey: rkey, record: record)
+        let response: PutRecordResponse = try await jsonRequest(
+            path: "/xrpc/com.atproto.repo.putRecord",
+            baseURL: credentials.pdsURL,
+            body: body,
+            bearer: session.accessJwt,
+            transport: transport
+        )
+        return Result(did: session.did, uri: response.uri)
+    }
+
+    private static func jsonRequest<Body: Encodable, Response: Decodable>(
+        path: String,
+        baseURL: URL,
+        body: Body,
+        bearer: String?,
+        transport: POSSEHTTPTransport
+    ) async throws -> Response {
+        guard let endpoint = URL(string: path, relativeTo: baseURL)?.absoluteURL else {
+            throw POSSEClientError.invalidEndpoint
+        }
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(body)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let bearer { request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization") }
+        let (data, response) = try await transport(request)
+        guard (200..<300).contains(response.statusCode) else {
+            throw POSSEClientError.rejected(platform: "Bluesky", status: response.statusCode)
+        }
+        guard let decoded = try? JSONDecoder().decode(Response.self, from: data) else {
+            throw POSSEClientError.invalidResponse(platform: "Bluesky")
+        }
+        return decoded
+    }
+}
+
 /// Derives the deterministic identifiers both clients use for duplicate protection
 /// (Mastodon's `Idempotency-Key`, Bluesky's `rkey`): the same site + canonical URL + platform
 /// must always map to the same key so a crash-retry is recognized as the same post.

--- a/Sources/AnglesiteCore/StandardSiteDocumentPlan.swift
+++ b/Sources/AnglesiteCore/StandardSiteDocumentPlan.swift
@@ -22,6 +22,16 @@ public enum StandardSiteDocumentPlan {
         public let publishedAt: Date
         /// The source file's modification date, when it's after `publishedAt` — signals the post
         /// was edited since it was first published. `nil` otherwise (nothing to report).
+        ///
+        /// Filesystem mtime, not git history — `siteDirectory` (`Foo.anglesite/Source/`) is the
+        /// persistent host working tree the editor/preview/git already operate on directly, and
+        /// neither the container build nor a fresh-device sync bootstrap touches it, so mtimes
+        /// are meaningful in the common case. The one path that *can* legitimately bump a file's
+        /// mtime without a real content edit is a multi-device merge: `SyncEngine.pull()`'s
+        /// `reconcileDivergence` does a force checkout of the merged tree into this same
+        /// directory, which re-stamps whichever files that particular merge touched. No git-log
+        /// based alternative exists in this codebase yet; this is a known, accepted gap for a
+        /// syncing owner, not a first-publish-only artifact from a fresh clone or container hydration.
         public let updatedAt: Date?
         /// Plain-text render of the body.
         public let textContent: String

--- a/Sources/AnglesiteCore/StandardSiteDocumentPlan.swift
+++ b/Sources/AnglesiteCore/StandardSiteDocumentPlan.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Network-free planning for `site.standard.document` records: enumerates every publishable
+/// content-collection entry under `src/content` — the same "posts" domain `SocialPublishPlan`
+/// walks — independent of any `posse:`/`syndicateTo` opt-in, since a Standard.site document is
+/// Atmosphere presence, not a cross-post. Reuses `SocialPublishPlan`'s file-walk, draft, and
+/// date-parsing helpers so the two planners can't drift on what counts as "published."
+public enum StandardSiteDocumentPlan {
+    /// One document-eligible content entry.
+    public struct Entry: Equatable, Sendable {
+        /// Project-relative POSIX path of the source markdown file.
+        public let sourceFile: String
+        /// URL path (leading and trailing slash, no host) joined with the publication's `url`
+        /// to form the document's canonical URL, e.g. `/blog/hello-world/`.
+        public let path: String
+        public let title: String
+        public let description: String?
+        public let tags: [String]
+        /// Frontmatter publish date, falling back to the source file's modification date when
+        /// the frontmatter has none — the record's `publishedAt` is required by the lexicon, so
+        /// there must always be a value.
+        public let publishedAt: Date
+        /// The source file's modification date, when it's after `publishedAt` — signals the post
+        /// was edited since it was first published. `nil` otherwise (nothing to report).
+        public let updatedAt: Date?
+        /// Plain-text render of the body.
+        public let textContent: String
+
+        /// Memberwise initializer, public for tests.
+        public init(
+            sourceFile: String, path: String, title: String, description: String?, tags: [String],
+            publishedAt: Date, updatedAt: Date?, textContent: String
+        ) {
+            self.sourceFile = sourceFile
+            self.path = path
+            self.title = title
+            self.description = description
+            self.tags = tags
+            self.publishedAt = publishedAt
+            self.updatedAt = updatedAt
+            self.textContent = textContent
+        }
+    }
+
+    /// The whole site's document plan for one deploy.
+    public struct Plan: Equatable, Sendable {
+        /// The plan's entries, sorted by source file for stable output.
+        public let entries: [Entry]
+
+        /// Memberwise initializer, public for tests.
+        public init(entries: [Entry]) { self.entries = entries }
+    }
+
+    /// Builds the document plan for a site's Astro project root (`Source/`): every non-draft,
+    /// non-future-dated entry under `src/content`.
+    public static func build(projectRoot: URL, referenceDate: Date = Date()) -> Plan {
+        let contentRoot = projectRoot.appendingPathComponent("src/content", isDirectory: true)
+        let files = SocialPublishPlan.walk(contentRoot)
+            .filter { SocialPublishPlan.entryExtensions.contains($0.pathExtension.lowercased()) }
+        let entries = files.compactMap { file -> Entry? in
+            guard let source = try? String(contentsOf: file, encoding: .utf8) else { return nil }
+            let frontmatter = Frontmatter.parse(source)
+            guard !SocialPublishPlan.isDraft(frontmatter["draft"]) else { return nil }
+
+            let relPath = SocialPublishPlan.relativePosix(file, from: projectRoot)
+            guard let path = documentPath(for: relPath, frontmatter: frontmatter) else { return nil }
+
+            let mtime = mtime(file)
+            let publishedAt = SocialPublishPlan.parseDate(
+                SocialPublishPlan.string(frontmatter["publishDate"])
+                    ?? SocialPublishPlan.string(frontmatter["pubDate"])
+                    ?? SocialPublishPlan.string(frontmatter["date"])
+            ) ?? mtime
+            guard publishedAt <= referenceDate else { return nil }
+            let updatedAt = mtime > publishedAt ? mtime : nil
+
+            let title = SocialPublishPlan.string(frontmatter["title"]) ?? fallbackTitle(path)
+            let description = SocialPublishPlan.string(frontmatter["description"])
+            let tags: [String]
+            if case let .array(values)? = frontmatter["tags"] { tags = values } else { tags = [] }
+            let textContent = SiteContentChunker.plainText(markdown: Frontmatter.body(source))
+
+            return Entry(
+                sourceFile: relPath, path: path, title: title, description: description, tags: tags,
+                publishedAt: publishedAt, updatedAt: updatedAt, textContent: textContent
+            )
+        }
+        return Plan(entries: entries.sorted { $0.sourceFile < $1.sourceFile })
+    }
+
+    /// `/<collection>/<slug>/` for a `src/content/<collection>/...` relative path — the same
+    /// collection/slug derivation `SocialPublishPlan.canonicalURL` uses, minus the host join.
+    private static func documentPath(for relPath: String, frontmatter: [String: FrontmatterValue]) -> String? {
+        let parts = relPath.split(separator: "/").map(String.init)
+        guard parts.count >= 4, parts[0] == "src", parts[1] == "content" else { return nil }
+        let collection = parts[2]
+        let collectionRelParts = Array(parts.dropFirst(3))
+        guard let lastPart = collectionRelParts.last else { return nil }
+        let fallbackSlug = (collectionRelParts.dropLast() + [basenameWithoutExtension(lastPart)])
+            .joined(separator: "/")
+        let slug = SocialPublishPlan.string(frontmatter["slug"]) ?? fallbackSlug
+        return "/\(collection)/\(slug)/"
+    }
+
+    private static func basenameWithoutExtension(_ fileName: String) -> String {
+        guard let dot = fileName.lastIndex(of: ".") else { return fileName }
+        return String(fileName[..<dot])
+    }
+
+    private static func fallbackTitle(_ path: String) -> String {
+        let slug = path.split(separator: "/").last.map(String.init) ?? "New post"
+        return slug.replacing("-", with: " ")
+    }
+
+    private static func mtime(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate)
+            ?? Date(timeIntervalSince1970: 0)
+    }
+}

--- a/Sources/AnglesiteCore/StandardSitePublishCommand.swift
+++ b/Sources/AnglesiteCore/StandardSitePublishCommand.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Best-effort post-deploy pass that publishes `site.standard.publication`/`site.standard.document`
+/// records to the Atmosphere (#1231) — see `docs/superpowers/specs/2026-08-04-atproto-standard-site-design.md`.
+/// Modeled on ``POSSESyndicationCommand``: never throws into the deploy result, ledgers in
+/// `Config/`, logs to the debug pane under a `standardsite:` source.
+///
+/// Reuses the site's Bluesky POSSE credential — zero new onboarding. No credential, or no real
+/// deployed `SITE_URL` yet, and the pass silently no-ops, matching how the POSSE pass skips
+/// unconfigured platforms.
+///
+/// Because rkeys are deterministic (``POSSEStableKey``) and writes go through
+/// ``AtprotoPutRecordClient/put(collection:rkey:record:credentials:transport:)`` (create-or-update),
+/// there is no ledger-gated skip: every
+/// eligible post's record is re-put on every run, so a content edit's next deploy always converges
+/// the record to match — "Updates are free" per the design doc. The ledger exists for debug-pane
+/// history and a future unpublish pass (v1.1), not as a dedup gate.
+public actor StandardSitePublishCommand {
+    private struct InFlight {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    /// `.site-config` key the session DID is persisted under after the first successful publish
+    /// — needed by increment 2's build-time well-known/link-tag emission.
+    static let didConfigKey = "ATPROTO_DID"
+    /// Optional `.site-config` escape hatch for a site description; nothing writes it yet (no
+    /// Settings field exists for it), but the app already treats `.site-config` as hand-editable
+    /// (git is the source of truth), so an owner can set it today and have it picked up here.
+    static let descriptionConfigKey = "SITE_DESCRIPTION"
+
+    private let credentials: POSSECredentialResolver.Provider
+    private let transport: POSSEHTTPTransport
+    private let logCenter: LogCenter
+    private let now: @Sendable () -> Date
+    private var inFlight: [String: InFlight] = [:]
+
+    var activeSiteCount: Int { inFlight.count }
+
+    /// Creates the command actor. Every dependency is injectable — credentials, HTTP transport,
+    /// log sink, and clock — so tests can drive a full publish pass with no network, secret
+    /// store, or real time; the defaults wire up production behavior.
+    public init(
+        credentials: @escaping POSSECredentialResolver.Provider = POSSECredentialResolver.provider(),
+        transport: @escaping POSSEHTTPTransport = POSSESyndicationCommand.defaultTransport,
+        logCenter: LogCenter = .shared,
+        now: @escaping @Sendable () -> Date = { Date.now }
+    ) {
+        self.credentials = credentials
+        self.transport = transport
+        self.logCenter = logCenter
+        self.now = now
+    }
+
+    /// Runs one post-deploy Standard.site publish pass for a site. Runs per site are serialized (a
+    /// newer call chains behind the in-flight one) so two overlapping deploys can't race the
+    /// ledger or `.site-config`; distinct sites proceed concurrently.
+    ///
+    /// Never throws: every per-entry failure is logged and skipped, and the pass as a whole no-ops
+    /// when the site has no Bluesky credential or no real deployed `SITE_URL` yet.
+    public func publish(siteID: String, siteDirectory: URL, configDirectory: URL) async {
+        let previous = inFlight[siteID]?.task
+        let id = UUID()
+        let task = Task<Void, Never> { [weak self] in
+            _ = await previous?.value
+            await self?.perform(siteID: siteID, siteDirectory: siteDirectory, configDirectory: configDirectory)
+        }
+        inFlight[siteID] = InFlight(id: id, task: task)
+        await task.value
+        if inFlight[siteID]?.id == id {
+            inFlight[siteID] = nil
+        }
+    }
+
+    private func perform(siteID: String, siteDirectory: URL, configDirectory: URL) async {
+        let source = "standardsite:\(siteID)"
+        guard let bluesky = credentials(siteID, configDirectory).bluesky else { return }
+        guard let siteURLString = DeployCoordinator.resolveSiteURL(siteDirectory: siteDirectory),
+              siteURLString != "https://example.com",
+              let siteURL = URL(string: siteURLString) else { return }
+
+        let plan = StandardSiteDocumentPlan.build(projectRoot: siteDirectory, referenceDate: now())
+
+        var ledger = StandardSitePublishLog.load(from: configDirectory) ?? StandardSitePublishLog()
+        let config = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        let siteName = SiteConfigValues.siteName(sourceDirectory: siteDirectory) ?? siteID
+        let description = nonBlank(SiteConfigFile.value(forKey: Self.descriptionConfigKey, in: config))
+
+        let publication = StandardSitePublicationRecord(name: siteName, url: siteURL.absoluteString, description: description)
+        let publicationRkey = "anglesite-\(POSSEStableKey.make(siteID))"
+
+        let publicationResult: AtprotoPutRecordClient.Result
+        do {
+            publicationResult = try await AtprotoPutRecordClient.put(
+                collection: "site.standard.publication", rkey: publicationRkey, record: publication,
+                credentials: bluesky, transport: transport
+            )
+        } catch {
+            await logError("couldn't publish site.standard.publication: \(error.localizedDescription)", source: source)
+            return
+        }
+        persistDID(publicationResult.did, siteDirectory: siteDirectory)
+        ledger.publicationURI = publicationResult.uri
+        try? ledger.save(to: configDirectory)
+
+        for entry in plan.entries {
+            let documentRkey = "anglesite-\(POSSEStableKey.make("\(siteID)\n\(entry.path)"))"
+            let document = StandardSiteDocumentRecord(
+                site: publicationResult.uri,
+                title: entry.title,
+                description: entry.description,
+                path: entry.path,
+                publishedAt: iso8601(entry.publishedAt),
+                updatedAt: entry.updatedAt.map(iso8601),
+                tags: entry.tags,
+                textContent: entry.textContent
+            )
+            do {
+                let documentResult = try await AtprotoPutRecordClient.put(
+                    collection: "site.standard.document", rkey: documentRkey, record: document,
+                    credentials: bluesky, transport: transport
+                )
+                ledger.record(StandardSitePublishLog.Entry(
+                    path: entry.path, uri: documentResult.uri,
+                    publishedAt: entry.publishedAt, lastPublishedAt: now()
+                ))
+                try ledger.save(to: configDirectory)
+                await logCenter.append(
+                    source: source, stream: .stdout,
+                    text: "standardsite: published \(entry.path) as \(documentResult.uri)"
+                )
+            } catch {
+                await logError("couldn't publish \(entry.path): \(error.localizedDescription)", source: source)
+                continue
+            }
+        }
+    }
+
+    /// Persists the session DID into `.site-config`'s `ATPROTO_DID` on first successful publish
+    /// (needed by increment 2's build-time well-known/link-tag emission). Best-effort, like every
+    /// other write-through call site — a write failure must never turn a successful publish pass
+    /// into a failed one. Skipped once the recorded value already matches, mirroring
+    /// `DeployCommand.persistWorkerDeployed`'s idempotent-write shape.
+    private func persistDID(_ did: String, siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: Self.didConfigKey, in: config) != did else { return }
+        let updated = SiteConfigFile.upsert([(Self.didConfigKey, did)], into: config)
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    private func iso8601(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private func nonBlank(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private func logError(_ message: String, source: String) async {
+        await logCenter.append(source: source, stream: .stderr, text: "standardsite: \(message)")
+    }
+}

--- a/Sources/AnglesiteCore/StandardSitePublishCommand.swift
+++ b/Sources/AnglesiteCore/StandardSitePublishCommand.swift
@@ -89,11 +89,22 @@ public actor StandardSitePublishCommand {
         let publication = StandardSitePublicationRecord(name: siteName, url: siteURL.absoluteString, description: description)
         let publicationRkey = "anglesite-\(POSSEStableKey.make(siteID))"
 
+        // One login for the whole run: every record write below reuses this session instead of
+        // creating a fresh one per `putRecord` call, which would otherwise be N+1 separate
+        // app-password logins against the PDS for N posts in a single deploy.
+        let session: AtprotoPutRecordClient.Session
+        do {
+            session = try await AtprotoPutRecordClient.createSession(credentials: bluesky, transport: transport)
+        } catch {
+            await logError("couldn't sign in to publish: \(error.localizedDescription)", source: source)
+            return
+        }
+
         let publicationResult: AtprotoPutRecordClient.Result
         do {
-            publicationResult = try await AtprotoPutRecordClient.put(
+            publicationResult = try await AtprotoPutRecordClient.putRecord(
                 collection: "site.standard.publication", rkey: publicationRkey, record: publication,
-                credentials: bluesky, transport: transport
+                pdsURL: bluesky.pdsURL, session: session, transport: transport
             )
         } catch {
             await logError("couldn't publish site.standard.publication: \(error.localizedDescription)", source: source)
@@ -115,24 +126,36 @@ public actor StandardSitePublishCommand {
                 tags: entry.tags,
                 textContent: entry.textContent
             )
+            let documentResult: AtprotoPutRecordClient.Result
             do {
-                let documentResult = try await AtprotoPutRecordClient.put(
+                documentResult = try await AtprotoPutRecordClient.putRecord(
                     collection: "site.standard.document", rkey: documentRkey, record: document,
-                    credentials: bluesky, transport: transport
-                )
-                ledger.record(StandardSitePublishLog.Entry(
-                    path: entry.path, uri: documentResult.uri,
-                    publishedAt: entry.publishedAt, lastPublishedAt: now()
-                ))
-                try ledger.save(to: configDirectory)
-                await logCenter.append(
-                    source: source, stream: .stdout,
-                    text: "standardsite: published \(entry.path) as \(documentResult.uri)"
+                    pdsURL: bluesky.pdsURL, session: session, transport: transport
                 )
             } catch {
                 await logError("couldn't publish \(entry.path): \(error.localizedDescription)", source: source)
                 continue
             }
+            // The record write above already succeeded — a failure past this point is a local
+            // ledger/logging problem, not a publish failure, so it gets its own message rather
+            // than falling into a shared catch that would misreport a live record as unpublished.
+            ledger.record(StandardSitePublishLog.Entry(
+                path: entry.path, uri: documentResult.uri,
+                publishedAt: entry.publishedAt, lastPublishedAt: now()
+            ))
+            do {
+                try ledger.save(to: configDirectory)
+            } catch {
+                await logError(
+                    "published \(entry.path) as \(documentResult.uri), but its ledger update failed: \(error.localizedDescription)",
+                    source: source
+                )
+                continue
+            }
+            await logCenter.append(
+                source: source, stream: .stdout,
+                text: "standardsite: published \(entry.path) as \(documentResult.uri)"
+            )
         }
     }
 

--- a/Sources/AnglesiteCore/StandardSitePublishLog.swift
+++ b/Sources/AnglesiteCore/StandardSitePublishLog.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Durable per-site Standard.site publish ledger. Records are content-addressed by deterministic
+/// rkey, so re-publishing is always safe without this ledger — it exists for debug-pane history
+/// and to give a future unpublish pass (v1.1) something to diff removed content against.
+public struct StandardSitePublishLog: Equatable, Sendable {
+    /// One successfully published `site.standard.document` record.
+    public struct Entry: Codable, Equatable, Sendable {
+        /// The document's URL path, e.g. `/blog/hello-world/` — identity for dedup purposes.
+        public let path: String
+        /// The record's resulting at-URI (`at://<did>/site.standard.document/<rkey>`).
+        public let uri: String
+        /// The record's `publishedAt` value.
+        public let publishedAt: Date
+        /// When this record was last successfully written (put), as opposed to `publishedAt`
+        /// which reflects the content's own publish date.
+        public let lastPublishedAt: Date
+
+        /// Memberwise initializer.
+        public init(path: String, uri: String, publishedAt: Date, lastPublishedAt: Date) {
+            self.path = path
+            self.uri = uri
+            self.publishedAt = publishedAt
+            self.lastPublishedAt = lastPublishedAt
+        }
+    }
+
+    /// The ledger's file name inside the package's `Config/` directory — app-owned state, so it
+    /// lives beside `settings.plist`, never in the site's git repo.
+    public static let filename = "standard-site-publish.json"
+    /// The site's `site.standard.publication` record's at-URI, once first published.
+    public var publicationURI: String?
+    /// All recorded documents, in the order they were first published.
+    public var entries: [Entry]
+
+    /// Creates a ledger; empty by default, matching a site that has never published.
+    public init(publicationURI: String? = nil, entries: [Entry] = []) {
+        self.publicationURI = publicationURI
+        self.entries = entries
+    }
+
+    private struct Envelope: Codable { let publicationURI: String?; let entries: [Entry] }
+
+    /// Loads the ledger from `configDirectory`, or `nil` if the file is missing or unreadable.
+    /// Deliberately non-throwing: a missing or corrupt ledger degrades to "never published"
+    /// rather than blocking the deploy pipeline — deterministic rkeys make every record safe to
+    /// re-put regardless.
+    public static func load(from configDirectory: URL) -> StandardSitePublishLog? {
+        guard let data = try? Data(contentsOf: configDirectory.appendingPathComponent(filename)) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let envelope = try? decoder.decode(Envelope.self, from: data) else { return nil }
+        return StandardSitePublishLog(publicationURI: envelope.publicationURI, entries: envelope.entries)
+    }
+
+    /// Atomically writes the ledger (creating `configDirectory` if needed). Pretty-printed with
+    /// sorted keys so the file diffs cleanly when a user inspects Config/ by hand.
+    public func save(to configDirectory: URL) throws {
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(Envelope(publicationURI: publicationURI, entries: entries))
+        try data.write(to: configDirectory.appendingPathComponent(Self.filename), options: .atomic)
+    }
+
+    /// Records or replaces the ledgered entry for `entry.path` — a re-publish overwrites the
+    /// prior entry's `uri`/`lastPublishedAt` in place rather than accumulating duplicates.
+    public mutating func record(_ entry: Entry) {
+        if let index = entries.firstIndex(where: { $0.path == entry.path }) {
+            entries[index] = entry
+        } else {
+            entries.append(entry)
+        }
+    }
+}

--- a/Sources/AnglesiteCore/StandardSiteRecords.swift
+++ b/Sources/AnglesiteCore/StandardSiteRecords.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Grapheme-limit truncation for Standard.site record text fields. The lexicon caps `title` at
+/// 500 graphemes and `description` at 3000 (https://standard.site/docs/lexicons/document).
+/// `String.count` already counts extended grapheme clusters, so `prefix` truncates on a grapheme
+/// boundary without any UTF-16/UTF-8 bookkeeping.
+public enum StandardSiteText {
+    /// `site.standard.publication`/`site.standard.document` `title` grapheme limit.
+    public static let titleGraphemeLimit = 500
+    /// `site.standard.document` `description` grapheme limit.
+    public static let descriptionGraphemeLimit = 3000
+
+    /// Truncates `value` to at most `graphemeLimit` graphemes; returns `value` unchanged when
+    /// already within the limit.
+    public static func truncate(_ value: String, graphemeLimit: Int) -> String {
+        guard value.count > graphemeLimit else { return value }
+        return String(value.prefix(graphemeLimit))
+    }
+}
+
+/// `site.standard.publication` record — one per site, describing it for Atmosphere indexers and
+/// Bluesky's link-preview enhancement. See https://standard.site/docs/lexicons/publication.
+///
+/// `name`/`description` are truncated to the lexicon's grapheme limits at construction, so every
+/// caller gets a conforming record without repeating the truncation call. Optional properties are
+/// omitted from the encoded JSON (not written as `null`) via Swift's synthesized `Encodable`
+/// behavior for `Optional` — the same convention `POSSEClients.swift`'s record types already rely
+/// on, so no custom `encode(to:)` is needed here either.
+public struct StandardSitePublicationRecord: Encodable, Equatable, Sendable {
+    let type = "site.standard.publication"
+    public let name: String
+    public let url: String
+    public let description: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type = "$type"
+        case name, url, description
+    }
+
+    /// Memberwise initializer.
+    /// - Parameters:
+    ///   - name: The site's display name.
+    ///   - url: The site's canonical public URL.
+    ///   - description: A short description of the site, if any.
+    public init(name: String, url: String, description: String?) {
+        self.name = StandardSiteText.truncate(name, graphemeLimit: StandardSiteText.titleGraphemeLimit)
+        self.url = url
+        self.description = description.map {
+            StandardSiteText.truncate($0, graphemeLimit: StandardSiteText.descriptionGraphemeLimit)
+        }
+    }
+}
+
+/// `site.standard.document` record — one per published post, linking back to the owner's
+/// publication record. See https://standard.site/docs/lexicons/document.
+///
+/// Same truncation-at-construction and optional-omission conventions as
+/// ``StandardSitePublicationRecord``.
+public struct StandardSiteDocumentRecord: Encodable, Equatable, Sendable {
+    let type = "site.standard.document"
+    /// The owning publication's at-URI (`at://<did>/site.standard.publication/<rkey>`).
+    public let site: String
+    public let title: String
+    public let description: String?
+    /// Joined with the publication's `url` to form the document's canonical URL, e.g. `/blog/hello/`.
+    public let path: String?
+    /// ISO 8601 timestamp string.
+    public let publishedAt: String
+    /// ISO 8601 timestamp string; `nil` when the source hasn't been edited since `publishedAt`.
+    public let updatedAt: String?
+    public let tags: [String]
+    /// Plain-text render of the body, for indexers; the lexicon's `content` open union is
+    /// deliberately left unset (see the design doc — the git repo stays the canonical format).
+    public let textContent: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type = "$type"
+        case site, title, description, path, publishedAt, updatedAt, tags, textContent
+    }
+
+    /// Memberwise initializer.
+    public init(
+        site: String,
+        title: String,
+        description: String?,
+        path: String?,
+        publishedAt: String,
+        updatedAt: String?,
+        tags: [String],
+        textContent: String?
+    ) {
+        self.site = site
+        self.title = StandardSiteText.truncate(title, graphemeLimit: StandardSiteText.titleGraphemeLimit)
+        self.description = description.map {
+            StandardSiteText.truncate($0, graphemeLimit: StandardSiteText.descriptionGraphemeLimit)
+        }
+        self.path = path
+        self.publishedAt = publishedAt
+        self.updatedAt = updatedAt
+        self.tags = tags
+        self.textContent = textContent
+    }
+}

--- a/Sources/AnglesiteCore/StandardSiteRecords.swift
+++ b/Sources/AnglesiteCore/StandardSiteRecords.swift
@@ -1,14 +1,19 @@
 import Foundation
 
 /// Grapheme-limit truncation for Standard.site record text fields. The lexicon caps `title` at
-/// 500 graphemes and `description` at 3000 (https://standard.site/docs/lexicons/document).
-/// `String.count` already counts extended grapheme clusters, so `prefix` truncates on a grapheme
-/// boundary without any UTF-16/UTF-8 bookkeeping.
+/// 500 graphemes, `description` at 3000, and each `tags` item at 128
+/// (https://standard.site/docs/lexicons/document) — `textContent` has no stated limit, so it's
+/// left untruncated. `String.count` already counts extended grapheme clusters, so `prefix`
+/// truncates on a grapheme boundary without any UTF-16/UTF-8 bookkeeping.
 public enum StandardSiteText {
     /// `site.standard.publication`/`site.standard.document` `title` grapheme limit.
     public static let titleGraphemeLimit = 500
     /// `site.standard.document` `description` grapheme limit.
     public static let descriptionGraphemeLimit = 3000
+    /// `site.standard.document` `tags` per-item grapheme limit. The lexicon states no limit on
+    /// the array's item *count*, only each item's length, so callers aren't expected to cap how
+    /// many tags they send.
+    public static let tagGraphemeLimit = 128
 
     /// Truncates `value` to at most `graphemeLimit` graphemes; returns `value` unchanged when
     /// already within the limit.
@@ -97,7 +102,7 @@ public struct StandardSiteDocumentRecord: Encodable, Equatable, Sendable {
         self.path = path
         self.publishedAt = publishedAt
         self.updatedAt = updatedAt
-        self.tags = tags
+        self.tags = tags.map { StandardSiteText.truncate($0, graphemeLimit: StandardSiteText.tagGraphemeLimit) }
         self.textContent = textContent
     }
 }

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -415,17 +415,19 @@ struct DeployCoordinatorTests {
         func record(_ name: String) { calls.append(name) }
     }
 
-    @Test("runs webmention-send, syndication, then subscriber notify in order, with a milestone immediately before each")
+    @Test("runs webmention-send, standard-site publish, syndication, then subscriber notify in order, with a milestone immediately before each")
     func postDeploySequencingRunsInOrder() async {
         let recorder = CallRecorder()
         await DeployCoordinator.runPostDeploySequencing(
             onMilestone: { progress in recorder.record("milestone:\(progress.phase)") },
             sendWebmentions: { recorder.record("send") },
+            publishStandardSite: { recorder.record("standardsite") },
             syndicate: { recorder.record("syndicate") },
             notifySubscribers: { recorder.record("notify") }
         )
         #expect(recorder.calls == [
             "milestone:webmentions", "send",
+            "milestone:standardSitePublishing", "standardsite",
             "milestone:syndicating", "syndicate",
             "milestone:websubPing", "notify",
             "milestone:activityPubBackfill",
@@ -438,10 +440,29 @@ struct DeployCoordinatorTests {
         await DeployCoordinator.runPostDeploySequencing(
             onMilestone: { _ in },
             sendWebmentions: { recorder.record("send") },
+            publishStandardSite: { recorder.record("standardsite") },
             syndicate: { recorder.record("syndicate") },
             notifySubscribers: { recorder.record("notify") }
         )
-        #expect(recorder.calls == ["send", "syndicate", "notify"])
+        #expect(recorder.calls == ["send", "standardsite", "syndicate", "notify"])
+    }
+
+    @Test("publishStandardSite defaults to a no-op so callers without a Standard.site pass change nothing")
+    func postDeploySequencingDefaultsStandardSiteToNoOp() async {
+        let recorder = CallRecorder()
+        await DeployCoordinator.runPostDeploySequencing(
+            onMilestone: { progress in recorder.record("milestone:\(progress.phase)") },
+            sendWebmentions: { recorder.record("send") },
+            syndicate: { recorder.record("syndicate") },
+            notifySubscribers: { recorder.record("notify") }
+        )
+        #expect(recorder.calls == [
+            "milestone:webmentions", "send",
+            "milestone:standardSitePublishing",
+            "milestone:syndicating", "syndicate",
+            "milestone:websubPing", "notify",
+            "milestone:activityPubBackfill",
+        ])
     }
 
     @Test("notifySubscribers defaults to a no-op so callers without a hub change nothing")
@@ -454,24 +475,27 @@ struct DeployCoordinatorTests {
         )
         #expect(recorder.calls == [
             "milestone:webmentions", "send",
+            "milestone:standardSitePublishing",
             "milestone:syndicating", "syndicate",
             "milestone:websubPing",
             "milestone:activityPubBackfill",
         ])
     }
 
-    @Test("backfillActivityPubOutbox runs last, after webmention-send, syndication, and subscriber notify, with a milestone immediately before it")
+    @Test("backfillActivityPubOutbox runs last, after webmention-send, standard-site publish, syndication, and subscriber notify, with a milestone immediately before it")
     func postDeploySequencingRunsBackfillLast() async {
         let recorder = CallRecorder()
         await DeployCoordinator.runPostDeploySequencing(
             onMilestone: { progress in recorder.record("milestone:\(progress.phase)") },
             sendWebmentions: { recorder.record("send") },
+            publishStandardSite: { recorder.record("standardsite") },
             syndicate: { recorder.record("syndicate") },
             notifySubscribers: { recorder.record("notify") },
             backfillActivityPubOutbox: { recorder.record("backfill") }
         )
         #expect(recorder.calls == [
             "milestone:webmentions", "send",
+            "milestone:standardSitePublishing", "standardsite",
             "milestone:syndicating", "syndicate",
             "milestone:websubPing", "notify",
             "milestone:activityPubBackfill", "backfill",

--- a/Tests/AnglesiteCoreTests/POSSESyndicationTests.swift
+++ b/Tests/AnglesiteCoreTests/POSSESyndicationTests.swift
@@ -27,6 +27,9 @@ struct POSSESyndicationTests {
             case "/xrpc/com.atproto.repo.createRecord":
                 status = 200
                 json = #"{"uri":"at://did:plc:owner/app.bsky.feed.post/record123"}"#
+            case "/xrpc/com.atproto.repo.putRecord":
+                status = 200
+                json = #"{"uri":"at://did:plc:owner/site.standard.publication/anglesite-stable","cid":"bafycid"}"#
             default:
                 // Existing ledger entries try standard Webmention discovery on the next deploy.
                 status = 200
@@ -126,6 +129,30 @@ struct POSSESyndicationTests {
         let record = try #require(object["record"] as? [String: Any])
         #expect(record["$type"] as? String == "app.bsky.feed.post")
         #expect((record["text"] as? String)?.hasSuffix(canonical.absoluteString) == true)
+        #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer jwt")
+    }
+
+    @Test("putRecord creates a session, then writes the record with the caller's collection/rkey — create-or-update, no 409 handling")
+    func putRecordRequest() async throws {
+        let stub = APIStub()
+        let record = StandardSitePublicationRecord(name: "Owner Site", url: "https://owner.example", description: nil)
+        let result = try await AtprotoPutRecordClient.put(
+            collection: "site.standard.publication",
+            rkey: "anglesite-stable",
+            record: record,
+            credentials: credentials.bluesky!,
+            transport: { request in try await stub.respond(request) }
+        )
+        #expect(result.did == "did:plc:owner")
+        #expect(result.uri == "at://did:plc:owner/site.standard.publication/anglesite-stable")
+        #expect(await stub.count(path: "/xrpc/com.atproto.server.createSession") == 1)
+        #expect(await stub.count(path: "/xrpc/com.atproto.repo.putRecord") == 1)
+        let request = await stub.first(path: "/xrpc/com.atproto.repo.putRecord")
+        let body = try #require(request?.httpBody)
+        let object = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(object["repo"] as? String == "did:plc:owner")
+        #expect(object["collection"] as? String == "site.standard.publication")
+        #expect(object["rkey"] as? String == "anglesite-stable")
         #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer jwt")
     }
 

--- a/Tests/AnglesiteCoreTests/POSSESyndicationTests.swift
+++ b/Tests/AnglesiteCoreTests/POSSESyndicationTests.swift
@@ -156,6 +156,36 @@ struct POSSESyndicationTests {
         #expect(request?.value(forHTTPHeaderField: "Authorization") == "Bearer jwt")
     }
 
+    @Test("createSession + putRecord let a caller reuse one session across multiple record writes")
+    func putRecordReusesSession() async throws {
+        let stub = APIStub()
+        let session = try await AtprotoPutRecordClient.createSession(
+            credentials: credentials.bluesky!,
+            transport: { request in try await stub.respond(request) }
+        )
+        #expect(session.did == "did:plc:owner")
+
+        let publication = StandardSitePublicationRecord(name: "Owner Site", url: "https://owner.example", description: nil)
+        let publicationResult = try await AtprotoPutRecordClient.putRecord(
+            collection: "site.standard.publication", rkey: "anglesite-pub", record: publication,
+            pdsURL: credentials.bluesky!.pdsURL, session: session,
+            transport: { request in try await stub.respond(request) }
+        )
+        let document = StandardSiteDocumentRecord(
+            site: publicationResult.uri, title: "Hello", description: nil, path: "/notes/hello/",
+            publishedAt: "2026-01-01T00:00:00Z", updatedAt: nil, tags: [], textContent: nil
+        )
+        _ = try await AtprotoPutRecordClient.putRecord(
+            collection: "site.standard.document", rkey: "anglesite-doc", record: document,
+            pdsURL: credentials.bluesky!.pdsURL, session: session,
+            transport: { request in try await stub.respond(request) }
+        )
+
+        // A single createSession call served both putRecord calls — the caller never re-logged in.
+        #expect(await stub.count(path: "/xrpc/com.atproto.server.createSession") == 1)
+        #expect(await stub.count(path: "/xrpc/com.atproto.repo.putRecord") == 2)
+    }
+
     @Test("command posts once, writes both u-syndication URLs, and repairs source from its ledger")
     func commandEndToEndAndIdempotency() async throws {
         let site = try makeSite()

--- a/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
+++ b/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
@@ -62,13 +62,16 @@ struct StandardSiteRecordsTests {
         #expect(publication.name.count == StandardSiteText.titleGraphemeLimit)
         #expect(publication.description?.count == StandardSiteText.descriptionGraphemeLimit)
 
+        let longTag = String(repeating: "G", count: 200)
         let document = StandardSiteDocumentRecord(
             site: "at://did:plc:owner/site.standard.publication/anglesite-abc",
             title: longTitle, description: longDescription, path: "/notes/hello/",
-            publishedAt: "2026-01-01T00:00:00Z", updatedAt: nil, tags: [], textContent: nil
+            publishedAt: "2026-01-01T00:00:00Z", updatedAt: nil, tags: [longTag, "short"], textContent: nil
         )
         #expect(document.title.count == StandardSiteText.titleGraphemeLimit)
         #expect(document.description?.count == StandardSiteText.descriptionGraphemeLimit)
+        #expect(document.tags[0].count == StandardSiteText.tagGraphemeLimit)
+        #expect(document.tags[1] == "short")
     }
 
     @Test("rkeys are deterministic for the same site/path and differ across sites/paths")

--- a/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
+++ b/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
@@ -274,6 +274,9 @@ struct StandardSitePublishCommandTests {
 
         await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
 
+        // One session for the whole run — the publication write and every document write reuse
+        // it, rather than logging into the PDS fresh for each of the two record writes.
+        #expect(await stub.count(path: "/xrpc/com.atproto.server.createSession") == 1)
         #expect(await stub.count(path: "/xrpc/com.atproto.repo.putRecord") == 2)
         let publicationBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.putRecord").first)
         #expect(publicationBody["collection"] as? String == "site.standard.publication")

--- a/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
+++ b/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
@@ -1,0 +1,298 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import Testing
+import AnglesiteTestSupport
+@testable import AnglesiteCore
+
+@Suite("Standard.site records")
+struct StandardSiteRecordsTests {
+    @Test("publication and document records carry the lexicon's $type")
+    func recordShape() throws {
+        let publication = StandardSitePublicationRecord(
+            name: "Owner Site", url: "https://owner.example", description: "A personal site."
+        )
+        let publicationData = try JSONEncoder().encode(publication)
+        let publicationObject = try #require(try JSONSerialization.jsonObject(with: publicationData) as? [String: Any])
+        #expect(publicationObject["$type"] as? String == "site.standard.publication")
+        #expect(publicationObject["name"] as? String == "Owner Site")
+        #expect(publicationObject["url"] as? String == "https://owner.example")
+        #expect(publicationObject["description"] as? String == "A personal site.")
+
+        let document = StandardSiteDocumentRecord(
+            site: "at://did:plc:owner/site.standard.publication/anglesite-abc",
+            title: "Hello", description: "A note.", path: "/notes/hello/",
+            publishedAt: "2026-01-01T00:00:00Z", updatedAt: nil, tags: ["a", "b"], textContent: "Body."
+        )
+        let documentData = try JSONEncoder().encode(document)
+        let documentObject = try #require(try JSONSerialization.jsonObject(with: documentData) as? [String: Any])
+        #expect(documentObject["$type"] as? String == "site.standard.document")
+        #expect(documentObject["site"] as? String == "at://did:plc:owner/site.standard.publication/anglesite-abc")
+        #expect(documentObject["title"] as? String == "Hello")
+        #expect(documentObject["publishedAt"] as? String == "2026-01-01T00:00:00Z")
+        #expect(documentObject["tags"] as? [String] == ["a", "b"])
+    }
+
+    @Test("nil optional fields are omitted from the encoded record, not written as null")
+    func optionalFieldsOmitted() throws {
+        let publication = StandardSitePublicationRecord(name: "Site", url: "https://owner.example", description: nil)
+        let data = try JSONEncoder().encode(publication)
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["description"] == nil)
+
+        let document = StandardSiteDocumentRecord(
+            site: "at://did:plc:owner/site.standard.publication/anglesite-abc",
+            title: "Hello", description: nil, path: nil,
+            publishedAt: "2026-01-01T00:00:00Z", updatedAt: nil, tags: [], textContent: nil
+        )
+        let documentData = try JSONEncoder().encode(document)
+        let documentObject = try #require(try JSONSerialization.jsonObject(with: documentData) as? [String: Any])
+        #expect(documentObject["description"] == nil)
+        #expect(documentObject["path"] == nil)
+        #expect(documentObject["updatedAt"] == nil)
+        #expect(documentObject["textContent"] == nil)
+    }
+
+    @Test("title and description are truncated to the lexicon's grapheme limits")
+    func truncatesLongText() {
+        let longTitle = String(repeating: "T", count: 600)
+        let longDescription = String(repeating: "D", count: 3500)
+        let publication = StandardSitePublicationRecord(name: longTitle, url: "https://owner.example", description: longDescription)
+        #expect(publication.name.count == StandardSiteText.titleGraphemeLimit)
+        #expect(publication.description?.count == StandardSiteText.descriptionGraphemeLimit)
+
+        let document = StandardSiteDocumentRecord(
+            site: "at://did:plc:owner/site.standard.publication/anglesite-abc",
+            title: longTitle, description: longDescription, path: "/notes/hello/",
+            publishedAt: "2026-01-01T00:00:00Z", updatedAt: nil, tags: [], textContent: nil
+        )
+        #expect(document.title.count == StandardSiteText.titleGraphemeLimit)
+        #expect(document.description?.count == StandardSiteText.descriptionGraphemeLimit)
+    }
+
+    @Test("rkeys are deterministic for the same site/path and differ across sites/paths")
+    func rkeyDeterminism() {
+        let publicationRkeyA = "anglesite-\(POSSEStableKey.make("site-1"))"
+        let publicationRkeyB = "anglesite-\(POSSEStableKey.make("site-1"))"
+        #expect(publicationRkeyA == publicationRkeyB)
+
+        let documentRkeyA = "anglesite-\(POSSEStableKey.make("site-1\n/notes/hello/"))"
+        let documentRkeyB = "anglesite-\(POSSEStableKey.make("site-1\n/notes/hello/"))"
+        #expect(documentRkeyA == documentRkeyB)
+
+        let documentOtherPath = "anglesite-\(POSSEStableKey.make("site-1\n/notes/other/"))"
+        #expect(documentRkeyA != documentOtherPath)
+
+        let documentOtherSite = "anglesite-\(POSSEStableKey.make("site-2\n/notes/hello/"))"
+        #expect(documentRkeyA != documentOtherSite)
+    }
+}
+
+@Suite("Standard.site document plan")
+struct StandardSiteDocumentPlanTests {
+    private let referenceDate = Date(timeIntervalSince1970: 1_782_777_600) // 2026-06-30T00:00:00Z
+
+    @Test("builds an entry per non-draft, non-future post with a derived path")
+    func buildsEligibleEntries() throws {
+        let root = try writeSiteTree(prefix: "standardsite-plan", [
+            "src/content/notes/hello.md": """
+            ---
+            title: Hello World
+            description: A note.
+            tags: [a, b]
+            publishDate: 2026-06-29
+            ---
+            Body text.
+            """,
+            "src/content/notes/draft.md": """
+            ---
+            draft: true
+            ---
+            Draft body.
+            """,
+            "src/content/notes/future-post.md": """
+            ---
+            publishDate: 2999-01-01
+            ---
+            Future body.
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let plan = StandardSiteDocumentPlan.build(projectRoot: root, referenceDate: referenceDate)
+        #expect(plan.entries.count == 1)
+        let entry = try #require(plan.entries.first)
+        #expect(entry.path == "/notes/hello/")
+        #expect(entry.title == "Hello World")
+        #expect(entry.description == "A note.")
+        #expect(entry.tags == ["a", "b"])
+        #expect(entry.textContent.contains("Body text."))
+    }
+
+    @Test("falls back to a de-hyphenated slug title when frontmatter has none")
+    func fallbackTitle() throws {
+        let root = try writeSiteTree(prefix: "standardsite-plan", [
+            "src/content/notes/no-title-post.md": """
+            ---
+            publishDate: 2026-06-29
+            ---
+            No title here.
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let plan = StandardSiteDocumentPlan.build(projectRoot: root, referenceDate: referenceDate)
+        let entry = try #require(plan.entries.first)
+        #expect(entry.title == "no title post")
+    }
+
+    @Test("an explicit slug frontmatter override wins over the filename-derived slug")
+    func slugOverride() throws {
+        let root = try writeSiteTree(prefix: "standardsite-plan", [
+            "src/content/notes/hello.md": """
+            ---
+            slug: custom-slug
+            publishDate: 2026-06-29
+            ---
+            Body.
+            """,
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let plan = StandardSiteDocumentPlan.build(projectRoot: root, referenceDate: referenceDate)
+        let entry = try #require(plan.entries.first)
+        #expect(entry.path == "/notes/custom-slug/")
+    }
+}
+
+@Suite("Standard.site publish pass")
+struct StandardSitePublishCommandTests {
+    private actor APIStub {
+        var requests: [URLRequest] = []
+        let did: String
+
+        init(did: String = "did:plc:owner") { self.did = did }
+
+        func respond(_ request: URLRequest) throws -> (Data, HTTPURLResponse) {
+            requests.append(request)
+            let url = request.url ?? URL(string: "https://invalid.example")!
+            let path = url.path
+            let json: String
+            switch path {
+            case "/xrpc/com.atproto.server.createSession":
+                json = #"{"accessJwt":"jwt","did":"\#(did)"}"#
+            case "/xrpc/com.atproto.repo.putRecord":
+                let body = (try? JSONSerialization.jsonObject(with: request.httpBody ?? Data())) as? [String: Any]
+                let collection = body?["collection"] as? String ?? "unknown"
+                let rkey = body?["rkey"] as? String ?? "unknown"
+                json = #"{"uri":"at://\#(did)/\#(collection)/\#(rkey)","cid":"bafycid"}"#
+            default:
+                json = "{}"
+            }
+            guard let response = HTTPURLResponse(
+                url: url, statusCode: 200, httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ) else { throw URLError(.badServerResponse) }
+            return (Data(json.utf8), response)
+        }
+
+        func count(path: String) -> Int { requests.count { $0.url?.path == path } }
+        func bodies(path: String) -> [[String: Any]] {
+            var results: [[String: Any]] = []
+            for request in requests where request.url?.path == path {
+                guard let data = request.httpBody else { continue }
+                guard let parsed = try? JSONSerialization.jsonObject(with: data) else { continue }
+                guard let dict = parsed as? [String: Any] else { continue }
+                results.append(dict)
+            }
+            return results
+        }
+    }
+
+    private var credentials: POSSECredentials {
+        POSSECredentials(bluesky: .init(pdsURL: URL(string: "https://pds.example")!, identifier: "owner.test", appPassword: "secret-b"))
+    }
+
+    private func makeSite(siteURL: String? = "https://owner.example") throws -> (root: URL, source: URL, config: URL) {
+        var files = [
+            "Source/src/content/notes/hello.md": """
+            ---
+            title: Hello world
+            description: A short update from my own site.
+            tags: [swift, atproto]
+            publishDate: 2026-01-01
+            ---
+            Full body text.
+            """,
+        ]
+        if let siteURL {
+            files["Source/.site-config"] = "SITE_NAME=Owner Site\nSITE_URL=\(siteURL)\n"
+        }
+        let root = try writeSiteTree(prefix: "standardsite-command", files)
+        return (root, root.appendingPathComponent("Source"), root.appendingPathComponent("Config"))
+    }
+
+    @Test("no-ops without a Bluesky credential")
+    func noopWithoutCredential() async throws {
+        let site = try makeSite()
+        defer { try? FileManager.default.removeItem(at: site.root) }
+        let stub = APIStub()
+        let command = StandardSitePublishCommand(
+            credentials: { _, _ in POSSECredentials() },
+            transport: { try await stub.respond($0) }
+        )
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+        #expect(await stub.count(path: "/xrpc/com.atproto.server.createSession") == 0)
+        #expect(StandardSitePublishLog.load(from: site.config) == nil)
+    }
+
+    @Test("no-ops when SITE_URL is absent (never deployed / still the scaffold default)")
+    func noopWithoutRealSiteURL() async throws {
+        let site = try makeSite(siteURL: nil)
+        defer { try? FileManager.default.removeItem(at: site.root) }
+        let stub = APIStub()
+        let command = StandardSitePublishCommand(
+            credentials: { _, _ in credentials },
+            transport: { try await stub.respond($0) }
+        )
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+        #expect(await stub.count(path: "/xrpc/com.atproto.server.createSession") == 0)
+    }
+
+    @Test("publishes the publication once, one document per post, ledgers entries, and persists ATPROTO_DID")
+    func endToEndPublish() async throws {
+        let site = try makeSite()
+        defer { try? FileManager.default.removeItem(at: site.root) }
+        let stub = APIStub()
+        let command = StandardSitePublishCommand(
+            credentials: { _, _ in credentials },
+            transport: { try await stub.respond($0) },
+            logCenter: LogCenter(),
+            now: { Date(timeIntervalSince1970: 1_782_777_600) } // 2026-06-30T00:00:00Z — after the fixture's publishDate
+        )
+
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+
+        #expect(await stub.count(path: "/xrpc/com.atproto.repo.putRecord") == 2)
+        let publicationBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.putRecord").first)
+        #expect(publicationBody["collection"] as? String == "site.standard.publication")
+        #expect(publicationBody["rkey"] as? String == "anglesite-\(POSSEStableKey.make("site-1"))")
+
+        let ledger = try #require(StandardSitePublishLog.load(from: site.config))
+        #expect(ledger.entries.count == 1)
+        #expect(ledger.entries.first?.path == "/notes/hello/")
+        #expect(ledger.publicationURI == "at://did:plc:owner/site.standard.publication/anglesite-\(POSSEStableKey.make("site-1"))")
+
+        let config = try String(contentsOf: site.source.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "ATPROTO_DID", in: config) == "did:plc:owner")
+
+        // Re-run: putRecord's create-or-update semantics make a repeat pass idempotent — same
+        // rkeys, same resulting ledger, no error — even though every eligible post is re-put.
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+        #expect(await stub.count(path: "/xrpc/com.atproto.repo.putRecord") == 4)
+        let ledgerAfter = try #require(StandardSitePublishLog.load(from: site.config))
+        #expect(ledgerAfter.entries.count == 1)
+        #expect(ledgerAfter.entries.first?.uri == ledger.entries.first?.uri)
+    }
+}


### PR DESCRIPTION
Closes #1231

## Summary

- Adds `site.standard.publication`/`site.standard.document` Encodable record structs (`StandardSiteRecords.swift`) with grapheme-limit truncation (title 500, description 3000) and a `StandardSiteDocumentPlan` that enumerates eligible posts from `src/content` (mirroring `SocialPublishPlan`'s file-walk/draft/date helpers, independent of any `posse:` opt-in).
- Extends the XRPC client surface with `AtprotoPutRecordClient` (`com.atproto.repo.putRecord`, create-or-update) in `POSSEClients.swift`, alongside `BlueskyPOSSEClient`.
- Adds `StandardSitePublishCommand`, a best-effort post-deploy actor modeled on `POSSESyndicationCommand`: deterministic `anglesite-`-prefixed rkeys (via `POSSEStableKey`) make re-publishing stateless and idempotent, it reuses the site's Bluesky POSSE credential, no-ops without one or without a real deployed `SITE_URL`, ledgers successes in `Config/` (`StandardSitePublishLog`), and logs to the debug pane under a `standardsite:` source.
- Persists the session DID to `.site-config`'s `ATPROTO_DID` on first successful publish, for increment 2's build-time well-known/link-tag emission.
- Wires the new pass into `DeployCoordinator.runPostDeploySequencing` (new `publishStandardSite` parameter + `deployStandardSitePublishing` milestone) after webmentions and before POSSE, so Atmosphere records exist before the Bluesky cross-post lands. Publishing runs host-side from Swift, same as the other POSSE/webmention passes — never enters the container guest env.

Increment 1 of #1230 (design: `docs/superpowers/specs/2026-08-04-atproto-standard-site-design.md`). Template verification (well-known claim + `<link>` tags) and the Settings toggle are later increments.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills`.

No MCP schema change — this is app-side Swift talking directly to the owner's existing atproto PDS over XRPC, reusing the already-vendored POSSE credential/transport seam.

## Test plan

- [x] `swift test --package-path .` — `AnglesiteCoreTests` isn't in the Linux-portable target set (`Package.swift`'s `#if !canImport(Darwin)` filter excludes it; only macOS CI runs it), so I couldn't execute the new/updated tests (`StandardSitePublishTests.swift`, `POSSESyndicationTests.swift`, `DeployCoordinatorTests.swift`) directly in this environment. `AnglesiteCore` itself *is* portable and built cleanly (`swift build`). As a substitute, I compiled and ran a standalone harness linking directly against the built `AnglesiteCore`/`AnglesiteSiteModel` object files, exercising record encoding/truncation/omitted-optionals, rkey determinism, `AtprotoPutRecordClient.put`, `StandardSiteDocumentPlan.build`, the full `StandardSitePublishCommand.publish` pass (including no-op gates and DID persistence), and `DeployCoordinator.runPostDeploySequencing`'s new ordering — this caught and let me fix a real date-fixture bug (`now`/reference date predating a fixture's `publishDate`, which silently filtered the post as future-dated) before it could land. Please have CI's macOS `swift test` lane confirm.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not runnable here (no Xcode/macOS host); `AnglesiteAppCore` (which contains the `DeployModel.swift` wiring) is similarly Darwin-only and un-buildable in this container, so that file's change is manually reviewed only. Also confirmed via `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` that the new doc comments introduce no new DocC symbol-link errors (5 pre-existing, Darwin-only-symbol errors are unchanged).
- [ ] Manual smoke: not applicable — no UI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmHLHis4RSvrrz4jtwJzUr)_