### PR TITLE
feat(#370): approval queue for hosted-community join requests

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -571,6 +571,9 @@
     "Apply…" : {
 
     },
+    "Approve" : {
+
+    },
     "Approve sign-in in your browser, then copy the final URL from the address bar (it will fail to load — that's expected) and paste it here." : {
 
     },
@@ -2223,6 +2226,9 @@
     "No open reports." : {
 
     },
+    "No pending requests." : {
+
+    },
     "No posts yet." : {
 
     },
@@ -2798,6 +2804,9 @@
 
     },
     "Repurpose “%@”" : {
+
+    },
+    "Requests" : {
 
     },
     "Require TLS for mail delivered to this domain. Start in testing mode and only switch to enforce after your mail provider is working cleanly." : {

--- a/Sources/AnglesiteApp/ModerationModel.swift
+++ b/Sources/AnglesiteApp/ModerationModel.swift
@@ -39,8 +39,10 @@ final class ModerationModel {
     }
 
     /// Records which site this pane talks to, resolves `ownActorURL`, and loads the moderator
-    /// list plus every member/post snapshot once, at site open. No network I/O. Unlike
-    /// `CommunitiesModel.configure(site:)` this is called unconditionally for *every* site
+    /// list plus every member/post snapshot once, at site open — plus one best-effort network
+    /// fetch of pending follow requests (see ``loadPendingFollowers()``, which never blocks this
+    /// on failure). Unlike `CommunitiesModel.configure(site:)` this is called unconditionally
+    /// for *every* site
     /// (including a plain personal one, not just once `canOpenModeration` is already true) —
     /// Moderation has no `.noSiteURL`-retry surface of its own, so there's nothing here to gate.
     /// This only loads once: the member/post snapshot files are written later, by
@@ -59,11 +61,12 @@ final class ModerationModel {
         await reload()
     }
 
-    /// Re-reads the moderator list plus every member/post snapshot from disk. No-ops until
-    /// ``configure(site:)`` has run at least once (no `sourceDirectory`/`configDirectory` to read
-    /// yet). Split out of ``configure(site:)`` so `SiteWindowModel.presentModeration()` can call
-    /// it on every presentation, not just once at site open — see that method's doc comment for
-    /// why a single load isn't enough.
+    /// Re-reads the moderator list plus every member/post snapshot from disk, and re-fetches the
+    /// pending-follow-request list from this site's own Worker (``loadPendingFollowers()``).
+    /// No-ops until ``configure(site:)`` has run at least once (no `sourceDirectory`/
+    /// `configDirectory` to read yet). Split out of ``configure(site:)`` so
+    /// `SiteWindowModel.presentModeration()` can call it on every presentation, not just once at
+    /// site open — see that method's doc comment for why a single load isn't enough.
     ///
     /// The settings load and both directory scans all run off the main actor: `Config/` and
     /// `Source/` live inside the `.anglesite` package, whose default home is the iCloud Drive

--- a/Sources/AnglesiteApp/ModerationModel.swift
+++ b/Sources/AnglesiteApp/ModerationModel.swift
@@ -81,25 +81,36 @@ final class ModerationModel {
             CommunityMember.self, from: sourceDirectory.appendingPathComponent("data/community-members"))
         async let loadedPosts = Self.decodeAll(
             AnnouncedPost.self, from: sourceDirectory.appendingPathComponent("data/community-posts"))
+        async let loadedPending = loadPendingFollowers()
         moderators = settings.moderators ?? []
         members = await loadedMembers
         posts = await loadedPosts
-        pendingFollowers = await loadPendingFollowers()
+        pendingFollowers = await loadedPending
     }
 
     /// Fetches pending join requests from this site's own Worker
-    /// (`CommunityMembershipClient.listFollowRequests()`). Fails silently to an empty list — same
-    /// "a bad read must never make the pane unusable" philosophy ``decodeAll(_:from:)`` follows for
-    /// member/post snapshots — because the underlying `GET <actor>/follow_requests` route
-    /// (`davidwkeith/workers` PR #488) postdates the latest tagged `@dwk/workers` release as of
-    /// this writing: a deployed community's Worker will 404 until it redeploys against a newer
-    /// one, and that expected 404 must never pop a blocking alert on every pane open. No-ops
+    /// (`CommunityMembershipClient.listFollowRequests()`). A 404 fails silently to an empty list
+    /// — same "a bad read must never make the pane unusable" philosophy ``decodeAll(_:from:)``
+    /// follows for member/post snapshots — because the underlying `GET <actor>/follow_requests`
+    /// route (`davidwkeith/workers` PR #488) postdates the latest tagged `@dwk/workers` release
+    /// as of this writing: a deployed community's Worker will 404 until it redeploys against a
+    /// newer one, and that expected 404 must never pop a blocking alert on every pane open. Any
+    /// other failure (an expired/revoked `publishToken`, a genuinely broken deploy) surfaces via
+    /// `errorMessage`, same as ``ban(_:)``/``removePost(_:)`` — swallowing *every* failure would
+    /// make a real regression on this endpoint invisible to the owner indefinitely. No-ops
     /// (returns `[]`) until `ownActorURL`/`publishToken` are both available, same guard
     /// ``ban(_:)``/``removePost(_:)`` use.
     private func loadPendingFollowers() async -> [PendingFollower] {
         guard let ownActorURL, let publishToken else { return [] }
         let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
-        return (try? await client.listFollowRequests()) ?? []
+        do {
+            return try await client.listFollowRequests()
+        } catch CommunityMembershipError.requestFailed(status: 404, body: _) {
+            return []
+        } catch {
+            errorMessage = "Couldn't load pending join requests: \(error.localizedDescription)"
+            return []
+        }
     }
 
     /// Reads every `.json` file in `directory` and decodes it as `T`, skipping (not throwing on)

--- a/Sources/AnglesiteApp/ModerationModel.swift
+++ b/Sources/AnglesiteApp/ModerationModel.swift
@@ -3,16 +3,18 @@ import Observation
 import AnglesiteCore
 
 /// Backs the Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderator-list
