### PR TITLE
feat(#1394): iOS SiteEntity source bound to iCloud discovery

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -139,7 +139,10 @@ var packageTargets: [Target] = [
     ),
     .target(
         name: "AnglesiteIntents",
-        dependencies: ["AnglesiteCore"],
+        dependencies: [
+            "AnglesiteCore",
+            .target(name: "AnglesiteIOS", condition: .when(platforms: [.iOS])),
+        ],
         path: "Sources/AnglesiteIntents",
         swiftSettings: strictConcurrency
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -139,10 +139,13 @@ var packageTargets: [Target] = [
     ),
     .target(
         name: "AnglesiteIntents",
-        dependencies: [
-            "AnglesiteCore",
-            .target(name: "AnglesiteIOS", condition: .when(platforms: [.iOS])),
-        ],
+        // `AnglesiteIOS` is unconditional despite the name: `UbiquityContainerResolving`,
+        // `UbiquitousPackageDiscovering`, and `NSMetadataQueryPackageDiscovery` are all
+        // platform-neutral and already build and test on the macOS host (see the unconditional
+        // `AnglesiteIOSTests` target below). Keeping the dependency gated to `.iOS` would force
+        // `SiteEntityUbiquityDiscovery`'s orchestration behind an `#if os(iOS)` gate that
+        // `swift test` can never reach (#1394).
+        dependencies: ["AnglesiteCore", "AnglesiteIOS"],
         path: "Sources/AnglesiteIntents",
         swiftSettings: strictConcurrency
     ),
@@ -302,7 +305,9 @@ packageTargets.append(
 packageTargets.append(
     .testTarget(
         name: "AnglesiteIntentsTests",
-        dependencies: ["AnglesiteIntents", "AnglesiteCore", "AnglesiteSiteModel"],
+        // `AnglesiteIOS` for the `UbiquitousPackageDiscovering` fakes `SiteEntityUbiquityDiscovery`
+        // is tested against; see the note on `AnglesiteIntents`' own dependency on it.
+        dependencies: ["AnglesiteIntents", "AnglesiteCore", "AnglesiteSiteModel", "AnglesiteIOS"],
         path: "Tests/AnglesiteIntentsTests",
         swiftSettings: strictConcurrency,
         linkerSettings: weakLinkFoundationModels

--- a/Package.swift
+++ b/Package.swift
@@ -299,7 +299,7 @@ packageTargets.append(
 packageTargets.append(
     .testTarget(
         name: "AnglesiteIntentsTests",
-        dependencies: ["AnglesiteIntents", "AnglesiteCore"],
+        dependencies: ["AnglesiteIntents", "AnglesiteCore", "AnglesiteSiteModel"],
         path: "Tests/AnglesiteIntentsTests",
         swiftSettings: strictConcurrency,
         linkerSettings: weakLinkFoundationModels

--- a/Sources/AnglesiteIntents/ContentHelpIntents.swift
+++ b/Sources/AnglesiteIntents/ContentHelpIntents.swift
@@ -7,7 +7,7 @@ import Foundation
 ///
 /// Not registered in AnglesiteShortcuts: only one phrase slot remains under the 10-phrase cap
 /// and it's reserved for higher-traffic intents; ReviewCopyIntent stays discoverable via the
-/// Shortcuts app and via `SiteEntityQuery` resolution.
+/// Shortcuts app and via `SiteEntity.defaultQuery` resolution.
 public struct ReviewCopyIntent: AppIntent {
     /// Action name in the Shortcuts library. Says "Site Copy", not just "Copy", to avoid
     /// reading as a clipboard/duplicate action out of context.
@@ -16,7 +16,7 @@ public struct ReviewCopyIntent: AppIntent {
     public static let description = IntentDescription(
         "Review a site's written copy for clarity, tone, and calls to action.")
 
-    /// The site to audit, resolved by ``SiteEntityQuery`` so "review copy on my portfolio"
+    /// The site to audit, resolved by ``SiteEntity``'s `defaultQuery` so "review copy on my portfolio"
     /// matches by name.
     @Parameter(title: "Site") public var site: SiteEntity
 
@@ -83,7 +83,7 @@ extension ReviewCopyIntent {
 /// before saving like `AddBookingIntent`.
 ///
 /// Not registered in AnglesiteShortcuts: same phrase-budget reasoning as `ReviewCopyIntent` —
-/// stays discoverable via the Shortcuts app and via `SiteEntityQuery` resolution.
+/// stays discoverable via the Shortcuts app and via `SiteEntity.defaultQuery` resolution.
 public struct PlanSocialMediaIntent: AppIntent {
     /// Action name in the Shortcuts library.
     public static let title: LocalizedStringResource = "Plan Social Media"
@@ -92,7 +92,7 @@ public struct PlanSocialMediaIntent: AppIntent {
     public static let description = IntentDescription(
         "Generate a social media plan and content calendar for a site.")
 
-    /// The site to plan for, resolved by ``SiteEntityQuery``.
+    /// The site to plan for, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     /// Planning horizon. Defaults to 4; `run()` clamps it to 1…8 rather than erroring, so a
     /// Shortcut passing a wild value still gets a usable plan.
@@ -161,7 +161,7 @@ extension PlanSocialMediaIntent {
 /// dialog, mirroring `ReviewCopyIntent`/`PlanSocialMediaIntent`.
 ///
 /// Not registered in AnglesiteShortcuts: same phrase-budget reasoning as `ReviewCopyIntent`/
-/// `PlanSocialMediaIntent` — stays discoverable via the Shortcuts app and via `SiteEntityQuery`
+/// `PlanSocialMediaIntent` — stays discoverable via the Shortcuts app and via `SiteEntity.defaultQuery`
 /// resolution.
 public struct RepurposePostIntent: AppIntent {
     /// Action name in the Shortcuts library.
@@ -171,7 +171,7 @@ public struct RepurposePostIntent: AppIntent {
     public static let description = IntentDescription(
         "Draft platform-sized social posts from one of a site's blog posts.")
 
-    /// The site owning the post, resolved by ``SiteEntityQuery``.
+    /// The site owning the post, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     /// The post to repurpose, identified by slug and loaded straight from the repo via
     /// `PostSource` (not resolved through ``PostEntityQuery``, whose graph is only populated

--- a/Sources/AnglesiteIntents/ContentIntents.swift
+++ b/Sources/AnglesiteIntents/ContentIntents.swift
@@ -30,7 +30,7 @@ public struct SearchContentIntent: AppIntent {
     /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Search a site's pages, posts, and images.")
 
-    /// The site to search, resolved by ``SiteEntityQuery`` from the recents registry.
+    /// The site to search, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     /// Free-text term. A blank/whitespace query returns no matches rather than the whole
     /// content graph (#234) — see `matches(graph:siteID:query:)`.
@@ -105,7 +105,7 @@ public struct FindContentByTypeIntent: AppIntent {
     /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("List a site's content of a given type, e.g. events or reviews.")
 
-    /// The site whose content to list, resolved by ``SiteEntityQuery``.
+    /// The site whose content to list, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     /// The typed kind to filter by — an `AppEnum` so Shortcuts offers a picker instead of a
     /// free-text collection name.
@@ -160,7 +160,7 @@ public struct SiteStatusIntent: AppIntent {
     /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Report how much content a site has.")
 
-    /// The site to report on, resolved by ``SiteEntityQuery``.
+    /// The site to report on, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var graph: SiteContentGraph
 
@@ -206,7 +206,7 @@ public struct PreviewSiteIntent: AppIntent {
     /// seen, so this can't run as a background intent.
     public static let openAppWhenRun = true
 
-    /// The site to preview, resolved by ``SiteEntityQuery``.
+    /// The site to preview, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     /// Optional page to navigate to once the dev server is up; `nil` opens the site's root.
     @Parameter(title: "Page") public var page: PageEntity?
@@ -239,7 +239,7 @@ public struct AddPageIntent: AppIntent {
     /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Scaffold a new page on a site with Anglesite.")
 
-    /// The site to add the page to, resolved by ``SiteEntityQuery``.
+    /// The site to add the page to, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     /// The page title; also the source of the derived route when none is given.
     @Parameter(
@@ -312,7 +312,7 @@ public struct AddPostIntent: AppIntent {
     /// One-line explanation shown under the action in the Shortcuts editor.
     public static let description = IntentDescription("Scaffold a new draft post on a site with Anglesite.")
 
-    /// The site to add the post to, resolved by ``SiteEntityQuery``.
+    /// The site to add the post to, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     /// The post title. Named `title2` only because `title` collides with the `AppIntent.title`
     /// static requirement; it still presents to the user as "Title".

--- a/Sources/AnglesiteIntents/DesignInterviewIntents.swift
+++ b/Sources/AnglesiteIntents/DesignInterviewIntents.swift
@@ -16,7 +16,7 @@ public struct StartDesignInterviewIntent: AppIntent {
     /// so this can't run as a background intent.
     public static let openAppWhenRun = true
 
-    /// The site whose look and feel the interview will redesign, resolved by ``SiteEntityQuery``.
+    /// The site whose look and feel the interview will redesign, resolved by ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
 
     /// Required by `AppIntent`; the AppIntents runtime fills the `@Parameter` value after

--- a/Sources/AnglesiteIntents/SiteEntity.swift
+++ b/Sources/AnglesiteIntents/SiteEntity.swift
@@ -2,16 +2,21 @@ import AppIntents
 import AnglesiteCore
 import Foundation
 
-/// An Anglesite site, addressable by Siri/Shortcuts. Backed live by `SiteStore` — no
-/// cache, so the entity never goes stale relative to the registry.
+/// An Anglesite site, addressable by Siri/Shortcuts. The source behind it is per-platform, via
+/// ``SiteEntity/defaultQuery``: on macOS it's backed live by `SiteStore` — no cache, so the entity
+/// never goes stale relative to the recents registry — while on iOS there is no registry, so
+/// `SiteEntityQueryIOS` discovers `.anglesite` packages in the iCloud ubiquity container and
+/// `SiteEntityUbiquitySource` maps them (briefly cached, see `SiteEntityUbiquityDiscovery`).
 ///
 /// Conforms to the `.wordProcessor.document` AppSchema so Siri/Spotlight treat each site
 /// as a document container. The schema macro synthesises `typeDisplayRepresentation`, so
 /// the explicit override is omitted here (the metadata processor requires its removal).
 @AppEntity(schema: .wordProcessor.document)
 public struct SiteEntity: Sendable {
-    /// The stable site UUID from `SiteStore.Site.id` — path-independent (#242), so a Shortcut
-    /// that captured an entity keeps resolving after the package moves or is renamed.
+    /// The stable site UUID — path-independent (#242), so a Shortcut that captured an entity keeps
+    /// resolving after the package moves or is renamed. Sourced from `SiteStore.Site.id` on macOS
+    /// and from the package's own `AnglesitePackage.Marker.siteID` on iOS; both are the same UUID,
+    /// since the registry stores the marker's.
     public let id: String
     /// The site's display name, exposed as a schema `@Property` so Siri can match it by voice.
     @Property(title: "Name")
@@ -26,10 +31,11 @@ public struct SiteEntity: Sendable {
 
     /// The original display name used by `displayRepresentation` and `SiteEntityQuery`.
     public var displayName: String { name }
-    /// The `.anglesite` **package root** (`SiteStore.Site.packageURL`) — NOT the `Source/` git
-    /// repo, so scaffolding, file scans, and git ops must not use this URL directly: derive
-    /// `AnglesitePackage(url:).sourceURL` from it (see `ApplyThemeIntent`), or resolve the site
-    /// by `id` via `SiteStore`/`SiteAccess.withScopedAccess`, which hands back `sourceDirectory`.
+    /// The `.anglesite` **package root** (`SiteStore.Site.packageURL` on macOS; the discovered
+    /// package URL on iOS) — NOT the `Source/` git repo, so scaffolding, file scans, and git ops
+    /// must not use this URL directly: derive `AnglesitePackage(url:).sourceURL` from it (see
+    /// `ApplyThemeIntent`), or, on macOS, resolve the site by `id` via
+    /// `SiteStore`/`SiteAccess.withScopedAccess`, which hands back `sourceDirectory`.
     /// App-internal rather than a schema `@Property`; nil only if AppIntents ever builds the
     /// entity via the macro init.
     public var directory: URL?

--- a/Sources/AnglesiteIntents/SiteEntity.swift
+++ b/Sources/AnglesiteIntents/SiteEntity.swift
@@ -42,7 +42,11 @@ public struct SiteEntity: Sendable {
 
     /// `AppEntity` requirement — the query the system uses whenever it must resolve a
     /// ``SiteEntity`` on its own (Shortcuts re-resolution, Siri disambiguation).
+    #if os(macOS)
     public static let defaultQuery = SiteEntityQuery()
+    #elseif os(iOS)
+    public static let defaultQuery = SiteEntityQueryIOS()
+    #endif
 
     /// Memberwise initializer. Prefer `init(_:)` from a `SiteStore.Site` — it fills the dates
     /// from the filesystem and sets `directory` correctly; this one exists for tests and for
@@ -71,6 +75,7 @@ public struct SiteEntity: Sendable {
     }
 }
 
+#if os(macOS)
 /// Resolves sites by id (Shortcuts re-resolution) and by name (Siri "my portfolio site").
 /// `load()` is called first so a cold background intent process sees the persisted registry.
 public struct SiteEntityQuery: EntityStringQuery {
@@ -119,3 +124,4 @@ public struct SiteEntityQuery: EntityStringQuery {
         return sites.count == 1 ? sites.first.map(SiteEntity.init) : nil
     }
 }
+#endif

--- a/Sources/AnglesiteIntents/SiteEntityQueryIOS.swift
+++ b/Sources/AnglesiteIntents/SiteEntityQueryIOS.swift
@@ -6,25 +6,24 @@ import Foundation
 
 /// Resolves `SiteEntity`s on iOS by discovering `.anglesite` packages in the app's iCloud
 /// ubiquity container — the same mechanism `SitePickerModel` uses in production
-/// (`Sources/AnglesiteIOS/SitePickerModel.swift`). All mapping/matching logic lives in
-/// `SiteEntityUbiquitySource`; this type's only job is resolving the discovered `[URL]` list and
-/// handing it off. Not exercised by `swift test` (excluded on a macOS host by this `#if
-/// os(iOS)` gate) — verified by `xcodebuild ... -scheme AnglesiteMobile ... build` only.
+/// (`Sources/AnglesiteIOS/SitePickerModel.swift`). Deliberately holds no logic of its own: the
+/// discovery (cached and coalesced across the several calls one Siri interaction makes) belongs to
+/// ``SiteEntityUbiquityDiscovery``, and the URL-to-entity mapping belongs to
+/// `SiteEntityUbiquitySource` — both gate-free and covered by `swift test`, so this `#if
+/// os(iOS)`-gated wrapper stays small enough to be verified by `xcodebuild ... -scheme
+/// AnglesiteMobile ... build` alone.
 public struct SiteEntityQueryIOS: EntityStringQuery {
-    private let containerResolver: any UbiquityContainerResolving
-    /// `NSMetadataQueryPackageDiscovery` is `@MainActor`-isolated (see
-    /// `Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift`), so its no-arg initializer can't
-    /// be called synchronously from this struct's plain, non-isolated `init()`. Storing a
-    /// `@MainActor`-isolated factory instead of an already-constructed instance defers that call
-    /// to `discoveredURLs()`, which is `async` and can `await` across the actor hop.
-    private let makePackageDiscovery: @MainActor @Sendable () -> any UbiquitousPackageDiscovering
+    private let discovery: SiteEntityUbiquityDiscovery
 
     /// The no-argument initializer AppIntents requires — binds to the real iCloud container
     /// resolver and `NSMetadataQuery`-backed discovery, matching every other production call
     /// site.
     public init() {
-        self.containerResolver = FileManager.default
-        self.makePackageDiscovery = { NSMetadataQueryPackageDiscovery() }
+        self.discovery = SiteEntityUbiquityDiscovery(
+            containerResolver: FileManager.default,
+            makePackageDiscovery: { NSMetadataQueryPackageDiscovery() },
+            ubiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier
+        )
     }
 
     /// Test seam: bind the query to fakes instead of real iCloud state.
@@ -32,37 +31,41 @@ public struct SiteEntityQueryIOS: EntityStringQuery {
         containerResolver: any UbiquityContainerResolving,
         packageDiscovery: any UbiquitousPackageDiscovering
     ) {
-        self.containerResolver = containerResolver
-        self.makePackageDiscovery = { packageDiscovery }
+        self.discovery = SiteEntityUbiquityDiscovery(
+            containerResolver: containerResolver,
+            makePackageDiscovery: { packageDiscovery },
+            ubiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier
+        )
     }
 
-    /// Ubiquity container check, then package discovery. `nil` container → `[]`, matching
-    /// `SitePickerModel.refresh()`'s `.iCloudUnavailable` short-circuit (this type has no
-    /// equivalent state to publish, so an empty result is the only signal available).
-    private func discoveredURLs() async -> [URL] {
-        guard containerResolver.url(
-            forUbiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier
-        ) != nil else {
-            return []
-        }
-        let packageDiscovery = await makePackageDiscovery()
-        return await packageDiscovery.discoverPackages()
+    /// Maps the discovered package URLs with `body`, off the calling task.
+    ///
+    /// Every `SiteEntityUbiquitySource` entry point calls `AnglesitePackage.readMarker` once per
+    /// package — an `Info.plist` read inside the ubiquity container, which can block on a
+    /// materializing iCloud item. `SitePickerModel.refresh()` gives those reads a
+    /// `Task.detached(priority: .userInitiated)` hop for exactly that reason; this does the same,
+    /// one hop for the whole list rather than one per package.
+    private func mapDiscovered<T: Sendable>(
+        _ body: @escaping @Sendable ([URL]) -> T
+    ) async -> T {
+        let urls = await discovery.discoveredURLs()
+        return await Task.detached(priority: .userInitiated) { body(urls) }.value
     }
 
     public func entities(for identifiers: [String]) async throws -> [SiteEntity] {
-        SiteEntityUbiquitySource.entities(for: identifiers, in: await discoveredURLs())
+        await mapDiscovered { SiteEntityUbiquitySource.entities(for: identifiers, in: $0) }
     }
 
     public func entities(matching string: String) async throws -> [SiteEntity] {
-        SiteEntityUbiquitySource.entities(matching: string, in: await discoveredURLs())
+        await mapDiscovered { SiteEntityUbiquitySource.entities(matching: string, in: $0) }
     }
 
     public func suggestedEntities() async throws -> [SiteEntity] {
-        SiteEntityUbiquitySource.siteEntities(fromPackageURLs: await discoveredURLs())
+        await mapDiscovered { SiteEntityUbiquitySource.siteEntities(fromPackageURLs: $0) }
     }
 
     public func defaultResult() async -> SiteEntity? {
-        SiteEntityUbiquitySource.defaultResult(in: await discoveredURLs())
+        await mapDiscovered { SiteEntityUbiquitySource.defaultResult(in: $0) }
     }
 }
 #endif

--- a/Sources/AnglesiteIntents/SiteEntityQueryIOS.swift
+++ b/Sources/AnglesiteIntents/SiteEntityQueryIOS.swift
@@ -1,0 +1,68 @@
+#if os(iOS)
+import AppIntents
+import AnglesiteCore
+import AnglesiteIOS
+import Foundation
+
+/// Resolves `SiteEntity`s on iOS by discovering `.anglesite` packages in the app's iCloud
+/// ubiquity container — the same mechanism `SitePickerModel` uses in production
+/// (`Sources/AnglesiteIOS/SitePickerModel.swift`). All mapping/matching logic lives in
+/// `SiteEntityUbiquitySource`; this type's only job is resolving the discovered `[URL]` list and
+/// handing it off. Not exercised by `swift test` (excluded on a macOS host by this `#if
+/// os(iOS)` gate) — verified by `xcodebuild ... -scheme AnglesiteMobile ... build` only.
+public struct SiteEntityQueryIOS: EntityStringQuery {
+    private let containerResolver: any UbiquityContainerResolving
+    /// `NSMetadataQueryPackageDiscovery` is `@MainActor`-isolated (see
+    /// `Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift`), so its no-arg initializer can't
+    /// be called synchronously from this struct's plain, non-isolated `init()`. Storing a
+    /// `@MainActor`-isolated factory instead of an already-constructed instance defers that call
+    /// to `discoveredURLs()`, which is `async` and can `await` across the actor hop.
+    private let makePackageDiscovery: @MainActor @Sendable () -> any UbiquitousPackageDiscovering
+
+    /// The no-argument initializer AppIntents requires — binds to the real iCloud container
+    /// resolver and `NSMetadataQuery`-backed discovery, matching every other production call
+    /// site.
+    public init() {
+        self.containerResolver = FileManager.default
+        self.makePackageDiscovery = { NSMetadataQueryPackageDiscovery() }
+    }
+
+    /// Test seam: bind the query to fakes instead of real iCloud state.
+    public init(
+        containerResolver: any UbiquityContainerResolving,
+        packageDiscovery: any UbiquitousPackageDiscovering
+    ) {
+        self.containerResolver = containerResolver
+        self.makePackageDiscovery = { packageDiscovery }
+    }
+
+    /// Ubiquity container check, then package discovery. `nil` container → `[]`, matching
+    /// `SitePickerModel.refresh()`'s `.iCloudUnavailable` short-circuit (this type has no
+    /// equivalent state to publish, so an empty result is the only signal available).
+    private func discoveredURLs() async -> [URL] {
+        guard containerResolver.url(
+            forUbiquityContainerIdentifier: AppSettings.ubiquityContainerIdentifier
+        ) != nil else {
+            return []
+        }
+        let packageDiscovery = await makePackageDiscovery()
+        return await packageDiscovery.discoverPackages()
+    }
+
+    public func entities(for identifiers: [String]) async throws -> [SiteEntity] {
+        SiteEntityUbiquitySource.entities(for: identifiers, in: await discoveredURLs())
+    }
+
+    public func entities(matching string: String) async throws -> [SiteEntity] {
+        SiteEntityUbiquitySource.entities(matching: string, in: await discoveredURLs())
+    }
+
+    public func suggestedEntities() async throws -> [SiteEntity] {
+        SiteEntityUbiquitySource.siteEntities(fromPackageURLs: await discoveredURLs())
+    }
+
+    public func defaultResult() async -> SiteEntity? {
+        SiteEntityUbiquitySource.defaultResult(in: await discoveredURLs())
+    }
+}
+#endif

--- a/Sources/AnglesiteIntents/SiteEntityUbiquityDiscovery.swift
+++ b/Sources/AnglesiteIntents/SiteEntityUbiquityDiscovery.swift
@@ -1,0 +1,93 @@
+import AnglesiteCore
+import AnglesiteIOS
+import Foundation
+
+/// Caches and coalesces iCloud package discovery behind `SiteEntityQueryIOS` (#1394).
+/// `NSMetadataQueryPackageDiscovery.discoverPackages()` runs a full `NSMetadataQuery` gather
+/// bounded at 25s (tuned for `SitePickerScreen`'s picker UX, not Siri's interaction budget) —
+/// AppIntents routinely calls more than one `EntityStringQuery` method per interaction (e.g.
+/// `defaultResult()` then `suggestedEntities()` for disambiguation), so without caching a single
+/// utterance could trigger 2-4 independent 25s-bounded gathers, each able to time out to an empty
+/// `[]` result — silently telling the user "no sites found" when sites exist.
+///
+/// Also restores the off-caller-task handling `SitePickerModel.refresh()` established for the
+/// container lookup (`UbiquityContainerResolving.url(forUbiquityContainerIdentifier:)` is
+/// documented as potentially slow — it may hit the network) by running it inside a
+/// `Task.detached`. The other half of that precedent, the per-package `readMarker` reads, happens
+/// in `SiteEntityUbiquitySource` rather than here, so `SiteEntityQueryIOS` gives *those* their own
+/// detached hop at the point it maps this type's URLs into entities.
+///
+/// No platform gate: `UbiquityContainerResolving`/`UbiquitousPackageDiscovering` are both
+/// platform-neutral, so this actor is `swift test`-able on the macOS host with fakes, unlike the
+/// `#if os(iOS)`-gated query type that owns an instance of it.
+actor SiteEntityUbiquityDiscovery {
+    private let containerResolver: any UbiquityContainerResolving
+    /// `NSMetadataQueryPackageDiscovery` is `@MainActor`-isolated (see
+    /// `Sources/AnglesiteIOS/UbiquitousPackageDiscovering.swift`), so its construction is deferred
+    /// to the discovery task rather than happening in `init()`, which is not isolated to the main
+    /// actor and so cannot call it. The real implementation holds no mutable state (each
+    /// `discoverPackages()` call builds and tears down its own gather session), so constructing it
+    /// per discovery rather than caching the instance costs nothing — and it keeps the whole
+    /// `@MainActor` hop inside the coalesced task, where it can't reintroduce a suspension point
+    /// ahead of `inFlight` being published.
+    private let makePackageDiscovery: @MainActor @Sendable () -> any UbiquitousPackageDiscovering
+    private let ubiquityContainerIdentifier: String
+    private let cacheTTL: Duration
+
+    private var cachedURLs: [URL]?
+    private var cachedAt: ContinuousClock.Instant?
+    private var inFlight: Task<[URL], Never>?
+    private let clock = ContinuousClock()
+
+    /// - Parameters:
+    ///   - cacheTTL: how long a cached result stays fresh before the next call re-discovers.
+    ///     Short on purpose: long enough to collapse the several `EntityStringQuery` calls one
+    ///     Siri interaction makes into a single gather, short enough that a newly-created or
+    ///     renamed site shows up quickly on the next interaction. Defaults to 5 seconds.
+    init(
+        containerResolver: any UbiquityContainerResolving,
+        makePackageDiscovery: @escaping @MainActor @Sendable () -> any UbiquitousPackageDiscovering,
+        ubiquityContainerIdentifier: String,
+        cacheTTL: Duration = .seconds(5)
+    ) {
+        self.containerResolver = containerResolver
+        self.makePackageDiscovery = makePackageDiscovery
+        self.ubiquityContainerIdentifier = ubiquityContainerIdentifier
+        self.cacheTTL = cacheTTL
+    }
+
+    /// Discovered package URLs: served from cache when fresh, coalesced with any in-flight
+    /// discovery so concurrent calls share one gather rather than racing two, or freshly
+    /// discovered (off this actor's task, via `Task.detached`) otherwise.
+    ///
+    /// An unavailable ubiquity container yields `[]` without starting a gather, matching
+    /// `SitePickerModel.refresh()`'s `.iCloudUnavailable` short-circuit (this type has no
+    /// equivalent state to publish, so an empty result is the only signal available).
+    func discoveredURLs() async -> [URL] {
+        if let cachedAt, let cachedURLs, cachedAt.duration(to: clock.now) < cacheTTL {
+            return cachedURLs
+        }
+        if let inFlight {
+            return await inFlight.value
+        }
+
+        // Everything between the `inFlight` check above and this assignment must stay
+        // `await`-free: a suspension point in here would let a second caller past the check and
+        // start a redundant gather, which is exactly what this type exists to prevent.
+        let resolver = containerResolver
+        let identifier = ubiquityContainerIdentifier
+        let make = makePackageDiscovery
+        let task = Task.detached(priority: .userInitiated) { () -> [URL] in
+            guard resolver.url(forUbiquityContainerIdentifier: identifier) != nil else {
+                return []
+            }
+            return await make().discoverPackages()
+        }
+        inFlight = task
+        let urls = await task.value
+        cachedURLs = urls
+        cachedAt = clock.now
+        inFlight = nil
+        return urls
+    }
+}

--- a/Sources/AnglesiteIntents/SiteEntityUbiquitySource.swift
+++ b/Sources/AnglesiteIntents/SiteEntityUbiquitySource.swift
@@ -13,10 +13,16 @@ enum SiteEntityUbiquitySource {
     /// read (mid-materializing iCloud item, corrupt or missing `Info.plist`) is dropped, not
     /// thrown — matches `SitePickerModel.refresh()`'s existing behavior
     /// (`Sources/AnglesiteIOS/SitePickerModel.swift`).
+    ///
+    /// Sorted by display name, for the same reason `SitePickerModel.refresh()` sorts its own
+    /// list: `NSMetadataQuery` result order is an implementation detail that can differ between
+    /// gathers, and a disambiguation list that reshuffles between two calls in one Siri
+    /// interaction is worse than one in a slightly arbitrary but *stable* order. Also brings iOS
+    /// in line with the macOS `SiteStore`-backed query, whose order is the registry's.
     static func siteEntities(
         fromPackageURLs urls: [URL], fileManager: FileManager = .default
     ) -> [SiteEntity] {
-        urls.compactMap { url in
+        urls.compactMap { url -> SiteEntity? in
             let package = AnglesitePackage(url: url)
             guard let marker = try? package.readMarker(fileManager: fileManager) else {
                 return nil
@@ -31,6 +37,7 @@ enum SiteEntityUbiquitySource {
                 directory: url
             )
         }
+        .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
     /// Exact-id resolution — the path Shortcuts uses to re-resolve a previously captured entity.

--- a/Sources/AnglesiteIntents/SiteEntityUbiquitySource.swift
+++ b/Sources/AnglesiteIntents/SiteEntityUbiquitySource.swift
@@ -1,0 +1,61 @@
+import AnglesiteSiteModel
+import Foundation
+
+/// Pure, platform-neutral mapping from discovered `.anglesite` package URLs to `SiteEntity`
+/// values. Deliberately carries **no** discovery of its own and **no** platform gate: callers own
+/// resolving the URL list (macOS's `SiteEntityQuery` doesn't use this at all — it stays
+/// `SiteStore`-backed; iOS's `SiteEntityQueryIOS` resolves the list via
+/// `UbiquityContainerResolving`/`UbiquitousPackageDiscovering` and hands it here). Keeping this
+/// logic gate-free is what makes it exercisable by plain `swift test` on the macOS host, unlike
+/// the `#if os(iOS)`-gated wrapper that calls it.
+enum SiteEntityUbiquitySource {
+    /// Reads each URL's package marker and builds a `SiteEntity`. A package whose marker fails to
+    /// read (mid-materializing iCloud item, corrupt or missing `Info.plist`) is dropped, not
+    /// thrown — matches `SitePickerModel.refresh()`'s existing behavior
+    /// (`Sources/AnglesiteIOS/SitePickerModel.swift`).
+    static func siteEntities(
+        fromPackageURLs urls: [URL], fileManager: FileManager = .default
+    ) -> [SiteEntity] {
+        urls.compactMap { url in
+            let package = AnglesitePackage(url: url)
+            guard let marker = try? package.readMarker(fileManager: fileManager) else {
+                return nil
+            }
+            let keys: Set<URLResourceKey> = [.creationDateKey, .contentModificationDateKey]
+            let values = try? package.sourceURL.resourceValues(forKeys: keys)
+            return SiteEntity(
+                id: marker.siteID.uuidString,
+                name: marker.displayName,
+                creationDate: values?.creationDate,
+                modificationDate: values?.contentModificationDate,
+                directory: url
+            )
+        }
+    }
+
+    /// Exact-id resolution — the path Shortcuts uses to re-resolve a previously captured entity.
+    /// Unknown ids are silently dropped (deleted/renamed sites), not errors.
+    static func entities(
+        for identifiers: [String], in urls: [URL], fileManager: FileManager = .default
+    ) -> [SiteEntity] {
+        siteEntities(fromPackageURLs: urls, fileManager: fileManager)
+            .filter { identifiers.contains($0.id) }
+    }
+
+    /// Case-insensitive substring match on the site name, for Siri utterances like "my portfolio
+    /// site".
+    static func entities(
+        matching string: String, in urls: [URL], fileManager: FileManager = .default
+    ) -> [SiteEntity] {
+        let needle = string.lowercased()
+        return siteEntities(fromPackageURLs: urls, fileManager: fileManager)
+            .filter { $0.name.lowercased().contains(needle) }
+    }
+
+    /// The single site when there is exactly one, so Siri can skip the "which site?" prompt
+    /// entirely; `nil` (forcing disambiguation) in every other case.
+    static func defaultResult(in urls: [URL], fileManager: FileManager = .default) -> SiteEntity? {
+        let sites = siteEntities(fromPackageURLs: urls, fileManager: fileManager)
+        return sites.count == 1 ? sites.first : nil
+    }
+}

--- a/Sources/AnglesiteIntents/SiteIntents.swift
+++ b/Sources/AnglesiteIntents/SiteIntents.swift
@@ -23,7 +23,7 @@ public struct DeploySiteIntent: AppIntent {
     /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Deploy a site to production with Anglesite.")
 
-    /// The site to deploy, resolved through ``SiteEntityQuery``.
+    /// The site to deploy, resolved through ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
 
@@ -89,7 +89,7 @@ public struct BackupSiteIntent: AppIntent {
     /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Commit and push a site backup with Anglesite.")
 
-    /// The site to back up, resolved through ``SiteEntityQuery``.
+    /// The site to back up, resolved through ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
 
@@ -141,7 +141,7 @@ public struct AuditSiteIntent: AppIntent {
     /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Run an Anglesite audit and report findings.")
 
-    /// The site to check, resolved through ``SiteEntityQuery``.
+    /// The site to check, resolved through ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     @Dependency private var ops: any SiteOperationsService
 

--- a/Sources/AnglesiteIntents/ThemeIntents.swift
+++ b/Sources/AnglesiteIntents/ThemeIntents.swift
@@ -18,7 +18,7 @@ public struct ApplyThemeIntent: AppIntent {
     /// One-line explanation shown in the Shortcuts action gallery.
     public static let description = IntentDescription("Apply a built-in visual theme to a site.")
 
-    /// The site whose design tokens the theme rewrites, resolved through ``SiteEntityQuery``.
+    /// The site whose design tokens the theme rewrites, resolved through ``SiteEntity``'s `defaultQuery`.
     @Parameter(title: "Site") public var site: SiteEntity
     /// The catalog id of the theme. A plain string (not an `AppEnum`) so the catalog can grow
     /// without a schema change; an unrecognized id gets a dialog listing what's available

--- a/Tests/AnglesiteIntentsTests/SiteEntityUbiquityDiscoveryTests.swift
+++ b/Tests/AnglesiteIntentsTests/SiteEntityUbiquityDiscoveryTests.swift
@@ -1,0 +1,161 @@
+import Testing
+import Foundation
+import AnglesiteCore
+import AnglesiteIOS
+@testable import AnglesiteIntents
+
+/// Same shape as `SitePickerModelTests`' fake of the same name
+/// (`Tests/AnglesiteIOSTests/SitePickerModelTests.swift`) — an independent copy rather than a
+/// shared one, since both are `private` to their own test target.
+private struct FakeUbiquityContainerResolver: UbiquityContainerResolving {
+    let result: URL?
+    func url(forUbiquityContainerIdentifier containerIdentifier: String?) -> URL? { result }
+}
+
+/// Records how many gathers actually happened — the whole point of `SiteEntityUbiquityDiscovery`
+/// is that this number stays at 1 across the several `EntityStringQuery` calls one Siri
+/// interaction makes.
+private actor CountingPackageDiscovery: UbiquitousPackageDiscovering {
+    private let urls: [URL]
+    private(set) var callCount = 0
+
+    init(urls: [URL]) { self.urls = urls }
+
+    func discoverPackages() async -> [URL] {
+        callCount += 1
+        return urls
+    }
+}
+
+/// Parks its *first* gather until `release()`, so a test can hold a discovery open and pile
+/// concurrent callers behind it. Mirrors `SitePickerModelTests`' `GatedPackageDiscovery`, but
+/// later calls return immediately rather than parking too: a coalescing regression must show up
+/// as a `callCount` assertion failure, never as a deadlocked test.
+private actor GatedPackageDiscovery: UbiquitousPackageDiscovering {
+    private let urls: [URL]
+    private(set) var callCount = 0
+    private var parked: CheckedContinuation<Void, Never>?
+    private var waitingForPark: CheckedContinuation<Void, Never>?
+    private var isParked = false
+    private var isReleased = false
+
+    init(urls: [URL]) { self.urls = urls }
+
+    func discoverPackages() async -> [URL] {
+        callCount += 1
+        guard callCount == 1, !isReleased else { return urls }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            parked = continuation
+            isParked = true
+            waitingForPark?.resume()
+            waitingForPark = nil
+        }
+        return urls
+    }
+
+    /// Event-driven rather than a sleep: resumes as soon as the first gather is actually parked.
+    func waitUntilParked() async {
+        guard !isParked else { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            waitingForPark = continuation
+        }
+    }
+
+    func release() {
+        isReleased = true
+        parked?.resume()
+        parked = nil
+    }
+}
+
+struct SiteEntityUbiquityDiscoveryTests {
+    private let container = URL(fileURLWithPath: "/tmp/fake-ubiquity-container", isDirectory: true)
+    private let siteA = URL(fileURLWithPath: "/tmp/fake-ubiquity-container/A.anglesite", isDirectory: true)
+    private let siteB = URL(fileURLWithPath: "/tmp/fake-ubiquity-container/B.anglesite", isDirectory: true)
+
+    private func makeSubject(
+        containerResult: URL?,
+        discovery: any UbiquitousPackageDiscovering,
+        cacheTTL: Duration = .seconds(60)
+    ) -> SiteEntityUbiquityDiscovery {
+        SiteEntityUbiquityDiscovery(
+            containerResolver: FakeUbiquityContainerResolver(result: containerResult),
+            makePackageDiscovery: { discovery },
+            ubiquityContainerIdentifier: "iCloud.io.dwk.anglesite.tests",
+            cacheTTL: cacheTTL
+        )
+    }
+
+    @Test("Discovered URLs pass through unchanged")
+    func discoveredURLsPassThrough() async {
+        let discovery = CountingPackageDiscovery(urls: [siteA, siteB])
+        let subject = makeSubject(containerResult: container, discovery: discovery)
+        #expect(await subject.discoveredURLs() == [siteA, siteB])
+    }
+
+    @Test("Repeated calls inside the TTL reuse one gather")
+    func repeatedCallsInsideTTLReuseOneGather() async {
+        let discovery = CountingPackageDiscovery(urls: [siteA])
+        let subject = makeSubject(containerResult: container, discovery: discovery)
+
+        let first = await subject.discoveredURLs()
+        let second = await subject.discoveredURLs()
+        let third = await subject.discoveredURLs()
+
+        #expect(first == [siteA])
+        #expect(second == first)
+        #expect(third == first)
+        let callCount = await discovery.callCount
+        #expect(callCount == 1)
+    }
+
+    @Test("A call after the TTL expires re-discovers")
+    func callAfterTTLExpiryRediscovers() async throws {
+        let discovery = CountingPackageDiscovery(urls: [siteA])
+        let subject = makeSubject(
+            containerResult: container, discovery: discovery, cacheTTL: .milliseconds(10))
+
+        _ = await subject.discoveredURLs()
+        try await Task.sleep(for: .milliseconds(150))
+        _ = await subject.discoveredURLs()
+
+        let callCount = await discovery.callCount
+        #expect(callCount == 2)
+    }
+
+    @Test("Concurrent callers share a single gather")
+    func concurrentCallersShareOneGather() async {
+        let discovery = GatedPackageDiscovery(urls: [siteA, siteB])
+        let subject = makeSubject(containerResult: container, discovery: discovery)
+        let callerCount = 6
+
+        let results = await withTaskGroup(of: [URL].self, returning: [[URL]].self) { group in
+            for _ in 0..<callerCount {
+                group.addTask { await subject.discoveredURLs() }
+            }
+            // Only unblock the gather once at least one caller is definitely inside it, so the
+            // remaining callers are racing a genuinely in-flight discovery rather than a
+            // finished one.
+            await discovery.waitUntilParked()
+            await discovery.release()
+            return await group.reduce(into: []) { $0.append($1) }
+        }
+
+        #expect(results.count == callerCount)
+        #expect(results.allSatisfy { $0 == [siteA, siteB] })
+        let callCount = await discovery.callCount
+        #expect(callCount == 1)
+    }
+
+    @Test("An unavailable container returns no URLs without gathering")
+    func unavailableContainerSkipsGather() async {
+        let discovery = CountingPackageDiscovery(urls: [siteA])
+        let subject = makeSubject(containerResult: nil, discovery: discovery)
+
+        let urls = await subject.discoveredURLs()
+
+        #expect(urls.isEmpty)
+        let callCount = await discovery.callCount
+        #expect(callCount == 0)
+    }
+}

--- a/Tests/AnglesiteIntentsTests/SiteEntityUbiquitySourceTests.swift
+++ b/Tests/AnglesiteIntentsTests/SiteEntityUbiquitySourceTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+@testable import AnglesiteIntents
+import AnglesiteSiteModel
+
+/// A `final class` (not `struct`) so `deinit` can clean up the scratch directory — mirrors
+/// `SitePickerModelTests`' pattern (`Tests/AnglesiteIOSTests/SitePickerModelTests.swift`).
+final class SiteEntityUbiquitySourceTests {
+    private let scratchRoot: URL
+
+    init() {
+        scratchRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SiteEntityUbiquitySourceTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    deinit {
+        let root = scratchRoot
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func makePackage(displayName: String) throws -> URL {
+        let url = scratchRoot.appendingPathComponent("\(displayName).anglesite", isDirectory: true)
+        _ = try AnglesitePackage.createSkeleton(at: url, displayName: displayName)
+        return url
+    }
+
+    @Test("A well-formed package maps to a SiteEntity with matching id and name")
+    func wellFormedPackageMapsToEntity() throws {
+        let url = try makePackage(displayName: "My Blog")
+        let entities = SiteEntityUbiquitySource.siteEntities(fromPackageURLs: [url])
+        #expect(entities.count == 1)
+        #expect(entities.first?.name == "My Blog")
+        #expect(entities.first?.directory == url)
+    }
+
+    @Test("A package with no marker (malformed) is dropped, not thrown")
+    func malformedPackageIsDropped() throws {
+        let url = scratchRoot.appendingPathComponent("Not A Package.anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        let entities = SiteEntityUbiquitySource.siteEntities(fromPackageURLs: [url])
+        #expect(entities.isEmpty)
+    }
+
+    @Test("Multiple packages all map, one bad package among good ones is skipped")
+    func mixedGoodAndBadPackages() throws {
+        let good = try makePackage(displayName: "Good Site")
+        let bad = scratchRoot.appendingPathComponent("Bad.anglesite", isDirectory: true)
+        try FileManager.default.createDirectory(at: bad, withIntermediateDirectories: true)
+        let entities = SiteEntityUbiquitySource.siteEntities(fromPackageURLs: [good, bad])
+        #expect(entities.count == 1)
+        #expect(entities.first?.name == "Good Site")
+    }
+
+    @Test("entities(for:) returns only ids that match")
+    func entitiesForIdentifiersFilters() throws {
+        let a = try makePackage(displayName: "Site A")
+        let b = try makePackage(displayName: "Site B")
+        let all = SiteEntityUbiquitySource.siteEntities(fromPackageURLs: [a, b])
+        let targetID = all.first { $0.name == "Site A" }!.id
+        let filtered = SiteEntityUbiquitySource.entities(for: [targetID], in: [a, b])
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.name == "Site A")
+    }
+
+    @Test("entities(matching:) is a case-insensitive substring match")
+    func entitiesMatchingIsCaseInsensitiveSubstring() throws {
+        let url = try makePackage(displayName: "My Portfolio Site")
+        let matches = SiteEntityUbiquitySource.entities(matching: "portfolio", in: [url])
+        #expect(matches.count == 1)
+        let noMatches = SiteEntityUbiquitySource.entities(matching: "nonexistent", in: [url])
+        #expect(noMatches.isEmpty)
+    }
+
+    @Test("defaultResult() returns the single site when exactly one exists")
+    func defaultResultReturnsSingleSite() throws {
+        let url = try makePackage(displayName: "Only Site")
+        #expect(SiteEntityUbiquitySource.defaultResult(in: [url])?.name == "Only Site")
+    }
+
+    @Test("defaultResult() returns nil when zero or multiple sites exist")
+    func defaultResultReturnsNilWhenNotExactlyOne() throws {
+        #expect(SiteEntityUbiquitySource.defaultResult(in: []) == nil)
+        let a = try makePackage(displayName: "Site A")
+        let b = try makePackage(displayName: "Site B")
+        #expect(SiteEntityUbiquitySource.defaultResult(in: [a, b]) == nil)
+    }
+}

--- a/docs/superpowers/plans/2026-08-10-ios-siteentity-icloud-source.md
+++ b/docs/superpowers/plans/2026-08-10-ios-siteentity-icloud-source.md
@@ -378,7 +378,7 @@ to:
 - [ ] **Step 3: Verify the macOS build and tests are unaffected**
 
 Run: `swift test --package-path . --filter SiteEntityUbiquitySourceTests`
-Expected: PASS, same 8 tests (macOS `SiteEntityQuery` itself has no existing dedicated test file to re-run; its behavior is unchanged, only newly gated).
+Expected: PASS, same 8 tests. Also re-run `Tests/AnglesiteIntentsTests/SiteEntityQueryTests.swift` (8 cases covering the macOS `SiteStore`-backed query, whose behavior is unchanged — only newly gated). *(Corrected after the fact: this step originally claimed no such test file existed. It does, and it did run and pass; the claim was a documentation error, not a missed check.)*
 
 Run: `swift build --package-path .`
 Expected: succeeds — confirms `SiteEntity.swift`'s macOS branch still compiles cleanly with the new `#if os(macOS)` wrapping.


### PR DESCRIPTION
Closes #1394

## Summary

- Gives iOS's `SiteEntity` AppIntents resolution a real backing: iCloud-discovered `.anglesite` packages, instead of the macOS-only `SiteStore`.
- Adds a pure, `swift test`-covered mapping layer (`SiteEntityUbiquitySource`) that maps `NSMetadataQuery`-discovered ubiquity items to `SiteEntity` values and handles search/matching, in a stable (name-sorted) order.
- Adds `SiteEntityUbiquityDiscovery`, a gate-free actor that caches and coalesces iCloud discovery so one Siri interaction triggers one `NSMetadataQuery` gather instead of 2-4.
- Adds `SiteEntityQueryIOS` — a thin `#if os(iOS)` `EntityStringQuery` over those two — as the platform-conditional backing for `SiteEntity.defaultQuery` on iOS, and makes `AnglesiteIntents` depend on `AnglesiteIOS` unconditionally.

### Design notes

- **This is sub-project A of a larger gap.** #1386's final review surfaced that linking `AnglesiteIntents` into `AnglesiteMobile` exposes `AnglesiteShortcuts` + ~28 `AppIntent`s to iOS Siri with no dependency bootstrap. Sub-projects B (iOS `ContentOperationsService`), C (iOS `IntegrationOperationsService`), D (`EditContentIntent` iOS wiring), and E (platform-gating the intents that can never run on iOS) are separate, unfiled follow-ups. **This PR does not resolve the Siri-crash risk on its own** — it only closes the `SiteEntity` resolution gap underneath it.

#### Final whole-branch review fix wave

A whole-branch review after the original three commits found one Critical and three Important issues. All are fixed in the three commits on top:

- **Critical — the iOS query was compiled by nothing.** `Package.swift` gated the `AnglesiteIOS` dependency to `.iOS`, and `AnglesiteMobile` didn't link `AnglesiteIntents` at all, so `SiteEntityQueryIOS.swift` was in no target on any platform. The earlier "iOS build succeeded" checks were true but hollow — that build never included the file. #1389 has since landed the `AnglesiteMobile` → `AnglesiteIntents` edge on main; this PR drops the other half, the `.iOS` condition. The iOS build now genuinely compiles both new files (verified in the build log), for the first time.
- **Important — one Siri utterance could run 2-4 independent 25s-bounded gathers.** AppIntents calls more than one `EntityStringQuery` method per interaction, and each was doing its own full `NSMetadataQuery` gather; on a degraded iCloud container each could time out to `[]`, telling the user "I couldn't find that site" when the site exists. `SiteEntityUbiquityDiscovery` now caches (short TTL) and coalesces concurrent callers onto one gather.
- **Important — the off-thread precedent had been dropped.** `SitePickerModel.refresh()` wraps both the ubiquity-container lookup (documented as potentially hitting the network) and the per-package `readMarker` reads in `Task.detached`; this branch's code did neither. Both hops are restored.
- **Important — the `#if os(iOS)` gate made the orchestration untestable.** The gate was only there because of the conditional dependency, which wasn't needed: `UbiquityContainerResolving`/`UbiquitousPackageDiscovering`/`NSMetadataQueryPackageDiscovery` are all platform-neutral and already build and test on the macOS host. With the dependency unconditional, the caching/coalescing logic lives in a gate-free actor with 5 `swift test` cases, and the gated wrapper shrinks to pure delegation.

Minor fixes in the same wave: stable name ordering for iOS-discovered entities (matching `SitePickerModel` and the macOS query's stable registry order); `SiteEntity` doc comments that described the macOS `SiteStore` path as universal; and ``SiteEntityQuery`` DocC links across the intent files, which no longer resolve on iOS now that the type is `#if os(macOS)`-gated (repointed at ``SiteEntity``'s `defaultQuery`).

One implementation note worth flagging for review: the `@MainActor` construction of `NSMetadataQueryPackageDiscovery` happens *inside* the discovery task, not on the actor's own path. As an `await` before `inFlight` is published it would have been a suspension point that let a second caller slip past the coalescing check — defeating the point of the type.

#### Rebase note

This branch was rebased onto `main` after #1389 merged. Four of its docs commits were dropped by git as "patch contents already upstream" (#1389 carried the same design and plan documents; the branch's final copy was confirmed byte-identical before accepting the drop). The anticipated `project.yml` conflict with #1389 is therefore already resolved — `project.yml` on this branch is now identical to `main`'s, and the branch is 3 fix-wave commits on top of the 3 original implementation commits.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite-skills#123 -->

## Test plan

All four re-run against the rebased branch.

- [x] `swift test --package-path .` — 9 of 10 test runs pass, including `3591 tests in 430 suites`; both `SiteEntityUbiquityDiscoveryTests` (5 new cases: pass-through, cache reuse, TTL expiry, 6-caller coalescing, container-unavailable) and `SiteEntityUbiquitySourceTests` pass. One failure, `ComponentEditorModelDraftStateTests."a second debounceColorCommit call cancels the first pending commit"` — a wall-clock debounce assertion in code this branch does not touch (the diff has zero files under `Sources/AnglesiteApp/`), which passed in the pre-rebase run and passes on isolated re-run (`18 tests in 1 suite passed`). Two concurrent `swift test` runs on the machine are the likely cause of the missed debounce window.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile -configuration Debug -destination 'generic/platform=iOS Simulator' build` — `** BUILD SUCCEEDED **`, and the log confirms `SiteEntityQueryIOS.swift` and `SiteEntityUbiquityDiscovery.swift` were actually compiled, warning-free.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — `** BUILD SUCCEEDED **`; the now-unconditional `AnglesiteIOS` links into the Mac app without incident.
- [x] `scripts/check-xcodeproj-sync.sh` — in sync (`Anglesite` 156 files under `Sources/AnglesiteApp`; `AnglesiteMobile` 9 files under `Sources/AnglesiteMobile`)
- [ ] Manual smoke (if UI-touching): not performed — this PR wires resolution plumbing only; no UI surface changed.
