### PR TITLE
fix(#1292): token EditorFocusRegistry's plainText by model identity

### DIFF
--- a/Sources/AnglesiteApp/ComponentEditorView.swift
+++ b/Sources/AnglesiteApp/ComponentEditorView.swift
@@ -108,9 +108,9 @@ struct ComponentEditorView: View {
                 .onChange(of: isSourcePaneFocused) { _, focused in
                     if focused {
                         EditorFocusRegistry.shared.activate(
-                            .plainText(isPresented: $fileEditor.isFindPresented), token: fileEditor.file.id)
+                            .plainText(isPresented: $fileEditor.isFindPresented), token: ObjectIdentifier(fileEditor))
                     } else {
-                        EditorFocusRegistry.shared.resign(token: fileEditor.file.id)
+                        EditorFocusRegistry.shared.resign(token: ObjectIdentifier(fileEditor))
                     }
                 }
                 .onDisappear {
@@ -118,7 +118,7 @@ struct ComponentEditorView: View {
                     // `.id(fileEditor.file.id)` swap on file switch) — unlike the `onChange`
                     // above, it doesn't depend on `@FocusState` teardown ordering (#517 review).
                     // `resign` no-ops if `isSourcePaneFocused`'s own resign already ran.
-                    EditorFocusRegistry.shared.resign(token: fileEditor.file.id)
+                    EditorFocusRegistry.shared.resign(token: ObjectIdentifier(fileEditor))
                 }
         }
     }

--- a/Sources/AnglesiteApp/EditorFocusRegistry.swift
+++ b/Sources/AnglesiteApp/EditorFocusRegistry.swift
@@ -26,6 +26,18 @@ final class Weak<T: AnyObject> {
 /// that view in favor of a bare SwiftUI `TextEditor`, and this case followed it once the Source
 /// pane got the same `.findNavigator` treatment as the plain-text editor rather than an
 /// AppKit-bridged one.
+///
+/// `.plainText`'s payload (`Binding<Bool>`) has no identity of its own, so call sites token
+/// `activate`/`resign` by `ObjectIdentifier` of the owning `FileEditorModel` rather than by the
+/// case's associated value. Earlier revisions tokened by `FileRef.id` (the file's absolute path)
+/// instead — that collided when the same file was focused from two different windows, since both
+/// windows' `activate()` calls would carry the identical path and the guard below would treat the
+/// second as a redundant no-op rather than a different editor taking real focus (#1292). Filing
+/// the issue confirmed the app's `WindowGroup(for:)` dedup (`SiteWindow.swift`) already makes that
+/// specific scenario unreachable through today's UI, but `FileEditorModel` is created fresh per
+/// window per open file (`SiteWindowModel.openFile`) regardless, so tokening by its
+/// `ObjectIdentifier` is the correct fix on its own terms — the registry no longer depends on the
+/// window layer's dedup to stay correct.
 @MainActor @Observable
 final class EditorFocusRegistry {
     static let shared = EditorFocusRegistry()

--- a/Sources/AnglesiteApp/MainPaneEditorView.swift
+++ b/Sources/AnglesiteApp/MainPaneEditorView.swift
@@ -96,9 +96,9 @@ struct MainPaneEditorView: View {
             .onChange(of: isPlainTextEditorFocused) { _, focused in
                 if focused {
                     EditorFocusRegistry.shared.activate(
-                        .plainText(isPresented: $model.isFindPresented), token: model.file.id)
+                        .plainText(isPresented: $model.isFindPresented), token: ObjectIdentifier(model))
                 } else {
-                    EditorFocusRegistry.shared.resign(token: model.file.id)
+                    EditorFocusRegistry.shared.resign(token: ObjectIdentifier(model))
                 }
             }
     }

--- a/Tests/AnglesiteAppTests/EditorFocusRegistryTests.swift
+++ b/Tests/AnglesiteAppTests/EditorFocusRegistryTests.swift
@@ -55,6 +55,34 @@ struct EditorFocusRegistryTests {
         #expect(isPresented == true)
     }
 
+    @Test("plainText activation from a different owning FileEditorModel always takes over (#1292)")
+    func plainTextDisambiguatesByOwnerIdentity() {
+        let registry = EditorFocusRegistry()
+        // Stand-ins for two windows' own `FileEditorModel` instances for the *same* open file —
+        // `MainPaneEditorView`/`ComponentEditorView` token by `ObjectIdentifier(model)`, not by
+        // `FileRef.id`, specifically so that two distinct instances (as two windows would each
+        // own for an identical path) never compare equal here. Before the fix, both call sites
+        // tokened by the shared file path, so the second `activate` below would have compared
+        // equal to the first and been silently dropped.
+        let owners = [NSObject(), NSObject()]
+
+        var presentedA = false
+        let bindingA = Binding(get: { presentedA }, set: { presentedA = $0 })
+        registry.activate(.plainText(isPresented: bindingA), token: ObjectIdentifier(owners[0]))
+
+        var presentedB = false
+        let bindingB = Binding(get: { presentedB }, set: { presentedB = $0 })
+        registry.activate(.plainText(isPresented: bindingB), token: ObjectIdentifier(owners[1]))
+
+        guard case .plainText(let presented) = registry.active else {
+            Issue.record("expected the second window's .plainText activation to be active")
+            return
+        }
+        presented.wrappedValue = true
+        #expect(presentedB == true)
+        #expect(presentedA == false)
+    }
+
     @Test("a deallocated weak reference reads as nil without crashing")
     func weakBoxReflectsDeallocation() {
         var controller: MarkdownEditorController? = MarkdownEditorController()


### PR DESCRIPTION
Closes #1292

## Summary

- `EditorFocusRegistry`'s `.plainText` call sites (`MainPaneEditorView.plainTextEditor`, `ComponentEditorView.sourcePane`) tokened `activate`/`resign` by `FileRef.id` (the file's absolute path) alone, which can't distinguish two windows' separate `FileEditorModel` instances editing the same file — a second window's `activate()` would carry an identical token and the registry's `activeToken != token` guard would silently no-op it, per #1273's review.
- Both call sites now token by `ObjectIdentifier` of the owning `FileEditorModel` instead. `FileEditorModel` is created fresh per window per open file (`SiteWindowModel.openFile`), so its `ObjectIdentifier` already disambiguates by window without the registry needing any window-specific concept.
- Per the issue's first scope item, I confirmed opening the same site in two windows is **not reachable today** — `WindowGroup(for:)` dedupes by the package's stable marker UUID (documented at `SiteWindow.swift`), so `openWindow(value:)` for an already-open site just focuses the existing window. The fix still lands because it's the objectively correct token semantics and doesn't add complexity — the registry shouldn't need to rely on the window layer's dedup to stay correct, and this closes the latent bug for any future code path that opens a second `FileEditorModel` for the same file (e.g. previews, tests, or a future duplicate-window feature).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 463 tests passed, including a new regression test (`plainTextDisambiguatesByOwnerIdentity`) simulating two windows' distinct `FileEditorModel` tokens for the same file.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — build succeeded.
- [ ] Manual smoke: not applicable — the scenario this fixes isn't reachable through the current UI (see Summary), so there's no window flow to click through.