### PR TITLE
Standard.site 4 (v1.1): bskyPostRef, blobs, unpublish

### DIFF
--- a/Sources/AnglesiteCore/POSSEClients.swift
+++ b/Sources/AnglesiteCore/POSSEClients.swift
@@ -229,6 +229,54 @@ public enum AtprotoPutRecordClient {
         public let uri: String
     }
 
+    /// A `com.atproto.repo.strongRef` — an at-URI paired with its content hash. Used both as
+    /// ``getRecord(collection:repo:rkey:pdsURL:session:transport:)``'s return shape and as the
+    /// `site.standard.document` `bskyPostRef` field's value (v1.1, #1234): a strong reference
+    /// tying a document to the Bluesky post it was cross-posted as.
+    public struct StrongRef: Codable, Equatable, Sendable {
+        public let uri: String
+        public let cid: String
+
+        /// Memberwise initializer.
+        public init(uri: String, cid: String) {
+            self.uri = uri
+            self.cid = cid
+        }
+    }
+
+    /// An uploaded blob's server-assigned reference, embeddable in a record field typed `blob`
+    /// (`site.standard.publication`'s `icon`, `site.standard.document`'s `coverImage`). Mirrors
+    /// the shape `com.atproto.repo.uploadBlob` returns verbatim, so it round-trips through
+    /// ``uploadBlob(data:mimeType:pdsURL:session:transport:)`` and back into a record's JSON
+    /// without any translation.
+    public struct BlobRef: Codable, Equatable, Sendable {
+        let type = "blob"
+        public let ref: Link
+        public let mimeType: String
+        public let size: Int
+
+        public struct Link: Codable, Equatable, Sendable {
+            public let link: String
+            enum CodingKeys: String, CodingKey { case link = "$link" }
+
+            /// Memberwise initializer.
+            public init(link: String) { self.link = link }
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case type = "$type"
+            case ref, mimeType, size
+        }
+
+        /// Memberwise initializer, for tests constructing an expected value; production instances
+        /// come from ``uploadBlob(data:mimeType:pdsURL:session:transport:)``'s decoded response.
+        public init(ref: Link, mimeType: String, size: Int) {
+            self.ref = ref
+            self.mimeType = mimeType
+            self.size = size
+        }
+    }
+
     /// An authenticated PDS session, reusable across multiple ``putRecord(collection:rkey:record:pdsURL:session:transport:)``
     /// calls — callers writing a batch of records (e.g. ``StandardSitePublishCommand``) should
     /// call ``createSession(credentials:transport:)`` once per run rather than once per record,
@@ -279,6 +327,107 @@ public enum AtprotoPutRecordClient {
             transport: transport
         )
         return Result(did: session.did, uri: response.uri)
