### PR TITLE
ci: bump github/codeql-action init and analyze together to v4.37.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
           sudo xcode-select -s "$LATEST"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -89,6 +89,6 @@ jobs:
         run: swift build --package-path .
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

- Bumps both `github/codeql-action/init` and `github/codeql-action/analyze` to v4.37.6 in `.github/workflows/codeql.yml`, in one commit.
- Dependabot opened this bump as two separate PRs (#1392 for `init`, #1393 for `analyze`). Both steps run in the same job and CodeQL requires them to match versions, so merging either PR alone fails CI with `Loaded a configuration file for version '4.37.6', but running version '4.37.4'` — confirmed on both PRs' `Analyze (actions)` / `Analyze (javascript-typescript)` jobs.
- Supersedes #1392 and #1393, which should be closed once this merges.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] Workflow YAML validated with `yaml.safe_load` (workflow-only change; no Swift/JS sources touched, so `swift test`/`xcodebuild` are unaffected).
- [ ] CI `Analyze (actions)` / `Analyze (javascript-typescript)` / `Analyze (swift)` jobs pass on this PR (both `init` and `analyze` now agree on v4.37.6).