### PR TITLE
fix(#1426): migrate src/lib framework files, exclude pack tooling

### DIFF
--- a/Sources/AnglesiteCore/TemplateScriptsBaseline.swift
+++ b/Sources/AnglesiteCore/TemplateScriptsBaseline.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 /// Reads/writes `Config/template-scripts-baseline.json` — a per-file content-hash snapshot the
-/// scripts/ refresh mechanism (design doc, #1053) uses to tell "stale" apart from "the owner
-/// edited this." App-owned state, never committed to the site's git repo (`Config/` sits outside
-/// `Source/` — see the `.anglesite` package model), mirroring `Config/dependency-baseline.json`'s
-/// placement rationale.
+/// app-owned-file refresh mechanism (design doc, #1053; extended to `src/lib/` by #1426) uses to
+/// tell "stale" apart from "the owner edited this." App-owned state, never committed to the
+/// site's git repo (`Config/` sits outside `Source/` — see the `.anglesite` package model),
+/// mirroring `Config/dependency-baseline.json`'s placement rationale.
 public struct TemplateScriptsBaseline: Codable, Equatable, Sendable {
-    /// The baseline record for one app-owned `scripts/` file: the last reconciled template
-    /// content hash, plus (when set) a divergence the owner already declined.
+    /// The baseline record for one app-owned file (`scripts/` or `src/lib/`): the last reconciled
+    /// template content hash, plus (when set) a divergence the owner already declined.
     public struct Entry: Codable, Equatable, Sendable {
         /// Hash (`VectorMath.stableHash`) of the template content this file was last
         /// successfully reconciled against — at scaffold time, at a prior silent refresh, or

--- a/Sources/AnglesiteCore/TemplateScriptsManifest.swift
+++ b/Sources/AnglesiteCore/TemplateScriptsManifest.swift
@@ -1,36 +1,72 @@
 import Foundation
 
-/// Enumerates the exact set of files `scripts/scaffold.sh`'s `rsync` copies from
-/// `Resources/Template/scripts/` into a scaffolded site — the "app-owned" set this refresh
-/// mechanism keeps current (design doc §Scope). Mirrors `scaffold.sh`'s own exclude list
-/// (`Resources/Template/scripts/scaffold.sh:40-46`) rather than re-parsing the shell script; the
-/// two lists are kept in sync by hand, the same way every other template-path consumer
-/// (`TemplateRuntime`, `ThemeCatalog`) already duplicates path knowledge rather than sharing it
-/// with the shell script.
+/// Enumerates the exact set of files this refresh mechanism keeps current in a site (the
+/// "app-owned" set, design doc §Scope): everything `scripts/scaffold.sh`'s `rsync` copies from
+/// `Resources/Template/scripts/`, plus every file under `Resources/Template/src/lib/` — pure
+/// framework logic (`robots-config.ts`, `rsl.ts`, `licensing.ts`, `embed-card.ts`, etc.) that
+/// several app-owned scripts (`edge-artifacts.ts`, `csp.ts`, `pre-deploy-check.ts`,
+/// `remark-embeds.ts`) import at build time. `src/lib/` is not "site content" the way
+/// `src/data/`, `src/content/`, and `src/pages/` are — no site ever customizes it, and
+/// `scaffold.sh` copies it wholesale with no excludes of its own, so it belongs in the same
+/// app-owned set as `scripts/` rather than behind #745's general "`src/` is out of scope"
+/// boundary (which is about site content, not this directory). Mirrors `scaffold.sh`'s own
+/// exclude list (`Resources/Template/scripts/scaffold.sh:33-43`) rather than re-parsing the shell
+/// script; the two lists are kept in sync by hand, the same way every other template-path
+/// consumer (`TemplateRuntime`, `ThemeCatalog`) already duplicates path knowledge rather than
+/// sharing it with the shell script.
 public enum TemplateScriptsManifest {
     /// Names excluded only when they sit directly inside `scripts/` itself — matches rsync's own
     /// anchoring rules for a pattern containing a slash (`scripts/themes.ts` does not match
     /// `scripts/embeds/themes.ts`). The `.test.ts` suffix exclusion below is applied with the same
     /// top-level-only restriction, deliberately reproducing the anchoring quirk `scaffold.sh` has
     /// today (design doc §Scope) rather than silently fixing it as a side effect of this feature.
-    private static let topLevelExcludedNames: Set<String> = ["scaffold.sh", "themes.ts", "themes.json"]
+    /// `check-pack.ts` and `build-packs.sh` are pack-authoring tooling `scaffold.sh` never ships
+    /// to a site at all (its own exclude list drops both) — this set must match that exactly, or
+    /// this mechanism ships a file into every site whose imports (`./themes`, correctly excluded
+    /// below) were never migrated alongside it.
+    private static let scriptsTopLevelExcludedNames: Set<String> = [
+        "scaffold.sh", "themes.ts", "themes.json", "check-pack.ts", "build-packs.sh",
+    ]
 
-    /// Relative paths (e.g. `"scripts/pre-deploy-check.ts"`, `"scripts/embeds/adapters.ts"`),
-    /// sorted for deterministic iteration order. Returns `[]` if `templateRoot/scripts` doesn't
-    /// exist or can't be enumerated.
+    /// Relative paths (e.g. `"scripts/pre-deploy-check.ts"`, `"scripts/embeds/adapters.ts"`,
+    /// `"src/lib/robots-config.ts"`), sorted for deterministic iteration order. Returns `[]` if
+    /// neither `templateRoot/scripts` nor `templateRoot/src/lib` exists or can be enumerated.
     public static func appOwnedRelativePaths(templateRoot: URL) -> [String] {
-        let scriptsRoot = templateRoot.appendingPathComponent("scripts")
+        var results = enumerate(
+            root: templateRoot.appendingPathComponent("scripts"),
+            relativePrefix: "scripts",
+            topLevelExcludedNames: scriptsTopLevelExcludedNames,
+            excludeTopLevelTestFiles: true
+        )
+        // `scaffold.sh` has no `src/lib/*` excludes at all (not even `.test.ts` files — those are
+        // shipped and run as part of every site's own `npm test`), so nothing is excluded here
+        // beyond `.DS_Store`.
+        results += enumerate(
+            root: templateRoot.appendingPathComponent("src/lib"),
+            relativePrefix: "src/lib",
+            topLevelExcludedNames: [],
+            excludeTopLevelTestFiles: false
+        )
+        return results.sorted()
+    }
+
+    private static func enumerate(
+        root: URL,
+        relativePrefix: String,
+        topLevelExcludedNames: Set<String>,
+        excludeTopLevelTestFiles: Bool
+    ) -> [String] {
         // No `.skipsHiddenFiles`: rsync's `--exclude='.DS_Store'` has no slash, so per rsync's own
         // anchoring rules it matches at *any* depth, not just top-level — but it names only that
         // one file. `.skipsHiddenFiles` would instead drop every dotfile at every depth, which is
         // a wider exclusion than `scaffold.sh` actually applies. `.DS_Store` is matched by name
         // below instead, keeping this manifest exact rather than incidentally broader.
         guard let enumerator = FileManager.default.enumerator(
-            at: scriptsRoot,
+            at: root,
             includingPropertiesForKeys: [.isDirectoryKey]
         ) else { return [] }
 
-        let scriptsRootPath = scriptsRoot.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
         var results: [String] = []
         for case let fileURL as URL in enumerator {
             let isDirectory = (try? fileURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
@@ -38,15 +74,15 @@ public enum TemplateScriptsManifest {
             if fileURL.lastPathComponent == ".DS_Store" { continue }
 
             let standardizedPath = fileURL.standardizedFileURL.path
-            guard standardizedPath.hasPrefix(scriptsRootPath + "/") else { continue }
-            let relativeToScripts = String(standardizedPath.dropFirst(scriptsRootPath.count + 1))
+            guard standardizedPath.hasPrefix(rootPath + "/") else { continue }
+            let relativeToRoot = String(standardizedPath.dropFirst(rootPath.count + 1))
 
-            let isTopLevel = !relativeToScripts.contains("/")
-            if isTopLevel && topLevelExcludedNames.contains(relativeToScripts) { continue }
-            if isTopLevel && relativeToScripts.hasSuffix(".test.ts") { continue }
+            let isTopLevel = !relativeToRoot.contains("/")
+            if isTopLevel && topLevelExcludedNames.contains(relativeToRoot) { continue }
+            if isTopLevel && excludeTopLevelTestFiles && relativeToRoot.hasSuffix(".test.ts") { continue }
 
-            results.append("scripts/" + relativeToScripts)
+            results.append(relativePrefix + "/" + relativeToRoot)
         }
-        return results.sorted()
+        return results
     }
 }

--- a/Sources/AnglesiteCore/TemplateScriptsSyncChecker.swift
+++ b/Sources/AnglesiteCore/TemplateScriptsSyncChecker.swift
@@ -6,8 +6,8 @@ import Foundation
 import OSLog
 #endif
 
-/// Detects which app-owned `scripts/` files a site needs refreshed, and which have been
-/// customized in a way the app can't silently resolve (design doc, #1053). Unlike
+/// Detects which app-owned files (`scripts/`, `src/lib/`) a site needs refreshed, and which have
+/// been customized in a way the app can't silently resolve (design doc, #1053). Unlike
 /// `DependencySyncChecker`, this type performs its own `Config/`-only baseline bookkeeping
 /// (backfilling a missing entry, initializing a first-encounter baseline) as it goes — see the
 /// design doc's "Note on checker purity." It never writes anything under `Source/`; only
@@ -26,7 +26,7 @@ public enum TemplateScriptsSyncChecker {
         #endif
     }
 
-    /// Compares every app-owned template `scripts/` file against the site's copy and the
+    /// Compares every app-owned template file against the site's copy and the
     /// recorded baseline, classifying each as silently appliable (missing, or unmodified-but-
     /// stale) vs. a divergence needing the owner (customized *and* the template moved on).
     /// Side effects are `Config/`-only: matching or first-encounter files get their baseline

--- a/Tests/AnglesiteCoreTests/TemplateScriptsManifestTests.swift
+++ b/Tests/AnglesiteCoreTests/TemplateScriptsManifestTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import AnglesiteTestSupport
 @testable import AnglesiteCore
 
 @Suite struct TemplateScriptsManifestTests {
@@ -23,6 +24,8 @@ import Foundation
         try writeFile("scaffold", to: scripts.appendingPathComponent("scaffold.sh"))
         try writeFile("themes", to: scripts.appendingPathComponent("themes.ts"))
         try writeFile("themesjson", to: scripts.appendingPathComponent("themes.json"))
+        try writeFile("checkpack", to: scripts.appendingPathComponent("check-pack.ts"))
+        try writeFile("buildpacks", to: scripts.appendingPathComponent("build-packs.sh"))
         try writeFile("drop", to: scripts.appendingPathComponent("drop.test.ts"))
         try writeFile("adapter", to: scripts.appendingPathComponent("embeds/adapter.ts"))
         try writeFile("adapterTest", to: scripts.appendingPathComponent("embeds/adapter.test.ts"))
@@ -59,5 +62,82 @@ import Foundation
             "scripts/.env.example",
             "scripts/keep.ts",
         ])
+    }
+
+    // MARK: - src/lib
+
+    @Test func includesEverySrcLibFileIncludingTestFiles() throws {
+        // Unlike `scripts/`, `scaffold.sh` has no `src/lib/*` excludes at all — every file there
+        // (including `.test.ts` files) is already shipped to every scaffolded site, so the
+        // app-owned manifest must not invent a `.test.ts` exclusion `scaffold.sh` doesn't have.
+        let root = tmpDir()
+        let lib = root.appendingPathComponent("src/lib")
+        try writeFile("robots", to: lib.appendingPathComponent("robots-config.ts"))
+        try writeFile("robotsTest", to: lib.appendingPathComponent("robots-config.test.ts"))
+        try writeFile("licensing", to: lib.appendingPathComponent("licensing.ts"))
+
+        let result = TemplateScriptsManifest.appOwnedRelativePaths(templateRoot: root)
+
+        #expect(result == [
+            "src/lib/licensing.ts",
+            "src/lib/robots-config.test.ts",
+            "src/lib/robots-config.ts",
+        ])
+    }
+
+    @Test func combinesScriptsAndSrcLibIntoOneSortedList() throws {
+        let root = tmpDir()
+        try writeFile("keep", to: root.appendingPathComponent("scripts/keep.ts"))
+        try writeFile("lib", to: root.appendingPathComponent("src/lib/rsl.ts"))
+
+        let result = TemplateScriptsManifest.appOwnedRelativePaths(templateRoot: root)
+
+        #expect(result == [
+            "scripts/keep.ts",
+            "src/lib/rsl.ts",
+        ])
+    }
+
+    @Test func returnsEmptyWhenSrcLibDirectoryIsMissing() {
+        let root = tmpDir()
+        try? FileManager.default.createDirectory(
+            at: root.appendingPathComponent("scripts"), withIntermediateDirectories: true
+        )
+        #expect(TemplateScriptsManifest.appOwnedRelativePaths(templateRoot: root).isEmpty)
+    }
+
+    @Test func excludesDSStoreUnderSrcLib() throws {
+        let root = tmpDir()
+        let lib = root.appendingPathComponent("src/lib")
+        try writeFile("keep", to: lib.appendingPathComponent("keep.ts"))
+        try writeFile("ds", to: lib.appendingPathComponent(".DS_Store"))
+
+        let result = TemplateScriptsManifest.appOwnedRelativePaths(templateRoot: root)
+
+        #expect(result == ["src/lib/keep.ts"])
+    }
+
+    // MARK: - Real template regression (#1426)
+
+    /// Pins this manifest against the actual in-repo template rather than only a synthetic
+    /// fixture — #1426 happened because `scaffold.sh`'s own exclude list and this hand-maintained
+    /// Swift mirror silently drifted apart. A synthetic-fixture-only test can't catch that kind of
+    /// drift; only checking the real files can.
+    @Test func matchesScaffoldShsExcludesAgainstTheRealTemplate() throws {
+        let paths = Set(TemplateScriptsManifest.appOwnedRelativePaths(templateRoot: try templateRoot()))
+
+        // scaffold.sh excludes these outright (pack-authoring tooling, not site runtime code) —
+        // shipping them into a site breaks its `./themes` import, since `themes.ts`/`themes.json`
+        // are correctly excluded right alongside them.
+        for excluded in ["scripts/check-pack.ts", "scripts/build-packs.sh", "scripts/scaffold.sh", "scripts/themes.ts", "scripts/themes.json"] {
+            #expect(!paths.contains(excluded), "\(excluded) should never be app-owned")
+        }
+
+        // The framework modules #1426's synced scripts actually import at build time — these must
+        // be part of the app-owned set or an existing-site migration ships call sites without their
+        // dependencies.
+        for required in ["src/lib/robots-config.ts", "src/lib/rsl.ts", "src/lib/licensing.ts", "src/lib/embed-card.ts"] {
+            #expect(paths.contains(required), "\(required) must be app-owned so migrated scripts keep a working import")
+        }
     }
 }

