### PR TITLE
fix(#1355): stop CloudflareOAuthSignInTests hang risk

### DIFF
--- a/Tests/AnglesiteAppTests/CloudflareOAuthSignInTests.swift
+++ b/Tests/AnglesiteAppTests/CloudflareOAuthSignInTests.swift
@@ -3,6 +3,11 @@ import Foundation
 import AnglesiteCore
 @testable import AnglesiteAppCore
 
+/// `.timeLimit`: see #1349/#1355 — the full `AnglesiteAppTests` target has hung indefinitely
+/// under local machine contention (many concurrent `swift test` runs oversubscribing the
+/// cooperative thread pool), with this suite one observed stall point. A wedged test now fails
+/// as an unambiguous time-limit violation instead of hanging the whole run for hours.
+@Suite(.timeLimit(.minutes(1)))
 struct CloudflareOAuthSignInTests {
     private let discoveryURL = URL(string: "https://dash.cloudflare.com/.well-known/openid-configuration")!
     private let redirectURI = URL(string: "https://auth.anglesite.dwk.io/oauth-callback")!
@@ -14,6 +19,17 @@ struct CloudflareOAuthSignInTests {
         HTTPURLResponse(url: discoveryURL, statusCode: code, httpVersion: nil, headerFields: nil)!
     }
 
+    /// Records a value written from a `@Sendable` closure. `run()`'s `present`/`transport`
+    /// callbacks are `@Sendable` and cross `await` suspension points, so the compiler can't prove
+    /// a plain captured `var` isn't accessed concurrently — actor isolation is the fix the rest of
+    /// this codebase already uses for the same shape of problem (see `CloudflareAPITokenTestEnvironment`,
+    /// `HTTPGitHubClientTests.RequestBox`).
+    actor Box<Value: Sendable> {
+        private(set) var value: Value
+        init(_ value: Value) { self.value = value }
+        func set(_ value: Value) { self.value = value }
+    }
+
     @Test("run() authorizes, presents, and exchanges the callback for a token")
     func fullRoundTrip() async throws {
         let client = CloudflareOAuthClient(
@@ -23,9 +39,9 @@ struct CloudflareOAuthSignInTests {
                 let body = #"{"access_token":"tok","token_type":"bearer","expires_in":3600,"refresh_token":"refresh"}"#
                 return (Data(body.utf8), self.response(200))
             })
-        var presentedURL: URL?
+        let presentedURLBox = Box<URL?>(nil)
         let signIn = CloudflareOAuthSignIn(client: client, present: { authorizeURL in
-            presentedURL = authorizeURL
+            await presentedURLBox.set(authorizeURL)
             let state = URLComponents(url: authorizeURL, resolvingAgainstBaseURL: false)?
                 .queryItems?.first { $0.name == "state" }?.value ?? ""
             return URL(string: "https://auth.anglesite.dwk.io/oauth-callback?code=auth-code&state=\(state)")!
@@ -36,6 +52,7 @@ struct CloudflareOAuthSignInTests {
         #expect(result.token.accessToken == "tok")
         #expect(result.token.refreshToken == "refresh")
         #expect(result.tokenEndpoint == URL(string: "https://dash.cloudflare.com/oauth2/token")!)
+        let presentedURL = await presentedURLBox.value
         #expect(presentedURL?.host == "dash.cloudflare.com")
     }
 
@@ -53,12 +70,12 @@ struct CloudflareOAuthSignInTests {
 
     @Test("a callback with a mismatched state throws before exchanging")
     func mismatchedStateNeverExchanges() async {
-        var exchangeCalled = false
+        let exchangeCalledBox = Box(false)
         let client = CloudflareOAuthClient(
             redirectURI: redirectURI, scope: "workers_scripts", discoveryURL: discoveryURL,
             transport: { req in
                 if req.url == self.discoveryURL { return (self.discoveryJSON, self.response(200)) }
-                exchangeCalled = true
+                await exchangeCalledBox.set(true)
                 return (Data(), self.response(200))
             })
         let signIn = CloudflareOAuthSignIn(client: client, present: { _ in
@@ -67,6 +84,7 @@ struct CloudflareOAuthSignInTests {
         await #expect(throws: CloudflareOAuthError.stateMismatch) {
             _ = try await signIn.run()
         }
+        let exchangeCalled = await exchangeCalledBox.value
         #expect(!exchangeCalled)
     }
 }


### PR DESCRIPTION
Closes #1355

## Summary

- `CloudflareOAuthSignInTests.swift` mutated plain captured `var`s (`presentedURL`,
  `exchangeCalled`) from inside `@Sendable async` closures (`present`/`transport`) that cross
  `await` suspension points — "mutation of captured var ... in concurrently-executing code; this
  is an error in the Swift 6 language mode". Replaced them with the actor-isolated `Box` pattern
  already used elsewhere in this suite family (`CloudflareAPITokenTestEnvironment`,
  `HTTPGitHubClientTests.RequestBox`).
- Added `@Suite(.timeLimit(.minutes(1)))`, matching #1350's precedent for hang-prone
  `AnglesiteAppTests` suites, so a future stall here fails loudly instead of hanging the whole
  run for hours — this suite predates #1350's sweep (landed in #1204, after that PR).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path . --filter CloudflareOAuthSignInTests` — was reproducibly
      hanging (17+ wall-clock hours observed); now passes cleanly in ~10ms per test, with no
      "captured var" warnings for this file, from a fresh from-scratch build.
- [ ] `swift test --package-path .` — not run in full; this machine currently has ~28 concurrent
      `swift-test` processes from other agent sessions (the exact contention pattern #1349
      documented), and a broader `--filter AnglesiteAppTests` run hit an unrelated pre-existing
      failure in `DeployModelTests` (`signInFailureStaysOnSheet`) that reproduces identically on
      unmodified `main` via `git stash` — flagged separately, out of scope here. Per #1349's
      established guidance, CI's `build-test` job is the reliable arbiter for the full suite.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` —
      not run; this PR only touches a test file, no app-target sources.
