### PR TITLE
fix(#1415): detect unsupported apply_edit ops before sending

### DIFF
--- a/Sources/AnglesiteCore/MCPApplyEditRouter.swift
+++ b/Sources/AnglesiteCore/MCPApplyEditRouter.swift
@@ -144,6 +144,20 @@ public struct MCPApplyEditRouter: EditRouter {
             return reply
         } catch is CancellationError {
             return EditReply(id: message.id, status: .failed, message: "canceled")
+        } catch MCPClient.MCPError.unsupportedOp(let op) {
+            // The connected sidecar's own `tools/list` schema doesn't list `op` — almost always a
+            // vendored container image older than a paired app/sidecar PR that added it (#1415),
+            // the per-op sibling of #1407's protocol-version guard. Name the likely cause instead
+            // of letting this fall to the generic catch below, which would stuff the raw
+            // `MCPError.unsupportedOp(op: "...")` enum dump into the toast text.
+            return EditReply(
+                id: message.id,
+                status: .failed,
+                message: "This site's preview server doesn't support the \"\(op)\" edit yet. "
+                    + "If you're developing Anglesite, the vendored container image is probably "
+                    + "older than a paired sidecar change — re-run scripts/vendor-container-image.sh.",
+                reason: "unsupported-op"
+            )
         } catch {
             return EditReply(id: message.id, status: .failed, message: "\(error)")
         }

--- a/Sources/AnglesiteCore/MCPClient.swift
+++ b/Sources/AnglesiteCore/MCPClient.swift
@@ -123,6 +123,15 @@ public actor MCPClient {
         /// image vendored from a sidecar checkout older than v1.9.0 (#1277). `detail` carries the
         /// server's own error message for diagnostics; `send(_:)` also logs it to `LogCenter`.
         case staleSidecarProtocol(detail: String)
+        /// `callTool(name:arguments:)` refused to send an `apply_edit` call because `op` isn't in
+        /// the set the connected sidecar's `tools/list` advertises for that tool (`apply_edit`'s
+        /// JSON-Schema `inputSchema.properties.op.enum` — see ``cachedApplyEditOps()``). The
+        /// sibling failure mode to ``staleSidecarProtocol(detail:)``: same root cause (a vendored
+        /// container image older than a paired app/sidecar PR), but a per-op *schema* mismatch
+        /// rather than a transport-*protocol-version* one, so it surfaces on one specific edit
+        /// instead of at connect time — see #1415, where a stale image predating sidecar PR #439
+        /// made every `insert-image` call fail as an opaque zod "Invalid params" RPC error.
+        case unsupportedOp(op: String)
     }
 
     /// One tool advertised by the server's `tools/list` response.
@@ -177,6 +186,11 @@ public actor MCPClient {
 
     private var nextRequestID: Int = 1
     private var pending: [Int: CheckedContinuation<JSONValue, Error>] = [:]
+
+    /// Cache for ``cachedApplyEditOps()`` — the `apply_edit` tool's advertised `op` enum, fetched
+    /// at most once per connection and cleared on ``teardown()`` so a reconnect (possibly to a
+    /// different container image) re-fetches rather than trusting a stale set.
+    private var applyEditOpsCache: Set<String>?
     private var started: Bool = false
 
     /// The MCP protocol revision this client speaks — replayed in every request's `_meta`
@@ -325,6 +339,30 @@ public actor MCPClient {
         }
     }
 
+    /// Lazily fetches and caches the connected sidecar's advertised `apply_edit` op set, read
+    /// straight out of `tools/list`'s standard JSON-Schema `inputSchema` — no bespoke capability
+    /// protocol needed, since the MCP tool catalog already carries this (zod's `editOps` enum,
+    /// converted to `{"properties": {"op": {"enum": [...]}}}` server-side). Returns `nil` — meaning
+    /// "unknown, don't gate on this" — when the server has no `apply_edit` tool, its schema
+    /// doesn't shape up as expected (e.g. a very old sidecar predating this check), or the fetch
+    /// itself fails; callers must treat `nil` as "fail open," not "no ops supported."
+    private func cachedApplyEditOps() async -> Set<String>? {
+        if let applyEditOpsCache { return applyEditOpsCache }
+        guard let tools = try? await listTools(),
+              let tool = tools.first(where: { $0.name == "apply_edit" }),
+              case .object(let schema)? = tool.inputSchema,
+              case .object(let properties)? = schema["properties"],
+              case .object(let opSchema)? = properties["op"],
+              case .array(let values)? = opSchema["enum"]
+        else { return nil }
+        let ops = Set(values.compactMap { value -> String? in
+            if case .string(let s) = value { return s }
+            return nil
+        })
+        applyEditOpsCache = ops
+        return ops
+    }
+
     /// Invokes a server tool and normalizes its result. Tool-level failure comes back as
     /// ``ToolCallResult/isError``, not a throw — only client/transport-layer problems throw,
     /// including ``MCPError/timeout`` after 30 seconds (deliberately longer than the other
@@ -334,6 +372,11 @@ public actor MCPClient {
     public func callTool(name: String, arguments: JSONValue = .object([:])) async throws -> ToolCallResult {
         guard started else { throw MCPError.notInitialized }
         try Task.checkCancellation()   // pre-call guard: never send for an already-cancelled task
+        if name == "apply_edit", case .object(let args) = arguments, case .string(let op)? = args["op"] {
+            if let supportedOps = await cachedApplyEditOps(), !supportedOps.contains(op) {
+                throw MCPError.unsupportedOp(op: op)
+            }
+        }
         let params: JSONValue = .object([
             "name": .string(name),
             "arguments": arguments,
@@ -508,6 +551,7 @@ public actor MCPClient {
         if let transport { await transport.close() }
         transport = nil
         started = false
+        applyEditOpsCache = nil
         for (_, cont) in pending { cont.resume(throwing: MCPError.notInitialized) }
         pending.removeAll()
     }

--- a/Sources/AnglesiteCore/MCPClient.swift
+++ b/Sources/AnglesiteCore/MCPClient.swift
@@ -125,7 +125,7 @@ public actor MCPClient {
         case staleSidecarProtocol(detail: String)
         /// `callTool(name:arguments:)` refused to send an `apply_edit` call because `op` isn't in
         /// the set the connected sidecar's `tools/list` advertises for that tool (`apply_edit`'s
-        /// JSON-Schema `inputSchema.properties.op.enum` — see ``cachedApplyEditOps()``). The
+        /// JSON-Schema `inputSchema.properties.op.enum` — see `cachedApplyEditOps()`). The
         /// sibling failure mode to ``staleSidecarProtocol(detail:)``: same root cause (a vendored
         /// container image older than a paired app/sidecar PR), but a per-op *schema* mismatch
         /// rather than a transport-*protocol-version* one, so it surfaces on one specific edit
@@ -187,8 +187,8 @@ public actor MCPClient {
     private var nextRequestID: Int = 1
     private var pending: [Int: CheckedContinuation<JSONValue, Error>] = [:]
 
-    /// Cache for ``cachedApplyEditOps()`` — the `apply_edit` tool's advertised `op` enum, fetched
-    /// at most once per connection and cleared on ``teardown()`` so a reconnect (possibly to a
+    /// Cache for `cachedApplyEditOps()` — the `apply_edit` tool's advertised `op` enum, fetched
+    /// at most once per connection and cleared on `teardown()` so a reconnect (possibly to a
     /// different container image) re-fetches rather than trusting a stale set.
     private var applyEditOpsCache: Set<String>?
     private var started: Bool = false

--- a/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPApplyEditRouterTests.swift
@@ -68,6 +68,20 @@ struct MCPApplyEditRouterTests {
         #expect(reply.message != nil)
     }
 
+    @Test("unsupportedOp maps to a clear message and machine-readable reason, not the raw error dump")
+    func unsupportedOpMapsToClearMessage() async {
+        // #1415: a stale vendored sidecar's tools/list schema doesn't list this op. The router
+        // must not fall through to its generic `"\(error)"` catch, which would surface the raw
+        // `unsupportedOp(op: "insert-image")` Swift enum dump as the toast text.
+        let recorder = ToolCallRecorder(result: .failure(MCPClient.MCPError.unsupportedOp(op: "insert-image")))
+        let router = MCPApplyEditRouter(toolCaller: { try await recorder.call(name: $0, arguments: $1) })
+        let reply = await router.apply(sampleMessage)
+        #expect(reply.status == .failed)
+        #expect(reply.reason == "unsupported-op")
+        #expect(reply.message?.contains("insert-image") == true)
+        #expect(reply.message?.contains("unsupportedOp") == false)
+    }
+
     // MARK: structured reply parse
 
     @Test("Successful reply with structured body exposes structured fields") func successfulReplyWithStructuredBodyExposesStructuredFields() async {

--- a/Tests/AnglesiteCoreTests/MCPClientTests.swift
+++ b/Tests/AnglesiteCoreTests/MCPClientTests.swift
@@ -101,6 +101,69 @@ struct MCPClientTests {
         }
     }
 
+    /// Fake server advertising an `apply_edit` tool with a deliberately narrow `op` enum in its
+    /// `inputSchema` — mirrors what a real sidecar's zod-derived JSON Schema looks like (#1415) —
+    /// so `MCPClient.callTool`'s client-side op-support gate has something real to check against.
+    /// Never actually applies anything; `tools/call` just echoes success for any op the schema
+    /// admits, since these tests only exercise the gate, not `apply-edit-dispatcher.mjs`.
+    private actor FakeApplyEditServerTransport: MCPTransport {
+        private var continuation: AsyncStream<JSONValue>.Continuation?
+        private let stream: AsyncStream<JSONValue>
+        static let supportedOps = ["replace-text", "replace-attr"]
+
+        init() {
+            var cont: AsyncStream<JSONValue>.Continuation!
+            stream = AsyncStream { cont = $0 }
+            continuation = cont
+        }
+
+        func open() async throws {}
+        nonisolated func inbound() -> AsyncStream<JSONValue> { stream }
+        func close() async { continuation?.finish() }
+
+        func send(_ message: JSONValue) async throws {
+            guard case .object(let obj) = message, case .string(let method)? = obj["method"] else { return }
+            guard case .int(let id)? = obj["id"] else { return }
+            switch method {
+            case "tools/list":
+                continuation?.yield(.object([
+                    "jsonrpc": .string("2.0"),
+                    "id": .int(id),
+                    "result": .object(["tools": .array([
+                        .object([
+                            "name": .string("apply_edit"),
+                            "description": .string("Applies a structured edit"),
+                            "inputSchema": .object([
+                                "type": .string("object"),
+                                "properties": .object([
+                                    "op": .object([
+                                        "type": .string("string"),
+                                        "enum": .array(Self.supportedOps.map { .string($0) }),
+                                    ]),
+                                ]),
+                            ]),
+                        ]),
+                    ])]),
+                ]))
+            case "tools/call":
+                continuation?.yield(.object([
+                    "jsonrpc": .string("2.0"),
+                    "id": .int(id),
+                    "result": .object([
+                        "content": .array([.object(["type": .string("text"), "text": .string("applied")])]),
+                        "isError": .bool(false),
+                    ]),
+                ]))
+            default:
+                continuation?.yield(.object([
+                    "jsonrpc": .string("2.0"),
+                    "id": .int(id),
+                    "error": .object(["code": .int(-32601), "message": .string("method not found")]),
+                ]))
+            }
+        }
+    }
+
     /// Fake server that handles one `crash` tool call (responds, then `exit(1)`) so the supervisor
     /// restarts it. The fresh instance behaves like the standard fake server. Lets us exercise
     /// reconnect — genuinely needs a real subprocess since it tests `ProcessSupervisor`'s
@@ -218,6 +281,47 @@ struct MCPClientTests {
         let client = MCPClient(supervisor: .shared)
         await #expect(throws: MCPClient.MCPError.notInitialized) {
             _ = try await client.callTool(name: "echo")
+        }
+    }
+
+    // MARK: apply_edit op-support gate (#1415)
+
+    @Test("apply_edit call for an op missing from the advertised schema throws unsupportedOp")
+    func applyEditUnadvertisedOpThrowsUnsupportedOp() async throws {
+        let transport = FakeApplyEditServerTransport()
+        let client = MCPClient(supervisor: .shared)
+        try await client.startWithTransport(transport, readyTimeout: 5, clientName: "test", clientVersion: "0")
+        defer { Task { await client.stop() } }
+
+        // "insert-image" isn't in FakeApplyEditServerTransport.supportedOps — mirrors #1415's
+        // stale-vendored-image repro, where the app sent an op the sidecar's schema didn't know.
+        await #expect(throws: MCPClient.MCPError.unsupportedOp(op: "insert-image")) {
+            _ = try await client.callTool(name: "apply_edit", arguments: .object(["op": .string("insert-image")]))
+        }
+    }
+
+    @Test("apply_edit call for an op present in the advertised schema goes through")
+    func applyEditAdvertisedOpSucceeds() async throws {
+        let transport = FakeApplyEditServerTransport()
+        let client = MCPClient(supervisor: .shared)
+        try await client.startWithTransport(transport, readyTimeout: 5, clientName: "test", clientVersion: "0")
+        defer { Task { await client.stop() } }
+
+        let result = try await client.callTool(name: "apply_edit", arguments: .object(["op": .string("replace-text")]))
+        #expect(result.isError == false)
+        #expect(result.content.first?.text == "applied")
+    }
+
+    @Test("apply_edit call fails open when the server doesn't advertise an apply_edit tool")
+    func applyEditFailsOpenWithoutSchema() async throws {
+        // Reuses the plain echo-only fake — no `apply_edit` tool in its tools/list at all, e.g. a
+        // very old sidecar predating this check. The gate must not invent a refusal; it should let
+        // the call through to the normal path, which then fails the ordinary way (unknown tool).
+        let (client, _) = try await makeFakeClient()
+        defer { Task { await client.stop() } }
+
+        await #expect(throws: MCPClient.MCPError.rpcError(code: -32601, message: "unknown tool")) {
+            _ = try await client.callTool(name: "apply_edit", arguments: .object(["op": .string("replace-text")]))
         }
     }
 


### PR DESCRIPTION
Closes #1415

## Summary

- A stale vendored `Resources/container-image/` (built before a paired sidecar PR adds a new
  `apply_edit` op — e.g. `insert-image` via PR #1413 / sidecar PR #439) let the app send an op
  the container's sidecar had never heard of, surfacing as a raw `MCPError.rpcError(...)` enum
  dump in the edit toast instead of an actionable message. Unlike #1407 (a protocol-*version*
  mismatch caught at connect time), this is a per-op *schema* mismatch on one specific call.
- `MCPClient.callTool` now caches the `apply_edit` tool's advertised `op` enum straight from
  `tools/list`'s standard JSON-Schema `inputSchema` (no bespoke capability protocol) and, before
  sending, checks the request's `op` against it — throwing a new `MCPError.unsupportedOp(op:)`
  client-side instead of round-tripping into an opaque `Invalid params` RPC error. Fails open
  (lets the call through as before) when the schema can't be introspected, so an older sidecar
  or a transient `tools/list` failure never blocks a real edit.
- `MCPApplyEditRouter.apply` maps `unsupportedOp` to a clear `EditReply` — human-readable message
  naming the op and pointing at `scripts/vendor-container-image.sh`, plus `reason: "unsupported-op"`
  for callers that want to branch on it — instead of falling through to the generic `"\(error)"` catch.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path . --skip Domain` (408 tests, 59 suites — `Domain` skipped per the known live #1366/#1367 hang, unrelated to this change)
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [x] New/updated unit coverage: `MCPClientTests` (op-support gate: throws for an unadvertised op, passes an advertised op through, fails open when the sidecar doesn't advertise `apply_edit` at all) and `MCPApplyEditRouterTests` (friendly-message mapping, not a raw error dump).

## Design notes

Filed and scoped in #1415. Deliberately skipped a `scripts/check-container-resources.sh`
git-log heuristic (comparing the vendored sidecar commit against the newest commit touching
`EditMessage.Op`/the overlay's op call sites) — that's an approximate, brittle cross-repo
correlation, and the live client-side schema check above already catches the real failure
accurately, so the heuristic would be redundant belt-and-suspenders for a two-repo hobby project.
