### PR TITLE
fix(#1410): refuse bare-tag edits missing current text

### DIFF
--- a/Sources/AnglesiteCore/ApplyEditTool.swift
+++ b/Sources/AnglesiteCore/ApplyEditTool.swift
@@ -46,6 +46,14 @@ public struct ApplyEditTool: Tool, Sendable {
         guard let selector = resolveSelector(arguments.selector) else {
             return "Couldn't identify which element to edit — select one in the preview, or name a simple tag like h1."
         }
+        // #1410: the bare-tag fallback path (below) has no `textContent` — and the sidecar
+        // locates the target element by searching for its *current* text/attribute value for
+        // every op except applyInstruction. Sending that incomplete selector downstream is
+        // guaranteed to fail two layers away with a confusing message; refuse clearly up front.
+        if contextSelector == nil, Self.requiresCurrentText(arguments.operation) {
+            return "I don't know this element's current text, so I can't find it in the page's source. "
+                + "Select it in the preview, or tell me its exact current text, and try again."
+        }
         let reply = await bridge.applyEdit(
             siteID: siteID,
             filePath: arguments.filePath,
@@ -92,6 +100,17 @@ public struct ApplyEditTool: Tool, Sendable {
     private static func isBareTag(_ s: String) -> Bool {
         guard let first = s.first, first.isLetter else { return false }
         return s.allSatisfy { $0.isLetter || $0.isNumber }
+    }
+
+    /// Ops whose server-side resolver locates the target element by searching for its *current*
+    /// text/attribute value (`selector.textContent` — see anglesite-skills' `patcher.mjs`,
+    /// `resolveAstro`/`getAttrSearchValue`). `applyInstruction` forwards the raw instruction for
+    /// server-side interpretation instead, so it needs no textContent hint.
+    private static func requiresCurrentText(_ op: EditOperation) -> Bool {
+        switch op {
+        case .replaceText, .replaceAttr, .replaceImageSrc: return true
+        case .applyInstruction: return false
+        }
     }
 
     /// Map the #154 ``EditOperation`` onto the `EditMessage.Op` string vocabulary (the bridge

--- a/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
+++ b/Tests/AnglesiteCoreTests/OnDeviceToolsTests.swift
@@ -80,15 +80,40 @@ struct ApplyEditToolTests {
         #expect(msg?.op == expectedOp)
     }
 
-    @Test("no context selector + bare-tag selector builds a minimal ElementInfo")
-    func bareTagBuildsMinimalElementInfo() async throws {
+    /// #1410: without a real overlay selection, the bare-tag fallback has no `textContent` — and
+    /// the sidecar's `.astro` resolver locates the target element by searching for its *current*
+    /// text/attribute value for every op except `applyInstruction` (`patcher.mjs`'s `resolveAstro`
+    /// / `getAttrSearchValue`). Sending that incomplete selector downstream was guaranteed to fail
+    /// with a confusing message; refusing here up front is both correct and clearer.
+    @Test("no context selector + bare-tag selector refuses ops that need the element's current text", arguments: [
+        EditOperation.replaceText, EditOperation.replaceAttr, EditOperation.replaceImageSrc,
+    ])
+    func bareTagRefusesOpsThatNeedCurrentText(operation: EditOperation) async throws {
         let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: nil))
         let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: nil)
         let cmd = GeneratedEditCommand(
             filePath: "src/pages/index.md",
             selector: "H1",
-            operation: .replaceAttr,
+            operation: operation,
             value: "hello",
+            explanation: "x"
+        )
+
+        let out = try await tool.call(arguments: cmd)
+
+        #expect(await router.received == nil)
+        #expect(out.contains("Select it in the preview"))
+    }
+
+    @Test("no context selector + bare-tag selector still forwards apply-instruction (no current text needed)")
+    func bareTagAllowsApplyInstruction() async throws {
+        let router = FakeEditRouter(reply: EditReply(id: "test-id", status: .applied, message: nil))
+        let tool = ApplyEditTool(bridge: makeBridge(router), siteID: "site1", contextSelector: nil)
+        let cmd = GeneratedEditCommand(
+            filePath: "src/pages/index.md",
+            selector: "H1",
+            operation: .applyInstruction,
+            value: "make it punchier",
             explanation: "x"
         )
 


### PR DESCRIPTION
Closes #1410

## Summary

- `ApplyEditTool`'s bare-tag selector fallback (used when nothing is selected in the preview) synthesizes an `ElementInfo` with no `textContent`.
- The sidecar's `.astro` resolver (`patcher.mjs`'s `resolveAstro`/`getAttrSearchValue`) needs `textContent` to locate the element for `replace-text`, `replace-attr`, and `replace-image-src` — so the edit was guaranteed to fail two layers downstream, and the on-device model then composed a confusing explanation around the sidecar's terse `"nothing to search for"` error instead of the real cause.
- `ApplyEditTool.call` now refuses clearly, before ever routing through the bridge, when there's no context selector and the operation needs current text (`applyInstruction` is unaffected — it doesn't search by text).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` (full suite, 3620+ tests across all targets, all passing)
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (BUILD SUCCEEDED)
- [ ] Manual smoke (if UI-touching): not UI-touching — pure tool-response logic; covered by unit tests exercising `ApplyEditTool.call` directly

## Design notes

The sidecar-side "more robust fix" the issue also proposed — giving `resolveAstro`/`findTextInAstroTemplate` a structural fallback so it can self-resolve the Nth `<tag>` when `textContent` is absent — is out of scope here (separate repo, needs a paired PR) and left for a follow-up.