### PR TITLE
iOS site discovery via iCloud (NSMetadataQuery site picker)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -133,7 +133,7 @@ var packageTargets: [Target] = [
     ),
     .target(
         name: "AnglesiteIOS",
-        dependencies: [],
+        dependencies: ["AnglesiteSiteModel", "AnglesiteCore"],
         path: "Sources/AnglesiteIOS",
         swiftSettings: strictConcurrency
     ),
@@ -192,6 +192,15 @@ var packageTargets: [Target] = [
         dependencies: ["AnglesiteBridge", "AnglesiteTestSupport"],
         path: "Tests/AnglesiteBridgeTests",
         swiftSettings: strictConcurrency,
+        linkerSettings: weakLinkFoundationModels
+    ),
+    .testTarget(
+        name: "AnglesiteIOSTests",
+        dependencies: ["AnglesiteIOS", "AnglesiteSiteModel", "AnglesiteCore"],
+        path: "Tests/AnglesiteIOSTests",
+        swiftSettings: strictConcurrency,
+        // Transitively depends on AnglesiteCore (via AnglesiteIOS), so it needs the same #541
+        // weak-link workaround as AnglesiteBridgeTests/AnglesiteBridgeCoreTests above.
         linkerSettings: weakLinkFoundationModels
     )
 ]

