### PR TITLE
fix(#1312): scope inFlightOpenFile clear to its own call

### DIFF
--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1262,7 +1262,15 @@ final class SiteWindowModel {
         // spell its own `[weak self]` capture without the compiler flagging the mismatch against an
         // implicitly-captured strong `self` in this outer scope.
         let task = Task { [self] in
-            defer { inFlightOpenFile = nil }
+            // Only clear the record if it's still this call's own — a *different* file's call
+            // that started and overwrote `inFlightOpenFile` while this one was suspended (e.g.
+            // awaiting `leaveCurrentEditor()`) must keep owning it, or a third call for that
+            // other file would wrongly conclude nothing is in flight and race a second `Task`
+            // against it — the exact bug this property exists to prevent, just one file removed
+            // (review finding on this PR). A same-file second call never reaches here at all (the
+            // guard above returns before spawning), so this file-id check is equivalent to (and
+            // simpler than) comparing task identity.
+            defer { if inFlightOpenFile?.file.id == file.id { inFlightOpenFile = nil } }
             guard await leaveCurrentEditor(), await leaveCurrentInspector() else {
                 pendingWebsiteSettingsTab = nil
                 return


### PR DESCRIPTION
Follow-up to #1357, which merged before this fix landed — #1357's own review flagged a real bug in the code it merged, and this closes it.

## Summary

- #1357's `openFile` `Task`'s `defer { inFlightOpenFile = nil }` cleared the record unconditionally. [Review comment on #1357](https://github.com/Anglesite/Anglesite/pull/1357#discussion_r3741713051) pointed out this reopens the same #1312 finding-3 race one file removed: if a call for file A finishes while a call for a *different* file B is still in flight (B's call started after A's, overwriting the shared record), A's unconditional clear wipes B's still-live entry — a third call for B would then wrongly conclude nothing is in flight and race a second `Task` against it.
- Fix: scope the clear to the file this `Task` actually owns — `defer { if inFlightOpenFile?.file.id == file.id { inFlightOpenFile = nil } }`. A same-file second call never reaches this code at all (it joins the in-flight `Task` via the guard above instead), so at most one `Task` ever owns a given file's entry — this file-id check is equivalent to (and simpler than) comparing `Task` identity.

No new automated test for the specific cross-file interleaving — see the discussion on #1357 for why it's not practically reproducible deterministically without new test-only instrumentation (this codebase's clean-file open path has no genuine suspension point before `activeEditor` is reassigned, so a test can't reliably land a third call inside the vulnerable window without a timing dependency I'm not confident is flake-proof on a loaded CI runner).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path . --filter "openWebsiteSettingsLandOnDoubleInvocationKeepsLatestTab|openWebsiteSettingsLandOnClearsPendingTabOnAbort|openWebsiteSettingsOpensInfoPlist"` — all pass.
- [x] `swift build --package-path .` — builds clean (pre-existing unrelated warnings only).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not re-run for this one-line follow-up; #1357 already verified the surrounding code builds.