### PR TITLE
feat(#81): add apply-edit container-probe gate, confirm case 8 fixed

### DIFF
--- a/Sources/AnglesiteContainerProbe/main.swift
+++ b/Sources/AnglesiteContainerProbe/main.swift
@@ -38,6 +38,13 @@ private struct PauseResumeProbeTimeout: Error {}
 //           confirm the resume-before-stop ordering: a direct `container.stop()` call while still
 //           paused must throw, and a resume-then-stop must succeed cleanly. The decision gate for
 //           the suspend-on-window-close plan.
+//   apply-edit — boots a `LocalContainerSiteRuntime`, drives a real `apply_edit` through
+//           `MCPApplyEditRouter` wired exactly like production (`PreviewModel.editPersister`:
+//           `persistEdit` only invoked when the reply carries a non-nil `commit`), and asserts
+//           both that the reply's `commit` is non-nil (the #718/#1066 regression — the in-guest
+//           `recordEdit` silently returning `undefined` on a missing git identity) and that the
+//           host `Source/` file actually changed. The #81 smoke matrix's "case 8" persistence
+//           gate, runnable without a GUI or a literal human hand.
 
 @main
 struct AnglesiteContainerProbe {
@@ -45,7 +52,7 @@ struct AnglesiteContainerProbe {
         let args = CommandLine.arguments.dropFirst()
         guard let subcommand = args.first else {
             FileHandle.standardError.write(
-                Data("usage: anglesite-container-probe <echo|boot|workers-dev|worker-toggle|pause-resume>\n".utf8))
+                Data("usage: anglesite-container-probe <echo|boot|workers-dev|worker-toggle|pause-resume|apply-edit>\n".utf8))
             exit(2)
         }
 
@@ -61,9 +68,11 @@ struct AnglesiteContainerProbe {
             exitCode = await runWorkerToggle()
         case "pause-resume":
             exitCode = await runPauseResume()
+        case "apply-edit":
+            exitCode = await runApplyEdit()
         default:
             FileHandle.standardError.write(
-                Data("unknown subcommand '\(subcommand)' (expected echo|boot|workers-dev|worker-toggle|pause-resume)\n".utf8))
+                Data("unknown subcommand '\(subcommand)' (expected echo|boot|workers-dev|worker-toggle|pause-resume|apply-edit)\n".utf8))
             exitCode = 2
         }
         exit(exitCode)
@@ -504,6 +513,118 @@ struct AnglesiteContainerProbe {
 
         print("GATE: PASS")
         await runtime.stop()
+        return 0
+    }
+
+    // MARK: - apply-edit
+
+    /// The #81 smoke matrix's "case 8" (MCP edit persistence) as an entitled CLI gate rather
+    /// than a GUI walkthrough. Boots a real `LocalContainerSiteRuntime` against a throwaway git
+    /// repo, drives a real `apply_edit` for its `<h1>` through a real `MCPApplyEditRouter` wired
+    /// exactly like `PreviewModel.editPersister` (`persistEdit` only invoked when the reply's
+    /// `commit` is non-nil), and asserts:
+    ///   1. the reply is `.applied` with a non-nil `commit` — the #718/#1066 regression was the
+    ///      in-guest `recordEdit` silently returning `undefined` on a missing git identity, which
+    ///      surfaces here as a nil `commit` (production then never calls `persistEdit` at all);
+    ///   2. the host-side `Source/` file (this repo's throwaway working tree, standing in for the
+    ///      package's `Source/`) actually reflects the edit once `router.apply` returns — that
+    ///      call already awaits `persistEdit` before yielding an `.applied` reply, so no
+    ///      additional wait/poll is needed.
+    private static func runApplyEdit() async -> Int32 {
+        let siteID = "apply-edit-probe"
+        let originalHeading = "Anglesite probe"
+        let newHeading = "Anglesite probe — apply-edit gate"
+
+        let repo: URL
+        do {
+            repo = try makeThrowawayAstroRepo()
+        } catch {
+            print("APPLY-EDIT: FAIL — could not create throwaway Astro repo: \(error)")
+            return 1
+        }
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let runtime = LocalContainerSiteRuntime(
+            ref: "HEAD",
+            control: ContainerizationControl(),
+            mcpClient: MCPClient(supervisor: .shared))
+
+        let clock = ContinuousClock()
+        let bootStart = clock.now
+        await runtime.start(siteID: siteID, siteDirectory: repo)
+        guard case .ready = await runtime.state else {
+            print("APPLY-EDIT: FAIL — expected .ready after boot, got \(await runtime.state)")
+            await runtime.stop()
+            return 1
+        }
+        let bootElapsed = clock.now - bootStart
+
+        let pagePath = repo.appendingPathComponent("src/pages/index.astro")
+        guard let before = try? String(contentsOf: pagePath, encoding: .utf8), before.contains(originalHeading) else {
+            print("APPLY-EDIT: FAIL — fixture heading '\(originalHeading)' not found in \(pagePath.path) before the edit")
+            await runtime.stop()
+            return 1
+        }
+
+        // Mirrors `PreviewModel.editPersister(for:)` exactly: `persistEdit` only runs when the
+        // reply carries a commit, and any thrown error there downgrades the reply to `.failed`
+        // with `commit` cleared — see `MCPApplyEditRouter.apply`'s hook-ordering doc.
+        let router = MCPApplyEditRouter(
+            mcpClient: { await runtime.mcpClient },
+            persistEdit: { reply in
+                guard reply.commit != nil else { return }
+                try await runtime.persistEdit(commit: reply.commit)
+            }
+        )
+
+        let message = EditMessage(
+            id: "apply-edit-probe-1",
+            type: .applyEdit,
+            path: "/",
+            selector: .object([
+                "tag": .string("H1"),
+                "classes": .array([]),
+                "nthChild": .int(1),
+                "textContent": .string(originalHeading),
+            ]),
+            op: "replace-text",
+            value: .string(newHeading)
+        )
+
+        let reply = await router.apply(message)
+
+        guard reply.status == .applied else {
+            print("APPLY-EDIT: FAIL — apply_edit did not succeed: status=\(reply.status) message=\(reply.message ?? "nil")")
+            await runtime.stop()
+            return 1
+        }
+
+        guard let commit = reply.commit, !commit.isEmpty else {
+            print(
+                "APPLY-EDIT: FAIL — apply_edit applied but returned no commit. This IS the #718/"
+                + "#1066 regression: the in-guest recordEdit silently failed (most likely a "
+                + "missing git identity for its commit-tree call), so production's "
+                + "editPersister never even calls persistEdit and the write never reaches host "
+                + "Source/.")
+            await runtime.stop()
+            return 1
+        }
+
+        guard let after = try? String(contentsOf: pagePath, encoding: .utf8) else {
+            print("APPLY-EDIT: FAIL — could not re-read \(pagePath.path) after the edit")
+            await runtime.stop()
+            return 1
+        }
+        guard after.contains(newHeading), !after.contains(">\(originalHeading)<") else {
+            print(
+                "APPLY-EDIT: FAIL — apply_edit reported commit \(commit) but host Source/ still "
+                + "reads:\n\(after)")
+            await runtime.stop()
+            return 1
+        }
+
+        await runtime.stop()
+        print("APPLY-EDIT: PASS (boot: \(bootElapsed), commit: \(commit), host Source/ updated)")
         return 0
     }
 

--- a/docs/qa/app-store-container-smoke-test.md
+++ b/docs/qa/app-store-container-smoke-test.md
@@ -82,7 +82,7 @@ Re-run 2026-07-27, real-signed Debug build of `main` @ `13131027`, Apple Develop
 | Runtime selection logs `LocalContainerSiteRuntime` | PASS | Debug pane `runtime` source: repeated `selected LocalContainerSiteRuntime`. |
 | No host Node preview fallback starts | PASS | Debug pane search for `LocalSiteRuntime`: zero matches. |
 | Preview loads through loopback proxy | PASS | `http://127.0.0.1:<port>` preview loads and live-reloads (Astro HMR) on edit. |
-| MCP/edit path applies a text edit through the in-container sidecar | **FAIL** (regression) | Heading edit committed in preview + container (MCP `accepted`/`dial-ok`, Astro HMR reload). But host `Source/index.astro` never changed: `git status --short` clean immediately, after an 8s wait, and after ⌘S. Reopening the site (fresh container clone from host) reverted the heading to its original text; `git log --all` has zero mentions of the edited text anywhere. Reproduces #718 despite merged #737. Filed as [#1066](https://github.com/Anglesite/Anglesite/issues/1066). |
+| MCP/edit path applies a text edit through the in-container sidecar | **PASS** (2026-08-10, was FAIL/regression) | Originally: heading edit committed in preview + container (MCP `accepted`/`dial-ok`, Astro HMR reload), but host `Source/index.astro` never changed — reproduced #718 despite merged #737, filed as [#1066](https://github.com/Anglesite/Anglesite/issues/1066). Root cause (missing guest git identity) fixed upstream and now confirmed against a real container guest boot via `scripts/run-container-probe.sh apply-edit` — see "Case 8 root-cause fix landed and confirmed in the real container guest" below. |
 | Example photo highlights as an image drop target; dropping a Finder image writes optimized assets under `Source/public/images/` | **INCONCLUSIVE** | The drop-zone highlight + "Drop onto a highlighted image to replace it" tooltip fires reproducibly on a synthetic Finder-desktop-icon drag (`left_click_drag`, tried 2x, plus a manual multi-step press/move/release, 2x). But no in-preview image change and no host `public/images/` write occurred either way — can't tell whether that's the same persistence bug as the text-edit case or whether the synthetic drag simply doesn't carry a real file payload (CGEventPost-based drags are a known-hard case for Finder→WebView file promises). Still needs a literal human hand to resolve, as originally noted. |
 | Build/preflight/deploy path reaches the expected Cloudflare token or wrangler result | PASS (partial) | Deploy button correctly opens the "Connect to Cloudflare" one-time API token dialog (link to Cloudflare API tokens page, paste-token field, disabled "Connect & deploy" until filled). Stopped there — entering/creating a Cloudflare API token is credential entry an agent should not perform; a full real `wrangler deploy` round-trip needs a human to paste their own token. |
 | Foundation Models chat is present | PASS | Chat toolbar icon opens a working "Ask the assistant…" panel. |
@@ -199,7 +199,7 @@ identity — see the Smoke Matrix above for full per-row evidence. Summary:
 [#1066](https://github.com/Anglesite/Anglesite/issues/1066)) and the
 still-unresolved image-drop row.
 
-### Case 8 root-cause fix landed, not yet re-verified in-guest (2026-08-10)
+### Case 8 root-cause fix landed and confirmed in the real container guest (2026-08-10)
 
 [#1066](https://github.com/Anglesite/Anglesite/issues/1066)'s root cause (guest
 `commit-tree` calls had no git identity, so `recordEdit` silently returned
@@ -210,16 +210,35 @@ env into every `commit-tree` call. Released in `anglesite-skills` v1.8.0; the
 app's CI pin was bumped to consume it in
 [#1070](https://github.com/Anglesite/Anglesite/pull/1070) (merged 2026-07-28).
 
-Verified from a non-GUI session against the sibling checkout at v1.9.0:
+First verified from a non-GUI session against the sibling checkout at v1.9.0:
 `AppliesEditEndToEndTests` passes, and `recordEdit` was exercised directly
-against a repo with no git identity configured anywhere (fresh `$HOME`, no
-global or repo-local config) — it now returns a real commit SHA. However, a
+against a repo with no git identity configured anywhere — it returns a real
+commit SHA. But that check runs the sidecar directly on the host, and a
 negative control (calling `commit-tree` with no identity env at all, in the
 same identity-less setup) *also* succeeded on macOS — its git falls back to a
 guessed identity in a way the original bug report says the Linux container
-guest's `node:22-bookworm-slim` base image does not (unresolvable hostname, so
-git refuses to guess an email). So this only confirms the fix is real and
-correctly wired, not a true before/after inside the failure environment. **Case
-8 still needs an actual re-run inside the real container guest** (signed app,
-or `scripts/run-container-probe.sh`) before #81 can mark it passing — a Swift
-test or host-level script can't substitute for that.
+guest's `node:22-bookworm-slim` base image does not. So it confirmed the fix
+was real and correctly wired, but not a true before/after inside the actual
+failure environment.
+
+**Since resolved for real:** `scripts/run-container-probe.sh` gained a new
+`apply-edit` subcommand (added alongside this note) that boots a real
+`LocalContainerSiteRuntime` under `com.apple.security.virtualization`, drives
+an actual `apply_edit` through `MCPApplyEditRouter` wired exactly like
+production (`PreviewModel.editPersister` — `persistEdit` only runs when the
+reply carries a non-nil `commit`), and asserts the host-side `Source/` file
+changed. Run twice against a real Apple Containerization VM (not a synthetic
+host-level substitute):
+
+```
+APPLY-EDIT: PASS (boot: 44.1s, commit: ea79416f9ca2de095b160b005dd445510cca4175, host Source/ updated)
+APPLY-EDIT: PASS (boot: 41.9s, commit: cca7fcfb22dfe9e1e74d333504ee0ba7836c85a5, host Source/ updated)
+```
+
+Two different real commit SHAs, two independent VM boots — case 8's specific
+regression (an `.applied` reply with a nil `commit`, silently skipping
+persistence) is confirmed fixed in the real guest. This subcommand is now the
+repeatable, no-GUI-required gate for this row: rerun it any time #81's
+persistence case needs re-checking (e.g. after a future sidecar bump) instead
+of a full manual smoke pass. It does **not** cover the image-drop row, which
+still has no non-human substitute (see above).

--- a/scripts/run-container-probe.sh
+++ b/scripts/run-container-probe.sh
@@ -16,6 +16,7 @@
 #   scripts/run-container-probe.sh workers-dev   # #708's gate (boot + local wrangler-dev HTTP poll)
 #   scripts/run-container-probe.sh worker-toggle # #919's gate (updateActiveWorkers toggle restart)
 #   scripts/run-container-probe.sh pause-resume  # suspend-on-close decision gate (vsock survives pause/resume)
+#   scripts/run-container-probe.sh apply-edit    # #81 case 8 gate (real apply_edit -> host Source/ persistence)
 #
 # The boot probe is also the #715 concurrent-vmnet regression gate. Before running it, use
 # `container network create anglesite-715-regression` to hold a second vmnet shared-mode network;
@@ -34,9 +35,9 @@ cd "${ROOT_DIR}"
 
 SUBCOMMAND="${1:-}"
 case "${SUBCOMMAND}" in
-    echo|boot|workers-dev|worker-toggle|pause-resume) ;;
+    echo|boot|workers-dev|worker-toggle|pause-resume|apply-edit) ;;
     *)
