### PR TITLE
fix(#1375): deflake Cloudflare token env races in AnglesiteAppTests

### DIFF
--- a/Tests/AnglesiteAppTests/PlistEditorModelInboxCaptureTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelInboxCaptureTests.swift
@@ -131,20 +131,14 @@ struct PlistEditorModelInboxCaptureTests {
     @Test("without a token, leaves the toggle off with an error and makes no capability-probe call")
     func turnOnWithoutToken() async throws {
         // `cloudflareToken()` falls back to the process-wide `CLOUDFLARE_API_TOKEN` env var when
-        // the keychain is empty. A couple of sibling test files (DomainConfigAuditModelTests,
-        // OnionRoutingModelTests) `setenv` that var without restoring it, and Swift Testing runs
-        // same-target tests concurrently in one process — so without this save/clear/restore,
-        // this test is flaky under a full-suite parallel run whenever one of those leaks the var
-        // into this test's window.
-        let previousEnvToken = ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
-        unsetenv("CLOUDFLARE_API_TOKEN")
-        defer {
-            if let previousEnvToken {
-                setenv("CLOUDFLARE_API_TOKEN", previousEnvToken, 1)
-            } else {
-                unsetenv("CLOUDFLARE_API_TOKEN")
-            }
-        }
+        // the keychain is empty, and sibling suites (DomainConfigAuditModelTests, HardenModelTests,
+        // OnionRoutingModelTests) legitimately hold that var *set* while their own tests run, via
+        // `CloudflareAPITokenTestEnvironment`. Claim the exclusive "cleared" state through that
+        // same coordinator rather than calling `unsetenv` directly: a raw unset yanks the var out
+        // from under a concurrent setter's claim, and a snapshot/restore `defer` can re-plant a
+        // stale value after that setter has released — both were real cross-suite flakes (#1375).
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
+        defer { cfToken.release() }
 
         let fixture = try await makeFixture(token: nil, proberTransport: { _ in
             Issue.record("capability prober must not be called without a token")

--- a/Tests/AnglesiteAppTests/PlistEditorModelRUMAnalyticsTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelRUMAnalyticsTests.swift
@@ -88,9 +88,18 @@ struct PlistEditorModelRUMAnalyticsTests {
         #expect(fixture.model.rumSummaryError == "boom")
     }
 
-    @Test("loadRUMSummary surfaces missingToken when no Cloudflare token is configured",
-          .enabled(if: ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"] == nil))
+    @Test("loadRUMSummary surfaces missingToken when no Cloudflare token is configured")
     func surfacesMissingToken() async throws {
+        // Claim the process-wide `CLOUDFLARE_API_TOKEN` env var in its exclusive "cleared" state:
+        // `CloudflareAPICredentials.resolve()` consults it before the injected keychain, and
+        // sibling setter suites (DomainConfigAuditModelTests, HardenModelTests,
+        // OnionRoutingModelTests) legitimately hold it set to "test-token" while their own tests
+        // run concurrently in this process (#1375). The claim replaces the old
+        // `.enabled(if: env == nil)` trait, which was evaluated once before the body ran and so
+        // couldn't keep a setter's claim window from overlapping it; claiming also lets this test
+        // run (rather than silently skip) on a machine whose shell exports a real token.
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
+        defer { cfToken.release() }
         let fixture = try await makeFixture(token: nil, siteTag: "site-tag-1")
 
         await fixture.model.loadRUMSummary()


### PR DESCRIPTION
Closes #1375

## Summary

- `PlistEditorModelInboxCaptureTests.turnOnWithoutToken` bypassed `CloudflareAPITokenTestEnvironment` with a raw `unsetenv("CLOUDFLARE_API_TOKEN")` + snapshot-restore `defer`: the unset yanked the var out from under concurrent setter suites (`HardenModelTests`, `DomainConfigAuditModelTests` — which then resolved *no* token and failed with the wrong phase/error), and the stale restore could re-plant `test-token` after the observed setter had released, leaking the var set for the rest of the process. Now claims the coordinator's exclusive "cleared" state instead.
- `PlistEditorModelRUMAnalyticsTests.surfacesMissingToken` needed the var unset but never claimed the coordinator; its `.enabled(if: env == nil)` trait was evaluated once before the body ran, so a setter's claim window (or the leak above) could overlap the test and make the stubbed provider produce a summary despite an empty injected keychain. Now claims "cleared" too; the redundant racy gate is dropped (the claim also lets the test run, not skip, on a machine whose shell exports a real token).
- The originally suspected real-login-keychain leak was ruled out: every credential source the failing fixtures consult is injected and service-scoped (`resolve(secretStore:)` call sites in `HardenModel`/`DomainConfigAuditModel`/`PlistEditorModel`, `InMemorySecretStore` in `DeployModelTests`). Full analysis in #1375.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` — one unrelated failure: `FoundationModelAssistant` › "converse trims the cached session's transcript…" (live on-device FM reply-content assertion, a different target this test-only diff cannot affect; known live-FM flake class — re-run in progress, will confirm in a comment)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — BUILD SUCCEEDED
- [ ] Manual smoke (if UI-touching): n/a — test-only change

### Flake verification

`swift test --package-path . --filter "AnglesiteAppTests.*" --skip DomainModelTests`, repeated:

- **Before:** 2 of 4 runs failed, reproducing exactly the reported set (RUM `missingToken` summary-despite-nil-token; `HardenModelTests` ×2 and `DomainConfigAuditModelTests` zone-not-found landing on "No Cloudflare API token found").
- **After:** 6 of 6 runs passed (399 tests / 54 suites each).
