### PR TITLE
fix(#1407): guard against stale vendored sidecar MCP protocol

### DIFF
--- a/Sources/AnglesiteCore/LocalContainerControl.swift
+++ b/Sources/AnglesiteCore/LocalContainerControl.swift
@@ -35,6 +35,12 @@ public enum LocalContainerError: Error, Equatable {
     case bootFailed(String)
     /// git clone of `Source/` into the guest failed.
     case cloneFailed(String)
+    /// The container booted, but `MCPClient.connect` couldn't complete its handshake with the
+    /// sidecar (e.g. an `HTTPTransport.HTTPError` — see `LocalContainerSiteRuntime.start()`). The
+    /// most common cause in local dev is a `Resources/container-image/` vendored before an
+    /// MCP-protocol bump (#1407); `friendlyMessage(for:)` points at re-vendoring rather than
+    /// surfacing the raw transport error.
+    case mcpHandshakeFailed(String)
 }
 
 /// Hydration precondition: a `LocalContainerControl.start()` implementation hard-depends on

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -427,7 +427,15 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
                 onOutput: { line, stream in continuation.yield((line, stream)) })
             containerStarted = true
             guard stateMachine.isCurrent(gen) else { await abandonSupersededAttempt(); return }
-            try await connect(mcpClient, session.mcpURL)
+            do {
+                try await connect(mcpClient, session.mcpURL)
+            } catch {
+                // Distinguished from other start() failures so friendlyMessage(for:) can point at
+                // re-vendoring the local sidecar image instead of surfacing the raw transport
+                // error (#1407) — this is exactly where an MCP-protocol mismatch between the app
+                // and a stale bundled image surfaces.
+                throw LocalContainerError.mcpHandshakeFailed("\(error)")
+            }
             guard stateMachine.isCurrent(gen) else { await abandonSupersededAttempt(); return }
             await knowledgeIndex?.rebuild(siteID: siteID, projectRoot: siteDirectory)
             await conventionsEngine?.rebuild(siteID: siteID, projectRoot: siteDirectory)
@@ -656,6 +664,10 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
             return "Couldn't start the local preview: \(m)"
         case LocalContainerError.cloneFailed(let m):
             return "Couldn't load this site into the preview: \(m)"
+        case LocalContainerError.mcpHandshakeFailed(let m):
+            return "The local preview sidecar rejected the connection (\(m)). If you're developing "
+                + "this app, the bundled container image may be out of date for this build's MCP "
+                + "protocol — run scripts/vendor-container-image.sh to rebuild it."
         default:
             return "Couldn't start the local preview: \(error)"
         }

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -162,6 +162,23 @@ struct LocalContainerSiteRuntimeTests {
         #expect(await box.url == Self.ok.mcpURL)
     }
 
