### PR TITLE
fix(#1312): coalesce openFile calls for the same file

### DIFF
--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -229,6 +229,17 @@ final class SiteWindowModel {
     /// shape as `pendingRedirectOfferRoute` above. Unused when Website Settings is already open —
     /// that case sets `PlistEditorModel.requestedTab` directly instead, see `openWebsiteSettings`.
     private var pendingWebsiteSettingsTab: SettingsTab?
+    /// The file and `Task` behind an in-flight `openFile` call (#1312, finding 3). `openFile`
+    /// spawns a `Task` per call with no de-duplication; two calls for the *same* file issued
+    /// before the first's `Task` body has run (e.g. a rapid double-click on the security-reports
+    /// badge's "View all" button, both routed through `openWebsiteSettings(landOn:)`) used to race
+    /// each other — each built its own `PlistEditorModel` and stashed/consumed
+    /// `pendingWebsiteSettingsTab` independently, so whichever `Task` assigned `activeEditor` last
+    /// won outright, discarding the other's model and often landing on neither requested tab. A
+    /// second call for the same file now joins the already-in-flight `Task` instead of spawning a
+    /// racing one; any freshly stashed `pendingWebsiteSettingsTab` is still picked up by that one
+    /// `Task` when it reaches its tab-consuming check.
+    private var inFlightOpenFile: (file: FileRef, task: Task<Void, Never>)?
     /// Editor/inspector state closed by a delete, keyed by the deleted file's relative path, so a
     /// ⌘Z restore of that file can put it back (#675). Written by every path that closes surfaces
     /// for a delete (`confirmDelete()` and `applyContentUndo`'s delete branch) and removed the
@@ -1241,10 +1252,17 @@ final class SiteWindowModel {
             mainPaneMode = .editor(file)
             return
         }
+        // A second call for the file an in-flight `Task` is already opening joins that `Task`
+        // rather than racing a second one against it (#1312, finding 3) — see
+        // `inFlightOpenFile`'s doc comment. Calls for a *different* file are unaffected.
+        if let inFlight = inFlightOpenFile, inFlight.file.id == file.id {
+            return
+        }
         // `[self]` is explicit rather than implicit so the `onOpenDependencyFix` closure below can
         // spell its own `[weak self]` capture without the compiler flagging the mismatch against an
         // implicitly-captured strong `self` in this outer scope.
-        Task { [self] in
+        let task = Task { [self] in
+            defer { inFlightOpenFile = nil }
             guard await leaveCurrentEditor(), await leaveCurrentInspector() else {
                 pendingWebsiteSettingsTab = nil
                 return
@@ -1320,6 +1338,7 @@ final class SiteWindowModel {
             }
             await ensureComponentEditorLoaded()
         }
+        inFlightOpenFile = (file, task)
     }
 
     /// Routes a Cleanup-section row: components/layouts/pages open in the existing in-app editor

--- a/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
+++ b/Tests/AnglesiteAppTests/SiteWindowModelTests.swift
@@ -833,6 +833,43 @@ extension SiteWindowModelTests {
         #expect(plistModel.requestedTab == nil)
     }
 
+    /// Review finding on PR #1304 (#1312, finding 3): `pendingWebsiteSettingsTab` is a single
+    /// shared `var`, and `openFile` spawns an independent `Task` per call with no de-duplication —
+    /// two `openWebsiteSettings(landOn:)` calls issued back-to-back (e.g. a rapid double-click on
+    /// the security-reports badge's "View all" button) each stash their tab and each spawn a `Task`
+    /// that builds its own `PlistEditorModel`. Pre-fix, whichever `Task` assigns `activeEditor`
+    /// last wins outright — discarding the other's model — and by then `pendingWebsiteSettingsTab`
+    /// has already been consumed by whichever `Task` got there first, so the surviving editor lands
+    /// on neither request. Fix: `openFile` coalesces a second call for the *same* file onto the
+    /// already-in-flight `Task` instead of racing a second one against it.
+    @Test("openWebsiteSettings(landOn:) issued twice back-to-back for the same file lands on the second (most recent) tab, not neither")
+    func openWebsiteSettingsLandOnDoubleInvocationKeepsLatestTab() async throws {
+        let (root, packageURL, package) = try makeSitePackage()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let model = makeModel()
+        model.site = SiteStore.Site(
+            id: "site-a", name: "Test", packageURL: packageURL,
+            isValid: true, missingSentinels: [], lastSeen: Date(), bookmarkData: nil
+        )
+
+        model.openWebsiteSettings(landOn: .analytics)
+        model.openWebsiteSettings(landOn: .securityReports)
+
+        while model.activeEditor == nil { await Task.yield() }
+        // Give a pre-fix second `Task` every chance to also finish and overwrite `activeEditor`
+        // with its own, tab-less model before asserting the settled state (same technique as
+        // `applyNavigatorSelectionDirectoryNavigatesPreview`'s stale-task drain below).
+        for _ in 0..<2_000 { await Task.yield() }
+
+        guard case .plist(let plistModel) = model.activeEditor else {
+            Issue.record("expected the Info.plist to open as a .plist editor")
+            return
+        }
+        #expect(plistModel.file.url == package.infoPlistURL)
+        #expect(plistModel.requestedTab == .securityReports)
+    }
+
     @Test("applyNavigatorSelection navigates the preview to a directory's route for .directory, clearing any open editor/inspector")
     func applyNavigatorSelectionDirectoryNavigatesPreview() async throws {
         let (root, packageURL, package) = try makeSitePackage()


### PR DESCRIPTION
Closes #1312

## Summary

- `SiteWindowModel.openFile` now tracks the file and `Task` behind an in-flight open (`inFlightOpenFile`). A second call for the *same* file while that `Task` is still running joins it instead of spawning a racing second one; calls for a different file are unaffected.
- This closes finding 3 of #1312: two back-to-back `openWebsiteSettings(landOn:)` calls (e.g. a rapid double-click on the security-reports badge's "View all" button) used to each build an independent `PlistEditorModel` and independently stash/consume `pendingWebsiteSettingsTab` — whichever `Task` assigned `activeEditor` last won outright, discarding the other's model and landing on neither requested tab.
- Findings 1 and 2 of #1312 (401/403 message, redundant git-remote resolution) were already fixed by #1314 and shipped as part of #1304, now on `main`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] Added a regression test (`openWebsiteSettingsLandOnDoubleInvocationKeepsLatestTab`) that reproduces the pre-fix race deterministically (fails without the fix, verified red before green).
- [x] `swift test --package-path . --filter "openWebsiteSettingsLandOnDoubleInvocationKeepsLatestTab|openWebsiteSettingsLandOnClearsPendingTabOnAbort|openWebsiteSettingsOpensInfoPlist"` — all pass, re-verified after rebasing onto `main` post-#1304-merge.
- [ ] `swift test --package-path .` (full `AnglesiteAppTests`) — **could not complete**: the build machine was running many concurrent `swift test` invocations from other worktrees at the same time, and three separate full-suite attempts each stalled for hours on a different, unrelated pre-existing test (`CloudflareOAuthSignInTests`, `DeployModelTests`, and a debounce-timer test) — none of which this change touches. ~1000 other tests passed cleanly around each stall, including all `SiteWindowModel` tests. Needs a re-run on a quieter machine before merge.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` via `scripts/build-app.sh` — **BUILD SUCCEEDED**, no errors.
- [ ] Manual smoke: not performed — the double-click-on-badge path is unverified in a running app.