### PR TITLE
Call ActivityPub "the Fediverse" in the UI

### DIFF
--- a/Sources/AnglesiteApp/FollowersView.swift
+++ b/Sources/AnglesiteApp/FollowersView.swift
@@ -26,8 +26,8 @@ struct FollowersView: View {
                     detail: Text("Publish it at least once, then followers will appear here."))
             case .notActivated:
                 message(
-                    "ActivityPub isn't turned on for this site",
-                    detail: Text("Turn on ActivityPub in Settings ▸ Workers, then publish again."))
+                    "The Fediverse isn't turned on for this site",
+                    detail: Text("Turn on The Fediverse in Settings ▸ Workers, then publish again."))
             case .unreachable(let reason):
                 // `reason` is server-supplied (HTTP body / error description) — untrusted remote
                 // content, never a localization key or format string. `Text(reason)` binds to the

--- a/Sources/AnglesiteApp/FollowersView.swift
+++ b/Sources/AnglesiteApp/FollowersView.swift
@@ -27,7 +27,7 @@ struct FollowersView: View {
             case .notActivated:
                 message(
                     "The Fediverse isn't turned on for this site",
-                    detail: Text("Turn on The Fediverse in Settings ▸ Workers, then publish again."))
+                    detail: Text("Turn on the Fediverse in Settings ▸ Workers, then publish again."))
             case .unreachable(let reason):
                 // `reason` is server-supplied (HTTP body / error description) — untrusted remote
                 // content, never a localization key or format string. `Text(reason)` binds to the

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -3216,9 +3216,6 @@
     "Turn On and Route Reports" : {
 
     },
-    "Turn on The Fediverse in Settings ▸ Workers, then publish again." : {
-
-    },
     "Turn on private vulnerability reporting for %@/%@?" : {
       "localizations" : {
         "en" : {
@@ -3228,6 +3225,9 @@
           }
         }
       }
+    },
+    "Turn on the Fediverse in Settings ▸ Workers, then publish again." : {
+
     },
     "Type" : {
 

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -280,9 +280,6 @@
     "Active — used on ^[%lld page](inflect: true)" : {
 
     },
-    "ActivityPub isn't turned on for this site" : {
-
-    },
     "Actual Size" : {
 
     },
@@ -1737,6 +1734,9 @@
     "Last checked %@" : {
 
     },
+    "Learn more about The Fediverse" : {
+
+    },
     "Learning %@’s conventions…" : {
 
     },
@@ -3081,6 +3081,9 @@
     "That's a different site — choose the original package folder instead." : {
 
     },
+    "The Fediverse isn't turned on for this site" : {
+
+    },
     "The Reader follows feeds and stores your timeline on this site's own Microsub endpoint — sign in as this site's owner to use it." : {
 
     },
@@ -3213,7 +3216,7 @@
     "Turn On and Route Reports" : {
 
     },
-    "Turn on ActivityPub in Settings ▸ Workers, then publish again." : {
+    "Turn on The Fediverse in Settings ▸ Workers, then publish again." : {
 
     },
     "Turn on private vulnerability reporting for %@/%@?" : {

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -702,7 +702,7 @@ struct PlistEditorView: View {
                         // (#1005) — point them at a plain-language explainer instead of renaming
                         // the manifest-owned worker row itself.
                         if group.rows.contains(where: { $0.id == WorkerComposition.activitypubWorkerID }) {
-                            Link("Learn more about The Fediverse", destination: fediverseLearnMoreURL)
+                            Link("Learn more about The Fediverse", destination: Self.fediverseLearnMoreURL)
                                 .font(.caption)
                         }
                     }
@@ -752,10 +752,9 @@ struct PlistEditorView: View {
 
     /// FediDB's plain-language explainer of the Fediverse (#1005) — linked from the Workers tab
     /// wherever the ActivityPub worker is offered, since "ActivityPub" means nothing to most
-    /// site owners.
-    private var fediverseLearnMoreURL: URL {
-        URL(string: "https://fedidb.com/welcome")!
-    }
+    /// site owners. Force-unwrapped like `BuyDomainModel.cloudflareDashboardURL` and
+    /// `ConnectDomainModel.cloudflareDomainsURL` — a hardcoded literal, never a runtime value.
+    private static let fediverseLearnMoreURL = URL(string: "https://fedidb.com/welcome")!
 
     private var displayDomain: String {
         let domain = MTAStsPolicyAsset.normalizedDomain(model.mtaStsSettings.domain)

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -696,7 +696,16 @@ struct PlistEditorView: View {
                 // Group keys are manifest-owned free text (design doc §3) — display-cased,
                 // never localized or enumerated here.
                 SettingsBox(verbatimTitle: group.name.capitalized) {
-                    workersGroupTable(group.rows)
+                    VStack(alignment: .leading, spacing: 8) {
+                        workersGroupTable(group.rows)
+                        // "ActivityPub"/"Fediverse" jargon is meaningless to most site owners
+                        // (#1005) — point them at a plain-language explainer instead of renaming
+                        // the manifest-owned worker row itself.
+                        if group.rows.contains(where: { $0.id == WorkerComposition.activitypubWorkerID }) {
+                            Link("Learn more about The Fediverse", destination: fediverseLearnMoreURL)
+                                .font(.caption)
+                        }
+                    }
                 }
             }
         }
@@ -739,6 +748,13 @@ struct PlistEditorView: View {
                     .frame(minWidth: 28, alignment: .leading)
             }
         }
+    }
+
+    /// FediDB's plain-language explainer of the Fediverse (#1005) — linked from the Workers tab
+    /// wherever the ActivityPub worker is offered, since "ActivityPub" means nothing to most
+    /// site owners.
+    private var fediverseLearnMoreURL: URL {
+        URL(string: "https://fedidb.com/welcome")!
     }
 
     private var displayDomain: String {


### PR DESCRIPTION
Closes #1005

## Summary

- Followers pane copy ("ActivityPub isn't turned on for this site" / "Turn on ActivityPub in Settings ▸ Workers…") now says "The Fediverse" instead of the ActivityPub/ActivityProtocol jargon average site owners have never heard of.
- The Workers tab now shows a "Learn more about The Fediverse" link (→ https://fedidb.com/welcome) next to whichever group contains the ActivityPub worker, without renaming the manifest-owned worker row itself (design doc §3: worker display names stay catalog-driven).
- Updated `Localizable.xcstrings` for the renamed/added user-facing strings.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — **could not run**: this session's container has no Swift toolchain (Linux, no `swift`/`xcodebuild` binaries available).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **could not run**, same reason.
- [x] `scripts/check-localization-catalog.sh` — passes, confirms the renamed/added strings have matching `Localizable.xcstrings` keys.
- [ ] Manual smoke — not performed (no macOS/Xcode environment available in this session); please verify the Workers tab renders the new link correctly and the Followers pane shows the updated copy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqJHgADvca4K6fyufzhcj4)_