### PR TITLE
feat(#889): verify-then-persist Control Worker connect flow

### DIFF
--- a/Sources/AnglesiteCore/SandboxControlOnboarding.swift
+++ b/Sources/AnglesiteCore/SandboxControlOnboarding.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Drives the iOS thin client's "connect Control Worker" flow — verify the drafted Worker URL /
+/// bearer token / site ID against the Worker, persist them only if they're good, surface the
+/// reachable status, then decide whether to proceed — independent of any SwiftUI (#889).
+///
+/// Mirrors `TokenOnboarding`/`GitHubTokenOnboarding`'s verify → persist → flash → re-check-cancel →
+/// proceed ordering. Verification reuses `SandboxControlClient.status(siteID:)` — any authorized
+/// response proves the URL + token pair reaches the user's Worker; no new server API is needed.
+/// The view-model (`RemoteSessionModel`) owns the observable state; this type owns the ordering,
+/// so the "a cancelled connect must not confirm behind the user's back" rule is unit-tested under
+/// `swift test` rather than only in an iOS-hosted app test.
+///
+/// `@MainActor` so it composes naturally with `RemoteSessionModel` (also MainActor) without
+/// `Sendable` gymnastics on the closures.
+@MainActor
+public struct SandboxControlOnboarding {
+    /// The trimmed, verified field set handed to `persist` — one value object so the persist
+    /// closure can't accidentally store an untrimmed draft.
+    public struct Credentials: Equatable, Sendable {
+        /// The Worker base URL exactly as it should be persisted (trimmed draft).
+        public let workerURLString: String
+        /// The verified bearer token (trimmed draft).
+        public let token: String
+        /// The site identifier the status probe ran against (trimmed draft).
+        public let siteID: String
+
+        /// Memberwise creation, public for tests.
+        public init(workerURLString: String, token: String, siteID: String) {
+            self.workerURLString = workerURLString
+            self.token = token
+            self.siteID = siteID
+        }
+    }
+
+    /// What the flow decided — the caller's whole contract. Three-way rather than a thrown error
+    /// so "keep the form editable" (``stay(message:)``) and "user walked away" (``abort``) can't
+    /// be conflated: only an explicit cancellation skips the connected confirmation.
+    public enum Outcome: Equatable {
+        /// The Worker answered the status probe — credentials verified and persisted.
+        case proceed(SandboxStatus)
+        /// Verification (or persistence) failed — the caller keeps the form open with `message`.
+        case stay(message: String)
+        /// The user cancelled during the flow — the caller does nothing.
+        case abort
+    }
+
+    private let makeClient: (URL, String) -> any SandboxControlClient
+
+    /// The client factory is the only injected dependency — production passes
+    /// `HTTPSandboxControlClient.init`, tests a fake, keeping the flow's ordering logic testable
+    /// without network.
+    public init(makeClient: @escaping (URL, String) -> any SandboxControlClient) {
+        self.makeClient = makeClient
+    }
+
+    /// - persist: stores the verified credentials (UserDefaults + Keychain writes); only called
+    ///   on a successful verify, and a throw turns the run into `.stay`.
+    /// - onConnected: surfaces the reachable status for the success flash, before `delay`.
+    /// - delay: the success-flash pause — injectable so tests don't wait real time.
+    /// - isCancelled: re-checked after verify + delay; `true` ⇒ `.abort` (no proceed).
+    public func run(
+        workerURLString: String,
+        token: String,
+        siteID: String,
+        persist: (Credentials) throws -> Void,
+        onConnected: (SandboxStatus) -> Void,
+        delay: () async -> Void,
+        isCancelled: () -> Bool
+    ) async -> Outcome {
+        let trimmedURLString = workerURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSiteID = siteID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedURLString.isEmpty, !trimmedToken.isEmpty, !trimmedSiteID.isEmpty else {
+            return .stay(message: "Fill in the Worker URL, token, and site ID first.")
+        }
+        // Same scheme rule as `RemoteSessionModel.workerURL` — the form's start path would
+        // reject anything else, so the verify path must too.
+        guard let workerURL = URL(string: trimmedURLString), workerURL.scheme?.hasPrefix("http") == true else {
+            return .stay(message: "That Worker URL doesn’t look valid.")
+        }
+
+        let client = makeClient(workerURL, trimmedToken)
+        let status: SandboxStatus
+        do {
+            status = try await client.status(siteID: trimmedSiteID)
+        } catch SandboxControlError.unauthorized {
+            return .stay(message: "That token was rejected by the Worker.")
+        } catch SandboxControlError.unreachable(let detail) {
+            return .stay(message: "Couldn’t reach the Worker: \(detail)")
+        } catch {
+            return .stay(message: "Couldn’t verify the Worker connection. Check the URL and try again.")
+        }
+
+        do {
+            try persist(Credentials(workerURLString: trimmedURLString, token: trimmedToken, siteID: trimmedSiteID))
+        } catch {
+            return .stay(message: "Couldn’t save to Keychain: \(error)")
+        }
+        // Let the user see the Worker answered, then re-check cancellation before confirming a
+        // connection behind their back.
+        onConnected(status)
+        await delay()
+        if isCancelled() { return .abort }
+        return .proceed(status)
+    }
+}

--- a/Sources/AnglesiteCore/SandboxControlOnboarding.swift
+++ b/Sources/AnglesiteCore/SandboxControlOnboarding.swift
@@ -45,6 +45,14 @@ public struct SandboxControlOnboarding {
         case abort
     }
 
+    /// The one definition of "a usable Worker base URL" (http/https scheme required) — shared by
+    /// this flow's verify guard and `RemoteSessionModel.workerURL`, so the two paths can't drift
+    /// apart on what they accept.
+    public static func workerURL(from string: String) -> URL? {
+        guard let url = URL(string: string), url.scheme?.hasPrefix("http") == true else { return nil }
+        return url
+    }
+
     private let makeClient: (URL, String) -> any SandboxControlClient
 
     /// The client factory is the only injected dependency — production passes
@@ -74,9 +82,9 @@ public struct SandboxControlOnboarding {
         guard !trimmedURLString.isEmpty, !trimmedToken.isEmpty, !trimmedSiteID.isEmpty else {
             return .stay(message: "Fill in the Worker URL, token, and site ID first.")
         }
-        // Same scheme rule as `RemoteSessionModel.workerURL` — the form's start path would
-        // reject anything else, so the verify path must too.
-        guard let workerURL = URL(string: trimmedURLString), workerURL.scheme?.hasPrefix("http") == true else {
+        // Same rule as the form's start path (`RemoteSessionModel.workerURL`), via the shared
+        // helper so the verify and start paths can't diverge on what they accept.
+        guard let workerURL = Self.workerURL(from: trimmedURLString) else {
             return .stay(message: "That Worker URL doesn’t look valid.")
         }
 

--- a/Sources/AnglesiteMobile/Localizable.xcstrings
+++ b/Sources/AnglesiteMobile/Localizable.xcstrings
@@ -34,13 +34,22 @@
     "Choose one of your sites to see its posts." : {
 
     },
+    "Cloudflare Container Setup Guide" : {
+
+    },
     "Cloudflare Control Worker" : {
+
+    },
+    "Connect" : {
 
     },
     "Connect via Cloudflare" : {
 
     },
     "Connect your Cloudflare Worker first." : {
+
+    },
+    "Connecting…" : {
 
     },
     "Connect…" : {
@@ -88,7 +97,7 @@
     "Finding your sites…" : {
 
     },
-    "From the one-time Deploy to Cloudflare setup. The token is stored in the Keychain on this device only." : {
+    "From the one-time Cloudflare Container setup. The token is stored in the Keychain on this device only, after the Worker confirms it." : {
 
     },
     "Keep Editing" : {
@@ -152,6 +161,9 @@
 
     },
     "Published — site rebuilding." : {
+
+    },
+    "Reached your Worker" : {
 
     },
     "Refresh" : {

--- a/Sources/AnglesiteMobile/RemoteSessionModel.swift
+++ b/Sources/AnglesiteMobile/RemoteSessionModel.swift
@@ -76,6 +76,12 @@ public final class RemoteSessionModel {
             token: token,
             siteID: siteID,
             persist: { credentials in
+                // `controlToken`'s `didSet` try?-swallows Keychain errors (a `didSet` can't
+                // throw), which would turn a failed write into a false "connected" flash and a
+                // silently unconfigured app on next launch. Write the token explicitly first so
+                // a Keychain failure genuinely throws and surfaces as `.stay`; the `didSet`'s
+                // repeat write of the same value is then a harmless no-op-equivalent.
+                try self.secretStore.write(credentials.token, account: SecretAccounts.sandboxControlToken)
                 self.workerURLString = credentials.workerURLString
                 self.controlToken = credentials.token
                 self.siteID = credentials.siteID
@@ -147,9 +153,10 @@ public final class RemoteSessionModel {
 
     /// ``workerURLString`` parsed and validated (http/https scheme required); `nil` while the
     /// field is empty or malformed. The form binds the string, everything else consumes this.
+    /// Delegates to the shared rule in `SandboxControlOnboarding` so the start and verify paths
+    /// can't drift on what they accept.
     public var workerURL: URL? {
-        guard let url = URL(string: workerURLString), url.scheme?.hasPrefix("http") == true else { return nil }
-        return url
+        SandboxControlOnboarding.workerURL(from: workerURLString)
     }
 
     /// ``gitRemoteString`` parsed and validated (any scheme accepted — https and ssh remotes are

--- a/Sources/AnglesiteMobile/RemoteSessionModel.swift
+++ b/Sources/AnglesiteMobile/RemoteSessionModel.swift
@@ -41,6 +41,58 @@ public final class RemoteSessionModel {
         }
     }
 
+    // MARK: Connect flow
+
+    /// Progress of the verify-then-persist connect flow (#889), consumed by the connect form's
+    /// status line. Mirrors `DeployModel.TokenVerification` on macOS.
+    public enum ConnectionCheck: Equatable {
+        /// Nothing in flight — the form's resting state.
+        case idle
+        /// The status probe against the drafted Worker URL + token is running.
+        case checking
+        /// The Worker answered — the success flash, before settling back to ``idle``.
+        case connected
+        /// Verification failed; the form stays editable with `message` inline.
+        case failed(message: String)
+    }
+
+    /// SwiftUI-observable progress of the connect flow. Only ``connect(workerURLString:token:siteID:)``
+    /// writes it.
+    public private(set) var connectionCheck: ConnectionCheck = .idle
+
+    /// Verify the drafted Worker URL / token / site ID against the Worker, and persist them into
+    /// the existing stores (UserDefaults / Keychain, via the property `didSet`s) only if the
+    /// Worker answers. The drafts live in the form; nothing here is stored until verification
+    /// succeeds — the whole point of #889's verify-then-persist rework.
+    public func connect(workerURLString: String, token: String, siteID: String) async {
+        guard connectionCheck != .checking else { return }
+        connectionCheck = .checking
+
+        let onboarding = SandboxControlOnboarding(makeClient: {
+            HTTPSandboxControlClient(workerBaseURL: $0, apiToken: $1)
+        })
+        let outcome = await onboarding.run(
+            workerURLString: workerURLString,
+            token: token,
+            siteID: siteID,
+            persist: { credentials in
+                self.workerURLString = credentials.workerURLString
+                self.controlToken = credentials.token
+                self.siteID = credentials.siteID
+            },
+            onConnected: { _ in self.connectionCheck = .connected },
+            delay: { try? await Task.sleep(for: .milliseconds(700)) },
+            isCancelled: { Task.isCancelled }
+        )
+
+        switch outcome {
+        case .proceed, .abort:
+            connectionCheck = .idle
+        case .stay(let message):
+            connectionCheck = .failed(message: message)
+        }
+    }
+
     // MARK: Session
 
     /// SwiftUI-observable mirror of the runtime's state stream. Read-only to views: state

--- a/Sources/AnglesiteMobile/RemoteSessionScreen.swift
+++ b/Sources/AnglesiteMobile/RemoteSessionScreen.swift
@@ -108,9 +108,12 @@ private struct RemoteSandboxPreview: View {
     }
 }
 
-/// Connect form: the Worker URL + bearer token from the one-time Deploy-to-Cloudflare
-/// provisioning, plus the site's git coordinates. The token field writes through to the iOS
-/// Keychain (`SecretAccounts.sandboxControlToken`), never to defaults.
+/// Connect form: the Worker URL + bearer token + site ID are local drafts that only persist via
+/// the verify-then-persist Connect flow (#889) — nothing is stored until the Worker actually
+/// answers a status probe with that URL + token. The token then writes through to the iOS
+/// Keychain (`SecretAccounts.sandboxControlToken`), never to defaults. The git coordinates below
+/// stay directly bound: they're not part of the verified secret pair and there's nothing to
+/// verify them against.
 private struct RemoteConnectForm: View {
     @Bindable var model: RemoteSessionModel
     @Environment(\.dismiss) private var dismiss
@@ -118,16 +121,38 @@ private struct RemoteConnectForm: View {
     @State private var isSigningInWithCloudflare = false
     @State private var cloudflareSignInError: String?
 
+    @State private var workerURLDraft: String
+    @State private var tokenDraft: String
+    @State private var siteIDDraft: String
+    @State private var connectTask: Task<Void, Never>?
+
+    /// Interim target until the Control Worker template repo ships (2026-07-21 design §4) —
+    /// labeled as a setup *guide* because tapping it doesn't deploy anything. Swapping in the
+    /// real Deploy-to-Cloudflare URL later is a one-line change.
+    private static let setupGuideURL = URL(string: "https://developers.cloudflare.com/containers/get-started/")!
+
+    init(model: RemoteSessionModel) {
+        self.model = model
+        _workerURLDraft = State(initialValue: model.workerURLString)
+        _tokenDraft = State(initialValue: model.controlToken)
+        _siteIDDraft = State(initialValue: model.siteID)
+    }
+
     var body: some View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("https://anglesite-sandbox.example.workers.dev", text: $model.workerURLString)
+                    Button {
+                        openSetupGuide()
+                    } label: {
+                        Label("Cloudflare Container Setup Guide", systemImage: "book")
+                    }
+                    TextField("https://anglesite-sandbox.example.workers.dev", text: $workerURLDraft)
                         .keyboardType(.URL)
                         .textContentType(.URL)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
-                    SecureField("Control Worker token", text: $model.controlToken)
+                    SecureField("Control Worker token", text: $tokenDraft)
                         // Disabled alongside the button below: a token pasted while the browser
                         // sheet is up would be silently overwritten when the flow completes.
                         .disabled(isSigningInWithCloudflare)
@@ -143,22 +168,24 @@ private struct RemoteConnectForm: View {
                         }
                     }
                     .disabled(isSigningInWithCloudflare)
+                    TextField("Site ID", text: $siteIDDraft)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    connectRow
                 } header: {
                     Text("Cloudflare Control Worker")
                 } footer: {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("From the one-time Deploy to Cloudflare setup. The token is stored in the Keychain on this device only.")
+                        connectFooter
                         if let cloudflareSignInError {
                             Text(cloudflareSignInError)
                                 .foregroundStyle(.red)
                         }
                     }
                 }
+                .disabled(model.connectionCheck == .checking)
 
                 Section {
-                    TextField("Site ID", text: $model.siteID)
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
                     TextField("https://github.com/you/site.git", text: $model.gitRemoteString)
                         .keyboardType(.URL)
                         .autocorrectionDisabled()
@@ -179,14 +206,73 @@ private struct RemoteConnectForm: View {
                     Button("Done") { dismiss() }
                 }
             }
+            .onDisappear {
+                // A torn-down form must not let an in-flight connect confirm behind the user's
+                // back — the onboarding re-checks this cancellation before proceeding.
+                connectTask?.cancel()
+            }
+        }
+    }
+
+    private var canConnect: Bool {
+        let blank = { (s: String) in s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        return !blank(workerURLDraft) && !blank(tokenDraft) && !blank(siteIDDraft)
+            && model.connectionCheck != .checking && !isSigningInWithCloudflare
+    }
+
+    private var connectRow: some View {
+        Button {
+            let workerURLString = workerURLDraft
+            let token = tokenDraft
+            let siteID = siteIDDraft
+            connectTask = Task {
+                await model.connect(workerURLString: workerURLString, token: token, siteID: siteID)
+            }
+        } label: {
+            if model.connectionCheck == .checking {
+                HStack(spacing: 8) {
+                    ProgressView()
+                    Text("Connecting…")
+                }
+            } else {
+                Text("Connect")
+            }
+        }
+        .disabled(!canConnect)
+    }
+
+    @ViewBuilder
+    private var connectFooter: some View {
+        switch model.connectionCheck {
+        case .connected:
+            Label("Reached your Worker", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .failed(let message):
+            Text(message)
+                .foregroundStyle(.red)
+        case .idle, .checking:
+            Text("From the one-time Cloudflare Container setup. The token is stored in the Keychain on this device only, after the Worker confirms it.")
+        }
+    }
+
+    private func openSetupGuide() {
+        Task {
+            // No callback ever comes back from a docs page — the user reads the guide and
+            // dismisses the sheet manually, so the resulting cancellation error is expected
+            // and swallowed, not surfaced.
+            _ = try? await webAuthenticationSession.authenticate(
+                using: Self.setupGuideURL,
+                callbackURLScheme: "anglesite"
+            )
         }
     }
 
     /// Runs the Cloudflare OAuth flow (#891) via the shared `CloudflareOAuthSignIn`
     /// orchestration (AnglesiteCore — the same sequencing `DeployModel` uses on macOS) and
-    /// fills the token field with the resulting access token — the same field the paste flow
-    /// writes, so nothing downstream changes. The browser sheet's callback is matched via
-    /// Associated Domains against the #891 callback Worker
+    /// fills the token *draft* with the resulting access token — the same draft the paste flow
+    /// writes, so it still only persists via the verify-then-persist Connect flow (#889); OAuth
+    /// is an additional way to populate the draft, not a bypass of verification. The browser
+    /// sheet's callback is matched via Associated Domains against the #891 callback Worker
     /// (`webcredentials:auth.anglesite.dwk.io`). Error split mirrors
     /// `DeployModel.signInWithCloudflare`: cancel and consent-decline are silent, everything
     /// else (including a `state` mismatch, never silently accepted) surfaces as one
@@ -209,7 +295,7 @@ private struct RemoteConnectForm: View {
             })
         do {
             let result = try await signIn.run()
-            model.controlToken = result.token.accessToken
+            tokenDraft = result.token.accessToken
         } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
             // The user dismissed the browser sheet — normal abort, no error banner.
         } catch CloudflareOAuthError.callbackDenied {

--- a/Tests/AnglesiteCoreTests/SandboxControlOnboardingTests.swift
+++ b/Tests/AnglesiteCoreTests/SandboxControlOnboardingTests.swift
@@ -1,0 +1,184 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Tests the iOS connect flow's verify → persist → (maybe) proceed orchestration in isolation
+/// from any UI, mirroring `TokenOnboardingTests`/`GitHubTokenOnboardingTests`. Verification is
+/// `SandboxControlClient.status(siteID:)` against `FakeSandboxControlClient`, so the "a cancelled
+/// connect must not confirm behind the user's back" rule is asserted deterministically under
+/// `swift test` (#889) — `RemoteSessionModel` itself lives in the iOS-only app target.
+@MainActor
+struct SandboxControlOnboardingTests {
+    private static let readyStatus = SandboxStatus(siteID: "site-1", previewReady: true, mcpReady: true)
+
+    private func makeOnboarding(
+        statusResult: Result<SandboxStatus, SandboxControlError>,
+        onMakeClient: @escaping (URL, String) -> Void = { _, _ in }
+    ) -> SandboxControlOnboarding {
+        SandboxControlOnboarding(makeClient: { url, token in
+            onMakeClient(url, token)
+            return FakeSandboxControlClient(
+                startResult: .failure(.notProvisioned),
+                statusResult: statusResult
+            )
+        })
+    }
+
+    @Test("A reachable Worker yields .proceed and persists the trimmed credentials once")
+    func proceedsWhenNotCancelled() async {
+        var clientURL: URL?
+        var clientToken: String?
+        let onboarding = makeOnboarding(statusResult: .success(Self.readyStatus)) { url, token in
+            clientURL = url
+            clientToken = token
+        }
+        var persisted: [SandboxControlOnboarding.Credentials] = []
+        var connected: SandboxStatus?
+        let outcome = await onboarding.run(
+            workerURLString: "  https://sandbox.example.workers.dev  ",
+            token: "  tok  ",
+            siteID: "  site-1  ",
+            persist: { persisted.append($0) },
+            onConnected: { connected = $0 },
+            delay: {},
+            isCancelled: { false }
+        )
+        #expect(outcome == .proceed(Self.readyStatus))
+        #expect(persisted == [SandboxControlOnboarding.Credentials(
+            workerURLString: "https://sandbox.example.workers.dev",
+            token: "tok",
+            siteID: "site-1"
+        )])
+        #expect(connected == Self.readyStatus)
+        #expect(clientURL == URL(string: "https://sandbox.example.workers.dev"))
+        #expect(clientToken == "tok")
+    }
+
+    @Test("Cancellation after a successful verify yields .abort (no proceed)")
+    func abortsWhenCancelled() async {
+        let onboarding = makeOnboarding(statusResult: .success(Self.readyStatus))
+        var persistCount = 0
+        let outcome = await onboarding.run(
+            workerURLString: "https://sandbox.example.workers.dev",
+            token: "tok",
+            siteID: "site-1",
+            persist: { _ in persistCount += 1 },
+            onConnected: { _ in },
+            delay: {},
+            isCancelled: { true }
+        )
+        #expect(outcome == .abort)
+        // The token verified against the Worker, so it's still persisted; only the
+        // connected-confirmation is skipped.
+        #expect(persistCount == 1)
+    }
+
+    @Test("A rejected token yields .stay with the rejection message and never persists")
+    func staysOnUnauthorized() async {
+        let onboarding = makeOnboarding(statusResult: .failure(.unauthorized))
+        var persistCount = 0
+        let outcome = await onboarding.run(
+            workerURLString: "https://sandbox.example.workers.dev",
+            token: "bad",
+            siteID: "site-1",
+            persist: { _ in persistCount += 1 },
+            onConnected: { _ in },
+            delay: {},
+            isCancelled: { false }
+        )
+        #expect(outcome == .stay(message: "That token was rejected by the Worker."))
+        #expect(persistCount == 0)
+    }
+
+    @Test("An unreachable Worker yields .stay carrying the transport detail")
+    func staysOnUnreachable() async {
+        let onboarding = makeOnboarding(statusResult: .failure(.unreachable("DNS lookup failed")))
+        var persistCount = 0
+        let outcome = await onboarding.run(
+            workerURLString: "https://sandbox.example.workers.dev",
+            token: "tok",
+            siteID: "site-1",
+            persist: { _ in persistCount += 1 },
+            onConnected: { _ in },
+            delay: {},
+            isCancelled: { false }
+        )
+        #expect(outcome == .stay(message: "Couldn’t reach the Worker: DNS lookup failed"))
+        #expect(persistCount == 0)
+    }
+
+    @Test("Any other verification failure yields a generic .stay and never persists")
+    func staysOnOtherError() async {
+        let onboarding = makeOnboarding(statusResult: .failure(.startFailed("boom")))
+        var persistCount = 0
+        let outcome = await onboarding.run(
+            workerURLString: "https://sandbox.example.workers.dev",
+            token: "tok",
+            siteID: "site-1",
+            persist: { _ in persistCount += 1 },
+            onConnected: { _ in },
+            delay: {},
+            isCancelled: { false }
+        )
+        if case .stay = outcome {} else { Issue.record("expected .stay, got \(outcome)") }
+        #expect(persistCount == 0)
+    }
+
+    @Test("Empty fields stay without building a client or persisting")
+    func staysOnEmptyFields() async {
+        var clientCount = 0
+        let onboarding = makeOnboarding(statusResult: .success(Self.readyStatus)) { _, _ in
+            clientCount += 1
+        }
+        var persistCount = 0
+        let outcome = await onboarding.run(
+            workerURLString: "https://sandbox.example.workers.dev",
+            token: "   ",
+            siteID: "site-1",
+            persist: { _ in persistCount += 1 },
+            onConnected: { _ in },
+            delay: {},
+            isCancelled: { false }
+        )
+        if case .stay = outcome {} else { Issue.record("expected .stay, got \(outcome)") }
+        #expect(persistCount == 0)
+        #expect(clientCount == 0)
+    }
+
+    @Test("A malformed Worker URL stays without building a client")
+    func staysOnMalformedURL() async {
+        var clientCount = 0
+        let onboarding = makeOnboarding(statusResult: .success(Self.readyStatus)) { _, _ in
+            clientCount += 1
+        }
+        var persistCount = 0
+        let outcome = await onboarding.run(
+            workerURLString: "not a url",
+            token: "tok",
+            siteID: "site-1",
+            persist: { _ in persistCount += 1 },
+            onConnected: { _ in },
+            delay: {},
+            isCancelled: { false }
+        )
+        if case .stay = outcome {} else { Issue.record("expected .stay, got \(outcome)") }
+        #expect(persistCount == 0)
+        #expect(clientCount == 0)
+    }
+
+    @Test("A persist failure surfaces as .stay, not .proceed")
+    func staysWhenPersistThrows() async {
+        struct Boom: Error {}
+        let onboarding = makeOnboarding(statusResult: .success(Self.readyStatus))
+        let outcome = await onboarding.run(
+            workerURLString: "https://sandbox.example.workers.dev",
+            token: "tok",
+            siteID: "site-1",
+            persist: { _ in throw Boom() },
+            onConnected: { _ in },
+            delay: {},
+            isCancelled: { false }
+        )
+        if case .stay = outcome {} else { Issue.record("expected .stay, got \(outcome)") }
+    }
+}

--- a/Tests/AnglesiteCoreTests/SandboxControlOnboardingTests.swift
+++ b/Tests/AnglesiteCoreTests/SandboxControlOnboardingTests.swift
@@ -166,6 +166,17 @@ struct SandboxControlOnboardingTests {
         #expect(clientCount == 0)
     }
 
+    @Test("workerURL(from:) accepts http(s) URLs and rejects missing or non-http schemes")
+    func workerURLParsing() {
+        #expect(SandboxControlOnboarding.workerURL(from: "https://sandbox.example.workers.dev")
+            == URL(string: "https://sandbox.example.workers.dev"))
+        #expect(SandboxControlOnboarding.workerURL(from: "http://localhost:8787")
+            == URL(string: "http://localhost:8787"))
+        #expect(SandboxControlOnboarding.workerURL(from: "sandbox.example.workers.dev") == nil)
+        #expect(SandboxControlOnboarding.workerURL(from: "ftp://sandbox.example") == nil)
+        #expect(SandboxControlOnboarding.workerURL(from: "not a url") == nil)
+    }
+
     @Test("A persist failure surfaces as .stay, not .proceed")
     func staysWhenPersistThrows() async {
         struct Boom: Error {}


### PR DESCRIPTION
Closes #889

## Summary

- New `SandboxControlOnboarding` (AnglesiteCore) mirrors `TokenOnboarding`/`GitHubTokenOnboarding`'s verify → persist → flash → re-check-cancel → proceed ordering, verifying the drafted Worker URL + bearer token + site ID via the existing `SandboxControlClient.status(siteID:)` — no new server API, and nothing persists until the Worker actually answers.
- `RemoteSessionModel` gains `connect(workerURLString:token:siteID:)` and a `connectionCheck` state (`.idle/.checking/.connected/.failed(message:)`); `RemoteConnectForm`'s three Cloudflare fields move to local `@State` drafts behind a **Connect** button (spinner → success flash → settle, inline error on failure), replacing the save-on-every-keystroke bindings. Git remote/ref fields are unchanged.
- Adds a **Cloudflare Container Setup Guide** button opening Cloudflare's Containers get-started docs in the `webAuthenticationSession` in-app browser — an honest interim target until the Control Worker template repo exists (dismissal cancellation swallowed per the 2026-07-21 design §4).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path . --skip DomainModelTests` — green (4,900+ tests). `DomainModelTests` is skipped because it hangs on current `main` (#1366; fix in flight in #1367), unrelated to this change. The new `SandboxControlOnboardingTests` (8 tests, written first, watched fail) cover proceed/abort/stay ordering, trimming, empty/malformed-URL guards, unauthorized/unreachable/other error mapping, and persist-failure handling against `FakeSandboxControlClient`.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (macOS)
- [x] `xcodebuild -scheme AnglesiteMobile -destination 'generic/platform=iOS Simulator' build` and a concrete iOS 27.0 simulator build
- [ ] Manual smoke on simulator — **blocked environmentally**: any build of this app (with or without this change) crashes at dyld load on the installed iOS 27.0 simulator runtime (seed 24A5355p) because the Xcode 27 beta SDK (24A5370g) references `FoundationModels.Generable.promptRepresentation`, which that runtime seed lacks — same FM SDK/OS symbol-mismatch class as #541. The verify-then-persist ordering is covered by the unit tests above; a live connect round-trip additionally needs a real Control Worker, which doesn't exist yet (design 2026-07-21 §Scope).

## Notes

- Two pre-existing test issues observed during verification, both unrelated to this diff: the live-FM `FoundationModelAssistant` #657 trim test failed once with `LanguageModelError error -1` (known on-device FM flakiness), and `AnglesiteAppTests`' Cloudflare-token-adjacent suites (RUM analytics #1114, `HardenModelTests`, `DomainConfigAuditModelTests`) fail nondeterministically ~1-in-3 full-bundle runs with *different* tests each time — reproduced on the identical binary and also absent/present across bare-`main` runs, so it's a parallel-scheduling leak, not this PR. Flagged for a separate fix.
- `Sources/AnglesiteMobile/Localizable.xcstrings` picks up this PR's new strings plus catch-up keys for `SitePickerScreen` strings (from #865/#866-era work) that were never CLI-synced; sync was scoped to this worktree's own `BUILD_DIR` per CONTRIBUTING, and the now-orphaned old footer key was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
