### PR TITLE
fix(#1385): bump adwaita-swift pin past Meta stateManager breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,13 +289,17 @@ jobs:
     if: needs.changes.outputs.swift == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # continue-on-error: adwaita-swift's pinned revision currently fails to build on this
-    # runner's x86_64 toolchain — a transitive-dependency breakage upstream (its own Meta
-    # dependency floats on a branch, and Meta's current main removed a field adwaita-swift
-    # still references at every revision tried, including its own HEAD), not something fixable
-    # from this repo's Package.swift. Tracked in #1385. Non-blocking until upstream resolves it
-    # or a workaround is found — AnglesiteLinux stays behind the ANGLESITE_LINUX_SHELL=1 opt-in
-    # gate regardless, so this doesn't affect what ships.
+    # continue-on-error: adwaita-swift's own dependencies (Meta and friends) float on branch
+    # `main` and cannot be frozen from this repo — SwiftPM rejects a root-level revision pin
+    # of a package another dependency requires by branch, and Package.resolved is gitignored —
+    # so an upstream push can break this lane with no change here. Not hypothetical: #1385 was
+    # exactly that (Meta's main dropped WidgetData.stateManager out from under every
+    # adwaita-swift revision, then restored it days later; the pin bump that closed #1385 rode
+    # the restoration). Non-blocking so upstream drift can't wedge unrelated PRs —
+    # AnglesiteLinux stays behind the ANGLESITE_LINUX_SHELL=1 opt-in gate regardless, so this
+    # doesn't affect what ships. If this lane fails on your PR, check whether the failure is
+    # in .build/checkouts (upstream drift — file an issue like #1385) before suspecting your
+    # own change.
     continue-on-error: true
     # Builds packaging/flatpak/io.dwk.anglesite.linux.yml for real and runs AnglesiteLinuxTests
     # inside the same GNOME-SDK sandbox — the CI lane

--- a/Package.swift
+++ b/Package.swift
@@ -502,9 +502,15 @@ if ProcessInfo.processInfo.environment["ANGLESITE_LINUX_SHELL"] == "1" {
     // Pinned to a commit, matching the SwiftGit2 policy above: adwaita-swift's only tag
     // (0.1.0) predates its current API, and tracking main would silently pick up unreviewed
     // commits. Bump deliberately. (Its own dependencies are branch-based, which SwiftPM
-    // permits under a revision pin.)
+    // permits under a revision pin — but they can only float: SwiftPM rejects a root-level
+    // revision pin of a dependency another package requires by branch ("required using two
+    // different revision-based requirements"), so Meta and friends cannot be frozen from
+    // here, and an upstream push to their main can break this target with no change in this
+    // repo. That is what #1385 was: Meta's main dropped WidgetData.stateManager out from
+    // under every adwaita-swift revision, then restored it a few commits later. This pin
+    // needs Meta main ≥ 266f6eb (WidgetData init's id: parameter).
     packageDependencies.append(
-        .package(url: "https://git.aparoksha.dev/aparoksha/adwaita-swift", revision: "15fe44efffa5c9ad5c2c5a703b104d0180c6af5e")
+        .package(url: "https://git.aparoksha.dev/aparoksha/adwaita-swift", revision: "8c986907fc67a1763fc9cd4334c4b3e515d86e30")
     )
     packageTargets.append(
         .systemLibrary(name: "CWebKitGTK", path: "Sources/CWebKitGTK", pkgConfig: "webkitgtk-6.0")

--- a/Sources/AnglesiteLinux/AnglesiteLinuxApp.swift
+++ b/Sources/AnglesiteLinux/AnglesiteLinuxApp.swift
@@ -55,7 +55,7 @@ struct AnglesiteLinuxApp: App {
                         Text(windowTitle)
                     }
                 }
-                .folderImporter(open: openDialog) { url in
+                .folderImporter(open: $openDialog) { url in
                     open(packageURL: url)
                 }
                 .onAppear {


### PR DESCRIPTION
Closes #1385

## Summary

- Bumps the `adwaita-swift` revision pin (`ANGLESITE_LINUX_SHELL=1` gate in `Package.swift`) from `15fe44e` to upstream HEAD `8c98690`. The old pin fails on CI's x86_64 `org.freedesktop.Sdk.Extension.swift6//25.08` toolchain with mutating-getter errors; the newer revision carries upstream's signal-handler overhaul (`ce1d27c`) that fixed them.
- The bump is possible now because the upstream `Meta` breakage that blocked it in #1385 has healed: Meta's `main` restored `WidgetData.stateManager` (`b04e2b4`) and added the `WidgetData` init `id:` parameter (`266f6eb`). Statically verified every call site from #1385's error log (`AnyView++.swift:312`, `FileDialog.swift:129`, `ToastOverlay+.swift:20`, `NavigationView+.swift:125`, `Window.swift:220`) against Meta `main` HEAD `394b376` — all match its public API.
- Migrates the one call site in `Sources/AnglesiteLinux` the overhaul changed: `folderImporter(open:)` now takes `Binding<Signal>`, so `AnglesiteLinuxApp` passes `$openDialog` (Meta's `@State` projects the binding). Surfaced by this PR's own `linux-flatpak-build` run — the first compile of the shell against the new pin; the rest of the shell's Adwaita/Meta API surface was audited against `8c98690` + Meta `394b376` and no other call site changed shape.
- Settles #1385's untested option 2 empirically: SwiftPM **rejects** a root-level `revision:` pin of a package another dependency requires by `branch:` (`error: meta is required using two different revision-based requirements (394b376… and main), which is not supported`), so the floating transitive deps cannot be frozen from this repo. The lane keeps `continue-on-error: true` for that reason; the `Package.swift` and `ci.yml` comments now document the durable constraint instead of the transient breakage.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift package dump-package` (manifest parses; the changed block is inside the `#if !canImport(Darwin)` + `ANGLESITE_LINUX_SHELL=1` gate, so no macOS/iOS target is affected)
- [x] Scratch-package `swift package resolve` against the new pin resolves cleanly (meta `394b376`, meta-sqlite `56bc247`, levenshtein `06577a2`)
- [x] `linux-flatpak-build` lane on this PR — the authoritative check (macOS can't compile the GTK stack, and the x86_64 Flathub swift6 extension is exactly the environment that failed): **green at `270f3ee`** — the Flatpak manifest built the full stack and `AnglesiteLinuxTests` passed inside the build sandbox. (First run at `18d7d3c` proved the upstream graph compiles and caught the `folderImporter` signature change; the lane is `continue-on-error`, so this checkbox reports the job's actual conclusion, not the required-check rollup.)
- [x] `swift test` / app build: not run locally — no macOS-visible change (see first item); CI's macOS lanes run on this PR regardless because `Package.swift` matched the `changes` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
