### PR TITLE
fix(#71): drop stale AnglesiteCore/Bridge dep check from readiness audit

### DIFF
--- a/docs/qa/ios-thin-client-readiness.md
+++ b/docs/qa/ios-thin-client-readiness.md
@@ -24,8 +24,13 @@ Expected today:
   `LocalContainerSiteRuntime` are `#if !os(iOS)`-gated out of iOS builds, and the
   AppKit-coupled Intents surface lives in its own macOS-gated file.
 
-The SwiftPM `AnglesiteIOS` shell target stays dependency-free (WebKit/SwiftUI only) — the audit
-enforces this. The iOS *app* target (`AnglesiteMobile`, Xcode-only) is where `AnglesiteCore`,
+The SwiftPM `AnglesiteIOS` shell target depends on `AnglesiteSiteModel` and `AnglesiteCore` (post
+Phase 8/#885, `AnglesiteCore` is iOS-portable, so the shell's models — `PostListModel`,
+`MicropubSession`, `SitePickerModel`, etc. — use it directly for `RemoteSandboxSiteRuntime`,
+`KeychainStore`, and the HTTP MCP client). The audit doesn't treat that dependency as unsafe; the
+dedicated checks above it (FSEvents, security-scoped bookmarks, host subprocess backend, local
+container runtime, AppKit imports) already verify `AnglesiteCore`/`AnglesiteBridge` compile clean
+for iOS. The iOS *app* target (`AnglesiteMobile`, Xcode-only) is where `AnglesiteCore`,
 `AnglesiteBridge`, and `AnglesiteIOS` compose; those products all build with
 `--triple arm64-apple-ios27.0`.
 

--- a/scripts/audit-ios-thin-client-readiness.sh
+++ b/scripts/audit-ios-thin-client-readiness.sh
@@ -124,18 +124,21 @@ file_is_ios_gated() {
 }
 
 ios_shell_target_is_safe() {
+    # A dependency on AnglesiteCore/AnglesiteBridge is not itself unsafe: the dedicated checks
+    # below (FSEvents, security-scoped bookmarks, host subprocess backend, local container
+    # runtime, AppKit imports) already verify those modules compile clean for iOS. Phase 8
+    # (#885) made AnglesiteCore iOS-portable specifically so AnglesiteIOS could depend on it for
+    # RemoteSandboxSiteRuntime, KeychainStore, etc. — treating that dependency as a blocker here
+    # would flag the intended, already-vetted shape of the shell target.
     path_exists "Sources/AnglesiteIOS" || return 1
     awk '
         /name: "AnglesiteIOS"/ { inTarget = 1; foundTarget = 1 }
-        inTarget && /dependencies:/ {
-            if ($0 ~ /AnglesiteBridge|AnglesiteCore/) { unsafeDependency = 1 }
-        }
         inTarget && /path: "Sources\/AnglesiteIOS"/ { sawPath = 1 }
         inTarget && /^[[:space:]]*\),[[:space:]]*$/ {
             inTarget = 0
         }
         END {
-            exit (foundTarget == 1 && sawPath == 1 && unsafeDependency != 1) ? 0 : 1
+            exit (foundTarget == 1 && sawPath == 1) ? 0 : 1
         }
     ' Package.swift
 }


### PR DESCRIPTION
## Summary

- Part of #71 — the iOS thin-client readiness audit (`scripts/audit-ios-thin-client-readiness.sh`) was reporting a phantom blocker: `ios_shell_target_is_safe` flagged `AnglesiteIOS`'s dependency on `AnglesiteCore` as unsafe, but Phase 8 (#885) made `AnglesiteCore` iOS-portable specifically so `AnglesiteIOS` could depend on it (`RemoteSandboxSiteRuntime`, `KeychainStore`, the HTTP MCP client). The check was never updated when #886 added that dependency.
- Dropped the unsafe-dependency check — the audit's other dedicated checks (FSEvents, security-scoped bookmarks, host subprocess backend, local container runtime, AppKit imports) already independently verify `AnglesiteCore`/`AnglesiteBridge` compile clean for iOS, so this was redundant as well as wrong.
- Updated `docs/qa/ios-thin-client-readiness.md`, which incorrectly claimed the `AnglesiteIOS` shell target stays "dependency-free."
- `scripts/audit-ios-thin-client-readiness.sh --expect-ready` now exits 0 with "No tracked iOS thin-client blockers remain." (previously exited 1 on this one stale blocker).

This is a documentation/tooling correctness fix only — it doesn't touch the remaining #71 scope (UIKit Siri annotations provider, multi-site UX, live e2e smoke against #66's Control Worker, which stays blocked).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `bash -n scripts/audit-ios-thin-client-readiness.sh`
- [x] `scripts/audit-ios-thin-client-readiness.sh` — exits 0, "No tracked iOS thin-client blockers remain."
- [x] `scripts/audit-ios-thin-client-readiness.sh --expect-ready` — exits 0 (was exiting 1 before this fix).
- [ ] `swift test --package-path .` / `xcodebuild` — not run; this PR only touches a shell script and a markdown doc, no Swift/project changes.