### PR TITLE
fix: DeployModelTests keychain leak + swift-testing Mirror-dump hang

### DIFF
--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -725,7 +725,11 @@ struct DeployModelTests {
         await executor.resumeBuild()
         while model.isRunning { await Task.yield() }
 
-        #expect(!model.tokenPromptPresented)
+        // Bind before asserting — see the comment on `tokenPromptPresented` in
+        // `signInFailureStaysOnSheet` for why a bare `#expect(model.tokenPromptPresented)` risks
+        // a hang on failure.
+        let tokenPromptPresented = model.tokenPromptPresented
+        #expect(!tokenPromptPresented)
     }
 
     @Test("an expired OAuth credential with no refresh token re-presents the sign-in sheet")
@@ -746,8 +750,13 @@ struct DeployModelTests {
 
         model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
 
-        #expect(model.tokenPromptPresented)
-        #expect(!model.isRunning)
+        // Bind before asserting — see the comment on `tokenPromptPresented` in
+        // `signInFailureStaysOnSheet` for why a bare `#expect(model.tokenPromptPresented)` risks
+        // a hang on failure.
+        let tokenPromptPresented = model.tokenPromptPresented
+        let isRunning = model.isRunning
+        #expect(tokenPromptPresented)
+        #expect(!isRunning)
     }
 
     @Test("signInWithCloudflare persists the credential and dispatches the parked deploy on success")
@@ -781,7 +790,11 @@ struct DeployModelTests {
         let directory = FileManager.default.temporaryDirectory
 
         model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
-        #expect(model.tokenPromptPresented)
+        // Bind before asserting — see the comment on `tokenPromptPresented` in
+        // `signInFailureStaysOnSheet` for why a bare `#expect(model.tokenPromptPresented)` risks
+        // a hang on failure.
+        let tokenPromptPresentedAfterDeploy = model.tokenPromptPresented
+        #expect(tokenPromptPresentedAfterDeploy)
 
         // `signInWithCloudflare()` internally calls `deploy(...)` again once sign-in succeeds,
         // which is what actually launches the (previously never-started) build step this time —
@@ -793,7 +806,8 @@ struct DeployModelTests {
         await executor.resumeBuild()
         while model.isRunning { await Task.yield() }
 
-        #expect(!model.tokenPromptPresented)
+        let tokenPromptPresentedAfterSignIn = model.tokenPromptPresented
+        #expect(!tokenPromptPresentedAfterSignIn)
         #expect(try keychain.readCloudflareOAuthCredential()?.accessToken == "new-oauth-tok")
         guard case .succeeded = model.phase else {
             Issue.record("expected the parked deploy to run after sign-in, got \(model.phase)"); return
@@ -811,13 +825,31 @@ struct DeployModelTests {
             discoveryURL: URL(string: "https://dash.cloudflare.com/.well-known/openid-configuration")!,
             transport: { _ in throw Boom() })
         let oauthSignIn = CloudflareOAuthSignIn(client: client, present: { _ in throw Boom() })
-        let model = DeployModel(command: command, logCenter: LogCenter(), oauthSignIn: oauthSignIn)
+        // Unlike every sibling test in this file, this one omitted the `keychain:` override —
+        // `DeployModel`'s default (`KeychainStore()`) reads the real macOS Keychain under the
+        // app's own production service id (`io.dwk.anglesite`). On a machine that has ever
+        // completed a real Cloudflare sign-in, `hasUsableToken()` finds that leftover credential,
+        // `deploy()` skips presenting the token prompt, and `tokenPromptPresented` never flips to
+        // `true` — an environment-dependent flake, not a logic bug in `DeployModel`.
+        let keychain = InMemorySecretStore()
+        let model = DeployModel(command: command, logCenter: LogCenter(), keychain: keychain, oauthSignIn: oauthSignIn)
         let directory = FileManager.default.temporaryDirectory
 
         model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
         await model.signInWithCloudflare()
 
-        #expect(model.tokenPromptPresented)
+        // Bind to a local before asserting rather than `#expect(model.tokenPromptPresented)`:
+        // swift-testing's `#expect` macro decomposes a member-access expression into (subject,
+        // member) and, on failure, recursively `Mirror`-dumps the *subject* too — `model` is a
+        // large, self-referential graph (`inFlight: Task<Void, Never>?` closes over `[weak
+        // self]`) that has been observed to make that dump take a combinatorially long time
+        // (an effective hang, since a synchronous `Mirror` walk doesn't yield for a suite
+        // `.timeLimit`'s cancellation check to land). Keeping `model` out of the `#expect(...)`
+        // call entirely — by asserting a local copy of just the field under test — sidesteps it;
+        // confirmed empirically (a deliberately-failed assertion) that a bare `#expect(model.x)`
+        // recurses through the whole object graph while `#expect(x)` on a local does not.
+        let tokenPromptPresented = model.tokenPromptPresented
+        #expect(tokenPromptPresented)
         guard case .failed = model.tokenVerification else {
             Issue.record("expected .failed, got \(model.tokenVerification)"); return
         }


### PR DESCRIPTION
Closes #1356

## Summary

- `signInFailureStaysOnSheet` was the only test in `DeployModelTests.swift` that never injected `keychain: InMemorySecretStore()`, so it fell back to the production `KeychainStore()` default and read the real macOS Keychain (service `io.dwk.anglesite`) — flaking on any machine with a leftover real Cloudflare credential.
- Bare `#expect(model.someProperty)` risks hanging on failure: swift-testing's `#expect` macro recursively `Mirror`-dumps the member-access subject (`model`) too, and `DeployModel` is a large, self-referential graph (`inFlight: Task<Void, Never>?` captures `[weak self]`) that's been observed to take a combinatorially long time to reflect — an effective hang well past the suite's `.timeLimit`. Confirmed empirically: a forced failure via bare `#expect(model.x)` dumped ~386 lines of nested state; hoisting to a local `let` first produced a clean, instant failure instead. `CustomTestStringConvertible` does not fix this — it only relabels the top line, children still get walked.
- Fixed the keychain injection plus the 5 `tokenPromptPresented`/OAuth-flow assertion sites this bug actually touches. ~26 other `#expect(model.xxx)` sites elsewhere in the file carry the same latent risk and are left for a scoped follow-up (flagged separately) to keep this PR focused on the reported bug.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path . --filter DeployModelTests` — all 23 tests pass in <1s, including the previously-hanging `signInWithCloudflare keeps the sheet open with a message on failure`.
- [x] Forced-failure verification: temporarily inverted the assertion to confirm the hoist-to-local pattern actually avoids the recursive Mirror dump (confirmed — failure reports `<not evaluated>` instead of a 386-line object graph).
- [x] `swift build --build-tests --package-path .` — full package builds clean.
- [ ] Full `swift test --package-path .` — ran to ~10,300 lines of output with the fixed test passing (`signInWithCloudflare keeps the sheet open with a message on failure passed after 0.491 seconds`) before the process was SIGKILLed elsewhere in an unrelated suite, consistent with known local-machine contention (see #1349) rather than this change — CI is the arbiter here.