### PR TITLE
ci: cache cloud-session Swift install via env setup script

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -3,9 +3,14 @@
 # SessionStart hook for Claude Code on the web.
 #
 # The Linux portable-target flow (see scripts/setup-dev-env.sh and
-# README.md#developing-on-linux) needs a Swift 6.3+ toolchain, installed via
-# swiftly, for `swift build`/`swift test` to work. Web session containers
-# don't ship one, so install it here.
+# README.md#developing-on-linux) needs a Swift 6.3+ toolchain for
+# `swift build`/`swift test` to work, and web session containers don't ship
+# one. The preferred install path is the cloud environment's **setup script**
+# (`bash scripts/install-swift-linux.sh`, cached with the environment — see
+# README.md#developing-on-linux); this hook is the per-session fallback for
+# environments without that cache, and it owns the part a setup script can't
+# do: persisting the toolchain's PATH/LD_LIBRARY_PATH into the session via
+# $CLAUDE_ENV_FILE.
 set -euo pipefail
 
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
@@ -14,54 +19,13 @@ fi
 
 : "${CLAUDE_ENV_FILE:?CLAUDE_ENV_FILE must be set}"
 
-SWIFTLY_ENV="$HOME/.local/share/swiftly/env.sh"
-[ -f "$SWIFTLY_ENV" ] && . "$SWIFTLY_ENV"
-
-swift_version_ok() {
-  command -v swift >/dev/null 2>&1 || return 1
-  local version minor
-  version=$(swift --version 2>/dev/null | sed -n 's/^Swift version \([0-9.]*\).*/\1/p' | head -1)
-  minor=$(printf '%s' "${version:-0}" | awk -F. '{ printf "%d%02d", $1, $2 }')
-  [ "${minor:-0}" -ge 603 ]
-}
-
-# Verifies the downloaded swiftly tarball against swift.org's published PGP
-# signature (https://www.swift.org/install/linux/swiftly/), in an isolated
-# GNUPGHOME so this doesn't touch any real user keyring. Runs unattended on
-# every qualifying web session, unlike the manual install instructions this
-# mirrors, so skipping verification here would be a bigger risk than there.
-# Best-effort: if gpg isn't available, warn and fall through rather than
-# blocking session bootstrap on an optional tool.
-verify_swiftly_tarball() {
-  local tarball="$1" sig="$2"
-  if ! command -v gpg >/dev/null 2>&1; then
-    echo "warning: gpg not found — skipping swiftly signature verification" >&2
-    return 0
-  fi
-  local gpg_home
-  gpg_home=$(mktemp -d)
-  # shellcheck disable=SC2064 (expand gpg_home now, not at trap time)
-  trap "rm -rf '$gpg_home'" RETURN
-  curl -fsSL --compressed https://www.swift.org/keys/all-keys.asc \
-    | gpg --homedir "$gpg_home" --quiet --import -
-  gpg --homedir "$gpg_home" --quiet --verify "$sig" "$tarball"
-}
-
-if ! swift_version_ok; then
-  if ! command -v swiftly >/dev/null 2>&1; then
-    curl -fsSL -o /tmp/swiftly.tar.gz "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
-    curl -fsSL -o /tmp/swiftly.tar.gz.sig "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz.sig"
-    verify_swiftly_tarball /tmp/swiftly.tar.gz /tmp/swiftly.tar.gz.sig
-    tar zxf /tmp/swiftly.tar.gz -C /tmp
-    /tmp/swiftly init -y --no-modify-profile --skip-install
-    rm -f /tmp/swiftly.tar.gz /tmp/swiftly.tar.gz.sig /tmp/swiftly
-    . "$SWIFTLY_ENV"
-  fi
-  swiftly install latest -y
-fi
+# Idempotent: no-ops fast when the environment cache (or an earlier session)
+# already installed a Swift 6.3+ toolchain.
+"${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}/scripts/install-swift-linux.sh"
 
 # Persist swiftly's PATH for the rest of this session (env.sh itself is a
 # no-op re-source: it only prepends SWIFTLY_BIN_DIR if not already present).
