### PR TITLE
WYSIWYG slice 3 — canvas chrome: inline text, palette drops, breakpoint views

### DIFF
--- a/JS/wysiwyg-engine/e2e/breakpoints-fixture-page.ts
+++ b/JS/wysiwyg-engine/e2e/breakpoints-fixture-page.ts
@@ -1,0 +1,78 @@
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { BreakpointCanvas } from "../src/breakpoints.js";
+import type { BlockModel } from "../src/types.js";
+import type { HandleRect } from "../src/selection.js";
+
+const initialModel: BlockModel = {
+  path: "src/pages/index.astro",
+  version: "fixture-initial",
+  rootIds: ["b1", "b2"],
+  blocks: {
+    b1: { id: "b1", kind: "astro", componentName: "Hero", props: { title: "Welcome" }, slots: {}, sourceSpan: [0, 10] },
+    b2: { id: "b2", kind: "astro", componentName: "Testimonial", props: { quote: "Great!" }, slots: {}, sourceSpan: [11, 20] },
+  },
+};
+
+const host = new FixtureHost(initialModel);
+const engine = new WysiwygEngine(initialModel, host);
+
+function render(model: BlockModel, doc: Document): void {
+  const root = doc.getElementById("canvas");
+  if (!root) return;
+  root.innerHTML = "";
+  for (const id of model.rootIds) {
+    const block = model.blocks[id];
+    if (!block) continue;
+    const el = doc.createElement("div");
+    el.setAttribute("data-anglesite-block-id", id);
+    el.textContent = block.componentName;
+    el.style.cssText = "padding:8px;margin:4px;border:1px solid #ccc;";
+    el.addEventListener("click", () => engine.selection.select(id));
+    root.appendChild(el);
+  }
+}
+
+const canvas = new BreakpointCanvas(engine, render);
+const frameNames = ["phone", "tablet", "desktop"] as const;
+
+function registerFrames(): void {
+  for (const name of frameNames) {
+    const iframe = document.getElementById(name) as HTMLIFrameElement | null;
+    const frameDoc = iframe?.contentDocument;
+    if (!frameDoc) throw new Error(`missing iframe document for ${name}`);
+    canvas.registerFrame({ name, doc: frameDoc });
+  }
+  // Cheap, poll-able readiness signal — engine.onEvent() below overwrites it on any later event.
+  document.title = "breakpoints:ready";
+}
+
+const iframes = frameNames
+  .map((name) => document.getElementById(name) as HTMLIFrameElement | null)
+  .filter((el): el is HTMLIFrameElement => el !== null);
+
+let loadedCount = 0;
+for (const iframe of iframes) {
+  iframe.addEventListener("load", () => {
+    loadedCount += 1;
+    if (loadedCount === iframes.length) registerFrames();
+  });
+}
+
+engine.onEvent((event) => {
+  document.title = `event:${event.type}`;
+});
+
+declare global {
+  interface Window {
+    __engine: WysiwygEngine;
+    __host: FixtureHost;
+    __canvas: BreakpointCanvas;
+    __handleRects: () => { name: string; rect: HandleRect }[];
+  }
+}
+
+window.__engine = engine;
+window.__host = host;
+window.__canvas = canvas;
+window.__handleRects = () => canvas.handleRectsForSelection();

--- a/JS/wysiwyg-engine/e2e/breakpoints-fixture-page.ts
+++ b/JS/wysiwyg-engine/e2e/breakpoints-fixture-page.ts
@@ -40,7 +40,14 @@ function registerFrames(): void {
   for (const name of frameNames) {
     const iframe = document.getElementById(name) as HTMLIFrameElement | null;
     const frameDoc = iframe?.contentDocument;
-    if (!frameDoc) throw new Error(`missing iframe document for ${name}`);
+    if (!frameDoc) {
+      // This throw can fire from inside an async `load` listener, where it becomes an unhandled
+      // error rather than a rejected promise — log first so a real failure here shows up as more
+      // than an opaque 30s `breakpoints:ready` timeout in the test output.
+      const message = `missing iframe document for ${name}`;
+      console.error(message);
+      throw new Error(message);
+    }
     canvas.registerFrame({ name, doc: frameDoc });
   }
   // Cheap, poll-able readiness signal — engine.onEvent() below overwrites it on any later event.
@@ -52,11 +59,22 @@ const iframes = frameNames
   .filter((el): el is HTMLIFrameElement => el !== null);
 
 let loadedCount = 0;
+function onFrameLoaded(): void {
+  loadedCount += 1;
+  if (loadedCount === iframes.length) registerFrames();
+}
 for (const iframe of iframes) {
-  iframe.addEventListener("load", () => {
-    loadedCount += 1;
-    if (loadedCount === iframes.length) registerFrames();
-  });
+  // An iframe's `load` event is a normal queued task, not deferred until the parent document
+  // finishes parsing — while this script (loaded from a parser-blocking <script> tag after the
+  // three <iframe> elements) was being fetched/compiled, any of those tiny frame.html documents
+  // may already have finished loading. A `load`-listener-only approach misses those and never
+  // reaches `iframes.length`, so check for already-complete frames first.
+  const doc = iframe.contentDocument;
+  if (doc && doc.readyState === "complete" && doc.URL !== "about:blank") {
+    onFrameLoaded();
+    continue;
+  }
+  iframe.addEventListener("load", onFrameLoaded, { once: true });
 }
 
 engine.onEvent((event) => {

--- a/JS/wysiwyg-engine/e2e/breakpoints-fixture-page.ts
+++ b/JS/wysiwyg-engine/e2e/breakpoints-fixture-page.ts
@@ -1,21 +1,39 @@
 import { WysiwygEngine } from "../src/engine.js";
 import { FixtureHost } from "../src/testing/fixture-host.js";
 import { BreakpointCanvas } from "../src/breakpoints.js";
-import type { BlockModel } from "../src/types.js";
+import { RichTextEditor } from "../src/rich-text.js";
+import type { BlockId, BlockModel, RichTextRun } from "../src/types.js";
 import type { HandleRect } from "../src/selection.js";
+import type { FormatKind } from "../src/rich-text.js";
 
 const initialModel: BlockModel = {
   path: "src/pages/index.astro",
   version: "fixture-initial",
-  rootIds: ["b1", "b2"],
+  rootIds: ["b1", "b2", "t1"],
   blocks: {
     b1: { id: "b1", kind: "astro", componentName: "Hero", props: { title: "Welcome" }, slots: {}, sourceSpan: [0, 10] },
     b2: { id: "b2", kind: "astro", componentName: "Testimonial", props: { quote: "Great!" }, slots: {}, sourceSpan: [11, 20] },
+    // A text block so this fixture can exercise the one thing only a real iframe can prove: a
+    // RichTextEditor living in the parent document editing an element from a *frame's* document.
+    t1: {
+      id: "t1",
+      kind: "text",
+      componentName: "paragraph",
+      props: {},
+      slots: {},
+      sourceSpan: [21, 30],
+      richText: [{ kind: "text", text: "Edit me" }],
+    },
   },
 };
 
 const host = new FixtureHost(initialModel);
 const engine = new WysiwygEngine(initialModel, host);
+const richText = new RichTextEditor(engine, { debounceMs: 300 });
+
+function plainText(runs: RichTextRun[]): string {
+  return runs.map((run) => run.text).join("");
+}
 
 function render(model: BlockModel, doc: Document): void {
   const root = doc.getElementById("canvas");
@@ -26,7 +44,9 @@ function render(model: BlockModel, doc: Document): void {
     if (!block) continue;
     const el = doc.createElement("div");
     el.setAttribute("data-anglesite-block-id", id);
-    el.textContent = block.componentName;
+    // Text blocks render their runs' plain text (no inline markup) — enough for a cross-frame
+    // selection + format golden, without duplicating fixture-page.ts's runs-to-markup projection.
+    el.textContent = block.kind === "text" ? plainText(block.richText ?? []) : block.componentName;
     el.style.cssText = "padding:8px;margin:4px;border:1px solid #ccc;";
     el.addEventListener("click", () => engine.selection.select(id));
     root.appendChild(el);
@@ -86,11 +106,24 @@ declare global {
     __engine: WysiwygEngine;
     __host: FixtureHost;
     __canvas: BreakpointCanvas;
+    __richText: RichTextEditor;
     __handleRects: () => { name: string; rect: HandleRect }[];
+    __enterRichTextInFrame: (frameName: string, blockId: BlockId) => BlockId | null;
+    __toggleFormat: (kind: FormatKind) => void;
   }
 }
 
 window.__engine = engine;
 window.__host = host;
 window.__canvas = canvas;
+window.__richText = richText;
 window.__handleRects = () => canvas.handleRectsForSelection();
+// The editor is constructed in THIS document but handed a block element from a frame's document —
+// the cross-realm case `enter()`'s guard has to survive.
+window.__enterRichTextInFrame = (frameName, blockId) => {
+  const frame = canvas.frames.find((f) => f.name === frameName);
+  if (!frame) throw new Error(`unregistered frame ${frameName}`);
+  richText.enter(blockId, frame.doc);
+  return richText.activeBlockId;
+};
+window.__toggleFormat = (kind) => richText.toggleFormat(kind);

--- a/JS/wysiwyg-engine/e2e/breakpoints-fixture.html
+++ b/JS/wysiwyg-engine/e2e/breakpoints-fixture.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>WYSIWYG breakpoints fixture</title>
+  </head>
+  <body>
+    <iframe id="phone" src="./frame.html" style="width: 375px; height: 400px"></iframe>
+    <iframe id="tablet" src="./frame.html" style="width: 768px; height: 400px"></iframe>
+    <iframe id="desktop" src="./frame.html" style="width: 1280px; height: 400px"></iframe>
+    <script src="./.generated/breakpoints-bundle.js"></script>
+  </body>
+</html>

--- a/JS/wysiwyg-engine/e2e/breakpoints.spec.ts
+++ b/JS/wysiwyg-engine/e2e/breakpoints.spec.ts
@@ -25,6 +25,59 @@ test("selecting a block in one frame draws handles in every registered frame", a
   }
 });
 
+test("hitTestFrame resolves a real point inside a frame to the block under it", async ({ page }) => {
+  // The only positive-path coverage of hitTestFrame at any tier: jsdom has no layout engine, so
+  // test/breakpoints.test.ts can only prove the unregistered-name -> null case.
+  await page.goto("/breakpoints-fixture.html");
+  await page.waitForFunction(() => document.title === "breakpoints:ready");
+
+  // Measured *inside* the frame, so these are the frame's own viewport coordinates — which is what
+  // hitTestFrame's `point` means (its elementFromPoint runs against the frame document).
+  const point = await page
+    .frameLocator("#phone")
+    .locator('[data-anglesite-block-id="b1"]')
+    .evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+    });
+
+  expect(await page.evaluate((pt) => window.__canvas.hitTestFrame("phone", pt), point)).toBe("b1");
+  expect(await page.evaluate((pt) => window.__canvas.hitTestFrame("nope", pt), point)).toBeNull();
+});
+
+test("RichTextEditor edits a block element belonging to a frame's document", async ({ page }) => {
+  // enter()'s element guard and the format commands' Selection/Range lookups both have to resolve
+  // against the *frame's* realm and document, not the one this module was loaded in.
+  await page.goto("/breakpoints-fixture.html");
+  await page.waitForFunction(() => document.title === "breakpoints:ready");
+
+  expect(await page.evaluate(() => window.__enterRichTextInFrame("phone", "t1"))).toBe("t1");
+
+  await page
+    .frameLocator("#phone")
+    .locator('[data-anglesite-block-id="t1"]')
+    .evaluate((el) => {
+      const textNode = el.firstChild;
+      if (!textNode) throw new Error("expected a text node");
+      const range = el.ownerDocument.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, 4); // "Edit" (of "Edit me")
+      const selection = el.ownerDocument.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+
+  await page.evaluate(() => window.__toggleFormat("strong"));
+  await page.evaluate(() => window.__richText.exit());
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const runs = await page.evaluate(() => window.__engine.modelSync.getBlock("t1")?.richText);
+  expect(runs).toEqual([
+    { kind: "strong", text: "Edit" },
+    { kind: "text", text: " me" },
+  ]);
+});
+
 test("an op applied via the shared engine re-renders every frame", async ({ page }) => {
   await page.goto("/breakpoints-fixture.html");
   await page.waitForFunction(() => document.title === "breakpoints:ready");

--- a/JS/wysiwyg-engine/e2e/breakpoints.spec.ts
+++ b/JS/wysiwyg-engine/e2e/breakpoints.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+
+test("registers all three frames and renders the model into each", async ({ page }) => {
+  await page.goto("/breakpoints-fixture.html");
+  await page.waitForFunction(() => document.title === "breakpoints:ready");
+
+  for (const name of ["phone", "tablet", "desktop"]) {
+    const frame = page.frameLocator(`#${name}`);
+    await expect(frame.locator('[data-anglesite-block-id="b1"]')).toHaveText("Hero");
+  }
+});
+
+test("selecting a block in one frame draws handles in every registered frame", async ({ page }) => {
+  await page.goto("/breakpoints-fixture.html");
+  await page.waitForFunction(() => document.title === "breakpoints:ready");
+
+  await page.frameLocator("#phone").locator('[data-anglesite-block-id="b2"]').click();
+  await page.waitForFunction(() => document.title === "event:selection-changed");
+
+  const rects = await page.evaluate(() => window.__handleRects());
+  expect(rects.map((r) => r.name).sort()).toEqual(["desktop", "phone", "tablet"]);
+  for (const { rect } of rects) {
+    expect(rect.width).toBeGreaterThan(0);
+    expect(rect.height).toBeGreaterThan(0);
+  }
+});
+
+test("an op applied via the shared engine re-renders every frame", async ({ page }) => {
+  await page.goto("/breakpoints-fixture.html");
+  await page.waitForFunction(() => document.title === "breakpoints:ready");
+
+  await page.evaluate(() =>
+    window.__engine.submit({
+      kind: "moveBlock",
+      blockId: "b2",
+      fromParentId: "__root__",
+      fromSlot: "default",
+      fromIndex: 1,
+      toParentId: "__root__",
+      toSlot: "default",
+      toIndex: 0,
+    }),
+  );
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  for (const name of ["phone", "tablet", "desktop"]) {
+    const frame = page.frameLocator(`#${name}`);
+    await expect(frame.locator("#canvas > div").first()).toHaveText("Testimonial");
+  }
+});

--- a/JS/wysiwyg-engine/e2e/drag-drop.spec.ts
+++ b/JS/wysiwyg-engine/e2e/drag-drop.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from "@playwright/test";
+
+test("a real pointer drag reorders blocks via DragReorderController", async ({ page }) => {
+  await page.goto("/fixture.html");
+  const b1Box = await page.locator('[data-anglesite-block-id="b1"]').boundingBox();
+  const b2Box = await page.locator('[data-anglesite-block-id="b2"]').boundingBox();
+  if (!b1Box || !b2Box) throw new Error("expected bounding boxes");
+
+  await page.mouse.move(b2Box.x + b2Box.width / 2, b2Box.y + b2Box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(b1Box.x + b1Box.width / 2, b1Box.y + 1, { steps: 5 });
+  await page.mouse.up();
+
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const order = await page.evaluate(() => window.__engine.modelSync.current.rootIds);
+  expect(order.indexOf("b2")).toBeLessThan(order.indexOf("b1"));
+});
+
+test("submitDrop inserts a new block at the given target", async ({ page }) => {
+  await page.goto("/fixture.html");
+  const result = await page.evaluate(() =>
+    window.__submitDrop(
+      { parentId: "__root__", slot: "default", index: 0 },
+      { kind: "astro", componentName: "Newsletter", props: {}, slots: {}, sourceSpan: [0, 0] },
+    ),
+  );
+  expect(result.status).toBe("applied");
+
+  const firstId = await page.evaluate(() => window.__engine.modelSync.current.rootIds[0]);
+  const firstName = await page.evaluate(
+    (id) => (id ? window.__engine.modelSync.getBlock(id)?.componentName : undefined),
+    firstId,
+  );
+  expect(firstName).toBe("Newsletter");
+});
+
+test("an external drop (palette-style payload) inserts a block via wireExternalDrop", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => {
+    const canvasEl = document.getElementById("canvas");
+    if (!canvasEl) throw new Error("missing #canvas");
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData(
+      "application/x-anglesite-block",
+      JSON.stringify({ kind: "astro", componentName: "CallToAction", props: {}, slots: {}, sourceSpan: [0, 0] }),
+    );
+    const rect = canvasEl.getBoundingClientRect();
+    const dropEvent = new DragEvent("drop", {
+      clientX: rect.x + 5,
+      clientY: rect.y + 5,
+      bubbles: true,
+      cancelable: true,
+      dataTransfer,
+    });
+    canvasEl.dispatchEvent(dropEvent);
+  });
+
+  await page.waitForFunction(() => document.title === "event:applied");
+  const componentNames = await page.evaluate(() =>
+    Object.values(window.__engine.modelSync.current.blocks).map((b) => b.componentName),
+  );
+  expect(componentNames).toContain("CallToAction");
+});
+
+test("dragover computes a drop-target indicator; dragleave clears it", async ({ page }) => {
+  // Task 7 shipped wireExternalDrop with zero unit tests (DragEvent/DataTransfer are
+  // unconstructable under this project's pinned jsdom) — this is the only test covering its
+  // dragover/dragleave indicator behavior at any tier.
+  await page.goto("/fixture.html");
+  await page.evaluate(() => {
+    const canvasEl = document.getElementById("canvas");
+    if (!canvasEl) throw new Error("missing #canvas");
+    const rect = canvasEl.getBoundingClientRect();
+    canvasEl.dispatchEvent(
+      new DragEvent("dragover", { clientX: rect.x + 5, clientY: rect.y + 5, bubbles: true, cancelable: true }),
+    );
+  });
+
+  const indicatorAfterDragover = await page.evaluate(() => window.__dropIndicator);
+  expect(indicatorAfterDragover).not.toBeNull();
+  expect(indicatorAfterDragover?.parentId).toBe("__root__");
+
+  await page.evaluate(() => {
+    document.getElementById("canvas")?.dispatchEvent(new DragEvent("dragleave", { bubbles: true }));
+  });
+  const indicatorAfterDragleave = await page.evaluate(() => window.__dropIndicator);
+  expect(indicatorAfterDragleave).toBeNull();
+});
+
+test("the disposer stops wireExternalDrop from responding to further drags", async ({ page }) => {
+  // The other half of Task 7's deferred coverage: the disposer itself has no test at any tier
+  // otherwise.
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__disposeExternalDrop());
+
+  const componentNamesBefore = await page.evaluate(() =>
+    Object.values(window.__engine.modelSync.current.blocks).map((b) => b.componentName),
+  );
+
+  await page.evaluate(() => {
+    const canvasEl = document.getElementById("canvas");
+    if (!canvasEl) throw new Error("missing #canvas");
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData(
+      "application/x-anglesite-block",
+      JSON.stringify({ kind: "astro", componentName: "ShouldNeverAppear", props: {}, slots: {}, sourceSpan: [0, 0] }),
+    );
+    const rect = canvasEl.getBoundingClientRect();
+    canvasEl.dispatchEvent(
+      new DragEvent("drop", { clientX: rect.x + 5, clientY: rect.y + 5, bubbles: true, cancelable: true, dataTransfer }),
+    );
+  });
+
+  // Disposed listeners never run, so no engine event fires and there's nothing to await — give
+  // any errant async work one beat to have shown up, then assert nothing changed.
+  await page.waitForTimeout(100);
+  const componentNamesAfter = await page.evaluate(() =>
+    Object.values(window.__engine.modelSync.current.blocks).map((b) => b.componentName),
+  );
+  expect(componentNamesAfter).toEqual(componentNamesBefore);
+});
+
+test("a version-mismatch rejection during a drop is visible and applies nothing", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__host.forceReject("version-mismatch", "stale"));
+
+  const result = await page.evaluate(() =>
+    window.__submitDrop(
+      { parentId: "__root__", slot: "default", index: 0 },
+      { kind: "astro", componentName: "ShouldNotAppear", props: {}, slots: {}, sourceSpan: [0, 0] },
+    ),
+  );
+  expect(result.status).toBe("rejected");
+
+  const componentNames = await page.evaluate(() =>
+    Object.values(window.__engine.modelSync.current.blocks).map((b) => b.componentName),
+  );
+  expect(componentNames).not.toContain("ShouldNotAppear");
+});

