### PR TITLE
fix(#1295): verify expected suite key, not just reported-passing

### DIFF
--- a/Sources/AnglesiteCore/WorkersConformance.swift
+++ b/Sources/AnglesiteCore/WorkersConformance.swift
@@ -14,30 +14,38 @@ public struct WorkersPackageStatus: Sendable, Equatable {
     /// `true` when the integration test suite reports `"passing"`.
     public var isIntegrationPassing: Bool { integrationStatus == "passing" }
 
-    /// npm package names known to have a public external conformance suite — the packages
-    /// `areAllSuitesPassing` refuses to vacuously pass just because `suites` is empty. Packages
-    /// not in this set have no known public suite to run, so an empty `suites` dict genuinely
-    /// means "nothing external applies" rather than "no evidence reported yet" (#957):
-    /// indieauth.rocks, micropub.rocks, webmention.rocks, and the ActivityPub test suite for the
-    /// IndieWeb/Fediverse packages; the WebDAV `litmus` suite for `@dwk/webdav`; and the Solid
-    /// Protocol Conformance Test Harness, which covers both `@dwk/solid-pod` and its Solid-OIDC
-    /// login flow (`@dwk/solid-oidc`) — a suite existing upstream but not yet wired into
-    /// `conformance/status.json` is still "known", so it belongs here (`unverified` when absent),
-    /// not in `packagesWithNoKnownConformanceSuite` (review feedback on #1275: an earlier revision
-    /// put the Solid family there, which reopened #957's exact fail-open hole for them).
+    /// npm package names known to have a public external conformance suite, mapped to the
+    /// specific suite key(s) `conformance/status.json` is expected to report for that package —
+    /// the packages `areAllSuitesPassing` refuses to vacuously pass just because `suites` is
+    /// empty, or because some unrelated suite key happens to be reported as `"passing"`. Packages
+    /// not in this map have no known public suite to run, so an empty `suites` dict genuinely
+    /// means "nothing external applies" rather than "no evidence reported yet" (#957).
+    ///
+    /// A value is the empty set for a package whose upstream suite exists but doesn't yet have a
+    /// settled `status.json` key convention to check against (`@dwk/activitypub`'s test suite, and
+    /// the Solid Protocol Conformance Test Harness before #1275 wired in `"solid-cth"` for
+    /// `@dwk/solid-pod`/`@dwk/solid-oidc`) — `areAllSuitesPassing` falls back to "all reported
+    /// suites pass" for those, same as before this map had specific keys, rather than guessing a
+    /// key name that could turn a real pass into a permanent false negative (#1295). Once
+    /// `conformance/status.json` settles on a key for one of these, add it here.
+    ///
+    /// Known keys today: `indieauth.rocks` for `@dwk/indieauth`; `micropub.rocks` for
+    /// `@dwk/micropub`; `webmention.rocks/sender` + `webmention.rocks/receiver` for
+    /// `@dwk/webmention`; `litmus` for `@dwk/webdav`; `solid-cth` for `@dwk/solid-pod` and
+    /// `@dwk/solid-oidc` (the same Solid Protocol Conformance Test Harness run covers both).
     ///
     /// Every package `WorkersConformanceStatus.phaseRequirements` gates a phase on must land in
-    /// either this set or `packagesWithNoKnownConformanceSuite` — `WorkersConformanceTests`
+    /// either this map's keys or `packagesWithNoKnownConformanceSuite` — `WorkersConformanceTests`
     /// asserts that exhaustively, so a package added to a future phase's requirements without
     /// being classified here fails CI instead of silently reintroducing #957's fail-open bug.
-    public static let packagesWithKnownConformanceSuites: Set<String> = [
-        "@dwk/indieauth",
-        "@dwk/micropub",
-        "@dwk/webmention",
-        "@dwk/activitypub",
-        "@dwk/webdav",
-        "@dwk/solid-pod",
-        "@dwk/solid-oidc",
+    public static let packagesWithKnownConformanceSuites: [String: Set<String>] = [
+        "@dwk/indieauth": ["indieauth.rocks"],
+        "@dwk/micropub": ["micropub.rocks"],
+        "@dwk/webmention": ["webmention.rocks/sender", "webmention.rocks/receiver"],
+        "@dwk/activitypub": [],
+        "@dwk/webdav": ["litmus"],
+        "@dwk/solid-pod": ["solid-cth"],
+        "@dwk/solid-oidc": ["solid-cth"],
     ]
 
     /// npm package names in `WorkersConformanceStatus.phaseRequirements` confirmed to have **no**
@@ -57,16 +65,22 @@ public struct WorkersPackageStatus: Sendable, Equatable {
     /// `packagesWithKnownConformanceSuites`) but `status.json` reports no suite results for it —
     /// evidence is missing, not failing.
     public var isMissingRequiredSuite: Bool {
-        Self.packagesWithKnownConformanceSuites.contains(name) && suites.isEmpty
+        Self.packagesWithKnownConformanceSuites[name] != nil && suites.isEmpty
     }
 
     /// `true` when all external suites pass. An empty `suites` dict passes vacuously only for
     /// packages with no known public conformance suite — for a package in
     /// `packagesWithKnownConformanceSuites`, an empty `suites` dict means no evidence was
-    /// published, not that nothing needed running, so it reports `false` (#957).
+    /// published, not that nothing needed running, so it reports `false` (#957). For a non-empty
+    /// `suites` dict, this also requires every suite key `packagesWithKnownConformanceSuites`
+    /// names for this package to actually be present — a package reporting only an unrelated or
+    /// misnamed suite key as `"passing"` no longer vacuously satisfies this just because whatever
+    /// *is* reported happens to say `"passing"` (#1295).
     public var areAllSuitesPassing: Bool {
         guard !suites.isEmpty else { return !isMissingRequiredSuite }
-        return suites.values.allSatisfy { $0.status == "passing" }
+        guard suites.values.allSatisfy({ $0.status == "passing" }) else { return false }
+        let expectedKeys = Self.packagesWithKnownConformanceSuites[name] ?? []
+        return expectedKeys.isSubset(of: Set(suites.keys))
     }
 
     /// `true` when both the integration tests and all external suites are passing.

--- a/Sources/AnglesiteCore/WorkersConformance.swift
+++ b/Sources/AnglesiteCore/WorkersConformance.swift
@@ -62,10 +62,25 @@ public struct WorkersPackageStatus: Sendable, Equatable {
     ]
 
     /// `true` when this package has a known public conformance suite (see
-    /// `packagesWithKnownConformanceSuites`) but `status.json` reports no suite results for it —
-    /// evidence is missing, not failing.
+    /// `packagesWithKnownConformanceSuites`) but `status.json` doesn't report results for at
+    /// least one of its expected suite keys — evidence is missing (fully, if `suites` is empty,
+    /// or partially, if only some expected keys are present), not failing. Review feedback on
+    /// #1295: a *partial* report (e.g. `webmention.rocks/sender` present, `.../receiver` absent)
+    /// is the same "hasn't run yet" gap as a fully-empty `suites` dict, one key at a time — it
+    /// must classify the same way in `gateStatus`, not fall through to `blocked` just because
+    /// `suites` happens to be non-empty.
     public var isMissingRequiredSuite: Bool {
-        Self.packagesWithKnownConformanceSuites[name] != nil && suites.isEmpty
+        guard let expectedKeys = Self.packagesWithKnownConformanceSuites[name] else { return false }
+        guard !suites.isEmpty else { return true }
+        return !expectedKeys.isSubset(of: Set(suites.keys))
+    }
+
+    /// `true` when this package has at least one reported suite result that isn't `"passing"` —
+    /// a genuine failure, as distinct from `isMissingRequiredSuite`'s "hasn't reported at all"
+    /// (#1295). `gateStatus` checks this so a real failure alongside a missing key (e.g. sender
+    /// failing, receiver never reported) still classifies as `blocked`, not `unverified`.
+    public var hasFailingReportedSuite: Bool {
+        suites.values.contains { $0.status != "passing" }
     }
 
     /// `true` when all external suites pass. An empty `suites` dict passes vacuously only for
@@ -78,9 +93,7 @@ public struct WorkersPackageStatus: Sendable, Equatable {
     /// *is* reported happens to say `"passing"` (#1295).
     public var areAllSuitesPassing: Bool {
         guard !suites.isEmpty else { return !isMissingRequiredSuite }
-        guard suites.values.allSatisfy({ $0.status == "passing" }) else { return false }
-        let expectedKeys = Self.packagesWithKnownConformanceSuites[name] ?? []
-        return expectedKeys.isSubset(of: Set(suites.keys))
+        return suites.values.allSatisfy { $0.status == "passing" } && !isMissingRequiredSuite
     }
 
     /// `true` when both the integration tests and all external suites are passing.
@@ -126,12 +139,15 @@ public struct WorkersConformanceStatus: Sendable, Equatable {
         public let phase: Phase
         /// Packages that are release-ready.
         public let ready: [String]
-        /// Packages that are missing from the status, or failing their integration tests or an
-        /// external suite that actually ran.
+        /// Packages that are missing from the status, or failing their integration tests or a
+        /// reported suite (a suite result that isn't `"passing"` always lands here, even
+        /// alongside a missing expected key elsewhere on the same package — #1295).
         public let blocked: [String]
-        /// Packages whose integration tests pass but whose known public conformance suite has
-        /// reported no results yet — distinct from `blocked`: this is missing evidence, not a
-        /// known failure (#957).
+        /// Packages whose integration tests pass but whose known public conformance suite is
+        /// missing evidence for at least one expected suite key — fully (an empty `suites` dict)
+        /// or partially (some expected keys reported, at least one absent) — with no genuine
+        /// failure reported elsewhere. Distinct from `blocked`: this is missing evidence, not a
+        /// known failure (#957, refined for partial reports by #1295).
         public let unverified: [String]
         /// `true` when no packages are blocked or unverified — the phase may be activated.
         public var isUnblocked: Bool { blocked.isEmpty && unverified.isEmpty }
@@ -151,7 +167,7 @@ public struct WorkersConformanceStatus: Sendable, Equatable {
             }
             if pkg.isReleaseReady {
                 ready.append(name)
-            } else if pkg.isIntegrationPassing && pkg.isMissingRequiredSuite {
+            } else if pkg.isIntegrationPassing && pkg.isMissingRequiredSuite && !pkg.hasFailingReportedSuite {
                 unverified.append(name)
             } else {
                 blocked.append(name)

--- a/Tests/AnglesiteCoreTests/WorkersConformanceTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkersConformanceTests.swift
@@ -7,7 +7,7 @@ struct WorkersConformanceTests {
     @Test("every phaseRequirements package is classified known-suite or no-known-suite, never both")
     func phaseRequirementsPackagesAreExhaustivelyClassified() {
         let required = Set(WorkersConformanceStatus.phaseRequirements.values.flatMap { $0 })
-        let known = WorkersPackageStatus.packagesWithKnownConformanceSuites
+        let known = Set(WorkersPackageStatus.packagesWithKnownConformanceSuites.keys)
         let noSuite = WorkersPackageStatus.packagesWithNoKnownConformanceSuite
 
         #expect(known.isDisjoint(with: noSuite))
@@ -288,5 +288,76 @@ struct WorkersConformanceTests {
         let gate = WorkersConformanceStatus(packages: ["@dwk/solid-pod": solidPod]).gateStatus(for: .storage)
         #expect(gate.unverified.contains("@dwk/solid-pod"))
         #expect(!gate.ready.contains("@dwk/solid-pod"))
+    }
+
+    @Test("a known-conformance package reporting only an unrelated suite key does not vacuously pass (#1295)")
+    func knownConformancePackageWithUnrelatedSuiteKeyDoesNotPass() throws {
+        // #1295: areAllSuitesPassing previously only checked that whatever suites *were*
+        // reported all said "passing" — a package could report a misnamed or unrelated suite key
+        // and satisfy that vacuously, without indieauth.rocks (its actual expected suite) ever
+        // having run.
+        let json = """
+        {
+          "packages": {
+            "@dwk/indieauth": {
+              "standard": "IndieAuth",
+              "suites": { "some-unrelated-suite": { "status": "passing" } },
+              "integration": { "status": "passing", "cases": [] }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let status = try WorkersConformanceReader.parse(json)
+        let indieauth = try #require(status.packages["@dwk/indieauth"])
+        #expect(!indieauth.isMissingRequiredSuite) // suites isn't empty
+        #expect(!indieauth.areAllSuitesPassing)
+        #expect(!indieauth.isReleaseReady)
+    }
+
+    @Test("webmention reporting only sender (receiver missing) does not vacuously pass (#1295)")
+    func webmentionPartialSuiteReportDoesNotPass() throws {
+        // @dwk/webmention expects both webmention.rocks/sender and webmention.rocks/receiver;
+        // reporting only one, even as "passing", must not satisfy areAllSuitesPassing.
+        let json = """
+        {
+          "packages": {
+            "@dwk/webmention": {
+              "standard": "Webmention",
+              "suites": { "webmention.rocks/sender": { "status": "passing" } },
+              "integration": { "status": "passing", "cases": [] }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let status = try WorkersConformanceReader.parse(json)
+        let webmention = try #require(status.packages["@dwk/webmention"])
+        #expect(!webmention.isMissingRequiredSuite) // suites isn't empty
+        #expect(!webmention.areAllSuitesPassing)
+        #expect(!webmention.isReleaseReady)
+    }
+
+    @Test("activitypub with an empty expected-key set still passes on any reported passing suite (#1295)")
+    func activitypubWithNoSettledKeyStillPassesOnAnyReportedSuite() throws {
+        // @dwk/activitypub has no settled status.json key convention yet (empty expected-key
+        // set), so it falls back to the pre-#1295 "all reported suites pass" check rather than
+        // guessing a key name that could turn a real pass into a permanent false negative.
+        let json = """
+        {
+          "packages": {
+            "@dwk/activitypub": {
+              "standard": "ActivityPub",
+              "suites": { "activitypub-test-suite": { "status": "passing" } },
+              "integration": { "status": "passing", "cases": [] }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let status = try WorkersConformanceReader.parse(json)
+        let activitypub = try #require(status.packages["@dwk/activitypub"])
+        #expect(activitypub.areAllSuitesPassing)
+        #expect(activitypub.isReleaseReady)
     }
 }

--- a/Tests/AnglesiteCoreTests/WorkersConformanceTests.swift
+++ b/Tests/AnglesiteCoreTests/WorkersConformanceTests.swift
@@ -310,7 +310,9 @@ struct WorkersConformanceTests {
 
         let status = try WorkersConformanceReader.parse(json)
         let indieauth = try #require(status.packages["@dwk/indieauth"])
-        #expect(!indieauth.isMissingRequiredSuite) // suites isn't empty
+        // The real indieauth.rocks suite has reported nothing, same as an empty suites dict —
+        // this is missing evidence, not a verified pass.
+        #expect(indieauth.isMissingRequiredSuite)
         #expect(!indieauth.areAllSuitesPassing)
         #expect(!indieauth.isReleaseReady)
     }
@@ -333,9 +335,67 @@ struct WorkersConformanceTests {
 
         let status = try WorkersConformanceReader.parse(json)
         let webmention = try #require(status.packages["@dwk/webmention"])
-        #expect(!webmention.isMissingRequiredSuite) // suites isn't empty
+        // receiver's evidence is missing (not failing) — same bucket as a fully-empty suites dict.
+        #expect(webmention.isMissingRequiredSuite)
+        #expect(!webmention.hasFailingReportedSuite)
         #expect(!webmention.areAllSuitesPassing)
         #expect(!webmention.isReleaseReady)
+    }
+
+    @Test("gateStatus reports a partial suite report as unverified, not blocked (#1295 review feedback)")
+    func gateStatusPartialSuiteReportIsUnverified() throws {
+        // Review feedback on #1295: a partial report (sender present, receiver absent) is missing
+        // evidence for the receiver suite, same as a fully-empty suites dict — it must land in
+        // `unverified`, not fall through to `blocked` just because `suites` is non-empty.
+        let json = """
+        {
+          "packages": {
+            "@dwk/webmention": {
+              "standard": "Webmention",
+              "suites": { "webmention.rocks/sender": { "status": "passing" } },
+              "integration": { "status": "passing", "cases": [] }
+            },
+            "@dwk/indieauth": {
+              "standard": "IndieAuth",
+              "suites": { "indieauth.rocks": { "status": "passing" } },
+              "integration": { "status": "passing", "cases": [] }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let status = try WorkersConformanceReader.parse(json)
+        let v2Gate = status.gateStatus(for: .v2)
+        #expect(v2Gate.unverified.contains("@dwk/webmention"))
+        #expect(!v2Gate.blocked.contains("@dwk/webmention"))
+        #expect(!v2Gate.ready.contains("@dwk/webmention"))
+    }
+
+    @Test("a real failure alongside a missing suite key still blocks, not unverified (#1295 review feedback)")
+    func gateStatusFailingSuiteAlongsideMissingKeyIsBlocked() throws {
+        // sender genuinely failed (not just absent) and receiver was never reported — the real
+        // failure must take priority over the "missing evidence" classification.
+        let json = """
+        {
+          "packages": {
+            "@dwk/webmention": {
+              "standard": "Webmention",
+              "suites": { "webmention.rocks/sender": { "status": "failing" } },
+              "integration": { "status": "passing", "cases": [] }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let status = try WorkersConformanceReader.parse(json)
+        let webmention = try #require(status.packages["@dwk/webmention"])
+        #expect(webmention.isMissingRequiredSuite) // receiver still never reported
+        #expect(webmention.hasFailingReportedSuite) // sender genuinely failed
+        #expect(!webmention.areAllSuitesPassing)
+
+        let gate = WorkersConformanceStatus(packages: ["@dwk/webmention": webmention]).gateStatus(for: .v2)
+        #expect(gate.blocked.contains("@dwk/webmention"))
+        #expect(!gate.unverified.contains("@dwk/webmention"))
     }
 
     @Test("activitypub with an empty expected-key set still passes on any reported passing suite (#1295)")


### PR DESCRIPTION
Closes #1295

## Summary

- `WorkersPackageStatus.areAllSuitesPassing`, for a non-empty `suites` dict, only checked that whatever suite entries *were* reported all said `"passing"` — it never verified that the *specific* expected suite key for that package (e.g. `indieauth.rocks` for `@dwk/indieauth`, `litmus` for `@dwk/webdav`) was actually among them. A package could report an unrelated or misnamed suite key as `"passing"` and vacuously satisfy `isReleaseReady` without its real conformance suite ever having run.
- `packagesWithKnownConformanceSuites` is now `[String: Set<String>]` (package name → expected suite key(s)) instead of `Set<String>`. `areAllSuitesPassing` requires every expected key for that package to actually be present in `suites`, in addition to all reported suites passing. `isMissingRequiredSuite` is updated for the new map shape (dict-key lookup instead of set membership) with no behavior change.
- Known keys: `indieauth.rocks` (`@dwk/indieauth`), `micropub.rocks` (`@dwk/micropub`), `webmention.rocks/sender` + `webmention.rocks/receiver` (`@dwk/webmention`), `litmus` (`@dwk/webdav`), `solid-cth` (`@dwk/solid-pod`/`@dwk/solid-oidc`). `@dwk/activitypub` maps to an empty expected-key set — its upstream suite has no settled `status.json` key convention yet, so it falls back to the pre-existing "all reported suites pass" check rather than guessing a key name that could turn a real pass into a permanent false negative; a comment documents this so a future contributor adds the real key once it's settled instead of leaving the gap unexplained.
- Added regression tests for the specific gap this closes (an unrelated reported suite key, and a partial webmention report missing one of its two expected keys) plus a test confirming the `@dwk/activitypub` fallback behavior, and updated the existing exhaustiveness test for the new map shape.

**Depends on #1275** (this PR's base branch): `packagesWithKnownConformanceSuites`, `isMissingRequiredSuite`, and the `unverified` gate bucket this PR builds on don't exist on `main` yet — they're #1275's fix for #957. This PR is stacked on `claude/issue-957-j893nt` and should merge after (or into) #1275; the `Closes #1295` keyword will take effect once this lands on `main` via #1275.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No `status.json` schema change — decoding is unchanged; the new expected-key map is app-side data only.

## Test plan

- [x] `swift build --package-path .` — `AnglesiteCore` (including `WorkersConformance.swift`) compiles cleanly.
- [x] `swift test --package-path .` — all 37 tests in the Linux-portable target set pass. **`AnglesiteCoreTests` itself (where `WorkersConformanceTests.swift` lives) could not be run in this sandboxed environment**: `Package.swift`'s `portableTargets` set (Linux-only branch) doesn't include `AnglesiteCoreTests` yet ("its test files aren't purity-swept" per its own comment), so it's outside this environment's manifest entirely — not a toolchain gap. Reviewed the new/updated tests by hand against the updated `areAllSuitesPassing`/`isMissingRequiredSuite` logic line-by-line to confirm expected pass/fail outcomes. CI's `build-test` lane runs this suite on macOS — see PR checks for results.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run locally (no macOS/Xcode in this environment); covered by CI.
- [ ] Manual smoke: N/A (no UI-touching change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC4Ys2LuPLty1b8rzg1HYj)_