### PR TITLE
Surface Cloudflare Agent Readiness score for published sites

### DIFF
--- a/Sources/AnglesiteApp/AgentReadinessModel.swift
+++ b/Sources/AnglesiteApp/AgentReadinessModel.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+import AnglesiteCore
+
+/// App-layer glue for #1248: fetches Cloudflare's Agent Readiness score for this site's deployed
+/// URL and translates its checks into owner-friendly language. Mirrors `DomainConfigAuditModel`'s
+/// shape (no user input — the target is resolved from the site itself, not typed in), simplified
+/// to a single async step since there's nothing here to apply/reconcile, only to read.
+@MainActor
+@Observable
+final class AgentReadinessModel {
+    enum Phase: Equatable {
+        case idle
+        case scanning(url: URL)
+        case succeeded(report: AgentReadinessReport, scannedURL: URL)
+        case failed(reason: String)
+    }
+
+    private(set) var phase: Phase = .idle
+    var sheetPresented: Bool = false
+
+    private let scanner: any AgentReadinessScanning
+    private let tokenSource: DeployCommand.TokenSource
+    private var inFlight: Task<Void, Never>?
+
+    private var currentSite: CurrentSite?
+
+    init(
+        scanner: any AgentReadinessScanning = HTTPCloudflareClient(),
+        tokenSource: @escaping DeployCommand.TokenSource = DeployCommand.keychainTokenSource
+    ) {
+        self.scanner = scanner
+        self.tokenSource = tokenSource
+    }
+
+    /// Threaded from `SiteWindowModel.loadAndStart`, mirroring `HardenModel.configure(site:)`.
+    func configure(site: CurrentSite) {
+        currentSite = site
+    }
+
+    var isRunning: Bool {
+        if case .scanning = phase { return true }
+        return false
+    }
+
+    func openSheet() {
+        guard !isRunning else { return }
+        phase = .idle
+        sheetPresented = true
+    }
+
+    func retryFromFailed() {
+        guard !isRunning else { return }
+        phase = .idle
+    }
+
+    /// Validates synchronously (site open, deployed URL known) and, only once that succeeds,
+    /// flips `phase` to `.scanning` before spawning the network task — same
+    /// synchronous-then-async split as `DomainConfigAuditModel.runAudit()`, so a caller polling
+    /// `isRunning` right after calling this never races the task's own first `phase` write.
+    func runScan() {
+        guard !isRunning else { return }
+        guard let site = currentSite else {
+            phase = .failed(reason: "No site is open.")
+            return
+        }
+        guard let urlString = DeployCoordinator.resolveSiteURL(siteDirectory: site.sourceDirectory),
+              let url = URL(string: urlString) else {
+            phase = .failed(reason: "This site hasn't been published yet. Publish it first, then check its Agent Readiness score.")
+            return
+        }
+
+        phase = .scanning(url: url)
+
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.performScan(url: url)
+        }
+    }
+
+    func dismissSheet() {
+        inFlight?.cancel()
+        inFlight = nil
+        sheetPresented = false
+        phase = .idle
+    }
+
+    // MARK: - Private
+
+    private func performScan(url: URL) async {
+        do {
+            guard let token = try await tokenSource() else {
+                phase = .failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials.")
+                return
+            }
+            let scanID = try await scanner.submitAgentReadinessScan(url: url, apiToken: token)
+            guard let report = try await poll(scanID: scanID, apiToken: token) else {
+                if !Task.isCancelled {
+                    phase = .failed(reason: "The scan didn't finish in time. Try again in a moment.")
+                }
+                return
+            }
+            guard !Task.isCancelled else { return }
+            phase = .succeeded(report: report, scannedURL: url)
+        } catch let error as CloudflareError {
+            phase = .failed(reason: Self.message(for: error))
+        } catch {
+            if !Task.isCancelled {
+                phase = .failed(reason: "Couldn't check Agent Readiness: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Polls every 3s, up to 20 times (~60s). A full Agent Readiness pass (page render plus 14
+    /// checks) is slower than the Registrar's 15s registration poll elsewhere in this codebase,
+    /// so this window is wider. Returns `nil` — not an error — on a cancelled task or a timeout;
+    /// both are "try again", not "something's wrong".
+    private func poll(scanID: UUID, apiToken: String) async throws -> AgentReadinessReport? {
+        for _ in 0..<20 {
+            if Task.isCancelled { return nil }
+            if let report = try await scanner.agentReadinessResult(scanID: scanID, apiToken: apiToken) {
+                return report
+            }
+            try? await Task.sleep(for: .seconds(3))
+        }
+        return nil
+    }
+
+    private static func message(for error: CloudflareError) -> String {
+        switch error {
+        case .unauthorized:
+            return "API token is unauthorized. Check that it has Account Settings Read permission."
+        case .http(let status):
+            return "Cloudflare API returned HTTP \(status)."
+        case .api(let message):
+            return "Cloudflare API error: \(message)"
+        case .malformedResponse:
+            return "Unexpected response from Cloudflare API."
+        }
+    }
+}

--- a/Sources/AnglesiteApp/AgentReadinessSheetView.swift
+++ b/Sources/AnglesiteApp/AgentReadinessSheetView.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+import AnglesiteCore
+
+struct AgentReadinessSheetView: View {
+    @Bindable var model: AgentReadinessModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            footer
+        }
+        .frame(minWidth: 540, idealWidth: 620, minHeight: 380, idealHeight: 520)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            statusIcon
+            VStack(alignment: .leading, spacing: 1) {
+                Text(headerTitle).font(.headline)
+                if let subtitle = headerSubtitle {
+                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch model.phase {
+        case .idle:
+            Image(systemName: "sparkle.magnifyingglass").font(.title3)
+        case .scanning:
+            ProgressView().controlSize(.small)
+        case .succeeded(let report, _):
+            Image(systemName: report.passedCount == report.totalCount ? "checkmark.seal.fill" : "exclamationmark.seal.fill")
+                .foregroundStyle(report.passedCount == report.totalCount ? .green : .yellow)
+                .font(.title3)
+        case .failed:
+            Image(systemName: "xmark.seal.fill")
+                .foregroundStyle(.red).font(.title3)
+        }
+    }
+
+    private var headerTitle: String {
+        switch model.phase {
+        case .idle:
+            return "Agent Readiness"
+        case .scanning(let url):
+            return "Checking \(url.host ?? url.absoluteString)…"
+        case .succeeded(let report, _):
+            return "\(report.levelName) (\(report.passedCount)/\(report.totalCount) checks passing)"
+        case .failed:
+            return "Couldn't check Agent Readiness"
+        }
+    }
+
+    private var headerSubtitle: String? {
+        switch model.phase {
+        case .idle:
+            return "See how easily AI agents and assistants can find and use this site."
+        case .scanning:
+            return "Cloudflare is scanning the deployed site — this can take up to a minute."
+        case .succeeded(let report, let url):
+            var subtitle = "Scanned \(url.absoluteString)."
+            if let nextLevel = report.nextLevel {
+                subtitle += " Next tier: \(nextLevel.name)."
+            }
+            return subtitle
+        case .failed:
+            return nil
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .idle:
+            idlePrompt
+        case .scanning:
+            VStack(spacing: 8) {
+                ProgressView()
+                Text("Scanning the deployed site for AI agent readiness…")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .succeeded(let report, _):
+            reportView(report)
+        case .failed(let reason):
+            VStack(spacing: 12) {
+                Image(systemName: "xmark.seal.fill")
+                    .foregroundStyle(.red).font(.largeTitle)
+                Text(reason)
+                    .font(.callout).foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 420)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var idlePrompt: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "sparkle.magnifyingglass")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+            Text("Is this site ready for AI agents?")
+                .font(.headline)
+            Text("Cloudflare's Agent Readiness score checks whether AI agents and assistants can discover, read, and act on your deployed site — the 2026 equivalent of a Lighthouse score, but for AI agents instead of browsers.")
+                .font(.callout).foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
+            Spacer()
+        }
+        .padding(16)
+    }
+
+    private func reportView(_ report: AgentReadinessReport) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 14) {
+                ForEach(report.categories) { category in
+                    Section {
+                        Text(category.displayName).font(.subheadline.weight(.semibold))
+                        ForEach(category.checks) { check in
+                            checkRow(check)
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private func checkRow(_ check: AgentReadinessReport.Check) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            checkStatusIcon(check.status)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(check.displayName).font(.callout.weight(.medium))
+                Text(check.hint).font(.caption).foregroundStyle(.secondary)
+                if check.status == .fail && check.anglesiteProvides {
+                    Text("Anglesite already supports this — redeploy the site to pick it up.")
+                        .font(.caption).foregroundStyle(.blue)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(rowBackground(check.status))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    @ViewBuilder
+    private func checkStatusIcon(_ status: AgentReadinessReport.Check.Status) -> some View {
+        switch status {
+        case .pass:
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+        case .fail:
+            Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+        case .neutral:
+            Image(systemName: "minus.circle.fill").foregroundStyle(.secondary)
+        }
+    }
+
+    private func rowBackground(_ status: AgentReadinessReport.Check.Status) -> Color {
+        switch status {
+        case .pass: return Color.green.opacity(0.06)
+        case .fail: return Color.secondary.opacity(0.06)
+        case .neutral: return Color.clear
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            switch model.phase {
+            case .idle:
+                Button("Check Score") { model.runScan() }
+                    .buttonStyle(.borderedProminent)
+            case .succeeded:
+                Button("Rescan") { model.runScan() }
+            case .failed:
+                Button("Try Again") { model.retryFromFailed() }
+            case .scanning:
+                EmptyView()
+            }
+            Spacer()
+            Button("Close") {
+                model.dismissSheet()
+            }
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -376,6 +376,12 @@
     "Advanced" : {
 
     },
+    "Agent Readiness" : {
+
+    },
+    "Agent Readiness…" : {
+
+    },
     "Agents" : {
 
     },
@@ -422,6 +428,9 @@
 
     },
     "Anglesite Website" : {
+
+    },
+    "Anglesite already supports this — redeploy the site to pick it up." : {
 
     },
     "Anglesite lost access to “%@”, likely after a restart. Locate it again to restore access." : {
@@ -735,10 +744,16 @@
     "Check Domain Config" : {
 
     },
+    "Check Score" : {
+
+    },
     "Check for domain config drift" : {
 
     },
     "Check whether Siri workflows are ready for this site" : {
+
+    },
+    "Checking Agent Readiness…" : {
 
     },
     "Checking Domain Config…" : {
@@ -827,6 +842,9 @@
 
     },
     "Cloudflare" : {
+
+    },
+    "Cloudflare's Agent Readiness score checks whether AI agents and assistants can discover, read, and act on your deployed site — the 2026 equivalent of a Lighthouse score, but for AI agents instead of browsers." : {
 
     },
     "Cloudflare's Content Signals Policy states a usage preference per purpose in robots.txt. It's a signal that well-behaved crawlers honor, not an enforced block." : {
@@ -1678,6 +1696,9 @@
 
     },
     "Is this email for you personally, or for a registered business?" : {
+
+    },
+    "Is this site ready for AI agents?" : {
 
     },
     "Join" : {
@@ -2682,6 +2703,9 @@
 
     },
     "Scan for Cleanup Opportunities" : {
+
+    },
+    "Scanning the deployed site for AI agent readiness…" : {
 
     },
     "Scanning…" : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -424,6 +424,23 @@ struct SiteWindow: View {
             }
             .defaultCustomization(.hidden)
 
+            ToolbarItem(id: SiteToolbarItemID.agentReadiness.rawValue, placement: .primaryAction) {
+                Button {
+                    model.agentReadiness.openSheet()
+                } label: {
+                    if model.agentReadiness.isRunning {
+                        Label("Checking Agent Readiness…", systemImage: "sparkle.magnifyingglass")
+                    } else {
+                        Label("Agent Readiness", systemImage: "sparkle.magnifyingglass")
+                    }
+                }
+                .disabled(!model.canRunAgentReadiness)
+                .help(site.isValid
+                      ? "Check Cloudflare's Agent Readiness score for this site's deployed URL"
+                      : "Site is missing required files")
+            }
+            .defaultCustomization(.hidden)
+
             ToolbarItem(id: SiteToolbarItemID.onionRouting.rawValue, placement: .primaryAction) {
                 Button {
                     model.onionRouting.openSheet()
@@ -635,6 +652,9 @@ struct SiteWindow: View {
         }
         .sheet(isPresented: $bindableModel.harden.sheetPresented) {
             HardenSheetView(model: model.harden)
+        }
+        .sheet(isPresented: $bindableModel.agentReadiness.sheetPresented) {
+            AgentReadinessSheetView(model: model.agentReadiness)
         }
         .sheet(isPresented: $bindableModel.onionRouting.sheetPresented) {
             OnionRoutingSheetView(model: model.onionRouting)

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -161,6 +161,8 @@ final class SiteWindowModel {
     var communities = CommunitiesModel()
     var harden = HardenModel()
     var domainConfigAudit = DomainConfigAuditModel()
+    /// Cloudflare Agent Readiness score for the deployed site (#1248).
+    var agentReadiness = AgentReadinessModel()
     var onionRouting = OnionRoutingModel()
     var domain = DomainModel()
     var connectDomain = ConnectDomainModel()
@@ -671,6 +673,7 @@ final class SiteWindowModel {
     var canRunAudit: Bool { site?.isValid == true && !siteOperationRunning && preview.canDeploy }
     var canRunHarden: Bool { site?.isValid == true && !harden.isRunning }
     var canRunDomainConfigAudit: Bool { site?.isValid == true && !domainConfigAudit.isRunning }
+    var canRunAgentReadiness: Bool { site?.isValid == true && !agentReadiness.isRunning }
     var canRunOnionRouting: Bool { site?.isValid == true && !onionRouting.isRunning }
     var canRecheckHealth: Bool { site != nil }
     var canOpenDomain: Bool { site != nil && !domain.isRunning }
@@ -1960,6 +1963,7 @@ final class SiteWindowModel {
         buyDomain.configure(site: currentSite)
         harden.configure(site: currentSite)
         domainConfigAudit.configure(site: currentSite)
+        agentReadiness.configure(site: currentSite)
         // Cold-open path for any `PreviewSiteIntent` (#139) navigation; the already-open window
         // is handled reactively by `.onChange(of: router.pendingNavigation)` in `body`.
         applyPendingNavigation(for: resolved.id)

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -65,6 +65,9 @@ struct WebsiteCommands: Commands {
             Button("Harden…") { model?.harden.openSheet() }
                 .disabled(model?.canRunHarden != true)
 
+            Button("Agent Readiness…") { model?.agentReadiness.openSheet() }
+                .disabled(model?.canRunAgentReadiness != true)
+
             Button("Onion Routing…") { model?.onionRouting.openSheet() }
                 .disabled(model?.canRunOnionRouting != true)
 

--- a/Sources/AnglesiteCore/AgentReadinessReport.swift
+++ b/Sources/AnglesiteCore/AgentReadinessReport.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// Cloudflare's Agent Readiness score for a scanned URL (Agents Week 2026, #1248): how easily an
+/// AI agent can discover, parse, authenticate against, and call a site — the AI-era analogue of a
+/// Lighthouse score. Distinct from `AuditReport` (human accessibility) and `CloudflareZoneState`
+/// (security posture); this grades agent-facing discoverability specifically.
+///
+/// Cloudflare's URL Scanner API reports a readiness *tier* (`level`/`levelName`), not a 0-100
+/// composite score — there is no published `score` field alongside it (confirmed against the
+/// live API reference at the time this was built). `passedCount`/`totalCount` stand in as the
+/// plain-language "how am I doing" summary the app surfaces alongside the tier.
+public struct AgentReadinessReport: Sendable, Equatable {
+    /// Cloudflare's readiness tier (0 = least ready).
+    public let level: Int
+    /// The tier's display label (e.g. "Bot-Aware") — the pairing Cloudflare shows on
+    /// isitagentready.com.
+    public let levelName: String
+    public let categories: [Category]
+    /// What it takes to reach the next tier; `nil` when Cloudflare reports none (e.g. top tier).
+    public let nextLevel: NextLevel?
+
+    public init(level: Int, levelName: String, categories: [Category], nextLevel: NextLevel?) {
+        self.level = level
+        self.levelName = levelName
+        self.categories = categories
+        self.nextLevel = nextLevel
+    }
+
+    public var passedCount: Int { categories.flatMap(\.checks).filter { $0.status == .pass }.count }
+    public var totalCount: Int { categories.flatMap(\.checks).count }
+
+    public struct Category: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let displayName: String
+        public let checks: [Check]
+
+        public init(id: String, displayName: String, checks: [Check]) {
+            self.id = id
+            self.displayName = displayName
+            self.checks = checks
+        }
+    }
+
+    public struct Check: Sendable, Equatable, Identifiable {
+        public let id: String
+        public let displayName: String
+        public let status: Status
+        /// Owner-friendly explanation of what this check means, translated from Cloudflare's
+        /// technical check name via `AgentReadinessCatalog` — not Cloudflare's own message text.
+        public let hint: String
+        /// `true` when Anglesite's site template already implements what this check looks for
+        /// (e.g. `robots.txt`, the sitemap). A failure on one of these means the deployed site is
+        /// stale or misconfigured, not that the app lacks the feature — drives "redeploy to
+        /// pick this up" copy instead of "not supported yet".
+        public let anglesiteProvides: Bool
+
+        public enum Status: String, Sendable, Equatable {
+            case pass
+            case fail
+            case neutral
+        }
+
+        public init(id: String, displayName: String, status: Status, hint: String, anglesiteProvides: Bool) {
+            self.id = id
+            self.displayName = displayName
+            self.status = status
+            self.hint = hint
+            self.anglesiteProvides = anglesiteProvides
+        }
+    }
+
+    public struct NextLevel: Sendable, Equatable {
+        public let name: String
+        public let target: Int
+
+        public init(name: String, target: Int) {
+            self.name = name
+            self.target = target
+        }
+    }
+}
+
+/// Owner-friendly copy for Cloudflare's Agent Readiness checks, keyed by Cloudflare's check id
+/// (the JSON key inside `meta.processors.agentReadiness.checks.<category>`). An id with no entry
+/// here still renders — `checkInfo(for:)` falls back to a humanized version of the id — so a
+/// check Cloudflare adds later degrades to readable-but-untranslated instead of disappearing.
+public enum AgentReadinessCatalog {
+    public struct CategoryInfo: Sendable {
+        public let displayName: String
+    }
+
+    public struct CheckInfo: Sendable {
+        public let displayName: String
+        public let passHint: String
+        public let failHint: String
+        /// See `AgentReadinessReport.Check.anglesiteProvides`.
+        public let anglesiteProvides: Bool
+    }
+
+    public static let categories: [String: CategoryInfo] = [
+        "discoverability": .init(displayName: "Discoverability"),
+        "contentAccessibility": .init(displayName: "Content"),
+        "botAccessControl": .init(displayName: "Bot Access Control"),
+        "discovery": .init(displayName: "Capabilities"),
+    ]
+
+    public static let checks: [String: CheckInfo] = [
+        "robotsTxt": .init(
+            displayName: "Crawling rules (robots.txt)",
+            passHint: "AI agents can find your site's crawling rules.",
+            failHint: "AI agents can't find crawling rules for your site.",
+            anglesiteProvides: true),
+        "sitemap": .init(
+            displayName: "Sitemap",
+            passHint: "AI agents can find a map of your site's pages.",
+            failHint: "AI agents can't find a map of your site's pages.",
+            anglesiteProvides: true),
+        "linkHeaders": .init(
+            displayName: "Page discovery links",
+            passHint: "Your pages point AI agents to related resources automatically.",
+            failHint: "Your pages don't point AI agents to related resources (RFC 8288 Link headers).",
+            anglesiteProvides: false),
+        "markdownNegotiation": .init(
+            displayName: "Markdown for AI agents",
+            passHint: "AI agents get a clean, Markdown version of your pages instead of raw HTML.",
+            failHint: "AI agents only see raw HTML — a plain-text Markdown version isn't offered yet.",
+            anglesiteProvides: false),
+        "contentSignals": .init(
+            displayName: "Content usage signals",
+            passHint: "Your site tells AI companies how they may use your content.",
+            failHint: "Your site doesn't say how AI companies may use your content.",
+            anglesiteProvides: true),
+        "robotsTxtAiRules": .init(
+            displayName: "AI crawler rules",
+            passHint: "Your crawling rules include AI-specific bot instructions.",
+            failHint: "Your crawling rules don't call out AI bots specifically.",
+            anglesiteProvides: true),
+        "webBotAuth": .init(
+            displayName: "Verified bot access",
+            passHint: "Your site can cryptographically verify trusted AI agents.",
+            failHint: "Your site can't yet verify trusted AI agents cryptographically (Web Bot Auth).",
+            anglesiteProvides: false),
+        "agentSkills": .init(
+            displayName: "Agent Skills manifest",
+            passHint: "Your site publishes a manifest of tasks AI agents can perform for visitors.",
+            failHint: "Your site doesn't publish a manifest of tasks AI agents can perform for visitors.",
+            anglesiteProvides: false),
+        "apiCatalog": .init(
+            displayName: "API catalog",
+            passHint: "Your site publishes a catalog of its APIs for AI agents to use.",
+            failHint: "Your site doesn't publish a catalog of its APIs for AI agents.",
+            anglesiteProvides: false),
+        "mcpServerCard": .init(
+            displayName: "MCP server listing",
+            passHint: "AI agents can discover your site's MCP server.",
+            failHint: "AI agents can't discover an MCP server for your site.",
+            anglesiteProvides: false),
+        "oauthDiscovery": .init(
+            displayName: "Sign-in discovery for agents",
+            passHint: "AI agents can find how to sign in on your visitors' behalf.",
+            failHint: "AI agents can't find how to sign in on your visitors' behalf (OAuth/OIDC discovery).",
+            anglesiteProvides: false),
+        "oauthProtectedResource": .init(
+            displayName: "Protected resource discovery",
+            passHint: "AI agents can find how to access your site's protected resources.",
+            failHint: "AI agents can't find how to access your site's protected resources.",
+            anglesiteProvides: false),
+        "webMcp": .init(
+            displayName: "In-browser agent tools (WebMCP)",
+            passHint: "AI agents browsing your site can use its in-page tools directly.",
+            failHint: "AI agents browsing your site can't use in-page tools directly (WebMCP).",
+            anglesiteProvides: false),
+        "a2aAgentCard": .init(
+            displayName: "Agent-to-agent card",
+            passHint: "Other AI agents can discover how to work with yours.",
+            failHint: "Other AI agents can't discover how to work with yours.",
+            anglesiteProvides: false),
+    ]
+
+    public static func categoryDisplayName(for id: String) -> String {
+        categories[id]?.displayName ?? humanize(id)
+    }
+
+    public static func checkInfo(for id: String) -> CheckInfo {
+        checks[id] ?? .init(
+            displayName: humanize(id),
+            passHint: "This check passed.",
+            failHint: "This check needs attention.",
+            anglesiteProvides: false)
+    }
+
+    /// Turns a camelCase check id (e.g. `"robotsTxtAiRules"`) into a readable fallback label
+    /// (`"Robots Txt Ai Rules"`) for ids not in the catalog above.
+    private static func humanize(_ camelCase: String) -> String {
+        var result = ""
+        for (index, character) in camelCase.enumerated() {
+            if character.isUppercase && index > 0 {
+                result.append(" ")
+            }
+            result.append(index == 0 ? Character(character.uppercased()) : character)
+        }
+        return result
+    }
+}

--- a/Sources/AnglesiteCore/AgentReadinessScanning.swift
+++ b/Sources/AnglesiteCore/AgentReadinessScanning.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Read-only seam for Cloudflare's Agent Readiness score (URL Scanner API's `agentReadiness`
+/// scan option, #1248). Token passed per call, matching `CloudflareReading`. The underlying scan
+/// is asynchronous — submit, then poll for a result — so this seam mirrors that with two calls
+/// instead of one.
+public protocol AgentReadinessScanning: Sendable {
+    /// Submits a scan of `url` with Agent Readiness checks enabled. Returns the scan id to poll
+    /// via `agentReadinessResult(scanID:apiToken:)`.
+    func submitAgentReadinessScan(url: URL, apiToken: String) async throws -> UUID
+
+    /// Polls a submitted scan. `nil` means the scan is still processing — callers should wait and
+    /// call again. Once Cloudflare finishes the scan, this decodes and returns the report;
+    /// if the finished result carries no Agent Readiness section at all (unexpected, since the
+    /// option was requested at submission), it throws `CloudflareError.malformedResponse` rather
+    /// than returning a report built from absent data.
+    func agentReadinessResult(scanID: UUID, apiToken: String) async throws -> AgentReadinessReport?
+}

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -95,6 +95,41 @@ private struct CFRegistrarRegistrationState: Decodable, Sendable {
 private struct CFWorkerScript: Decodable, Sendable { let id: String }
 private struct CFWorkerDomain: Decodable, Sendable { let hostname: String; let service: String }
 
+/// URL Scanner `POST .../urlscanner/v2/scan` response — a flat object, unlike the rest of this
+/// file's v4 endpoints: no `{success, result, errors}` envelope (confirmed against the live API
+/// reference). Only `uuid` (the scan id to poll) is needed here.
+private struct CFURLScanSubmission: Decodable, Sendable { let uuid: String }
+
+/// One Agent Readiness check's result, as nested under
+/// `meta.processors.agentReadiness.checks.<category>.<checkID>` in a finished scan's result.
+private struct CFAgentReadinessCheck: Decodable, Sendable { let status: String }
+
+/// The four *scored* Agent Readiness categories. `commerce` (x402/UCP/ACP) is deliberately
+/// omitted — Cloudflare tracks it but excludes it from the tier, per the blog announcement.
+private struct CFAgentReadinessChecks: Decodable, Sendable {
+    let botAccessControl: [String: CFAgentReadinessCheck]?
+    let contentAccessibility: [String: CFAgentReadinessCheck]?
+    let discoverability: [String: CFAgentReadinessCheck]?
+    let discovery: [String: CFAgentReadinessCheck]?
+}
+
+private struct CFAgentReadinessNextLevel: Decodable, Sendable { let name: String; let target: Int }
+
+private struct CFAgentReadiness: Decodable, Sendable {
+    let level: Int
+    let levelName: String
+    let checks: CFAgentReadinessChecks
+    let nextLevel: CFAgentReadinessNextLevel?
+}
+
+private struct CFScanResult: Decodable, Sendable {
+    struct Meta: Decodable, Sendable {
+        struct Processors: Decodable, Sendable { let agentReadiness: CFAgentReadiness? }
+        let processors: Processors?
+    }
+    let meta: Meta?
+}
+
 /// Body for DELETE requests, which Cloudflare's API doesn't require but tolerates.
 private struct CFEmptyBody: Encodable, Sendable {}
 private struct CFBotManagement: Decodable, Sendable {
@@ -743,5 +778,91 @@ extension HTTPCloudflareClient: CloudflareRegistrarWriting {
             return outcome
         }
         return .stillProcessing
+    }
+}
+
+// MARK: - AgentReadinessScanning conformance
+
+extension HTTPCloudflareClient: AgentReadinessScanning {
+    /// `POST /accounts/{id}/urlscanner/v2/scan` with `options.agentReadiness: true`. Submitted
+    /// `unlisted` — the app shouldn't publish an owner's scan to Cloudflare's public URL Scanner
+    /// listing without their say-so. Reuses `resolveAccountID` (the Registrar conformance above,
+    /// same file so its `private` scope still applies) since URL Scanner is account-scoped too.
+    public func submitAgentReadinessScan(url: URL, apiToken: String) async throws -> UUID {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        struct ScanRequest: Encodable, Sendable {
+            struct Options: Encodable, Sendable { let agentReadiness: Bool }
+            let url: String
+            let visibility: String
+            let options: Options
+        }
+        let body = ScanRequest(url: url.absoluteString, visibility: "unlisted", options: .init(agentReadiness: true))
+        let (data, _) = try await send(method: "POST", "/accounts/\(accountID)/urlscanner/v2/scan", body: body, apiToken: apiToken)
+        let submission: CFURLScanSubmission
+        do {
+            submission = try JSONDecoder().decode(CFURLScanSubmission.self, from: data)
+        } catch {
+            throw CloudflareError.malformedResponse
+        }
+        guard let scanID = UUID(uuidString: submission.uuid) else { throw CloudflareError.malformedResponse }
+        return scanID
+    }
+
+    /// `GET /accounts/{id}/urlscanner/v2/result/{scan_id}`. A 404 means the scan hasn't finished
+    /// processing yet (the URL Scanner API's documented behavior for an in-flight scan id) — that
+    /// maps to `nil` rather than an error so callers can poll in a loop without special-casing it.
+    public func agentReadinessResult(scanID: UUID, apiToken: String) async throws -> AgentReadinessReport? {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        guard let url = URL(string: Self.base + "/accounts/\(accountID)/urlscanner/v2/result/\(scanID.uuidString.lowercased())") else {
+            throw CloudflareError.malformedResponse
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let (data, http) = try await transport(request)
+        if http.statusCode == 404 { return nil }
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        let result: CFScanResult
+        do {
+            result = try JSONDecoder().decode(CFScanResult.self, from: data)
+        } catch {
+            throw CloudflareError.malformedResponse
+        }
+        guard let readiness = result.meta?.processors?.agentReadiness else {
+            throw CloudflareError.malformedResponse
+        }
+        return Self.mapAgentReadinessReport(readiness)
+    }
+
+    /// Maps the raw wire shape to the public report, translating each check id through
+    /// `AgentReadinessCatalog` for owner-friendly copy. A category with no checks in the response
+    /// (all four are optional on the wire) is dropped rather than shown empty.
+    private static func mapAgentReadinessReport(_ raw: CFAgentReadiness) -> AgentReadinessReport {
+        func category(_ dict: [String: CFAgentReadinessCheck]?, id: String) -> AgentReadinessReport.Category? {
+            guard let dict, !dict.isEmpty else { return nil }
+            let checks = dict.map { checkID, rawCheck -> AgentReadinessReport.Check in
+                let info = AgentReadinessCatalog.checkInfo(for: checkID)
+                let status = AgentReadinessReport.Check.Status(rawValue: rawCheck.status.lowercased()) ?? .neutral
+                return AgentReadinessReport.Check(
+                    id: checkID, displayName: info.displayName, status: status,
+                    hint: status == .pass ? info.passHint : info.failHint,
+                    anglesiteProvides: info.anglesiteProvides)
+            }.sorted { $0.displayName < $1.displayName }
+            return AgentReadinessReport.Category(
+                id: id, displayName: AgentReadinessCatalog.categoryDisplayName(for: id), checks: checks)
+        }
+
+        let categories = [
+            category(raw.checks.discoverability, id: "discoverability"),
+            category(raw.checks.contentAccessibility, id: "contentAccessibility"),
+            category(raw.checks.botAccessControl, id: "botAccessControl"),
+            category(raw.checks.discovery, id: "discovery"),
+        ].compactMap { $0 }
+
+        return AgentReadinessReport(
+            level: raw.level, levelName: raw.levelName, categories: categories,
+            nextLevel: raw.nextLevel.map { AgentReadinessReport.NextLevel(name: $0.name, target: $0.target) })
     }
 }

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -415,6 +415,28 @@ public struct HTTPCloudflareClient: CloudflareReading {
         return (data, http)
     }
 
+    /// GET `path` with no body, mapping 401/403 to ``CloudflareError/unauthorized`` and any other
+    /// non-2xx status to ``CloudflareError/http(status:)`` — the read-side counterpart to
+    /// `send(method:_:body:apiToken:)`, for endpoints (like URL Scanner) that don't wrap responses
+    /// in the `{success, result, errors}` v4 envelope `getEnvelope`/`get` assume, so those helpers
+    /// don't fit. `passthroughStatuses` lets a caller opt specific non-2xx statuses out of the
+    /// `.http` mapping to inspect the raw response itself (e.g. a 404 that means "not ready yet"
+    /// rather than "doesn't exist").
+    private func fetchRaw(
+        _ path: String, apiToken: String, passthroughStatuses: Set<Int> = []
+    ) async throws -> (Data, HTTPURLResponse) {
+        guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let (data, http) = try await transport(request)
+        if passthroughStatuses.contains(http.statusCode) { return (data, http) }
+        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
+        return (data, http)
+    }
+
     private func mutate<Body: Encodable & Sendable>(
         method: String,
         _ path: String,
@@ -808,22 +830,27 @@ extension HTTPCloudflareClient: AgentReadinessScanning {
         return scanID
     }
 
-    /// `GET /accounts/{id}/urlscanner/v2/result/{scan_id}`. A 404 means the scan hasn't finished
-    /// processing yet (the URL Scanner API's documented behavior for an in-flight scan id) — that
-    /// maps to `nil` rather than an error so callers can poll in a loop without special-casing it.
+    /// `GET /accounts/{id}/urlscanner/v2/result/{scan_id}`. Two different "not ready yet" shapes
+    /// both map to `nil` rather than an error, so callers can poll in a loop without
+    /// special-casing either: a 404 (the URL Scanner API's documented behavior for an in-flight
+    /// scan id that hasn't produced *any* result yet), and a 200 whose `meta.processors` doesn't
+    /// carry an `agentReadiness` section yet. That second case matters because the scan's base
+    /// result (page load, requests) can land before its async processors — `agentReadiness`
+    /// included — finish; without it, the very first poll (or every poll before that processor
+    /// completes) would otherwise hard-fail with `.malformedResponse` instead of just meaning "not
+    /// done yet". This was flagged in review (#1248) as unverified against a live scan — Cloudflare
+    /// doesn't document a separate in-progress marker (e.g. on `task`) to distinguish that from a
+    /// scan that's genuinely finished with no Agent Readiness data at all, so a persistently
+    /// missing section still resolves the same way an in-progress one does: the caller's poll loop
+    /// times out and surfaces "didn't finish in time" rather than a hard error either way. A
+    /// response that doesn't even decode as the expected shape is left as `.malformedResponse` —
+    /// that's a different, more clearly broken case than an optional inner section being absent.
     public func agentReadinessResult(scanID: UUID, apiToken: String) async throws -> AgentReadinessReport? {
         let accountID = try await resolveAccountID(apiToken: apiToken)
-        guard let url = URL(string: Self.base + "/accounts/\(accountID)/urlscanner/v2/result/\(scanID.uuidString.lowercased())") else {
-            throw CloudflareError.malformedResponse
-        }
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        let (data, http) = try await transport(request)
+        let (data, http) = try await fetchRaw(
+            "/accounts/\(accountID)/urlscanner/v2/result/\(scanID.uuidString.lowercased())",
+            apiToken: apiToken, passthroughStatuses: [404])
         if http.statusCode == 404 { return nil }
-        if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
-        guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
         let result: CFScanResult
         do {
             result = try JSONDecoder().decode(CFScanResult.self, from: data)
@@ -831,7 +858,7 @@ extension HTTPCloudflareClient: AgentReadinessScanning {
             throw CloudflareError.malformedResponse
         }
         guard let readiness = result.meta?.processors?.agentReadiness else {
-            throw CloudflareError.malformedResponse
+            return nil
         }
         return Self.mapAgentReadinessReport(readiness)
     }

--- a/Sources/AnglesiteCore/SiteToolbarItemID.swift
+++ b/Sources/AnglesiteCore/SiteToolbarItemID.swift
@@ -17,6 +17,8 @@ public enum SiteToolbarItemID: String, CaseIterable, Sendable {
     case harden
     /// Domain config drift audit + reconcile (#1171): declared `anglesite.json` vs live Cloudflare.
     case domainConfigAudit
+    /// Cloudflare Agent Readiness score for the deployed site (#1248).
+    case agentReadiness
     case onionRouting
     case domain
     case integration

--- a/Tests/AnglesiteAppTests/AgentReadinessModelTests.swift
+++ b/Tests/AnglesiteAppTests/AgentReadinessModelTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+private final class StubScanner: AgentReadinessScanning, @unchecked Sendable {
+    private let scanID: UUID
+    private let pollSequence: [AgentReadinessReport?]
+    private let submitError: Error?
+    private(set) var submittedURL: URL?
+    private(set) var submittedToken: String?
+    private var pollIndex = 0
+
+    init(scanID: UUID = UUID(), pollSequence: [AgentReadinessReport?] = [], submitError: Error? = nil) {
+        self.scanID = scanID
+        self.pollSequence = pollSequence
+        self.submitError = submitError
+    }
+
+    func submitAgentReadinessScan(url: URL, apiToken: String) async throws -> UUID {
+        submittedURL = url
+        submittedToken = apiToken
+        if let submitError { throw submitError }
+        return scanID
+    }
+
+    func agentReadinessResult(scanID: UUID, apiToken: String) async throws -> AgentReadinessReport? {
+        defer { pollIndex = min(pollIndex + 1, pollSequence.count - 1) }
+        guard !pollSequence.isEmpty else { return nil }
+        return pollSequence[min(pollIndex, pollSequence.count - 1)]
+    }
+}
+
+private let sampleReport = AgentReadinessReport(
+    level: 2, levelName: "Bot-Aware",
+    categories: [
+        .init(id: "discoverability", displayName: "Discoverability", checks: [
+            .init(id: "robotsTxt", displayName: "Crawling rules (robots.txt)", status: .pass,
+                  hint: "AI agents can find your site's crawling rules.", anglesiteProvides: true),
+        ]),
+    ],
+    nextLevel: nil)
+
+@Suite(.serialized)
+struct AgentReadinessModelTests {
+    private func tempSite(siteURL: String? = "https://example.workers.dev") throws -> (CurrentSite, () -> Void) {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        if let siteURL {
+            try "SITE_URL=\(siteURL)\n".write(
+                to: tmp.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        }
+        let site = CurrentSite(id: "s1", packageURL: tmp, sourceDirectory: tmp)
+        return (site, { try? FileManager.default.removeItem(at: tmp) })
+    }
+
+    @MainActor
+    @Test("runScan() fails clearly when no site is open")
+    func runScanNoSite() async {
+        let model = AgentReadinessModel(scanner: StubScanner(), tokenSource: { "token" })
+        model.runScan()
+        guard case .failed(let reason) = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        #expect(reason.contains("No site is open"))
+    }
+
+    @MainActor
+    @Test("runScan() fails clearly when the site has no known deployed URL")
+    func runScanNoDeployedURL() async throws {
+        let (site, cleanup) = try tempSite(siteURL: nil)
+        defer { cleanup() }
+        let model = AgentReadinessModel(scanner: StubScanner(), tokenSource: { "token" })
+        model.configure(site: site)
+
+        model.runScan()
+
+        guard case .failed(let reason) = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        #expect(reason.contains("published"))
+    }
+
+    @MainActor
+    @Test("runScan() fails clearly when no Cloudflare token is available")
+    func runScanNoToken() async throws {
+        let (site, cleanup) = try tempSite()
+        defer { cleanup() }
+        let model = AgentReadinessModel(scanner: StubScanner(), tokenSource: { nil })
+        model.configure(site: site)
+
+        model.runScan()
+        while model.isRunning { await Task.yield() }
+
+        guard case .failed(let reason) = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        #expect(reason.contains("No Cloudflare API token"))
+    }
+
+    @MainActor
+    @Test("runScan() submits the site's resolved URL and surfaces the polled report")
+    func runScanSucceeds() async throws {
+        let (site, cleanup) = try tempSite()
+        defer { cleanup() }
+        let scanner = StubScanner(pollSequence: [sampleReport])
+        let model = AgentReadinessModel(scanner: scanner, tokenSource: { "token" })
+        model.configure(site: site)
+
+        model.runScan()
+        while model.isRunning { await Task.yield() }
+
+        #expect(scanner.submittedURL == URL(string: "https://example.workers.dev"))
+        #expect(scanner.submittedToken == "token")
+        guard case .succeeded(let report, let scannedURL) = model.phase else {
+            Issue.record("expected .succeeded, got \(model.phase)")
+            return
+        }
+        #expect(report == sampleReport)
+        #expect(scannedURL == URL(string: "https://example.workers.dev"))
+    }
+
+    @MainActor
+    @Test("runScan() surfaces a Cloudflare API error")
+    func runScanCloudflareError() async throws {
+        let (site, cleanup) = try tempSite()
+        defer { cleanup() }
+        let scanner = StubScanner(submitError: CloudflareError.unauthorized)
+        let model = AgentReadinessModel(scanner: scanner, tokenSource: { "token" })
+        model.configure(site: site)
+
+        model.runScan()
+        while model.isRunning { await Task.yield() }
+
+        guard case .failed(let reason) = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        #expect(reason.contains("unauthorized"))
+    }
+
+    @MainActor
+    @Test("openSheet() resets phase and presents")
+    func openSheetResets() {
+        let model = AgentReadinessModel(scanner: StubScanner(), tokenSource: { "token" })
+        model.openSheet()
+        #expect(model.sheetPresented == true)
+        #expect(model.phase == .idle)
+    }
+
+    @MainActor
+    @Test("dismissSheet() clears the presented flag and resets phase")
+    func dismissSheetClearsPresented() {
+        let model = AgentReadinessModel(scanner: StubScanner(), tokenSource: { "token" })
+        model.openSheet()
+        model.dismissSheet()
+        #expect(model.sheetPresented == false)
+        #expect(model.phase == .idle)
+    }
+}

--- a/Tests/AnglesiteCoreTests/AgentReadinessScanningTests.swift
+++ b/Tests/AnglesiteCoreTests/AgentReadinessScanningTests.swift
@@ -101,11 +101,25 @@ struct AgentReadinessScanningTests {
         #expect(mcp.status == .neutral)
     }
 
-    @Test("agentReadinessResult throws malformedResponse when the finished scan has no agentReadiness section")
-    func resultMissingAgentReadinessThrows() async throws {
+    @Test("agentReadinessResult returns nil (not an error) when a 200 result has no agentReadiness section yet")
+    func resultMissingAgentReadinessReturnsNil() async throws {
+        // The base scan (page load, requests) can land before its async processors —
+        // agentReadiness included — finish, so this is "not ready yet", same as a 404, not a
+        // hard failure. See the doc comment on `agentReadinessResult` for the full reasoning.
         let client = HTTPCloudflareClient(transport: fakeTransport([
             "/accounts?per_page=1": (200, accountsJSON),
             "/urlscanner/v2/result/": (200, "{\"meta\":{\"processors\":{}}}"),
+        ]))
+
+        let report = try await client.agentReadinessResult(scanID: UUID(), apiToken: "t")
+        #expect(report == nil)
+    }
+
+    @Test("agentReadinessResult throws malformedResponse when the response doesn't decode at all")
+    func resultUndecodableThrows() async throws {
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/urlscanner/v2/result/": (200, "not json"),
         ]))
 
         await #expect(throws: CloudflareError.malformedResponse) {

--- a/Tests/AnglesiteCoreTests/AgentReadinessScanningTests.swift
+++ b/Tests/AnglesiteCoreTests/AgentReadinessScanningTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct AgentReadinessScanningTests {
+    private let accountsJSON = """
+    {"success":true,"errors":[],"result":[{"id":"acct1"}]}
+    """
+
+    @Test("submitAgentReadinessScan posts agentReadiness:true, unlisted visibility, and returns the scan uuid")
+    func submitReturnsScanID() async throws {
+        let spy = TransportSpy()
+        let submissionJSON = """
+        {"uuid":"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e","url":"https://example.com","result":"r","api":"a","visibility":"unlisted","message":"Submission successful"}
+        """
+        let client = HTTPCloudflareClient(transport: spyTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/urlscanner/v2/scan": (200, submissionJSON),
+        ], spy: spy))
+
+        let scanID = try await client.submitAgentReadinessScan(url: URL(string: "https://example.com")!, apiToken: "t")
+
+        #expect(scanID.uuidString.lowercased() == "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e")
+
+        let scanRequest = try #require(spy.requests.first { $0.url?.absoluteString.contains("/urlscanner/v2/scan") == true })
+        #expect(scanRequest.httpMethod == "POST")
+        #expect(scanRequest.url?.absoluteString.contains("/accounts/acct1/urlscanner/v2/scan") == true)
+        let body = try #require(scanRequest.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["url"] as? String == "https://example.com")
+        #expect(json["visibility"] as? String == "unlisted")
+        #expect((json["options"] as? [String: Any])?["agentReadiness"] as? Bool == true)
+    }
+
+    @Test("agentReadinessResult returns nil while the scan is still processing (404)")
+    func resultPendingReturnsNil() async throws {
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/urlscanner/v2/result/": (404, "{}"),
+        ]))
+
+        let report = try await client.agentReadinessResult(scanID: UUID(), apiToken: "t")
+        #expect(report == nil)
+    }
+
+    @Test("agentReadinessResult maps checks, statuses, categories, and next-level info")
+    func resultDecodesReport() async throws {
+        let resultJSON = """
+        {
+          "meta": {
+            "processors": {
+              "agentReadiness": {
+                "level": 2,
+                "levelName": "Bot-Aware",
+                "checks": {
+                  "discoverability": {
+                    "robotsTxt": {"status": "pass"},
+                    "sitemap": {"status": "fail"}
+                  },
+                  "contentAccessibility": {
+                    "markdownNegotiation": {"status": "fail"}
+                  },
+                  "botAccessControl": {
+                    "contentSignals": {"status": "pass"}
+                  },
+                  "discovery": {
+                    "mcpServerCard": {"status": "neutral"}
+                  }
+                },
+                "nextLevel": {"name": "Agent-Readable", "target": 3}
+              }
+            }
+          }
+        }
+        """
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/urlscanner/v2/result/": (200, resultJSON),
+        ]))
+
+        let report = try await client.agentReadinessResult(scanID: UUID(), apiToken: "t")
+        let unwrapped = try #require(report)
+
+        #expect(unwrapped.level == 2)
+        #expect(unwrapped.levelName == "Bot-Aware")
+        #expect(unwrapped.nextLevel == AgentReadinessReport.NextLevel(name: "Agent-Readable", target: 3))
+        #expect(unwrapped.totalCount == 5)
+        #expect(unwrapped.passedCount == 2)
+
+        let discoverability = try #require(unwrapped.categories.first { $0.id == "discoverability" })
+        #expect(discoverability.displayName == "Discoverability")
+        let robotsTxt = try #require(discoverability.checks.first { $0.id == "robotsTxt" })
+        #expect(robotsTxt.status == .pass)
+        #expect(robotsTxt.anglesiteProvides == true)
+        let sitemap = try #require(discoverability.checks.first { $0.id == "sitemap" })
+        #expect(sitemap.status == .fail)
+        #expect(sitemap.hint == AgentReadinessCatalog.checkInfo(for: "sitemap").failHint)
+
+        let discovery = try #require(unwrapped.categories.first { $0.id == "discovery" })
+        let mcp = try #require(discovery.checks.first { $0.id == "mcpServerCard" })
+        #expect(mcp.status == .neutral)
+    }
+
+    @Test("agentReadinessResult throws malformedResponse when the finished scan has no agentReadiness section")
+    func resultMissingAgentReadinessThrows() async throws {
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/urlscanner/v2/result/": (200, "{\"meta\":{\"processors\":{}}}"),
+        ]))
+
+        await #expect(throws: CloudflareError.malformedResponse) {
+            _ = try await client.agentReadinessResult(scanID: UUID(), apiToken: "t")
+        }
+    }
+
+    @Test("agentReadinessResult maps 401 to unauthorized")
+    func resultUnauthorized() async throws {
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/urlscanner/v2/result/": (401, "{}"),
+        ]))
+
+        await #expect(throws: CloudflareError.unauthorized) {
+            _ = try await client.agentReadinessResult(scanID: UUID(), apiToken: "t")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
@@ -15,6 +15,7 @@ struct SiteToolbarItemIDTests {
             "openInBrowser",
             "harden",
             "domainConfigAudit",
+            "agentReadiness",
             "onionRouting",
             "domain",
             "integration",


### PR DESCRIPTION
Closes #1248

## Summary

- Adds `Website ▸ Agent Readiness…` (menu + palette toolbar item) — scans the site's deployed URL via Cloudflare's URL Scanner API (`options.agentReadiness: true`), polls for the result, and shows the readiness tier plus a per-check breakdown translated into owner-friendly language via a new `AgentReadinessCatalog`.
- Checks the template already implements (`robots.txt`, sitemap, Content Signals, AI bot rules in `robots.txt`) are flagged `anglesiteProvides: true` so a failure there reads as "redeploy to pick this up" rather than "not supported" — the app doesn't ask the owner to do anything technical for those.
- Cloudflare doesn't publish a 0–100 composite score field on this endpoint (confirmed against the live API reference — only a readiness *tier*, `level`/`levelName`), so the UI leads with the tier and a plain "N/M checks passing" count instead of inventing a score.
- Filed #1326 to track the template-side gaps the score reveals that aren't covered yet (RFC 8288 Link headers, Web Bot Auth, Agent Skills, API Catalog, MCP Server Card, agent-facing OAuth discovery, WebMCP) — Markdown for Agents is already tracked separately as #1247, so it's excluded from that follow-up and just shows "not supported yet" here.
- Reuses the existing `DeployCommand.keychainTokenSource` resolver (env → OAuth, refreshed → legacy token) so this doesn't need to wait on #1211's cross-call-site migration — that resolver is already usable standalone from any call site, not embedded in the deploy path.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — ran the Linux-portable subset (`AnglesiteCore`, `AnglesiteSiteModel`, `AnglesiteQuickLookSupport`, `AnglesiteBridgeCore`); all pass. `AnglesiteCoreTests` itself isn't in that portable set (pre-existing, unrelated Darwin-only test files), so I additionally smoke-compiled it locally by temporarily widening `Package.swift`'s portable-target list (not committed) — `AgentReadinessScanningTests.swift` compiled clean, with the only errors coming from a pre-existing unrelated `CoreGraphics` import.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **could not run**: this session has no macOS/Xcode. The new `AnglesiteApp`/`AnglesiteAppCore` files (`AgentReadinessModel.swift`, `AgentReadinessSheetView.swift`, the `SiteWindow`/`SiteWindowModel`/`WebsiteCommands` wiring, and `AgentReadinessModelTests.swift`) are unverified by a compiler — I reviewed them carefully against existing sibling patterns (`HardenModel`/`DomainConfigAuditModel`/`HardenSheetView`) and matched established idioms (e.g. `DeployCommand.TokenSource` closure literals, `CurrentSite` fixture init) but this needs a real macOS build/test pass before merge.
- [ ] Manual smoke: not done — no live Cloudflare account/token in this session to exercise a real scan end-to-end. The wire schema (`meta.processors.agentReadiness.checks.<category>.<id>.status`, `level`/`levelName`, `nextLevel`) is built from Cloudflare's published API reference (no full example response is publicly documented for this field), so it's worth double-checking against one real scan result before shipping.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015WNE55wyi6pfXgqdt8mTVD)_