### PR TITLE
fix(#1408): allow drop-to-insert on an image-less page

### DIFF
--- a/JS/edit-overlay/src/overlay.ts
+++ b/JS/edit-overlay/src/overlay.ts
@@ -190,7 +190,14 @@ function attachImageDrop(awaitReply: (id: string, handler: (r: EditReply) => voi
     // Prevent WKWebView from navigating to a dropped local file. A target outside an image is
     // still handled below with guidance instead of silently discarding the gesture.
     ev.preventDefault();
-    if (ev.dataTransfer) ev.dataTransfer.dropEffect = target ? "copy" : "none";
+    // Accept the drop over a highlighted image target (replace), OR anywhere on a page with no
+    // images at all (insert-first-image — see the `drop` handler's matching `!hadTargets` branch
+    // below). Without the second condition, dropEffect stayed "none" for every point that isn't
+    // literally over an <img>, which on an image-less page is every point on the page: the OS
+    // rejects the drop outright (macOS's drag "poof back to origin" animation) and `drop` never
+    // even fires, so the insert-new-image path below was unreachable from a real drag.
+    const acceptsDrop = target !== null || imageTargets().length === 0;
+    if (ev.dataTransfer) ev.dataTransfer.dropEffect = acceptsDrop ? "copy" : "none";
   });
   const replaceImage = (target: HTMLImageElement, file: File): void => {
     // Save originals before the optimistic swap so we can revert on failure.

--- a/JS/edit-overlay/test/overlay.test.ts
+++ b/JS/edit-overlay/test/overlay.test.ts
@@ -236,6 +236,26 @@ describe("image drop", () => {
     expect(img.classList.contains(IMAGE_DROP_ACTIVE_CLASS)).toBe(true);
   });
 
+  it("accepts the drop anywhere on a page with no images, not just directly over an image", () => {
+    // Regression guard: dropEffect must become "copy" here, or the OS rejects the drop (macOS's
+    // "poof back to origin" animation) before the `drop` handler's insert-new-image branch ever
+    // runs — the exact bug this test would have caught.
+    const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
+
+    const event = dragOn("dragover", document.body, file);
+
+    expect((event as unknown as { dataTransfer: { dropEffect: string } }).dataTransfer.dropEffect).toBe("copy");
+  });
+
+  it("keeps rejecting drops away from any image when the page already has one (replace-only stays gated)", () => {
+    makeImg("/images/hero.jpg");
+    const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });
+
+    const event = dragOn("dragover", document.body, file);
+
+    expect((event as unknown as { dataTransfer: { dropEffect: string } }).dataTransfer.dropEffect).toBe("none");
+  });
+
   it("clears image targets when the drag leaves the page", () => {
     const img = makeImg("/images/hero.jpg");
     const file = new File([new Uint8Array([0xff, 0xd8])], "vacation.jpg", { type: "image/jpeg" });


### PR DESCRIPTION
Closes #1408

## Summary

- Root cause of "dragging an image onto an empty page does nothing (it just bounces back to the desktop)": `attachImageDrop`'s `dragover` handler in `JS/edit-overlay/src/overlay.ts` unconditionally set `dataTransfer.dropEffect = target ? "copy" : "none"`. On a page with zero `<img>` elements, `target` is always `null`, so `dropEffect` stayed `"none"` for every point on the page — the OS rejects the drop outright (macOS's drag "poof back to origin" animation) before the `drop` event, and therefore the `drop` handler's already-correct insert-new-image branch, ever fires.
- Fix: `dropEffect` is now `"copy"` when hovering a highlighted image target (replace, unchanged) **or** when the page has no images at all (insert-first-image, the missing case). Matches the exact condition the `drop` handler already uses to decide whether to call `insertNewImage`.
- Existing coverage (`test/overlay.test.ts`'s "inserts a new image when dropped anywhere on a page with no images") dispatched a synthetic `drop` event directly at `document.body`, bypassing `dragover` entirely — so it never exercised the actual gate a real drag goes through. Added two regression tests that dispatch `dragover` and assert `dropEffect`: one confirming the image-less-page case is now accepted, one confirming the existing replace-only gating (drops away from any image on a page that already has one) still correctly stays rejected.

Found via manual real-drag testing on a real signed build (not synthetic/CGEventPost — this is a genuine human-drag repro), after ruling out a schema mismatch between the client payload and the server's `resolveInsertImage`/`processImageDrop` pipeline (that part was already correctly wired).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` (from `JS/edit-overlay/`) — 27/27 tests pass, including the 2 new ones.
- [ ] `swift test --package-path .` — not run; no Swift changes.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run standalone; verified via the overlay's own build/test pipeline instead.
- [x] Manual: real (non-synthetic) drag-and-drop of a Finder image file onto a freshly created site's empty homepage, in a running signed Debug build — confirms the fix resolves the originally reported bug.