-        echo "usage: $(basename "$0") <echo|boot|workers-dev|worker-toggle|pause-resume>" >&2
+        echo "usage: $(basename "$0") <echo|boot|workers-dev|worker-toggle|pause-resume|apply-edit>" >&2
         exit 2
         ;;
 esac


### PR DESCRIPTION
## Summary

- Adds an `apply-edit` subcommand to `scripts/run-container-probe.sh` / `Sources/AnglesiteContainerProbe/main.swift`: boots a real `LocalContainerSiteRuntime` under `com.apple.security.virtualization`, drives an actual `apply_edit` through `MCPApplyEditRouter` wired exactly like production (`PreviewModel.editPersister` — `persistEdit` only runs when the reply carries a non-nil `commit`), and asserts the host-side `Source/` file changed.
- Ran it three times against real Apple Containerization VM boots (once pre-rebase, twice on this branch) — all three passed with distinct real commit SHAs:
  ```
  APPLY-EDIT: PASS (boot: 44.1s, commit: ea79416f9c..., host Source/ updated)
  APPLY-EDIT: PASS (boot: 41.9s, commit: cca7fcfb22..., host Source/ updated)
  APPLY-EDIT: PASS (boot: 39.9s, commit: c4a09271ab..., host Source/ updated)
  ```
- This confirms #1066's fix (`anglesite-skills` v1.8.0+, consumed via #1070) holds in the real container guest — the one environment a host-level Swift test couldn't reach (see PR #1403, already merged, for that earlier partial check and its stated gap).
- Updates `docs/qa/app-store-container-smoke-test.md`'s case 8 matrix row from FAIL to PASS, with the evidence and a note that this subcommand is now the repeatable, no-GUI gate for re-checking this row (e.g. after a future sidecar bump).
- Does not touch the image-drop row, which still has no non-human substitute.

Closes nothing directly — #81 stays open on the remaining image-drop + "updates are App Store-managed" rows, but this clears its persistence blocker (case 8). Relates to #59, #81, #1066.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: <!-- e.g. Anglesite/anglesite-skills#123 -->

## Test plan

- [x] `swift build --package-path . --product anglesite-container-probe` — builds clean.
- [x] `swift build --package-path .` (full package) — builds clean.
- [x] `scripts/run-container-probe.sh apply-edit` — **PASS** x3 against real VM boots (see Summary).
- [ ] `swift test --package-path .` — not run (no test-target changes; this only touches an executable target, a shell script, and docs).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (no `AnglesiteApp` changes).