+    /// Regression test for #1407: a failed MCP connect (e.g. a stale vendored sidecar image
+    /// rejecting this build's protocol version) must not surface as a bare "http(status: 400)" —
+    /// it should point the developer at re-vendoring instead.
+    @Test("a failed MCP handshake settles to .failed with a re-vendor hint")
+    func startMCPHandshakeFailureSurfacesRevendorHint() async {
+        struct FakeTransportError: Error, CustomStringConvertible {
+            var description: String { "http(status: 400)" }
+        }
+        let (rt, _) = makeRuntime(.success(Self.ok), connect: { _, _ in throw FakeTransportError() })
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        if case .failed(let id, let msg) = await rt.state {
+            #expect(id == "s1")
+            #expect(msg.contains("scripts/vendor-container-image.sh"))
+            #expect(msg.contains("http(status: 400)"))
+        } else { Issue.record("expected .failed, got \(await rt.state)") }
+    }
+
     @Test("persistEdit hands the guest commit back to canonical Source")
     func persistEditRunsCanonicalGitHandoff() async throws {
         let commit = "abc1234567890abcdef1234567890abcdef12345"

--- a/scripts/check-container-resources.sh
+++ b/scripts/check-container-resources.sh
@@ -42,6 +42,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 RESOURCES="$REPO_ROOT/Resources"
 source "$SCRIPT_DIR/lib/artifact-lock.sh"
+source "$SCRIPT_DIR/lib/mcp-protocol-version.sh"
 
 # Appends to `missing` iff the lock has a real pin for $1 that disagrees with $2 (the digest/hash
 # just computed from the on-disk artifact). Silent no-op when unpinned ("null") — see comment
@@ -70,6 +71,27 @@ check_vminit_layout() {
     fi
 }
 
+# Appends to `missing` iff the vendored image's protocol-version stamp (vendor-manifest.json,
+# written by vendor-container-image.sh) is missing or disagrees with this app build's current
+# MCPClient.protocolVersion. Unlike check_digest above, there is no external pin to compare
+# against — the image is a non-deterministic local build (#616 excluded it from digest-pinning
+# for exactly that reason) — so this checks the stamp against the app's own live source of truth
+# instead. A missing stamp (image vendored before this check existed) is flagged the same as a
+# mismatch: both mean the bundled sidecar's MCP protocol support is unverified (#1407).
+check_mcp_protocol_stamp() {
+    local manifest="$1" label="$2"
+    local expected actual
+    expected="$(mcp_protocol_version)"
+    if [[ ! -f "$manifest" ]]; then
+        missing+=("$label has no vendor-manifest.json (vendored before the MCP-protocol staleness check existed) — re-run scripts/vendor-container-image.sh so the bundled sidecar matches MCP-Protocol-Version $expected.")
+        return
+    fi
+    actual="$(grep -m1 '"mcpProtocolVersion"' "$manifest" | sed -E 's/.*"mcpProtocolVersion"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+    if [[ "$actual" != "$expected" ]]; then
+        missing+=("$label was vendored for MCP protocol $actual but this app build now expects $expected — re-run scripts/vendor-container-image.sh, or the local preview's MCP handshake will fail with an opaque HTTP error.")
+    fi
+}
+
 # Per-artifact runtime overrides (BundledImage honors these at runtime, so a dev
 # running against external artifacts shouldn't be nagged about unvendored dirs).
 # Mirror BundledImage.swift exactly: a set override still gets its own
@@ -81,9 +103,13 @@ missing=()
 if [[ -n "${ANGLESITE_CONTAINER_IMAGE:-}" ]]; then
     if [[ ! -f "$ANGLESITE_CONTAINER_IMAGE/index.json" ]]; then
         missing+=("ANGLESITE_CONTAINER_IMAGE=$ANGLESITE_CONTAINER_IMAGE has no index.json — fix or unset the override")
+    else
+        check_mcp_protocol_stamp "$ANGLESITE_CONTAINER_IMAGE/vendor-manifest.json" "ANGLESITE_CONTAINER_IMAGE"
     fi
 elif [[ ! -f "$RESOURCES/container-image/index.json" ]]; then
     missing+=("Resources/container-image is unvendored (no index.json) — run scripts/vendor-container-image.sh")
+else
+    check_mcp_protocol_stamp "$RESOURCES/container-image/vendor-manifest.json" "Resources/container-image"
 fi
 
 if [[ -n "${ANGLESITE_CONTAINER_KERNEL:-}" ]]; then

--- a/scripts/lib/mcp-protocol-version.sh
+++ b/scripts/lib/mcp-protocol-version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Extracts the MCP protocol version this app build expects — the single source of truth is
+# `MCPClient.protocolVersion` in Sources/AnglesiteCore/MCPClient.swift. Shared by
+# vendor-container-image.sh (stamps Resources/container-image/vendor-manifest.json with the
+# version in effect at vendor time) and check-container-resources.sh (compares that stamp
+# against the current value on every build, so a protocol bump that outpaces a locally vendored
+# image is caught at build time instead of surfacing as an opaque MCP-connect HTTP error).
+# Source this file, then call mcp_protocol_version.
+
+mcp_protocol_version() {
+    local root
+    root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    local file="$root/Sources/AnglesiteCore/MCPClient.swift"
+    local version
+    version="$(grep -m1 'public static let protocolVersion' "$file" | sed -E 's/.*"([^"]+)".*/\1/')"
+    if [[ -z "$version" ]]; then
+        echo "ERROR: could not extract MCPClient.protocolVersion from $file" >&2
+        return 1
+    fi
+    echo "$version"
+}

--- a/scripts/vendor-container-image.sh
+++ b/scripts/vendor-container-image.sh
@@ -12,12 +12,17 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 source "$ROOT/scripts/lib/container-cli.sh"
 source "$ROOT/scripts/lib/stage-dev-image-context.sh"
+source "$ROOT/scripts/lib/mcp-protocol-version.sh"
 # Fail fast, before staging work: no point copying the sidecar/template if the CLI is missing.
 ensure_container_cli
 CTX="$ROOT/Containers/anglesite-dev"
 OUT="$ROOT/Resources/container-image"
 
 stage_dev_image_context "$CTX"
+
+# Captured now, before stage_dev_image_context's EXIT trap removes the staged sidecar copy — used
+# below to stamp vendor-manifest.json once the image itself is built.
+SIDECAR_VERSION="$(grep -m1 '"version"' "$CTX/mcp-sidecar/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
 
 echo "Building anglesite-dev:latest (linux/arm64)…"
 
@@ -52,6 +57,19 @@ rm -f "$ARCHIVE"
 for f in oci-layout index.json blobs/sha256; do
     [[ -e "$OUT/$f" ]] || { echo "ERROR: OCI layout missing $f" >&2; exit 1; }
 done
+
+# Stamp the vendored image with the MCP protocol version this app build expects and the sidecar
+# version it was built from — scripts/check-container-resources.sh compares the protocol version
+# against the app's current expectation on every build, so a sidecar/app protocol drift (e.g. a
+# later `git pull` that bumps MCPClient.protocolVersion) is caught before it surfaces as an
+# opaque MCP-connect HTTP error at preview time (#1407).
+cat > "$OUT/vendor-manifest.json" <<EOF
+{
+  "mcpProtocolVersion": "$(mcp_protocol_version)",
+  "sidecarVersion": "$SIDECAR_VERSION",
+  "vendoredAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
 
 echo "Done. Resources/container-image/ now holds an OCI layout."
 echo "Contents:"


### PR DESCRIPTION
Closes #1407

## Summary

- Stamps `Resources/container-image/vendor-manifest.json` with the MCP protocol version (`MCPClient.protocolVersion`) and sidecar version in effect at `scripts/vendor-container-image.sh` run time.
- `scripts/check-container-resources.sh` (already an automatic Xcode `preBuildScripts` phase, Debug-warn/Release-error) now compares that stamp against the app's *current* expected protocol version on every build — a developer who pulls a protocol bump without re-vendoring gets a clear warning at build time instead of a runtime surprise.
- `LocalContainerSiteRuntime.friendlyMessage(for:)` gets a dedicated case for MCP-connect-phase failures (new `LocalContainerError.mcpHandshakeFailed`), pointing at `scripts/vendor-container-image.sh` instead of dumping the raw transport error — a safety net for anyone who bypasses the preflight (bare `xcodebuild`, or an image vendored before this guard shipped).

Repro that motivated this: #1377 (app: adopt MCP 2026-07-28 stateless client) and `anglesite-skills`#432 (sidecar: same protocol) merged as a paired PR set on 2026-08-10. A `Resources/container-image/` vendored before that merge — gitignored, not re-vendored by `git pull` — leaves an app binary speaking the new protocol against a bundled sidecar still speaking the old one. Every new-site preview then failed with a bare `Couldn't start the local preview: http(status: 400)`, with no hint that the fix is re-running the vendor script. Full details in #1407.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills`.

## Test plan

- [x] `swift test --package-path . --skip Domain` (408 tests, all passing, including a new regression test for the friendlyMessage hint)
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (BUILD SUCCEEDED)
- [x] Manually exercised `check-container-resources.sh`'s new check via `ANGLESITE_CONTAINER_IMAGE` across missing-manifest / mismatched-version / matching-version scenarios — each produces the expected warning (or silence when current).