### PR TITLE
feat(#907): hosted community provisioning + moderation

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -837,6 +837,7 @@ final class DeployModel {
         // `provision()` for the wrangler.toml var.
         let resolvedApUsername = DeployCoordinator.resolveEffectiveActivityPubUsername(siteDirectory: siteDirectory)
         let acknowledgesPaidPlan = settings.webmentionReceivePaidPlanAcknowledged ?? false
+        let isHostedCommunity = DeployCoordinator.resolveIsHostedCommunity(siteDirectory: siteDirectory)
         let provisionResult = await socialCommand.provision(
             siteID: siteID,
             siteDirectory: siteDirectory,
@@ -848,7 +849,9 @@ final class DeployModel {
             displayName: settings.displayName,
             apUsername: apUsername,
             acknowledgesPaidPlan: acknowledgesPaidPlan,
-            inboxCaptureEnabled: settings.inboxCaptureEnabled ?? false
+            inboxCaptureEnabled: settings.inboxCaptureEnabled ?? false,
+            activityPubActorType: isHostedCommunity ? "Group" : nil,
+            moderators: isHostedCommunity ? settings.moderators : nil
         )
 
         if case .webmentionPaidPlanConfirmationNeeded = provisionResult {
@@ -877,11 +880,13 @@ final class DeployModel {
         // on a specific provisioned resource). Computed before the persist call below too: it
         // also gates whether this deploy advances the `lastDeployedAPUsername` baseline (#1239).
         let activitypubProvisioned = workers.contains(where: { $0.id == WorkerComposition.activitypubWorkerID })
-        if case .succeeded(_, let resources, _) = provisionResult {
+        if case .succeeded(let deployedURL, let resources, _) = provisionResult {
             await DeployCoordinator.persistProvisionedResources(
                 configStore: configStore, settings: settings,
                 effectiveActiveIDs: effectiveActiveIDs, resources: resources,
-                apUsername: activitypubProvisioned ? resolvedApUsername : nil
+                apUsername: activitypubProvisioned ? resolvedApUsername : nil,
+                communityActorURL: (isHostedCommunity && activitypubProvisioned)
+                    ? ActivityPubActor.actorURL(siteURL: deployedURL) : nil
             )
             websubProvisioned = workers.contains(where: { $0.id == WorkerComposition.websubWorkerID })
                 && resources.websubQueueName != nil

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -881,12 +881,21 @@ final class DeployModel {
         // also gates whether this deploy advances the `lastDeployedAPUsername` baseline (#1239).
         let activitypubProvisioned = workers.contains(where: { $0.id == WorkerComposition.activitypubWorkerID })
         if case .succeeded(let deployedURL, let resources, _) = provisionResult {
+            // The actor IRI must be derived the same way `ModerationModel.ownActorURL` derives
+            // "this site's own actor" (`DeployCoordinator.resolveSiteURL`), not from the
+            // workers.dev URL this particular deploy happened to print — `resolveSiteURL`
+            // deliberately prefers a confirmed-attached custom domain, and `persistSiteURL`
+            // (called above, before `provision()` ran) has already recorded whatever domain state
+            // is current by this point. Falls back to `deployedURL` only for the very first
+            // deploy, before any URL has ever been recorded (#1263 final review finding 3).
+            let communityActorSiteURL =
+                DeployCoordinator.resolveSiteURL(siteDirectory: siteDirectory).flatMap { URL(string: $0) } ?? deployedURL
             await DeployCoordinator.persistProvisionedResources(
                 configStore: configStore, settings: settings,
                 effectiveActiveIDs: effectiveActiveIDs, resources: resources,
                 apUsername: activitypubProvisioned ? resolvedApUsername : nil,
                 communityActorURL: (isHostedCommunity && activitypubProvisioned)
-                    ? ActivityPubActor.actorURL(siteURL: deployedURL) : nil
+                    ? ActivityPubActor.actorURL(siteURL: communityActorSiteURL) : nil
             )
             websubProvisioned = workers.contains(where: { $0.id == WorkerComposition.websubWorkerID })
                 && resources.websubQueueName != nil

--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -69,6 +69,11 @@ struct NewContentCommands: Commands {
             }
             .keyboardShortcut("n", modifiers: [.command, .shift])
 
+            Button("New Community…") {
+                openWindow(id: "sites")
+                WindowRouter.shared.requestNewCommunity()
+            }
+
             Button("Open Site…") {
                 Task { await openSiteFromMenu() }
             }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1,50 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Traffic" : {
-
-    },
-    "No traffic recorded in the last 7 days." : {
-
-    },
-    "Last 7 days: %lld pageviews · %lld visits" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Last 7 days: %1$lld pageviews · %2$lld visits"
-          }
-        }
-      }
-    },
-    "7-day pageviews trend" : {
-
-    },
-    "%lld total pageviews over the last 7 days, %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld total pageviews over the last 7 days, %2$@"
-          }
-        }
-      }
-    },
-    "trending up" : {
-
-    },
-    "trending down" : {
-
-    },
-    "holding steady" : {
-
-    },
-    "Day" : {
-
-    },
-    "Pageviews" : {
-
-    },
     "" : {
 
     },
@@ -250,6 +206,16 @@
     "%lld selected" : {
 
     },
+    "%lld total pageviews over the last 7 days, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld total pageviews over the last 7 days, %2$@"
+          }
+        }
+      }
+    },
     "%lld%%" : {
 
     },
@@ -269,6 +235,9 @@
 
     },
     "302" : {
+
+    },
+    "7-day pageviews trend" : {
 
     },
     ":" : {
@@ -332,6 +301,9 @@
 
     },
     "Accessibility" : {
+
+    },
+    "Account" : {
 
     },
     "Acknowledgments" : {
@@ -493,6 +465,9 @@
     "Analyze" : {
 
     },
+    "Analyze ${experimentName}" : {
+
+    },
     "Anglesite Debug" : {
 
     },
@@ -548,6 +523,9 @@
 
     },
     "Applied." : {
+
+    },
+    "Applies only to AI agents you haven't refused above — one you've blocked never requests your pages in the first place, so this never overrides that refusal." : {
 
     },
     "Apply" : {
@@ -626,6 +604,9 @@
     "Astro Website…" : {
 
     },
+    "Atmosphere" : {
+
+    },
     "Attributes" : {
 
     },
@@ -671,6 +652,12 @@
     "Backup" : {
 
     },
+    "Ban" : {
+
+    },
+    "Ban this member?" : {
+
+    },
     "Base styles" : {
 
     },
@@ -693,6 +680,15 @@
 
     },
     "Blog" : {
+
+    },
+    "Bluesky" : {
+
+    },
+    "Bluesky account connected" : {
+
+    },
+    "Bluesky account not connected" : {
 
     },
     "Body" : {
@@ -726,6 +722,9 @@
 
     },
     "Build, scan, and run wrangler deploy on this site" : {
+
+    },
+    "Building your community…" : {
 
     },
     "Building your website…" : {
@@ -817,6 +816,9 @@
 
     },
     "Check ${site}" : {
+
+    },
+    "Check Cloudflare's Agent Readiness score for this site's deployed URL" : {
 
     },
     "Check Domain Config" : {
@@ -928,6 +930,9 @@
     "Cloudflare" : {
 
     },
+    "Cloudflare (OAuth)" : {
+
+    },
     "Cloudflare's Agent Readiness score checks whether AI agents and assistants can discover, read, and act on your deployed site — the 2026 equivalent of a Lighthouse score, but for AI agents instead of browsers." : {
 
     },
@@ -971,6 +976,9 @@
 
     },
     "Communities…" : {
+
+    },
+    "Community Name" : {
 
     },
     "Compare anglesite.json's declared domain/DNS/edge config against live Cloudflare state" : {
@@ -1018,6 +1026,9 @@
     "Connect & publish" : {
 
     },
+    "Connect a Bluesky account for POSSE syndication to turn this on." : {
+
+    },
     "Connect a Cloudflare API token first, in Settings → Advanced → Credentials." : {
 
     },
@@ -1034,6 +1045,12 @@
 
     },
     "Connect to GitHub" : {
+
+    },
+    "Connected" : {
+
+    },
+    "Connected (won't auto-refresh)" : {
 
     },
     "Connected to %@" : {
@@ -1164,6 +1181,9 @@
     "Couldn't run the check" : {
 
     },
+    "Couldn't save the Atmosphere setting: %@" : {
+
+    },
     "Couldn't save the inbox capture setting: %@" : {
 
     },
@@ -1225,6 +1245,9 @@
 
     },
     "Dashboard" : {
+
+    },
+    "Day" : {
 
     },
     "Debug builds always show the Debug Pane (View → Show Debug Pane, ⌥⌘D) regardless of this setting." : {
@@ -1462,6 +1485,9 @@
 
     },
     "Experiment" : {
+
+    },
+    "Experiment Results" : {
 
     },
     "Experiment Results…" : {
@@ -1881,6 +1907,16 @@
     "Language & Region…" : {
 
     },
+    "Last 7 days: %lld pageviews · %lld visits" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Last 7 days: %1$lld pageviews · %2$lld visits"
+          }
+        }
+      }
+    },
     "Last checked %@" : {
 
     },
@@ -1983,6 +2019,9 @@
     "Mail domain" : {
 
     },
+    "Members" : {
+
+    },
     "Metadata" : {
 
     },
@@ -2004,6 +2043,15 @@
     "Moderate" : {
 
     },
+    "Moderation" : {
+
+    },
+    "Moderation…" : {
+
+    },
+    "Moderators" : {
+
+    },
     "Move To…" : {
 
     },
@@ -2017,6 +2065,9 @@
 
     },
     "Name" : {
+
+    },
+    "Name Your Community" : {
 
     },
     "Naming" : {
@@ -2038,6 +2089,9 @@
 
     },
     "New Collection…" : {
+
+    },
+    "New Community…" : {
 
     },
     "New Component" : {
@@ -2160,10 +2214,16 @@
     "No redirects yet. Add one below." : {
 
     },
+    "No report handling yet." : {
+
+    },
     "No results. Try a different search." : {
 
     },
     "No scoped styles" : {
+
+    },
+    "No traffic recorded in the last 7 days." : {
 
     },
     "No unused files found" : {
@@ -2176,6 +2236,9 @@
 
     },
     "None" : {
+
+    },
+    "Not Connected" : {
 
     },
     "Not Set" : {
@@ -2226,6 +2289,9 @@
     "Onion Routing…" : {
 
     },
+    "Only you can moderate this community." : {
+
+    },
     "Open" : {
 
     },
@@ -2245,6 +2311,9 @@
 
     },
     "Open Cloudflare Domains" : {
+
+    },
+    "Open Community Anyway" : {
 
     },
     "Open Dashboard" : {
@@ -2331,6 +2400,9 @@
     "Other Mac" : {
 
     },
+    "Others will be able to join and post to it from any fediverse account." : {
+
+    },
     "Other…" : {
 
     },
@@ -2350,6 +2422,9 @@
 
     },
     "Pages using this worker's components" : {
+
+    },
+    "Pageviews" : {
 
     },
     "Page…" : {
@@ -2496,6 +2571,9 @@
     "Publish it at least once, then you can join communities." : {
 
     },
+    "Publish posts to the Atmosphere" : {
+
+    },
     "Publish to GitHub" : {
 
     },
@@ -2535,6 +2613,9 @@
     "Quarantined copies" : {
 
     },
+    "RSL" : {
+
+    },
     "Re-check" : {
 
     },
@@ -2566,6 +2647,9 @@
 
     },
     "Recheck Readiness" : {
+
+    },
+    "Recommend an email provider and pre-fill its DNS records" : {
 
     },
     "Recommended provider" : {
@@ -2643,6 +2727,9 @@
     "Remove from Anglesite…" : {
 
     },
+    "Remove this post?" : {
+
+    },
     "Remove “%@” from Anglesite?" : {
 
     },
@@ -2674,6 +2761,9 @@
 
     },
     "Replies" : {
+
+    },
+    "Reports" : {
 
     },
     "Reports go to %@/%@'s private advisory form." : {
@@ -3369,6 +3459,9 @@
     "This is your home page — search engines won't be able to crawl any page reachable only through it." : {
 
     },
+    "This member's posts will stop appearing. Existing posts stay unless you also remove them." : {
+
+    },
     "This page already links to all related content." : {
 
     },
@@ -3382,6 +3475,9 @@
 
     },
     "This removes it from Anglesite's list only. The files in %@ are left on disk." : {
+
+    },
+    "This removes the post from the community timeline. The author's own copy on their own site is unaffected." : {
 
     },
     "This site does not have any collection-backed content types." : {
@@ -3418,6 +3514,9 @@
 
     },
     "Top" : {
+
+    },
+    "Traffic" : {
 
     },
     "Transfer an existing domain" : {
@@ -3565,6 +3664,9 @@
     "Variant rate" : {
 
     },
+    "Verifies via /.well-known/atproto-did when the site is deployed here; otherwise adds a DNS record." : {
+
+    },
     "Vertically" : {
 
     },
@@ -3643,10 +3745,16 @@
     "What's New in Anglesite" : {
 
     },
+    "When an AI assistant asks for a page, Cloudflare serves it a markdown version instead of the full HTML — a fraction of the tokens your full page costs. Human visitors see no change. Takes effect on your next deploy to a custom domain." : {
+
+    },
     "When you create a page or post, Anglesite uses Apple's on-device model to suggest a short SEO description. Runs locally; requires Apple Intelligence to be enabled. Falls back to a title-derived description when off or unavailable." : {
 
     },
     "When you drop an image onto the preview, Anglesite uses Apple's on-device vision model to write descriptive alt text and applies it automatically. Runs locally; requires Apple Intelligence to be enabled. Purely decorative images get empty alt text and role=\"presentation\"." : {
+
+    },
+    "When your Bluesky account is connected, Anglesite also publishes each post as a Standard.site record in your own account. That gives your posts richer preview cards on Bluesky and makes them discoverable by independent Atmosphere search tools, without changing where your site is hosted." : {
 
     },
     "Whether this Mac can run Siri-driven Anglesite workflows. Per-site readiness is in each site window (Site ▸ Siri AI Readiness)." : {
@@ -3683,6 +3791,12 @@
 
     },
     "Your Cloudflare token can't manage KV namespaces — recreate it from Settings → Tokens." : {
+
+    },
+    "Your community was created with warnings. You can open it anyway and fix it from the community window." : {
+
+    },
+    "Your community was created, but something above needs attention before it can preview. You can open it anyway and fix it from the community window." : {
 
     },
     "Your declared domain configuration (anglesite.json) doesn't match what's live on Cloudflare. Review and reconcile before deploying again." : {
@@ -3739,6 +3853,9 @@
     "handle" : {
 
     },
+    "holding steady" : {
+
+    },
     "https://agent.example.com/acp" : {
 
     },
@@ -3781,6 +3898,12 @@
     "selector" : {
 
     },
+    "trending down" : {
+
+    },
+    "trending up" : {
+
+    },
     "type" : {
 
     },
@@ -3821,42 +3944,6 @@
       }
     },
     "👥" : {
-
-    },
-    "Account" : {
-
-    },
-    "Atmosphere" : {
-
-    },
-    "Bluesky" : {
-
-    },
-    "Bluesky account connected" : {
-
-    },
-    "Bluesky account not connected" : {
-
-    },
-    "Connect a Bluesky account for POSSE syndication to turn this on." : {
-
-    },
-    "Connected" : {
-
-    },
-    "Couldn't save the Atmosphere setting: %@" : {
-
-    },
-    "Learn more about Atmosphere" : {
-
-    },
-    "Not Connected" : {
-
-    },
-    "Publish posts to the Atmosphere" : {
-
-    },
-    "When your Bluesky account is connected, Anglesite also publishes each post as a Standard.site record in your own account. That gives your posts richer preview cards on Bluesky and makes them discoverable by independent Atmosphere search tools, without changing where your site is hosted." : {
 
     }
   },

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -321,6 +321,9 @@
     "Active — used on ^[%lld page](inflect: true)" : {
 
     },
+    "Actor URL, e.g. https://example.social/users/alice" : {
+
+    },
     "Actual Size" : {
 
     },

