### PR TITLE
feat(#869): iOS posting UI: compose form, publish flow, split shell

### DIFF
--- a/Sources/AnglesiteCore/MicropubComposerProjection.swift
+++ b/Sources/AnglesiteCore/MicropubComposerProjection.swift
@@ -1,0 +1,110 @@
+// Sources/AnglesiteCore/MicropubComposerProjection.swift
+import Foundation
+
+/// The write-direction inverse of `MicropubContentSync`'s mf2-to-field mapping (#869): projects a
+/// typed form's `TypedContentEditor.Values` back into the raw mf2 property map a Micropub
+/// create/update body carries. The two directions live in the same module on purpose — the iOS
+/// composer writes through this projection and the Mac's sync bridge reads through
+/// `MicropubContentSync.values(for:properties:updatedAt:slug:)`, so a post edited on the phone
+/// resolves to the same field values when it syncs back into the site's git repo.
+///
+/// Pure value mapping, no I/O — `MicropubClient` transports whatever this produces.
+public enum MicropubComposerProjection {
+    /// Builds the mf2 property map for `descriptor`'s fields from `values`, stamping
+    /// `post-status` from `status`.
+    ///
+    /// Per-field rules mirror `MicropubContentSync`'s read direction:
+    /// - `draft` is skipped — it has no mf2 property of its own; the Post Status extension's
+    ///   `post-status` property (stamped here from `status`) is its wire form.
+    /// - Fields with no mf2 mapping on the descriptor are skipped — they have no wire form.
+    /// - Empty/unset values are omitted rather than sent as blank scalars, matching the read
+    ///   direction's omit-don't-placeholder rule for optional fields.
+    ///
+    /// `mp-slug` is deliberately NOT this projection's concern: it's a create-only command
+    /// (re-slugging an existing post on every update would move its URL), so the composer adds it
+    /// at create time via ``MicropubClient/deriveSlug(title:explicitSlug:)``.
+    ///
+    /// - Parameters:
+    ///   - descriptor: The content type whose fields are being projected.
+    ///   - values: The form's per-field values.
+    ///   - status: Stamped as the `post-status` property.
+    /// - Returns: The mf2 property map for a create body or an update's `replace` map.
+    public static func properties(
+        for descriptor: ContentTypeDescriptor,
+        values: TypedContentEditor.Values,
+        status: MicropubPostStatus
+    ) -> [String: [JSONValue]] {
+        var out: [String: [JSONValue]] = ["post-status": [.string(status.rawValue)]]
+        for field in descriptor.fields where field.name != "draft" {
+            guard let property = descriptor.projections.rawMf2Property(forField: field.name),
+                  let value = values[field.name],
+                  let encoded = mf2Values(for: value, kind: field.kind)
+            else { continue }
+            out[property] = encoded
+        }
+        return out
+    }
+
+    /// The mf2 property names `descriptor` can round-trip at all — every field with an mf2
+    /// mapping except `draft`. The composer uses this to compute an update's `delete` list:
+    /// a baseline property in this set whose field value was cleared must be deleted server-side,
+    /// while properties outside it (another client's vocabulary) are left untouched.
+    ///
+    /// - Parameter descriptor: The content type whose mapped properties to list.
+    /// - Returns: The raw (unprefixed) mf2 property names, in field declaration order.
+    public static func mappedProperties(for descriptor: ContentTypeDescriptor) -> [String] {
+        descriptor.fields
+            .filter { $0.name != "draft" }
+            .compactMap { descriptor.projections.rawMf2Property(forField: $0.name) }
+    }
+
+    /// Encodes one field value as its mf2 property values, or `nil` to omit the property
+    /// entirely (empty/unset — the read direction's fallbacks or defaults reconstruct it).
+    ///
+    /// - Parameters:
+    ///   - value: The form value to encode.
+    ///   - kind: The field's declared kind, which picks the wire shape (e.g. date-only vs.
+    ///     full ISO 8601 for `.date` vs. `.datetime`).
+    /// - Returns: The property's ordered value list, or `nil` when it should be omitted.
+    public static func mf2Values(
+        for value: TypedContentEditor.FieldValue,
+        kind: ContentTypeField.Kind
+    ) -> [JSONValue]? {
+        switch value {
+        case .text(let s):
+            return s.isEmpty ? nil : [.string(s)]
+        case .flag(let b):
+            // No built-in field maps a bool to an mf2 property today (`draft` rides
+            // `post-status` instead); encoded anyway so a future mapped bool isn't silently
+            // dropped — `MicropubContentSync.fieldValue`'s `.bool` arm documents the same gap.
+            return [.bool(b)]
+        case .date(let d):
+            guard let d else { return nil }
+            let full = Self.iso.string(from: d)
+            return [.string(kind == .date ? String(full.prefix(10)) : full)]
+        case .number(let n):
+            guard let n else { return nil }
+            // Integral values travel as JSON integers — the shape the read direction checks
+            // first, and what a rating like 4 (not 4.0) looks like from other Micropub clients.
+            if n == n.rounded(), abs(n) < 1e15 { return [.int(Int(n))] }
+            return [.double(n)]
+        case .list(let items):
+            let kept = items.filter { !$0.isEmpty }
+            return kept.isEmpty ? nil : kept.map { .string($0) }
+        case .records:
+            // `objectArray` fields have no wire form here: no built-in collection-stored type
+            // declares one (h-resume is a singleton, outside the posting flow), and the read
+            // direction doesn't reconstruct nested mf2 objects either. Omitted, not flattened.
+            return nil
+        }
+    }
+
+    /// Same format as `TypedContentEditor`'s frontmatter dates (internet date-time with
+    /// fractional seconds; `.date` kinds truncate to the `yyyy-MM-dd` prefix), so a value
+    /// round-trips identically whether it reaches the site over Micropub or through a file.
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+}

--- a/Sources/AnglesiteCore/MicropubComposerProjection.swift
+++ b/Sources/AnglesiteCore/MicropubComposerProjection.swift
@@ -80,7 +80,7 @@ public enum MicropubComposerProjection {
             return [.bool(b)]
         case .date(let d):
             guard let d else { return nil }
-            let full = Self.iso.string(from: d)
+            let full = MicropubContentSync.isoWithFractionalSeconds.string(from: d)
             return [.string(kind == .date ? String(full.prefix(10)) : full)]
         case .number(let n):
             guard let n else { return nil }
@@ -99,12 +99,4 @@ public enum MicropubComposerProjection {
         }
     }
 
-    /// Same format as `TypedContentEditor`'s frontmatter dates (internet date-time with
-    /// fractional seconds; `.date` kinds truncate to the `yyyy-MM-dd` prefix), so a value
-    /// round-trips identically whether it reaches the site over Micropub or through a file.
-    private static let iso: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
 }

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -93,7 +93,9 @@ public enum MicropubContentSync {
         slug.split(separator: "-").map { $0.capitalized }.joined(separator: " ")
     }
 
