### PR TITLE
Map Micropub photo to AS2 attachment in the ActivityPub fan-out

### DIFF
--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -1381,6 +1381,38 @@ test("micropub-to-activitypub fan-out (#1240): a photo-less JSON create publishe
   expect(published?.object?.attachment).toBeUndefined();
 });
 
+test("micropub-to-activitypub fan-out (#1240, #1325 review): a photo-only create with no caption still fans out", async () => {
+  // The primary case #1240 exists to fix: Pixelfed renders only posts with an attachment, and a
+  // bare photo with no caption text is a normal, common Micropub shape — it must not be dropped
+  // by a `content`-only guard (a bug caught in PR review before merge).
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const ctx = createExecutionContext();
+  const createResponse = await worker.fetch(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: { photo: ["https://media.example/caption-less.jpg"] },
+    }),
+  }), testEnv, ctx);
+  expect(createResponse.status).toBe(201);
+  await waitOnExecutionContext(ctx);
+
+  const outboxPageResponse = await fetchWorker(new Request("https://owner.example/users/site/outbox?page=1"));
+  const outboxPage = await outboxPageResponse.json() as { orderedItems?: FanOutOutboxItem[] };
+  const published = outboxPage.orderedItems?.find((item) =>
+    item.object?.attachment?.some((attachment) => attachment.url === "https://media.example/caption-less.jpg"),
+  );
+  expect(published?.object?.attachment).toEqual([
+    { type: "Image", url: "https://media.example/caption-less.jpg" },
+  ]);
+});
+
 test("micropub-to-activitypub fan-out (#1240): a form-encoded create with photo fields lands the same attachment mapping", async () => {
   const { token, keyPair } = await mintAccessToken("create");
   const url = "https://owner.example/micropub";
@@ -1408,6 +1440,37 @@ test("micropub-to-activitypub fan-out (#1240): a form-encoded create with photo 
   expect(published?.object?.attachment).toEqual([
     { type: "Image", url: "https://media.example/form-a.jpg" },
     { type: "Image", url: "https://media.example/form-b.jpg" },
+  ]);
+});
+
+test("micropub-to-activitypub fan-out (#1240, #1325 review): a form-encoded create using the properties[photo][] nesting convention still attaches", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const ctx = createExecutionContext();
+  const body = new URLSearchParams();
+  body.append("h", "entry");
+  // Same `properties[x]` nesting convention `content` already falls back to
+  // (`form.get("properties[content]")`) — a client using it for `photo` must not have its
+  // attachments silently dropped from the fan-out.
+  body.append("properties[content]", "Nested-properties photo post");
+  body.append("properties[photo][]", "https://media.example/nested.jpg");
+  const createResponse = await worker.fetch(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: body.toString(),
+  }), testEnv, ctx);
+  expect(createResponse.status).toBe(201);
+  await waitOnExecutionContext(ctx);
+
+  const outboxPageResponse = await fetchWorker(new Request("https://owner.example/users/site/outbox?page=1"));
+  const outboxPage = await outboxPageResponse.json() as { orderedItems?: FanOutOutboxItem[] };
+  const published = outboxPage.orderedItems?.find((item) => item.object?.content?.includes("Nested-properties photo post"));
+  expect(published?.object?.attachment).toEqual([
+    { type: "Image", url: "https://media.example/nested.jpg" },
   ]);
 });
 

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -1320,6 +1320,97 @@ test("micropub-to-activitypub fan-out: an html-only mf2 rich-text content object
   expect(outboxPage.orderedItems?.some((item) => item.object?.content?.includes("Hello, html-only fediverse"))).toBe(true);
 });
 