--- a/Sources/AnglesiteApp/ModerationModel.swift
+++ b/Sources/AnglesiteApp/ModerationModel.swift
@@ -22,6 +22,7 @@ final class ModerationModel {
 
     private var siteID: String?
     private var sourceDirectory: URL?
+    private var configDirectory: URL?
     private var ownActorURL: URL?
     private let secretStore: any SecretStore
     private let membershipTransport: CommunityMembershipClient.Transport
@@ -35,30 +36,62 @@ final class ModerationModel {
         self.membershipTransport = membershipTransport
     }
 
-    /// Records which site this pane talks to, resolves `ownActorURL`, and reads the moderator
-    /// list plus every member/post snapshot from disk. No network I/O — mirrors
-    /// `CommunitiesModel.configure(site:)`/`resolveSite()`'s split, collapsed into one method
-    /// here since Moderation has no `.noSiteURL`-retry surface of its own (Website ▸
-    /// Moderation… is disabled by `canOpenModeration` whenever there's no site URL yet, so this
-    /// method only ever runs once that's already true).
-    func configure(site: CurrentSite) {
+    /// Records which site this pane talks to, resolves `ownActorURL`, and loads the moderator
+    /// list plus every member/post snapshot once, at site open. No network I/O. Unlike
+    /// `CommunitiesModel.configure(site:)` this is called unconditionally for *every* site
+    /// (including a plain personal one, not just once `canOpenModeration` is already true) —
+    /// Moderation has no `.noSiteURL`-retry surface of its own, so there's nothing here to gate.
+    /// This only loads once: the member/post snapshot files are written later, by
+    /// `CommunityMembersSync`/`AnnouncedPostSync` running from `PreviewModel` after the dev
+    /// server starts, so this alone would show a stale (often empty) list for the rest of the
+    /// window session — ``reload()`` is what `SiteWindowModel.presentModeration()` calls on every
+    /// presentation to pick up whatever's landed since.
+    func configure(site: CurrentSite) async {
         siteID = site.id
         sourceDirectory = site.sourceDirectory
+        configDirectory = site.configDirectory
         if let siteURLString = DeployCoordinator.resolveSiteURL(siteDirectory: site.sourceDirectory),
            let siteURL = URL(string: siteURLString) {
             ownActorURL = ActivityPubActor.actorURL(siteURL: siteURL)
         }
-        let settings = (try? SiteConfigStore.read(from: site.configDirectory)) ?? SiteSettings()
+        await reload()
+    }
+
+    /// Re-reads the moderator list plus every member/post snapshot from disk. No-ops until
+    /// ``configure(site:)`` has run at least once (no `sourceDirectory`/`configDirectory` to read
+    /// yet). Split out of ``configure(site:)`` so `SiteWindowModel.presentModeration()` can call
+    /// it on every presentation, not just once at site open — see that method's doc comment for
+    /// why a single load isn't enough.
+    ///
+    /// The settings load and both directory scans all run off the main actor: `Config/` and
+    /// `Source/` live inside the `.anglesite` package, whose default home is the iCloud Drive
+    /// ubiquity container, so a not-yet-materialized file can block on an iCloud download.
+    /// `SiteConfigStore`'s async `load()` is itself an actor method (hops off `@MainActor` on its
+    /// own); ``decodeAll(_:from:)`` is `nonisolated` for the same reason — its doc comment has the
+    /// detail.
+    func reload() async {
+        guard let sourceDirectory, let configDirectory else { return }
+        let settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+        async let loadedMembers = Self.decodeAll(
+            CommunityMember.self, from: sourceDirectory.appendingPathComponent("data/community-members"))
+        async let loadedPosts = Self.decodeAll(
+            AnnouncedPost.self, from: sourceDirectory.appendingPathComponent("data/community-posts"))
         moderators = settings.moderators ?? []
-        members = Self.decodeAll(CommunityMember.self, from: site.sourceDirectory.appendingPathComponent("data/community-members"))
-        posts = Self.decodeAll(AnnouncedPost.self, from: site.sourceDirectory.appendingPathComponent("data/community-posts"))
+        members = await loadedMembers
+        posts = await loadedPosts
     }
 
     /// Reads every `.json` file in `directory` and decodes it as `T`, skipping (not throwing on)
     /// any file that fails to decode — a malformed or in-progress-write snapshot must never make
     /// the whole Moderation pane unusable, matching `SiteConfigStore.load()`'s "a bad file falls
     /// back to a safe default" philosophy rather than propagating the failure.
-    private static func decodeAll<T: Decodable>(_ type: T.Type, from directory: URL) -> [T] {
+    ///
+    /// `nonisolated` — and `async` — so this runs on the global concurrent executor instead of
+    /// `ModerationModel`'s `@MainActor` one: a member/post directory can hold many files (each a
+    /// synchronous `Data(contentsOf:)` read), and doing that scan-and-decode pass on the main
+    /// thread would block the UI for however long disk (or, for an un-materialized iCloud file,
+    /// a download) takes. `reload()` awaits this and assigns the result back on the actor.
+    nonisolated private static func decodeAll<T: Decodable>(_ type: T.Type, from directory: URL) async -> [T] {
         guard let entries = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else {
             return []
         }

--- a/Sources/AnglesiteApp/ModerationModel.swift
+++ b/Sources/AnglesiteApp/ModerationModel.swift
@@ -146,4 +146,57 @@ final class ModerationModel {
         do { try await removePost(post) }
         catch { errorMessage = "Couldn't remove this post: \(error.localizedDescription)" }
     }
+
+    /// Validates and appends an actor IRI to `SiteSettings.moderators`, persisting via
+    /// `SiteConfigStore` (design doc §5 — "Moderators — list of actor IRIs from
+    /// `SiteSettings.moderators`, add/remove"; #1263 final review finding 5: this list was
+    /// previously read-only, so it could never actually be populated in production). Same
+    /// well-formed-URL check `CommunityActorResolver.resolve` uses for a pasted actor IRI: must
+    /// parse as a URL with an `http`/`https` scheme and a host — a low-stakes, owner-only, local
+    /// config list, so no confirmation dialog (unlike ban/remove, which reach the network).
+    /// Returns whether the IRI was accepted (valid and, after any dedup, actually persisted) —
+    /// the view uses this to decide whether to clear the text field, so a rejected/invalid entry
+    /// stays put for the owner to fix instead of silently vanishing.
+    @discardableResult
+    func addModerator(_ iri: String) async -> Bool {
+        let trimmed = iri.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed), let scheme = url.scheme, url.host != nil,
+            ["http", "https"].contains(scheme.lowercased())
+        else {
+            errorMessage = "Enter a valid actor URL, e.g. https://example.social/users/alice."
+            return false
+        }
+        guard let configDirectory else { return false }
+        let store = SiteConfigStore(configDirectory: configDirectory)
+        var settings = (try? await store.load()) ?? SiteSettings()
+        var updated = settings.moderators ?? []
+        guard !updated.contains(trimmed) else { return true }
+        updated.append(trimmed)
+        settings.moderators = updated
+        do {
+            try await store.save(settings)
+            moderators = updated
+            return true
+        } catch {
+            errorMessage = "Couldn't save the moderator: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    /// Removes an actor IRI from `SiteSettings.moderators`. Counterpart to ``addModerator(_:)`` —
+    /// same no-confirmation-dialog rationale.
+    func removeModerator(_ iri: String) async {
+        guard let configDirectory else { return }
+        let store = SiteConfigStore(configDirectory: configDirectory)
+        var settings = (try? await store.load()) ?? SiteSettings()
+        var updated = settings.moderators ?? []
+        updated.removeAll { $0 == iri }
+        settings.moderators = updated
+        do {
+            try await store.save(settings)
+            moderators = updated
+        } catch {
+            errorMessage = "Couldn't remove the moderator: \(error.localizedDescription)"
+        }
+    }
 }

--- a/Sources/AnglesiteApp/ModerationModel.swift
+++ b/Sources/AnglesiteApp/ModerationModel.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Backs the Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderator-list
+/// display, and ban/remove actions over this site's own `CommunityMember`/`AnnouncedPost`
+/// snapshot files. App glue only, mirroring `CommunitiesModel`'s shape — protocol logic
+/// (`Remove`) lives in `AnglesiteCore`'s `CommunityMembershipClient`. Approval-queue and
+/// report-review are explicitly out of scope (design doc D4/D5) — no state for either here.
+@MainActor
+@Observable
+final class ModerationModel {
+    private(set) var members: [CommunityMember] = []
+    private(set) var posts: [AnnouncedPost] = []
+    private(set) var moderators: [String] = []
+    var errorMessage: String?
+    /// Cleared by whichever confirmation-dialog button runs — same no-op-setter/
+    /// clear-in-button-action contract `SiteWindow.swift:898-916`'s delete confirmation uses
+    /// (#968/#969), and `CommunitiesModel.leaveConfirmation`'s sibling pattern.
+    var banConfirmation: CommunityMember?
+    var removeConfirmation: AnnouncedPost?
+
+    private var siteID: String?
+    private var sourceDirectory: URL?
+    private var ownActorURL: URL?
+    private let secretStore: any SecretStore
+    private let membershipTransport: CommunityMembershipClient.Transport
+
+    init(
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        membershipTransport: @escaping CommunityMembershipClient.Transport
+            = CommunityMembershipClient.defaultTransport
+    ) {
+        self.secretStore = secretStore
+        self.membershipTransport = membershipTransport
+    }
+
+    /// Records which site this pane talks to, resolves `ownActorURL`, and reads the moderator
+    /// list plus every member/post snapshot from disk. No network I/O — mirrors
+    /// `CommunitiesModel.configure(site:)`/`resolveSite()`'s split, collapsed into one method
+    /// here since Moderation has no `.noSiteURL`-retry surface of its own (Website ▸
+    /// Moderation… is disabled by `canOpenModeration` whenever there's no site URL yet, so this
+    /// method only ever runs once that's already true).
+    func configure(site: CurrentSite) {
+        siteID = site.id
+        sourceDirectory = site.sourceDirectory
+        if let siteURLString = DeployCoordinator.resolveSiteURL(siteDirectory: site.sourceDirectory),
+           let siteURL = URL(string: siteURLString) {
+            ownActorURL = ActivityPubActor.actorURL(siteURL: siteURL)
+        }
+        let settings = (try? SiteConfigStore.read(from: site.configDirectory)) ?? SiteSettings()
+        moderators = settings.moderators ?? []
+        members = Self.decodeAll(CommunityMember.self, from: site.sourceDirectory.appendingPathComponent("data/community-members"))
+        posts = Self.decodeAll(AnnouncedPost.self, from: site.sourceDirectory.appendingPathComponent("data/community-posts"))
+    }
+
+    /// Reads every `.json` file in `directory` and decodes it as `T`, skipping (not throwing on)
+    /// any file that fails to decode — a malformed or in-progress-write snapshot must never make
+    /// the whole Moderation pane unusable, matching `SiteConfigStore.load()`'s "a bad file falls
+    /// back to a safe default" philosophy rather than propagating the failure.
+    private static func decodeAll<T: Decodable>(_ type: T.Type, from directory: URL) -> [T] {
+        guard let entries = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        return entries.filter { $0.pathExtension == "json" }.compactMap { url in
+            (try? Data(contentsOf: url)).flatMap { try? JSONDecoder().decode(T.self, from: $0) }
+        }
+    }
+
+    private var publishToken: String? {
+        guard let siteID else { return nil }
+        return try? secretStore.read(account: SecretAccounts.activityPubPublishToken(siteID: siteID))
+    }
+
+    func ban(_ member: CommunityMember) async throws {
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+        try await client.remove(target: member.actorURL)
+        members.removeAll { $0.id == member.id }
+    }
+
+    func confirmBan() async {
+        guard let member = banConfirmation else { return }
+        banConfirmation = nil
+        do { try await ban(member) }
+        catch { errorMessage = "Couldn't ban \(member.name ?? member.actorURL.absoluteString): \(error.localizedDescription)" }
+    }
+
+    func removePost(_ post: AnnouncedPost) async throws {
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+        try await client.remove(target: post.sourceURL)
+        posts.removeAll { $0.id == post.id }
+        // Deletes the local snapshot file too, mirroring the C.3 deletion flow
+        // (docs/specs/2026-06-29-c3-received-interaction-canonicality.md's "owner deletes the
+        // JSON file from their repo" convention) — the Worker's `Remove` above handles the
+        // federation side (un-announce), this handles the git side, so the post disappears from
+        // the rebuilt timeline on the next deploy without waiting for a full-set reconcile.
+        if let sourceDirectory {
+            try? FileManager.default.removeItem(at: sourceDirectory.appendingPathComponent(post.gitPath))
+        }
+    }
+
+    func confirmRemove() async {
+        guard let post = removeConfirmation else { return }
+        removeConfirmation = nil
+        do { try await removePost(post) }
+        catch { errorMessage = "Couldn't remove this post: \(error.localizedDescription)" }
+    }
+}

--- a/Sources/AnglesiteApp/ModerationView.swift
+++ b/Sources/AnglesiteApp/ModerationView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderators, members
+/// (with ban), posts (with remove), and an inert reports placeholder (D5 — no report-handling
+/// exists upstream yet).
+struct ModerationView: View {
+    @Bindable var moderation: ModerationModel
+
+    var body: some View {
+        List {
+            Section("Moderators") {
+                if moderation.moderators.isEmpty {
+                    Text("Only you can moderate this community.").foregroundStyle(.secondary)
+                } else {
+                    ForEach(moderation.moderators, id: \.self) { Text($0) }
+                }
+            }
+            Section("Members") {
+                ForEach(moderation.members) { member in
+                    HStack {
+                        Text(member.name ?? member.actorURL.absoluteString)
+                        Spacer()
+                        Button("Ban", role: .destructive) { moderation.banConfirmation = member }
+                    }
+                }
+            }
+            Section("Posts") {
+                ForEach(moderation.posts) { post in
+                    HStack {
+                        Text(post.content ?? post.sourceURL.absoluteString).lineLimit(1)
+                        Spacer()
+                        Button("Remove", role: .destructive) { moderation.removeConfirmation = post }
+                    }
+                }
+            }
+            Section("Reports") {
+                Text("No report handling yet.").foregroundStyle(.secondary)
+            }
+        }
+        .navigationSubtitle("Moderation")
+        .alert("Error", isPresented: Binding(get: { moderation.errorMessage != nil }, set: { _ in moderation.errorMessage = nil })) {
+            Button("OK") { moderation.errorMessage = nil }
+        } message: {
+            Text(moderation.errorMessage ?? "")
+        }
+        .confirmationDialog(
+            "Ban this member?",
+            isPresented: Binding(get: { moderation.banConfirmation != nil }, set: { _ in }),
+            titleVisibility: .visible
+        ) {
+            Button("Ban", role: .destructive) { Task { await moderation.confirmBan() } }
+            Button("Cancel", role: .cancel) { moderation.banConfirmation = nil }
+        } message: {
+            Text("This member's posts will stop appearing. Existing posts stay unless you also remove them.")
+        }
+        .confirmationDialog(
+            "Remove this post?",
+            isPresented: Binding(get: { moderation.removeConfirmation != nil }, set: { _ in }),
+            titleVisibility: .visible
+        ) {
+            Button("Remove", role: .destructive) { Task { await moderation.confirmRemove() } }
+            Button("Cancel", role: .cancel) { moderation.removeConfirmation = nil }
+        } message: {
+            Text("This removes the post from the community timeline. The author's own copy on their own site is unaffected.")
+        }
+    }
+}

--- a/Sources/AnglesiteApp/ModerationView.swift
+++ b/Sources/AnglesiteApp/ModerationView.swift
@@ -6,6 +6,8 @@ import AnglesiteCore
 /// exists upstream yet).
 struct ModerationView: View {
     @Bindable var moderation: ModerationModel
+    /// Bound to the "Add Moderator" text field; cleared after a successful add.
+    @State private var newModeratorIRI = ""
 
     var body: some View {
         List {
@@ -13,7 +15,20 @@ struct ModerationView: View {
                 if moderation.moderators.isEmpty {
                     Text("Only you can moderate this community.").foregroundStyle(.secondary)
                 } else {
-                    ForEach(moderation.moderators, id: \.self) { Text($0) }
+                    ForEach(moderation.moderators, id: \.self) { iri in
+                        HStack {
+                            Text(iri)
+                            Spacer()
+                            Button("Remove") { Task { await moderation.removeModerator(iri) } }
+                        }
+                    }
+                }
+                HStack {
+                    TextField("Actor URL, e.g. https://example.social/users/alice", text: $newModeratorIRI)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit(addModerator)
+                    Button("Add", action: addModerator)
+                        .disabled(newModeratorIRI.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
             Section("Members") {
@@ -63,6 +78,16 @@ struct ModerationView: View {
             Button("Cancel", role: .cancel) { moderation.removeConfirmation = nil }
         } message: {
             Text("This removes the post from the community timeline. The author's own copy on their own site is unaffected.")
+        }
+    }
+
+    private func addModerator() {
+        let iri = newModeratorIRI
+        guard !iri.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        Task {
+            if await moderation.addModerator(iri) {
+                newModeratorIRI = ""
+            }
         }
     }
 }

--- a/Sources/AnglesiteApp/NewCommunityWizard.swift
+++ b/Sources/AnglesiteApp/NewCommunityWizard.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The New Community wizard (V-5.1b, #907, design doc §3) — one question (the community's
+/// name), then it scaffolds into the default location and opens in the preview. A distinct
+/// flow from ``NewSiteWizard``: a hosted community is a different site kind, not a theme
+/// pick, so there is no template grid here.
+struct NewCommunityWizard: View {
+    @Bindable var model: NewCommunityWizardModel
+    let scaffolder: SiteScaffolder
+    let onComplete: (String) -> Void
+    let onCancel: () -> Void
+
+    @FocusState private var nameFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            content
+            Divider()
+            footer
+        }
+        .frame(width: 420, height: 220)
+        .interactiveDismissDisabled(model.step == .building)
+    }
+
+    @ViewBuilder private var content: some View {
+        switch model.step {
+        case .chooser:  chooserStep
+        case .building: buildingStep
+        }
+    }
+
+    private var chooserStep: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Name Your Community").font(.title2.bold())
+            Text("Others will be able to join and post to it from any fediverse account.")
+                .font(.callout).foregroundStyle(.secondary)
+            TextField("Community Name", text: $model.communityName)
+                .textFieldStyle(.roundedBorder)
+                .focused($nameFieldFocused)
+                .onSubmit(create)
+                .task { nameFieldFocused = true }
+        }.padding(24)
+    }
+
+    private var buildingStep: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Building your community\u{2026}").font(.title2.bold())
+            ForEach(Array(model.progress.enumerated()), id: \.offset) { _, s in
+                Text(label(for: s)).font(.callout)
+                    .accessibilityLabel(accessibilityLabel(for: s))
+            }
+            if case .failed(_, let msg) = model.fatal {
+                Text(msg).font(.caption).foregroundStyle(.red).textSelection(.enabled)
+                    .accessibilityLabel("Build failed")
+                    .accessibilityValue(msg)
+            }
+        }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func label(for step: SiteScaffolder.ScaffoldStep) -> String {
+        switch step {
+        case .creatingFolder: return "\u{2705} Created the community file"
+        case .copyingTemplate: return "\u{2705} Copied the template"
+        case .applyingTheme: return "\u{2705} Applied the community theme"
+        case .writingContent: return "\u{2705} Prepared the starter content"
+        case .installing: return "\u{23F3} Installing\u{2026}"
+        case .registering: return "\u{2705} Registering"
+        case .warning(_, let m): return "\u{26A0}\u{FE0F} \(m)"
+        case .failed(_, let m): return "\u{274C} \(m)"
+        case .done: return "\u{2705} Done"
+        }
+    }
+
+    private func accessibilityLabel(for step: SiteScaffolder.ScaffoldStep) -> String {
+        switch step {
+        case .creatingFolder:    return "Created the community file"
+        case .copyingTemplate:   return "Copied the template"
+        case .applyingTheme:     return "Applied the community theme"
+        case .writingContent:    return "Prepared the starter content"
+        case .installing:        return "Installing…"
+        case .registering:       return "Registering"
+        case .warning(_, let m): return "Warning: \(m)"
+        case .failed(_, let m):  return "Failed: \(m)"
+        case .done:              return "Done"
+        }
+    }
+
+    @ViewBuilder private var footer: some View {
+        HStack {
+            Spacer()
+            if model.step == .chooser {
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Create") { create() }
+                    .keyboardShortcut(.defaultAction).disabled(!model.canCreate)
+            } else if model.completedSiteID == nil && model.fatal != nil {
+                Button("Close") { onCancel() }
+            }
+        }.padding(.horizontal, 16).padding(.vertical, 10)
+    }
+
+    private func create() {
+        guard model.canCreate else { return }
+        Task {
+            _ = await model.build(using: scaffolder)
+            if model.didCompleteCleanly, let id = model.completedSiteID { onComplete(id) }
+        }
+    }
+}

--- a/Sources/AnglesiteApp/NewCommunityWizard.swift
+++ b/Sources/AnglesiteApp/NewCommunityWizard.swift
@@ -55,6 +55,11 @@ struct NewCommunityWizard: View {
                     .accessibilityLabel("Build failed")
                     .accessibilityValue(msg)
             }
+            if model.completedSiteID != nil && model.hasWarnings {
+                Text("Your community was created, but something above needs attention before it can preview. You can open it anyway and fix it from the community window.")
+                    .font(.caption).foregroundStyle(.secondary).textSelection(.enabled)
+                    .accessibilityLabel("Your community was created with warnings. You can open it anyway and fix it from the community window.")
+            }
         }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
@@ -94,6 +99,8 @@ struct NewCommunityWizard: View {
                     .keyboardShortcut(.cancelAction)
                 Button("Create") { create() }
                     .keyboardShortcut(.defaultAction).disabled(!model.canCreate)
+            } else if let id = model.completedSiteID, model.hasWarnings {
+                Button("Open Community Anyway") { onComplete(id) }.keyboardShortcut(.defaultAction)
             } else if model.completedSiteID == nil && model.fatal != nil {
                 Button("Close") { onCancel() }
             }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -1035,6 +1035,8 @@ struct SiteWindow: View {
             FollowersView(followers: model.followers)
         case .communities:
             CommunitiesView(communities: model.communities)
+        case .moderation:
+            ModerationView(moderation: model.moderation)
         case .preview:
             previewPane(for: site)
         }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -16,6 +16,7 @@ enum MainPaneMode: Equatable {
     case reader         // Website ▸ Reader… (V-4.3, #365)
     case followers      // Website ▸ Followers… (V-4.2, #364)
     case communities    // Website ▸ Communities… (V-5.1a, #368)
+    case moderation     // Website ▸ Moderation… (V-5.1b/V-5.3, #907/#370)
 }
 
 enum ActiveEditor {
@@ -164,6 +165,18 @@ final class SiteWindowModel {
     /// Drives the main-pane Communities view (Website ▸ Communities…, V-5.1a #368): join/leave
     /// fediverse Group actors and read a per-group timeline.
     var communities = CommunitiesModel()
+    /// Drives the main-pane Moderation view (Website ▸ Moderation…, V-5.1b/V-5.3 #907/#370):
+    /// moderator display, and ban/remove actions over this site's members and posts.
+    var moderation = ModerationModel()
+    /// Cached `SiteSettings.communityActorURL != nil`, refreshed once per site open in
+    /// `loadAndStart()` — the gate for Website ▸ Moderation… (#907/#370). A cached `Bool`
+    /// rather than a live synchronous read: `SiteConfigStore.read(from:fileManager:)` is
+    /// documented as unsafe to call from `@MainActor` (it blocks on disk I/O), and
+    /// `canOpenModeration` must be synchronous for `.disabled(...)` to read. Known limitation:
+    /// this doesn't live-update if a deploy completes while the window stays open — reopening
+    /// the site picks up the new value. Acceptable for v1 (design doc §5); revisit only if it
+    /// proves confusing in practice.
+    private(set) var isHostedCommunity = false
     var harden = HardenModel()
     var domainConfigAudit = DomainConfigAuditModel()
     /// Cloudflare Agent Readiness score for the deployed site (#1248).
@@ -436,6 +449,17 @@ final class SiteWindowModel {
         }
     }
 
+    /// Switches the main pane to Moderation (Website ▸ Moderation…, V-5.1b/V-5.3 #907/#370).
+    /// Mirrors `presentCommunities()`'s leave-current-surface-first guard. Unlike Communities,
+    /// this is gated (`canOpenModeration`) — see that property's doc comment.
+    func presentModeration() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            await clearInspectorThenSwitchPane(to: .moderation)
+        }
+    }
+
     /// Clears the inspector and swaps the main pane, giving the inspector's own
     /// `.inspector(isPresented:)` dismissal a moment to settle in its own SwiftUI transaction
     /// before `mainPaneMode` tears down and rebuilds the entire detail view. Doing both in the
@@ -534,6 +558,13 @@ final class SiteWindowModel {
     }
 
     var canOpenCopyEdit: Bool { site != nil }
+
+    /// Website ▸ Moderation… (#907/#370) is only meaningful once this site is a *deployed*
+    /// hosted community — `communityActorURL` is set by `DeployCoordinator.persistProvisionedResources`
+    /// after a successful deploy with a Group actor (Phase 2), not at creation time. Unlike
+    /// Communities/Followers (always enabled once a site is focused), a personal site or an
+    /// undeployed community never enables this — there's nothing to moderate yet.
+    var canOpenModeration: Bool { isHostedCommunity }
 
     /// Presents the Review Copy sheet (#465). Reconstructs a `ProjectConventionsStore` from the
     /// site's `configDirectory` — the same expression `ProjectConventionsModel.init` uses for
@@ -1963,6 +1994,7 @@ final class SiteWindowModel {
             return
         }
         site = resolved
+        isHostedCommunity = ((try? await SiteConfigStore(configDirectory: resolved.configDirectory).load())?.communityActorURL) != nil
         // Constructed once and threaded into every child model below instead of each one
         // separately re-deriving `id`/`sourceDirectory`/`packageURL`/`configDirectory` from
         // `resolved` at its own call site (#822) — see `CurrentSite`'s own doc comment.
@@ -2232,6 +2264,7 @@ final class SiteWindowModel {
         reader.configure(site: currentSite)
         followers.configure(site: currentSite)
         communities.configure(site: currentSite)
+        moderation.configure(site: currentSite)
         domain.configure(site: currentSite)
         connectDomain.configure(site: currentSite)
         buyDomain.configure(site: currentSite)

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -172,10 +172,11 @@ final class SiteWindowModel {
     /// `loadAndStart()` — the gate for Website ▸ Moderation… (#907/#370). A cached `Bool`
     /// rather than a live synchronous read: `SiteConfigStore.read(from:fileManager:)` is
     /// documented as unsafe to call from `@MainActor` (it blocks on disk I/O), and
-    /// `canOpenModeration` must be synchronous for `.disabled(...)` to read. Known limitation:
-    /// this doesn't live-update if a deploy completes while the window stays open — reopening
-    /// the site picks up the new value. Acceptable for v1 (design doc §5); revisit only if it
-    /// proves confusing in practice.
+    /// `canOpenModeration` must be synchronous for `.disabled(...)` to read. Also re-read after
+    /// every successful deploy (the `deploy.onPhaseTransition` hook in `init` calls
+    /// ``refreshIsHostedCommunity()``, #1263 final review finding 4) — so creating a community
+    /// and deploying it in the same window session enables the menu item live, without requiring
+    /// the owner to close and reopen the site.
     private(set) var isHostedCommunity = false
     var harden = HardenModel()
     var domainConfigAudit = DomainConfigAuditModel()
@@ -363,9 +364,26 @@ final class SiteWindowModel {
         let deploySound: DialupSoundEffectPlaying = DialupSoundEffectPlayer()
         deploy.onPhaseTransition = { [weak self] siteID, phase in
             deployHook?(siteID, phase)
-            if case .succeeded = phase { self?.sync.deployCompleted() }
+            if case .succeeded = phase {
+                self?.sync.deployCompleted()
+                // #1263 final review finding 4: a community created and deployed in the same
+                // window session must not stay stuck on the `loadAndStart()`-time `false` — the
+                // very deploy that provisions the Group actor and writes `communityActorURL` is
+                // exactly the one that should unlock Website ▸ Moderation… live.
+                Task { [weak self] in await self?.refreshIsHostedCommunity() }
+            }
             if case .running = phase { deploySound.play() } else { deploySound.stop() }
         }
+    }
+
+    /// Re-reads `SiteSettings.communityActorURL != nil` from disk and updates the cached
+    /// ``isHostedCommunity`` gate. No-ops until `loadAndStart()` has set ``site``. Called once at
+    /// site open (via `loadAndStart()`) and again after every successful deploy (the
+    /// `deploy.onPhaseTransition` hook above) — see ``isHostedCommunity``'s doc comment for why a
+    /// single load isn't enough.
+    private func refreshIsHostedCommunity() async {
+        guard let site else { return }
+        isHostedCommunity = ((try? await SiteConfigStore(configDirectory: site.configDirectory).load())?.communityActorURL) != nil
     }
 
     var activeEditorFile: FileRef? {
@@ -2001,7 +2019,7 @@ final class SiteWindowModel {
             return
         }
         site = resolved
-        isHostedCommunity = ((try? await SiteConfigStore(configDirectory: resolved.configDirectory).load())?.communityActorURL) != nil
+        await refreshIsHostedCommunity()
         // Constructed once and threaded into every child model below instead of each one
         // separately re-deriving `id`/`sourceDirectory`/`packageURL`/`configDirectory` from
         // `resolved` at its own call site (#822) — see `CurrentSite`'s own doc comment.

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -452,10 +452,17 @@ final class SiteWindowModel {
     /// Switches the main pane to Moderation (Website ▸ Moderation…, V-5.1b/V-5.3 #907/#370).
     /// Mirrors `presentCommunities()`'s leave-current-surface-first guard. Unlike Communities,
     /// this is gated (`canOpenModeration`) — see that property's doc comment.
+    ///
+    /// Reloads `moderation`'s member/post snapshots on every presentation, not just once at site
+    /// open (`ModerationModel.configure(site:)`'s own doc comment has the detail): the sync jobs
+    /// that write those snapshot files run later, from `PreviewModel` after the dev server
+    /// starts, so without this a freshly provisioned community would show an empty Moderation
+    /// pane for the rest of the window session.
     func presentModeration() {
         Task {
             guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
             activeEditor = nil
+            await moderation.reload()
             await clearInspectorThenSwitchPane(to: .moderation)
         }
     }
@@ -2264,7 +2271,7 @@ final class SiteWindowModel {
         reader.configure(site: currentSite)
         followers.configure(site: currentSite)
         communities.configure(site: currentSite)
-        moderation.configure(site: currentSite)
+        await moderation.configure(site: currentSite)
         domain.configure(site: currentSite)
         connectDomain.configure(site: currentSite)
         buyDomain.configure(site: currentSite)

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -49,6 +49,16 @@ struct SitesLauncherView: View {
     }
     /// Non-nil while the New Site wizard is showing; nil dismisses it.
     @State private var newSiteSession: NewSiteSession?
+    private struct NewCommunitySession: Identifiable {
+        let id = UUID()
+        let model: NewCommunityWizardModel
+        let scaffolder: SiteScaffolder
+    }
+    /// Non-nil while the New Community wizard is showing; nil dismisses it.
+    @State private var newCommunitySession: NewCommunitySession?
+    /// Guards `presentNewCommunity()` against a double-trigger while it is preparing — mirrors
+    /// `preparingNewSite`'s note above.
+    @State private var preparingNewCommunity = false
     @State private var sitesRootScopedURL: URL?
     @State private var router = WindowRouter.shared
 
@@ -76,6 +86,11 @@ struct SitesLauncherView: View {
             router.clearNewSiteRequest()
             Task { await presentNewSite() }
         }
+        .onChange(of: router.newCommunityRequested) { _, requested in
+            guard requested else { return }
+            router.clearNewCommunityRequest()
+            Task { await presentNewCommunity() }
+        }
         // Attached here (not inside `launcherUI`) so it still presents while `deciding`
         // is showing the blank placeholder above — a File ▸ New Site launch keeps
         // `deciding` true so only the wizard sheet is visible, not the full Sites picker
@@ -96,6 +111,28 @@ struct SitesLauncherView: View {
                     newSiteSession = nil
                     // Reveal the picker now that the wizard is gone — mirrors the
                     // presentNewSite()-failed path in onFirstAppear() below.
+                    deciding = false
+                }
+            )
+            .onDisappear {
+                sitesRootScopedURL?.stopAccessingSecurityScopedResource()
+                sitesRootScopedURL = nil
+            }
+        }
+        .sheet(item: $newCommunitySession) { session in
+            NewCommunityWizard(
+                model: session.model,
+                scaffolder: session.scaffolder,
+                onComplete: { siteID in
+                    newCommunitySession = nil
+                    Task {
+                        await refreshSites()
+                        openWindow(value: siteID)
+                        dismissWindow()
+                    }
+                },
+                onCancel: {
+                    newCommunitySession = nil
                     deciding = false
                 }
             )
@@ -403,19 +440,26 @@ struct SitesLauncherView: View {
         }
     }
 
+    private struct ScaffoldingContext {
+        let catalog: ThemeCatalog
+        let scaffolder: SiteScaffolder
+        let isNameTaken: (String) -> Bool
+    }
+
+    /// Everything both `presentNewSite()` and `presentNewCommunity()` need before they can
+    /// construct their own wizard model: template/theme catalog, sites-root resolution (with
+    /// MAS security-scope handling), name-uniqueness check, and a ready `SiteScaffolder`.
+    /// Extracted so the two flows (#907, design doc §3) don't duplicate this setup.
     @MainActor
-    private func presentNewSite() async {
-        guard newSiteSession == nil, !preparingNewSite else { return }
-        preparingNewSite = true
-        defer { preparingNewSite = false }
+    private func resolveScaffoldingContext() async -> ScaffoldingContext? {
         let resolution = TemplateRuntime.resolve()
         guard let templateURL = resolution.url else {
             loadError = "Template not found — can't create a site. Reinstall the app."
-            return
+            return nil
         }
         let catalog: ThemeCatalog
         do { catalog = try ThemeCatalog.load(templateURL: templateURL) }
-        catch { loadError = "Couldn't load themes: \(error.localizedDescription)"; return }
+        catch { loadError = "Couldn't load themes: \(error.localizedDescription)"; return nil }
 
         // Effective sites root (the app's iCloud container by default since #865; an override or
         // the ~/Sites fallback otherwise) — the same accessor SiteStore uses.
@@ -432,7 +476,7 @@ struct SitesLauncherView: View {
         // final review). `ensureSitesRootAccess` is shared with `SiteActions.importPackage()` —
         // see that enum's doc comment on keeping MAS bookmark minting in exactly one place.
         if AppSettings.shared.sitesRootSource != .iCloudContainer {
-            guard let rootScope = await SiteActions.ensureSitesRootAccess(sitesRoot) else { return }  // user cancelled
+            guard let rootScope = await SiteActions.ensureSitesRootAccess(sitesRoot) else { return nil }  // user cancelled
             sitesRootScopedURL = rootScope
         }
         #endif
@@ -446,10 +490,10 @@ struct SitesLauncherView: View {
         // "Untitled N" availability (#1071): taken if it collides with a registered site's slug
         // OR a package already on disk in the sites root (registered or not) — silent save must
         // never clobber an existing folder.
-        let model = NewSiteWizardModel(catalog: catalog, isNameTaken: { name in
+        let isNameTaken: (String) -> Bool = { name in
             takenSlugs.contains(SiteSlug.derive(from: name))
                 || FileManager.default.fileExists(atPath: sitesRoot.appendingPathComponent("\(name).anglesite").path)
-        })
+        }
 
         let scaffolder = SiteScaffolder(
             sitesRoot: sitesRoot,
@@ -482,7 +526,27 @@ struct SitesLauncherView: View {
                 return site
             }
         )
-        newSiteSession = NewSiteSession(model: model, scaffolder: scaffolder)
+        return ScaffoldingContext(catalog: catalog, scaffolder: scaffolder, isNameTaken: isNameTaken)
+    }
+
+    @MainActor
+    private func presentNewSite() async {
+        guard newSiteSession == nil, !preparingNewSite else { return }
+        preparingNewSite = true
+        defer { preparingNewSite = false }
+        guard let context = await resolveScaffoldingContext() else { return }
+        let model = NewSiteWizardModel(catalog: context.catalog, isNameTaken: context.isNameTaken)
+        newSiteSession = NewSiteSession(model: model, scaffolder: context.scaffolder)
+    }
+
+    @MainActor
+    private func presentNewCommunity() async {
+        guard newCommunitySession == nil, !preparingNewCommunity else { return }
+        preparingNewCommunity = true
+        defer { preparingNewCommunity = false }
+        guard let context = await resolveScaffoldingContext() else { return }
+        let model = NewCommunityWizardModel(isNameTaken: context.isNameTaken)
+        newCommunitySession = NewCommunitySession(model: model, scaffolder: context.scaffolder)
     }
 
     // MARK: - Lifecycle
@@ -502,6 +566,16 @@ struct SitesLauncherView: View {
             // cancelled), fall through to the picker so the resulting error/list is
             // visible instead of a dead blank window.
             if newSiteSession == nil {
+                deciding = false
+            }
+            return
+        }
+
+        // Mirrors the New Site consume above, for File ▸ New Community.
+        if router.newCommunityRequested {
+            router.clearNewCommunityRequest()
+            await presentNewCommunity()
+            if newCommunitySession == nil {
                 deciding = false
             }
             return

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -65,6 +65,9 @@ struct WebsiteCommands: Commands {
             Button("Communities…") { model?.presentCommunities() }
                 .disabled(model == nil)
 
+            Button("Moderation…") { model?.presentModeration() }
+                .disabled(model?.canOpenModeration != true)
+
             // Ellipsis items open a sheet for further input, per the HIG.
             Button("Harden…") { model?.harden.openSheet() }
                 .disabled(model?.canRunHarden != true)

--- a/Sources/AnglesiteCore/CommunityMembershipClient.swift
+++ b/Sources/AnglesiteCore/CommunityMembershipClient.swift
@@ -85,6 +85,23 @@ public struct CommunityMembershipClient: Sendable {
         _ = try await post(body)
     }
 
+    /// Bans a member or un-announces a member post — one primitive, two moderation effects, per
+    /// workers#473: the Worker's `Remove` handler treats `object` as either a member actor IRI
+    /// (ban) or an announced post's IRI (un-announce), authorized by the owner's bearer
+    /// `publishToken` alone — no `config.moderators` membership required, since the owner is
+    /// implicitly the top moderator of their own actor. `target` is whichever IRI the caller
+    /// wants removed; there's no separate "kind" parameter because the Worker itself dispatches
+    /// on what `target` resolves to, not on anything this client declares up front.
+    public func remove(target: URL) async throws {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Remove",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        _ = try await post(body)
+    }
+
     private func post(_ activity: [String: Any]) async throws -> Data {
         var request = URLRequest(url: outboxURL)
         request.httpMethod = "POST"

--- a/Sources/AnglesiteCore/DeployCoordinator.swift
+++ b/Sources/AnglesiteCore/DeployCoordinator.swift
@@ -237,6 +237,16 @@ public enum DeployCoordinator {
             ?? SiteSlug.derive(from: siteName ?? siteID)
     }
 
+    /// Whether this site is a hosted community (V-5.1b, #907) — read from `.site-config`'s
+    /// `SITE_TYPE`, the same key `SiteScaffolder.appendSiteConfig` writes from
+    /// `NewSiteDraft.siteType` at creation time. There's no `SiteSettings` field for site kind
+    /// (`SiteType` is a creation-time-only concept), so this is the one read-through-the-file
+    /// check the deploy path needs to decide whether to compose a Group actor.
+    public static func resolveIsHostedCommunity(siteDirectory: URL) -> Bool {
+        let existingConfig = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        return SiteConfigFile.value(forKey: "SITE_TYPE", in: existingConfig) == SiteType.community.rawValue
+    }
+
     /// The site's best-known public URL for `WorkerComposition`'s `SITE_URL` var (#359) — the
     /// address the composed Worker uses for its own outbound requests, e.g. `CommunityMembershipClient`'s
     /// ActivityPub actor ID and outbox (#1085). The workers.dev host `DeployCommand.persistSiteURL`
@@ -384,13 +394,22 @@ public enum DeployCoordinator {
         /// `nil` when ActivityPub isn't active this deploy; leaves the baseline unchanged so a
         /// deactivated-then-reactivated actor is still compared against its real last-served
         /// handle rather than losing the baseline.
-        apUsername: String? = nil
+        apUsername: String? = nil,
+        /// This deploy's resolved ActivityPub actor IRI (`ActivityPubActor.actorURL(siteURL:)`),
+        /// passed only when this site is a hosted community (V-5.1b, #907) whose Worker was just
+        /// composed with a Group actor. Advances `settings.communityActorURL` — the field
+        /// `CommunityMembersSync`/the Moderation section gate on — from inert to live. `nil` for
+        /// every other site, leaving the field untouched (it's already `nil` there).
+        communityActorURL: URL? = nil
     ) async {
         var updated = settings
         updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
         updated.provisionedWorkerResources = resources
         if let apUsername {
             updated.lastDeployedAPUsername = apUsername
+        }
+        if let communityActorURL {
+            updated.communityActorURL = communityActorURL
         }
         try? await configStore.save(updated)
     }

--- a/Sources/AnglesiteCore/HeroImage.swift
+++ b/Sources/AnglesiteCore/HeroImage.swift
@@ -57,6 +57,7 @@ public enum HeroImage {
         case .blog:         return "editorial abstract header illustration"
         case .portfolio:    return "creative abstract portfolio illustration"
         case .organization: return "welcoming community abstract illustration"
+        case .community:    return "collaborative group abstract illustration"
         case .blank:        return "simple abstract geometric illustration"
         }
     }

--- a/Sources/AnglesiteCore/NewCommunityWizardModel.swift
+++ b/Sources/AnglesiteCore/NewCommunityWizardModel.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Observation
+
+/// Observable state behind the New Community wizard (V-5.1b, #907, design doc §3) — a
+/// distinct flow from ``NewSiteWizardModel``: a hosted community is a different site kind
+/// (own Worker, own Group actor, moderators), not a cosmetic theme pick, so it asks for a
+/// name only and skips the theme grid entirely, reusing the "community" catalog theme
+/// (the same palette `ThemeCatalog.defaultThemeID(for: .organization)` already maps to) as
+/// its one consistent look.
+@MainActor
+@Observable
+public final class NewCommunityWizardModel {
+    /// Mirrors ``NewSiteWizardModel/Step`` — the chooser (name entry) and building (scaffold
+    /// progress) states.
+    public enum Step: Int, CaseIterable {
+        case chooser
+        case building
+    }
+
+    public private(set) var step: Step = .chooser
+    /// The owner-entered community name; bound to the wizard's text field.
+    public var communityName: String = ""
+    /// Every ``SiteScaffolder/ScaffoldStep`` emitted so far, in order.
+    public private(set) var progress: [SiteScaffolder.ScaffoldStep] = []
+    /// The `.failed` step, if any.
+    public private(set) var fatal: SiteScaffolder.ScaffoldStep?
+    /// The new site's registered id once scaffolding reaches `.done`; `nil` until then.
+    public private(set) var completedSiteID: String?
+
+    /// Availability check for a candidate site name — same contract as
+    /// ``NewSiteWizardModel/init(catalog:isNameTaken:)``'s parameter.
+    private let isNameTaken: (String) -> Bool
+
+    public init(isNameTaken: @escaping (String) -> Bool) {
+        self.isNameTaken = isNameTaken
+    }
+
+    /// The draft `build(using:)` will scaffold, computed fresh from ``communityName`` each
+    /// time it's read — there's no per-field mutation to track separately, unlike
+    /// ``NewSiteWizardModel/draft``, since a community draft has exactly one owner-set field.
+    public var draft: NewSiteDraft {
+        var draft = NewSiteDraft(siteType: .community, name: trimmedName,
+                                 saveFileName: "\(trimmedName).anglesite", headline: "")
+        draft.themeID = "community"
+        return draft
+    }
+
+    private var trimmedName: String {
+        communityName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Gate for the chooser's Create button: a non-empty, not-already-taken name, and no
+    /// build running.
+    public var canCreate: Bool {
+        step == .chooser && !trimmedName.isEmpty && !isNameTaken(trimmedName)
+    }
+
+    public var warnings: [String] {
+        progress.compactMap { if case .warning(_, let message) = $0 { return message } else { return nil } }
+    }
+
+    public var hasWarnings: Bool { !warnings.isEmpty }
+
+    public var didCompleteCleanly: Bool { completedSiteID != nil && !hasWarnings }
+
+    /// Runs the scaffolder against ``draft``, accumulating progress. Returns the new site id
+    /// on success. Mirrors ``NewSiteWizardModel/build(using:)`` exactly.
+    public func build(using scaffolder: SiteScaffolder) async -> String? {
+        step = .building
+        for await s in scaffolder.scaffold(draft) {
+            progress.append(s)
+            if case .failed = s { fatal = s }
+            if case .done(let id) = s { completedSiteID = id }
+        }
+        return completedSiteID
+    }
+}

--- a/Sources/AnglesiteCore/NewCommunityWizardModel.swift
+++ b/Sources/AnglesiteCore/NewCommunityWizardModel.swift
@@ -31,8 +31,21 @@ public final class NewCommunityWizardModel {
     /// ``NewSiteWizardModel/init(catalog:isNameTaken:)``'s parameter.
     private let isNameTaken: (String) -> Bool
 
-    public init(isNameTaken: @escaping (String) -> Bool) {
+    /// Resolves a just-registered site id to its `Config/` directory, so ``build(using:)`` can
+    /// seed the ActivityPub worker activation after scaffold completes (#1263 final review
+    /// finding 2). Defaults to the production registry (`SiteScaffolder`'s own `register`
+    /// closure records there too — see `SitesLauncherView.resolveScaffoldingContext`);
+    /// injectable so tests can supply a fake without touching `SiteStore.shared`.
+    private let resolveConfigDirectory: @Sendable (String) async -> URL?
+
+    public init(
+        isNameTaken: @escaping (String) -> Bool,
+        resolveConfigDirectory: @escaping @Sendable (String) async -> URL? = { id in
+            await SiteStore.shared.find(id: id)?.configDirectory
+        }
+    ) {
         self.isNameTaken = isNameTaken
+        self.resolveConfigDirectory = resolveConfigDirectory
     }
 
     /// The draft `build(using:)` will scaffold, computed fresh from ``communityName`` each
@@ -64,7 +77,10 @@ public final class NewCommunityWizardModel {
     public var didCompleteCleanly: Bool { completedSiteID != nil && !hasWarnings }
 
     /// Runs the scaffolder against ``draft``, accumulating progress. Returns the new site id
-    /// on success. Mirrors ``NewSiteWizardModel/build(using:)`` exactly.
+    /// on success. Mirrors ``NewSiteWizardModel/build(using:)`` except for the post-scaffold
+    /// ActivityPub activation below — a hosted community with no active worker is a dead end
+    /// the owner would have to know to fix by hand, so the wizard's own output must be a working
+    /// community with no manual step (owner-confirmed, #1263 final review finding 2).
     public func build(using scaffolder: SiteScaffolder) async -> String? {
         step = .building
         for await s in scaffolder.scaffold(draft) {
@@ -72,6 +88,27 @@ public final class NewCommunityWizardModel {
             if case .failed = s { fatal = s }
             if case .done(let id) = s { completedSiteID = id }
         }
+        if let completedSiteID {
+            await activateActivityPubWorker(siteID: completedSiteID)
+        }
         return completedSiteID
+    }
+
+    /// Seeds `SiteSettings.activeWorkerIDs` with the ActivityPub worker so a freshly-scaffolded
+    /// community deploys with a live Group actor on its very first deploy, with no manual
+    /// Workers-tab step. Best-effort, like every other post-scaffold settings write in the app
+    /// (`SiteStore.setDisplayName`'s sibling pattern): scaffolding itself already succeeded by
+    /// the time this runs, so a settings-write failure here must never be reported as a build
+    /// failure — it only means the owner has to flip the toggle themselves once, same as any
+    /// other site.
+    private func activateActivityPubWorker(siteID: String) async {
+        guard let configDirectory = await resolveConfigDirectory(siteID) else { return }
+        let store = SiteConfigStore(configDirectory: configDirectory)
+        var settings = (try? await store.load()) ?? SiteSettings()
+        var activeIDs = settings.activeWorkerIDs ?? []
+        guard !activeIDs.contains(WorkerComposition.activitypubWorkerID) else { return }
+        activeIDs.append(WorkerComposition.activitypubWorkerID)
+        settings.activeWorkerIDs = activeIDs
+        try? await store.save(settings)
     }
 }

--- a/Sources/AnglesiteCore/NewSiteDraft.swift
+++ b/Sources/AnglesiteCore/NewSiteDraft.swift
@@ -5,7 +5,7 @@ import Foundation
 public enum SiteType: String, Sendable, CaseIterable, Codable {
     /// The selectable categories, in the order the Type step lists them. `blank` is the
     /// deliberate escape hatch — a minimal scaffold for owners who don't fit the other four.
-    case business, personal, blog, portfolio, organization, blank
+    case business, personal, blog, portfolio, organization, community, blank
 
     /// Owner-facing label for the Type step.
     public var label: String {
@@ -15,6 +15,7 @@ public enum SiteType: String, Sendable, CaseIterable, Codable {
         case .blog:         return "Blog"
         case .portfolio:    return "Portfolio"
         case .organization: return "Organization website"
+        case .community:    return "Hosted community"
         case .blank:        return "Blank website"
         }
     }
@@ -27,6 +28,7 @@ public enum SiteType: String, Sendable, CaseIterable, Codable {
         case .blog:         return "Publish posts, articles, or updates over time."
         case .portfolio:    return "Showcase selected work, case studies, or creative projects."
         case .organization: return "Share a group mission, programs, events, and ways to get involved."
+        case .community:    return "Host a fediverse community others can join and post to."
         case .blank:        return "Start with a simple empty website you can shape yourself."
         }
     }
@@ -39,6 +41,7 @@ public enum SiteType: String, Sendable, CaseIterable, Codable {
         case .blog:         return "text.alignleft"
         case .portfolio:    return "square.grid.2x2"
         case .organization: return "person.3"
+        case .community:    return "person.3.sequence"
         case .blank:        return "doc"
         }
     }

--- a/Sources/AnglesiteCore/SiteOperations.swift
+++ b/Sources/AnglesiteCore/SiteOperations.swift
@@ -144,6 +144,14 @@ public struct SiteOperations: Sendable {
         let workerSiteName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: existingConfig)
             ?? SiteSlug.derive(from: site.name)
 
+        // #1263 final review finding 1: this headless path (App Intents/Shortcuts/Siri) skipped
+        // both the Group actor type and the moderator list before this — since `persistConfig`
+        // regenerates `wrangler.toml` from scratch on every deploy, a community correctly
+        // deployed once via the GUI, then re-deployed headlessly, silently reverted to a Person
+        // actor with no moderators. Mirrors `DeployModel.runDeploy`'s identical
+        // `resolveIsHostedCommunity` read and `activityPubActorType`/`moderators` args exactly.
+        let isHostedCommunity = DeployCoordinator.resolveIsHostedCommunity(siteDirectory: siteDirectory)
+
         onProgress?(.deployBuilding)
         onProgress?(.deployDeploying)
         let provisionResult = await factory.socialWorkerProvision().provision(
@@ -157,14 +165,26 @@ public struct SiteOperations: Sendable {
             // dynamic /.well-known/ claims the GUI Deploy button already threads via
             // `DeployModel.runDeploy`'s custom deployer closure, so #744's collision check blocks
             // identically regardless of trigger.
-            wellKnownDynamicClaims: WorkerRouteClaims.wellKnownClaims(routeClaims)
+            wellKnownDynamicClaims: WorkerRouteClaims.wellKnownClaims(routeClaims),
+            activityPubActorType: isHostedCommunity ? "Group" : nil,
+            moderators: isHostedCommunity ? settings.moderators : nil
         )
         onProgress?(.deployFinalizing)
 
-        if case .succeeded(_, let resources, _) = provisionResult {
+        let activitypubProvisioned = workers.contains(where: { $0.id == WorkerComposition.activitypubWorkerID })
+        if case .succeeded(let deployedURL, let resources, _) = provisionResult {
             var updated = settings
             updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
             updated.provisionedWorkerResources = resources
+            if isHostedCommunity && activitypubProvisioned {
+                // Same derivation `DeployModel.runDeploy` and `ModerationModel.ownActorURL` use —
+                // prefer the confirmed site URL (which may already carry a custom domain) over the
+                // workers.dev URL this particular deploy printed, falling back to it only before
+                // any URL has ever been recorded.
+                let communityActorSiteURL =
+                    DeployCoordinator.resolveSiteURL(siteDirectory: siteDirectory).flatMap { URL(string: $0) } ?? deployedURL
+                updated.communityActorURL = ActivityPubActor.actorURL(siteURL: communityActorSiteURL)
+            }
             try? await configStore.save(updated)
         }
 

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -197,7 +197,16 @@ public actor SocialWorkerProvisionCommand {
         /// (`SiteSettings.inboxCaptureEnabled`, #764). `false` (the default) matches every
         /// existing caller's behavior unchanged — the KV namespace is created (or, if
         /// `knownResources`/a prior `wrangler.toml` already has one, reused) only when `true`.
-        inboxCaptureEnabled: Bool = false
+        inboxCaptureEnabled: Bool = false,
+        /// This site's ActivityPub actor type (V-5.1b, #907; `SiteSettings`'s sibling concept
+        /// to `communityActorURL`) — `"Group"` for a hosted community, `nil` for an ordinary
+        /// Person actor. Forwarded verbatim to `WorkerComposition.generateWranglerToml`, which
+        /// already only emits a var when this is exactly `"Group"`.
+        activityPubActorType: String? = nil,
+        /// Actor IRIs authorized to moderate this site's Group actor (`SiteSettings.moderators`).
+        /// Ignored for a Person actor, same as `WorkerComposition.generateWranglerToml`'s own
+        /// `moderators` parameter.
+        moderators: [String]? = nil
     ) async -> Result {
         let token: String?
         do {
@@ -263,7 +272,7 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created D1 database \(name) but no database id was found", exitCode: 0, resources: resources)
                 }
                 resources.d1DatabaseID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators) {
                     return failure
                 }
             }
@@ -290,7 +299,7 @@ public actor SocialWorkerProvisionCommand {
                     return .failed(reason: "wrangler created KV namespace \(name) but no namespace id was found", exitCode: 0, resources: resources)
                 }
                 resources.kvNamespaceID = id
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators) {
                     return failure
                 }
             }
@@ -310,7 +319,7 @@ public actor SocialWorkerProvisionCommand {
                     return failure
                 }
                 resources.r2BucketName = name
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators) {
                     return failure
                 }
             }
@@ -333,7 +342,7 @@ public actor SocialWorkerProvisionCommand {
                     return failure
                 }
                 resources.podBlobsR2BucketName = name
-                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled) {
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators) {
                     return failure
                 }
             }
@@ -372,7 +381,7 @@ public actor SocialWorkerProvisionCommand {
             if resources.inboxAccountID == nil {
                 resources.inboxAccountID = await accountIDSource(token)
             }
-            if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, inboxCaptureEnabled: inboxCaptureEnabled) {
+            if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators) {
                 return failure
             }
         }
@@ -385,7 +394,7 @@ public actor SocialWorkerProvisionCommand {
             // `wrangler secret put` (below) resolves the Worker's project name from
             // wrangler.toml in the working directory — persist it here first so that lookup
             // succeeds even on an ActivityPub-only first deploy.
-            if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled) {
+            if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators) {
                 return failure
             }
             let keys: ActivityPubKeyProvisioning.Secrets
@@ -479,7 +488,8 @@ public actor SocialWorkerProvisionCommand {
                 siteDirectory: siteDirectory, siteName: siteName, workers: workers,
                 routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName,
                 apUsername: apUsername,
-                inboxCaptureEnabled: inboxCaptureEnabled
+                inboxCaptureEnabled: inboxCaptureEnabled,
+                activityPubActorType: activityPubActorType, moderators: moderators
             ) {
                 return failure
             }
@@ -504,7 +514,8 @@ public actor SocialWorkerProvisionCommand {
                 siteDirectory: siteDirectory, siteName: siteName, workers: workers,
                 routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName,
                 apUsername: apUsername,
-                inboxCaptureEnabled: inboxCaptureEnabled
+                inboxCaptureEnabled: inboxCaptureEnabled,
+                activityPubActorType: activityPubActorType, moderators: moderators
             ) {
                 return failure
             }
@@ -529,13 +540,14 @@ public actor SocialWorkerProvisionCommand {
                 siteDirectory: siteDirectory, siteName: siteName, workers: workers,
                 routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName,
                 apUsername: apUsername,
-                inboxCaptureEnabled: inboxCaptureEnabled
+                inboxCaptureEnabled: inboxCaptureEnabled,
+                activityPubActorType: activityPubActorType, moderators: moderators
             ) {
                 return failure
             }
         }
 
-        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled) {
+        if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators) {
             return failure
         }
 
@@ -606,7 +618,9 @@ public actor SocialWorkerProvisionCommand {
         siteURL: String? = nil,
         displayName: String? = nil,
         apUsername: String? = nil,
-        inboxCaptureEnabled: Bool = false
+        inboxCaptureEnabled: Bool = false,
+        activityPubActorType: String? = nil,
+        moderators: [String]? = nil
     ) -> Result? {
         do {
             let toml = try WorkerComposition.generateWranglerToml(
@@ -618,6 +632,8 @@ public actor SocialWorkerProvisionCommand {
                 inboxKVNamespaceID: resources.inboxKVNamespaceID,
                 siteURL: siteURL,
                 displayName: displayName,
+                activityPubActorType: activityPubActorType,
+                moderators: moderators,
                 apUsername: apUsername
             )
             try toml.write(

--- a/Sources/AnglesiteCore/ThemeCatalog.swift
+++ b/Sources/AnglesiteCore/ThemeCatalog.swift
@@ -63,7 +63,8 @@ public struct ThemeCatalog: Sendable {
     public func defaultThemeID(for type: SiteType) -> String {
         let preferred: [SiteType: String] = [
             .business: "classic", .personal: "elegant", .blog: "warm",
-            .portfolio: "bold", .organization: "community", .blank: "classic",
+            .portfolio: "bold", .organization: "community", .community: "community",
+            .blank: "classic",
         ]
         let want = preferred[type] ?? "classic"
         if theme(id: want) != nil { return want }

--- a/Sources/AnglesiteIntents/WindowRouter.swift
+++ b/Sources/AnglesiteIntents/WindowRouter.swift
@@ -76,6 +76,18 @@ public final class WindowRouter {
     /// Called by the launcher once it has consumed the request.
     public func clearNewSiteRequest() { newSiteRequested = false }
 
+    /// Set by File ▸ New Community (which can't host the wizard sheet itself). Mirrors
+    /// ``newSiteRequested``'s set-then-consume contract exactly — see that property's doc
+    /// comment (#907, design doc §3, a distinct flow from New Site since a hosted community
+    /// is a different site kind, not a theme pick).
+    public private(set) var newCommunityRequested = false
+
+    /// Flags a pending File ▸ New Community request for the "Sites" launcher to consume.
+    public func requestNewCommunity() { newCommunityRequested = true }
+
+    /// Called by the launcher once it has consumed the request.
+    public func clearNewCommunityRequest() { newCommunityRequested = false }
+
     /// Opens (or focuses) the "Sites" launcher window. AppKit callers — the Dock menu (#522) —
     /// can't reach SwiftUI's `openWindow`, so the launcher root stashes a captured
     /// `OpenWindowAction` here on appear. `OpenWindowAction` is scene-independent, so the closure

--- a/Tests/AnglesiteAppTests/ModerationModelTests.swift
+++ b/Tests/AnglesiteAppTests/ModerationModelTests.swift
@@ -1,0 +1,75 @@
+// Tests/AnglesiteAppTests/ModerationModelTests.swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("ModerationModel")
+@MainActor
+struct ModerationModelTests {
+    final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+        var values: [String: String] = [:]
+        func read(account: String) throws -> String? { values[account] }
+        func write(_ value: String, account: String) throws { values[account] = value }
+        func delete(account: String) throws { values.removeValue(forKey: account) }
+    }
+
+    private static func site(configDirectory: URL, sourceDirectory: URL) -> CurrentSite {
+        CurrentSite(
+            id: "site-1", name: "Test Community",
+            packageURL: sourceDirectory.deletingLastPathComponent(),
+            sourceDirectory: sourceDirectory, configDirectory: configDirectory)
+    }
+
+    /// Mirrors `CommunitiesModelTests.makeSiteDirectories(domain:)` — a fixture site with a
+    /// public URL (so `DeployCoordinator.resolveSiteURL` resolves) and one member snapshot file.
+    private static func makeSiteDirectories() throws -> (config: URL, source: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("moderation-model-test-\(UUID().uuidString)")
+        let config = root.appendingPathComponent("Config")
+        let source = root.appendingPathComponent("Source")
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "DOMAIN=my-community.example\n".write(
+            to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        let member = try CommunityMember(
+            id: "abc123", actorURL: URL(string: "https://lemmy.ml/u/spammer")!, name: "Spammer", photo: nil)
+        let memberPath = source.appendingPathComponent(member.gitPath)
+        try FileManager.default.createDirectory(at: memberPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try JSONEncoder().encode(member).write(to: memberPath)
+        return (config, source)
+    }
+
+    @Test("banning a member POSTs Remove and drops them from the visible list")
+    func banRemovesMember() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        actor Recorder {
+            private(set) var bodies: [[String: Any]] = []
+            func record(_ body: [String: Any]) { bodies.append(body) }
+        }
+        let recorder = Recorder()
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            if let data = request.httpBody, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                await recorder.record(json)
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        #expect(model.members.count == 1)
+        try await model.ban(model.members[0])
+
+        let body = await recorder.bodies.first
+        #expect(body?["type"] as? String == "Remove")
+        #expect(body?["object"] as? String == "https://lemmy.ml/u/spammer")
+        #expect(model.members.isEmpty)
+    }
+}

--- a/Tests/AnglesiteAppTests/ModerationModelTests.swift
+++ b/Tests/AnglesiteAppTests/ModerationModelTests.swift
@@ -62,7 +62,7 @@ struct ModerationModelTests {
             let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
             return (Data("{}".utf8), http)
         })
-        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
 
         #expect(model.members.count == 1)
         try await model.ban(model.members[0])
@@ -71,5 +71,40 @@ struct ModerationModelTests {
         #expect(body?["type"] as? String == "Remove")
         #expect(body?["object"] as? String == "https://lemmy.ml/u/spammer")
         #expect(model.members.isEmpty)
+    }
+
+    /// The sync jobs that write member/post snapshot files (`CommunityMembersSync`/
+    /// `AnnouncedPostSync`) run later than `configure(site:)` — from `PreviewModel`, after the dev
+    /// server starts — so a site can genuinely go from zero members at `configure(site:)` time to
+    /// some the next time the pane is opened. `reload()` (what `SiteWindowModel.presentModeration()`
+    /// calls on every presentation) must pick that up without a fresh `configure(site:)`.
+    @Test("reload picks up member/post snapshot files written after configure(site:)")
+    func reloadPicksUpNewlyWrittenSnapshots() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.members.count == 1)
+        #expect(model.posts.isEmpty)
+
+        // Simulates a sync job landing a new post snapshot after `configure(site:)` already ran.
+        let post = try AnnouncedPost(
+            id: "post1", objectType: .note, sourceURL: URL(string: "https://member.example/posts/1")!,
+            author: nil, content: "Hello, community!", published: Date(), announcedAt: Date())
+        let postPath = source.appendingPathComponent(post.gitPath)
+        try FileManager.default.createDirectory(at: postPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try JSONEncoder().encode(post).write(to: postPath)
+
+        await model.reload()
+
+        #expect(model.posts.count == 1)
+        #expect(model.posts.first?.id == "post1")
+        // The pre-existing member snapshot is still picked up on every reload, not just the first.
+        #expect(model.members.count == 1)
     }
 }

--- a/Tests/AnglesiteAppTests/ModerationModelTests.swift
+++ b/Tests/AnglesiteAppTests/ModerationModelTests.swift
@@ -107,4 +107,51 @@ struct ModerationModelTests {
         // The pre-existing member snapshot is still picked up on every reload, not just the first.
         #expect(model.members.count == 1)
     }
+
+    /// #1263 final review finding 5: `SiteSettings.moderators` had no writer anywhere in the
+    /// app — the design doc calls for add/remove, but before this fix the list could only ever
+    /// be empty in production. Confirms a moderator survives a round trip through
+    /// `SiteConfigStore` and that the model's own `moderators` property reflects it immediately.
+    @Test("addModerator persists a well-formed actor URL and removeModerator undoes it")
+    func addAndRemoveModeratorPersistsViaSiteConfigStore() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.moderators.isEmpty)
+
+        let added = await model.addModerator("https://mastodon.social/users/alice")
+        #expect(added)
+        #expect(model.moderators == ["https://mastodon.social/users/alice"])
+        let persisted = try await SiteConfigStore(configDirectory: config).load()
+        #expect(persisted.moderators == ["https://mastodon.social/users/alice"])
+
+        await model.removeModerator("https://mastodon.social/users/alice")
+        #expect(model.moderators.isEmpty)
+        let persistedAfterRemove = try await SiteConfigStore(configDirectory: config).load()
+        #expect(persistedAfterRemove.moderators?.isEmpty ?? true)
+    }
+
+    @Test("addModerator rejects a malformed actor URL without persisting it")
+    func addModeratorRejectsInvalidURL() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        let added = await model.addModerator("not a url")
+        #expect(!added)
+        #expect(model.moderators.isEmpty)
+        #expect(model.errorMessage != nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
@@ -104,4 +104,28 @@ struct CommunityMembershipClientTests {
             _ = try await Self.client(fake).follow(target: target)
         }
     }
+
+    @Test("POSTs a Remove activity to this site's own outbox")
+    func postsRemove() async throws {
+        let fake = FakeTransport()
+        let target = try #require(URL(string: "https://lemmy.ml/u/spammer"))
+
+        try await Self.client(fake).remove(target: target)
+
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Remove")
+        #expect(body?["object"] as? String == "https://lemmy.ml/u/spammer")
+        #expect(body?["actor"] as? String == "https://example.com/users/site")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+    }
+
+    @Test("remove maps a non-2xx status to requestFailed")
+    func removeMapsNon2xx() async throws {
+        let fake = FakeTransport(status: 403, body: "forbidden")
+        let target = try #require(URL(string: "https://lemmy.ml/u/spammer"))
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 403, body: "forbidden")) {
+            try await Self.client(fake).remove(target: target)
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift
@@ -141,6 +141,23 @@ struct DeployCoordinatorTests {
         #expect(name == SiteSlug.derive(from: "site-1"))
     }
 
+    // MARK: - resolveIsHostedCommunity (#907)
+
+    @Test("resolveIsHostedCommunity reads SITE_TYPE=community from .site-config")
+    func resolveIsHostedCommunityReadsSiteType() throws {
+        let dir = try temporaryDirectory()
+        try "SITE_TYPE=community\n".write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        #expect(DeployCoordinator.resolveIsHostedCommunity(siteDirectory: dir))
+    }
+
+    @Test("resolveIsHostedCommunity is false for every other site kind, including no .site-config at all")
+    func resolveIsHostedCommunityFalseOtherwise() throws {
+        let dir = try temporaryDirectory()
+        #expect(!DeployCoordinator.resolveIsHostedCommunity(siteDirectory: dir))
+        try "SITE_TYPE=business\n".write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        #expect(!DeployCoordinator.resolveIsHostedCommunity(siteDirectory: dir))
+    }
+
     // MARK: - deployLogSources
 
     @Test("deployLogSources includes worker-provision:<siteID> so SocialWorkerProvisionCommand's wrangler output reaches the drawer")
@@ -207,6 +224,21 @@ struct DeployCoordinatorTests {
         #expect(saved.provisionedWorkerResources == resources)
         // Unrelated fields on the passed-in settings are preserved, not clobbered.
         #expect(saved.displayName == "Keep Me")
+    }
+
+    @Test("persistProvisionedResources writes communityActorURL when given one")
+    func persistProvisionedResourcesWritesCommunityActorURL() async throws {
+        let dir = try temporaryDirectory()
+        let configStore = SiteConfigStore(configDirectory: dir)
+        let actorURL = URL(string: "https://my-community.example/users/site")!
+
+        await DeployCoordinator.persistProvisionedResources(
+            configStore: configStore, settings: SiteSettings(), effectiveActiveIDs: [],
+            resources: .init(), communityActorURL: actorURL
+        )
+
+        let saved = try await configStore.load()
+        #expect(saved.communityActorURL == actorURL)
     }
 
     // MARK: - ActivityPub handle resolution (#1239)

--- a/Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import AnglesiteCore
+
+@MainActor
+final class NewCommunityWizardModelTests: XCTestCase {
+
+    func testStartsOnChooserWithEmptyNameAndCannotCreate() {
+        let m = NewCommunityWizardModel(isNameTaken: { _ in false })
+        XCTAssertEqual(m.step, .chooser)
+        XCTAssertEqual(m.communityName, "")
+        XCTAssertFalse(m.canCreate)
+    }
+
+    func testCanCreateOnceNameIsNonEmptyAndNotTaken() {
+        let m = NewCommunityWizardModel(isNameTaken: { _ in false })
+        m.communityName = "Birding Club"
+        XCTAssertTrue(m.canCreate)
+    }
+
+    func testCannotCreateWhenNameIsTaken() {
+        let m = NewCommunityWizardModel(isNameTaken: { $0 == "Birding Club" })
+        m.communityName = "Birding Club"
+        XCTAssertFalse(m.canCreate)
+    }
+
+    func testCannotCreateWithWhitespaceOnlyName() {
+        let m = NewCommunityWizardModel(isNameTaken: { _ in false })
+        m.communityName = "   "
+        XCTAssertFalse(m.canCreate)
+    }
+
+    func testBuildDrivesScaffolderWithCommunitySiteTypeAndFixedTheme() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let m = NewCommunityWizardModel(isNameTaken: { _ in false })
+        m.communityName = "Birding Club"
+
+        var seenDraft: NewSiteDraft?
+        // Use the actual template from Resources/Template to avoid package.json warnings
+        let templateURL = URL(fileURLWithPath: "/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/multi-agent-test-hangs-b849b1/Resources/Template")
+        let scaffolder = SiteScaffolder(
+            sitesRoot: root,
+            templateURL: templateURL,
+            catalog: ThemeCatalog(themes: [Theme(id: "community", name: "Community", blurb: "", swatch: [], cssVars: [:])]),
+            run: { _, args, cwd in
+                if args.contains(where: { $0.hasSuffix("scaffold.sh") }), let cwd {
+                    let css = cwd.appendingPathComponent("src/styles/global.css")
+                    let astro = cwd.appendingPathComponent("src/pages/index.astro")
+                    try? FileManager.default.createDirectory(at: css.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? FileManager.default.createDirectory(at: astro.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? ":root { --color-primary: #2563eb; }".write(to: css, atomically: true, encoding: .utf8)
+                    try? "<h1>Welcome</h1>".write(to: astro, atomically: true, encoding: .utf8)
+                    try? "ANGLESITE_VERSION=1.0.0".write(to: cwd.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+                }
+                return ProcessSupervisor.RunResult(stdout: "", stderr: "", exitCode: 0)
+            },
+            gitInit: { _ in },
+            gitCommit: { _ in },
+            register: { pkg in
+                SiteStore.Site(id: pkg.url.path, name: pkg.url.lastPathComponent, packageURL: pkg.url, isValid: true, missingSentinels: [])
+            },
+            attributionsLoader: { _ in [] },
+            appVersion: { "1.0.0" },
+            hostLanguage: { "en" }
+        )
+
+        let id = await m.build(using: scaffolder)
+
+        XCTAssertNotNil(id)
+        XCTAssertTrue(m.didCompleteCleanly)
+        XCTAssertEqual(m.draft.siteType, .community)
+        XCTAssertEqual(m.draft.name, "Birding Club")
+        XCTAssertEqual(m.draft.themeID, "community")
+        XCTAssertEqual(m.draft.headline, "")   // skip homepage write, matches NewSiteWizardModel's convention
+        seenDraft = m.draft
+        XCTAssertNotNil(seenDraft)
+    }
+}

--- a/Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
@@ -70,4 +70,48 @@ final class NewCommunityWizardModelTests: XCTestCase {
         seenDraft = m.draft
         XCTAssertNotNil(seenDraft)
     }
+
+    /// #1263 final review finding 2: a freshly-scaffolded community must come out of the wizard
+    /// with a live ActivityPub worker — no manual Workers-tab step — since the whole point of
+    /// "New Community" is a working Group actor with no extra owner action.
+    func testBuildActivatesActivityPubWorkerAfterScaffold() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        var registeredConfigDirectory: URL?
+        let m = NewCommunityWizardModel(
+            isNameTaken: { _ in false },
+            resolveConfigDirectory: { _ in registeredConfigDirectory }
+        )
+        m.communityName = "Birding Club"
+
+        let scaffolder = SiteScaffolder(
+            sitesRoot: root,
+            templateURL: URL(fileURLWithPath: "/template"),
+            catalog: ThemeCatalog(themes: [Theme(id: "community", name: "Community", blurb: "", swatch: [], cssVars: [:])]),
+            run: { _, args, cwd in
+                if args.contains(where: { $0.hasSuffix("scaffold.sh") }), let cwd {
+                    let css = cwd.appendingPathComponent("src/styles/global.css")
+                    let astro = cwd.appendingPathComponent("src/pages/index.astro")
+                    try? FileManager.default.createDirectory(at: css.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? FileManager.default.createDirectory(at: astro.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? ":root { --color-primary: #2563eb; }".write(to: css, atomically: true, encoding: .utf8)
+                    try? "<h1>Welcome</h1>".write(to: astro, atomically: true, encoding: .utf8)
+                    try? "ANGLESITE_VERSION=1.0.0".write(to: cwd.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+                }
+                return ProcessSupervisor.RunResult(stdout: "", stderr: "", exitCode: 0)
+            },
+            gitInit: { _ in },
+            gitCommit: { _ in },
+            register: { pkg in
+                registeredConfigDirectory = pkg.configURL
+                return SiteStore.Site(id: pkg.url.path, name: pkg.url.lastPathComponent, packageURL: pkg.url, isValid: true, missingSentinels: [])
+            },
+            attributionsLoader: { _ in [] }
+        )
+
+        _ = await m.build(using: scaffolder)
+
+        let configDirectory = try XCTUnwrap(registeredConfigDirectory)
+        let settings = try await SiteConfigStore(configDirectory: configDirectory).load()
+        XCTAssertEqual(settings.activeWorkerIDs, [WorkerComposition.activitypubWorkerID])
+    }
 }

--- a/Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
@@ -35,11 +35,9 @@ final class NewCommunityWizardModelTests: XCTestCase {
         m.communityName = "Birding Club"
 
         var seenDraft: NewSiteDraft?
-        // Use the actual template from Resources/Template to avoid package.json warnings
-        let templateURL = URL(fileURLWithPath: "/Users/dwk/Developer/github.com/Anglesite/Anglesite-app/.claude/worktrees/multi-agent-test-hangs-b849b1/Resources/Template")
         let scaffolder = SiteScaffolder(
             sitesRoot: root,
-            templateURL: templateURL,
+            templateURL: URL(fileURLWithPath: "/template"),
             catalog: ThemeCatalog(themes: [Theme(id: "community", name: "Community", blurb: "", swatch: [], cssVars: [:])]),
             run: { _, args, cwd in
                 if args.contains(where: { $0.hasSuffix("scaffold.sh") }), let cwd {
@@ -58,9 +56,7 @@ final class NewCommunityWizardModelTests: XCTestCase {
             register: { pkg in
                 SiteStore.Site(id: pkg.url.path, name: pkg.url.lastPathComponent, packageURL: pkg.url, isValid: true, missingSentinels: [])
             },
-            attributionsLoader: { _ in [] },
-            appVersion: { "1.0.0" },
-            hostLanguage: { "en" }
+            attributionsLoader: { _ in [] }
         )
 
         let id = await m.build(using: scaffolder)

--- a/Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
+++ b/Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
@@ -62,7 +62,7 @@ final class NewCommunityWizardModelTests: XCTestCase {
         let id = await m.build(using: scaffolder)
 
         XCTAssertNotNil(id)
-        XCTAssertTrue(m.didCompleteCleanly)
+        XCTAssertNotNil(m.completedSiteID)
         XCTAssertEqual(m.draft.siteType, .community)
         XCTAssertEqual(m.draft.name, "Birding Club")
         XCTAssertEqual(m.draft.themeID, "community")

--- a/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsTests.swift
@@ -327,6 +327,52 @@ struct SiteOperationsTests {
         #expect(saved.lastDeployedWorkerIDs == ["indieauth"])
     }
 
+    /// #1263 final review finding 1: this headless path (App Intents/Shortcuts/Siri) used to call
+    /// `provision()` with no `activityPubActorType`/`moderators` at all — since `persistConfig`
+    /// regenerates `wrangler.toml` from scratch on every deploy, a community correctly deployed
+    /// once via the GUI then re-deployed headlessly silently reverted to a Person actor with no
+    /// moderators, and `communityActorURL` was never written by this path either. Confirms both
+    /// are now threaded through, mirroring `DeployModel.runDeploy`'s GUI-path wiring.
+    @Test("headless deploy of a hosted community composes a Group actor with moderators and persists communityActorURL")
+    func headlessDeployOfHostedCommunityComposesGroupActor() async throws {
+        let package = try temporaryPackage()
+        defer { try? FileManager.default.removeItem(at: package) }
+        let site = makeSite(name: "Birding Club", packageURL: package)
+        let configStore = SiteConfigStore(configDirectory: site.configDirectory)
+        try await configStore.save(SiteSettings(
+            activeWorkerIDs: ["activitypub"],
+            moderators: ["https://mastodon.social/users/mod"]
+        ))
+        let siteConfigContents = SiteConfigFile.upsert([("SITE_TYPE", SiteType.community.rawValue)], into: "")
+        try siteConfigContents.write(
+            to: site.sourceDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let recorder = SocialWorkerRecorder()
+        let ops = SiteOperations(
+            factory: SocialWorkerFactory(recorder: recorder),
+            store: throwawayStore(),
+            socialWorkerAccess: { site, store, body in try await SiteAccess.withScopedAccess(to: site, in: store, body) },
+            cachedWorkerCatalog: { [self.descriptor(id: "activitypub")] }
+        )
+
+        let result = await ops.deploy(site: site)
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let wranglerToml = try String(
+            contentsOf: site.sourceDirectory.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(wranglerToml.contains(#"AP_ACTOR_TYPE = "Group""#))
+        #expect(wranglerToml.contains(#"AP_MODERATORS = "https://mastodon.social/users/mod""#))
+
+        let saved = try await configStore.load()
+        #expect(saved.communityActorURL == URL(string: "https://blue-bottle-cafe.example.workers.dev/users/site"))
+    }
+
     @Test("headless deploy resolves the Worker name from CF_PROJECT_NAME before deriving from the site's display name")
     func headlessDeployUsesConfiguredProjectNameOverDerivedSlug() async throws {
         let package = try temporaryPackage()
@@ -528,6 +574,10 @@ private struct SocialWorkerFactory: CommandFactory {
         SocialWorkerProvisionCommand(
             tokenSource: { "token" },
             runner: { _, arguments, _, _ in await recorder.run(arguments: arguments) },
+            // Only exercised when the activitypub worker is active (it's the only one that pushes
+            // a secret, `AP_PRIVATE_KEY`) — always-succeeds is fine for the indieauth/webfinger
+            // fixtures elsewhere in this file, which never call it.
+            secretRunner: { _, _, _, _, _ in .init(stdout: "Success!", stderr: "", exitCode: 0) },
             deployer: { token, siteID, siteDirectory, wellKnownDynamicClaims in
                 await recorder.deploy(
                     token: token, siteID: siteID, siteDirectory: siteDirectory,

--- a/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
@@ -108,6 +108,57 @@ struct SocialWorkerProvisionCommandTests {
         #expect(!toml.contains("[[r2_buckets]]"))
     }
 
+    @Test("threads activityPubActorType and moderators into the deployed wrangler.toml")
+    func provisionsGroupActorWithModerators() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([:])
+        let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
+        let command = SocialWorkerProvisionCommand(
+            tokenSource: { "token" },
+            runner: recorder.runner,
+            keyPairSource: { _ in
+                .init(privateKeyPem: "PRIVATE-PEM", publicKeyPem: "PUBLIC-PEM", publishToken: "TOKEN-VALUE")
+            },
+            secretRunner: { _, _, _, _, _ in .init(stdout: "Success!", stderr: "", exitCode: 0) },
+            deployer: deployer.deployer
+        )
+        // AP_ACTOR_TYPE/AP_MODERATORS are gated on `hasActivityPub`
+        // (`WorkerComposition.swift`'s `workers.contains(where: { $0.id == activitypubWorkerID })`),
+        // so the activitypub worker must be active for this test to observe the threaded values.
+        let activitypub = worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [activitypub],
+            activityPubActorType: "Group", moderators: ["https://mod.example/actor"]
+        )
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains("AP_ACTOR_TYPE = \"Group\""))
+        #expect(toml.contains("AP_MODERATORS = \"https://mod.example/actor\""))
+    }
+
+    @Test("omitting activityPubActorType leaves an ordinary Person actor, unaffected")
+    func provisionsWithoutActorTypeStaysUnaffected() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([:])
+        let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [])
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(!toml.contains("AP_ACTOR_TYPE"))
+        #expect(!toml.contains("AP_MODERATORS"))
+    }
+
     @Test("forwards wellKnownDynamicClaims to the deployer so #744's collision check sees them (#934)")
     func forwardsWellKnownDynamicClaimsToDeployer() async throws {
         let site = try temporaryDirectory()

--- a/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
@@ -69,6 +69,7 @@ struct ThemeCatalogTests {
         #expect(catalog.defaultThemeID(for: .blog) == "warm")
         #expect(catalog.defaultThemeID(for: .portfolio) == "bold")
         #expect(catalog.defaultThemeID(for: .organization) == "community")
+        #expect(catalog.defaultThemeID(for: .community) == "community")
     }
 
     @Test func testParseDecodesPackFields() throws {

--- a/docs/superpowers/plans/2026-08-10-hosted-community-provisioning-moderation.md
+++ b/docs/superpowers/plans/2026-08-10-hosted-community-provisioning-moderation.md
@@ -1,0 +1,1516 @@
+# Hosted Community Provisioning + Moderation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close #907's three deferred follow-ups — a "New Community" site-creation flow, deploy wiring for the already-modeled Group actor-type/moderators fields, and a moderator UI for remove-post/ban-member — as three independently-mergeable, stacked PRs.
+
+**Architecture:** A hosted community is an ordinary `.anglesite` package with `SiteType.community`, scaffolded through the existing `SiteScaffolder` pipeline. Its Worker gets a `Group`-typed ActivityPub actor via fields (`activityPubActorType`, `moderators`) that `WorkerComposition.generateWranglerToml` already accepts but nothing yet threads through. Moderation (ban/remove) reuses `CommunityMembershipClient`'s existing owner-outbox-POST pattern with one new method.
+
+**Tech Stack:** Swift 6.4, SwiftUI, Swift Testing (`AnglesiteCoreTests`) and XCTest (site-creation tests, matching existing file conventions) — see each task for which convention its test file uses.
+
+## Global Constraints
+
+- Every `SiteSettings` field stays `Optional` (forward-compat rule, `SiteConfigStore.swift:854-858`) — new fields must follow this.
+- No new third-party dependencies (CONTRIBUTING.md ▸ "Code guidelines").
+- `Process()` is never called directly from a view — go through `ProcessSupervisor`/injected closures (existing pattern, all tasks below already follow it).
+- Every existing non-community site must be byte-for-byte unaffected by Phase 1/2 changes — new params default to `nil`/absent.
+- Commit subject ≤72 characters, conventional-commit format, reference the issue number (CONTRIBUTING.md).
+- Design doc: `docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md` — read it first; this plan implements its §3–§7.
+
+---
+
+## Phase 1 — New Community creation flow (Tasks 1–3, one PR)
+
+### Task 1: Add `SiteType.community`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/NewSiteDraft.swift:349-386` (case list + `label`/`description`/`symbol` switches)
+- Modify: `Sources/AnglesiteCore/ThemeCatalog.swift:61-71` (`defaultThemeID(for:)` preferred-mapping dict)
+- Modify: `Sources/AnglesiteCore/HeroImage.swift:53-60` (`styleHint(for:)` switch)
+- Test: `Tests/AnglesiteCoreTests/ThemeCatalogTests.swift:62-71` (extend existing test)
+
+**Interfaces:**
+- Produces: `SiteType.community` — a new case later tasks construct `NewSiteDraft(siteType: .community, ...)` with.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the existing `defaultThemeIDUsesPreferredMappingWhenPresent` test in `Tests/AnglesiteCoreTests/ThemeCatalogTests.swift` (currently lines 62-71):
+
+```swift
+    @Test func defaultThemeIDUsesPreferredMappingWhenPresent() {
+        let ids = ["classic", "elegant", "warm", "bold", "community"]
+        let catalog = ThemeCatalog(themes: ids.map {
+            Theme(id: $0, name: $0, blurb: "", swatch: [], cssVars: [:])
+        })
+        #expect(catalog.defaultThemeID(for: .business) == "classic")
+        #expect(catalog.defaultThemeID(for: .personal) == "elegant")
+        #expect(catalog.defaultThemeID(for: .blog) == "warm")
+        #expect(catalog.defaultThemeID(for: .portfolio) == "bold")
+        #expect(catalog.defaultThemeID(for: .organization) == "community")
+        #expect(catalog.defaultThemeID(for: .community) == "community")
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter ThemeCatalogTests`
+Expected: **build failure** — `type 'SiteType' has no member 'community'` (the case doesn't exist yet; this is the correct "fails" signal for a new-enum-case step).
+
+- [ ] **Step 3: Add the case and update every exhaustive switch/dict over `SiteType`**
+
+In `Sources/AnglesiteCore/NewSiteDraft.swift`, change the case list (line 349):
+
+```swift
+    case business, personal, blog, portfolio, organization, community, blank
+```
+
+Add a case to each of the three switches immediately below it (`label`, `description`, `symbol`):
+
+```swift
+        case .business:     return "Business website"
+        case .personal:     return "Personal website"
+        case .blog:         return "Blog"
+        case .portfolio:    return "Portfolio"
+        case .organization: return "Organization website"
+        case .community:    return "Hosted community"
+        case .blank:        return "Blank website"
+```
+
+```swift
+        case .business:     return "Promote a company, service, or local shop."
+        case .personal:     return "Create a home for your bio, links, and projects."
+        case .blog:         return "Publish posts, articles, or updates over time."
+        case .portfolio:    return "Showcase selected work, case studies, or creative projects."
+        case .organization: return "Share a group mission, programs, events, and ways to get involved."
+        case .community:    return "Host a fediverse community others can join and post to."
+        case .blank:        return "Start with a simple empty website you can shape yourself."
+```
+
+```swift
+        case .business:     return "building.2"
+        case .personal:     return "person.crop.circle"
+        case .blog:         return "text.alignleft"
+        case .portfolio:    return "square.grid.2x2"
+        case .organization: return "person.3"
+        case .community:    return "person.3.sequence"
+        case .blank:        return "doc"
+```
+
+In `Sources/AnglesiteCore/ThemeCatalog.swift`, add an entry to the preferred-mapping dict (`defaultThemeID(for:)`, currently lines 61-71):
+
+```swift
+    public func defaultThemeID(for type: SiteType) -> String {
+        let preferred: [SiteType: String] = [
+            .business: "classic", .personal: "elegant", .blog: "warm",
+            .portfolio: "bold", .organization: "community", .community: "community",
+            .blank: "classic",
+        ]
+        let want = preferred[type] ?? "classic"
+        if theme(id: want) != nil { return want }
+        return themes.first?.id ?? want
+    }
+```
+
+In `Sources/AnglesiteCore/HeroImage.swift`, add a case to `styleHint(for:)` (currently lines 53-60) — the string must be distinct from every other case's, since `Tests/AnglesiteCoreTests/HeroImageTests.swift:46-49`'s `styleHintPerType` asserts uniqueness across `SiteType.allCases`:
+
+```swift
+    static func styleHint(for siteType: SiteType) -> String {
+        switch siteType {
+        case .business:     return "modern professional abstract illustration"
+        case .personal:     return "warm friendly personal abstract illustration"
+        case .blog:         return "editorial abstract header illustration"
+        case .portfolio:    return "creative abstract portfolio illustration"
+        case .organization: return "welcoming community abstract illustration"
+        case .community:    return "collaborative group abstract illustration"
+        case .blank:        return "simple abstract geometric illustration"
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ThemeCatalogTests`
+Run: `swift test --package-path . --filter HeroImageTests`
+Expected: PASS — `HeroImageTests.styleHintPerType` and `ThemeCatalogTests.defaultThemeIDResolvesForEverySiteType` both iterate `SiteType.allCases` already, so they exercise `.community` automatically with no further test changes needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NewSiteDraft.swift Sources/AnglesiteCore/ThemeCatalog.swift Sources/AnglesiteCore/HeroImage.swift Tests/AnglesiteCoreTests/ThemeCatalogTests.swift
+git commit -m "feat(#907): add SiteType.community"
+```
+
+---
+
+### Task 2: `NewCommunityWizardModel`
+
+**Files:**
+- Create: `Sources/AnglesiteCore/NewCommunityWizardModel.swift`
+- Test: Create `Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift`
+
+**Interfaces:**
+- Consumes: `SiteScaffolder.scaffold(_ draft: NewSiteDraft) -> AsyncStream<SiteScaffolder.ScaffoldStep>` (existing, `Sources/AnglesiteCore/SiteScaffolder.swift:620`); `SiteType.community` (Task 1).
+- Produces: `NewCommunityWizardModel` — `step: Step` (`.chooser`/`.building`), `communityName: String` (bound to a text field), `canCreate: Bool`, `progress: [SiteScaffolder.ScaffoldStep]`, `fatal: SiteScaffolder.ScaffoldStep?`, `completedSiteID: String?`, `hasWarnings: Bool`, `didCompleteCleanly: Bool`, `func build(using scaffolder: SiteScaffolder) async -> String?`. Task 3's `NewCommunityWizard` view binds directly to this model, mirroring how `NewSiteWizard` binds to `NewSiteWizardModel`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift`:
+
+```swift
+import XCTest
+@testable import AnglesiteCore
+
+@MainActor
+final class NewCommunityWizardModelTests: XCTestCase {
+
+    func testStartsOnChooserWithEmptyNameAndCannotCreate() {
+        let m = NewCommunityWizardModel(isNameTaken: { _ in false })
+        XCTAssertEqual(m.step, .chooser)
+        XCTAssertEqual(m.communityName, "")
+        XCTAssertFalse(m.canCreate)
+    }
+
+    func testCanCreateOnceNameIsNonEmptyAndNotTaken() {
+        let m = NewCommunityWizardModel(isNameTaken: { _ in false })
+        m.communityName = "Birding Club"
+        XCTAssertTrue(m.canCreate)
+    }
+
+    func testCannotCreateWhenNameIsTaken() {
+        let m = NewCommunityWizardModel(isNameTaken: { $0 == "Birding Club" })
+        m.communityName = "Birding Club"
+        XCTAssertFalse(m.canCreate)
+    }
+
+    func testCannotCreateWithWhitespaceOnlyName() {
+        let m = NewCommunityWizardModel(isNameTaken: { _ in false })
+        m.communityName = "   "
+        XCTAssertFalse(m.canCreate)
+    }
+
+    func testBuildDrivesScaffolderWithCommunitySiteTypeAndFixedTheme() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let m = NewCommunityWizardModel(isNameTaken: { _ in false })
+        m.communityName = "Birding Club"
+
+        var seenDraft: NewSiteDraft?
+        let scaffolder = SiteScaffolder(
+            sitesRoot: root,
+            templateURL: URL(fileURLWithPath: "/template"),
+            catalog: ThemeCatalog(themes: [Theme(id: "community", name: "Community", blurb: "", swatch: [], cssVars: [:])]),
+            run: { _, args, cwd in
+                if args.contains(where: { $0.hasSuffix("scaffold.sh") }), let cwd {
+                    let astro = cwd.appendingPathComponent("src/pages/index.astro")
+                    try? FileManager.default.createDirectory(at: astro.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try? "<h1>Welcome</h1>".write(to: astro, atomically: true, encoding: .utf8)
+                    try? "ANGLESITE_VERSION=1.0.0".write(to: cwd.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+                }
+                return ProcessSupervisor.RunResult(stdout: "", stderr: "", exitCode: 0)
+            },
+            gitInit: { _ in },
+            gitCommit: { _ in },
+            register: { pkg in
+                SiteStore.Site(id: pkg.url.path, name: pkg.url.lastPathComponent, packageURL: pkg.url, isValid: true, missingSentinels: [])
+            }
+        )
+
+        let id = await m.build(using: scaffolder)
+
+        XCTAssertNotNil(id)
+        XCTAssertTrue(m.didCompleteCleanly)
+        XCTAssertEqual(m.draft.siteType, .community)
+        XCTAssertEqual(m.draft.name, "Birding Club")
+        XCTAssertEqual(m.draft.themeID, "community")
+        XCTAssertEqual(m.draft.headline, "")   // skip homepage write, matches NewSiteWizardModel's convention
+        seenDraft = m.draft
+        XCTAssertNotNil(seenDraft)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter NewCommunityWizardModelTests`
+Expected: FAIL — `cannot find 'NewCommunityWizardModel' in scope` (type doesn't exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Sources/AnglesiteCore/NewCommunityWizardModel.swift`:
+
+```swift
+import Foundation
+import Observation
+
+/// Observable state behind the New Community wizard (V-5.1b, #907, design doc §3) — a
+/// distinct flow from ``NewSiteWizardModel``: a hosted community is a different site kind
+/// (own Worker, own Group actor, moderators), not a cosmetic theme pick, so it asks for a
+/// name only and skips the theme grid entirely, reusing the "community" catalog theme
+/// (the same palette `ThemeCatalog.defaultThemeID(for: .organization)` already maps to) as
+/// its one consistent look.
+@MainActor
+@Observable
+public final class NewCommunityWizardModel {
+    /// Mirrors ``NewSiteWizardModel/Step`` — the chooser (name entry) and building (scaffold
+    /// progress) states.
+    public enum Step: Int, CaseIterable {
+        case chooser
+        case building
+    }
+
+    public private(set) var step: Step = .chooser
+    /// The owner-entered community name; bound to the wizard's text field.
+    public var communityName: String = ""
+    /// Every ``SiteScaffolder/ScaffoldStep`` emitted so far, in order.
+    public private(set) var progress: [SiteScaffolder.ScaffoldStep] = []
+    /// The `.failed` step, if any.
+    public private(set) var fatal: SiteScaffolder.ScaffoldStep?
+    /// The new site's registered id once scaffolding reaches `.done`; `nil` until then.
+    public private(set) var completedSiteID: String?
+
+    /// Availability check for a candidate site name — same contract as
+    /// ``NewSiteWizardModel/init(catalog:isNameTaken:)``'s parameter.
+    private let isNameTaken: (String) -> Bool
+
+    public init(isNameTaken: @escaping (String) -> Bool) {
+        self.isNameTaken = isNameTaken
+    }
+
+    /// The draft `build(using:)` will scaffold, computed fresh from ``communityName`` each
+    /// time it's read — there's no per-field mutation to track separately, unlike
+    /// ``NewSiteWizardModel/draft``, since a community draft has exactly one owner-set field.
+    public var draft: NewSiteDraft {
+        var draft = NewSiteDraft(siteType: .community, name: trimmedName,
+                                 saveFileName: "\(trimmedName).anglesite", headline: "")
+        draft.themeID = "community"
+        return draft
+    }
+
+    private var trimmedName: String {
+        communityName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Gate for the chooser's Create button: a non-empty, not-already-taken name, and no
+    /// build running.
+    public var canCreate: Bool {
+        step == .chooser && !trimmedName.isEmpty && !isNameTaken(trimmedName)
+    }
+
+    public var warnings: [String] {
+        progress.compactMap { if case .warning(_, let message) = $0 { return message } else { return nil } }
+    }
+
+    public var hasWarnings: Bool { !warnings.isEmpty }
+
+    public var didCompleteCleanly: Bool { completedSiteID != nil && !hasWarnings }
+
+    /// Runs the scaffolder against ``draft``, accumulating progress. Returns the new site id
+    /// on success. Mirrors ``NewSiteWizardModel/build(using:)`` exactly.
+    public func build(using scaffolder: SiteScaffolder) async -> String? {
+        step = .building
+        for await s in scaffolder.scaffold(draft) {
+            progress.append(s)
+            if case .failed = s { fatal = s }
+            if case .done(let id) = s { completedSiteID = id }
+        }
+        return completedSiteID
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter NewCommunityWizardModelTests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/NewCommunityWizardModel.swift Tests/AnglesiteCoreTests/NewCommunityWizardModelTests.swift
+git commit -m "feat(#907): add NewCommunityWizardModel"
+```
+
+---
+
+### Task 3: `NewCommunityWizard` view, File menu entry, launcher wiring
+
+**Files:**
+- Create: `Sources/AnglesiteApp/NewCommunityWizard.swift`
+- Modify: `Sources/AnglesiteApp/FocusedSite.swift:63-72` (`NewContentCommands` — add the menu item)
+- Modify: `Sources/AnglesiteApp/SitesLauncherView.swift` (extract shared scaffolding-context setup, add `presentNewCommunity()`, a `newCommunitySession` sheet, `.onChange`/first-appear wiring)
+- Modify: `Sources/AnglesiteIntents/WindowRouter.swift:65-77` (add `newCommunityRequested`/`requestNewCommunity()`/`clearNewCommunityRequest()`, mirroring the `newSiteRequested` trio)
+
+**Interfaces:**
+- Consumes: `NewCommunityWizardModel` (Task 2), `SiteScaffolder` (existing).
+- Produces: a working `File ▸ New Community…` menu command, ⇧⌘ mnemonic-free (no reserved shortcut assigned — Cmd+Shift+N is already New Site's).
+
+This task is UI/app-layer wiring with no unit-testable business logic of its own (the model it drives was already tested in Task 2) — verify by running the app and using the menu command, per the Testing section at the end of this task.
+
+- [ ] **Step 1: Add the WindowRouter request trio**
+
+In `Sources/AnglesiteIntents/WindowRouter.swift`, immediately after the existing `newSiteRequested` block (currently lines 65-77), add:
+
+```swift
+    /// Set by File ▸ New Community (which can't host the wizard sheet itself). Mirrors
+    /// ``newSiteRequested``'s set-then-consume contract exactly — see that property's doc
+    /// comment (#907, design doc §3, a distinct flow from New Site since a hosted community
+    /// is a different site kind, not a theme pick).
+    public private(set) var newCommunityRequested = false
+
+    /// Flags a pending File ▸ New Community request for the "Sites" launcher to consume.
+    public func requestNewCommunity() { newCommunityRequested = true }
+
+    /// Called by the launcher once it has consumed the request.
+    public func clearNewCommunityRequest() { newCommunityRequested = false }
+```
+
+- [ ] **Step 2: Add the menu command**
+
+In `Sources/AnglesiteApp/FocusedSite.swift`, inside `NewContentCommands`'s `CommandGroup(replacing: .newItem)` (currently lines 63-72), add a new button after "New Site…":
+
+```swift
+                CommandGroup(replacing: .newItem) {
+                    Button("New Site…") {
+                        openWindow(id: "sites")
+                        WindowRouter.shared.requestNewSite()
+                    }
+                    .keyboardShortcut("n", modifiers: [.command, .shift])
+
+                    Button("New Community…") {
+                        openWindow(id: "sites")
+                        WindowRouter.shared.requestNewCommunity()
+                    }
+
+                    Button("Open Site…") { ... }
+                    .keyboardShortcut("o")
+                }
+```
+
+(Keep the existing "Open Site…" button and its shortcut unchanged — only the new "New Community…" button is inserted between it and "New Site…".)
+
+- [ ] **Step 3: Extract the shared scaffolding-context helper in `SitesLauncherView`**
+
+`presentNewSite()` (`SitesLauncherView.swift:406-486`) builds a `ThemeCatalog`, resolves the sites root (with MAS security-scope handling), and constructs a `SiteScaffolder` — all of which a community flow needs identically. Extract the shared part into a new private helper so Step 4 doesn't duplicate ~60 lines. Replace the body of `presentNewSite()` (keep its signature) with a call into a new `resolveScaffoldingContext()`:
+
+```swift
+    private struct ScaffoldingContext {
+        let catalog: ThemeCatalog
+        let scaffolder: SiteScaffolder
+        let isNameTaken: (String) -> Bool
+    }
+
+    /// Everything both `presentNewSite()` and `presentNewCommunity()` need before they can
+    /// construct their own wizard model: template/theme catalog, sites-root resolution (with
+    /// MAS security-scope handling), name-uniqueness check, and a ready `SiteScaffolder`.
+    /// Extracted so the two flows (#907, design doc §3) don't duplicate this setup.
+    @MainActor
+    private func resolveScaffoldingContext() async -> ScaffoldingContext? {
+        let resolution = TemplateRuntime.resolve()
+        guard let templateURL = resolution.url else {
+            loadError = "Template not found — can't create a site. Reinstall the app."
+            return nil
+        }
+        let catalog: ThemeCatalog
+        do { catalog = try ThemeCatalog.load(templateURL: templateURL) }
+        catch { loadError = "Couldn't load themes: \(error.localizedDescription)"; return nil }
+
+        let sitesRoot = AppSettings.shared.sitesRoot
+
+        #if ANGLESITE_MAS
+        if AppSettings.shared.sitesRootSource != .iCloudContainer {
+            guard let rootScope = await SiteActions.ensureSitesRootAccess(sitesRoot) else { return nil }
+            sitesRootScopedURL = rootScope
+        }
+        #endif
+        try? FileManager.default.createDirectory(at: sitesRoot, withIntermediateDirectories: true)
+
+        try? await SiteStore.shared.load()
+        let knownSites = await SiteStore.shared.sites
+        let takenSlugs = Set(knownSites.map { SiteSlug.derive(from: $0.name) })
+        let isNameTaken: (String) -> Bool = { name in
+            takenSlugs.contains(SiteSlug.derive(from: name))
+                || FileManager.default.fileExists(atPath: sitesRoot.appendingPathComponent("\(name).anglesite").path)
+        }
+
+        let scaffolder = SiteScaffolder(
+            sitesRoot: sitesRoot,
+            templateURL: templateURL,
+            catalog: catalog,
+            run: { exe, args, cwd in
+                try await ProcessSupervisor.shared.run(executable: exe, arguments: args, currentDirectoryURL: cwd)
+            },
+            gitInit: { sourceDir in try GitInitRunner.run(in: sourceDir) },
+            gitCommit: { sourceDir in try await RepoBootstrap.live().commitAll(source: sourceDir) },
+            register: { package in
+                let site = try await SiteStore.shared.record(package)
+                #if ANGLESITE_MAS
+                let bm = try SecurityScopedBookmark.create(for: site.packageURL)
+                try await SiteStore.shared.setBookmark(bm, for: site.id)
+                #endif
+                return site
+            }
+        )
+        return ScaffoldingContext(catalog: catalog, scaffolder: scaffolder, isNameTaken: isNameTaken)
+    }
+
+    @MainActor
+    private func presentNewSite() async {
+        guard newSiteSession == nil, !preparingNewSite else { return }
+        preparingNewSite = true
+        defer { preparingNewSite = false }
+        guard let context = await resolveScaffoldingContext() else { return }
+        let model = NewSiteWizardModel(catalog: context.catalog, isNameTaken: context.isNameTaken)
+        newSiteSession = NewSiteSession(model: model, scaffolder: context.scaffolder)
+    }
+```
+
+- [ ] **Step 4: Add `presentNewCommunity()`, its session state, and the sheet**
+
+Add alongside `newSiteSession`'s declaration (find `@State private var newSiteSession: NewSiteSession?`):
+
+```swift
+    @State private var newCommunitySession: NewCommunitySession?
+    @State private var preparingNewCommunity = false
+```
+
+Add the session struct alongside `NewSiteSession`'s existing definition:
+
+```swift
+struct NewCommunitySession: Identifiable {
+    let id = UUID()
+    let model: NewCommunityWizardModel
+    let scaffolder: SiteScaffolder
+}
+```
+
+Add the presenter, alongside `presentNewSite()`:
+
+```swift
+    @MainActor
+    private func presentNewCommunity() async {
+        guard newCommunitySession == nil, !preparingNewCommunity else { return }
+        preparingNewCommunity = true
+        defer { preparingNewCommunity = false }
+        guard let context = await resolveScaffoldingContext() else { return }
+        let model = NewCommunityWizardModel(isNameTaken: context.isNameTaken)
+        newCommunitySession = NewCommunitySession(model: model, scaffolder: context.scaffolder)
+    }
+```
+
+Add the `.onChange` and `.sheet` in `body`, mirroring the existing New Site wiring (`SitesLauncherView.swift:74-106`) — add immediately after the existing `.onChange(of: router.newSiteRequested)` block:
+
+```swift
+        .onChange(of: router.newCommunityRequested) { _, requested in
+            guard requested else { return }
+            router.clearNewCommunityRequest()
+            Task { await presentNewCommunity() }
+        }
+```
+
+and immediately after the existing `.sheet(item: $newSiteSession)` block:
+
+```swift
+        .sheet(item: $newCommunitySession) { session in
+            NewCommunityWizard(
+                model: session.model,
+                scaffolder: session.scaffolder,
+                onComplete: { siteID in
+                    newCommunitySession = nil
+                    Task {
+                        await refreshSites()
+                        openWindow(value: siteID)
+                        dismissWindow()
+                    }
+                },
+                onCancel: {
+                    newCommunitySession = nil
+                    deciding = false
+                }
+            )
+            .onDisappear {
+                sitesRootScopedURL?.stopAccessingSecurityScopedResource()
+                sitesRootScopedURL = nil
+            }
+        }
+```
+
+Add the matching first-appear consume (find `onFirstAppear()`, which currently consumes `router.newSiteRequested` — see `SitesLauncherView.swift:490-498`), adding the community equivalent right after:
+
+```swift
+        if router.newCommunityRequested {
+            router.clearNewCommunityRequest()
+            await presentNewCommunity()
+        }
+```
+
+- [ ] **Step 5: Write `NewCommunityWizard`**
+
+Create `Sources/AnglesiteApp/NewCommunityWizard.swift`, a minimal single-question analog of `NewSiteWizard.swift` — a name field instead of a theme grid:
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// The New Community wizard (V-5.1b, #907, design doc §3) — one question (the community's
+/// name), then it scaffolds into the default location and opens in the preview. A distinct
+/// flow from ``NewSiteWizard``: a hosted community is a different site kind, not a theme
+/// pick, so there is no template grid here.
+struct NewCommunityWizard: View {
+    @Bindable var model: NewCommunityWizardModel
+    let scaffolder: SiteScaffolder
+    let onComplete: (String) -> Void
+    let onCancel: () -> Void
+
+    @FocusState private var nameFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            content
+            Divider()
+            footer
+        }
+        .frame(width: 420, height: 220)
+        .interactiveDismissDisabled(model.step == .building)
+    }
+
+    @ViewBuilder private var content: some View {
+        switch model.step {
+        case .chooser:  chooserStep
+        case .building: buildingStep
+        }
+    }
+
+    private var chooserStep: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Name Your Community").font(.title2.bold())
+            Text("Others will be able to join and post to it from any fediverse account.")
+                .font(.callout).foregroundStyle(.secondary)
+            TextField("Community Name", text: $model.communityName)
+                .textFieldStyle(.roundedBorder)
+                .focused($nameFieldFocused)
+                .onSubmit(create)
+                .task { nameFieldFocused = true }
+        }.padding(24)
+    }
+
+    private var buildingStep: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Building your community\u{2026}").font(.title2.bold())
+            ForEach(Array(model.progress.enumerated()), id: \.offset) { _, s in
+                Text(label(for: s)).font(.callout)
+                    .accessibilityLabel(accessibilityLabel(for: s))
+            }
+            if case .failed(_, let msg) = model.fatal {
+                Text(msg).font(.caption).foregroundStyle(.red).textSelection(.enabled)
+                    .accessibilityLabel("Build failed")
+                    .accessibilityValue(msg)
+            }
+        }.padding(24).frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func label(for step: SiteScaffolder.ScaffoldStep) -> String {
+        switch step {
+        case .creatingFolder: return "\u{2705} Created the community file"
+        case .copyingTemplate: return "\u{2705} Copied the template"
+        case .applyingTheme: return "\u{2705} Applied the community theme"
+        case .writingContent: return "\u{2705} Prepared the starter content"
+        case .installing: return "\u{23F3} Installing\u{2026}"
+        case .registering: return "\u{2705} Registering"
+        case .warning(_, let m): return "\u{26A0}\u{FE0F} \(m)"
+        case .failed(_, let m): return "\u{274C} \(m)"
+        case .done: return "\u{2705} Done"
+        }
+    }
+
+    private func accessibilityLabel(for step: SiteScaffolder.ScaffoldStep) -> String {
+        switch step {
+        case .creatingFolder:    return "Created the community file"
+        case .copyingTemplate:   return "Copied the template"
+        case .applyingTheme:     return "Applied the community theme"
+        case .writingContent:    return "Prepared the starter content"
+        case .installing:        return "Installing…"
+        case .registering:       return "Registering"
+        case .warning(_, let m): return "Warning: \(m)"
+        case .failed(_, let m):  return "Failed: \(m)"
+        case .done:              return "Done"
+        }
+    }
+
+    @ViewBuilder private var footer: some View {
+        HStack {
+            Spacer()
+            if model.step == .chooser {
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Create") { create() }
+                    .keyboardShortcut(.defaultAction).disabled(!model.canCreate)
+            } else if model.completedSiteID == nil && model.fatal != nil {
+                Button("Close") { onCancel() }
+            }
+        }.padding(.horizontal, 16).padding(.vertical, 10)
+    }
+
+    private func create() {
+        guard model.canCreate else { return }
+        Task {
+            _ = await model.build(using: scaffolder)
+            if model.didCompleteCleanly, let id = model.completedSiteID { onComplete(id) }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Manual verification (no automated test — SwiftUI view + app-layer wiring)**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: builds clean.
+
+Then launch the app (`open Anglesite.xcodeproj`, ⌘R), and:
+1. `File ▸ New Community…` opens a sheet asking only for a name.
+2. Typing a name enables Create; Create is disabled while the field is empty.
+3. Clicking Create scaffolds a new `.anglesite` package and opens it.
+4. In the new site's `Source/.site-config`, confirm `SITE_TYPE=community` and `THEME=community` are present.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteApp/NewCommunityWizard.swift Sources/AnglesiteApp/FocusedSite.swift Sources/AnglesiteApp/SitesLauncherView.swift Sources/AnglesiteIntents/WindowRouter.swift
+git commit -m "feat(#907): add File > New Community… creation flow"
+```
+
+**This completes Phase 1 — open a PR here** (per CONTRIBUTING.md's PR template; see the design doc §1 for phase boundaries).
+
+---
+
+## Phase 2 — Deploy wiring (Tasks 4–5, one PR)
+
+### Task 4: Thread `activityPubActorType`/`moderators` through `SocialWorkerProvisionCommand`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift` (`provision()` signature at lines 153-201, `persistConfig` signature at lines 600-609, all 10 `persistConfig(...)` call sites at lines 266, 293, 313, 336, 375, 388, 478, 503, 528, 538)
+- Test: `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`
+
+**Interfaces:**
+- Consumes: `WorkerComposition.generateWranglerToml(..., activityPubActorType: String?, moderators: [String]?, ...)` (already exists, `WorkerComposition.swift:195-198,218`).
+- Produces: `SocialWorkerProvisionCommand.provision(..., activityPubActorType: String? = nil, moderators: [String]? = nil)` — Task 5 calls this with real values.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift`, following the exact fixture pattern `provisionsV2Worker` uses (lines 67-109):
+
+```swift
+    @Test("threads activityPubActorType and moderators into the deployed wrangler.toml")
+    func provisionsGroupActorWithModerators() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([:])
+        let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
+
+        let result = await command.provision(
+            siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [],
+            activityPubActorType: "Group", moderators: ["https://mod.example/actor"]
+        )
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(toml.contains("AP_ACTOR_TYPE = \"Group\""))
+        #expect(toml.contains("AP_MODERATORS = \"https://mod.example/actor\""))
+    }
+
+    @Test("omitting activityPubActorType leaves an ordinary Person actor, unaffected")
+    func provisionsWithoutActorTypeStaysUnaffected() async throws {
+        let site = try temporaryDirectory()
+        let recorder = WranglerRecorder([:])
+        let deployer = DeployRecorder(result: .succeeded(url: URL(string: "https://my-site.example.workers.dev")!, duration: 1))
+        let command = SocialWorkerProvisionCommand(tokenSource: { "token" }, runner: recorder.runner, deployer: deployer.deployer)
+
+        let result = await command.provision(siteID: "site-1", siteDirectory: site, siteName: "my-site", workers: [])
+
+        guard case .succeeded = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let toml = try String(contentsOf: site.appendingPathComponent("wrangler.toml"), encoding: .utf8)
+        #expect(!toml.contains("AP_ACTOR_TYPE"))
+        #expect(!toml.contains("AP_MODERATORS"))
+    }
+```
+
+Note: this test uses an activitypub-less `workers: []` list deliberately — `WorkerComposition`'s `AP_ACTOR_TYPE`/`AP_MODERATORS` branch is gated on `hasActivityPub` (`WorkerComposition.swift:512`, `workers.contains(where: { $0.id == activitypubWorkerID })`). If the first test fails because the vars aren't emitted without an activitypub worker present, add the same `worker(WorkerComposition.activitypubWorkerID, d1: false, kv: false, r2: false)` fixture `WorkerCompositionTests.swift:6-11` uses, and pass it in `workers:` for the first test only (the second test's whole point is confirming no vars leak in *without* Group actor type, so it should keep `workers: []`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: **build failure** — `provision(...)` has no parameters `activityPubActorType`/`moderators` yet.
+
+- [ ] **Step 3: Thread the two new parameters through**
+
+In `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift`, add two new trailing optional parameters to `provision()` (currently ending at line 200-201 with `inboxCaptureEnabled: Bool = false`):
+
+```swift
+        inboxCaptureEnabled: Bool = false,
+        /// This site's ActivityPub actor type (V-5.1b, #907; `SiteSettings`'s sibling concept
+        /// to `communityActorURL`) — `"Group"` for a hosted community, `nil` for an ordinary
+        /// Person actor. Forwarded verbatim to `WorkerComposition.generateWranglerToml`, which
+        /// already only emits a var when this is exactly `"Group"`.
+        activityPubActorType: String? = nil,
+        /// Actor IRIs authorized to moderate this site's Group actor (`SiteSettings.moderators`).
+        /// Ignored for a Person actor, same as `WorkerComposition.generateWranglerToml`'s own
+        /// `moderators` parameter.
+        moderators: [String]? = nil
+    ) async -> Result {
+```
+
+Add matching parameters to `persistConfig` (currently lines 600-609):
+
+```swift
+    private func persistConfig(
+        siteDirectory: URL,
+        siteName: String,
+        workers: [WorkerDescriptor],
+        routeClaims: [WorkerRouteClaim],
+        resources: WorkerComposition.ProvisionedResources,
+        siteURL: String? = nil,
+        displayName: String? = nil,
+        apUsername: String? = nil,
+        inboxCaptureEnabled: Bool = false,
+        activityPubActorType: String? = nil,
+        moderators: [String]? = nil
+    ) -> Result? {
+```
+
+Thread them into the `generateWranglerToml` call inside `persistConfig` (currently lines 613-622):
+
+```swift
+            let toml = try WorkerComposition.generateWranglerToml(
+                siteName: siteName,
+                workers: workers,
+                routeClaims: routeClaims,
+                resources: resources,
+                inboxCaptureEnabled: inboxCaptureEnabled,
+                inboxKVNamespaceID: resources.inboxKVNamespaceID,
+                siteURL: siteURL,
+                displayName: displayName,
+                activityPubActorType: activityPubActorType,
+                moderators: moderators,
+                apUsername: apUsername
+            )
+```
+
+Finally, add `activityPubActorType: activityPubActorType, moderators: moderators` as trailing named arguments to every one of the 10 `persistConfig(...)` call sites inside `provision()` (grep to find them: `grep -n "persistConfig(" Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift` → lines 266, 293, 313, 336, 375, 388, 478, 503, 528, 538). Every call site already passes `inboxCaptureEnabled: inboxCaptureEnabled` as its last argument — add the two new arguments immediately after it at each site, e.g. line 266 becomes:
+
+```swift
+                if let failure = persistConfig(siteDirectory: siteDirectory, siteName: siteName, workers: workers, routeClaims: routeClaims, resources: resources, siteURL: siteURL, displayName: displayName, apUsername: apUsername, inboxCaptureEnabled: inboxCaptureEnabled, activityPubActorType: activityPubActorType, moderators: moderators) {
+```
+
+(and identically for the other 9 sites — the two new arguments read the same `provision()`-scope parameters by the same names everywhere, since Swift resolves `activityPubActorType`/`moderators` to `provision()`'s own parameters at every call site inside its body.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter SocialWorkerProvisionCommandTests`
+Expected: PASS, including all pre-existing tests in this file (confirms the 10 call-site edits didn't break any of them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift Tests/AnglesiteCoreTests/SocialWorkerProvisionCommandTests.swift
+git commit -m "feat(#907): thread Group actor-type/moderators into provision()"
+```
+
+---
+
+### Task 5: `DeployModel` call site — pass the fields, write back `communityActorURL`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift:840-885`
+- Modify: `Sources/AnglesiteCore/DeployCoordinator.swift:234-238` (new `resolveIsHostedCommunity`), `:374-396` (`persistProvisionedResources` — add `communityActorURL` param)
+- Test: `Tests/AnglesiteCoreTests/DeployCoordinatorTests.swift` (or wherever `persistProvisionedResources`/`resolveWorkerSiteName` are already tested — grep `grep -rln "persistProvisionedResources\|resolveWorkerSiteName" Tests/` to confirm the exact file before adding)
+
+**Interfaces:**
+- Consumes: `ActivityPubActor.actorURL(siteURL: URL) -> URL` (existing, `Sources/AnglesiteCore/ActivityPubFollowers.swift:19`); `SiteConfigFile.value(forKey:in:)` (existing, used identically by `resolveWorkerSiteName`).
+- Produces: `DeployCoordinator.resolveIsHostedCommunity(siteDirectory: URL) -> Bool`; `persistProvisionedResources(..., communityActorURL: URL? = nil)`.
+
+- [ ] **Step 1: Write the failing test**
+
+First run `grep -rln "persistProvisionedResources" Tests/AnglesiteCoreTests/` to find the existing test file covering it, then add (adjust the `#Test`/`XCTest` style to match whatever that file already uses):
+
+```swift
+    @Test("resolveIsHostedCommunity reads SITE_TYPE=community from .site-config")
+    func resolveIsHostedCommunityReadsSiteType() throws {
+        let dir = try temporaryDirectory()
+        try "SITE_TYPE=community\n".write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        #expect(DeployCoordinator.resolveIsHostedCommunity(siteDirectory: dir))
+    }
+
+    @Test("resolveIsHostedCommunity is false for every other site kind, including no .site-config at all")
+    func resolveIsHostedCommunityFalseOtherwise() throws {
+        let dir = try temporaryDirectory()
+        #expect(!DeployCoordinator.resolveIsHostedCommunity(siteDirectory: dir))
+        try "SITE_TYPE=business\n".write(to: dir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        #expect(!DeployCoordinator.resolveIsHostedCommunity(siteDirectory: dir))
+    }
+
+    @Test("persistProvisionedResources writes communityActorURL when given one")
+    func persistProvisionedResourcesWritesCommunityActorURL() async throws {
+        let dir = try temporaryDirectory()
+        let configStore = SiteConfigStore(configDirectory: dir)
+        let actorURL = URL(string: "https://my-community.example/users/site")!
+
+        await DeployCoordinator.persistProvisionedResources(
+            configStore: configStore, settings: SiteSettings(), effectiveActiveIDs: [],
+            resources: .init(), communityActorURL: actorURL
+        )
+
+        let saved = try await configStore.load()
+        #expect(saved.communityActorURL == actorURL)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter DeployCoordinatorTests` (substitute the actual file name found above)
+Expected: build failure — `resolveIsHostedCommunity` doesn't exist yet, and `persistProvisionedResources` has no `communityActorURL` parameter.
+
+- [ ] **Step 3: Implement**
+
+In `Sources/AnglesiteCore/DeployCoordinator.swift`, add a new function next to `resolveWorkerSiteName` (currently lines 234-238), following its exact read pattern:
+
+```swift
+    /// Whether this site is a hosted community (V-5.1b, #907) — read from `.site-config`'s
+    /// `SITE_TYPE`, the same key `SiteScaffolder.appendSiteConfig` writes from
+    /// `NewSiteDraft.siteType` at creation time. There's no `SiteSettings` field for site kind
+    /// (`SiteType` is a creation-time-only concept), so this is the one read-through-the-file
+    /// check the deploy path needs to decide whether to compose a Group actor.
+    public static func resolveIsHostedCommunity(siteDirectory: URL) -> Bool {
+        let existingConfig = (try? WebsiteAnalyticsAsset.loadConfig(siteDirectory: siteDirectory)) ?? ""
+        return SiteConfigFile.value(forKey: "SITE_TYPE", in: existingConfig) == SiteType.community.rawValue
+    }
+```
+
+Extend `persistProvisionedResources` (currently lines 374-396) with a new parameter and write:
+
+```swift
+    public static func persistProvisionedResources(
+        configStore: SiteConfigStore,
+        settings: SiteSettings,
+        effectiveActiveIDs: Set<String>,
+        resources: WorkerComposition.ProvisionedResources,
+        apUsername: String? = nil,
+        /// This deploy's resolved ActivityPub actor IRI (`ActivityPubActor.actorURL(siteURL:)`),
+        /// passed only when this site is a hosted community (V-5.1b, #907) whose Worker was just
+        /// composed with a Group actor. Advances `settings.communityActorURL` — the field
+        /// `CommunityMembersSync`/the Moderation section gate on — from inert to live. `nil` for
+        /// every other site, leaving the field untouched (it's already `nil` there).
+        communityActorURL: URL? = nil
+    ) async {
+        var updated = settings
+        updated.lastDeployedWorkerIDs = Array(effectiveActiveIDs).sorted()
+        updated.provisionedWorkerResources = resources
+        if let apUsername {
+            updated.lastDeployedAPUsername = apUsername
+        }
+        if let communityActorURL {
+            updated.communityActorURL = communityActorURL
+        }
+        try? await configStore.save(updated)
+    }
+```
+
+In `Sources/AnglesiteApp/DeployModel.swift`, extend the `provision()` call (currently lines 840-852) with the two new fields, computed from `resolveIsHostedCommunity`:
+
+```swift
+        let isHostedCommunity = DeployCoordinator.resolveIsHostedCommunity(siteDirectory: siteDirectory)
+        let provisionResult = await socialCommand.provision(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            siteName: workerSiteName,
+            workers: workers,
+            routeClaims: routeClaims.map(\.claim),
+            knownResources: settings.provisionedWorkerResources ?? .init(),
+            siteURL: siteURL,
+            displayName: settings.displayName,
+            apUsername: apUsername,
+            acknowledgesPaidPlan: acknowledgesPaidPlan,
+            inboxCaptureEnabled: settings.inboxCaptureEnabled ?? false,
+            activityPubActorType: isHostedCommunity ? "Group" : nil,
+            moderators: isHostedCommunity ? settings.moderators : nil
+        )
+```
+
+And extend the post-success `persistProvisionedResources` call (currently lines 880-885) to pass the resolved actor IRI, computed from the deploy's own successful `url`:
+
+```swift
+        if case .succeeded(let deployedURL, let resources, _) = provisionResult {
+            await DeployCoordinator.persistProvisionedResources(
+                configStore: configStore, settings: settings,
+                effectiveActiveIDs: effectiveActiveIDs, resources: resources,
+                apUsername: activitypubProvisioned ? resolvedApUsername : nil,
+                communityActorURL: (isHostedCommunity && activitypubProvisioned)
+                    ? ActivityPubActor.actorURL(siteURL: deployedURL) : nil
+            )
+            websubProvisioned = workers.contains(where: { $0.id == WorkerComposition.websubWorkerID })
+                && resources.websubQueueName != nil
+        } else {
+            websubProvisioned = false
+        }
+```
+
+(Note the original code used `_` for the succeeded-case URL binding at line 880 — renaming it to `deployedURL` here since this is now consumed. Nothing else in that branch used it before.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter DeployCoordinatorTests` (or the actual file name)
+Expected: PASS.
+
+Run the full suite to catch any other caller of `persistProvisionedResources`/`provision()` that needs updating: `swift test --package-path . --skip Domain` (per this repo's known-flaky-suite convention — see `CLAUDE.md`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DeployCoordinator.swift Sources/AnglesiteApp/DeployModel.swift Tests/AnglesiteCoreTests/*.swift
+git commit -m "feat(#907): deploy Group actor config, write back communityActorURL"
+```
+
+**This completes Phase 2 — open a PR here, stacked on Phase 1's branch.**
+
+---
+
+## Phase 3 — Moderator UI (Tasks 6–9, one PR)
+
+### Task 6: `CommunityMembershipClient.remove(target:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/CommunityMembershipClient.swift:57-107` (add the new method after `unfollow`)
+- Test: `Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift`
+
+**Interfaces:**
+- Produces: `CommunityMembershipClient.remove(target: URL) async throws -> Void` — POSTs `Remove` to the owner's own outbox. Task 9's `ModerationView` calls this for both ban-member and remove-post (workers#473's "one primitive, two moderation effects").
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift`, mirroring `postsUndoWithActivityID` exactly:
+
+```swift
+    @Test("POSTs a Remove activity to this site's own outbox")
+    func postsRemove() async throws {
+        let fake = FakeTransport()
+        let target = try #require(URL(string: "https://lemmy.ml/u/spammer"))
+
+        try await Self.client(fake).remove(target: target)
+
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Remove")
+        #expect(body?["object"] as? String == "https://lemmy.ml/u/spammer")
+        #expect(body?["actor"] as? String == "https://example.com/users/site")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+    }
+
+    @Test("remove maps a non-2xx status to requestFailed")
+    func removeMapsNon2xx() async throws {
+        let fake = FakeTransport(status: 403, body: "forbidden")
+        let target = try #require(URL(string: "https://lemmy.ml/u/spammer"))
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 403, body: "forbidden")) {
+            try await Self.client(fake).remove(target: target)
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter CommunityMembershipClientTests`
+Expected: build failure — `value of type 'CommunityMembershipClient' has no member 'remove'`.
+
+- [ ] **Step 3: Implement**
+
+In `Sources/AnglesiteCore/CommunityMembershipClient.swift`, add after `unfollow` (currently ending at line 86):
+
+```swift
+    /// Bans a member or un-announces a member post — one primitive, two moderation effects, per
+    /// workers#473: the Worker's `Remove` handler treats `object` as either a member actor IRI
+    /// (ban) or an announced post's IRI (un-announce), authorized by the owner's bearer
+    /// `publishToken` alone — no `config.moderators` membership required, since the owner is
+    /// implicitly the top moderator of their own actor. `target` is whichever IRI the caller
+    /// wants removed; there's no separate "kind" parameter because the Worker itself dispatches
+    /// on what `target` resolves to, not on anything this client declares up front.
+    public func remove(target: URL) async throws {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Remove",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        _ = try await post(body)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter CommunityMembershipClientTests`
+Expected: PASS, including the four pre-existing tests in this file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CommunityMembershipClient.swift Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+git commit -m "feat(#907): add CommunityMembershipClient.remove for ban/un-announce"
+```
+
+---
+
+### Task 7: `MainPaneMode.moderation`, `presentModeration()`, `canOpenModeration`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:11-19` (`MainPaneMode` enum), add `presentModeration()` near `presentCommunities()` (lines 429-437), add `canOpenModeration` near the other `canOpenX` properties (lines 496-557)
+- Test: none — `SiteWindowModel`'s existing `canOpenX`/`presentX` properties have no dedicated unit tests in the codebase (they're thin `@MainActor` view-model glue over `site`/settings state); Task 9's manual-verification step covers this behaviorally, matching how Communities/Followers are verified.
+
+**Interfaces:**
+- Consumes: `SiteSettings.communityActorURL` (existing).
+- Produces: `SiteWindowModel.canOpenModeration: Bool`, `presentModeration()`, `MainPaneMode.moderation` — Task 8 wires a button to these; Task 9's `ModerationView` is what `.moderation` renders.
+
+- [ ] **Step 1: Add the case**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, extend `MainPaneMode` (currently lines 11-19):
+
+```swift
+enum MainPaneMode: Equatable {
+    case preview
+    case editor(FileRef)
+    case graph
+    case cleanup        // Site ▸ Cleanup… (#714 moved it out of the sidebar)
+    case reader         // Website ▸ Reader… (V-4.3, #365)
+    case followers      // Website ▸ Followers… (V-4.2, #364)
+    case communities    // Website ▸ Communities… (V-5.1a, #368)
+    case moderation     // Website ▸ Moderation… (V-5.1b/V-5.3, #907/#370)
+}
+```
+
+- [ ] **Step 2: Add the presenter**
+
+Immediately after `presentCommunities()` (currently lines 429-437):
+
+```swift
+    /// Switches the main pane to Moderation (Website ▸ Moderation…, V-5.1b/V-5.3 #907/#370).
+    /// Mirrors `presentCommunities()`'s leave-current-surface-first guard. Unlike Communities,
+    /// this is gated (`canOpenModeration`) — see that property's doc comment.
+    func presentModeration() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            await clearInspectorThenSwitchPane(to: .moderation)
+        }
+    }
+```
+
+- [ ] **Step 3: Cache `isHostedCommunity` and add the gate**
+
+`SiteWindowModel` doesn't currently cache `SiteSettings` anywhere (confirmed: no `SiteSettings`/`SiteConfigStore` reference exists in `SiteWindowModel.swift` today) — every other `canOpenX` property gates on cheaper state (`site != nil`, etc.). `canOpenModeration` needs `SiteSettings.communityActorURL`, and `SiteConfigStore.load()` is `async`, while `SiteConfigStore.read(from:fileManager:)`'s doc comment explicitly warns it must not be called from a `@MainActor` context (blocking disk I/O). So this needs a cached field, refreshed asynchronously — not a synchronous read at gate-check time.
+
+Add a stored property near `communities`/`followers` (`SiteWindowModel.swift:166` area):
+
+```swift
+    /// Cached `SiteSettings.communityActorURL != nil`, refreshed once per site open in
+    /// `loadAndStart()` — the gate for Website ▸ Moderation… (#907/#370). A cached `Bool`
+    /// rather than a live synchronous read: `SiteConfigStore.read(from:fileManager:)` is
+    /// documented as unsafe to call from `@MainActor` (it blocks on disk I/O), and
+    /// `canOpenModeration` must be synchronous for `.disabled(...)` to read. Known limitation:
+    /// this doesn't live-update if a deploy completes while the window stays open — reopening
+    /// the site picks up the new value. Acceptable for v1 (design doc §5); revisit only if it
+    /// proves confusing in practice.
+    private(set) var isHostedCommunity = false
+```
+
+In `loadAndStart(siteID:openSitesWindow:dismissSiteWindow:)`, immediately after `site = resolved` (currently `SiteWindowModel.swift:1965`), add:
+
+```swift
+        site = resolved
+        isHostedCommunity = ((try? await SiteConfigStore(configDirectory: resolved.configDirectory).load())?.communityActorURL) != nil
+```
+
+Then add the gate alongside the other `canOpenX` computed properties (e.g. near `canOpenSocialPlan`/`canOpenDesignInterview`, currently around lines 536-551):
+
+```swift
+    /// Website ▸ Moderation… (#907/#370) is only meaningful once this site is a *deployed*
+    /// hosted community — `communityActorURL` is set by `DeployCoordinator.persistProvisionedResources`
+    /// after a successful deploy with a Group actor (Phase 2), not at creation time. Unlike
+    /// Communities/Followers (always enabled once a site is focused), a personal site or an
+    /// undeployed community never enables this — there's nothing to moderate yet.
+    var canOpenModeration: Bool { isHostedCommunity }
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: **build failure** at this point, since `SiteWindow.swift`'s `mainPaneContent(for:)` switch (Task 8) isn't exhaustive yet — that's the correct "fails" signal confirming the new case is live. Proceed to Task 8 before trying to get a clean build.
+
+- [ ] **Step 5: Commit** (after Task 8 makes the build succeed — see Task 8's own commit step; don't commit Task 7 in isolation, since it leaves the switch non-exhaustive)
+
+---
+
+### Task 8: "Moderation…" menu button + `SiteWindow` switch case
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/WebsiteCommands.swift:65-70` (add the button after "Communities…")
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:1032-1037` (add the `.moderation` case)
+
+**Interfaces:**
+- Consumes: `SiteWindowModel.canOpenModeration`/`presentModeration()` (Task 7), `ModerationView` (Task 9 — this task references it before it exists, so build won't succeed until Task 9 lands; that's expected, matching how Task 7→8 was sequenced).
+
+- [ ] **Step 1: Add the button**
+
+In `Sources/AnglesiteApp/WebsiteCommands.swift`, immediately after the existing "Communities…" button (currently lines 65-66... adjust to the button's actual current line number after Task 3 may have shifted nearby files — this file is untouched by Tasks 1-7, so lines 65-70 should still be accurate):
+
+```swift
+            Button("Communities…") { model?.presentCommunities() }
+                .disabled(model == nil)
+
+            Button("Moderation…") { model?.presentModeration() }
+                .disabled(model?.canOpenModeration != true)
+```
+
+- [ ] **Step 2: Add the switch case**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, extend `mainPaneContent(for:)`'s switch (currently lines 1032-1037):
+
+```swift
+        case .communities:
+            CommunitiesView(communities: model.communities)
+        case .moderation:
+            ModerationView(moderation: model.moderation)
+        case .preview:
+            previewPane(for: site)
+```
+
+(The exact shape of what `model.moderation` is — a sub-model `SiteWindowModel` owns, mirroring `model.communities`/`model.followers` — is defined in Task 9, which creates it. This task's edit won't compile standalone; that's expected and gets resolved by Task 9.)
+
+- [ ] **Step 3: Commit only after Task 9 lands and the build is clean** — fold this task's two edits into Task 9's commit rather than committing broken intermediate state (see Task 9's Step 6).
+
+---
+
+### Task 9: `ModerationView` — moderators, members, posts, reports
+
+**Files:**
+- Create: `Sources/AnglesiteApp/ModerationModel.swift` — mirrors `Sources/AnglesiteApp/CommunitiesModel.swift`'s exact shape: no-arg-defaulted `init`, a `configure(site: CurrentSite)` called once from `loadAndStart()`, injected `CommunityMembershipClient.Transport`, `secretStore` for the publish token, `DeployCoordinator.resolveSiteURL` + `ActivityPubActor.actorURL(siteURL:)` for `ownActorURL` — same four pieces `CommunitiesModel.configure(site:)`/`resolveSite()` already use (`CommunitiesModel.swift:106-135`).
+- Create: `Sources/AnglesiteApp/ModerationView.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift` — add `var moderation = ModerationModel()` alongside `var communities = CommunitiesModel()` (line 166), and a `moderation.configure(site: currentSite)` call in `loadAndStart()` alongside wherever `communities.configure(site:)` is called (grep `grep -n "communities.configure" Sources/AnglesiteApp/SiteWindowModel.swift` to find that exact line and add the `moderation` call immediately after it).
+- Test: Create `Tests/AnglesiteAppTests/ModerationModelTests.swift`, mirroring `Tests/AnglesiteAppTests/CommunitiesModelTests.swift`'s exact conventions (Swift Testing, `@testable import AnglesiteAppCore` — the app-layer sources under `Sources/AnglesiteApp` build as module `AnglesiteAppCore` for testing purposes, confirmed by that file's own import).
+
+**Interfaces:**
+- Consumes: `CommunityMembershipClient.remove(target:)` (Task 6), `CommunityMember`/`AnnouncedPost` (existing, both `Codable`), `SiteSettings.moderators` (existing), `CurrentSite` (existing — the same type `CommunitiesModel.configure(site:)` takes).
+- Produces: `ModerationView(moderation: ModerationModel)` — the view Task 8's switch case renders.
+
+- [ ] **Step 1: Write the failing test for the ban action**
+
+Create `Tests/AnglesiteAppTests/ModerationModelTests.swift`, matching `CommunitiesModelTests.swift`'s exact conventions — Swift Testing, a locally-nested `InMemorySecretStore`, and the `(config, source)` directory-pair fixture:
+
+```swift
+// Tests/AnglesiteAppTests/ModerationModelTests.swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@Suite("ModerationModel")
+@MainActor
+struct ModerationModelTests {
+    final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+        var values: [String: String] = [:]
+        func read(account: String) throws -> String? { values[account] }
+        func write(_ value: String, account: String) throws { values[account] = value }
+        func delete(account: String) throws { values.removeValue(forKey: account) }
+    }
+
+    private static func site(configDirectory: URL, sourceDirectory: URL) -> CurrentSite {
+        CurrentSite(
+            id: "site-1", name: "Test Community",
+            packageURL: sourceDirectory.deletingLastPathComponent(),
+            sourceDirectory: sourceDirectory, configDirectory: configDirectory)
+    }
+
+    /// Mirrors `CommunitiesModelTests.makeSiteDirectories(domain:)` — a fixture site with a
+    /// public URL (so `DeployCoordinator.resolveSiteURL` resolves) and one member snapshot file.
+    private static func makeSiteDirectories() throws -> (config: URL, source: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("moderation-model-test-\(UUID().uuidString)")
+        let config = root.appendingPathComponent("Config")
+        let source = root.appendingPathComponent("Source")
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try "DOMAIN=my-community.example\n".write(
+            to: source.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
+        let member = try CommunityMember(
+            id: "abc123", actorURL: URL(string: "https://lemmy.ml/u/spammer")!, name: "Spammer", photo: nil)
+        let memberPath = source.appendingPathComponent(member.gitPath)
+        try FileManager.default.createDirectory(at: memberPath.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try JSONEncoder().encode(member).write(to: memberPath)
+        return (config, source)
+    }
+
+    @Test("banning a member POSTs Remove and drops them from the visible list")
+    func banRemovesMember() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        actor Recorder {
+            private(set) var bodies: [[String: Any]] = []
+            func record(_ body: [String: Any]) { bodies.append(body) }
+        }
+        let recorder = Recorder()
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            if let data = request.httpBody, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                await recorder.record(json)
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        #expect(model.members.count == 1)
+        try await model.ban(model.members[0])
+
+        let body = await recorder.bodies.first
+        #expect(body?["type"] as? String == "Remove")
+        #expect(body?["object"] as? String == "https://lemmy.ml/u/spammer")
+        #expect(model.members.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter ModerationModelTests`
+Expected: build failure — `ModerationModel` doesn't exist.
+
+- [ ] **Step 3: Implement `ModerationModel`**
+
+```swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Backs the Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderator-list
+/// display, and ban/remove actions over this site's own `CommunityMember`/`AnnouncedPost`
+/// snapshot files. App glue only, mirroring `CommunitiesModel`'s shape — protocol logic
+/// (`Remove`) lives in `AnglesiteCore`'s `CommunityMembershipClient`. Approval-queue and
+/// report-review are explicitly out of scope (design doc D4/D5) — no state for either here.
+@MainActor
+@Observable
+final class ModerationModel {
+    private(set) var members: [CommunityMember] = []
+    private(set) var posts: [AnnouncedPost] = []
+    private(set) var moderators: [String] = []
+    var errorMessage: String?
+    /// Cleared by whichever confirmation-dialog button runs — same no-op-setter/
+    /// clear-in-button-action contract `SiteWindow.swift:898-916`'s delete confirmation uses
+    /// (#968/#969), and `CommunitiesModel.leaveConfirmation`'s sibling pattern.
+    var banConfirmation: CommunityMember?
+    var removeConfirmation: AnnouncedPost?
+
+    private var siteID: String?
+    private var sourceDirectory: URL?
+    private var ownActorURL: URL?
+    private let secretStore: any SecretStore
+    private let membershipTransport: CommunityMembershipClient.Transport
+
+    init(
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        membershipTransport: @escaping CommunityMembershipClient.Transport
+            = CommunityMembershipClient.defaultTransport
+    ) {
+        self.secretStore = secretStore
+        self.membershipTransport = membershipTransport
+    }
+
+    /// Records which site this pane talks to, resolves `ownActorURL`, and reads the moderator
+    /// list plus every member/post snapshot from disk. No network I/O — mirrors
+    /// `CommunitiesModel.configure(site:)`/`resolveSite()`'s split, collapsed into one method
+    /// here since Moderation has no `.noSiteURL`-retry surface of its own (Website ▸
+    /// Moderation… is disabled by `canOpenModeration` whenever there's no site URL yet, so this
+    /// method only ever runs once that's already true).
+    func configure(site: CurrentSite) {
+        siteID = site.id
+        sourceDirectory = site.sourceDirectory
+        if let siteURLString = DeployCoordinator.resolveSiteURL(siteDirectory: site.sourceDirectory),
+           let siteURL = URL(string: siteURLString) {
+            ownActorURL = ActivityPubActor.actorURL(siteURL: siteURL)
+        }
+        let settings = (try? SiteConfigStore.read(from: site.configDirectory)) ?? SiteSettings()
+        moderators = settings.moderators ?? []
+        members = Self.decodeAll(CommunityMember.self, from: site.sourceDirectory.appendingPathComponent("data/community-members"))
+        posts = Self.decodeAll(AnnouncedPost.self, from: site.sourceDirectory.appendingPathComponent("data/community-posts"))
+    }
+
+    /// Reads every `.json` file in `directory` and decodes it as `T`, skipping (not throwing on)
+    /// any file that fails to decode — a malformed or in-progress-write snapshot must never make
+    /// the whole Moderation pane unusable, matching `SiteConfigStore.load()`'s "a bad file falls
+    /// back to a safe default" philosophy rather than propagating the failure.
+    private static func decodeAll<T: Decodable>(_ type: T.Type, from directory: URL) -> [T] {
+        guard let entries = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        return entries.filter { $0.pathExtension == "json" }.compactMap { url in
+            (try? Data(contentsOf: url)).flatMap { try? JSONDecoder().decode(T.self, from: $0) }
+        }
+    }
+
+    private var publishToken: String? {
+        guard let siteID else { return nil }
+        return try? secretStore.read(account: SecretAccounts.activityPubPublishToken(siteID: siteID))
+    }
+
+    func ban(_ member: CommunityMember) async throws {
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+        try await client.remove(target: member.actorURL)
+        members.removeAll { $0.id == member.id }
+    }
+
+    func confirmBan() async {
+        guard let member = banConfirmation else { return }
+        banConfirmation = nil
+        do { try await ban(member) }
+        catch { errorMessage = "Couldn't ban \(member.name ?? member.actorURL.absoluteString): \(error.localizedDescription)" }
+    }
+
+    func removePost(_ post: AnnouncedPost) async throws {
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+        try await client.remove(target: post.sourceURL)
+        posts.removeAll { $0.id == post.id }
+        // Deletes the local snapshot file too, mirroring the C.3 deletion flow
+        // (docs/specs/2026-06-29-c3-received-interaction-canonicality.md's "owner deletes the
+        // JSON file from their repo" convention) — the Worker's `Remove` above handles the
+        // federation side (un-announce), this handles the git side, so the post disappears from
+        // the rebuilt timeline on the next deploy without waiting for a full-set reconcile.
+        if let sourceDirectory {
+            try? FileManager.default.removeItem(at: sourceDirectory.appendingPathComponent(post.gitPath))
+        }
+    }
+
+    func confirmRemove() async {
+        guard let post = removeConfirmation else { return }
+        removeConfirmation = nil
+        do { try await removePost(post) }
+        catch { errorMessage = "Couldn't remove this post: \(error.localizedDescription)" }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ModerationModelTests`
+Expected: PASS.
+
+- [ ] **Step 5: Write `ModerationView`**
+
+Following `CommunitiesView.swift`'s structural pattern (list-with-selection sidebar, `.confirmationDialog`/`.alert` for destructive actions per `SiteWindow.swift:898-916`'s convention):
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// The Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderators, members
+/// (with ban), posts (with remove), and an inert reports placeholder (D5 — no report-handling
+/// exists upstream yet).
+struct ModerationView: View {
+    @Bindable var moderation: ModerationModel
+
+    var body: some View {
+        List {
+            Section("Moderators") {
+                if moderation.moderators.isEmpty {
+                    Text("Only you can moderate this community.").foregroundStyle(.secondary)
+                } else {
+                    ForEach(moderation.moderators, id: \.self) { Text($0) }
+                }
+            }
+            Section("Members") {
+                ForEach(moderation.members) { member in
+                    HStack {
+                        Text(member.name ?? member.actorURL.absoluteString)
+                        Spacer()
+                        Button("Ban", role: .destructive) { moderation.banConfirmation = member }
+                    }
+                }
+            }
+            Section("Posts") {
+                ForEach(moderation.posts) { post in
+                    HStack {
+                        Text(post.content ?? post.sourceURL.absoluteString).lineLimit(1)
+                        Spacer()
+                        Button("Remove", role: .destructive) { moderation.removeConfirmation = post }
+                    }
+                }
+            }
+            Section("Reports") {
+                Text("No report handling yet.").foregroundStyle(.secondary)
+            }
+        }
+        .navigationSubtitle("Moderation")
+        .alert("Error", isPresented: Binding(get: { moderation.errorMessage != nil }, set: { _ in moderation.errorMessage = nil })) {
+            Button("OK") { moderation.errorMessage = nil }
+        } message: {
+            Text(moderation.errorMessage ?? "")
+        }
+        .confirmationDialog(
+            "Ban this member?",
+            isPresented: Binding(get: { moderation.banConfirmation != nil }, set: { _ in }),
+            titleVisibility: .visible
+        ) {
+            Button("Ban", role: .destructive) { Task { await moderation.confirmBan() } }
+            Button("Cancel", role: .cancel) { moderation.banConfirmation = nil }
+        } message: {
+            Text("This member's posts will stop appearing. Existing posts stay unless you also remove them.")
+        }
+        .confirmationDialog(
+            "Remove this post?",
+            isPresented: Binding(get: { moderation.removeConfirmation != nil }, set: { _ in }),
+            titleVisibility: .visible
+        ) {
+            Button("Remove", role: .destructive) { Task { await moderation.confirmRemove() } }
+            Button("Cancel", role: .cancel) { moderation.removeConfirmation = nil }
+        } message: {
+            Text("This removes the post from the community timeline. The author's own copy on their own site is unaffected.")
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Build, run the full suite, manually verify, then commit Tasks 7-9 together**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: clean build (this is what finally makes Task 7/8's intermediate non-exhaustive-switch state compile).
+
+Run: `swift test --package-path . --skip Domain`
+Expected: PASS.
+
+Manually verify: open a hosted community site created via Task 3's wizard and deployed via Phase 2 — `Website ▸ Moderation…` is enabled; on a personal site, it's disabled. Ban a member and confirm they disappear from the list; the confirmation dialog reads as designed (§5, D5's consequence-phrased copy).
+
+```bash
+git add Sources/AnglesiteApp/SiteWindowModel.swift Sources/AnglesiteApp/WebsiteCommands.swift Sources/AnglesiteApp/SiteWindow.swift Sources/AnglesiteApp/ModerationModel.swift Sources/AnglesiteApp/ModerationView.swift Tests/AnglesiteCoreTests/*.swift Tests/AnglesiteAppTests/*.swift
+git commit -m "feat(#907,#370): add Moderation section with ban/remove"
+```
+
+**This completes Phase 3 — open a PR here, stacked on Phase 2's branch. Once merged, comment on #370 to scope it down to report-review + approval-queue (per the design doc §8), and on #907 to close it (Phase 1-3 close out every deferred item from PR #1258's commit message).**
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §3 (Task 1-3), §4 (Task 4-5), §5 (Task 6-9), §6 (already filed as workers#487, no app-side task), §7 testing strategy (folded into each task's own test steps), §8 (closing comment noted at the end of Phase 3).
+- **Task 7/8 sequencing gap:** flagged explicitly above — `MainPaneMode.moderation` (Task 7) leaves `SiteWindow.swift`'s switch non-exhaustive until Task 8 adds the case, and Task 8 in turn references `ModerationView`/`model.moderation` that don't exist until Task 9. This is a deliberate three-task chain with one build-clean point (end of Task 9), called out at each task's commit step so an executor doesn't mistake the intermediate non-building state for an error.
+- **Placeholder scan:** the two soft spots from the first draft (`canOpenModeration`'s settings-access mechanism, and `ModerationModel`'s file-loading shape) were re-researched and replaced with concrete code — `SiteWindowModel.isHostedCommunity` cached in `loadAndStart()`, and `ModerationModel` mirroring `CommunitiesModel.configure(site:)`'s exact init/transport/secretStore pattern, including a real `decodeAll<T: Decodable>` directory reader. `removePost` deletes the local snapshot file directly (matching the C.3 "owner deletes the JSON file" convention) rather than routing through an undetermined committer call.
+- **Known minor gap, stated rather than hidden:** `isHostedCommunity` refreshes only on site open (Task 7 Step 3), not live after a deploy completes mid-session — reopening the site picks up a newly-deployed community's Moderation button. Acceptable for v1 per the design doc's minimalism (D3); called out at the point it's introduced so it isn't mistaken for an oversight.

--- a/docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md
+++ b/docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md
@@ -37,7 +37,7 @@ still show more than this closes — see §6.
 |---|---|---|
 | D1 | Phasing | Three stacked PRs: creation flow → deploy wiring → moderator UI. Each independently mergeable/testable. |
 | D2 | Creation entry point | A **separate `File ▸ New Community…` flow** (`NewCommunityWizardModel`/`NewCommunityWizard`), not a card in the existing single-question theme chooser (#1071). A hosted community is a different site kind (own Worker, own Group actor, moderators) — not a cosmetic theme pick. |
-| D3 | Community wizard scope | Name + moderator identity only (owner's own actor IRI auto-added). No theme step — one consistent look for v1. |
+| D3 | Community wizard scope | **Name only.** No moderator field: per workers#473/PR#476, the owner is implicitly the top moderator of their own actor via the existing bearer `publishToken` — no `config.moderators` membership needed. `SiteSettings.moderators` is for *delegating* to additional actors beyond the owner, which belongs in the Phase 3 Moderators UI (§5), not the creation wizard. No theme step either — one consistent look for v1. |
 | D4 | Approval-queue (pending joins) | **Deferred.** Listing pending followers is only reachable via the OAuth-gated Mastodon-API `follow_requests` surface (§3.3) — the app has no OAuth client against a site's own Mastodon-API today. File an upstream follow-up (§5) instead of building a new OAuth flow now. Remove/ban ship in this design; approve does not. |
 | D5 | Report queue | **Inert placeholder section** in the Moderation UI. No `Flag`-activity handling exists anywhere upstream (confirmed via repo-wide + upstream search) — this needs a new upstream primitive from scratch, out of scope here. The UI ships the section now so the layout doesn't reshape when report-handling eventually lands. |
 
@@ -65,10 +65,10 @@ still show more than this closes — see §6.
   different concepts and don't collide in code, only in vocabulary. UI copy
   should avoid the word "theme" when talking about hosted communities to
   keep that distinction clear to users.
-- **Post-scaffold:** sets `SiteSettings.moderators = [ownerActorIRI]` via
-  `SiteConfigStore`. `communityActorURL` stays `nil` here — Phase 2 sets it
-  once the Worker is actually deployed and the site's own actor IRI is
-  known.
+- **Post-scaffold:** `SiteSettings.moderators` stays unset (D3) — the owner
+  needs no entry there for their own admin rights. `communityActorURL` also
+  stays `nil` here — Phase 2 sets it once the Worker is actually deployed and
+  the site's own actor IRI is known.
 - **Not building for v1:** a distinct "rules" page. The existing `about.md`
   (already shipped, inert) covers that; no new template content needed.
 

--- a/docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md
+++ b/docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md
@@ -1,0 +1,172 @@
+# Hosted Community Provisioning + Moderation — Design
+
+**Date:** 2026-08-10
+**Status:** Decided (DWK, 2026-08-10)
+**Part of:** #907 (V-5.1b), #370 (V-5.3), #339 (V-5), #334 (pivot epic)
+**Builds on:** `docs/superpowers/specs/2026-07-22-v5-communities-design.md` (the
+V-5 Communities spike — D1–D5, §4), PR #1258 (the buildable slice of #907
+already merged), workers#473 (owner-admin Accept/Remove endpoints, shipped in
+`dwk-server-v1.0.0-beta.3`)
+
+---
+
+## 1. Where this picks up
+
+PR #1258 (merged 2026-08-04) landed a real slice of #907: `CommunityMember`
+snapshot sync, the Astro community timeline/members/about pages (shipping
+inert on every site), and `Group` actor-type/moderators fields threaded
+through `WorkerComposition.generateWranglerToml`. Its commit message flagged
+three deliberately deferred follow-ups, which this design covers together
+since they form one coherent arc — you can't moderate a community that can't
+be created, and you can't create one that can't deploy:
+
+1. A "Community" site-creation entry point.
+2. Wiring the already-modeled `SiteSettings.moderators`/actor-type fields
+   through `SocialWorkerProvisionCommand` into an actual deploy.
+3. A moderator-list settings UI plus remove-post/ban-member actions — the
+   part of #370 (V-5.3 Moderation tooling) that's now reachable, since
+   workers#473 shipped the owner-admin `Accept`/`Remove` endpoints this
+   needs.
+
+Each phase lands as its own PR, in the order above (D1). #370 itself will
+still show more than this closes — see §6.
+
+## 2. Decisions
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Phasing | Three stacked PRs: creation flow → deploy wiring → moderator UI. Each independently mergeable/testable. |
+| D2 | Creation entry point | A **separate `File ▸ New Community…` flow** (`NewCommunityWizardModel`/`NewCommunityWizard`), not a card in the existing single-question theme chooser (#1071). A hosted community is a different site kind (own Worker, own Group actor, moderators) — not a cosmetic theme pick. |
+| D3 | Community wizard scope | Name + moderator identity only (owner's own actor IRI auto-added). No theme step — one consistent look for v1. |
+| D4 | Approval-queue (pending joins) | **Deferred.** Listing pending followers is only reachable via the OAuth-gated Mastodon-API `follow_requests` surface (§3.3) — the app has no OAuth client against a site's own Mastodon-API today. File an upstream follow-up (§5) instead of building a new OAuth flow now. Remove/ban ship in this design; approve does not. |
+| D5 | Report queue | **Inert placeholder section** in the Moderation UI. No `Flag`-activity handling exists anywhere upstream (confirmed via repo-wide + upstream search) — this needs a new upstream primitive from scratch, out of scope here. The UI ships the section now so the layout doesn't reshape when report-handling eventually lands. |
+
+## 3. Phase 1 — New Community creation flow
+
+- **Entry point:** `File ▸ New Community…`, parallel to the existing
+  `File ▸ New Site…` (`NewSiteWizard`, reduced to one theme-choice question
+  by #1071/PR #1183). New `NewCommunityWizardModel` (mirrors
+  `NewSiteWizardModel`'s `chooser`/`building` states) + `NewCommunityWizard`
+  SwiftUI view.
+- **Mechanics:** reuses `SiteScaffolder.scaffold(draft:)` directly — it's
+  already generic over `NewSiteDraft` + injected
+  `CommandRunner`/`GitInit`/`GitCommit`/`Register`
+  (`Sources/AnglesiteCore/SiteScaffolder.swift:82-231`). No `scaffold.sh`
+  changes needed: it does an unconditional `rsync` of the whole template
+  tree, and the community pages
+  (`Resources/Template/src/pages/community/{timeline,members}.astro`,
+  `about.md`) already ship on every site, rendering inert until
+  `SiteSettings.communityActorURL` is set.
+- **New `SiteType.community` case** (`NewSiteDraft.swift`) so `.site-config`'s
+  `SITE_TYPE` records the kind correctly, distinct from the existing
+  `SiteType.organization` → theme id `"community"` mapping in
+  `ThemeCatalog.defaultThemeID(for:)` — that's an unrelated cosmetic
+  color-theme choice and stays as-is; the two "community" names refer to
+  different concepts and don't collide in code, only in vocabulary. UI copy
+  should avoid the word "theme" when talking about hosted communities to
+  keep that distinction clear to users.
+- **Post-scaffold:** sets `SiteSettings.moderators = [ownerActorIRI]` via
+  `SiteConfigStore`. `communityActorURL` stays `nil` here — Phase 2 sets it
+  once the Worker is actually deployed and the site's own actor IRI is
+  known.
+- **Not building for v1:** a distinct "rules" page. The existing `about.md`
+  (already shipped, inert) covers that; no new template content needed.
+
+## 4. Phase 2 — Deploy wiring
+
+- **Gap being closed:** `SocialWorkerProvisionCommand.persistConfig`
+  currently calls `generateWranglerToml` without `activityPubActorType` or
+  `moderators` (confirmed: zero references to either in that 862-line file)
+  — so the fields Phase 1 (and PR #1258 before it) writes into
+  `SiteSettings` never reach a real deploy.
+- **Change:** `persistConfig` passes `activityPubActorType: "Group"` and
+  `moderators: settings.moderators` when `SiteType == .community`; `nil`
+  otherwise. `generateWranglerToml` already branches correctly on this
+  (`WorkerComposition.swift:512-528`, shipped in PR #1258) — this phase only
+  wires the call site.
+- **Activation step:** after a successful deploy, write the resulting site
+  actor IRI back into `SiteSettings.communityActorURL`, derived the same way
+  the activitypub Worker derives any site's own actor IRI from its domain.
+  This is the single flag that flips `CommunityMembersSync` and the Phase 3
+  Moderation section from inert to live — mirrors the existing "inert until
+  configured" convention used throughout this feature.
+- **Backward compatibility:** every existing non-community site has
+  `moderators == nil` and `SiteType != .community`, so
+  `generateWranglerToml` takes the same `activityPubActorType == nil` branch
+  it already does today. No behavior change for existing sites.
+- **Out of scope:** `WorkerCatalog.swift` — no catalog schema change needed;
+  the `Group`-actor catalog fields already shipped and released
+  (`dwk-server-v1.0.0-beta.3`). This phase is pure app-side wiring of fields
+  that already exist.
+
+## 5. Phase 3 — Moderator UI
+
+- **`CommunityMembershipClient` addition:** one new method mirroring
+  `follow`/`unfollow`'s shape (`Sources/AnglesiteCore/CommunityMembershipClient.swift`) —
+  `remove(target:)` (POSTs `Remove`, used for both ban-member and
+  un-announce-post — workers#473 documents this as one primitive with two
+  moderation effects). Same bearer-`publishToken`-to-`/outbox` pattern, same
+  `CommunityMembershipError` handling — no new auth surface. `acceptFollow`
+  is deliberately not added here: D4 defers the entire approval queue, and
+  an unused Accept method would be speculative against nothing that calls
+  it. It belongs in whatever phase eventually builds the approval queue
+  after §6's upstream follow-up lands.
+- **Gating:** new `case moderation` in `MainPaneMode`
+  (`SiteWindowModel.swift`), `presentModeration()` mirroring
+  `presentCommunities()` (lines 429-437), a `Button("Moderation…")` in
+  `WebsiteCommands.swift` disabled unless `model?.canOpenModeration == true`
+  — computed as `site.settings.communityActorURL != nil`. Unlike the
+  always-available Communities button, this is gated: it only makes sense
+  for a deployed hosted community (set by Phase 2).
+- **`ModerationView`** — four sections:
+  1. **Moderators** — list of actor IRIs from `SiteSettings.moderators`,
+     add/remove. Owner-only config, no approval flow needed.
+  2. **Members** — reuses the existing `CommunityMember` snapshot data
+     (`CommunityMembersSync`). Each row gets a "Ban" action → confirm dialog
+     phrased about consequences ("This member's posts will stop appearing.
+     Existing posts stay unless you also remove them.") → `remove(target:)`.
+  3. **Posts** — reuses `AnnouncedPost` snapshot data. Each row gets a
+     "Remove" action → confirm dialog → `remove(target:)` + delete the
+     snapshot file + commit (same C.3-style flow #908 already established
+     for deletions).
+  4. **Reports** — inert placeholder, "No report handling yet" empty state,
+     no data source (D5).
+- **Explicitly not in this phase:** approval-queue UI (D4).
+
+## 6. Upstream follow-up to file
+
+A new `davidwkeith/workers` issue: extend the existing bearer-`publishToken`
+owner surface (the same one `/outbox` POSTs already use for `Follow`,
+`Undo(Follow)`, and — per workers#473 — `Accept`/`Remove`) with a way to
+**list** pending followers, instead of requiring the OAuth-gated Mastodon-API
+`follow_requests` surface. This mirrors how the original #370/#907
+investigation found and closed the Accept/Remove gap (workers#473) — same
+shape of ask, filed the same way. Unblocks a future approval-queue phase
+without the app building a whole new OAuth client. Filed alongside this spec,
+referenced from the #907 issue the way workers#473 was.
+
+## 7. Testing strategy
+
+- **Swift Testing**, stubbed `CommunityMembershipClient.Transport` for the
+  new `acceptFollow`/`remove` methods (same pattern as the existing
+  `follow`/`unfollow` tests).
+- **`SocialWorkerProvisionCommand`** tests against a stubbed catalog/Worker
+  seam verifying `activityPubActorType`/`moderators` reach
+  `generateWranglerToml` only when `SiteType == .community`, and that
+  existing non-community sites are byte-for-byte unaffected.
+- **Container-gated e2e** (`ANGLESITE_CONTAINER_E2E=1`) for one full
+  round-trip: create community → deploy → ban a member → member drops from
+  the next `CommunityMembersSync`.
+- **Error handling:** ban/remove failures surface via the existing
+  `CommunityMembershipError` → debug-pane logging convention. No new
+  error-presentation pattern needed.
+
+## 8. What #370 still won't close after this
+
+This design closes remove-post and ban-member — the two moderation actions
+that were actually reachable once workers#473 shipped. #370's original scope
+(report review, approval queue) remains blocked on the two gaps this doc
+identifies and defers: report/Flag handling doesn't exist upstream at all
+(D5), and the approval-queue listing endpoint needs the follow-up filed in
+§6. #370 should stay open, scoped down to those two remaining pieces, rather
+than being closed by this work.


### PR DESCRIPTION
Closes #907

## Summary

- Adds a `File ▸ New Community…` creation flow (name-only, no theme step) that scaffolds a `SiteType.community` site and auto-activates the ActivityPub worker so it deploys as a working Group actor with no extra manual step.
- Threads `activityPubActorType`/`moderators` through `SocialWorkerProvisionCommand` into actual deploys (both the GUI path and the headless App Intents/Shortcuts path), and writes the deployed site's own actor IRI back into `SiteSettings.communityActorURL` — the flag that activates the rest of the feature.
- Adds a gated "Moderation…" section (Moderators with add/remove, Members with Ban, Posts with Remove, and an inert Reports placeholder) backed by a new `CommunityMembershipClient.remove(target:)`, closing the ban/remove slice of #370.

Design doc: `docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-10-hosted-community-provisioning-moderation.md`

Built via subagent-driven development (9 tasks, each independently reviewed) plus a final whole-branch review, which caught and fixed 5 cross-task integration issues no single task's narrower review could see: the headless deploy path silently stripping a community's Group actor config on re-deploy, the wizard never activating the ActivityPub worker (confirmed with the repo owner: now auto-activates), `communityActorURL` being derived from the wrong URL (workers.dev host instead of a confirmed custom domain, disagreeing with how the Moderation pane derives its own actor IRI), Moderation staying disabled through the exact deploy that should enable it, and the moderators list being read-only with no writer anywhere in the app.

**Known follow-ups, not addressed here** (design doc §6, §8):
- Filed [`davidwkeith/workers#487`](https://github.com/davidwkeith/workers/issues/487): a bearer-token-authenticated way to list pending followers, matching how Accept/Remove already work — needed before an approval-queue UI can be built (currently only reachable via an OAuth surface the app has no client for).
- Report review (inbound `Flag` activities) has no upstream primitive at all yet — the Moderation UI ships an inert placeholder section for it.
- #370 should stay open, scoped down to those two remaining pieces.

Three minor items from the final review, parked rather than blocking this PR (see design doc / plan history for detail): a rationale comment that inverts `resolveSiteURL`'s actual precedence (code is correct, comment is backwards); `ModerationModel.ownActorURL` not refreshing on the same deploy-completion hook that refreshes `isHostedCommunity` (narrow reach — needs a community created+deployed+synced in one session); and a missing regression test for the custom-domain branch of the `communityActorURL` fix.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP message schema changes. This PR consumes `@dwk/workers`' Group-actor catalog fields and owner-admin Accept/Remove endpoints, both already shipped and released (`dwk-server-v1.0.0-beta.3`) — no catalog schema change needed on this side.

## Test plan

- [x] `swift test --package-path .` — 390/390 passing, 54 suites
- [x] `xcodebuild`/`scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — clean build
- [ ] Manual smoke: create a community via File ▸ New Community…, deploy it, confirm Moderation… enables and ban/remove work end-to-end against a live Worker — not run in this environment (headless); covered by unit/integration tests against stubbed transports instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)