+SWIFTLY_ENV="$HOME/.local/share/swiftly/env.sh"
 if [ -f "$SWIFTLY_ENV" ]; then
   echo ". \"$SWIFTLY_ENV\"" >> "$CLAUDE_ENV_FILE"
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "timeout": 900
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ Notes:
 - **Working on the port itself:** `ANGLESITE_PORT_WIP=1 swift build --target AnglesiteCore` opts the not-yet-portable core into the manifest so in-flight seam work can be compile-checked locally. Apple-only targets (`AnglesiteBridge`, `AnglesiteIntents`, `AnglesiteContainer`, …) never build off-Darwin.
 - **Containers:** `podman` is not needed for the purity phase; it becomes relevant with the Linux MVP's `PodmanSiteRuntime`.
 
+### Claude Code cloud sessions
+
+Claude Code's cloud session containers (claude.ai/code) are Linux and ship no Swift toolchain, so agents there need the same swiftly install as any Linux contributor. Two pieces make that work, and both need a one-time tweak to the repo's cloud **environment settings** on claude.ai/code:
+
+1. **Setup script** (preferred): set the environment's setup script to `bash scripts/install-swift-linux.sh`. It runs at environment provisioning and the installed toolchain is cached, so every session starts with Swift ready instead of re-downloading it.
+2. **Network access:** the install downloads from swift.org, which is not in the default package-registry allowlist. If the environment restricts network access, allowlist `swift.org`, `www.swift.org`, and `download.swift.org`.
+
+The checked-in `SessionStart` hook ([`.claude/hooks/session-start.sh`](.claude/hooks/session-start.sh)) remains as a per-session fallback: it runs the same install script when no cached toolchain is present (needing the same allowlist), and persists the toolchain's `PATH` and the libxml2-shim `LD_LIBRARY_PATH` into each session via `$CLAUDE_ENV_FILE` — something a setup script can't do.
+
 ## Relationship to the sidecar repo
 
 This repo expects a sibling checkout of the sidecar repo, [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills), in a directory named `anglesite` next to this one (both under the same parent directory) — or set `ANGLESITE_SIDECAR_SRC` to point elsewhere (`ANGLESITE_PLUGIN_SRC` remains a compatibility alias). The sibling repo supplies the **MCP sidecar** (`server/`), which the container-image scripts (`scripts/vendor-container-image.sh`, `scripts/build-podman-image.sh`) stage into the dev-server image; the MCP end-to-end tests also spawn it directly from the checkout (`ANGLESITE_PLUGIN_PATH`). Nothing from the sibling repo is bundled into the app itself anymore (#466).

--- a/scripts/install-swift-linux.sh
+++ b/scripts/install-swift-linux.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Install a Swift 6.3+ toolchain on Linux via swiftly
+# (https://www.swift.org/install/linux/), mirroring the manual instructions
+# scripts/setup-dev-env.sh prints. Idempotent: no-ops fast when a new-enough
+# toolchain is already on PATH (including one swiftly installed previously).
+#
+# Two consumers:
+#
+#   * The Claude Code cloud environment **setup script** (claude.ai/code →
+#     environment settings): `bash scripts/install-swift-linux.sh`. The result
+#     is cached with the environment, so sessions start with Swift already
+#     installed. See README.md#developing-on-linux.
+#   * `.claude/hooks/session-start.sh`, the per-session fallback for cloud
+#     sessions whose environment has no cached toolchain. The hook also owns
+#     persisting PATH/LD_LIBRARY_PATH for the session — this script only
+#     installs.
+#
+# Needs network egress to www.swift.org and download.swift.org; a cloud
+# environment with restricted network access must allowlist those hosts.
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "install-swift-linux.sh: Linux only — on macOS, install Xcode (see README.md#requirements)" >&2
+  exit 1
+fi
+
+SWIFTLY_ENV="$HOME/.local/share/swiftly/env.sh"
+# shellcheck source=/dev/null
+[ -f "$SWIFTLY_ENV" ] && . "$SWIFTLY_ENV"
+
+swift_version_ok() {
+  command -v swift >/dev/null 2>&1 || return 1
+  local version minor
+  version=$(swift --version 2>/dev/null | sed -n 's/^Swift version \([0-9.]*\).*/\1/p' | head -1)
+  minor=$(printf '%s' "${version:-0}" | awk -F. '{ printf "%d%02d", $1, $2 }')
+  [ "${minor:-0}" -ge 603 ]
+}
+
+# Verifies the downloaded swiftly tarball against swift.org's published PGP
+# signature (https://www.swift.org/install/linux/swiftly/), in an isolated
+# GNUPGHOME so this doesn't touch any real user keyring. Runs unattended,
+# unlike the manual install instructions this mirrors, so skipping
+# verification here would be a bigger risk than there. Best-effort: if gpg
+# isn't available, warn and fall through rather than blocking bootstrap on an
+# optional tool.
+verify_swiftly_tarball() {
+  local tarball="$1" sig="$2"
+  if ! command -v gpg >/dev/null 2>&1; then
+    echo "warning: gpg not found — skipping swiftly signature verification" >&2
+    return 0
+  fi
+  local gpg_home
+  gpg_home=$(mktemp -d)
+  # Expand gpg_home now, not at trap time.
+  # shellcheck disable=SC2064
+  trap "rm -rf '$gpg_home'" RETURN
+  curl -fsSL --compressed https://www.swift.org/keys/all-keys.asc \
+    | gpg --homedir "$gpg_home" --quiet --import -
+  gpg --homedir "$gpg_home" --quiet --verify "$sig" "$tarball"
+}
+
+if swift_version_ok; then
+  echo "Swift already present ($(swift --version 2>/dev/null | head -1)) — nothing to install"
+  exit 0
+fi
+
+if ! command -v swiftly >/dev/null 2>&1; then
+  curl -fsSL -o /tmp/swiftly.tar.gz "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
+  curl -fsSL -o /tmp/swiftly.tar.gz.sig "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz.sig"
+  verify_swiftly_tarball /tmp/swiftly.tar.gz /tmp/swiftly.tar.gz.sig
+  tar zxf /tmp/swiftly.tar.gz -C /tmp
+  /tmp/swiftly init -y --no-modify-profile --skip-install
+  rm -f /tmp/swiftly.tar.gz /tmp/swiftly.tar.gz.sig /tmp/swiftly
+  # shellcheck source=/dev/null
+  . "$SWIFTLY_ENV"
+fi
+swiftly install latest -y


### PR DESCRIPTION
## Summary

- Cloud agents still land in sessions with no Swift toolchain despite the `SessionStart` hook from #1287 — likely the toolchain download blowing the session-start window, and/or swift.org missing from the cloud environment's network allowlist.
- Extract the swiftly install into `scripts/install-swift-linux.sh` so it can run as the cloud environment's **setup script** (`bash scripts/install-swift-linux.sh`), where the installed toolchain is cached with the environment instead of re-downloading every session. The hook becomes a thin per-session fallback that delegates the install and keeps what only a hook can do: persisting `PATH`/`LD_LIBRARY_PATH` via `$CLAUDE_ENV_FILE`. Also adds an explicit 900s `timeout` to the hook.
- Documents the required claude.ai/code environment settings in `README.md#developing-on-linux`: the setup script above, plus allowlisting `swift.org` / `www.swift.org` / `download.swift.org` when network access is restricted. Those two settings changes are owner actions on claude.ai/code, not repo changes (@dwk is applying the allowlist).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path .` (no Swift sources touched — CI runs it regardless)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (no app sources touched)
- [x] `shellcheck` + `bash -n` clean on both scripts; `.claude/settings.json` parses.
- [x] Guard smoke tests: install script refuses non-Linux with a clear message; hook no-ops when `CLAUDE_CODE_REMOTE` unset; hook fails fast with a clear message when `CLAUDE_ENV_FILE` is missing.
- [x] Delegation seam: ran the hook from an unrelated cwd without `CLAUDE_PROJECT_DIR` — it resolved and invoked `scripts/install-swift-linux.sh` via the script-relative fallback (observable through the install script's Linux-only guard).
- [ ] Linux end-to-end install not re-run here (macOS host, container runtime not up) — the swiftly install/verify/libxml2 logic is extracted verbatim from the #1287 script that was container-tested yesterday; the next cloud session exercises the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)