### PR TITLE
fix(a11y): drop browser-only DOMParser from link-text check

### DIFF
--- a/Resources/Template/scripts/a11y-validate.test.ts
+++ b/Resources/Template/scripts/a11y-validate.test.ts
@@ -70,6 +70,13 @@ test("validateLinkText: flags 'click here'", () => {
   assert.match(issues[0].message, /click here/);
 });
 
+test("validateLinkText: decodes entities before matching generic patterns", () => {
+  const html = '<a href="/about">click&nbsp;here</a>';
+  const issues = validateLinkText(html);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].rule, "link-text-generic");
+});
+
 test("validateLinkText: flags 'read more'", () => {
   const html = '<a href="/post">Read More</a>';
   const issues = validateLinkText(html);

--- a/Resources/Template/scripts/a11y-validate.ts
+++ b/Resources/Template/scripts/a11y-validate.ts
@@ -82,6 +82,21 @@ const GENERIC_LINK_PATTERNS = [
 ];
 
 /**
+ * Strip HTML tags, repeating until the string stabilizes so that
+ * overlapping/nested tag-like sequences (e.g. "<<script>script>") can't
+ * survive a single removal pass.
+ */
+function stripTags(html: string): string {
+  let previous: string;
+  let current = html;
+  do {
+    previous = current;
+    current = current.replace(/<[^>]*>/g, "");
+  } while (current !== previous);
+  return current;
+}
+
+/**
  * Validate link text quality.
  * html-validate catches empty links (wcag/h30).
  * Heuristic catches generic phrases ("click here", "read more").
@@ -98,9 +113,7 @@ export function validateLinkText(html: string): A11yIssue[] {
 
   while ((match = linkRegex.exec(html)) !== null) {
     const attrs = match[1];
-    const linkInnerHtml = match[2];
-    const parsed = new DOMParser().parseFromString(linkInnerHtml, "text/html");
-    const text = (parsed.body.textContent ?? "").trim();
+    const text = stripTags(match[2]).trim();
     if (!text || /aria-label\s*=/.test(attrs)) continue;
 
     for (const pattern of GENERIC_LINK_PATTERNS) {

--- a/Resources/Template/scripts/a11y-validate.ts
+++ b/Resources/Template/scripts/a11y-validate.ts
@@ -96,6 +96,33 @@ function stripTags(html: string): string {
   return current;
 }
 
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+/**
+ * Decode the small set of HTML entities that commonly appear in authored
+ * link text (mirrors what a DOM parser's textContent would have resolved).
+ */
+function decodeEntities(text: string): string {
+  return text.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, entity: string) => {
+    if (entity[0] === "#") {
+      const codePoint =
+        entity[1]?.toLowerCase() === "x"
+          ? parseInt(entity.slice(2), 16)
+          : parseInt(entity.slice(1), 10);
+      return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint);
+    }
+    const replacement = NAMED_ENTITIES[entity.toLowerCase()];
+    return replacement ?? match;
+  });
+}
+
 /**
  * Validate link text quality.
  * html-validate catches empty links (wcag/h30).
@@ -113,7 +140,7 @@ export function validateLinkText(html: string): A11yIssue[] {
 
   while ((match = linkRegex.exec(html)) !== null) {
     const attrs = match[1];
-    const text = stripTags(match[2]).trim();
+    const text = decodeEntities(stripTags(match[2])).trim();
     if (!text || /aria-label\s*=/.test(attrs)) continue;
 
     for (const pattern of GENERIC_LINK_PATTERNS) {


### PR DESCRIPTION
Closes #1336

## Summary

- #1310's CodeQL autofix for `validateLinkText`'s tag-stripping regex swapped it for `new DOMParser().parseFromString(...)` — a browser-only API that doesn't exist under the plain Node `tsx --test` runner this template's scripts run under. Every `a11y-validate`/`a11y-audit` test exercising `validateLinkText` now throws `ReferenceError: DOMParser is not defined`, which broke the `Template (build/test)` CI lane on `main` and on any PR branch merged with it (surfaced via PR #1315's CI after a routine merge from `main`).
- Replaced it with a loop-until-stable tag strip: the original CodeQL finding was that a single regex pass can leave behind reconstituted tags from overlapping/nested input, and repeating the removal until the string stops changing addresses that without needing a DOM implementation.

No tracked issue existed when this was opened — caught live via a failing CI check on an unrelated PR. #1336 was filed independently a few hours later by another session that hit the same failure and (incorrectly) diagnosed it as CI-runner flakiness/a stale-cache mismatch rather than the deterministic `ReferenceError` it actually is; linking it here now so it closes when this merges. A second independent duplicate fix (#1337) reached the same root cause and the same `stripTags()` shape but without this PR's `decodeEntities()` step — closed in favor of this one.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

Template-only change (`Resources/Template/scripts/a11y-validate.ts`) — app-only per `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `npx tsx --test scripts/a11y-validate.test.ts scripts/a11y-audit.test.ts` (from `Resources/Template/`) — 61/61 pass.
- [x] `npm test` (from `Resources/Template/`) — 746/750 pass, 3 pre-existing skips, 1 pre-existing unrelated failure (`scaffold.test.ts`'s `spawnSync /bin/zsh ENOENT` — no zsh binary in this sandbox, unrelated to this change).
- [ ] `swift test --package-path .` — could not run in this sandbox (no Swift toolchain available). This change is TypeScript-only (`Resources/Template/scripts/`), so no Swift-side impact is expected.
- Not applicable: no app-target UI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMqr1bMrDrgneETZLJgv47)_