-/// display, and ban/remove actions over this site's own `CommunityMember`/`AnnouncedPost`
-/// snapshot files. App glue only, mirroring `CommunitiesModel`'s shape — protocol logic
-/// (`Remove`) lives in `AnglesiteCore`'s `CommunityMembershipClient`. Approval-queue and
-/// report-review are explicitly out of scope (design doc D4/D5) — no state for either here.
+/// display, ban/remove actions over this site's own `CommunityMember`/`AnnouncedPost` snapshot
+/// files, and the approval queue (design doc D4, unblocked by `davidwkeith/workers` PR #488).
+/// App glue only, mirroring `CommunitiesModel`'s shape — protocol logic (`Remove`/`Accept`/the
+/// `follow_requests` listing) lives in `AnglesiteCore`'s `CommunityMembershipClient`.
+/// Report-review remains explicitly out of scope (design doc D5) — no state for it here.
 @MainActor
 @Observable
 final class ModerationModel {
     private(set) var members: [CommunityMember] = []
     private(set) var posts: [AnnouncedPost] = []
     private(set) var moderators: [String] = []
+    private(set) var pendingFollowers: [PendingFollower] = []
     var errorMessage: String?
     /// Cleared by whichever confirmation-dialog button runs — same no-op-setter/
     /// clear-in-button-action contract `SiteWindow.swift:898-916`'s delete confirmation uses
@@ -79,6 +81,22 @@ final class ModerationModel {
         moderators = settings.moderators ?? []
         members = await loadedMembers
         posts = await loadedPosts
+        pendingFollowers = await loadPendingFollowers()
+    }
+
+    /// Fetches pending join requests from this site's own Worker
+    /// (`CommunityMembershipClient.listFollowRequests()`). Fails silently to an empty list — same
+    /// "a bad read must never make the pane unusable" philosophy ``decodeAll(_:from:)`` follows for
+    /// member/post snapshots — because the underlying `GET <actor>/follow_requests` route
+    /// (`davidwkeith/workers` PR #488) postdates the latest tagged `@dwk/workers` release as of
+    /// this writing: a deployed community's Worker will 404 until it redeploys against a newer
+    /// one, and that expected 404 must never pop a blocking alert on every pane open. No-ops
+    /// (returns `[]`) until `ownActorURL`/`publishToken` are both available, same guard
+    /// ``ban(_:)``/``removePost(_:)`` use.
+    private func loadPendingFollowers() async -> [PendingFollower] {
+        guard let ownActorURL, let publishToken else { return [] }
+        let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+        return (try? await client.listFollowRequests()) ?? []
     }
 
     /// Reads every `.json` file in `directory` and decodes it as `T`, skipping (not throwing on)
@@ -120,6 +138,24 @@ final class ModerationModel {
         banConfirmation = nil
         do { try await ban(member) }
         catch { errorMessage = "Couldn't ban \(member.name ?? member.actorURL.absoluteString): \(error.localizedDescription)" }
+    }
+
+    /// Confirms a pending join request. No confirmation dialog (unlike ``ban(_:)``/
+    /// ``removePost(_:)``) — admitting a member isn't destructive; a bad admit is reversible via
+    /// the existing ``ban(_:)`` action, so this mirrors ``addModerator(_:)``'s no-confirmation
+    /// precedent.
+    func approve(_ follower: PendingFollower) async {
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+        do {
+            try await client.acceptFollow(target: follower.actor)
+            pendingFollowers.removeAll { $0.id == follower.id }
+        } catch {
+            errorMessage = "Couldn't approve \(follower.actor.absoluteString): \(error.localizedDescription)"
+        }
     }
 
     func removePost(_ post: AnnouncedPost) async throws {

--- a/Sources/AnglesiteApp/ModerationView.swift
+++ b/Sources/AnglesiteApp/ModerationView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 import AnglesiteCore
 
-/// The Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderators, members
-/// (with ban), posts (with remove), and an inert reports placeholder (D5 — no report-handling
-/// exists upstream yet).
+/// The Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderators, an approval
+/// queue for pending join requests, members (with ban), posts (with remove), and an inert
+/// reports placeholder (D5 — no report-handling exists upstream yet).
 struct ModerationView: View {
     @Bindable var moderation: ModerationModel
     /// Bound to the "Add Moderator" text field; cleared after a successful add.
@@ -29,6 +29,19 @@ struct ModerationView: View {
                         .onSubmit(addModerator)
                     Button("Add", action: addModerator)
                         .disabled(newModeratorIRI.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            Section("Requests") {
+                if moderation.pendingFollowers.isEmpty {
+                    Text("No pending requests.").foregroundStyle(.secondary)
+                } else {
+                    ForEach(moderation.pendingFollowers) { follower in
+                        HStack {
+                            Text(follower.actor.absoluteString)
+                            Spacer()
+                            Button("Approve") { Task { await moderation.approve(follower) } }
+                        }
+                    }
                 }
             }
             Section("Members") {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -474,11 +474,11 @@ final class SiteWindowModel {
     /// Mirrors `presentCommunities()`'s leave-current-surface-first guard. Unlike Communities,
     /// this is gated (`canOpenModeration`) — see that property's doc comment.
     ///
-    /// Reloads `moderation`'s member/post snapshots on every presentation, not just once at site
-    /// open (`ModerationModel.configure(site:)`'s own doc comment has the detail): the sync jobs
-    /// that write those snapshot files run later, from `PreviewModel` after the dev server
-    /// starts, so without this a freshly provisioned community would show an empty Moderation
-    /// pane for the rest of the window session.
+    /// Reloads `moderation`'s member/post snapshots and pending-follow-request list on every
+    /// presentation, not just once at site open (`ModerationModel.configure(site:)`'s own doc
+    /// comment has the detail): the sync jobs that write those snapshot files run later, from
+    /// `PreviewModel` after the dev server starts, so without this a freshly provisioned
+    /// community would show an empty Moderation pane for the rest of the window session.
     func presentModeration() {
         Task {
             guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }

--- a/Sources/AnglesiteCore/CommunityMembershipClient.swift
+++ b/Sources/AnglesiteCore/CommunityMembershipClient.swift
@@ -183,6 +183,7 @@ public struct CommunityMembershipClient: Sendable {
         request.setValue("application/activity+json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
         request.httpBody = try JSONSerialization.data(withJSONObject: activity)
+        request.timeoutInterval = ActorProfileFetcher.timeout
         return try await send(request)
     }
 

--- a/Sources/AnglesiteCore/CommunityMembershipClient.swift
+++ b/Sources/AnglesiteCore/CommunityMembershipClient.swift
@@ -126,16 +126,20 @@ public struct CommunityMembershipClient: Sendable {
         var request = URLRequest(url: ownActorURL.appendingPathComponent("follow_requests"))
         request.httpMethod = "GET"
         request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = ActorProfileFetcher.timeout
         let data = try await send(request)
         return Self.decodeFollowRequests(data)
     }
 
-    /// Decodes the Worker's `{items: [{actor, addedAt}], total}` response. A malformed body, or
-    /// an item whose `addedAt` doesn't parse as ISO 8601 (with or without fractional seconds —
-    /// `Date.toISOString()` always emits `.000`-style milliseconds, which the plain
-    /// `ISO8601DateFormatter()` default options reject), is dropped rather than failing the whole
-    /// call — same "a bad item never blocks the good ones" rule ``ModerationModel``'s snapshot
-    /// decoding already follows.
+    /// Decodes the Worker's `{items: [{actor, addedAt}], total}` response. A response that
+    /// doesn't parse as this shape at all (missing `items`, wrong field types) yields an empty
+    /// list — same "a bad read must never make the pane unusable" rule ``ModerationModel``'s
+    /// snapshot decoding already follows. An individual item's `addedAt` that fails ISO 8601
+    /// parsing (with or without fractional seconds — `Date.toISOString()` always emits
+    /// `.000`-style milliseconds, which the plain `ISO8601DateFormatter()` default options
+    /// reject) defaults to `.distantPast` rather than dropping the item: a malformed timestamp
+    /// must never make a real pending requester silently unapprovable.
     private static func decodeFollowRequests(_ data: Data) -> [PendingFollower] {
         struct Response: Decodable {
             struct Item: Decodable { let actor: URL; let addedAt: String }
@@ -148,10 +152,8 @@ public struct CommunityMembershipClient: Sendable {
             return formatter
         }()
         let plain = ISO8601DateFormatter()
-        return response.items.compactMap { item in
-            guard let date = withFractional.date(from: item.addedAt) ?? plain.date(from: item.addedAt) else {
-                return nil
-            }
+        return response.items.map { item in
+            let date = withFractional.date(from: item.addedAt) ?? plain.date(from: item.addedAt) ?? .distantPast
             return PendingFollower(actor: item.actor, addedAt: date)
         }
     }

--- a/Sources/AnglesiteCore/CommunityMembershipClient.swift
+++ b/Sources/AnglesiteCore/CommunityMembershipClient.swift
@@ -102,13 +102,65 @@ public struct CommunityMembershipClient: Sendable {
         _ = try await post(body)
     }
 
-    private func post(_ activity: [String: Any]) async throws -> Data {
-        var request = URLRequest(url: outboxURL)
-        request.httpMethod = "POST"
-        request.setValue("application/activity+json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try JSONSerialization.data(withJSONObject: activity)
+    /// Confirms a pending join request — the owner-triggered half of workers#473's `Accept`
+    /// routing, which already ships in `dwk-server-v1.0.0-beta.3`. Same shorthand `object` shape
+    /// as ``remove(target:)``: a bare actor IRI, which the Worker's `#singleFollowTarget` resolves
+    /// against the stored `Follow` row.
+    public func acceptFollow(target: URL) async throws {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Accept",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        _ = try await post(body)
+    }
 
+    /// Lists everyone whose `Follow` is awaiting this owner's `Accept` — the bearer-gated
+    /// `GET <actor>/follow_requests` `davidwkeith/workers` PR #488 added (closing workers#487),
+    /// mirroring `GET <actor>/blocked`'s unpaged flat `{items, total}` JSON exactly. **Not yet in
+    /// a tagged `@dwk/workers` release** as of `dwk-server-v1.0.0-beta.3` — callers must treat a
+    /// failure here (most likely a 404 from a not-yet-updated deployed Worker) as "nothing
+    /// pending", never as a user-facing error; see `ModerationModel.loadPendingFollowers()`.
+    public func listFollowRequests() async throws -> [PendingFollower] {
+        var request = URLRequest(url: ownActorURL.appendingPathComponent("follow_requests"))
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
+        let data = try await send(request)
+        return Self.decodeFollowRequests(data)
+    }
+
+    /// Decodes the Worker's `{items: [{actor, addedAt}], total}` response. A malformed body, or
+    /// an item whose `addedAt` doesn't parse as ISO 8601 (with or without fractional seconds —
+    /// `Date.toISOString()` always emits `.000`-style milliseconds, which the plain
+    /// `ISO8601DateFormatter()` default options reject), is dropped rather than failing the whole
+    /// call — same "a bad item never blocks the good ones" rule ``ModerationModel``'s snapshot
+    /// decoding already follows.
+    private static func decodeFollowRequests(_ data: Data) -> [PendingFollower] {
+        struct Response: Decodable {
+            struct Item: Decodable { let actor: URL; let addedAt: String }
+            let items: [Item]
+        }
+        guard let response = try? JSONDecoder().decode(Response.self, from: data) else { return [] }
+        let withFractional: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+        let plain = ISO8601DateFormatter()
+        return response.items.compactMap { item in
+            guard let date = withFractional.date(from: item.addedAt) ?? plain.date(from: item.addedAt) else {
+                return nil
+            }
+            return PendingFollower(actor: item.actor, addedAt: date)
+        }
+    }
+
+    /// Shared POST/GET status handling: maps a transport error or non-2xx response to
+    /// ``CommunityMembershipError/requestFailed(status:body:)``, otherwise returns the raw body.
+    /// Factored out of `post(_:)` so ``listFollowRequests()``'s GET reuses the exact same mapping
+    /// instead of duplicating it.
+    private func send(_ request: URLRequest) async throws -> Data {
         let data: Data
         let http: HTTPURLResponse
         do {
@@ -121,6 +173,15 @@ public struct CommunityMembershipClient: Sendable {
                 status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
         }
         return data
+    }
+
+    private func post(_ activity: [String: Any]) async throws -> Data {
+        var request = URLRequest(url: outboxURL)
+        request.httpMethod = "POST"
+        request.setValue("application/activity+json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: activity)
+        return try await send(request)
     }
 
     static func activityID(from data: Data) -> String? {

--- a/Sources/AnglesiteCore/PendingFollower.swift
+++ b/Sources/AnglesiteCore/PendingFollower.swift
@@ -1,0 +1,26 @@
+// Sources/AnglesiteCore/PendingFollower.swift
+import Foundation
+
+/// One pending join request against this site's hosted `Group` actor: someone who sent a
+/// `Follow` while the actor requires manual approval, awaiting the owner's `Accept`/`Reject`
+/// (`davidwkeith/workers` PR #488's bearer-gated `GET <actor>/follow_requests`, closing
+/// workers#487 — see
+/// `docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md` §6).
+///
+/// Transient: fetched live from this site's own Worker on every `ModerationModel.reload()`,
+/// never written to `Source/` git — unlike ``CommunityMember``/`AnnouncedPost`, which snapshot
+/// *confirmed* state, this is a live read of state the Worker alone owns.
+public struct PendingFollower: Sendable, Equatable, Identifiable {
+    /// The requester's own actor IRI — also this struct's ``id``, since it's the unique key
+    /// the Worker itself uses (`followers.actor`).
+    public let actor: URL
+    /// When the `Follow` was recorded, decoded from the Worker's ISO 8601 `addedAt` string.
+    public let addedAt: Date
+
+    public var id: URL { actor }
+
+    public init(actor: URL, addedAt: Date) {
+        self.actor = actor
+        self.addedAt = addedAt
+    }
+}

--- a/Tests/AnglesiteAppTests/ModerationModelTests.swift
+++ b/Tests/AnglesiteAppTests/ModerationModelTests.swift
@@ -206,6 +206,28 @@ struct ModerationModelTests {
         #expect(model.errorMessage == nil)
     }
 
+    /// Only a 404 is the expected "route not yet released" case (see the test above). Any other
+    /// failure — an expired/revoked publish token, a genuinely broken deploy — must surface via
+    /// `errorMessage` like `ban(_:)`/`removePost(_:)` do, rather than swallowing it the same way
+    /// as the 404 case: silently hiding a real regression on this endpoint would leave the owner
+    /// with no signal that requests might be piling up unseen.
+    @Test("a non-404 failure from follow_requests surfaces via errorMessage")
+    func reloadSurfacesNon404FollowRequestsFailure() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            let http = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (Data("server error".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        #expect(model.pendingFollowers.isEmpty)
+        #expect(model.errorMessage != nil)
+    }
+
     @Test("approving a follower POSTs Accept and drops them from the pending list")
     func approveAcceptsAndRemovesFromPendingList() async throws {
         let (config, source) = try Self.makeSiteDirectories()

--- a/Tests/AnglesiteAppTests/ModerationModelTests.swift
+++ b/Tests/AnglesiteAppTests/ModerationModelTests.swift
@@ -17,6 +17,15 @@ struct ModerationModelTests {
         func delete(account: String) throws { values.removeValue(forKey: account) }
     }
 
+    /// Captures the JSON bodies of every POST a test's `membershipTransport` sees, so a test can
+    /// assert on the activity shape (`type`/`object`) sent to the Worker. Shared by
+    /// `banRemovesMember()` and `approveAcceptsAndRemovesFromPendingList()` — hoisted out of both
+    /// to a single definition instead of each declaring its own local copy.
+    private actor Recorder {
+        private(set) var bodies: [[String: Any]] = []
+        func record(_ body: [String: Any]) { bodies.append(body) }
+    }
+
     private static func site(configDirectory: URL, sourceDirectory: URL) -> CurrentSite {
         CurrentSite(
             id: "site-1", name: "Test Community",
@@ -49,10 +58,6 @@ struct ModerationModelTests {
         defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
         let secretStore = InMemorySecretStore()
         secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
-        actor Recorder {
-            private(set) var bodies: [[String: Any]] = []
-            func record(_ body: [String: Any]) { bodies.append(body) }
-        }
         let recorder = Recorder()
 
         let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
@@ -207,10 +212,6 @@ struct ModerationModelTests {
         defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
         let secretStore = InMemorySecretStore()
         secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
-        actor Recorder {
-            private(set) var bodies: [[String: Any]] = []
-            func record(_ body: [String: Any]) { bodies.append(body) }
-        }
         let recorder = Recorder()
 
         let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in

--- a/Tests/AnglesiteAppTests/ModerationModelTests.swift
+++ b/Tests/AnglesiteAppTests/ModerationModelTests.swift
@@ -154,4 +154,88 @@ struct ModerationModelTests {
         #expect(model.moderators.isEmpty)
         #expect(model.errorMessage != nil)
     }
+
+    @Test("reload fetches pending follow requests from this site's own actor")
+    func reloadLoadsPendingFollowRequests() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            if request.url?.lastPathComponent == "follow_requests" {
+                let http = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (
+                    Data(
+                        #"{"items":[{"actor":"https://lemmy.ml/u/newmember","addedAt":"2026-08-10T18:28:14.000Z"}],"total":1}"#
+                            .utf8), http
+                )
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        #expect(model.pendingFollowers.count == 1)
+        #expect(model.pendingFollowers.first?.actor.absoluteString == "https://lemmy.ml/u/newmember")
+    }
+
+    /// The upstream listing endpoint (`davidwkeith/workers` PR #488) postdates the latest tagged
+    /// `@dwk/workers` release as of this writing (see the plan's Global Constraints) — a deployed
+    /// community's Worker will 404 on this route until it redeploys against a newer release. That
+    /// must degrade to an empty list, never a blocking alert.
+    @Test("a 404 from follow_requests leaves pendingFollowers empty without surfacing an error")
+    func reloadIgnoresFollowRequests404() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            let http = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+            return (Data("Not Found".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        #expect(model.pendingFollowers.isEmpty)
+        #expect(model.errorMessage == nil)
+    }
+
+    @Test("approving a follower POSTs Accept and drops them from the pending list")
+    func approveAcceptsAndRemovesFromPendingList() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        actor Recorder {
+            private(set) var bodies: [[String: Any]] = []
+            func record(_ body: [String: Any]) { bodies.append(body) }
+        }
+        let recorder = Recorder()
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            if request.url?.lastPathComponent == "follow_requests" {
+                let http = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (
+                    Data(
+                        #"{"items":[{"actor":"https://lemmy.ml/u/newmember","addedAt":"2026-08-10T18:28:14.000Z"}],"total":1}"#
+                            .utf8), http
+                )
+            }
+            if let data = request.httpBody, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                await recorder.record(json)
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.pendingFollowers.count == 1)
+
+        await model.approve(model.pendingFollowers[0])
+
+        let body = await recorder.bodies.first
+        #expect(body?["type"] as? String == "Accept")
+        #expect(body?["object"] as? String == "https://lemmy.ml/u/newmember")
+        #expect(model.pendingFollowers.isEmpty)
+    }
 }

--- a/Tests/AnglesiteAppTests/ModerationModelTests.swift
+++ b/Tests/AnglesiteAppTests/ModerationModelTests.swift
@@ -239,4 +239,32 @@ struct ModerationModelTests {
         #expect(body?["object"] as? String == "https://lemmy.ml/u/newmember")
         #expect(model.pendingFollowers.isEmpty)
     }
+
+    @Test("a failed approve sets errorMessage and leaves the follower in the pending list")
+    func approveFailureSetsErrorMessage() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            if request.url?.lastPathComponent == "follow_requests" {
+                let http = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (
+                    Data(
+                        #"{"items":[{"actor":"https://lemmy.ml/u/newmember","addedAt":"2026-08-10T18:28:14.000Z"}],"total":1}"#
+                            .utf8), http
+                )
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+            return (Data("forbidden".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.pendingFollowers.count == 1)
+
+        await model.approve(model.pendingFollowers[0])
+
+        #expect(model.errorMessage != nil)
+        #expect(model.pendingFollowers.count == 1)
+    }
 }

--- a/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
@@ -128,4 +128,58 @@ struct CommunityMembershipClientTests {
             try await Self.client(fake).remove(target: target)
         }
     }
+
+    @Test("POSTs an Accept activity to this site's own outbox")
+    func postsAccept() async throws {
+        let fake = FakeTransport()
+        let target = try #require(URL(string: "https://lemmy.ml/u/newmember"))
+
+        try await Self.client(fake).acceptFollow(target: target)
+
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Accept")
+        #expect(body?["object"] as? String == "https://lemmy.ml/u/newmember")
+        #expect(body?["actor"] as? String == "https://example.com/users/site")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+    }
+
+    @Test("acceptFollow maps a non-2xx status to requestFailed")
+    func acceptMapsNon2xx() async throws {
+        let fake = FakeTransport(status: 403, body: "forbidden")
+        let target = try #require(URL(string: "https://lemmy.ml/u/newmember"))
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 403, body: "forbidden")) {
+            try await Self.client(fake).acceptFollow(target: target)
+        }
+    }
+
+    @Test("GETs pending follow requests from this site's own actor endpoint")
+    func listsFollowRequests() async throws {
+        let fake = FakeTransport(
+            status: 200,
+            body: #"{"items":[{"actor":"https://lemmy.ml/u/newmember","addedAt":"2026-08-10T18:28:14.000Z"}],"total":1}"#)
+
+        let requests = try await Self.client(fake).listFollowRequests()
+
+        #expect(requests.count == 1)
+        #expect(requests.first?.actor.absoluteString == "https://lemmy.ml/u/newmember")
+        #expect(await fake.requestedURLs.first?.absoluteString == "https://example.com/users/site/follow_requests")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+    }
+
+    @Test("listFollowRequests returns an empty list when there are none")
+    func listsEmptyFollowRequests() async throws {
+        let fake = FakeTransport(status: 200, body: #"{"items":[],"total":0}"#)
+        let requests = try await Self.client(fake).listFollowRequests()
+        #expect(requests.isEmpty)
+    }
+
+    @Test("listFollowRequests maps a non-2xx status to requestFailed")
+    func listFollowRequestsMapsNon2xx() async throws {
+        let fake = FakeTransport(status: 404, body: "Not Found")
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 404, body: "Not Found")) {
+            _ = try await Self.client(fake).listFollowRequests()
+        }
+    }
 }

--- a/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
@@ -13,6 +13,7 @@ struct CommunityMembershipClientTests {
         private(set) var requestedURLs: [URL] = []
         private(set) var requestedHeaders: [[String: String]] = []
         private(set) var requestedBodies: [[String: Any]] = []
+        private(set) var requestedTimeouts: [TimeInterval] = []
 
         init(status: Int = 202, body: String = "{}") {
             self.status = status
@@ -22,6 +23,7 @@ struct CommunityMembershipClientTests {
         private func respond(to request: URLRequest) throws -> (Data, HTTPURLResponse) {
             requestedURLs.append(request.url!)
             requestedHeaders.append(request.allHTTPHeaderFields ?? [:])
+            requestedTimeouts.append(request.timeoutInterval)
             if let bodyData = request.httpBody,
                let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any] {
                 requestedBodies.append(json)
@@ -142,6 +144,7 @@ struct CommunityMembershipClientTests {
         #expect(body?["actor"] as? String == "https://example.com/users/site")
         let headers = await fake.requestedHeaders.first
         #expect(headers?["Authorization"] == "Bearer secret-token")
+        #expect(await fake.requestedTimeouts.first == ActorProfileFetcher.timeout)
     }
 
     @Test("acceptFollow maps a non-2xx status to requestFailed")
@@ -166,6 +169,7 @@ struct CommunityMembershipClientTests {
         #expect(await fake.requestedURLs.first?.absoluteString == "https://example.com/users/site/follow_requests")
         let headers = await fake.requestedHeaders.first
         #expect(headers?["Authorization"] == "Bearer secret-token")
+        #expect(await fake.requestedTimeouts.first == ActorProfileFetcher.timeout)
     }
 
     @Test("listFollowRequests returns an empty list when there are none")

--- a/docs/superpowers/plans/2026-08-12-community-approval-queue.md
+++ b/docs/superpowers/plans/2026-08-12-community-approval-queue.md
@@ -1,0 +1,596 @@
+# Community Approval Queue (V-5.3 slice) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a community owner see who is waiting to join their hosted `Group` and approve them from the Moderation pane — the approval-queue slice of #370 that design-doc decision D4 deferred pending an upstream listing endpoint, which has since shipped (`davidwkeith/workers` PR #488, closing workers#487).
+
+**Architecture:** `CommunityMembershipClient` (`AnglesiteCore`) gets two new methods mirroring its existing `follow`/`remove` shape exactly: `listFollowRequests()` (bearer-`GET` `<actor>/follow_requests`, decodes the Worker's flat `{items, total}` JSON) and `acceptFollow(target:)` (bearer-`POST` an `Accept` activity to the outbox, same shape as `remove(target:)` but `type: "Accept"`). `ModerationModel` (`AnglesiteApp`) fetches the pending list on every `reload()` and exposes an `approve(_:)` action; `ModerationView` renders a new "Requests" section between Moderators and Members.
+
+**Tech Stack:** Swift 6.4, Swift Testing, `URLSession`/`URLRequest` via the existing `CommunityMembershipClient.Transport` test seam, SwiftUI.
+
+## Global Constraints
+
+- The `davidwkeith/workers` route this consumes (`GET <actor>/follow_requests`) merged in workers PR #488 **after** the latest tagged release (`dwk-server-v1.0.0-beta.3`, cut 2026-08-10T18:28:14Z; the PR merged 2026-08-10T21:37:47Z). Per `CONTRIBUTING.md` ▸ "`@dwk/workers` catalog coordination": keep this feature backward-compatible and inert-safe until a newer tagged release ships — a 404/error from `listFollowRequests()` must **never** surface a blocking error to the owner; it must fail silently to an empty list, exactly like `ModerationModel.decodeAll`'s "a bad read must never make the pane unusable" philosophy already in this file.
+- `acceptFollow(target:)`'s underlying `Accept`-via-outbox routing already shipped in beta.3 (workers#473, closed 2026-07-31) — this half is *not* pending-release and works today.
+- Match existing code conventions exactly: doc-comment style (see `docs/comment-style-guide.md` if unsure), `Sendable`/`Equatable` on public model types, Swift Testing (`@Test`, `#expect`, `#require`) — not XCTest — for every new test in these two files.
+- No confirmation dialog for "Approve" — unlike ban/remove, admitting a member is not destructive (a bad admit is reversible via the existing Ban action), so this mirrors `addModerator`'s no-confirmation precedent, not `ban`/`removePost`'s confirmation-dialog one.
+- Run `swift test --package-path .` after each task and confirm the new tests plus the full existing suite pass before committing.
+
+---
+
+### Task 1: `PendingFollower` model + `CommunityMembershipClient` GET/Accept methods
+
+**Files:**
+- Create: `Sources/AnglesiteCore/PendingFollower.swift`
+- Modify: `Sources/AnglesiteCore/CommunityMembershipClient.swift`
+- Test: `Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift`
+
+**Interfaces:**
+- Produces: `public struct PendingFollower: Sendable, Equatable, Identifiable` with `actor: URL`, `addedAt: Date`, `id: URL { actor }`, `public init(actor: URL, addedAt: Date)`.
+- Produces: `CommunityMembershipClient.acceptFollow(target: URL) async throws` (mirrors `remove(target:)`).
+- Produces: `CommunityMembershipClient.listFollowRequests() async throws -> [PendingFollower]`.
+- Consumes: nothing new from outside this task — `CommunityMembershipError`, `Transport` already exist in the file.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these four tests to the end of `Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift`, just before the suite's closing `}` (after `removeMapsNon2xx`):
+
+```swift
+    @Test("POSTs an Accept activity to this site's own outbox")
+    func postsAccept() async throws {
+        let fake = FakeTransport()
+        let target = try #require(URL(string: "https://lemmy.ml/u/newmember"))
+
+        try await Self.client(fake).acceptFollow(target: target)
+
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Accept")
+        #expect(body?["object"] as? String == "https://lemmy.ml/u/newmember")
+        #expect(body?["actor"] as? String == "https://example.com/users/site")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+    }
+
+    @Test("acceptFollow maps a non-2xx status to requestFailed")
+    func acceptMapsNon2xx() async throws {
+        let fake = FakeTransport(status: 403, body: "forbidden")
+        let target = try #require(URL(string: "https://lemmy.ml/u/newmember"))
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 403, body: "forbidden")) {
+            try await Self.client(fake).acceptFollow(target: target)
+        }
+    }
+
+    @Test("GETs pending follow requests from this site's own actor endpoint")
+    func listsFollowRequests() async throws {
+        let fake = FakeTransport(
+            status: 200,
+            body: #"{"items":[{"actor":"https://lemmy.ml/u/newmember","addedAt":"2026-08-10T18:28:14.000Z"}],"total":1}"#)
+
+        let requests = try await Self.client(fake).listFollowRequests()
+
+        #expect(requests.count == 1)
+        #expect(requests.first?.actor.absoluteString == "https://lemmy.ml/u/newmember")
+        #expect(await fake.requestedURLs.first?.absoluteString == "https://example.com/users/site/follow_requests")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+    }
+
+    @Test("listFollowRequests returns an empty list when there are none")
+    func listsEmptyFollowRequests() async throws {
+        let fake = FakeTransport(status: 200, body: #"{"items":[],"total":0}"#)
+        let requests = try await Self.client(fake).listFollowRequests()
+        #expect(requests.isEmpty)
+    }
+
+    @Test("listFollowRequests maps a non-2xx status to requestFailed")
+    func listFollowRequestsMapsNon2xx() async throws {
+        let fake = FakeTransport(status: 404, body: "Not Found")
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 404, body: "Not Found")) {
+            _ = try await Self.client(fake).listFollowRequests()
+        }
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter CommunityMembershipClientTests`
+Expected: FAIL to compile — `acceptFollow`/`listFollowRequests` don't exist yet on `CommunityMembershipClient`.
+
+- [ ] **Step 3: Create `PendingFollower`**
+
+Create `Sources/AnglesiteCore/PendingFollower.swift`:
+
+```swift
+// Sources/AnglesiteCore/PendingFollower.swift
+import Foundation
+
+/// One pending join request against this site's hosted `Group` actor: someone who sent a
+/// `Follow` while the actor requires manual approval, awaiting the owner's `Accept`/`Reject`
+/// (`davidwkeith/workers` PR #488's bearer-gated `GET <actor>/follow_requests`, closing
+/// workers#487 — see
+/// `docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md` §6).
+///
+/// Transient: fetched live from this site's own Worker on every `ModerationModel.reload()`,
+/// never written to `Source/` git — unlike ``CommunityMember``/`AnnouncedPost`, which snapshot
+/// *confirmed* state, this is a live read of state the Worker alone owns.
+public struct PendingFollower: Sendable, Equatable, Identifiable {
+    /// The requester's own actor IRI — also this struct's ``id``, since it's the unique key
+    /// the Worker itself uses (`followers.actor`).
+    public let actor: URL
+    /// When the `Follow` was recorded, decoded from the Worker's ISO 8601 `addedAt` string.
+    public let addedAt: Date
+
+    public var id: URL { actor }
+
+    public init(actor: URL, addedAt: Date) {
+        self.actor = actor
+        self.addedAt = addedAt
+    }
+}
+```
+
+- [ ] **Step 4: Add the GET/Accept methods to `CommunityMembershipClient`**
+
+In `Sources/AnglesiteCore/CommunityMembershipClient.swift`, replace the `remove(target:)` method through the end of the `post(_:)` method (i.e. replace this exact block):
+
+```swift
+    public func remove(target: URL) async throws {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Remove",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        _ = try await post(body)
+    }
+
+    private func post(_ activity: [String: Any]) async throws -> Data {
+        var request = URLRequest(url: outboxURL)
+        request.httpMethod = "POST"
+        request.setValue("application/activity+json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: activity)
+
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw CommunityMembershipError.requestFailed(status: 0, body: "\(error)")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunityMembershipError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        return data
+    }
+```
+
+with:
+
+```swift
+    public func remove(target: URL) async throws {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Remove",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        _ = try await post(body)
+    }
+
+    /// Confirms a pending join request — the owner-triggered half of workers#473's `Accept`
+    /// routing, which already ships in `dwk-server-v1.0.0-beta.3`. Same shorthand `object` shape
+    /// as ``remove(target:)``: a bare actor IRI, which the Worker's `#singleFollowTarget` resolves
+    /// against the stored `Follow` row.
+    public func acceptFollow(target: URL) async throws {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Accept",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        _ = try await post(body)
+    }
+
+    /// Lists everyone whose `Follow` is awaiting this owner's `Accept` — the bearer-gated
+    /// `GET <actor>/follow_requests` `davidwkeith/workers` PR #488 added (closing workers#487),
+    /// mirroring `GET <actor>/blocked`'s unpaged flat `{items, total}` JSON exactly. **Not yet in
+    /// a tagged `@dwk/workers` release** as of `dwk-server-v1.0.0-beta.3` — callers must treat a
+    /// failure here (most likely a 404 from a not-yet-updated deployed Worker) as "nothing
+    /// pending", never as a user-facing error; see `ModerationModel.loadPendingFollowers()`.
+    public func listFollowRequests() async throws -> [PendingFollower] {
+        var request = URLRequest(url: ownActorURL.appendingPathComponent("follow_requests"))
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
+        let data = try await send(request)
+        return Self.decodeFollowRequests(data)
+    }
+
+    /// Decodes the Worker's `{items: [{actor, addedAt}], total}` response. A malformed body, or
+    /// an item whose `addedAt` doesn't parse as ISO 8601 (with or without fractional seconds —
+    /// `Date.toISOString()` always emits `.000`-style milliseconds, which the plain
+    /// `ISO8601DateFormatter()` default options reject), is dropped rather than failing the whole
+    /// call — same "a bad item never blocks the good ones" rule ``ModerationModel``'s snapshot
+    /// decoding already follows.
+    private static func decodeFollowRequests(_ data: Data) -> [PendingFollower] {
+        struct Response: Decodable {
+            struct Item: Decodable { let actor: URL; let addedAt: String }
+            let items: [Item]
+        }
+        guard let response = try? JSONDecoder().decode(Response.self, from: data) else { return [] }
+        let withFractional: ISO8601DateFormatter = {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }()
+        let plain = ISO8601DateFormatter()
+        return response.items.compactMap { item in
+            guard let date = withFractional.date(from: item.addedAt) ?? plain.date(from: item.addedAt) else {
+                return nil
+            }
+            return PendingFollower(actor: item.actor, addedAt: date)
+        }
+    }
+
+    /// Shared POST/GET status handling: maps a transport error or non-2xx response to
+    /// ``CommunityMembershipError/requestFailed(status:body:)``, otherwise returns the raw body.
+    /// Factored out of `post(_:)` so ``listFollowRequests()``'s GET reuses the exact same mapping
+    /// instead of duplicating it.
+    private func send(_ request: URLRequest) async throws -> Data {
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw CommunityMembershipError.requestFailed(status: 0, body: "\(error)")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw CommunityMembershipError.requestFailed(
+                status: http.statusCode, body: String(decoding: data.prefix(400), as: UTF8.self))
+        }
+        return data
+    }
+
+    private func post(_ activity: [String: Any]) async throws -> Data {
+        var request = URLRequest(url: outboxURL)
+        request.httpMethod = "POST"
+        request.setValue("application/activity+json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(publishToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: activity)
+        return try await send(request)
+    }
+```
+
+Note this also changes `CommunityMembershipError.decodingFailed`'s doc comment from "currently unused" to reflect it's still unused (decode failures here fall back to `[]`, not to that case) — leave the enum case and its doc comment as-is; `decodeFollowRequests` intentionally doesn't throw it, per the "never surface a blocking error for this" global constraint.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter CommunityMembershipClientTests`
+Expected: PASS — all tests in the suite, including the 5 pre-existing ones and the 5 new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/PendingFollower.swift Sources/AnglesiteCore/CommunityMembershipClient.swift Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+git commit -m "feat(#370): add follow-request listing + accept to CommunityMembershipClient"
+```
+
+---
+
+### Task 2: Wire the approval queue into `ModerationModel` + `ModerationView`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/ModerationModel.swift`
+- Modify: `Sources/AnglesiteApp/ModerationView.swift`
+- Test: `Tests/AnglesiteAppTests/ModerationModelTests.swift`
+
+**Interfaces:**
+- Consumes: `PendingFollower` (Task 1, `actor: URL`, `addedAt: Date`, `id: URL`), `CommunityMembershipClient.listFollowRequests() async throws -> [PendingFollower]`, `CommunityMembershipClient.acceptFollow(target: URL) async throws` (Task 1).
+- Produces: `ModerationModel.pendingFollowers: [PendingFollower]` (read-only, published), `ModerationModel.approve(_ follower: PendingFollower) async` (non-throwing, sets `errorMessage` on failure — the view calls this directly, no confirmation state needed).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these three tests to `Tests/AnglesiteAppTests/ModerationModelTests.swift`, just before the suite's closing `}` (after `addModeratorRejectsInvalidURL`):
+
+```swift
+    @Test("reload fetches pending follow requests from this site's own actor")
+    func reloadLoadsPendingFollowRequests() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            if request.url?.lastPathComponent == "follow_requests" {
+                let http = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (
+                    Data(
+                        #"{"items":[{"actor":"https://lemmy.ml/u/newmember","addedAt":"2026-08-10T18:28:14.000Z"}],"total":1}"#
+                            .utf8), http
+                )
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        #expect(model.pendingFollowers.count == 1)
+        #expect(model.pendingFollowers.first?.actor.absoluteString == "https://lemmy.ml/u/newmember")
+    }
+
+    /// The upstream listing endpoint (`davidwkeith/workers` PR #488) postdates the latest tagged
+    /// `@dwk/workers` release as of this writing (see the plan's Global Constraints) — a deployed
+    /// community's Worker will 404 on this route until it redeploys against a newer release. That
+    /// must degrade to an empty list, never a blocking alert.
+    @Test("a 404 from follow_requests leaves pendingFollowers empty without surfacing an error")
+    func reloadIgnoresFollowRequests404() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            let http = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+            return (Data("Not Found".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+
+        #expect(model.pendingFollowers.isEmpty)
+        #expect(model.errorMessage == nil)
+    }
+
+    @Test("approving a follower POSTs Accept and drops them from the pending list")
+    func approveAcceptsAndRemovesFromPendingList() async throws {
+        let (config, source) = try Self.makeSiteDirectories()
+        defer { try? FileManager.default.removeItem(at: config.deletingLastPathComponent()) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        actor Recorder {
+            private(set) var bodies: [[String: Any]] = []
+            func record(_ body: [String: Any]) { bodies.append(body) }
+        }
+        let recorder = Recorder()
+
+        let model = ModerationModel(secretStore: secretStore, membershipTransport: { request in
+            if request.url?.lastPathComponent == "follow_requests" {
+                let http = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (
+                    Data(
+                        #"{"items":[{"actor":"https://lemmy.ml/u/newmember","addedAt":"2026-08-10T18:28:14.000Z"}],"total":1}"#
+                            .utf8), http
+                )
+            }
+            if let data = request.httpBody, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                await recorder.record(json)
+            }
+            let http = HTTPURLResponse(url: request.url!, statusCode: 202, httpVersion: nil, headerFields: nil)!
+            return (Data("{}".utf8), http)
+        })
+        await model.configure(site: Self.site(configDirectory: config, sourceDirectory: source))
+        #expect(model.pendingFollowers.count == 1)
+
+        await model.approve(model.pendingFollowers[0])
+
+        let body = await recorder.bodies.first
+        #expect(body?["type"] as? String == "Accept")
+        #expect(body?["object"] as? String == "https://lemmy.ml/u/newmember")
+        #expect(model.pendingFollowers.isEmpty)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter ModerationModelTests`
+Expected: FAIL to compile — `pendingFollowers`/`approve(_:)` don't exist yet on `ModerationModel`.
+
+- [ ] **Step 3: Add `pendingFollowers` state and loading to `ModerationModel`**
+
+In `Sources/AnglesiteApp/ModerationModel.swift`, replace:
+
+```swift
+    private(set) var members: [CommunityMember] = []
+    private(set) var posts: [AnnouncedPost] = []
+    private(set) var moderators: [String] = []
+```
+
+with:
+
+```swift
+    private(set) var members: [CommunityMember] = []
+    private(set) var posts: [AnnouncedPost] = []
+    private(set) var moderators: [String] = []
+    private(set) var pendingFollowers: [PendingFollower] = []
+```
+
+Then replace:
+
+```swift
+    func reload() async {
+        guard let sourceDirectory, let configDirectory else { return }
+        let settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+        async let loadedMembers = Self.decodeAll(
+            CommunityMember.self, from: sourceDirectory.appendingPathComponent("data/community-members"))
+        async let loadedPosts = Self.decodeAll(
+            AnnouncedPost.self, from: sourceDirectory.appendingPathComponent("data/community-posts"))
+        moderators = settings.moderators ?? []
+        members = await loadedMembers
+        posts = await loadedPosts
+    }
+```
+
+with:
+
+```swift
+    func reload() async {
+        guard let sourceDirectory, let configDirectory else { return }
+        let settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+        async let loadedMembers = Self.decodeAll(
+            CommunityMember.self, from: sourceDirectory.appendingPathComponent("data/community-members"))
+        async let loadedPosts = Self.decodeAll(
+            AnnouncedPost.self, from: sourceDirectory.appendingPathComponent("data/community-posts"))
+        moderators = settings.moderators ?? []
+        members = await loadedMembers
+        posts = await loadedPosts
+        pendingFollowers = await loadPendingFollowers()
+    }
+
+    /// Fetches pending join requests from this site's own Worker
+    /// (`CommunityMembershipClient.listFollowRequests()`). Fails silently to an empty list — same
+    /// "a bad read must never make the pane unusable" philosophy ``decodeAll(_:from:)`` follows for
+    /// member/post snapshots — because the underlying `GET <actor>/follow_requests` route
+    /// (`davidwkeith/workers` PR #488) postdates the latest tagged `@dwk/workers` release as of
+    /// this writing: a deployed community's Worker will 404 until it redeploys against a newer
+    /// one, and that expected 404 must never pop a blocking alert on every pane open. No-ops
+    /// (returns `[]`) until `ownActorURL`/`publishToken` are both available, same guard
+    /// ``ban(_:)``/``removePost(_:)`` use.
+    private func loadPendingFollowers() async -> [PendingFollower] {
+        guard let ownActorURL, let publishToken else { return [] }
+        let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+        return (try? await client.listFollowRequests()) ?? []
+    }
+```
+
+Then, after the `confirmBan()` method and before `func removePost(...)`, insert the `approve` action (this keeps membership-related actions — ban, approve — grouped together, ahead of the post-removal actions):
+
+Replace:
+
+```swift
+    func confirmBan() async {
+        guard let member = banConfirmation else { return }
+        banConfirmation = nil
+        do { try await ban(member) }
+        catch { errorMessage = "Couldn't ban \(member.name ?? member.actorURL.absoluteString): \(error.localizedDescription)" }
+    }
+
+    func removePost(_ post: AnnouncedPost) async throws {
+```
+
+with:
+
+```swift
+    func confirmBan() async {
+        guard let member = banConfirmation else { return }
+        banConfirmation = nil
+        do { try await ban(member) }
+        catch { errorMessage = "Couldn't ban \(member.name ?? member.actorURL.absoluteString): \(error.localizedDescription)" }
+    }
+
+    /// Confirms a pending join request. No confirmation dialog (unlike ``ban(_:)``/
+    /// ``removePost(_:)``) — admitting a member isn't destructive; a bad admit is reversible via
+    /// the existing ``ban(_:)`` action, so this mirrors ``addModerator(_:)``'s no-confirmation
+    /// precedent.
+    func approve(_ follower: PendingFollower) async {
+        guard let ownActorURL, let publishToken else {
+            errorMessage = "This site has no known public URL yet — deploy it at least once first."
+            return
+        }
+        let client = CommunityMembershipClient(ownActorURL: ownActorURL, publishToken: publishToken, transport: membershipTransport)
+        do {
+            try await client.acceptFollow(target: follower.actor)
+            pendingFollowers.removeAll { $0.id == follower.id }
+        } catch {
+            errorMessage = "Couldn't approve \(follower.actor.absoluteString): \(error.localizedDescription)"
+        }
+    }
+
+    func removePost(_ post: AnnouncedPost) async throws {
+```
+
+Finally, update the file's top doc comment — replace:
+
+```swift
+/// Backs the Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderator-list
+/// display, and ban/remove actions over this site's own `CommunityMember`/`AnnouncedPost`
+/// snapshot files. App glue only, mirroring `CommunitiesModel`'s shape — protocol logic
+/// (`Remove`) lives in `AnglesiteCore`'s `CommunityMembershipClient`. Approval-queue and
+/// report-review are explicitly out of scope (design doc D4/D5) — no state for either here.
+```
+
+with:
+
+```swift
+/// Backs the Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderator-list
+/// display, ban/remove actions over this site's own `CommunityMember`/`AnnouncedPost` snapshot
+/// files, and the approval queue (design doc D4, unblocked by `davidwkeith/workers` PR #488).
+/// App glue only, mirroring `CommunitiesModel`'s shape — protocol logic (`Remove`/`Accept`/the
+/// `follow_requests` listing) lives in `AnglesiteCore`'s `CommunityMembershipClient`.
+/// Report-review remains explicitly out of scope (design doc D5) — no state for it here.
+```
+
+- [ ] **Step 4: Add the "Requests" section to `ModerationView`**
+
+In `Sources/AnglesiteApp/ModerationView.swift`, replace:
+
+```swift
+            Section("Members") {
+                ForEach(moderation.members) { member in
+```
+
+with:
+
+```swift
+            Section("Requests") {
+                if moderation.pendingFollowers.isEmpty {
+                    Text("No pending requests.").foregroundStyle(.secondary)
+                } else {
+                    ForEach(moderation.pendingFollowers) { follower in
+                        HStack {
+                            Text(follower.actor.absoluteString)
+                            Spacer()
+                            Button("Approve") { Task { await moderation.approve(follower) } }
+                        }
+                    }
+                }
+            }
+            Section("Members") {
+                ForEach(moderation.members) { member in
+```
+
+Then update the file's top doc comment — replace:
+
+```swift
+/// The Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderators, members
+/// (with ban), posts (with remove), and an inert reports placeholder (D5 — no report-handling
+/// exists upstream yet).
+```
+
+with:
+
+```swift
+/// The Moderation section (V-5.1b/V-5.3, #907/#370, design doc §5): moderators, an approval
+/// queue for pending join requests, members (with ban), posts (with remove), and an inert
+/// reports placeholder (D5 — no report-handling exists upstream yet).
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter ModerationModelTests`
+Expected: PASS — all tests in the suite, including the 4 pre-existing ones and the 3 new ones.
+
+Then run the full suite to confirm nothing else broke:
+
+Run: `swift test --package-path .`
+Expected: PASS — all suites (390+ tests as of this writing).
+
+- [ ] **Step 6: Build the app target**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: clean build (`ModerationView.swift` is an app-target file `swift test` alone doesn't compile).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ModerationModel.swift Sources/AnglesiteApp/ModerationView.swift Tests/AnglesiteAppTests/ModerationModelTests.swift
+git commit -m "feat(#370): surface pending join requests in the Moderation pane"
+```
+
+---
+
+## After both tasks: update the tracking issue
+
+This closes the approval-queue slice of #370, leaving only report-review (D5, no upstream primitive at all) open. Before opening the PR:
+
+- [ ] Update `docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md` D4's row to note it shipped, referencing this plan.
+- [ ] In the PR body's Paired PR check section, note (per `CONTRIBUTING.md` ▸ "`@dwk/workers` catalog coordination"): this consumes `davidwkeith/workers` PR #488 (`GET <actor>/follow_requests`), which has **not shipped in a tagged release yet** as of `dwk-server-v1.0.0-beta.3` — the feature is safe to merge now (fails inert-empty until the release ships and existing communities redeploy against it), but flag it so a human tracks when to consider #370 fully scoped down to just report-review.
+- [ ] Do **not** close #370 or #339 in this PR — report-review (D5) still has no upstream primitive, so #370 stays open and #339 stays blocked on it. Leave a comment on #370 narrowing its remaining scope to report-review only, referencing this PR.

--- a/docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md
+++ b/docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md
@@ -38,7 +38,7 @@ still show more than this closes — see §6.
 | D1 | Phasing | Three stacked PRs: creation flow → deploy wiring → moderator UI. Each independently mergeable/testable. |
 | D2 | Creation entry point | A **separate `File ▸ New Community…` flow** (`NewCommunityWizardModel`/`NewCommunityWizard`), not a card in the existing single-question theme chooser (#1071). A hosted community is a different site kind (own Worker, own Group actor, moderators) — not a cosmetic theme pick. |
 | D3 | Community wizard scope | **Name only.** No moderator field: per workers#473/PR#476, the owner is implicitly the top moderator of their own actor via the existing bearer `publishToken` — no `config.moderators` membership needed. `SiteSettings.moderators` is for *delegating* to additional actors beyond the owner, which belongs in the Phase 3 Moderators UI (§5), not the creation wizard. No theme step either — one consistent look for v1. |
-| D4 | Approval-queue (pending joins) | **Deferred.** Listing pending followers is only reachable via the OAuth-gated Mastodon-API `follow_requests` surface (§3.3) — the app has no OAuth client against a site's own Mastodon-API today. File an upstream follow-up (§5) instead of building a new OAuth flow now. Remove/ban ship in this design; approve does not. |
+| D4 | Approval-queue (pending joins) | **Deferred.** Listing pending followers is only reachable via the OAuth-gated Mastodon-API `follow_requests` surface (§3.3) — the app has no OAuth client against a site's own Mastodon-API today. File an upstream follow-up (§5) instead of building a new OAuth flow now. Remove/ban ship in this design; approve does not. **Update (2026-08-12):** the upstream follow-up shipped (`davidwkeith/workers` PR #488, closing workers#487) and approve now ships too — see `docs/superpowers/plans/2026-08-12-community-approval-queue.md`. |
 | D5 | Report queue | **Inert placeholder section** in the Moderation UI. No `Flag`-activity handling exists anywhere upstream (confirmed via repo-wide + upstream search) — this needs a new upstream primitive from scratch, out of scope here. The UI ships the section now so the layout doesn't reshape when report-handling eventually lands. |
 
 ## 3. Phase 1 — New Community creation flow
@@ -110,7 +110,10 @@ still show more than this closes — see §6.
   is deliberately not added here: D4 defers the entire approval queue, and
   an unused Accept method would be speculative against nothing that calls
   it. It belongs in whatever phase eventually builds the approval queue
-  after §6's upstream follow-up lands.
+  after §6's upstream follow-up lands. That phase landed 2026-08-12
+  (`docs/superpowers/plans/2026-08-12-community-approval-queue.md`) —
+  `acceptFollow(target:)` was added to `CommunityMembershipClient` and wired
+  into `ModerationModel`/`ModerationView`'s new "Requests" section.
 - **Gating:** new `case moderation` in `MainPaneMode`
   (`SiteWindowModel.swift`), `presentModeration()` mirroring
   `presentCommunities()` (lines 429-437), a `Button("Moderation…")` in
@@ -131,7 +134,9 @@ still show more than this closes — see §6.
      for deletions).
   4. **Reports** — inert placeholder, "No report handling yet" empty state,
      no data source (D5).
-- **Explicitly not in this phase:** approval-queue UI (D4).
+- **Explicitly not in this phase:** approval-queue UI (D4, shipped 2026-08-12
+  in a later phase — see
+  `docs/superpowers/plans/2026-08-12-community-approval-queue.md`).
 
 ## 6. Upstream follow-up to file
 
@@ -165,8 +170,9 @@ referenced from the #907 issue the way workers#473 was.
 
 This design closes remove-post and ban-member — the two moderation actions
 that were actually reachable once workers#473 shipped. #370's original scope
-(report review, approval queue) remains blocked on the two gaps this doc
-identifies and defers: report/Flag handling doesn't exist upstream at all
-(D5), and the approval-queue listing endpoint needs the follow-up filed in
-§6. #370 should stay open, scoped down to those two remaining pieces, rather
-than being closed by this work.
+also included report review and the approval queue; the approval queue
+shipped 2026-08-12 (`docs/superpowers/plans/2026-08-12-community-approval-queue.md`),
+once the follow-up filed in §6 landed upstream. Only report review (D5)
+remains blocked — report/Flag handling doesn't exist upstream at all. #370
+should stay open, scoped down to that one remaining piece, rather than being
+closed by this work.


### PR DESCRIPTION
## Summary

- Adds the approval-queue slice of #370 (V-5.3 hosted-community moderation, part of the #339 V-5 epic): a community owner can now see who is waiting to join their hosted ActivityPub `Group` actor and approve them from the Moderation pane's new "Requests" section — previously only ban/remove/moderator-management existed (#1402).
- `CommunityMembershipClient` (`AnglesiteCore`) gains `listFollowRequests()` (bearer-`GET` `<actor>/follow_requests`, decodes the Worker's `{items, total}` JSON) and `acceptFollow(target:)` (bearer-`POST` an `Accept` activity, mirroring the existing `remove(target:)`).
- `ModerationModel`/`ModerationView` wire these in: `reload()` fetches the pending list on every pane open and fails silently to empty on error (see Paired PR check below), and approving is a single click with no confirmation dialog — unlike ban/remove, admitting a member isn't destructive.
- Design doc `docs/superpowers/specs/2026-08-10-hosted-community-provisioning-moderation-design.md` updated (D4, §5, §8) to reflect this shipped; implementation plan at `docs/superpowers/plans/2026-08-12-community-approval-queue.md`.

This does **not** close #370 or #339 — #370's other remaining piece (report review / inbound `Flag` activities) has no upstream primitive at all yet, so it stays open, now scoped down to just that.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP message schema change. Consumes a `davidwkeith/workers` HTTP endpoint instead (`GET <actor>/follow_requests`, PR [davidwkeith/workers#488](https://github.com/davidwkeith/workers/pull/488), closing workers#487) — flagging per the spirit of `CONTRIBUTING.md` ▸ "`@dwk/workers` catalog coordination": **that route has not shipped in a tagged `@dwk/workers` release yet** (latest tag `dwk-server-v1.0.0-beta.3` predates the merge by a few hours). The feature is safe to merge now — a deployed community's Worker will 404 until it redeploys against a newer release, and `listFollowRequests()`'s failure is required to degrade silently to an empty list (tested), never a blocking alert. `acceptFollow(target:)`'s underlying `Accept`-via-outbox routing already ships today (workers#473, in beta.3).

## Test plan

- [x] `swift test --package-path .` — 459/459 passing, 63 suites
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — clean build
- [ ] Manual smoke — not run (headless environment); covered by unit/integration tests against stubbed transports (`CommunityMembershipClientTests`, `ModerationModelTests`) instead, including a silent-404 case and a loud-on-explicit-approve-failure case.

## Design notes

Built with subagent-driven development: two independently-reviewed tasks (client methods, then UI wiring), each with a fix round, plus a final whole-branch review that caught 4 Important findings — a missing request timeout on the new GET (it sat on two previously-local-only, UI-blocking paths), two doc comments left stale ("No network I/O" / "from disk"), the design doc not yet reflecting the shipped state, and the plan file itself being untracked — all fixed in one follow-up commit and re-verified.