### PR TITLE
In-app analytics data viewing (Web Analytics / RUM)

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1,6 +1,50 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Traffic" : {
+
+    },
+    "No traffic recorded in the last 7 days." : {
+
+    },
+    "Last 7 days: %lld pageviews · %lld visits" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Last 7 days: %1$lld pageviews · %2$lld visits"
+          }
+        }
+      }
+    },
+    "7-day pageviews trend" : {
+
+    },
+    "%lld total pageviews over the last 7 days, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld total pageviews over the last 7 days, %2$@"
+          }
+        }
+      }
+    },
+    "trending up" : {
+
+    },
+    "trending down" : {
+
+    },
+    "holding steady" : {
+
+    },
+    "Day" : {
+
+    },
+    "Pageviews" : {
+
+    },
     "" : {
 
     },

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -9,6 +9,7 @@ final class PlistEditorModel {
     let sourceDirectory: URL
     private let initialWebsiteTitle: String
     private let analyticsProvider: any CloudflareWebAnalyticsProviding
+    private let rumAnalyticsProvider: any CloudflareRUMAnalyticsProviding
     private let customAnalyticsValidator: any CustomAnalyticsHTMLValidating
     private let keychain: KeychainStore
     private let capabilityProber: CloudflareCapabilityProber
@@ -23,6 +24,9 @@ final class PlistEditorModel {
     private(set) var isInstallingIcons = false
     private(set) var isSavingAnalytics = false
     private(set) var isConfiguringCloudflareAnalytics = false
+    private(set) var isLoadingRUMSummary = false
+    private(set) var rumSummary: RUMAnalyticsSummary?
+    private(set) var rumSummaryError: String?
     private(set) var hasWebsiteIcons = false
     var analyticsSettings = WebsiteAnalyticsAsset.Settings() {
         didSet {
@@ -214,6 +218,7 @@ final class PlistEditorModel {
          graphSnapshotProvider: @escaping @MainActor () -> SiteGraphExplorerSnapshot? = { nil },
          onActiveWorkersChanged: @escaping (SiteSettings) async -> Void = { _ in },
          analyticsProvider: any CloudflareWebAnalyticsProviding = CloudflareWebAnalyticsClient(),
+         rumAnalyticsProvider: any CloudflareRUMAnalyticsProviding = CloudflareRUMAnalyticsClient(),
          customAnalyticsValidator: (any CustomAnalyticsHTMLValidating)? = nil,
          containerControlProvider: @escaping AstroHTMLValidator.ContainerControlProvider = { nil },
          keychain: KeychainStore = KeychainStore(),
@@ -237,6 +242,7 @@ final class PlistEditorModel {
         self.graphSnapshotProvider = graphSnapshotProvider
         self.onActiveWorkersChanged = onActiveWorkersChanged
         self.analyticsProvider = analyticsProvider
+        self.rumAnalyticsProvider = rumAnalyticsProvider
         // `customAnalyticsValidator` lets tests inject a fake directly; production leaves it nil
         // and instead wires `containerControlProvider` through to the real `AstroHTMLValidator`,
         // resolved lazily at validation time (#961).
@@ -842,6 +848,29 @@ final class PlistEditorModel {
             _ = await saveAnalytics()
         } catch {
             analyticsError = error.localizedDescription
+        }
+    }
+
+    /// Fetches the last 7 days' pageviews/visits summary for the Analytics tab (#1114). A no-op
+    /// when Cloudflare Analytics isn't enabled for this site — there's no siteTag to query. A
+    /// thrown error clears any prior summary rather than leaving a stale one on screen.
+    func loadRUMSummary() async {
+        guard cloudflareAnalyticsEnabled else { return }
+        guard !isLoadingRUMSummary else { return }
+        isLoadingRUMSummary = true
+        rumSummaryError = nil
+        defer { isLoadingRUMSummary = false }
+        do {
+            guard let token = try await cloudflareToken(), !token.isEmpty else {
+                rumSummary = nil
+                rumSummaryError = CloudflareWebAnalyticsError.missingToken.localizedDescription
+                return
+            }
+            rumSummary = try await rumAnalyticsProvider.summary(
+                siteTag: analyticsSettings.cloudflareToken, apiToken: token, days: 7)
+        } catch {
+            rumSummary = nil
+            rumSummaryError = error.localizedDescription
         }
     }
 

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -376,6 +376,7 @@ struct PlistEditorView: View {
                             Text("No traffic recorded in the last 7 days.")
                                 .foregroundStyle(.secondary)
                         } else {
+                            let trend = rumTrendDescription(for: summary.dailyPageviews)
                             Text("Last 7 days: \(summary.totalPageviews) pageviews · \(summary.totalVisits) visits")
                             Chart(summary.dailyPageviews, id: \.date) { day in
                                 BarMark(
@@ -385,11 +386,33 @@ struct PlistEditorView: View {
                             }
                             .frame(height: 60)
                             .accessibilityLabel("7-day pageviews trend")
-                            .accessibilityValue("\(summary.totalPageviews) total pageviews over the last 7 days")
+                            .accessibilityValue("\(summary.totalPageviews) total pageviews over the last 7 days, \(trend)")
                         }
                     }
                 }
             }
+        }
+    }
+
+    /// Describes the shape of a 7-day pageviews trend in words, for the sparkline's
+    /// `accessibilityValue` — VoiceOver users get no benefit from the bar chart itself, so the totals
+    /// line needs to say in words what the bars show. Compares the average of the first half of the
+    /// window to the second half (rather than just first-day-vs-last-day) so one noisy day doesn't flip
+    /// the description.
+    private func rumTrendDescription(for days: [DailyCount]) -> String {
+        guard days.count >= 2 else { return "holding steady" }
+        let midpoint = days.count / 2
+        let firstHalf = days[..<midpoint]
+        let secondHalf = days[midpoint...]
+        let firstAverage = Double(firstHalf.reduce(0) { $0 + $1.pageviews }) / Double(firstHalf.count)
+        let secondAverage = Double(secondHalf.reduce(0) { $0 + $1.pageviews }) / Double(secondHalf.count)
+        let threshold = max(1.0, firstAverage * 0.1)
+        if secondAverage - firstAverage > threshold {
+            return "trending up"
+        } else if firstAverage - secondAverage > threshold {
+            return "trending down"
+        } else {
+            return "holding steady"
         }
     }
 

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import Charts
 import AnglesiteCore
 
 struct PlistEditorView: View {
@@ -342,7 +343,9 @@ struct PlistEditorView: View {
                         .font(.callout)
                 }
             }
+            rumSummarySection
         }
+        .task { await model.loadRUMSummary() }
         .popover(isPresented: $showingCustomAnalyticsHelp, arrowEdge: .trailing) {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Custom Analytics")
@@ -353,6 +356,40 @@ struct PlistEditorView: View {
                     .frame(width: 280, alignment: .leading)
             }
             .padding()
+        }
+    }
+
+    @ViewBuilder
+    private var rumSummarySection: some View {
+        if model.cloudflareAnalyticsEnabled {
+            SettingsBox(title: "Traffic") {
+                VStack(alignment: .leading, spacing: 8) {
+                    if model.isLoadingRUMSummary {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else if let rumSummaryError = model.rumSummaryError {
+                        Label(rumSummaryError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.callout)
+                    } else if let summary = model.rumSummary {
+                        if summary.dailyPageviews.isEmpty {
+                            Text("No traffic recorded in the last 7 days.")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Last 7 days: \(summary.totalPageviews) pageviews · \(summary.totalVisits) visits")
+                            Chart(summary.dailyPageviews, id: \.date) { day in
+                                BarMark(
+                                    x: .value("Day", day.date, unit: .day),
+                                    y: .value("Pageviews", day.pageviews)
+                                )
+                            }
+                            .frame(height: 60)
+                            .accessibilityLabel("7-day pageviews trend")
+                            .accessibilityValue("\(summary.totalPageviews) total pageviews over the last 7 days")
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/Sources/AnglesiteApp/PlistEditorView.swift
+++ b/Sources/AnglesiteApp/PlistEditorView.swift
@@ -345,7 +345,7 @@ struct PlistEditorView: View {
             }
             rumSummarySection
         }
-        .task { await model.loadRUMSummary() }
+        .task(id: model.cloudflareAnalyticsEnabled) { await model.loadRUMSummary() }
         .popover(isPresented: $showingCustomAnalyticsHelp, arrowEdge: .trailing) {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Custom Analytics")
@@ -400,7 +400,7 @@ struct PlistEditorView: View {
     /// window to the second half (rather than just first-day-vs-last-day) so one noisy day doesn't flip
     /// the description.
     private func rumTrendDescription(for days: [DailyCount]) -> String {
-        guard days.count >= 2 else { return "holding steady" }
+        guard days.count >= 2 else { return String(localized: "holding steady") }
         let midpoint = days.count / 2
         let firstHalf = days[..<midpoint]
         let secondHalf = days[midpoint...]
@@ -408,11 +408,11 @@ struct PlistEditorView: View {
         let secondAverage = Double(secondHalf.reduce(0) { $0 + $1.pageviews }) / Double(secondHalf.count)
         let threshold = max(1.0, firstAverage * 0.1)
         if secondAverage - firstAverage > threshold {
-            return "trending up"
+            return String(localized: "trending up")
         } else if firstAverage - secondAverage > threshold {
-            return "trending down"
+            return String(localized: "trending down")
         } else {
-            return "holding steady"
+            return String(localized: "holding steady")
         }
     }
 

--- a/Sources/AnglesiteCore/CloudflareRUMAnalyticsClient.swift
+++ b/Sources/AnglesiteCore/CloudflareRUMAnalyticsClient.swift
@@ -82,6 +82,12 @@ public struct CloudflareRUMAnalyticsClient: CloudflareRUMAnalyticsProviding {
             guard let date = Self.parseDate(group.dimensions.date) else { return nil }
             return DailyCount(date: date, pageviews: group.count)
         }.sorted { $0.date < $1.date }
+        // `groups` had real, nonzero data, but none of it had a date in either format
+        // `parseDate` understands — that's a parse failure, not "no traffic in this window," and
+        // must not be conflated with the genuinely-empty (`groups.isEmpty`) case below.
+        if !groups.isEmpty && daily.isEmpty {
+            throw CloudflareWebAnalyticsError.invalidResponse
+        }
         return RUMAnalyticsSummary(
             totalPageviews: groups.reduce(0) { $0 + $1.count },
             totalVisits: groups.reduce(0) { $0 + $1.sum.visits },

--- a/Sources/AnglesiteCore/CloudflareRUMAnalyticsClient.swift
+++ b/Sources/AnglesiteCore/CloudflareRUMAnalyticsClient.swift
@@ -1,0 +1,195 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// One day's pageview count within a ``RUMAnalyticsSummary``'s trend.
+public struct DailyCount: Sendable, Equatable {
+    public let date: Date
+    public let pageviews: Int
+
+    public init(date: Date, pageviews: Int) {
+        self.date = date
+        self.pageviews = pageviews
+    }
+}
+
+/// A pageviews/visits summary for one Web Analytics (RUM) site over a recent window — the
+/// in-app answer to "how's my traffic doing," with the Cloudflare dashboard (linked via
+/// `WorkerDashboardLinks`) as the deep-dive destination for anything beyond a glance.
+public struct RUMAnalyticsSummary: Sendable, Equatable {
+    public let totalPageviews: Int
+    public let totalVisits: Int
+    /// Ascending by date, one entry per day the API returned data for.
+    public let dailyPageviews: [DailyCount]
+
+    public init(totalPageviews: Int, totalVisits: Int, dailyPageviews: [DailyCount]) {
+        self.totalPageviews = totalPageviews
+        self.totalVisits = totalVisits
+        self.dailyPageviews = dailyPageviews
+    }
+}
+
+/// Seam for fetching a Web Analytics (RUM) summary, so callers (the Analytics tab) can inject a
+/// fake instead of hitting Cloudflare's GraphQL API in tests. Kept separate from
+/// ``CloudflareWebAnalyticsProviding`` (site-tag resolution): that's a one-time REST lookup done
+/// during onboarding, this is a repeated GraphQL query done on every Analytics tab view — two
+/// different Cloudflare APIs with two different call shapes and cadences.
+public protocol CloudflareRUMAnalyticsProviding: Sendable {
+    /// Fetches a summary for the last `days` days for the Web Analytics site identified by
+    /// `siteTag`.
+    func summary(siteTag: String, apiToken: String, days: Int) async throws -> RUMAnalyticsSummary
+}
+
+/// Production ``CloudflareRUMAnalyticsProviding``: queries Cloudflare's GraphQL Analytics API
+/// (`rumPageloadEventsAdaptiveGroups`) for a day-by-day pageviews/visits breakdown.
+public struct CloudflareRUMAnalyticsClient: CloudflareRUMAnalyticsProviding {
+    private let baseURL: URL
+    private let urlSession: URLSession
+
+    /// Both parameters exist for tests — point `baseURL` at a local stub server to exercise the
+    /// real request/decode path. Production callers take the defaults.
+    public init(baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
+                urlSession: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.urlSession = urlSession
+    }
+
+    public func summary(siteTag: String, apiToken: String, days: Int) async throws -> RUMAnalyticsSummary {
+        let accounts = try await accounts(apiToken: apiToken)
+        guard let accountID = accounts.first?.id else { throw CloudflareWebAnalyticsError.noAccount }
+
+        let until = Date()
+        let since = Calendar(identifier: .gregorian).date(byAdding: .day, value: -days, to: until) ?? until
+        let isoFormatter = ISO8601DateFormatter()
+        let body: [String: Any] = [
+            "query": Self.query,
+            "variables": [
+                "accountTag": accountID,
+                "siteTag": siteTag,
+                "since": isoFormatter.string(from: since),
+                "until": isoFormatter.string(from: until)
+            ]
+        ]
+        let response: GraphQLResponse = try await post(path: "graphql", apiToken: apiToken, jsonBody: body)
+        if let message = response.errors?.first?.message {
+            throw CloudflareWebAnalyticsError.api(message)
+        }
+        guard let groups = response.data?.viewer.accounts.first?.rumPageloadEventsAdaptiveGroups else {
+            throw CloudflareWebAnalyticsError.invalidResponse
+        }
+        let daily = groups.compactMap { group -> DailyCount? in
+            guard let date = Self.parseDate(group.dimensions.date) else { return nil }
+            return DailyCount(date: date, pageviews: group.count)
+        }.sorted { $0.date < $1.date }
+        return RUMAnalyticsSummary(
+            totalPageviews: groups.reduce(0) { $0 + $1.count },
+            totalVisits: groups.reduce(0) { $0 + $1.sum.visits },
+            dailyPageviews: daily)
+    }
+
+    /// Cloudflare's GraphQL `Date`/`Time` scalars have shown up as both a bare day
+    /// (`"2026-08-01"`) and a full timestamp (`"2026-08-01T00:00:00Z"`) across adaptive-groups
+    /// datasets — this tries the full form first, then falls back to the bare day, so the client
+    /// doesn't hard-fail if the live API returns the form this wasn't verified against (see the
+    /// "Verify-before-build note" above).
+    private static func parseDate(_ raw: String) -> Date? {
+        if let date = ISO8601DateFormatter().date(from: raw) { return date }
+        let dayFormatter = DateFormatter()
+        dayFormatter.dateFormat = "yyyy-MM-dd"
+        dayFormatter.timeZone = TimeZone(identifier: "UTC")
+        return dayFormatter.date(from: raw)
+    }
+
+    private static let query = """
+        query RUMSummary($accountTag: string!, $siteTag: string!, $since: Time!, $until: Time!) {
+          viewer {
+            accounts(filter: { accountTag: $accountTag }) {
+              rumPageloadEventsAdaptiveGroups(
+                limit: 1000
+                orderBy: [date_ASC]
+                filter: { siteTag: $siteTag, datetime_geq: $since, datetime_lt: $until }
+              ) {
+                count
+                sum { visits }
+                dimensions { date }
+              }
+            }
+          }
+        }
+        """
+
+    private func accounts(apiToken: String) async throws -> [Account] {
+        let envelope: Envelope<[Account]> = try await get("accounts", apiToken: apiToken)
+        return envelope.result
+    }
+
+    private func get<T: Decodable>(_ path: String, apiToken: String) async throws -> T {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return try await send(request)
+    }
+
+    private func post<T: Decodable>(path: String, apiToken: String, jsonBody: [String: Any]) async throws -> T {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: jsonBody)
+        return try await send(request)
+    }
+
+    private func send<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let (data, response) = try await urlSession.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            let message = (try? JSONDecoder().decode(ErrorEnvelope.self, from: data).errors.first?.message)
+                ?? "Cloudflare API request failed with HTTP \(http.statusCode)."
+            throw CloudflareWebAnalyticsError.api(message)
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw CloudflareWebAnalyticsError.invalidResponse
+        }
+    }
+
+    private struct Envelope<Result: Decodable>: Decodable {
+        let result: Result
+    }
+
+    private struct ErrorEnvelope: Decodable {
+        let errors: [APIError]
+    }
+
+    private struct APIError: Decodable {
+        let message: String
+    }
+
+    private struct Account: Decodable {
+        let id: String
+    }
+
+    private struct GraphQLResponse: Decodable {
+        struct DataBody: Decodable {
+            struct Viewer: Decodable {
+                struct AccountNode: Decodable {
+                    let rumPageloadEventsAdaptiveGroups: [Group]
+                }
+                let accounts: [AccountNode]
+            }
+            let viewer: Viewer
+        }
+        struct Group: Decodable {
+            struct Sum: Decodable { let visits: Int }
+            struct Dimensions: Decodable { let date: String }
+            let count: Int
+            let sum: Sum
+            let dimensions: Dimensions
+        }
+        struct GraphQLError: Decodable { let message: String }
+        let data: DataBody?
+        let errors: [GraphQLError]?
+    }
+}

--- a/Tests/AnglesiteAppTests/PlistEditorModelRUMAnalyticsTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelRUMAnalyticsTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@Suite("PlistEditorModel RUM analytics summary (#1114)")
+@MainActor
+struct PlistEditorModelRUMAnalyticsTests {
+    private static let emptyPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict/></plist>
+        """
+
+    private struct FakeRUMAnalyticsProvider: CloudflareRUMAnalyticsProviding {
+        let result: Result<RUMAnalyticsSummary, Error>
+        func summary(siteTag: String, apiToken: String, days: Int) async throws -> RUMAnalyticsSummary {
+            try result.get()
+        }
+    }
+
+    private struct Fixture {
+        let model: PlistEditorModel
+    }
+
+    private func makeFixture(
+        token: String? = "test-token",
+        siteTag: String = "",
+        rumResult: Result<RUMAnalyticsSummary, Error> = .success(
+            RUMAnalyticsSummary(totalPageviews: 100, totalVisits: 40, dailyPageviews: []))
+    ) async throws -> Fixture {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PlistEditorModelRUMAnalyticsTests-\(UUID().uuidString)", isDirectory: true)
+        let sourceDir = dir.appendingPathComponent("Source", isDirectory: true)
+        let configDir = dir.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let plistURL = sourceDir.appendingPathComponent("Info.plist")
+        try Self.emptyPlist.write(to: plistURL, atomically: true, encoding: .utf8)
+        let keychainService = "io.dwk.anglesite.test-\(UUID().uuidString)"
+        let keychain = KeychainStore(service: keychainService)
+        if let token {
+            try keychain.writeCloudflareToken(token)
+        }
+        let model = PlistEditorModel(
+            file: FileRef(url: plistURL, group: .metadata, name: "Info.plist"),
+            websiteTitle: "My Test Site",
+            sourceDirectory: sourceDir,
+            configDirectory: configDir,
+            rumAnalyticsProvider: FakeRUMAnalyticsProvider(result: rumResult),
+            keychain: keychain)
+        model.analyticsSettings.cloudflareToken = siteTag
+        return Fixture(model: model)
+    }
+
+    @Test("loadRUMSummary does nothing when Cloudflare Analytics is not enabled")
+    func skipsWhenAnalyticsDisabled() async throws {
+        let fixture = try await makeFixture(siteTag: "")
+
+        await fixture.model.loadRUMSummary()
+
+        #expect(fixture.model.rumSummary == nil)
+        #expect(fixture.model.rumSummaryError == nil)
+    }
+
+    @Test("loadRUMSummary populates rumSummary on success")
+    func populatesSummaryOnSuccess() async throws {
+        let summary = RUMAnalyticsSummary(
+            totalPageviews: 240, totalVisits: 90,
+            dailyPageviews: [DailyCount(date: Date(timeIntervalSince1970: 0), pageviews: 240)])
+        let fixture = try await makeFixture(siteTag: "site-tag-1", rumResult: .success(summary))
+
+        await fixture.model.loadRUMSummary()
+
+        #expect(fixture.model.rumSummary == summary)
+        #expect(fixture.model.rumSummaryError == nil)
+    }
+
+    @Test("loadRUMSummary surfaces a provider error and clears any prior summary")
+    func surfacesProviderError() async throws {
+        let fixture = try await makeFixture(
+            siteTag: "site-tag-1",
+            rumResult: .failure(CloudflareWebAnalyticsError.api("boom")))
+
+        await fixture.model.loadRUMSummary()
+
+        #expect(fixture.model.rumSummary == nil)
+        #expect(fixture.model.rumSummaryError == "boom")
+    }
+
+    @Test("loadRUMSummary surfaces missingToken when no Cloudflare token is configured",
+          .enabled(if: ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"] == nil))
+    func surfacesMissingToken() async throws {
+        let fixture = try await makeFixture(token: nil, siteTag: "site-tag-1")
+
+        await fixture.model.loadRUMSummary()
+
+        #expect(fixture.model.rumSummary == nil)
+        #expect(fixture.model.rumSummaryError == CloudflareWebAnalyticsError.missingToken.localizedDescription)
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareRUMAnalyticsClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareRUMAnalyticsClientTests.swift
@@ -1,0 +1,133 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Routes each request to a canned status/body keyed by exact URL string — mirrors
+/// `RDAPStubURLProtocol` (`RDAPClientTests.swift`): one fixed response per endpoint, since this
+/// client always hits the same two URLs (`/accounts`, `/graphql`) rather than URLs that vary per
+/// call.
+private final class RUMAnalyticsStubURLProtocol: URLProtocol, @unchecked Sendable {
+    struct Stub { let statusCode: Int; let body: String }
+    nonisolated(unsafe) static var responses: [String: Stub] = [:]
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let key = request.url?.absoluteString ?? ""
+        guard let stub = Self.responses[key] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: stub.statusCode, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(stub.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset() { responses = [:] }
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RUMAnalyticsStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: tests share RUMAnalyticsStubURLProtocol's mutable static response table, which
+// would race under Swift Testing's default parallel execution.
+@Suite(.serialized) struct CloudflareRUMAnalyticsClientTests {
+    private let baseURL = URL(string: "https://example.invalid/client/v4")!
+    private var accountsURL: String { "\(baseURL.absoluteString)/accounts" }
+    private var graphqlURL: String { "\(baseURL.absoluteString)/graphql" }
+    private let accountsJSON = #"{"result":[{"id":"acc1"}]}"#
+
+    @Test("decodes a successful summary with full-timestamp dates")
+    func decodesSummaryWithFullTimestampDates() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(statusCode: 200, body: """
+            {"data":{"viewer":{"accounts":[{"rumPageloadEventsAdaptiveGroups":[
+                {"count":100,"sum":{"visits":40},"dimensions":{"date":"2026-08-01T00:00:00Z"}},
+                {"count":140,"sum":{"visits":60},"dimensions":{"date":"2026-08-02T00:00:00Z"}}
+            ]}]}}}
+            """)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        let summary = try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+
+        #expect(summary.totalPageviews == 240)
+        #expect(summary.totalVisits == 100)
+        #expect(summary.dailyPageviews.map(\.pageviews) == [100, 140])
+    }
+
+    @Test("decodes a successful summary with bare-day dates")
+    func decodesSummaryWithBareDayDates() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(statusCode: 200, body: """
+            {"data":{"viewer":{"accounts":[{"rumPageloadEventsAdaptiveGroups":[
+                {"count":10,"sum":{"visits":4},"dimensions":{"date":"2026-08-01"}}
+            ]}]}}}
+            """)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        let summary = try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+
+        #expect(summary.totalPageviews == 10)
+        #expect(summary.dailyPageviews.count == 1)
+    }
+
+    @Test("throws noAccount when the token has no Cloudflare account")
+    func throwsWhenNoAccount() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: #"{"result":[]}"#)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.noAccount) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+
+    @Test("throws api error on a non-2xx GraphQL response")
+    func throwsOnNon2xxResponse() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(
+            statusCode: 403, body: #"{"errors":[{"message":"Invalid token"}]}"#)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.api("Invalid token")) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+
+    @Test("throws api error when a 200 response carries GraphQL-level errors")
+    func throwsOnGraphQLLevelErrors() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(
+            statusCode: 200, body: #"{"data":null,"errors":[{"message":"siteTag not found"}]}"#)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.api("siteTag not found")) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+
+    @Test("throws invalidResponse when the body doesn't decode")
+    func throwsOnUndecodableBody() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(statusCode: 200, body: "not json")
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.invalidResponse) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/CloudflareRUMAnalyticsClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareRUMAnalyticsClientTests.swift
@@ -9,12 +9,18 @@ import Foundation
 private final class RUMAnalyticsStubURLProtocol: URLProtocol, @unchecked Sendable {
     struct Stub { let statusCode: Int; let body: String }
     nonisolated(unsafe) static var responses: [String: Stub] = [:]
+    /// Outgoing request bodies, keyed by URL — lets tests assert on what the client actually sent
+    /// (e.g. the GraphQL `variables`), not just what it received back.
+    nonisolated(unsafe) static var capturedBodies: [String: Data] = [:]
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
         let key = request.url?.absoluteString ?? ""
+        if let body = Self.bodyData(from: request) {
+            Self.capturedBodies[key] = body
+        }
         guard let stub = Self.responses[key] else {
             client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
             return
@@ -29,12 +35,39 @@ private final class RUMAnalyticsStubURLProtocol: URLProtocol, @unchecked Sendabl
 
     override func stopLoading() {}
 
-    static func reset() { responses = [:] }
+    static func reset() {
+        responses = [:]
+        capturedBodies = [:]
+    }
 
     static func makeSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [RUMAnalyticsStubURLProtocol.self]
         return URLSession(configuration: config)
+    }
+
+    /// `URLSession` moves a POST body set via `URLRequest.httpBody` into `httpBodyStream` for
+    /// requests routed through a custom `URLProtocol` — `request.httpBody` alone comes back `nil`
+    /// here even though the client set it, so fall back to draining the stream.
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let httpBody = request.httpBody {
+            return httpBody
+        }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(&buffer, maxLength: bufferSize)
+            if bytesRead > 0 {
+                data.append(buffer, count: bytesRead)
+            } else {
+                break
+            }
+        }
+        return data
     }
 }
 
@@ -129,5 +162,49 @@ private final class RUMAnalyticsStubURLProtocol: URLProtocol, @unchecked Sendabl
         await #expect(throws: CloudflareWebAnalyticsError.invalidResponse) {
             try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
         }
+    }
+
+    @Test("throws invalidResponse when every group's date fails to parse, rather than reporting empty traffic")
+    func throwsWhenAllDatesUnparseable() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(statusCode: 200, body: """
+            {"data":{"viewer":{"accounts":[{"rumPageloadEventsAdaptiveGroups":[
+                {"count":100,"sum":{"visits":40},"dimensions":{"date":"not-a-date"}}
+            ]}]}}}
+            """)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.invalidResponse) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+
+    @Test("sends the expected siteTag and a roughly 7-day since/until window")
+    func sendsExpectedSiteTagAndDateWindow() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(statusCode: 200, body: """
+            {"data":{"viewer":{"accounts":[{"rumPageloadEventsAdaptiveGroups":[]}]}}}
+            """)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        _ = try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+
+        let capturedBody = try #require(RUMAnalyticsStubURLProtocol.capturedBodies[graphqlURL])
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: capturedBody) as? [String: Any])
+        let variables = try #require(json["variables"] as? [String: Any])
+
+        #expect(variables["siteTag"] as? String == "site-tag-1")
+
+        let isoFormatter = ISO8601DateFormatter()
+        let sinceString = try #require(variables["since"] as? String)
+        let untilString = try #require(variables["until"] as? String)
+        let since = try #require(isoFormatter.date(from: sinceString))
+        let until = try #require(isoFormatter.date(from: untilString))
+        let span = until.timeIntervalSince(since)
+        let sevenDays: TimeInterval = 7 * 24 * 60 * 60
+        #expect(abs(span - sevenDays) < 3600 * 4)
     }
 }

--- a/docs/superpowers/plans/2026-08-07-in-app-analytics.md
+++ b/docs/superpowers/plans/2026-08-07-in-app-analytics.md
@@ -1,0 +1,814 @@
+# In-app analytics data viewing (Web Analytics / RUM) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface a 7-day Cloudflare Web Analytics (RUM) summary — total pageviews, total visits, and a daily trend — in Site Settings ▸ Analytics, for sites with Cloudflare Analytics enabled.
+
+**Architecture:** A new `CloudflareRUMAnalyticsClient`/`CloudflareRUMAnalyticsProviding` pair in AnglesiteCore queries Cloudflare's GraphQL Analytics API (`rumPageloadEventsAdaptiveGroups`), independent of the existing `CloudflareWebAnalyticsClient` (which only resolves the `siteTag`). `PlistEditorModel` gets a `loadRUMSummary()` method wired to a new provider-injection point, fetching once when the Analytics tab appears. `PlistEditorView` renders the result as a small Swift Charts sparkline below the existing Cloudflare toggle.
+
+**Tech Stack:** Swift 6.4, SwiftUI, Swift Charts (system framework, no new dependency), Swift Testing.
+
+**Spec:** [`docs/superpowers/specs/2026-08-07-in-app-analytics-design.md`](../specs/2026-08-07-in-app-analytics-design.md)
+
+## Global Constraints
+
+- Swift/SwiftUI with Apple frameworks only — no third-party dependencies (spec §3, CONTRIBUTING.md).
+- Fixed 7-day window, totals + daily trend only — no selectable ranges, no breakdowns, no polling (spec §2).
+- Fetch on Analytics-tab appearance only — no manual refresh control (spec §4).
+- New user-visible strings must go through CONTRIBUTING.md's String Catalog CLI-sync step.
+- Errors must suppress the summary entirely (never a stale/zero-filled chart); an empty-but-successful response is a distinct "No traffic recorded" state, never conflated with an error (spec §4).
+- Verify `app target builds` via `scripts/build-app.sh` before considering UI work done — `swift test` alone doesn't prove the app links (CONTRIBUTING.md, CLAUDE.md).
+
+---
+
+### Task 1: `CloudflareRUMAnalyticsClient` (AnglesiteCore)
+
+**Files:**
+- Create: `Sources/AnglesiteCore/CloudflareRUMAnalyticsClient.swift`
+- Test: `Tests/AnglesiteCoreTests/CloudflareRUMAnalyticsClientTests.swift`
+
+**Interfaces:**
+- Produces (used by Task 2):
+  ```swift
+  public struct DailyCount: Sendable, Equatable {
+      public let date: Date
+      public let pageviews: Int
+      public init(date: Date, pageviews: Int)
+  }
+  public struct RUMAnalyticsSummary: Sendable, Equatable {
+      public let totalPageviews: Int
+      public let totalVisits: Int
+      public let dailyPageviews: [DailyCount]  // ascending by date
+      public init(totalPageviews: Int, totalVisits: Int, dailyPageviews: [DailyCount])
+  }
+  public protocol CloudflareRUMAnalyticsProviding: Sendable {
+      func summary(siteTag: String, apiToken: String, days: Int) async throws -> RUMAnalyticsSummary
+  }
+  public struct CloudflareRUMAnalyticsClient: CloudflareRUMAnalyticsProviding {
+      public init(baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!, urlSession: URLSession = .shared)
+  }
+  ```
+- Consumes: `CloudflareWebAnalyticsError` (existing, `Sources/AnglesiteCore/CloudflareWebAnalyticsClient.swift`) for its `.noAccount`, `.invalidResponse`, `.api(String)` cases — this client throws those same cases rather than defining a parallel error type.
+
+**Verify-before-build note (spec §3):** the exact GraphQL dimension field name for day-level grouping in `rumPageloadEventsAdaptiveGroups` was not confirmed against Cloudflare's live schema — only against the sibling `httpRequestsAdaptiveGroups` dataset's documented shape, which follows the same "Adaptive Groups" filter/aggregate conventions. The implementation below assumes a `dimensions { date }` field returning either a bare day (`"2026-08-01"`) or a full timestamp (`"2026-08-01T00:00:00Z"`), and decodes defensively for both. Step 3 below includes verifying this against Cloudflare's GraphiQL explorer (linked from `developers.cloudflare.com/analytics/graphql-api/getting-started/compose-graphql-query/`) with a real account token as part of finishing this task — adjust the `GraphQLResponse` nested types and `query` string if the live schema differs.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/CloudflareRUMAnalyticsClientTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Routes each request to a canned status/body keyed by exact URL string — mirrors
+/// `RDAPStubURLProtocol` (`RDAPClientTests.swift`): one fixed response per endpoint, since this
+/// client always hits the same two URLs (`/accounts`, `/graphql`) rather than URLs that vary per
+/// call.
+private final class RUMAnalyticsStubURLProtocol: URLProtocol, @unchecked Sendable {
+    struct Stub { let statusCode: Int; let body: String }
+    nonisolated(unsafe) static var responses: [String: Stub] = [:]
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let key = request.url?.absoluteString ?? ""
+        guard let stub = Self.responses[key] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: stub.statusCode, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(stub.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset() { responses = [:] }
+
+    static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RUMAnalyticsStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+// .serialized: tests share RUMAnalyticsStubURLProtocol's mutable static response table, which
+// would race under Swift Testing's default parallel execution.
+@Suite(.serialized) struct CloudflareRUMAnalyticsClientTests {
+    private let baseURL = URL(string: "https://example.invalid/client/v4")!
+    private var accountsURL: String { "\(baseURL.absoluteString)/accounts" }
+    private var graphqlURL: String { "\(baseURL.absoluteString)/graphql" }
+    private let accountsJSON = #"{"result":[{"id":"acc1"}]}"#
+
+    @Test("decodes a successful summary with full-timestamp dates")
+    func decodesSummaryWithFullTimestampDates() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(statusCode: 200, body: """
+            {"data":{"viewer":{"accounts":[{"rumPageloadEventsAdaptiveGroups":[
+                {"count":100,"sum":{"visits":40},"dimensions":{"date":"2026-08-01T00:00:00Z"}},
+                {"count":140,"sum":{"visits":60},"dimensions":{"date":"2026-08-02T00:00:00Z"}}
+            ]}]}}}
+            """)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        let summary = try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+
+        #expect(summary.totalPageviews == 240)
+        #expect(summary.totalVisits == 100)
+        #expect(summary.dailyPageviews.map(\.pageviews) == [100, 140])
+    }
+
+    @Test("decodes a successful summary with bare-day dates")
+    func decodesSummaryWithBareDayDates() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(statusCode: 200, body: """
+            {"data":{"viewer":{"accounts":[{"rumPageloadEventsAdaptiveGroups":[
+                {"count":10,"sum":{"visits":4},"dimensions":{"date":"2026-08-01"}}
+            ]}]}}}
+            """)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        let summary = try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+
+        #expect(summary.totalPageviews == 10)
+        #expect(summary.dailyPageviews.count == 1)
+    }
+
+    @Test("throws noAccount when the token has no Cloudflare account")
+    func throwsWhenNoAccount() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: #"{"result":[]}"#)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.noAccount) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+
+    @Test("throws api error on a non-2xx GraphQL response")
+    func throwsOnNon2xxResponse() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(
+            statusCode: 403, body: #"{"errors":[{"message":"Invalid token"}]}"#)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.api("Invalid token")) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+
+    @Test("throws api error when a 200 response carries GraphQL-level errors")
+    func throwsOnGraphQLLevelErrors() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(
+            statusCode: 200, body: #"{"data":null,"errors":[{"message":"siteTag not found"}]}"#)
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.api("siteTag not found")) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+
+    @Test("throws invalidResponse when the body doesn't decode")
+    func throwsOnUndecodableBody() async throws {
+        RUMAnalyticsStubURLProtocol.reset()
+        RUMAnalyticsStubURLProtocol.responses[accountsURL] = .init(statusCode: 200, body: accountsJSON)
+        RUMAnalyticsStubURLProtocol.responses[graphqlURL] = .init(statusCode: 200, body: "not json")
+        let client = CloudflareRUMAnalyticsClient(baseURL: baseURL, urlSession: RUMAnalyticsStubURLProtocol.makeSession())
+
+        await #expect(throws: CloudflareWebAnalyticsError.invalidResponse) {
+            try await client.summary(siteTag: "site-tag-1", apiToken: "token", days: 7)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter CloudflareRUMAnalyticsClientTests`
+Expected: FAIL to compile — `CloudflareRUMAnalyticsClient`, `CloudflareRUMAnalyticsProviding`, `RUMAnalyticsSummary`, `DailyCount` don't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/CloudflareRUMAnalyticsClient.swift`:
+
+```swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// One day's pageview count within a ``RUMAnalyticsSummary``'s trend.
+public struct DailyCount: Sendable, Equatable {
+    public let date: Date
+    public let pageviews: Int
+
+    public init(date: Date, pageviews: Int) {
+        self.date = date
+        self.pageviews = pageviews
+    }
+}
+
+/// A pageviews/visits summary for one Web Analytics (RUM) site over a recent window — the
+/// in-app answer to "how's my traffic doing," with the Cloudflare dashboard (linked via
+/// `WorkerDashboardLinks`) as the deep-dive destination for anything beyond a glance.
+public struct RUMAnalyticsSummary: Sendable, Equatable {
+    public let totalPageviews: Int
+    public let totalVisits: Int
+    /// Ascending by date, one entry per day the API returned data for.
+    public let dailyPageviews: [DailyCount]
+
+    public init(totalPageviews: Int, totalVisits: Int, dailyPageviews: [DailyCount]) {
+        self.totalPageviews = totalPageviews
+        self.totalVisits = totalVisits
+        self.dailyPageviews = dailyPageviews
+    }
+}
+
+/// Seam for fetching a Web Analytics (RUM) summary, so callers (the Analytics tab) can inject a
+/// fake instead of hitting Cloudflare's GraphQL API in tests. Kept separate from
+/// ``CloudflareWebAnalyticsProviding`` (site-tag resolution): that's a one-time REST lookup done
+/// during onboarding, this is a repeated GraphQL query done on every Analytics tab view — two
+/// different Cloudflare APIs with two different call shapes and cadences.
+public protocol CloudflareRUMAnalyticsProviding: Sendable {
+    /// Fetches a summary for the last `days` days for the Web Analytics site identified by
+    /// `siteTag`.
+    func summary(siteTag: String, apiToken: String, days: Int) async throws -> RUMAnalyticsSummary
+}
+
+/// Production ``CloudflareRUMAnalyticsProviding``: queries Cloudflare's GraphQL Analytics API
+/// (`rumPageloadEventsAdaptiveGroups`) for a day-by-day pageviews/visits breakdown.
+public struct CloudflareRUMAnalyticsClient: CloudflareRUMAnalyticsProviding {
+    private let baseURL: URL
+    private let urlSession: URLSession
+
+    /// Both parameters exist for tests — point `baseURL` at a local stub server to exercise the
+    /// real request/decode path. Production callers take the defaults.
+    public init(baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
+                urlSession: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.urlSession = urlSession
+    }
+
+    public func summary(siteTag: String, apiToken: String, days: Int) async throws -> RUMAnalyticsSummary {
+        let accounts = try await accounts(apiToken: apiToken)
+        guard let accountID = accounts.first?.id else { throw CloudflareWebAnalyticsError.noAccount }
+
+        let until = Date()
+        let since = Calendar(identifier: .gregorian).date(byAdding: .day, value: -days, to: until) ?? until
+        let isoFormatter = ISO8601DateFormatter()
+        let body: [String: Any] = [
+            "query": Self.query,
+            "variables": [
+                "accountTag": accountID,
+                "siteTag": siteTag,
+                "since": isoFormatter.string(from: since),
+                "until": isoFormatter.string(from: until)
+            ]
+        ]
+        let response: GraphQLResponse = try await post(path: "graphql", apiToken: apiToken, jsonBody: body)
+        if let message = response.errors?.first?.message {
+            throw CloudflareWebAnalyticsError.api(message)
+        }
+        guard let groups = response.data?.viewer.accounts.first?.rumPageloadEventsAdaptiveGroups else {
+            throw CloudflareWebAnalyticsError.invalidResponse
+        }
+        let daily = groups.compactMap { group -> DailyCount? in
+            guard let date = Self.parseDate(group.dimensions.date) else { return nil }
+            return DailyCount(date: date, pageviews: group.count)
+        }.sorted { $0.date < $1.date }
+        return RUMAnalyticsSummary(
+            totalPageviews: groups.reduce(0) { $0 + $1.count },
+            totalVisits: groups.reduce(0) { $0 + $1.sum.visits },
+            dailyPageviews: daily)
+    }
+
+    /// Cloudflare's GraphQL `Date`/`Time` scalars have shown up as both a bare day
+    /// (`"2026-08-01"`) and a full timestamp (`"2026-08-01T00:00:00Z"`) across adaptive-groups
+    /// datasets — this tries the full form first, then falls back to the bare day, so the client
+    /// doesn't hard-fail if the live API returns the form this wasn't verified against (see the
+    /// "Verify-before-build note" above).
+    private static func parseDate(_ raw: String) -> Date? {
+        if let date = ISO8601DateFormatter().date(from: raw) { return date }
+        let dayFormatter = DateFormatter()
+        dayFormatter.dateFormat = "yyyy-MM-dd"
+        dayFormatter.timeZone = TimeZone(identifier: "UTC")
+        return dayFormatter.date(from: raw)
+    }
+
+    private static let query = """
+        query RUMSummary($accountTag: string!, $siteTag: string!, $since: Time!, $until: Time!) {
+          viewer {
+            accounts(filter: { accountTag: $accountTag }) {
+              rumPageloadEventsAdaptiveGroups(
+                limit: 1000
+                orderBy: [date_ASC]
+                filter: { siteTag: $siteTag, datetime_geq: $since, datetime_lt: $until }
+              ) {
+                count
+                sum { visits }
+                dimensions { date }
+              }
+            }
+          }
+        }
+        """
+
+    private func accounts(apiToken: String) async throws -> [Account] {
+        let envelope: Envelope<[Account]> = try await get("accounts", apiToken: apiToken)
+        return envelope.result
+    }
+
+    private func get<T: Decodable>(_ path: String, apiToken: String) async throws -> T {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return try await send(request)
+    }
+
+    private func post<T: Decodable>(path: String, apiToken: String, jsonBody: [String: Any]) async throws -> T {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: jsonBody)
+        return try await send(request)
+    }
+
+    private func send<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let (data, response) = try await urlSession.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            let message = (try? JSONDecoder().decode(ErrorEnvelope.self, from: data).errors.first?.message)
+                ?? "Cloudflare API request failed with HTTP \(http.statusCode)."
+            throw CloudflareWebAnalyticsError.api(message)
+        }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw CloudflareWebAnalyticsError.invalidResponse
+        }
+    }
+
+    private struct Envelope<Result: Decodable>: Decodable {
+        let result: Result
+    }
+
+    private struct ErrorEnvelope: Decodable {
+        let errors: [APIError]
+    }
+
+    private struct APIError: Decodable {
+        let message: String
+    }
+
+    private struct Account: Decodable {
+        let id: String
+    }
+
+    private struct GraphQLResponse: Decodable {
+        struct DataBody: Decodable {
+            struct Viewer: Decodable {
+                struct AccountNode: Decodable {
+                    let rumPageloadEventsAdaptiveGroups: [Group]
+                }
+                let accounts: [AccountNode]
+            }
+            let viewer: Viewer
+        }
+        struct Group: Decodable {
+            struct Sum: Decodable { let visits: Int }
+            struct Dimensions: Decodable { let date: String }
+            let count: Int
+            let sum: Sum
+            let dimensions: Dimensions
+        }
+        struct GraphQLError: Decodable { let message: String }
+        let data: DataBody?
+        let errors: [GraphQLError]?
+    }
+}
+```
+
+Note the `errors` decode in `throwsOnGraphQLLevelErrors` above hits the top-level `GraphQLResponse.errors` field (a 200 response can still carry GraphQL-level errors with `data: null`) — this is checked before the `guard let groups = ...` line, so a `null` `data` field never reaches the `invalidResponse` fallback for this case.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter CloudflareRUMAnalyticsClientTests`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Verify the live GraphQL schema and adjust if needed**
+
+Using a real Cloudflare account token with Web Analytics enabled for at least one site, open Cloudflare's GraphiQL explorer (linked from `https://developers.cloudflare.com/analytics/graphql-api/getting-started/compose-graphql-query/`) and run the `query` string from `CloudflareRUMAnalyticsClient.query` (substituting real `accountTag`/`siteTag`/`since`/`until` values). Confirm the `dimensions { date }` field exists and returns a value in one of the two forms `parseDate` handles. If the live schema differs (a different field name, a different date format), update `Self.query` and `GraphQLResponse`'s nested types to match, then re-run Step 4's tests with matching fixture JSON before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CloudflareRUMAnalyticsClient.swift Tests/AnglesiteCoreTests/CloudflareRUMAnalyticsClientTests.swift
+git commit -m "feat(core): add CloudflareRUMAnalyticsClient for Web Analytics summaries (#1114)"
+```
+
+---
+
+### Task 2: Wire `loadRUMSummary()` into `PlistEditorModel`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/PlistEditorModel.swift:11` (stored property), `:25` (state vars), `:216` (init param), `:238` (init body), after `:846` (new method)
+- Test: `Tests/AnglesiteAppTests/PlistEditorModelRUMAnalyticsTests.swift`
+
+**Interfaces:**
+- Consumes: `CloudflareRUMAnalyticsProviding`, `CloudflareRUMAnalyticsClient`, `RUMAnalyticsSummary`, `DailyCount` (Task 1); existing `PlistEditorModel.cloudflareAnalyticsEnabled: Bool`, `analyticsSettings.cloudflareToken: String` (the resolved siteTag), and the existing private `cloudflareToken() async throws -> String?` method.
+- Produces (used by Task 3):
+  ```swift
+  private(set) var rumSummary: RUMAnalyticsSummary?
+  private(set) var isLoadingRUMSummary: Bool
+  private(set) var rumSummaryError: String?
+  func loadRUMSummary() async
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteAppTests/PlistEditorModelRUMAnalyticsTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+@testable import AnglesiteCore
+
+@Suite("PlistEditorModel RUM analytics summary (#1114)")
+@MainActor
+struct PlistEditorModelRUMAnalyticsTests {
+    private static let emptyPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict/></plist>
+        """
+
+    private struct FakeRUMAnalyticsProvider: CloudflareRUMAnalyticsProviding {
+        let result: Result<RUMAnalyticsSummary, Error>
+        func summary(siteTag: String, apiToken: String, days: Int) async throws -> RUMAnalyticsSummary {
+            try result.get()
+        }
+    }
+
+    private struct Fixture {
+        let model: PlistEditorModel
+    }
+
+    private func makeFixture(
+        token: String? = "test-token",
+        siteTag: String = "",
+        rumResult: Result<RUMAnalyticsSummary, Error> = .success(
+            RUMAnalyticsSummary(totalPageviews: 100, totalVisits: 40, dailyPageviews: []))
+    ) async throws -> Fixture {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PlistEditorModelRUMAnalyticsTests-\(UUID().uuidString)", isDirectory: true)
+        let sourceDir = dir.appendingPathComponent("Source", isDirectory: true)
+        let configDir = dir.appendingPathComponent("Config", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let plistURL = sourceDir.appendingPathComponent("Info.plist")
+        try Self.emptyPlist.write(to: plistURL, atomically: true, encoding: .utf8)
+        let keychainService = "io.dwk.anglesite.test-\(UUID().uuidString)"
+        let keychain = KeychainStore(service: keychainService)
+        if let token {
+            try keychain.writeCloudflareToken(token)
+        }
+        let model = PlistEditorModel(
+            file: FileRef(url: plistURL, group: .metadata, name: "Info.plist"),
+            websiteTitle: "My Test Site",
+            sourceDirectory: sourceDir,
+            configDirectory: configDir,
+            rumAnalyticsProvider: FakeRUMAnalyticsProvider(result: rumResult),
+            keychain: keychain)
+        model.analyticsSettings.cloudflareToken = siteTag
+        return Fixture(model: model)
+    }
+
+    @Test("loadRUMSummary does nothing when Cloudflare Analytics is not enabled")
+    func skipsWhenAnalyticsDisabled() async throws {
+        let fixture = try await makeFixture(siteTag: "")
+
+        await fixture.model.loadRUMSummary()
+
+        #expect(fixture.model.rumSummary == nil)
+        #expect(fixture.model.rumSummaryError == nil)
+    }
+
+    @Test("loadRUMSummary populates rumSummary on success")
+    func populatesSummaryOnSuccess() async throws {
+        let summary = RUMAnalyticsSummary(
+            totalPageviews: 240, totalVisits: 90,
+            dailyPageviews: [DailyCount(date: Date(timeIntervalSince1970: 0), pageviews: 240)])
+        let fixture = try await makeFixture(siteTag: "site-tag-1", rumResult: .success(summary))
+
+        await fixture.model.loadRUMSummary()
+
+        #expect(fixture.model.rumSummary == summary)
+        #expect(fixture.model.rumSummaryError == nil)
+    }
+
+    @Test("loadRUMSummary surfaces a provider error and clears any prior summary")
+    func surfacesProviderError() async throws {
+        let fixture = try await makeFixture(
+            siteTag: "site-tag-1",
+            rumResult: .failure(CloudflareWebAnalyticsError.api("boom")))
+
+        await fixture.model.loadRUMSummary()
+
+        #expect(fixture.model.rumSummary == nil)
+        #expect(fixture.model.rumSummaryError == "boom")
+    }
+
+    @Test("loadRUMSummary surfaces missingToken when no Cloudflare token is configured",
+          .enabled(if: ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"] == nil))
+    func surfacesMissingToken() async throws {
+        let fixture = try await makeFixture(token: nil, siteTag: "site-tag-1")
+
+        await fixture.model.loadRUMSummary()
+
+        #expect(fixture.model.rumSummary == nil)
+        #expect(fixture.model.rumSummaryError == CloudflareWebAnalyticsError.missingToken.localizedDescription)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter PlistEditorModelRUMAnalyticsTests`
+Expected: FAIL to compile — `rumAnalyticsProvider` init param, `loadRUMSummary()`, `rumSummary`, `rumSummaryError` don't exist yet.
+
+- [ ] **Step 3: Add the stored property and state**
+
+In `Sources/AnglesiteApp/PlistEditorModel.swift`, change:
+
+```swift
+    private let analyticsProvider: any CloudflareWebAnalyticsProviding
+    private let customAnalyticsValidator: any CustomAnalyticsHTMLValidating
+```
+
+to:
+
+```swift
+    private let analyticsProvider: any CloudflareWebAnalyticsProviding
+    private let rumAnalyticsProvider: any CloudflareRUMAnalyticsProviding
+    private let customAnalyticsValidator: any CustomAnalyticsHTMLValidating
+```
+
+and change:
+
+```swift
+    private(set) var isSavingAnalytics = false
+    private(set) var isConfiguringCloudflareAnalytics = false
+```
+
+to:
+
+```swift
+    private(set) var isSavingAnalytics = false
+    private(set) var isConfiguringCloudflareAnalytics = false
+    private(set) var isLoadingRUMSummary = false
+    private(set) var rumSummary: RUMAnalyticsSummary?
+    private(set) var rumSummaryError: String?
+```
+
+- [ ] **Step 4: Wire the init parameter**
+
+Change:
+
+```swift
+         analyticsProvider: any CloudflareWebAnalyticsProviding = CloudflareWebAnalyticsClient(),
+         customAnalyticsValidator: (any CustomAnalyticsHTMLValidating)? = nil,
+```
+
+to:
+
+```swift
+         analyticsProvider: any CloudflareWebAnalyticsProviding = CloudflareWebAnalyticsClient(),
+         rumAnalyticsProvider: any CloudflareRUMAnalyticsProviding = CloudflareRUMAnalyticsClient(),
+         customAnalyticsValidator: (any CustomAnalyticsHTMLValidating)? = nil,
+```
+
+and in the init body, change:
+
+```swift
+        self.analyticsProvider = analyticsProvider
+```
+
+to:
+
+```swift
+        self.analyticsProvider = analyticsProvider
+        self.rumAnalyticsProvider = rumAnalyticsProvider
+```
+
+- [ ] **Step 5: Add `loadRUMSummary()`**
+
+Immediately after the closing brace of `setCloudflareAnalyticsEnabled(_:)` (the method ending just before `/// Also returns the raw \`.site-config\` contents...`), add:
+
+```swift
+    /// Fetches the last 7 days' pageviews/visits summary for the Analytics tab (#1114). A no-op
+    /// when Cloudflare Analytics isn't enabled for this site — there's no siteTag to query. A
+    /// thrown error clears any prior summary rather than leaving a stale one on screen.
+    func loadRUMSummary() async {
+        guard cloudflareAnalyticsEnabled else { return }
+        guard !isLoadingRUMSummary else { return }
+        isLoadingRUMSummary = true
+        rumSummaryError = nil
+        defer { isLoadingRUMSummary = false }
+        do {
+            guard let token = try await cloudflareToken(), !token.isEmpty else {
+                rumSummary = nil
+                rumSummaryError = CloudflareWebAnalyticsError.missingToken.localizedDescription
+                return
+            }
+            rumSummary = try await rumAnalyticsProvider.summary(
+                siteTag: analyticsSettings.cloudflareToken, apiToken: token, days: 7)
+        } catch {
+            rumSummary = nil
+            rumSummaryError = error.localizedDescription
+        }
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter PlistEditorModelRUMAnalyticsTests`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 7: Run the full AnglesiteAppCore/AnglesiteCore suites to check for regressions**
+
+Run: `swift test --package-path .`
+Expected: PASS (no regressions in `PlistEditorModel`'s other tab tests)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PlistEditorModel.swift Tests/AnglesiteAppTests/PlistEditorModelRUMAnalyticsTests.swift
+git commit -m "feat(app): wire loadRUMSummary into PlistEditorModel (#1114)"
+```
+
+---
+
+### Task 3: Analytics tab UI — summary card with a Swift Charts sparkline
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/PlistEditorView.swift:3` (import), `:333-346` (analyticsTab body), after `:357` (new `rumSummarySection` computed property)
+
+**Interfaces:**
+- Consumes: `PlistEditorModel.cloudflareAnalyticsEnabled`, `.isLoadingRUMSummary`, `.rumSummary`, `.rumSummaryError`, `.loadRUMSummary()` (Task 2); `RUMAnalyticsSummary`, `DailyCount` (Task 1).
+
+- [ ] **Step 1: Add the Charts import**
+
+In `Sources/AnglesiteApp/PlistEditorView.swift`, change:
+
+```swift
+import AppKit
+import SwiftUI
+import AnglesiteCore
+```
+
+to:
+
+```swift
+import AppKit
+import SwiftUI
+import Charts
+import AnglesiteCore
+```
+
+- [ ] **Step 2: Add the trigger and summary section to `analyticsTab`**
+
+Change:
+
+```swift
+            HStack(spacing: 8) {
+                if model.isSavingAnalytics {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                if let customAnalyticsMessage {
+                    Label(customAnalyticsMessage, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.callout)
+                }
+            }
+        }
+        .popover(isPresented: $showingCustomAnalyticsHelp, arrowEdge: .trailing) {
+```
+
+to:
+
+```swift
+            HStack(spacing: 8) {
+                if model.isSavingAnalytics {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                if let customAnalyticsMessage {
+                    Label(customAnalyticsMessage, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.callout)
+                }
+            }
+            rumSummarySection
+        }
+        .task { await model.loadRUMSummary() }
+        .popover(isPresented: $showingCustomAnalyticsHelp, arrowEdge: .trailing) {
+```
+
+- [ ] **Step 3: Add the `rumSummarySection` view**
+
+Immediately after `analyticsTab`'s closing (after the `.popover { ... }` block's closing brace, before the `/// Stable per-row identity...` comment above `RedirectRow`), add:
+
+```swift
+    @ViewBuilder
+    private var rumSummarySection: some View {
+        if model.cloudflareAnalyticsEnabled {
+            SettingsBox(title: "Traffic") {
+                VStack(alignment: .leading, spacing: 8) {
+                    if model.isLoadingRUMSummary {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else if let rumSummaryError = model.rumSummaryError {
+                        Label(rumSummaryError, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .font(.callout)
+                    } else if let summary = model.rumSummary {
+                        if summary.dailyPageviews.isEmpty {
+                            Text("No traffic recorded in the last 7 days.")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Last 7 days: \(summary.totalPageviews) pageviews · \(summary.totalVisits) visits")
+                            Chart(summary.dailyPageviews, id: \.date) { day in
+                                BarMark(
+                                    x: .value("Day", day.date, unit: .day),
+                                    y: .value("Pageviews", day.pageviews)
+                                )
+                            }
+                            .frame(height: 60)
+                            .accessibilityLabel("7-day pageviews trend")
+                            .accessibilityValue("\(summary.totalPageviews) total pageviews over the last 7 days")
+                        }
+                    }
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Build the app target**
+
+Run:
+```bash
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+Expected: BUILD SUCCEEDED. This is the only way to prove Swift Charts links correctly and the view compiles — `swift test` alone doesn't build `AnglesiteApp`'s SwiftUI view files through Xcode's toolchain the same way (CONTRIBUTING.md).
+
+- [ ] **Step 5: Sync the String Catalog**
+
+New user-visible text was added ("Traffic", "No traffic recorded in the last 7 days.", the pageviews/visits line) via a CLI-only build, so the merge into `Localizable.xcstrings` needs a manual sync. Follow CONTRIBUTING.md's "Commit String Catalog updates" recipe exactly (derive `BUILD_DIR` from `-showBuildSettings`, scope the `.stringsdata` glob to this worktree, use `--skip-marking-strings-stale`), then review the resulting diff to confirm it only adds the new keys from this task before committing it.
+
+- [ ] **Step 6: Manual GUI smoke — verify in the running app**
+
+With a real `.anglesite` package that has Cloudflare Web Analytics enabled (or a fake enabled via test data), open Site Settings ▸ Analytics and confirm:
+- A site with analytics enabled and a successful fetch shows the totals line and sparkline.
+- A site with analytics disabled shows nothing new in the tab.
+- Toggling analytics on with an invalid/missing token surfaces the error message with no chart.
+
+- [ ] **Step 7: File the manual GUI smoke follow-up issue**
+
+Per the design doc's §7 follow-up, file a tracking issue for a fuller manual QA pass (multiple real sites, revoked-token case, empty-traffic case) using this repo's standard owed-QA pattern:
+
+```bash
+gh issue create \
+  --title "Manual GUI smoke: Analytics tab traffic summary (#1114)" \
+  --body "Follow-up from #1114 (docs/superpowers/specs/2026-08-07-in-app-analytics-design.md §6-7): manually verify the Analytics tab's traffic summary card across a site with real traffic, a site with analytics disabled, a site with analytics enabled but no traffic yet, and a revoked-token error case." \
+  --label "🏭 Ready"
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/AnglesiteApp/PlistEditorView.swift Sources/AnglesiteApp/Localizable.xcstrings
+git commit -m "feat(app): add RUM traffic summary card to Analytics tab (#1114)"
+```
+
+---
+
+## Final verification
+
+- [ ] `swift test --package-path .` passes in full.
+- [ ] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` succeeds.
+- [ ] Manual GUI smoke from Task 3 Step 6 completed.
+- [ ] PR body includes `Closes #1114` and follows `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings (Summary, Paired PR check, Test plan) per CONTRIBUTING.md — note in "Paired PR check" that this is app-only (no MCP schema change, no sidecar PR needed).

--- a/docs/superpowers/specs/2026-08-07-in-app-analytics-design.md
+++ b/docs/superpowers/specs/2026-08-07-in-app-analytics-design.md
@@ -1,0 +1,167 @@
+# In-app analytics data viewing (Web Analytics / RUM) — design
+
+**Issue:** [#1114](https://github.com/Anglesite/Anglesite/issues/1114)
+**Date:** 2026-08-07
+**Status:** Approved
+
+## 1. Problem
+
+#1114 was split out of #699's design (`docs/superpowers/specs/2026-07-30-server-debug-panel-design.md`
+§2/§6) as the follow-up for "in-app analytics data viewing," explicitly out of scope for that
+work. Today, once a site owner enables Cloudflare Web Analytics from Site Settings, the app can
+only deep-link out to the Cloudflare dashboard (`WorkerDashboardLinks`, shipped with #710) to see
+any traffic numbers. This design adds a small in-app summary — recent pageviews, visits, and a
+trend — so an owner can get a quick read on their site's traffic without leaving the app.
+
+**Non-goals** (unchanged from the parent issue): local-dev analytics (local `wrangler dev` has no
+analytics; the Debug Pane's worker log/status rows from #699 cover local visibility), and
+replacing the Cloudflare dashboard for deep investigation — the existing deep-links remain the
+answer for anything beyond a glance.
+
+## 2. Scope
+
+**In:**
+- A 7-day pageviews + visits summary with a daily trend sparkline, shown in Site Settings ▸
+  Analytics tab, for sites with Cloudflare Web Analytics enabled.
+- A new `CloudflareRUMAnalyticsClient`/`CloudflareRUMAnalyticsProviding` pair in AnglesiteCore
+  that queries Cloudflare's GraphQL Analytics API (`rumPageloadEventsAdaptiveGroups`) for that
+  summary.
+
+**Out (explicit, with rationale):**
+- **Any UI in the Workers tab.** The Workers tab only knows the deployed worker's name (for
+  `WorkerDashboardLinks`' dashboard deep-links); it has no notion of the RUM `siteTag`. The
+  Analytics tab already resolves and persists that `siteTag` (`PlistEditorModel.swift:840-841`,
+  stored as `analyticsSettings.cloudflareToken`) as part of turning Cloudflare Analytics on, so
+  it is the natural home with no new token/siteTag plumbing.
+- **A dedicated Analytics window/surface.** More navigation surface (menu item, window
+  lifecycle) than a summary card justifies; revisit only if this grows into a full dashboard.
+- **Selectable time ranges, top-pages/referrer breakdowns, auto-refresh/polling.** YAGNI for a
+  "quick glance" feature — a fixed 7-day window, totals-only (no breakdowns), and fetch-on-tab-
+  appear (no timers) keep the query, the UI, and the test matrix small. Any of these can be
+  added later without changing the architecture below.
+- **Manual refresh control.** Reopening the tab (or the site window) re-fetches; no separate
+  button. A 7-day trend doesn't need hour-to-hour freshness enforcement.
+
+## 3. Architecture
+
+A new pair in `Sources/AnglesiteCore/`, mirroring the existing
+`CloudflareWebAnalyticsClient`/`CloudflareWebAnalyticsProviding` pattern used for `siteTag`
+resolution — but kept as a **separate** type rather than folded into that client, because the two
+calls are different Cloudflare APIs (REST v4 for site-tag resolution, done once during
+onboarding; GraphQL for metrics, done on every tab view) with different request/response shapes
+and different call cadences. Keeping them separate keeps each independently fakeable in tests
+without either one growing into a grab-bag.
+
+```swift
+public struct DailyCount: Sendable, Equatable {
+    public let date: Date
+    public let pageviews: Int
+}
+
+public struct RUMAnalyticsSummary: Sendable, Equatable {
+    public let totalPageviews: Int
+    public let totalVisits: Int
+    public let dailyPageviews: [DailyCount]   // ascending by date, one entry per day in range
+}
+
+public protocol CloudflareRUMAnalyticsProviding: Sendable {
+    /// Fetches a pageviews/visits summary for the last `days` days for the Web Analytics site
+    /// identified by `siteTag`.
+    func summary(siteTag: String, apiToken: String, days: Int) async throws -> RUMAnalyticsSummary
+}
+
+public struct CloudflareRUMAnalyticsClient: CloudflareRUMAnalyticsProviding {
+    // POSTs to https://api.cloudflare.com/client/v4/graphql, same Bearer-token auth as
+    // CloudflareWebAnalyticsClient. Reuses CloudflareWebAnalyticsError for its failure cases
+    // (.missingToken, .invalidResponse, .api) — this client fails the same ways (bad token, bad
+    // response, non-2xx) as the sibling REST client, so a second error enum would be redundant.
+}
+```
+
+**Query shape.** `rumPageloadEventsAdaptiveGroups` belongs to Cloudflare's "Adaptive Groups"
+dataset family (confirmed against Cloudflare's own migration-guide example for the sibling
+`httpRequestsAdaptiveGroups` dataset, which shares the same filter/aggregate conventions):
+`filter: { siteTag: ..., datetime_geq: ..., datetime_lt: ... }`, `count` and `sum { visits }`
+aggregates, and a `dimensions { ... }` block carrying a per-day grouping field. The account tag
+needed to scope the query is already resolved by the existing `accounts(apiToken:)` REST call
+inside `CloudflareWebAnalyticsClient` — `CloudflareRUMAnalyticsClient` makes the equivalent call
+itself (same `/accounts` endpoint) rather than threading the account ID through from the other
+client, keeping the two providers independent.
+
+**Verify-before-build note:** the exact dimension field name for day-level grouping in the RUM
+dataset specifically (as opposed to the confirmed sibling dataset) should be confirmed against
+Cloudflare's live GraphQL schema (introspection, or the GraphiQL explorer linked from
+`developers.cloudflare.com/analytics/graphql-api/getting-started/compose-graphql-query/`) as the
+first implementation step, using a real account token. This is normal due diligence for any
+external API integration — the architecture, decoding boundary, and test strategy below do not
+depend on which exact field name it turns out to be.
+
+**Wiring into `PlistEditorModel`:** a new `rumAnalyticsProvider: any CloudflareRUMAnalyticsProviding
+= CloudflareRUMAnalyticsClient()` init parameter, injected exactly like the existing
+`analyticsProvider` — production takes the default, tests inject a fake.
+
+## 4. Data flow
+
+- **Trigger:** `PlistEditorModel` gains a `loadRUMSummary()` method, called from a `.task`
+  attached to the Analytics tab's content (fires when that tab is selected — the tab already
+  lazy-loads nothing before being shown, same as the Workers tab's catalog state). It only runs
+  when `cloudflareAnalyticsEnabled` is `true`; sites without analytics enabled never fetch.
+- **State** (mirrors the existing `isConfiguringCloudflareAnalytics`/`analyticsError` pair):
+  ```swift
+  private(set) var rumSummary: RUMAnalyticsSummary?
+  private(set) var isLoadingRUMSummary = false
+  private(set) var rumSummaryError: String?
+  ```
+- **`loadRUMSummary()`:** guards `!isLoadingRUMSummary`; resolves the API token via the existing
+  `cloudflareToken()` helper; calls `rumAnalyticsProvider.summary(siteTag: analyticsSettings
+  .cloudflareToken, apiToken: token, days: 7)`; stores the result in `rumSummary` or the
+  localized error in `rumSummaryError`. Single attempt per tab-appear — no retry/backoff,
+  consistent with the fetch-on-appear-only decision in §2.
+- **Error handling:** any thrown error (missing/revoked token, non-2xx, undecodable body)
+  surfaces as `rumSummaryError` and suppresses the summary card entirely — never a stale or
+  zero-filled chart standing in for "the fetch failed."
+- **Empty-but-successful response** (a real site with genuinely no traffic in the window) is a
+  distinct third state from both loading and error: rendered as "No traffic recorded in the last
+  7 days," not a blank or zeroed chart — conflating "no data" with "fetch failed" would hide real
+  outages behind what looks like a quiet site.
+
+## 5. UI
+
+- **Placement:** Site Settings ▸ Analytics tab, in a new `rumSummarySection` below the existing
+  "Enable Cloudflare Web Analytics" toggle. Rendered only when `cloudflareAnalyticsEnabled` is
+  `true` — nothing added to the tab for sites without analytics enabled.
+- **Content:** "Last 7 days" label; two stat lines (total pageviews, total visits); a small
+  `Chart` (Swift Charts — `import Charts`, a system framework already available at this
+  deployment target via Apple's own SDK, same as `AppKit`/`SwiftUI` today; no `project.yml`
+  change needed) rendering `dailyPageviews` as a `BarMark` sparkline.
+- **States:** loading shows a `ProgressView` in place of the card; error shows `rumSummaryError`
+  as inline secondary text with no chart; empty-but-successful shows the "No traffic recorded"
+  message per §4.
+- **Accessibility:** the chart carries an `accessibilityLabel`/`accessibilityValue` summarizing
+  the trend in words (e.g. "7-day pageviews, 1,240 total, trending up") per the macOS spec's
+  VoiceOver requirement — a sparkline with no textual equivalent is invisible to VoiceOver.
+- **Strings:** new user-visible text goes through CONTRIBUTING.md's String Catalog CLI-sync step,
+  same as any other new text in this file.
+
+## 6. Testing
+
+- **`CloudflareRUMAnalyticsClientTests`** (AnglesiteCoreTests, Swift Testing): request
+  construction (correct `siteTag` and date-window bounds in the GraphQL request body), a
+  successful-response decode into `RUMAnalyticsSummary`, and each error path (missing token,
+  non-2xx, undecodable body) — mirrors `CloudflareWebAnalyticsClientTests`' existing shape
+  against a stub `URLSession`/local server.
+- **`PlistEditorModelTests`:** `loadRUMSummary()` only fires when `cloudflareAnalyticsEnabled` is
+  `true`; a fake `CloudflareRUMAnalyticsProviding` drives the success, error, and empty-summary
+  cases into `rumSummary`/`rumSummaryError`.
+- **No new UI/snapshot tests** — `PlistEditorView` has no snapshot-testing pattern for its other
+  tabs today; this feature doesn't introduce one.
+- **App target build** via `scripts/build-app.sh` (a `swift test` pass alone doesn't prove the
+  app links — repo rule), plus the String Catalog sync for the new strings.
+- **Manual GUI smoke** (this repo's standard owed-QA pattern, e.g. #918), filed as a follow-up
+  checklist issue: verify the card for a site with analytics enabled and real traffic, a site
+  with analytics disabled (nothing shown), a site with analytics enabled but no traffic yet
+  (empty state), and a revoked-token error case.
+
+## 7. Follow-ups filed with this work
+
+- **Manual GUI smoke checklist** for the new Analytics tab summary card — new issue.


### PR DESCRIPTION
Closes #1114

## Summary

- Adds `CloudflareRUMAnalyticsClient` (AnglesiteCore), querying Cloudflare's GraphQL Analytics API for a 7-day pageviews/visits summary, independent of the existing `CloudflareWebAnalyticsClient` (which only resolves the site tag).
- Wires `loadRUMSummary()` into `PlistEditorModel`, fetching once when the Analytics tab appears (re-fetching if analytics is toggled on while the tab is open), gated entirely on `cloudflareAnalyticsEnabled`.
- Adds a "Traffic" summary card to Site Settings ▸ Analytics: total pageviews/visits plus a Swift Charts sparkline, with a spoken trend description ("trending up/down/holding steady") for VoiceOver.
- Design spec: `docs/superpowers/specs/2026-08-07-in-app-analytics-design.md`. Implementation plan: `docs/superpowers/plans/2026-08-07-in-app-analytics.md`.

**Known follow-up (tracked, not blocking this PR structurally, but should land before this feature is considered release-ready):** #1347 — the GraphQL query's exact field names were never verified against Cloudflare's live schema (no account token available in any environment this branch was built in), and the manual GUI smoke of the actual running Analytics tab couldn't be exercised either (no native macOS UI driver available). Both need a real Cloudflare account before ship.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP message schema changes — this is app-only (new AnglesiteCore client + PlistEditorModel/PlistEditorView UI).

## Test plan

- [x] `swift test --package-path . --filter CloudflareRUMAnalyticsClientTests` (8/8 pass)
- [x] `swift test --package-path . --filter PlistEditorModelRUMAnalyticsTests` (4/4 pass)
- [ ] `swift test --package-path .` (full suite) — **could not run**: reproducible pre-existing environmental hang on this dev machine (macOS 27 beta/Xcode 27 beta), proven via `git stash` A/B to occur identically with and without this branch's changes, at a location unrelated to any file this branch touches. Filed as a separate investigation suggestion.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`, re-run after every Swift/SwiftUI commit)
- [x] `scripts/check-localization-catalog.sh`
- [ ] Manual smoke (UI-touching): not performed in this environment (no native macOS UI driver available to any agent here) — tracked as release-blocking in #1347.