--- a/docs/superpowers/specs/2026-08-06-existing-site-template-migration-design.md
+++ b/docs/superpowers/specs/2026-08-06-existing-site-template-migration-design.md
@@ -41,11 +41,21 @@ one-time classification (prompt, or a Preserve default in noninteractive flows) 
 No historical-hash-across-releases registry is needed to make this safe; see "Data model" below for
 why.
 
+> **Amendment (#1426):** `TemplateScriptsManifest.appOwnedRelativePaths` now also enumerates
+> `src/lib/*` — pure framework logic (`robots-config.ts`, `rsl.ts`, `licensing.ts`,
+> `embed-card.ts`, etc.) that several app-owned scripts import at build time, and that
+> `scaffold.sh` already ships to every site with no excludes of its own. This narrows the "src/ —
+> unchanged, still out of scope" non-goal below: it was written to keep site *content*
+> (`src/data/`, `src/content/`, `src/pages/`) out of migration's reach, not framework code that
+> merely happens to live under `src/` for Astro's import resolution. Kind 1 below (and the
+> checker/applier it reuses) covers both roots identically — there is no new "kind."
+
 ## Scope: the four migration kinds
 
 1. **App-owned script files** (`edge-artifacts.ts`, `csp.ts`, `pre-deploy-check.ts`, everything
-   `TemplateScriptsManifest.appOwnedRelativePaths` already enumerates) — reuses #1053's
-   checker/applier unchanged, except for the legacy-classification fix above.
+   `TemplateScriptsManifest.appOwnedRelativePaths` already enumerates — as of #1426, this includes
+   `src/lib/*` alongside `scripts/*`) — reuses #1053's checker/applier unchanged, except for the
+   legacy-classification fix above.
 2. **`SECURITY_TXT_MODE` backfill + legacy `security.txt` classification** — new: a config-key
    write plus a generated-artifact ownership decision, neither of which #1053 handles (it only
    syncs script *source*, not generated output or `.site-config` keys).
