### PR TITLE
fix(#1446): verify disk removal before reporting delete success

### DIFF
--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -658,6 +658,25 @@ public struct NativeContentOperations: ContentOperationsService {
         guard repo.headHasEntry(atPath: relPath) else { return nil }
         guard case .success = repo.remove(path: relPath) else { return nil }
 
+        // remove(path:)'s working-tree unlink is best-effort (it swallows the error via `try?`,
+        // to tolerate a file that's already gone) — so a `.success` here only guarantees the
+        // index was updated, not that the file actually left disk. An immutable/locked file (or
+        // any other unlink failure) would otherwise commit a "deleted" entry while the file sits
+        // on disk, now orphaned and untracked (#1446). Verify explicitly before trusting it.
+        if FileManager.default.fileExists(atPath: projectRoot.appendingPathComponent(relPath).path) {
+            // The file itself was never touched (the unlink that would have modified it failed
+            // before any write), so its content still matches HEAD's blob — re-staging it via
+            // `add(path:)` (a read + index update) restores the index without writing to the
+            // working tree. `restorePathFromHEAD`'s force-checkout would try to overwrite that
+            // same unwritable file and fail for the identical reason the unlink did.
+            if case .failure = repo.add(path: relPath) {
+                await LogCenter.shared.append(
+                    source: "dead-assets:delete", stream: .stderr,
+                    text: "processGitDelete: remove(path:) reported success for \(relPath) but the file is still on disk (working-tree unlink likely failed) AND rollback (add(path:)) also failed — the git index may be desynced from the working tree. Manual recovery may be needed in \(projectRoot.path).")
+            }
+            return nil
+        }
+
         let signature = await GitIdentity.signature(for: repo)
         guard case .success(let commit) = repo.commit(message: message, signature: signature) else {
             // remove(path:) already removed the file from the index and working tree before the

--- a/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
+++ b/Tests/AnglesiteCoreTests/NativeContentOperationsTests.swift
@@ -2,6 +2,9 @@
 import Testing
 import Foundation
 @testable import AnglesiteCore
+#if canImport(Darwin)
+import Darwin
+#endif
 
 @Suite("NativeContentOperations")
 struct NativeContentOperationsTests {
@@ -464,6 +467,36 @@ struct NativeContentOperationsTests {
         let status = try await ProcessSupervisor.shared.run(executable: git, arguments: ["status", "--porcelain"], currentDirectoryURL: repo)
         #expect(status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
+
+    #if canImport(Darwin)
+    @Test("processGitDelete reports failure and rolls back when the file survives on disk (#1446)")
+    func rollbackOnWorkingTreeUnlinkFailure() async throws {
+        // SwiftGit2's `remove(path:)` updates the git index, then best-effort unlinks the
+        // working-tree file via `try? FileManager.default.removeItem(...)` — swallowing the
+        // error, so an immutable/locked file that can't actually be unlinked still reports
+        // `.success`. Reproduces the #1446 repro: `chflags uchg` a committed file, then delete it.
+        let repo = FileManager.default.temporaryDirectory.appendingPathComponent("git-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        for args in [["init"], ["config", "user.email", "t@t.io"], ["config", "user.name", "t"]] {
+            _ = try await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: repo)
+        }
+        let filePath = repo.appendingPathComponent("search.astro")
+        try "<div>original</div>".write(to: filePath, atomically: true, encoding: .utf8)
+        _ = await NativeContentOperations.processGitCommit(repo, "search.astro", "add search.astro")
+
+        #expect(chflags(filePath.path, UInt32(UF_IMMUTABLE)) == 0)
+        defer { _ = chflags(filePath.path, 0) }
+
+        let sha = await NativeContentOperations.processGitDelete(repo, "search.astro", "anglesite: delete search.astro")
+        #expect(sha == nil)
+        #expect(FileManager.default.fileExists(atPath: filePath.path))
+        #expect(try String(contentsOf: filePath, encoding: .utf8) == "<div>original</div>")
+
+        let status = try await ProcessSupervisor.shared.run(executable: git, arguments: ["status", "--porcelain"], currentDirectoryURL: repo)
+        #expect(status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+    #endif
 
     @Test("hasCommit finds an exact commit-message match in a real repo, and doesn't substring-match a shorter message")
     func realGitHasCommit() async throws {


### PR DESCRIPTION
Closes #1446

## Summary

- `NativeContentOperations.processGitDelete` (Darwin/SwiftGit2 path) now verifies the file is actually gone from disk after `repo.remove(path:)` reports `.success`, instead of trusting that result blindly.
- SwiftGit2's `remove(path:)` swallows the working-tree unlink error via `try?` (to tolerate an already-missing file), so an immutable/locked file previously reported success at the git-index level while the file survived on disk, orphaned and untracked, with a "delete" commit claiming it was gone.
- On a still-present file, the rollback re-stages it via `repo.add(path:)` rather than `repo.restorePathFromHEAD(path:)`: the file was never actually touched (the unlink failed before any write), so its content already matches HEAD — `add(path:)` only reads it back into the index, whereas `restorePathFromHEAD`'s force-checkout would try to overwrite the same unwritable file and fail for the identical reason the unlink did.
- Added a regression test that `chflags uchg`'s a committed file and asserts the delete now reports failure with the file and git index untouched, reproducing the issue's exact repro (`git status --short` showing an orphaned `?? file` after a "deleted" commit).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite passes (3651+ Swift Testing tests, all XCTest suites), including the new regression test.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — builds clean.
- [ ] Manual smoke (if UI-touching): N/A — no UI change; the app already surfaces `.failed(reason:)` via the existing delete-failure alert path (#586), this only fixes the delete-success/failure classification.