### PR TITLE
test: bound and de-risk hang-prone AnglesiteAppTests suites

### DIFF
--- a/Tests/AnglesiteAppTests/AgentReadinessModelTests.swift
+++ b/Tests/AnglesiteAppTests/AgentReadinessModelTests.swift
@@ -41,7 +41,11 @@ private let sampleReport = AgentReadinessReport(
     ],
     nextLevel: nil)
 
-@Suite(.serialized)
+/// `.timeLimit`: see #1349 — the full `AnglesiteAppTests` target has hung indefinitely under
+/// local machine contention (many concurrent `swift test` runs oversubscribing the cooperative
+/// thread pool), with this suite one of the observed stall points. A wedged test now fails as an
+/// unambiguous time-limit violation instead of hanging the whole run forever.
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct AgentReadinessModelTests {
     private func tempSite(siteURL: String? = "https://example.workers.dev") throws -> (CurrentSite, () -> Void) {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)

--- a/Tests/AnglesiteAppTests/CloudflareAPITokenTestEnvironment.swift
+++ b/Tests/AnglesiteAppTests/CloudflareAPITokenTestEnvironment.swift
@@ -13,16 +13,26 @@ import Foundation
 ///
 /// This is a readers/writer problem — setters are the readers, clearers are the writer — so
 /// `claimSet()`/`claimClear()` are `async` and suspend until the requested state is safe to hold,
-/// via a continuation-based waiter queue rather than by blocking the calling thread. Swift Testing
-/// runs on a cooperative thread pool; a blocking wait (e.g. `NSCondition.wait()`) inside an async
-/// test body risks starving it. Release is synchronous by design: `deinit` can't `await`, and
+/// via a continuation-based waiter queue. This type is an `actor` (not a class guarded by an
+/// `NSLock`, as it was before #1349): every access to `mode`/`setWaiters`/`clearWaiters` is
+/// already serialized by actor isolation, so there's no lock to acquire and nothing here ever
+/// blocks an OS thread. That matters because Swift Testing runs on the finite cooperative thread
+/// pool — a blocking primitive (`NSLock.lock()`, `NSCondition.wait()`, …) called from inside async
+/// test code, even briefly, risks starving that pool under contention, which is exactly the
+/// failure mode #1349 investigated. Release is synchronous by design: `deinit` can't `await`, and
 /// neither can a Swift `defer` body, so every caller does
 ///
 /// ```swift
 /// let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
 /// defer { cfToken.release() }
 /// ```
-final class CloudflareAPITokenTestEnvironment: @unchecked Sendable {
+///
+/// `release()` hands off to the actor via a detached `Task`, so the actual state transition (and
+/// any waiter it wakes) may complete a moment after `release()` returns rather than synchronously
+/// with it. That's invisible to callers: the next claimer always `await`s its own `claimSet()`/
+/// `claimClear()` and is correctly suspended until that transition has actually happened, however
+/// long it takes.
+actor CloudflareAPITokenTestEnvironment {
     static let shared = CloudflareAPITokenTestEnvironment()
 
     /// A held claim on the env var. `release()` is synchronous so it can run from a `defer` block.
@@ -37,7 +47,6 @@ final class CloudflareAPITokenTestEnvironment: @unchecked Sendable {
         case cleared
     }
 
-    private let lock = NSLock()
     private var mode: Mode = .idle
     private var previousValue: String?
     private var setWaiters: [CheckedContinuation<Void, Never>] = []
@@ -48,11 +57,9 @@ final class CloudflareAPITokenTestEnvironment: @unchecked Sendable {
     /// Claims the var in the "set" state. Suspends while a clearer holds exclusive "cleared" state.
     func claimSet(value: String = "test-token") async -> Token {
         while true {
-            lock.lock()
             if case .cleared = mode {
                 await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                     setWaiters.append(continuation)
-                    lock.unlock()
                 }
                 continue
             }
@@ -66,8 +73,10 @@ final class CloudflareAPITokenTestEnvironment: @unchecked Sendable {
             case .cleared:
                 fatalError("unreachable: handled above")
             }
-            lock.unlock()
-            return Token { [weak self] in self?.releaseSet() }
+            return Token { [weak self] in
+                guard let self else { return }
+                Task { await self.releaseSet() }
+            }
         }
     }
 
@@ -75,51 +84,44 @@ final class CloudflareAPITokenTestEnvironment: @unchecked Sendable {
     /// another clearer holds "cleared".
     func claimClear() async -> Token {
         while true {
-            lock.lock()
             if case .idle = mode {
                 previousValue = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
                 unsetenv("CLOUDFLARE_API_TOKEN")
                 mode = .cleared
-                lock.unlock()
-                return Token { [weak self] in self?.releaseClear() }
+                return Token { [weak self] in
+                    guard let self else { return }
+                    Task { await self.releaseClear() }
+                }
             }
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 clearWaiters.append(continuation)
-                lock.unlock()
             }
         }
     }
 
     private func releaseSet() {
-        lock.lock()
         guard case .set(let holders) = mode else {
-            lock.unlock()
             assertionFailure("releaseSet() called without a matching claimSet()")
             return
         }
         if holders > 1 {
             mode = .set(holders: holders - 1)
-            lock.unlock()
             return
         }
         restoreEnvAndGoIdle()
     }
 
     private func releaseClear() {
-        lock.lock()
         guard case .cleared = mode else {
-            lock.unlock()
             assertionFailure("releaseClear() called without a matching claimClear()")
             return
         }
         restoreEnvAndGoIdle()
     }
 
-    /// Must be called with `lock` held; unlocks before returning. Restores the env var to whatever
-    /// it was before the just-released claim, then wakes whichever waiters can now proceed: a
-    /// clearer first (exclusive, so at most one), otherwise every waiting setter (mutually
-    /// compatible). Continuations are only resumed after `lock` is released, so a waiter that
-    /// immediately re-claims on resume never re-enters this type while it's still locked.
+    /// Restores the env var to whatever it was before the just-released claim, then wakes
+    /// whichever waiters can now proceed: a clearer first (exclusive, so at most one), otherwise
+    /// every waiting setter (mutually compatible).
     private func restoreEnvAndGoIdle() {
         if let previousValue {
             setenv("CLOUDFLARE_API_TOKEN", previousValue, 1)
@@ -136,7 +138,6 @@ final class CloudflareAPITokenTestEnvironment: @unchecked Sendable {
         } else {
             toResume = []
         }
-        lock.unlock()
         for continuation in toResume {
             continuation.resume()
         }

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -88,7 +88,11 @@ private struct StubTokenVerifying: TokenVerifying {
 /// `setenv`/`unsetenv` directly — it serializes the two incompatible desired states against each
 /// other instead of letting them race. Claim at the top of a test body (before any other `await`,
 /// so no other test's `deploy()` check can interleave) and release via `defer`.
-@Suite("DeployModel")
+/// `.timeLimit`: see #1349 — the full `AnglesiteAppTests` target has hung indefinitely under
+/// local machine contention (many concurrent `swift test` runs oversubscribing the cooperative
+/// thread pool), with a stall observed immediately after this suite. A wedged test now fails as
+/// an unambiguous time-limit violation instead of hanging the whole run forever.
+@Suite("DeployModel", .timeLimit(.minutes(1)))
 @MainActor
 struct DeployModelTests {
     @Test("sudden termination stays disabled until a deploy finishes")

--- a/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
+++ b/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
@@ -55,7 +55,11 @@ private final class StubWriter: CloudflareWriting, @unchecked Sendable {
     func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
 }
 
-@Suite(.serialized)
+/// `.timeLimit`: see #1349 — the full `AnglesiteAppTests` target has hung indefinitely under
+/// local machine contention (many concurrent `swift test` runs oversubscribing the cooperative
+/// thread pool), with this suite one of the observed stall points. A wedged test now fails as an
+/// unambiguous time-limit violation instead of hanging the whole run forever.
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct DomainConfigAuditModelTests {
     /// A per-case scratch service (see `KeychainStore`'s own doc comment) so these tests never
     /// touch the developer's real login keychain — every test that claims `CLOUDFLARE_API_TOKEN`

--- a/Tests/AnglesiteAppTests/OnionRoutingModelTests.swift
+++ b/Tests/AnglesiteAppTests/OnionRoutingModelTests.swift
@@ -55,7 +55,11 @@ private final class StubWriter: CloudflareWriting, @unchecked Sendable {
     }
 }
 
-@Suite(.serialized)
+/// `.timeLimit`: see #1349 — the full `AnglesiteAppTests` target has hung indefinitely under
+/// local machine contention (many concurrent `swift test` runs oversubscribing the cooperative
+/// thread pool), with this suite one of the observed stall points. A wedged test now fails as an
+/// unambiguous time-limit violation instead of hanging the whole run forever.
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct OnionRoutingModelTests {
     @MainActor
     @Test("load() ignores blank domain input")


### PR DESCRIPTION
Closes #1349

## Summary

- `CloudflareAPITokenTestEnvironment` was a class guarded by `NSLock`, with `lock.lock()`
  called synchronously inside `claimSet()`/`claimClear()` — both `async` functions run on
  Swift Testing's cooperative thread pool. Blocking that finite pool is a known
  deadlock/starvation hazard; converted the type to an `actor` so every access is
  serialized by isolation instead, with no lock at all.
- No suite in `AnglesiteAppTests` carried a Swift Testing `.timeLimit` trait, so a stall
  anywhere hangs the whole run forever with no failure signal. Added a 1-minute per-test
  limit (matching the existing `VsockTCPProxyTests` precedent) to the four suites observed
  as stall points while investigating #1349: `AgentReadinessModelTests`, `DeployModelTests`,
  `DomainConfigAuditModelTests`, `OnionRoutingModelTests`.

#1349 has the full investigation. Root cause is environmental, not these suites: CI's
`build-test` job runs the identical unfiltered `swift test -c debug --parallel` on
macos-26 and reliably completes in ~3-4 minutes — it never hangs. The hang only
reproduces on a local machine that's chronically running several concurrent full
`swift test` invocations across worktrees, oversubscribing Swift's cooperative thread
pool (directly observed during this investigation: 4+ simultaneous `swift-test`
processes each burning 100-135% CPU on a 28-core box). These two changes don't fix that
underlying contention — they make a stall fail loudly instead of hanging forever, and
remove one confirmed anti-pattern that becomes more dangerous under exactly that kind
of contention.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path . --filter "AgentReadinessModelTests|DeployModelTests|DomainConfigAuditModelTests|OnionRoutingModelTests"` — 43 tests, 4 suites, completes in <1s. Only failure is the pre-existing, unrelated `DeployModelTests` "signInWithCloudflare keeps the sheet open with a message on failure" flake (reproduces on `main` too — see #1349).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`.
- [ ] Full unfiltered `swift test --package-path .` — not run locally, per #1349 this is the exact command known to hang on this machine independent of this diff. CI's `build-test` job runs it and is the authoritative signal.
