### PR TITLE
fix(#1360): scope signInFailureStaysOnSheet to an in-memory keychain

### DIFF
--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -811,7 +811,12 @@ struct DeployModelTests {
             discoveryURL: URL(string: "https://dash.cloudflare.com/.well-known/openid-configuration")!,
             transport: { _ in throw Boom() })
         let oauthSignIn = CloudflareOAuthSignIn(client: client, present: { _ in throw Boom() })
-        let model = DeployModel(command: command, logCenter: LogCenter(), oauthSignIn: oauthSignIn)
+        // Without an explicit keychain, `DeployModel` defaults to the real `KeychainStore()` — if
+        // this machine has ever stored a real Cloudflare credential, `hasUsableToken()` returns
+        // true, `deploy()` never parks a `pendingDeploy`, and `signInWithCloudflare()` below fails
+        // with "No deploy is waiting" instead of exercising the sign-in-failure path under test.
+        let keychain = InMemorySecretStore()
+        let model = DeployModel(command: command, logCenter: LogCenter(), keychain: keychain, oauthSignIn: oauthSignIn)
         let directory = FileManager.default.temporaryDirectory
 
         model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])


### PR DESCRIPTION
Closes #1360

## Summary

- `signInFailureStaysOnSheet` in `Tests/AnglesiteAppTests/DeployModelTests.swift` was the only Cloudflare-keychain test in the file that didn't pass an explicit `keychain:` to `DeployModel`, so it fell back to the real `KeychainStore()` (production service `io.dwk.anglesite`) instead of an `InMemorySecretStore()`.
- On a machine with a real stored Cloudflare credential, `hasUsableToken()` read it, `deploy()` never parked a `pendingDeploy`/presented the token sheet, and the immediately-following `signInWithCloudflare()` failed with "No deploy is waiting" instead of exercising the sign-in-failure path under test.
- Fix: construct and pass an `InMemorySecretStore()`, matching the pattern already used by the three sibling tests (`oauthCredentialSatisfiesHasUsableToken`, `deadOAuthCredentialDoesNotSatisfyHasUsableToken`, `signInSuccessPersistsAndDispatches`).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path . --filter DeployModelTests` — 23/23 passing, including `signInFailureStaysOnSheet` (was reliably failing before this fix).
- [ ] `swift test --package-path .` (full suite) — not completed locally; this machine has several other agents' `swift test` processes running concurrently in sibling worktrees and the full run stalled under that contention rather than finishing in CI's usual ~3-4 min. Deferring to CI as the arbiter here.
- [ ] `xcodebuild ... build` — not run; this is a test-only change with no app-target source touched.