--- a/JS/wysiwyg-engine/e2e/drag-drop.spec.ts
+++ b/JS/wysiwyg-engine/e2e/drag-drop.spec.ts
@@ -17,6 +17,30 @@ test("a real pointer drag reorders blocks via DragReorderController", async ({ p
   expect(order.indexOf("b2")).toBeLessThan(order.indexOf("b1"));
 });
 
+test("a downward pointer drag lands the block where the indicator showed it", async ({ page }) => {
+  // The upward golden above can't catch the off-by-one that `moveBlock`'s post-removal `toIndex`
+  // introduces (types.ts): for fromIndex < toIndex the pre-removal index computeDropTarget measures
+  // is one too high. Only a downward drag exercises that branch.
+  await page.goto("/fixture.html");
+  const b1Box = await page.locator('[data-anglesite-block-id="b1"]').boundingBox();
+  const b2Box = await page.locator('[data-anglesite-block-id="b2"]').boundingBox();
+  if (!b1Box || !b2Box) throw new Error("expected bounding boxes");
+
+  await page.mouse.move(b1Box.x + b1Box.width / 2, b1Box.y + b1Box.height / 2);
+  await page.mouse.down();
+  // Below b2's vertical midpoint but above t1's — the indicator resolves to index 2, i.e. "between
+  // b2 and t1".
+  await page.mouse.move(b2Box.x + b2Box.width / 2, b2Box.y + b2Box.height - 1, { steps: 5 });
+  const indicator = await page.evaluate(() => window.__dropIndicator);
+  expect(indicator?.index).toBe(2);
+  await page.mouse.up();
+
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const order = await page.evaluate(() => window.__engine.modelSync.current.rootIds);
+  expect(order).toEqual(["b2", "b1", "t1"]);
+});
+
 test("submitDrop inserts a new block at the given target", async ({ page }) => {
   await page.goto("/fixture.html");
   const result = await page.evaluate(() =>

--- a/JS/wysiwyg-engine/e2e/drag-drop.spec.ts
+++ b/JS/wysiwyg-engine/e2e/drag-drop.spec.ts
@@ -112,6 +112,38 @@ test("dragover computes a drop-target indicator; dragleave clears it", async ({ 
   expect(indicatorAfterDragleave).toBeNull();
 });
 
+test("dragleave bubbling from one in-canvas block to another doesn't flicker the indicator", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => {
+    const canvasEl = document.getElementById("canvas");
+    if (!canvasEl) throw new Error("missing #canvas");
+    const rect = canvasEl.getBoundingClientRect();
+    canvasEl.dispatchEvent(
+      new DragEvent("dragover", { clientX: rect.x + 5, clientY: rect.y + 5, bubbles: true, cancelable: true }),
+    );
+  });
+  expect(await page.evaluate(() => window.__dropIndicator)).not.toBeNull();
+
+  // Simulate the drag crossing from over one block to over a sibling block, both still inside
+  // the canvas: dragleave fires on the first block (bubbling to canvasEl) with relatedTarget set
+  // to the second block, not to anything outside the canvas.
+  await page.evaluate(() => {
+    const b1 = document.querySelector('[data-anglesite-block-id="b1"]');
+    const b2 = document.querySelector('[data-anglesite-block-id="b2"]');
+    if (!b1 || !b2) throw new Error("missing block elements");
+    b1.dispatchEvent(new DragEvent("dragleave", { bubbles: true, relatedTarget: b2 }));
+  });
+  expect(await page.evaluate(() => window.__dropIndicator)).not.toBeNull();
+
+  // A real exit (relatedTarget outside the canvas entirely) still clears it.
+  await page.evaluate(() => {
+    const canvasEl = document.getElementById("canvas");
+    const outside = document.body;
+    canvasEl?.dispatchEvent(new DragEvent("dragleave", { bubbles: true, relatedTarget: outside }));
+  });
+  expect(await page.evaluate(() => window.__dropIndicator)).toBeNull();
+});
+
 test("the disposer stops wireExternalDrop from responding to further drags", async ({ page }) => {
   // The other half of Task 7's deferred coverage: the disposer itself has no test at any tier
   // otherwise.

--- a/JS/wysiwyg-engine/e2e/fixture-page.ts
+++ b/JS/wysiwyg-engine/e2e/fixture-page.ts
@@ -2,26 +2,69 @@ import { WysiwygEngine } from "../src/engine.js";
 import { FixtureHost } from "../src/testing/fixture-host.js";
 import { computeHandleRect } from "../src/selection.js";
 import { ROOT_PARENT_ID } from "../src/types.js";
+import { RichTextEditor } from "../src/rich-text.js";
+import { DragReorderController, wireExternalDrop, submitDrop } from "../src/drag-drop.js";
 import type { HandleRect } from "../src/selection.js";
-import type { BlockModel, OpResult } from "../src/types.js";
+import type { BlockModel, OpResult, RichTextRun, BlockNode } from "../src/types.js";
+import type { DropTarget } from "../src/drag-drop.js";
+import type { FormatKind } from "../src/rich-text.js";
 
 const initialModel: BlockModel = {
   path: "src/pages/index.astro",
   version: "fixture-initial",
-  rootIds: ["b1", "b2"],
+  rootIds: ["b1", "b2", "t1"],
   blocks: {
     b1: { id: "b1", kind: "astro", componentName: "Hero", props: { title: "Welcome" }, slots: {}, sourceSpan: [0, 10] },
     b2: { id: "b2", kind: "astro", componentName: "Testimonial", props: { quote: "Great!" }, slots: {}, sourceSpan: [11, 20] },
+    t1: {
+      id: "t1",
+      kind: "text",
+      componentName: "paragraph",
+      props: {},
+      slots: {},
+      sourceSpan: [21, 30],
+      richText: [
+        { kind: "text", text: "Edit " },
+        { kind: "strong", text: "me" },
+      ],
+    },
   },
 };
 
 const host = new FixtureHost(initialModel);
 const engine = new WysiwygEngine(initialModel, host);
+const richText = new RichTextEditor(engine, { debounceMs: 300 });
 
 function canvas(): HTMLElement {
   const el = document.getElementById("canvas");
   if (!el) throw new Error("fixture.html is missing #canvas");
   return el;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Host-owned rendering of RichTextRun[] into markup — the inverse of runsFromElement, and, like
+ *  the rest of this fixture's render(), a stand-in for what a real host's DOM projection does. */
+function renderRuns(runs: RichTextRun[]): string {
+  return runs
+    .map((run) => {
+      const text = escapeHtml(run.text);
+      switch (run.kind) {
+        case "strong":
+          return `<strong>${text}</strong>`;
+        case "em":
+          return `<em>${text}</em>`;
+        case "link":
+          return `<a href="${escapeHtml(run.href ?? "")}">${text}</a>`;
+        case "code":
+          return `<code>${text}</code>`;
+        default:
+          return text;
+      }
+    })
+    .join("");
 }
 
 function render(model: BlockModel): void {
@@ -34,16 +77,40 @@ function render(model: BlockModel): void {
     el.setAttribute("data-anglesite-block-id", id);
     el.setAttribute("data-component", block.componentName);
     el.setAttribute("data-anglesite-selected", "false");
-    el.textContent = `${block.componentName} (${id})`;
+    if (block.kind === "text") {
+      el.innerHTML = renderRuns(block.richText ?? []);
+    } else {
+      el.textContent = `${block.componentName} (${id})`;
+    }
     el.style.cssText = "padding:8px;margin:4px;border:1px solid #ccc;";
     el.addEventListener("click", () => engine.selection.select(id));
+    el.addEventListener("pointerdown", () => dragReorder.startDrag(id));
     root.appendChild(el);
   }
 }
 
+const dragReorder = new DragReorderController(
+  engine,
+  (target) => {
+    window.__dropIndicator = target;
+  },
+  canvas(),
+);
+
+const disposeExternalDrop = wireExternalDrop(
+  canvas(),
+  (target) => {
+    window.__dropIndicator = target;
+  },
+  (target, dataTransfer) => {
+    const json = dataTransfer.getData("application/x-anglesite-block");
+    if (!json) return;
+    const block = JSON.parse(json) as Omit<BlockNode, "id">;
+    void submitDrop(engine, target, block);
+  },
+);
+
 engine.onEvent((event) => {
-  // A rejection carrying a model adopted the host's fresh one — that is a model swap the canvas
-  // must follow, exactly like "applied"/"model-updated", or the DOM silently drifts from the host.
   if (event.type === "model-updated" || event.type === "applied" || (event.type === "rejected" && event.model)) {
     render(engine.modelSync.current);
   }
@@ -63,17 +130,26 @@ declare global {
   interface Window {
     __engine: WysiwygEngine;
     __host: FixtureHost;
+    __richText: RichTextEditor;
+    __dragReorder: DragReorderController;
+    __dropIndicator: DropTarget | null;
     __moveBlock: (blockId: string, toIndex: number) => Promise<OpResult>;
     __computeHandleRect: (blockId: string) => HandleRect | null;
+    __submitDrop: (target: DropTarget, block: Omit<BlockNode, "id">) => Promise<OpResult>;
+    __toggleFormat: (kind: FormatKind) => void;
+    __disposeExternalDrop: () => void;
   }
 }
 
 window.__engine = engine;
 window.__host = host;
-// Bridged onto `window` (unlike `hitTest`, which the engine already exposes as a method) so
-// e2e/geometry.spec.ts can exercise it against a real layout engine — jsdom's
-// getBoundingClientRect is all zeros, so unit tests can only prove the wiring.
+window.__richText = richText;
+window.__dragReorder = dragReorder;
+window.__dropIndicator = null;
 window.__computeHandleRect = (blockId) => computeHandleRect(blockId);
+window.__submitDrop = (target, block) => submitDrop(engine, target, block);
+window.__toggleFormat = (kind) => richText.toggleFormat(kind);
+window.__disposeExternalDrop = disposeExternalDrop;
 window.__moveBlock = (blockId, toIndex) => {
   const model = engine.modelSync.current;
   const fromIndex = model.rootIds.indexOf(blockId);

--- a/JS/wysiwyg-engine/e2e/fixture-page.ts
+++ b/JS/wysiwyg-engine/e2e/fixture-page.ts
@@ -41,8 +41,11 @@ function canvas(): HTMLElement {
   return el;
 }
 
+/** `"` matters as much as `<`/`&` here: renderRuns' `link` case interpolates escaped text into an
+ *  `href="…"` attribute, and this slice's own setLinkFormat can put arbitrary user text into a real
+ *  `link` run through a live edit — so the attribute context is reachable, not hypothetical. */
 function escapeHtml(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 /** Host-owned rendering of RichTextRun[] into markup — the inverse of runsFromElement, and, like
@@ -111,6 +114,8 @@ const disposeExternalDrop = wireExternalDrop(
 );
 
 engine.onEvent((event) => {
+  // A `rejected` event that carries a model carries the host's *fresh* one — the engine has already
+  // adopted it, so the host has to re-render from it too or the DOM silently drifts from the model.
   if (event.type === "model-updated" || event.type === "applied" || (event.type === "rejected" && event.model)) {
     render(engine.modelSync.current);
   }
@@ -146,6 +151,8 @@ window.__host = host;
 window.__richText = richText;
 window.__dragReorder = dragReorder;
 window.__dropIndicator = null;
+// Bridged for e2e/geometry.spec.ts: jsdom's getBoundingClientRect() is all zeros, so the unit tests
+// can only prove computeHandleRect's wiring — real on-screen geometry needs a browser.
 window.__computeHandleRect = (blockId) => computeHandleRect(blockId);
 window.__submitDrop = (target, block) => submitDrop(engine, target, block);
 window.__toggleFormat = (kind) => richText.toggleFormat(kind);

--- a/JS/wysiwyg-engine/e2e/frame.html
+++ b/JS/wysiwyg-engine/e2e/frame.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>frame</title>
+  </head>
+  <body>
+    <div id="canvas"></div>
+  </body>
+</html>

--- a/JS/wysiwyg-engine/e2e/rich-text.spec.ts
+++ b/JS/wysiwyg-engine/e2e/rich-text.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+test("typing in an entered text block commits an editText op with honest runs after the debounce", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__richText.enter("t1"));
+
+  const block = page.locator('[data-anglesite-block-id="t1"]');
+  await block.evaluate((el) => {
+    el.textContent = "Edit me now";
+  });
+  await block.dispatchEvent("input");
+
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const runs = await page.evaluate(() => window.__engine.modelSync.getBlock("t1")?.richText);
+  expect(runs).toEqual([{ kind: "text", text: "Edit me now" }]);
+});
+
+test("toggling bold on a selection wraps it in <strong>, never a styled span", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__richText.enter("t1"));
+
+  const block = page.locator('[data-anglesite-block-id="t1"]');
+  await block.evaluate((el) => {
+    const textNode = el.firstChild;
+    if (!textNode) throw new Error("expected a text node");
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 4); // "Edit" (of "Edit ")
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  });
+
+  await page.evaluate(() => window.__toggleFormat("strong"));
+  await page.evaluate(() => window.__richText.exit());
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const runs = await page.evaluate(() => window.__engine.modelSync.getBlock("t1")?.richText);
+  expect(runs).toEqual([
+    { kind: "strong", text: "Edit" },
+    { kind: "text", text: " " },
+    { kind: "strong", text: "me" },
+  ]);
+});
+
+test("exiting without any change does not submit a no-op editText", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__richText.enter("t1"));
+  await page.evaluate(() => window.__richText.exit());
+
+  // No typing happened, so nothing should have committed — the title (flipped only by engine
+  // events) stays at its initial, pre-any-event value.
+  await page.waitForTimeout(100);
+  expect(await page.title()).toBe("WYSIWYG engine fixture");
+});

--- a/JS/wysiwyg-engine/e2e/rich-text.spec.ts
+++ b/JS/wysiwyg-engine/e2e/rich-text.spec.ts
@@ -44,13 +44,38 @@ test("toggling bold on a selection wraps it in <strong>, never a styled span", a
   ]);
 });
 
+test("a link run's href cannot break out of the rendered href attribute", async ({ page }) => {
+  // setLinkFormat can now put a host-supplied href into a real `link` run, so the fixture's
+  // runs-to-markup projection interpolates it into an href="…" attribute for real — the escaper
+  // has to cover `"` and not just `<`/`&`.
+  await page.goto("/fixture.html");
+  await page.evaluate(() =>
+    window.__engine.submit({
+      kind: "editText",
+      blockId: "t1",
+      runs: [{ kind: "link", text: "click", href: 'https://example.com/" onmouseover="boom' }],
+      previousRuns: [
+        { kind: "text", text: "Edit " },
+        { kind: "strong", text: "me" },
+      ],
+    }),
+  );
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const anchor = page.locator('[data-anglesite-block-id="t1"] a');
+  await expect(anchor).toHaveAttribute("href", 'https://example.com/" onmouseover="boom');
+  expect(await anchor.evaluate((el) => el.hasAttribute("onmouseover"))).toBe(false);
+});
+
 test("exiting without any change does not submit a no-op editText", async ({ page }) => {
   await page.goto("/fixture.html");
   await page.evaluate(() => window.__richText.enter("t1"));
   await page.evaluate(() => window.__richText.exit());
 
   // No typing happened, so nothing should have committed — the title (flipped only by engine
-  // events) stays at its initial, pre-any-event value.
-  await page.waitForTimeout(100);
+  // events) stays at its initial, pre-any-event value. Wait comfortably past the fixture's 300ms
+  // debounce: a regression that merely failed to *cancel* a pending commit would still look clean
+  // at t+100ms and only fire afterwards.
+  await page.waitForTimeout(500);
   expect(await page.title()).toBe("WYSIWYG engine fixture");
 });

--- a/JS/wysiwyg-engine/e2e/rich-text.spec.ts
+++ b/JS/wysiwyg-engine/e2e/rich-text.spec.ts
@@ -32,8 +32,9 @@ test("toggling bold on a selection wraps it in <strong>, never a styled span", a
     selection?.addRange(range);
   });
 
+  // No explicit exit()/flush() here — toggleFormat() must commit on its own, immediately, per the
+  // documented contract (design doc §4: "immediately on blur, Escape, or a format command").
   await page.evaluate(() => window.__toggleFormat("strong"));
-  await page.evaluate(() => window.__richText.exit());
   await page.waitForFunction(() => document.title === "event:applied");
 
   const runs = await page.evaluate(() => window.__engine.modelSync.getBlock("t1")?.richText);
@@ -41,6 +42,42 @@ test("toggling bold on a selection wraps it in <strong>, never a styled span", a
     { kind: "strong", text: "Edit" },
     { kind: "text", text: " " },
     { kind: "strong", text: "me" },
+  ]);
+});
+
+test("toggling italic on a selection already inside bold nests the formats — composition survives commit", async ({
+  page,
+}) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__richText.enter("t1"));
+
+  const block = page.locator('[data-anglesite-block-id="t1"]');
+  await block.evaluate((el) => {
+    const strong = el.querySelector("strong");
+    const textNode = strong?.firstChild;
+    if (!strong || !textNode) throw new Error("expected an existing <strong> with a text node");
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 1); // "m" (of "me")
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  });
+
+  await page.evaluate(() => window.__toggleFormat("em"));
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const runs = await page.evaluate(() => window.__engine.modelSync.getBlock("t1")?.richText);
+  expect(runs).toEqual([
+    { kind: "text", text: "Edit " },
+    {
+      kind: "strong",
+      text: "me",
+      children: [
+        { kind: "em", text: "m" },
+        { kind: "text", text: "e" },
+      ],
+    },
   ]);
 });
 

--- a/JS/wysiwyg-engine/e2e/static-server.mjs
+++ b/JS/wysiwyg-engine/e2e/static-server.mjs
@@ -4,14 +4,17 @@ import { join } from "node:path";
 
 const root = new URL(".", import.meta.url).pathname;
 
-// This fixture server has exactly two files to serve — enumerate them explicitly rather than
-// building a filesystem path from the request URL. There is no dynamic path expression here for
-// a path-traversal scanner (or a future edit) to worry about: `route.file` below is always one
-// of these two literals, never derived from `req.url`.
+// This fixture server has a fixed, small set of files to serve — enumerate them explicitly
+// rather than building a filesystem path from the request URL. There is no dynamic path
+// expression here for a path-traversal scanner (or a future edit) to worry about: `route.file`
+// below is always one of these literals, never derived from `req.url`.
 const ROUTES = {
   "/": { file: "fixture.html", type: "text/html" },
   "/fixture.html": { file: "fixture.html", type: "text/html" },
   "/.generated/fixture-bundle.js": { file: ".generated/fixture-bundle.js", type: "text/javascript" },
+  "/breakpoints-fixture.html": { file: "breakpoints-fixture.html", type: "text/html" },
+  "/frame.html": { file: "frame.html", type: "text/html" },
+  "/.generated/breakpoints-bundle.js": { file: ".generated/breakpoints-bundle.js", type: "text/javascript" },
 };
 
 createServer(async (req, res) => {

--- a/JS/wysiwyg-engine/package.json
+++ b/JS/wysiwyg-engine/package.json
@@ -9,7 +9,7 @@
     "lint": "oxlint src test e2e",
     "test": "vitest run",
     "test:watch": "vitest",
-    "build:e2e": "esbuild e2e/fixture-page.ts --bundle --format=iife --target=es2022 --outfile=e2e/.generated/fixture-bundle.js",
+    "build:e2e": "esbuild e2e/fixture-page.ts --bundle --format=iife --target=es2022 --outfile=e2e/.generated/fixture-bundle.js && esbuild e2e/breakpoints-fixture-page.ts --bundle --format=iife --target=es2022 --outfile=e2e/.generated/breakpoints-bundle.js",
     "test:e2e": "npm run build:e2e && playwright test"
   },
   "devDependencies": {

--- a/JS/wysiwyg-engine/src/breakpoints.ts
+++ b/JS/wysiwyg-engine/src/breakpoints.ts
@@ -42,6 +42,9 @@ export class BreakpointCanvas {
     return this.#frames;
   }
 
+  /** `point` is in the *named frame's* own viewport coordinate space, not the parent document's — a
+   *  host resolving a pointer event from a parent-document overlay must first subtract the iframe's
+   *  offset. */
   hitTestFrame(name: string, point: { x: number; y: number }): BlockId | null {
     const frame = this.#frames.find((f) => f.name === name);
     if (!frame) return null;
@@ -50,7 +53,10 @@ export class BreakpointCanvas {
 
   /** Selection-handle geometry for every frame currently rendering the selected block — callers
    *  redraw their own outline chrome from this, mirroring how the engine itself owns no rendering
-   *  (spec §3.1). Call after any engine event that could move or reselect a block. */
+   *  (spec §3.1). Call after any engine event that could move or reselect a block.
+   *
+   *  Each rect is in its own frame's viewport coordinate space, not the parent document's — a host
+   *  drawing overlay chrome in the parent document must translate each by that iframe's offset. */
   handleRectsForSelection(): { name: string; rect: HandleRect }[] {
     const selected = this.#engine.selection.current;
     if (!selected) return [];

--- a/JS/wysiwyg-engine/src/breakpoints.ts
+++ b/JS/wysiwyg-engine/src/breakpoints.ts
@@ -1,0 +1,77 @@
+import type { BlockId, BlockModel } from "./types.js";
+import type { WysiwygEngine, EngineEvent } from "./engine.js";
+import { computeHandleRect } from "./selection.js";
+import type { HandleRect } from "./selection.js";
+
+export interface BreakpointFrame {
+  name: string;
+  doc: Document;
+}
+
+export type RenderFn = (model: BlockModel, doc: Document) => void;
+
+/**
+ * Drives N breakpoint frame documents from one shared `WysiwygEngine` (design doc §6, spec §5:
+ * breakpoints are views, not modes). Because `hitTest()`/`computeHandleRect()` already accept an
+ * explicit document/root instead of assuming the global `document`, one engine — one model, one
+ * selection, one op queue — can resolve gestures against any registered frame: selecting a block in
+ * one frame is reflected in every frame automatically, with no cross-frame sync layer.
+ */
+export class BreakpointCanvas {
+  #engine: WysiwygEngine;
+  #render: RenderFn;
+  #frames: BreakpointFrame[] = [];
+  #unsubscribe: () => void;
+
+  constructor(engine: WysiwygEngine, render: RenderFn) {
+    this.#engine = engine;
+    this.#render = render;
+    this.#unsubscribe = engine.onEvent((event) => this.#onEngineEvent(event));
+  }
+
+  registerFrame(frame: BreakpointFrame): void {
+    this.#frames.push(frame);
+    this.#render(this.#engine.modelSync.current, frame.doc);
+  }
+
+  unregisterFrame(name: string): void {
+    this.#frames = this.#frames.filter((f) => f.name !== name);
+  }
+
+  get frames(): readonly BreakpointFrame[] {
+    return this.#frames;
+  }
+
+  hitTestFrame(name: string, point: { x: number; y: number }): BlockId | null {
+    const frame = this.#frames.find((f) => f.name === name);
+    if (!frame) return null;
+    return this.#engine.hitTest(point, frame.doc);
+  }
+
+  /** Selection-handle geometry for every frame currently rendering the selected block — callers
+   *  redraw their own outline chrome from this, mirroring how the engine itself owns no rendering
+   *  (spec §3.1). Call after any engine event that could move or reselect a block. */
+  handleRectsForSelection(): { name: string; rect: HandleRect }[] {
+    const selected = this.#engine.selection.current;
+    if (!selected) return [];
+    const rects: { name: string; rect: HandleRect }[] = [];
+    for (const frame of this.#frames) {
+      const rect = computeHandleRect(selected, frame.doc);
+      if (rect) rects.push({ name: frame.name, rect });
+    }
+    return rects;
+  }
+
+  dispose(): void {
+    this.#unsubscribe();
+    this.#frames = [];
+  }
+
+  #onEngineEvent(event: EngineEvent): void {
+    const shouldRerender =
+      event.type === "model-updated" || event.type === "applied" || (event.type === "rejected" && event.model !== undefined);
+    if (!shouldRerender) return;
+    const model = this.#engine.modelSync.current;
+    for (const frame of this.#frames) this.#render(model, frame.doc);
+  }
+}

--- a/JS/wysiwyg-engine/src/drag-drop.ts
+++ b/JS/wysiwyg-engine/src/drag-drop.ts
@@ -64,3 +64,82 @@ export function submitDrop(engine: WysiwygEngine, target: DropTarget, block: Omi
     block,
   });
 }
+
+/**
+ * Pointer-based (not HTML5 Drag and Drop) in-canvas block reordering — more reliable for
+ * same-document dragging and behaves uniformly whether the block lives in a single canvas or one
+ * of several breakpoint frames (design doc §5). Tracks a live `DropTarget` indicator during the
+ * drag via `onIndicator` and, on release, submits `moveBlock` to that target.
+ */
+export class DragReorderController {
+  #engine: WysiwygEngine;
+  #container: ParentNode;
+  #onIndicator: (target: DropTarget | null) => void;
+  #draggingId: BlockId | null = null;
+  #indicatorTarget: DropTarget | null = null;
+  #doc: Document | null = null;
+  #onMove = (event: PointerEvent) => this.#handleMove(event);
+  #onUp = () => {
+    void this.#handleUp();
+  };
+
+  constructor(engine: WysiwygEngine, onIndicator: (target: DropTarget | null) => void, container: ParentNode = document) {
+    this.#engine = engine;
+    this.#onIndicator = onIndicator;
+    this.#container = container;
+  }
+
+  get isDragging(): boolean {
+    return this.#draggingId !== null;
+  }
+
+  startDrag(blockId: BlockId, doc: Document = document): void {
+    this.#draggingId = blockId;
+    this.#doc = doc;
+    doc.addEventListener("pointermove", this.#onMove);
+    doc.addEventListener("pointerup", this.#onUp);
+  }
+
+  dispose(): void {
+    this.#doc?.removeEventListener("pointermove", this.#onMove);
+    this.#doc?.removeEventListener("pointerup", this.#onUp);
+    this.#draggingId = null;
+    this.#doc = null;
+  }
+
+  #handleMove(event: PointerEvent): void {
+    if (!this.#draggingId) return;
+    this.#indicatorTarget = computeDropTarget({ x: event.clientX, y: event.clientY }, this.#container);
+    this.#onIndicator(this.#indicatorTarget);
+  }
+
+  async #handleUp(): Promise<void> {
+    this.#doc?.removeEventListener("pointermove", this.#onMove);
+    this.#doc?.removeEventListener("pointerup", this.#onUp);
+    this.#doc = null;
+
+    const blockId = this.#draggingId;
+    const target = this.#indicatorTarget;
+    this.#draggingId = null;
+    this.#indicatorTarget = null;
+    this.#onIndicator(null);
+    if (!blockId || !target) return;
+
+    const model = this.#engine.modelSync.current;
+    const fromIndex = model.rootIds.indexOf(blockId);
+    // The dragged block was removed by a concurrent model update (design doc §7) — abort cleanly
+    // rather than submit a moveBlock against a now-invalid index.
+    if (fromIndex === -1) return;
+
+    await this.#engine.submit({
+      kind: "moveBlock",
+      blockId,
+      fromParentId: ROOT_PARENT_ID,
+      fromSlot: "default",
+      fromIndex,
+      toParentId: target.parentId,
+      toSlot: target.slot,
+      toIndex: target.index,
+    });
+  }
+}

--- a/JS/wysiwyg-engine/src/drag-drop.ts
+++ b/JS/wysiwyg-engine/src/drag-drop.ts
@@ -70,6 +70,14 @@ export function submitDrop(engine: WysiwygEngine, target: DropTarget, block: Omi
  * same-document dragging and behaves uniformly whether the block lives in a single canvas or one
  * of several breakpoint frames (design doc §5). Tracks a live `DropTarget` indicator during the
  * drag via `onIndicator` and, on release, submits `moveBlock` to that target.
+ *
+ * **One controller per document.** `container` is captured once at construction and every
+ * `pointermove` is measured against it, but `startDrag`'s `doc` decides which document's pointer
+ * events are listened to. Those two must belong to the same document, or the gesture is measured in
+ * the wrong coordinate space and produces a plausible-looking but wrong drop index. Omitting
+ * `startDrag`'s `doc` therefore requires `container` to come from the global `document`. A host
+ * driving several breakpoint frames needs one `DragReorderController` per frame, not one shared
+ * instance — see the design doc's "Known limitations carried into slice 4".
  */
 export class DragReorderController {
   #engine: WysiwygEngine;
@@ -93,6 +101,9 @@ export class DragReorderController {
     return this.#draggingId !== null;
   }
 
+  /** Begins tracking a drag of `blockId`. `doc` must be the document `container` belongs to (see
+   *  the class doc comment) — pointer coordinates from a different document are measured against
+   *  the wrong coordinate space. */
   startDrag(blockId: BlockId, doc: Document = document): void {
     this.#draggingId = blockId;
     this.#doc = doc;
@@ -131,6 +142,15 @@ export class DragReorderController {
     // rather than submit a moveBlock against a now-invalid index.
     if (fromIndex === -1) return;
 
+    // `computeDropTarget` measures against the DOM *including* the still-present dragged element, so
+    // its index is in pre-removal coordinates; `moveBlock.toIndex` is post-removal (types.ts). Those
+    // agree except when moving a block later in its own slot, where every index past `fromIndex`
+    // shifts down by one once the block is lifted out. This controller only ever moves within the
+    // root slot today, but check the actual from/to slot so a future nested-slot target can't
+    // silently inherit the same-slot adjustment.
+    const sameSlot = target.parentId === ROOT_PARENT_ID && target.slot === "default";
+    const toIndex = sameSlot && fromIndex < target.index ? target.index - 1 : target.index;
+
     await this.#engine.submit({
       kind: "moveBlock",
       blockId,
@@ -139,7 +159,7 @@ export class DragReorderController {
       fromIndex,
       toParentId: target.parentId,
       toSlot: target.slot,
-      toIndex: target.index,
+      toIndex,
     });
   }
 }

--- a/JS/wysiwyg-engine/src/drag-drop.ts
+++ b/JS/wysiwyg-engine/src/drag-drop.ts
@@ -115,7 +115,9 @@ export class DragReorderController {
     this.#doc?.removeEventListener("pointermove", this.#onMove);
     this.#doc?.removeEventListener("pointerup", this.#onUp);
     this.#draggingId = null;
+    this.#indicatorTarget = null;
     this.#doc = null;
+    this.#onIndicator(null);
   }
 
   #handleMove(event: PointerEvent): void {
@@ -193,7 +195,15 @@ export function wireExternalDrop(
     event.preventDefault();
     onIndicator(computeDropTarget({ x: event.clientX, y: event.clientY }, container, parentId, slot));
   };
-  const onDragLeave = () => onIndicator(null);
+  // dragleave bubbles from every child block element the drag passes over, not just from a true
+  // exit of canvasEl itself — clearing the indicator on every bubbled event would flicker it off
+  // and back on as the drag crosses in-canvas block boundaries. Only clear when the drag has
+  // actually left canvasEl's subtree (relatedTarget is where the pointer went, null at the
+  // viewport edge — that's also a real exit).
+  const onDragLeave = (event: DragEvent) => {
+    if (event.relatedTarget instanceof Node && canvasEl.contains(event.relatedTarget)) return;
+    onIndicator(null);
+  };
   const onDropEvent = (event: DragEvent) => {
     event.preventDefault();
     onIndicator(null);

--- a/JS/wysiwyg-engine/src/drag-drop.ts
+++ b/JS/wysiwyg-engine/src/drag-drop.ts
@@ -143,3 +143,52 @@ export class DragReorderController {
     });
   }
 }
+
+export type ExternalDropHandler = (target: DropTarget, dataTransfer: DataTransfer) => void;
+
+export interface WireExternalDropOptions {
+  container?: ParentNode;
+  parentId?: ParentRef;
+  slot?: string;
+}
+
+/**
+ * Wires native `dragover`/`dragleave`/`drop` DOM events on `canvasEl` for external drags (palette,
+ * Finder) — real OS/host-originated drags surface as native drag events even inside a WKWebView.
+ * The engine never interprets `DataTransfer` itself (design doc §5): `onDrop` receives the computed
+ * target and the raw `DataTransfer`, and the host decides what block (if any) to build and calls
+ * `submitDrop`. Returns a disposer that removes all three listeners.
+ */
+export function wireExternalDrop(
+  canvasEl: HTMLElement,
+  onIndicator: (target: DropTarget | null) => void,
+  onDrop: ExternalDropHandler,
+  options: WireExternalDropOptions = {},
+): () => void {
+  const container = options.container ?? canvasEl;
+  const parentId = options.parentId ?? ROOT_PARENT_ID;
+  const slot = options.slot ?? "default";
+
+  const onDragOver = (event: DragEvent) => {
+    event.preventDefault();
+    onIndicator(computeDropTarget({ x: event.clientX, y: event.clientY }, container, parentId, slot));
+  };
+  const onDragLeave = () => onIndicator(null);
+  const onDropEvent = (event: DragEvent) => {
+    event.preventDefault();
+    onIndicator(null);
+    if (!event.dataTransfer) return;
+    const target = computeDropTarget({ x: event.clientX, y: event.clientY }, container, parentId, slot);
+    onDrop(target, event.dataTransfer);
+  };
+
+  canvasEl.addEventListener("dragover", onDragOver);
+  canvasEl.addEventListener("dragleave", onDragLeave);
+  canvasEl.addEventListener("drop", onDropEvent);
+
+  return () => {
+    canvasEl.removeEventListener("dragover", onDragOver);
+    canvasEl.removeEventListener("dragleave", onDragLeave);
+    canvasEl.removeEventListener("drop", onDropEvent);
+  };
+}

--- a/JS/wysiwyg-engine/src/drag-drop.ts
+++ b/JS/wysiwyg-engine/src/drag-drop.ts
@@ -1,0 +1,66 @@
+import type { BlockId, BlockNode, OpResult, ParentRef } from "./types.js";
+import type { WysiwygEngine } from "./engine.js";
+import { ROOT_PARENT_ID } from "./types.js";
+import { BLOCK_ID_ATTR } from "./hit-test.js";
+
+export interface DropTarget {
+  parentId: ParentRef;
+  slot: string;
+  index: number;
+}
+
+/**
+ * Pure geometry: given a vertical point and the ordered rects of the candidate siblings, finds the
+ * nearest valid insertion index by comparing against each sibling's vertical midpoint. Split out
+ * from `computeDropTarget`'s DOM-querying half so it's unit-testable without a real layout engine
+ * (mirrors hit-test.ts's split between `hitTest()` and `blockIdForElement()`).
+ */
+export function nearestIndexInSlot(pointY: number, siblingRects: { top: number; bottom: number }[]): number {
+  for (let i = 0; i < siblingRects.length; i++) {
+    const rect = siblingRects[i];
+    if (!rect) continue;
+    const midpoint = (rect.top + rect.bottom) / 2;
+    if (pointY < midpoint) return i;
+  }
+  return siblingRects.length;
+}
+
+/**
+ * Computes the nearest valid insertion point for a point-based drag/drop gesture among the direct
+ * block-children of `container`. Root-level only for this slice, matching the fixture host/e2e
+ * convention that already treats top-level blocks as `ROOT_PARENT_ID`/"default" — the `parentId`/
+ * `slot` parameters leave room for nested-slot targeting in a future slice without an API change.
+ */
+export function computeDropTarget(
+  point: { x: number; y: number },
+  container: ParentNode,
+  parentId: ParentRef = ROOT_PARENT_ID,
+  slot = "default",
+): DropTarget {
+  const children = Array.from(container.children).filter((el) => el.hasAttribute(BLOCK_ID_ATTR));
+  const rects = children.map((el) => el.getBoundingClientRect());
+  return { parentId, slot, index: nearestIndexInSlot(point.y, rects) };
+}
+
+let idCounter = 0;
+
+/** Block IDs are engine-generated, never raw user text (types.ts) — this is chrome's generator for
+ *  blocks created by a drop, distinct per call within a session. */
+export function generateBlockId(): BlockId {
+  idCounter += 1;
+  return `chrome-${Date.now().toString(36)}-${idCounter}`;
+}
+
+/** Builds and submits the `insertBlock` op for a drop at `target`. The engine never inspects a
+ *  drag's `DataTransfer` itself (design doc §5) — by the time `submitDrop` is called, the host has
+ *  already decided what `block` to build. */
+export function submitDrop(engine: WysiwygEngine, target: DropTarget, block: Omit<BlockNode, "id">): Promise<OpResult> {
+  return engine.submit({
+    kind: "insertBlock",
+    parentId: target.parentId,
+    slot: target.slot,
+    index: target.index,
+    newId: generateBlockId(),
+    block,
+  });
+}

--- a/JS/wysiwyg-engine/src/index.ts
+++ b/JS/wysiwyg-engine/src/index.ts
@@ -8,3 +8,6 @@ export * from "./hit-test.js";
 export * from "./selection.js";
 export * from "./op-queue.js";
 export * from "./engine.js";
+export * from "./rich-text.js";
+export * from "./drag-drop.js";
+export * from "./breakpoints.js";

--- a/JS/wysiwyg-engine/src/rich-text.ts
+++ b/JS/wysiwyg-engine/src/rich-text.ts
@@ -18,6 +18,11 @@ const INLINE_TAG_TO_RUN_KIND: Record<string, RichTextRun["kind"]> = {
  * contenteditable implementation might inject — a stray `<div>` from a paste, a styled `<span>` —
  * is not represented; its text content flattens into the surrounding run. This is the structural
  * backstop for roundtrip honesty, independent of how careful the editing UI upstream is.
+ *
+ * Composing two recognized formats (bold containing italic, etc.) nests one recognized tag inside
+ * another — that nesting is preserved via `RichTextRun.children`, not flattened. `text` on a
+ * composed run still carries the full flattened content, so a consumer that ignores `children`
+ * gets a reasonable plain-text fallback rather than nothing.
  */
 export function runsFromElement(el: Element): RichTextRun[] {
   const runs: RichTextRun[] = [];
@@ -42,8 +47,20 @@ function runFromNode(node: ChildNode): RichTextRun | null {
   if (text.length === 0) return null;
 
   if (!kind) return { kind: "text", text };
-  if (kind === "link") return { kind, text, href: el.getAttribute("href") ?? "" };
-  return { kind, text };
+
+  // Composing two recognized formats (e.g. toggling italic on a selection already inside a bold
+  // run) nests one recognized tag inside another — an entirely ordinary editing gesture. Recurse
+  // so that composition survives a commit instead of collapsing to a single flat run via
+  // `textContent`; `children` is populated only when a genuinely nested format is present, so a
+  // plain (non-composed) recognized run stays exactly as flat as before.
+  const children = runsFromElement(el);
+  const isComposed = children.some((child) => child.kind !== "text");
+
+  if (kind === "link") {
+    const href = el.getAttribute("href") ?? "";
+    return isComposed ? { kind, text, href, children } : { kind, text, href };
+  }
+  return isComposed ? { kind, text, children } : { kind, text };
 }
 
 function mergeAdjacentTextRuns(runs: RichTextRun[]): RichTextRun[] {

--- a/JS/wysiwyg-engine/src/rich-text.ts
+++ b/JS/wysiwyg-engine/src/rich-text.ts
@@ -1,0 +1,57 @@
+import type { RichTextRun } from "./types.js";
+
+const INLINE_TAG_TO_RUN_KIND: Record<string, RichTextRun["kind"]> = {
+  strong: "strong",
+  b: "strong",
+  em: "em",
+  i: "em",
+  a: "link",
+  code: "code",
+};
+
+/**
+ * Serializes a contenteditable element's live DOM into the honest-runs vocabulary (spec §4): only
+ * strong/em/link/code ever survive as anything but text. Anything else the browser's
+ * contenteditable implementation might inject — a stray `<div>` from a paste, a styled `<span>` —
+ * is not represented; its text content flattens into the surrounding run. This is the structural
+ * backstop for roundtrip honesty, independent of how careful the editing UI upstream is.
+ */
+export function runsFromElement(el: Element): RichTextRun[] {
+  const runs: RichTextRun[] = [];
+  for (const node of Array.from(el.childNodes)) {
+    const run = runFromNode(node);
+    if (run) runs.push(run);
+  }
+  return mergeAdjacentTextRuns(runs);
+}
+
+function runFromNode(node: ChildNode): RichTextRun | null {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent ?? "";
+    return text.length > 0 ? { kind: "text", text } : null;
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return null;
+
+  const el = node as Element;
+  const tag = el.tagName.toLowerCase();
+  const kind = INLINE_TAG_TO_RUN_KIND[tag];
+  const text = el.textContent ?? "";
+  if (text.length === 0) return null;
+
+  if (!kind) return { kind: "text", text };
+  if (kind === "link") return { kind, text, href: el.getAttribute("href") ?? "" };
+  return { kind, text };
+}
+
+function mergeAdjacentTextRuns(runs: RichTextRun[]): RichTextRun[] {
+  const merged: RichTextRun[] = [];
+  for (const run of runs) {
+    const prev = merged[merged.length - 1];
+    if (prev && prev.kind === "text" && run.kind === "text") {
+      prev.text += run.text;
+    } else {
+      merged.push({ ...run });
+    }
+  }
+  return merged;
+}

--- a/JS/wysiwyg-engine/src/rich-text.ts
+++ b/JS/wysiwyg-engine/src/rich-text.ts
@@ -55,3 +55,40 @@ function mergeAdjacentTextRuns(runs: RichTextRun[]): RichTextRun[] {
   }
   return merged;
 }
+
+/** Coalesces a burst of changes into a single `commit()` call after `delayMs` of quiet, or
+ *  immediately via `flush()` — the mechanism behind `RichTextEditor`'s debounced `editText`
+ *  commits (design doc §4). Pure timer logic, no DOM dependency. */
+export class DebouncedCommitter {
+  #commit: () => void;
+  #delayMs: number;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(commit: () => void, delayMs: number) {
+    this.#commit = commit;
+    this.#delayMs = delayMs;
+  }
+
+  notifyChange(): void {
+    this.cancel();
+    this.#timer = setTimeout(() => {
+      this.#timer = null;
+      this.#commit();
+    }, this.#delayMs);
+  }
+
+  /** Commits now if a debounced commit is pending; otherwise does nothing. */
+  flush(): void {
+    const pending = this.#timer !== null;
+    this.cancel();
+    if (pending) this.#commit();
+  }
+
+  /** Discards a pending commit without running it. */
+  cancel(): void {
+    if (this.#timer !== null) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+  }
+}

--- a/JS/wysiwyg-engine/src/rich-text.ts
+++ b/JS/wysiwyg-engine/src/rich-text.ts
@@ -216,8 +216,12 @@ export class RichTextEditor {
     if (this.#activeBlockId === blockId) return;
     if (this.#activeBlockId !== null) this.exit();
 
-    const el = findBlockElement(blockId, root);
-    if (!(el instanceof HTMLElement)) return;
+    // `root` exists precisely so a caller can pass another frame's Document (BreakpointCanvas), and
+    // an element from another realm is not `instanceof` *this* realm's HTMLElement — an
+    // `instanceof` guard here silently no-ops every cross-document edit. Duck-type on the DOM
+    // interface instead, the way hit-test.ts already does.
+    const el = findBlockElement(blockId, root) as HTMLElement | null;
+    if (el === null || el.nodeType !== 1 /* Node.ELEMENT_NODE */) return;
 
     this.#baselineRuns = this.#engine.modelSync.getBlock(blockId)?.richText ?? [];
     this.#activeBlockId = blockId;
@@ -244,21 +248,26 @@ export class RichTextEditor {
     this.#baselineRuns = [];
   }
 
+  // The three format commands all derive their Document from the active element rather than letting
+  // the format helpers fall back to the global `document`: the active element can live in a
+  // breakpoint frame, whose Selection/Range — and whose ownership of any wrapper element created by
+  // `wrapRange` — belong to that frame's document, not this module's.
+
   toggleFormat(kind: FormatKind): void {
     if (!this.#activeElement) return;
-    toggleInlineFormat(this.#activeElement, kind);
+    toggleInlineFormat(this.#activeElement, kind, this.#activeElement.ownerDocument);
     this.#committer.notifyChange();
   }
 
   setLink(href: string): void {
     if (!this.#activeElement) return;
-    setLinkFormat(this.#activeElement, href);
+    setLinkFormat(this.#activeElement, href, this.#activeElement.ownerDocument);
     this.#committer.notifyChange();
   }
 
   unsetLink(): void {
     if (!this.#activeElement) return;
-    unsetLinkFormat(this.#activeElement);
+    unsetLinkFormat(this.#activeElement, this.#activeElement.ownerDocument);
     this.#committer.notifyChange();
   }
 

--- a/JS/wysiwyg-engine/src/rich-text.ts
+++ b/JS/wysiwyg-engine/src/rich-text.ts
@@ -1,4 +1,7 @@
 import type { RichTextRun } from "./types.js";
+import type { BlockId } from "./types.js";
+import type { WysiwygEngine } from "./engine.js";
+import { findBlockElement } from "./selection.js";
 
 const INLINE_TAG_TO_RUN_KIND: Record<string, RichTextRun["kind"]> = {
   strong: "strong",
@@ -172,4 +175,104 @@ export function unsetLinkFormat(root: HTMLElement, doc: Document = document): vo
   if (!selection || selection.rangeCount === 0) return;
   const existing = findAncestorTag(selection.getRangeAt(0).commonAncestorContainer, "a", root);
   if (existing) unwrapElement(existing);
+}
+
+export interface RichTextEditorOptions {
+  debounceMs?: number;
+}
+
+const DEFAULT_DEBOUNCE_MS = 400;
+
+/**
+ * Contenteditable lifecycle for one text block at a time (design doc §4). `enter()` activates
+ * editing and snapshots the current runs as the commit baseline; an `input` listener schedules a
+ * debounced `editText` commit; `exit()` flushes any pending commit and deactivates. `previousRuns`
+ * on every commit is always the baseline captured at `enter()`, not the prior debounce tick — so a
+ * version-mismatch rejection mid-edit discards the whole in-progress edit in one step rather than
+ * reconstructing intermediate state.
+ */
+export class RichTextEditor {
+  #engine: WysiwygEngine;
+  #committer: DebouncedCommitter;
+  #activeBlockId: BlockId | null = null;
+  #activeElement: HTMLElement | null = null;
+  #baselineRuns: RichTextRun[] = [];
+  #onInput = () => this.#committer.notifyChange();
+  #onBlur = () => this.exit();
+  #onKeydown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") this.exit();
+  };
+
+  constructor(engine: WysiwygEngine, options: RichTextEditorOptions = {}) {
+    this.#engine = engine;
+    this.#committer = new DebouncedCommitter(() => this.#commit(), options.debounceMs ?? DEFAULT_DEBOUNCE_MS);
+  }
+
+  get activeBlockId(): BlockId | null {
+    return this.#activeBlockId;
+  }
+
+  enter(blockId: BlockId, root: ParentNode = document): void {
+    if (this.#activeBlockId === blockId) return;
+    if (this.#activeBlockId !== null) this.exit();
+
+    const el = findBlockElement(blockId, root);
+    if (!(el instanceof HTMLElement)) return;
+
+    this.#baselineRuns = this.#engine.modelSync.getBlock(blockId)?.richText ?? [];
+    this.#activeBlockId = blockId;
+    this.#activeElement = el;
+    el.contentEditable = "true";
+    el.addEventListener("input", this.#onInput);
+    el.addEventListener("blur", this.#onBlur);
+    el.addEventListener("keydown", this.#onKeydown);
+    el.focus();
+  }
+
+  /** Flushes any pending debounced commit and deactivates — called explicitly, or automatically on
+   *  blur/Escape (design doc §4: both commit immediately, alongside a format command). */
+  exit(): void {
+    this.#committer.flush();
+    if (this.#activeElement) {
+      this.#activeElement.removeEventListener("input", this.#onInput);
+      this.#activeElement.removeEventListener("blur", this.#onBlur);
+      this.#activeElement.removeEventListener("keydown", this.#onKeydown);
+      this.#activeElement.contentEditable = "false";
+    }
+    this.#activeBlockId = null;
+    this.#activeElement = null;
+    this.#baselineRuns = [];
+  }
+
+  toggleFormat(kind: FormatKind): void {
+    if (!this.#activeElement) return;
+    toggleInlineFormat(this.#activeElement, kind);
+    this.#committer.notifyChange();
+  }
+
+  setLink(href: string): void {
+    if (!this.#activeElement) return;
+    setLinkFormat(this.#activeElement, href);
+    this.#committer.notifyChange();
+  }
+
+  unsetLink(): void {
+    if (!this.#activeElement) return;
+    unsetLinkFormat(this.#activeElement);
+    this.#committer.notifyChange();
+  }
+
+  dispose(): void {
+    this.exit();
+  }
+
+  #commit(): void {
+    if (!this.#activeBlockId || !this.#activeElement) return;
+    void this.#engine.submit({
+      kind: "editText",
+      blockId: this.#activeBlockId,
+      runs: runsFromElement(this.#activeElement),
+      previousRuns: this.#baselineRuns,
+    });
+  }
 }

--- a/JS/wysiwyg-engine/src/rich-text.ts
+++ b/JS/wysiwyg-engine/src/rich-text.ts
@@ -92,3 +92,84 @@ export class DebouncedCommitter {
     }
   }
 }
+
+/** Walks up from `node` to the nearest ancestor (inclusive) whose tag matches `tagName`, stopping
+ *  at (and not including past) `root`. */
+export function findAncestorTag(node: Node, tagName: string, root: Element): HTMLElement | null {
+  let current: Node | null = node;
+  while (current && current !== root.parentNode) {
+    if (current.nodeType === Node.ELEMENT_NODE && (current as Element).tagName.toLowerCase() === tagName) {
+      return current as HTMLElement;
+    }
+    if (current === root) return null;
+    current = current.parentNode;
+  }
+  return null;
+}
+
+/** Wraps `range`'s contents in a new `tagName` element, replacing the range with it, and leaves
+ *  the element's contents selected (so a follow-up format command composes naturally). */
+export function wrapRange(range: Range, tagName: string, doc: Document = document): HTMLElement {
+  const wrapper = doc.createElement(tagName);
+  wrapper.appendChild(range.extractContents());
+  range.insertNode(wrapper);
+  range.selectNodeContents(wrapper);
+  const selection = doc.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  return wrapper;
+}
+
+/** Replaces `el` with its own children, at the same position — the inverse of `wrapRange`. */
+export function unwrapElement(el: HTMLElement): void {
+  const parent = el.parentNode;
+  if (!parent) return;
+  while (el.firstChild) parent.insertBefore(el.firstChild, el);
+  parent.removeChild(el);
+}
+
+export type FormatKind = "strong" | "em" | "code";
+
+const FORMAT_TAG: Record<FormatKind, string> = { strong: "strong", em: "em", code: "code" };
+
+/**
+ * Toggles `kind` on the current selection within `root`: unwraps if the selection is already
+ * inside a matching element, otherwise wraps it. Live-`Selection`-dependent — real behavior is
+ * covered by Playwright e2e goldens (Task 9), not jsdom, matching this package's established
+ * test split (jsdom has no real text-selection behavior to verify against).
+ */
+export function toggleInlineFormat(root: HTMLElement, kind: FormatKind, doc: Document = document): void {
+  const selection = doc.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.commonAncestorContainer)) return;
+
+  const tagName = FORMAT_TAG[kind];
+  const existing = findAncestorTag(range.commonAncestorContainer, tagName, root);
+  if (existing) {
+    unwrapElement(existing);
+  } else {
+    wrapRange(range, tagName, doc);
+  }
+}
+
+/** Wraps the current selection in `<a href>`, replacing any existing link ancestor first. */
+export function setLinkFormat(root: HTMLElement, href: string, doc: Document = document): void {
+  const selection = doc.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.commonAncestorContainer)) return;
+
+  const existing = findAncestorTag(range.commonAncestorContainer, "a", root);
+  if (existing) unwrapElement(existing);
+  const anchor = wrapRange(range, "a", doc);
+  anchor.setAttribute("href", href);
+}
+
+/** Removes the link ancestor around the current selection or caret, if any. */
+export function unsetLinkFormat(root: HTMLElement, doc: Document = document): void {
+  const selection = doc.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+  const existing = findAncestorTag(selection.getRangeAt(0).commonAncestorContainer, "a", root);
+  if (existing) unwrapElement(existing);
+}

--- a/JS/wysiwyg-engine/src/rich-text.ts
+++ b/JS/wysiwyg-engine/src/rich-text.ts
@@ -257,18 +257,21 @@ export class RichTextEditor {
     if (!this.#activeElement) return;
     toggleInlineFormat(this.#activeElement, kind, this.#activeElement.ownerDocument);
     this.#committer.notifyChange();
+    this.#committer.flush();
   }
 
   setLink(href: string): void {
     if (!this.#activeElement) return;
     setLinkFormat(this.#activeElement, href, this.#activeElement.ownerDocument);
     this.#committer.notifyChange();
+    this.#committer.flush();
   }
 
   unsetLink(): void {
     if (!this.#activeElement) return;
     unsetLinkFormat(this.#activeElement, this.#activeElement.ownerDocument);
     this.#committer.notifyChange();
+    this.#committer.flush();
   }
 
   dispose(): void {

--- a/JS/wysiwyg-engine/src/rich-text.ts
+++ b/JS/wysiwyg-engine/src/rich-text.ts
@@ -230,15 +230,19 @@ export class RichTextEditor {
   }
 
   enter(blockId: BlockId, root: ParentNode = document): void {
-    if (this.#activeBlockId === blockId) return;
-    if (this.#activeBlockId !== null) this.exit();
-
     // `root` exists precisely so a caller can pass another frame's Document (BreakpointCanvas), and
     // an element from another realm is not `instanceof` *this* realm's HTMLElement — an
     // `instanceof` guard here silently no-ops every cross-document edit. Duck-type on the DOM
     // interface instead, the way hit-test.ts already does.
     const el = findBlockElement(blockId, root) as HTMLElement | null;
     if (el === null || el.nodeType !== 1 /* Node.ELEMENT_NODE */) return;
+
+    // Compare by element identity, not just blockId: BreakpointCanvas renders the same blockId into
+    // every frame simultaneously, so re-entering "the same block" can still mean switching to a
+    // different frame's element. Only a redundant call for the exact element already being edited
+    // is a true no-op.
+    if (this.#activeElement === el) return;
+    if (this.#activeBlockId !== null) this.exit();
 
     this.#baselineRuns = this.#engine.modelSync.getBlock(blockId)?.richText ?? [];
     this.#activeBlockId = blockId;
@@ -297,10 +301,15 @@ export class RichTextEditor {
 
   #commit(): void {
     if (!this.#activeBlockId || !this.#activeElement) return;
+    const runs = runsFromElement(this.#activeElement);
+    // A touch-and-revert (type, then delete back to the exact original text before the debounce or
+    // a blur/Escape flush fires) would otherwise still submit a spurious no-op editText, reaching
+    // the host/undo pipeline for an edit that never actually happened.
+    if (JSON.stringify(runs) === JSON.stringify(this.#baselineRuns)) return;
     void this.#engine.submit({
       kind: "editText",
       blockId: this.#activeBlockId,
-      runs: runsFromElement(this.#activeElement),
+      runs,
       previousRuns: this.#baselineRuns,
     });
   }

--- a/JS/wysiwyg-engine/src/types.ts
+++ b/JS/wysiwyg-engine/src/types.ts
@@ -70,6 +70,8 @@ export type Op =
       fromIndex: number;
       toParentId: ParentRef;
       toSlot: string;
+      /** Interpreted against the destination slot AFTER `blockId` has been removed from `fromIndex`
+       *  — a same-slot move whose pre-removal target index is `n` submits `n - 1` when moving down. */
       toIndex: number;
     }
   | {

--- a/JS/wysiwyg-engine/test/breakpoints.test.ts
+++ b/JS/wysiwyg-engine/test/breakpoints.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { BreakpointCanvas } from "../src/breakpoints.js";
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { BLOCK_ID_ATTR } from "../src/hit-test.js";
+import type { BlockModel } from "../src/types.js";
+
+function makeModel(): BlockModel {
+  return {
+    path: "src/pages/index.astro",
+    version: "v1",
+    rootIds: ["b1"],
+    blocks: { b1: { id: "b1", kind: "astro", componentName: "Hero", props: { title: "Welcome" }, slots: {}, sourceSpan: [0, 1] } },
+  };
+}
+
+/** Minimal render function mirroring e2e/fixture-page.ts's render(): one <div> per root block,
+ *  carrying BLOCK_ID_ATTR, for a given frame document. */
+function render(model: BlockModel, doc: Document): void {
+  const root = doc.body;
+  root.innerHTML = "";
+  for (const id of model.rootIds) {
+    const block = model.blocks[id];
+    if (!block) continue;
+    const el = doc.createElement("div");
+    el.setAttribute(BLOCK_ID_ATTR, id);
+    el.textContent = block.componentName;
+    root.appendChild(el);
+  }
+}
+
+describe("BreakpointCanvas", () => {
+  it("renders the current model into a frame as soon as it's registered", () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const frameDoc = document.implementation.createHTMLDocument("phone");
+
+    canvas.registerFrame({ name: "phone", doc: frameDoc });
+
+    expect(frameDoc.querySelector(`[${BLOCK_ID_ATTR}="b1"]`)?.textContent).toBe("Hero");
+  });
+
+  it("re-renders every registered frame when the model changes via an applied op", async () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    const desktopDoc = document.implementation.createHTMLDocument("desktop");
+    canvas.registerFrame({ name: "phone", doc: phoneDoc });
+    canvas.registerFrame({ name: "desktop", doc: desktopDoc });
+
+    await engine.submit({ kind: "setProp", blockId: "b1", propName: "title", value: "Updated", previousValue: "Welcome" });
+
+    // The fixture render() above doesn't project props into text, so re-invocation is what we can
+    // observe directly here — assert both frames still reflect the (single, shared) current model
+    // by checking the block element survived a re-render in each, proving render() ran per frame.
+    expect(phoneDoc.querySelector(`[${BLOCK_ID_ATTR}="b1"]`)).not.toBeNull();
+    expect(desktopDoc.querySelector(`[${BLOCK_ID_ATTR}="b1"]`)).not.toBeNull();
+  });
+
+  it("unregisterFrame stops future re-renders for that frame", async () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    canvas.registerFrame({ name: "phone", doc: phoneDoc });
+    canvas.unregisterFrame("phone");
+
+    phoneDoc.body.innerHTML = "<p>untouched</p>";
+    await engine.submit({ kind: "setProp", blockId: "b1", propName: "title", value: "Updated", previousValue: "Welcome" });
+
+    expect(phoneDoc.body.innerHTML).toBe("<p>untouched</p>");
+    expect(canvas.frames).toHaveLength(0);
+  });
+
+  it("handleRectsForSelection returns one rect per frame currently rendering the selected block", () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    const desktopDoc = document.implementation.createHTMLDocument("desktop");
+    canvas.registerFrame({ name: "phone", doc: phoneDoc });
+    canvas.registerFrame({ name: "desktop", doc: desktopDoc });
+
+    expect(canvas.handleRectsForSelection()).toEqual([]);
+
+    engine.selection.select("b1");
+
+    // jsdom has no layout engine, so every rect is zero here — real handle geometry across frames
+    // is covered by Playwright e2e goldens (Task 9), matching selection.test.ts's own convention.
+    expect(canvas.handleRectsForSelection()).toEqual([
+      { name: "phone", rect: { x: 0, y: 0, width: 0, height: 0 } },
+      { name: "desktop", rect: { x: 0, y: 0, width: 0, height: 0 } },
+    ]);
+  });
+
+  it("hitTestFrame returns null for an unregistered frame name", () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    expect(canvas.hitTestFrame("phone", { x: 0, y: 0 })).toBeNull();
+  });
+
+  it("dispose() unsubscribes from engine events and clears registered frames", async () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    canvas.registerFrame({ name: "phone", doc: phoneDoc });
+
+    canvas.dispose();
+    phoneDoc.body.innerHTML = "<p>untouched</p>";
+    await engine.submit({ kind: "setProp", blockId: "b1", propName: "title", value: "Updated", previousValue: "Welcome" });
+
+    expect(phoneDoc.body.innerHTML).toBe("<p>untouched</p>");
+    expect(canvas.frames).toHaveLength(0);
+  });
+});

--- a/JS/wysiwyg-engine/test/drag-drop.test.ts
+++ b/JS/wysiwyg-engine/test/drag-drop.test.ts
@@ -250,4 +250,23 @@ describe("DragReorderController", () => {
     expect(moveOps).toEqual([]);
     expect(engine.modelSync.current.rootIds).toEqual(["b2"]);
   });
+
+  it("dispose() mid-drag clears the drop indicator, not just the drag state", () => {
+    document.body.innerHTML = `<div id="empty"></div>`;
+    const container = document.getElementById("empty");
+    if (!container) throw new Error("fixture missing");
+    const model = makeTwoBlockModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const indicators: unknown[] = [];
+    const controller = new DragReorderController(engine, (target) => indicators.push(target), container);
+
+    controller.startDrag("b1");
+    document.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 0 }));
+    expect(indicators).toEqual([{ parentId: "__root__", slot: "default", index: 0 }]);
+
+    controller.dispose();
+
+    expect(indicators).toEqual([{ parentId: "__root__", slot: "default", index: 0 }, null]);
+    expect(controller.isDragging).toBe(false);
+  });
 });

--- a/JS/wysiwyg-engine/test/drag-drop.test.ts
+++ b/JS/wysiwyg-engine/test/drag-drop.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { nearestIndexInSlot, computeDropTarget, generateBlockId, submitDrop } from "../src/drag-drop.js";
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { ROOT_PARENT_ID } from "../src/types.js";
+import { BLOCK_ID_ATTR } from "../src/hit-test.js";
+import type { BlockModel } from "../src/types.js";
+
+describe("nearestIndexInSlot", () => {
+  it("returns 0 for an empty sibling list", () => {
+    expect(nearestIndexInSlot(100, [])).toBe(0);
+  });
+
+  it("returns the index of the first sibling whose midpoint is below the point", () => {
+    const rects = [
+      { top: 0, bottom: 20 }, // midpoint 10
+      { top: 20, bottom: 60 }, // midpoint 40
+      { top: 60, bottom: 100 }, // midpoint 80
+    ];
+    expect(nearestIndexInSlot(5, rects)).toBe(0);
+    expect(nearestIndexInSlot(25, rects)).toBe(1);
+    expect(nearestIndexInSlot(85, rects)).toBe(3);
+  });
+});
+
+describe("computeDropTarget", () => {
+  // jsdom has no layout engine, so every element's getBoundingClientRect() is all zeros here —
+  // real point-vs-midpoint geometry is covered by Playwright e2e goldens (Task 9), matching this
+  // package's established test split (hit-test.ts/selection.ts). What's provable in jsdom: the
+  // container is queried for BLOCK_ID_ATTR children (not arbitrary children), and parentId/slot
+  // pass through unchanged.
+  it("only counts children carrying BLOCK_ID_ATTR, and passes parentId/slot through", () => {
+    document.body.innerHTML = `
+      <div id="canvas">
+        <div ${BLOCK_ID_ATTR}="b1"></div>
+        <span>not a block</span>
+        <div ${BLOCK_ID_ATTR}="b2"></div>
+      </div>
+    `;
+    const canvas = document.getElementById("canvas");
+    if (!canvas) throw new Error("fixture missing #canvas");
+
+    const target = computeDropTarget({ x: 0, y: 0 }, canvas, "some-parent", "gallery");
+    expect(target.parentId).toBe("some-parent");
+    expect(target.slot).toBe("gallery");
+    // All rects are zero under jsdom, so every midpoint is 0; a non-negative point.y never beats
+    // that, so the pure fallback ("append after the last sibling") is what's observable here.
+    expect(target.index).toBe(2);
+  });
+
+  it("defaults to ROOT_PARENT_ID and the 'default' slot", () => {
+    document.body.innerHTML = `<div id="canvas"></div>`;
+    const canvas = document.getElementById("canvas");
+    if (!canvas) throw new Error("fixture missing #canvas");
+    expect(computeDropTarget({ x: 0, y: 0 }, canvas)).toEqual({ parentId: ROOT_PARENT_ID, slot: "default", index: 0 });
+  });
+});
+
+describe("generateBlockId", () => {
+  it("returns a non-empty string, unique across calls", () => {
+    const a = generateBlockId();
+    const b = generateBlockId();
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+});
+
+describe("submitDrop", () => {
+  function makeModel(): BlockModel {
+    return {
+      path: "src/pages/index.astro",
+      version: "v1",
+      rootIds: ["b1"],
+      blocks: { b1: { id: "b1", kind: "astro", componentName: "Hero", props: {}, slots: {}, sourceSpan: [0, 1] } },
+    };
+  }
+
+  it("submits an insertBlock op at the given target and the block appears in the model", async () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+
+    const result = await submitDrop(
+      engine,
+      { parentId: ROOT_PARENT_ID, slot: "default", index: 0 },
+      { kind: "astro", componentName: "Newsletter", props: {}, slots: {}, sourceSpan: [0, 0] },
+    );
+
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied") throw new Error("expected applied");
+    expect(result.model.rootIds).toHaveLength(2);
+    const newId = result.model.rootIds.find((id) => id !== "b1");
+    expect(newId).toBeDefined();
+    expect(newId && result.model.blocks[newId]?.componentName).toBe("Newsletter");
+  });
+});

--- a/JS/wysiwyg-engine/test/drag-drop.test.ts
+++ b/JS/wysiwyg-engine/test/drag-drop.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect } from "vitest";
-import { nearestIndexInSlot, computeDropTarget, generateBlockId, submitDrop } from "../src/drag-drop.js";
+import { nearestIndexInSlot, computeDropTarget, generateBlockId, submitDrop, DragReorderController } from "../src/drag-drop.js";
 import { WysiwygEngine } from "../src/engine.js";
 import { FixtureHost } from "../src/testing/fixture-host.js";
 import { ROOT_PARENT_ID } from "../src/types.js";
@@ -93,5 +93,93 @@ describe("submitDrop", () => {
     const newId = result.model.rootIds.find((id) => id !== "b1");
     expect(newId).toBeDefined();
     expect(newId && result.model.blocks[newId]?.componentName).toBe("Newsletter");
+  });
+});
+
+describe("DragReorderController", () => {
+  function makeTwoBlockModel(): BlockModel {
+    return {
+      path: "src/pages/index.astro",
+      version: "v1",
+      rootIds: ["b1", "b2"],
+      blocks: {
+        b1: { id: "b1", kind: "astro", componentName: "Hero", props: {}, slots: {}, sourceSpan: [0, 1] },
+        b2: { id: "b2", kind: "astro", componentName: "Testimonial", props: {}, slots: {}, sourceSpan: [1, 2] },
+      },
+    };
+  }
+
+  it("reports an indicator target on pointermove while dragging", () => {
+    document.body.innerHTML = `<div id="empty"></div>`;
+    const container = document.getElementById("empty");
+    if (!container) throw new Error("fixture missing");
+    const model = makeTwoBlockModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const indicators: unknown[] = [];
+    const controller = new DragReorderController(engine, (target) => indicators.push(target), container);
+
+    expect(controller.isDragging).toBe(false);
+    controller.startDrag("b1");
+    expect(controller.isDragging).toBe(true);
+
+    document.dispatchEvent(new PointerEvent("pointermove", { clientX: 10, clientY: 20 }));
+
+    // `container` has no BLOCK_ID_ATTR children, so computeDropTarget's fallback (nearestIndexInSlot
+    // on an empty list) deterministically resolves to index 0 regardless of point — the real
+    // point-vs-midpoint geometry needs a layout engine and is e2e-covered (Task 9).
+    expect(indicators).toEqual([{ parentId: "__root__", slot: "default", index: 0 }]);
+  });
+
+  it("submits a moveBlock op to the indicator target on pointerup", async () => {
+    document.body.innerHTML = `<div id="empty"></div>`;
+    const container = document.getElementById("empty");
+    if (!container) throw new Error("fixture missing");
+    const model = makeTwoBlockModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const controller = new DragReorderController(engine, () => {}, container);
+
+    const applied = new Promise<void>((resolve) => {
+      const unsubscribe = engine.onEvent((event) => {
+        if (event.type === "applied") {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    controller.startDrag("b2");
+    document.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 0 }));
+    document.dispatchEvent(new PointerEvent("pointerup"));
+    await applied;
+
+    expect(engine.modelSync.current.rootIds).toEqual(["b2", "b1"]);
+    expect(controller.isDragging).toBe(false);
+  });
+
+  it("aborts cleanly, submitting nothing, when the dragged block vanishes mid-drag", () => {
+    document.body.innerHTML = `<div id="empty"></div>`;
+    const container = document.getElementById("empty");
+    if (!container) throw new Error("fixture missing");
+    const model = makeTwoBlockModel();
+    const host = new FixtureHost(model);
+    const engine = new WysiwygEngine(model, host);
+    const moveOps: unknown[] = [];
+    engine.onEvent((event) => {
+      if (event.type === "applied" && event.op.kind === "moveBlock") moveOps.push(event.op);
+    });
+    const controller = new DragReorderController(engine, () => {}, container);
+
+    controller.startDrag("b1");
+    document.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 0 }));
+    host.simulateExternalEdit({
+      ...model,
+      version: "v2",
+      rootIds: ["b2"],
+      blocks: { b2: model.blocks.b2 as NonNullable<typeof model.blocks.b2> },
+    });
+    document.dispatchEvent(new PointerEvent("pointerup"));
+
+    expect(moveOps).toEqual([]);
+    expect(engine.modelSync.current.rootIds).toEqual(["b2"]);
   });
 });

--- a/JS/wysiwyg-engine/test/drag-drop.test.ts
+++ b/JS/wysiwyg-engine/test/drag-drop.test.ts
@@ -109,6 +109,18 @@ describe("DragReorderController", () => {
     };
   }
 
+  function makeThreeBlockModel(): BlockModel {
+    const model = makeTwoBlockModel();
+    return {
+      ...model,
+      rootIds: [...model.rootIds, "b3"],
+      blocks: {
+        ...model.blocks,
+        b3: { id: "b3", kind: "astro", componentName: "Newsletter", props: {}, slots: {}, sourceSpan: [2, 3] },
+      },
+    };
+  }
+
   it("reports an indicator target on pointermove while dragging", () => {
     document.body.innerHTML = `<div id="empty"></div>`;
     const container = document.getElementById("empty");
@@ -128,6 +140,62 @@ describe("DragReorderController", () => {
     // on an empty list) deterministically resolves to index 0 regardless of point — the real
     // point-vs-midpoint geometry needs a layout engine and is e2e-covered (Task 9).
     expect(indicators).toEqual([{ parentId: "__root__", slot: "default", index: 0 }]);
+
+    // This test never releases the pointer, so the document-level listeners startDrag() attached
+    // would outlive it and see the *next* test's synthetic events. Clean up explicitly rather than
+    // relying on test ordering to absorb them.
+    controller.dispose();
+  });
+
+  it("submits a downward same-slot move against post-removal indices", async () => {
+    // computeDropTarget measures with the dragged element still in the DOM; moveBlock.toIndex is
+    // post-removal (types.ts). jsdom reports all-zero rects, so stub the geometry directly — this
+    // is the unit-tier guard for the off-by-one the e2e downward-drag golden covers end to end.
+    // Three blocks are the minimum that can tell the bug apart: with two, an unadjusted index 2 and
+    // a correct index 1 both land at the end of the post-removal list.
+    document.body.innerHTML = `
+      <div id="canvas">
+        <div ${BLOCK_ID_ATTR}="b1"></div>
+        <div ${BLOCK_ID_ATTR}="b2"></div>
+        <div ${BLOCK_ID_ATTR}="b3"></div>
+      </div>
+    `;
+    const container = document.getElementById("canvas");
+    if (!container) throw new Error("fixture missing");
+    const bounds = [
+      { top: 0, bottom: 20 },
+      { top: 20, bottom: 40 },
+      { top: 40, bottom: 60 },
+    ];
+    Array.from(container.children).forEach((child, i) => {
+      const b = bounds[i];
+      if (!b) return;
+      child.getBoundingClientRect = () => ({ ...b, left: 0, right: 10, x: 0, y: b.top, width: 10, height: 20, toJSON: () => ({}) });
+    });
+
+    const model = makeThreeBlockModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const indicators: { index: number }[] = [];
+    const controller = new DragReorderController(engine, (t) => t && indicators.push(t), container);
+
+    const applied = new Promise<void>((resolve) => {
+      const unsubscribe = engine.onEvent((event) => {
+        if (event.type === "applied") {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    controller.startDrag("b1");
+    // Below b2's midpoint (30) but above b3's (50) — the indicator reads "between b2 and b3", i.e.
+    // pre-removal index 2.
+    document.dispatchEvent(new PointerEvent("pointermove", { clientX: 5, clientY: 35 }));
+    expect(indicators.map((t) => t.index)).toEqual([2]);
+    document.dispatchEvent(new PointerEvent("pointerup"));
+    await applied;
+
+    expect(engine.modelSync.current.rootIds).toEqual(["b2", "b1", "b3"]);
   });
 
   it("submits a moveBlock op to the indicator target on pointerup", async () => {

--- a/JS/wysiwyg-engine/test/rich-text.test.ts
+++ b/JS/wysiwyg-engine/test/rich-text.test.ts
@@ -1,6 +1,17 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { runsFromElement, DebouncedCommitter, findAncestorTag, wrapRange, unwrapElement } from "../src/rich-text.js";
+import {
+  runsFromElement,
+  DebouncedCommitter,
+  findAncestorTag,
+  wrapRange,
+  unwrapElement,
+  RichTextEditor,
+} from "../src/rich-text.js";
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { BLOCK_ID_ATTR } from "../src/hit-test.js";
+import type { BlockModel } from "../src/types.js";
 
 function setBody(html: string): Element {
   document.body.innerHTML = `<div id="root">${html}</div>`;
@@ -141,5 +152,192 @@ describe("findAncestorTag / wrapRange / unwrapElement", () => {
 
     unwrapElement(strong);
     expect(root.innerHTML).toBe("a bold b");
+  });
+});
+
+function makeTextModel(): BlockModel {
+  return {
+    path: "src/pages/index.astro",
+    version: "v1",
+    rootIds: ["t1"],
+    blocks: {
+      t1: {
+        id: "t1",
+        kind: "text",
+        componentName: "paragraph",
+        props: {},
+        slots: {},
+        sourceSpan: [0, 5],
+        richText: [{ kind: "text", text: "Hello" }],
+      },
+    },
+  };
+}
+
+describe("RichTextEditor", () => {
+  it("enter() makes the block contenteditable; exit() reverts it", () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    expect(el.contentEditable).toBe("true");
+
+    editor.exit();
+    expect(el.contentEditable).toBe("false");
+    expect(editor.activeBlockId).toBeNull();
+  });
+
+  it("commits a debounced editText op with the typed runs after the debounce window", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine, { debounceMs: 400 });
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(engine.modelSync.getBlock("t1")?.richText).toEqual([{ kind: "text", text: "Hello world" }]);
+    vi.useRealTimers();
+  });
+
+  it("multiple edits before the debounce fires still send the entry-time baseline as previousRuns", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const applied: { op: unknown }[] = [];
+    engine.onEvent((event) => {
+      if (event.type === "applied") applied.push({ op: event.op });
+    });
+    const editor = new RichTextEditor(engine, { debounceMs: 400 });
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+
+    el.textContent = "Hello w";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(200);
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(applied).toEqual([
+      {
+        op: {
+          kind: "editText",
+          blockId: "t1",
+          runs: [{ kind: "text", text: "Hello world" }],
+          previousRuns: [{ kind: "text", text: "Hello" }],
+        },
+      },
+    ]);
+    vi.useRealTimers();
+  });
+
+  it("exit() flushes a pending commit immediately instead of discarding it", async () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine, { debounceMs: 10_000 });
+
+    const applied = new Promise<void>((resolve) => {
+      const unsubscribe = engine.onEvent((event) => {
+        if (event.type === "applied") {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+
+    editor.exit();
+    await applied;
+
+    expect(engine.modelSync.getBlock("t1")?.richText).toEqual([{ kind: "text", text: "Hello world" }]);
+  });
+
+  it("entering a different block exits the previous one first", () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div><div ${BLOCK_ID_ATTR}="t2">World</div>`;
+    const base = makeTextModel();
+    const model: BlockModel = {
+      ...base,
+      rootIds: ["t1", "t2"],
+      blocks: {
+        ...base.blocks,
+        t2: {
+          id: "t2",
+          kind: "text",
+          componentName: "paragraph",
+          props: {},
+          slots: {},
+          sourceSpan: [6, 11],
+          richText: [{ kind: "text", text: "World" }],
+        },
+      },
+    };
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1");
+    editor.enter("t2");
+
+    expect(editor.activeBlockId).toBe("t2");
+    const t1 = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    expect(t1.contentEditable).toBe("false");
+  });
+
+  it("blur exits editing and flushes a pending commit (design doc §4: commit immediately on blur)", async () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine, { debounceMs: 10_000 });
+
+    const applied = new Promise<void>((resolve) => {
+      const unsubscribe = engine.onEvent((event) => {
+        if (event.type === "applied") {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new FocusEvent("blur"));
+
+    // Synchronous: exit()'s state cleanup happens before the flushed commit's async submit resolves.
+    expect(editor.activeBlockId).toBeNull();
+    expect(el.contentEditable).toBe("false");
+
+    await applied;
+    expect(engine.modelSync.getBlock("t1")?.richText).toEqual([{ kind: "text", text: "Hello world" }]);
+  });
+
+  it("pressing Escape exits editing (design doc §4: commit immediately on Escape)", () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect(editor.activeBlockId).toBeNull();
+    expect(el.contentEditable).toBe("false");
   });
 });

--- a/JS/wysiwyg-engine/test/rich-text.test.ts
+++ b/JS/wysiwyg-engine/test/rich-text.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
-import { runsFromElement } from "../src/rich-text.js";
+import { describe, it, expect, vi } from "vitest";
+import { runsFromElement, DebouncedCommitter } from "../src/rich-text.js";
 
 function setBody(html: string): Element {
   document.body.innerHTML = `<div id="root">${html}</div>`;
@@ -49,5 +49,61 @@ describe("runsFromElement", () => {
 
   it("returns an empty array for an empty element", () => {
     expect(runsFromElement(setBody(""))).toEqual([]);
+  });
+});
+
+describe("DebouncedCommitter", () => {
+  it("commits once, after the delay, following a burst of notifyChange calls", () => {
+    vi.useFakeTimers();
+    let commits = 0;
+    const committer = new DebouncedCommitter(() => {
+      commits += 1;
+    }, 400);
+
+    committer.notifyChange();
+    vi.advanceTimersByTime(200);
+    committer.notifyChange(); // resets the timer
+    vi.advanceTimersByTime(200);
+    expect(commits).toBe(0); // still within the debounce window from the second call
+
+    vi.advanceTimersByTime(200);
+    expect(commits).toBe(1);
+
+    vi.useRealTimers();
+  });
+
+  it("flush() commits immediately if a commit is pending, and is a no-op otherwise", () => {
+    vi.useFakeTimers();
+    let commits = 0;
+    const committer = new DebouncedCommitter(() => {
+      commits += 1;
+    }, 400);
+
+    committer.flush();
+    expect(commits).toBe(0); // nothing pending
+
+    committer.notifyChange();
+    committer.flush();
+    expect(commits).toBe(1);
+
+    vi.advanceTimersByTime(400);
+    expect(commits).toBe(1); // flush() already cancelled the pending timer
+
+    vi.useRealTimers();
+  });
+
+  it("cancel() discards a pending commit without running it", () => {
+    vi.useFakeTimers();
+    let commits = 0;
+    const committer = new DebouncedCommitter(() => {
+      commits += 1;
+    }, 400);
+
+    committer.notifyChange();
+    committer.cancel();
+    vi.advanceTimersByTime(400);
+    expect(commits).toBe(0);
+
+    vi.useRealTimers();
   });
 });

--- a/JS/wysiwyg-engine/test/rich-text.test.ts
+++ b/JS/wysiwyg-engine/test/rich-text.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { runsFromElement } from "../src/rich-text.js";
+
+function setBody(html: string): Element {
+  document.body.innerHTML = `<div id="root">${html}</div>`;
+  const root = document.getElementById("root");
+  if (!root) throw new Error("missing #root");
+  return root;
+}
+
+describe("runsFromElement", () => {
+  it("reads plain text as a single text run", () => {
+    expect(runsFromElement(setBody("Hello world"))).toEqual([{ kind: "text", text: "Hello world" }]);
+  });
+
+  it("recognizes strong, em, link, and code", () => {
+    const root = setBody('Hi <strong>bold</strong> and <em>emph</em> and <a href="/x">link</a> and <code>x</code>.');
+    expect(runsFromElement(root)).toEqual([
+      { kind: "text", text: "Hi " },
+      { kind: "strong", text: "bold" },
+      { kind: "text", text: " and " },
+      { kind: "em", text: "emph" },
+      { kind: "text", text: " and " },
+      { kind: "link", text: "link", href: "/x" },
+      { kind: "text", text: " and " },
+      { kind: "code", text: "x" },
+      { kind: "text", text: "." },
+    ]);
+  });
+
+  it("treats <b> and <i> as strong/em aliases", () => {
+    const root = setBody("<b>bold</b><i>italic</i>");
+    expect(runsFromElement(root)).toEqual([
+      { kind: "strong", text: "bold" },
+      { kind: "em", text: "italic" },
+    ]);
+  });
+
+  it("flattens unrecognized markup to its text content — the honest-runs backstop", () => {
+    const root = setBody('<div>block</div><span style="color:red">styled</span>');
+    expect(runsFromElement(root)).toEqual([{ kind: "text", text: "blockstyled" }]);
+  });
+
+  it("merges adjacent text runs produced by flattening", () => {
+    const root = setBody("start <span>middle</span> end");
+    expect(runsFromElement(root)).toEqual([{ kind: "text", text: "start middle end" }]);
+  });
+
+  it("returns an empty array for an empty element", () => {
+    expect(runsFromElement(setBody(""))).toEqual([]);
+  });
+});

--- a/JS/wysiwyg-engine/test/rich-text.test.ts
+++ b/JS/wysiwyg-engine/test/rich-text.test.ts
@@ -326,10 +326,15 @@ describe("RichTextEditor", () => {
     });
 
     editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    // A real content change, independent of jsdom's unreliable Selection support — jsdom has no
+    // live Selection, so toggleFormat()'s own DOM wrapping no-ops here (that path is e2e-covered),
+    // but the already-changed content must still flush immediately when toggleFormat is called.
+    el.textContent = "Hello world";
     editor.toggleFormat("strong");
     await applied;
 
-    expect(engine.modelSync.getBlock("t1")).toBeDefined();
+    expect(engine.modelSync.getBlock("t1")?.richText).toEqual([{ kind: "text", text: "Hello world" }]);
   });
 
   it("entering a different block exits the previous one first", () => {
@@ -360,6 +365,73 @@ describe("RichTextEditor", () => {
     expect(editor.activeBlockId).toBe("t2");
     const t1 = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
     expect(t1.contentEditable).toBe("false");
+  });
+
+  it("re-entering the same blockId in a different frame switches to that frame's element", () => {
+    // BreakpointCanvas renders the identical blockId into every frame simultaneously — re-entering
+    // "the same block" can still mean switching frames, not a no-op.
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    phoneDoc.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const tabletDoc = document.implementation.createHTMLDocument("tablet");
+    tabletDoc.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1", phoneDoc);
+    const phoneEl = phoneDoc.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    expect(phoneEl.contentEditable).toBe("true");
+
+    editor.enter("t1", tabletDoc);
+    const tabletEl = tabletDoc.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+
+    expect(phoneEl.contentEditable).toBe("false");
+    expect(tabletEl.contentEditable).toBe("true");
+  });
+
+  it("re-entering the exact same element is a true no-op (doesn't reset the baseline)", () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.textContent = "Hello world"; // an in-progress, uncommitted edit
+    editor.enter("t1"); // redundant re-entry of the same element
+
+    // If this had gone through exit()+enter() again, the baseline would have been re-snapshotted
+    // from the (still "Hello") model and the in-progress DOM edit would have been silently
+    // discarded via exit()'s contentEditable=false toggle.
+    expect(el.textContent).toBe("Hello world");
+    expect(el.contentEditable).toBe("true");
+  });
+
+  it("a fully reverted edit (touch-and-revert) does not submit a spurious no-op commit", async () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const applied: unknown[] = [];
+    engine.onEvent((event) => {
+      if (event.type === "applied") applied.push(event.op);
+    });
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.textContent = "Hello"; // revert back to the exact enter()-time baseline before exiting
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+
+    editor.exit();
+    // Nothing to await: a genuinely no-op flush resolves synchronously with no engine.submit() call
+    // at all, so there's no "applied" event to wait for — give any errant async submit one beat.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(applied).toEqual([]);
   });
 
   it("blur exits editing and flushes a pending commit (design doc §4: commit immediately on blur)", async () => {

--- a/JS/wysiwyg-engine/test/rich-text.test.ts
+++ b/JS/wysiwyg-engine/test/rich-text.test.ts
@@ -268,6 +268,30 @@ describe("RichTextEditor", () => {
     expect(engine.modelSync.getBlock("t1")?.richText).toEqual([{ kind: "text", text: "Hello world" }]);
   });
 
+  it("toggleFormat/setLink/unsetLink commit immediately, not after the debounce window", async () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    // A debounce long enough that this test would time out waiting for it to elapse — proving
+    // the commit did NOT go through the debounce path.
+    const editor = new RichTextEditor(engine, { debounceMs: 10_000 });
+
+    const applied = new Promise<void>((resolve) => {
+      const unsubscribe = engine.onEvent((event) => {
+        if (event.type === "applied") {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    editor.enter("t1");
+    editor.toggleFormat("strong");
+    await applied;
+
+    expect(engine.modelSync.getBlock("t1")).toBeDefined();
+  });
+
   it("entering a different block exits the previous one first", () => {
     document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div><div ${BLOCK_ID_ATTR}="t2">World</div>`;
     const base = makeTextModel();

--- a/JS/wysiwyg-engine/test/rich-text.test.ts
+++ b/JS/wysiwyg-engine/test/rich-text.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { runsFromElement, DebouncedCommitter } from "../src/rich-text.js";
+import { runsFromElement, DebouncedCommitter, findAncestorTag, wrapRange, unwrapElement } from "../src/rich-text.js";
 
 function setBody(html: string): Element {
   document.body.innerHTML = `<div id="root">${html}</div>`;
@@ -105,5 +105,41 @@ describe("DebouncedCommitter", () => {
     expect(commits).toBe(0);
 
     vi.useRealTimers();
+  });
+});
+
+describe("findAncestorTag / wrapRange / unwrapElement", () => {
+  it("finds the nearest ancestor with the given tag, stopping at root", () => {
+    document.body.innerHTML = '<div id="root"><strong id="s"><span id="inner">x</span></strong></div>';
+    const root = document.getElementById("root");
+    const inner = document.getElementById("inner");
+    if (!root || !inner) throw new Error("fixture missing");
+    expect(findAncestorTag(inner, "strong", root)?.id).toBe("s");
+    expect(findAncestorTag(inner, "em", root)).toBeNull();
+  });
+
+  it("wrapRange wraps the range's contents in a new element and returns it", () => {
+    document.body.innerHTML = '<div id="root">hello world</div>';
+    const root = document.getElementById("root");
+    const textNode = root?.firstChild;
+    if (!root || !textNode) throw new Error("fixture missing");
+
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 5); // "hello"
+
+    const wrapped = wrapRange(range, "strong", document);
+    expect(wrapped.tagName.toLowerCase()).toBe("strong");
+    expect(root.innerHTML).toBe("<strong>hello</strong> world");
+  });
+
+  it("unwrapElement replaces the element with its children in place", () => {
+    document.body.innerHTML = '<div id="root">a <strong id="s">bold</strong> b</div>';
+    const root = document.getElementById("root");
+    const strong = document.getElementById("s");
+    if (!root || !strong) throw new Error("fixture missing");
+
+    unwrapElement(strong);
+    expect(root.innerHTML).toBe("a bold b");
   });
 });

--- a/JS/wysiwyg-engine/test/rich-text.test.ts
+++ b/JS/wysiwyg-engine/test/rich-text.test.ts
@@ -48,6 +48,46 @@ describe("runsFromElement", () => {
     ]);
   });
 
+  it("preserves nested recognized formats via children, instead of flattening them away", () => {
+    // The ordinary composition gesture: toggling italic on a sub-selection already inside a bold
+    // run nests <em> inside <strong>. Before this test's fix, runFromNode() read el.textContent on
+    // the outer <strong> and discarded the inner <em> entirely.
+    const root = setBody("<strong>Ed<em>i</em>t</strong>");
+    expect(runsFromElement(root)).toEqual([
+      {
+        kind: "strong",
+        text: "Edit",
+        children: [
+          { kind: "text", text: "Ed" },
+          { kind: "em", text: "i" },
+          { kind: "text", text: "t" },
+        ],
+      },
+    ]);
+  });
+
+  it("does not add a children field to a plain (non-composed) recognized run", () => {
+    // children is populated only when genuine composition is present — a plain <strong> stays
+    // exactly as flat as it was before nesting support existed.
+    const root = setBody("<strong>bold</strong>");
+    expect(runsFromElement(root)).toEqual([{ kind: "strong", text: "bold" }]);
+  });
+
+  it("preserves nesting inside a link run alongside its href", () => {
+    const root = setBody('<a href="/x">see <strong>this</strong></a>');
+    expect(runsFromElement(root)).toEqual([
+      {
+        kind: "link",
+        text: "see this",
+        href: "/x",
+        children: [
+          { kind: "text", text: "see " },
+          { kind: "strong", text: "this" },
+        ],
+      },
+    ]);
+  });
+
   it("flattens unrecognized markup to its text content — the honest-runs backstop", () => {
     const root = setBody('<div>block</div><span style="color:red">styled</span>');
     expect(runsFromElement(root)).toEqual([{ kind: "text", text: "blockstyled" }]);

--- a/docs/superpowers/plans/2026-08-08-wysiwyg-canvas-chrome.md
+++ b/docs/superpowers/plans/2026-08-08-wysiwyg-canvas-chrome.md
@@ -1440,6 +1440,14 @@ git commit -m "feat(#1224): add wireExternalDrop for palette/Finder drags"
 
 - [ ] **Step 1: Write the failing test** `JS/wysiwyg-engine/test/breakpoints.test.ts`
 
+This file uses the global `document` (via `document.implementation.createHTMLDocument(...)`), which only exists under jsdom — this project's `vitest.config.ts` defaults to the "node" environment, so the file needs the same per-file opt-in Task 5 used for `drag-drop.test.ts`. Start the file with:
+
+```ts
+// @vitest-environment jsdom
+```
+
+Then:
+
 ```ts
 import { describe, it, expect } from "vitest";
 import { BreakpointCanvas } from "../src/breakpoints.js";

--- a/docs/superpowers/plans/2026-08-08-wysiwyg-canvas-chrome.md
+++ b/docs/superpowers/plans/2026-08-08-wysiwyg-canvas-chrome.md
@@ -1,0 +1,2277 @@
+# WYSIWYG Canvas Chrome (Slice 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the interactive canvas chrome for the WYSIWYG editor (issue #1224, epic #1221): inline rich-text editing writing honest runs, drag/drop handling (in-canvas reorder and external palette/Finder drops) landing as `insertBlock`/`moveBlock` at an engine-computed index, and a responsive breakpoint canvas that drives multiple frame documents from one shared engine.
+
+**Architecture:** Extends `JS/wysiwyg-engine/` (merged slice 2) in place with three new modules — `rich-text.ts`, `drag-drop.ts`, `breakpoints.ts` — each consuming the existing `WysiwygEngine`/`SelectionState`/`hitTest`/`OpQueue` primitives rather than replacing them. No new package, no Swift changes (design spec §2). A single `WysiwygEngine` instance (one model, one selection, one op queue) drives every breakpoint frame document, because `hitTest(point, doc)` and `computeHandleRect(id, root)` already accept an explicit document/root instead of assuming the global `document`.
+
+**Tech Stack:** TypeScript (ES2022 target, strict), Vitest (+ jsdom), Playwright e2e goldens, esbuild for e2e bundles, oxlint. No new runtime dependencies — every new module imports nothing beyond the TypeScript standard lib and DOM types, matching slice 2.
+
+## Global Constraints
+
+- Zero new runtime dependencies — `src/**` may only use ES2022/DOM APIs (spec §3.1, carried from slice 2's own constraint).
+- Every commit path (`editText`, `insertBlock` from a drop, `moveBlock` from a reorder) goes through the existing `engine.submit()` → `OpQueue` — no new op-application or rejection-handling logic; this slice only adds callers.
+- **Scoped exception to "the engine never mutates the DOM as an act of editing":** that principle (slice 2) governs the *block-structure* model — ops are the only path that changes what blocks exist and how they nest. Inline text editing is different: a `contenteditable` region is inherently a live text-input surface, and `rich-text.ts`'s Range-wrapping code mutates that surface directly while an edit is active. What keeps this honest is that the wrapping code can only ever produce `<strong>`/`<em>`/`<a href>`/`<code>` — exactly the vocabulary `runsFromElement()` reads back — so the local draft always re-grounds into the model boundary on commit (spec §8.5 treats `contenteditable` as the accepted mechanism, with a native-`NSTextView` contingency out of scope for this slice).
+- Match established test-split convention from slice 2 (`hit-test.test.ts`, `selection.test.ts`): pure logic (DOM traversal that doesn't need real layout, or geometry given explicit numeric rects) is unit-tested under `vitest`/jsdom; anything depending on real `getBoundingClientRect`/`elementFromPoint`/live `Selection` behavior is deferred to Playwright e2e goldens, never asserted against jsdom's zeroed-out layout.
+- `noUncheckedIndexedAccess: true` — every indexed/`Record` access is `T | undefined`; guard before use.
+- `verbatimModuleSyntax: true` — every type-only import is a separate `import type { ... }` statement.
+- No new CI wiring needed: `.github/workflows/ci.yml`'s `wysiwyg` path filter already matches `JS/wysiwyg-engine/**` (added in slice 2), so every file this plan touches is already gated by the existing `wysiwyg-engine` job.
+
+---
+
+## File Structure
+
+```
+JS/wysiwyg-engine/src/
+├── rich-text.ts        # honest-runs serialization, debounced commit, Range-based format
+│                         # commands, RichTextEditor (contenteditable lifecycle)
+├── drag-drop.ts         # drop-target geometry, in-canvas reorder (DragReorderController),
+│                         # external drop wiring (wireExternalDrop), submitDrop()
+├── breakpoints.ts       # BreakpointCanvas — one engine driving N frame documents
+└── index.ts              # MODIFY: barrel-export the three new modules
+JS/wysiwyg-engine/test/
+├── rich-text.test.ts
+├── drag-drop.test.ts
+└── breakpoints.test.ts
+JS/wysiwyg-engine/e2e/
+├── fixture-page.ts       # MODIFY: add a "text" block + richText rendering, rich-text and
+│                         #   drag-drop bridges
+├── frame.html            # NEW: minimal iframe document (just #canvas) for breakpoint frames
+├── breakpoints-fixture.html      # NEW: hosts three iframes (phone/tablet/desktop)
+├── breakpoints-fixture-page.ts   # NEW: wires one engine + BreakpointCanvas across the iframes
+├── rich-text.spec.ts     # NEW
+├── drag-drop.spec.ts     # NEW
+└── breakpoints.spec.ts   # NEW
+JS/wysiwyg-engine/package.json  # MODIFY: build:e2e builds both bundles
+```
+
+---
+
+### Task 1: Honest-runs serialization
+
+**Files:**
+- Create: `JS/wysiwyg-engine/src/rich-text.ts`
+- Test: `JS/wysiwyg-engine/test/rich-text.test.ts`
+
+**Interfaces:**
+- Consumes: `RichTextRun` (types.ts).
+- Produces: `runsFromElement(el: Element): RichTextRun[]` — consumed by Task 4's `RichTextEditor` and by Task 9's e2e goldens.
+
+- [ ] **Step 1: Write the failing test** `JS/wysiwyg-engine/test/rich-text.test.ts`
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { runsFromElement } from "../src/rich-text.js";
+
+function setBody(html: string): Element {
+  document.body.innerHTML = `<div id="root">${html}</div>`;
+  const root = document.getElementById("root");
+  if (!root) throw new Error("missing #root");
+  return root;
+}
+
+describe("runsFromElement", () => {
+  it("reads plain text as a single text run", () => {
+    expect(runsFromElement(setBody("Hello world"))).toEqual([{ kind: "text", text: "Hello world" }]);
+  });
+
+  it("recognizes strong, em, link, and code", () => {
+    const root = setBody('Hi <strong>bold</strong> and <em>emph</em> and <a href="/x">link</a> and <code>x</code>.');
+    expect(runsFromElement(root)).toEqual([
+      { kind: "text", text: "Hi " },
+      { kind: "strong", text: "bold" },
+      { kind: "text", text: " and " },
+      { kind: "em", text: "emph" },
+      { kind: "text", text: " and " },
+      { kind: "link", text: "link", href: "/x" },
+      { kind: "text", text: " and " },
+      { kind: "code", text: "x" },
+      { kind: "text", text: "." },
+    ]);
+  });
+
+  it("treats <b> and <i> as strong/em aliases", () => {
+    const root = setBody("<b>bold</b><i>italic</i>");
+    expect(runsFromElement(root)).toEqual([
+      { kind: "strong", text: "bold" },
+      { kind: "em", text: "italic" },
+    ]);
+  });
+
+  it("flattens unrecognized markup to its text content — the honest-runs backstop", () => {
+    const root = setBody('<div>block</div><span style="color:red">styled</span>');
+    expect(runsFromElement(root)).toEqual([{ kind: "text", text: "blockstyled" }]);
+  });
+
+  it("merges adjacent text runs produced by flattening", () => {
+    const root = setBody("start <span>middle</span> end");
+    expect(runsFromElement(root)).toEqual([{ kind: "text", text: "start middle end" }]);
+  });
+
+  it("returns an empty array for an empty element", () => {
+    expect(runsFromElement(setBody(""))).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd JS/wysiwyg-engine && npm test -- rich-text`
+Expected: FAIL — `Cannot find module '../src/rich-text.js'`
+
+- [ ] **Step 3: Write `src/rich-text.ts`**
+
+```ts
+import type { RichTextRun } from "./types.js";
+
+const INLINE_TAG_TO_RUN_KIND: Record<string, RichTextRun["kind"]> = {
+  strong: "strong",
+  b: "strong",
+  em: "em",
+  i: "em",
+  a: "link",
+  code: "code",
+};
+
+/**
+ * Serializes a contenteditable element's live DOM into the honest-runs vocabulary (spec §4): only
+ * strong/em/link/code ever survive as anything but text. Anything else the browser's
+ * contenteditable implementation might inject — a stray `<div>` from a paste, a styled `<span>` —
+ * is not represented; its text content flattens into the surrounding run. This is the structural
+ * backstop for roundtrip honesty, independent of how careful the editing UI upstream is.
+ */
+export function runsFromElement(el: Element): RichTextRun[] {
+  const runs: RichTextRun[] = [];
+  for (const node of Array.from(el.childNodes)) {
+    const run = runFromNode(node);
+    if (run) runs.push(run);
+  }
+  return mergeAdjacentTextRuns(runs);
+}
+
+function runFromNode(node: ChildNode): RichTextRun | null {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent ?? "";
+    return text.length > 0 ? { kind: "text", text } : null;
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return null;
+
+  const el = node as Element;
+  const tag = el.tagName.toLowerCase();
+  const kind = INLINE_TAG_TO_RUN_KIND[tag];
+  const text = el.textContent ?? "";
+  if (text.length === 0) return null;
+
+  if (!kind) return { kind: "text", text };
+  if (kind === "link") return { kind, text, href: el.getAttribute("href") ?? "" };
+  return { kind, text };
+}
+
+function mergeAdjacentTextRuns(runs: RichTextRun[]): RichTextRun[] {
+  const merged: RichTextRun[] = [];
+  for (const run of runs) {
+    const prev = merged[merged.length - 1];
+    if (prev && prev.kind === "text" && run.kind === "text") {
+      prev.text += run.text;
+    } else {
+      merged.push({ ...run });
+    }
+  }
+  return merged;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd JS/wysiwyg-engine && npm test -- rich-text`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add JS/wysiwyg-engine/src/rich-text.ts JS/wysiwyg-engine/test/rich-text.test.ts
+git commit -m "feat(#1224): add honest-runs DOM serialization"
+```
+
+---
+
+### Task 2: Debounced commit helper
+
+**Files:**
+- Modify: `JS/wysiwyg-engine/src/rich-text.ts`
+- Modify: `JS/wysiwyg-engine/test/rich-text.test.ts`
+
+**Interfaces:**
+- Produces: `class DebouncedCommitter { constructor(commit: () => void, delayMs: number); notifyChange(): void; flush(): void; cancel(): void }` — consumed by Task 4's `RichTextEditor`. Pure logic, no DOM dependency, independently testable with fake timers.
+
+- [ ] **Step 1: Add the failing test** (append to `test/rich-text.test.ts`, above the closing of the file — as a new top-level `describe` block, alongside the existing `runsFromElement` one)
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { runsFromElement, DebouncedCommitter } from "../src/rich-text.js";
+```
+
+Replace the existing `import { describe, it, expect } from "vitest";` / `import { runsFromElement } from "../src/rich-text.js";` lines at the top of the file with the two lines above, then append this block at the end of the file:
+
+```ts
+
+describe("DebouncedCommitter", () => {
+  it("commits once, after the delay, following a burst of notifyChange calls", () => {
+    vi.useFakeTimers();
+    let commits = 0;
+    const committer = new DebouncedCommitter(() => {
+      commits += 1;
+    }, 400);
+
+    committer.notifyChange();
+    vi.advanceTimersByTime(200);
+    committer.notifyChange(); // resets the timer
+    vi.advanceTimersByTime(200);
+    expect(commits).toBe(0); // still within the debounce window from the second call
+
+    vi.advanceTimersByTime(200);
+    expect(commits).toBe(1);
+
+    vi.useRealTimers();
+  });
+
+  it("flush() commits immediately if a commit is pending, and is a no-op otherwise", () => {
+    vi.useFakeTimers();
+    let commits = 0;
+    const committer = new DebouncedCommitter(() => {
+      commits += 1;
+    }, 400);
+
+    committer.flush();
+    expect(commits).toBe(0); // nothing pending
+
+    committer.notifyChange();
+    committer.flush();
+    expect(commits).toBe(1);
+
+    vi.advanceTimersByTime(400);
+    expect(commits).toBe(1); // flush() already cancelled the pending timer
+
+    vi.useRealTimers();
+  });
+
+  it("cancel() discards a pending commit without running it", () => {
+    vi.useFakeTimers();
+    let commits = 0;
+    const committer = new DebouncedCommitter(() => {
+      commits += 1;
+    }, 400);
+
+    committer.notifyChange();
+    committer.cancel();
+    vi.advanceTimersByTime(400);
+    expect(commits).toBe(0);
+
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd JS/wysiwyg-engine && npm test -- rich-text`
+Expected: FAIL — `DebouncedCommitter` is not exported from `../src/rich-text.js`
+
+- [ ] **Step 3: Add `DebouncedCommitter` to `src/rich-text.ts`** (append to the file)
+
+```ts
+
+/** Coalesces a burst of changes into a single `commit()` call after `delayMs` of quiet, or
+ *  immediately via `flush()` — the mechanism behind `RichTextEditor`'s debounced `editText`
+ *  commits (design doc §4). Pure timer logic, no DOM dependency. */
+export class DebouncedCommitter {
+  #commit: () => void;
+  #delayMs: number;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(commit: () => void, delayMs: number) {
+    this.#commit = commit;
+    this.#delayMs = delayMs;
+  }
+
+  notifyChange(): void {
+    this.cancel();
+    this.#timer = setTimeout(() => {
+      this.#timer = null;
+      this.#commit();
+    }, this.#delayMs);
+  }
+
+  /** Commits now if a debounced commit is pending; otherwise does nothing. */
+  flush(): void {
+    const pending = this.#timer !== null;
+    this.cancel();
+    if (pending) this.#commit();
+  }
+
+  /** Discards a pending commit without running it. */
+  cancel(): void {
+    if (this.#timer !== null) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd JS/wysiwyg-engine && npm test -- rich-text`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add JS/wysiwyg-engine/src/rich-text.ts JS/wysiwyg-engine/test/rich-text.test.ts
+git commit -m "feat(#1224): add DebouncedCommitter for editText commit timing"
+```
+
+---
+
+### Task 3: Inline format commands
+
+**Files:**
+- Modify: `JS/wysiwyg-engine/src/rich-text.ts`
+- Modify: `JS/wysiwyg-engine/test/rich-text.test.ts`
+
+**Interfaces:**
+- Consumes: none beyond DOM types.
+- Produces: `findAncestorTag(node: Node, tagName: string, root: Element): HTMLElement | null`, `wrapRange(range: Range, tagName: string, doc?: Document): HTMLElement`, `unwrapElement(el: HTMLElement): void` (pure Range primitives, unit-tested here), `type FormatKind = "strong" | "em" | "code"`, `toggleInlineFormat(root: HTMLElement, kind: FormatKind, doc?: Document): void`, `setLinkFormat(root: HTMLElement, href: string, doc?: Document): void`, `unsetLinkFormat(root: HTMLElement, doc?: Document): void` (live-`Selection`-based, e2e-covered in Task 9 per this plan's DOM-behavior test split) — all consumed by Task 4's `RichTextEditor`.
+
+- [ ] **Step 1: Add the failing test** (append to `test/rich-text.test.ts`)
+
+Update the top-of-file import to include the new names:
+
+```ts
+import { runsFromElement, DebouncedCommitter, findAncestorTag, wrapRange, unwrapElement } from "../src/rich-text.js";
+```
+
+Append:
+
+```ts
+
+describe("findAncestorTag / wrapRange / unwrapElement", () => {
+  it("finds the nearest ancestor with the given tag, stopping at root", () => {
+    document.body.innerHTML = '<div id="root"><strong id="s"><span id="inner">x</span></strong></div>';
+    const root = document.getElementById("root");
+    const inner = document.getElementById("inner");
+    if (!root || !inner) throw new Error("fixture missing");
+    expect(findAncestorTag(inner, "strong", root)?.id).toBe("s");
+    expect(findAncestorTag(inner, "em", root)).toBeNull();
+  });
+
+  it("wrapRange wraps the range's contents in a new element and returns it", () => {
+    document.body.innerHTML = '<div id="root">hello world</div>';
+    const root = document.getElementById("root");
+    const textNode = root?.firstChild;
+    if (!root || !textNode) throw new Error("fixture missing");
+
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 5); // "hello"
+
+    const wrapped = wrapRange(range, "strong", document);
+    expect(wrapped.tagName.toLowerCase()).toBe("strong");
+    expect(root.innerHTML).toBe("<strong>hello</strong> world");
+  });
+
+  it("unwrapElement replaces the element with its children in place", () => {
+    document.body.innerHTML = '<div id="root">a <strong id="s">bold</strong> b</div>';
+    const root = document.getElementById("root");
+    const strong = document.getElementById("s");
+    if (!root || !strong) throw new Error("fixture missing");
+
+    unwrapElement(strong);
+    expect(root.innerHTML).toBe("a bold b");
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd JS/wysiwyg-engine && npm test -- rich-text`
+Expected: FAIL — `findAncestorTag`/`wrapRange`/`unwrapElement` not exported
+
+- [ ] **Step 3: Add the Range primitives and Selection-based format commands to `src/rich-text.ts`** (append to the file)
+
+```ts
+
+/** Walks up from `node` to the nearest ancestor (inclusive) whose tag matches `tagName`, stopping
+ *  at (and not including past) `root`. */
+export function findAncestorTag(node: Node, tagName: string, root: Element): HTMLElement | null {
+  let current: Node | null = node;
+  while (current && current !== root.parentNode) {
+    if (current.nodeType === Node.ELEMENT_NODE && (current as Element).tagName.toLowerCase() === tagName) {
+      return current as HTMLElement;
+    }
+    if (current === root) return null;
+    current = current.parentNode;
+  }
+  return null;
+}
+
+/** Wraps `range`'s contents in a new `tagName` element, replacing the range with it, and leaves
+ *  the element's contents selected (so a follow-up format command composes naturally). */
+export function wrapRange(range: Range, tagName: string, doc: Document = document): HTMLElement {
+  const wrapper = doc.createElement(tagName);
+  wrapper.appendChild(range.extractContents());
+  range.insertNode(wrapper);
+  range.selectNodeContents(wrapper);
+  const selection = doc.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  return wrapper;
+}
+
+/** Replaces `el` with its own children, at the same position — the inverse of `wrapRange`. */
+export function unwrapElement(el: HTMLElement): void {
+  const parent = el.parentNode;
+  if (!parent) return;
+  while (el.firstChild) parent.insertBefore(el.firstChild, el);
+  parent.removeChild(el);
+}
+
+export type FormatKind = "strong" | "em" | "code";
+
+const FORMAT_TAG: Record<FormatKind, string> = { strong: "strong", em: "em", code: "code" };
+
+/**
+ * Toggles `kind` on the current selection within `root`: unwraps if the selection is already
+ * inside a matching element, otherwise wraps it. Live-`Selection`-dependent — real behavior is
+ * covered by Playwright e2e goldens (Task 9), not jsdom, matching this package's established
+ * test split (jsdom has no real text-selection behavior to verify against).
+ */
+export function toggleInlineFormat(root: HTMLElement, kind: FormatKind, doc: Document = document): void {
+  const selection = doc.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.commonAncestorContainer)) return;
+
+  const tagName = FORMAT_TAG[kind];
+  const existing = findAncestorTag(range.commonAncestorContainer, tagName, root);
+  if (existing) {
+    unwrapElement(existing);
+  } else {
+    wrapRange(range, tagName, doc);
+  }
+}
+
+/** Wraps the current selection in `<a href>`, replacing any existing link ancestor first. */
+export function setLinkFormat(root: HTMLElement, href: string, doc: Document = document): void {
+  const selection = doc.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.commonAncestorContainer)) return;
+
+  const existing = findAncestorTag(range.commonAncestorContainer, "a", root);
+  if (existing) unwrapElement(existing);
+  const anchor = wrapRange(range, "a", doc);
+  anchor.setAttribute("href", href);
+}
+
+/** Removes the link ancestor around the current selection or caret, if any. */
+export function unsetLinkFormat(root: HTMLElement, doc: Document = document): void {
+  const selection = doc.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+  const existing = findAncestorTag(selection.getRangeAt(0).commonAncestorContainer, "a", root);
+  if (existing) unwrapElement(existing);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd JS/wysiwyg-engine && npm test -- rich-text`
+Expected: PASS (12 tests)
+
+Also run `npm run typecheck && npm run lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add JS/wysiwyg-engine/src/rich-text.ts JS/wysiwyg-engine/test/rich-text.test.ts
+git commit -m "feat(#1224): add Range-based inline format commands"
+```
+
+---
+
+### Task 4: RichTextEditor class
+
+**Files:**
+- Modify: `JS/wysiwyg-engine/src/rich-text.ts`
+- Modify: `JS/wysiwyg-engine/test/rich-text.test.ts`
+
+**Interfaces:**
+- Consumes: `BlockId`, `RichTextRun` (types.ts); `WysiwygEngine` (engine.ts, type-only); `findBlockElement` (selection.ts); `DebouncedCommitter`, `runsFromElement`, `FormatKind`, `toggleInlineFormat`, `setLinkFormat`, `unsetLinkFormat` (this file, earlier tasks).
+- Produces: `interface RichTextEditorOptions { debounceMs?: number }`, `class RichTextEditor { constructor(engine: WysiwygEngine, options?: RichTextEditorOptions); get activeBlockId(): BlockId | null; enter(blockId: BlockId, root?: ParentNode): void; exit(): void; toggleFormat(kind: FormatKind): void; setLink(href: string): void; unsetLink(): void; dispose(): void }` — the module's top-level consumer-facing API, exported from `index.ts` (Task 9) and driven directly by e2e goldens.
+
+- [ ] **Step 1: Add the failing test** — replace the top-of-file imports in `test/rich-text.test.ts` with:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import {
+  runsFromElement,
+  DebouncedCommitter,
+  findAncestorTag,
+  wrapRange,
+  unwrapElement,
+  RichTextEditor,
+} from "../src/rich-text.js";
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { BLOCK_ID_ATTR } from "../src/hit-test.js";
+import type { BlockModel } from "../src/types.js";
+```
+
+Append this block at the end of the file:
+
+```ts
+
+function makeTextModel(): BlockModel {
+  return {
+    path: "src/pages/index.astro",
+    version: "v1",
+    rootIds: ["t1"],
+    blocks: {
+      t1: {
+        id: "t1",
+        kind: "text",
+        componentName: "paragraph",
+        props: {},
+        slots: {},
+        sourceSpan: [0, 5],
+        richText: [{ kind: "text", text: "Hello" }],
+      },
+    },
+  };
+}
+
+describe("RichTextEditor", () => {
+  it("enter() makes the block contenteditable; exit() reverts it", () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    expect(el.contentEditable).toBe("true");
+
+    editor.exit();
+    expect(el.contentEditable).toBe("false");
+    expect(editor.activeBlockId).toBeNull();
+  });
+
+  it("commits a debounced editText op with the typed runs after the debounce window", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine, { debounceMs: 400 });
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(engine.modelSync.getBlock("t1")?.richText).toEqual([{ kind: "text", text: "Hello world" }]);
+    vi.useRealTimers();
+  });
+
+  it("multiple edits before the debounce fires still send the entry-time baseline as previousRuns", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const applied: { op: unknown }[] = [];
+    engine.onEvent((event) => {
+      if (event.type === "applied") applied.push({ op: event.op });
+    });
+    const editor = new RichTextEditor(engine, { debounceMs: 400 });
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+
+    el.textContent = "Hello w";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(200);
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(applied).toEqual([
+      {
+        op: {
+          kind: "editText",
+          blockId: "t1",
+          runs: [{ kind: "text", text: "Hello world" }],
+          previousRuns: [{ kind: "text", text: "Hello" }],
+        },
+      },
+    ]);
+    vi.useRealTimers();
+  });
+
+  it("exit() flushes a pending commit immediately instead of discarding it", async () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine, { debounceMs: 10_000 });
+
+    const applied = new Promise<void>((resolve) => {
+      const unsubscribe = engine.onEvent((event) => {
+        if (event.type === "applied") {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+
+    editor.exit();
+    await applied;
+
+    expect(engine.modelSync.getBlock("t1")?.richText).toEqual([{ kind: "text", text: "Hello world" }]);
+  });
+
+  it("entering a different block exits the previous one first", () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div><div ${BLOCK_ID_ATTR}="t2">World</div>`;
+    const base = makeTextModel();
+    const model: BlockModel = {
+      ...base,
+      rootIds: ["t1", "t2"],
+      blocks: {
+        ...base.blocks,
+        t2: {
+          id: "t2",
+          kind: "text",
+          componentName: "paragraph",
+          props: {},
+          slots: {},
+          sourceSpan: [6, 11],
+          richText: [{ kind: "text", text: "World" }],
+        },
+      },
+    };
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1");
+    editor.enter("t2");
+
+    expect(editor.activeBlockId).toBe("t2");
+    const t1 = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    expect(t1.contentEditable).toBe("false");
+  });
+
+  it("blur exits editing and flushes a pending commit (design doc §4: commit immediately on blur)", async () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine, { debounceMs: 10_000 });
+
+    const applied = new Promise<void>((resolve) => {
+      const unsubscribe = engine.onEvent((event) => {
+        if (event.type === "applied") {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.textContent = "Hello world";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    el.dispatchEvent(new FocusEvent("blur"));
+
+    // Synchronous: exit()'s state cleanup happens before the flushed commit's async submit resolves.
+    expect(editor.activeBlockId).toBeNull();
+    expect(el.contentEditable).toBe("false");
+
+    await applied;
+    expect(engine.modelSync.getBlock("t1")?.richText).toEqual([{ kind: "text", text: "Hello world" }]);
+  });
+
+  it("pressing Escape exits editing (design doc §4: commit immediately on Escape)", () => {
+    document.body.innerHTML = `<div ${BLOCK_ID_ATTR}="t1">Hello</div>`;
+    const model = makeTextModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const editor = new RichTextEditor(engine);
+
+    editor.enter("t1");
+    const el = document.querySelector(`[${BLOCK_ID_ATTR}="t1"]`) as HTMLElement;
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect(editor.activeBlockId).toBeNull();
+    expect(el.contentEditable).toBe("false");
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd JS/wysiwyg-engine && npm test -- rich-text`
+Expected: FAIL — `RichTextEditor` is not exported from `../src/rich-text.js`
+
+- [ ] **Step 3: Add `RichTextEditor` to `src/rich-text.ts`**
+
+Add this import line to the top of `src/rich-text.ts`, alongside the existing `import type { RichTextRun } from "./types.js";`:
+
+```ts
+import type { BlockId } from "./types.js";
+import type { WysiwygEngine } from "./engine.js";
+import { findBlockElement } from "./selection.js";
+```
+
+Append to the end of the file:
+
+```ts
+
+export interface RichTextEditorOptions {
+  debounceMs?: number;
+}
+
+const DEFAULT_DEBOUNCE_MS = 400;
+
+/**
+ * Contenteditable lifecycle for one text block at a time (design doc §4). `enter()` activates
+ * editing and snapshots the current runs as the commit baseline; an `input` listener schedules a
+ * debounced `editText` commit; `exit()` flushes any pending commit and deactivates. `previousRuns`
+ * on every commit is always the baseline captured at `enter()`, not the prior debounce tick — so a
+ * version-mismatch rejection mid-edit discards the whole in-progress edit in one step rather than
+ * reconstructing intermediate state.
+ */
+export class RichTextEditor {
+  #engine: WysiwygEngine;
+  #committer: DebouncedCommitter;
+  #activeBlockId: BlockId | null = null;
+  #activeElement: HTMLElement | null = null;
+  #baselineRuns: RichTextRun[] = [];
+  #onInput = () => this.#committer.notifyChange();
+  #onBlur = () => this.exit();
+  #onKeydown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") this.exit();
+  };
+
+  constructor(engine: WysiwygEngine, options: RichTextEditorOptions = {}) {
+    this.#engine = engine;
+    this.#committer = new DebouncedCommitter(() => this.#commit(), options.debounceMs ?? DEFAULT_DEBOUNCE_MS);
+  }
+
+  get activeBlockId(): BlockId | null {
+    return this.#activeBlockId;
+  }
+
+  enter(blockId: BlockId, root: ParentNode = document): void {
+    if (this.#activeBlockId === blockId) return;
+    if (this.#activeBlockId !== null) this.exit();
+
+    const el = findBlockElement(blockId, root);
+    if (!(el instanceof HTMLElement)) return;
+
+    this.#baselineRuns = this.#engine.modelSync.getBlock(blockId)?.richText ?? [];
+    this.#activeBlockId = blockId;
+    this.#activeElement = el;
+    el.contentEditable = "true";
+    el.addEventListener("input", this.#onInput);
+    el.addEventListener("blur", this.#onBlur);
+    el.addEventListener("keydown", this.#onKeydown);
+    el.focus();
+  }
+
+  /** Flushes any pending debounced commit and deactivates — called explicitly, or automatically on
+   *  blur/Escape (design doc §4: both commit immediately, alongside a format command). */
+  exit(): void {
+    this.#committer.flush();
+    if (this.#activeElement) {
+      this.#activeElement.removeEventListener("input", this.#onInput);
+      this.#activeElement.removeEventListener("blur", this.#onBlur);
+      this.#activeElement.removeEventListener("keydown", this.#onKeydown);
+      this.#activeElement.contentEditable = "false";
+    }
+    this.#activeBlockId = null;
+    this.#activeElement = null;
+    this.#baselineRuns = [];
+  }
+
+  toggleFormat(kind: FormatKind): void {
+    if (!this.#activeElement) return;
+    toggleInlineFormat(this.#activeElement, kind);
+    this.#committer.notifyChange();
+  }
+
+  setLink(href: string): void {
+    if (!this.#activeElement) return;
+    setLinkFormat(this.#activeElement, href);
+    this.#committer.notifyChange();
+  }
+
+  unsetLink(): void {
+    if (!this.#activeElement) return;
+    unsetLinkFormat(this.#activeElement);
+    this.#committer.notifyChange();
+  }
+
+  dispose(): void {
+    this.exit();
+  }
+
+  #commit(): void {
+    if (!this.#activeBlockId || !this.#activeElement) return;
+    void this.#engine.submit({
+      kind: "editText",
+      blockId: this.#activeBlockId,
+      runs: runsFromElement(this.#activeElement),
+      previousRuns: this.#baselineRuns,
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd JS/wysiwyg-engine && npm test -- rich-text`
+Expected: PASS (19 tests)
+
+Also run `npm run typecheck && npm run lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add JS/wysiwyg-engine/src/rich-text.ts JS/wysiwyg-engine/test/rich-text.test.ts
+git commit -m "feat(#1224): add RichTextEditor contenteditable lifecycle"
+```
+
+---
+
+### Task 5: Drop-target geometry and `submitDrop`
+
+**Files:**
+- Create: `JS/wysiwyg-engine/src/drag-drop.ts`
+- Test: `JS/wysiwyg-engine/test/drag-drop.test.ts`
+
+**Interfaces:**
+- Consumes: `BlockId`, `BlockNode`, `OpResult`, `ParentRef`, `ROOT_PARENT_ID` (types.ts); `WysiwygEngine` (engine.ts, type-only); `BLOCK_ID_ATTR` (hit-test.ts).
+- Produces: `interface DropTarget { parentId: ParentRef; slot: string; index: number }`, `nearestIndexInSlot(pointY: number, siblingRects: { top: number; bottom: number }[]): number` (pure, unit-tested), `computeDropTarget(point: { x: number; y: number }, container: ParentNode, parentId?: ParentRef, slot?: string): DropTarget` (real-geometry, e2e-covered per this plan's test split), `generateBlockId(): BlockId`, `submitDrop(engine: WysiwygEngine, target: DropTarget, block: Omit<BlockNode, "id">): Promise<OpResult>` — all consumed by Task 6 (`DragReorderController`), Task 7 (`wireExternalDrop`), and Task 9's e2e goldens.
+
+- [ ] **Step 1: Write the failing test** `JS/wysiwyg-engine/test/drag-drop.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { nearestIndexInSlot, computeDropTarget, generateBlockId, submitDrop } from "../src/drag-drop.js";
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { ROOT_PARENT_ID } from "../src/types.js";
+import { BLOCK_ID_ATTR } from "../src/hit-test.js";
+import type { BlockModel } from "../src/types.js";
+
+describe("nearestIndexInSlot", () => {
+  it("returns 0 for an empty sibling list", () => {
+    expect(nearestIndexInSlot(100, [])).toBe(0);
+  });
+
+  it("returns the index of the first sibling whose midpoint is below the point", () => {
+    const rects = [
+      { top: 0, bottom: 20 }, // midpoint 10
+      { top: 20, bottom: 60 }, // midpoint 40
+      { top: 60, bottom: 100 }, // midpoint 80
+    ];
+    expect(nearestIndexInSlot(5, rects)).toBe(0);
+    expect(nearestIndexInSlot(25, rects)).toBe(1);
+    expect(nearestIndexInSlot(85, rects)).toBe(3);
+  });
+});
+
+describe("computeDropTarget", () => {
+  // jsdom has no layout engine, so every element's getBoundingClientRect() is all zeros here —
+  // real point-vs-midpoint geometry is covered by Playwright e2e goldens (Task 9), matching this
+  // package's established test split (hit-test.ts/selection.ts). What's provable in jsdom: the
+  // container is queried for BLOCK_ID_ATTR children (not arbitrary children), and parentId/slot
+  // pass through unchanged.
+  it("only counts children carrying BLOCK_ID_ATTR, and passes parentId/slot through", () => {
+    document.body.innerHTML = `
+      <div id="canvas">
+        <div ${BLOCK_ID_ATTR}="b1"></div>
+        <span>not a block</span>
+        <div ${BLOCK_ID_ATTR}="b2"></div>
+      </div>
+    `;
+    const canvas = document.getElementById("canvas");
+    if (!canvas) throw new Error("fixture missing #canvas");
+
+    const target = computeDropTarget({ x: 0, y: 0 }, canvas, "some-parent", "gallery");
+    expect(target.parentId).toBe("some-parent");
+    expect(target.slot).toBe("gallery");
+    // All rects are zero under jsdom, so every midpoint is 0; a non-negative point.y never beats
+    // that, so the pure fallback ("append after the last sibling") is what's observable here.
+    expect(target.index).toBe(2);
+  });
+
+  it("defaults to ROOT_PARENT_ID and the 'default' slot", () => {
+    document.body.innerHTML = `<div id="canvas"></div>`;
+    const canvas = document.getElementById("canvas");
+    if (!canvas) throw new Error("fixture missing #canvas");
+    expect(computeDropTarget({ x: 0, y: 0 }, canvas)).toEqual({ parentId: ROOT_PARENT_ID, slot: "default", index: 0 });
+  });
+});
+
+describe("generateBlockId", () => {
+  it("returns a non-empty string, unique across calls", () => {
+    const a = generateBlockId();
+    const b = generateBlockId();
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+});
+
+describe("submitDrop", () => {
+  function makeModel(): BlockModel {
+    return {
+      path: "src/pages/index.astro",
+      version: "v1",
+      rootIds: ["b1"],
+      blocks: { b1: { id: "b1", kind: "astro", componentName: "Hero", props: {}, slots: {}, sourceSpan: [0, 1] } },
+    };
+  }
+
+  it("submits an insertBlock op at the given target and the block appears in the model", async () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+
+    const result = await submitDrop(
+      engine,
+      { parentId: ROOT_PARENT_ID, slot: "default", index: 0 },
+      { kind: "astro", componentName: "Newsletter", props: {}, slots: {}, sourceSpan: [0, 0] },
+    );
+
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied") throw new Error("expected applied");
+    expect(result.model.rootIds).toHaveLength(2);
+    const newId = result.model.rootIds.find((id) => id !== "b1");
+    expect(newId).toBeDefined();
+    expect(newId && result.model.blocks[newId]?.componentName).toBe("Newsletter");
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd JS/wysiwyg-engine && npm test -- drag-drop`
+Expected: FAIL — `Cannot find module '../src/drag-drop.js'`
+
+- [ ] **Step 3: Write `src/drag-drop.ts`**
+
+```ts
+import type { BlockId, BlockNode, OpResult, ParentRef } from "./types.js";
+import type { WysiwygEngine } from "./engine.js";
+import { ROOT_PARENT_ID } from "./types.js";
+import { BLOCK_ID_ATTR } from "./hit-test.js";
+
+export interface DropTarget {
+  parentId: ParentRef;
+  slot: string;
+  index: number;
+}
+
+/**
+ * Pure geometry: given a vertical point and the ordered rects of the candidate siblings, finds the
+ * nearest valid insertion index by comparing against each sibling's vertical midpoint. Split out
+ * from `computeDropTarget`'s DOM-querying half so it's unit-testable without a real layout engine
+ * (mirrors hit-test.ts's split between `hitTest()` and `blockIdForElement()`).
+ */
+export function nearestIndexInSlot(pointY: number, siblingRects: { top: number; bottom: number }[]): number {
+  for (let i = 0; i < siblingRects.length; i++) {
+    const rect = siblingRects[i];
+    if (!rect) continue;
+    const midpoint = (rect.top + rect.bottom) / 2;
+    if (pointY < midpoint) return i;
+  }
+  return siblingRects.length;
+}
+
+/**
+ * Computes the nearest valid insertion point for a point-based drag/drop gesture among the direct
+ * block-children of `container`. Root-level only for this slice, matching the fixture host/e2e
+ * convention that already treats top-level blocks as `ROOT_PARENT_ID`/"default" — the `parentId`/
+ * `slot` parameters leave room for nested-slot targeting in a future slice without an API change.
+ */
+export function computeDropTarget(
+  point: { x: number; y: number },
+  container: ParentNode,
+  parentId: ParentRef = ROOT_PARENT_ID,
+  slot = "default",
+): DropTarget {
+  const children = Array.from(container.children).filter((el) => el.hasAttribute(BLOCK_ID_ATTR));
+  const rects = children.map((el) => el.getBoundingClientRect());
+  return { parentId, slot, index: nearestIndexInSlot(point.y, rects) };
+}
+
+let idCounter = 0;
+
+/** Block IDs are engine-generated, never raw user text (types.ts) — this is chrome's generator for
+ *  blocks created by a drop, distinct per call within a session. */
+export function generateBlockId(): BlockId {
+  idCounter += 1;
+  return `chrome-${Date.now().toString(36)}-${idCounter}`;
+}
+
+/** Builds and submits the `insertBlock` op for a drop at `target`. The engine never inspects a
+ *  drag's `DataTransfer` itself (design doc §5) — by the time `submitDrop` is called, the host has
+ *  already decided what `block` to build. */
+export function submitDrop(engine: WysiwygEngine, target: DropTarget, block: Omit<BlockNode, "id">): Promise<OpResult> {
+  return engine.submit({
+    kind: "insertBlock",
+    parentId: target.parentId,
+    slot: target.slot,
+    index: target.index,
+    newId: generateBlockId(),
+    block,
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd JS/wysiwyg-engine && npm test -- drag-drop`
+Expected: PASS (6 tests)
+
+Also run `npm run typecheck && npm run lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add JS/wysiwyg-engine/src/drag-drop.ts JS/wysiwyg-engine/test/drag-drop.test.ts
+git commit -m "feat(#1224): add drop-target geometry and submitDrop"
+```
+
+---
+
+### Task 6: In-canvas reorder (`DragReorderController`)
+
+**Files:**
+- Modify: `JS/wysiwyg-engine/src/drag-drop.ts`
+- Modify: `JS/wysiwyg-engine/test/drag-drop.test.ts`
+
+**Interfaces:**
+- Consumes: `DropTarget`, `computeDropTarget` (this file, Task 5); `BlockId`, `ROOT_PARENT_ID` (types.ts); `WysiwygEngine` (engine.ts, type-only).
+- Produces: `class DragReorderController { constructor(engine: WysiwygEngine, onIndicator: (target: DropTarget | null) => void, container?: ParentNode); get isDragging(): boolean; startDrag(blockId: BlockId, doc?: Document): void; dispose(): void }` — consumed by Task 9's e2e goldens and (in a future slice) real host pointer-drag wiring.
+
+- [ ] **Step 1: Add the failing test** — add this import line to the top of `test/drag-drop.test.ts`:
+
+```ts
+import { DragReorderController } from "../src/drag-drop.js";
+```
+
+Append at the end of the file:
+
+```ts
+
+describe("DragReorderController", () => {
+  function makeTwoBlockModel(): BlockModel {
+    return {
+      path: "src/pages/index.astro",
+      version: "v1",
+      rootIds: ["b1", "b2"],
+      blocks: {
+        b1: { id: "b1", kind: "astro", componentName: "Hero", props: {}, slots: {}, sourceSpan: [0, 1] },
+        b2: { id: "b2", kind: "astro", componentName: "Testimonial", props: {}, slots: {}, sourceSpan: [1, 2] },
+      },
+    };
+  }
+
+  it("reports an indicator target on pointermove while dragging", () => {
+    document.body.innerHTML = `<div id="empty"></div>`;
+    const container = document.getElementById("empty");
+    if (!container) throw new Error("fixture missing");
+    const model = makeTwoBlockModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const indicators: unknown[] = [];
+    const controller = new DragReorderController(engine, (target) => indicators.push(target), container);
+
+    expect(controller.isDragging).toBe(false);
+    controller.startDrag("b1");
+    expect(controller.isDragging).toBe(true);
+
+    document.dispatchEvent(new PointerEvent("pointermove", { clientX: 10, clientY: 20 }));
+
+    // `container` has no BLOCK_ID_ATTR children, so computeDropTarget's fallback (nearestIndexInSlot
+    // on an empty list) deterministically resolves to index 0 regardless of point — the real
+    // point-vs-midpoint geometry needs a layout engine and is e2e-covered (Task 9).
+    expect(indicators).toEqual([{ parentId: "__root__", slot: "default", index: 0 }]);
+  });
+
+  it("submits a moveBlock op to the indicator target on pointerup", async () => {
+    document.body.innerHTML = `<div id="empty"></div>`;
+    const container = document.getElementById("empty");
+    if (!container) throw new Error("fixture missing");
+    const model = makeTwoBlockModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const controller = new DragReorderController(engine, () => {}, container);
+
+    const applied = new Promise<void>((resolve) => {
+      const unsubscribe = engine.onEvent((event) => {
+        if (event.type === "applied") {
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+
+    controller.startDrag("b2");
+    document.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 0 }));
+    document.dispatchEvent(new PointerEvent("pointerup"));
+    await applied;
+
+    expect(engine.modelSync.current.rootIds).toEqual(["b2", "b1"]);
+    expect(controller.isDragging).toBe(false);
+  });
+
+  it("aborts cleanly, submitting nothing, when the dragged block vanishes mid-drag", () => {
+    document.body.innerHTML = `<div id="empty"></div>`;
+    const container = document.getElementById("empty");
+    if (!container) throw new Error("fixture missing");
+    const model = makeTwoBlockModel();
+    const host = new FixtureHost(model);
+    const engine = new WysiwygEngine(model, host);
+    const moveOps: unknown[] = [];
+    engine.onEvent((event) => {
+      if (event.type === "applied" && event.op.kind === "moveBlock") moveOps.push(event.op);
+    });
+    const controller = new DragReorderController(engine, () => {}, container);
+
+    controller.startDrag("b1");
+    document.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 0 }));
+    host.simulateExternalEdit({
+      ...model,
+      version: "v2",
+      rootIds: ["b2"],
+      blocks: { b2: model.blocks.b2 as NonNullable<typeof model.blocks.b2> },
+    });
+    document.dispatchEvent(new PointerEvent("pointerup"));
+
+    expect(moveOps).toEqual([]);
+    expect(engine.modelSync.current.rootIds).toEqual(["b2"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd JS/wysiwyg-engine && npm test -- drag-drop`
+Expected: FAIL — `DragReorderController` is not exported from `../src/drag-drop.js`
+
+- [ ] **Step 3: Add `DragReorderController` to `src/drag-drop.ts`**
+
+Add this import line to the top of the file, alongside the existing `import { ROOT_PARENT_ID } from "./types.js";`:
+
+```ts
+import type { WysiwygEngine } from "./engine.js";
+```
+
+Append to the end of the file:
+
+```ts
+
+/**
+ * Pointer-based (not HTML5 Drag and Drop) in-canvas block reordering — more reliable for
+ * same-document dragging and behaves uniformly whether the block lives in a single canvas or one
+ * of several breakpoint frames (design doc §5). Tracks a live `DropTarget` indicator during the
+ * drag via `onIndicator` and, on release, submits `moveBlock` to that target.
+ */
+export class DragReorderController {
+  #engine: WysiwygEngine;
+  #container: ParentNode;
+  #onIndicator: (target: DropTarget | null) => void;
+  #draggingId: BlockId | null = null;
+  #indicatorTarget: DropTarget | null = null;
+  #doc: Document | null = null;
+  #onMove = (event: PointerEvent) => this.#handleMove(event);
+  #onUp = () => {
+    void this.#handleUp();
+  };
+
+  constructor(engine: WysiwygEngine, onIndicator: (target: DropTarget | null) => void, container: ParentNode = document) {
+    this.#engine = engine;
+    this.#onIndicator = onIndicator;
+    this.#container = container;
+  }
+
+  get isDragging(): boolean {
+    return this.#draggingId !== null;
+  }
+
+  startDrag(blockId: BlockId, doc: Document = document): void {
+    this.#draggingId = blockId;
+    this.#doc = doc;
+    doc.addEventListener("pointermove", this.#onMove);
+    doc.addEventListener("pointerup", this.#onUp);
+  }
+
+  dispose(): void {
+    this.#doc?.removeEventListener("pointermove", this.#onMove);
+    this.#doc?.removeEventListener("pointerup", this.#onUp);
+    this.#draggingId = null;
+    this.#doc = null;
+  }
+
+  #handleMove(event: PointerEvent): void {
+    if (!this.#draggingId) return;
+    this.#indicatorTarget = computeDropTarget({ x: event.clientX, y: event.clientY }, this.#container);
+    this.#onIndicator(this.#indicatorTarget);
+  }
+
+  async #handleUp(): Promise<void> {
+    this.#doc?.removeEventListener("pointermove", this.#onMove);
+    this.#doc?.removeEventListener("pointerup", this.#onUp);
+    this.#doc = null;
+
+    const blockId = this.#draggingId;
+    const target = this.#indicatorTarget;
+    this.#draggingId = null;
+    this.#indicatorTarget = null;
+    this.#onIndicator(null);
+    if (!blockId || !target) return;
+
+    const model = this.#engine.modelSync.current;
+    const fromIndex = model.rootIds.indexOf(blockId);
+    // The dragged block was removed by a concurrent model update (design doc §7) — abort cleanly
+    // rather than submit a moveBlock against a now-invalid index.
+    if (fromIndex === -1) return;
+
+    await this.#engine.submit({
+      kind: "moveBlock",
+      blockId,
+      fromParentId: ROOT_PARENT_ID,
+      fromSlot: "default",
+      fromIndex,
+      toParentId: target.parentId,
+      toSlot: target.slot,
+      toIndex: target.index,
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd JS/wysiwyg-engine && npm test -- drag-drop`
+Expected: PASS (9 tests)
+
+Also run `npm run typecheck && npm run lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add JS/wysiwyg-engine/src/drag-drop.ts JS/wysiwyg-engine/test/drag-drop.test.ts
+git commit -m "feat(#1224): add DragReorderController for in-canvas reordering"
+```
+
+---
+
+### Task 7: External drop wiring (`wireExternalDrop`)
+
+**Files:**
+- Modify: `JS/wysiwyg-engine/src/drag-drop.ts`
+- Modify: `JS/wysiwyg-engine/test/drag-drop.test.ts`
+
+**Interfaces:**
+- Consumes: `DropTarget`, `computeDropTarget` (this file, Task 5); `ParentRef`, `ROOT_PARENT_ID` (types.ts).
+- Produces: `type ExternalDropHandler = (target: DropTarget, dataTransfer: DataTransfer) => void`, `interface WireExternalDropOptions { container?: ParentNode; parentId?: ParentRef; slot?: string }`, `wireExternalDrop(canvasEl: HTMLElement, onIndicator: (target: DropTarget | null) => void, onDrop: ExternalDropHandler, options?: WireExternalDropOptions): () => void` (returns a disposer, matching the `onChange`/`onEvent` unsubscribe convention used throughout this package) — consumed by Task 9's e2e goldens and a future host's palette/Finder integration.
+
+- [ ] **Step 1: Add the failing test** — add this import line to the top of `test/drag-drop.test.ts`:
+
+```ts
+import { wireExternalDrop } from "../src/drag-drop.js";
+```
+
+Append at the end of the file:
+
+```ts
+
+describe("wireExternalDrop", () => {
+  it("calls onIndicator on dragover, clears it on dragleave, and preventsDefault to allow the drop", () => {
+    document.body.innerHTML = `<div id="canvas"></div>`;
+    const canvas = document.getElementById("canvas");
+    if (!canvas) throw new Error("fixture missing #canvas");
+    const indicators: unknown[] = [];
+    wireExternalDrop(canvas, (target) => indicators.push(target), () => {});
+
+    const dragOver = new DragEvent("dragover", { clientX: 0, clientY: 0, cancelable: true, bubbles: true });
+    canvas.dispatchEvent(dragOver);
+    expect(dragOver.defaultPrevented).toBe(true);
+    expect(indicators).toEqual([{ parentId: "__root__", slot: "default", index: 0 }]);
+
+    canvas.dispatchEvent(new DragEvent("dragleave", { bubbles: true }));
+    expect(indicators).toEqual([{ parentId: "__root__", slot: "default", index: 0 }, null]);
+  });
+
+  it("calls onDrop with the computed target and the event's DataTransfer", () => {
+    document.body.innerHTML = `<div id="canvas"></div>`;
+    const canvas = document.getElementById("canvas");
+    if (!canvas) throw new Error("fixture missing #canvas");
+    const drops: unknown[] = [];
+    wireExternalDrop(canvas, () => {}, (target, dataTransfer) => drops.push({ target, dataTransfer }));
+
+    const dataTransfer = new DataTransfer();
+    const dropEvent = new DragEvent("drop", { clientX: 0, clientY: 0, cancelable: true, bubbles: true, dataTransfer });
+    canvas.dispatchEvent(dropEvent);
+
+    expect(dropEvent.defaultPrevented).toBe(true);
+    expect(drops).toEqual([{ target: { parentId: "__root__", slot: "default", index: 0 }, dataTransfer }]);
+  });
+
+  it("the returned disposer removes all three listeners", () => {
+    document.body.innerHTML = `<div id="canvas"></div>`;
+    const canvas = document.getElementById("canvas");
+    if (!canvas) throw new Error("fixture missing #canvas");
+    const indicators: unknown[] = [];
+    const dispose = wireExternalDrop(canvas, (target) => indicators.push(target), () => {});
+
+    dispose();
+    canvas.dispatchEvent(new DragEvent("dragover", { clientX: 0, clientY: 0, bubbles: true }));
+    canvas.dispatchEvent(new DragEvent("dragleave", { bubbles: true }));
+
+    expect(indicators).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd JS/wysiwyg-engine && npm test -- drag-drop`
+Expected: FAIL — `wireExternalDrop` is not exported from `../src/drag-drop.js`
+
+- [ ] **Step 3: Add `wireExternalDrop` to `src/drag-drop.ts`**
+
+Add this import line to the top of the file, alongside the existing `import type { BlockId, BlockNode, OpResult, ParentRef } from "./types.js";`:
+
+no changes needed there — `ParentRef` is already imported. Append to the end of the file:
+
+```ts
+
+export type ExternalDropHandler = (target: DropTarget, dataTransfer: DataTransfer) => void;
+
+export interface WireExternalDropOptions {
+  container?: ParentNode;
+  parentId?: ParentRef;
+  slot?: string;
+}
+
+/**
+ * Wires native `dragover`/`dragleave`/`drop` DOM events on `canvasEl` for external drags (palette,
+ * Finder) — real OS/host-originated drags surface as native drag events even inside a WKWebView.
+ * The engine never interprets `DataTransfer` itself (design doc §5): `onDrop` receives the computed
+ * target and the raw `DataTransfer`, and the host decides what block (if any) to build and calls
+ * `submitDrop`. Returns a disposer that removes all three listeners.
+ */
+export function wireExternalDrop(
+  canvasEl: HTMLElement,
+  onIndicator: (target: DropTarget | null) => void,
+  onDrop: ExternalDropHandler,
+  options: WireExternalDropOptions = {},
+): () => void {
+  const container = options.container ?? canvasEl;
+  const parentId = options.parentId ?? ROOT_PARENT_ID;
+  const slot = options.slot ?? "default";
+
+  const onDragOver = (event: DragEvent) => {
+    event.preventDefault();
+    onIndicator(computeDropTarget({ x: event.clientX, y: event.clientY }, container, parentId, slot));
+  };
+  const onDragLeave = () => onIndicator(null);
+  const onDropEvent = (event: DragEvent) => {
+    event.preventDefault();
+    onIndicator(null);
+    if (!event.dataTransfer) return;
+    const target = computeDropTarget({ x: event.clientX, y: event.clientY }, container, parentId, slot);
+    onDrop(target, event.dataTransfer);
+  };
+
+  canvasEl.addEventListener("dragover", onDragOver);
+  canvasEl.addEventListener("dragleave", onDragLeave);
+  canvasEl.addEventListener("drop", onDropEvent);
+
+  return () => {
+    canvasEl.removeEventListener("dragover", onDragOver);
+    canvasEl.removeEventListener("dragleave", onDragLeave);
+    canvasEl.removeEventListener("drop", onDropEvent);
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd JS/wysiwyg-engine && npm test -- drag-drop`
+Expected: PASS (12 tests). If `DragEvent`/`DataTransfer` construction is unsupported by the pinned jsdom version, the failure will name the unsupported constructor explicitly — in that case, move the two affected assertions into `e2e/drag-drop.spec.ts` (Task 9) instead of forcing a jsdom workaround, consistent with this plan's real-DOM-behavior-goes-to-e2e split.
+
+Also run `npm run typecheck && npm run lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add JS/wysiwyg-engine/src/drag-drop.ts JS/wysiwyg-engine/test/drag-drop.test.ts
+git commit -m "feat(#1224): add wireExternalDrop for palette/Finder drags"
+```
+
+---
+
+### Task 8: Breakpoint canvas (`BreakpointCanvas`)
+
+**Files:**
+- Create: `JS/wysiwyg-engine/src/breakpoints.ts`
+- Test: `JS/wysiwyg-engine/test/breakpoints.test.ts`
+
+**Interfaces:**
+- Consumes: `BlockId`, `BlockModel` (types.ts); `WysiwygEngine`, `EngineEvent` (engine.ts); `computeHandleRect`, `HandleRect` (selection.ts).
+- Produces: `interface BreakpointFrame { name: string; doc: Document }`, `type RenderFn = (model: BlockModel, doc: Document) => void`, `class BreakpointCanvas { constructor(engine: WysiwygEngine, render: RenderFn); registerFrame(frame: BreakpointFrame): void; unregisterFrame(name: string): void; get frames(): readonly BreakpointFrame[]; hitTestFrame(name: string, point: { x: number; y: number }): BlockId | null; handleRectsForSelection(): { name: string; rect: HandleRect }[]; dispose(): void }` — consumed by Task 9's e2e goldens and a future host's multi-viewport wiring.
+
+- [ ] **Step 1: Write the failing test** `JS/wysiwyg-engine/test/breakpoints.test.ts`
+
+```ts
+import { describe, it, expect } from "vitest";
+import { BreakpointCanvas } from "../src/breakpoints.js";
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { BLOCK_ID_ATTR } from "../src/hit-test.js";
+import type { BlockModel } from "../src/types.js";
+
+function makeModel(): BlockModel {
+  return {
+    path: "src/pages/index.astro",
+    version: "v1",
+    rootIds: ["b1"],
+    blocks: { b1: { id: "b1", kind: "astro", componentName: "Hero", props: { title: "Welcome" }, slots: {}, sourceSpan: [0, 1] } },
+  };
+}
+
+/** Minimal render function mirroring e2e/fixture-page.ts's render(): one <div> per root block,
+ *  carrying BLOCK_ID_ATTR, for a given frame document. */
+function render(model: BlockModel, doc: Document): void {
+  const root = doc.body;
+  root.innerHTML = "";
+  for (const id of model.rootIds) {
+    const block = model.blocks[id];
+    if (!block) continue;
+    const el = doc.createElement("div");
+    el.setAttribute(BLOCK_ID_ATTR, id);
+    el.textContent = block.componentName;
+    root.appendChild(el);
+  }
+}
+
+describe("BreakpointCanvas", () => {
+  it("renders the current model into a frame as soon as it's registered", () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const frameDoc = document.implementation.createHTMLDocument("phone");
+
+    canvas.registerFrame({ name: "phone", doc: frameDoc });
+
+    expect(frameDoc.querySelector(`[${BLOCK_ID_ATTR}="b1"]`)?.textContent).toBe("Hero");
+  });
+
+  it("re-renders every registered frame when the model changes via an applied op", async () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    const desktopDoc = document.implementation.createHTMLDocument("desktop");
+    canvas.registerFrame({ name: "phone", doc: phoneDoc });
+    canvas.registerFrame({ name: "desktop", doc: desktopDoc });
+
+    await engine.submit({ kind: "setProp", blockId: "b1", propName: "title", value: "Updated", previousValue: "Welcome" });
+
+    // The fixture render() above doesn't project props into text, so re-invocation is what we can
+    // observe directly here — assert both frames still reflect the (single, shared) current model
+    // by checking the block element survived a re-render in each, proving render() ran per frame.
+    expect(phoneDoc.querySelector(`[${BLOCK_ID_ATTR}="b1"]`)).not.toBeNull();
+    expect(desktopDoc.querySelector(`[${BLOCK_ID_ATTR}="b1"]`)).not.toBeNull();
+  });
+
+  it("unregisterFrame stops future re-renders for that frame", async () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    canvas.registerFrame({ name: "phone", doc: phoneDoc });
+    canvas.unregisterFrame("phone");
+
+    phoneDoc.body.innerHTML = "<p>untouched</p>";
+    await engine.submit({ kind: "setProp", blockId: "b1", propName: "title", value: "Updated", previousValue: "Welcome" });
+
+    expect(phoneDoc.body.innerHTML).toBe("<p>untouched</p>");
+    expect(canvas.frames).toHaveLength(0);
+  });
+
+  it("handleRectsForSelection returns one rect per frame currently rendering the selected block", () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    const desktopDoc = document.implementation.createHTMLDocument("desktop");
+    canvas.registerFrame({ name: "phone", doc: phoneDoc });
+    canvas.registerFrame({ name: "desktop", doc: desktopDoc });
+
+    expect(canvas.handleRectsForSelection()).toEqual([]);
+
+    engine.selection.select("b1");
+
+    // jsdom has no layout engine, so every rect is zero here — real handle geometry across frames
+    // is covered by Playwright e2e goldens (Task 9), matching selection.test.ts's own convention.
+    expect(canvas.handleRectsForSelection()).toEqual([
+      { name: "phone", rect: { x: 0, y: 0, width: 0, height: 0 } },
+      { name: "desktop", rect: { x: 0, y: 0, width: 0, height: 0 } },
+    ]);
+  });
+
+  it("hitTestFrame returns null for an unregistered frame name", () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    expect(canvas.hitTestFrame("phone", { x: 0, y: 0 })).toBeNull();
+  });
+
+  it("dispose() unsubscribes from engine events and clears registered frames", async () => {
+    const model = makeModel();
+    const engine = new WysiwygEngine(model, new FixtureHost(model));
+    const canvas = new BreakpointCanvas(engine, render);
+    const phoneDoc = document.implementation.createHTMLDocument("phone");
+    canvas.registerFrame({ name: "phone", doc: phoneDoc });
+
+    canvas.dispose();
+    phoneDoc.body.innerHTML = "<p>untouched</p>";
+    await engine.submit({ kind: "setProp", blockId: "b1", propName: "title", value: "Updated", previousValue: "Welcome" });
+
+    expect(phoneDoc.body.innerHTML).toBe("<p>untouched</p>");
+    expect(canvas.frames).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd JS/wysiwyg-engine && npm test -- breakpoints`
+Expected: FAIL — `Cannot find module '../src/breakpoints.js'`
+
+- [ ] **Step 3: Write `src/breakpoints.ts`**
+
+```ts
+import type { BlockId, BlockModel } from "./types.js";
+import type { WysiwygEngine, EngineEvent } from "./engine.js";
+import { computeHandleRect } from "./selection.js";
+import type { HandleRect } from "./selection.js";
+
+export interface BreakpointFrame {
+  name: string;
+  doc: Document;
+}
+
+export type RenderFn = (model: BlockModel, doc: Document) => void;
+
+/**
+ * Drives N breakpoint frame documents from one shared `WysiwygEngine` (design doc §6, spec §5:
+ * breakpoints are views, not modes). Because `hitTest()`/`computeHandleRect()` already accept an
+ * explicit document/root instead of assuming the global `document`, one engine — one model, one
+ * selection, one op queue — can resolve gestures against any registered frame: selecting a block in
+ * one frame is reflected in every frame automatically, with no cross-frame sync layer.
+ */
+export class BreakpointCanvas {
+  #engine: WysiwygEngine;
+  #render: RenderFn;
+  #frames: BreakpointFrame[] = [];
+  #unsubscribe: () => void;
+
+  constructor(engine: WysiwygEngine, render: RenderFn) {
+    this.#engine = engine;
+    this.#render = render;
+    this.#unsubscribe = engine.onEvent((event) => this.#onEngineEvent(event));
+  }
+
+  registerFrame(frame: BreakpointFrame): void {
+    this.#frames.push(frame);
+    this.#render(this.#engine.modelSync.current, frame.doc);
+  }
+
+  unregisterFrame(name: string): void {
+    this.#frames = this.#frames.filter((f) => f.name !== name);
+  }
+
+  get frames(): readonly BreakpointFrame[] {
+    return this.#frames;
+  }
+
+  hitTestFrame(name: string, point: { x: number; y: number }): BlockId | null {
+    const frame = this.#frames.find((f) => f.name === name);
+    if (!frame) return null;
+    return this.#engine.hitTest(point, frame.doc);
+  }
+
+  /** Selection-handle geometry for every frame currently rendering the selected block — callers
+   *  redraw their own outline chrome from this, mirroring how the engine itself owns no rendering
+   *  (spec §3.1). Call after any engine event that could move or reselect a block. */
+  handleRectsForSelection(): { name: string; rect: HandleRect }[] {
+    const selected = this.#engine.selection.current;
+    if (!selected) return [];
+    const rects: { name: string; rect: HandleRect }[] = [];
+    for (const frame of this.#frames) {
+      const rect = computeHandleRect(selected, frame.doc);
+      if (rect) rects.push({ name: frame.name, rect });
+    }
+    return rects;
+  }
+
+  dispose(): void {
+    this.#unsubscribe();
+    this.#frames = [];
+  }
+
+  #onEngineEvent(event: EngineEvent): void {
+    const shouldRerender =
+      event.type === "model-updated" || event.type === "applied" || (event.type === "rejected" && event.model !== undefined);
+    if (!shouldRerender) return;
+    const model = this.#engine.modelSync.current;
+    for (const frame of this.#frames) this.#render(model, frame.doc);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd JS/wysiwyg-engine && npm test -- breakpoints`
+Expected: PASS (6 tests)
+
+Also run `npm run typecheck && npm run lint`, then the full suite: `npm test`.
+
+- [ ] **Step 5: Add the barrel export**
+
+`src/index.ts` currently reads:
+
+```ts
+export * from "./types.js";
+export * from "./ops.js";
+export * from "./model-sync.js";
+export * from "./hit-test.js";
+export * from "./selection.js";
+export * from "./op-queue.js";
+export * from "./engine.js";
+```
+
+Change it to:
+
+```ts
+export * from "./types.js";
+export * from "./ops.js";
+export * from "./model-sync.js";
+export * from "./hit-test.js";
+export * from "./selection.js";
+export * from "./op-queue.js";
+export * from "./engine.js";
+export * from "./rich-text.js";
+export * from "./drag-drop.js";
+export * from "./breakpoints.js";
+```
+
+- [ ] **Step 6: Run the full local check set**
+
+Run: `cd JS/wysiwyg-engine && npm run lint && npm run typecheck && npm test`
+Expected: all PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add JS/wysiwyg-engine/src/breakpoints.ts JS/wysiwyg-engine/test/breakpoints.test.ts JS/wysiwyg-engine/src/index.ts
+git commit -m "feat(#1224): add BreakpointCanvas and export canvas-chrome modules"
+```
+
+---
+
+### Task 9: Playwright e2e goldens
+
+**Files:**
+- Modify: `JS/wysiwyg-engine/e2e/fixture-page.ts`
+- Create: `JS/wysiwyg-engine/e2e/rich-text.spec.ts`
+- Create: `JS/wysiwyg-engine/e2e/drag-drop.spec.ts`
+- Create: `JS/wysiwyg-engine/e2e/frame.html`
+- Create: `JS/wysiwyg-engine/e2e/breakpoints-fixture.html`
+- Create: `JS/wysiwyg-engine/e2e/breakpoints-fixture-page.ts`
+- Create: `JS/wysiwyg-engine/e2e/breakpoints.spec.ts`
+- Modify: `JS/wysiwyg-engine/package.json`
+
+**Interfaces:**
+- Consumes: `RichTextEditor` (rich-text.ts), `DragReorderController`, `wireExternalDrop`, `submitDrop`, `DropTarget` (drag-drop.ts), `BreakpointCanvas` (breakpoints.ts) — all from earlier tasks.
+- Produces: `window.__richText: RichTextEditor`, `window.__dragReorder: DragReorderController`, `window.__submitDrop`, `window.__toggleFormat` on the main fixture page; `window.__canvas: BreakpointCanvas`, `window.__handleRects` on the breakpoints fixture — the surface the three new golden spec files drive.
+
+- [ ] **Step 1: Replace `e2e/fixture-page.ts`** with the full updated file (adds a `"text"` block rendered from its `richText` runs, and wires `RichTextEditor`/`DragReorderController`/`wireExternalDrop` onto the same canvas):
+
+```ts
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { computeHandleRect } from "../src/selection.js";
+import { ROOT_PARENT_ID } from "../src/types.js";
+import { RichTextEditor } from "../src/rich-text.js";
+import { DragReorderController, wireExternalDrop, submitDrop } from "../src/drag-drop.js";
+import type { HandleRect } from "../src/selection.js";
+import type { BlockModel, OpResult, RichTextRun, BlockNode } from "../src/types.js";
+import type { DropTarget } from "../src/drag-drop.js";
+import type { FormatKind } from "../src/rich-text.js";
+
+const initialModel: BlockModel = {
+  path: "src/pages/index.astro",
+  version: "fixture-initial",
+  rootIds: ["b1", "b2", "t1"],
+  blocks: {
+    b1: { id: "b1", kind: "astro", componentName: "Hero", props: { title: "Welcome" }, slots: {}, sourceSpan: [0, 10] },
+    b2: { id: "b2", kind: "astro", componentName: "Testimonial", props: { quote: "Great!" }, slots: {}, sourceSpan: [11, 20] },
+    t1: {
+      id: "t1",
+      kind: "text",
+      componentName: "paragraph",
+      props: {},
+      slots: {},
+      sourceSpan: [21, 30],
+      richText: [
+        { kind: "text", text: "Edit " },
+        { kind: "strong", text: "me" },
+      ],
+    },
+  },
+};
+
+const host = new FixtureHost(initialModel);
+const engine = new WysiwygEngine(initialModel, host);
+const richText = new RichTextEditor(engine, { debounceMs: 300 });
+
+function canvas(): HTMLElement {
+  const el = document.getElementById("canvas");
+  if (!el) throw new Error("fixture.html is missing #canvas");
+  return el;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Host-owned rendering of RichTextRun[] into markup — the inverse of runsFromElement, and, like
+ *  the rest of this fixture's render(), a stand-in for what a real host's DOM projection does. */
+function renderRuns(runs: RichTextRun[]): string {
+  return runs
+    .map((run) => {
+      const text = escapeHtml(run.text);
+      switch (run.kind) {
+        case "strong":
+          return `<strong>${text}</strong>`;
+        case "em":
+          return `<em>${text}</em>`;
+        case "link":
+          return `<a href="${escapeHtml(run.href ?? "")}">${text}</a>`;
+        case "code":
+          return `<code>${text}</code>`;
+        default:
+          return text;
+      }
+    })
+    .join("");
+}
+
+function render(model: BlockModel): void {
+  const root = canvas();
+  root.innerHTML = "";
+  for (const id of model.rootIds) {
+    const block = model.blocks[id];
+    if (!block) continue;
+    const el = document.createElement("div");
+    el.setAttribute("data-anglesite-block-id", id);
+    el.setAttribute("data-component", block.componentName);
+    el.setAttribute("data-anglesite-selected", "false");
+    if (block.kind === "text") {
+      el.innerHTML = renderRuns(block.richText ?? []);
+    } else {
+      el.textContent = `${block.componentName} (${id})`;
+    }
+    el.style.cssText = "padding:8px;margin:4px;border:1px solid #ccc;";
+    el.addEventListener("click", () => engine.selection.select(id));
+    el.addEventListener("pointerdown", () => dragReorder.startDrag(id));
+    root.appendChild(el);
+  }
+}
+
+const dragReorder = new DragReorderController(
+  engine,
+  (target) => {
+    window.__dropIndicator = target;
+  },
+  canvas(),
+);
+
+wireExternalDrop(
+  canvas(),
+  (target) => {
+    window.__dropIndicator = target;
+  },
+  (target, dataTransfer) => {
+    const json = dataTransfer.getData("application/x-anglesite-block");
+    if (!json) return;
+    const block = JSON.parse(json) as Omit<BlockNode, "id">;
+    void submitDrop(engine, target, block);
+  },
+);
+
+engine.onEvent((event) => {
+  if (event.type === "model-updated" || event.type === "applied" || (event.type === "rejected" && event.model)) {
+    render(engine.modelSync.current);
+  }
+  if (event.type === "selection-changed") {
+    for (const el of Array.from(canvas().children)) {
+      const selected = el.getAttribute("data-anglesite-block-id") === event.blockId;
+      el.setAttribute("data-anglesite-selected", String(selected));
+    }
+  }
+  // Cheap, poll-able signal Playwright can wait on without a custom event bridge.
+  document.title = `event:${event.type}`;
+});
+
+render(initialModel);
+
+declare global {
+  interface Window {
+    __engine: WysiwygEngine;
+    __host: FixtureHost;
+    __richText: RichTextEditor;
+    __dragReorder: DragReorderController;
+    __dropIndicator: DropTarget | null;
+    __moveBlock: (blockId: string, toIndex: number) => Promise<OpResult>;
+    __computeHandleRect: (blockId: string) => HandleRect | null;
+    __submitDrop: (target: DropTarget, block: Omit<BlockNode, "id">) => Promise<OpResult>;
+    __toggleFormat: (kind: FormatKind) => void;
+  }
+}
+
+window.__engine = engine;
+window.__host = host;
+window.__richText = richText;
+window.__dragReorder = dragReorder;
+window.__dropIndicator = null;
+window.__computeHandleRect = (blockId) => computeHandleRect(blockId);
+window.__submitDrop = (target, block) => submitDrop(engine, target, block);
+window.__toggleFormat = (kind) => richText.toggleFormat(kind);
+window.__moveBlock = (blockId, toIndex) => {
+  const model = engine.modelSync.current;
+  const fromIndex = model.rootIds.indexOf(blockId);
+  return engine.submit({
+    kind: "moveBlock",
+    blockId,
+    fromParentId: ROOT_PARENT_ID,
+    fromSlot: "default",
+    fromIndex,
+    toParentId: ROOT_PARENT_ID,
+    toSlot: "default",
+    toIndex,
+  });
+};
+```
+
+- [ ] **Step 2: Rebuild the fixture bundle and run the existing goldens to confirm nothing broke**
+
+Run: `cd JS/wysiwyg-engine && npm run test:e2e`
+Expected: PASS — `gestures.spec.ts`/`rendering.spec.ts`/`rejection.spec.ts` (slice 2) still pass unchanged against the extended fixture; the new `t1` block doesn't interfere (those specs only ever reference `b1`/`b2`).
+
+- [ ] **Step 3: Write `e2e/rich-text.spec.ts`**
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test("typing in an entered text block commits an editText op with honest runs after the debounce", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__richText.enter("t1"));
+
+  const block = page.locator('[data-anglesite-block-id="t1"]');
+  await block.evaluate((el) => {
+    el.textContent = "Edit me now";
+  });
+  await block.dispatchEvent("input");
+
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const runs = await page.evaluate(() => window.__engine.modelSync.getBlock("t1")?.richText);
+  expect(runs).toEqual([{ kind: "text", text: "Edit me now" }]);
+});
+
+test("toggling bold on a selection wraps it in <strong>, never a styled span", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__richText.enter("t1"));
+
+  const block = page.locator('[data-anglesite-block-id="t1"]');
+  await block.evaluate((el) => {
+    const textNode = el.firstChild;
+    if (!textNode) throw new Error("expected a text node");
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 4); // "Edit" (of "Edit ")
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  });
+
+  await page.evaluate(() => window.__toggleFormat("strong"));
+  await page.evaluate(() => window.__richText.exit());
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const runs = await page.evaluate(() => window.__engine.modelSync.getBlock("t1")?.richText);
+  expect(runs).toEqual([
+    { kind: "strong", text: "Edit" },
+    { kind: "text", text: " " },
+    { kind: "strong", text: "me" },
+  ]);
+});
+
+test("exiting without any change does not submit a no-op editText", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__richText.enter("t1"));
+  await page.evaluate(() => window.__richText.exit());
+
+  // No typing happened, so nothing should have committed — the title (flipped only by engine
+  // events) stays at its initial, pre-any-event value.
+  await page.waitForTimeout(100);
+  expect(await page.title()).toBe("WYSIWYG engine fixture");
+});
+```
+
+- [ ] **Step 4: Run the rich-text goldens**
+
+Run: `cd JS/wysiwyg-engine && npm run test:e2e -- rich-text`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Write `e2e/drag-drop.spec.ts`**
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test("a real pointer drag reorders blocks via DragReorderController", async ({ page }) => {
+  await page.goto("/fixture.html");
+  const b1Box = await page.locator('[data-anglesite-block-id="b1"]').boundingBox();
+  const b2Box = await page.locator('[data-anglesite-block-id="b2"]').boundingBox();
+  if (!b1Box || !b2Box) throw new Error("expected bounding boxes");
+
+  await page.mouse.move(b2Box.x + b2Box.width / 2, b2Box.y + b2Box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(b1Box.x + b1Box.width / 2, b1Box.y + 1, { steps: 5 });
+  await page.mouse.up();
+
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  const order = await page.evaluate(() => window.__engine.modelSync.current.rootIds);
+  expect(order.indexOf("b2")).toBeLessThan(order.indexOf("b1"));
+});
+
+test("submitDrop inserts a new block at the given target", async ({ page }) => {
+  await page.goto("/fixture.html");
+  const result = await page.evaluate(() =>
+    window.__submitDrop(
+      { parentId: "__root__", slot: "default", index: 0 },
+      { kind: "astro", componentName: "Newsletter", props: {}, slots: {}, sourceSpan: [0, 0] },
+    ),
+  );
+  expect(result.status).toBe("applied");
+
+  const firstId = await page.evaluate(() => window.__engine.modelSync.current.rootIds[0]);
+  const firstName = await page.evaluate(
+    (id) => (id ? window.__engine.modelSync.getBlock(id)?.componentName : undefined),
+    firstId,
+  );
+  expect(firstName).toBe("Newsletter");
+});
+
+test("an external drop (palette-style payload) inserts a block via wireExternalDrop", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => {
+    const canvasEl = document.getElementById("canvas");
+    if (!canvasEl) throw new Error("missing #canvas");
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData(
+      "application/x-anglesite-block",
+      JSON.stringify({ kind: "astro", componentName: "CallToAction", props: {}, slots: {}, sourceSpan: [0, 0] }),
+    );
+    const rect = canvasEl.getBoundingClientRect();
+    const dropEvent = new DragEvent("drop", {
+      clientX: rect.x + 5,
+      clientY: rect.y + 5,
+      bubbles: true,
+      cancelable: true,
+      dataTransfer,
+    });
+    canvasEl.dispatchEvent(dropEvent);
+  });
+
+  await page.waitForFunction(() => document.title === "event:applied");
+  const componentNames = await page.evaluate(() =>
+    Object.values(window.__engine.modelSync.current.blocks).map((b) => b.componentName),
+  );
+  expect(componentNames).toContain("CallToAction");
+});
+
+test("a version-mismatch rejection during a drop is visible and applies nothing", async ({ page }) => {
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__host.forceReject("version-mismatch", "stale"));
+
+  const result = await page.evaluate(() =>
+    window.__submitDrop(
+      { parentId: "__root__", slot: "default", index: 0 },
+      { kind: "astro", componentName: "ShouldNotAppear", props: {}, slots: {}, sourceSpan: [0, 0] },
+    ),
+  );
+  expect(result.status).toBe("rejected");
+
+  const componentNames = await page.evaluate(() =>
+    Object.values(window.__engine.modelSync.current.blocks).map((b) => b.componentName),
+  );
+  expect(componentNames).not.toContain("ShouldNotAppear");
+});
+```
+
+- [ ] **Step 6: Run the drag-drop goldens**
+
+Run: `cd JS/wysiwyg-engine && npm run test:e2e -- drag-drop`
+Expected: PASS (4 tests)
+
+- [ ] **Step 7: Write `e2e/frame.html`**
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>frame</title>
+  </head>
+  <body>
+    <div id="canvas"></div>
+  </body>
+</html>
+```
+
+- [ ] **Step 8: Write `e2e/breakpoints-fixture.html`**
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>WYSIWYG breakpoints fixture</title>
+  </head>
+  <body>
+    <iframe id="phone" src="./frame.html" style="width: 375px; height: 400px"></iframe>
+    <iframe id="tablet" src="./frame.html" style="width: 768px; height: 400px"></iframe>
+    <iframe id="desktop" src="./frame.html" style="width: 1280px; height: 400px"></iframe>
+    <script src="./.generated/breakpoints-bundle.js"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 9: Write `e2e/breakpoints-fixture-page.ts`**
+
+```ts
+import { WysiwygEngine } from "../src/engine.js";
+import { FixtureHost } from "../src/testing/fixture-host.js";
+import { BreakpointCanvas } from "../src/breakpoints.js";
+import type { BlockModel } from "../src/types.js";
+import type { HandleRect } from "../src/selection.js";
+
+const initialModel: BlockModel = {
+  path: "src/pages/index.astro",
+  version: "fixture-initial",
+  rootIds: ["b1", "b2"],
+  blocks: {
+    b1: { id: "b1", kind: "astro", componentName: "Hero", props: { title: "Welcome" }, slots: {}, sourceSpan: [0, 10] },
+    b2: { id: "b2", kind: "astro", componentName: "Testimonial", props: { quote: "Great!" }, slots: {}, sourceSpan: [11, 20] },
+  },
+};
+
+const host = new FixtureHost(initialModel);
+const engine = new WysiwygEngine(initialModel, host);
+
+function render(model: BlockModel, doc: Document): void {
+  const root = doc.getElementById("canvas");
+  if (!root) return;
+  root.innerHTML = "";
+  for (const id of model.rootIds) {
+    const block = model.blocks[id];
+    if (!block) continue;
+    const el = doc.createElement("div");
+    el.setAttribute("data-anglesite-block-id", id);
+    el.textContent = block.componentName;
+    el.style.cssText = "padding:8px;margin:4px;border:1px solid #ccc;";
+    el.addEventListener("click", () => engine.selection.select(id));
+    root.appendChild(el);
+  }
+}
+
+const canvas = new BreakpointCanvas(engine, render);
+const frameNames = ["phone", "tablet", "desktop"] as const;
+
+function registerFrames(): void {
+  for (const name of frameNames) {
+    const iframe = document.getElementById(name) as HTMLIFrameElement | null;
+    const frameDoc = iframe?.contentDocument;
+    if (!frameDoc) throw new Error(`missing iframe document for ${name}`);
+    canvas.registerFrame({ name, doc: frameDoc });
+  }
+  // Cheap, poll-able readiness signal — engine.onEvent() below overwrites it on any later event.
+  document.title = "breakpoints:ready";
+}
+
+const iframes = frameNames
+  .map((name) => document.getElementById(name) as HTMLIFrameElement | null)
+  .filter((el): el is HTMLIFrameElement => el !== null);
+
+let loadedCount = 0;
+for (const iframe of iframes) {
+  iframe.addEventListener("load", () => {
+    loadedCount += 1;
+    if (loadedCount === iframes.length) registerFrames();
+  });
+}
+
+engine.onEvent((event) => {
+  document.title = `event:${event.type}`;
+});
+
+declare global {
+  interface Window {
+    __engine: WysiwygEngine;
+    __host: FixtureHost;
+    __canvas: BreakpointCanvas;
+    __handleRects: () => { name: string; rect: HandleRect }[];
+  }
+}
+
+window.__engine = engine;
+window.__host = host;
+window.__canvas = canvas;
+window.__handleRects = () => canvas.handleRectsForSelection();
+```
+
+- [ ] **Step 10: Write `e2e/breakpoints.spec.ts`**
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test("registers all three frames and renders the model into each", async ({ page }) => {
+  await page.goto("/breakpoints-fixture.html");
+  await page.waitForFunction(() => document.title === "breakpoints:ready");
+
+  for (const name of ["phone", "tablet", "desktop"]) {
+    const frame = page.frameLocator(`#${name}`);
+    await expect(frame.locator('[data-anglesite-block-id="b1"]')).toHaveText("Hero");
+  }
+});
+
+test("selecting a block in one frame draws handles in every registered frame", async ({ page }) => {
+  await page.goto("/breakpoints-fixture.html");
+  await page.waitForFunction(() => document.title === "breakpoints:ready");
+
+  await page.frameLocator("#phone").locator('[data-anglesite-block-id="b2"]').click();
+  await page.waitForFunction(() => document.title === "event:selection-changed");
+
+  const rects = await page.evaluate(() => window.__handleRects());
+  expect(rects.map((r) => r.name).sort()).toEqual(["desktop", "phone", "tablet"]);
+  for (const { rect } of rects) {
+    expect(rect.width).toBeGreaterThan(0);
+    expect(rect.height).toBeGreaterThan(0);
+  }
+});
+
+test("an op applied via the shared engine re-renders every frame", async ({ page }) => {
+  await page.goto("/breakpoints-fixture.html");
+  await page.waitForFunction(() => document.title === "breakpoints:ready");
+
+  await page.evaluate(() =>
+    window.__engine.submit({
+      kind: "moveBlock",
+      blockId: "b2",
+      fromParentId: "__root__",
+      fromSlot: "default",
+      fromIndex: 1,
+      toParentId: "__root__",
+      toSlot: "default",
+      toIndex: 0,
+    }),
+  );
+  await page.waitForFunction(() => document.title === "event:applied");
+
+  for (const name of ["phone", "tablet", "desktop"]) {
+    const frame = page.frameLocator(`#${name}`);
+    await expect(frame.locator("#canvas > div").first()).toHaveText("Testimonial");
+  }
+});
+```
+
+- [ ] **Step 11: Wire the second e2e bundle into `package.json`**
+
+In `JS/wysiwyg-engine/package.json`, change the `build:e2e` script from:
+
+```json
+    "build:e2e": "esbuild e2e/fixture-page.ts --bundle --format=iife --target=es2022 --outfile=e2e/.generated/fixture-bundle.js",
+```
+
+to:
+
+```json
+    "build:e2e": "esbuild e2e/fixture-page.ts --bundle --format=iife --target=es2022 --outfile=e2e/.generated/fixture-bundle.js && esbuild e2e/breakpoints-fixture-page.ts --bundle --format=iife --target=es2022 --outfile=e2e/.generated/breakpoints-bundle.js",
+```
+
+- [ ] **Step 12: Run the breakpoints goldens**
+
+Run: `cd JS/wysiwyg-engine && npm run test:e2e -- breakpoints`
+Expected: PASS (3 tests)
+
+- [ ] **Step 13: Run the full local check set**
+
+Run: `cd JS/wysiwyg-engine && npm run lint && npm run typecheck && npm test && npm run test:e2e`
+Expected: all PASS (every unit test file from Tasks 1–8, plus all seven e2e spec files — the three pre-existing slice-2 goldens plus this task's four new ones)
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add JS/wysiwyg-engine/e2e/ JS/wysiwyg-engine/package.json
+git commit -m "feat(#1224): add Playwright goldens for rich text, drag/drop, and breakpoints"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (`docs/superpowers/specs/2026-08-08-wysiwyg-canvas-chrome-design.md`, cross-checked section by section):
+
+- §2 scope boundary (pure JS/TS, zero Swift, no native palette/Finder ingestion) → enforced throughout: every file this plan touches is under `JS/wysiwyg-engine/`; no `Sources/**` file appears in any task. No CI task, because the existing `wysiwyg-engine` job (from slice 2) already gates the whole `JS/wysiwyg-engine/**` path.
+- §3 architecture (three new modules on top of slice 2's primitives; one engine drives N frames) → Tasks 1–4 build `rich-text.ts`, Tasks 5–7 build `drag-drop.ts`, Task 8 builds `breakpoints.ts`; Task 8's `BreakpointCanvas` is the concrete realization of "one `WysiwygEngine` instance drives multiple frame documents," using `hitTest(point, doc)`/`computeHandleRect(id, root)`'s existing document parameter rather than new coordination machinery.
+- §4 inline rich-text editing:
+  - "Honest runs only, no styled spans" → Task 1's `runsFromElement` (only strong/em/link/code survive; everything else flattens to text).
+  - "Manual Range wrapping/unwrapping, not execCommand" → Task 3's `wrapRange`/`unwrapElement`/`toggleInlineFormat`/`setLinkFormat`/`unsetLinkFormat`.
+  - "Debounce ~400ms, immediate on blur/Escape/format command" → Task 2's `DebouncedCommitter` (default 400ms) + Task 4's `RichTextEditor`, which now wires `blur` and `keydown`(Escape) listeners alongside the format-command methods, each calling `exit()`/`notifyChange()` for an immediate flush — added during this plan's self-review after the first draft only wired `input`; see Task 4's revised implementation and its two new tests.
+  - "`previousRuns` is the entry-time baseline, not the prior debounce tick" → Task 4's `#baselineRuns`, captured once in `enter()`, unit-tested by the "multiple edits before the debounce fires" test.
+- §5 drag & drop:
+  - "`computeDropTarget` pure geometry" → Task 5.
+  - "In-canvas reorder via pointer events, not HTML5 DnD" → Task 6's `DragReorderController`.
+  - "External drop via native `dragover`/`drop`, engine never inspects `DataTransfer`" → Task 7's `wireExternalDrop`, which forwards the raw `DataTransfer` to a host-supplied callback and never parses it itself.
+  - "`submitDrop` builds/submits `insertBlock`" → Task 5.
+- §6 breakpoint views: "same block model into N frames, gestures resolve through the one shared engine, no per-breakpoint style surface" → Task 8's `BreakpointCanvas.registerFrame`/`#onEngineEvent` (re-render) and `hitTestFrame`/`handleRectsForSelection` (shared-engine gesture resolution); no op or type introduced anywhere in this plan carries a breakpoint-scoped value, so there is structurally no such surface to remove.
+- §7 error handling: "commit paths reuse the existing `OpQueue` rejection handling; an in-progress gesture aborts visibly, never silently" → every submitting call (`RichTextEditor.#commit`, `DragReorderController.#handleUp`, `submitDrop`) goes through `engine.submit()` with no new rejection logic (Global Constraints); `DragReorderController`'s vanished-block abort (Task 6) and the version-mismatch goldens (`rich-text`/`drag-drop` e2e specs reusing the `forceReject`/`rejected`-event pattern from slice 2's `rejection.spec.ts`) exercise this directly.
+- §8 testing: "vitest for pure logic, Playwright e2e for real-geometry/real-`Selection`/real-DnD behavior, no new test infrastructure" → every task follows this split explicitly (see each task's test-file comments); Task 9 reuses the existing `static-server.mjs`/fixture-host pattern and only adds one new esbuild bundle target for the breakpoints fixture, not a new toolchain.
+- §9 out of scope confirmed absent from this plan: no Swift/WKWebView mounting, no native palette UI, no `NSUndoManager` wiring, no Finder file ingestion, no menu-bar commands, no multi-select.
+
+**Placeholder scan:** no TBD/TODO markers; every step contains literal, complete code — including the one gap this self-review found and fixed (blur/Escape auto-exit) rather than leaving it as a follow-up note.
+
+**Type consistency:** `DropTarget`, `nearestIndexInSlot`, `computeDropTarget`, `generateBlockId`, `submitDrop` (Task 5) are consumed with identical signatures by `DragReorderController` (Task 6), `wireExternalDrop` (Task 7), and the e2e fixtures (Task 9) — none re-declare or shadow them. `RichTextEditor`, `DebouncedCommitter`, `FormatKind`, `toggleInlineFormat`/`setLinkFormat`/`unsetLinkFormat` (Tasks 1–4) are imported by name into `e2e/fixture-page.ts` (Task 9) exactly as exported. `BreakpointCanvas`'s `RenderFn = (model: BlockModel, doc: Document) => void` matches both the unit test's local `render()` (Task 8) and `e2e/breakpoints-fixture-page.ts`'s `render()` (Task 9) argument-for-argument. `src/index.ts`'s barrel export (Task 8, Step 5) re-exports all three new modules, so every symbol referenced across tasks resolves through the same public surface a real host would eventually consume.

--- a/docs/superpowers/plans/2026-08-08-wysiwyg-canvas-chrome.md
+++ b/docs/superpowers/plans/2026-08-08-wysiwyg-canvas-chrome.md
@@ -1721,7 +1721,9 @@ git commit -m "feat(#1224): add BreakpointCanvas and export canvas-chrome module
 
 **Interfaces:**
 - Consumes: `RichTextEditor` (rich-text.ts), `DragReorderController`, `wireExternalDrop`, `submitDrop`, `DropTarget` (drag-drop.ts), `BreakpointCanvas` (breakpoints.ts) — all from earlier tasks.
-- Produces: `window.__richText: RichTextEditor`, `window.__dragReorder: DragReorderController`, `window.__submitDrop`, `window.__toggleFormat` on the main fixture page; `window.__canvas: BreakpointCanvas`, `window.__handleRects` on the breakpoints fixture — the surface the three new golden spec files drive.
+- Produces: `window.__richText: RichTextEditor`, `window.__dragReorder: DragReorderController`, `window.__submitDrop`, `window.__toggleFormat`, `window.__disposeExternalDrop: () => void` on the main fixture page; `window.__canvas: BreakpointCanvas`, `window.__handleRects` on the breakpoints fixture — the surface the three new golden spec files drive.
+
+**Coverage note:** Task 7's `wireExternalDrop` shipped with zero unit tests — `DragEvent`/`DataTransfer` are unconstructable under this project's pinned jsdom (verified: `jsdom@30.0.1` throws `"is not a constructor"` for both), so all three of Task 7's planned unit tests were correctly dropped per its brief's own anticipated fallback, deferring 100% of `wireExternalDrop`'s behavioral coverage to this task. The two new `drag-drop.spec.ts` cases below (dragover indicator + dragleave clear, and disposer cleanup) exist specifically to close that gap — do not treat them as optional/nice-to-have additions to this task.
 
 - [ ] **Step 1: Replace `e2e/fixture-page.ts`** with the full updated file (adds a `"text"` block rendered from its `richText` runs, and wires `RichTextEditor`/`DragReorderController`/`wireExternalDrop` onto the same canvas):
 
@@ -1825,7 +1827,7 @@ const dragReorder = new DragReorderController(
   canvas(),
 );
 
-wireExternalDrop(
+const disposeExternalDrop = wireExternalDrop(
   canvas(),
   (target) => {
     window.__dropIndicator = target;
@@ -1865,6 +1867,7 @@ declare global {
     __computeHandleRect: (blockId: string) => HandleRect | null;
     __submitDrop: (target: DropTarget, block: Omit<BlockNode, "id">) => Promise<OpResult>;
     __toggleFormat: (kind: FormatKind) => void;
+    __disposeExternalDrop: () => void;
   }
 }
 
@@ -1876,6 +1879,7 @@ window.__dropIndicator = null;
 window.__computeHandleRect = (blockId) => computeHandleRect(blockId);
 window.__submitDrop = (target, block) => submitDrop(engine, target, block);
 window.__toggleFormat = (kind) => richText.toggleFormat(kind);
+window.__disposeExternalDrop = disposeExternalDrop;
 window.__moveBlock = (blockId, toIndex) => {
   const model = engine.modelSync.current;
   const fromIndex = model.rootIds.indexOf(blockId);
@@ -2031,6 +2035,64 @@ test("an external drop (palette-style payload) inserts a block via wireExternalD
   expect(componentNames).toContain("CallToAction");
 });
 
+test("dragover computes a drop-target indicator; dragleave clears it", async ({ page }) => {
+  // Task 7 shipped wireExternalDrop with zero unit tests (DragEvent/DataTransfer are
+  // unconstructable under this project's pinned jsdom) — this is the only test covering its
+  // dragover/dragleave indicator behavior at any tier.
+  await page.goto("/fixture.html");
+  await page.evaluate(() => {
+    const canvasEl = document.getElementById("canvas");
+    if (!canvasEl) throw new Error("missing #canvas");
+    const rect = canvasEl.getBoundingClientRect();
+    canvasEl.dispatchEvent(
+      new DragEvent("dragover", { clientX: rect.x + 5, clientY: rect.y + 5, bubbles: true, cancelable: true }),
+    );
+  });
+
+  const indicatorAfterDragover = await page.evaluate(() => window.__dropIndicator);
+  expect(indicatorAfterDragover).not.toBeNull();
+  expect(indicatorAfterDragover?.parentId).toBe("__root__");
+
+  await page.evaluate(() => {
+    document.getElementById("canvas")?.dispatchEvent(new DragEvent("dragleave", { bubbles: true }));
+  });
+  const indicatorAfterDragleave = await page.evaluate(() => window.__dropIndicator);
+  expect(indicatorAfterDragleave).toBeNull();
+});
+
+test("the disposer stops wireExternalDrop from responding to further drags", async ({ page }) => {
+  // The other half of Task 7's deferred coverage: the disposer itself has no test at any tier
+  // otherwise.
+  await page.goto("/fixture.html");
+  await page.evaluate(() => window.__disposeExternalDrop());
+
+  const componentNamesBefore = await page.evaluate(() =>
+    Object.values(window.__engine.modelSync.current.blocks).map((b) => b.componentName),
+  );
+
+  await page.evaluate(() => {
+    const canvasEl = document.getElementById("canvas");
+    if (!canvasEl) throw new Error("missing #canvas");
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData(
+      "application/x-anglesite-block",
+      JSON.stringify({ kind: "astro", componentName: "ShouldNeverAppear", props: {}, slots: {}, sourceSpan: [0, 0] }),
+    );
+    const rect = canvasEl.getBoundingClientRect();
+    canvasEl.dispatchEvent(
+      new DragEvent("drop", { clientX: rect.x + 5, clientY: rect.y + 5, bubbles: true, cancelable: true, dataTransfer }),
+    );
+  });
+
+  // Disposed listeners never run, so no engine event fires and there's nothing to await — give
+  // any errant async work one beat to have shown up, then assert nothing changed.
+  await page.waitForTimeout(100);
+  const componentNamesAfter = await page.evaluate(() =>
+    Object.values(window.__engine.modelSync.current.blocks).map((b) => b.componentName),
+  );
+  expect(componentNamesAfter).toEqual(componentNamesBefore);
+});
+
 test("a version-mismatch rejection during a drop is visible and applies nothing", async ({ page }) => {
   await page.goto("/fixture.html");
   await page.evaluate(() => window.__host.forceReject("version-mismatch", "stale"));
@@ -2053,7 +2115,7 @@ test("a version-mismatch rejection during a drop is visible and applies nothing"
 - [ ] **Step 6: Run the drag-drop goldens**
 
 Run: `cd JS/wysiwyg-engine && npm run test:e2e -- drag-drop`
-Expected: PASS (4 tests)
+Expected: PASS (6 tests)
 
 - [ ] **Step 7: Write `e2e/frame.html`**
 
@@ -2248,7 +2310,7 @@ Expected: PASS (3 tests)
 - [ ] **Step 13: Run the full local check set**
 
 Run: `cd JS/wysiwyg-engine && npm run lint && npm run typecheck && npm test && npm run test:e2e`
-Expected: all PASS (every unit test file from Tasks 1–8, plus all seven e2e spec files — the three pre-existing slice-2 goldens plus this task's four new ones)
+Expected: all PASS (every unit test file from Tasks 1–8, plus all six e2e spec files — the three pre-existing slice-2 goldens plus this task's three new ones)
 
 - [ ] **Step 14: Commit**
 

--- a/docs/superpowers/specs/2026-08-08-wysiwyg-canvas-chrome-design.md
+++ b/docs/superpowers/specs/2026-08-08-wysiwyg-canvas-chrome-design.md
@@ -1,0 +1,212 @@
+# WYSIWYG canvas chrome (slice 3) — design
+
+**Date:** 2026-08-08
+**Status:** Approved, pre-plan
+**Related:** Issue #1224 (this slice), epic #1221, vision spec
+`docs/superpowers/specs/2026-08-03-modern-wysiwyg-editor-design.md` (§3–§5, §8),
+slice 2 implementation plan `docs/superpowers/plans/2026-08-07-wysiwyg-overlay-engine-core.md`,
+`JS/wysiwyg-engine/` (merged, slice 2)
+
+## 1. Summary
+
+Slice 3 of the modern WYSIWYG editor epic builds the interactive canvas chrome the
+vision spec assigns to "the Engine" (§3.1): inline rich-text editing, drag/drop
+handling for both in-canvas reordering and external (palette/Finder) drops, and
+responsive breakpoint views. It extends the existing `JS/wysiwyg-engine/` package
+(merged as slice 2) rather than introducing a new package or touching Swift.
+
+Slice 1 (sidecar ops protocol / real `HostTransport`, issue #1222) is still open
+and blocked on a human decision. This slice does not need it: like slice 2, it is
+built and tested entirely against the in-memory `FixtureHost` and Playwright
+goldens — the engine only ever talks to the abstract `HostTransport` interface.
+Native integration (mounting this chrome in the real app window, the native block
+palette, `NSUndoManager`, Finder file ingestion) is explicitly out of scope here —
+that is slice 4, "Mac host chrome" (#1225).
+
+## 2. Scope boundary
+
+Mirrors slice 2's shape exactly: **pure JS/TS, zero Swift changes.** Confirmed by:
+
+- Slice 2 shipped as an entirely JS/TS deliverable (`git log` shows only
+  `feat(#1223): ...` commits under `JS/wysiwyg-engine/`); nothing in `Sources/`
+  references it.
+- The epic's own slice breakdown assigns menus, `NSUndoManager` undo, the native
+  inspector, and the native block palette to slice 4, not slice 3.
+- Spec §8.3–§8.4 describes the palette as "a native source list" and Finder-drop
+  asset ingestion as host-owned — both slice-4 concerns.
+
+Everything in this design lives in `JS/wysiwyg-engine/`, is testable via `vitest`
+(unit) and Playwright (e2e goldens against a fixture host + static server), and
+introduces no new runtime dependencies.
+
+## 3. Architecture
+
+Three new modules join the existing `src/` layout, each consuming — not
+replacing — slice 2's primitives (`WysiwygEngine`, `SelectionState`, `hitTest`,
+`OpQueue`, `ModelSync`):
+
+```
+JS/wysiwyg-engine/src/
+├── rich-text.ts     # inline text editing: contenteditable lifecycle, honest-runs
+│                     # serialization, format commands, debounced editText commit
+├── drag-drop.ts      # computeDropTarget(), in-canvas reorder (moveBlock),
+│                     # external drop wiring (insertBlock via host callback)
+└── breakpoints.ts    # BreakpointCanvas: one shared engine driving N frame documents
+```
+
+All three route every mutation through the existing `engine.submit()` →
+`OpQueue` path. None of them add new error-recovery logic — they consume the
+`applied`/`rejected` events slice 2 already emits and must not swallow them
+(§7).
+
+A key existing-code finding shapes this design: `hitTest(point, doc: Document =
+document)` and `computeHandleRect(id, root: ParentNode = document)` already take
+an explicit document/root parameter rather than assuming the global `document`.
+That lets **one `WysiwygEngine` instance (one model, one selection, one op
+queue) drive multiple breakpoint frame documents simultaneously** — see §6.
+
+## 4. Inline rich-text editing
+
+Honest runs only: `strong`, `em`, `link` (`<a href>`), `code` — no styled spans,
+matching spec §4's WYSIWYM lesson.
+
+- **`RichTextEditor.enter(blockId)`** — sets the target text block's element
+  `contenteditable="true"`, focuses it, snapshots the current `RichTextRun[]` as
+  the editing baseline (used to detect no-op exits and to build the `editText`
+  op's `previousRuns`).
+- **Format commands** (bold/italic/link/code — spec §8.1's ⌘B/⌘I/⌘K are a
+  slice-4 menu concern, but the underlying command implementation lives here) use
+  **manual DOM Range wrapping/unwrapping**, not `document.execCommand` — it is
+  deprecated, browser-inconsistent, and would let arbitrary style markup leak
+  into the DOM. Wrapping a selection only ever produces `<strong>`, `<em>`,
+  `<a href>`, or `<code>` elements; unwrapping removes them.
+- **`runsFromElement(el): RichTextRun[]`** serializes the live contenteditable
+  DOM into the honest-runs shape. It recognizes exactly: `strong`/`b` → strong,
+  `em`/`i` → em, `a[href]` → link, `code` → code. Any other element the browser's
+  contenteditable implementation might inject (a stray `<div>` from a paste, a
+  styled `<span>`) is **not represented** — its text content is flattened into
+  the surrounding run. This is the structural backstop for roundtrip honesty:
+  even if the DOM the user produced by typing/pasting is messier than the
+  recognized set, the serializer refuses to promote any of that mess into the
+  ops protocol.
+- **Commit timing:** debounced ~400ms after typing pauses, and immediately on
+  blur, Escape, or a format command. Each commit serializes the current DOM and
+  submits `{ kind: "editText", blockId, runs, previousRuns }` via
+  `engine.submit()`. `previousRuns` is always the *baseline at `enter()`*, not
+  the prior debounce tick — so a version-mismatch rejection mid-edit can cleanly
+  discard the whole in-progress edit and re-render from the fresh model (§7)
+  without needing to reconstruct intermediate state.
+- **`RichTextEditor.exit()`** flushes any pending debounced commit synchronously,
+  then sets `contenteditable="false"`.
+
+## 5. Drag & drop
+
+One geometry primitive serves two gestures.
+
+**`computeDropTarget(point, doc): { parentId, slot, index } | null`** — walks the
+block elements in `doc`, compares `point` against sibling block rects' midpoints,
+and returns the nearest valid insertion target, or `null` when the point isn't
+over anything droppable. Pure geometry; no DOM mutation, no op submission.
+
+**In-canvas reorder (drag-source).** Pointer-based drag (`pointerdown` /
+`pointermove` / `pointerup`), not the HTML5 Drag and Drop API — more reliable for
+same-document reordering and behaves uniformly whether the block lives in a
+single canvas or one of several breakpoint frames (§6). Dragging a selected
+block's handle tracks `computeDropTarget` live (driving an insertion-line
+indicator) and on release emits `moveBlock` from the block's current position to
+the computed target.
+
+**External drop (palette/Finder → `insertBlock`).** The canvas listens for
+native `dragover`/`drop` DOM events (real OS/host-originated drags surface as
+native drag events even inside a WKWebView). `dragover` calls
+`computeDropTarget` for the same insertion-line feedback and calls
+`preventDefault()` to allow the drop. On `drop`, **the engine does not interpret
+`DataTransfer` itself** — it forwards `{ target, dataTransfer }` to a
+host-supplied `onExternalDrop` callback. The host decides what block descriptor
+(if any) to build — reading a custom MIME payload for a palette-originated drag,
+or kicking off asynchronous Finder-file ingestion — and calls
+**`submitDrop(engine, target, block): Promise<OpResult>`** (computes/validates
+the target and builds+submits the `insertBlock` op) once it has one. This keeps
+the engine ignorant of "what a palette item is" and "how Finder ingestion
+works" — both confirmed slice-4/host concerns — while slice 3 still owns all the
+real geometry, event wiring, and op construction.
+
+## 6. Responsive breakpoint views
+
+Breakpoints are views, not modes (spec §5): the same block model rendered at
+multiple widths, all live and interactive at once — confirmed during
+brainstorming that side-by-side frames should **all** be fully interactive, not
+just one "active" frame with read-only mirrors.
+
+**`BreakpointCanvas`** registers a set of `{ name: "phone" | "tablet" |
+"desktop", doc: Document }` frames (in tests, N `<iframe>` documents within one
+fixture page; a future host wires real iframes or its own multi-viewport
+rendering — that wiring is out of scope here per §2).
+
+- On construction, and on every `model-updated`/`applied` engine event, the same
+  render function runs once per registered frame document — each frame is an
+  independent DOM projection of the identical model.
+- Gesture listeners (click, pointer-drag, dragover/drop) are attached
+  per-frame, but each just resolves through the **one shared engine**:
+  `engine.hitTest(point, thatFrame.doc)` and `engine.selection.select(id)`.
+  Because selection state lives in one place, selecting a block in the phone
+  frame draws handles (via `computeHandleRect(id, thatFrame.doc)`) in the
+  tablet and desktop frames too, with no new cross-frame sync mechanism.
+- No per-breakpoint style authoring surface exists anywhere in this module, by
+  construction — every op this slice emits (`editText`, `insertBlock`,
+  `moveBlock`) carries content/structure, never a breakpoint-scoped value. This
+  is what "welds the iWeb trap door shut" (spec §5): the tools to create a
+  desktop-only design don't exist at this layer.
+
+## 7. Error handling
+
+No new rejection-handling logic — every commit path in this slice
+(`editText` flush, drop-triggered `insertBlock`, reorder-triggered `moveBlock`)
+goes through the existing `engine.submit()` → `OpQueue`, which already:
+
+- adopts the host's fresh model and emits a visible `rejected` event on
+  version-mismatch (built in slice 2), and
+- lets `WysiwygEngine` invalidate a selection that a model swap removed.
+
+This slice's only new responsibility is **not swallowing those events**:
+
+- An in-progress text edit whose commit is rejected discards its local draft and
+  re-renders from the fresh model rather than retrying blindly — visible, per
+  spec §9, never silent.
+- An in-progress drag (reorder or external drop) whose target block is removed
+  by a concurrent `model-updated` aborts cleanly instead of emitting a
+  `moveBlock`/`insertBlock` against a now-invalid index.
+- Exact user-visible presentation of a rejected/aborted gesture (toast, flash,
+  etc.) is a host concern (slice 4); this slice's obligation ends at firing the
+  engine event.
+
+## 8. Testing
+
+Mirrors slice 2's established pattern — no new test infrastructure:
+
+- `vitest` unit tests per module. DOM-serialization logic (`runsFromElement`,
+  Range wrapping) is testable under jsdom; point-based geometry
+  (`computeDropTarget`, real handle rects across frames) needs a real layout
+  engine, so those cases are deferred to e2e, matching how `hit-test.test.ts`
+  already splits pure-traversal unit tests from Playwright-covered point
+  resolution.
+- New Playwright e2e goldens in `e2e/`, against the existing fixture-host +
+  static-server setup:
+  - `rich-text.spec.ts` — type → format → blur → `applied` `editText` event
+    carrying the expected honest runs.
+  - `drag-drop.spec.ts` — synthetic drag → `insertBlock`/`moveBlock` at the
+    expected index; a version-mismatch mid-drag aborts visibly.
+  - `breakpoints.spec.ts` — selecting in one frame shows handles in every
+    registered frame; an edit applied in one frame re-renders all frames.
+
+## 9. Out of scope (deferred to slice 4 or later)
+
+- Mounting this chrome in the real Anglesite app window / WKWebView.
+- The native block palette UI (spec §8.3's "native source list").
+- `NSUndoManager` registration and typing-coalescing (spec §8.2) — this slice's
+  debounced commits are what a host's undo coalescing groups, but the grouping
+  itself is host-owned.
+- Finder file ingestion, asset upload, AI alt-text proposals (spec §8.4, §6).
+- Menu-bar commands (Insert/Format menus, spec §8.1).
+- Multi-select (per slice 2's `selection.ts`, still explicitly out of scope
+  unless a real need surfaces).

--- a/docs/superpowers/specs/2026-08-08-wysiwyg-canvas-chrome-design.md
+++ b/docs/superpowers/specs/2026-08-08-wysiwyg-canvas-chrome-design.md
@@ -180,6 +180,45 @@ This slice's only new responsibility is **not swallowing those events**:
   etc.) is a host concern (slice 4); this slice's obligation ends at firing the
   engine event.
 
+## 7a. Known limitations carried into slice 4
+
+Surfaced by the whole-branch review of this slice. None block the slice — each
+is a documented boundary of what "canvas chrome, host-agnostic" covers, and each
+lands squarely on slice 4's host-integration work.
+
+- **Re-render granularity vs. an in-flight `RichTextEditor` session.** Any
+  applied op makes the host replace the whole block subtree — including the
+  editing block's own successful `editText` commit — which disconnects the
+  element `RichTextEditor` holds as its active element. `RichTextEditor` does
+  not subscribe to engine events, so nothing tells it this happened; it recovers
+  only because a disconnected focused element incidentally fires `blur` in a real
+  browser. §7's first bullet ("an in-progress text edit whose commit is rejected
+  discards its local draft and re-renders from the fresh model") therefore has no
+  explicit implementation the way the drag-abort bullet does. A slice-4 host
+  wanting a durable editing session needs either finer-grained re-rendering or an
+  explicit engine-event subscription in the editor — not the current accident.
+- **`DragReorderController` is one-per-document.** Its `container` is captured at
+  construction and every `pointermove` is measured against it, while
+  `startDrag`'s `doc` decides which document's pointer events are observed. A
+  host driving several breakpoint frames needs one controller per frame; a shared
+  instance would measure frame coordinates against another document's container
+  and compute a plausible-looking but wrong drop index. Documented on the class
+  rather than enforced by the signature, since the module's real current usage is
+  a single global-document canvas.
+- **Frame-local coordinate spaces.** `BreakpointCanvas.handleRectsForSelection()`
+  returns rects in each frame's own viewport coordinate space, and
+  `hitTestFrame()` expects its `point` in the target frame's. A host drawing
+  overlay chrome in a parent document over an iframe must translate by that
+  iframe's offset in both directions. The engine deliberately owns no rendering
+  (spec §3.1), so it can't do that translation itself.
+- **Cross-module composition is only spot-covered.** Each of the three modules is
+  unit- and e2e-tested in isolation; the only tests exercising two together are
+  the targeted cross-document regressions this review added (a
+  `RichTextEditor` session against a `BreakpointCanvas` frame document). There is
+  still no test of drag-reorder inside a breakpoint frame, or of an edit and a
+  reorder interleaved. Slice 4's test plan should cover the combinations its own
+  host actually wires up.
+
 ## 8. Testing
 
 Mirrors slice 2's established pattern — no new test infrastructure:


### PR DESCRIPTION
Closes #1224

## Summary

- Extends `JS/wysiwyg-engine/` (slice 2, already merged) with three new modules, per the approved design spec: `src/rich-text.ts` (honest-runs inline text editing — Range-based format commands, never `execCommand`, debounced `editText` commits), `src/drag-drop.ts` (pointer-based in-canvas reorder + native external palette/Finder drop wiring, both landing as `insertBlock`/`moveBlock`), and `src/breakpoints.ts` (`BreakpointCanvas`, driving phone/tablet/desktop frame documents from one shared `WysiwygEngine`).
- Adds Playwright e2e goldens for all three modules (rich text, drag/drop, breakpoints), plus a second three-iframe fixture for multi-frame testing.
- Design doc (`docs/superpowers/specs/2026-08-08-wysiwyg-canvas-chrome-design.md`) and implementation plan (`docs/superpowers/plans/2026-08-08-wysiwyg-canvas-chrome.md`) included; the design doc's new §7a documents known limitations carried into slice 4 (Mac host chrome, #1225) — re-render granularity vs. an in-flight text edit, `DragReorderController`'s one-controller-per-document invariant, and frame-local coordinate spaces.
- Pure JS/TS — no Swift changes, no new runtime dependencies. No CI wiring needed: the existing `wysiwyg-engine` CI job (from slice 2) already gates the whole `JS/wysiwyg-engine/**` path.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite-skills#123 -->

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path .` — not run; this PR touches only `JS/wysiwyg-engine/` and `docs/`, no `Sources/`/`Resources/Template/`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run, same reason
- [ ] Manual smoke (if UI-touching): n/a — no native UI in this slice

### JS test plan (this PR's actual scope)

- [x] `cd JS/wysiwyg-engine && npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 74/74 unit tests passing
- [x] `npm run test:e2e` — 23/23 Playwright e2e tests passing (includes downward-drag reorder, cross-frame rich-text editing, `hitTestFrame`, `wireExternalDrop` dragover/disposer goldens added during final review)