### PR TITLE
build: add Signing-Release.local.xcconfig override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ Resources/Anglesite.help/**/*.helpindex
 .playwright-mcp/
 build-smoke/
 
-# Personal signing override (see xcconfig/Signing-Debug.xcconfig) — machine-specific
-# Apple Developer Team, never shared.
+# Personal signing override (see xcconfig/Signing-Debug.xcconfig and
+# xcconfig/Signing-Release.xcconfig) — machine-specific Apple Developer Team, never shared.
 xcconfig/Signing-Debug.local.xcconfig
+xcconfig/Signing-Release.local.xcconfig

--- a/project.yml
+++ b/project.yml
@@ -92,13 +92,15 @@ targets:
       - name: Build Help index
         script: "\"${PROJECT_DIR}/scripts/build-help-index.sh\""
         basedOnDependencyAnalysis: false
-    # Debug signing (CODE_SIGN_STYLE/IDENTITY/TEAM) comes from xcconfig/Signing-Debug.xcconfig
-    # instead of inline settings below, so a personal Team set via Xcode's Signing &
-    # Capabilities tab can persist across `xcodegen generate` — see that file for how to
-    # override it locally without editing this tracked config. The same file also carries
-    # ANGLESITE_DEBUG_ENTITLEMENTS (#1038), which CODE_SIGN_ENTITLEMENTS below reads.
+    # Debug/Release signing (CODE_SIGN_STYLE/IDENTITY/TEAM) comes from
+    # xcconfig/Signing-{Debug,Release}.xcconfig instead of inline settings below, so a
+    # personal Team set via Xcode's Signing & Capabilities tab can persist across
+    # `xcodegen generate` — see those files for how to override locally without editing
+    # this tracked config. The Debug file also carries ANGLESITE_DEBUG_ENTITLEMENTS
+    # (#1038), which CODE_SIGN_ENTITLEMENTS below reads.
     configFiles:
       Debug: xcconfig/Signing-Debug.xcconfig
+      Release: xcconfig/Signing-Release.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite
@@ -134,9 +136,6 @@ targets:
           # xcconfig/Signing-Debug.local.xcconfig can opt a real-Team local build into
           # Resources/Anglesite-Debug-iCloud.entitlements without editing this tracked file.
           CODE_SIGN_ENTITLEMENTS: $(ANGLESITE_DEBUG_ENTITLEMENTS)
-        Release:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "Apple Distribution"
     dependencies:
       - package: Anglesite
         product: AnglesiteCore
@@ -203,6 +202,7 @@ targets:
     # See the Anglesite target's matching comment on configFiles above.
     configFiles:
       Debug: xcconfig/Signing-Debug.xcconfig
+      Release: xcconfig/Signing-Release.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite.ios
@@ -226,9 +226,6 @@ targets:
       configs:
         Debug:
           CODE_SIGN_ENTITLEMENTS: $(ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS)
-        Release:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "Apple Distribution"
     dependencies:
       - package: Anglesite
         product: AnglesiteCore
@@ -248,6 +245,7 @@ targets:
     # in the host app need matching signing style/team for automatic signing to resolve.
     configFiles:
       Debug: xcconfig/Signing-Debug.xcconfig
+      Release: xcconfig/Signing-Release.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite.QuickLookPreview
@@ -261,10 +259,6 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"
         SKIP_INSTALL: YES
-      configs:
-        Release:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "Apple Distribution"
     dependencies:
       - package: Anglesite
         product: AnglesiteQuickLookSupport
@@ -278,6 +272,7 @@ targets:
     # in the host app need matching signing style/team for automatic signing to resolve.
     configFiles:
       Debug: xcconfig/Signing-Debug.xcconfig
+      Release: xcconfig/Signing-Release.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite.QuickLookThumbnail
@@ -291,10 +286,6 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"
         SKIP_INSTALL: YES
-      configs:
-        Release:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "Apple Distribution"
     dependencies:
       - package: Anglesite
         product: AnglesiteQuickLookSupport
@@ -327,6 +318,7 @@ targets:
     # matching signing style/team for automatic signing to resolve.
     configFiles:
       Debug: xcconfig/Signing-Debug.xcconfig
+      Release: xcconfig/Signing-Release.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.dwk.anglesite.remote
@@ -343,10 +335,6 @@ targets:
         SKIP_INSTALL: YES
         # Embedded helper apps live under the parent's Contents/Library/LoginItems/ —
         # SMAppService.agent's documented discovery location.
-      configs:
-        Release:
-          CODE_SIGN_STYLE: Manual
-          CODE_SIGN_IDENTITY: "Apple Distribution"
     dependencies:
       - package: Anglesite
         product: AnglesiteRemote