+type FanOutAttachment = { type?: string; url?: string; name?: string };
+type FanOutOutboxItem = { object?: { content?: string; attachment?: FanOutAttachment[] } };
+
+test("micropub-to-activitypub fan-out (#1240): a JSON create with photos lands a Note carrying the expected attachment array", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const ctx = createExecutionContext();
+  const createResponse = await worker.fetch(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: {
+        content: ["A photo for Pixelfed"],
+        // Mixed shapes: a bare URL string and the mf2 alt-text object form { value, alt } —
+        // both must map to an AS2 `Image` attachment.
+        photo: ["https://media.example/plain.jpg", { value: "https://media.example/alt.jpg", alt: "A view" }],
+      },
+    }),
+  }), testEnv, ctx);
+  expect(createResponse.status).toBe(201);
+  await waitOnExecutionContext(ctx);
+
+  const outboxPageResponse = await fetchWorker(new Request("https://owner.example/users/site/outbox?page=1"));
+  const outboxPage = await outboxPageResponse.json() as { orderedItems?: FanOutOutboxItem[] };
+  const published = outboxPage.orderedItems?.find((item) => item.object?.content?.includes("A photo for Pixelfed"));
+  expect(published?.object?.attachment).toEqual([
+    { type: "Image", url: "https://media.example/plain.jpg" },
+    { type: "Image", url: "https://media.example/alt.jpg", name: "A view" },
+  ]);
+});
+
+test("micropub-to-activitypub fan-out (#1240): a photo-less JSON create publishes a Note with no attachment field", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const ctx = createExecutionContext();
+  const createResponse = await worker.fetch(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: JSON.stringify({
+      type: ["h-entry"],
+      properties: { content: ["No photo here"] },
+    }),
+  }), testEnv, ctx);
+  expect(createResponse.status).toBe(201);
+  await waitOnExecutionContext(ctx);
+
+  const outboxPageResponse = await fetchWorker(new Request("https://owner.example/users/site/outbox?page=1"));
+  const outboxPage = await outboxPageResponse.json() as { orderedItems?: FanOutOutboxItem[] };
+  const published = outboxPage.orderedItems?.find((item) => item.object?.content?.includes("No photo here"));
+  expect(published?.object?.attachment).toBeUndefined();
+});
+
+test("micropub-to-activitypub fan-out (#1240): a form-encoded create with photo fields lands the same attachment mapping", async () => {
+  const { token, keyPair } = await mintAccessToken("create");
+  const url = "https://owner.example/micropub";
+  const ctx = createExecutionContext();
+  const body = new URLSearchParams();
+  body.append("h", "entry");
+  body.append("content", "Form-encoded photo post");
+  body.append("photo", "https://media.example/form-a.jpg");
+  body.append("photo[]", "https://media.example/form-b.jpg");
+  const createResponse = await worker.fetch(new Request(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      authorization: `DPoP ${token}`,
+      DPoP: await dpopProof(url, "POST", keyPair, token),
+    },
+    body: body.toString(),
+  }), testEnv, ctx);
+  expect(createResponse.status).toBe(201);
+  await waitOnExecutionContext(ctx);
+
+  const outboxPageResponse = await fetchWorker(new Request("https://owner.example/users/site/outbox?page=1"));
+  const outboxPage = await outboxPageResponse.json() as { orderedItems?: FanOutOutboxItem[] };
+  const published = outboxPage.orderedItems?.find((item) => item.object?.content?.includes("Form-encoded photo post"));
+  expect(published?.object?.attachment).toEqual([
+    { type: "Image", url: "https://media.example/form-a.jpg" },
+    { type: "Image", url: "https://media.example/form-b.jpg" },
+  ]);
+});
+
 test("micropub-to-activitypub fan-out: never fires when ActivityPub isn't provisioned", async () => {
   const { AP_PUBLISH_TOKEN: _unusedToken, ...envWithoutToken } = testEnv;
   const { token, keyPair } = await mintAccessToken("create");

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -1052,13 +1052,22 @@ function handleMicropub(
       }
       const form = await cloned.formData();
       const content = String(form.get("content") ?? form.get("properties[content]") ?? "");
-      // Form-encoded `photo`/`photo[]` fields carry a bare URL string per entry; the mf2
-      // `{ value, alt }` alt-text shape has no flat-form equivalent (per `@dwk/micropub`'s own
-      // `parseFormBody`, only one `photo[sub]` nested object can round-trip per request), so
-      // form-encoded photos never carry alt text — same fidelity Micropub form clients get today.
-      const rawPhotos = [...form.getAll("photo"), ...form.getAll("photo[]")].filter(
-        (value): value is string => typeof value === "string" && value.length > 0,
-      );
+      // Form-encoded `photo`/`photo[]`/`properties[photo][]` fields carry a bare URL string per
+      // entry — the mf2 `{ value, alt }` alt-text shape has no flat-form equivalent (per
+      // `@dwk/micropub`'s own `parseFormBody`, only one `photo[sub]` nested object can round-trip
+      // per request), so form-encoded photos never carry alt text — same fidelity Micropub form
+      // clients get today. `properties[photo][]` mirrors `content`'s `properties[content]`
+      // fallback two lines up — a client using that nesting convention for `content` would
+      // otherwise have its photos silently dropped from the fan-out (#1325 review). Walking
+      // `form.entries()` once (rather than concatenating separate `getAll()` calls) preserves
+      // submission order across mixed field names (#1325 review).
+      const photoFieldNames = new Set(["photo", "photo[]", "properties[photo][]"]);
+      const rawPhotos: string[] = [];
+      for (const [key, value] of form.entries()) {
+        if (photoFieldNames.has(key) && typeof value === "string" && value.length > 0) {
+          rawPhotos.push(value);
+        }
+      }
       return { content, photos: extractMf2Photos(rawPhotos) };
     } catch {
       // Can't recover the post content — skip the fan-out rather than publish an empty Note.
@@ -1098,7 +1107,10 @@ async function fanOutMicropubCreateToActivityPub(
   ctx: ExecutionContext,
 ): Promise<void> {
   if (!env.AP_PUBLISH_TOKEN) return;
-  if (!content) return;
+  // A photo-only create (no caption) must still fan out (#1240, #1325 review) — requiring
+  // `content` alone would drop exactly the case this issue exists to fix: a bare photo post
+  // with no text is a normal, common shape, and Pixelfed only needs the `attachment` to render.
+  if (!content && photos.length === 0) return;
   const location = micropubResponse.headers.get("location");
   if (!location) return;
 

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -954,6 +954,41 @@ function extractMf2ContentString(raw: unknown): string {
   return "";
 }
 
+/** A photo attachment extracted from an mf2 `photo` property entry, ready for AS2 mapping. */
+interface ExtractedPhoto {
+  readonly url: string;
+  readonly alt?: string;
+}
+
+/**
+ * Extracts `{ url, alt? }` pairs from an mf2 `photo` property array (#1240) — each entry is
+ * either a plain URL string or the mf2 alt-text object shape `{ value, alt }`, mirroring
+ * {@link extractMf2ContentString}'s tolerance for `content`'s two accepted shapes. Feeds the AS2
+ * `attachment` mapping in `fanOutMicropubCreateToActivityPub` so a photo post is renderable by
+ * media-only Fediverse clients (Pixelfed shows only posts with attachments).
+ */
+function extractMf2Photos(raw: unknown): ExtractedPhoto[] {
+  if (!Array.isArray(raw)) return [];
+  const photos: ExtractedPhoto[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string" && entry.length > 0) {
+      photos.push({ url: entry });
+      continue;
+    }
+    if (entry && typeof entry === "object") {
+      const obj = entry as { value?: unknown; alt?: unknown };
+      if (typeof obj.value === "string" && obj.value.length > 0) {
+        photos.push(
+          typeof obj.alt === "string" && obj.alt.length > 0
+            ? { url: obj.value, alt: obj.alt }
+            : { url: obj.value },
+        );
+      }
+    }
+  }
+  return photos;
+}
+
 /**
  * Micropub server (V-3.2, #360).
  *
@@ -1001,25 +1036,39 @@ function handleMicropub(
   // a locked stream reader could silently break the fan-out with no visible failure). Doing the
   // extraction up front — before `micropub(request, ...)` is called — sidesteps that hazard
   // entirely rather than relying on it.
-  const contentPromise: Promise<string> = (async () => {
-    if (!env.AP_PUBLISH_TOKEN || request.method !== "POST") return "";
+  const contentPromise: Promise<{ content: string; photos: ExtractedPhoto[] }> = (async () => {
+    if (!env.AP_PUBLISH_TOKEN || request.method !== "POST") return { content: "", photos: [] };
     const cloned = request.clone();
     try {
       const contentType = cloned.headers.get("content-type") ?? "";
       if (contentType.includes("application/json")) {
-        const body = (await cloned.json()) as { properties?: { content?: unknown[] } };
-        return extractMf2ContentString(body.properties?.content?.[0]);
+        const body = (await cloned.json()) as {
+          properties?: { content?: unknown[]; photo?: unknown[] };
+        };
+        return {
+          content: extractMf2ContentString(body.properties?.content?.[0]),
+          photos: extractMf2Photos(body.properties?.photo),
+        };
       }
       const form = await cloned.formData();
-      return String(form.get("content") ?? form.get("properties[content]") ?? "");
+      const content = String(form.get("content") ?? form.get("properties[content]") ?? "");
+      // Form-encoded `photo`/`photo[]` fields carry a bare URL string per entry; the mf2
+      // `{ value, alt }` alt-text shape has no flat-form equivalent (per `@dwk/micropub`'s own
+      // `parseFormBody`, only one `photo[sub]` nested object can round-trip per request), so
+      // form-encoded photos never carry alt text — same fidelity Micropub form clients get today.
+      const rawPhotos = [...form.getAll("photo"), ...form.getAll("photo[]")].filter(
+        (value): value is string => typeof value === "string" && value.length > 0,
+      );
+      return { content, photos: extractMf2Photos(rawPhotos) };
     } catch {
-      return ""; // Can't recover the post content — skip the fan-out rather than publish an empty Note.
+      // Can't recover the post content — skip the fan-out rather than publish an empty Note.
+      return { content: "", photos: [] };
     }
   })();
   return micropub(request, micropubEnv, ctx).then(async (response) => {
     if (request.method === "POST" && response.status === 201) {
-      const content = await contentPromise;
-      ctx.waitUntil(fanOutMicropubCreateToActivityPub(content, baseUrl, response, env, ctx));
+      const { content, photos } = await contentPromise;
+      ctx.waitUntil(fanOutMicropubCreateToActivityPub(content, photos, baseUrl, response, env, ctx));
     }
     return response;
   });
@@ -1033,9 +1082,16 @@ function handleMicropub(
  * round-trip. Only runs when ActivityPub is provisioned (`AP_PUBLISH_TOKEN` set); activating
  * Micropub alone never attempts to federate. Failure here must never fail the Micropub create
  * response (the post is already saved) — logged and swallowed.
+ *
+ * `photos` becomes AS2 `attachment` (#1240): media-only Fediverse clients such as Pixelfed
+ * render only posts carrying an attachment, so a bare `Note` from `content` alone is invisible
+ * to a Pixelfed follower. `@dwk/activitypub`'s outbox wraps the posted object with `{ ...input }`
+ * (see its `#asOutboxActivity`), so `attachment` passes through to delivery unmodified — no
+ * package-side change needed.
  */
 async function fanOutMicropubCreateToActivityPub(
   content: string,
+  photos: readonly ExtractedPhoto[],
   baseUrl: string,
   micropubResponse: Response,
   env: WorkerEnv,
@@ -1053,6 +1109,15 @@ async function fanOutMicropubCreateToActivityPub(
     attributedTo: actorIRI,
     content,
     url: location,
+    ...(photos.length > 0
+      ? {
+          attachment: photos.map((photo) => ({
+            type: "Image",
+            url: photo.url,
+            ...(photo.alt !== undefined ? { name: photo.alt } : {}),
+          })),
+        }
+      : {}),
     // No `cc` naming the followers collection: unlike the convention some AP implementations
     // use for "public post, also cc followers" addressing, @dwk/activitypub's owner-publish
     // outbox handler (`#publish` in its Durable Object) fans out to every current follower's


### PR DESCRIPTION
Closes #1240

## Summary

- `handleMicropub`'s pre-`micropub()` body extraction now pulls `photo` alongside `content`, for both JSON and form-encoded creates — each entry may be a plain URL string or the mf2 alt-text shape `{ value, alt }`.
- `fanOutMicropubCreateToActivityPub` maps extracted photos onto AS2 `attachment`: `Image` objects with `url` and `name` (alt text, when present) on the fanned-out `Note`. Photo-less posts are unchanged (no `attachment` key).
- Verified `@dwk/activitypub`'s owner-publish outbox endpoint already passes `attachment` through untouched: its `#asOutboxActivity` wraps a bare object as `{ ...input, id, attributedTo, published }`, spreading all caller-supplied fields (including `attachment`) into the stored/delivered activity. No package-side change or paired PR is needed.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [ ] `swift test --package-path .` — could not run in this session's environment (no Swift toolchain available); change is confined to `Resources/Template/worker/` and touches no Swift-facing contract.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — could not run (macOS/Xcode unavailable in this environment).
- [x] `npx vitest run --config vitest.config.ts` (from `Resources/Template/`) — all 144 tests pass, including three new cases: a JSON create with mixed plain-URL/`{value, alt}` photos producing the expected `attachment` array, a photo-less create producing no `attachment` field, and a form-encoded create with repeated `photo`/`photo[]` fields producing the same mapping.
- Manual verification against a live Pixelfed instance (per the issue's acceptance criteria) was not performed in this session — no Fediverse test infrastructure available here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf4TNjgb2prFRurQps5E8B)_