-    private static let isoWithFractionalSeconds: ISO8601DateFormatter = {
+    /// Internal (not file-private) so `MicropubComposerProjection` shares this instance rather
+    /// than declaring an identically-configured duplicate (#1370 review).
+    static let isoWithFractionalSeconds: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f

--- a/Sources/AnglesiteCore/MicropubContentSync.swift
+++ b/Sources/AnglesiteCore/MicropubContentSync.swift
@@ -39,7 +39,9 @@ public enum MicropubContentSync {
     /// post gets when its mf2 type wasn't recognized at create time, or a malformed URL. This
     /// bridge only ever reads the collection out of the URL — it never re-derives it from mf2
     /// properties, so classification happens exactly once (Worker-side, at create time).
-    static func collectionAndSlug(from urlString: String) -> (collection: String, slug: String)? {
+    /// Public since #869: the iOS composer's post list uses the same parse to group a
+    /// `q=source` list by content type, so classification stays URL-derived there too.
+    public static func collectionAndSlug(from urlString: String) -> (collection: String, slug: String)? {
         guard let url = URL(string: urlString) else { return nil }
         let segments = url.path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
         guard segments.count == 2 else { return nil }
@@ -164,7 +166,9 @@ public enum MicropubContentSync {
     /// - `slug`: the post URL's slug, used as a `title`/`name` fallback for a post whose required
     ///   title-like field has no resolvable mf2 value (e.g. a nameless multi-photo post Post Type
     ///   Discovery still routes to `albums`).
-    static func values(
+    /// Public since #869: the iOS composer decodes a `q=source` post into form values through
+    /// this same mapping, so the phone's edit form and the Mac's sync bridge can't diverge.
+    public static func values(
         for descriptor: ContentTypeDescriptor,
         properties: [String: [JSONValue]],
         updatedAt: Int,

--- a/Sources/AnglesiteIOS/ComposerDraftStore.swift
+++ b/Sources/AnglesiteIOS/ComposerDraftStore.swift
@@ -1,0 +1,128 @@
+// Sources/AnglesiteIOS/ComposerDraftStore.swift
+import Foundation
+import AnglesiteCore
+
+/// One in-progress or queued composition, as plain `Codable` state on disk — the iOS design's
+/// §3 restore contract (current draft survives backgrounding/interruption) and §6/§7 offline
+/// fallback (a send that failed retryably becomes a locally-queued draft with an explicit
+/// "waiting for network" state, retried later). There is no git or working copy on the phone;
+/// this file IS the local state.
+public struct ComposerDraft: Codable, Equatable, Sendable {
+    /// The site the draft belongs to (`AnglesitePackage.Marker.siteID`).
+    public var siteID: UUID
+    /// The content type's registry id (e.g. `note`, `article`).
+    public var typeID: String
+    /// The post's canonical URL when editing an existing post; `nil` for a new one.
+    public var postURL: URL?
+    /// The form's field values at capture time.
+    public var values: [String: Value]
+    /// The status the pending send should stamp (`draft` for Save, `published` for Publish);
+    /// `nil` while merely composing (nothing queued yet).
+    public var queuedStatus: String?
+
+    /// Creates a draft snapshot.
+    public init(
+        siteID: UUID, typeID: String, postURL: URL? = nil,
+        values: [String: Value], queuedStatus: String? = nil
+    ) {
+        self.siteID = siteID
+        self.typeID = typeID
+        self.postURL = postURL
+        self.values = values
+        self.queuedStatus = queuedStatus
+    }
+
+    /// A `Codable` mirror of `TypedContentEditor.FieldValue` (which is deliberately not
+    /// `Codable` itself — its module keeps persistence concerns out of the editor seam).
+    public indirect enum Value: Codable, Equatable, Sendable {
+        case text(String)
+        case flag(Bool)
+        case date(Date?)
+        case number(Double?)
+        case list([String])
+        case records([[String: Value]])
+
+        /// Wraps an editor value for persistence.
+        public init(_ value: TypedContentEditor.FieldValue) {
+            switch value {
+            case .text(let s): self = .text(s)
+            case .flag(let b): self = .flag(b)
+            case .date(let d): self = .date(d)
+            case .number(let n): self = .number(n)
+            case .list(let l): self = .list(l)
+            case .records(let rows): self = .records(rows.map { $0.mapValues(Value.init) })
+            }
+        }
+
+        /// The editor value this persisted one restores to.
+        public var fieldValue: TypedContentEditor.FieldValue {
+            switch self {
+            case .text(let s): return .text(s)
+            case .flag(let b): return .flag(b)
+            case .date(let d): return .date(d)
+            case .number(let n): return .number(n)
+            case .list(let l): return .list(l)
+            case .records(let rows): return .records(rows.map { $0.mapValues(\.fieldValue) })
+            }
+        }
+    }
+
+    /// Snapshot of a live editing session's values.
+    public init(
+        siteID: UUID, typeID: String, postURL: URL?,
+        editorValues: TypedContentEditor.Values, fieldNames: [String], queuedStatus: String? = nil
+    ) {
+        var values: [String: Value] = [:]
+        for name in fieldNames {
+            if let value = editorValues[name] { values[name] = Value(value) }
+        }
+        self.init(
+            siteID: siteID, typeID: typeID, postURL: postURL,
+            values: values, queuedStatus: queuedStatus)
+    }
+
+    /// The editor values this draft restores to.
+    public var editorValues: TypedContentEditor.Values {
+        var out = TypedContentEditor.Values()
+        for (name, value) in values { out[name] = value.fieldValue }
+        return out
+    }
+}
+
+/// Reads and writes the single per-site current draft under Application Support — one file per
+/// site (`micropub-draft-<siteID>.json`), because the composer edits one post at a time and the
+/// restore contract covers "any in-progress draft", singular (§3). Injectable directory so tests
+/// point it at a scratch location.
+public struct ComposerDraftStore: Sendable {
+    private let directory: URL
+
+    /// Creates a store rooted at `directory`, defaulting to the app's Application Support.
+    public init(directory: URL? = nil) {
+        self.directory = directory
+            ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("Anglesite", isDirectory: true)
+    }
+
+    private func fileURL(forSite siteID: UUID) -> URL {
+        directory.appendingPathComponent("micropub-draft-\(siteID.uuidString).json")
+    }
+
+    /// Persists `draft` as its site's current draft, replacing any previous one.
+    public func save(_ draft: ComposerDraft) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(draft)
+        try data.write(to: fileURL(forSite: draft.siteID), options: .atomic)
+    }
+
+    /// The site's current draft, or `nil` when none is stored (or the stored one no longer
+    /// decodes — stale-format state restores as a fresh start, never a crash).
+    public func load(forSite siteID: UUID) -> ComposerDraft? {
+        guard let data = try? Data(contentsOf: fileURL(forSite: siteID)) else { return nil }
+        return try? JSONDecoder().decode(ComposerDraft.self, from: data)
+    }
+
+    /// Removes the site's current draft (after a successful send, or an explicit discard).
+    public func clear(forSite siteID: UUID) {
+        try? FileManager.default.removeItem(at: fileURL(forSite: siteID))
+    }
+}

--- a/Sources/AnglesiteIOS/ComposerDraftStore.swift
+++ b/Sources/AnglesiteIOS/ComposerDraftStore.swift
@@ -1,5 +1,6 @@
 // Sources/AnglesiteIOS/ComposerDraftStore.swift
 import Foundation
+import CryptoKit
 import AnglesiteCore
 
 /// One in-progress or queued composition, as plain `Codable` state on disk — the iOS design's
@@ -19,17 +20,22 @@ public struct ComposerDraft: Codable, Equatable, Sendable {
     /// The status the pending send should stamp (`draft` for Save, `published` for Publish);
     /// `nil` while merely composing (nothing queued yet).
     public var queuedStatus: String?
+    /// The compare-and-swap baseline for a queued *update* — the `{type, properties}` JSON of
+    /// the post as it was when editing began — so restoring the draft restores the CAS guard
+    /// too, not just the values (#1370 review). `nil` for new posts.
+    public var baselineJSON: Data?
 
     /// Creates a draft snapshot.
     public init(
         siteID: UUID, typeID: String, postURL: URL? = nil,
-        values: [String: Value], queuedStatus: String? = nil
+        values: [String: Value], queuedStatus: String? = nil, baselineJSON: Data? = nil
     ) {
         self.siteID = siteID
         self.typeID = typeID
         self.postURL = postURL
         self.values = values
         self.queuedStatus = queuedStatus
+        self.baselineJSON = baselineJSON
     }
 
     /// A `Codable` mirror of `TypedContentEditor.FieldValue` (which is deliberately not
@@ -70,7 +76,8 @@ public struct ComposerDraft: Codable, Equatable, Sendable {
     /// Snapshot of a live editing session's values.
     public init(
         siteID: UUID, typeID: String, postURL: URL?,
-        editorValues: TypedContentEditor.Values, fieldNames: [String], queuedStatus: String? = nil
+        editorValues: TypedContentEditor.Values, fieldNames: [String],
+        queuedStatus: String? = nil, baseline: MicropubPost? = nil
     ) {
         var values: [String: Value] = [:]
         for name in fieldNames {
@@ -78,7 +85,8 @@ public struct ComposerDraft: Codable, Equatable, Sendable {
         }
         self.init(
             siteID: siteID, typeID: typeID, postURL: postURL,
-            values: values, queuedStatus: queuedStatus)
+            values: values, queuedStatus: queuedStatus,
+            baselineJSON: baseline.flatMap(Self.encodeBaseline))
     }
 
     /// The editor values this draft restores to.
@@ -87,12 +95,43 @@ public struct ComposerDraft: Codable, Equatable, Sendable {
         for (name, value) in values { out[name] = value.fieldValue }
         return out
     }
+
+    /// The restored CAS baseline, when one was captured and still decodes.
+    public var baseline: MicropubPost? {
+        baselineJSON.flatMap(Self.decodeBaseline)
+    }
+
+    /// Serializes a post's `{type, properties}` through its `JSONValue` raw form — the same
+    /// wire shape `q=source` returns, so the round-trip is lossless for anything the server
+    /// can store.
+    static func encodeBaseline(_ post: MicropubPost) -> Data? {
+        let object: [String: Any] = [
+            "type": post.type,
+            "properties": post.properties.mapValues { $0.map(\.rawValue) },
+        ]
+        return try? JSONSerialization.data(withJSONObject: object)
+    }
+
+    static func decodeBaseline(_ data: Data) -> MicropubPost? {
+        guard let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let rawType = object["type"] as? [Any],
+              let rawProperties = object["properties"] as? [String: [Any]]
+        else { return nil }
+        let type = rawType.compactMap { $0 as? String }
+        guard !type.isEmpty else { return nil }
+        var properties: [String: [JSONValue]] = [:]
+        for (key, values) in rawProperties {
+            properties[key] = values.compactMap(JSONValue.from)
+        }
+        return MicropubPost(type: type, properties: properties)
+    }
 }
 
-/// Reads and writes the single per-site current draft under Application Support — one file per
-/// site (`micropub-draft-<siteID>.json`), because the composer edits one post at a time and the
-/// restore contract covers "any in-progress draft", singular (§3). Injectable directory so tests
-/// point it at a scratch location.
+/// Reads and writes composer drafts under Application Support, one file per draft identity —
+/// a queued update keyed by its post URL, a new composition keyed by its content type — so a
+/// failed "note" send is never silently clobbered by a later "article" composition on the same
+/// site (#1370 review; the original single-per-site file lost queued sends that way).
+/// Injectable directory so tests point it at a scratch location.
 public struct ComposerDraftStore: Sendable {
     private let directory: URL
 
@@ -103,26 +142,63 @@ public struct ComposerDraftStore: Sendable {
                 .appendingPathComponent("Anglesite", isDirectory: true)
     }
 
-    private func fileURL(forSite siteID: UUID) -> URL {
-        directory.appendingPathComponent("micropub-draft-\(siteID.uuidString).json")
+    /// A draft's stable identity: the post it updates, or — for a not-yet-created post — the
+    /// content type it composes. Two different posts (or a post and a new composition) never
+    /// share a file.
+    static func key(postURL: URL?, typeID: String) -> String {
+        postURL.map { "post:\($0.absoluteString)" } ?? "new:\(typeID)"
     }
 
-    /// Persists `draft` as its site's current draft, replacing any previous one.
+    private func fileURL(forSite siteID: UUID, key: String) -> URL {
+        // Hashed: post URLs aren't filesystem-safe and can exceed name-length limits.
+        let digest = SHA256.hash(data: Data(key.utf8))
+            .map { String(format: "%02x", $0) }.joined().prefix(16)
+        return directory.appendingPathComponent(
+            "micropub-draft-\(siteID.uuidString)-\(digest).json")
+    }
+
+    /// Persists `draft` under its identity, replacing any previous draft of the same identity
+    /// only.
     public func save(_ draft: ComposerDraft) throws {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let data = try JSONEncoder().encode(draft)
-        try data.write(to: fileURL(forSite: draft.siteID), options: .atomic)
+        let key = Self.key(postURL: draft.postURL, typeID: draft.typeID)
+        try data.write(to: fileURL(forSite: draft.siteID, key: key), options: .atomic)
     }
 
-    /// The site's current draft, or `nil` when none is stored (or the stored one no longer
-    /// decodes — stale-format state restores as a fresh start, never a crash).
-    public func load(forSite siteID: UUID) -> ComposerDraft? {
-        guard let data = try? Data(contentsOf: fileURL(forSite: siteID)) else { return nil }
+    /// The site's in-progress *new* composition of `typeID`, or `nil`. Never returns a queued
+    /// update to an existing post — the "New Post" entry point must never silently resume an
+    /// unrelated post's pending edit (#1370 review).
+    public func loadNewDraft(forSite siteID: UUID, typeID: String) -> ComposerDraft? {
+        guard let draft = load(forSite: siteID, key: Self.key(postURL: nil, typeID: typeID)),
+              draft.postURL == nil
+        else { return nil }
+        return draft
+    }
+
+    /// The site's queued/in-progress draft for the existing post at `postURL`, or `nil` — how
+    /// reopening a post from the list discovers its own pending edit (#1370 review).
+    public func loadDraft(forSite siteID: UUID, postURL: URL) -> ComposerDraft? {
+        load(forSite: siteID, key: Self.key(postURL: postURL, typeID: ""))
+    }
+
+    private func load(forSite siteID: UUID, key: String) -> ComposerDraft? {
+        guard let data = try? Data(contentsOf: fileURL(forSite: siteID, key: key)) else {
+            return nil
+        }
+        // Stale-format state restores as a fresh start, never a crash.
         return try? JSONDecoder().decode(ComposerDraft.self, from: data)
     }
 
-    /// Removes the site's current draft (after a successful send, or an explicit discard).
-    public func clear(forSite siteID: UUID) {
-        try? FileManager.default.removeItem(at: fileURL(forSite: siteID))
+    /// Removes the draft with `draft`'s identity (after a successful send, a terminal
+    /// rejection, or an explicit discard).
+    public func clear(_ draft: ComposerDraft) {
+        clear(forSite: draft.siteID, postURL: draft.postURL, typeID: draft.typeID)
+    }
+
+    /// Removes the draft for the given identity.
+    public func clear(forSite siteID: UUID, postURL: URL?, typeID: String) {
+        let key = Self.key(postURL: postURL, typeID: typeID)
+        try? FileManager.default.removeItem(at: fileURL(forSite: siteID, key: key))
     }
 }

--- a/Sources/AnglesiteIOS/MarkdownTextView.swift
+++ b/Sources/AnglesiteIOS/MarkdownTextView.swift
@@ -1,0 +1,90 @@
+// Sources/AnglesiteIOS/MarkdownTextView.swift
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// The iOS counterpart of the Mac's `MarkdownTextView` (#869) — the Micropub composer's body
+/// surface, mirroring the AppKit seam's shape (`$text` binding, `documentId`, `fitsContent`).
+///
+/// **Substrate spike result (#869, 2026-08-08):** the design (2026-07-21, §6) called for
+/// `UIViewRepresentable` over the same `swift-markdown-engine` substrate the Mac editor uses,
+/// on the parent spec's assertion that the engine "already supports both AppKit and UIKit".
+/// The spike falsified that: both the pinned Anglesite fork and upstream
+/// `nodes-app/swift-markdown-engine` declare `platforms: [.macOS(.v14)]` only, and every view
+/// file imports AppKit (`NativeTextViewWrapper` is `NSViewRepresentable`) — there is no UIKit
+/// support to wrap. Rather than block the posting client on a cross-repo engine port, v1 wraps a
+/// plain `UITextView` configured to preserve Markdown byte-for-byte; live styled editing arrives
+/// when the engine fork grows UIKit support.
+///
+/// What "configured for Markdown" means here (the same corruption vectors the Mac seam disables
+/// on the engine): smart quotes/dashes are OFF (they'd corrupt frontmatter, code spans, and
+/// `--`-style constructs), as is smart insert/delete (invisible whitespace edits). Autocorrection
+/// and sentence capitalization stay ON — this is prose-first compose, and neither rewrites text
+/// the user didn't touch. The view never transforms the bound string: what the user typed is
+/// what the binding holds, so an open→close with no edits is byte-identical by construction.
+public struct MarkdownTextView: UIViewRepresentable {
+    @Binding public var text: String
+    /// Names the logical document, mirroring the Mac seam's parameter. `UITextView` keys its
+    /// undo manager to the view instance, so embedders apply this via `.id(documentId)` to force
+    /// a fresh editor per document — two documents never share one editor's undo stack.
+    public var documentId: String
+    /// `true` for form embedding (typed-entry body): the editor sizes to its content and the
+    /// enclosing `Form`/`ScrollView` scrolls. `false` (default) scrolls internally.
+    public var fitsContent = false
+
+    public init(text: Binding<String>, documentId: String, fitsContent: Bool = false) {
+        self._text = text
+        self.documentId = documentId
+        self.fitsContent = fitsContent
+    }
+
+    public func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.delegate = context.coordinator
+        view.font = .preferredFont(forTextStyle: .body)
+        view.adjustsFontForContentSizeCategory = true
+        view.backgroundColor = .clear
+        // Markdown-preserving input: see the type doc for why each of these is off.
+        view.smartQuotesType = .no
+        view.smartDashesType = .no
+        view.smartInsertDeleteType = .no
+        view.isScrollEnabled = !fitsContent
+        view.textContainerInset = .zero
+        view.textContainer.lineFragmentPadding = 0
+        // Growing views collapse to nothing inside a Form row without a floor; scrolling views
+        // let the enclosing layout size them.
+        if fitsContent {
+            view.setContentHuggingPriority(.defaultLow, for: .vertical)
+            view.setContentCompressionResistancePriority(.required, for: .vertical)
+        }
+        view.text = text
+        return view
+    }
+
+    public func updateUIView(_ view: UITextView, context: Context) {
+        // Only push external changes; echoing the view's own text back mid-edit resets the
+        // caret and the marked-text (multistage input) state.
+        if view.text != text {
+            view.text = text
+        }
+        view.isScrollEnabled = !fitsContent
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    /// Forwards edits into the binding verbatim — no normalization, no trimming.
+    public final class Coordinator: NSObject, UITextViewDelegate {
+        private let text: Binding<String>
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        public func textViewDidChange(_ textView: UITextView) {
+            text.wrappedValue = textView.text
+        }
+    }
+}
+#endif

--- a/Sources/AnglesiteIOS/MediaUploadGuard.swift
+++ b/Sources/AnglesiteIOS/MediaUploadGuard.swift
@@ -1,0 +1,46 @@
+// Sources/AnglesiteIOS/MediaUploadGuard.swift
+import Foundation
+
+/// The pre-upload size/format check the iOS design's error-handling section calls for (§7):
+/// error handling before the media-endpoint request, not capture/compression UX (explicitly out
+/// of scope per the parent spec). `MicropubClient.uploadMedia` transports whatever it's handed,
+/// so this gate is the caller's — checked here once so the composer and any future capture
+/// surface reject the same things the same way.
+public enum MediaUploadGuard {
+    /// Why an upload was rejected before any network request.
+    public enum Rejection: Equatable, Sendable {
+        /// The payload exceeds ``maximumBytes``; carries the actual size for the message.
+        case tooLarge(bytes: Int)
+        /// The MIME type isn't one of ``allowedMIMETypes``; carries the offending type.
+        case unsupportedFormat(mimeType: String)
+        /// A zero-byte payload — a failed Photos export, not a real file.
+        case empty
+    }
+
+    /// The upload ceiling: 25 MB. Cloudflare's free-plan request-body limit is 100 MB, but a
+    /// phone uploading over cellular needs a bound long before that; 25 MB clears any
+    /// full-resolution HEIC/JPEG photo while stopping multi-minute video-sized mistakes.
+    public static let maximumBytes = 25 * 1024 * 1024
+
+    /// The web-servable image formats the posting flow accepts — what the template's `<img>`
+    /// pipeline and every browser render. HEIC is deliberately absent: browsers don't render it,
+    /// and the picker layer transcodes Photos exports to JPEG before this gate sees them.
+    public static let allowedMIMETypes: Set<String> = [
+        "image/jpeg", "image/png", "image/gif", "image/webp", "image/avif", "image/svg+xml",
+    ]
+
+    /// Checks one candidate upload.
+    ///
+    /// - Parameters:
+    ///   - data: The file bytes as they would be uploaded.
+    ///   - mimeType: The candidate's MIME type.
+    /// - Returns: The rejection, or `nil` when the upload may proceed.
+    public static func rejection(for data: Data, mimeType: String) -> Rejection? {
+        if data.isEmpty { return .empty }
+        if !allowedMIMETypes.contains(mimeType.lowercased()) {
+            return .unsupportedFormat(mimeType: mimeType)
+        }
+        if data.count > maximumBytes { return .tooLarge(bytes: data.count) }
+        return nil
+    }
+}

--- a/Sources/AnglesiteIOS/MicropubSession.swift
+++ b/Sources/AnglesiteIOS/MicropubSession.swift
@@ -1,12 +1,13 @@
 // Sources/AnglesiteIOS/MicropubSession.swift
 import Foundation
 import AnglesiteCore
+import AnglesiteSiteModel
 
 /// The credential + endpoint bundle the compose surfaces need to talk to one site's Micropub
-/// endpoint (#869) — the seam between this issue's posting UI and the sibling IndieAuth
-/// onboarding issue (#868), which is where sessions are actually minted (endpoint discovery from
-/// the site's well-knowns, `ASWebAuthenticationSession` sign-in, Keychain storage). The compose
-/// stack only ever *consumes* a session; with no provider wired it shows its signed-out state.
+/// endpoint (#869) — the seam between the posting UI and the IndieAuth onboarding flow (#868),
+/// which mints the underlying credentials (endpoint discovery from the site's well-knowns,
+/// `ASWebAuthenticationSession` sign-in, Keychain storage). The compose stack only ever
+/// *consumes* a session; with none resolvable it shows its signed-out state.
 public struct MicropubSession: Sendable {
     /// The site's Micropub endpoint (absolute URL, no query).
     public let micropubEndpoint: URL
@@ -17,7 +18,7 @@ public struct MicropubSession: Sendable {
     /// The key pair the token is bound to — the same grant's pair, or every call fails auth.
     public let dpopKeyPair: DPoPKeyPair
 
-    /// Memberwise creation — public so the onboarding flow (#868) and tests can build sessions.
+    /// Memberwise creation — public so providers and tests can build sessions.
     public init(
         micropubEndpoint: URL,
         mediaEndpoint: URL?,
@@ -49,19 +50,84 @@ public struct MicropubSession: Sendable {
 }
 
 /// Hands the compose stack a site's Micropub session, or `nil` when the site hasn't been
-/// onboarded yet (or its token was revoked and needs a fresh sign-in). Implemented by the
-/// IndieAuth onboarding flow (#868); the shell threads one provider through its screens.
+/// onboarded yet (or its stored credential is gone and needs a fresh sign-in). Production is
+/// ``StoredMicropubSessions``; tests substitute their own.
 public protocol MicropubSessionProviding: Sendable {
-    /// The session for the site identified by `siteID` (the `.anglesite` package's stable site
-    /// UUID), or `nil` when none exists yet.
-    func session(forSite siteID: UUID) async -> MicropubSession?
+    /// The session for `site`, or `nil` when none can be assembled.
+    func session(for site: SitePickerModel.DiscoveredSite) async -> MicropubSession?
 }
 
-/// The no-onboarding-yet default: every site reads as signed out, so the shell renders its
-/// sign-in-required state until #868's provider replaces this.
+/// Assembles a session from what the IndieAuth onboarding flow (#868) persisted: the
+/// `micropub:<siteID>` token + DPoP key pair from the Keychain, plus a fresh endpoint
+/// discovery — `MicropubOnboardingModel` deliberately does not persist discovery, leaving the
+/// re-discovery on restore to "the composer's own flow", which is this type.
+public struct StoredMicropubSessions: MicropubSessionProviding {
+    private let secretStore: any SecretStore
+    private let discovery: MicropubEndpointDiscovery
+    private let clientTransport: MicropubClient.Transport
+    /// `DeployCoordinator.resolveSiteURL` behind a seam so tests don't need a real
+    /// `.site-config` on disk.
+    private let resolveSiteURL: @Sendable (URL) -> String?
+
+    /// Creates the provider.
+    ///
+    /// - Parameters:
+    ///   - secretStore: Where #868's onboarding stored the per-site credential.
+    ///   - discovery: Finds the site's `micropub` endpoint from its homepage rels.
+    ///   - clientTransport: Transport for the `q=config` media-endpoint probe.
+    ///   - resolveSiteURL: Maps a package's `Source/` directory to its deployed URL.
+    public init(
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        discovery: MicropubEndpointDiscovery = MicropubEndpointDiscovery(),
+        clientTransport: @escaping MicropubClient.Transport = MicropubClient.defaultTransport,
+        resolveSiteURL: @escaping @Sendable (URL) -> String? = {
+            DeployCoordinator.resolveSiteURL(siteDirectory: $0)
+        }
+    ) {
+        self.secretStore = secretStore
+        self.discovery = discovery
+        self.clientTransport = clientTransport
+        self.resolveSiteURL = resolveSiteURL
+    }
+
+    public func session(for site: SitePickerModel.DiscoveredSite) async -> MicropubSession? {
+        let siteID = site.id.uuidString
+        guard let token = try? secretStore.readMicropubAccessToken(siteID: siteID),
+              !token.isEmpty,
+              let keyPair = try? secretStore.readMicropubDPoPKeyPair(siteID: siteID)
+        else { return nil }
+        // `.site-config` is real file I/O inside a possibly-still-materializing iCloud
+        // package — hop off the main actor, same as `MicropubOnboardingModel.configure`.
+        let sourceURL = AnglesitePackage(url: site.packageURL).sourceURL
+        let resolve = resolveSiteURL
+        let siteURL = await Task.detached(priority: .userInitiated) {
+            resolve(sourceURL).flatMap(URL.init(string:))
+        }.value
+        guard let siteURL,
+              let endpoints = try? await discovery.discover(siteURL: siteURL)
+        else { return nil }
+        // Media endpoint via `q=config`, best-effort: without it composing and publishing
+        // still work — only in-form image uploads report the not-configured error.
+        let probe = MicropubClient(
+            endpoint: endpoints.micropub, accessToken: token, dpopKeyPair: keyPair,
+            transport: clientTransport)
+        let mediaEndpoint = (try? await probe.configuration())?.mediaEndpoint
+        return MicropubSession(
+            micropubEndpoint: endpoints.micropub,
+            mediaEndpoint: mediaEndpoint,
+            accessToken: token,
+            dpopKeyPair: keyPair
+        )
+    }
+}
+
+/// The empty provider: every site reads as signed out. Previews and tests of the signed-out
+/// surface use this.
 public struct NoMicropubSessions: MicropubSessionProviding {
     /// Creates the empty provider.
     public init() {}
 
-    public func session(forSite siteID: UUID) async -> MicropubSession? { nil }
+    public func session(for site: SitePickerModel.DiscoveredSite) async -> MicropubSession? {
+        nil
+    }
 }

--- a/Sources/AnglesiteIOS/MicropubSession.swift
+++ b/Sources/AnglesiteIOS/MicropubSession.swift
@@ -1,0 +1,67 @@
+// Sources/AnglesiteIOS/MicropubSession.swift
+import Foundation
+import AnglesiteCore
+
+/// The credential + endpoint bundle the compose surfaces need to talk to one site's Micropub
+/// endpoint (#869) — the seam between this issue's posting UI and the sibling IndieAuth
+/// onboarding issue (#868), which is where sessions are actually minted (endpoint discovery from
+/// the site's well-knowns, `ASWebAuthenticationSession` sign-in, Keychain storage). The compose
+/// stack only ever *consumes* a session; with no provider wired it shows its signed-out state.
+public struct MicropubSession: Sendable {
+    /// The site's Micropub endpoint (absolute URL, no query).
+    public let micropubEndpoint: URL
+    /// The media endpoint uploads go to, when discovery found one (`q=config`).
+    public let mediaEndpoint: URL?
+    /// The IndieAuth access token, DPoP-bound to `dpopKeyPair`.
+    public let accessToken: String
+    /// The key pair the token is bound to — the same grant's pair, or every call fails auth.
+    public let dpopKeyPair: DPoPKeyPair
+
+    /// Memberwise creation — public so the onboarding flow (#868) and tests can build sessions.
+    public init(
+        micropubEndpoint: URL,
+        mediaEndpoint: URL?,
+        accessToken: String,
+        dpopKeyPair: DPoPKeyPair
+    ) {
+        self.micropubEndpoint = micropubEndpoint
+        self.mediaEndpoint = mediaEndpoint
+        self.accessToken = accessToken
+        self.dpopKeyPair = dpopKeyPair
+    }
+
+    /// A `MicropubClient` presenting this session's credential.
+    ///
+    /// - Parameter transport: Defaults to the client's plain-`URLSession` transport; tests
+    ///   inject a fake.
+    /// - Returns: A ready client.
+    public func makeClient(
+        transport: @escaping MicropubClient.Transport = MicropubClient.defaultTransport
+    ) -> MicropubClient {
+        MicropubClient(
+            endpoint: micropubEndpoint,
+            mediaEndpoint: mediaEndpoint,
+            accessToken: accessToken,
+            dpopKeyPair: dpopKeyPair,
+            transport: transport
+        )
+    }
+}
+
+/// Hands the compose stack a site's Micropub session, or `nil` when the site hasn't been
+/// onboarded yet (or its token was revoked and needs a fresh sign-in). Implemented by the
+/// IndieAuth onboarding flow (#868); the shell threads one provider through its screens.
+public protocol MicropubSessionProviding: Sendable {
+    /// The session for the site identified by `siteID` (the `.anglesite` package's stable site
+    /// UUID), or `nil` when none exists yet.
+    func session(forSite siteID: UUID) async -> MicropubSession?
+}
+
+/// The no-onboarding-yet default: every site reads as signed out, so the shell renders its
+/// sign-in-required state until #868's provider replaces this.
+public struct NoMicropubSessions: MicropubSessionProviding {
+    /// Creates the empty provider.
+    public init() {}
+
+    public func session(forSite siteID: UUID) async -> MicropubSession? { nil }
+}

--- a/Sources/AnglesiteIOS/PostComposerModel.swift
+++ b/Sources/AnglesiteIOS/PostComposerModel.swift
@@ -93,17 +93,20 @@ public final class PostComposerModel {
         }
         var restoredURL: URL?
         var restoredStatus: MicropubPostStatus?
+        var restoredBaseline: MicropubPost?
         if let restoringDraft, restoringDraft.typeID == descriptor.id {
             let restored = restoringDraft.editorValues
             for field in descriptor.fields {
                 if let value = restored[field.name] { values[field.name] = value }
             }
             restoredURL = restoringDraft.postURL
+            restoredBaseline = restoringDraft.baseline
             restoredStatus = restoringDraft.queuedStatus
                 .flatMap(MicropubPostStatus.init(rawValue:))
         }
         self.values = values
         self.postURL = restoredURL
+        self.baseline = restoredBaseline
         self.queuedStatus = restoredStatus
         if restoredStatus != nil { self.phase = .waitingForNetwork }
     }
@@ -131,23 +134,30 @@ public final class PostComposerModel {
         let post = try await client.source(url: url)
         let model = PostComposerModel(
             descriptor: descriptor, siteID: siteID, client: client, draftStore: draftStore)
-        model.adopt(post: post, url: url)
+        guard model.adopt(post: post, url: url) else {
+            throw MicropubError.decodingFailed(
+                "post at \(url.absoluteString) doesn't decode into \(descriptor.id)'s fields")
+        }
         return model
     }
 
     /// Replaces the composition's values and baseline with `post` — the open-existing path and
-    /// ``takeTheirs()`` both land here.
-    private func adopt(post: MicropubPost, url: URL) {
+    /// ``takeTheirs()`` both land here. `false` when the post doesn't decode into this
+    /// descriptor's fields (a required field with no resolvable value): adopting it anyway
+    /// would blank the form over a real baseline, and the next save's cleared-property delete
+    /// pass would then wipe the post's actual content server-side (#1370 review) — so the
+    /// caller must surface an error instead.
+    private func adopt(post: MicropubPost, url: URL) -> Bool {
         let slug = MicropubContentSync.collectionAndSlug(from: url.absoluteString)?.slug ?? ""
-        let decoded = MicropubContentSync.values(
+        guard let decoded = MicropubContentSync.values(
             for: descriptor,
             properties: post.properties,
             updatedAt: Int(Date.now.timeIntervalSince1970),
             slug: slug
-        )
+        ) else { return false }
         var values = TypedContentEditor.Values()
         for field in descriptor.fields {
-            values[field.name] = decoded?[field.name]
+            values[field.name] = decoded[field.name]
                 ?? TypedContentEditor.defaultValue(for: field.kind)
         }
         self.values = values
@@ -155,6 +165,7 @@ public final class PostComposerModel {
         self.postURL = url
         self.baseline = post
         self.phase = .editing
+        return true
     }
 
     // MARK: - Send path
@@ -189,10 +200,15 @@ public final class PostComposerModel {
     }
 
     /// Discards this composition's changes in favor of the server's current copy — the owner
-    /// chose the other device's version. Back to editing with the fresh values.
+    /// chose the other device's version. Back to editing with the fresh values; if the site's
+    /// copy doesn't decode into this type's fields, the composition fails visibly instead of
+    /// silently blanking the form over a live baseline.
     public func takeTheirs() {
         guard case .conflict(let theirs) = phase, let url = postURL else { return }
-        adopt(post: theirs, url: url)
+        guard adopt(post: theirs, url: url) else {
+            phase = .failed("The site's copy of this post couldn't be read.")
+            return
+        }
         clearQueuedDraft()
     }
 
@@ -209,18 +225,18 @@ public final class PostComposerModel {
             if let url = postURL {
                 // Compare-and-swap: an existing post is only updated if the server still holds
                 // the copy this composition was loaded from (§6). New posts skip this — there is
-                // nothing to conflict with.
+                // nothing to conflict with. The compare ignores server-injected bookkeeping
+                // (`url`) and stripped-on-store commands (`mp-*`) so only real content edits
+                // read as conflicts.
                 let current = try await client.source(url: url)
-                if let baseline, current != baseline {
+                if let baseline, Self.casComparable(current) != Self.casComparable(baseline) {
                     phase = .conflict(current)
                     return
                 }
                 try await update(url: url, status: status)
-                baseline = try? await client.source(url: url)
             } else {
                 let url = try await create(status: status)
                 postURL = url
-                baseline = try? await client.source(url: url)
             }
             clearQueuedDraft()
             if let url = postURL {
@@ -235,11 +251,28 @@ public final class PostComposerModel {
                 persistQueuedDraft(status: status)
                 phase = .waitingForNetwork
             } else {
+                // Terminal: the same payload can never succeed, so a draft queued by an
+                // earlier retryable failure must not resurrect it as "waiting for network"
+                // on the next launch (#1370 review).
+                clearQueuedDraft()
                 phase = .failed(Self.describe(error))
             }
         } catch {
+            clearQueuedDraft()
             phase = .failed(error.localizedDescription)
         }
+    }
+
+    /// A post's properties with server-side bookkeeping removed, for the compare-and-swap
+    /// equality: `url` (injected by the server, never a content edit) and `mp-*` commands
+    /// (stripped before storing, so a locally-constructed baseline may carry them while a
+    /// `q=source` read never does).
+    private static func casComparable(_ post: MicropubPost) -> MicropubPost {
+        var normalized = post
+        normalized.properties = post.properties.filter { key, _ in
+            key != "url" && !key.hasPrefix("mp-")
+        }
+        return normalized
     }
 
     private func create(status: MicropubPostStatus) async throws -> URL {
@@ -254,7 +287,14 @@ public final class PostComposerModel {
         if let slug = MicropubClient.deriveSlug(title: title) {
             properties["mp-slug"] = [.string(slug)]
         }
-        return try await client.create(MicropubPost(properties: properties))
+        let post = MicropubPost(properties: properties)
+        let url = try await client.create(post)
+        // The new CAS baseline is what was just stored, constructed locally rather than
+        // re-fetched: a failed `try?` refetch used to null the baseline and silently disable
+        // both the conflict check and cleared-property deletes for the rest of the session
+        // (#1370 review). `casComparable` strips the create-only `mp-*` commands on compare.
+        baseline = post
+        return url
     }
 
     private func update(url: URL, status: MicropubPostStatus) async throws {
@@ -271,6 +311,13 @@ public final class PostComposerModel {
             replace: replace,
             delete: cleared.isEmpty ? nil : .properties(cleared)
         )
+        // New baseline = the update applied to the old one, constructed locally (same
+        // no-refetch reasoning as `create`): replaced properties overwrite, cleared ones go,
+        // untouched ones — including other clients' vocabulary — carry over unchanged.
+        var properties = baseline?.properties ?? [:]
+        for name in cleared { properties[name] = nil }
+        for (name, values) in replace { properties[name] = values }
+        baseline = MicropubPost(type: baseline?.type ?? ["h-entry"], properties: properties)
     }
 
     // MARK: - Media
@@ -316,13 +363,22 @@ public final class PostComposerModel {
         let draft = ComposerDraft(
             siteID: siteID, typeID: descriptor.id, postURL: postURL,
             editorValues: values, fieldNames: descriptor.fields.map(\.name),
-            queuedStatus: status?.rawValue)
+            queuedStatus: status?.rawValue,
+            // The CAS baseline persists with a queued update so restoring the draft restores
+            // the conflict guard too, not just the values (#1370 review).
+            baseline: postURL != nil ? baseline : nil)
         try? draftStore.save(draft)
     }
 
     private func clearQueuedDraft() {
         queuedStatus = nil
-        draftStore.clear(forSite: siteID)
+        // Both identities this composition may have persisted under: its pre-create
+        // "new:<type>" file and, once created, its "post:<url>" file — a create transitions
+        // from the first to the second mid-session.
+        draftStore.clear(forSite: siteID, postURL: nil, typeID: descriptor.id)
+        if let postURL {
+            draftStore.clear(forSite: siteID, postURL: postURL, typeID: descriptor.id)
+        }
     }
 
     private static func describe(_ error: MicropubError) -> String {
@@ -383,7 +439,9 @@ public final class PostComposerModel {
             get: { [weak self] in
                 guard let self else { return "" }
                 if let draft = self.numberDrafts[name] { return draft }
-                if case .number(let n?)? = self.values[name] { return Self.displayNumber(n) }
+                if case .number(let n?)? = self.values[name] {
+                    return ComposerNumberFormat.display(n)
+                }
                 return ""
             },
             set: { [weak self] raw in
@@ -421,8 +479,15 @@ public final class PostComposerModel {
         )
     }
 
-    /// Integral values render without a trailing ".0" — same rule as the Mac form.
-    private static func displayNumber(_ n: Double) -> String {
+}
+
+/// The composer's one number-display rule, shared by the top-level form bindings and the
+/// nested record editor so the two can't drift (#1370 review): integral values render without
+/// a trailing ".0" (the magnitude guard avoids the `Int(_:)` overflow trap), mirroring the Mac
+/// form's convention.
+public enum ComposerNumberFormat {
+    /// The display string for a stored number.
+    public static func display(_ n: Double) -> String {
         if n == n.rounded(), abs(n) < 1e15 { return String(Int(n)) }
         return String(n)
     }

--- a/Sources/AnglesiteIOS/PostComposerModel.swift
+++ b/Sources/AnglesiteIOS/PostComposerModel.swift
@@ -119,7 +119,7 @@ public final class PostComposerModel {
     ///   - client: The site's Micropub client.
     ///   - draftStore: Where queued/restored drafts persist.
     /// - Returns: A composer editing the post.
-    /// - Throws: ``MicropubError`` when the source fetch fails; the caller surfaces it in the
+    /// - Throws: `MicropubError` when the source fetch fails; the caller surfaces it in the
     ///   list UI rather than opening a broken composer.
     public static func openExisting(
         url: URL,

--- a/Sources/AnglesiteIOS/PostComposerModel.swift
+++ b/Sources/AnglesiteIOS/PostComposerModel.swift
@@ -1,0 +1,429 @@
+// Sources/AnglesiteIOS/PostComposerModel.swift
+import Foundation
+import SwiftUI
+import AnglesiteCore
+
+/// Drives the iOS composer (#869): a typed, registry-driven form over one post, written through
+/// `MicropubClient` — the same write path the Mac's CMS-mode save uses, so Mac and phone edits
+/// can't diverge (design §6).
+///
+/// The publish model is the design's real-time-first contract: Save/Publish attempts an
+/// **immediate foreground request**. Only on a retryable failure (5xx, unreachable/offline) does
+/// the composition drop to a locally-queued draft with an explicit ``Phase/waitingForNetwork``
+/// state; composing itself never needs the network. A 401/403 surfaces as
+/// ``Phase/authRequired`` — an IndieAuth matter for the onboarding flow (#868), not a network
+/// failure (§7). Concurrent edits are compare-and-swap: before updating an existing post the
+/// model re-fetches `q=source` and compares against the baseline it loaded from — a changed
+/// server copy becomes ``Phase/conflict(_:)`` for the owner to resolve, phrased by the screen in
+/// terms of their post, never a merge (§6).
+@MainActor
+@Observable
+public final class PostComposerModel {
+    /// Where the composition stands. One phase at a time — the screen renders exactly this.
+    public enum Phase: Equatable {
+        /// Composing; no request in flight.
+        case editing
+        /// A foreground send (save or publish) is in flight.
+        case sending
+        /// The last send failed retryably (offline/5xx); the draft is queued locally and
+        /// ``retry()`` re-attempts it. The design's explicit "waiting for network" state — the
+        /// screen must not promise a delivery time (§ open questions).
+        case waitingForNetwork
+        /// The server copy changed since this composition's baseline; carries the server's
+        /// current post. Resolve with ``keepMine()`` or ``takeTheirs()``.
+        case conflict(MicropubPost)
+        /// The token was rejected (401/403) — route to IndieAuth re-auth (#868), distinct from
+        /// any network failure.
+        case authRequired
+        /// A terminal failure (a 4xx the same payload can't fix, or a malformed response);
+        /// carries a short description.
+        case failed(String)
+        /// The post is saved server-side as a draft; carries its canonical URL.
+        case savedDraft(URL)
+        /// `post-status` flipped to published — the Worker-side bake is running. The screen shows
+        /// "Published — site rebuilding" and never fakes a live preview (§6).
+        case publishedRebuilding(URL)
+    }
+
+    /// The content type being composed.
+    public let descriptor: ContentTypeDescriptor
+    /// The site this composition belongs to (keys the draft store).
+    public let siteID: UUID
+    /// The form's field values — the single source the bindings below read and write.
+    public var values: TypedContentEditor.Values
+    /// The composition's phase — see ``Phase``.
+    public private(set) var phase: Phase = .editing
+    /// The post's canonical URL: `nil` until a create succeeds, then stable across updates.
+    public private(set) var postURL: URL?
+
+    /// The `q=source` snapshot this composition edits against — the compare-and-swap baseline.
+    /// `nil` for a new post (nothing to conflict with).
+    private var baseline: MicropubPost?
+    /// The status a queued (failed-retryable) send should stamp when retried.
+    private var queuedStatus: MicropubPostStatus?
+    private let client: MicropubClient
+    private let draftStore: ComposerDraftStore
+    /// In-progress number text per field, so a mid-edit draft like "3." never clobbers a valid
+    /// stored number — mirrors `TypedEntryEditorModel.numberDrafts` on the Mac.
+    private var numberDrafts: [String: String] = [:]
+
+    /// Starts a new composition of `descriptor` for `siteID`, empty-by-default values.
+    ///
+    /// - Parameters:
+    ///   - descriptor: The content type to compose.
+    ///   - siteID: The site's stable UUID (draft-store key).
+    ///   - client: The site's Micropub client (from the ``MicropubSession``).
+    ///   - draftStore: Where queued/restored drafts persist; tests inject a scratch directory.
+    ///   - restoringDraft: A previously persisted draft to restore (same site + type), e.g.
+    ///     after an interrupted session.
+    public init(
+        descriptor: ContentTypeDescriptor,
+        siteID: UUID,
+        client: MicropubClient,
+        draftStore: ComposerDraftStore = ComposerDraftStore(),
+        restoringDraft: ComposerDraft? = nil
+    ) {
+        self.descriptor = descriptor
+        self.siteID = siteID
+        self.client = client
+        self.draftStore = draftStore
+        var values = TypedContentEditor.Values()
+        for field in descriptor.fields {
+            values[field.name] = TypedContentEditor.defaultValue(for: field.kind)
+        }
+        var restoredURL: URL?
+        var restoredStatus: MicropubPostStatus?
+        if let restoringDraft, restoringDraft.typeID == descriptor.id {
+            let restored = restoringDraft.editorValues
+            for field in descriptor.fields {
+                if let value = restored[field.name] { values[field.name] = value }
+            }
+            restoredURL = restoringDraft.postURL
+            restoredStatus = restoringDraft.queuedStatus
+                .flatMap(MicropubPostStatus.init(rawValue:))
+        }
+        self.values = values
+        self.postURL = restoredURL
+        self.queuedStatus = restoredStatus
+        if restoredStatus != nil { self.phase = .waitingForNetwork }
+    }
+
+    /// Opens an existing post for editing: fetches its `q=source` baseline and decodes it into
+    /// form values through the same mapping the Mac's sync bridge reads with
+    /// (`MicropubContentSync.values`).
+    ///
+    /// - Parameters:
+    ///   - url: The post's canonical URL.
+    ///   - descriptor: Its content type (resolved by the post list from the URL's collection).
+    ///   - siteID: The site's stable UUID.
+    ///   - client: The site's Micropub client.
+    ///   - draftStore: Where queued/restored drafts persist.
+    /// - Returns: A composer editing the post.
+    /// - Throws: ``MicropubError`` when the source fetch fails; the caller surfaces it in the
+    ///   list UI rather than opening a broken composer.
+    public static func openExisting(
+        url: URL,
+        descriptor: ContentTypeDescriptor,
+        siteID: UUID,
+        client: MicropubClient,
+        draftStore: ComposerDraftStore = ComposerDraftStore()
+    ) async throws -> PostComposerModel {
+        let post = try await client.source(url: url)
+        let model = PostComposerModel(
+            descriptor: descriptor, siteID: siteID, client: client, draftStore: draftStore)
+        model.adopt(post: post, url: url)
+        return model
+    }
+
+    /// Replaces the composition's values and baseline with `post` — the open-existing path and
+    /// ``takeTheirs()`` both land here.
+    private func adopt(post: MicropubPost, url: URL) {
+        let slug = MicropubContentSync.collectionAndSlug(from: url.absoluteString)?.slug ?? ""
+        let decoded = MicropubContentSync.values(
+            for: descriptor,
+            properties: post.properties,
+            updatedAt: Int(Date.now.timeIntervalSince1970),
+            slug: slug
+        )
+        var values = TypedContentEditor.Values()
+        for field in descriptor.fields {
+            values[field.name] = decoded?[field.name]
+                ?? TypedContentEditor.defaultValue(for: field.kind)
+        }
+        self.values = values
+        self.numberDrafts = [:]
+        self.postURL = url
+        self.baseline = post
+        self.phase = .editing
+    }
+
+    // MARK: - Send path
+
+    /// Saves the composition server-side as a draft (creates or updates with
+    /// `post-status: draft`). Foreground-first; see ``Phase`` for the failure routing.
+    public func saveDraft() async {
+        await send(status: .draft)
+    }
+
+    /// Publishes the composition (creates or updates with `post-status: published`), which
+    /// triggers the Worker-side bake — on success the phase is ``Phase/publishedRebuilding(_:)``.
+    public func publish() async {
+        await send(status: .published)
+    }
+
+    /// Re-attempts a queued send from ``Phase/waitingForNetwork`` — wired to the screen's Retry
+    /// button and its network-restored trigger.
+    public func retry() async {
+        guard case .waitingForNetwork = phase, let status = queuedStatus else { return }
+        await send(status: status)
+    }
+
+    /// Proceeds with this composition's values despite the conflict — the owner chose their
+    /// version. The server's current copy becomes the new baseline first, so the retried send's
+    /// own compare-and-swap passes unless a *further* edit lands in between.
+    public func keepMine() async {
+        guard case .conflict(let theirs) = phase, postURL != nil else { return }
+        baseline = theirs
+        phase = .editing
+        await send(status: queuedStatus ?? .draft)
+    }
+
+    /// Discards this composition's changes in favor of the server's current copy — the owner
+    /// chose the other device's version. Back to editing with the fresh values.
+    public func takeTheirs() {
+        guard case .conflict(let theirs) = phase, let url = postURL else { return }
+        adopt(post: theirs, url: url)
+        clearQueuedDraft()
+    }
+
+    /// Acknowledges a terminal state (``Phase/failed(_:)``, ``Phase/savedDraft(_:)``,
+    /// ``Phase/publishedRebuilding(_:)``) and returns to editing.
+    public func resumeEditing() {
+        phase = .editing
+    }
+
+    private func send(status: MicropubPostStatus) async {
+        phase = .sending
+        queuedStatus = status
+        do {
+            if let url = postURL {
+                // Compare-and-swap: an existing post is only updated if the server still holds
+                // the copy this composition was loaded from (§6). New posts skip this — there is
+                // nothing to conflict with.
+                let current = try await client.source(url: url)
+                if let baseline, current != baseline {
+                    phase = .conflict(current)
+                    return
+                }
+                try await update(url: url, status: status)
+                baseline = try? await client.source(url: url)
+            } else {
+                let url = try await create(status: status)
+                postURL = url
+                baseline = try? await client.source(url: url)
+            }
+            clearQueuedDraft()
+            if let url = postURL {
+                phase = status == .published ? .publishedRebuilding(url) : .savedDraft(url)
+            } else {
+                phase = .editing
+            }
+        } catch let error as MicropubError {
+            if error.requiresReauthorization {
+                phase = .authRequired
+            } else if error.isRetryable {
+                persistQueuedDraft(status: status)
+                phase = .waitingForNetwork
+            } else {
+                phase = .failed(Self.describe(error))
+            }
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+
+    private func create(status: MicropubPostStatus) async throws -> URL {
+        var properties = MicropubComposerProjection.properties(
+            for: descriptor, values: values, status: status)
+        // `mp-slug` is create-only: derive it from the title field the same way the Mac's
+        // file-based create does, so both paths land the same slug for the same title.
+        let title = descriptor.titleField.flatMap { field -> String? in
+            if case .text(let s)? = values[field.name] { return s }
+            return nil
+        }
+        if let slug = MicropubClient.deriveSlug(title: title) {
+            properties["mp-slug"] = [.string(slug)]
+        }
+        return try await client.create(MicropubPost(properties: properties))
+    }
+
+    private func update(url: URL, status: MicropubPostStatus) async throws {
+        let replace = MicropubComposerProjection.properties(
+            for: descriptor, values: values, status: status)
+        // A mapped property present on the baseline but absent from this send was cleared in
+        // the form — delete it server-side. Unmapped properties (another client's vocabulary)
+        // are never touched.
+        let cleared = MicropubComposerProjection.mappedProperties(for: descriptor).filter {
+            baseline?.properties[$0] != nil && replace[$0] == nil
+        }
+        try await client.update(
+            url: url,
+            replace: replace,
+            delete: cleared.isEmpty ? nil : .properties(cleared)
+        )
+    }
+
+    // MARK: - Media
+
+    /// Uploads one picked image through the media endpoint, guarded by ``MediaUploadGuard``
+    /// first (§7's pre-upload size/format check — error handling, not compression UX).
+    ///
+    /// - Parameters:
+    ///   - data: The image bytes (the picker layer transcodes Photos exports to JPEG first).
+    ///   - filename: The upload's filename.
+    ///   - mimeType: The image's MIME type.
+    /// - Returns: The stored media's URL, ready to set as an image field's value.
+    /// - Throws: ``MediaUploadError`` wrapping either the local rejection or the transport
+    ///   failure — media failures stay inline in the form; they never change ``phase``.
+    public func uploadImage(data: Data, filename: String, mimeType: String) async throws -> URL {
+        if let rejection = MediaUploadGuard.rejection(for: data, mimeType: mimeType) {
+            throw MediaUploadError.rejected(rejection)
+        }
+        do {
+            return try await client.uploadMedia(data, filename: filename, mimeType: mimeType)
+        } catch let error as MicropubError {
+            throw MediaUploadError.transport(error)
+        }
+    }
+
+    /// Why ``uploadImage(data:filename:mimeType:)`` failed — local guard or transport.
+    public enum MediaUploadError: Error, Equatable {
+        /// Rejected before any request — see ``MediaUploadGuard/Rejection``.
+        case rejected(MediaUploadGuard.Rejection)
+        /// The upload itself failed.
+        case transport(MicropubError)
+    }
+
+    // MARK: - Draft persistence
+
+    /// Persists the current values as the site's in-progress draft — the screen calls this on
+    /// backgrounding so an interrupted session restores (§3).
+    public func persistDraft() {
+        persistQueuedDraft(status: nil)
+    }
+
+    private func persistQueuedDraft(status: MicropubPostStatus?) {
+        let draft = ComposerDraft(
+            siteID: siteID, typeID: descriptor.id, postURL: postURL,
+            editorValues: values, fieldNames: descriptor.fields.map(\.name),
+            queuedStatus: status?.rawValue)
+        try? draftStore.save(draft)
+    }
+
+    private func clearQueuedDraft() {
+        queuedStatus = nil
+        draftStore.clear(forSite: siteID)
+    }
+
+    private static func describe(_ error: MicropubError) -> String {
+        switch error {
+        case .requestFailed(let status, _):
+            return "The site declined the request (HTTP \(status))."
+        case .decodingFailed:
+            return "The site's response wasn't understood."
+        case .mediaEndpointNotConfigured:
+            return "This site has no media endpoint configured."
+        case .dpopUnavailable:
+            return "Secure signing is unavailable on this device."
+        case .unauthorized, .serverError, .unreachable:
+            // Routed to dedicated phases before reaching here; text kept for completeness.
+            return "The request failed."
+        }
+    }
+
+    // MARK: - Form bindings (mirroring TypedEntryEditorModel's surface on the Mac)
+
+    /// Two-way text binding for string-like fields (and the markdown body).
+    public func textBinding(_ name: String) -> Binding<String> {
+        Binding(
+            get: { [weak self] in
+                if case .text(let s)? = self?.values[name] { return s }
+                return ""
+            },
+            set: { [weak self] in self?.values[name] = .text($0) }
+        )
+    }
+
+    /// Two-way toggle binding for bool fields.
+    public func boolBinding(_ name: String) -> Binding<Bool> {
+        Binding(
+            get: { [weak self] in
+                if case .flag(let b)? = self?.values[name] { return b }
+                return false
+            },
+            set: { [weak self] in self?.values[name] = .flag($0) }
+        )
+    }
+
+    /// Two-way date binding for date/datetime fields (an unset date reads as now).
+    public func dateBinding(_ name: String) -> Binding<Date> {
+        Binding(
+            get: { [weak self] in
+                if case .date(let d?)? = self?.values[name] { return d }
+                return Date()
+            },
+            set: { [weak self] in self?.values[name] = .date($0) }
+        )
+    }
+
+    /// Two-way text binding for number fields, buffering unparseable mid-edit drafts so "3."
+    /// on its way to "3.5" never clobbers a stored value.
+    public func numberBinding(_ name: String) -> Binding<String> {
+        Binding(
+            get: { [weak self] in
+                guard let self else { return "" }
+                if let draft = self.numberDrafts[name] { return draft }
+                if case .number(let n?)? = self.values[name] { return Self.displayNumber(n) }
+                return ""
+            },
+            set: { [weak self] raw in
+                guard let self else { return }
+                self.numberDrafts[name] = raw
+                let trimmed = raw.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty {
+                    self.values[name] = .number(nil)
+                } else if let parsed = Double(trimmed) {
+                    self.values[name] = .number(parsed)
+                }
+            }
+        )
+    }
+
+    /// Two-way binding for string-array/image-array fields.
+    public func listBinding(_ name: String) -> Binding<[String]> {
+        Binding(
+            get: { [weak self] in
+                if case .list(let a)? = self?.values[name] { return a }
+                return []
+            },
+            set: { [weak self] in self?.values[name] = .list($0) }
+        )
+    }
+
+    /// Two-way binding for object-array fields' record rows.
+    public func recordsBinding(_ name: String) -> Binding<[[String: TypedContentEditor.FieldValue]]> {
+        Binding(
+            get: { [weak self] in
+                if case .records(let r)? = self?.values[name] { return r }
+                return []
+            },
+            set: { [weak self] in self?.values[name] = .records($0) }
+        )
+    }
+
+    /// Integral values render without a trailing ".0" — same rule as the Mac form.
+    private static func displayNumber(_ n: Double) -> String {
+        if n == n.rounded(), abs(n) < 1e15 { return String(Int(n)) }
+        return String(n)
+    }
+}

--- a/Sources/AnglesiteIOS/PostListModel.swift
+++ b/Sources/AnglesiteIOS/PostListModel.swift
@@ -1,0 +1,142 @@
+// Sources/AnglesiteIOS/PostListModel.swift
+import Foundation
+import SwiftUI
+import AnglesiteCore
+
+/// Drives the iOS shell's post list (#869): browses a site's posts — published and draft alike —
+/// via the Micropub `q=source` list extension (design §6's deliberate choice over the public
+/// feed, which by definition never shows drafts). Requires the site's IndieAuth session, same as
+/// editing; there is no unauthenticated browse path.
+@MainActor
+@Observable
+public final class PostListModel {
+    /// One row: a post resolved to enough to list and open it.
+    public struct Item: Identifiable, Hashable, Sendable {
+        /// The post's canonical URL — its identity everywhere in the Micropub model.
+        public let id: URL
+        /// The row's title: the post's `name`, or its content's first line for title-less notes.
+        public let title: String
+        /// The post's collection, parsed from its URL's first path segment (never re-derived
+        /// from mf2 — classification happened Worker-side at create time). `nil` for a post
+        /// whose URL doesn't have the `{collection}/{slug}` shape.
+        public let collection: String?
+        /// Whether the post is a draft (the Post Status extension's `post-status`).
+        public let isDraft: Bool
+    }
+
+    /// The list's loading state.
+    public enum State: Equatable {
+        case loading
+        /// The token was rejected — route to IndieAuth re-auth (#868).
+        case authRequired
+        /// The fetch failed; carries a short description and the rows from the last good fetch
+        /// (empty on first load) so a refresh failure doesn't blank an already-shown list.
+        case failed(String, previous: [Item])
+        case posts([Item])
+    }
+
+    /// Current state — see ``State``.
+    public private(set) var state: State = .loading
+
+    private let client: MicropubClient
+    private let registry: ContentTypeRegistry
+    /// Generation guard for overlapping refreshes, same pattern as `SitePickerModel`.
+    private var refreshGeneration: UInt64 = 0
+
+    /// Creates a list over `client`'s site.
+    ///
+    /// - Parameters:
+    ///   - client: The site's Micropub client (from the ``MicropubSession``).
+    ///   - registry: Resolves each post's collection to its content type.
+    public init(client: MicropubClient, registry: ContentTypeRegistry = .default) {
+        self.client = client
+        self.registry = registry
+    }
+
+    /// The rows currently showable, regardless of state (previous rows during a failed refresh).
+    public var items: [Item] {
+        switch state {
+        case .posts(let items): return items
+        case .failed(_, let previous): return previous
+        case .loading, .authRequired: return []
+        }
+    }
+
+    /// Rows filtered to one content type's collection, for the shell's per-type lists.
+    ///
+    /// - Parameter collection: The collection name to filter by; `nil` returns everything.
+    /// - Returns: The matching rows, server order (newest first).
+    public func items(inCollection collection: String?) -> [Item] {
+        guard let collection else { return items }
+        return items.filter { $0.collection == collection }
+    }
+
+    /// Re-fetches the list. Safe to call repeatedly (initial `.task`, pull-to-refresh, and
+    /// after the composer returns); overlapping calls are ordered by generation, latest wins.
+    public func refresh() async {
+        refreshGeneration &+= 1
+        let generation = refreshGeneration
+        if case .authRequired = state { state = .loading }
+        do {
+            let posts = try await client.listPosts()
+            guard generation == refreshGeneration else { return }
+            state = .posts(posts.compactMap(Self.item(for:)))
+        } catch let error as MicropubError {
+            guard generation == refreshGeneration else { return }
+            if error.requiresReauthorization {
+                state = .authRequired
+            } else {
+                state = .failed(Self.describe(error), previous: items)
+            }
+        } catch {
+            guard generation == refreshGeneration else { return }
+            state = .failed(error.localizedDescription, previous: items)
+        }
+    }
+
+    /// Maps one listed post to a row; `nil` for an item without the canonical URL every list
+    /// item is contracted to carry (nothing to open, nothing to identify the row by).
+    static func item(for post: MicropubPost) -> Item? {
+        guard let url = post.url else { return nil }
+        let title = post.firstString("name")
+            ?? post.firstString("content").map(Self.firstLine)
+            ?? url.lastPathComponent
+        let collection = MicropubContentSync.collectionAndSlug(from: url.absoluteString)
+            .map(\.collection)
+        return Item(
+            id: url,
+            title: title,
+            collection: collection,
+            isDraft: post.status == .draft
+        )
+    }
+
+    /// The content type for a row, resolved through the registry's collection lookup.
+    ///
+    /// - Parameter item: The row to resolve.
+    /// - Returns: The descriptor, or `nil` when the collection isn't a registered type.
+    public func descriptor(for item: Item) -> ContentTypeDescriptor? {
+        item.collection.flatMap { registry.descriptor(forCollection: $0) }
+    }
+
+    private static func firstLine(_ content: String) -> String {
+        let line = content.split(separator: "\n", omittingEmptySubsequences: true).first
+            .map(String.init) ?? content
+        return line.trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func describe(_ error: MicropubError) -> String {
+        switch error {
+        case .unreachable:
+            return "Your site can't be reached right now."
+        case .serverError(let status, _):
+            return "Your site's server had trouble (HTTP \(status))."
+        case .requestFailed(let status, _):
+            return "The site declined the request (HTTP \(status))."
+        case .decodingFailed:
+            return "The site's response wasn't understood."
+        case .unauthorized, .mediaEndpointNotConfigured, .dpopUnavailable:
+            return "The request failed."
+        }
+    }
+}

--- a/Sources/AnglesiteMobile/AnglesiteMobileApp.swift
+++ b/Sources/AnglesiteMobile/AnglesiteMobileApp.swift
@@ -1,14 +1,16 @@
 import SwiftUI
 
-/// Entry point (#866): lists `.anglesite` packages discovered via iCloud. `RemoteSessionScreen`
-/// (the #71 remote-sandbox thin client, deferred to v2.0 under #342) is still in this target but
-/// no longer wired to the root scene — see this file's git history, and #800's owner decision
-/// (2026-07-17) that the iCloud-discovery + Micropub flow is the default iOS experience now.
+/// Entry point: the adaptive posting shell (#869) — iCloud-discovered sites in a
+/// `NavigationSplitView` that collapses to a stack on iPhone (design §3). `SitePickerScreen`
+/// (#866's standalone list) and `RemoteSessionScreen` (the #71 remote-sandbox thin client,
+/// deferred to v2.0 under #342) remain in this target but are no longer wired to the root
+/// scene — see this file's git history, and #800's owner decision (2026-07-17) that the
+/// iCloud-discovery + Micropub flow is the default iOS experience now.
 @main
 struct AnglesiteMobileApp: App {
     var body: some Scene {
         WindowGroup {
-            SitePickerScreen()
+            SiteSplitScreen()
         }
     }
 }

--- a/Sources/AnglesiteMobile/ComposeScreen.swift
+++ b/Sources/AnglesiteMobile/ComposeScreen.swift
@@ -1,0 +1,613 @@
+// Sources/AnglesiteMobile/ComposeScreen.swift
+import SwiftUI
+import UIKit
+import PhotosUI
+import Network
+import UniformTypeIdentifiers
+import AnglesiteIOS
+import AnglesiteCore
+
+/// The composer (#869): a registry-driven typed form over one post, with the Markdown body
+/// surface and the Save Draft / Publish actions. All state lives in `PostComposerModel`
+/// (`AnglesiteIOS`); this screen renders its phase and forwards intents.
+struct ComposeScreen: View {
+    @Bindable var model: PostComposerModel
+    /// Called after a successful send so the enclosing list refreshes.
+    var onSent: () -> Void = {}
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some View {
+        MicropubEntryForm(model: model)
+            .navigationTitle(model.descriptor.displayName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Button("Save Draft") { Task { await model.saveDraft(); notifyIfSent() } }
+                        .disabled(isSending)
+                    Button("Publish") { Task { await model.publish(); notifyIfSent() } }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(isSending)
+                }
+            }
+            .safeAreaInset(edge: .bottom) { phaseBanner }
+            .confirmationDialog(
+                Text("This post changed on your site since you started editing."),
+                isPresented: conflictPresented,
+                titleVisibility: .visible
+            ) {
+                Button("Keep My Version") { Task { await model.keepMine(); notifyIfSent() } }
+                Button("Use the Site's Version", role: .destructive) { model.takeTheirs() }
+                Button("Decide Later", role: .cancel) {}
+            } message: {
+                Text("Keeping your version replaces the site's copy. Using the site's version discards the changes you made here.")
+            }
+            .onChange(of: scenePhase) { _, phase in
+                // §3's restore contract: an interrupted session keeps its in-progress draft.
+                if phase == .background { model.persistDraft() }
+            }
+            .task(id: isWaitingForNetwork) {
+                guard isWaitingForNetwork else { return }
+                await Self.waitForNetwork()
+                guard !Task.isCancelled else { return }
+                await model.retry()
+                notifyIfSent()
+            }
+    }
+
+    private var isSending: Bool {
+        if case .sending = model.phase { return true }
+        return false
+    }
+
+    private var isWaitingForNetwork: Bool {
+        if case .waitingForNetwork = model.phase { return true }
+        return false
+    }
+
+    private var conflictPresented: Binding<Bool> {
+        Binding(
+            get: {
+                if case .conflict = model.phase { return true }
+                return false
+            },
+            set: { presented in
+                // Dismissing without choosing keeps editing; the conflict re-arms on next send.
+                if !presented, case .conflict = model.phase { model.resumeEditing() }
+            }
+        )
+    }
+
+    private func notifyIfSent() {
+        switch model.phase {
+        case .savedDraft, .publishedRebuilding: onSent()
+        default: break
+        }
+    }
+
+    /// The phase strip under the form: sending progress, the explicit waiting-for-network state,
+    /// publish/bake status, or a terminal failure. One at a time, matching the model's phase.
+    @ViewBuilder
+    private var phaseBanner: some View {
+        switch model.phase {
+        case .editing:
+            EmptyView()
+        case .sending:
+            banner { ProgressView(); Text("Sending to your site…") }
+        case .waitingForNetwork:
+            // Deliberately no delivery-time promise (design § open questions).
+            banner(role: .warning) {
+                Image(systemName: "wifi.slash")
+                Text("Waiting for network — your draft is saved on this device.")
+                Spacer()
+                Button("Retry") { Task { await model.retry(); notifyIfSent() } }
+            }
+        case .authRequired:
+            banner(role: .warning) {
+                Image(systemName: "person.badge.key")
+                Text("Your site needs you to sign in again.")
+            }
+        case .failed(let message):
+            banner(role: .error) {
+                Image(systemName: "exclamationmark.triangle")
+                Text(verbatim: message)
+                Spacer()
+                Button("Dismiss") { model.resumeEditing() }
+            }
+        case .savedDraft:
+            banner {
+                Image(systemName: "checkmark.circle")
+                Text("Draft saved to your site.")
+                Spacer()
+                Button("Keep Editing") { model.resumeEditing() }
+            }
+        case .publishedRebuilding:
+            // "Published — site rebuilding": the bake is in flight; never a faked live preview.
+            banner {
+                ProgressView()
+                Text("Published — site rebuilding.")
+                Spacer()
+                Button("Keep Editing") { model.resumeEditing() }
+            }
+        case .conflict:
+            EmptyView()   // rendered by the confirmation dialog above
+        }
+    }
+
+    private enum BannerRole { case info, warning, error }
+
+    private func banner(
+        role: BannerRole = .info, @ViewBuilder content: () -> some View
+    ) -> some View {
+        HStack(spacing: 8) { content() }
+            .font(.callout)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.bar)
+            .overlay(alignment: .top) { Divider() }
+    }
+
+    /// Resolves when the network path is satisfied — the waiting-for-network state's automatic
+    /// retry trigger while the app is running. (OS-scheduled background retry after the app
+    /// exits is the design's noted follow-up; the queued draft persists either way.)
+    private static func waitForNetwork() async {
+        let monitor = NWPathMonitor()
+        defer { monitor.cancel() }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            monitor.pathUpdateHandler = { path in
+                if path.status == .satisfied {
+                    monitor.pathUpdateHandler = nil
+                    continuation.resume()
+                }
+            }
+            monitor.start(queue: DispatchQueue(label: "io.dwk.anglesite.network-wait"))
+        }
+    }
+}
+
+/// The schema-driven form body — one control per field `Kind`, ordered by the descriptor,
+/// mirroring the Mac's `TypedEntryForm` with iOS idioms (`PhotosPicker`/`fileImporter` where the
+/// Mac uses `NSOpenPanel`).
+struct MicropubEntryForm: View {
+    @Bindable var model: PostComposerModel
+
+    var body: some View {
+        Form {
+            ForEach(scalarFields, id: \.name) { field in
+                control(for: field)
+            }
+            if let body = bodyField {
+                Section("Body") {
+                    MarkdownTextView(
+                        text: model.textBinding(body.name),
+                        documentId: model.postURL?.absoluteString ?? model.descriptor.id,
+                        fitsContent: true
+                    )
+                    .id(model.postURL?.absoluteString ?? model.descriptor.id)
+                    .frame(minHeight: 160)
+                }
+            }
+        }
+    }
+
+    /// `draft` is omitted: its wire form is `post-status`, which the Save Draft / Publish
+    /// actions stamp — a checkbox alongside those buttons would fight them.
+    private var scalarFields: [ContentTypeField] {
+        model.descriptor.fields.filter { $0.kind != .markdown && $0.name != "draft" }
+    }
+
+    private var bodyField: ContentTypeField? {
+        model.descriptor.fields.first { $0.kind == .markdown }
+    }
+
+    @ViewBuilder
+    private func control(for field: ContentTypeField) -> some View {
+        let label = field.name + (field.required ? " *" : "")
+        switch field.kind {
+        case .string, .language:
+            TextField(label, text: model.textBinding(field.name))
+        case .url:
+            TextField(label, text: model.textBinding(field.name))
+                .keyboardType(.URL)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+        case .image:
+            ImageFieldControl(label: label, model: model, text: model.textBinding(field.name))
+        case .text:
+            VStack(alignment: .leading) {
+                Text(label).font(.caption).foregroundStyle(.secondary)
+                TextField("", text: model.textBinding(field.name), axis: .vertical)
+                    .lineLimit(2...6)
+            }
+        case .bool:
+            Toggle(label, isOn: model.boolBinding(field.name))
+        case .date, .datetime:
+            DatePicker(
+                label, selection: model.dateBinding(field.name),
+                displayedComponents: field.kind == .date ? [.date] : [.date, .hourAndMinute])
+        case .number:
+            TextField(label, text: model.numberBinding(field.name))
+                .keyboardType(.decimalPad)
+        case .stringArray:
+            StringListEditor(title: label, items: model.listBinding(field.name), model: nil)
+        case .imageArray:
+            StringListEditor(title: label, items: model.listBinding(field.name), model: model)
+        case .objectArray(let memberFields):
+            ObjectArrayEditor(
+                title: label, memberFields: memberFields,
+                records: model.recordsBinding(field.name))
+        case .markdown:
+            EmptyView()   // handled by the Body section
+        }
+    }
+}
+
+/// One image field: the value (a URL once uploaded) plus a `PhotosPicker` and a Files chooser —
+/// the iOS replacements for the Mac form's `NSOpenPanel`. Picked images upload through the
+/// site's media endpoint immediately (guarded by `MediaUploadGuard`); the resulting URL becomes
+/// the field's value.
+private struct ImageFieldControl: View {
+    let label: String
+    let model: PostComposerModel
+    @Binding var text: String
+    @State private var pickerItem: PhotosPickerItem?
+    @State private var importerPresented = false
+    @State private var uploading = false
+    @State private var uploadError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                TextField(label, text: $text)
+                if uploading {
+                    ProgressView()
+                } else {
+                    PhotosPicker(selection: $pickerItem, matching: .images) {
+                        Image(systemName: "photo.badge.plus")
+                    }
+                    .accessibilityLabel(Text("Choose Photo"))
+                    Button {
+                        importerPresented = true
+                    } label: {
+                        Image(systemName: "folder")
+                    }
+                    .accessibilityLabel(Text("Choose File"))
+                }
+            }
+            if let uploadError {
+                Text(verbatim: uploadError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .onChange(of: pickerItem) { _, item in
+            guard let item else { return }
+            Task { await uploadPicked(item); pickerItem = nil }
+        }
+        .fileImporter(isPresented: $importerPresented, allowedContentTypes: [.image]) { result in
+            guard case .success(let url) = result else { return }
+            Task { await uploadFile(at: url) }
+        }
+        .buttonStyle(.borderless)
+    }
+
+    private func uploadPicked(_ item: PhotosPickerItem) async {
+        guard let data = try? await item.loadTransferable(type: Data.self) else {
+            uploadError = String(localized: "That photo couldn't be read.")
+            return
+        }
+        // Photos exports are commonly HEIC, which browsers don't render — transcode to JPEG
+        // before the guard sees it (the guard's allow-list is web-servable formats only).
+        guard let image = UIImage(data: data),
+              let jpeg = image.jpegData(compressionQuality: 0.9)
+        else {
+            uploadError = String(localized: "That photo couldn't be converted for the web.")
+            return
+        }
+        await upload(data: jpeg, filename: "photo.jpg", mimeType: "image/jpeg")
+    }
+
+    private func uploadFile(at url: URL) async {
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+        guard let data = try? Data(contentsOf: url) else {
+            uploadError = String(localized: "That file couldn't be read.")
+            return
+        }
+        await upload(
+            data: data, filename: url.lastPathComponent, mimeType: Self.mimeType(for: url))
+    }
+
+    private func upload(data: Data, filename: String, mimeType: String) async {
+        uploading = true
+        uploadError = nil
+        defer { uploading = false }
+        do {
+            let url = try await model.uploadImage(
+                data: data, filename: filename, mimeType: mimeType)
+            text = url.absoluteString
+        } catch let error as PostComposerModel.MediaUploadError {
+            uploadError = Self.describe(error)
+        } catch {
+            uploadError = error.localizedDescription
+        }
+    }
+
+    private static func mimeType(for url: URL) -> String {
+        UTType(filenameExtension: url.pathExtension)?.preferredMIMEType
+            ?? "application/octet-stream"
+    }
+
+    private static func describe(_ error: PostComposerModel.MediaUploadError) -> String {
+        switch error {
+        case .rejected(.tooLarge(let bytes)):
+            let size = ByteCountFormatter.string(
+                fromByteCount: Int64(bytes), countStyle: .file)
+            return String(localized: "That image is \(size) — the limit is 25 MB.")
+        case .rejected(.unsupportedFormat(let mimeType)):
+            return String(localized: "\(mimeType) images can't be shown on the web.")
+        case .rejected(.empty):
+            return String(localized: "That file is empty.")
+        case .transport(let micropubError) where micropubError.requiresReauthorization:
+            return String(localized: "Your site needs you to sign in again.")
+        case .transport:
+            return String(localized: "The upload didn't go through — try again.")
+        }
+    }
+}
+
+/// The iOS counterpart of the Mac form's list editor for `stringArray`/`imageArray` fields.
+/// Rows carry stable UUID identity so deleting one never re-binds a survivor's editor. When
+/// `model` is non-nil the field is image-flavored and each row offers the photo picker.
+private struct StringListEditor: View {
+    let title: String
+    @Binding var items: [String]
+    /// Non-nil enables per-row image picking (imageArray fields).
+    let model: PostComposerModel?
+
+    private struct Row: Identifiable, Equatable {
+        let id = UUID()
+        var value: String
+    }
+    @State private var rows: [Row] = []
+    @State private var pickerItem: PhotosPickerItem?
+    @State private var uploadError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            ForEach($rows) { $row in
+                HStack {
+                    TextField("", text: $row.value)
+                    Button(role: .destructive) {
+                        rows.removeAll { $0.id == row.id }
+                    } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .accessibilityLabel(Text("Remove"))
+                }
+            }
+            HStack {
+                Button {
+                    rows.append(Row(value: ""))
+                } label: {
+                    Label("Add", systemImage: "plus.circle")
+                }
+                if model != nil {
+                    PhotosPicker(selection: $pickerItem, matching: .images) {
+                        Label("Add Photo", systemImage: "photo.badge.plus")
+                    }
+                }
+            }
+            if let uploadError {
+                Text(verbatim: uploadError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .buttonStyle(.borderless)
+        .onAppear { syncRowsFromItems() }
+        .onChange(of: items) { _, new in
+            if new != rows.map(\.value) { rows = new.map(Row.init(value:)) }
+        }
+        .onChange(of: rows) { _, new in
+            let mapped = new.map(\.value)
+            if mapped != items { items = mapped }
+        }
+        .onChange(of: pickerItem) { _, item in
+            guard let item, let model else { return }
+            Task {
+                await uploadPicked(item, model: model)
+                pickerItem = nil
+            }
+        }
+    }
+
+    private func syncRowsFromItems() {
+        if items != rows.map(\.value) { rows = items.map(Row.init(value:)) }
+    }
+
+    private func uploadPicked(_ item: PhotosPickerItem, model: PostComposerModel) async {
+        uploadError = nil
+        guard let data = try? await item.loadTransferable(type: Data.self),
+              let image = UIImage(data: data),
+              let jpeg = image.jpegData(compressionQuality: 0.9)
+        else {
+            uploadError = String(localized: "That photo couldn't be read.")
+            return
+        }
+        do {
+            let url = try await model.uploadImage(
+                data: jpeg, filename: "photo.jpg", mimeType: "image/jpeg")
+            rows.append(Row(value: url.absoluteString))
+        } catch {
+            uploadError = String(localized: "The upload didn't go through — try again.")
+        }
+    }
+}
+
+/// The iOS counterpart of the Mac form's `objectArray` editor — one block per record, member
+/// fields inline, stable row identity. The member-kind convention (no markdown/array/nested
+/// kinds inside a record) is enforced the same way: unsupported kinds fail visibly.
+private struct ObjectArrayEditor: View {
+    let title: String
+    let memberFields: [ContentTypeField]
+    @Binding var records: [[String: TypedContentEditor.FieldValue]]
+
+    private struct Row: Identifiable, Equatable {
+        let id = UUID()
+        var values: [String: TypedContentEditor.FieldValue]
+    }
+    @State private var rows: [Row] = []
+    /// Per-row, per-field mid-edit number drafts — see the Mac editor's identical buffer.
+    @State private var numberDrafts: [Row.ID: [String: String]] = [:]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            ForEach($rows) { $row in
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(memberFields, id: \.name) { field in
+                        memberControl(for: field, in: $row.values, rowID: row.id)
+                    }
+                    HStack {
+                        Spacer()
+                        Button(role: .destructive) {
+                            removeRow(row.id)
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .accessibilityLabel(Text("Remove"))
+                    }
+                }
+                .padding(8)
+                .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary))
+            }
+            Button {
+                rows.append(Row(values: emptyRecord()))
+            } label: {
+                Label("Add", systemImage: "plus.circle")
+            }
+        }
+        .buttonStyle(.borderless)
+        .onAppear { syncRowsFromRecords() }
+        .onChange(of: records) { _, new in
+            if new != rows.map(\.values) {
+                rows = new.map(Row.init(values:))
+                numberDrafts.removeAll()
+            }
+        }
+        .onChange(of: rows) { _, new in
+            let mapped = new.map(\.values)
+            if mapped != records { records = mapped }
+        }
+    }
+
+    private func removeRow(_ id: Row.ID) {
+        rows.removeAll { $0.id == id }
+        numberDrafts[id] = nil
+    }
+
+    private func emptyRecord() -> [String: TypedContentEditor.FieldValue] {
+        Dictionary(uniqueKeysWithValues: memberFields.map {
+            ($0.name, TypedContentEditor.defaultValue(for: $0.kind))
+        })
+    }
+
+    private func syncRowsFromRecords() {
+        if records != rows.map(\.values) { rows = records.map(Row.init(values:)) }
+    }
+
+    @ViewBuilder
+    private func memberControl(
+        for field: ContentTypeField,
+        in values: Binding<[String: TypedContentEditor.FieldValue]>,
+        rowID: Row.ID
+    ) -> some View {
+        let label = field.name + (field.required ? " *" : "")
+        // Exhaustive on purpose, mirroring the Mac editor: a catch-all would render the four
+        // kinds a member field must not use as a working-looking control that corrupts the
+        // record on save.
+        switch field.kind {
+        case .string, .language, .text, .url, .image:
+            TextField(label, text: textBinding(field.name, in: values))
+        case .bool:
+            Toggle(label, isOn: flagBinding(field.name, in: values))
+        case .date, .datetime:
+            DatePicker(
+                label, selection: dateBinding(field.name, in: values),
+                displayedComponents: field.kind == .date ? [.date] : [.date, .hourAndMinute])
+        case .number:
+            TextField(label, text: numberBinding(field.name, in: values, rowID: rowID))
+                .keyboardType(.decimalPad)
+        case .markdown, .stringArray, .imageArray, .objectArray:
+            Text(verbatim: "\(field.name) — unsupported member field kind")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func textBinding(
+        _ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                if case .text(let s)? = values.wrappedValue[name] { return s }
+                return ""
+            },
+            set: { values.wrappedValue[name] = .text($0) }
+        )
+    }
+
+    private func flagBinding(
+        _ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>
+    ) -> Binding<Bool> {
+        Binding(
+            get: {
+                if case .flag(let b)? = values.wrappedValue[name] { return b }
+                return false
+            },
+            set: { values.wrappedValue[name] = .flag($0) }
+        )
+    }
+
+    private func dateBinding(
+        _ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>
+    ) -> Binding<Date> {
+        Binding(
+            get: {
+                if case .date(let d?)? = values.wrappedValue[name] { return d }
+                return Date()
+            },
+            set: { values.wrappedValue[name] = .date($0) }
+        )
+    }
+
+    private func numberBinding(
+        _ name: String, in values: Binding<[String: TypedContentEditor.FieldValue]>,
+        rowID: Row.ID
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                if let draft = numberDrafts[rowID]?[name] { return draft }
+                if case .number(let n?)? = values.wrappedValue[name] {
+                    return Self.displayNumber(n)
+                }
+                return ""
+            },
+            set: { raw in
+                numberDrafts[rowID, default: [:]][name] = raw
+                let trimmed = raw.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty {
+                    values.wrappedValue[name] = .number(nil)
+                } else if let parsed = Double(trimmed) {
+                    values.wrappedValue[name] = .number(parsed)
+                }
+            }
+        )
+    }
+
+    private static func displayNumber(_ n: Double) -> String {
+        if n == n.rounded(), abs(n) < 1e15 { return String(Int(n)) }
+        return String(n)
+    }
+}

--- a/Sources/AnglesiteMobile/ComposeScreen.swift
+++ b/Sources/AnglesiteMobile/ComposeScreen.swift
@@ -149,18 +149,61 @@ struct ComposeScreen: View {
     /// Resolves when the network path is satisfied — the waiting-for-network state's automatic
     /// retry trigger while the app is running. (OS-scheduled background retry after the app
     /// exits is the design's noted follow-up; the queued draft persists either way.)
+    ///
+    /// Honors task cancellation: SwiftUI cancels the enclosing `.task` when the composer goes
+    /// away, and a bare `withCheckedContinuation` would leave the monitor and a suspended
+    /// continuation alive until the device's network actually returned (#1370 review). The
+    /// caller re-checks `Task.isCancelled` after this returns, so an early cancel-resume never
+    /// triggers a retry.
     private static func waitForNetwork() async {
         let monitor = NWPathMonitor()
         defer { monitor.cancel() }
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            monitor.pathUpdateHandler = { path in
-                if path.status == .satisfied {
-                    monitor.pathUpdateHandler = nil
-                    continuation.resume()
+        let gate = ContinuationGate()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                gate.arm(continuation)
+                monitor.pathUpdateHandler = { path in
+                    if path.status == .satisfied { gate.resume() }
                 }
+                monitor.start(queue: DispatchQueue(label: "io.dwk.anglesite.network-wait"))
             }
-            monitor.start(queue: DispatchQueue(label: "io.dwk.anglesite.network-wait"))
+        } onCancel: {
+            gate.resume()
         }
+    }
+}
+
+/// Resumes a `Void` continuation exactly once, from whichever of the path-satisfied callback or
+/// the cancellation handler fires first — both race on background queues, and a double resume
+/// is a crash while a dropped one is a leak.
+private final class ContinuationGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    /// Set when `resume()` ran before `arm(_:)` — cancellation can fire before the
+    /// continuation exists; arming after that resumes immediately.
+    private var resumedEarly = false
+
+    func arm(_ continuation: CheckedContinuation<Void, Never>) {
+        lock.lock()
+        if resumedEarly {
+            lock.unlock()
+            continuation.resume()
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func resume() {
+        lock.lock()
+        guard let continuation else {
+            resumedEarly = true
+            lock.unlock()
+            return
+        }
+        self.continuation = nil
+        lock.unlock()
+        continuation.resume()
     }
 }
 
@@ -590,7 +633,7 @@ private struct ObjectArrayEditor: View {
             get: {
                 if let draft = numberDrafts[rowID]?[name] { return draft }
                 if case .number(let n?)? = values.wrappedValue[name] {
-                    return Self.displayNumber(n)
+                    return ComposerNumberFormat.display(n)
                 }
                 return ""
             },
@@ -604,10 +647,5 @@ private struct ObjectArrayEditor: View {
                 }
             }
         )
-    }
-
-    private static func displayNumber(_ n: Double) -> String {
-        if n == n.rounded(), abs(n) < 1e15 { return String(Int(n)) }
-        return String(n)
     }
 }

--- a/Sources/AnglesiteMobile/Localizable.xcstrings
+++ b/Sources/AnglesiteMobile/Localizable.xcstrings
@@ -1,10 +1,37 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
+
+    },
+    "%@ images can't be shown on the web." : {
+
+    },
+    "Add" : {
+
+    },
+    "Add Photo" : {
+
+    },
+    "All Posts" : {
+
+    },
     "Anglesite" : {
 
     },
+    "Body" : {
+
+    },
     "Branch" : {
+
+    },
+    "Choose File" : {
+
+    },
+    "Choose Photo" : {
+
+    },
+    "Choose one of your sites to see its posts." : {
 
     },
     "Cloudflare Control Worker" : {
@@ -19,7 +46,16 @@
     "Connect…" : {
 
     },
+    "Content" : {
+
+    },
     "Control Worker token" : {
+
+    },
+    "Couldn't Load Posts" : {
+
+    },
+    "Couldn't Open Post" : {
 
     },
     "Couldn't Open Site" : {
@@ -31,16 +67,46 @@
     "Couldn't sign in to Cloudflare. Try again in a moment." : {
 
     },
+    "Decide Later" : {
+
+    },
     "Deploy this site from Anglesite on your Mac first, then come back to post from here." : {
 
     },
+    "Dismiss" : {
+
+    },
     "Done" : {
+
+    },
+    "Draft" : {
+
+    },
+    "Draft saved to your site." : {
 
     },
     "Finding your sites…" : {
 
     },
     "From the one-time Deploy to Cloudflare setup. The token is stored in the Keychain on this device only." : {
+
+    },
+    "Keep Editing" : {
+
+    },
+    "Keep My Version" : {
+
+    },
+    "Keeping your version replaces the site's copy. Using the site's version discards the changes you made here." : {
+
+    },
+    "Loading posts…" : {
+
+    },
+    "New Post" : {
+
+    },
+    "No Posts Yet" : {
 
     },
     "No Site Open" : {
@@ -55,10 +121,19 @@
     "Not Deployed Yet" : {
 
     },
+    "Nothing Selected" : {
+
+    },
     "Open Site" : {
 
     },
     "Open your site in the remote sandbox to preview and edit it." : {
+
+    },
+    "Pick a Site" : {
+
+    },
+    "Pick a post to edit, or start a new one." : {
 
     },
     "Post to Your Site" : {
@@ -67,10 +142,34 @@
     "Posting Not Available" : {
 
     },
+    "Posting to this site needs a sign-in with your site itself. Site sign-in arrives with IndieAuth onboarding." : {
+
+    },
+    "Posts you create appear here, drafts included." : {
+
+    },
+    "Publish" : {
+
+    },
+    "Published — site rebuilding." : {
+
+    },
     "Refresh" : {
 
     },
     "Remote Session" : {
+
+    },
+    "Remove" : {
+
+    },
+    "Retry" : {
+
+    },
+    "Save Draft" : {
+
+    },
+    "Sending to your site…" : {
 
     },
     "Session Expired" : {
@@ -83,6 +182,12 @@
 
     },
     "Sign In" : {
+
+    },
+    "Sign In Needed" : {
+
+    },
+    "Sign In to Post" : {
 
     },
     "Sign Out" : {
@@ -118,6 +223,9 @@
     "Site Unreachable" : {
 
     },
+    "Sites" : {
+
+    },
     "Something went wrong while signing in. Try again." : {
 
     },
@@ -127,7 +235,37 @@
     "Stop" : {
 
     },
+    "That content type isn't available." : {
+
+    },
+    "That file couldn't be read." : {
+
+    },
+    "That file is empty." : {
+
+    },
+    "That image is %@ — the limit is 25 MB." : {
+
+    },
+    "That photo couldn't be converted for the web." : {
+
+    },
+    "That photo couldn't be read." : {
+
+    },
+    "The post couldn't be loaded from your site." : {
+
+    },
     "The sandbox clones this repository — git stays the source of truth for your site." : {
+
+    },
+    "The upload didn't go through — try again." : {
+
+    },
+    "This post changed on your site since you started editing." : {
+
+    },
+    "This post's type isn't one this app can edit." : {
 
     },
     "This site doesn't offer IndieAuth sign-in yet. Update and redeploy it from Anglesite on your Mac." : {
@@ -139,6 +277,12 @@
     "Try Again" : {
 
     },
+    "Use the Site's Version" : {
+
+    },
+    "Waiting for network — your draft is saved on this device." : {
+
+    },
     "Waiting for sign-in…" : {
 
     },
@@ -146,6 +290,12 @@
 
     },
     "Your Sites" : {
+
+    },
+    "Your site needs you to sign in again before your posts can be shown." : {
+
+    },
+    "Your site needs you to sign in again." : {
 
     },
     "Your site signed you out. Sign in again to keep posting." : {

--- a/Sources/AnglesiteMobile/PostListScreen.swift
+++ b/Sources/AnglesiteMobile/PostListScreen.swift
@@ -1,0 +1,89 @@
+// Sources/AnglesiteMobile/PostListScreen.swift
+import SwiftUI
+import AnglesiteIOS
+import AnglesiteCore
+
+/// The middle column (#869): a site's posts — drafts included — from the Micropub `q=source`
+/// list, optionally filtered to one content type. Selection drives the composer column.
+struct PostListScreen: View {
+    let model: PostListModel
+    /// The collection to filter by (`nil` = every post).
+    let collection: String?
+    @Binding var selection: PostListItemSelection?
+
+    var body: some View {
+        Group {
+            switch model.state {
+            case .loading:
+                ProgressView("Loading posts…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .authRequired:
+                ContentUnavailableView {
+                    Label("Sign In Needed", systemImage: "person.badge.key")
+                } description: {
+                    Text("Your site needs you to sign in again before your posts can be shown.")
+                }
+            case .failed(let message, previous: let previous) where previous.isEmpty:
+                ContentUnavailableView {
+                    Label("Couldn't Load Posts", systemImage: "wifi.slash")
+                } description: {
+                    Text(verbatim: message)
+                } actions: {
+                    Button("Try Again") { Task { await model.refresh() } }
+                        .buttonStyle(.borderedProminent)
+                }
+            case .posts, .failed:
+                list
+            }
+        }
+        .task { await model.refresh() }
+        .refreshable { await model.refresh() }
+    }
+
+    private var rows: [PostListModel.Item] { model.items(inCollection: collection) }
+
+    private var list: some View {
+        List(selection: $selection) {
+            if case .failed(let message, _) = model.state {
+                Label {
+                    Text(verbatim: message)
+                } icon: {
+                    Image(systemName: "wifi.slash")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            ForEach(rows) { item in
+                NavigationLink(value: PostListItemSelection.existing(item)) {
+                    HStack {
+                        Text(verbatim: item.title)
+                            .lineLimit(2)
+                        Spacer()
+                        if item.isDraft {
+                            Text("Draft")
+                                .font(.caption)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(.quaternary))
+                        }
+                    }
+                }
+            }
+        }
+        .overlay {
+            if rows.isEmpty {
+                ContentUnavailableView {
+                    Label("No Posts Yet", systemImage: "square.and.pencil")
+                } description: {
+                    Text("Posts you create appear here, drafts included.")
+                }
+            }
+        }
+    }
+}
+
+/// What the composer column shows: a fresh composition of a type, or an existing post.
+enum PostListItemSelection: Hashable {
+    case new(typeID: String)
+    case existing(PostListModel.Item)
+}

--- a/Sources/AnglesiteMobile/SiteSignInScreen.swift
+++ b/Sources/AnglesiteMobile/SiteSignInScreen.swift
@@ -25,6 +25,10 @@ private struct SessionWebAuthenticator: SiteWebAuthenticating {
 /// web-auth sheet; the resulting token stays in the Keychain, scoped to this site.
 struct SiteSignInScreen: View {
     let site: SitePickerModel.DiscoveredSite
+    /// Fired whenever this screen's flow reaches the signed-in state — including a restore
+    /// found on configure — so an embedding shell (`SiteSplitScreen`, #869) can re-resolve the
+    /// site's session and swap in the posting surfaces.
+    var onAuthenticated: () -> Void = {}
 
     @Environment(\.webAuthenticationSession) private var webAuthenticationSession
     @State private var model: MicropubOnboardingModel?
@@ -42,7 +46,12 @@ struct SiteSignInScreen: View {
                     webAuthenticator: SessionWebAuthenticator(session: webAuthenticationSession))
                 self.model = model
                 await model.configure(site: site)
+                notifyIfSignedIn()
             }
+    }
+
+    private func notifyIfSignedIn() {
+        if case .signedIn = model?.state { onAuthenticated() }
     }
 
     @ViewBuilder
@@ -94,7 +103,10 @@ struct SiteSignInScreen: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
             Button {
-                Task { await model?.signIn() }
+                Task {
+                    await model?.signIn()
+                    notifyIfSignedIn()
+                }
             } label: {
                 Text("Sign In")
                     .frame(maxWidth: .infinity)
@@ -164,7 +176,10 @@ struct SiteSignInScreen: View {
 
     private var retryButton: some View {
         Button("Try Again") {
-            Task { await model?.signIn() }
+            Task {
+                await model?.signIn()
+                notifyIfSignedIn()
+            }
         }
         .buttonStyle(.borderedProminent)
     }

--- a/Sources/AnglesiteMobile/SiteSplitScreen.swift
+++ b/Sources/AnglesiteMobile/SiteSplitScreen.swift
@@ -1,0 +1,337 @@
+// Sources/AnglesiteMobile/SiteSplitScreen.swift
+import SwiftUI
+import AnglesiteIOS
+import AnglesiteCore
+
+/// The app's shell (#869, design §3): one `NavigationSplitView`, adaptive — three columns on
+/// iPad (sites/content-types sidebar, post list, composer), collapsing to a single
+/// `NavigationStack` on iPhone. Single scene, no multi-window for v1.
+///
+/// Sessions come from a ``MicropubSessionProviding`` — the seam the IndieAuth onboarding issue
+/// (#868) fills in. Until a site has a session, its panes show the sign-in-required state; there
+/// is no unauthenticated browse path (design §6).
+struct SiteSplitScreen: View {
+    /// The session source; the default reads every site as signed out until #868's provider
+    /// replaces it.
+    var sessions: any MicropubSessionProviding = NoMicropubSessions()
+
+    @State private var sitePicker = SitePickerModel()
+    @State private var selectedSite: SitePickerModel.DiscoveredSite?
+    /// The sidebar's content-type filter: a registry type id, or `nil` for "All Posts".
+    @State private var selectedTypeID: String?
+    @State private var selection: PostListItemSelection?
+    /// The selected site's session pane state — re-resolved whenever the site changes.
+    @State private var sessionState: SessionState = .none
+    private let registry = ContentTypeRegistry.default
+
+    private enum SessionState: Equatable {
+        case none
+        case checking
+        case signedOut
+        case ready
+    }
+
+    /// The resolved session's models, rebuilt per site.
+    @State private var postList: PostListModel?
+    @State private var session: MicropubSession?
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+                .navigationTitle(Text("Anglesite"))
+        } content: {
+            contentPane
+                .navigationTitle(contentTitle)
+        } detail: {
+            detailPane
+        }
+        .task { await sitePicker.refresh() }
+        .task(id: selectedSite?.id) { await resolveSession() }
+    }
+
+    // MARK: - Sidebar (sites + content types)
+
+    @ViewBuilder
+    private var sidebar: some View {
+        switch sitePicker.state {
+        case .loading:
+            ProgressView("Finding your sites…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .iCloudUnavailable:
+            ContentUnavailableView {
+                Label("iCloud Unavailable", systemImage: "icloud.slash")
+            } description: {
+                Text("Sign in to iCloud and turn on iCloud Drive to see your Anglesite sites.")
+            } actions: {
+                Button("Try Again") { Task { await sitePicker.refresh() } }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .empty:
+            ContentUnavailableView {
+                Label("No Sites Found", systemImage: "globe")
+            } description: {
+                Text("No sites found — create a site in Anglesite on your Mac first.")
+            } actions: {
+                Button("Refresh") { Task { await sitePicker.refresh() } }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .sites(let sites):
+            List(selection: sidebarSelection) {
+                Section("Sites") {
+                    ForEach(sites) { site in
+                        Label {
+                            Text(verbatim: site.displayName)
+                        } icon: {
+                            Image(systemName: "globe")
+                        }
+                        .tag(SidebarSelection.site(site.id))
+                    }
+                }
+                if selectedSite != nil {
+                    Section("Content") {
+                        Label {
+                            Text("All Posts")
+                        } icon: {
+                            Image(systemName: "tray.full")
+                        }
+                        .tag(SidebarSelection.allPosts)
+                        ForEach(postTypes) { descriptor in
+                            Label {
+                                Text(verbatim: descriptor.displayName)
+                            } icon: {
+                                Image(systemName: "square.and.pencil")
+                            }
+                            .tag(SidebarSelection.type(descriptor.id))
+                        }
+                    }
+                }
+            }
+            .refreshable { await sitePicker.refresh() }
+        }
+    }
+
+    /// The content types a phone can post: collection-stored (post-family) descriptors.
+    /// Pages and singletons (business profile, résumé) are site-editing, not posting — v2.0
+    /// scope (#66/#71).
+    private var postTypes: [ContentTypeDescriptor] {
+        registry.all.filter { $0.collection != nil }
+    }
+
+    private enum SidebarSelection: Hashable {
+        case site(UUID)
+        case allPosts
+        case type(String)
+    }
+
+    /// One `List` selection over both sections: picking a site switches sites (resetting the
+    /// type filter); picking a content row narrows the post list.
+    private var sidebarSelection: Binding<SidebarSelection?> {
+        Binding(
+            get: {
+                if let selectedTypeID { return .type(selectedTypeID) }
+                if selectedSite != nil { return .allPosts }
+                return nil
+            },
+            set: { newValue in
+                switch newValue {
+                case .site(let id):
+                    guard case .sites(let sites) = sitePicker.state,
+                          let site = sites.first(where: { $0.id == id })
+                    else { return }
+                    if site != selectedSite {
+                        selectedSite = site
+                        selectedTypeID = nil
+                        selection = nil
+                    }
+                case .allPosts:
+                    selectedTypeID = nil
+                case .type(let id):
+                    selectedTypeID = id
+                case nil:
+                    break
+                }
+            }
+        )
+    }
+
+    // MARK: - Content (post list)
+
+    private var contentTitle: Text {
+        if let selectedTypeID, let descriptor = registry.descriptor(id: selectedTypeID) {
+            return Text(verbatim: descriptor.displayName)
+        }
+        return Text("All Posts")
+    }
+
+    @ViewBuilder
+    private var contentPane: some View {
+        if selectedSite == nil {
+            ContentUnavailableView {
+                Label("Pick a Site", systemImage: "globe")
+            } description: {
+                Text("Choose one of your sites to see its posts.")
+            }
+        } else {
+            switch sessionState {
+            case .none, .checking:
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .signedOut:
+                signInRequired
+            case .ready:
+                if let postList {
+                    PostListScreen(
+                        model: postList,
+                        collection: selectedCollection,
+                        selection: $selection
+                    )
+                    .toolbar {
+                        ToolbarItem(placement: .primaryAction) {
+                            newPostButton
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var selectedCollection: String? {
+        selectedTypeID.flatMap { registry.descriptor(id: $0)?.collection }
+    }
+
+    /// Starts a new composition — of the sidebar-selected type, or `note` (the quickest
+    /// capture) when browsing all posts.
+    private var newPostButton: some View {
+        Button {
+            selection = .new(typeID: selectedTypeID ?? "note")
+        } label: {
+            Label("New Post", systemImage: "square.and.pencil")
+        }
+    }
+
+    /// The conformance/onboarding gate state: names the requirement instead of degrading
+    /// silently (design §1/§7). The actual sign-in flow is #868's.
+    private var signInRequired: some View {
+        ContentUnavailableView {
+            Label("Sign In to Post", systemImage: "person.badge.key")
+        } description: {
+            Text("Posting to this site needs a sign-in with your site itself. Site sign-in arrives with IndieAuth onboarding.")
+        }
+    }
+
+    // MARK: - Detail (composer)
+
+    @ViewBuilder
+    private var detailPane: some View {
+        if let session, let site = selectedSite, let selection {
+            ComposerPane(
+                selection: selection,
+                session: session,
+                siteID: site.id,
+                registry: registry,
+                postList: postList,
+                onSent: { Task { await postList?.refresh() } }
+            )
+            // A fresh pane per selection: composer state must never leak across posts.
+            .id(selection)
+        } else {
+            ContentUnavailableView {
+                Label("Nothing Selected", systemImage: "square.and.pencil")
+            } description: {
+                Text("Pick a post to edit, or start a new one.")
+            }
+        }
+    }
+
+    private func resolveSession() async {
+        guard let site = selectedSite else {
+            sessionState = .none
+            session = nil
+            postList = nil
+            return
+        }
+        sessionState = .checking
+        let resolved = await sessions.session(forSite: site.id)
+        // The site may have changed while resolving; only publish for the current one.
+        guard site == selectedSite else { return }
+        if let resolved {
+            session = resolved
+            postList = PostListModel(client: resolved.makeClient(), registry: registry)
+            sessionState = .ready
+        } else {
+            session = nil
+            postList = nil
+            sessionState = .signedOut
+        }
+    }
+}
+
+/// Builds the right composer for a selection: a fresh model for a new post (restoring any
+/// interrupted draft of the same site + type), or an async `q=source` load for an existing one.
+private struct ComposerPane: View {
+    let selection: PostListItemSelection
+    let session: MicropubSession
+    let siteID: UUID
+    let registry: ContentTypeRegistry
+    let postList: PostListModel?
+    var onSent: () -> Void
+
+    @State private var model: PostComposerModel?
+    @State private var loadFailure: String?
+
+    var body: some View {
+        Group {
+            if let model {
+                ComposeScreen(model: model, onSent: onSent)
+            } else if let loadFailure {
+                ContentUnavailableView {
+                    Label("Couldn't Open Post", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(verbatim: loadFailure)
+                } actions: {
+                    Button("Try Again") { Task { await load() } }
+                        .buttonStyle(.borderedProminent)
+                }
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .task { await load() }
+    }
+
+    private func load() async {
+        loadFailure = nil
+        switch selection {
+        case .new(let typeID):
+            guard let descriptor = registry.descriptor(id: typeID) else {
+                loadFailure = String(localized: "That content type isn't available.")
+                return
+            }
+            let store = ComposerDraftStore()
+            let draft = store.load(forSite: siteID)
+            model = PostComposerModel(
+                descriptor: descriptor,
+                siteID: siteID,
+                client: session.makeClient(),
+                draftStore: store,
+                restoringDraft: draft?.typeID == typeID ? draft : nil
+            )
+        case .existing(let item):
+            guard let descriptor = postList?.descriptor(for: item) else {
+                loadFailure = String(localized: "This post's type isn't one this app can edit.")
+                return
+            }
+            do {
+                model = try await PostComposerModel.openExisting(
+                    url: item.id,
+                    descriptor: descriptor,
+                    siteID: siteID,
+                    client: session.makeClient()
+                )
+            } catch {
+                loadFailure = String(localized: "The post couldn't be loaded from your site.")
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteMobile/SiteSplitScreen.swift
+++ b/Sources/AnglesiteMobile/SiteSplitScreen.swift
@@ -7,13 +7,14 @@ import AnglesiteCore
 /// iPad (sites/content-types sidebar, post list, composer), collapsing to a single
 /// `NavigationStack` on iPhone. Single scene, no multi-window for v1.
 ///
-/// Sessions come from a ``MicropubSessionProviding`` — the seam the IndieAuth onboarding issue
-/// (#868) fills in. Until a site has a session, its panes show the sign-in-required state; there
-/// is no unauthenticated browse path (design §6).
+/// Sessions come from a ``MicropubSessionProviding`` — in production
+/// ``StoredMicropubSessions``, which assembles a session from the credential the IndieAuth
+/// onboarding flow (#868) stored plus a fresh endpoint discovery. A site with no stored
+/// credential shows `SiteSignInScreen` in the content pane; there is no unauthenticated browse
+/// path (design §6).
 struct SiteSplitScreen: View {
-    /// The session source; the default reads every site as signed out until #868's provider
-    /// replaces it.
-    var sessions: any MicropubSessionProviding = NoMicropubSessions()
+    /// The session source; previews/tests can substitute ``NoMicropubSessions`` or a fake.
+    var sessions: any MicropubSessionProviding = StoredMicropubSessions()
 
     @State private var sitePicker = SitePickerModel()
     @State private var selectedSite: SitePickerModel.DiscoveredSite?
@@ -177,7 +178,13 @@ struct SiteSplitScreen: View {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .signedOut:
-                signInRequired
+                // #868's onboarding flow, embedded: when it lands signed-in, re-resolve so
+                // the freshly stored credential becomes this shell's session.
+                if let site = selectedSite {
+                    SiteSignInScreen(site: site) {
+                        Task { await resolveSession() }
+                    }
+                }
             case .ready:
                 if let postList {
                     PostListScreen(
@@ -206,16 +213,6 @@ struct SiteSplitScreen: View {
             selection = .new(typeID: selectedTypeID ?? "note")
         } label: {
             Label("New Post", systemImage: "square.and.pencil")
-        }
-    }
-
-    /// The conformance/onboarding gate state: names the requirement instead of degrading
-    /// silently (design §1/§7). The actual sign-in flow is #868's.
-    private var signInRequired: some View {
-        ContentUnavailableView {
-            Label("Sign In to Post", systemImage: "person.badge.key")
-        } description: {
-            Text("Posting to this site needs a sign-in with your site itself. Site sign-in arrives with IndieAuth onboarding.")
         }
     }
 
@@ -251,7 +248,7 @@ struct SiteSplitScreen: View {
             return
         }
         sessionState = .checking
-        let resolved = await sessions.session(forSite: site.id)
+        let resolved = await sessions.session(for: site)
         // The site may have changed while resolving; only publish for the current one.
         guard site == selectedSite else { return }
         if let resolved {

--- a/Sources/AnglesiteMobile/SiteSplitScreen.swift
+++ b/Sources/AnglesiteMobile/SiteSplitScreen.swift
@@ -309,17 +309,35 @@ private struct ComposerPane: View {
                 return
             }
             let store = ComposerDraftStore()
-            let draft = store.load(forSite: siteID)
             model = PostComposerModel(
                 descriptor: descriptor,
                 siteID: siteID,
                 client: session.makeClient(),
                 draftStore: store,
-                restoringDraft: draft?.typeID == typeID ? draft : nil
+                // Only a genuinely-new draft of this type restores here — a queued *update*
+                // to an existing post must never resume from the "New Post" entry point
+                // (#1370 review); it surfaces when that post itself is reopened, below.
+                restoringDraft: store.loadNewDraft(forSite: siteID, typeID: typeID)
             )
         case .existing(let item):
             guard let descriptor = postList?.descriptor(for: item) else {
                 loadFailure = String(localized: "This post's type isn't one this app can edit.")
+                return
+            }
+            let store = ComposerDraftStore()
+            // A queued/pending edit for this very post takes precedence over the server copy:
+            // reopening the post is the natural recovery path after a failed send, so the
+            // pending edit (and its waiting-for-network state) must be discoverable here, not
+            // hidden behind a fresh fetch (#1370 review).
+            if let pending = store.loadDraft(forSite: siteID, postURL: item.id),
+               pending.typeID == descriptor.id {
+                model = PostComposerModel(
+                    descriptor: descriptor,
+                    siteID: siteID,
+                    client: session.makeClient(),
+                    draftStore: store,
+                    restoringDraft: pending
+                )
                 return
             }
             do {
@@ -327,7 +345,8 @@ private struct ComposerPane: View {
                     url: item.id,
                     descriptor: descriptor,
                     siteID: siteID,
-                    client: session.makeClient()
+                    client: session.makeClient(),
+                    draftStore: store
                 )
             } catch {
                 loadFailure = String(localized: "The post couldn't be loaded from your site.")

--- a/Tests/AnglesiteCoreTests/MicropubComposerProjectionTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubComposerProjectionTests.swift
@@ -1,0 +1,178 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Exercises the composer's write-direction projection (#869) against every
+/// `ContentTypeField.Kind`, and its round-trip through `MicropubContentSync`'s read direction —
+/// the two halves that keep a phone-composed post and its git-synced file from diverging.
+struct MicropubComposerProjectionTests {
+    /// A synthetic descriptor declaring every field kind, each mapped to an mf2 property —
+    /// broader than any single built-in type, so the per-kind matrix is exhaustive by
+    /// construction rather than by whichever kinds the built-ins happen to use.
+    private static let everyKind = ContentTypeDescriptor(
+        id: "everyKind",
+        displayName: "Every Kind",
+        storage: .collection("mixed"),
+        fields: [
+            ContentTypeField("title", .string, required: true),
+            ContentTypeField("lang", .language),
+            ContentTypeField("summary", .text),
+            ContentTypeField("body", .markdown, required: true),
+            ContentTypeField("publishDate", .datetime, required: true),
+            ContentTypeField("day", .date),
+            ContentTypeField("flagged", .bool),
+            ContentTypeField("link", .url),
+            ContentTypeField("hero", .image),
+            ContentTypeField("rating", .number),
+            ContentTypeField("tags", .stringArray),
+            ContentTypeField("photos", .imageArray),
+            ContentTypeField(
+                "jobs", .objectArray(fields: [ContentTypeField("role", .string)])),
+            ContentTypeField("draft", .bool),
+        ],
+        projections: ContentTypeProjections(
+            microformat: "h-entry",
+            microformatProperties: [
+                "title": "p-name",
+                "lang": "p-lang",
+                "summary": "p-summary",
+                "body": "e-content",
+                "publishDate": "dt-published",
+                "day": "dt-day",
+                "flagged": "p-flagged",
+                "link": "u-link",
+                "hero": "u-hero",
+                "rating": "p-rating",
+                "tags": "p-category",
+                "photos": "u-photo",
+                "jobs": "p-jobs",
+            ],
+            schemaType: nil
+        )
+    )
+
+    private static func filledValues() -> TypedContentEditor.Values {
+        var values = TypedContentEditor.Values()
+        values["title"] = .text("Hello World")
+        values["lang"] = .text("fr")
+        values["summary"] = .text("A summary")
+        values["body"] = .text("It's — \"quoted\"\nline two\t✨ `code`")
+        values["publishDate"] = .date(Date(timeIntervalSince1970: 1_721_558_400))
+        values["day"] = .date(Date(timeIntervalSince1970: 1_721_520_000))   // midnight UTC
+        values["flagged"] = .flag(true)
+        values["link"] = .text("https://elsewhere.example/thing")
+        values["hero"] = .text("https://owner.example/media/hero.jpg")
+        values["rating"] = .number(4)
+        values["tags"] = .list(["alpha", "beta"])
+        values["photos"] = .list(["https://owner.example/media/a.jpg"])
+        values["jobs"] = .records([["role": .text("Engineer")]])
+        values["draft"] = .flag(false)
+        return values
+    }
+
+    @Test("every mapped kind projects to its mf2 property; draft rides post-status")
+    func projectsEveryKind() {
+        let properties = MicropubComposerProjection.properties(
+            for: Self.everyKind, values: Self.filledValues(), status: .draft)
+
+        #expect(properties["name"] == [.string("Hello World")])
+        #expect(properties["lang"] == [.string("fr")])
+        #expect(properties["summary"] == [.string("A summary")])
+        #expect(properties["content"] == [.string("It's — \"quoted\"\nline two\t✨ `code`")])
+        #expect(properties["published"] == [.string("2024-07-21T10:40:00.000Z")])
+        #expect(properties["day"] == [.string("2024-07-21")])
+        #expect(properties["flagged"] == [.bool(true)])
+        #expect(properties["link"] == [.string("https://elsewhere.example/thing")])
+        #expect(properties["hero"] == [.string("https://owner.example/media/hero.jpg")])
+        #expect(properties["rating"] == [.int(4)])
+        #expect(properties["category"] == [.string("alpha"), .string("beta")])
+        #expect(properties["photo"] == [.string("https://owner.example/media/a.jpg")])
+        // objectArray has no wire form (no built-in collection type declares one; the read
+        // direction doesn't reconstruct nested mf2 either) — omitted, not flattened.
+        #expect(properties["jobs"] == nil)
+        // draft's wire form is the Post Status extension's property, not an mf2 property.
+        #expect(properties["draft"] == nil)
+        #expect(properties["post-status"] == [.string("draft")])
+    }
+
+    @Test("a non-integral number projects as a JSON double")
+    func nonIntegralNumber() {
+        let encoded = MicropubComposerProjection.mf2Values(for: .number(4.5), kind: .number)
+        #expect(encoded == [.double(4.5)])
+    }
+
+    @Test("empty and unset values are omitted, never sent as blank scalars")
+    func emptyValuesOmitted() {
+        var values = TypedContentEditor.Values()
+        values["title"] = .text("Required Title")
+        values["body"] = .text("Body")
+        values["publishDate"] = .date(Date(timeIntervalSince1970: 1_721_558_400))
+        values["summary"] = .text("")
+        values["day"] = .date(nil)
+        values["rating"] = .number(nil)
+        values["tags"] = .list([])
+        values["photos"] = .list(["", ""])   // blank rows a form's Add button left behind
+        let properties = MicropubComposerProjection.properties(
+            for: Self.everyKind, values: values, status: .published)
+
+        #expect(properties["summary"] == nil)
+        #expect(properties["day"] == nil)
+        #expect(properties["rating"] == nil)
+        #expect(properties["category"] == nil)
+        #expect(properties["photo"] == nil)
+        #expect(properties["post-status"] == [.string("published")])
+    }
+
+    @Test("mappedProperties lists every wire property except draft's")
+    func mappedPropertiesListsWireForms() {
+        let mapped = MicropubComposerProjection.mappedProperties(for: Self.everyKind)
+        #expect(mapped == [
+            "name", "lang", "summary", "content", "published", "day", "flagged", "link",
+            "hero", "rating", "category", "photo", "jobs",
+        ])
+    }
+
+    @Test("a composed post round-trips through the sync bridge's read direction")
+    func roundTripsThroughSyncBridge() throws {
+        let original = Self.filledValues()
+        let properties = MicropubComposerProjection.properties(
+            for: Self.everyKind, values: original, status: .draft)
+        let decoded = try #require(MicropubContentSync.values(
+            for: Self.everyKind, properties: properties,
+            updatedAt: 0, slug: "hello-world"))
+
+        for name in ["title", "lang", "summary", "body", "link", "hero"] {
+            #expect(decoded[name] == original[name], "field \(name)")
+        }
+        #expect(decoded["publishDate"] == original["publishDate"])
+        #expect(decoded["day"] == original["day"])
+        #expect(decoded["rating"] == original["rating"])
+        #expect(decoded["tags"] == original["tags"])
+        #expect(decoded["photos"] == original["photos"])
+        // post-status: draft → the draft flag, the sync bridge's special case.
+        #expect(decoded["draft"] == .flag(true))
+        // Documented one-way gaps, not silent drops: records have no wire form (decode
+        // reconstructs the empty default), and a mapped bool decodes through the read
+        // direction's defense-in-depth arm.
+        #expect(decoded["jobs"] == .records([]))
+        #expect(decoded["flagged"] == .flag(false))
+    }
+
+    @Test("the Markdown body survives the wire byte-identically")
+    func bodySurvivesByteIdentically() throws {
+        // The compose surface's parity contract (#869): the plain-text editor path never
+        // transforms the body, so what was typed is what q=source hands back — including the
+        // smart-quote bait, mixed line endings, and emoji a styled editor might normalize.
+        let body = "It's — \"quoted\"\r\nline two\nreste à voir…\t✨ `code` \u{202F}thin"
+        var values = TypedContentEditor.Values()
+        values["title"] = .text("Parity")
+        values["body"] = .text(body)
+        values["publishDate"] = .date(Date(timeIntervalSince1970: 1_721_558_400))
+        let properties = MicropubComposerProjection.properties(
+            for: Self.everyKind, values: values, status: .draft)
+        let decoded = try #require(MicropubContentSync.values(
+            for: Self.everyKind, properties: properties, updatedAt: 0, slug: "parity"))
+        let roundTripped = decoded["body"]
+        #expect(roundTripped == .text(body))
+    }
+}

--- a/Tests/AnglesiteIOSTests/PostComposerModelTests.swift
+++ b/Tests/AnglesiteIOSTests/PostComposerModelTests.swift
@@ -1,0 +1,421 @@
+import Testing
+import Foundation
+// URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin platforms
+// (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import AnglesiteIOS
+@testable import AnglesiteCore
+
+/// A swappable `MicropubClient.Transport`: tests route requests by method/query and swap the
+/// handler mid-test (e.g. heal the network after a failure) — the same faked-seam style as
+/// `MicropubClientTests`, one level up.
+private final class TransportBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _handler: @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+
+    init(_ handler: @escaping @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)) {
+        _handler = handler
+    }
+
+    var handler: @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse) {
+        get { lock.withLock { _handler } }
+        set { lock.withLock { _handler = newValue } }
+    }
+
+    var transport: MicropubClient.Transport {
+        { [self] request in try await handler(request) }
+    }
+}
+
+/// Drives `PostComposerModel`'s publish state machine (#869) against a faked transport: the
+/// foreground-first send, the retryable-failure → queued-draft → retry path, the auth and
+/// terminal failures, and compare-and-swap conflict resolution.
+@MainActor
+struct PostComposerModelTests {
+    nonisolated private static let endpoint = URL(string: "https://owner.example/micropub")!
+    nonisolated private static let postURL = URL(string: "https://owner.example/notes/first-note")!
+
+    nonisolated private static func response(
+        _ code: Int, url: URL = endpoint, headers: [String: String]? = nil
+    ) -> HTTPURLResponse {
+        HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: headers)!
+    }
+
+    nonisolated private static func sourceJSON(properties: [String: Any]) -> Data {
+        try! JSONSerialization.data(withJSONObject: [
+            "type": ["h-entry"], "properties": properties,
+        ])
+    }
+
+    nonisolated private static func isSourceFetch(_ request: URLRequest) -> Bool {
+        request.httpMethod == "GET"
+            && request.url?.query()?.contains("q=source") == true
+    }
+
+    private static func scratchStore() -> ComposerDraftStore {
+        ComposerDraftStore(
+            directory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("composer-tests-\(UUID().uuidString)", isDirectory: true))
+    }
+
+    private static func noteDescriptor() -> ContentTypeDescriptor {
+        ContentTypeRegistry.default.descriptor(id: "note")!
+    }
+
+    private static func model(
+        transport: @escaping MicropubClient.Transport,
+        store: ComposerDraftStore = scratchStore(),
+        siteID: UUID = UUID()
+    ) -> PostComposerModel {
+        PostComposerModel(
+            descriptor: noteDescriptor(),
+            siteID: siteID,
+            client: MicropubClient(
+                endpoint: endpoint, mediaEndpoint: URL(string: "https://owner.example/media"),
+                accessToken: "tok", dpopKeyPair: DPoPKeyPair(), transport: transport),
+            draftStore: store
+        )
+    }
+
+    // MARK: - Foreground-first send
+
+    @Test("a successful save lands savedDraft with the created post's URL")
+    func saveDraftCreates() async throws {
+        // The create is a POST; the post-create baseline re-fetch is a q=source GET.
+        let box = TransportBox { request in
+            if Self.isSourceFetch(request) {
+                return (Self.sourceJSON(properties: ["content": ["hi"]]), Self.response(200))
+            }
+            #expect(request.httpMethod == "POST")
+            return (Data(), Self.response(201, headers: ["Location": Self.postURL.absoluteString]))
+        }
+        let model = Self.model(transport: box.transport)
+        model.values["body"] = .text("hi")
+
+        await model.saveDraft()
+
+        let phase = model.phase
+        #expect(phase == .savedDraft(Self.postURL))
+        let url = model.postURL
+        #expect(url == Self.postURL)
+    }
+
+    @Test("publish lands publishedRebuilding — the bake-in-flight state, no faked live URL")
+    func publishShowsRebuilding() async {
+        let box = TransportBox { request in
+            if Self.isSourceFetch(request) {
+                return (Self.sourceJSON(properties: ["content": ["hi"]]), Self.response(200))
+            }
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+                as? [String: Any]
+            let properties = body?["properties"] as? [String: [Any]]
+            #expect(properties?["post-status"] as? [String] == ["published"])
+            return (Data(), Self.response(201, headers: ["Location": Self.postURL.absoluteString]))
+        }
+        let model = Self.model(transport: box.transport)
+        model.values["body"] = .text("hi")
+
+        await model.publish()
+
+        let phase = model.phase
+        #expect(phase == .publishedRebuilding(Self.postURL))
+    }
+
+    // MARK: - Failure routing (#867's taxonomy, surfaced as phases)
+
+    @Test("a 401 routes to authRequired — an IndieAuth matter, not a network failure")
+    func unauthorizedRoutesToReauth() async {
+        let box = TransportBox { _ in (Data(), Self.response(401)) }
+        let model = Self.model(transport: box.transport)
+        model.values["body"] = .text("hi")
+
+        await model.saveDraft()
+
+        let phase = model.phase
+        #expect(phase == .authRequired)
+    }
+
+    @Test("a terminal 4xx routes to failed, not the offline queue")
+    func terminalFailureNotQueued() async {
+        let store = Self.scratchStore()
+        let siteID = UUID()
+        let box = TransportBox { _ in (Data(), Self.response(422)) }
+        let model = Self.model(transport: box.transport, store: store, siteID: siteID)
+        model.values["body"] = .text("hi")
+
+        await model.saveDraft()
+
+        guard case .failed = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        let queued = store.load(forSite: siteID)
+        #expect(queued == nil)
+    }
+
+    @Test("a 5xx queues the draft locally with the explicit waiting-for-network state")
+    func retryableFailureQueuesDraft() async throws {
+        let store = Self.scratchStore()
+        let siteID = UUID()
+        let box = TransportBox { _ in (Data(), Self.response(503)) }
+        let model = Self.model(transport: box.transport, store: store, siteID: siteID)
+        model.values["body"] = .text("composed offline")
+
+        await model.publish()
+
+        let phase = model.phase
+        #expect(phase == .waitingForNetwork)
+        let queued = try #require(store.load(forSite: siteID))
+        #expect(queued.queuedStatus == "published")
+        let body = queued.editorValues["body"]
+        #expect(body == .text("composed offline"))
+    }
+
+    @Test("an unreachable network queues the same way")
+    func unreachableQueuesDraft() async {
+        let box = TransportBox { _ in throw URLError(.notConnectedToInternet) }
+        let model = Self.model(transport: box.transport)
+        model.values["body"] = .text("hi")
+
+        await model.saveDraft()
+
+        let phase = model.phase
+        #expect(phase == .waitingForNetwork)
+    }
+
+    @Test("retry after the network heals sends the queued status and clears the local draft")
+    func retryAfterHealing() async {
+        let store = Self.scratchStore()
+        let siteID = UUID()
+        let box = TransportBox { _ in (Data(), Self.response(503)) }
+        let model = Self.model(transport: box.transport, store: store, siteID: siteID)
+        model.values["body"] = .text("hi")
+        await model.publish()
+
+        box.handler = { request in
+            if Self.isSourceFetch(request) {
+                return (Self.sourceJSON(properties: ["content": ["hi"]]), Self.response(200))
+            }
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+                as? [String: Any]
+            let properties = body?["properties"] as? [String: [Any]]
+            // The retried send must carry the status that was queued, not a default.
+            #expect(properties?["post-status"] as? [String] == ["published"])
+            return (Data(), Self.response(201, headers: ["Location": Self.postURL.absoluteString]))
+        }
+        await model.retry()
+
+        let phase = model.phase
+        #expect(phase == .publishedRebuilding(Self.postURL))
+        let queued = store.load(forSite: siteID)
+        #expect(queued == nil)
+    }
+
+    @Test("a queued draft restores into waitingForNetwork across a relaunch")
+    func queuedDraftRestores() {
+        let siteID = UUID()
+        let draft = ComposerDraft(
+            siteID: siteID, typeID: "note", postURL: nil,
+            values: ["body": .text("restored body")], queuedStatus: "draft")
+        let box = TransportBox { _ in (Data(), Self.response(500)) }
+        let model = PostComposerModel(
+            descriptor: Self.noteDescriptor(), siteID: siteID,
+            client: MicropubClient(
+                endpoint: Self.endpoint, accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+                transport: box.transport),
+            draftStore: Self.scratchStore(),
+            restoringDraft: draft)
+
+        let phase = model.phase
+        #expect(phase == .waitingForNetwork)
+        let body = model.values["body"]
+        #expect(body == .text("restored body"))
+    }
+
+    // MARK: - Editing an existing post (q=source + compare-and-swap)
+
+    private static func existingModel(box: TransportBox) async throws -> PostComposerModel {
+        try await PostComposerModel.openExisting(
+            url: postURL,
+            descriptor: noteDescriptor(),
+            siteID: UUID(),
+            client: MicropubClient(
+                endpoint: endpoint, accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+                transport: box.transport),
+            draftStore: scratchStore()
+        )
+    }
+
+    @Test("openExisting decodes the q=source post into form values")
+    func openExistingDecodes() async throws {
+        let box = TransportBox { request in
+            #expect(Self.isSourceFetch(request))
+            return (
+                Self.sourceJSON(properties: [
+                    "content": ["the body"], "category": ["one", "two"],
+                    "post-status": ["draft"],
+                ]),
+                Self.response(200)
+            )
+        }
+        let model = try await Self.existingModel(box: box)
+
+        let body = model.values["body"]
+        #expect(body == .text("the body"))
+        let tags = model.values["tags"]
+        #expect(tags == .list(["one", "two"]))
+        let url = model.postURL
+        #expect(url == Self.postURL)
+    }
+
+    @Test("a server copy that changed since the baseline surfaces as a conflict, not an update")
+    func concurrentEditConflicts() async throws {
+        let baseline: [String: Any] = ["content": ["original"]]
+        let box = TransportBox { _ in
+            (Self.sourceJSON(properties: baseline), Self.response(200))
+        }
+        let model = try await Self.existingModel(box: box)
+        model.values["body"] = .text("my edit")
+
+        // Another device edited the post: the pre-update CAS re-fetch now sees a new copy.
+        let theirs: [String: Any] = ["content": ["their newer edit"]]
+        box.handler = { request in
+            #expect(Self.isSourceFetch(request), "no update may be sent on a conflict")
+            return (Self.sourceJSON(properties: theirs), Self.response(200))
+        }
+        await model.saveDraft()
+
+        guard case .conflict(let theirPost) = model.phase else {
+            Issue.record("expected .conflict, got \(model.phase)")
+            return
+        }
+        let theirContent = theirPost.firstString("content")
+        #expect(theirContent == "their newer edit")
+    }
+
+    @Test("takeTheirs adopts the site's version and returns to editing")
+    func takeTheirsAdopts() async throws {
+        let box = TransportBox { _ in
+            (Self.sourceJSON(properties: ["content": ["original"]]), Self.response(200))
+        }
+        let model = try await Self.existingModel(box: box)
+        model.values["body"] = .text("my edit")
+        box.handler = { _ in
+            (Self.sourceJSON(properties: ["content": ["their newer edit"]]), Self.response(200))
+        }
+        await model.saveDraft()
+
+        model.takeTheirs()
+
+        let phase = model.phase
+        #expect(phase == .editing)
+        let body = model.values["body"]
+        #expect(body == .text("their newer edit"))
+    }
+
+    @Test("keepMine re-sends over the site's version after re-baselining")
+    func keepMineOverwrites() async throws {
+        let box = TransportBox { _ in
+            (Self.sourceJSON(properties: ["content": ["original"]]), Self.response(200))
+        }
+        let model = try await Self.existingModel(box: box)
+        model.values["body"] = .text("my edit")
+        let theirs: [String: Any] = ["content": ["their newer edit"]]
+        box.handler = { _ in (Self.sourceJSON(properties: theirs), Self.response(200)) }
+        await model.saveDraft()
+
+        // The site still holds "theirs"; keeping mine must now update straight over it.
+        nonisolated(unsafe) var updateBody: [String: Any]?
+        box.handler = { request in
+            if Self.isSourceFetch(request) {
+                return (Self.sourceJSON(properties: theirs), Self.response(200))
+            }
+            updateBody = try JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+                as? [String: Any]
+            return (Data(), Self.response(204))
+        }
+        await model.keepMine()
+
+        let phase = model.phase
+        #expect(phase == .savedDraft(Self.postURL))
+        let action = updateBody?["action"] as? String
+        #expect(action == "update")
+        let replaced = (updateBody?["replace"] as? [String: [Any]])?["content"] as? [String]
+        #expect(replaced == ["my edit"])
+    }
+
+    @Test("clearing a mapped field deletes its property; unmapped properties stay untouched")
+    func clearedFieldsDelete() async throws {
+        let box = TransportBox { _ in
+            (
+                Self.sourceJSON(properties: [
+                    "content": ["body"], "category": ["old-tag"],
+                    "syndication": ["https://social.example/123"],   // another client's property
+                ]),
+                Self.response(200)
+            )
+        }
+        let model = try await Self.existingModel(box: box)
+        model.values["tags"] = .list([])   // owner cleared the tags in the form
+
+        nonisolated(unsafe) var updateBody: [String: Any]?
+        box.handler = { request in
+            if Self.isSourceFetch(request) {
+                return (
+                    Self.sourceJSON(properties: [
+                        "content": ["body"], "category": ["old-tag"],
+                        "syndication": ["https://social.example/123"],
+                    ]),
+                    Self.response(200)
+                )
+            }
+            updateBody = try JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+                as? [String: Any]
+            return (Data(), Self.response(204))
+        }
+        await model.saveDraft()
+
+        let deleted = updateBody?["delete"] as? [String]
+        #expect(deleted == ["category"])
+        let replace = updateBody?["replace"] as? [String: [Any]]
+        #expect(replace?["syndication"] == nil)
+    }
+
+    // MARK: - Media guard (§7: error handling before the upload, not compression UX)
+
+    @Test("the media guard rejects before any request; a passing image uploads")
+    func mediaGuardAndUpload() async throws {
+        nonisolated(unsafe) var requestCount = 0
+        let box = TransportBox { _ in
+            requestCount += 1
+            return (Data(), Self.response(
+                201, headers: ["Location": "https://owner.example/media/a.jpg"]))
+        }
+        let model = Self.model(transport: box.transport)
+
+        await #expect(throws: PostComposerModel.MediaUploadError.rejected(.empty)) {
+            _ = try await model.uploadImage(data: Data(), filename: "a.jpg", mimeType: "image/jpeg")
+        }
+        await #expect(throws: PostComposerModel.MediaUploadError.rejected(
+            .unsupportedFormat(mimeType: "image/heic"))
+        ) {
+            _ = try await model.uploadImage(
+                data: Data([1]), filename: "a.heic", mimeType: "image/heic")
+        }
+        let oversized = Data(count: MediaUploadGuard.maximumBytes + 1)
+        await #expect(throws: PostComposerModel.MediaUploadError.rejected(
+            .tooLarge(bytes: oversized.count))
+        ) {
+            _ = try await model.uploadImage(
+                data: oversized, filename: "a.jpg", mimeType: "image/jpeg")
+        }
+        #expect(requestCount == 0, "rejections must never reach the network")
+
+        let url = try await model.uploadImage(
+            data: Data([0xFF, 0xD8]), filename: "a.jpg", mimeType: "image/jpeg")
+        #expect(url == URL(string: "https://owner.example/media/a.jpg")!)
+        #expect(requestCount == 1)
+    }
+}

--- a/Tests/AnglesiteIOSTests/PostComposerModelTests.swift
+++ b/Tests/AnglesiteIOSTests/PostComposerModelTests.swift
@@ -83,11 +83,8 @@ struct PostComposerModelTests {
 
     @Test("a successful save lands savedDraft with the created post's URL")
     func saveDraftCreates() async throws {
-        // The create is a POST; the post-create baseline re-fetch is a q=source GET.
+        // A create is exactly one POST — the CAS baseline is constructed locally, no refetch.
         let box = TransportBox { request in
-            if Self.isSourceFetch(request) {
-                return (Self.sourceJSON(properties: ["content": ["hi"]]), Self.response(200))
-            }
             #expect(request.httpMethod == "POST")
             return (Data(), Self.response(201, headers: ["Location": Self.postURL.absoluteString]))
         }
@@ -151,7 +148,7 @@ struct PostComposerModelTests {
             Issue.record("expected .failed, got \(model.phase)")
             return
         }
-        let queued = store.load(forSite: siteID)
+        let queued = store.loadNewDraft(forSite: siteID, typeID: "note")
         #expect(queued == nil)
     }
 
@@ -167,7 +164,7 @@ struct PostComposerModelTests {
 
         let phase = model.phase
         #expect(phase == .waitingForNetwork)
-        let queued = try #require(store.load(forSite: siteID))
+        let queued = try #require(store.loadNewDraft(forSite: siteID, typeID: "note"))
         #expect(queued.queuedStatus == "published")
         let body = queued.editorValues["body"]
         #expect(body == .text("composed offline"))
@@ -209,7 +206,7 @@ struct PostComposerModelTests {
 
         let phase = model.phase
         #expect(phase == .publishedRebuilding(Self.postURL))
-        let queued = store.load(forSite: siteID)
+        let queued = store.loadNewDraft(forSite: siteID, typeID: "note")
         #expect(queued == nil)
     }
 
@@ -417,5 +414,212 @@ struct PostComposerModelTests {
             data: Data([0xFF, 0xD8]), filename: "a.jpg", mimeType: "image/jpeg")
         #expect(url == URL(string: "https://owner.example/media/a.jpg")!)
         #expect(requestCount == 1)
+    }
+
+    // MARK: - #1370 review regressions
+
+    @Test("a terminal 4xx on retry clears the previously queued draft")
+    func terminalRetryClearsQueuedDraft() async {
+        let store = Self.scratchStore()
+        let siteID = UUID()
+        let box = TransportBox { _ in (Data(), Self.response(503)) }
+        let model = Self.model(transport: box.transport, store: store, siteID: siteID)
+        model.values["body"] = .text("hi")
+        await model.saveDraft()
+        #expect(store.loadNewDraft(forSite: siteID, typeID: "note") != nil)
+
+        // The retry is answered with a validation rejection: the payload can never succeed,
+        // so the on-disk draft must not resurrect it as "waiting for network" next launch.
+        box.handler = { _ in (Data(), Self.response(422)) }
+        await model.retry()
+
+        guard case .failed = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        let queued = store.loadNewDraft(forSite: siteID, typeID: "note")
+        #expect(queued == nil)
+    }
+
+    @Test("CAS survives a completed update — no refetch, baseline constructed locally")
+    func casSurvivesCompletedUpdate() async throws {
+        let original: [String: Any] = ["content": ["original"], "category": ["keep-me"]]
+        nonisolated(unsafe) var capturedReplace: [String: [Any]]?
+        let box = TransportBox { request in
+            if Self.isSourceFetch(request) {
+                return (Self.sourceJSON(properties: original), Self.response(200))
+            }
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+                as? [String: Any]
+            capturedReplace = body?["replace"] as? [String: [Any]]
+            return (Data(), Self.response(204))
+        }
+        let model = try await Self.existingModel(box: box)
+        model.values["body"] = .text("first edit")
+        await model.saveDraft()
+        let firstPhase = model.phase
+        #expect(firstPhase == .savedDraft(Self.postURL))
+
+        // The server now holds exactly what the update wrote. The next save's CAS fetch
+        // returns that state — it must match the locally-constructed baseline (which the old
+        // `try?`-refetch code silently nulled on any blip), so no conflict fires...
+        var serverNow = original
+        for (name, values) in capturedReplace ?? [:] { serverNow[name] = values }
+        model.resumeEditing()
+        model.values["body"] = .text("second edit")
+        box.handler = { request in
+            if Self.isSourceFetch(request) {
+                return (Self.sourceJSON(properties: serverNow), Self.response(200))
+            }
+            return (Data(), Self.response(204))
+        }
+        await model.saveDraft()
+        let secondPhase = model.phase
+        #expect(secondPhase == .savedDraft(Self.postURL))
+
+        // ...while a genuinely concurrent edit still does.
+        model.resumeEditing()
+        model.values["body"] = .text("third edit")
+        box.handler = { request in
+            #expect(Self.isSourceFetch(request), "no update may be sent on a conflict")
+            return (
+                Self.sourceJSON(properties: ["content": ["their concurrent edit"]]),
+                Self.response(200)
+            )
+        }
+        await model.saveDraft()
+        guard case .conflict = model.phase else {
+            Issue.record("expected .conflict, got \(model.phase)")
+            return
+        }
+    }
+
+    @Test("cleared fields still delete on the save after a completed save")
+    func clearedFieldsDeleteAfterPriorSave() async throws {
+        let original: [String: Any] = ["content": ["body"], "category": ["old-tag"]]
+        nonisolated(unsafe) var capturedReplace: [String: [Any]]?
+        let box = TransportBox { request in
+            if Self.isSourceFetch(request) {
+                return (Self.sourceJSON(properties: original), Self.response(200))
+            }
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+                as? [String: Any]
+            capturedReplace = body?["replace"] as? [String: [Any]]
+            return (Data(), Self.response(204))
+        }
+        let model = try await Self.existingModel(box: box)
+        await model.saveDraft()
+
+        // Clear the tags only on the SECOND save: the delete is computed against the
+        // locally-updated baseline, which must still know `category` exists server-side.
+        var serverNow = original
+        for (name, values) in capturedReplace ?? [:] { serverNow[name] = values }
+        model.resumeEditing()
+        model.values["tags"] = .list([])
+        nonisolated(unsafe) var capturedDelete: [String]?
+        box.handler = { request in
+            if Self.isSourceFetch(request) {
+                return (Self.sourceJSON(properties: serverNow), Self.response(200))
+            }
+            let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+                as? [String: Any]
+            capturedDelete = body?["delete"] as? [String]
+            return (Data(), Self.response(204))
+        }
+        await model.saveDraft()
+
+        #expect(capturedDelete == ["category"])
+    }
+
+    @Test("a restored queued update keeps its CAS baseline — retry over a concurrent edit conflicts")
+    func restoredQueuedUpdateKeepsCASBaseline() async {
+        let siteID = UUID()
+        let baseline = MicropubPost(properties: ["content": [.string("original")]])
+        let draft = ComposerDraft(
+            siteID: siteID, typeID: "note", postURL: Self.postURL,
+            values: ["body": .text("my queued edit")], queuedStatus: "draft",
+            baselineJSON: ComposerDraft.encodeBaseline(baseline))
+        let box = TransportBox { request in
+            #expect(Self.isSourceFetch(request), "no update may be sent on a conflict")
+            return (
+                Self.sourceJSON(properties: ["content": ["their concurrent edit"]]),
+                Self.response(200)
+            )
+        }
+        let model = PostComposerModel(
+            descriptor: Self.noteDescriptor(), siteID: siteID,
+            client: MicropubClient(
+                endpoint: Self.endpoint, accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+                transport: box.transport),
+            draftStore: Self.scratchStore(),
+            restoringDraft: draft)
+        let restoredPhase = model.phase
+        #expect(restoredPhase == .waitingForNetwork)
+
+        await model.retry()
+
+        guard case .conflict(let theirs) = model.phase else {
+            Issue.record("expected .conflict, got \(model.phase)")
+            return
+        }
+        let theirContent = theirs.firstString("content")
+        #expect(theirContent == "their concurrent edit")
+    }
+
+    @Test("openExisting throws for a post whose required field can't be decoded")
+    func openExistingUndecodableThrows() async {
+        // `photo` requires its `image` field, which has no decode fallback — a source post
+        // without `photo` must fail the open, never silently blank the form over a live
+        // baseline (whose delete pass would then wipe the post server-side).
+        let box = TransportBox { _ in
+            (Self.sourceJSON(properties: ["summary": ["a caption, no image"]]), Self.response(200))
+        }
+        let photo = ContentTypeRegistry.default.descriptor(id: "photo")!
+        do {
+            _ = try await PostComposerModel.openExisting(
+                url: URL(string: "https://owner.example/photos/p1")!,
+                descriptor: photo,
+                siteID: UUID(),
+                client: MicropubClient(
+                    endpoint: Self.endpoint, accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+                    transport: box.transport))
+            Issue.record("expected openExisting to throw")
+        } catch let error as MicropubError {
+            guard case .decodingFailed = error else {
+                Issue.record("expected .decodingFailed, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("expected MicropubError, got \(error)")
+        }
+    }
+
+    @Test("queued-update and new-composition drafts coexist per site, each behind its own key")
+    func draftStoreKeysByIdentity() throws {
+        let store = Self.scratchStore()
+        let siteID = UUID()
+        let newNote = ComposerDraft(
+            siteID: siteID, typeID: "note", postURL: nil,
+            values: ["body": .text("fresh note")])
+        let queuedUpdate = ComposerDraft(
+            siteID: siteID, typeID: "article", postURL: Self.postURL,
+            values: ["body": .text("queued update")], queuedStatus: "published")
+        try store.save(newNote)
+        try store.save(queuedUpdate)
+
+        // Neither overwrote the other, and neither entry point sees the wrong one: "New Post"
+        // never surfaces a queued update, and the post's own reopen path finds its edit.
+        let restoredNew = store.loadNewDraft(forSite: siteID, typeID: "note")
+        #expect(restoredNew == newNote)
+        let restoredQueued = store.loadDraft(forSite: siteID, postURL: Self.postURL)
+        #expect(restoredQueued == queuedUpdate)
+        let noArticleNew = store.loadNewDraft(forSite: siteID, typeID: "article")
+        #expect(noArticleNew == nil)
+
+        store.clear(queuedUpdate)
+        let cleared = store.loadDraft(forSite: siteID, postURL: Self.postURL)
+        #expect(cleared == nil)
+        let survivor = store.loadNewDraft(forSite: siteID, typeID: "note")
+        #expect(survivor == newNote)
     }
 }

--- a/Tests/AnglesiteIOSTests/PostListModelTests.swift
+++ b/Tests/AnglesiteIOSTests/PostListModelTests.swift
@@ -1,0 +1,160 @@
+import Testing
+import Foundation
+// URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin platforms
+// (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import AnglesiteIOS
+@testable import AnglesiteCore
+
+/// Drives `PostListModel` (#869's browse surface — the `q=source` list, drafts included)
+/// against a faked transport: row mapping, per-collection filtering, and the auth/failure states.
+@MainActor
+struct PostListModelTests {
+    nonisolated private static let endpoint = URL(string: "https://owner.example/micropub")!
+
+    nonisolated private static func client(
+        _ handler: @escaping @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+    ) -> MicropubClient {
+        MicropubClient(
+            endpoint: endpoint, accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: handler)
+    }
+
+    nonisolated private static func response(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: endpoint, statusCode: code, httpVersion: nil, headerFields: nil)!
+    }
+
+    nonisolated private static func listJSON(_ items: [[String: Any]]) -> Data {
+        try! JSONSerialization.data(withJSONObject: ["items": items])
+    }
+
+    @Test("rows map title, collection, and draft state from each listed post")
+    func mapsRows() async throws {
+        let model = PostListModel(client: Self.client { _ in
+            (
+                Self.listJSON([
+                    [
+                        "type": ["h-entry"],
+                        "properties": [
+                            "name": ["Hello World"],
+                            "url": ["https://owner.example/articles/hello-world"],
+                        ],
+                    ],
+                    [
+                        "type": ["h-entry"],
+                        "properties": [
+                            "content": ["First line of a note\nSecond line"],
+                            "url": ["https://owner.example/notes/first-note"],
+                            "post-status": ["draft"],
+                        ],
+                    ],
+                ]),
+                Self.response(200)
+            )
+        })
+
+        await model.refresh()
+
+        let items = model.items
+        #expect(items.count == 2)
+        let article = try #require(items.first)
+        #expect(article.title == "Hello World")
+        #expect(article.collection == "articles")
+        #expect(article.isDraft == false)
+        let note = try #require(items.last)
+        // Title-less note: the row falls back to the content's first line.
+        #expect(note.title == "First line of a note")
+        #expect(note.collection == "notes")
+        #expect(note.isDraft == true)
+    }
+
+    @Test("filtering by collection narrows to that content type's rows")
+    func filtersByCollection() async {
+        let model = PostListModel(client: Self.client { _ in
+            (
+                Self.listJSON([
+                    [
+                        "type": ["h-entry"],
+                        "properties": [
+                            "name": ["A"], "url": ["https://owner.example/articles/a"],
+                        ],
+                    ],
+                    [
+                        "type": ["h-entry"],
+                        "properties": [
+                            "content": ["b"], "url": ["https://owner.example/notes/b"],
+                        ],
+                    ],
+                ]),
+                Self.response(200)
+            )
+        })
+        await model.refresh()
+
+        let notes = model.items(inCollection: "notes")
+        #expect(notes.map(\.title) == ["b"])
+        let all = model.items(inCollection: nil)
+        #expect(all.count == 2)
+    }
+
+    @Test("a rejected token reads as authRequired, not a generic failure")
+    func unauthorizedState() async {
+        let model = PostListModel(client: Self.client { _ in (Data(), Self.response(401)) })
+
+        await model.refresh()
+
+        let state = model.state
+        #expect(state == .authRequired)
+    }
+
+    @Test("a failed refresh keeps the previously loaded rows on screen")
+    func failedRefreshKeepsRows() async {
+        let box = FailableHandler(healthy: Self.listJSON([
+            [
+                "type": ["h-entry"],
+                "properties": ["name": ["Keep Me"], "url": ["https://owner.example/notes/keep"]],
+            ],
+        ]))
+        let model = PostListModel(client: Self.client { request in
+            try await box.handle(request)
+        })
+        await model.refresh()
+        #expect(model.items.count == 1)
+
+        await box.fail()
+        await model.refresh()
+
+        guard case .failed(_, let previous) = model.state else {
+            Issue.record("expected .failed, got \(model.state)")
+            return
+        }
+        #expect(previous.map(\.title) == ["Keep Me"])
+        let stillShowable = model.items
+        #expect(stillShowable.map(\.title) == ["Keep Me"])
+    }
+}
+
+/// Serves a healthy list until told to fail — the refresh-after-success fixture.
+private actor FailableHandler {
+    private let healthy: Data
+    private var failing = false
+
+    init(healthy: Data) {
+        self.healthy = healthy
+    }
+
+    func fail() {
+        failing = true
+    }
+
+    func handle(_ request: URLRequest) throws -> (Data, HTTPURLResponse) {
+        if failing { throw URLError(.notConnectedToInternet) }
+        return (
+            healthy,
+            HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        )
+    }
+}

--- a/Tests/AnglesiteIOSTests/StoredMicropubSessionsTests.swift
+++ b/Tests/AnglesiteIOSTests/StoredMicropubSessionsTests.swift
@@ -1,0 +1,153 @@
+import Testing
+import Foundation
+// URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin platforms
+// (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import AnglesiteIOS
+@testable import AnglesiteCore
+
+/// A dictionary-backed `SecretStore` so tests seed the `micropub:<siteID>` slots #868's
+/// onboarding writes without touching the real Keychain.
+private final class DictionarySecretStore: SecretStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [String: String] = [:]
+
+    func read(account: String) throws -> String? {
+        lock.withLock { entries[account] }
+    }
+
+    func write(_ value: String, account: String) throws {
+        lock.withLock {
+            if value.isEmpty { entries[account] = nil } else { entries[account] = value }
+        }
+    }
+
+    func delete(account: String) throws {
+        lock.withLock { entries[account] = nil }
+    }
+}
+
+/// Exercises `StoredMicropubSessions` (#869's rebase-time integration with #868): assembling a
+/// session from the stored credential + fresh endpoint discovery, per
+/// `MicropubOnboardingModel`'s restored-session contract (discovery is never persisted).
+struct StoredMicropubSessionsTests {
+    private static let site = SitePickerModel.DiscoveredSite(
+        id: UUID(),
+        displayName: "Owner Site",
+        packageURL: URL(fileURLWithPath: "/tmp/Owner.anglesite"))
+
+    private static func response(
+        _ code: Int, headers: [String: String]? = nil
+    ) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://owner.example/")!, statusCode: code,
+            httpVersion: nil, headerFields: headers)!
+    }
+
+    /// A homepage response advertising both rels the discovery requires.
+    private static let discoveryResponse: (Data, HTTPURLResponse) = (
+        Data(),
+        response(200, headers: [
+            "Link": "<https://owner.example/micropub>; rel=\"micropub\", "
+                + "<https://owner.example/.well-known/oauth-authorization-server>; rel=\"indieauth-metadata\"",
+        ])
+    )
+
+    private static func onboardedStore() throws -> DictionarySecretStore {
+        let store = DictionarySecretStore()
+        try store.writeMicropubAccessToken("stored-token", siteID: site.id.uuidString)
+        try store.writeMicropubDPoPKeyPair(DPoPKeyPair(), siteID: site.id.uuidString)
+        return store
+    }
+
+    @Test("no stored credential resolves to nil without any network I/O")
+    func noCredentialIsSignedOut() async {
+        nonisolated(unsafe) var requests = 0
+        let provider = StoredMicropubSessions(
+            secretStore: DictionarySecretStore(),
+            discovery: MicropubEndpointDiscovery(transport: { _ in
+                requests += 1
+                return Self.discoveryResponse
+            }),
+            clientTransport: { _ in
+                requests += 1
+                return (Data(), Self.response(200))
+            },
+            resolveSiteURL: { _ in "https://owner.example" }
+        )
+
+        let session = await provider.session(for: Self.site)
+
+        #expect(session == nil)
+        #expect(requests == 0, "a signed-out site must not hit the network")
+    }
+
+    @Test("a stored credential re-discovers the endpoint and probes the media endpoint")
+    func restoredSessionAssembles() async throws {
+        let provider = StoredMicropubSessions(
+            secretStore: try Self.onboardedStore(),
+            discovery: MicropubEndpointDiscovery(transport: { _ in Self.discoveryResponse }),
+            clientTransport: { request in
+                // The q=config probe presents the stored, DPoP-bound credential.
+                #expect(request.value(forHTTPHeaderField: "Authorization") == "DPoP stored-token")
+                let config = try JSONSerialization.data(withJSONObject: [
+                    "media-endpoint": "https://owner.example/media",
+                    "q": ["config", "source"],
+                ])
+                return (config, Self.response(200))
+            },
+            resolveSiteURL: { _ in "https://owner.example" }
+        )
+
+        let session = try #require(await provider.session(for: Self.site))
+
+        #expect(session.micropubEndpoint == URL(string: "https://owner.example/micropub")!)
+        #expect(session.mediaEndpoint == URL(string: "https://owner.example/media")!)
+        #expect(session.accessToken == "stored-token")
+    }
+
+    @Test("a failed q=config still yields a session, just without a media endpoint")
+    func mediaProbeFailureIsNotFatal() async throws {
+        let provider = StoredMicropubSessions(
+            secretStore: try Self.onboardedStore(),
+            discovery: MicropubEndpointDiscovery(transport: { _ in Self.discoveryResponse }),
+            clientTransport: { _ in throw URLError(.timedOut) },
+            resolveSiteURL: { _ in "https://owner.example" }
+        )
+
+        let session = try #require(await provider.session(for: Self.site))
+
+        #expect(session.mediaEndpoint == nil)
+        #expect(session.micropubEndpoint == URL(string: "https://owner.example/micropub")!)
+    }
+
+    @Test("an unreachable or rel-less site resolves to nil")
+    func discoveryFailureIsSignedOut() async throws {
+        let provider = StoredMicropubSessions(
+            secretStore: try Self.onboardedStore(),
+            discovery: MicropubEndpointDiscovery(transport: { _ in
+                (Data(), Self.response(200))   // no Link header, no rels
+            }),
+            clientTransport: { _ in (Data(), Self.response(200)) },
+            resolveSiteURL: { _ in "https://owner.example" }
+        )
+
+        let session = await provider.session(for: Self.site)
+        #expect(session == nil)
+    }
+
+    @Test("an undeployed site (no resolvable site URL) resolves to nil")
+    func undeployedSiteIsSignedOut() async throws {
+        let provider = StoredMicropubSessions(
+            secretStore: try Self.onboardedStore(),
+            discovery: MicropubEndpointDiscovery(transport: { _ in Self.discoveryResponse }),
+            clientTransport: { _ in (Data(), Self.response(200)) },
+            resolveSiteURL: { _ in nil }
+        )
+
+        let session = await provider.session(for: Self.site)
+        #expect(session == nil)
+    }
+}


### PR DESCRIPTION
Closes #869

## Summary

- **Adaptive shell (design §3):** one `NavigationSplitView` — sites/content-types sidebar, post list, composer/detail — three columns on iPad, collapsing to a `NavigationStack` on iPhone. Single scene. Sessions come from a new `MicropubSessionProviding` seam that the in-flight IndieAuth onboarding issue (#868) fills in; until then sites read as signed out and the shell names the requirement instead of degrading silently.
- **Composer + typed form:** `PostComposerModel` (AnglesiteIOS, fully unit-tested) drives a registry-driven form covering every `ContentTypeField.Kind`, with `PhotosPicker`/`fileImporter` replacing the Mac form's `NSOpenPanel` and a `MediaUploadGuard` size/format gate before every media-endpoint upload (§7 — error handling, not compression UX). The write path is a new `MicropubComposerProjection` (AnglesiteCore), the exact inverse of `MicropubContentSync`'s mf2→field mapping, so a phone-composed post resolves to identical field values when the Mac's sync bridge pulls it into git.
- **Publish model (§6/§7):** Save/Publish is an immediate foreground request. Only a retryable failure (5xx/offline) drops to a locally-queued `Codable` draft with an explicit "waiting for network" state — retried on tap or when `NWPathMonitor` sees the network return; 401/403 routes to a distinct re-auth state; concurrent edits compare-and-swap via a `q=source` re-fetch with an owner-consequences conflict dialog (never a merge UI); publishing shows "Published — site rebuilding", never a faked live preview. Browse is the `q=source` list extension, drafts included.

**Substrate spike result (the issue's ordered spike):** the design assumed `swift-markdown-engine` "already supports both AppKit and UIKit". It does not — the pinned fork **and** upstream declare `platforms: [.macOS(.v14)]` only, every view file imports AppKit, and `NativeTextViewWrapper` is `NSViewRepresentable`. Rather than block the posting client on a cross-repo engine port, the v1 body surface is a `UIViewRepresentable` over a plain `UITextView` configured to preserve Markdown byte-for-byte (smart quotes/dashes/insert-delete off — the same corruption vectors the Mac seam disables on the engine), keeping the Mac seam's shape (`$text`, `documentId`, `fitsContent`) so a styled engine can slot in later. Round-trip parity is asserted at the platform-neutral seam (see tests); the UIKit layer adds no transformation by construction.

**Scope notes:**
- The opt-in live e2e from the issue's checklist is deferred: it requires IndieAuth onboarding (#868, in flight — this PR's session seam is its integration point) plus a real Cloudflare account. The rest of the checklist is implemented.
- Background-`URLSession` retry after the app exits is the design's noted follow-up; the queued draft persists across relaunch (restores into the waiting state) and retries in-app on network return.
- Model error strings in `AnglesiteIOS` are plain (SwiftPM target, no string catalog); screen strings live in `AnglesiteMobile`'s catalog, synced per the CONTRIBUTING recipe scoped to this worktree's own `BUILD_DIR`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --filter "MicropubComposerProjectionTests|PostComposerModelTests|PostListModelTests"` — all 24 new tests pass: projection exercised against **every** `ContentTypeField.Kind` + round-trip through the sync bridge's read direction, byte-identical body parity, the full publish state machine (create/publish/401/terminal-4xx/5xx-queue/retry/restore), CAS conflict (keep-mine / take-theirs / cleared-property deletes), and the media guard.
- [x] `swift test --package-path . --skip Domain` — 3,763 swift-testing tests + every XCTest bundle (incl. `AnglesiteAppTests.xctest`) passed with zero failures before the run was killed externally mid-way through the slow live-FM tests; a clean end-to-end rerun is in flight. The `Domain*` app suites are skipped because current main **deterministically hangs** every full local `AnglesiteAppTests` run (#1366, pre-existing from #1320; fix is open PR #1367 — my first unskipped run hung 17h in exactly that suite, with the same pre-existing `DomainModelTests`/`HardenModelTests`/`DomainConfigAuditModelTests` scaffold-URL failures that PR documents). Nothing in this PR touches domain code.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile -configuration Debug -destination 'generic/platform=iOS Simulator' build` — BUILD SUCCEEDED (the CI `ios-build` lane's command).
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED (Mac app unaffected by the AnglesiteCore visibility change + new file).
- [ ] Manual smoke: not possible yet — the compose flow needs an onboarded IndieAuth session, which is #868's in-flight deliverable; the shell's signed-out and empty states are the reachable surface today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)