+    }
+
+    /// Fetches `collection`/`rkey` from `repo` via `com.atproto.repo.getRecord`, returning its
+    /// current at-URI + cid, or `nil` when the record doesn't exist (a 404 is the expected,
+    /// non-error outcome — e.g. ``StandardSitePublishCommand``'s `bskyPostRef` linkage (v1.1,
+    /// #1234) looks up a Bluesky post that may not have been cross-posted yet).
+    ///
+    /// - Throws: ``POSSEClientError`` for a bad endpoint, a non-2xx/404 status, or an undecodable
+    ///   body.
+    public static func getRecord(
+        collection: String,
+        repo: String,
+        rkey: String,
+        pdsURL: URL,
+        session: Session,
+        transport: POSSEHTTPTransport
+    ) async throws -> StrongRef? {
+        var components = URLComponents(url: pdsURL, resolvingAgainstBaseURL: true)
+        components?.path = "/xrpc/com.atproto.repo.getRecord"
+        components?.queryItems = [
+            URLQueryItem(name: "repo", value: repo),
+            URLQueryItem(name: "collection", value: collection),
+            URLQueryItem(name: "rkey", value: rkey)
+        ]
+        guard let endpoint = components?.url else { throw POSSEClientError.invalidEndpoint }
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(session.accessJwt)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await transport(request)
+        if response.statusCode == 404 { return nil }
+        guard (200..<300).contains(response.statusCode) else {
+            throw POSSEClientError.rejected(platform: "Bluesky", status: response.statusCode)
+        }
+        struct GetRecordResponse: Decodable { let uri: String; let cid: String }
+        guard let decoded = try? JSONDecoder().decode(GetRecordResponse.self, from: data) else {
+            throw POSSEClientError.invalidResponse(platform: "Bluesky")
+        }
+        return StrongRef(uri: decoded.uri, cid: decoded.cid)
+    }
+
+    /// Deletes `collection`/`rkey` from `session`'s repo via `com.atproto.repo.deleteRecord` —
+    /// used by ``StandardSitePublishCommand``'s unpublish pass (v1.1, #1234) for documents whose
+    /// source post no longer exists. Idempotent server-side: deleting an already-absent record
+    /// still returns 2xx, so callers don't need to check existence first.
+    ///
+    /// - Throws: ``POSSEClientError`` for a bad endpoint, non-2xx status, or undecodable body.
+    public static func deleteRecord(
+        collection: String,
+        rkey: String,
+        pdsURL: URL,
+        session: Session,
+        transport: POSSEHTTPTransport
+    ) async throws {
+        struct DeleteRecordRequest: Encodable { let repo: String; let collection: String; let rkey: String }
+        guard let endpoint = URL(string: "/xrpc/com.atproto.repo.deleteRecord", relativeTo: pdsURL)?.absoluteURL else {
+            throw POSSEClientError.invalidEndpoint
+        }
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(
+            DeleteRecordRequest(repo: session.did, collection: collection, rkey: rkey)
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(session.accessJwt)", forHTTPHeaderField: "Authorization")
+        let (_, response) = try await transport(request)
+        guard (200..<300).contains(response.statusCode) else {
+            throw POSSEClientError.rejected(platform: "Bluesky", status: response.statusCode)
+        }
+    }
+
+    /// Uploads raw bytes via `com.atproto.repo.uploadBlob`, returning the server-assigned
+    /// ``BlobRef`` to embed in a record's `blob`-typed field (`site.standard.publication.icon`,
+    /// `site.standard.document.coverImage` — v1.1, #1234). The PDS enforces its own size ceiling;
+    /// callers are expected to pre-check against the lexicon's stated limit (1 MB for both fields)
+    /// before calling this, since a rejected upload here is reported as a generic HTTP failure.
+    ///
+    /// - Throws: ``POSSEClientError`` for a bad endpoint, non-2xx status, or undecodable body.
+    public static func uploadBlob(
+        data: Data,
+        mimeType: String,
+        pdsURL: URL,
+        session: Session,
+        transport: POSSEHTTPTransport
+    ) async throws -> BlobRef {
+        guard let endpoint = URL(string: "/xrpc/com.atproto.repo.uploadBlob", relativeTo: pdsURL)?.absoluteURL else {
+            throw POSSEClientError.invalidEndpoint
+        }
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.httpBody = data
+        request.setValue(mimeType, forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(session.accessJwt)", forHTTPHeaderField: "Authorization")
+        let (responseData, response) = try await transport(request)
+        guard (200..<300).contains(response.statusCode) else {
+            throw POSSEClientError.rejected(platform: "Bluesky", status: response.statusCode)
+        }
+        struct UploadBlobResponse: Decodable { let blob: BlobRef }
+        guard let decoded = try? JSONDecoder().decode(UploadBlobResponse.self, from: responseData) else {
+            throw POSSEClientError.invalidResponse(platform: "Bluesky")
+        }
+        return decoded.blob
     }
 
     /// Convenience for a single record write: ``createSession(credentials:transport:)`` followed by

--- a/Sources/AnglesiteCore/StandardSiteDocumentPlan.swift
+++ b/Sources/AnglesiteCore/StandardSiteDocumentPlan.swift
@@ -35,11 +35,17 @@ public enum StandardSiteDocumentPlan {
         public let updatedAt: Date?
         /// Plain-text render of the body.
         public let textContent: String
+        /// Frontmatter `image` value, root-relative to the site (e.g. `/uploads/hero.jpg`) —
+        /// the same convention `OutboxBackfillPlan`'s photo collections use. `nil` when the post
+        /// has no `image` frontmatter field. Resolving this to a local file and preparing it for
+        /// upload is ``StandardSitePublishCommand``'s job (v1.1, #1234) — network/blob I/O has no
+        /// place in this network-free planner.
+        public let coverImageSourcePath: String?
 
         /// Memberwise initializer, public for tests.
         public init(
             sourceFile: String, path: String, title: String, description: String?, tags: [String],
-            publishedAt: Date, updatedAt: Date?, textContent: String
+            publishedAt: Date, updatedAt: Date?, textContent: String, coverImageSourcePath: String? = nil
         ) {
             self.sourceFile = sourceFile
             self.path = path
@@ -49,6 +55,7 @@ public enum StandardSiteDocumentPlan {
             self.publishedAt = publishedAt
             self.updatedAt = updatedAt
             self.textContent = textContent
+            self.coverImageSourcePath = coverImageSourcePath
         }
     }
 
@@ -89,10 +96,12 @@ public enum StandardSiteDocumentPlan {
             let tags: [String]
             if case let .array(values)? = frontmatter["tags"] { tags = values } else { tags = [] }
             let textContent = SiteContentChunker.plainText(markdown: Frontmatter.body(source))
+            let coverImageSourcePath = SocialPublishPlan.string(frontmatter["image"])
 
             return Entry(
                 sourceFile: relPath, path: path, title: title, description: description, tags: tags,
-                publishedAt: publishedAt, updatedAt: updatedAt, textContent: textContent
+                publishedAt: publishedAt, updatedAt: updatedAt, textContent: textContent,
+                coverImageSourcePath: coverImageSourcePath
             )
         }
         return Plan(entries: entries.sorted { $0.sourceFile < $1.sourceFile })

--- a/Sources/AnglesiteCore/StandardSiteImageBlob.swift
+++ b/Sources/AnglesiteCore/StandardSiteImageBlob.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Prepares local image files for upload as Standard.site `blob` fields (`site.standard.publication`
+/// `icon`, `site.standard.document` `coverImage` — v1.1, #1234). Both fields are capped at 1 MB by
+/// the lexicon; this type enforces that cap by size alone rather than downscaling. `AnglesiteCore`
+/// is a portable target (builds and tests on Linux — see CONTRIBUTING "Developing on Linux") with
+/// no CoreGraphics/ImageIO dependency anywhere in it today, and adding real image
+/// decode/downscale here would be the first exception to that. An oversize source image is
+/// skipped (logged, not uploaded) rather than downscaled — a known, deliberate gap versus the
+/// design doc's "downscale as needed," left for a follow-up that can thread a downscaling closure
+/// in from the Darwin-only app target the way every other dependency in ``StandardSitePublishCommand``
+/// is injected.
+public enum StandardSiteImageBlob {
+    /// The lexicon's shared size ceiling for `icon` and `coverImage`
+    /// (https://standard.site/docs/lexicons/document, /publication).
+    public static let maxBytes = 1_000_000
+
+    /// One image file, read and ready to hand to
+    /// ``AtprotoPutRecordClient/uploadBlob(data:mimeType:pdsURL:session:transport:)``.
+    public struct Prepared: Equatable, Sendable {
+        public let data: Data
+        public let mimeType: String
+    }
+
+    /// Reason a local image couldn't be prepared for upload — every case is a *skip*, not an
+    /// error: the publish pass omits the blob field and (for oversize images) logs why, but never
+    /// fails the pass over it.
+    public enum SkipReason: Error, Equatable, Sendable {
+        case fileNotFound
+        case unsupportedExtension(String)
+        case tooLarge(bytes: Int)
+    }
+
+    /// Reads `fileURL` and returns it ready for upload, or the reason it can't be. Never throws —
+    /// every failure mode here (missing file, unsupported extension, oversize) is expected and
+    /// handled by the caller as a skip.
+    public static func prepare(fileURL: URL, fileManager: FileManager = .default) -> Result<Prepared, SkipReason> {
+        guard let mimeType = mimeType(for: fileURL) else {
+            return .failure(.unsupportedExtension(fileURL.pathExtension))
+        }
+        guard let data = try? Data(contentsOf: fileURL) else {
+            return .failure(.fileNotFound)
+        }
+        guard data.count <= maxBytes else {
+            return .failure(.tooLarge(bytes: data.count))
+        }
+        return .success(Prepared(data: data, mimeType: mimeType))
+    }
+
+    /// Maps a file extension to its MIME type for the formats standard.site readers are expected
+    /// to render; `nil` for anything else rather than guessing `application/octet-stream`, since
+    /// an unrecognized extension is far more likely to be a non-image frontmatter value than a
+    /// real image the caller should upload.
+    static func mimeType(for fileURL: URL) -> String? {
+        switch fileURL.pathExtension.lowercased() {
+        case "png": "image/png"
+        case "jpg", "jpeg": "image/jpeg"
+        case "gif": "image/gif"
+        case "webp": "image/webp"
+        default: nil
+        }
+    }
+}

--- a/Sources/AnglesiteCore/StandardSitePublishCommand.swift
+++ b/Sources/AnglesiteCore/StandardSitePublishCommand.swift
@@ -98,7 +98,10 @@ public actor StandardSitePublishCommand {
         let siteName = SiteConfigValues.siteName(sourceDirectory: siteDirectory) ?? siteID
         let description = nonBlank(SiteConfigFile.value(forKey: Self.descriptionConfigKey, in: config))
 
-        let publication = StandardSitePublicationRecord(name: siteName, url: siteURL.absoluteString, description: description)
+        let iconFileURL = siteDirectory
+            .appendingPathComponent(WebsiteIconAsset.publicDirectoryRelativePath, isDirectory: true)
+            .appendingPathComponent(WebsiteIconAsset.icon512Name)
+
         let publicationRkey = "anglesite-\(POSSEStableKey.make(siteID))"
 
         // One login for the whole run: every record write below reuses this session instead of
@@ -111,6 +114,13 @@ public actor StandardSitePublishCommand {
             await logError("couldn't sign in to publish: \(error.localizedDescription)", source: source)
             return
         }
+
+        let icon = await prepareImageBlob(
+            fileURL: iconFileURL, label: "site icon", pdsURL: bluesky.pdsURL, session: session, source: source
+        )
+        let publication = StandardSitePublicationRecord(
+            name: siteName, url: siteURL.absoluteString, description: description, icon: icon
+        )
 
         let publicationResult: AtprotoPutRecordClient.Result
         do {
@@ -133,9 +143,20 @@ public actor StandardSitePublishCommand {
         var updatedCount = 0
         var failedCount = 0
 
+        // Loaded once for the whole pass: every entry's `bskyPostRef` lookup below reads this
+        // same snapshot rather than re-loading per document.
+        let posseLedger = POSSESyndicationLog.load(from: configDirectory)
+
         for entry in plan.entries {
             let wasAlreadyPublished = ledger.entries.contains { $0.path == entry.path }
             let documentRkey = "anglesite-\(POSSEStableKey.make("\(siteID)\n\(entry.path)"))"
+            let bskyPostRef = await resolveBskyPostRef(
+                entry: entry, siteID: siteID, siteURL: siteURL, posseLedger: posseLedger,
+                bluesky: bluesky, session: session
+            )
+            let coverImage = await resolveCoverImage(
+                entry: entry, siteDirectory: siteDirectory, pdsURL: bluesky.pdsURL, session: session, source: source
+            )
             let document = StandardSiteDocumentRecord(
                 site: publicationResult.uri,
                 title: entry.title,
@@ -144,7 +165,9 @@ public actor StandardSitePublishCommand {
                 publishedAt: iso8601(entry.publishedAt),
                 updatedAt: entry.updatedAt.map(iso8601),
                 tags: entry.tags,
-                textContent: entry.textContent
+                textContent: entry.textContent,
+                bskyPostRef: bskyPostRef,
+                coverImage: coverImage
             )
             let documentResult: AtprotoPutRecordClient.Result
             do {
@@ -189,6 +212,43 @@ public actor StandardSitePublishCommand {
             }
         }
 
+        // Unpublish (v1.1, #1234): a ledgered document whose path no longer appears in the
+        // current plan means its source post was deleted, or renamed — deterministic rkeys are
+        // keyed on path, so a rename orphans the old record the same way a deletion does (see the
+        // design doc's open questions). Diff first, delete after, so a `deleteRecord` failure
+        // leaves the ledger entry in place for the next pass to retry rather than losing track of
+        // a record that's still live.
+        let currentPaths = Set(plan.entries.map(\.path))
+        let staleEntries = ledger.entries.filter { !currentPaths.contains($0.path) }
+        var unpublishedCount = 0
+        for staleEntry in staleEntries {
+            guard let rkey = staleEntry.uri.split(separator: "/").last else { continue }
+            do {
+                try await AtprotoPutRecordClient.deleteRecord(
+                    collection: "site.standard.document", rkey: String(rkey),
+                    pdsURL: bluesky.pdsURL, session: session, transport: transport
+                )
+            } catch {
+                failedCount += 1
+                await logError("couldn't unpublish \(staleEntry.path): \(error.localizedDescription)", source: source)
+                continue
+            }
+            ledger.entries.removeAll { $0.path == staleEntry.path }
+            do {
+                try ledger.save(to: configDirectory)
+            } catch {
+                await logError(
+                    "unpublished \(staleEntry.path), but its ledger update failed: \(error.localizedDescription)",
+                    source: source
+                )
+                continue
+            }
+            unpublishedCount += 1
+            await logCenter.append(
+                source: source, stream: .stdout, text: "standardsite: unpublished \(staleEntry.path)"
+            )
+        }
+
         // No per-document "skipped" bucket here on purpose: deterministic rkeys mean every
         // eligible document is always re-put ("updates are free," per the design doc), so each
         // plan entry lands in exactly one of the three counts above. A document being excluded
@@ -198,8 +258,95 @@ public actor StandardSitePublishCommand {
         // above ("skipped — ...") rather than a count folded into this summary.
         await logCenter.append(
             source: source, stream: .stdout,
-            text: "standardsite: done — published \(publishedCount), updated \(updatedCount), failed \(failedCount)"
+            text: "standardsite: done — published \(publishedCount), updated \(updatedCount), "
+                + "unpublished \(unpublishedCount), failed \(failedCount)"
         )
+    }
+
+    /// Resolves the strong reference to link `entry`'s document to the Bluesky post it was
+    /// cross-posted as (v1.1, #1234), or `nil` when there is none yet. Independent of
+    /// `POSSESyndicationCommand`/`BlueskyPOSSEClient` by design: both this pass and POSSE derive
+    /// the same deterministic Bluesky rkey from the same site + canonical URL inputs (see
+    /// ``POSSEStableKey``), and both authenticate the same Bluesky account, so the post's at-URI
+    /// is computable without any coordination — only its `cid` needs a lookup. Because
+    /// `publishStandardSite` runs *before* `syndicate` in `runPostDeploySequencing`, the earliest
+    /// a document can carry its `bskyPostRef` is the deploy *after* the one that first
+    /// cross-posted it — this reads whatever `POSSESyndicationLog` a prior deploy already wrote.
+    private func resolveBskyPostRef(
+        entry: StandardSiteDocumentPlan.Entry,
+        siteID: String,
+        siteURL: URL,
+        posseLedger: POSSESyndicationLog?,
+        bluesky: POSSECredentials.Bluesky,
+        session: AtprotoPutRecordClient.Session
+    ) async -> AtprotoPutRecordClient.StrongRef? {
+        guard let posseLedger,
+              let canonicalURL = URL(string: entry.path, relativeTo: siteURL)?.absoluteURL,
+              posseLedger.contains(canonicalURL: canonicalURL, platform: "bluesky")
+        else { return nil }
+        let rkey = "anglesite-\(POSSEStableKey.make("\(siteID)\n\(canonicalURL.absoluteString)\nbluesky"))"
+        // Best-effort: a lookup failure (network hiccup, the post since deleted) just means no
+        // linkage this pass, not a publish failure — the next pass tries again.
+        guard let ref = try? await AtprotoPutRecordClient.getRecord(
+            collection: "app.bsky.feed.post", repo: session.did, rkey: rkey,
+            pdsURL: bluesky.pdsURL, session: session, transport: transport
+        ) else { return nil }
+        return ref
+    }
+
+    /// Resolves `entry`'s frontmatter `image` field to an uploaded cover-image blob (v1.1,
+    /// #1234), or `nil` when the post has none. Only a root-relative path (`/uploads/hero.jpg` —
+    /// Astro's `public/` served at the site root, the same convention `LogoAsset`/`WebsiteIconAsset`
+    /// use) resolves to a local file; anything else (an external URL, a colocated-asset relative
+    /// path) is left unresolved rather than guessed at.
+    private func resolveCoverImage(
+        entry: StandardSiteDocumentPlan.Entry,
+        siteDirectory: URL,
+        pdsURL: URL,
+        session: AtprotoPutRecordClient.Session,
+        source: String
+    ) async -> AtprotoPutRecordClient.BlobRef? {
+        guard let sourcePath = entry.coverImageSourcePath, sourcePath.hasPrefix("/") else { return nil }
+        let fileURL = siteDirectory
+            .appendingPathComponent(WebsiteIconAsset.publicDirectoryRelativePath, isDirectory: true)
+            .appendingPathComponent(String(sourcePath.dropFirst()))
+        return await prepareImageBlob(
+            fileURL: fileURL, label: "\(entry.path) cover image", pdsURL: pdsURL, session: session, source: source
+        )
+    }
+
+    /// Reads and uploads one local image as a Standard.site blob field (v1.1, #1234) — shared by
+    /// the publication `icon` and each document's `coverImage`. Never throws: a missing file, an
+    /// unsupported extension, or an oversize image (see ``StandardSiteImageBlob`` — no
+    /// downscaling yet) all degrade to "no blob for this field" rather than failing the pass;
+    /// only the oversize case is worth telling the owner about, since it's the one actionable gap.
+    private func prepareImageBlob(
+        fileURL: URL,
+        label: String,
+        pdsURL: URL,
+        session: AtprotoPutRecordClient.Session,
+        source: String
+    ) async -> AtprotoPutRecordClient.BlobRef? {
+        switch StandardSiteImageBlob.prepare(fileURL: fileURL) {
+        case .success(let prepared):
+            do {
+                return try await AtprotoPutRecordClient.uploadBlob(
+                    data: prepared.data, mimeType: prepared.mimeType,
+                    pdsURL: pdsURL, session: session, transport: transport
+                )
+            } catch {
+                await logError("couldn't upload \(label): \(error.localizedDescription)", source: source)
+                return nil
+            }
+        case .failure(.tooLarge(let bytes)):
+            await logCenter.append(
+                source: source, stream: .stdout,
+                text: "standardsite: skipped \(label) — \(bytes) bytes exceeds the 1 MB limit (no downscaling yet)"
+            )
+            return nil
+        case .failure:
+            return nil
+        }
     }
 
     /// Persists the session DID into `.site-config`'s `ATPROTO_DID` on first successful publish

--- a/Sources/AnglesiteCore/StandardSitePublishCommand.swift
+++ b/Sources/AnglesiteCore/StandardSitePublishCommand.swift
@@ -318,8 +318,11 @@ public actor StandardSitePublishCommand {
     /// Reads and uploads one local image as a Standard.site blob field (v1.1, #1234) — shared by
     /// the publication `icon` and each document's `coverImage`. Never throws: a missing file, an
     /// unsupported extension, or an oversize image (see ``StandardSiteImageBlob`` — no
-    /// downscaling yet) all degrade to "no blob for this field" rather than failing the pass;
-    /// only the oversize case is worth telling the owner about, since it's the one actionable gap.
+    /// downscaling yet) all degrade to "no blob for this field" rather than failing the pass.
+    /// `.fileNotFound` stays silent — the common case is simply no icon/cover image configured,
+    /// nothing for the owner to act on — but the other two skip reasons mean the owner *did* set
+    /// something (an oversize file, or an extension this doesn't recognize) that's silently not
+    /// showing up on the Atmosphere side, so both are worth a log line.
     private func prepareImageBlob(
         fileURL: URL,
         label: String,
@@ -344,7 +347,13 @@ public actor StandardSitePublishCommand {
                 text: "standardsite: skipped \(label) — \(bytes) bytes exceeds the 1 MB limit (no downscaling yet)"
             )
             return nil
-        case .failure:
+        case .failure(.unsupportedExtension(let ext)):
+            await logCenter.append(
+                source: source, stream: .stdout,
+                text: "standardsite: skipped \(label) — unrecognized image extension \"\(ext)\""
+            )
+            return nil
+        case .failure(.fileNotFound):
             return nil
         }
     }

--- a/Sources/AnglesiteCore/StandardSiteRecords.swift
+++ b/Sources/AnglesiteCore/StandardSiteRecords.swift
@@ -36,10 +36,14 @@ public struct StandardSitePublicationRecord: Encodable, Equatable, Sendable {
     public let name: String
     public let url: String
     public let description: String?
+    /// Square publication icon (≥256×256 recommended, ≤1 MB per the lexicon), uploaded via
+    /// `com.atproto.repo.uploadBlob` (v1.1, #1234). `nil` when the site has no installed icon, or
+    /// the icon exceeds the size limit.
+    public let icon: AtprotoPutRecordClient.BlobRef?
 
     enum CodingKeys: String, CodingKey {
         case type = "$type"
-        case name, url, description
+        case name, url, description, icon
     }
 
     /// Memberwise initializer.
@@ -47,12 +51,14 @@ public struct StandardSitePublicationRecord: Encodable, Equatable, Sendable {
     ///   - name: The site's display name.
     ///   - url: The site's canonical public URL.
     ///   - description: A short description of the site, if any.
-    public init(name: String, url: String, description: String?) {
+    ///   - icon: The site's uploaded icon blob, if any (v1.1, #1234).
+    public init(name: String, url: String, description: String?, icon: AtprotoPutRecordClient.BlobRef? = nil) {
         self.name = StandardSiteText.truncate(name, graphemeLimit: StandardSiteText.titleGraphemeLimit)
         self.url = url
         self.description = description.map {
             StandardSiteText.truncate($0, graphemeLimit: StandardSiteText.descriptionGraphemeLimit)
         }
+        self.icon = icon
     }
 }
 
@@ -77,10 +83,19 @@ public struct StandardSiteDocumentRecord: Encodable, Equatable, Sendable {
     /// Plain-text render of the body, for indexers; the lexicon's `content` open union is
     /// deliberately left unset (see the design doc — the git repo stays the canonical format).
     public let textContent: String?
+    /// Strong reference to the Bluesky post this document was cross-posted as, set on a later
+    /// pass once the POSSE pass has published it (v1.1, #1234) — `publishStandardSite` runs
+    /// before `syndicate` in `runPostDeploySequencing`, so this is always `nil` on the same pass
+    /// a document is first published and filled in on a subsequent deploy.
+    public let bskyPostRef: AtprotoPutRecordClient.StrongRef?
+    /// Cover image blob (≤1 MB per the lexicon), uploaded from the post's frontmatter `image`
+    /// field via `com.atproto.repo.uploadBlob` (v1.1, #1234). `nil` when the post has no cover
+    /// image, or it exceeds the size limit.
+    public let coverImage: AtprotoPutRecordClient.BlobRef?
 
     enum CodingKeys: String, CodingKey {
         case type = "$type"
-        case site, title, description, path, publishedAt, updatedAt, tags, textContent
+        case site, title, description, path, publishedAt, updatedAt, tags, textContent, bskyPostRef, coverImage
     }
 
     /// Memberwise initializer.
@@ -92,7 +107,9 @@ public struct StandardSiteDocumentRecord: Encodable, Equatable, Sendable {
         publishedAt: String,
         updatedAt: String?,
         tags: [String],
-        textContent: String?
+        textContent: String?,
+        bskyPostRef: AtprotoPutRecordClient.StrongRef? = nil,
+        coverImage: AtprotoPutRecordClient.BlobRef? = nil
     ) {
         self.site = site
         self.title = StandardSiteText.truncate(title, graphemeLimit: StandardSiteText.titleGraphemeLimit)
@@ -104,5 +121,7 @@ public struct StandardSiteDocumentRecord: Encodable, Equatable, Sendable {
         self.updatedAt = updatedAt
         self.tags = tags.map { StandardSiteText.truncate($0, graphemeLimit: StandardSiteText.tagGraphemeLimit) }
         self.textContent = textContent
+        self.bskyPostRef = bskyPostRef
+        self.coverImage = coverImage
     }
 }

--- a/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
+++ b/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
@@ -174,6 +174,11 @@ struct StandardSitePublishCommandTests {
     private actor APIStub {
         var requests: [URLRequest] = []
         let did: String
+        /// `getRecord` response for every rkey by default; `nil` means every lookup 404s (no
+        /// Bluesky cross-post found yet) — the common case for most tests.
+        var getRecordResponse: (uri: String, cid: String)?
+        var uploadBlobResponse: (cid: String, mimeType: String, size: Int) = (cid: "bafyblob", mimeType: "image/png", size: 100)
+        var deleteRecordStatus: Int = 200
 
         init(did: String = "did:plc:owner") { self.did = did }
 
@@ -181,26 +186,42 @@ struct StandardSitePublishCommandTests {
             requests.append(request)
             let url = request.url ?? URL(string: "https://invalid.example")!
             let path = url.path
-            let json: String
             switch path {
             case "/xrpc/com.atproto.server.createSession":
-                json = #"{"accessJwt":"jwt","did":"\#(did)"}"#
+                return json(#"{"accessJwt":"jwt","did":"\#(did)"}"#, url: url)
             case "/xrpc/com.atproto.repo.putRecord":
                 let body = (try? JSONSerialization.jsonObject(with: request.httpBody ?? Data())) as? [String: Any]
                 let collection = body?["collection"] as? String ?? "unknown"
                 let rkey = body?["rkey"] as? String ?? "unknown"
-                json = #"{"uri":"at://\#(did)/\#(collection)/\#(rkey)","cid":"bafycid"}"#
+                return json(#"{"uri":"at://\#(did)/\#(collection)/\#(rkey)","cid":"bafycid"}"#, url: url)
+            case "/xrpc/com.atproto.repo.getRecord":
+                guard let getRecordResponse else { return json("{}", url: url, statusCode: 404) }
+                return json(#"{"uri":"\#(getRecordResponse.uri)","cid":"\#(getRecordResponse.cid)"}"#, url: url)
+            case "/xrpc/com.atproto.repo.deleteRecord":
+                return json("{}", url: url, statusCode: deleteRecordStatus)
+            case "/xrpc/com.atproto.repo.uploadBlob":
+                let blob = uploadBlobResponse
+                return json(
+                    #"{"blob":{"$type":"blob","ref":{"$link":"\#(blob.cid)"},"mimeType":"\#(blob.mimeType)","size":\#(blob.size)}}"#,
+                    url: url
+                )
             default:
-                json = "{}"
+                return json("{}", url: url)
             }
-            guard let response = HTTPURLResponse(
-                url: url, statusCode: 200, httpVersion: nil,
-                headerFields: ["Content-Type": "application/json"]
-            ) else { throw URLError(.badServerResponse) }
-            return (Data(json.utf8), response)
         }
 
+        private func json(_ body: String, url: URL, statusCode: Int = 200) -> (Data, HTTPURLResponse) {
+            let response = HTTPURLResponse(
+                url: url, statusCode: statusCode, httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (Data(body.utf8), response)
+        }
+
+        func set(getRecordResponse: (uri: String, cid: String)?) { self.getRecordResponse = getRecordResponse }
+
         func count(path: String) -> Int { requests.count { $0.url?.path == path } }
+        func requests(path: String) -> [URLRequest] { requests.filter { $0.url?.path == path } }
         func bodies(path: String) -> [[String: Any]] {
             var results: [[String: Any]] = []
             for request in requests where request.url?.path == path {
@@ -331,7 +352,7 @@ struct StandardSitePublishCommandTests {
         // published, not updated.
         let firstPassLines = await logCenter.snapshot()
         #expect(firstPassLines.contains { $0.text.contains("published /notes/hello/ as") })
-        #expect(firstPassLines.contains { $0.text.contains("done — published 1, updated 0, failed 0") })
+        #expect(firstPassLines.contains { $0.text.contains("done — published 1, updated 0, unpublished 0, failed 0") })
 
         // Re-run: putRecord's create-or-update semantics make a repeat pass idempotent — same
         // rkeys, same resulting ledger, no error — even though every eligible post is re-put.
@@ -343,6 +364,179 @@ struct StandardSitePublishCommandTests {
         #expect(ledgerAfter.entries.first?.uri == ledger.entries.first?.uri)
         let secondPassLines = await logCenter.snapshot()
         #expect(secondPassLines.contains { $0.text.contains("updated /notes/hello/ as") })
-        #expect(secondPassLines.contains { $0.text.contains("done — published 0, updated 1, failed 0") })
+        #expect(secondPassLines.contains { $0.text.contains("done — published 0, updated 1, unpublished 0, failed 0") })
+    }
+
+    // MARK: - v1.1 (#1234): bskyPostRef, blobs, unpublish
+
+    @Test("bskyPostRef is unset on the first pass, then filled in once POSSE has cross-posted")
+    func bskyPostRefLinkage() async throws {
+        let site = try makeSite()
+        defer { try? FileManager.default.removeItem(at: site.root) }
+        let stub = APIStub()
+        let command = StandardSitePublishCommand(
+            credentials: { _, _ in credentials },
+            transport: { try await stub.respond($0) },
+            now: { Date(timeIntervalSince1970: 1_782_777_600) }
+        )
+
+        // First pass: `publishStandardSite` always runs before `syndicate` in
+        // `runPostDeploySequencing`, so no POSSESyndicationLog exists yet — bskyPostRef must be
+        // unset.
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+        let firstDocumentBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.putRecord").last)
+        let firstRecord = try #require(firstDocumentBody["record"] as? [String: Any])
+        #expect(firstRecord["bskyPostRef"] == nil)
+
+        // Simulate a POSSE pass having run between deploys: ledger a Bluesky cross-post for the
+        // same canonical URL this document plan resolves to.
+        let canonicalURL = try #require(URL(string: "/notes/hello/", relativeTo: URL(string: "https://owner.example")))
+        var posseLedger = POSSESyndicationLog()
+        posseLedger.record(POSSESyndicationLog.Entry(
+            sourceFile: "src/content/notes/hello.md",
+            canonicalURL: canonicalURL.absoluteURL,
+            platform: "bluesky",
+            syndicationURL: URL(string: "https://bsky.app/profile/owner.test/post/anglesite-x")!,
+            postedAt: Date(timeIntervalSince1970: 1_782_777_600)
+        ))
+        try posseLedger.save(to: site.config)
+        await stub.set(getRecordResponse: (uri: "at://did:plc:owner/app.bsky.feed.post/anglesite-x", cid: "bafypostcid"))
+
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+        let secondDocumentBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.putRecord").last)
+        let secondRecord = try #require(secondDocumentBody["record"] as? [String: Any])
+        let bskyPostRef = try #require(secondRecord["bskyPostRef"] as? [String: Any])
+        #expect(bskyPostRef["uri"] as? String == "at://did:plc:owner/app.bsky.feed.post/anglesite-x")
+        #expect(bskyPostRef["cid"] as? String == "bafypostcid")
+
+        // The lookup targets the same rkey POSSE itself derives for this canonical URL/platform.
+        let getRecordRequest = try #require(await stub.requests(path: "/xrpc/com.atproto.repo.getRecord").last)
+        let queryItems = URLComponents(url: getRecordRequest.url!, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let expectedRkey = "anglesite-\(POSSEStableKey.make("site-1\n\(canonicalURL.absoluteURL.absoluteString)\nbluesky"))"
+        #expect(queryItems.contains(URLQueryItem(name: "rkey", value: expectedRkey)))
+        #expect(queryItems.contains(URLQueryItem(name: "collection", value: "app.bsky.feed.post")))
+    }
+
+    @Test("publication icon and document coverImage are uploaded as blobs when present and within the size limit")
+    func blobUpload() async throws {
+        let site = try makeSite()
+        defer { try? FileManager.default.removeItem(at: site.root) }
+
+        // Site icon, at the fixed path `StandardSitePublishCommand` looks for.
+        let publicDir = site.source.appendingPathComponent("public", isDirectory: true)
+        try FileManager.default.createDirectory(at: publicDir, withIntermediateDirectories: true)
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: publicDir.appendingPathComponent("icon-512.png"))
+
+        // Post cover image, referenced by frontmatter `image` (root-relative, like
+        // `OutboxBackfillPlan`'s photo collections).
+        let uploadsDir = publicDir.appendingPathComponent("uploads", isDirectory: true)
+        try FileManager.default.createDirectory(at: uploadsDir, withIntermediateDirectories: true)
+        try Data([0xFF, 0xD8, 0xFF]).write(to: uploadsDir.appendingPathComponent("hero.jpg"))
+        let postURL = site.source.appendingPathComponent("src/content/notes/hello.md")
+        var post = try String(contentsOf: postURL, encoding: .utf8)
+        post = post.replacingOccurrences(of: "publishDate: 2026-01-01", with: "publishDate: 2026-01-01\nimage: /uploads/hero.jpg")
+        try post.write(to: postURL, atomically: true, encoding: .utf8)
+
+        let stub = APIStub()
+        let command = StandardSitePublishCommand(
+            credentials: { _, _ in credentials },
+            transport: { try await stub.respond($0) },
+            now: { Date(timeIntervalSince1970: 1_782_777_600) }
+        )
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+
+        let uploadRequests = await stub.requests(path: "/xrpc/com.atproto.repo.uploadBlob")
+        #expect(uploadRequests.count == 2)
+        // The icon (.png) and cover image (.jpg) each carry their own real Content-Type, not a
+        // canned/shared one — confirms `StandardSiteImageBlob.mimeType(for:)` is per-file.
+        let contentTypes = Set(uploadRequests.map { $0.value(forHTTPHeaderField: "Content-Type") })
+        #expect(contentTypes == ["image/png", "image/jpeg"])
+
+        let publicationBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.putRecord").first)
+        let publicationRecord = try #require(publicationBody["record"] as? [String: Any])
+        let icon = try #require(publicationRecord["icon"] as? [String: Any])
+        #expect((icon["ref"] as? [String: Any])?["$link"] as? String == "bafyblob")
+
+        let documentBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.putRecord").last)
+        let documentRecord = try #require(documentBody["record"] as? [String: Any])
+        #expect((documentRecord["coverImage"] as? [String: Any])?["$type"] as? String == "blob")
+    }
+
+    @Test("an oversize cover image is skipped and logged rather than downscaled")
+    func oversizeCoverImageIsSkipped() async throws {
+        let site = try makeSite()
+        defer { try? FileManager.default.removeItem(at: site.root) }
+        let publicDir = site.source.appendingPathComponent("public", isDirectory: true)
+        let uploadsDir = publicDir.appendingPathComponent("uploads", isDirectory: true)
+        try FileManager.default.createDirectory(at: uploadsDir, withIntermediateDirectories: true)
+        try Data(repeating: 0, count: StandardSiteImageBlob.maxBytes + 1).write(to: uploadsDir.appendingPathComponent("huge.png"))
+        let postURL = site.source.appendingPathComponent("src/content/notes/hello.md")
+        var post = try String(contentsOf: postURL, encoding: .utf8)
+        post = post.replacingOccurrences(of: "publishDate: 2026-01-01", with: "publishDate: 2026-01-01\nimage: /uploads/huge.png")
+        try post.write(to: postURL, atomically: true, encoding: .utf8)
+
+        let stub = APIStub()
+        let logCenter = LogCenter()
+        let command = StandardSitePublishCommand(
+            credentials: { _, _ in credentials },
+            transport: { try await stub.respond($0) },
+            logCenter: logCenter,
+            now: { Date(timeIntervalSince1970: 1_782_777_600) }
+        )
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+
+        #expect(await stub.count(path: "/xrpc/com.atproto.repo.uploadBlob") == 0)
+        let documentBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.putRecord").last)
+        let documentRecord = try #require(documentBody["record"] as? [String: Any])
+        #expect(documentRecord["coverImage"] == nil)
+        let lines = await logCenter.snapshot()
+        #expect(lines.contains { $0.text.contains("exceeds the 1 MB limit") })
+    }
+
+    @Test("a document whose source post no longer exists is unpublished (deleteRecord) and pruned from the ledger")
+    func unpublishesRemovedPost() async throws {
+        let site = try makeSite()
+        defer { try? FileManager.default.removeItem(at: site.root) }
+        // A second post, so the pass has one survivor and one to delete.
+        try """
+        ---
+        title: Second post
+        publishDate: 2026-01-02
+        ---
+        Second body.
+        """.write(
+            to: site.source.appendingPathComponent("src/content/notes/second.md"), atomically: true, encoding: .utf8
+        )
+
+        let stub = APIStub()
+        let logCenter = LogCenter()
+        let command = StandardSitePublishCommand(
+            credentials: { _, _ in credentials },
+            transport: { try await stub.respond($0) },
+            logCenter: logCenter,
+            now: { Date(timeIntervalSince1970: 1_782_777_600) }
+        )
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+        let ledgerBefore = try #require(StandardSitePublishLog.load(from: site.config))
+        #expect(ledgerBefore.entries.count == 2)
+        let removedURI = try #require(ledgerBefore.entries.first { $0.path == "/notes/second/" }?.uri)
+
+        // Delete the second post's source file — the next pass should unpublish its document.
+        try FileManager.default.removeItem(at: site.source.appendingPathComponent("src/content/notes/second.md"))
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+
+        #expect(await stub.count(path: "/xrpc/com.atproto.repo.deleteRecord") == 1)
+        let deleteBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.deleteRecord").first)
+        #expect(deleteBody["collection"] as? String == "site.standard.document")
+        let expectedRkey = try #require(removedURI.split(separator: "/").last).description
+        #expect(deleteBody["rkey"] as? String == expectedRkey)
+
+        let ledgerAfter = try #require(StandardSitePublishLog.load(from: site.config))
+        #expect(ledgerAfter.entries.count == 1)
+        #expect(ledgerAfter.entries.first?.path == "/notes/hello/")
+
+        let lines = await logCenter.snapshot()
+        #expect(lines.contains { $0.text.contains("unpublished /notes/second/") })
+        #expect(lines.contains { $0.text.contains("done — published 0, updated 1, unpublished 1, failed 0") })
     }
 }

--- a/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
+++ b/Tests/AnglesiteCoreTests/StandardSitePublishTests.swift
@@ -493,6 +493,41 @@ struct StandardSitePublishCommandTests {
         #expect(lines.contains { $0.text.contains("exceeds the 1 MB limit") })
     }
 
+    @Test("a cover image with an unrecognized extension is skipped and logged, unlike a simply-unset one")
+    func unsupportedCoverImageExtensionIsLoggedButMissingIconIsSilent() async throws {
+        let site = try makeSite()
+        defer { try? FileManager.default.removeItem(at: site.root) }
+        // Deliberately no icon-512.png — the common "no icon configured" case must stay silent.
+        let publicDir = site.source.appendingPathComponent("public", isDirectory: true)
+        let uploadsDir = publicDir.appendingPathComponent("uploads", isDirectory: true)
+        try FileManager.default.createDirectory(at: uploadsDir, withIntermediateDirectories: true)
+        try Data([0x00]).write(to: uploadsDir.appendingPathComponent("hero.avif"))
+        let postURL = site.source.appendingPathComponent("src/content/notes/hello.md")
+        var post = try String(contentsOf: postURL, encoding: .utf8)
+        post = post.replacingOccurrences(of: "publishDate: 2026-01-01", with: "publishDate: 2026-01-01\nimage: /uploads/hero.avif")
+        try post.write(to: postURL, atomically: true, encoding: .utf8)
+
+        let stub = APIStub()
+        let logCenter = LogCenter()
+        let command = StandardSitePublishCommand(
+            credentials: { _, _ in credentials },
+            transport: { try await stub.respond($0) },
+            logCenter: logCenter,
+            now: { Date(timeIntervalSince1970: 1_782_777_600) }
+        )
+        await command.publish(siteID: "site-1", siteDirectory: site.source, configDirectory: site.config)
+
+        #expect(await stub.count(path: "/xrpc/com.atproto.repo.uploadBlob") == 0)
+        let documentBody = try #require(await stub.bodies(path: "/xrpc/com.atproto.repo.putRecord").last)
+        let documentRecord = try #require(documentBody["record"] as? [String: Any])
+        #expect(documentRecord["coverImage"] == nil)
+
+        let lines = await logCenter.snapshot()
+        #expect(lines.contains { $0.text.contains("unrecognized image extension \"avif\"") })
+        // The missing site icon is a plain "nothing configured" case — no matching log line for it.
+        #expect(!lines.contains { $0.text.contains("site icon") })
+    }
+
     @Test("a document whose source post no longer exists is unpublished (deleteRecord) and pruned from the ledger")
     func unpublishesRemovedPost() async throws {
         let site = try makeSite()


### PR DESCRIPTION
Closes #1234

## Summary

- **`bskyPostRef` linkage** — `StandardSitePublishCommand` now resolves each document's Bluesky strong reference independently of `POSSESyndicationCommand`: both derive the same deterministic rkey from the same site + canonical URL inputs (`POSSEStableKey`) and authenticate the same Bluesky account, so the post's at-URI needs no coordination — only its `cid` needs a `com.atproto.repo.getRecord` lookup. Because `publishStandardSite` runs *before* `syndicate` in `runPostDeploySequencing`, a document's `bskyPostRef` is always unset on the pass that first publishes it and gets filled in on the deploy after POSSE has cross-posted it (reading whatever `POSSESyndicationLog` a prior deploy already wrote).
- **Blobs** — adds `com.atproto.repo.uploadBlob`/`getRecord`/`deleteRecord` to `AtprotoPutRecordClient`. The publication's `icon` comes from the installed `icon-512.png`; a document's `coverImage` comes from its frontmatter `image` field (same root-relative convention `OutboxBackfillPlan`'s photo collections use). Both are size-gated at the lexicon's 1 MB cap — an oversize image is skipped and logged, not uploaded. **Known gap:** the design doc asks for "downscale as needed"; `AnglesiteCore` has no CoreGraphics/ImageIO dependency anywhere today (it's a portable target — builds and tests on Linux) and adding real image decode/resize here would be the first exception to that, so this PR skips oversize images instead of downscaling them. A follow-up can thread a downscaling closure in from the Darwin-only app target, the same way every other `StandardSitePublishCommand` dependency is injected.
- **Unpublish** — after each pass's publish loop, ledgered documents whose path no longer appears in the current `StandardSiteDocumentPlan` (deleted post, or slug rename — deterministic rkeys are keyed on path, so a rename orphans the old record the same way a deletion does) are removed via `com.atproto.repo.deleteRecord` and pruned from the ledger. The debug-pane summary line gained an `unpublished N` count alongside `published`/`updated`/`failed`.

Built on #1231/#1313 (record types + pass) and #1233/#1328 (Settings toggle) — this PR targets `claude/beautiful-turing-5d8nfz` (which itself targets `claude/issue-1231-aikode`) rather than `main`, since increments 1 and 3 aren't merged yet. Increment 2 (#1232, template verification/well-known) is still unmerged too, but none of this PR's three pieces depend on it functionally — only on the increment 1 record/pass plumbing.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP schema change — this extends the existing host-side XRPC client (`AtprotoPutRecordClient`) talking directly to the owner's atproto PDS, the same seam #1231 established.

## Test plan

- [x] `swift build` / `swift build --target AnglesiteCore` — clean, no errors (confirmed here directly: this environment has a working Swift 6.3.3 toolchain via swiftly).
- [x] `swift test` (portable suite) — 37/37 pass, unaffected by this change (`AnglesiteCoreTests`, where the new/updated `StandardSitePublishTests.swift` cases live, isn't in the Linux-portable target set — same limitation #1313/#1328 hit). Reviewed the new/updated cases line-by-line against the exact production signatures instead: first-pass-unset/second-pass-filled `bskyPostRef` linkage (including the `getRecord` query targeting the same rkey POSSE derives), icon + cover-image blob upload (asserting the real per-file `Content-Type`, not a canned one), an oversize-image skip-and-log case, and an unpublish case (delete a post, confirm `deleteRecord`'s rkey/collection and the ledger prune). Also updated the two pre-existing summary-line assertions for the new `unpublished N` segment. Please have CI's macOS `swift test` lane confirm.
- [x] `swift package generate-documentation --target AnglesiteCore --warnings-as-errors` — same 5 pre-existing Darwin-only-symbol errors as #1313/#1320 noted, unrelated to this change; no new DocC symbol-link errors from the new doc comments.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not runnable here (no Xcode/macOS host); this PR has no `AnglesiteApp`/UI changes, so nothing new for it to cover.
- [x] `scripts/check-localization-catalog.sh` — passes (no new user-facing strings; no UI touched).
- [ ] Manual smoke: not applicable — no UI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWthsVCMSkgrjZZaWb6Gcr)_