--- a/Resources/AnglesiteMobile-Debug-iCloud.entitlements
+++ b/Resources/AnglesiteMobile-Debug-iCloud.entitlements
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Opt-in Debug entitlements (mirrors Resources/Anglesite-Debug-iCloud.entitlements, #1038):
+	     identical to AnglesiteMobile-Debug.entitlements plus the iCloud capability. Requires a
+	     real Team/provisioning profile — see Signing-Debug.local.xcconfig.example. -->
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.io.dwk.anglesite</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+</dict>
+</plist>

--- a/Resources/AnglesiteMobile-Debug.entitlements
+++ b/Resources/AnglesiteMobile-Debug.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- NO iCloud entitlement here (mirrors Resources/Anglesite-Debug.entitlements, #1038): the
+	     iCloud capability needs a real provisioning profile even under ad-hoc/no-Team signing,
+	     which would break the no-Apple-account Debug build CI's ios-build lane (#864) relies on.
+	     SitePickerModel already treats "no ubiquity container" the same as "iCloud unavailable"
+	     and shows that state instead of crashing. Contributors with a real Team who want to
+	     exercise iCloud discovery locally: point ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS at
+	     Resources/AnglesiteMobile-Debug-iCloud.entitlements from
+	     xcconfig/Signing-Debug.local.xcconfig (see Signing-Debug.local.xcconfig.example). -->
+</dict>
+</plist>

--- a/Resources/AnglesiteMobile.entitlements
+++ b/Resources/AnglesiteMobile.entitlements
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- iCloud site discovery (#866): must match AppSettings.ubiquityContainerIdentifier
+	     (AnglesiteCore) and the NSUbiquitousContainers key in Resources/Info-iOS.plist. Same
+	     container the Mac app's default site storage (#865) writes into. -->
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.io.dwk.anglesite</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+</dict>
+</plist>

--- a/Resources/Info-iOS.plist
+++ b/Resources/Info-iOS.plist
@@ -37,5 +37,17 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSUbiquitousContainers</key>
+	<dict>
+		<key>iCloud.io.dwk.anglesite</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>Any</string>
+			<key>NSUbiquitousContainerName</key>
+			<string>Anglesite</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -82,7 +82,10 @@ public final class AppSettings: @unchecked Sendable {
     /// omits this entitlement (#1038 — it requires a real provisioning profile, breaking the
     /// no-Apple-account Debug build); `Resources/Anglesite-Debug-iCloud.entitlements` is the
     /// opt-in local variant that carries it.
-    static let ubiquityContainerIdentifier = "iCloud.io.dwk.anglesite"
+    /// Public so `AnglesiteIOS`'s site-discovery seam (#866) can reuse the exact same identifier
+    /// instead of duplicating this literal — it's the same physical iCloud container on both
+    /// platforms.
+    public static let ubiquityContainerIdentifier = "iCloud.io.dwk.anglesite"
 
     private let ubiquityCacheLock = NSLock()
     /// `nil` = not resolved yet; `.some(nil)` = resolved, iCloud unavailable.

--- a/Sources/AnglesiteCore/UbiquityContainerResolving.swift
+++ b/Sources/AnglesiteCore/UbiquityContainerResolving.swift
@@ -8,7 +8,14 @@ import Foundation
 /// ad-hoc-signed Debug build, which has no Team ID) deterministically, without depending on the
 /// real iCloud account state of the machine running the test. Darwin-only: this `FileManager`
 /// method doesn't exist in swift-corelibs-foundation, and `AnglesiteCore` also builds on Linux.
-public protocol UbiquityContainerResolving {
+///
+/// `Sendable` because the method it wraps is documented as potentially slow (it may hit the
+/// network) and not to be called on the main thread, so callers with somewhere to hop — e.g.
+/// `AnglesiteIOS`'s `SitePickerModel.refresh()` (#866), which is `async` — can resolve the
+/// container off the main actor. Conformers are stateless answer-providers in practice, and
+/// `AppSettings` (itself `@unchecked Sendable`) already stores one across isolation domains, so
+/// this documents a constraint that was already being relied on rather than adding a new one.
+public protocol UbiquityContainerResolving: Sendable {
     /// Mirrors `FileManager`'s method of the same name: returns the container's root URL, or
     /// `nil` when the container isn't available for any reason. `containerIdentifier: nil` means
     /// "the app's first `com.apple.developer.icloud-container-identifiers` entry".

--- a/Sources/AnglesiteIOS/SitePickerModel.swift
+++ b/Sources/AnglesiteIOS/SitePickerModel.swift
@@ -35,6 +35,10 @@ public final class SitePickerModel {
     private let packageDiscovery: UbiquitousPackageDiscovering
     private let fileManager: FileManager
 
+    /// Bumped by every `refresh()` call; a call only publishes its result while it still owns the
+    /// latest value. See `refresh()`.
+    private var refreshGeneration: UInt64 = 0
+
     public init(
         ubiquityContainerResolver: UbiquityContainerResolving = FileManager.default,
         packageDiscovery: UbiquitousPackageDiscovering = NSMetadataQueryPackageDiscovery(),
@@ -51,7 +55,18 @@ public final class SitePickerModel {
     /// The `.loading` placeholder is only published when there's nothing on screen yet: a refresh
     /// from an already-populated list (pull-to-refresh) re-queries quietly underneath the existing
     /// rows instead of tearing the list down to a spinner mid-gesture.
+    ///
+    /// Overlapping calls are ordered by a generation counter rather than serialized: `refresh()`
+    /// has two independent callers in `SitePickerScreen` (the initial `.task` and
+    /// `.refreshable`), so a pull-to-refresh shortly after launch can start a second discovery
+    /// while the first is still gathering. Whichever call started last owns the result — an
+    /// older, slower call finds its generation stale on resume and drops its findings instead of
+    /// reverting the list to a pre-refresh snapshot. Every caller still awaits its own work, so
+    /// the pull-to-refresh spinner stays up for the duration of the gesture's own query.
     public func refresh() async {
+        refreshGeneration &+= 1
+        let generation = refreshGeneration
+
         switch state {
         case .sites:
             break
@@ -68,22 +83,31 @@ public final class SitePickerModel {
         let hasContainer = await Task.detached(priority: .userInitiated) {
             resolver.url(forUbiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier) != nil
         }.value
+        guard generation == refreshGeneration else { return }
         guard hasContainer else {
             state = .iCloudUnavailable
             return
         }
 
         let packageURLs = await packageDiscovery.discoverPackages()
-        let sites = packageURLs
-            .compactMap { url -> DiscoveredSite? in
-                let package = AnglesitePackage(url: url)
-                guard let marker = try? package.readMarker(fileManager: fileManager) else {
-                    return nil
+        // Same reason the container hop above is detached: `readMarker` is a per-package
+        // `Info.plist` read inside the ubiquity container, which can block on a materializing
+        // iCloud item. One hop covers the whole list rather than one per package.
+        let fileManager = self.fileManager
+        let sites = await Task.detached(priority: .userInitiated) {
+            packageURLs
+                .compactMap { url -> DiscoveredSite? in
+                    let package = AnglesitePackage(url: url)
+                    guard let marker = try? package.readMarker(fileManager: fileManager) else {
+                        return nil
+                    }
+                    return DiscoveredSite(
+                        id: marker.siteID, displayName: marker.displayName, packageURL: url)
                 }
-                return DiscoveredSite(id: marker.siteID, displayName: marker.displayName, packageURL: url)
-            }
-            .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+                .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+        }.value
 
+        guard generation == refreshGeneration else { return }
         state = sites.isEmpty ? .empty : .sites(sites)
     }
 }

--- a/Sources/AnglesiteIOS/SitePickerModel.swift
+++ b/Sources/AnglesiteIOS/SitePickerModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftUI
+import AnglesiteCore
+import AnglesiteSiteModel
+
+/// Drives the iOS app's entry point (#866): lists the user's `.anglesite` packages found in their
+/// iCloud ubiquity container, in place of the old "type a site URL" flow. `@MainActor` +
+/// `@Observable` so `SitePickerScreen` (`AnglesiteMobile`) can bind to it directly, matching
+/// `RemoteSessionModel`'s existing convention in this target.
+@MainActor
+@Observable
+public final class SitePickerModel {
+    /// A discovered `.anglesite` package, ready to show in the picker.
+    public struct DiscoveredSite: Identifiable, Sendable, Equatable {
+        /// The package's stable site UUID (`AnglesitePackage.Marker.siteID`) — path-independent,
+        /// matching how `SiteStore.Site` identifies sites on the Mac.
+        public let id: UUID
+        public let displayName: String
+        public let packageURL: URL
+    }
+
+    /// Distinguishes "iCloud itself isn't available" from "iCloud is available but has no sites
+    /// yet" — the design's explicit requirement (spec §4/§7): the empty state's "create a site on
+    /// your Mac" message must never show when the real problem is iCloud access.
+    public enum State: Equatable {
+        case loading
+        case iCloudUnavailable
+        case empty
+        case sites([DiscoveredSite])
+    }
+
+    public private(set) var state: State = .loading
+
+    private let ubiquityContainerResolver: UbiquityContainerResolving
+    private let packageDiscovery: UbiquitousPackageDiscovering
+    private let fileManager: FileManager
+
+    public init(
+        ubiquityContainerResolver: UbiquityContainerResolving = FileManager.default,
+        packageDiscovery: UbiquitousPackageDiscovering = NSMetadataQueryPackageDiscovery(),
+        fileManager: FileManager = .default
+    ) {
+        self.ubiquityContainerResolver = ubiquityContainerResolver
+        self.packageDiscovery = packageDiscovery
+        self.fileManager = fileManager
+    }
+
+    /// Re-runs discovery from scratch. Safe to call repeatedly (pull-to-refresh, a "Try Again"
+    /// button, or the initial `.task` on `SitePickerScreen`).
+    public func refresh() async {
+        state = .loading
+        guard ubiquityContainerResolver.url(
+            forUbiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier
+        ) != nil else {
+            state = .iCloudUnavailable
+            return
+        }
+
+        let packageURLs = await packageDiscovery.discoverPackages()
+        let sites = packageURLs
+            .compactMap { url -> DiscoveredSite? in
+                let package = AnglesitePackage(url: url)
+                guard let marker = try? package.readMarker(fileManager: fileManager) else {
+                    return nil
+                }
+                return DiscoveredSite(id: marker.siteID, displayName: marker.displayName, packageURL: url)
+            }
+            .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+
+        state = sites.isEmpty ? .empty : .sites(sites)
+    }
+}

--- a/Sources/AnglesiteIOS/SitePickerModel.swift
+++ b/Sources/AnglesiteIOS/SitePickerModel.swift
@@ -47,11 +47,28 @@ public final class SitePickerModel {
 
     /// Re-runs discovery from scratch. Safe to call repeatedly (pull-to-refresh, a "Try Again"
     /// button, or the initial `.task` on `SitePickerScreen`).
+    ///
+    /// The `.loading` placeholder is only published when there's nothing on screen yet: a refresh
+    /// from an already-populated list (pull-to-refresh) re-queries quietly underneath the existing
+    /// rows instead of tearing the list down to a spinner mid-gesture.
     public func refresh() async {
-        state = .loading
-        guard ubiquityContainerResolver.url(
-            forUbiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier
-        ) != nil else {
+        switch state {
+        case .sites:
+            break
+        case .loading, .iCloudUnavailable, .empty:
+            state = .loading
+        }
+        // `url(forUbiquityContainerIdentifier:)` is documented as potentially slow (it may hit the
+        // network) and not to be called on the main thread — see the same warning on
+        // `AppSettings.resolvedUbiquityContainerURL()`, which has to accept that cost because
+        // `sitesRoot` is a synchronous `@MainActor` property. `refresh()` is `async`, so it can
+        // simply hop off instead, matching the `Task.detached(priority:)` IO idiom used across
+        // `AnglesiteApp`'s models.
+        let resolver = ubiquityContainerResolver
+        let hasContainer = await Task.detached(priority: .userInitiated) {
+            resolver.url(forUbiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier) != nil
+        }.value
+        guard hasContainer else {
             state = .iCloudUnavailable
             return
         }

--- a/Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift
+++ b/Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift
@@ -1,0 +1,56 @@
+import Foundation
+import AnglesiteSiteModel
+
+/// Wraps `NSMetadataQuery` so `SitePickerModel` can be tested against fixtured results (#866)
+/// instead of the real iCloud state of whatever machine runs `swift test` — mirrors
+/// `AnglesiteCore`'s `UbiquityContainerResolving`/`FakeUbiquityContainerResolver` seam (#865).
+public protocol UbiquitousPackageDiscovering: Sendable {
+    /// Runs a one-shot query for `.anglesite` packages in the app's iCloud ubiquity container
+    /// and returns their URLs once the initial gather completes. Callers are expected to have
+    /// already confirmed the container is available (`UbiquityContainerResolving`) before calling
+    /// this — it does not itself distinguish "no container" from "container has no packages".
+    func discoverPackages() async -> [URL]
+}
+
+/// Real `NSMetadataQuery`-backed implementation. Scoped to
+/// `NSMetadataQueryUbiquitousDocumentsScope` (the app's own ubiquity container's `Documents/`
+/// folder — matching `AppSettings.sitesRoot`'s `container/Documents` convention, #865) rather than
+/// a raw file-URL scope or a broader ubiquitous-data scope: per `SyncModel.observeBundleChanges`'s
+/// prior art (`Sources/AnglesiteApp/SyncModel.swift`), ubiquitous item metadata keys like
+/// `NSMetadataItemPathKey` aren't reliably populated until an item is first resolved, so filtering
+/// by path prefix is unreliable — the predefined scope constant is the documented-correct way to
+/// scope a search to this app's own ubiquitous documents instead.
+///
+/// No stored mutable state: each call creates and tears down its own query and observer, so
+/// concurrent calls can't interfere with each other.
+public final class NSMetadataQueryPackageDiscovery: UbiquitousPackageDiscovering, @unchecked Sendable {
+    public init() {}
+
+    public func discoverPackages() async -> [URL] {
+        await withCheckedContinuation { continuation in
+            let query = NSMetadataQuery()
+            query.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+            query.predicate = NSPredicate(
+                format: "%K ENDSWITH %@",
+                NSMetadataItemFSNameKey, ".\(AnglesitePackage.packageExtension)"
+            )
+
+            var observer: NSObjectProtocol?
+            observer = NotificationCenter.default.addObserver(
+                forName: .NSMetadataQueryDidFinishGathering, object: query, queue: .main
+            ) { _ in
+                query.disableUpdates()
+                query.stop()
+                if let observer {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+                let urls = (0..<query.resultCount).compactMap { index -> URL? in
+                    (query.result(at: index) as? NSMetadataItem)?
+                        .value(forAttribute: NSMetadataItemURLKey) as? URL
+                }
+                continuation.resume(returning: urls)
+            }
+            query.start()
+        }
+    }
+}

--- a/Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift
+++ b/Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift
@@ -23,7 +23,16 @@ public protocol UbiquitousPackageDiscovering: Sendable {
 ///
 /// No stored mutable state: each call creates and tears down its own query and observer, so
 /// concurrent calls can't interfere with each other.
-public final class NSMetadataQueryPackageDiscovery: UbiquitousPackageDiscovering, @unchecked Sendable {
+///
+/// `@MainActor`-isolated on purpose: `NSMetadataQuery` only gathers and delivers its notifications
+/// when started from a thread with a serviced run loop, which in practice means the main thread —
+/// exactly what `SyncModel.observeBundleChanges` (`Sources/AnglesiteApp/SyncModel.swift`) relies on
+/// by virtue of running from a `@MainActor` model. A plain `async` method here would instead run
+/// its body on the cooperative thread pool, where `.NSMetadataQueryDidFinishGathering` may never
+/// fire and the continuation would hang forever. The isolation still satisfies the non-isolated
+/// `async` protocol requirement above — the hop happens transparently at each `await` call site.
+@MainActor
+public final class NSMetadataQueryPackageDiscovery: UbiquitousPackageDiscovering {
     public init() {}
 
     public func discoverPackages() async -> [URL] {
@@ -50,7 +59,18 @@ public final class NSMetadataQueryPackageDiscovery: UbiquitousPackageDiscovering
                 }
                 continuation.resume(returning: urls)
             }
-            query.start()
+            // A `false` return means gathering never begins (malformed predicate or scope), so
+            // `.NSMetadataQueryDidFinishGathering` would never fire and the continuation would
+            // hang forever. Unreachable with the constants above, but the failure mode is a
+            // permanently stuck "Finding your sites…", so tear the observer back down and report
+            // "no packages" instead.
+            guard query.start() else {
+                if let observer {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+                continuation.resume(returning: [])
+                return
+            }
         }
     }
 }

--- a/Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift
+++ b/Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift
@@ -9,6 +9,10 @@ public protocol UbiquitousPackageDiscovering: Sendable {
     /// and returns their URLs once the initial gather completes. Callers are expected to have
     /// already confirmed the container is available (`UbiquityContainerResolving`) before calling
     /// this — it does not itself distinguish "no container" from "container has no packages".
+    ///
+    /// Implementations must always return: a conforming type may report "no packages" but may
+    /// never leave the caller suspended indefinitely, because `SitePickerModel.refresh()`'s
+    /// `.loading` state has no other way out.
     func discoverPackages() async -> [URL]
 }
 
@@ -21,7 +25,7 @@ public protocol UbiquitousPackageDiscovering: Sendable {
 /// by path prefix is unreliable — the predefined scope constant is the documented-correct way to
 /// scope a search to this app's own ubiquitous documents instead.
 ///
-/// No stored mutable state: each call creates and tears down its own query and observer, so
+/// No stored mutable state: each call creates and tears down its own `GatherSession`, so
 /// concurrent calls can't interfere with each other.
 ///
 /// `@MainActor`-isolated on purpose: `NSMetadataQuery` only gathers and delivers its notifications
@@ -33,44 +37,107 @@ public protocol UbiquitousPackageDiscovering: Sendable {
 /// `async` protocol requirement above — the hop happens transparently at each `await` call site.
 @MainActor
 public final class NSMetadataQueryPackageDiscovery: UbiquitousPackageDiscovering {
+    /// How long to wait for `.NSMetadataQueryDidFinishGathering` before giving up and reporting
+    /// "no packages". Generous on purpose: a cold ubiquity container on a slow network can take a
+    /// few seconds to finish its first gather, and a spurious "No Sites Found" is a worse failure
+    /// than a slightly longer spinner. Bounded all the same, because the alternative — the
+    /// notification never arriving (iCloud daemon hiccup, degraded network) — strands the iOS
+    /// app's only root scene on a `ProgressView` with no way out. Same bounded-wait convention as
+    /// `AnglesiteCore`'s server-readiness budget, which reports an overrun rather than hanging.
+    static let gatherTimeout: Duration = .seconds(25)
+
     public init() {}
 
     public func discoverPackages() async -> [URL] {
-        await withCheckedContinuation { continuation in
-            let query = NSMetadataQuery()
-            query.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
-            query.predicate = NSPredicate(
-                format: "%K ENDSWITH %@",
-                NSMetadataItemFSNameKey, ".\(AnglesitePackage.packageExtension)"
-            )
-
-            var observer: NSObjectProtocol?
-            observer = NotificationCenter.default.addObserver(
-                forName: .NSMetadataQueryDidFinishGathering, object: query, queue: .main
-            ) { _ in
-                query.disableUpdates()
-                query.stop()
-                if let observer {
-                    NotificationCenter.default.removeObserver(observer)
-                }
-                let urls = (0..<query.resultCount).compactMap { index -> URL? in
-                    (query.result(at: index) as? NSMetadataItem)?
-                        .value(forAttribute: NSMetadataItemURLKey) as? URL
-                }
-                continuation.resume(returning: urls)
-            }
-            // A `false` return means gathering never begins (malformed predicate or scope), so
-            // `.NSMetadataQueryDidFinishGathering` would never fire and the continuation would
-            // hang forever. Unreachable with the constants above, but the failure mode is a
-            // permanently stuck "Finding your sites…", so tear the observer back down and report
-            // "no packages" instead.
-            guard query.start() else {
-                if let observer {
-                    NotificationCenter.default.removeObserver(observer)
-                }
-                continuation.resume(returning: [])
-                return
-            }
+        let session = GatherSession()
+        return await withCheckedContinuation { continuation in
+            session.begin(timeout: Self.gatherTimeout, continuation: continuation)
         }
+    }
+}
+
+/// One in-flight `NSMetadataQuery` gather and everything that has to be torn down with it.
+///
+/// The query, its observer token, and the timeout task live as properties here rather than as
+/// locals captured by the observer block: `addObserver(forName:object:queue:using:)`'s block is
+/// `@Sendable @escaping`, so the self-removing-observer idiom (assign a captured local `var
+/// observer` *after* building the closure that reads it) is exactly the shape strict concurrency
+/// warns about. `SyncModel.observeBundleChanges` avoids it by storing the token on the model;
+/// this type does the same, but scoped to a single call rather than to the discovery object, so
+/// two overlapping `discoverPackages()` calls still get fully independent queries.
+@MainActor
+private final class GatherSession {
+    private let query = NSMetadataQuery()
+    private var observer: NSObjectProtocol?
+    private var timeoutTask: Task<Void, Never>?
+    /// Non-`nil` until whichever of {gather finished, timeout, failed start} happens first —
+    /// `finish(with:)` uses it as the "not yet resumed" flag, so the continuation is resumed
+    /// exactly once no matter how many of those race.
+    private var continuation: CheckedContinuation<[URL], Never>?
+
+    func begin(timeout: Duration, continuation: CheckedContinuation<[URL], Never>) {
+        self.continuation = continuation
+
+        query.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+        // Filename-suffix matching, not a UTI/content-type match: `NSMetadataItemContentTypeTreeKey`
+        // is only populated once iCloud has resolved an item, so a UTI predicate would miss
+        // packages this device has never opened. A stray non-package item merely *named*
+        // `something.anglesite` therefore also matches; that's the accepted fallback, since it
+        // fails `AnglesitePackage.readMarker(fileManager:)` and gets skipped by the caller.
+        query.predicate = NSPredicate(
+            format: "%K ENDSWITH %@",
+            NSMetadataItemFSNameKey, ".\(AnglesitePackage.packageExtension)"
+        )
+
+        observer = NotificationCenter.default.addObserver(
+            forName: .NSMetadataQueryDidFinishGathering, object: query, queue: .main
+        ) { [self] _ in
+            // `queue: .main` guarantees this block runs on the main thread, which is the main
+            // actor's executor — the same assumption `SyncModel`'s metadata observer makes.
+            MainActor.assumeIsolated { finishGathering() }
+        }
+
+        timeoutTask = Task { [weak self] in
+            try? await Task.sleep(for: timeout)
+            guard !Task.isCancelled else { return }
+            self?.finish(with: [])
+        }
+
+        // A `false` return means gathering never begins (malformed predicate or scope), so
+        // `.NSMetadataQueryDidFinishGathering` would never fire. Unreachable with the constants
+        // above, and the timeout would eventually cover it anyway, but there's no reason to make
+        // the user wait out the full budget for a failure we already know about.
+        guard query.start() else {
+            finish(with: [])
+            return
+        }
+    }
+
+    private func finishGathering() {
+        let urls = (0..<query.resultCount).compactMap { index -> URL? in
+            (query.result(at: index) as? NSMetadataItem)?
+                .value(forAttribute: NSMetadataItemURLKey) as? URL
+        }
+        finish(with: urls)
+    }
+
+    /// Tears the query and observer down and resumes the caller. Idempotent: later callers (a
+    /// gather that lands just after the timeout fired, say) find `continuation == nil` and return
+    /// without double-resuming. Stopping a query that never started is harmless, so every exit
+    /// path can share this teardown.
+    private func finish(with urls: [URL]) {
+        guard let continuation else { return }
+        self.continuation = nil
+
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        query.disableUpdates()
+        query.stop()
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+            self.observer = nil
+        }
+
+        continuation.resume(returning: urls)
     }
 }

--- a/Sources/AnglesiteMobile/AnglesiteMobileApp.swift
+++ b/Sources/AnglesiteMobile/AnglesiteMobileApp.swift
@@ -1,15 +1,14 @@
 import SwiftUI
 
-/// iOS thin client (#71): a remote-only shell over `RemoteSandboxSiteRuntime`. No local files,
-/// no subprocesses, no local containers — the site runs in the user's Cloudflare sandbox and
-/// this app is a `WKWebView` plus MCP-over-HTTPS edits (design 2026-06-23).
+/// Entry point (#866): lists `.anglesite` packages discovered via iCloud. `RemoteSessionScreen`
+/// (the #71 remote-sandbox thin client, deferred to v2.0 under #342) is still in this target but
+/// no longer wired to the root scene — see this file's git history, and #800's owner decision
+/// (2026-07-17) that the iCloud-discovery + Micropub flow is the default iOS experience now.
 @main
 struct AnglesiteMobileApp: App {
-    @State private var model = RemoteSessionModel()
-
     var body: some Scene {
         WindowGroup {
-            RemoteSessionScreen(model: model)
+            SitePickerScreen()
         }
     }
 }

--- a/Sources/AnglesiteMobile/SitePickerScreen.swift
+++ b/Sources/AnglesiteMobile/SitePickerScreen.swift
@@ -14,8 +14,12 @@ struct SitePickerScreen: View {
         NavigationStack {
             content
                 .navigationTitle(Text("Your Sites"))
-                .task { await model.refresh() }
         }
+        // Attached to the `NavigationStack`, not to `content`: `content` is a `switch` over
+        // `model.state`, so its view identity changes on every state transition — and `refresh()`
+        // starts by publishing a new state. Hanging `.task` off it risks re-firing discovery on
+        // each transition; the stack's identity is stable, so this runs once on first appearance.
+        .task { await model.refresh() }
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteMobile/SitePickerScreen.swift
+++ b/Sources/AnglesiteMobile/SitePickerScreen.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import AnglesiteIOS
+
+/// The iOS app's entry point (#866): lists `.anglesite` packages discovered in the user's iCloud
+/// container instead of asking for a typed site URL. Replaces `RemoteSessionScreen` as
+/// `AnglesiteMobileApp`'s root — per #800's owner decision (2026-07-17) that this iCloud-discovery
+/// + Micropub flow, not the older remote-sandbox thin client (#71, deferred to v2.0 under #342),
+/// is the default iOS experience. Picking a site doesn't do anything yet — that's the sibling
+/// IndieAuth-onboarding issue.
+struct SitePickerScreen: View {
+    @State private var model = SitePickerModel()
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text("Your Sites"))
+                .task { await model.refresh() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.state {
+        case .loading:
+            ProgressView("Finding your sites…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .iCloudUnavailable:
+            ContentUnavailableView {
+                Label("iCloud Unavailable", systemImage: "icloud.slash")
+            } description: {
+                Text("Sign in to iCloud and turn on iCloud Drive to see your Anglesite sites.")
+            } actions: {
+                Button("Try Again") { Task { await model.refresh() } }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .empty:
+            ContentUnavailableView {
+                Label("No Sites Found", systemImage: "globe")
+            } description: {
+                Text("No sites found — create a site in Anglesite on your Mac first.")
+            } actions: {
+                Button("Refresh") { Task { await model.refresh() } }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .sites(let sites):
+            List(sites) { site in
+                Text(site.displayName)
+            }
+            .refreshable { await model.refresh() }
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/AppSettingsTests.swift
+++ b/Tests/AnglesiteCoreTests/AppSettingsTests.swift
@@ -31,7 +31,9 @@ final class AppSettingsTests {
     /// `AppSettings` resolves the (documented-as-slow) ubiquity container only once per instance.
     /// A `final class` because `UbiquityContainerResolving.url(forUbiquityContainerIdentifier:)`
     /// is non-mutating and the counter has to survive being read back through the protocol.
-    private final class CallCountingUbiquityContainerResolver: UbiquityContainerResolving {
+    /// `@unchecked Sendable` because the counter is already `NSLock`-guarded — the protocol
+    /// requires `Sendable` (#866) so callers can resolve the container off the main actor.
+    private final class CallCountingUbiquityContainerResolver: UbiquityContainerResolving, @unchecked Sendable {
         private let result: URL?
         private let lock = NSLock()
         private var _callCount = 0

--- a/Tests/AnglesiteIOSTests/SitePickerModelTests.swift
+++ b/Tests/AnglesiteIOSTests/SitePickerModelTests.swift
@@ -1,0 +1,99 @@
+import Testing
+import Foundation
+@testable import AnglesiteIOS
+import AnglesiteCore
+import AnglesiteSiteModel
+
+private struct FakeUbiquityContainerResolver: UbiquityContainerResolving {
+    let result: URL?
+    func url(forUbiquityContainerIdentifier containerIdentifier: String?) -> URL? { result }
+}
+
+private struct FakeUbiquitousPackageDiscovery: UbiquitousPackageDiscovering {
+    let urls: [URL]
+    func discoverPackages() async -> [URL] { urls }
+}
+
+/// A `final class` (not a `struct`) so `deinit` can clean up the scratch directory, mirroring
+/// `AppSettingsTests`' scratch-`UserDefaults`-suite pattern.
+@MainActor
+final class SitePickerModelTests {
+    private let scratchRoot: URL
+    private let fakeContainer = URL(fileURLWithPath: "/tmp/fake-ubiquity-container", isDirectory: true)
+
+    init() {
+        scratchRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SitePickerModelTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    deinit {
+        let root = scratchRoot
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func makePackage(displayName: String) throws -> URL {
+        let url = scratchRoot.appendingPathComponent("\(displayName).anglesite", isDirectory: true)
+        _ = try AnglesitePackage.createSkeleton(at: url, displayName: displayName)
+        return url
+    }
+
+    @Test("Missing iCloud container surfaces iCloudUnavailable, not empty")
+    func missingContainerSurfacesUnavailable() async {
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: nil),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: []))
+        await model.refresh()
+        #expect(model.state == .iCloudUnavailable)
+    }
+
+    @Test("Available container with no packages surfaces empty")
+    func emptyContainerSurfacesEmpty() async {
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: []))
+        await model.refresh()
+        #expect(model.state == .empty)
+    }
+
+    @Test("Single discovered package surfaces one site")
+    func singleSiteSurfacesInList() async throws {
+        let packageURL = try makePackage(displayName: "My Blog")
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: [packageURL]))
+        await model.refresh()
+        guard case .sites(let sites) = model.state else {
+            Issue.record("expected .sites, got \(model.state)")
+            return
+        }
+        #expect(sites.count == 1)
+        #expect(sites.first?.displayName == "My Blog")
+        #expect(sites.first?.packageURL == packageURL)
+    }
+
+    @Test("Multiple discovered packages surface sorted by display name")
+    func multipleSitesSortedByName() async throws {
+        let zebra = try makePackage(displayName: "Zebra Site")
+        let apple = try makePackage(displayName: "Apple Site")
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: [zebra, apple]))
+        await model.refresh()
+        guard case .sites(let sites) = model.state else {
+            Issue.record("expected .sites, got \(model.state)")
+            return
+        }
+        #expect(sites.map(\.displayName) == ["Apple Site", "Zebra Site"])
+    }
+
+    @Test("A package with no readable Info.plist marker is silently skipped")
+    func unreadableMarkerSkipped() async throws {
+        let corruptURL = scratchRoot.appendingPathComponent("Corrupt.anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(at: corruptURL, withIntermediateDirectories: true)
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: [corruptURL]))
+        await model.refresh()
+        #expect(model.state == .empty)
+    }
+}

--- a/Tests/AnglesiteIOSTests/SitePickerModelTests.swift
+++ b/Tests/AnglesiteIOSTests/SitePickerModelTests.swift
@@ -14,6 +14,74 @@ private struct FakeUbiquitousPackageDiscovery: UbiquitousPackageDiscovering {
     func discoverPackages() async -> [URL] { urls }
 }
 
+/// Runs `probe` at the moment `SitePickerModel.refresh()` reaches discovery — i.e. after it has
+/// decided whether to publish `.loading` — so a test can assert what was on screen mid-flight.
+private struct ProbingPackageDiscovery: UbiquitousPackageDiscovering {
+    let urls: [URL]
+    let probe: @Sendable @MainActor () -> Void
+    func discoverPackages() async -> [URL] {
+        await probe()
+        return urls
+    }
+}
+
+/// Holds the model under test so a `ProbingPackageDiscovery` built *before* the model can still
+/// read its state (the discovery has to be passed to the model's initializer).
+@MainActor
+private final class StateProbe {
+    weak var model: SitePickerModel?
+    var observedStates: [SitePickerModel.State] = []
+
+    func record() {
+        if let state = model?.state { observedStates.append(state) }
+    }
+}
+
+/// Parks the first `discoverPackages()` call until `release()`, so a test can start a slow
+/// refresh, complete a faster one behind its back, and then let the slow one finish last.
+private actor GatedPackageDiscovery: UbiquitousPackageDiscovering {
+    private let firstCallURLs: [URL]
+    private let laterCallURLs: [URL]
+    private var callCount = 0
+    private var parked: CheckedContinuation<Void, Never>?
+    private var waitingForPark: CheckedContinuation<Void, Never>?
+    private var isParked = false
+    private var isReleased = false
+
+    init(firstCallURLs: [URL], laterCallURLs: [URL]) {
+        self.firstCallURLs = firstCallURLs
+        self.laterCallURLs = laterCallURLs
+    }
+
+    func discoverPackages() async -> [URL] {
+        callCount += 1
+        guard callCount == 1 else { return laterCallURLs }
+        if !isReleased {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                parked = continuation
+                isParked = true
+                waitingForPark?.resume()
+                waitingForPark = nil
+            }
+        }
+        return firstCallURLs
+    }
+
+    /// Event-driven rather than a sleep: resumes as soon as the first call is actually parked.
+    func waitUntilParked() async {
+        guard !isParked else { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            waitingForPark = continuation
+        }
+    }
+
+    func release() {
+        isReleased = true
+        parked?.resume()
+        parked = nil
+    }
+}
+
 /// A `final class` (not a `struct`) so `deinit` can clean up the scratch directory, mirroring
 /// `AppSettingsTests`' scratch-`UserDefaults`-suite pattern.
 @MainActor
@@ -84,6 +152,60 @@ final class SitePickerModelTests {
             return
         }
         #expect(sites.map(\.displayName) == ["Apple Site", "Zebra Site"])
+    }
+
+    @Test("Refreshing an already-listed set of sites doesn't flicker back to loading")
+    func refreshFromSitesSkipsLoading() async throws {
+        let packageURL = try makePackage(displayName: "My Blog")
+        let probe = StateProbe()
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: ProbingPackageDiscovery(urls: [packageURL]) { probe.record() })
+        probe.model = model
+
+        // First refresh: nothing on screen yet, so `.loading` is the right thing to show.
+        await model.refresh()
+        #expect(probe.observedStates == [.loading])
+        guard case .sites(let sites) = model.state else {
+            Issue.record("expected .sites after the first refresh, got \(model.state)")
+            return
+        }
+
+        // Second refresh (the pull-to-refresh case): the list must stay up while it re-queries.
+        await model.refresh()
+        #expect(probe.observedStates.count == 2)
+        #expect(probe.observedStates.last == .sites(sites))
+        #expect(model.state == .sites(sites))
+    }
+
+    @Test("A slower earlier refresh can't overwrite a newer refresh's results")
+    func staleRefreshDoesNotOverwriteNewerResult() async throws {
+        let packageURL = try makePackage(displayName: "Made On The Mac")
+        // The first (launch-time) query predates the new site and would report an empty container;
+        // the second (pull-to-refresh) query sees it. The first one finishes last.
+        let discovery = GatedPackageDiscovery(firstCallURLs: [], laterCallURLs: [packageURL])
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: discovery)
+
+        let launchRefresh = Task { await model.refresh() }
+        await discovery.waitUntilParked()
+
+        await model.refresh()
+        guard case .sites(let afterManualRefresh) = model.state else {
+            Issue.record("expected .sites after the manual refresh, got \(model.state)")
+            return
+        }
+        #expect(afterManualRefresh.map(\.displayName) == ["Made On The Mac"])
+
+        await discovery.release()
+        await launchRefresh.value
+        // Without the generation guard this would have reverted to `.empty`.
+        guard case .sites(let sites) = model.state else {
+            Issue.record("expected the newer refresh's .sites to survive, got \(model.state)")
+            return
+        }
+        #expect(sites.map(\.displayName) == ["Made On The Mac"])
     }
 
     @Test("A package with no readable Info.plist marker is silently skipped")

--- a/docs/superpowers/plans/2026-08-07-ios-site-discovery-icloud.md
+++ b/docs/superpowers/plans/2026-08-07-ios-site-discovery-icloud.md
@@ -1,0 +1,809 @@
+# iOS Site Discovery via iCloud Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the iOS app (`AnglesiteMobile`) a real entry point that lists the user's `.anglesite`
+packages from their iCloud ubiquity container — via `NSMetadataQuery`, the App-Sandbox/iCloud-
+appropriate mechanism — instead of the manual "type a Worker URL" flow it has today, with explicit
+empty and iCloud-unavailable states and fixtured unit tests. Closes #866.
+
+**Architecture:** A testable `SitePickerModel` (`@MainActor @Observable`) lives in the `AnglesiteIOS`
+SwiftPM library alongside a small protocol seam (`UbiquitousPackageDiscovering`) wrapping
+`NSMetadataQuery`, mirroring the existing `UbiquityContainerResolving`/`FakeUbiquityContainerResolver`
+seam that `AnglesiteCore`'s `AppSettings.sitesRoot` already uses for the Mac's iCloud default storage
+(#865). Because `AnglesiteIOS` is a plain SwiftPM target (unlike `AnglesiteMobile`, which is an
+Xcode-only app target with no `swift test` coverage — see `CLAUDE.md`'s note on keeping app-target
+logic thin and pushed into a testable library), this is where all the real logic and its tests live.
+`AnglesiteMobile` gets only a thin SwiftUI screen (`SitePickerScreen`) that renders `SitePickerModel`'s
+state and becomes `AnglesiteMobileApp`'s new root scene.
+
+**Tech Stack:** Swift 6.4 / SwiftUI, `Foundation.NSMetadataQuery`, Swift Testing (`import Testing`),
+XcodeGen (`project.yml`), SwiftPM (`Package.swift`).
+
+## Global Constraints
+
+- Toolchain: Xcode 27+ / Swift 6.4 (per `CLAUDE.md`).
+- `AnglesiteIOS` and its new test target are Darwin-only — never added to `Package.swift`'s
+  `portableTargets` set (the Linux CI leg), so no `#if canImport(Darwin)` gating is needed inside
+  their new files.
+- Any new SwiftPM test target that transitively depends on `AnglesiteCore` needs
+  `linkerSettings: weakLinkFoundationModels` (see `Package.swift`'s `#541` comment) — otherwise a
+  beta-SDK/OS symbol mismatch can abort the test bundle at `dlopen`.
+- The iOS Debug build must stay buildable with **no Apple Developer account** (CI's `ios-build` lane
+  uses ad-hoc signing via `xcconfig/Signing-Debug.xcconfig`) — the iCloud entitlement requires a real
+  provisioning profile, so it must **not** land in the default Debug entitlements file. Mirror the
+  Mac target's existing `Resources/Anglesite-Debug.entitlements` /
+  `Resources/Anglesite-Debug-iCloud.entitlements` split (#1038) exactly.
+- iCloud container identifier is `iCloud.io.dwk.anglesite` everywhere (entitlements, `Info.plist`
+  keys, `AppSettings.ubiquityContainerIdentifier`) — must match across Mac and iOS since it's the
+  same physical container.
+- Out of scope (per the issue): site creation on iOS, and IndieAuth sign-in. Do not build either.
+- Do not delete or modify `Sources/AnglesiteMobile/RemoteSessionScreen.swift` /
+  `RemoteSessionModel.swift` / their supporting files — they belong to the separate, still-open #71
+  "remote sandbox thin client" epic (deferred to v2.0 under #342). This plan only stops referencing
+  `RemoteSessionScreen` from `AnglesiteMobileApp`'s root scene, per #800's owner decision
+  (2026-07-17) that the Micropub/iCloud-discovery flow is now the default iOS experience — it does
+  not remove the older code.
+
+---
+
+## File Structure
+
+- **Modify** `Sources/AnglesiteCore/AppSettings.swift` — widen `ubiquityContainerIdentifier` to
+  `public` so `AnglesiteIOS` can reuse the exact same constant instead of duplicating the literal.
+- **Create** `Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift` — the `NSMetadataQuery`
+  protocol seam + real implementation.
+- **Create** `Sources/AnglesiteIOS/SitePickerModel.swift` — `@MainActor @Observable` model +
+  `DiscoveredSite`.
+- **Create** `Tests/AnglesiteIOSTests/SitePickerModelTests.swift` — fixtured unit tests (missing
+  container, empty container, single site, multiple sites, unreadable marker).
+- **Modify** `Package.swift` — `AnglesiteIOS` target dependencies, new `AnglesiteIOSTests` target.
+- **Create** `Sources/AnglesiteMobile/SitePickerScreen.swift` — the SwiftUI screen.
+- **Modify** `Sources/AnglesiteMobile/AnglesiteMobileApp.swift` — new root scene.
+- **Create** `Resources/AnglesiteMobile.entitlements`, `Resources/AnglesiteMobile-Debug.entitlements`,
+  `Resources/AnglesiteMobile-Debug-iCloud.entitlements`.
+- **Modify** `project.yml` — `AnglesiteMobile` target's `CODE_SIGN_ENTITLEMENTS`.
+- **Modify** `xcconfig/Signing-Debug.xcconfig`, `xcconfig/Signing-Debug.local.xcconfig.example` — new
+  `ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS` indirection, mirroring `ANGLESITE_DEBUG_ENTITLEMENTS`.
+- **Modify** `Resources/Info-iOS.plist` — add `NSUbiquitousContainers`.
+
+---
+
+### Task 1: Expose `AppSettings.ubiquityContainerIdentifier` publicly
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/AppSettings.swift:85`
+
+**Interfaces:**
+- Produces: `public static let AppSettings.ubiquityContainerIdentifier: String` (was `internal`) —
+  Task 2's `SitePickerModel` reads this directly instead of duplicating the container-ID literal.
+
+- [ ] **Step 1: Widen the access modifier**
+
+In `Sources/AnglesiteCore/AppSettings.swift`, change line 85 from:
+
+```swift
+    static let ubiquityContainerIdentifier = "iCloud.io.dwk.anglesite"
+```
+
+to:
+
+```swift
+    /// Public so `AnglesiteIOS`'s site-discovery seam (#866) can reuse the exact same identifier
+    /// instead of duplicating this literal — it's the same physical iCloud container on both
+    /// platforms.
+    public static let ubiquityContainerIdentifier = "iCloud.io.dwk.anglesite"
+```
+
+- [ ] **Step 2: Run the existing AppSettings suite to confirm nothing broke**
+
+Run: `swift test --package-path . --filter AppSettingsTests`
+Expected: PASS (all existing cases still pass; a wider access modifier can't break internal callers).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteCore/AppSettings.swift
+git commit -m "feat(#866): expose AppSettings.ubiquityContainerIdentifier publicly"
+```
+
+---
+
+### Task 2: Site-discovery seam + `SitePickerModel` in `AnglesiteIOS`
+
+**Files:**
+- Modify: `Package.swift:134-139` (AnglesiteIOS target dependencies), `Package.swift:190-196` (add
+  new test target after `AnglesiteBridgeTests`)
+- Create: `Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift`
+- Create: `Sources/AnglesiteIOS/SitePickerModel.swift`
+- Create: `Tests/AnglesiteIOSTests/SitePickerModelTests.swift`
+
+**Interfaces:**
+- Consumes: `AnglesiteSiteModel.AnglesitePackage` (`init(url:)`, `readMarker(fileManager:) throws ->
+  Marker`, `Marker.siteID: UUID`, `Marker.displayName: String`, `static createSkeleton(at:displayName:
+  fileManager:) throws -> (AnglesitePackage, Marker)`, `static packageExtension: String`);
+  `AnglesiteCore.UbiquityContainerResolving` (`func url(forUbiquityContainerIdentifier:) -> URL?`,
+  `FileManager` already conforms); `AnglesiteCore.AppSettings.ubiquityContainerIdentifier: String`
+  (Task 1).
+- Produces: `public protocol UbiquitousPackageDiscovering { func discoverPackages() async -> [URL] }`;
+  `public final class NSMetadataQueryPackageDiscovery: UbiquitousPackageDiscovering`; `public final
+  class SitePickerModel` with `public enum State: Equatable { case loading, iCloudUnavailable, empty,
+  sites([DiscoveredSite]) }`, `public struct DiscoveredSite: Identifiable, Sendable, Equatable { let
+  id: UUID; let displayName: String; let packageURL: URL }`, `public private(set) var state: State`,
+  `public init(ubiquityContainerResolver: UbiquityContainerResolving = FileManager.default,
+  packageDiscovery: UbiquitousPackageDiscovering = NSMetadataQueryPackageDiscovery(), fileManager:
+  FileManager = .default)`, `public func refresh() async`. Task 3's `SitePickerScreen` consumes all
+  of this from `AnglesiteMobile`.
+
+- [ ] **Step 1: Wire the new dependencies and test target in `Package.swift`**
+
+Change `Package.swift:134-139` from:
+
+```swift
+    .target(
+        name: "AnglesiteIOS",
+        dependencies: [],
+        path: "Sources/AnglesiteIOS",
+        swiftSettings: strictConcurrency
+    ),
+```
+
+to:
+
+```swift
+    .target(
+        name: "AnglesiteIOS",
+        dependencies: ["AnglesiteSiteModel", "AnglesiteCore"],
+        path: "Sources/AnglesiteIOS",
+        swiftSettings: strictConcurrency
+    ),
+```
+
+Then, immediately after the `AnglesiteBridgeTests` target definition (`Package.swift:190-196`,
+which currently ends the `packageTargets` array literal with `]`), add a new test target so the
+array becomes:
+
+```swift
+    .testTarget(
+        name: "AnglesiteBridgeTests",
+        dependencies: ["AnglesiteBridge", "AnglesiteTestSupport"],
+        path: "Tests/AnglesiteBridgeTests",
+        swiftSettings: strictConcurrency,
+        linkerSettings: weakLinkFoundationModels
+    ),
+    .testTarget(
+        name: "AnglesiteIOSTests",
+        dependencies: ["AnglesiteIOS", "AnglesiteSiteModel", "AnglesiteCore"],
+        path: "Tests/AnglesiteIOSTests",
+        swiftSettings: strictConcurrency,
+        // Transitively depends on AnglesiteCore (via AnglesiteIOS), so it needs the same #541
+        // weak-link workaround as AnglesiteBridgeTests/AnglesiteBridgeCoreTests above.
+        linkerSettings: weakLinkFoundationModels
+    )
+]
+```
+
+(i.e. move the closing `]` of the array literal to after the new target, same as the existing
+targets' comma-separated style.)
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `Tests/AnglesiteIOSTests/SitePickerModelTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteIOS
+import AnglesiteCore
+import AnglesiteSiteModel
+
+private struct FakeUbiquityContainerResolver: UbiquityContainerResolving {
+    let result: URL?
+    func url(forUbiquityContainerIdentifier containerIdentifier: String?) -> URL? { result }
+}
+
+private struct FakeUbiquitousPackageDiscovery: UbiquitousPackageDiscovering {
+    let urls: [URL]
+    func discoverPackages() async -> [URL] { urls }
+}
+
+/// A `final class` (not a `struct`) so `deinit` can clean up the scratch directory, mirroring
+/// `AppSettingsTests`' scratch-`UserDefaults`-suite pattern.
+@MainActor
+final class SitePickerModelTests {
+    private let scratchRoot: URL
+    private let fakeContainer = URL(fileURLWithPath: "/tmp/fake-ubiquity-container", isDirectory: true)
+
+    init() {
+        scratchRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SitePickerModelTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    deinit {
+        let root = scratchRoot
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func makePackage(displayName: String) throws -> URL {
+        let url = scratchRoot.appendingPathComponent("\(displayName).anglesite", isDirectory: true)
+        _ = try AnglesitePackage.createSkeleton(at: url, displayName: displayName)
+        return url
+    }
+
+    @Test("Missing iCloud container surfaces iCloudUnavailable, not empty")
+    func missingContainerSurfacesUnavailable() async {
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: nil),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: []))
+        await model.refresh()
+        #expect(model.state == .iCloudUnavailable)
+    }
+
+    @Test("Available container with no packages surfaces empty")
+    func emptyContainerSurfacesEmpty() async {
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: []))
+        await model.refresh()
+        #expect(model.state == .empty)
+    }
+
+    @Test("Single discovered package surfaces one site")
+    func singleSiteSurfacesInList() async throws {
+        let packageURL = try makePackage(displayName: "My Blog")
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: [packageURL]))
+        await model.refresh()
+        guard case .sites(let sites) = model.state else {
+            Issue.record("expected .sites, got \(model.state)")
+            return
+        }
+        #expect(sites.count == 1)
+        #expect(sites.first?.displayName == "My Blog")
+        #expect(sites.first?.packageURL == packageURL)
+    }
+
+    @Test("Multiple discovered packages surface sorted by display name")
+    func multipleSitesSortedByName() async throws {
+        let zebra = try makePackage(displayName: "Zebra Site")
+        let apple = try makePackage(displayName: "Apple Site")
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: [zebra, apple]))
+        await model.refresh()
+        guard case .sites(let sites) = model.state else {
+            Issue.record("expected .sites, got \(model.state)")
+            return
+        }
+        #expect(sites.map(\.displayName) == ["Apple Site", "Zebra Site"])
+    }
+
+    @Test("A package with no readable Info.plist marker is silently skipped")
+    func unreadableMarkerSkipped() async throws {
+        let corruptURL = scratchRoot.appendingPathComponent("Corrupt.anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(at: corruptURL, withIntermediateDirectories: true)
+        let model = SitePickerModel(
+            ubiquityContainerResolver: FakeUbiquityContainerResolver(result: fakeContainer),
+            packageDiscovery: FakeUbiquitousPackageDiscovery(urls: [corruptURL]))
+        await model.refresh()
+        #expect(model.state == .empty)
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail (types don't exist yet)**
+
+Run: `swift test --package-path . --filter AnglesiteIOSTests`
+Expected: FAIL to build — `SitePickerModel`, `UbiquitousPackageDiscovering`,
+`FakeUbiquitousPackageDiscovery`'s conformance target, etc. don't exist yet.
+
+- [ ] **Step 4: Write the discovery seam**
+
+Create `Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift`:
+
+```swift
+import Foundation
+import AnglesiteSiteModel
+
+/// Wraps `NSMetadataQuery` so `SitePickerModel` can be tested against fixtured results (#866)
+/// instead of the real iCloud state of whatever machine runs `swift test` — mirrors
+/// `AnglesiteCore`'s `UbiquityContainerResolving`/`FakeUbiquityContainerResolver` seam (#865).
+public protocol UbiquitousPackageDiscovering: Sendable {
+    /// Runs a one-shot query for `.anglesite` packages in the app's iCloud ubiquity container
+    /// and returns their URLs once the initial gather completes. Callers are expected to have
+    /// already confirmed the container is available (`UbiquityContainerResolving`) before calling
+    /// this — it does not itself distinguish "no container" from "container has no packages".
+    func discoverPackages() async -> [URL]
+}
+
+/// Real `NSMetadataQuery`-backed implementation. Scoped to
+/// `NSMetadataQueryUbiquitousDocumentsScope` (the app's own ubiquity container's `Documents/`
+/// folder — matching `AppSettings.sitesRoot`'s `container/Documents` convention, #865) rather than
+/// a raw file-URL scope or a broader ubiquitous-data scope: per `SyncModel.observeBundleChanges`'s
+/// prior art (`Sources/AnglesiteApp/SyncModel.swift`), ubiquitous item metadata keys like
+/// `NSMetadataItemPathKey` aren't reliably populated until an item is first resolved, so filtering
+/// by path prefix is unreliable — the predefined scope constant is the documented-correct way to
+/// scope a search to this app's own ubiquitous documents instead.
+///
+/// No stored mutable state: each call creates and tears down its own query and observer, so
+/// concurrent calls can't interfere with each other.
+public final class NSMetadataQueryPackageDiscovery: UbiquitousPackageDiscovering, @unchecked Sendable {
+    public init() {}
+
+    public func discoverPackages() async -> [URL] {
+        await withCheckedContinuation { continuation in
+            let query = NSMetadataQuery()
+            query.searchScopes = [NSMetadataQueryUbiquitousDocumentsScope]
+            query.predicate = NSPredicate(
+                format: "%K ENDSWITH %@",
+                NSMetadataItemFSNameKey, ".\(AnglesitePackage.packageExtension)"
+            )
+
+            var observer: NSObjectProtocol?
+            observer = NotificationCenter.default.addObserver(
+                forName: .NSMetadataQueryDidFinishGathering, object: query, queue: .main
+            ) { _ in
+                query.disableUpdates()
+                query.stop()
+                if let observer {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+                let urls = (0..<query.resultCount).compactMap { index -> URL? in
+                    (query.result(at: index) as? NSMetadataItem)?
+                        .value(forAttribute: NSMetadataItemURLKey) as? URL
+                }
+                continuation.resume(returning: urls)
+            }
+            query.start()
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Write `SitePickerModel`**
+
+Create `Sources/AnglesiteIOS/SitePickerModel.swift`:
+
+```swift
+import Foundation
+import SwiftUI
+import AnglesiteCore
+import AnglesiteSiteModel
+
+/// Drives the iOS app's entry point (#866): lists the user's `.anglesite` packages found in their
+/// iCloud ubiquity container, in place of the old "type a site URL" flow. `@MainActor` +
+/// `@Observable` so `SitePickerScreen` (`AnglesiteMobile`) can bind to it directly, matching
+/// `RemoteSessionModel`'s existing convention in this target.
+@MainActor
+@Observable
+public final class SitePickerModel {
+    /// A discovered `.anglesite` package, ready to show in the picker.
+    public struct DiscoveredSite: Identifiable, Sendable, Equatable {
+        /// The package's stable site UUID (`AnglesitePackage.Marker.siteID`) — path-independent,
+        /// matching how `SiteStore.Site` identifies sites on the Mac.
+        public let id: UUID
+        public let displayName: String
+        public let packageURL: URL
+    }
+
+    /// Distinguishes "iCloud itself isn't available" from "iCloud is available but has no sites
+    /// yet" — the design's explicit requirement (spec §4/§7): the empty state's "create a site on
+    /// your Mac" message must never show when the real problem is iCloud access.
+    public enum State: Equatable {
+        case loading
+        case iCloudUnavailable
+        case empty
+        case sites([DiscoveredSite])
+    }
+
+    public private(set) var state: State = .loading
+
+    private let ubiquityContainerResolver: UbiquityContainerResolving
+    private let packageDiscovery: UbiquitousPackageDiscovering
+    private let fileManager: FileManager
+
+    public init(
+        ubiquityContainerResolver: UbiquityContainerResolving = FileManager.default,
+        packageDiscovery: UbiquitousPackageDiscovering = NSMetadataQueryPackageDiscovery(),
+        fileManager: FileManager = .default
+    ) {
+        self.ubiquityContainerResolver = ubiquityContainerResolver
+        self.packageDiscovery = packageDiscovery
+        self.fileManager = fileManager
+    }
+
+    /// Re-runs discovery from scratch. Safe to call repeatedly (pull-to-refresh, a "Try Again"
+    /// button, or the initial `.task` on `SitePickerScreen`).
+    public func refresh() async {
+        state = .loading
+        guard ubiquityContainerResolver.url(
+            forUbiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier
+        ) != nil else {
+            state = .iCloudUnavailable
+            return
+        }
+
+        let packageURLs = await packageDiscovery.discoverPackages()
+        let sites = packageURLs
+            .compactMap { url -> DiscoveredSite? in
+                let package = AnglesitePackage(url: url)
+                guard let marker = try? package.readMarker(fileManager: fileManager) else {
+                    return nil
+                }
+                return DiscoveredSite(id: marker.siteID, displayName: marker.displayName, packageURL: url)
+            }
+            .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+
+        state = sites.isEmpty ? .empty : .sites(sites)
+    }
+}
+```
+
+(The `import SwiftUI` is unused by this file today but matches `RemoteSessionModel`'s existing
+import style for `@Observable` models in this codebase — drop it if `swift build` warns about an
+unused import; keep `import Foundation` and `import AnglesiteCore`/`AnglesiteSiteModel` regardless.)
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter AnglesiteIOSTests`
+Expected: PASS — all 5 tests green.
+
+- [ ] **Step 7: Run the full portable + Darwin suite to confirm no regressions**
+
+Run: `swift test --package-path .`
+Expected: PASS (existing suites unaffected; this also exercises `AnglesiteIOS`'s new dependency
+edges compile cleanly for the macOS host target, which is how `AnglesiteIOS` already builds under
+plain `swift test`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Package.swift Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift \
+  Sources/AnglesiteIOS/SitePickerModel.swift Tests/AnglesiteIOSTests/SitePickerModelTests.swift
+git commit -m "feat(#866): add NSMetadataQuery-backed iCloud site discovery to AnglesiteIOS"
+```
+
+---
+
+### Task 3: `SitePickerScreen` and new app entry point
+
+**Files:**
+- Create: `Sources/AnglesiteMobile/SitePickerScreen.swift`
+- Modify: `Sources/AnglesiteMobile/AnglesiteMobileApp.swift`
+
+**Interfaces:**
+- Consumes: `AnglesiteIOS.SitePickerModel` (`init()`, `state: State`, `func refresh() async`),
+  `SitePickerModel.State`, `SitePickerModel.DiscoveredSite` (Task 2).
+- Produces: `struct SitePickerScreen: View` — the new root view referenced by
+  `AnglesiteMobileApp.body`.
+
+This task has no `swift test` coverage of its own: `AnglesiteMobile` is an Xcode-only app target
+(not a `Package.swift` target), so its build is verified with `xcodebuild`, matching how
+`RemoteSessionScreen.swift` (its sibling file) has none either. All the testable logic already
+landed in Task 2.
+
+- [ ] **Step 1: Write the screen**
+
+Create `Sources/AnglesiteMobile/SitePickerScreen.swift`:
+
+```swift
+import SwiftUI
+import AnglesiteIOS
+
+/// The iOS app's entry point (#866): lists `.anglesite` packages discovered in the user's iCloud
+/// container instead of asking for a typed site URL. Replaces `RemoteSessionScreen` as
+/// `AnglesiteMobileApp`'s root — per #800's owner decision (2026-07-17) that this iCloud-discovery
+/// + Micropub flow, not the older remote-sandbox thin client (#71, deferred to v2.0 under #342),
+/// is the default iOS experience. Picking a site doesn't do anything yet — that's the sibling
+/// IndieAuth-onboarding issue.
+struct SitePickerScreen: View {
+    @State private var model = SitePickerModel()
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text("Your Sites"))
+                .task { await model.refresh() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.state {
+        case .loading:
+            ProgressView("Finding your sites…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .iCloudUnavailable:
+            ContentUnavailableView {
+                Label("iCloud Unavailable", systemImage: "icloud.slash")
+            } description: {
+                Text("Sign in to iCloud and turn on iCloud Drive to see your Anglesite sites.")
+            } actions: {
+                Button("Try Again") { Task { await model.refresh() } }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .empty:
+            ContentUnavailableView {
+                Label("No Sites Found", systemImage: "globe")
+            } description: {
+                Text("No sites found — create a site in Anglesite on your Mac first.")
+            } actions: {
+                Button("Refresh") { Task { await model.refresh() } }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .sites(let sites):
+            List(sites) { site in
+                Text(site.displayName)
+            }
+            .refreshable { await model.refresh() }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire it as the app's root scene**
+
+Change `Sources/AnglesiteMobile/AnglesiteMobileApp.swift` from:
+
+```swift
+import SwiftUI
+
+/// iOS thin client (#71): a remote-only shell over `RemoteSandboxSiteRuntime`. No local files,
+/// no subprocesses, no local containers — the site runs in the user's Cloudflare sandbox and
+/// this app is a `WKWebView` plus MCP-over-HTTPS edits (design 2026-06-23).
+@main
+struct AnglesiteMobileApp: App {
+    @State private var model = RemoteSessionModel()
+
+    var body: some Scene {
+        WindowGroup {
+            RemoteSessionScreen(model: model)
+        }
+    }
+}
+```
+
+to:
+
+```swift
+import SwiftUI
+
+/// Entry point (#866): lists `.anglesite` packages discovered via iCloud. `RemoteSessionScreen`
+/// (the #71 remote-sandbox thin client, deferred to v2.0 under #342) is still in this target but
+/// no longer wired to the root scene — see this file's git history, and #800's owner decision
+/// (2026-07-17) that the iCloud-discovery + Micropub flow is the default iOS experience now.
+@main
+struct AnglesiteMobileApp: App {
+    var body: some Scene {
+        WindowGroup {
+            SitePickerScreen()
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteMobile/SitePickerScreen.swift Sources/AnglesiteMobile/AnglesiteMobileApp.swift
+git commit -m "feat(#866): make the iCloud site picker the iOS app's entry point"
+```
+
+(Building this task is verified together with Task 4's entitlements wiring in Task 5, since
+`xcodebuild` for `AnglesiteMobile` needs the entitlements file the next task creates to exist
+first — `CODE_SIGN_ENTITLEMENTS` isn't set until Task 4.)
+
+---
+
+### Task 4: iOS iCloud entitlements + `Info-iOS.plist`
+
+**Files:**
+- Create: `Resources/AnglesiteMobile.entitlements`
+- Create: `Resources/AnglesiteMobile-Debug.entitlements`
+- Create: `Resources/AnglesiteMobile-Debug-iCloud.entitlements`
+- Modify: `project.yml:156-209` (the `AnglesiteMobile` target block)
+- Modify: `xcconfig/Signing-Debug.xcconfig`
+- Modify: `xcconfig/Signing-Debug.local.xcconfig.example`
+- Modify: `Resources/Info-iOS.plist`
+
+**Interfaces:** None (build configuration only, no Swift symbols).
+
+- [ ] **Step 1: Create the Release/base entitlements file (has iCloud)**
+
+Create `Resources/AnglesiteMobile.entitlements`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- iCloud site discovery (#866): must match AppSettings.ubiquityContainerIdentifier
+	     (AnglesiteCore) and the NSUbiquitousContainers key in Resources/Info-iOS.plist. Same
+	     container the Mac app's default site storage (#865) writes into. -->
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.io.dwk.anglesite</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: Create the default (CI-safe, no-iCloud) Debug entitlements file**
+
+Create `Resources/AnglesiteMobile-Debug.entitlements`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- NO iCloud entitlement here (mirrors Resources/Anglesite-Debug.entitlements, #1038): the
+	     iCloud capability needs a real provisioning profile even under ad-hoc/no-Team signing,
+	     which would break the no-Apple-account Debug build CI's ios-build lane (#864) relies on.
+	     SitePickerModel already treats "no ubiquity container" the same as "iCloud unavailable"
+	     and shows that state instead of crashing. Contributors with a real Team who want to
+	     exercise iCloud discovery locally: point ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS at
+	     Resources/AnglesiteMobile-Debug-iCloud.entitlements from
+	     xcconfig/Signing-Debug.local.xcconfig (see Signing-Debug.local.xcconfig.example). -->
+</dict>
+</plist>
+```
+
+- [ ] **Step 3: Create the opt-in Debug-with-iCloud entitlements file**
+
+Create `Resources/AnglesiteMobile-Debug-iCloud.entitlements`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Opt-in Debug entitlements (mirrors Resources/Anglesite-Debug-iCloud.entitlements, #1038):
+	     identical to AnglesiteMobile-Debug.entitlements plus the iCloud capability. Requires a
+	     real Team/provisioning profile — see Signing-Debug.local.xcconfig.example. -->
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.io.dwk.anglesite</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+</dict>
+</plist>
+```
+
+- [ ] **Step 4: Add the `ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS` xcconfig indirection**
+
+In `xcconfig/Signing-Debug.xcconfig`, after the existing `ANGLESITE_DEBUG_ENTITLEMENTS = ...` line
+and before the `#include? "Signing-Debug.local.xcconfig"` line, add:
+
+```
+// The AnglesiteMobile target's CODE_SIGN_ENTITLEMENTS (Debug config) reads this indirection
+// (#866, mirrors ANGLESITE_DEBUG_ENTITLEMENTS above) so a local override can point at
+// Resources/AnglesiteMobile-Debug-iCloud.entitlements without editing this tracked file. Must
+// stay the no-iCloud file by default — same CI-safe reason as the Mac target above.
+ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS = Resources/AnglesiteMobile-Debug.entitlements
+```
+
+- [ ] **Step 5: Document the opt-in in the local xcconfig example**
+
+In `xcconfig/Signing-Debug.local.xcconfig.example`, after the existing commented-out
+`ANGLESITE_DEBUG_ENTITLEMENTS = ...` line, add:
+
+```
+// Same idea for the iOS target (#866):
+// ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS = Resources/AnglesiteMobile-Debug-iCloud.entitlements
+```
+
+- [ ] **Step 6: Wire `CODE_SIGN_ENTITLEMENTS` into the `AnglesiteMobile` target**
+
+In `project.yml`, inside the `AnglesiteMobile` target's `settings.base` block, add
+`CODE_SIGN_ENTITLEMENTS` next to the existing `INFOPLIST_FILE`/`GENERATE_INFOPLIST_FILE` lines:
+
+```yaml
+        INFOPLIST_FILE: Resources/Info-iOS.plist
+        GENERATE_INFOPLIST_FILE: NO
+        # Release keeps the clean iCloud entitlements; Debug overrides to the no-iCloud file by
+        # default (#866, mirrors the Anglesite/Mac target's CODE_SIGN_ENTITLEMENTS below).
+        CODE_SIGN_ENTITLEMENTS: Resources/AnglesiteMobile.entitlements
+```
+
+Then, inside the same target's `settings.configs.Debug` block (create it if it doesn't exist yet;
+today only `configs.Release` exists), add the override:
+
+```yaml
+      configs:
+        Debug:
+          CODE_SIGN_ENTITLEMENTS: $(ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS)
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+```
+
+- [ ] **Step 7: Add `NSUbiquitousContainers` to `Info-iOS.plist`**
+
+In `Resources/Info-iOS.plist`, add this key before the closing `</dict>`:
+
+```xml
+	<key>NSUbiquitousContainers</key>
+	<dict>
+		<key>iCloud.io.dwk.anglesite</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>Any</string>
+			<key>NSUbiquitousContainerName</key>
+			<string>Anglesite</string>
+		</dict>
+	</dict>
+```
+
+- [ ] **Step 8: Regenerate the Xcode project and build the iOS target**
+
+Run:
+```bash
+xcodegen generate --quiet
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile \
+  -configuration Debug -destination 'generic/platform=iOS Simulator' build
+```
+Expected: `BUILD SUCCEEDED` — this is the exact invocation CI's `ios-build` lane runs
+(`.github/workflows/ci.yml`), so it proves both this task's entitlements wiring and Task 3's new
+root scene compile together under the ad-hoc, no-Apple-account-safe Debug config.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Resources/AnglesiteMobile.entitlements Resources/AnglesiteMobile-Debug.entitlements \
+  Resources/AnglesiteMobile-Debug-iCloud.entitlements Resources/Info-iOS.plist \
+  project.yml xcconfig/Signing-Debug.xcconfig xcconfig/Signing-Debug.local.xcconfig.example
+git commit -m "feat(#866): add iOS iCloud entitlements for site discovery"
+```
+
+---
+
+### Task 5: Full verification pass
+
+**Files:** None (verification only).
+
+**Interfaces:** None.
+
+- [ ] **Step 1: Run the full SwiftPM suite**
+
+Run: `swift test --package-path .`
+Expected: PASS, including the new `AnglesiteIOSTests`.
+
+- [ ] **Step 2: Build the macOS app target (confirm the AnglesiteCore access-level change didn't
+  break the Mac build)**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 3: Re-confirm the iOS build (already run in Task 4, re-run after the full sequence)**
+
+Run:
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile \
+  -configuration Debug -destination 'generic/platform=iOS Simulator' build
+```
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Diff review against `CONTRIBUTING.md`**
+
+Confirm: commit subjects ≤72 chars; no drive-by unrelated changes; `RemoteSessionScreen.swift` /
+`RemoteSessionModel.swift` untouched; String Catalog note acknowledged (no new
+`Text`/`Label`/`String(localized:)` literals need catalog merging beyond what `SitePickerScreen.swift`
+introduces — note in the PR body that the CLI build can't merge `Localizable.xcstrings` and this
+was not done, per `CONTRIBUTING.md`'s caveat, since no interactive Xcode session is available here).
+
+- [ ] **Step 5: Open the PR**
+
+Follow `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings (Summary, Paired PR check, Test plan).
+Body must include `Closes #866`. Note in Test plan which commands were run (Steps 1-3 above) and
+that `xcstringstool sync` was not run (no interactive Xcode session available).

--- a/project.yml
+++ b/project.yml
@@ -185,6 +185,9 @@ targets:
         PRODUCT_NAME: Anglesite
         INFOPLIST_FILE: Resources/Info-iOS.plist
         GENERATE_INFOPLIST_FILE: NO
+        # Release keeps the clean iCloud entitlements; Debug overrides to the no-iCloud file by
+        # default (#866, mirrors the Anglesite/Mac target's CODE_SIGN_ENTITLEMENTS below).
+        CODE_SIGN_ENTITLEMENTS: Resources/AnglesiteMobile.entitlements
         IPHONEOS_DEPLOYMENT_TARGET: "27.0"
         TARGETED_DEVICE_FAMILY: "1,2"
         SUPPORTS_MACCATALYST: NO
@@ -197,6 +200,8 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"
       configs:
+        Debug:
+          CODE_SIGN_ENTITLEMENTS: $(ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS)
         Release:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Apple Distribution"

--- a/xcconfig/Signing-Debug.local.xcconfig.example
+++ b/xcconfig/Signing-Debug.local.xcconfig.example
@@ -11,3 +11,6 @@ DEVELOPMENT_TEAM = YOUR_TEAM_ID
 // provisioning profile for the iCloud capability, which ad-hoc signing can't self-grant.
 // Uncomment to opt in:
 // ANGLESITE_DEBUG_ENTITLEMENTS = Resources/Anglesite-Debug-iCloud.entitlements
+
+// Same idea for the iOS target (#866):
+// ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS = Resources/AnglesiteMobile-Debug-iCloud.entitlements

--- a/xcconfig/Signing-Debug.xcconfig
+++ b/xcconfig/Signing-Debug.xcconfig
@@ -17,4 +17,10 @@ DEVELOPMENT_TEAM =
 // under the ad-hoc signing above, which breaks the no-Apple-account Debug build promise.
 ANGLESITE_DEBUG_ENTITLEMENTS = Resources/Anglesite-Debug.entitlements
 
+// The AnglesiteMobile target's CODE_SIGN_ENTITLEMENTS (Debug config) reads this indirection
+// (#866, mirrors ANGLESITE_DEBUG_ENTITLEMENTS above) so a local override can point at
+// Resources/AnglesiteMobile-Debug-iCloud.entitlements without editing this tracked file. Must
+// stay the no-iCloud file by default — same CI-safe reason as the Mac target above.
+ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS = Resources/AnglesiteMobile-Debug.entitlements
+
 #include? "Signing-Debug.local.xcconfig"


### PR DESCRIPTION
Closes #866

## Summary

- Adds `SitePickerModel` + `NSMetadataQueryPackageDiscovery` (`AnglesiteIOS`) — enumerates `.anglesite` packages in the app's iCloud ubiquity container via `NSMetadataQuery` and reads each package's `Info.plist` marker, with explicit `.loading`/`.iCloudUnavailable`/`.empty`/`.sites` states so "iCloud itself isn't available" never shows the "create a site on your Mac" copy.
- Makes the picker (`SitePickerScreen`) the iOS app's new entry point, replacing `RemoteSessionScreen` as `AnglesiteMobileApp`'s root scene — per #800's owner decision (2026-07-17) that this iCloud-discovery flow is now the default iOS experience. `RemoteSessionScreen`/`RemoteSessionModel` (the #71 remote-sandbox thin client) are untouched, just no longer wired to the root — that epic is deferred to v2.0 under #342, not removed.
- Adds the iOS iCloud entitlements (`com.apple.developer.icloud-container-identifiers`/`icloud-services`) with the same Debug/Debug-iCloud/Release split the Mac target already uses (#1038), so CI's `ios-build` lane keeps building with no Apple Developer account.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite run to completion once (4,570+ passing; 3 pre-existing failures unrelated to this branch — see note below). Focused `swift test --package-path . --filter AnglesiteIOSTests` (5/5, pristine) re-confirmed on the final commit; `swift build --build-tests` (compiles every test target, including ones the full run can't reliably finish) is clean.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile -configuration Debug -destination 'generic/platform=iOS Simulator' build` — BUILD SUCCEEDED (matches CI's `ios-build` lane invocation exactly).
- [ ] Manual smoke: not run — no way to drive the iOS Simulator or real iCloud state from this session. The picker's four states are covered by the unit tests against real temp-directory `.anglesite` package fixtures, but nobody has watched it run on-device against a real iCloud account yet.

### Design notes / known follow-ups

- **A design-level gap, not a regression**: a package whose `Info.plist` hasn't finished downloading from iCloud yet is silently skipped this round (same as any other unreadable marker), so a very-recently-synced site might not appear until a later refresh. Caught in review; accepted as a v1 limitation rather than blocking this PR — worth a tracked follow-up if it turns out to bite real users.
- Duplicate site UUIDs (e.g. a package cloned via Finder) could collide in the picker's `List` identity — not handled.
- `discoverPackages()` doesn't observe task cancellation — a dismissed screen leaves the in-flight query running until it gathers. Harmless today.
- The String Catalog (`Sources/AnglesiteMobile/Localizable.xcstrings`) was **not** updated for the new SwiftUI strings in `SitePickerScreen.swift` — per `CONTRIBUTING.md`, that merge only happens in an interactive Xcode session, which wasn't available here. Needs a follow-up sync.
- `iCloud.io.dwk.anglesite` needs to be attached to the `io.dwk.anglesite.ios` App ID in the Apple Developer portal for the Release entitlement to actually provision — a one-time account-side step, not something this PR can do.
- Commit `ba18e438`'s subject is 76 characters (repo convention caps at 72) — left as-is rather than rewriting pushed history; this repo's recent history looks squash-merge-per-PR, so the PR title above (kept ≤72 chars) is what should actually land in `main`.
- Full-suite `swift test --package-path .` runs are unreliable on this dev machine independent of this branch: a `DeployModelTests` assertion failure (Cloudflare sign-in flow, `AnglesiteAppTests`) occasionally hangs for a very long time while printing its failure diff, rather than completing normally — reproduced twice at the identical spot, unrelated to any file this PR touches. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)