### PR TITLE
feat(deploy): enable Cloudflare Markdown for Agents (#1247)

### DIFF
--- a/Sources/AnglesiteApp/ContentLicensingTab.swift
+++ b/Sources/AnglesiteApp/ContentLicensingTab.swift
@@ -325,6 +325,25 @@ struct ContentLicensingTab: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Toggle(
+                    "Serve a lightweight version of your pages to AI assistants",
+                    isOn: Binding(
+                        get: { model.markdownForAgentsEnabled },
+                        set: { newValue in Task { await model.setMarkdownForAgentsEnabled(newValue) } }))
+                    .toggleStyle(.switch)
+                Text(model.licensingPolicy.usage.blockAICrawlers
+                     ? "Applies only to AI agents you haven't refused above — one you've blocked never requests your pages in the first place, so this never overrides that refusal."
+                     : "When an AI assistant asks for a page, Cloudflare serves it a markdown version instead of the full HTML — a fraction of the tokens your full page costs. Human visitors see no change. Takes effect on your next deploy to a custom domain.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                if let markdownForAgentsError = model.markdownForAgentsError {
+                    Text(markdownForAgentsError)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                }
+            }
         }
     }
 

--- a/Sources/AnglesiteApp/DeployDrawerView.swift
+++ b/Sources/AnglesiteApp/DeployDrawerView.swift
@@ -75,6 +75,14 @@ struct DeployDrawerView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+                // Markdown for Agents (#1247) requires a Cloudflare Pro plan or higher — surfaced
+                // so a Free-plan owner who turned the toggle on learns it isn't actually taking
+                // effect, instead of only finding out by reading the debug log.
+                if case .succeeded = model.phase, case .failed(let hostname) = model.markdownForAgentsStatus {
+                    Text("Couldn't enable Markdown for Agents for \(hostname) — often a Cloudflare plan limit (Pro plan or higher). See the debug log for details.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
                 // First-publish nudge (#1180): shown exactly once, on the deploy that flips
                 // `.site-config`'s CF_WORKER_DEPLOYED from unset to set. `wasFirstDeploy`
                 // structurally cannot be true again for this site afterward, so this line cannot

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -54,6 +54,10 @@ final class DeployModel {
     /// as a Workers Custom Domain (#1077), captured from the deploy's `onDomainAttach` observer.
     /// `nil` before any deploy has completed this session; only ever set on a `.succeeded` deploy.
     private(set) var domainAttachStatus: CustomDomainAttachCommand.Result?
+    /// Outcome of applying the Markdown for Agents zone setting (#1247), captured from the
+    /// deploy's `onMarkdownForAgents` observer. `nil` before any deploy has completed this
+    /// session, or when the deploy never confirmed a custom domain (no zone to apply it to).
+    private(set) var markdownForAgentsStatus: MarkdownForAgentsCommand.Result?
     /// Whether the deploy currently in flight (or most recently completed) is this site's first
     /// successful publish — captured from `.site-config`'s `CF_WORKER_DEPLOYED` *before* the
     /// deploy pipeline runs (#1180), so it reflects the site's history going into this attempt,
@@ -579,6 +583,7 @@ final class DeployModel {
                 tokenSource: command.tokenSource,
                 workerScriptNamesSource: command.workerScriptNamesSource,
                 customDomainAttachCommand: command.customDomainAttachCommand,
+                markdownForAgentsCommand: command.markdownForAgentsCommand,
                 executor: ContainerDeployExecutor(
                     control: cc.control,
                     siteID: cc.siteID,
@@ -688,6 +693,9 @@ final class DeployModel {
                     // or removed, this needs an explicit wait instead of relying on scheduling.
                     onDomainAttach: { [weak self] outcome in
                         Task { @MainActor in self?.domainAttachStatus = outcome }
+                    },
+                    onMarkdownForAgents: { [weak self] outcome in
+                        Task { @MainActor in self?.markdownForAgentsStatus = outcome }
                     },
                     onProgress: { [weak self] progress in
                         Task { @MainActor in

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1029,6 +1029,9 @@
         }
       }
     },
+    "Couldn't enable Markdown for Agents for %@ — often a Cloudflare plan limit (Pro plan or higher). See the debug log for details." : {
+
+    },
     "Couldn't finish setup" : {
 
     },

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1053,6 +1053,9 @@
     "Couldn't save the worker change: %@" : {
 
     },
+    "Couldn't save this change: %@" : {
+
+    },
     "Couldn't update this file — see the debug log for details." : {
 
     },
@@ -2766,6 +2769,9 @@
 
     },
     "Send to Back" : {
+
+    },
+    "Serve a lightweight version of your pages to AI assistants" : {
 
     },
     "Server" : {

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -61,6 +61,12 @@ final class PlistEditorModel {
     private(set) var licensingError: String?
     private(set) var isSavingLicensing = false
     private(set) var licensingLoadFailed = false
+    /// Whether Markdown for Agents (#1247) is enabled for this site's deploys — `Config/`-backed
+    /// (`SiteSettings.markdownForAgentsDisabled`), not part of `licensingPolicy`'s git-tracked
+    /// `licensing.json`: it's a Cloudflare zone setting applied at deploy time, not generated
+    /// content. Defaults to `true` (enabled), matching the feature's default-on ask.
+    private(set) var markdownForAgentsEnabled = true
+    private(set) var markdownForAgentsError: String?
     var mtaStsSettings = MTAStsPolicyAsset.Settings()
     private(set) var savedMtaStsSettings = MTAStsPolicyAsset.Settings()
     private(set) var mtaStsError: String?
@@ -247,6 +253,13 @@ final class PlistEditorModel {
                 licensingError = "Couldn't load existing licensing.json — it may be corrupted or hand-edited. Fix it externally or your next save will discard it. (\(error.localizedDescription))"
                 licensingLoadFailed = true
             }
+            if let configDirectory {
+                let settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+                markdownForAgentsEnabled = !(settings.markdownForAgentsDisabled ?? false)
+            } else {
+                markdownForAgentsEnabled = true
+            }
+            markdownForAgentsError = nil
             let lang = SiteLanguageAsset.parseSettings(from: config)
             langSettings = lang
             savedLangSettings = lang
@@ -924,6 +937,23 @@ final class PlistEditorModel {
             }
         }
         await onActiveWorkersChanged(settings)
+    }
+
+    /// Persists the Markdown for Agents opt-out immediately (#1247) — read-modify-write of
+    /// `Config/settings.plist`, same immediate-persist contract as `setWorkerActive`: this is
+    /// app-owned deploy-mechanics state, not part of the tab's dirty-tracked licensing save.
+    func setMarkdownForAgentsEnabled(_ enabled: Bool) async {
+        guard let configDirectory else { return }
+        let store = SiteConfigStore(configDirectory: configDirectory)
+        var settings = (try? await store.load()) ?? SiteSettings()
+        settings.markdownForAgentsDisabled = enabled ? nil : true
+        do {
+            try await store.save(settings)
+            markdownForAgentsEnabled = enabled
+            markdownForAgentsError = nil
+        } catch {
+            markdownForAgentsError = String(localized: "Couldn't save this change: \(error.localizedDescription)")
+        }
     }
 
     /// Dashboard deep-links are enabled only after the first deploy that included a worker

--- a/Sources/AnglesiteCore/CloudflareWriting.swift
+++ b/Sources/AnglesiteCore/CloudflareWriting.swift
@@ -38,6 +38,15 @@ public protocol CloudflareWriting: Sendable {
     func attachWorkersCustomDomain(
         hostname: String, workerScriptName: String, apiToken: String
     ) async throws -> CustomDomainAttachResult
+    /// Toggles Markdown for Agents (`content_converter`) for the zone owning `hostname` — the
+    /// edge feature that serves an HTML→Markdown-converted response to requests carrying
+    /// `Accept: text/markdown` (#1247). Resolves the zone from `hostname` itself, mirroring
+    /// `attachWorkersCustomDomain`, since callers (post-deploy, after a custom domain is
+    /// confirmed attached) only have the hostname on hand. Returns `false` when the zone isn't
+    /// visible to this token yet — a transient condition callers should treat as best-effort
+    /// skip, not an error.
+    @discardableResult
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool
 }
 
 /// Payload for creating a DNS record via the Cloudflare API.

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -92,6 +92,11 @@ public actor DeployCommand {
     /// `wrangler` step; never fires on a failed/blocked deploy.
     public typealias DomainAttachObserver = @Sendable (CustomDomainAttachCommand.Result) -> Void
 
+    /// Fires once the Markdown for Agents step resolves (#1247) — only for a site whose domain
+    /// attach just confirmed a live zone; never fires when there's no custom domain, or on a
+    /// failed/blocked deploy.
+    public typealias MarkdownForAgentsObserver = @Sendable (MarkdownForAgentsCommand.Result) -> Void
+
     /// Returns the account's existing Worker script names for the given token. Production
     /// callers use `DeployCommand.defaultWorkerScriptNames` (`HTTPCloudflareClient`); tests
     /// inject a fake list or a throwing closure.
@@ -119,6 +124,9 @@ public actor DeployCommand {
     /// Exposed like `tokenSource`/`workerScriptNamesSource` so `DeployModel.runDeploy` can forward
     /// the exact same seam into a container-path `DeployCommand` it constructs on the fly (#1077).
     public nonisolated let customDomainAttachCommand: CustomDomainAttachCommand
+    /// Exposed like `customDomainAttachCommand` so `DeployModel.runDeploy` can forward the exact
+    /// same seam into a container-path `DeployCommand` it constructs on the fly (#1247).
+    public nonisolated let markdownForAgentsCommand: MarkdownForAgentsCommand
     /// Exposed like the other seams above so callers building a parallel `DeployCommand` (e.g.
     /// `SocialWorkerProvisionCommand`'s `defaultDeployer`) forward the same one rather than
     /// silently defaulting to production and diverging from a test's injected fake.
@@ -133,12 +141,14 @@ public actor DeployCommand {
         tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
         workerScriptNamesSource: @escaping WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,
         customDomainAttachCommand: CustomDomainAttachCommand = CustomDomainAttachCommand(),
+        markdownForAgentsCommand: MarkdownForAgentsCommand = MarkdownForAgentsCommand(),
         executor: any DeployExecutor = HostDeployExecutor(),
         domainConfigDriftSource: @escaping DomainConfigDriftSource = DeployCommand.defaultDomainConfigDriftSource
     ) {
         self.tokenSource = tokenSource
         self.workerScriptNamesSource = workerScriptNamesSource
         self.customDomainAttachCommand = customDomainAttachCommand
+        self.markdownForAgentsCommand = markdownForAgentsCommand
         self.executor = executor
         self.domainConfigDriftSource = domainConfigDriftSource
     }
@@ -165,6 +175,7 @@ public actor DeployCommand {
         wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim] = [],
         onPreflight: PreflightObserver? = nil,
         onDomainAttach: DomainAttachObserver? = nil,
+        onMarkdownForAgents: MarkdownForAgentsObserver? = nil,
         onProgress: ProgressHandler? = nil
     ) async -> Result {
         // Pre-spawn checks. The token comes first so we never spend time on a build or scan
@@ -380,6 +391,15 @@ public actor DeployCommand {
                 let domainAttachOutcome = await customDomainAttachCommand.attach(
                     siteDirectory: siteDirectory, apiToken: token, source: "deploy:\(siteID)")
                 onDomainAttach?(domainAttachOutcome)
+                // Only a confirmed-attached custom domain has a zone to configure — a
+                // workers.dev-only site (or one not yet delegated) has nothing for Markdown for
+                // Agents to apply to (#1247).
+                if case .confirmed(let hostname) = domainAttachOutcome {
+                    let markdownOutcome = await markdownForAgentsCommand.apply(
+                        hostname: hostname, configDirectory: configDirectory, apiToken: token,
+                        source: "deploy:\(siteID)")
+                    onMarkdownForAgents?(markdownOutcome)
+                }
                 Self.persistSiteURL(url, siteDirectory: siteDirectory)
                 Self.persistWorkerDeployed(siteDirectory: siteDirectory)
                 if let configDirectory {

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -396,8 +396,8 @@ public actor DeployCommand {
                 // Agents to apply to (#1247).
                 if case .confirmed(let hostname) = domainAttachOutcome {
                     let markdownOutcome = await markdownForAgentsCommand.apply(
-                        hostname: hostname, configDirectory: configDirectory, apiToken: token,
-                        source: "deploy:\(siteID)")
+                        hostname: hostname, siteDirectory: siteDirectory, configDirectory: configDirectory,
+                        apiToken: token, source: "deploy:\(siteID)")
                     onMarkdownForAgents?(markdownOutcome)
                 }
                 Self.persistSiteURL(url, siteDirectory: siteDirectory)

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -550,6 +550,15 @@ extension HTTPCloudflareClient: CloudflareWriting {
         return .attached
     }
 
+    /// `PATCH /zones/{id}/settings/content_converter`, mapping `enabled` to `"on"/"off"` — same
+    /// shape as `setSpeedBrain`/`setECH`. See ``CloudflareWriting/setMarkdownForAgents(hostname:enabled:apiToken:)``.
+    public func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool {
+        guard let zoneID = try await resolveZoneID(domain: hostname, apiToken: apiToken) else { return false }
+        try await mutate(method: "PATCH", "/zones/\(zoneID)/settings/content_converter",
+                         body: ["value": enabled ? "on" : "off"], apiToken: apiToken)
+        return true
+    }
+
     /// Adds a zstd-first (zstd → brotli → gzip) `compress_response` rule to the zone's
     /// `http_response_compression` ruleset, creating the ruleset when absent. Idempotent by
     /// inspection: an existing zstd rule means return without writing, so repeated hardening

--- a/Sources/AnglesiteCore/MarkdownForAgentsCommand.swift
+++ b/Sources/AnglesiteCore/MarkdownForAgentsCommand.swift
@@ -8,10 +8,12 @@ public actor MarkdownForAgentsCommand {
     /// Outcome of one apply attempt. Every case is deliberately non-fatal — same rationale as
     /// `CustomDomainAttachCommand.Result`.
     public enum Result: Sendable, Equatable {
-        /// The owner opted out (`SiteSettings.markdownForAgentsDisabled == true`) — no network
-        /// call made.
+        /// The zone is already confirmed off for this hostname — either the owner opted out and
+        /// it was never turned on in the first place, or opting out just turned an already-on
+        /// zone back off.
         case optedOut
-        /// The zone setting was written successfully.
+        /// The zone setting is confirmed on for this hostname — either freshly written this
+        /// deploy, or already matching from a prior one (no network call in the latter case).
         case applied(hostname: String)
         /// The hostname's zone isn't visible to this token yet — retried automatically on the
         /// next deploy, same as `CustomDomainAttachCommand.Result.notConnected`.
@@ -20,6 +22,13 @@ public actor MarkdownForAgentsCommand {
         /// feature) — logged, not fatal.
         case failed(hostname: String)
     }
+
+    /// `.site-config` key recording the last hostname:state this command successfully wrote to
+    /// Cloudflare, e.g. `example.com:on` — mirrors `CustomDomainAttachCommand`'s
+    /// `CF_DOMAIN_ATTACHED` idempotency marker (#1321 review): without it, a confirmed-attached
+    /// site would re-PATCH this zone setting on every single future deploy forever, even once it
+    /// already matches the owner's desired state.
+    private static let markerKey = "CF_MARKDOWN_FOR_AGENTS"
 
     private let client: any CloudflareWriting
 
@@ -31,11 +40,14 @@ public actor MarkdownForAgentsCommand {
 
     /// `hostname` is the confirmed-attached custom domain (`CustomDomainAttachCommand.Result
     /// .confirmed`'s payload) — sites with no custom domain have no zone to configure and never
-    /// reach this call. `configDirectory` reads the owner's opt-out from `Config/settings.plist`;
-    /// `nil` (missing config, or the field unset) means enabled, matching the feature's
-    /// default-on ask. `source` tags the `LogCenter` line written on a Cloudflare API failure.
+    /// reach this call. `siteDirectory` is where `.site-config` lives (the idempotency marker,
+    /// git-tracked alongside `CF_DOMAIN_ATTACHED`). `configDirectory` reads the owner's opt-out
+    /// from `Config/settings.plist`; `nil` (missing config, or the field unset) means enabled,
+    /// matching the feature's default-on ask. `source` tags the `LogCenter` line written on a
+    /// Cloudflare API failure.
     public func apply(
-        hostname: String, configDirectory: URL?, apiToken: String, source: String = "markdown-for-agents"
+        hostname: String, siteDirectory: URL, configDirectory: URL?, apiToken: String,
+        source: String = "markdown-for-agents"
     ) async -> Result {
         let disabled: Bool
         if let configDirectory {
@@ -43,16 +55,40 @@ public actor MarkdownForAgentsCommand {
         } else {
             disabled = false
         }
-        guard !disabled else { return .optedOut }
+        let enabled = !disabled
+
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let desiredMarker = "\(hostname):\(enabled ? "on" : "off")"
+        let existingMarker = SiteConfigFile.value(forKey: Self.markerKey, in: config)
+
+        if existingMarker == desiredMarker {
+            return enabled ? .applied(hostname: hostname) : .optedOut
+        }
+        if existingMarker == nil, !enabled {
+            // Never touched this zone — Cloudflare defaults the setting off, so there's nothing
+            // to undo. Avoids a pointless disable call on a site that opted out from the start.
+            return .optedOut
+        }
 
         do {
-            let zoneFound = try await client.setMarkdownForAgents(hostname: hostname, enabled: true, apiToken: apiToken)
-            return zoneFound ? .applied(hostname: hostname) : .zoneNotFound(hostname: hostname)
+            let zoneFound = try await client.setMarkdownForAgents(hostname: hostname, enabled: enabled, apiToken: apiToken)
+            guard zoneFound else { return .zoneNotFound(hostname: hostname) }
+            persist(marker: desiredMarker, siteDirectory: siteDirectory)
+            return enabled ? .applied(hostname: hostname) : .optedOut
         } catch {
             await LogCenter.shared.append(
                 source: source, stream: .stderr,
-                text: "couldn't enable Markdown for Agents for \(hostname): \(error)")
+                text: "couldn't set Markdown for Agents (\(enabled ? "on" : "off")) for \(hostname): \(error)")
             return .failed(hostname: hostname)
         }
+    }
+
+    private func persist(marker: String, siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: Self.markerKey, in: config) != marker else { return }
+        let updated = SiteConfigFile.upsert([(Self.markerKey, marker)], into: config)
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
     }
 }

--- a/Sources/AnglesiteCore/MarkdownForAgentsCommand.swift
+++ b/Sources/AnglesiteCore/MarkdownForAgentsCommand.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Applies the Markdown for Agents zone setting (#1247) once a custom domain is confirmed
+/// attached during deploy. Runs from `DeployCommand` right after `CustomDomainAttachCommand`
+/// resolves to `.confirmed` — best-effort, like that command: a Cloudflare API failure here must
+/// never turn an already-successful deploy into a failed one.
+public actor MarkdownForAgentsCommand {
+    /// Outcome of one apply attempt. Every case is deliberately non-fatal — same rationale as
+    /// `CustomDomainAttachCommand.Result`.
+    public enum Result: Sendable, Equatable {
+        /// The owner opted out (`SiteSettings.markdownForAgentsDisabled == true`) — no network
+        /// call made.
+        case optedOut
+        /// The zone setting was written successfully.
+        case applied(hostname: String)
+        /// The hostname's zone isn't visible to this token yet — retried automatically on the
+        /// next deploy, same as `CustomDomainAttachCommand.Result.notConnected`.
+        case zoneNotFound(hostname: String)
+        /// The Cloudflare API call failed (network, auth, or a plan that doesn't carry this
+        /// feature) — logged, not fatal.
+        case failed(hostname: String)
+    }
+
+    private let client: any CloudflareWriting
+
+    /// Creates the command. The default client talks to the live Cloudflare API; tests inject a
+    /// fake ``CloudflareWriting``.
+    public init(client: any CloudflareWriting = HTTPCloudflareClient()) {
+        self.client = client
+    }
+
+    /// `hostname` is the confirmed-attached custom domain (`CustomDomainAttachCommand.Result
+    /// .confirmed`'s payload) — sites with no custom domain have no zone to configure and never
+    /// reach this call. `configDirectory` reads the owner's opt-out from `Config/settings.plist`;
+    /// `nil` (missing config, or the field unset) means enabled, matching the feature's
+    /// default-on ask. `source` tags the `LogCenter` line written on a Cloudflare API failure.
+    public func apply(
+        hostname: String, configDirectory: URL?, apiToken: String, source: String = "markdown-for-agents"
+    ) async -> Result {
+        let disabled: Bool
+        if let configDirectory {
+            disabled = (try? await SiteConfigStore(configDirectory: configDirectory).load())?.markdownForAgentsDisabled ?? false
+        } else {
+            disabled = false
+        }
+        guard !disabled else { return .optedOut }
+
+        do {
+            let zoneFound = try await client.setMarkdownForAgents(hostname: hostname, enabled: true, apiToken: apiToken)
+            return zoneFound ? .applied(hostname: hostname) : .zoneNotFound(hostname: hostname)
+        } catch {
+            await LogCenter.shared.append(
+                source: source, stream: .stderr,
+                text: "couldn't enable Markdown for Agents for \(hostname): \(error)")
+            return .failed(hostname: hostname)
+        }
+    }
+}

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -87,6 +87,13 @@ public struct SiteSettings: Sendable, Codable, Equatable {
     /// parameter), which is inert until that wiring lands.
     public var moderators: [String]?
 
+    /// Owner opt-out from Markdown for Agents (#1247) — the Cloudflare zone setting that serves
+    /// an HTML→Markdown-converted response to requests carrying `Accept: text/markdown`, cutting
+    /// AI-agent token usage. `nil`/`false` (the default) means enabled: `DeployCommand` turns the
+    /// zone setting on for every site with a confirmed custom domain, matching the issue's
+    /// default-on ask. `true` means the owner explicitly opted out in Site Settings.
+    public var markdownForAgentsDisabled: Bool?
+
     /// Memberwise creation. Every parameter defaults to `nil`, matching the type-level
     /// forward-compat rule that all fields stay optional — `SiteSettings()` is the canonical
     /// "no settings yet" value ``SiteConfigStore/load()`` falls back to.
@@ -105,7 +112,8 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         webmentionReceivePaidPlanAcknowledged: Bool? = nil,
         communityOutboxURL: URL? = nil,
         communityActorURL: URL? = nil,
-        moderators: [String]? = nil
+        moderators: [String]? = nil,
+        markdownForAgentsDisabled: Bool? = nil
     ) {
         self.displayName = displayName
         self.inboxCaptureAccountID = inboxCaptureAccountID
@@ -122,6 +130,7 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         self.communityOutboxURL = communityOutboxURL
         self.communityActorURL = communityActorURL
         self.moderators = moderators
+        self.markdownForAgentsDisabled = markdownForAgentsDisabled
     }
 }
 

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -68,6 +68,7 @@ private final class FakeDomainAttachWriter: CloudflareWriting, @unchecked Sendab
     func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
     func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {}
     func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
 }
 
 private struct StubTokenVerifying: TokenVerifying {
@@ -280,6 +281,7 @@ struct DeployModelTests {
         let command = DeployCommand(
             tokenSource: { "test-token" },
             customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+            markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -312,6 +314,7 @@ struct DeployModelTests {
         let command = DeployCommand(
             tokenSource: { "test-token" },
             customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+            markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })

--- a/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
+++ b/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
@@ -52,6 +52,7 @@ private final class StubWriter: CloudflareWriting, @unchecked Sendable {
     func attachWorkersCustomDomain(hostname: String, workerScriptName: String, apiToken: String) async throws -> CustomDomainAttachResult {
         .attached
     }
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
 }
 
 @Suite(.serialized)

--- a/Tests/AnglesiteAppTests/OnionRoutingModelTests.swift
+++ b/Tests/AnglesiteAppTests/OnionRoutingModelTests.swift
@@ -44,6 +44,7 @@ private final class StubWriter: CloudflareWriting, @unchecked Sendable {
     func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {}
     func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
     func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
     func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {
         if let errorToThrow { throw errorToThrow }
         lastZoneID = zoneID

--- a/Tests/AnglesiteCoreTests/CustomDomainAttachCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/CustomDomainAttachCommandTests.swift
@@ -27,6 +27,7 @@ final class FakeCloudflareWriting: CloudflareWriting, @unchecked Sendable {
     func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
     func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {}
     func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
 }
 
 struct CustomDomainAttachCommandTests {

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -1415,19 +1415,23 @@ struct DeployCommandTests {
         let command = DeployCommand(
             tokenSource: { "test-token" },
             customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+            markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer),
             executor: executor
         )
 
         var observed: CustomDomainAttachCommand.Result?
+        var observedMarkdown: MarkdownForAgentsCommand.Result?
         let result = await command.deploy(
             siteID: "test", siteDirectory: siteDir,
-            onDomainAttach: { observed = $0 }
+            onDomainAttach: { observed = $0 },
+            onMarkdownForAgents: { observedMarkdown = $0 }
         )
         guard case .succeeded = result else {
             Issue.record("expected .succeeded, got \(result)")
             return
         }
         #expect(observed == .confirmed(hostname: "example.com"))
+        #expect(observedMarkdown == .applied(hostname: "example.com"))
         let config = try String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(config.contains("CF_DOMAIN_ATTACHED=example.com"))
         // #1124: a domain confirmed attached *in this same deploy* must win immediately —

--- a/Tests/AnglesiteCoreTests/DomainOperationsServiceTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainOperationsServiceTests.swift
@@ -264,6 +264,7 @@ final class FakeWriter: CloudflareWriting, @unchecked Sendable {
     func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
     func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {}
     func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
     func attachWorkersCustomDomain(hostname: String, workerScriptName: String, apiToken: String) async throws -> CustomDomainAttachResult {
         return .attached
     }

--- a/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/HardenExecutorTests.swift
@@ -291,4 +291,8 @@ final class MockCloudflareWriter: CloudflareWriting, @unchecked Sendable {
         try record("attachWorkersCustomDomain:\(hostname)")
         return .attached
     }
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool {
+        try record("setMarkdownForAgents:\(hostname)")
+        return true
+    }
 }

--- a/Tests/AnglesiteCoreTests/MarkdownForAgentsCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/MarkdownForAgentsCommandTests.swift
@@ -1,0 +1,99 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+private final class FakeMarkdownWriter: CloudflareWriting, @unchecked Sendable {
+    var result: Swift.Result<Bool, Error> = .success(true)
+    private(set) var calls: [(hostname: String, enabled: Bool)] = []
+
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool {
+        calls.append((hostname, enabled))
+        return try result.get()
+    }
+
+    func enableDNSSEC(zoneID: String, apiToken: String) async throws {}
+    func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool, apiToken: String) async throws {}
+    func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws {}
+    func deleteDNSRecord(zoneID: String, recordID: String, apiToken: String) async throws {}
+    func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {}
+    func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
+    func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func attachWorkersCustomDomain(
+        hostname: String, workerScriptName: String, apiToken: String
+    ) async throws -> CustomDomainAttachResult {
+        .attached
+    }
+}
+
+private struct FakeError: Error {}
+
+struct MarkdownForAgentsCommandTests {
+    private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+    private func makeConfigDir() throws -> URL {
+        let dir = tmpDir.appendingPathComponent("markdown-for-agents-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("applies the zone setting when no opt-out is configured")
+    func appliesWhenNotOptedOut() async throws {
+        let dir = try makeConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let writer = FakeMarkdownWriter()
+        let command = MarkdownForAgentsCommand(client: writer)
+        let result = await command.apply(hostname: "example.com", configDirectory: dir, apiToken: "t")
+        #expect(result == .applied(hostname: "example.com"))
+        #expect(writer.calls.count == 1)
+        #expect(writer.calls.first?.hostname == "example.com")
+        #expect(writer.calls.first?.enabled == true)
+    }
+
+    @Test("applies with no configDirectory at all (defaults to enabled)")
+    func appliesWithNoConfigDirectory() async throws {
+        let writer = FakeMarkdownWriter()
+        let command = MarkdownForAgentsCommand(client: writer)
+        let result = await command.apply(hostname: "example.com", configDirectory: nil, apiToken: "t")
+        #expect(result == .applied(hostname: "example.com"))
+        #expect(writer.calls.count == 1)
+    }
+
+    @Test("opts out with no network call when the owner disabled it in Site Settings")
+    func optsOutWhenDisabled() async throws {
+        let dir = try makeConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await SiteConfigStore(configDirectory: dir).save(SiteSettings(markdownForAgentsDisabled: true))
+        let writer = FakeMarkdownWriter()
+        let command = MarkdownForAgentsCommand(client: writer)
+        let result = await command.apply(hostname: "example.com", configDirectory: dir, apiToken: "t")
+        #expect(result == .optedOut)
+        #expect(writer.calls.isEmpty)
+    }
+
+    @Test("reports .zoneNotFound when the token can't see the zone yet")
+    func reportsZoneNotFound() async throws {
+        let dir = try makeConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let writer = FakeMarkdownWriter()
+        writer.result = .success(false)
+        let command = MarkdownForAgentsCommand(client: writer)
+        let result = await command.apply(hostname: "example.com", configDirectory: dir, apiToken: "t")
+        #expect(result == .zoneNotFound(hostname: "example.com"))
+    }
+
+    @Test("reports .failed without throwing when the Cloudflare API call fails")
+    func reportsFailedOnThrow() async throws {
+        let dir = try makeConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let writer = FakeMarkdownWriter()
+        writer.result = .failure(FakeError())
+        let command = MarkdownForAgentsCommand(client: writer)
+        let result = await command.apply(hostname: "example.com", configDirectory: dir, apiToken: "t")
+        #expect(result == .failed(hostname: "example.com"))
+    }
+}

--- a/Tests/AnglesiteCoreTests/MarkdownForAgentsCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/MarkdownForAgentsCommandTests.swift
@@ -35,65 +35,110 @@ private struct FakeError: Error {}
 struct MarkdownForAgentsCommandTests {
     private let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
 
-    private func makeConfigDir() throws -> URL {
+    private func makeSiteDir(config: String = "") throws -> URL {
         let dir = tmpDir.appendingPathComponent("markdown-for-agents-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if !config.isEmpty {
+            try config.write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        }
         return dir
     }
 
-    @Test("applies the zone setting when no opt-out is configured")
+    @Test("applies the zone setting and persists CF_MARKDOWN_FOR_AGENTS when no opt-out is configured")
     func appliesWhenNotOptedOut() async throws {
-        let dir = try makeConfigDir()
+        let dir = try makeSiteDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let writer = FakeMarkdownWriter()
         let command = MarkdownForAgentsCommand(client: writer)
-        let result = await command.apply(hostname: "example.com", configDirectory: dir, apiToken: "t")
+        let result = await command.apply(hostname: "example.com", siteDirectory: dir, configDirectory: dir, apiToken: "t")
         #expect(result == .applied(hostname: "example.com"))
         #expect(writer.calls.count == 1)
         #expect(writer.calls.first?.hostname == "example.com")
         #expect(writer.calls.first?.enabled == true)
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(config.contains("CF_MARKDOWN_FOR_AGENTS=example.com:on"))
     }
 
     @Test("applies with no configDirectory at all (defaults to enabled)")
     func appliesWithNoConfigDirectory() async throws {
+        let dir = try makeSiteDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
         let writer = FakeMarkdownWriter()
         let command = MarkdownForAgentsCommand(client: writer)
-        let result = await command.apply(hostname: "example.com", configDirectory: nil, apiToken: "t")
+        let result = await command.apply(hostname: "example.com", siteDirectory: dir, configDirectory: nil, apiToken: "t")
         #expect(result == .applied(hostname: "example.com"))
         #expect(writer.calls.count == 1)
     }
 
-    @Test("opts out with no network call when the owner disabled it in Site Settings")
-    func optsOutWhenDisabled() async throws {
-        let dir = try makeConfigDir()
+    @Test("a second deploy after a confirmed apply makes no further network call (#1321 review)")
+    func secondDeploySkipsNetworkCallWhenAlreadyApplied() async throws {
+        let dir = try makeSiteDir(config: "CF_MARKDOWN_FOR_AGENTS=example.com:on\n")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let writer = FakeMarkdownWriter()
+        let command = MarkdownForAgentsCommand(client: writer)
+        let result = await command.apply(hostname: "example.com", siteDirectory: dir, configDirectory: dir, apiToken: "t")
+        #expect(result == .applied(hostname: "example.com"))
+        #expect(writer.calls.isEmpty)
+    }
+
+    @Test("opts out with no network call when never applied and the owner disabled it from the start")
+    func optsOutWithNoNetworkCallWhenNeverApplied() async throws {
+        let dir = try makeSiteDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try await SiteConfigStore(configDirectory: dir).save(SiteSettings(markdownForAgentsDisabled: true))
         let writer = FakeMarkdownWriter()
         let command = MarkdownForAgentsCommand(client: writer)
-        let result = await command.apply(hostname: "example.com", configDirectory: dir, apiToken: "t")
+        let result = await command.apply(hostname: "example.com", siteDirectory: dir, configDirectory: dir, apiToken: "t")
         #expect(result == .optedOut)
         #expect(writer.calls.isEmpty)
     }
 
+    @Test("opting out after a prior apply calls the API to turn the zone setting back off")
+    func optingOutAfterPriorApplyTurnsOff() async throws {
+        let dir = try makeSiteDir(config: "CF_MARKDOWN_FOR_AGENTS=example.com:on\n")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await SiteConfigStore(configDirectory: dir).save(SiteSettings(markdownForAgentsDisabled: true))
+        let writer = FakeMarkdownWriter()
+        let command = MarkdownForAgentsCommand(client: writer)
+        let result = await command.apply(hostname: "example.com", siteDirectory: dir, configDirectory: dir, apiToken: "t")
+        #expect(result == .optedOut)
+        #expect(writer.calls.count == 1)
+        #expect(writer.calls.first?.enabled == false)
+        let config = try String(contentsOf: dir.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(config.contains("CF_MARKDOWN_FOR_AGENTS=example.com:off"))
+    }
+
+    @Test("a later deploy after opting back in re-applies with a fresh network call")
+    func optingBackInReapplies() async throws {
+        let dir = try makeSiteDir(config: "CF_MARKDOWN_FOR_AGENTS=example.com:off\n")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let writer = FakeMarkdownWriter()
+        let command = MarkdownForAgentsCommand(client: writer)
+        let result = await command.apply(hostname: "example.com", siteDirectory: dir, configDirectory: dir, apiToken: "t")
+        #expect(result == .applied(hostname: "example.com"))
+        #expect(writer.calls.count == 1)
+        #expect(writer.calls.first?.enabled == true)
+    }
+
     @Test("reports .zoneNotFound when the token can't see the zone yet")
     func reportsZoneNotFound() async throws {
-        let dir = try makeConfigDir()
+        let dir = try makeSiteDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let writer = FakeMarkdownWriter()
         writer.result = .success(false)
         let command = MarkdownForAgentsCommand(client: writer)
-        let result = await command.apply(hostname: "example.com", configDirectory: dir, apiToken: "t")
+        let result = await command.apply(hostname: "example.com", siteDirectory: dir, configDirectory: dir, apiToken: "t")
         #expect(result == .zoneNotFound(hostname: "example.com"))
     }
 
     @Test("reports .failed without throwing when the Cloudflare API call fails")
     func reportsFailedOnThrow() async throws {
-        let dir = try makeConfigDir()
+        let dir = try makeSiteDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let writer = FakeMarkdownWriter()
         writer.result = .failure(FakeError())
         let command = MarkdownForAgentsCommand(client: writer)
-        let result = await command.apply(hostname: "example.com", configDirectory: dir, apiToken: "t")
+        let result = await command.apply(hostname: "example.com", siteDirectory: dir, configDirectory: dir, apiToken: "t")
         #expect(result == .failed(hostname: "example.com"))
     }
 }


### PR DESCRIPTION
Closes #1247

## Summary

- Adds `HTTPCloudflareClient.setMarkdownForAgents(hostname:enabled:apiToken:)` (`PATCH /zones/{id}/settings/content_converter`), following the existing `setSpeedBrain`/`setECH` on/off-setting pattern.
- Adds `MarkdownForAgentsCommand`, a best-effort post-deploy step (mirroring `CustomDomainAttachCommand`) that enables the zone setting once `DeployCommand` confirms a custom domain is attached — a Cloudflare API failure here never turns an already-successful deploy into a failed one.
- Adds a Site Settings opt-out (`SiteSettings.markdownForAgentsDisabled`, `Config/settings.plist`, default enabled) with a toggle in the Licensing tab's "AI and Crawlers" section, right beside "Refuse AI crawlers in robots.txt" — its copy explicitly notes the two controls don't conflict (an already-refused crawler never reaches the markdown response in the first place).

Scoped to what's implementable without #1211/#1015: the deploy-time call reuses `DeployCommand`'s existing OAuth-aware `tokenSource` (already used for the same site's other Cloudflare API calls), so it doesn't need #1211's shared-credential resolver. Since the app has exactly one deploy path today, the new call is trivially "behind" that path — #1015's not-yet-existent `DeployTarget` seam isn't a blocker.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP schema changes and no `Resources/Template/` changes — this is a zone-level Cloudflare setting toggled from the app's own deploy pipeline.

## Test plan

- [x] `swift test --package-path .` (portable targets — `AnglesiteCoreTests`/`AnglesiteAppTests` are Darwin-only and not in the Linux portable set, so I hand-verified those edits and added `Tests/AnglesiteCoreTests/MarkdownForAgentsCommandTests.swift` for the new command)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (no macOS toolchain available in this session)
- [ ] Manual smoke: not run — no macOS/Xcode available in this session to exercise the Site Settings toggle or a real deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTY3bwZze2biPNJreVdVt5)_