### PR TITLE
fix(#1423): make Edit ▸ Delete's onDeleteCommand exclusive

### DIFF
--- a/Sources/AnglesiteApp/FocusedSite.swift
+++ b/Sources/AnglesiteApp/FocusedSite.swift
@@ -22,10 +22,13 @@ struct NewContentActions {
 /// branch always reports `publish`/`unpublish` nil, having no equivalent) — that's what lets the
 /// Edit-menu items enable/disable correctly without the menu needing to know either surface's
 /// internals. Delete has no field here (#989) — it's driven entirely by `SiteNavigatorView`'s
-/// `.onDeleteCommand` / the canvas's own `.onDeleteCommand` (`SiteWindow.previewPane(for:)`),
-/// whichever is reachable through AppKit's responder chain, which is also what AppKit's standard
-/// Edit ▸ Delete menu item invokes; a second Commands-level Delete button here would just
-/// re-create the duplicate-item bug.
+/// `.onDeleteCommand` / the canvas's own `.onDeleteCommand` (`SiteWindow.previewPane(for:)`), which
+/// are now mutually exclusive: each is attached only while `WYSIWYGCanvasController
+/// .hasKeyboardFocus` says it should be the live one (#1423), rather than left for AppKit's
+/// responder chain to arbitrate between two simultaneously-attached handlers — that arbitration is
+/// what made the shared Edit ▸ Delete item unreliable once the canvas target (#1225 Task 11)
+/// started coexisting with the Navigator's. A second Commands-level Delete button here would still
+/// just re-create the duplicate-item bug #989 already ruled out.
 struct NavigatorSelectionActions {
     let duplicate: (@MainActor () -> Void)?
     let publish: (@MainActor () -> Void)?
@@ -106,7 +109,8 @@ struct NewContentCommands: Commands {
 /// macOS convention for selection-scoped duplicate/destructive actions — rather than the File
 /// menu. Delete is deliberately not a Commands item here (#989): AppKit's standard Edit ▸ Delete
 /// already appears in this group and is wired to the same action via `SiteNavigatorView`'s /
-/// the canvas's own `.onDeleteCommand`, so a second one just duplicated it with no distinguishing
+/// the canvas's own `.onDeleteCommand` — now mutually exclusive per `NavigatorSelectionActions`'s
+/// doc comment (#1423) — so a second one here would just duplicate it with no distinguishing
 /// label.
 struct NavigatorEditCommands: Commands {
     @FocusedValue(\.navigatorSelectionActions) private var actions

--- a/Sources/AnglesiteApp/PreviewView.swift
+++ b/Sources/AnglesiteApp/PreviewView.swift
@@ -266,3 +266,23 @@ extension View {
         }
     }
 }
+
+/// Attaches `.onDeleteCommand` only while `isActive` (#1423) — `previewPane(for:)`'s canvas delete
+/// target and `SiteNavigatorView`'s Navigator delete target both use this, gated on
+/// `WYSIWYGCanvasController.hasKeyboardFocus` (this sentinel above), so exactly one
+/// `.onDeleteCommand` is ever attached to the window's view tree at a time. Two coexisting
+/// `.onDeleteCommand`s made AppKit's Edit ▸ Delete menu-bridging non-deterministic: sometimes the
+/// item stayed disabled with a valid Navigator selection, sometimes clicking it invoked the
+/// canvas's handler (a silent no-op with no block selected) instead of the Navigator's. Splitting
+/// them back into mutually-exclusive attachment restores the single-handler shape #989 already
+/// validated as reliable, before the canvas target (#1225 Task 11) started coexisting with it.
+extension View {
+    @ViewBuilder
+    func onDeleteCommand(active isActive: Bool, perform action: @escaping () -> Void) -> some View {
+        if isActive {
+            onDeleteCommand(perform: action)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -5,6 +5,12 @@ import AnglesiteCore
 /// changes and either navigates the preview or opens the editor.
 struct SiteNavigatorView: View {
     @Bindable var model: SiteNavigatorModel
+    /// True while the WYSIWYG canvas holds real keyboard focus elsewhere in the window (#1423) —
+    /// while true, this view's `.onDeleteCommand` is withheld so exactly one `.onDeleteCommand` is
+    /// attached to the window's tree at a time. See `SiteWindow.previewPane(for:)`'s matching
+    /// canvas-side gate and `onDeleteCommand(active:perform:)`'s doc comment (`PreviewView.swift`)
+    /// for why two simultaneously-attached handlers made AppKit's Edit ▸ Delete menu unreliable.
+    var canvasHasKeyboardFocus: Bool = false
     var onDeleteRequested: (NavigatorItem) -> Void
     var onDuplicateRequested: (NavigatorItem) -> Void
     var onRepurposeRequested: (NavigatorItem) -> Void
@@ -25,8 +31,10 @@ struct SiteNavigatorView: View {
         // also the ONLY Commands-level wiring for content delete (#989): `.onDeleteCommand` is
         // what AppKit's standard Edit ▸ Delete menu item invokes too, so it doubles as that item's
         // handler — a separate Commands `Button("Delete")` alongside it just renders as a second,
-        // indistinguishable "Delete" row.
-        .onDeleteCommand {
+        // indistinguishable "Delete" row. The `active:` gate (#1423) keeps this the ONLY
+        // `.onDeleteCommand` attached while the canvas has focus — see `canvasHasKeyboardFocus`'s
+        // doc comment above.
+        .onDeleteCommand(active: !canvasHasKeyboardFocus) {
             if let item = model.deletableSelection() {
                 onDeleteRequested(item)
             }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -205,6 +205,7 @@ struct SiteWindow: View {
             if let navigator = model.navigator {
                 SiteNavigatorView(
                     model: navigator,
+                    canvasHasKeyboardFocus: model.preview.wysiwygCanvas?.hasKeyboardFocus == true,
                     onDeleteRequested: { item in
                         contentDeleteTitle = "Delete “\(item.title)”?"
                         model.deleteConfirmation = item
@@ -1078,11 +1079,14 @@ struct SiteWindow: View {
                 onWebViewDismantled: { [preview = model.preview] webView in preview.detachWebView(webView) }
             )
             .wysiwygCanvasFocusTracking(model.preview.wysiwygCanvas)
-            // #1225 Task 11: the canvas's own Delete target, reachable only while the sentinel
-            // above reports real keyboard focus on the canvas — bare Delete otherwise belongs to
-            // `SiteNavigatorView`'s `.onDeleteCommand` (menu-bar IA spec's "one focus-scoped
-            // command" rule; no second Commands-level Delete button).
-            .onDeleteCommand {
+            // #1225 Task 11 / #1423: the canvas's own Delete target — attached only while the
+            // sentinel above reports real keyboard focus on the canvas (menu-bar IA spec's "one
+            // focus-scoped command" rule; no second Commands-level Delete button). The `active:`
+            // gate (not just a nil-selection guard inside the closure) is load-bearing: leaving
+            // this `.onDeleteCommand` attached unconditionally alongside `SiteNavigatorView`'s made
+            // AppKit's Edit ▸ Delete menu-bridging pick between the two non-deterministically — see
+            // `onDeleteCommand(active:perform:)`'s doc comment (`PreviewView.swift`).
+            .onDeleteCommand(active: model.preview.wysiwygCanvas?.hasKeyboardFocus == true) {
                 guard let canvas = model.preview.wysiwygCanvas else { return }
                 Task { await canvas.deleteSelectedBlock() }
             }

--- a/Sources/AnglesiteApp/WYSIWYGCanvasController.swift
+++ b/Sources/AnglesiteApp/WYSIWYGCanvasController.swift
@@ -142,11 +142,15 @@ final class WYSIWYGCanvasController {
         await submit(.insertBlock(parentId: rootParentID, slot: "main", index: model.rootIds.count, newId: newId, block: content))
     }
 
-    /// The canvas's own `.onDeleteCommand` target (#1225 Task 11) — reachable only when the
-    /// canvas holds real keyboard focus (`hasKeyboardFocus`), so AppKit's responder chain decides
-    /// whether a bare Delete keypress reaches this or `SiteNavigatorView`'s `.onDeleteCommand`,
-    /// rather than a second Commands-level Delete button (menu-bar IA spec, same rule as
-    /// `duplicateSelectedBlock()` above). PR1 only supports root-level blocks (see
+    /// The canvas's own `.onDeleteCommand` target (#1225 Task 11) — reachable only when the canvas
+    /// holds real keyboard focus (`hasKeyboardFocus`). `SiteWindow.previewPane(for:)` and
+    /// `SiteNavigatorView` both gate their `.onDeleteCommand` attachment on this flag directly
+    /// (#1423) rather than leaving both permanently attached for AppKit's responder chain to
+    /// arbitrate — that arbitration turned out unreliable for the shared Edit ▸ Delete menu item
+    /// once two `.onDeleteCommand`s coexisted, even though it correctly scopes menu-bar IA's "one
+    /// focus-scoped command" rule for physical keypresses (matching `duplicateSelectedBlock()`
+    /// above, unaffected since Duplicate has no auto-generated menu item to conflict over). PR1
+    /// only supports root-level blocks (see
     /// `duplicateSelectedBlock()`'s doc comment) — `rootIds.firstIndex(of:)` returning `nil` for a
     /// nested block just no-ops, same as `guard let node` above.
     func deleteSelectedBlock() async {


### PR DESCRIPTION
Closes #1423

## Summary

- The WYSIWYG canvas got its own `.onDeleteCommand` in #1225 Task 11 (PR #1400), which started coexisting with `SiteNavigatorView`'s in the same window. SwiftUI's Edit ▸ Delete menu-bridging can't reliably arbitrate between two simultaneously-attached `.onDeleteCommand` handlers — it sometimes left the menu item disabled with a valid Navigator selection, and sometimes fired the canvas's handler (a silent no-op with no block selected) instead of the Navigator's.
- Adds a small `onDeleteCommand(active:perform:)` `View` helper (`PreviewView.swift`) and gates both call sites on `WYSIWYGCanvasController.hasKeyboardFocus`, so exactly one `.onDeleteCommand` is ever attached to the window's tree at a time — restoring the single-handler shape #989 already validated as reliable, before the canvas target started coexisting with it.
- ⌘⌫ and the bare-Delete-keypress path are unchanged (both already reported working reliably in #1423) — this fix is scoped to the menu-item bridging only.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (460 tests, all passing)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`, succeeds with no new warnings)
- [x] Manual smoke: launched a fresh instance of the built app (a new process, so as not to disturb other running dev instances) and drove it via Accessibility/AppleScript UI scripting against the `anglesite-smoke` fixture site. With the Navigator's "Resume" page selected and genuine keyboard focus on the sidebar list, Edit ▸ Delete was reliably **enabled** (previously intermittent) and invoking it opened "Delete "Resume"?" — the correct item, not a no-op. As a negative control, selecting the non-deletable "Album" collection folder and invoking Delete correctly did nothing (no dialog, file untouched) — the item's `enabled` state doesn't distinguish content-vs-non-content rows (a pre-existing `.onDeleteCommand` coarse-enablement characteristic, not something #1423 reported or this fix changes), but the actual delete action stays correctly gated by `SiteNavigatorModel.deletableSelection()`. Could not exercise the WYSIWYG-canvas-focused branch in this environment (needs the local container runtime for the dev server/edit mode, unavailable here) — that path is covered by the same `hasKeyboardFocus` gate and is symmetric to the Navigator path verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)