### PR TITLE
Give ThemeApplyWizard a UI entry point (Website menu)

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -497,6 +497,9 @@
     "Apply a Theme" : {
 
     },
+    "Apply a Theme…" : {
+
+    },
     "Apply this rewrite?" : {
 
     },

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -817,6 +817,17 @@ struct SiteWindow: View {
                     }
             }
         }
+        .sheet(item: $bindableModel.themeApplyWizardModel) { wizardModel in
+            NavigationStack {
+                ThemeApplyWizard(model: wizardModel, onDone: { model.themeApplyWizardModel = nil })
+                    .navigationTitle("Apply a Theme")
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { model.themeApplyWizardModel = nil }
+                        }
+                    }
+            }
+        }
         .alert("Revert to the last saved version?", isPresented: $bindableModel.revertConfirmationPresented) {
             Button("Revert", role: .destructive) { Task { await model.confirmRevertToSaved() } }
             Button("Cancel", role: .cancel) {}

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -460,21 +460,30 @@ final class SiteWindowModel {
         integrationWizardModel = IntegrationWizardModel(service: integrationOps, siteID: site.id)
     }
 
-    var canOpenThemeApplyWizard: Bool { site != nil }
+    /// Mirrors `canOpenSiriReadiness`/`openSiriReadiness`: the enablement check reuses the exact
+    /// same catalog resolution `openThemeApplyWizard` guards on, so the menu item can never be
+    /// enabled for a click that silently does nothing (#1181 review).
+    var canOpenThemeApplyWizard: Bool { site != nil && resolvedThemeCatalog() != nil }
 
     /// Presents the Apply a Theme wizard (Website ▸ Apply a Theme…, #1181), same fresh-
-    /// construction-from-`site` pattern as `presentDesignInterview`. The bundled `ThemeCatalog`
-    /// load is best-effort — same tolerance `AssistantSessionAssembler` uses for `SetupThemeTool` —
-    /// so a missing/unreadable template leaves the wizard un-openable rather than crashing.
-    func openThemeApplyWizard() {
-        guard themeApplyWizardModel == nil, let site else { return }
-        guard let templateURL = TemplateRuntime.resolve().url,
-              let catalog = try? ThemeCatalog.load(templateURL: templateURL) else { return }
+    /// construction-from-`site` pattern as `presentDesignInterview`.
+    func openThemeApplyWizard(settings: AppSettings = .shared, bundle: Bundle = .main) {
+        guard themeApplyWizardModel == nil, let site,
+              let catalog = resolvedThemeCatalog(settings: settings, bundle: bundle) else { return }
         themeApplyWizardModel = ThemeApplyWizardModel(
             catalog: catalog,
             businessType: SiteBusinessType.read(sourceDirectory: site.sourceDirectory) ?? "",
             package: AnglesitePackage(url: site.packageURL)
         )
+    }
+
+    /// Best-effort load of the bundled `ThemeCatalog` — same tolerance `AssistantSessionAssembler`
+    /// uses for `SetupThemeTool`, so a missing/unreadable template resolves to `nil` rather than
+    /// crashing. `settings`/`bundle` mirror `TemplateRuntime.resolve(settings:bundle:)`'s own test
+    /// seam (defaulting to the live app values) so tests can point at a fixture template.
+    private func resolvedThemeCatalog(settings: AppSettings = .shared, bundle: Bundle = .main) -> ThemeCatalog? {
+        guard let templateURL = TemplateRuntime.resolve(settings: settings, bundle: bundle).url else { return nil }
+        return try? ThemeCatalog.load(templateURL: templateURL)
     }
 
     func openStyleGuide() {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -119,6 +119,11 @@ final class SiteWindowModel {
     /// Non-nil ⟺ the Experiment Results sheet is presented (`.sheet(item:)`), same fresh-
     /// construction-from-`site` pattern as `copyEditModel`/`emailSetupModel` (#769).
     var experimentStatsModel: ExperimentStatsModel?
+    /// Non-nil ⟺ the Apply a Theme wizard is presented (`.sheet(item:)`), same coupling as
+    /// `integrationWizardModel` (#1181). Fresh-construction-from-`site` like `designInterviewModel`,
+    /// loading the same bundled `ThemeCatalog` `AssistantSessionAssembler` resolves for
+    /// `SetupThemeTool`.
+    var themeApplyWizardModel: ThemeApplyWizardModel?
     /// The window's `UndoManager`, published down from `SiteWindow`'s
     /// `@Environment(\.undoManager)` so applied edits register for Edit ▸ Undo (#527). Weak +
     /// `@ObservationIgnored`: the window owns it and it isn't render state. Forwarded on set
@@ -453,6 +458,23 @@ final class SiteWindowModel {
     func openIntegrationWizard() {
         guard integrationWizardModel == nil, let site else { return }
         integrationWizardModel = IntegrationWizardModel(service: integrationOps, siteID: site.id)
+    }
+
+    var canOpenThemeApplyWizard: Bool { site != nil }
+
+    /// Presents the Apply a Theme wizard (Website ▸ Apply a Theme…, #1181), same fresh-
+    /// construction-from-`site` pattern as `presentDesignInterview`. The bundled `ThemeCatalog`
+    /// load is best-effort — same tolerance `AssistantSessionAssembler` uses for `SetupThemeTool` —
+    /// so a missing/unreadable template leaves the wizard un-openable rather than crashing.
+    func openThemeApplyWizard() {
+        guard themeApplyWizardModel == nil, let site else { return }
+        guard let templateURL = TemplateRuntime.resolve().url,
+              let catalog = try? ThemeCatalog.load(templateURL: templateURL) else { return }
+        themeApplyWizardModel = ThemeApplyWizardModel(
+            catalog: catalog,
+            businessType: SiteBusinessType.read(sourceDirectory: site.sourceDirectory) ?? "",
+            package: AnglesitePackage(url: site.packageURL)
+        )
     }
 
     func openStyleGuide() {

--- a/Sources/AnglesiteApp/ThemeApplyWizard.swift
+++ b/Sources/AnglesiteApp/ThemeApplyWizard.swift
@@ -4,15 +4,16 @@ import AnglesiteCore
 
 struct ThemeApplyWizard: View {
     @Bindable var model: ThemeApplyWizardModel
-    @Environment(\.dismiss) private var dismiss
+    /// Called when the owner dismisses a finished wizard (the applying step's "Done" button).
+    /// The caller nils its `.sheet(item:)` model, matching every other wizard/sheet in
+    /// `SiteWindow` (`IntegrationWizard`'s `onClose`, `EmailSetupSheetView`'s `onDone`) rather
+    /// than relying on `@Environment(\.dismiss)` to clear an item-bound sheet's identity.
+    let onDone: () -> Void
 
     private let columns = [GridItem(.adaptive(minimum: 140, maximum: 180), spacing: 12)]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Apply a Theme")
-                .font(.title2.bold())
-
             Group {
                 switch model.step {
                 case .pickSource: pickSourceStep
@@ -142,7 +143,7 @@ struct ThemeApplyWizard: View {
             case .success:
                 Label("Theme applied.", systemImage: "checkmark.circle.fill")
                     .foregroundStyle(.green)
-                Button("Done") { dismiss() }
+                Button("Done") { onDone() }
             case .failure(let error):
                 Label("Couldn't apply that theme: \(String(describing: error))", systemImage: "exclamationmark.triangle.fill")
                     .foregroundStyle(.red)

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -88,6 +88,9 @@ struct WebsiteCommands: Commands {
             Button("Animations…") { model?.presentAnimations() }
                 .disabled(model?.canOpenAnimations != true)
 
+            Button("Apply a Theme…") { model?.openThemeApplyWizard() }
+                .disabled(model?.canOpenThemeApplyWizard != true)
+
             Menu("Assistant") {
                 Button("Review Copy…") { model?.presentCopyEdit() }
                     .disabled(model?.canOpenCopyEdit != true)

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -550,6 +550,24 @@ extension SiteWindowModelTests {
         #expect(model.designInterviewModel === first)
     }
 
+    @Test("canOpenThemeApplyWizard reflects whether a site is open")
+    func canOpenThemeApplyWizardTracksSite() {
+        let model = makeModel()
+        #expect(model.canOpenThemeApplyWizard == false)
+
+        model.site = siteWithNonexistentPackage()
+        #expect(model.canOpenThemeApplyWizard == true)
+    }
+
+    @Test("openThemeApplyWizard no-ops when there is no open site")
+    func openThemeApplyWizardNoSiteIsNoOp() {
+        let model = makeModel()
+
+        model.openThemeApplyWizard()
+
+        #expect(model.themeApplyWizardModel == nil)
+    }
+
     @Test("applyPendingDesignInterviewRequest presents the sheet when a request is pending for this site")
     func applyPendingDesignInterviewRequestConsumesPendingRequest() {
         let model = makeModel()

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -550,13 +550,16 @@ extension SiteWindowModelTests {
         #expect(model.designInterviewModel === first)
     }
 
-    @Test("canOpenThemeApplyWizard reflects whether a site is open")
+    @Test("canOpenThemeApplyWizard requires both an open site and a resolvable bundled template")
     func canOpenThemeApplyWizardTracksSite() {
         let model = makeModel()
         #expect(model.canOpenThemeApplyWizard == false)
 
         model.site = siteWithNonexistentPackage()
-        #expect(model.canOpenThemeApplyWizard == true)
+        // No bundled/override template resolves in this test process, so a site alone must not
+        // enable the menu item — the #1181 review flagged the earlier version of this check
+        // (`site != nil` only) for exactly that drift: enabled, but a click silently no-ops.
+        #expect(model.canOpenThemeApplyWizard == false)
     }
 
     @Test("openThemeApplyWizard no-ops when there is no open site")
@@ -566,6 +569,73 @@ extension SiteWindowModelTests {
         model.openThemeApplyWizard()
 
         #expect(model.themeApplyWizardModel == nil)
+    }
+
+    @Test("openThemeApplyWizard no-ops when the bundled template can't be resolved")
+    func openThemeApplyWizardNoTemplateIsNoOp() throws {
+        let model = makeModel()
+        model.site = siteWithNonexistentPackage()
+        let (settings, cleanup) = try makeIsolatedSettings()
+        defer { cleanup() }
+        let bareDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("theme-apply-wizard-bare-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: bareDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: bareDir) }
+        settings.templatePathOverride = bareDir // exists, but isn't a template directory
+
+        model.openThemeApplyWizard(settings: settings)
+
+        #expect(model.themeApplyWizardModel == nil)
+    }
+
+    @Test("openThemeApplyWizard builds a fresh model from the open site when the template resolves")
+    func openThemeApplyWizardBuildsModel() throws {
+        let model = makeModel()
+        model.site = siteWithNonexistentPackage()
+        let (settings, cleanup) = try makeIsolatedSettings()
+        defer { cleanup() }
+        let template = try makeFixtureThemeTemplate()
+        defer { try? FileManager.default.removeItem(at: template) }
+        settings.templatePathOverride = template
+
+        model.openThemeApplyWizard(settings: settings)
+
+        #expect(model.themeApplyWizardModel != nil)
+        #expect(model.themeApplyWizardModel?.catalog.themes.map(\.id) == ["classic"])
+        #expect(model.themeApplyWizardModel?.businessType == "")
+    }
+
+    /// An isolated `AppSettings` backed by its own `UserDefaults` suite, mirroring
+    /// `TemplateRuntimeTests`' setup — never mutate `AppSettings.shared` directly, since that's a
+    /// real singleton other tests/suites could observe.
+    private func makeIsolatedSettings() throws -> (AppSettings, cleanup: () -> Void) {
+        let suiteName = "test-anglesite-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (AppSettings(defaults: defaults), { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    /// A minimal on-disk template — `scripts/themes.ts` (what `TemplateRuntime.isTemplateDirectory`
+    /// checks for) plus `scripts/themes.json` (what `ThemeCatalog.load` actually reads) — good
+    /// enough for `openThemeApplyWizard` to resolve a real one-theme catalog.
+    private func makeFixtureThemeTemplate() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("theme-apply-wizard-\(UUID().uuidString)")
+        let scriptsDir = root.appendingPathComponent("scripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
+        try Data("export const THEMES".utf8).write(to: scriptsDir.appendingPathComponent("themes.ts"))
+        let themesJSON = """
+        [
+          {
+            "id": "classic",
+            "displayName": "Classic",
+            "description": "Traditional, trustworthy, professional",
+            "bestFor": ["legal"],
+            "vars": { "color-primary": "#1e3a5f", "color-accent": "#c8a951" }
+          }
+        ]
+        """
+        try Data(themesJSON.utf8).write(to: scriptsDir.appendingPathComponent("themes.json"))
+        return root
     }
 
     @Test("applyPendingDesignInterviewRequest presents the sheet when a request is pending for this site")


### PR DESCRIPTION
Closes #1181

## Summary

- Add a **Website ▸ Apply a Theme…** menu item (`WebsiteCommands.swift`) that opens `ThemeApplyWizard` as a sheet, gated on `canOpenThemeApplyWizard` (a site is open).
- Add `SiteWindowModel.openThemeApplyWizard()`, which constructs a fresh `ThemeApplyWizardModel` from the open site — same pattern as `presentDesignInterview`/`openIntegrationWizard` — loading the bundled `ThemeCatalog` the same best-effort way `AssistantSessionAssembler` does for `SetupThemeTool` (a missing/unreadable template just leaves the wizard un-openable, no crash).
- Wire the sheet into `SiteWindow.swift` (`NavigationStack` + `navigationTitle` + toolbar Cancel), matching `IntegrationWizard`'s wiring.
- `ThemeApplyWizard` previously dismissed itself via `@Environment(\.dismiss)`, which no other item-bound sheet in this codebase relies on (they all nil the model explicitly via an `onDone`/`onClose` closure — e.g. `IntegrationWizard`, `EmailSetupSheetView`). Swapped it for an explicit `onDone: () -> Void` closure so the wizard reliably clears from `SiteWindowModel.themeApplyWizardModel`. Also removed the view's now-redundant inline "Apply a Theme" title in favor of the sheet's `navigationTitle`.
- Added `Localizable.xcstrings` entry for the new "Apply a Theme…" menu string (the existing "Apply a Theme" key is reused for the navigation title).
- Added `SiteWindowModelTests` coverage for `canOpenThemeApplyWizard`/`openThemeApplyWizard`'s no-open-site case.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [ ] `swift test --package-path .` — **could not run**: this session's container has no Swift/Xcode toolchain (Linux, no `swift` on `PATH`). `AnglesiteAppCore`/`AnglesiteAppTests` (where all the changed/tested code lives) only compile under `#if compiler(>=6.4) && canImport(Darwin)` per `Package.swift`, so this needs a macOS run.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **could not run**, same toolchain limitation; `xcodegen` is also unavailable here.
- [x] `scripts/check-localization-catalog.sh` — passes (new "Apply a Theme…" string is cataloged).
- [x] `scripts/check-xcstrings-newline.sh` — passes.
- [x] `scripts/check-help-links.sh` — passes.
- [ ] Manual smoke — **not run** (no macOS GUI in this environment): Website ▸ Apply a Theme… should open the wizard sheet, walk through built-in/freedesignmd source picking, and apply cleanly; Cancel and the post-apply Done button should both dismiss and clear the sheet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnUs4t5c4UqdG4KqbBEgih)_