### PR TITLE
fix(#1429): name the vendor script in NotProvisioned errors

### DIFF
--- a/Sources/AnglesiteContainer/BundledImage.swift
+++ b/Sources/AnglesiteContainer/BundledImage.swift
@@ -194,13 +194,31 @@ public enum BundledImage {
 /// A bundled container artifact failed to resolve — the app was built without the vendored
 /// container resources (see `scripts/vendor-container-image.sh`) and no env override points at a
 /// local copy.
-public enum BundledImageError: Error, Equatable {
+///
+/// `CustomStringConvertible` so `"\(error)"` (how `BundledImage.artifactStatus` records the
+/// missing reason, and thus what `LiveSiteRuntimeFactory` surfaces in the debug pane) names the
+/// vendor script to run instead of the bare case name (#1429): a fresh worktree/clone builds fine
+/// with unvendored `Resources/container-{image,kernel,initfs}/` — `check-container-resources.sh`
+/// only warns in Debug — so this runtime message is often the first, and easiest to miss, signal
+/// a developer gets that provisioning never happened.
+public enum BundledImageError: Error, Equatable, CustomStringConvertible {
     /// The OCI app layout is not vendored and no `ANGLESITE_CONTAINER_IMAGE` override was set.
     case imageLayoutNotProvisioned
     /// The Linux kernel binary is not vendored and no `ANGLESITE_CONTAINER_KERNEL` override was set.
     case kernelNotProvisioned
     /// The vminit initfs is not vendored and no `ANGLESITE_CONTAINER_INITFS` override was set.
     case initfsNotProvisioned
+
+    public var description: String {
+        switch self {
+        case .imageLayoutNotProvisioned:
+            "imageLayoutNotProvisioned (run scripts/vendor-container-image.sh)"
+        case .kernelNotProvisioned:
+            "kernelNotProvisioned (run scripts/vendor-container-kernel.sh)"
+        case .initfsNotProvisioned:
+            "initfsNotProvisioned (run scripts/vendor-container-kernel.sh)"
+        }
+    }
 }
 
 /// Resolution status of all three bundled artifacts the container runtime needs to boot

--- a/Tests/AnglesiteContainerLocalTests/BundledImageTests.swift
+++ b/Tests/AnglesiteContainerLocalTests/BundledImageTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import AnglesiteContainer
+
+/// Pure-logic coverage for `BundledImageError`'s remediation text (#1429). No VM boot or
+/// entitlement needed — unlike the rest of this target's suites — but it lives here anyway
+/// because `BundledImage`/`BundledImageError` are only visible from AnglesiteContainer, whose
+/// product this target already links.
+struct BundledImageErrorTests {
+    @Test("each NotProvisioned case names the vendor script that fixes it")
+    func describesRemediation() {
+        #expect("\(BundledImageError.imageLayoutNotProvisioned)".contains("scripts/vendor-container-image.sh"))
+        #expect("\(BundledImageError.kernelNotProvisioned)".contains("scripts/vendor-container-kernel.sh"))
+        #expect("\(BundledImageError.initfsNotProvisioned)".contains("scripts/vendor-container-kernel.sh"))
+    }
+
+    @Test("missingDescriptions surfaces the remediation for every unprovisioned artifact")
+    func missingDescriptionsIncludeRemediation() {
+        let report = BundledImageProvisioningReport(
+            image: .missing(reason: "\(BundledImageError.imageLayoutNotProvisioned)"),
+            kernel: .missing(reason: "\(BundledImageError.kernelNotProvisioned)"),
+            initfs: .missing(reason: "\(BundledImageError.initfsNotProvisioned)")
+        )
+        #expect(report.missingDescriptions.count == 3)
+        #expect(report.missingDescriptions.allSatisfy { $0.contains("scripts/vendor-container") })
+    }
+}


### PR DESCRIPTION
Closes #1429

## Summary

- `BundledImageError`'s bare enum-case text (`imageLayoutNotProvisioned`, `kernelNotProvisioned`, `initfsNotProvisioned`) reached the debug pane verbatim, via `"\(error)"` interpolation flowing through `BundledImage.artifactStatus` → `missingDescriptions` → `LiveSiteRuntimeFactory`'s "no host runtime fallback" message.
- A fresh worktree/clone builds fine with unvendored `Resources/container-{image,kernel,initfs}/` (`check-container-resources.sh` only warns for Debug, and that warning is easy to miss in Xcode's issue navigator or CLI build noise) — so this runtime message was often the *first* actionable signal a developer got that provisioning never happened, and it gave no hint what to do about it.
- `BundledImageError` now conforms to `CustomStringConvertible`, naming the exact vendor script (`scripts/vendor-container-image.sh` / `scripts/vendor-container-kernel.sh`) to run for each missing artifact, so the message is actionable instead of a bare case name repeated on every Retry click.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 462 tests / 63 suites pass, including new `BundledImageErrorTests` (`ANGLESITE_CONTAINER_TESTS=1 swift test --filter BundledImageErrorTests`).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — BUILD SUCCEEDED.
- [ ] Manual smoke (if UI-touching): not applicable — this only changes error-message text surfaced in the existing debug pane / failed-runtime UI, no new UI added.