### PR TITLE
Use plain "Fediverse" wording, add learn-more link (#1005)

### DIFF
--- a/Sources/AnglesiteApp/FollowersView.swift
+++ b/Sources/AnglesiteApp/FollowersView.swift
@@ -26,8 +26,8 @@ struct FollowersView: View {
                     detail: Text("Publish it at least once, then followers will appear here."))
             case .notActivated:
                 message(
-                    "ActivityPub isn't turned on for this site",
-                    detail: Text("Turn on ActivityPub in Settings ▸ Workers, then publish again."))
+                    "The Fediverse isn't turned on for this site",
+                    detail: Text("Turn on the Fediverse in Settings ▸ Workers, then publish again."))
             case .unreachable(let reason):
                 // `reason` is server-supplied (HTTP body / error description) — untrusted remote
                 // content, never a localization key or format string. `Text(reason)` binds to the

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -280,9 +280,6 @@
     "Active — used on ^[%lld page](inflect: true)" : {
 
     },
-    "ActivityPub isn't turned on for this site" : {
-
-    },
     "Actual Size" : {
 
     },
@@ -1737,6 +1734,9 @@
     "Last checked %@" : {
 
     },
+    "Learn more about The Fediverse" : {
+
+    },
     "Learning %@’s conventions…" : {
 
     },
@@ -3081,6 +3081,9 @@
     "That's a different site — choose the original package folder instead." : {
 
     },
+    "The Fediverse isn't turned on for this site" : {
+
+    },
     "The Reader follows feeds and stores your timeline on this site's own Microsub endpoint — sign in as this site's owner to use it." : {
 
     },
@@ -3213,9 +3216,6 @@
     "Turn On and Route Reports" : {
 
     },
-    "Turn on ActivityPub in Settings ▸ Workers, then publish again." : {
-
-    },
     "Turn on private vulnerability reporting for %@/%@?" : {
       "localizations" : {
         "en" : {
@@ -3225,6 +3225,9 @@
           }
         }
       }
+    },
+    "Turn on the Fediverse in Settings ▸ Workers, then publish again." : {
+
     },
     "Type" : {
 

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -696,7 +696,19 @@ struct PlistEditorView: View {
                 // Group keys are manifest-owned free text (design doc §3) — display-cased,
                 // never localized or enumerated here.
                 SettingsBox(verbatimTitle: group.name.capitalized) {
-                    workersGroupTable(group.rows)
+                    VStack(alignment: .leading, spacing: 8) {
+                        workersGroupTable(group.rows)
+                        // "social" is the one group id this view already treats as known (it's
+                        // the stable catalog convention the ActivityPub/webmention/IndieAuth
+                        // workers publish under — see `WorkerDescriptor.group`'s doc comment and
+                        // the catalog fixtures throughout `Tests/`), not a specific worker name —
+                        // the average site owner has never heard "ActivityPub" (#1005), so the
+                        // link is framed around the plain-language term instead.
+                        if group.id == "social" {
+                            Link("Learn more about The Fediverse", destination: fediverseLearnMoreURL)
+                                .font(.callout)
+                        }
+                    }
                 }
             }
         }
@@ -739,6 +751,13 @@ struct PlistEditorView: View {
                     .frame(minWidth: 28, alignment: .leading)
             }
         }
+    }
+
+    /// Where the Workers tab's "Learn more about The Fediverse" link sends an owner who wants
+    /// plain-language background before turning on the ActivityPub/webmention/IndieAuth workers
+    /// (#1005) — a general-audience explainer, not a protocol spec.
+    private var fediverseLearnMoreURL: URL {
+        URL(string: "https://fedidb.com/welcome")!
     }
 
     private var displayDomain: String {


### PR DESCRIPTION
Closes #1005

## Summary

- Replaced the ActivityPub jargon in the Followers pane's "not activated" prompt with plain "the Fediverse" wording — average site owners have never heard of ActivityPub.
- Added a "Learn more about The Fediverse" link (https://fedidb.com/welcome) alongside the social workers section in Website Settings ▸ Workers, where the ActivityPub/webmention/IndieAuth toggles live.
- Updated `Localizable.xcstrings` for the changed/added user-facing strings (hand-edited per `CONTRIBUTING.md`, since the real catalog merge only happens in the Xcode IDE).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — could not run; no Swift toolchain available in this sandbox (Linux container with no `swift`/Xcode installed).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — could not run for the same reason (macOS/Xcode-only).
- [x] `scripts/check-localization-catalog.sh` — passes, confirming the new/changed literals have matching catalog keys.
- [ ] Manual smoke — not performed (no macOS host available in this environment); please verify the Workers tab's new link and the Followers pane's copy in a local build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz8DZeSaV2d6zQyET5P7Zh)_