### PR TITLE
feat(#71): iOS multi-site switcher polish

### DIFF
--- a/Sources/AnglesiteIOS/SiteSelectionModel.swift
+++ b/Sources/AnglesiteIOS/SiteSelectionModel.swift
@@ -1,0 +1,45 @@
+// Sources/AnglesiteIOS/SiteSelectionModel.swift
+import Foundation
+import Observation
+
+/// Owns which site the iOS shell (`SiteSplitScreen`, #869) currently has selected, and persists
+/// that choice across launches (#71 "multi-site UX" follow-up). Deliberately separate from
+/// `SitePickerModel`, which only discovers sites and is also used standalone by `SitePickerScreen`
+/// (no selection concept there) — folding selection into it would blur that model's one job.
+@MainActor
+@Observable
+public final class SiteSelectionModel {
+    public private(set) var selectedSite: SitePickerModel.DiscoveredSite?
+
+    private let defaults: UserDefaults
+    private static let selectedSiteIDKey = "siteSelection.selectedSiteID"
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// User-driven selection (a sidebar tap or the switcher menu). Always wins immediately and
+    /// persists the choice; `nil` clears both.
+    public func select(_ site: SitePickerModel.DiscoveredSite?) {
+        selectedSite = site
+        if let site {
+            defaults.set(site.id.uuidString, forKey: Self.selectedSiteIDKey)
+        } else {
+            defaults.removeObject(forKey: Self.selectedSiteIDKey)
+        }
+    }
+
+    /// Called once discovery produces a list. Resolves the persisted site ID against `sites` and
+    /// selects it if found. A no-op when a site is already selected — a user tapping around before
+    /// discovery/restore settles must never be clobbered by a late restore — or when nothing is
+    /// persisted, or the persisted site isn't in `sites` (deleted, moved, not yet synced): in every
+    /// one of those cases the screen's existing empty/picker state is already correct.
+    public func restoreSelection(from sites: [SitePickerModel.DiscoveredSite]) {
+        guard selectedSite == nil,
+              let storedIDString = defaults.string(forKey: Self.selectedSiteIDKey),
+              let storedID = UUID(uuidString: storedIDString),
+              let match = sites.first(where: { $0.id == storedID })
+        else { return }
+        selectedSite = match
+    }
+}

--- a/Sources/AnglesiteIOS/SiteSelectionModel.swift
+++ b/Sources/AnglesiteIOS/SiteSelectionModel.swift
@@ -3,9 +3,9 @@ import Foundation
 import Observation
 
 /// Owns which site the iOS shell (`SiteSplitScreen`, #869) currently has selected, and persists
-/// that choice across launches (#71 "multi-site UX" follow-up). Deliberately separate from
-/// `SitePickerModel`, which only discovers sites and is also used standalone by `SitePickerScreen`
-/// (no selection concept there) — folding selection into it would blur that model's one job.
+/// that choice across launches (#71 "multi-site UX" follow-up). Kept separate from
+/// `SitePickerModel`, which owns pure discovery with no selection concept of its own — folding
+/// selection in would blur that responsibility.
 @MainActor
 @Observable
 public final class SiteSelectionModel {

--- a/Sources/AnglesiteMobile/SiteSplitScreen.swift
+++ b/Sources/AnglesiteMobile/SiteSplitScreen.swift
@@ -17,7 +17,7 @@ struct SiteSplitScreen: View {
     var sessions: any MicropubSessionProviding = StoredMicropubSessions()
 
     @State private var sitePicker = SitePickerModel()
-    @State private var selectedSite: SitePickerModel.DiscoveredSite?
+    @State private var siteSelection = SiteSelectionModel()
     /// The sidebar's content-type filter: a registry type id, or `nil` for "All Posts".
     @State private var selectedTypeID: String?
     @State private var selection: PostListItemSelection?
@@ -47,7 +47,12 @@ struct SiteSplitScreen: View {
             detailPane
         }
         .task { await sitePicker.refresh() }
-        .task(id: selectedSite?.id) { await resolveSession() }
+        .task(id: siteSelection.selectedSite?.id) { await resolveSession() }
+        .onChange(of: sitePicker.state) { _, newState in
+            if case .sites(let sites) = newState {
+                siteSelection.restoreSelection(from: sites)
+            }
+        }
     }
 
     // MARK: - Sidebar (sites + content types)
@@ -88,7 +93,7 @@ struct SiteSplitScreen: View {
                         .tag(SidebarSelection.site(site.id))
                     }
                 }
-                if selectedSite != nil {
+                if siteSelection.selectedSite != nil {
                     Section("Content") {
                         Label {
                             Text("All Posts")
@@ -118,6 +123,22 @@ struct SiteSplitScreen: View {
         registry.all.filter { $0.collection != nil }
     }
 
+    /// The discovered site list, or empty when discovery hasn't produced one yet — feeds
+    /// `SiteSwitcherMenu`, which is hidden entirely below 2 sites.
+    private var switcherSites: [SitePickerModel.DiscoveredSite] {
+        guard case .sites(let sites) = sitePicker.state else { return [] }
+        return sites
+    }
+
+    @ToolbarContentBuilder
+    private func siteSwitcherToolbarItem() -> some ToolbarContent {
+        if switcherSites.count >= 2 {
+            ToolbarItem(placement: .navigation) {
+                SiteSwitcherMenu(sites: switcherSites, selected: siteSelection.selectedSite, onSelect: selectSite)
+            }
+        }
+    }
+
     private enum SidebarSelection: Hashable {
         case site(UUID)
         case allPosts
@@ -130,7 +151,7 @@ struct SiteSplitScreen: View {
         Binding(
             get: {
                 if let selectedTypeID { return .type(selectedTypeID) }
-                if selectedSite != nil { return .allPosts }
+                if siteSelection.selectedSite != nil { return .allPosts }
                 return nil
             },
             set: { newValue in
@@ -139,11 +160,7 @@ struct SiteSplitScreen: View {
                     guard case .sites(let sites) = sitePicker.state,
                           let site = sites.first(where: { $0.id == id })
                     else { return }
-                    if site != selectedSite {
-                        selectedSite = site
-                        selectedTypeID = nil
-                        selection = nil
-                    }
+                    selectSite(site)
                 case .allPosts:
                     selectedTypeID = nil
                 case .type(let id):
@@ -166,38 +183,41 @@ struct SiteSplitScreen: View {
 
     @ViewBuilder
     private var contentPane: some View {
-        if selectedSite == nil {
+        if siteSelection.selectedSite == nil {
             ContentUnavailableView {
                 Label("Pick a Site", systemImage: "globe")
             } description: {
                 Text("Choose one of your sites to see its posts.")
             }
         } else {
-            switch sessionState {
-            case .none, .checking:
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .signedOut:
-                // #868's onboarding flow, embedded: when it lands signed-in, re-resolve so
-                // the freshly stored credential becomes this shell's session.
-                if let site = selectedSite {
-                    SiteSignInScreen(site: site) {
-                        Task { await resolveSession() }
+            Group {
+                switch sessionState {
+                case .none, .checking:
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                case .signedOut:
+                    if let site = siteSelection.selectedSite {
+                        SiteSignInScreen(site: site) {
+                            Task { await resolveSession() }
+                        }
                     }
-                }
-            case .ready:
-                if let postList {
-                    PostListScreen(
-                        model: postList,
-                        collection: selectedCollection,
-                        selection: $selection
-                    )
-                    .toolbar {
-                        ToolbarItem(placement: .primaryAction) {
-                            newPostButton
+                case .ready:
+                    if let postList {
+                        PostListScreen(
+                            model: postList,
+                            collection: selectedCollection,
+                            selection: $selection
+                        )
+                        .toolbar {
+                            ToolbarItem(placement: .primaryAction) {
+                                newPostButton
+                            }
                         }
                     }
                 }
+            }
+            .toolbar {
+                siteSwitcherToolbarItem()
             }
         }
     }
@@ -220,7 +240,7 @@ struct SiteSplitScreen: View {
 
     @ViewBuilder
     private var detailPane: some View {
-        if let session, let site = selectedSite, let selection {
+        if let session, let site = siteSelection.selectedSite, let selection {
             ComposerPane(
                 selection: selection,
                 session: session,
@@ -231,6 +251,9 @@ struct SiteSplitScreen: View {
             )
             // A fresh pane per selection: composer state must never leak across posts.
             .id(selection)
+            .toolbar {
+                siteSwitcherToolbarItem()
+            }
         } else {
             ContentUnavailableView {
                 Label("Nothing Selected", systemImage: "square.and.pencil")
@@ -241,7 +264,7 @@ struct SiteSplitScreen: View {
     }
 
     private func resolveSession() async {
-        guard let site = selectedSite else {
+        guard let site = siteSelection.selectedSite else {
             sessionState = .none
             session = nil
             postList = nil
@@ -250,7 +273,7 @@ struct SiteSplitScreen: View {
         sessionState = .checking
         let resolved = await sessions.session(for: site)
         // The site may have changed while resolving; only publish for the current one.
-        guard site == selectedSite else { return }
+        guard site == siteSelection.selectedSite else { return }
         if let resolved {
             session = resolved
             postList = PostListModel(client: resolved.makeClient(), registry: registry)
@@ -260,6 +283,15 @@ struct SiteSplitScreen: View {
             postList = nil
             sessionState = .signedOut
         }
+    }
+
+    /// Single path for every site-switch trigger (sidebar row, switcher menu) so the
+    /// reset-filter-and-selection side effect can't drift between call sites.
+    private func selectSite(_ site: SitePickerModel.DiscoveredSite) {
+        guard site != siteSelection.selectedSite else { return }
+        siteSelection.select(site)
+        selectedTypeID = nil
+        selection = nil
     }
 }
 

--- a/Sources/AnglesiteMobile/SiteSplitScreen.swift
+++ b/Sources/AnglesiteMobile/SiteSplitScreen.swift
@@ -131,10 +131,10 @@ struct SiteSplitScreen: View {
     }
 
     @ToolbarContentBuilder
-    private func siteSwitcherToolbarItem() -> some ToolbarContent {
+    private func siteSwitcherToolbarItem(site: SitePickerModel.DiscoveredSite) -> some ToolbarContent {
         if switcherSites.count >= 2 {
             ToolbarItem(placement: .navigation) {
-                SiteSwitcherMenu(sites: switcherSites, selected: siteSelection.selectedSite, onSelect: selectSite)
+                SiteSwitcherMenu(sites: switcherSites, selected: site, onSelect: selectSite)
             }
         }
     }
@@ -183,23 +183,17 @@ struct SiteSplitScreen: View {
 
     @ViewBuilder
     private var contentPane: some View {
-        if siteSelection.selectedSite == nil {
-            ContentUnavailableView {
-                Label("Pick a Site", systemImage: "globe")
-            } description: {
-                Text("Choose one of your sites to see its posts.")
-            }
-        } else {
+        if let site = siteSelection.selectedSite {
             Group {
                 switch sessionState {
                 case .none, .checking:
                     ProgressView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 case .signedOut:
-                    if let site = siteSelection.selectedSite {
-                        SiteSignInScreen(site: site) {
-                            Task { await resolveSession() }
-                        }
+                    // #868's onboarding flow, embedded: when it lands signed-in, re-resolve so
+                    // the freshly stored credential becomes this shell's session.
+                    SiteSignInScreen(site: site) {
+                        Task { await resolveSession() }
                     }
                 case .ready:
                     if let postList {
@@ -217,7 +211,13 @@ struct SiteSplitScreen: View {
                 }
             }
             .toolbar {
-                siteSwitcherToolbarItem()
+                siteSwitcherToolbarItem(site: site)
+            }
+        } else {
+            ContentUnavailableView {
+                Label("Pick a Site", systemImage: "globe")
+            } description: {
+                Text("Choose one of your sites to see its posts.")
             }
         }
     }
@@ -252,7 +252,7 @@ struct SiteSplitScreen: View {
             // A fresh pane per selection: composer state must never leak across posts.
             .id(selection)
             .toolbar {
-                siteSwitcherToolbarItem()
+                siteSwitcherToolbarItem(site: site)
             }
         } else {
             ContentUnavailableView {
@@ -288,8 +288,12 @@ struct SiteSplitScreen: View {
     /// Single path for every site-switch trigger (sidebar row, switcher menu) so the
     /// reset-filter-and-selection side effect can't drift between call sites.
     private func selectSite(_ site: SitePickerModel.DiscoveredSite) {
-        guard site != siteSelection.selectedSite else { return }
+        guard site.id != siteSelection.selectedSite?.id else { return }
         siteSelection.select(site)
+        // Drop to the loading state synchronously — otherwise the previous site's session/post
+        // list keeps rendering under the new site's name until `.task(id:)` re-resolves a frame
+        // or two later.
+        sessionState = .checking
         selectedTypeID = nil
         selection = nil
     }

--- a/Sources/AnglesiteMobile/SiteSwitcherMenu.swift
+++ b/Sources/AnglesiteMobile/SiteSwitcherMenu.swift
@@ -1,0 +1,32 @@
+// Sources/AnglesiteMobile/SiteSwitcherMenu.swift
+import SwiftUI
+import AnglesiteIOS
+
+/// A compact site switcher for a toolbar (#71 "multi-site UX"): shows the current site's name with
+/// a chevron, and a `Menu` listing every discovered site with a checkmark on the current one.
+/// `SiteSplitScreen` attaches this to both its content and detail panes so the current site stays
+/// visible even when the sidebar column isn't (iPhone's collapsed `NavigationStack`).
+struct SiteSwitcherMenu: View {
+    let sites: [SitePickerModel.DiscoveredSite]
+    let selected: SitePickerModel.DiscoveredSite?
+    var onSelect: (SitePickerModel.DiscoveredSite) -> Void
+
+    var body: some View {
+        Menu {
+            ForEach(sites) { site in
+                Button {
+                    onSelect(site)
+                } label: {
+                    if site == selected {
+                        Label(site.displayName, systemImage: "checkmark")
+                    } else {
+                        Text(verbatim: site.displayName)
+                    }
+                }
+            }
+        } label: {
+            Label(selected?.displayName ?? "", systemImage: "chevron.down")
+                .labelStyle(.titleAndIcon)
+        }
+    }
+}

--- a/Sources/AnglesiteMobile/SiteSwitcherMenu.swift
+++ b/Sources/AnglesiteMobile/SiteSwitcherMenu.swift
@@ -8,7 +8,7 @@ import AnglesiteIOS
 /// visible even when the sidebar column isn't (iPhone's collapsed `NavigationStack`).
 struct SiteSwitcherMenu: View {
     let sites: [SitePickerModel.DiscoveredSite]
-    let selected: SitePickerModel.DiscoveredSite?
+    let selected: SitePickerModel.DiscoveredSite
     var onSelect: (SitePickerModel.DiscoveredSite) -> Void
 
     var body: some View {
@@ -17,16 +17,22 @@ struct SiteSwitcherMenu: View {
                 Button {
                     onSelect(site)
                 } label: {
-                    if site == selected {
+                    if site.id == selected.id {
                         Label(site.displayName, systemImage: "checkmark")
+                            .accessibilityAddTraits(.isSelected)
                     } else {
                         Text(verbatim: site.displayName)
                     }
                 }
             }
         } label: {
-            Label(selected?.displayName ?? "", systemImage: "chevron.down")
-                .labelStyle(.titleAndIcon)
+            HStack {
+                Text(verbatim: selected.displayName)
+                Image(systemName: "chevron.down")
+                    .font(.caption)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(Text("Current site: \(selected.displayName)"))
         }
     }
 }

--- a/Tests/AnglesiteIOSTests/SiteSelectionModelTests.swift
+++ b/Tests/AnglesiteIOSTests/SiteSelectionModelTests.swift
@@ -1,0 +1,96 @@
+import Testing
+import Foundation
+@testable import AnglesiteIOS
+
+/// A `final class` (not a `struct`) so `deinit` can drop the throwaway `UserDefaults` suite,
+/// mirroring `AppSettingsTests`' scratch-suite pattern (`Tests/AnglesiteCoreTests/AppSettingsTests.swift`).
+@MainActor
+final class SiteSelectionModelTests {
+    private let suiteName: String
+    private let defaults: UserDefaults
+
+    init() {
+        let suite = "test-site-selection-\(UUID().uuidString)"
+        suiteName = suite
+        defaults = UserDefaults(suiteName: suite)!
+    }
+
+    deinit {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func makeSite(name: String, id: UUID = UUID()) -> SitePickerModel.DiscoveredSite {
+        SitePickerModel.DiscoveredSite(
+            id: id, displayName: name, packageURL: URL(fileURLWithPath: "/tmp/\(name).anglesite"))
+    }
+
+    @Test("select persists the site and updates selectedSite")
+    func selectPersists() {
+        let model = SiteSelectionModel(defaults: defaults)
+        let site = makeSite(name: "My Blog")
+
+        model.select(site)
+
+        #expect(model.selectedSite == site)
+        #expect(defaults.string(forKey: "siteSelection.selectedSiteID") == site.id.uuidString)
+    }
+
+    @Test("select(nil) clears the persisted site")
+    func selectNilClears() {
+        let model = SiteSelectionModel(defaults: defaults)
+        model.select(makeSite(name: "My Blog"))
+
+        model.select(nil)
+
+        #expect(model.selectedSite == nil)
+        #expect(defaults.string(forKey: "siteSelection.selectedSiteID") == nil)
+    }
+
+    @Test("restoreSelection selects the persisted site when present in the list")
+    func restoreSelectsPersistedSite() {
+        let site = makeSite(name: "My Blog")
+        let other = makeSite(name: "Other Site")
+        let writer = SiteSelectionModel(defaults: defaults)
+        writer.select(site)
+
+        let restored = SiteSelectionModel(defaults: defaults)
+        restored.restoreSelection(from: [other, site])
+
+        #expect(restored.selectedSite == site)
+    }
+
+    @Test("restoreSelection leaves selectedSite nil when the persisted site isn't in the list")
+    func restoreLeavesNilWhenMissing() {
+        let site = makeSite(name: "My Blog")
+        let writer = SiteSelectionModel(defaults: defaults)
+        writer.select(site)
+
+        let restored = SiteSelectionModel(defaults: defaults)
+        restored.restoreSelection(from: [makeSite(name: "Different Site")])
+
+        #expect(restored.selectedSite == nil)
+    }
+
+    @Test("restoreSelection leaves selectedSite nil when nothing was persisted")
+    func restoreLeavesNilWhenNothingPersisted() {
+        let model = SiteSelectionModel(defaults: defaults)
+
+        model.restoreSelection(from: [makeSite(name: "My Blog")])
+
+        #expect(model.selectedSite == nil)
+    }
+
+    @Test("restoreSelection never overwrites an already-active selection")
+    func restoreDoesNotOverwriteActiveSelection() {
+        let active = makeSite(name: "Active Site")
+        let persisted = makeSite(name: "Persisted Site")
+        let writer = SiteSelectionModel(defaults: defaults)
+        writer.select(persisted)
+
+        let model = SiteSelectionModel(defaults: defaults)
+        model.select(active)
+        model.restoreSelection(from: [persisted, active])
+
+        #expect(model.selectedSite == active)
+    }
+}

--- a/Tests/AnglesiteIOSTests/SiteSelectionModelTests.swift
+++ b/Tests/AnglesiteIOSTests/SiteSelectionModelTests.swift
@@ -93,4 +93,32 @@ final class SiteSelectionModelTests {
 
         #expect(model.selectedSite == active)
     }
+
+    @Test("restoreSelection treats a corrupt persisted value as nothing persisted")
+    func restoreLeavesNilWhenPersistedValueIsCorrupt() {
+        defaults.set("not-a-uuid", forKey: "siteSelection.selectedSiteID")
+
+        let model = SiteSelectionModel(defaults: defaults)
+        model.restoreSelection(from: [makeSite(name: "My Blog")])
+
+        #expect(model.selectedSite == nil)
+    }
+
+    @Test("restoreSelection matches by id, not whole-struct equality")
+    func restoreMatchesByIDNotWholeStructEquality() {
+        let id = UUID()
+        let original = makeSite(name: "My Blog", id: id)
+        let writer = SiteSelectionModel(defaults: defaults)
+        writer.select(original)
+
+        // Same site, renamed/moved since persisting — same id, different displayName/packageURL.
+        let renamed = SitePickerModel.DiscoveredSite(
+            id: id, displayName: "My Renamed Blog", packageURL: URL(fileURLWithPath: "/tmp/moved.anglesite"))
+
+        let restored = SiteSelectionModel(defaults: defaults)
+        restored.restoreSelection(from: [renamed])
+
+        #expect(restored.selectedSite == renamed)
+        #expect(restored.selectedSite?.displayName == "My Renamed Blog")
+    }
 }

--- a/docs/superpowers/plans/2026-08-10-ios-multi-site-switcher.md
+++ b/docs/superpowers/plans/2026-08-10-ios-multi-site-switcher.md
@@ -1,0 +1,573 @@
+# iOS multi-site switcher polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the iOS Micropub posting shell (`SiteSplitScreen`) visible site context and a fast switcher, and remember the last-selected site across launches.
+
+**Architecture:** A new `@Observable` model, `SiteSelectionModel` (`AnglesiteIOS`), owns which site is selected and persists it to `UserDefaults`; `SiteSplitScreen` (`AnglesiteMobile`) replaces its bare `@State` selection with this model and adds a small new `SiteSwitcherMenu` view to both its content and detail panes' toolbars.
+
+**Tech Stack:** Swift 6.4, SwiftUI, `Observation` framework, Swift Testing (`import Testing`), SwiftPM (`AnglesiteIOS`/`AnglesiteIOSTests` targets) + XcodeGen/`xcodebuild` (`AnglesiteMobile` app target).
+
+## Global Constraints
+
+- Toolchain: macOS 27+ / Xcode 27+ / Swift 6.4. Apple frameworks only — no new third-party dependencies.
+- Persisted site not found on restore (deleted, moved, iCloud not yet synced) → silently fall back to no selection. No new error UI for this case.
+- The switcher UI is hidden entirely when fewer than 2 sites are discovered.
+- `SiteSelectionModel.restoreSelection(from:)` must never overwrite an already-active `selectedSite`.
+- Commit subjects ≤72 characters (`CONTRIBUTING.md` ▸ "Commits and pull requests").
+- `swift test --package-path .` and the `AnglesiteMobile` iOS-simulator `xcodebuild` must both pass before this is done.
+
+---
+
+### Task 1: `SiteSelectionModel`
+
+**Files:**
+- Create: `Sources/AnglesiteIOS/SiteSelectionModel.swift`
+- Test: `Tests/AnglesiteIOSTests/SiteSelectionModelTests.swift`
+
+**Interfaces:**
+- Consumes: `SitePickerModel.DiscoveredSite` (`Sources/AnglesiteIOS/SitePickerModel.swift:15-21`) — `Identifiable, Sendable, Hashable`, with `id: UUID`, `displayName: String`, `packageURL: URL`. Its memberwise init is internal, reachable from `Tests/AnglesiteIOSTests` via `@testable import AnglesiteIOS` (same pattern already used in `Tests/AnglesiteIOSTests/MicropubOnboardingModelTests.swift:98-99` and `StoredMicropubSessionsTests.swift`).
+- Produces (consumed by Task 3):
+  ```swift
+  @MainActor
+  @Observable
+  public final class SiteSelectionModel {
+      public private(set) var selectedSite: SitePickerModel.DiscoveredSite?
+      public init(defaults: UserDefaults = .standard)
+      public func select(_ site: SitePickerModel.DiscoveredSite?)
+      public func restoreSelection(from sites: [SitePickerModel.DiscoveredSite])
+  }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteIOSTests/SiteSelectionModelTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteIOS
+
+/// A `final class` (not a `struct`) so `deinit` can drop the throwaway `UserDefaults` suite,
+/// mirroring `AppSettingsTests`' scratch-suite pattern (`Tests/AnglesiteCoreTests/AppSettingsTests.swift`).
+@MainActor
+final class SiteSelectionModelTests {
+    private let suiteName: String
+    private let defaults: UserDefaults
+
+    init() {
+        let suite = "test-site-selection-\(UUID().uuidString)"
+        suiteName = suite
+        defaults = UserDefaults(suiteName: suite)!
+    }
+
+    deinit {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func makeSite(name: String, id: UUID = UUID()) -> SitePickerModel.DiscoveredSite {
+        SitePickerModel.DiscoveredSite(
+            id: id, displayName: name, packageURL: URL(fileURLWithPath: "/tmp/\(name).anglesite"))
+    }
+
+    @Test("select persists the site and updates selectedSite")
+    func selectPersists() {
+        let model = SiteSelectionModel(defaults: defaults)
+        let site = makeSite(name: "My Blog")
+
+        model.select(site)
+
+        #expect(model.selectedSite == site)
+        #expect(defaults.string(forKey: "siteSelection.selectedSiteID") == site.id.uuidString)
+    }
+
+    @Test("select(nil) clears the persisted site")
+    func selectNilClears() {
+        let model = SiteSelectionModel(defaults: defaults)
+        model.select(makeSite(name: "My Blog"))
+
+        model.select(nil)
+
+        #expect(model.selectedSite == nil)
+        #expect(defaults.string(forKey: "siteSelection.selectedSiteID") == nil)
+    }
+
+    @Test("restoreSelection selects the persisted site when present in the list")
+    func restoreSelectsPersistedSite() {
+        let site = makeSite(name: "My Blog")
+        let other = makeSite(name: "Other Site")
+        let writer = SiteSelectionModel(defaults: defaults)
+        writer.select(site)
+
+        let restored = SiteSelectionModel(defaults: defaults)
+        restored.restoreSelection(from: [other, site])
+
+        #expect(restored.selectedSite == site)
+    }
+
+    @Test("restoreSelection leaves selectedSite nil when the persisted site isn't in the list")
+    func restoreLeavesNilWhenMissing() {
+        let site = makeSite(name: "My Blog")
+        let writer = SiteSelectionModel(defaults: defaults)
+        writer.select(site)
+
+        let restored = SiteSelectionModel(defaults: defaults)
+        restored.restoreSelection(from: [makeSite(name: "Different Site")])
+
+        #expect(restored.selectedSite == nil)
+    }
+
+    @Test("restoreSelection leaves selectedSite nil when nothing was persisted")
+    func restoreLeavesNilWhenNothingPersisted() {
+        let model = SiteSelectionModel(defaults: defaults)
+
+        model.restoreSelection(from: [makeSite(name: "My Blog")])
+
+        #expect(model.selectedSite == nil)
+    }
+
+    @Test("restoreSelection never overwrites an already-active selection")
+    func restoreDoesNotOverwriteActiveSelection() {
+        let active = makeSite(name: "Active Site")
+        let persisted = makeSite(name: "Persisted Site")
+        let writer = SiteSelectionModel(defaults: defaults)
+        writer.select(persisted)
+
+        let model = SiteSelectionModel(defaults: defaults)
+        model.select(active)
+        model.restoreSelection(from: [persisted, active])
+
+        #expect(model.selectedSite == active)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter SiteSelectionModelTests`
+Expected: FAIL to compile — `SiteSelectionModel` doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteIOS/SiteSelectionModel.swift`:
+
+```swift
+// Sources/AnglesiteIOS/SiteSelectionModel.swift
+import Foundation
+import Observation
+
+/// Owns which site the iOS shell (`SiteSplitScreen`, #869) currently has selected, and persists
+/// that choice across launches (#71 "multi-site UX" follow-up). Deliberately separate from
+/// `SitePickerModel`, which only discovers sites and is also used standalone by `SitePickerScreen`
+/// (no selection concept there) — folding selection into it would blur that model's one job.
+@MainActor
+@Observable
+public final class SiteSelectionModel {
+    public private(set) var selectedSite: SitePickerModel.DiscoveredSite?
+
+    private let defaults: UserDefaults
+    private static let selectedSiteIDKey = "siteSelection.selectedSiteID"
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// User-driven selection (a sidebar tap or the switcher menu). Always wins immediately and
+    /// persists the choice; `nil` clears both.
+    public func select(_ site: SitePickerModel.DiscoveredSite?) {
+        selectedSite = site
+        if let site {
+            defaults.set(site.id.uuidString, forKey: Self.selectedSiteIDKey)
+        } else {
+            defaults.removeObject(forKey: Self.selectedSiteIDKey)
+        }
+    }
+
+    /// Called once discovery produces a list. Resolves the persisted site ID against `sites` and
+    /// selects it if found. A no-op when a site is already selected — a user tapping around before
+    /// discovery/restore settles must never be clobbered by a late restore — or when nothing is
+    /// persisted, or the persisted site isn't in `sites` (deleted, moved, not yet synced): in every
+    /// one of those cases the screen's existing empty/picker state is already correct.
+    public func restoreSelection(from sites: [SitePickerModel.DiscoveredSite]) {
+        guard selectedSite == nil,
+              let storedIDString = defaults.string(forKey: Self.selectedSiteIDKey),
+              let storedID = UUID(uuidString: storedIDString),
+              let match = sites.first(where: { $0.id == storedID })
+        else { return }
+        selectedSite = match
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter SiteSelectionModelTests`
+Expected: PASS, all 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteIOS/SiteSelectionModel.swift Tests/AnglesiteIOSTests/SiteSelectionModelTests.swift
+git commit -m "feat(#71): add SiteSelectionModel for persisted site choice"
+```
+
+---
+
+### Task 2: `SiteSwitcherMenu` view
+
+**Files:**
+- Create: `Sources/AnglesiteMobile/SiteSwitcherMenu.swift`
+
+**Interfaces:**
+- Consumes: `SitePickerModel.DiscoveredSite` (as above).
+- Produces (consumed by Task 3):
+  ```swift
+  struct SiteSwitcherMenu: View {
+      let sites: [SitePickerModel.DiscoveredSite]
+      let selected: SitePickerModel.DiscoveredSite?
+      var onSelect: (SitePickerModel.DiscoveredSite) -> Void
+  }
+  ```
+
+This is a plain SwiftUI view with no model of its own (same convention as `ComposerPane` in
+`SiteSplitScreen.swift`) — there's no SwiftPM test target for `AnglesiteMobile` views in this
+codebase (they're verified by building + manual simulator smoke, consistent with how
+`SitePickerScreen`/`SiteSignInScreen` are handled), so this task has no automated test step.
+
+- [ ] **Step 1: Write the view**
+
+Create `Sources/AnglesiteMobile/SiteSwitcherMenu.swift`:
+
+```swift
+// Sources/AnglesiteMobile/SiteSwitcherMenu.swift
+import SwiftUI
+import AnglesiteIOS
+
+/// A compact site switcher for a toolbar (#71 "multi-site UX"): shows the current site's name with
+/// a chevron, and a `Menu` listing every discovered site with a checkmark on the current one.
+/// `SiteSplitScreen` attaches this to both its content and detail panes so the current site stays
+/// visible even when the sidebar column isn't (iPhone's collapsed `NavigationStack`).
+struct SiteSwitcherMenu: View {
+    let sites: [SitePickerModel.DiscoveredSite]
+    let selected: SitePickerModel.DiscoveredSite?
+    var onSelect: (SitePickerModel.DiscoveredSite) -> Void
+
+    var body: some View {
+        Menu {
+            ForEach(sites) { site in
+                Button {
+                    onSelect(site)
+                } label: {
+                    if site == selected {
+                        Label(site.displayName, systemImage: "checkmark")
+                    } else {
+                        Text(verbatim: site.displayName)
+                    }
+                }
+            }
+        } label: {
+            Label(selected?.displayName ?? "", systemImage: "chevron.down")
+                .labelStyle(.titleAndIcon)
+        }
+    }
+}
+```
+
+This file can't be independently compiled here: `Sources/AnglesiteMobile` is an Xcode-only app
+target (not listed in `Package.swift`), so there is no `swift build` invocation that touches it.
+Task 3 Step 5's `xcodebuild` is the first real compile check for this file, once it's actually
+referenced from `SiteSplitScreen.swift` — Xcode/`xcodebuild` only type-checks files that are part
+of a build phase's source list, which XcodeGen populates from `project.yml`'s `Sources/AnglesiteMobile`
+path glob, so this new file is already picked up automatically; no `project.yml` change is needed.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Sources/AnglesiteMobile/SiteSwitcherMenu.swift
+git commit -m "feat(#71): add SiteSwitcherMenu toolbar view"
+```
+
+---
+
+### Task 3: Wire `SiteSelectionModel` + `SiteSwitcherMenu` into `SiteSplitScreen`
+
+**Files:**
+- Modify: `Sources/AnglesiteMobile/SiteSplitScreen.swift`
+
+**Interfaces:**
+- Consumes: `SiteSelectionModel` (Task 1), `SiteSwitcherMenu` (Task 2).
+- Produces: no new public API — `SiteSplitScreen` stays an internal `View`.
+
+This task has no automated test (SwiftUI view wiring, same as Task 2) — verified by building the
+`AnglesiteMobile` scheme and a manual simulator smoke covering the four checks the design calls
+out.
+
+- [ ] **Step 1: Replace the bare `@State` selection with `SiteSelectionModel`**
+
+In `Sources/AnglesiteMobile/SiteSplitScreen.swift`, replace line 20:
+
+```swift
+    @State private var selectedSite: SitePickerModel.DiscoveredSite?
+```
+
+with:
+
+```swift
+    @State private var siteSelection = SiteSelectionModel()
+```
+
+Then replace every other read of `selectedSite` in the file with `siteSelection.selectedSite`:
+
+- Line 91 (`if selectedSite != nil {` inside the sidebar's `Content` section): →
+  `if siteSelection.selectedSite != nil {`
+- Line 131 (`if let selectedTypeID { ... }` / `if selectedSite != nil { return .allPosts }` inside
+  `sidebarSelection`'s `get`): → `if siteSelection.selectedSite != nil { return .allPosts }`
+- Line 169 (`if selectedSite == nil {` in `contentPane`): → `if siteSelection.selectedSite == nil {`
+- Line 183 (`if let site = selectedSite {` in the `.signedOut` case): →
+  `if let site = siteSelection.selectedSite {`
+- Line 223 (`if let session, let site = selectedSite, let selection {` in `detailPane`): →
+  `if let session, let site = siteSelection.selectedSite, let selection {`
+- Line 244 (`guard let site = selectedSite else {` in `resolveSession()`): →
+  `guard let site = siteSelection.selectedSite else {`
+- Line 253 (`guard site == selectedSite else { return }` in `resolveSession()`): →
+  `guard site == siteSelection.selectedSite else { return }`
+
+- [ ] **Step 2: Replace the sidebar's inline site-select logic with a shared helper**
+
+Replace the `sidebarSelection` binding's `.site(let id)` case (originally lines 138-146):
+
+```swift
+                case .site(let id):
+                    guard case .sites(let sites) = sitePicker.state,
+                          let site = sites.first(where: { $0.id == id })
+                    else { return }
+                    if site != selectedSite {
+                        selectedSite = site
+                        selectedTypeID = nil
+                        selection = nil
+                    }
+```
+
+with:
+
+```swift
+                case .site(let id):
+                    guard case .sites(let sites) = sitePicker.state,
+                          let site = sites.first(where: { $0.id == id })
+                    else { return }
+                    selectSite(site)
+```
+
+Add the new helper as a private method on `SiteSplitScreen`, near `resolveSession()`:
+
+```swift
+    /// Single path for every site-switch trigger (sidebar row, switcher menu) so the
+    /// reset-filter-and-selection side effect can't drift between call sites.
+    private func selectSite(_ site: SitePickerModel.DiscoveredSite) {
+        guard site != siteSelection.selectedSite else { return }
+        siteSelection.select(site)
+        selectedTypeID = nil
+        selection = nil
+    }
+```
+
+- [ ] **Step 3: Restore the persisted selection once discovery has results**
+
+In `body`, add an `.onChange(of:)` alongside the existing `.task` modifiers:
+
+```swift
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+                .navigationTitle(Text("Anglesite"))
+        } content: {
+            contentPane
+                .navigationTitle(contentTitle)
+        } detail: {
+            detailPane
+        }
+        .task { await sitePicker.refresh() }
+        .task(id: siteSelection.selectedSite?.id) { await resolveSession() }
+        .onChange(of: sitePicker.state) { _, newState in
+            if case .sites(let sites) = newState {
+                siteSelection.restoreSelection(from: sites)
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Add the switcher to the content and detail panes**
+
+Add a computed property near `postTypes` that reads the current site list once:
+
+```swift
+    /// The discovered site list, or empty when discovery hasn't produced one yet — feeds
+    /// `SiteSwitcherMenu`, which is hidden entirely below 2 sites.
+    private var switcherSites: [SitePickerModel.DiscoveredSite] {
+        guard case .sites(let sites) = sitePicker.state else { return [] }
+        return sites
+    }
+
+    @ToolbarContentBuilder
+    private func siteSwitcherToolbarItem() -> some ToolbarContent {
+        if switcherSites.count >= 2 {
+            ToolbarItem(placement: .navigation) {
+                SiteSwitcherMenu(sites: switcherSites, selected: siteSelection.selectedSite, onSelect: selectSite)
+            }
+        }
+    }
+```
+
+Replace `contentPane` (originally lines 167-203) with:
+
+```swift
+    @ViewBuilder
+    private var contentPane: some View {
+        if siteSelection.selectedSite == nil {
+            ContentUnavailableView {
+                Label("Pick a Site", systemImage: "globe")
+            } description: {
+                Text("Choose one of your sites to see its posts.")
+            }
+        } else {
+            Group {
+                switch sessionState {
+                case .none, .checking:
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                case .signedOut:
+                    if let site = siteSelection.selectedSite {
+                        SiteSignInScreen(site: site) {
+                            Task { await resolveSession() }
+                        }
+                    }
+                case .ready:
+                    if let postList {
+                        PostListScreen(
+                            model: postList,
+                            collection: selectedCollection,
+                            selection: $selection
+                        )
+                        .toolbar {
+                            ToolbarItem(placement: .primaryAction) {
+                                newPostButton
+                            }
+                        }
+                    }
+                }
+            }
+            .toolbar {
+                siteSwitcherToolbarItem()
+            }
+        }
+    }
+```
+
+Replace `detailPane` (originally lines 221-241) with:
+
+```swift
+    @ViewBuilder
+    private var detailPane: some View {
+        if let session, let site = siteSelection.selectedSite, let selection {
+            ComposerPane(
+                selection: selection,
+                session: session,
+                siteID: site.id,
+                registry: registry,
+                postList: postList,
+                onSent: { Task { await postList?.refresh() } }
+            )
+            // A fresh pane per selection: composer state must never leak across posts.
+            .id(selection)
+            .toolbar {
+                siteSwitcherToolbarItem()
+            }
+        } else {
+            ContentUnavailableView {
+                Label("Nothing Selected", systemImage: "square.and.pencil")
+            } description: {
+                Text("Pick a post to edit, or start a new one.")
+            }
+        }
+    }
+```
+
+Add the `import AnglesiteIOS` requirement check: `SiteSplitScreen.swift` already imports
+`AnglesiteIOS` (line 3), so no import changes are needed — `SiteSwitcherMenu` lives in the same
+`AnglesiteMobile` target and needs no extra import either.
+
+- [ ] **Step 5: Regenerate the Xcode project and build the iOS target**
+
+Run:
+```bash
+xcodegen generate --quiet
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile \
+  -configuration Debug -destination 'generic/platform=iOS Simulator' build
+```
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 6: Manual simulator smoke test**
+
+Using the iOS Simulator (a real `.anglesite` package with at least 2 sites signed in via Micropub
+is needed for full coverage — if unavailable, note in the PR body which checks couldn't run):
+
+1. Launch the app with 2+ discovered sites, none previously selected — confirm no switcher appears
+   until you pick one (fewer than 2 selectable is not the "hide" case here; this checks first-launch
+   behavior).
+2. Pick a site, confirm the switcher (site name + chevron) appears in the post-list toolbar.
+3. Tap the switcher, confirm it lists all sites with a checkmark on the current one; pick another —
+   confirm the post list refreshes for the new site and the switcher updates.
+4. Open a post into the composer, confirm the switcher also appears there and switching sites from
+   the composer navigates back to that site's post list (via the existing `selection = nil` reset).
+5. Force-quit and relaunch the app — confirm it lands directly on the last-selected site's post
+   list instead of "Pick a Site."
+6. With only 1 discovered site, confirm the switcher never appears.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteMobile/SiteSplitScreen.swift
+git commit -m "feat(#71): wire site selection + switcher into SiteSplitScreen"
+```
+
+---
+
+### Task 4: Full verification pass
+
+**Files:** None (verification only).
+
+**Interfaces:** None.
+
+- [ ] **Step 1: Run the full SwiftPM suite**
+
+Run: `swift test --package-path .`
+Expected: PASS, including the new `SiteSelectionModelTests`.
+
+- [ ] **Step 2: Build the macOS app target (confirm nothing in shared code broke)**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 3: Re-confirm the iOS build**
+
+Run:
+```bash
+xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile \
+  -configuration Debug -destination 'generic/platform=iOS Simulator' build
+```
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Diff review against `CONTRIBUTING.md`**
+
+Confirm: commit subjects ≤72 chars; no drive-by unrelated changes (in particular,
+`RemoteSessionScreen.swift`/`RemoteSessionModel.swift` — the dead, unwired #71 remote-sandbox
+path — stay untouched, that's separate cleanup, not this plan's scope); PR body uses the
+template's exact headings (Summary / Paired PR check / Test plan) with `Closes #71` only if this
+was the issue's last remaining piece (it isn't — Siri annotations and the blocked live e2e smoke
+remain, so use a non-closing reference like the audit-script PR did).
+
+- [ ] **Step 5: Open the PR**
+
+Follow `CONTRIBUTING.md` ▸ "Commits and pull requests": use `.github/PULL_REQUEST_TEMPLATE.md`'s
+exact section headings, note this is app-only (no paired sidecar PR — no MCP schema touched),
+and list the manual simulator smoke results from Task 3 Step 6 in the Test plan section.

--- a/docs/superpowers/specs/2026-08-10-ios-multi-site-switcher-design.md
+++ b/docs/superpowers/specs/2026-08-10-ios-multi-site-switcher-design.md
@@ -1,0 +1,174 @@
+# iOS multi-site switcher polish — design
+
+**Date:** 2026-08-10
+**Issue:** #71 follow-up ("multi-site UX," tracked in the issue's 2026-07-22 comment). Builds on
+`SitePickerModel` (#866), `MicropubOnboardingModel` (#868), and `SiteSplitScreen` (#869).
+**Status:** Approved design; ready for implementation planning.
+
+## Scope
+
+By the time this design was written, "multi-site UX" already had substantial coverage that
+predates this slice: `SitePickerModel` discovers every `.anglesite` package in the user's iCloud
+container, `SiteSplitScreen`'s sidebar lets you switch between them, and each site gets its own
+IndieAuth token, DPoP key pair, Micropub session, and drafts, all keyed by `siteID`. That base
+implementation is not revisited here.
+
+What's missing is UX polish around that existing switching mechanism, found by reading the current
+`SiteSplitScreen`/`PostListScreen`/`ComposeScreen` code rather than assumed:
+
+1. **No site-name context** in the post-list or composer navigation titles. On iPad the sidebar
+   stays visible so the selected site is never really ambiguous, but on iPhone (`NavigationSplitView`
+   collapses to a plain `NavigationStack`) you can be several screens deep in a post list or
+   composer with nothing on screen naming which site you're editing.
+2. **No remembered site across launches.** `selectedSite` is a bare `@State` in `SiteSplitScreen`,
+   so every cold launch lands back on "pick a site" even if you posted to the same site five
+   minutes ago.
+3. **No fast way to switch sites on iPhone** short of navigating back to the sidebar screen.
+
+This is app-side only — no changes to `AnglesiteCore`'s Micropub/IndieAuth machinery, no MCP schema
+changes, no paired sidecar PR.
+
+## Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Persisted-site-not-found fallback | Silently fall back to no selection | Not a real error — matches today's cold-launch behavior; owner call during brainstorming |
+| Switcher UI pattern | Toolbar button (site name + chevron) opening a `Menu` | Owner preference over a pull-down-title pattern; works identically from the post list or the composer |
+| Switcher visibility | Hidden entirely below 2 sites | A switcher for one site is noise, not signal |
+| Selection-persistence ownership | New dedicated `SiteSelectionModel`, not inline in `SiteSplitScreen` and not bolted onto `SitePickerModel` | Matches this codebase's strict convention that every stateful concern is a unit-testable `@Observable` model behind a plain view; `SitePickerModel` is also used standalone by `SitePickerScreen`, which has no selection concept, so adding it there would blur that model's one job |
+
+## Components
+
+### 1. `SiteSelectionModel` (`AnglesiteIOS`, new)
+
+`@MainActor @Observable`, same shape as `SitePickerModel`/`RemoteSessionModel`:
+
+```swift
+@MainActor
+@Observable
+public final class SiteSelectionModel {
+    public private(set) var selectedSite: SitePickerModel.DiscoveredSite?
+
+    public init(defaults: UserDefaults = .standard)
+
+    /// User-driven selection (sidebar row, switcher menu). Always wins immediately and persists.
+    public func select(_ site: SitePickerModel.DiscoveredSite?)
+
+    /// Called once discovery produces a list. Looks up the persisted site ID in `sites`; selects
+    /// it if found. Never overwrites an already-active `selectedSite` (a user tapping around
+    /// before discovery/restore settles must not be clobbered by a late restore).
+    public func restoreSelection(from sites: [SitePickerModel.DiscoveredSite])
+}
+```
+
+- `select(_:)` persists `site?.id.uuidString` to `UserDefaults` (or removes the key for `nil`) via
+  the same `didSet`-on-assignment idiom `RemoteSessionModel` uses, then updates `selectedSite`.
+- `restoreSelection(from:)` is a no-op if `selectedSite != nil` or no persisted ID exists or the
+  persisted ID isn't in `sites` — in every one of those cases the screen's existing empty/picker
+  state is exactly right already, so there is nothing else for it to do.
+- Injectable `UserDefaults` in `init`, matching `RemoteSessionModel`'s pattern, so tests don't touch
+  real defaults.
+
+### 2. `SiteSplitScreen` changes (`AnglesiteMobile`)
+
+- Replaces `@State private var selectedSite: SitePickerModel.DiscoveredSite?` with
+  `@State private var siteSelection = SiteSelectionModel()`; every existing read of `selectedSite`
+  becomes `siteSelection.selectedSite`.
+- The sidebar's `sidebarSelection` binding's `.site(let id)` case and the new switcher menu's tap
+  handler both route through one new private helper, `selectSite(_:)`, which calls
+  `siteSelection.select(site)` and resets `selectedTypeID`/`selection` — the existing
+  reset-on-switch side effect, now defined once instead of duplicated between two call sites.
+- A new `.task(id: sitePicker.state)`-driven call (or equivalent — reacting to `sitePicker.state`
+  transitioning into `.sites(...)`) invokes `siteSelection.restoreSelection(from: sites)`. Existing
+  `.task(id: siteSelection.selectedSite?.id)` (session resolution) is unchanged; a successful
+  restore drives it exactly like a manual tap does.
+- Both `contentPane` and `detailPane` gain a `ToolbarItem(placement: .navigation)` holding
+  `SiteSwitcherMenu`, populated only when `sitePicker.state` is `.sites` with 2+ entries.
+
+### 3. `SiteSwitcherMenu` (`AnglesiteMobile`, new)
+
+```swift
+struct SiteSwitcherMenu: View {
+    let sites: [SitePickerModel.DiscoveredSite]
+    let selected: SitePickerModel.DiscoveredSite?
+    var onSelect: (SitePickerModel.DiscoveredSite) -> Void
+
+    var body: some View {
+        Menu {
+            ForEach(sites) { site in
+                Button {
+                    onSelect(site)
+                } label: {
+                    if site == selected {
+                        Label(site.displayName, systemImage: "checkmark")
+                    } else {
+                        Text(verbatim: site.displayName)
+                    }
+                }
+            }
+        } label: {
+            Label(selected?.displayName ?? "", systemImage: "chevron.down")
+                .labelStyle(.titleAndIcon)
+        }
+    }
+}
+```
+
+Pure view, no model of its own — `SiteSplitScreen` owns all state and passes it down, same
+convention as `ComposerPane`.
+
+## Data flow
+
+1. **Cold launch:** `sitePicker.refresh()` (existing) → `.sites(sites)` → `restoreSelection(from:
+   sites)` → if a persisted site ID matches, `siteSelection.selectedSite` is set → existing
+   `.task(id: siteSelection.selectedSite?.id)` resolves that site's Micropub session, landing
+   directly on its post list instead of the picker.
+2. **Manual switch (sidebar or menu):** tap → `selectSite(_:)` → `siteSelection.select(site)` →
+   persists + updates `selectedSite` → same session-resolution task re-runs.
+3. **Persisted site missing:** `restoreSelection` finds no match → `selectedSite` stays `nil` →
+   today's existing "Pick a Site" content-pane empty state renders, unchanged.
+
+## Error handling & edge cases
+
+- Persisted site no longer discoverable (deleted, package moved, iCloud not yet synced): silent
+  fallback to no selection, per the locked decision above — this is not a failure state and gets no
+  new UI.
+- Exactly 0 or 1 discovered sites: `SiteSwitcherMenu` is omitted from the toolbar entirely (checked
+  where it's constructed in `SiteSplitScreen`, not inside the view itself, so there's no
+  disabled/greyed-out state to design for).
+- A restore racing a manual tap (e.g., discovery resolves just as the user taps a different site in
+  the sidebar): `restoreSelection`'s "never overwrite an already-active selection" rule means
+  whichever happens last only matters if `selectedSite` was still `nil` beforehand — a manual tap
+  always wins once it lands, since it happens synchronously against `@State`.
+
+## Testing
+
+- `SiteSelectionModelTests` (new, Swift Testing, `Tests/AnglesiteIOSTests/`):
+  - `select` persists the ID and updates `selectedSite`; `select(nil)` clears the persisted key.
+  - `restoreSelection` selects the persisted site when present in the given list.
+  - `restoreSelection` leaves `selectedSite` as `nil` when the persisted ID isn't in the list.
+  - `restoreSelection` is a no-op when `selectedSite` is already set (doesn't get overwritten by a
+    stale persisted value).
+  - All against an injected `UserDefaults(suiteName:)` instance, never `.standard`.
+- No new tests for `SiteSwitcherMenu` or the `SiteSplitScreen` wiring itself — consistent with this
+  codebase's existing practice of not unit-testing SwiftUI view bodies. Verified instead by building
+  the `AnglesiteMobile` scheme and a manual simulator smoke: site name appears in post-list/composer
+  toolbars, switcher menu changes site and refreshes the post list, relaunching the app after
+  picking a site lands directly on that site's post list, switcher is absent with only one
+  discovered site.
+
+## Open items (verify during implementation; non-blocking)
+
+- Exact SwiftUI mechanism for reacting to `sitePicker.state` becoming `.sites(...)` to call
+  `restoreSelection` — `.onChange(of:)` vs. folding it into the existing `.task`. Either is
+  consistent with the design; pick whichever reads cleaner once the code is in front of you.
+- `SiteSwitcherMenu`'s exact toolbar placement (`.navigation` vs. `.topBarLeading` vs.
+  `.principal`) should be settled by how it actually renders next to the existing `newPostButton`
+  and `ComposeScreen`'s `ToolbarItemGroup(placement: .primaryAction)` — verify visually in the
+  simulator rather than guessing from the API alone.
+
+## Epic touchpoints
+
+- **#71 iOS thin client** — closes out the "multi-site UX" line from the issue's 2026-07-22 comment.
+- **#866 / #868 / #869** — the discovery, auth, and split-shell foundation this polish sits on top
+  of; no changes to any of their models beyond `SiteSplitScreen`'s own state ownership.


### PR DESCRIPTION
## Summary

- Part of #71 — adds the multi-site switcher polish for the iOS thin client. `SiteSelectionModel` (`Sources/AnglesiteIOS/SiteSelectionModel.swift`) tracks and persists the user's selected site across sessions.
- `SiteSwitcherMenu` (`Sources/AnglesiteMobile/SiteSwitcherMenu.swift`) is a toolbar menu that lists the signed-in sites with a checkmark on the active one.
- `SiteSplitScreen` is wired to both: it now drives selection through `SiteSelectionModel` (replacing the old bare `@State` site), restores the persisted selection once discovery completes, and surfaces the switcher in the post-list and composer toolbars only when 2+ sites are signed in.
- A follow-up commit addresses a whole-branch review pass: VoiceOver labeling + `.isSelected` trait on the switcher, the site name now leads with a trailing chevron (was rendering backwards), a dropped doc comment restored, `SiteSwitcherMenu.selected` made non-optional, site identity comparisons switched from whole-struct equality to `.id` (so a renamed/moved package doesn't lose its "current site" state), a synchronous `.checking` transition on switch (was letting the old site's posts flash under the new site's name for a frame), a corrected code comment, and two new `SiteSelectionModel` tests (corrupt-persisted-value, id-based restore matching).

This covers the multi-site UX slice of #71's remaining scope. The Siri annotations provider and the live e2e smoke test (blocked on #66) are not part of this PR and stay open on the tracking issue.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 433 tests, 57 suites, all passed (re-confirmed after the review fix commit, including 8/8 new `SiteSelectionModelTests`).
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile -configuration Debug -destination 'generic/platform=iOS Simulator' build` — `** BUILD SUCCEEDED **` (re-confirmed after the fix commit too).
- [ ] Manual simulator smoke — attempted directly (not just disclosed as skipped): booted a simulator and tried to launch the built app via device-automation tooling. Blocked by two independent constraints, neither fixable from this session: (1) no simulator device-access permission has been granted in this session — only a human can grant that from the simulator panel; (2) real multi-site discovery needs a signed-in iCloud test account with synced `.anglesite` packages, which an agent must not create/sign into. The 6 manual checks from the plan (switcher hidden until 2+ sites, switcher appears in post-list/composer toolbars, switching refreshes the post list, selection persists across relaunch, switcher hidden for a single site, layout doesn't crowd the back button/composer toolbar) remain unverified at runtime. Everything statically verifiable (visibility gating logic, id-based identity, accessibility API usage, chevron ordering) was checked in code review instead.