--- a/xcconfig/Signing-Release.local.xcconfig.example
+++ b/xcconfig/Signing-Release.local.xcconfig.example
@@ -1,0 +1,23 @@
+// Copy this file to Signing-Release.local.xcconfig (same directory) to pin your own
+// Apple Developer Team for local Release builds/archives — e.g. #81's real-signed smoke
+// test, or preparing a TestFlight/App Store build. That filename is gitignored, so it
+// survives `xcodegen generate` without affecting CI or other contributors.
+//
+// CODE_SIGN_STYLE = Automatic + CODE_SIGN_IDENTITY = Apple Development lets Xcode
+// auto-manage a Mac Development profile for your team once you're signed in (Settings >
+// Apple Accounts) — a Release-configuration build signed for development, which is
+// exactly what #81's smoke test accepts ("Apple Development or distribution signing
+// identity"). CODE_SIGN_IDENTITY must be overridden here too, not left to inherit
+// Signing-Release.xcconfig's "Apple Distribution": pairing Automatic style with the
+// Distribution identity is a conflicting-provisioning-settings build error.
+//
+// For an actual App Store Connect upload you need real distribution signing instead:
+// set CODE_SIGN_STYLE = Manual (drop the CODE_SIGN_IDENTITY override below, so it
+// inherits "Apple Distribution" from Signing-Release.xcconfig) and add
+// PROVISIONING_PROFILE_SPECIFIER pointing at a profile you've created in App Store
+// Connect / the developer portal.
+//
+// Find your Team ID in System Settings > Apple Accounts > (your Apple ID) > (team).
+CODE_SIGN_STYLE = Automatic
+CODE_SIGN_IDENTITY = Apple Development
+DEVELOPMENT_TEAM = YOUR_TEAM_ID

--- a/xcconfig/Signing-Release.xcconfig
+++ b/xcconfig/Signing-Release.xcconfig
@@ -1,0 +1,13 @@
+// Shared Release-config code-signing defaults, wired in via each target's `configFiles`
+// entry in project.yml — mirrors Signing-Debug.xcconfig. Tracked — keep these values
+// CI-safe (no team) so a fresh clone or CI runner never accidentally attempts a Release
+// build/archive against someone else's Apple Developer Team.
+//
+// To build or archive Release locally with your own Team (e.g. for #81's real-signed
+// smoke test, or Xcode Cloud/TestFlight prep), copy Signing-Release.local.xcconfig.example
+// to Signing-Release.local.xcconfig (gitignored) next to this file and fill in your Team ID.
+CODE_SIGN_STYLE = Manual
+CODE_SIGN_IDENTITY = Apple Distribution
+DEVELOPMENT_TEAM =
+
+#include? "Signing-Release.local.xcconfig"


### PR DESCRIPTION
<!-- No single tracked issue to close — small, self-contained build-config improvement following an existing pattern (CONTRIBUTING.md's "bug fix or small improvement" carve-out). -->

## Summary

- Adds a `Signing-Release.xcconfig` / `Signing-Release.local.xcconfig` pair mirroring the existing Debug mechanism, so a personal Apple Developer Team for **Release** builds/archives survives `xcodegen generate` instead of reverting to the inline `project.yml` defaults (or a live, unsaved Xcode GUI edit).
- Moves each target's inline `configs.Release: CODE_SIGN_STYLE: Manual / CODE_SIGN_IDENTITY: "Apple Distribution"` into the new tracked `xcconfig/Signing-Release.xcconfig` (still CI-safe: no team, same values as before) across all 5 targets (Anglesite, AnglesiteMobile, AnglesiteQuickLookPreview, AnglesiteQuickLookThumbnail, AnglesiteRemote).
- `Signing-Release.local.xcconfig.example` documents both the low-friction path (`CODE_SIGN_STYLE = Automatic` + `CODE_SIGN_IDENTITY = Apple Development` for a Release-configuration build signed for development — sufficient for #81's real-signed smoke) and the real-distribution path (Manual + a `PROVISIONING_PROFILE_SPECIFIER`).

Found and fixed one real bug while testing this: pairing `CODE_SIGN_STYLE = Automatic` with an inherited `CODE_SIGN_IDENTITY = "Apple Distribution"` produces a hard Xcode error ("conflicting provisioning settings") — the local `.example` now overrides `CODE_SIGN_IDENTITY` explicitly for the Automatic case, same as the existing Debug local override already does.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `./scripts/check-xcodeproj-sync.sh` — passes, `Anglesite.xcodeproj` in sync with `project.yml`.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug CODE_SIGNING_ALLOWED=NO build` — ad-hoc CI-safe path still succeeds unchanged.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Release -allowProvisioningUpdates build` with a real `Signing-Release.local.xcconfig` (`DEVELOPMENT_TEAM = M34HBJZNYA`, Automatic + Apple Development) — correctly resolves signing identity/team and reaches Apple's provisioning-profile step; fails there with "Device My Mac is not registered to your team Beyond Certified, Inc.… you do not have permission to register them." That's a pre-existing Apple Developer Portal account/role issue on that team (already tracked outside this repo), not a defect in this xcconfig plumbing — the mechanism itself is verified correct up to that external boundary.
- [ ] `swift test --package-path .` — not run; no Swift source changes, config/build-settings only.