### PR TITLE
fix: replace browser-only DOMParser with Node-safe stripTags

### DIFF
--- a/Resources/Template/scripts/a11y-validate.test.ts
+++ b/Resources/Template/scripts/a11y-validate.test.ts
@@ -5,6 +5,7 @@ import {
   validateLinkText,
   validateImageAlt,
   validateHtml,
+  stripTags,
 } from "./a11y-validate";
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,37 @@ test("validateLinkText: flags empty link text", () => {
 test("validateLinkText: does not flag empty links with aria-label", () => {
   const html = '<a href="/page" aria-label="Home"></a>';
   assert.deepEqual(validateLinkText(html), []);
+});
+
+test("validateLinkText: strips nested markup instead of crashing (no DOMParser in Node)", () => {
+  const html = '<a href="/about"><span>click <b>here</b></span></a>';
+  const issues = validateLinkText(html);
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0].rule, "link-text-generic");
+  assert.match(issues[0].message, /click here/);
+});
+
+// ---------------------------------------------------------------------------
+// stripTags
+// ---------------------------------------------------------------------------
+
+test("stripTags: removes simple tags", () => {
+  assert.equal(stripTags("<b>hello</b> <i>world</i>"), "hello world");
+});
+
+test("stripTags: removes nested tags", () => {
+  assert.equal(stripTags("<span>click <b>here</b></span>"), "click here");
+});
+
+test("stripTags: is a fixed point — running it again changes nothing further", () => {
+  // The property the fixed-point loop guarantees: whatever it returns has no more tags to
+  // strip, so re-running stripTags on its own output is always a no-op.
+  const once = stripTags("<<b>a<i>b</i>c</b>>");
+  assert.equal(stripTags(once), once);
+});
+
+test("stripTags: is a no-op on plain text", () => {
+  assert.equal(stripTags("no markup here"), "no markup here");
 });
 
 // ---------------------------------------------------------------------------

--- a/Resources/Template/scripts/a11y-validate.ts
+++ b/Resources/Template/scripts/a11y-validate.ts
@@ -82,6 +82,25 @@ const GENERIC_LINK_PATTERNS = [
 ];
 
 /**
+ * Strips HTML tags from `html` to recover its plain-text content, looping the removal to a
+ * fixed point (re-running until a pass makes no further change) rather than a single
+ * `replace(/<[^>]*>/g, "")` call — the fixed-point form is the standard mitigation for
+ * CodeQL's "incomplete multi-character sanitization" rule class, which #1310 originally
+ * (and incorrectly) tried to satisfy by parsing with `DOMParser` instead. `DOMParser` is a
+ * browser API with no global in the plain Node.js (`npx tsx`) runtime this script actually
+ * runs under, which broke every real invocation — see the regression this restores.
+ */
+export function stripTags(html: string): string {
+  let previous: string;
+  let current = html;
+  do {
+    previous = current;
+    current = current.replace(/<[^>]*>/g, "");
+  } while (current !== previous);
+  return current;
+}
+
+/**
  * Validate link text quality.
  * html-validate catches empty links (wcag/h30).
  * Heuristic catches generic phrases ("click here", "read more").
@@ -99,8 +118,7 @@ export function validateLinkText(html: string): A11yIssue[] {
   while ((match = linkRegex.exec(html)) !== null) {
     const attrs = match[1];
     const linkInnerHtml = match[2];
-    const parsed = new DOMParser().parseFromString(linkInnerHtml, "text/html");
-    const text = (parsed.body.textContent ?? "").trim();
+    const text = stripTags(linkInnerHtml).trim();
     if (!text || /aria-label\s*=/.test(attrs)) continue;
 
     for (const pattern of GENERIC_LINK_PATTERNS) {


### PR DESCRIPTION
Closes #1336

## Summary

- `Resources/Template/scripts/a11y-validate.ts`'s `validateLinkText` threw `ReferenceError: DOMParser is not defined` on every call — `DOMParser` is a browser API with no global in the plain Node.js (`npx tsx`) runtime this script actually runs under. Introduced by #1310 (a Copilot Autofix for a CodeQL "incomplete multi-character sanitization" alert) that swapped a single-pass tag-stripping regex for `new DOMParser().parseFromString(...)`.
- Restores a working, dependency-free fix: a new `stripTags()` helper strips tags in a loop to a fixed point (re-running the regex until a pass makes no further change) instead of a single pass — the standard mitigation shape for that CodeQL rule class, without needing a DOM.
- This wasn't just a test artifact: `validateLinkText` backs the app's real accessibility-audit feature (`Sources/AnglesiteCore/A11yAuditRunner.swift` → `npm run a11y`), so any page with an `<a>` tag currently crashes the audit.
- Added regression tests: `validateLinkText` with nested markup (the original crash trigger), plus direct `stripTags` coverage (simple tags, nested tags, fixed-point idempotency, plain-text no-op).

**Correcting #1336's diagnosis:** this is not CI-runner-only flakiness or a stale-cache/committed-source mismatch. I pulled the actual CI job log for PR #1331's run (job 92767322730) directly via the GitHub Actions API and it shows the identical `ReferenceError: DOMParser is not defined` at `a11y-validate.ts:102:20` — which is exactly where `new DOMParser()` is called in the real committed source (not near the `aria-label` check #1336 describes seeing at that line, which suggests that reproduction attempt was against a different checkout state or a stale local `node_modules`/`tsx` cache). `DOMParser` is unconditionally absent from Node.js — I confirmed no polyfill exists anywhere in `html-validate`'s dependency tree (checked directly: importing/constructing `HtmlValidate` does not define a global `DOMParser`), and reproduced the failure identically on both this container's Node 22 and a fresh `origin/main` checkout. It's fully deterministic, not flaky — rerunning the job will never make it pass.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP schema change — template-only script fix, app-only per `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `npx tsx --test scripts/a11y-validate.test.ts scripts/a11y-audit.test.ts` (from `Resources/Template/`) — 66/66 pass (previously 16 failures, all `ReferenceError: DOMParser is not defined`).
- [x] `npx tsx --test "scripts/**/*.test.ts" "src/**/*.test.ts"` — 756/760 pass, 3 skipped, 1 pre-existing failure unrelated to this change (`scaffold.test.ts` needs `/bin/zsh`, not installed in this container).
- [x] `npx astro check` and `npx tsc --noEmit` (after `npx astro sync`) — 0 errors on the whole project.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not runnable here (no Xcode/macOS host); this PR touches no Swift.
- [ ] Manual smoke: not applicable — no interactive UI changes (fixes a script the app shells out to; verified via the test suite above).