@@ -242,7 +252,9 @@ file** / **Keep my version** pair.
 
 ## Non-goals / explicitly deferred
 
-- `src/` — unchanged, still out of scope (per #1053).
+- `src/` **except `src/lib/`** — still out of scope (per #1053). `src/lib/` was carved out by the
+  #1426 amendment above; `src/data/`, `src/content/`, `src/pages/`, and everything else under
+  `src/` remains untouched.
 - The pre-deploy envelope version (#742) — no migration path exists or is added; an unsupported
   version remains a hard "update the app" error by design.
 - File removals/renames on the template side — #1053's existing known gap, not touched here.


### PR DESCRIPTION
Closes #1426

## Summary

- `Sources/AnglesiteCore/TemplateScriptsManifest.swift`'s exclude list was missing `check-pack.ts`/`build-packs.sh` (present in `scaffold.sh`'s own exclude list), so existing-site migration wrongly shipped `check-pack.ts` — which imports the deliberately-unmigrated `themes.ts` — into every migrated site.
- Existing-site migration only ever synced `scripts/`, never `src/lib/`, even though several app-owned scripts it *does* sync (`edge-artifacts.ts`, `csp.ts`, `pre-deploy-check.ts`, `remark-embeds.ts`) import from `src/lib/robots-config.ts`, `rsl.ts`, `licensing.ts`, `embed-card.ts`. `src/lib/*` is pure framework logic no site customizes (unlike `src/data/`, `src/content/`, `src/pages/`), and `scaffold.sh` already ships it wholesale with no excludes — so the manifest now treats it the same as `scripts/*`, reusing the existing checker/applier/baseline plumbing unchanged. Amended `docs/superpowers/specs/2026-08-06-existing-site-template-migration-design.md` to reflect the narrower `src/` boundary.
- Investigated the other two items reported in #1426: the `schema-dts`/`astro-seo-schema` peer conflict doesn't reproduce against the current template (already pinned correctly since #381), and the `ANGLESITE_VERSION` "regression" is correct behavior (real pre-1.0 app version, not a hardcoded literal). Full writeup in the [issue comment](https://github.com/Anglesite/Anglesite/issues/1426#issuecomment-5273221916). The `astro`/`@astrojs/cloudflare` peer conflict is real but is a separate, larger gap (a site's own untracked dependency vs. a legitimate template-driven bump) — split out to #1440 for design discussion rather than folded in here.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passes (3645 tests in AnglesiteCoreTests alone, plus all other targets).
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED.
- [x] Added a regression test (`matchesScaffoldShsExcludesAgainstTheRealTemplate`) against the real in-repo template, not just synthetic fixtures — this exact class of bug was `scaffold.sh` and its Swift mirror silently drifting apart.