### PR TITLE
fix(#1312): distinguish 401/403, coalesce git-remote resolution

### DIFF
--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -721,10 +721,27 @@ final class PlistEditorModel {
         return true
     }
 
+    /// Coalesces concurrent `currentRemoteRepo()` callers onto a single `git remote get-url
+    /// origin` spawn. `refreshRepoSecurityState()` and `refreshSecurityReports()` both call it
+    /// from `.task` modifiers that start together when the Security Reports tab loads; without
+    /// this, that's two subprocess spawns for the same answer on every site open. Cleared once
+    /// the in-flight resolution completes, so a later explicit recheck (e.g. the "Check for
+    /// Reports" button) still re-resolves rather than reusing a possibly-stale answer.
+    private var pendingRemoteRepoResolution: Task<RemoteRepo?, Never>?
+
     private func currentRemoteRepo() async -> RemoteRepo? {
-        guard let result = try? await gitRunner(sourceDirectory, ["remote", "get-url", "origin"]),
-              result.exitCode == 0 else { return nil }
-        return RemoteRepo.parse(remoteURL: result.stdout)
+        if let pending = pendingRemoteRepoResolution {
+            return await pending.value
+        }
+        let task = Task<RemoteRepo?, Never> { [gitRunner, sourceDirectory] in
+            guard let result = try? await gitRunner(sourceDirectory, ["remote", "get-url", "origin"]),
+                  result.exitCode == 0 else { return nil }
+            return RemoteRepo.parse(remoteURL: result.stdout)
+        }
+        pendingRemoteRepoResolution = task
+        let repo = await task.value
+        pendingRemoteRepoResolution = nil
+        return repo
     }
 
     private func repoSecurityMessage(for error: any Error) -> String {

--- a/Sources/AnglesiteCore/HTTPGitHubClient.swift
+++ b/Sources/AnglesiteCore/HTTPGitHubClient.swift
@@ -11,9 +11,10 @@ public enum GitHubRepoAPIError: Error, Equatable, Sendable {
     /// distinct from `.api`, which means GitHub responded with a rejection.
     case network
     /// GitHub returned 401 or 403 — the token is invalid, expired, or missing the required scope.
-    /// Both statuses collapse into one case because the user-facing remedy is identical: fix the
-    /// token in Settings.
-    case unauthorized
+    /// Carries the actual status so callers that need to tell the two apart (e.g. a 403 can mean
+    /// a repo feature is simply off, not a bad token) can — most callers still show the same
+    /// "fix the token in Settings" remedy either way and can ignore the associated value.
+    case unauthorized(status: Int)
     /// A 422 whose `errors[].message` says the repository name is taken. Split out from `.api`
     /// so callers can offer a rename instead of showing a raw API message.
     case nameAlreadyExists
@@ -61,7 +62,9 @@ public struct HTTPGitHubClient: Sendable {
             throw GitHubRepoAPIError.network
         }
 
-        if http.statusCode == 401 || http.statusCode == 403 { throw GitHubRepoAPIError.unauthorized }
+        if http.statusCode == 401 || http.statusCode == 403 {
+            throw GitHubRepoAPIError.unauthorized(status: http.statusCode)
+        }
         if http.statusCode == 422 {
             let envelope = try? JSONDecoder().decode(GitHubErrorResponse.self, from: data)
             // The name-conflict detail lives in `errors[].message`, not the top-level `message`
@@ -100,7 +103,9 @@ public struct HTTPGitHubClient: Sendable {
         } catch {
             throw GitHubRepoAPIError.network
         }
-        if http.statusCode == 401 || http.statusCode == 403 { throw GitHubRepoAPIError.unauthorized }
+        if http.statusCode == 401 || http.statusCode == 403 {
+            throw GitHubRepoAPIError.unauthorized(status: http.statusCode)
+        }
         guard (200..<300).contains(http.statusCode) else { throw GitHubRepoAPIError.http(status: http.statusCode) }
         return data
     }

--- a/Sources/AnglesiteCore/SecurityReportsModel.swift
+++ b/Sources/AnglesiteCore/SecurityReportsModel.swift
@@ -141,17 +141,20 @@ public final class SecurityReportsModel {
 
     /// The both-halves-failed message. A 401 on either half means the token itself is invalid —
     /// an unambiguous shared cause worth sending the user to Settings for regardless of the other
-    /// half's status. A 403 on *both* halves is not that: `openDependabotAlerts` 403s whenever
+    /// half's status. A 403 on *either* half is not that: `openDependabotAlerts` 403s whenever
     /// Dependabot alerts are simply off for the repo (see `recheck`'s doc comment), and advisories
-    /// can 403 on its own repo-config grounds too — two 403s don't establish the token is at
-    /// fault, so this doesn't send the user to recreate one that may already be correctly scoped.
+    /// can 403 on its own repo-config grounds too — a 403 doesn't establish the token is at fault
+    /// even when the *other* half failed for an unrelated reason (network, a 500, …), so this
+    /// checks each half's status independently rather than requiring both to be 403. That also
+    /// means the fallback below never actually reaches `wholeCheckMessage(for:)`'s `.unauthorized`
+    /// arm — every `.unauthorized` status, 401 or 403, is handled by one of the two checks above it.
     private static func wholeCheckMessage(advisoriesError: any Error, alertsError: any Error) -> String {
         let advisoriesStatus = unauthorizedStatus(for: advisoriesError)
         let alertsStatus = unauthorizedStatus(for: alertsError)
         if advisoriesStatus == 401 || alertsStatus == 401 {
             return "Your GitHub token doesn't have permission to read this repository's security advisories and Dependabot alerts. Recreate it with Repository security advisories: Read and Dependabot alerts: Read."
         }
-        if advisoriesStatus == 403, alertsStatus == 403 {
+        if advisoriesStatus == 403 || alertsStatus == 403 {
             return "GitHub denied access to this repository's security advisories and Dependabot alerts. This can mean the token is missing Repository security advisories: Read or Dependabot alerts: Read, or that one or both features simply aren't enabled for this repository."
         }
         return wholeCheckMessage(for: advisoriesError)

--- a/Sources/AnglesiteCore/SecurityReportsModel.swift
+++ b/Sources/AnglesiteCore/SecurityReportsModel.swift
@@ -109,10 +109,8 @@ public final class SecurityReportsModel {
         switch (advisoriesError, alertsError) {
         case (nil, nil):
             return nil
-        case (.some(let error), .some):
-            // Both halves failed, so a shared cause (invalid token, offline) is the likely one and
-            // the whole-check message — including its token remedy — is accurate again.
-            return wholeCheckMessage(for: error)
+        case (.some(let advisoriesErr), .some(let alertsErr)):
+            return wholeCheckMessage(advisoriesError: advisoriesErr, alertsError: alertsErr)
         case (.some(let error), nil):
             return "Couldn't check this repository's security advisories (\(reason(for: error))). Its open Dependabot alerts are still shown."
         case (nil, .some(let error)):
@@ -120,6 +118,9 @@ public final class SecurityReportsModel {
         }
     }
 
+    /// The both-failed message when the two halves' errors don't share an unambiguous cause.
+    /// `message(advisoriesError:alertsError:)` routes the (401-involved) and (403, 403) cases to
+    /// `wholeCheckMessage(advisoriesError:alertsError:)` before falling back to this.
     private static func wholeCheckMessage(for error: any Error) -> String {
         guard let apiError = error as? GitHubRepoAPIError else {
             return "Couldn't check this repository's security reports."
@@ -136,6 +137,33 @@ public final class SecurityReportsModel {
         case .malformedResponse, .nameAlreadyExists:
             return "GitHub returned an unexpected response."
         }
+    }
+
+    /// The both-halves-failed message. A 401 on either half means the token itself is invalid —
+    /// an unambiguous shared cause worth sending the user to Settings for regardless of the other
+    /// half's status. A 403 on *both* halves is not that: `openDependabotAlerts` 403s whenever
+    /// Dependabot alerts are simply off for the repo (see `recheck`'s doc comment), and advisories
+    /// can 403 on its own repo-config grounds too — two 403s don't establish the token is at
+    /// fault, so this doesn't send the user to recreate one that may already be correctly scoped.
+    private static func wholeCheckMessage(advisoriesError: any Error, alertsError: any Error) -> String {
+        let advisoriesStatus = unauthorizedStatus(for: advisoriesError)
+        let alertsStatus = unauthorizedStatus(for: alertsError)
+        if advisoriesStatus == 401 || alertsStatus == 401 {
+            return "Your GitHub token doesn't have permission to read this repository's security advisories and Dependabot alerts. Recreate it with Repository security advisories: Read and Dependabot alerts: Read."
+        }
+        if advisoriesStatus == 403, alertsStatus == 403 {
+            return "GitHub denied access to this repository's security advisories and Dependabot alerts. This can mean the token is missing Repository security advisories: Read or Dependabot alerts: Read, or that one or both features simply aren't enabled for this repository."
+        }
+        return wholeCheckMessage(for: advisoriesError)
+    }
+
+    /// The HTTP status behind a `.unauthorized` failure, or `nil` for any other error (including
+    /// other `GitHubRepoAPIError` cases).
+    private static func unauthorizedStatus(for error: any Error) -> Int? {
+        guard let apiError = error as? GitHubRepoAPIError, case .unauthorized(let status) = apiError else {
+            return nil
+        }
+        return status
     }
 
     /// A short parenthetical cause, for the half-failed messages above.

--- a/Tests/AnglesiteAppTests/PlistEditorModelSecurityReportsTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelSecurityReportsTests.swift
@@ -242,7 +242,7 @@ struct PlistEditorModelSecurityReportsTests {
         // Reads succeed (so readiness lands on .needsPVR); only the write is forbidden — exactly
         // what a token without repo admin looks like.
         let model = try makeModel(config: "SECURITY_CONTACT=a@example.com\n",
-                                  repoSecurity: FakeRepoSecurity(pvr: false, writeFailure: .unauthorized))
+                                  repoSecurity: FakeRepoSecurity(pvr: false, writeFailure: .unauthorized(status: 403)))
         await model.load()
         await model.refreshRepoSecurityState()
         #expect(model.securityReportingReadiness == .needsPVR)

--- a/Tests/AnglesiteAppTests/PlistEditorModelSecurityReportsTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelSecurityReportsTests.swift
@@ -57,7 +57,8 @@ struct PlistEditorModelSecurityReportsTests {
         config: String? = nil,
         remote: String = "https://github.com/acme/site.git\n",
         repoSecurity: any RepoSecurityReading & RepoSecurityWriting = FakeRepoSecurity(),
-        token: String? = "tok"
+        token: String? = "tok",
+        gitRunner: BackupCommand.GitRunner? = nil
     ) throws -> PlistEditorModel {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("PlistEditorModelSecurityReportsTests-\(UUID().uuidString)")
@@ -70,7 +71,7 @@ struct PlistEditorModelSecurityReportsTests {
             websiteTitle: "Test Site",
             sourceDirectory: directory,
             repoSecurity: repoSecurity,
-            gitRunner: { _, _ in ProcessSupervisor.RunResult(stdout: remote, stderr: "", exitCode: 0) },
+            gitRunner: gitRunner ?? { _, _ in ProcessSupervisor.RunResult(stdout: remote, stderr: "", exitCode: 0) },
             githubToken: { token })
     }
 
@@ -342,6 +343,40 @@ struct PlistEditorModelSecurityReportsTests {
 
         #expect(await fake.enableCalls == 1)
         #expect(model.securityReportingReadiness == .alreadyConfigured)
+    }
+
+    /// Counts `gitRunner` invocations so a coalescing test can assert the subprocess spawned
+    /// once, not once per caller. An actor because the runner closure is `@Sendable` and callers
+    /// race concurrently.
+    actor CallCountingGitRunner {
+        private(set) var callCount = 0
+        private let result: ProcessSupervisor.RunResult
+        init(result: ProcessSupervisor.RunResult) { self.result = result }
+        func run(_ directory: URL, _ arguments: [String]) -> ProcessSupervisor.RunResult {
+            callCount += 1
+            return result
+        }
+    }
+
+    /// `PlistEditorView`'s `.task { await model.refreshRepoSecurityState() }` and
+    /// `.task { await model.refreshSecurityReports() }` start together on every site open; both
+    /// resolve the same git `origin` remote. Without coalescing in `currentRemoteRepo()`, that's
+    /// two `git remote get-url origin` spawns for one answer (#1312).
+    @Test("two concurrent refreshes share one git-remote resolution, not two")
+    func concurrentRefreshesCoalesceGitRemoteResolution() async throws {
+        let counter = CallCountingGitRunner(
+            result: ProcessSupervisor.RunResult(stdout: "https://github.com/acme/site.git\n", stderr: "", exitCode: 0))
+        let model = try makeModel(
+            config: "SECURITY_CONTACT=a@example.com\n",
+            gitRunner: { url, arguments in await counter.run(url, arguments) })
+        await model.load()
+
+        async let first: Void = model.refreshRepoSecurityState()
+        async let second: Void = model.refreshSecurityReports()
+        _ = await (first, second)
+
+        #expect(await counter.callCount == 1)
+        #expect(model.securityReportingRepo?.owner == "acme")
     }
 
     @Test("a partial adopt failure (PVR enabled, save fails) still reports .ready, not .needsPVR")

--- a/Tests/AnglesiteCoreTests/HTTPGitHubClientTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPGitHubClientTests.swift
@@ -37,7 +37,7 @@ struct HTTPGitHubClientTests {
     @Test("a 401 maps to .unauthorized")
     func unauthorized() async {
         let client = HTTPGitHubClient(transport: Self.transport(status: 401, json: #"{"message":"Bad credentials"}"#))
-        await #expect(throws: GitHubRepoAPIError.unauthorized) {
+        await #expect(throws: GitHubRepoAPIError.unauthorized(status: 401)) {
             _ = try await client.createRepo(name: "site", isPrivate: true, token: "bad")
         }
     }
@@ -45,7 +45,7 @@ struct HTTPGitHubClientTests {
     @Test("a 403 also maps to .unauthorized")
     func forbidden() async {
         let client = HTTPGitHubClient(transport: Self.transport(status: 403, json: #"{"message":"Forbidden"}"#))
-        await #expect(throws: GitHubRepoAPIError.unauthorized) {
+        await #expect(throws: GitHubRepoAPIError.unauthorized(status: 403)) {
             _ = try await client.createRepo(name: "site", isPrivate: true, token: "scoped-wrong")
         }
     }
@@ -172,7 +172,7 @@ struct HTTPGitHubClientTests {
     func enablePVRWithoutAdmin() async {
         let client = HTTPGitHubClient(transport: Self.transport(
             status: 403, json: #"{"message":"Must have admin rights to Repository."}"#))
-        await #expect(throws: GitHubRepoAPIError.unauthorized) {
+        await #expect(throws: GitHubRepoAPIError.unauthorized(status: 403)) {
             try await client.enablePrivateVulnerabilityReporting(owner: "acme", name: "site", token: "tok")
         }
     }
@@ -247,7 +247,7 @@ struct HTTPGitHubClientTests {
     @Test("a 401 on advisories maps to .unauthorized")
     func openSecurityAdvisoriesUnauthorized() async {
         let client = HTTPGitHubClient(transport: Self.transport(status: 401, json: #"{"message":"Bad credentials"}"#))
-        await #expect(throws: GitHubRepoAPIError.unauthorized) {
+        await #expect(throws: GitHubRepoAPIError.unauthorized(status: 401)) {
             _ = try await client.openSecurityAdvisories(owner: "acme", name: "site", token: "bad")
         }
     }
@@ -260,7 +260,7 @@ struct HTTPGitHubClientTests {
     @Test("a 403 on alerts (Dependabot disabled for the repo) also maps to .unauthorized")
     func openDependabotAlertsForbidden() async {
         let client = HTTPGitHubClient(transport: Self.transport(status: 403, json: #"{"message":"Dependabot alerts are disabled"}"#))
-        await #expect(throws: GitHubRepoAPIError.unauthorized) {
+        await #expect(throws: GitHubRepoAPIError.unauthorized(status: 403)) {
             _ = try await client.openDependabotAlerts(owner: "acme", name: "site", token: "tok")
         }
     }

--- a/Tests/AnglesiteCoreTests/SecurityReportsModelTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityReportsModelTests.swift
@@ -167,6 +167,20 @@ struct SecurityReportsModelTests {
         #expect(model.lastError?.contains("Recreate it") == true)
     }
 
+    /// A lone 403 paired with an *unrelated* failure on the other half (not itself an
+    /// `.unauthorized`) is the asymmetric case the (403, 403) test above doesn't cover: the 403
+    /// half can still just mean a repo-config setting, so the pairing must not fall through to
+    /// `wholeCheckMessage(for:)`'s status-blind `.unauthorized` arm and claim the token is at
+    /// fault (#1312).
+    @Test("a 403 on one half paired with an unrelated failure on the other does not recommend recreating the token")
+    func lone403WithUnrelatedFailureDoesNotRecommendTokenRecreation() async {
+        let model = SecurityReportsModel(reader: FakeReader(
+            advisoriesFailure: .unauthorized(status: 403), alertsFailure: .network))
+        await model.recheck(repo: Self.repo, token: "tok").value
+        #expect(model.lastError?.contains("Recreate it") == false)
+        #expect(model.lastError != nil)
+    }
+
     @Test("recheck cancels a prior in-flight run and discards its stale result")
     func recheckCancelsPrior() async {
         // The first call's fetch is slow and returns data distinguishable from the second

--- a/Tests/AnglesiteCoreTests/SecurityReportsModelTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityReportsModelTests.swift
@@ -105,7 +105,7 @@ struct SecurityReportsModelTests {
 
     @Test("a failed check sets lastError and leaves the lists empty")
     func failureSetsError() async {
-        let model = SecurityReportsModel(reader: FakeReader(failure: .unauthorized))
+        let model = SecurityReportsModel(reader: FakeReader(failure: .unauthorized(status: 401)))
         await model.recheck(repo: Self.repo, token: "tok").value
         #expect(model.lastError != nil)
         #expect(model.totalCount == 0)
@@ -118,7 +118,7 @@ struct SecurityReportsModelTests {
         // GitHub answers the Dependabot endpoint with 403 whenever alerts are disabled for the
         // repository — an ordinary setting, which must not take the advisories down with it.
         let model = SecurityReportsModel(reader: FakeReader(
-            advisories: [Self.highAdvisory], alerts: [Self.lowAlert], alertsFailure: .unauthorized))
+            advisories: [Self.highAdvisory], alerts: [Self.lowAlert], alertsFailure: .unauthorized(status: 403)))
         await model.recheck(repo: Self.repo, token: "tok").value
         #expect(model.openAdvisories == [Self.highAdvisory])
         #expect(model.openAlerts.isEmpty)
@@ -139,6 +139,32 @@ struct SecurityReportsModelTests {
         #expect(model.lastError != nil)
         #expect(model.lastCheckedAt != nil)
         #expect(!model.isRunning)
+    }
+
+    @Test("both halves failing with 401 sends the user to recreate their token")
+    func bothFailWith401RecommendsTokenRecreation() async {
+        let model = SecurityReportsModel(reader: FakeReader(failure: .unauthorized(status: 401)))
+        await model.recheck(repo: Self.repo, token: "tok").value
+        #expect(model.lastError?.contains("Recreate it") == true)
+    }
+
+    /// Both endpoints can 403 for unrelated repo-config reasons (e.g. Dependabot alerts are off
+    /// AND the token happens to lack advisories scope) — that pairing must not claim the token
+    /// itself needs recreating, since it may already be correctly scoped (#1312).
+    @Test("both halves failing with 403 does not claim the token needs recreating")
+    func bothFailWith403DoesNotRecommendTokenRecreation() async {
+        let model = SecurityReportsModel(reader: FakeReader(failure: .unauthorized(status: 403)))
+        await model.recheck(repo: Self.repo, token: "tok").value
+        #expect(model.lastError?.contains("Recreate it") == false)
+        #expect(model.lastError != nil)
+    }
+
+    @Test("a 401 on one half and a 403 on the other still recommends recreating the token")
+    func mixed401And403RecommendsTokenRecreation() async {
+        let model = SecurityReportsModel(reader: FakeReader(
+            advisoriesFailure: .unauthorized(status: 401), alertsFailure: .unauthorized(status: 403)))
+        await model.recheck(repo: Self.repo, token: "tok").value
+        #expect(model.lastError?.contains("Recreate it") == true)
     }
 
     @Test("recheck cancels a prior in-flight run and discards its stale result")


### PR DESCRIPTION
Closes #1312

## Summary

- `GitHubRepoAPIError.unauthorized` now carries the HTTP status (401 vs 403). `SecurityReportsModel`'s both-halves-failed message only tells the user to recreate their GitHub token when a real 401 is involved; two simultaneous 403s (e.g. Dependabot alerts disabled for the repo plus an unrelated advisories 403) now get a message that doesn't send the user to recreate a token that may already be correctly scoped.
- `PlistEditorModel.currentRemoteRepo()` now coalesces concurrent callers onto a single in-flight `git remote get-url origin` resolution, so `PlistEditorView`'s two `.task` modifiers (`refreshRepoSecurityState()` and `refreshSecurityReports()`), which start together on every site open, spawn the subprocess once instead of twice. The cache clears once the resolution completes, so a later explicit recheck (the "Check for Reports" button) still re-resolves rather than reusing a stale answer.

**Base branch note:** both fixes touch code introduced in #1304 (`SecurityReportsModel.swift`, the `PlistEditorView` `.task` pair), which hasn't merged to `main` yet — issue #1312 was filed from that PR's final review as deliberately-deferred follow-up work. This PR targets `claude/issue-975-2b5594` (#1304's branch) rather than `main` so it lands as part of the same feature once #1304 merges. One consequence: `ci.yml`/`codeql.yml` only trigger on `pull_request` against `main`, so no checks will report directly on this PR — merging it into `claude/issue-975-2b5594` will trigger a `synchronize` re-run on PR #1304 itself (whose base is `main`), which is where this diff actually gets CI coverage.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — the portable Linux target set (`AnglesiteSiteModelTests`, `AnglesiteQuickLookSupportTests`, `AnglesiteBridgeCoreTests`) passes (37/37). `AnglesiteCoreTests` (which holds `HTTPGitHubClientTests`/`SecurityReportsModelTests`, updated here) and `AnglesiteAppTests` (which holds `PlistEditorModelSecurityReportsTests`, also updated) are Darwin-only per `Package.swift`'s portable-target filter and could not run in this Linux session — needs a macOS run before merge (see base-branch note above for how that coverage actually arrives).
- [x] `swift build --package-path .` — the portable library targets, including the modified `AnglesiteCore`, build clean with no new warnings. `AnglesiteAppCore` (which holds the modified `PlistEditorModel.swift`) is Darwin-only and could not be built in this Linux session.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; no macOS/Xcode toolchain available in this session.
- [ ] Manual smoke: not performed — the Security Reports tab's both-failed banner text and the coalesced git-remote spawn are unverified in a running app.
