### PR TITLE
fix(#1288): migrate persistRegistrarInfo onto DomainConfigStore.update

### DIFF
--- a/Sources/AnglesiteApp/ConnectDomainModel.swift
+++ b/Sources/AnglesiteApp/ConnectDomainModel.swift
@@ -202,10 +202,10 @@ final class ConnectDomainModel {
     }
 
     private func persistRegistrarInfo(_ info: RDAPDomainInfo, hostname: String, sourceDirectory: URL) {
-        let store = DomainConfigStore(sourceDirectory: sourceDirectory)
-        guard var config = try? store.load(), config.domain?.hostname == hostname else { return }
-        config.domain?.registrar = info.registrar
-        config.domain?.expiresAt = info.expiresAt
-        try? store.save(config)
+        DomainConfigStore.update(sourceDirectory: sourceDirectory) { config in
+            guard config.domain?.hostname == hostname else { return }
+            config.domain?.registrar = info.registrar
+            config.domain?.expiresAt = info.expiresAt
+        }
     }
 }

--- a/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
+++ b/Tests/AnglesiteAppTests/ConnectDomainModelTests.swift
@@ -332,4 +332,36 @@ private actor ControllableRDAPLookupService: RDAPLookupService {
         #expect(saved.domain?.registrar != "Old Registrar, LLC")
         #expect(saved.domain?.expiresAt != "2020-01-01T00:00:00Z")
     }
+
+    /// `persistRegistrarInfo`'s guard (`config.domain?.hostname == hostname`) protects against a
+    /// concurrent producer (e.g. `DomainIntentRecorder`) declaring a different hostname on disk
+    /// between when a lookup starts and when it resolves — reachable even though the model's own
+    /// generation tracking (`reopeningBeforeFirstLookupResolvesKeepsNewerResult`) doesn't catch it,
+    /// since that write happens outside the model entirely. The on-disk hostname declared by the
+    /// concurrent producer must survive untouched, with no registrar attached to it.
+    @Test func persistRegistrarInfoSkipsWhenOnDiskHostnameNoLongerMatches() async throws {
+        let fake = ControllableRDAPLookupService()
+        let model = ConnectDomainModel(rdap: fake)
+        let (site, dir) = try makeSite()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        model.configure(site: site)
+        try DomainConfigStore(sourceDirectory: dir).save(
+            DomainConfig(domain: .init(hostname: "example.com", choice: "transfer", attach: true)))
+
+        model.openSheet()
+        while await fake.callCount() < 1 { await Task.yield() }
+
+        try DomainConfigStore(sourceDirectory: dir).save(
+            DomainConfig(domain: .init(hostname: "other.example.com", choice: "transfer", attach: true)))
+
+        await fake.resolve(
+            callIndex: 0,
+            with: RDAPDomainInfo(registrar: "Namecheap", expiresAt: "2028-01-01T00:00:00Z"))
+        repeat { await Task.yield() } while model.isLookingUpRegistrarInfo
+
+        let saved = try DomainConfigStore(sourceDirectory: dir).load()
+        #expect(saved.domain?.hostname == "other.example.com")
+        #expect(saved.domain?.registrar == nil)
+        #expect(saved.domain?.expiresAt == nil)
+    }
 }


### PR DESCRIPTION
Closes #1288

## Summary

- `ConnectDomainModel.persistRegistrarInfo` hand-rolled its own `load()`/`save()` sequence instead of routing through the shared `DomainConfigStore.update(sourceDirectory:_:)` helper that the other six `anglesite.json` write-through producers (`HardenExecutor`, `EmailSetupExecutor`, `DomainIntentRecorder`, `DomainOperationsService`, `DeployCoordinator`) already use (#1188/#1255) — this was the one call site #1264's `update()` migration missed.
- Moved the load and the two field mutations into the `update(sourceDirectory:_:)` mutate closure, preserving the existing "only touch the config if the on-disk hostname still matches" guard (now a no-op inside the closure instead of an early return before `load()`).
- **Known, low-risk behavior change on the mismatched-hostname branch** (review finding): `update(...)` always calls `save()` after the closure returns, even when the guard's early `return` fired and nothing was mutated. Before this PR, that branch returned before ever calling `save()` — a pure no-op. After, it now re-saves the unchanged config (extra lock-acquire + read + re-encode + atomic write of `Source/anglesite.json`). `save()`'s unknown-key merge and `version` no-downgrade guard mean the written content is byte-identical, so there's no data-loss/correctness risk — just redundant I/O on an already-rare path (only hit when a concurrent producer changes the on-disk hostname while a registrar lookup is in flight). Added a regression test (`persistRegistrarInfoSkipsWhenOnDiskHostnameNoLongerMatches`) exercising this branch directly, since no existing test covered it before or after this change.
- Once #1264 (still open, adds the atomic lock-held-across-load+save to `update()` itself) lands, this call site picks up that atomicity for free with no further changes needed here.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [ ] `swift test --package-path .` — **could not run**: no Swift toolchain is available in this remote execution environment. CI's `Linux (portable SwiftPM targets)` lane should cover this; please watch for its results.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — same toolchain limitation, could not run locally.
- [x] Manual code review, plus a new regression test covering the previously-untested stale-hostname guard branch.