### PR TITLE
fix(#1285): wire Find into component fallback TextEditor

### DIFF
--- a/Sources/AnglesiteApp/MainPaneEditorView.swift
+++ b/Sources/AnglesiteApp/MainPaneEditorView.swift
@@ -39,20 +39,7 @@ struct MainPaneEditorView: View {
                 } else {
                     switch EditorKind.resolve(for: model.file) {
                     case .text, .plist:
-                        TextEditor(text: $model.text)
-                            .font(.system(.body, design: .monospaced))
-                            .scrollContentBackground(.hidden)
-                            .findNavigator(isPresented: $model.isFindPresented)
-                            .focused($isPlainTextEditorFocused)
-                            .id(model.file.id)
-                            .onChange(of: isPlainTextEditorFocused) { _, focused in
-                                if focused {
-                                    EditorFocusRegistry.shared.activate(
-                                        .plainText(isPresented: $model.isFindPresented), token: model.file.id)
-                                } else {
-                                    EditorFocusRegistry.shared.resign(token: model.file.id)
-                                }
-                            }
+                        plainTextEditor
                     case .markdown:
                         MarkdownTextView(
                             text: $model.text,
@@ -65,9 +52,12 @@ struct MainPaneEditorView: View {
                                 model: componentEditor, fileEditor: model,
                                 onWebView: onCanvasWebView)
                         } else {
-                            TextEditor(text: $model.text)
-                                .font(.system(.body, design: .monospaced))
-                                .scrollContentBackground(.hidden)
+                            // Brief loading-state fallback before `componentEditor` finishes
+                            // activating (#1285) — reuses the same wiring and `isFindPresented`
+                            // flag as the `.text`/`.plist` case above rather than its own state,
+                            // since it's the same file and the real Source pane takes over once
+                            // loaded.
+                            plainTextEditor
                         }
                     }
                 }
@@ -91,6 +81,26 @@ struct MainPaneEditorView: View {
         } message: {
             Text("Another tool edited this file while you had unsaved changes.")
         }
+    }
+
+    /// The plain-text `TextEditor` with `.findNavigator`/`EditorFocusRegistry` wiring, shared by
+    /// the `.text`/`.plist` case and the `.component` case's pre-load fallback (#1285) — both show
+    /// the same file's text, so ⌘F should work identically in either.
+    private var plainTextEditor: some View {
+        TextEditor(text: $model.text)
+            .font(.system(.body, design: .monospaced))
+            .scrollContentBackground(.hidden)
+            .findNavigator(isPresented: $model.isFindPresented)
+            .focused($isPlainTextEditorFocused)
+            .id(model.file.id)
+            .onChange(of: isPlainTextEditorFocused) { _, focused in
+                if focused {
+                    EditorFocusRegistry.shared.activate(
+                        .plainText(isPresented: $model.isFindPresented), token: model.file.id)
+                } else {
+                    EditorFocusRegistry.shared.resign(token: model.file.id)
+                }
+            }
     }
 
     private var header: some View {


### PR DESCRIPTION
Closes #1285

## Summary

- `MainPaneEditorView`'s `.component` case fell back to a bare `TextEditor` while `componentEditor` hadn't finished loading, with no `.findNavigator`/`EditorFocusRegistry` wiring at all, so ⌘F was a silent no-op during that brief window.
- Extracted the `.text`/`.plist` case's `.findNavigator`/`@FocusState`/`.id`/`.onChange` modifier chain into a shared `plainTextEditor` computed property, and reused it for the `.component` fallback.
- No new state was needed: the fallback shows the same file as the `.text`/`.plist` case would, so it reuses the same `FileEditorModel.isFindPresented` flag and the same `model.file.id` token — once `componentEditor` finishes loading, `ComponentEditorView` takes over and the shared flag carries forward cleanly.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> No MCP schema changes — this is app-side SwiftUI view wiring only, reusing an existing focus-registry pattern.

## Test plan

- [ ] `swift test --package-path .` — **could not run**: no Swift toolchain (`swift`/`xcodebuild`/`xcodegen`) is available in this remote execution environment. Please watch CI for verification.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — same toolchain limitation, could not run locally.
- [ ] Manual smoke (if UI-touching): open an `.astro` component file and press ⌘F during the brief pre-load window (before `componentEditor` finishes activating) — the find navigator should now open, matching the plain-text editor's behavior; not run interactively in this environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_0118iTZN4jLJyP2QfoatK62L)_