### PR TITLE
feat(#800): Mac CMS-mode save path

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -3498,6 +3498,9 @@
     "This page has no incoming links and will be permanently removed." : {
 
     },
+    "This post is stored in your site's CMS. The file on disk is a read-only export." : {
+
+    },
     "This removes it from Anglesite's list only. The files in %@ are left on disk." : {
 
     },

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -773,6 +773,12 @@
     "By default, Anglesite saves new and imported site packages to the Anglesite folder in iCloud Drive, falling back to `~/Sites/` when iCloud is unavailable. Override this for development or testing." : {
 
     },
+    "CMS Mode Not Available" : {
+
+    },
+    "Can't Connect" : {
+
+    },
     "Can't Open Component" : {
 
     },
@@ -1035,6 +1041,9 @@
     "Connect & publish" : {
 
     },
+    "Connect This Site" : {
+
+    },
     "Connect a Bluesky account for POSSE syndication to turn this on." : {
 
     },
@@ -1048,6 +1057,12 @@
 
     },
     "Connect a domain…" : {
+
+    },
+    "Connect for CMS Mode" : {
+
+    },
+    "Connect for CMS Mode…" : {
 
     },
     "Connect to Cloudflare" : {
@@ -1185,6 +1200,9 @@
 
     },
     "Couldn't reach this site" : {
+
+    },
+    "Couldn't reach this site. Check your connection and try again." : {
 
     },
     "Couldn't read your Cloudflare API token: %@" : {
@@ -2019,6 +2037,9 @@
     "Logs…" : {
 
     },
+    "Looking for this site's Micropub endpoint…" : {
+
+    },
     "Looking up registrar info…" : {
 
     },
@@ -2260,6 +2281,9 @@
 
     },
     "Not Connected" : {
+
+    },
+    "Not Deployed Yet" : {
 
     },
     "Not Set" : {
@@ -2593,6 +2617,9 @@
 
     },
     "Publish posts to the Atmosphere" : {
+
+    },
+    "Publish this site at least once before connecting it for CMS mode." : {
 
     },
     "Publish to GitHub" : {
@@ -3089,6 +3116,9 @@
     "Server" : {
 
     },
+    "Session Expired" : {
+
+    },
     "Set Password…" : {
 
     },
@@ -3182,6 +3212,9 @@
     "Shows this site's open GitHub security advisories and Dependabot alerts" : {
 
     },
+    "Sign In" : {
+
+    },
     "Sign In…" : {
 
     },
@@ -3192,6 +3225,18 @@
 
     },
     "Sign in with Cloudflare" : {
+
+    },
+    "Sign in with this site's own IndieAuth server to enable editing it as a CMS from other devices." : {
+
+    },
+    "Sign-In Canceled" : {
+
+    },
+    "Sign-In Failed" : {
+
+    },
+    "Sign-In Not Available" : {
 
     },
     "Signed in" : {
@@ -3236,6 +3281,9 @@
     "Site Scripts Customized" : {
 
     },
+    "Site Unreachable" : {
+
+    },
     "Site graph overview" : {
 
     },
@@ -3273,6 +3321,9 @@
 
     },
     "Software or SaaS" : {
+
+    },
+    "Something went wrong while signing in. Try again." : {
 
     },
     "Sound" : {
@@ -3510,13 +3561,25 @@
     "This site does not have any collection-backed content types." : {
 
     },
+    "This site doesn't offer IndieAuth sign-in yet. Redeploy it with a current Anglesite build." : {
+
+    },
     "This site hasn't been published yet" : {
 
     },
     "This site publishes a security.txt Anglesite didn't generate. Adopt it so Anglesite keeps it current going forward, or leave it as yours to maintain." : {
 
     },
+    "This site signed you out. Sign in again to keep CMS mode connected." : {
+
+    },
     "This site will stop receiving posts from " : {
+
+    },
+    "This site's Worker doesn't include Micropub yet. Redeploy it with a current Anglesite build." : {
+
+    },
+    "This site's identity couldn't be read. Try reopening it and connecting again." : {
 
     },
     "This will remove the file from your site. You can bring it back with Edit ▸ Undo." : {
@@ -3727,6 +3790,9 @@
     "Waiting for output…" : {
 
     },
+    "Waiting for sign-in…" : {
+
+    },
     "Warnings" : {
 
     },
@@ -3812,6 +3878,9 @@
 
     },
     "Yes, mostly Apple" : {
+
+    },
+    "You closed the sign-in page before finishing. Sign in when you're ready." : {
 
     },
     "You'll need to add these yourself" : {

--- a/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
+++ b/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+import AnglesiteCore
+import AnglesiteIOS
+
+/// Mac-side entry point for the same IndieAuth onboarding flow the iOS app already ships (#868)
+/// — reused as-is via `MicropubOnboardingModel`, with `SiteMicropubSignIn` (Task A1) standing in
+/// as the AppKit `ASWebAuthenticationSession` adapter where iOS drives SwiftUI's
+/// `webAuthenticationSession` environment value instead (see `SiteMicropubSignIn.swift`'s doc
+/// comment). A successful sign-in leaves a `MicropubSession` resolvable from Keychain for this
+/// site (`SecretStore.readMicropubAccessToken(siteID:)`) — the CMS-mode save path (Task A5)
+/// checks for exactly that.
+///
+/// Presented from Website ▸ Connect for CMS Mode… (`WebsiteCommands`); the site is captured at
+/// sheet-presentation time from `SiteWindowModel.site`, mirroring how `SiteWindow.swift` already
+/// passes `site` into `NewPageSheet`/`NewCollectionEntrySheet` for its other `.sheet(isPresented:)`
+/// presentations.
+struct MicropubSiteConnectSheet: View {
+    let site: SiteStore.Site
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var model: MicropubOnboardingModel?
+    /// Set when `site.id` (a `String`) doesn't parse as a `UUID` — `SitePickerModel.DiscoveredSite`
+    /// requires a real `UUID`, unlike `SiteStore.Site`. This should never happen in practice (both
+    /// ultimately trace back to the same `AnglesitePackage.Marker.siteID`), but `configure(site:)`
+    /// can't run without one, so this is surfaced rather than silently substituting a fresh
+    /// `UUID()` that would scope Keychain reads/writes to the wrong identity.
+    @State private var invalidSiteID = false
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Connect for CMS Mode")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+        }
+        .padding()
+        .frame(minWidth: 380, minHeight: 220)
+        // Guarded the same way `SiteSignInScreen.task` guards its `model == nil` check: the
+        // outer `NavigationStack`/`content` identity is stable across the state transitions
+        // this drives, so `.task` only runs configuration once per sheet presentation.
+        .task {
+            guard model == nil, !invalidSiteID else { return }
+            guard let siteID = UUID(uuidString: site.id) else {
+                invalidSiteID = true
+                return
+            }
+            let discovered = SitePickerModel.DiscoveredSite(
+                id: siteID, displayName: site.name, packageURL: site.packageURL)
+            let model = MicropubOnboardingModel(webAuthenticator: SiteMicropubSignIn())
+            self.model = model
+            await model.configure(site: discovered)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if invalidSiteID {
+            ContentUnavailableView {
+                Label("Can't Connect", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text("This site's identity couldn't be read. Try reopening it and connecting again.")
+            }
+        } else {
+            switch model?.state ?? .idle {
+            case .idle, .discovering:
+                ProgressView("Looking for this site's Micropub endpoint…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .needsDeployedSite:
+                ContentUnavailableView {
+                    Label("Not Deployed Yet", systemImage: "icloud.and.arrow.up")
+                } description: {
+                    Text("Publish this site at least once before connecting it for CMS mode.")
+                }
+            case .signedOut:
+                signInPrompt(
+                    title: Text("Connect This Site"),
+                    message: Text(
+                        "Sign in with this site's own IndieAuth server to enable editing it as a CMS from other devices."
+                    )
+                )
+            case .exchanging:
+                ProgressView("Signing in…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .authorizing:
+                // The web-auth sheet is up; this sits behind it.
+                ProgressView("Waiting for sign-in…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .signedIn(let me):
+                signedIn(me: me)
+            case .cancelled:
+                signInPrompt(
+                    title: Text("Sign-In Canceled"),
+                    message: Text("You closed the sign-in page before finishing. Sign in when you're ready.")
+                )
+            case .reauthorizationRequired:
+                signInPrompt(
+                    title: Text("Session Expired"),
+                    message: Text("This site signed you out. Sign in again to keep CMS mode connected.")
+                )
+            case .failed(let reason):
+                failure(reason: reason)
+            }
+        }
+    }
+
+    private func signInPrompt(title: Text, message: Text) -> some View {
+        VStack(spacing: 12) {
+            title.font(.title2.bold())
+            message
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            Button("Sign In") { Task { await model?.signIn() } }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func signedIn(me: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.largeTitle)
+                .foregroundStyle(.green)
+            Text("Connected")
+                .font(.title2.bold())
+            Text(verbatim: me)
+                .font(.callout.monospaced())
+                .foregroundStyle(.secondary)
+            Button("Done") { dismiss() }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 8)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func failure(reason: MicropubOnboardingModel.FailureReason) -> some View {
+        switch reason {
+        case .micropubNotSupported:
+            ContentUnavailableView {
+                Label("CMS Mode Not Available", systemImage: "server.rack")
+            } description: {
+                Text("This site's Worker doesn't include Micropub yet. Redeploy it with a current Anglesite build.")
+            }
+        case .indieAuthNotSupported:
+            ContentUnavailableView {
+                Label("Sign-In Not Available", systemImage: "person.crop.circle.badge.questionmark")
+            } description: {
+                Text("This site doesn't offer IndieAuth sign-in yet. Redeploy it with a current Anglesite build.")
+            }
+        case .siteUnreachable:
+            ContentUnavailableView {
+                Label("Site Unreachable", systemImage: "wifi.slash")
+            } description: {
+                Text("Couldn't reach this site. Check your connection and try again.")
+            } actions: {
+                retryButton
+            }
+        case .signInFailed:
+            ContentUnavailableView {
+                Label("Sign-In Failed", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text("Something went wrong while signing in. Try again.")
+            } actions: {
+                retryButton
+            }
+        }
+    }
+
+    private var retryButton: some View {
+        Button("Try Again") { Task { await model?.signIn() } }
+            .buttonStyle(.borderedProminent)
+    }
+}

--- a/Sources/AnglesiteApp/SiteMicropubSignIn.swift
+++ b/Sources/AnglesiteApp/SiteMicropubSignIn.swift
@@ -3,40 +3,73 @@ import AuthenticationServices
 import AnglesiteIOS
 
 /// macOS conformer of `SiteWebAuthenticating` (`AnglesiteIOS/MicropubOnboardingModel.swift`) —
-/// the per-site IndieAuth sign-in adapter `MicropubOnboardingModel` needs on the Mac. Mirrors
-/// `CloudflareOAuthSignIn.defaultPresenter`'s AppKit `ASWebAuthenticationSession` wrapper
-/// (`CloudflareOAuthSignIn.swift`), including its lifetime-management idiom: the presentation
-/// context and session are locals declared inside (or just before) the
-/// `withCheckedThrowingContinuation` closure, kept alive for free by the suspended async frame
-/// rather than by any manual retain trick, until the completion handler resumes the
-/// continuation. This flow matches a custom-scheme callback (IndieAuth's redirect URI) rather
-/// than an Associated-Domains HTTPS callback — the same distinction the iOS counterpart,
-/// `SessionWebAuthenticator` in `AnglesiteMobile/SiteSignInScreen.swift`, draws via SwiftUI's
-/// `webAuthenticationSession` environment. This type can't use that SwiftUI environment key
-/// (it isn't a View), so it drives `ASWebAuthenticationSession` directly, like
-/// `CloudflareOAuthSignIn` does.
+/// the per-site IndieAuth sign-in adapter `MicropubOnboardingModel` needs on the Mac. Presents an
+/// `ASWebAuthenticationSession` directly (unlike the iOS counterpart, `SessionWebAuthenticator`
+/// in `AnglesiteMobile/SiteSignInScreen.swift`, which drives SwiftUI's `webAuthenticationSession`
+/// environment — not available here since this isn't a View). Matches a custom-scheme callback
+/// (IndieAuth's redirect URI) rather than an Associated-Domains HTTPS callback.
+///
+/// `ASWebAuthenticationSession` doesn't retain itself, and `presentationContextProvider` is a
+/// *weak* property, so both the session and its context provider need an explicit strong owner
+/// for the lifetime of the operation — a bare local in the `withCheckedThrowingContinuation`
+/// setup closure is not enough, since that closure is synchronous/non-escaping and returns (and
+/// its locals become collectible) as soon as `.start()` is called, typically well before the OS
+/// invokes the completion handler. `SessionRetainer` below is that owner: it's captured strongly
+/// by the completion handler closure that `session` itself stores, which — because `retainer`
+/// also stores `session` — forms a deliberate, temporary retain cycle (retainer → session →
+/// completion handler → retainer). A cycle can't be prematurely collected by ARC (Swift has no
+/// cycle collector), so the whole group is guaranteed to survive until the handler fires; the
+/// handler then breaks the cycle itself by clearing `retainer`'s stored properties, so nothing
+/// leaks past that point.
 struct SiteMicropubSignIn: SiteWebAuthenticating {
+    @MainActor
     func authenticate(authorizeURL: URL, callbackScheme: String) async throws -> URL {
-        let contextProvider = SiteMicropubSignInPresentationContext()
+        let retainer = SessionRetainer()
         return try await withCheckedThrowingContinuation { continuation in
+            let contextProvider = SiteMicropubSignInPresentationContext()
             let session = ASWebAuthenticationSession(
                 url: authorizeURL,
                 callback: .customScheme(callbackScheme)
             ) { callbackURL, error in
-                if let callbackURL {
-                    continuation.resume(returning: callbackURL)
-                } else if let error = error as? ASWebAuthenticationSessionError,
-                    error.code == .canceledLogin
-                {
-                    continuation.resume(throwing: SiteWebAuthenticationCancelled())
-                } else {
-                    continuation.resume(throwing: error ?? SiteWebAuthenticationCancelled())
+                // Breaks the retain cycle described above now that the session is done with —
+                // must run after `mapCompletion` reads `callbackURL`/`error` (it doesn't touch
+                // `retainer`), but before returning, so nothing outlives this call.
+                defer {
+                    retainer.session = nil
+                    retainer.contextProvider = nil
                 }
+                continuation.resume(with: Self.mapCompletion(callbackURL: callbackURL, error: error))
             }
+            retainer.session = session
+            retainer.contextProvider = contextProvider
             session.presentationContextProvider = contextProvider
             session.start()
         }
     }
+
+    /// Pure mapping from `ASWebAuthenticationSession`'s completion-handler arguments to the
+    /// `Result` `authenticate` resolves with. Split out from the closure above so the
+    /// cancellation/error-mapping logic — the only part of this type with any real branching —
+    /// is unit-testable without driving a real `ASWebAuthenticationSession`, which needs system
+    /// UI and can't run headlessly.
+    static func mapCompletion(callbackURL: URL?, error: Error?) -> Result<URL, Error> {
+        if let callbackURL {
+            return .success(callbackURL)
+        } else if let error = error as? ASWebAuthenticationSessionError,
+            error.code == .canceledLogin
+        {
+            return .failure(SiteWebAuthenticationCancelled())
+        } else {
+            return .failure(error ?? SiteWebAuthenticationCancelled())
+        }
+    }
+}
+
+/// Strong owner of the in-flight session + presentation context, for the reason explained on
+/// `SiteMicropubSignIn.authenticate`.
+private final class SessionRetainer {
+    var session: ASWebAuthenticationSession?
+    var contextProvider: SiteMicropubSignInPresentationContext?
 }
 
 /// Anchors the sign-in sheet to the app's key window — same approach as

--- a/Sources/AnglesiteApp/SiteMicropubSignIn.swift
+++ b/Sources/AnglesiteApp/SiteMicropubSignIn.swift
@@ -1,0 +1,51 @@
+import AppKit
+import AuthenticationServices
+import AnglesiteIOS
+
+/// macOS conformer of `SiteWebAuthenticating` (`AnglesiteIOS/MicropubOnboardingModel.swift`) —
+/// the per-site IndieAuth sign-in adapter `MicropubOnboardingModel` needs on the Mac. Mirrors
+/// `CloudflareOAuthSignIn.defaultPresenter`'s AppKit `ASWebAuthenticationSession` wrapper
+/// (`CloudflareOAuthSignIn.swift`), including its lifetime-management idiom: the presentation
+/// context and session are locals declared inside (or just before) the
+/// `withCheckedThrowingContinuation` closure, kept alive for free by the suspended async frame
+/// rather than by any manual retain trick, until the completion handler resumes the
+/// continuation. This flow matches a custom-scheme callback (IndieAuth's redirect URI) rather
+/// than an Associated-Domains HTTPS callback — the same distinction the iOS counterpart,
+/// `SessionWebAuthenticator` in `AnglesiteMobile/SiteSignInScreen.swift`, draws via SwiftUI's
+/// `webAuthenticationSession` environment. This type can't use that SwiftUI environment key
+/// (it isn't a View), so it drives `ASWebAuthenticationSession` directly, like
+/// `CloudflareOAuthSignIn` does.
+struct SiteMicropubSignIn: SiteWebAuthenticating {
+    func authenticate(authorizeURL: URL, callbackScheme: String) async throws -> URL {
+        let contextProvider = SiteMicropubSignInPresentationContext()
+        return try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: authorizeURL,
+                callback: .customScheme(callbackScheme)
+            ) { callbackURL, error in
+                if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else if let error = error as? ASWebAuthenticationSessionError,
+                    error.code == .canceledLogin
+                {
+                    continuation.resume(throwing: SiteWebAuthenticationCancelled())
+                } else {
+                    continuation.resume(throwing: error ?? SiteWebAuthenticationCancelled())
+                }
+            }
+            session.presentationContextProvider = contextProvider
+            session.start()
+        }
+    }
+}
+
+/// Anchors the sign-in sheet to the app's key window — same approach as
+/// `CloudflareOAuthPresentationContext`, kept as its own type because it's a distinct sign-in
+/// flow (Micropub/IndieAuth, not Cloudflare OAuth).
+private final class SiteMicropubSignInPresentationContext: NSObject,
+    ASWebAuthenticationPresentationContextProviding
+{
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        NSApp.keyWindow ?? NSApp.windows.first ?? ASPresentationAnchor()
+    }
+}

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -963,6 +963,9 @@ struct SiteWindow: View {
         .sheet(isPresented: $bindableModel.animationsPresented) {
             AnimationsGalleryView()
         }
+        .sheet(isPresented: $bindableModel.micropubConnectPresented) {
+            MicropubSiteConnectSheet(site: site)
+        }
         .annotatedAsSite(site)
     }
 

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1512,7 +1512,9 @@ final class SiteWindowModel {
         let url = source.appendingPathComponent(relPath)
         let file = FileRef(url: url, group: group, name: displayName)
         if let descriptor = ContentTypeResolver.descriptor(forRelativePath: relPath) {
-            return .typed(TypedEntryEditorModel(file: file, descriptor: descriptor, route: route, sourceDirectory: source))
+            return .typed(TypedEntryEditorModel(
+                file: file, descriptor: descriptor, route: route, sourceDirectory: source,
+                configDirectory: site?.configDirectory, siteID: site?.id))
         }
         if isFrontmatterPage(relPath) {
             return .page(PageMetadataModel(file: file, route: route, sourceDirectory: source))

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -228,6 +228,11 @@ final class SiteWindowModel {
     /// `AnimationsGalleryModel`, resolves the bundled template itself) so a plain Bool is enough —
     /// no per-site data to carry, unlike the `.sheet(item:)` models above.
     var animationsPresented = false
+    /// Website ▸ Connect for CMS Mode… (#800). `MicropubSiteConnectSheet` builds its own
+    /// `MicropubOnboardingModel` from the `site` `SiteWindow`'s `.sheet(isPresented:)` closure
+    /// already has in scope (same as the `NewPageSheet`/`NewCollectionEntrySheet` sheets), so a
+    /// plain Bool is enough here too — same reasoning as `animationsPresented`.
+    var micropubConnectPresented = false
     /// Non-nil ⟺ the Delete confirmation dialog is showing for this navigator item (#516).
     /// Hosted in `SiteWindow` (mirrors `revertConfirmationPresented`'s alert-hosting pattern) —
     /// set from both the navigator's row context menu and the Edit ▸ Delete menu command.
@@ -620,6 +625,16 @@ final class SiteWindowModel {
     /// `mainPaneMode` — the gallery is a modal browse surface, not a main-pane mode.
     func presentAnimations() {
         animationsPresented = true
+    }
+
+    /// Website ▸ Connect for CMS Mode… (#800), same shape as `canOpenAnimations` — gated on a
+    /// site window being focused.
+    var canOpenMicropubConnect: Bool { site != nil }
+
+    /// Presents the CMS-mode connect sheet (Website ▸ Connect for CMS Mode…, #800). Same
+    /// plain-Bool pattern as `presentAnimations()`.
+    func presentMicropubConnect() {
+        micropubConnectPresented = true
     }
 
     /// Presents the Social Media Plan sheet (#465), same pattern as `presentCopyEdit`.

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -66,6 +66,14 @@ final class TypedEntryEditorModel: InspectorEditorModel {
     /// default" label in `LanguagePicker` for `.language` fields. Defaults to `"en"` when the file
     /// is absent or has no `LANG` key, matching `SiteLanguageAsset.parseSettings`'s own default.
     private(set) var siteDefaultLangTag = "en"
+    /// Whether this file's site is CMS-mode provisioned — mirrors `save()`'s own branch condition
+    /// (`CMSModeStatus.isProvisioned`), so `TypedEntryEditorView` can show a read-only-export banner
+    /// without reimplementing the check. Computed once in `load()`, not as a computed `var`: a plain
+    /// getter can't `await`, and the underlying check is actor-hopping disk I/O
+    /// (`SiteConfigStore.load()`) — calling the synchronous `.read(from:)` instead would block the
+    /// main thread, exactly what its own doc comment warns against for a `@MainActor` caller like
+    /// this model. Mirrors how `siteDefaultLangTag` above is precomputed the same way.
+    private(set) var isCMSMode = false
     var conflictDiskContents: String? {
         get { fileSession.conflictDiskContents }
         set { fileSession.conflictDiskContents = newValue }
@@ -115,6 +123,12 @@ final class TypedEntryEditorModel: InspectorEditorModel {
         savedDisallowCrawlEnabled = flags.disallowCrawl
         if let config = try? String(contentsOf: sourceDirectory.appendingPathComponent(".site-config"), encoding: .utf8) {
             siteDefaultLangTag = SiteLanguageAsset.parseSettings(from: config).lang
+        }
+        if let configDirectory,
+           let settings = try? await SiteConfigStore(configDirectory: configDirectory).load() {
+            isCMSMode = CMSModeStatus.isProvisioned(settings: settings)
+        } else {
+            isCMSMode = false
         }
     }
 

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -3,6 +3,7 @@ import Foundation
 import SwiftUI
 import Observation
 import AnglesiteCore
+import AnglesiteIOS
 
 /// Editor state for one open *typed* content file. Parallels `FileEditorModel` but exposes the
 /// file as per-field `TypedContentEditor.Values` (bound by `TypedEntryEditorView`) and commits each
@@ -12,12 +13,38 @@ import AnglesiteCore
 @MainActor
 @Observable
 final class TypedEntryEditorModel: InspectorEditorModel {
+    /// Resolves a ready-to-use `MicropubClient` for `siteID`/`sourceDirectory`, or `nil` when no
+    /// CMS-mode session has been onboarded for this site yet (Task A2's connect sheet never ran,
+    /// or the stored session was signed out). Injectable so `save()`'s CMS-mode branch is
+    /// unit-testable without touching the real Keychain or network.
+    typealias MicropubClientFactory = @Sendable (_ siteID: String, _ sourceDirectory: URL) async -> MicropubClient?
+
+    /// Production factory: resolves the session via `StoredMicropubSessions` (Keychain read +
+    /// endpoint re-discovery — discovery is never persisted, see its doc comment) and builds a
+    /// client from it. `nonisolated` (rather than implicitly `@MainActor`, like every other
+    /// member of this class) because `init`'s default-argument expressions run in a nonisolated
+    /// context, not the initializer body's — this is what `init` calls to build its own default.
+    private nonisolated static func defaultMicropubClientFactory(
+        sessions: StoredMicropubSessions = StoredMicropubSessions()
+    ) -> MicropubClientFactory {
+        { siteID, sourceDirectory in
+            await sessions.session(siteID: siteID, sourceDirectory: sourceDirectory)?.makeClient()
+        }
+    }
+
     let file: FileRef
     let descriptor: ContentTypeDescriptor
     let route: String
     /// Command/find seam for the body field's markdown editor.
     let markdownController = MarkdownEditorController()
     private let sourceDirectory: URL
+    /// The site's `Config/` directory, or `nil` for a call site with no CMS-mode context (rare —
+    /// every real site window has one). Read in `save()` to check `CMSModeStatus.isProvisioned`.
+    private let configDirectory: URL?
+    /// The site's stable marker UUID string (`SiteStore.Site.id`), or `nil` alongside
+    /// `configDirectory`. Needed to resolve a Micropub session/credential for this site.
+    private let siteID: String?
+    private let makeMicropubClient: MicropubClientFactory
     private let gitCommit: NativeContentOperations.GitCommit
 
     var values: TypedContentEditor.Values = .init()
@@ -53,12 +80,18 @@ final class TypedEntryEditorModel: InspectorEditorModel {
          descriptor: ContentTypeDescriptor,
          route: String,
          sourceDirectory: URL,
-         gitCommit: @escaping NativeContentOperations.GitCommit = NativeContentOperations.processGitCommit) {
+         configDirectory: URL? = nil,
+         siteID: String? = nil,
+         gitCommit: @escaping NativeContentOperations.GitCommit = NativeContentOperations.processGitCommit,
+         makeMicropubClient: @escaping MicropubClientFactory = TypedEntryEditorModel.defaultMicropubClientFactory()) {
         self.file = file
         self.descriptor = descriptor
         self.route = route
         self.sourceDirectory = sourceDirectory
+        self.configDirectory = configDirectory
+        self.siteID = siteID
         self.gitCommit = gitCommit
+        self.makeMicropubClient = makeMicropubClient
     }
 
     func load() async {
@@ -90,6 +123,24 @@ final class TypedEntryEditorModel: InspectorEditorModel {
         guard isDirty, !isSaving else { return true }
         isSaving = true
         defer { isSaving = false }
+        // CMS mode (#800): once the site's composed Worker includes Micropub and this window has
+        // a resolvable session for it, content writes go through `MicropubClient` instead of
+        // file+git — the site's canonical copy moves to the deployed CMS. `SiteConfigStore.load()`
+        // (not the synchronous `.read(from:)`) is deliberate: this method runs on the main actor,
+        // and `.read(from:)`'s own doc comment warns it blocks the calling thread on disk I/O.
+        if let configDirectory, let siteID,
+           let settings = try? await SiteConfigStore(configDirectory: configDirectory).load(),
+           CMSModeStatus.isProvisioned(settings: settings),
+           let client = await makeMicropubClient(siteID, sourceDirectory) {
+            return await saveViaMicropub(client: client, configDirectory: configDirectory)
+        }
+        return await saveViaFile()
+    }
+
+    /// The original (pre-CMS-mode) save mechanics: writes the file to disk, applies the robots
+    /// side channel, and commits both to git. Also `save()`'s fallback when the site isn't
+    /// CMS-mode provisioned or no Micropub session is available yet.
+    private func saveViaFile() async -> Bool {
         let descriptor = self.descriptor
         let base = contents
         let edited = values
@@ -101,19 +152,72 @@ final class TypedEntryEditorModel: InspectorEditorModel {
             fileSession = session
             savedValues = edited
             warnIfNoModificationDate(after: "save")
-            let robotsChanged = try RobotsConfigFile.apply(
-                source: robotsSource, noindex: noindexEnabled, disallowCrawl: disallowCrawlEnabled,
-                path: route, under: sourceDirectory
-            )
-            savedNoindexEnabled = noindexEnabled
-            savedDisallowCrawlEnabled = disallowCrawlEnabled
+            try await applyRobotsConfig()
             await commit()
-            if robotsChanged { await commitRobotsConfig() }
             return true
         } catch {
             loadError = "Save failed: \(error.localizedDescription)"
             return false
         }
+    }
+
+    /// CMS-mode save: projects `values` to mf2 properties (`MicropubComposerProjection`) and
+    /// creates or updates the post through `client`, keyed by whether this file's `Source/`-
+    /// relative path already has a synced post URL (`Config/micropubSync.json`, Task A4). Deletes
+    /// mapped-but-now-absent properties on update — the two-parties concern
+    /// `MicropubComposerProjection.mappedProperties(for:)`'s doc comment documents — computed
+    /// fresh from the current mapped-property set rather than a cached baseline, since this model
+    /// (unlike `PostComposerModel`) doesn't keep one around; deleting an already-absent property
+    /// is a harmless no-op server-side.
+    ///
+    /// Deliberately never touches the local file or git: the CMS's stored copy is now this file's
+    /// canonical content, not `Source/`'s — the read-side sync (Task A6/B1) is what reconciles
+    /// `Source/` back to it. The robots-config side channel is the one exception, applied
+    /// regardless of save path since it's site-wide state, not a per-post mf2 property.
+    private func saveViaMicropub(client: MicropubClient, configDirectory: URL) async -> Bool {
+        let relPath = relativePath(of: file.url, under: sourceDirectory)
+        var syncState = MicropubContentCommitter.readSyncState(from: configDirectory)
+        let status: MicropubPostStatus = values["draft"] == .flag(true) ? .draft : .published
+        let properties = MicropubComposerProjection.properties(
+            for: descriptor, values: values, status: status)
+        do {
+            if let existingURLString = syncState.first(where: { $0.value == relPath })?.key,
+               let existingURL = URL(string: existingURLString) {
+                let mapped = Set(MicropubComposerProjection.mappedProperties(for: descriptor))
+                let cleared = mapped.subtracting(properties.keys).sorted()
+                try await client.update(
+                    url: existingURL, replace: properties,
+                    delete: cleared.isEmpty ? nil : .properties(cleared))
+            } else {
+                let post = MicropubPost(properties: properties)
+                let newURL = try await client.create(post)
+                syncState[newURL.absoluteString] = relPath
+                try MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
+            }
+            savedValues = values
+            try await applyRobotsConfig()
+            return true
+        } catch let error as MicropubError where error.requiresReauthorization {
+            loadError = "Sign in again to save changes to this site's CMS."
+            return false
+        } catch {
+            loadError = "CMS save failed: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    /// Applies pending noindex/disallowCrawl toggle changes to the shared `robots-config.json`
+    /// and commits it if it changed. Factored out of `saveViaFile`/`saveViaMicropub` because it's
+    /// independent of which path wrote the content itself — robots config isn't a per-post mf2
+    /// property, so CMS mode doesn't redirect it.
+    private func applyRobotsConfig() async throws {
+        let robotsChanged = try RobotsConfigFile.apply(
+            source: robotsSource, noindex: noindexEnabled, disallowCrawl: disallowCrawlEnabled,
+            path: route, under: sourceDirectory
+        )
+        savedNoindexEnabled = noindexEnabled
+        savedDisallowCrawlEnabled = disallowCrawlEnabled
+        if robotsChanged { await commitRobotsConfig() }
     }
 
     func flushBeforeLeaving() async -> Bool {

--- a/Sources/AnglesiteApp/TypedEntryEditorModel.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorModel.swift
@@ -140,6 +140,12 @@ final class TypedEntryEditorModel: InspectorEditorModel {
     /// The original (pre-CMS-mode) save mechanics: writes the file to disk, applies the robots
     /// side channel, and commits both to git. Also `save()`'s fallback when the site isn't
     /// CMS-mode provisioned or no Micropub session is available yet.
+    ///
+    /// Commit order is deliberate and predates this task's CMS-mode branch (#800 review, fix
+    /// round 1): the entry file's own commit goes first, and the shared `robots-config.json`
+    /// commit — conditional on it actually having changed — goes second. `applyRobotsConfig()`
+    /// only computes/writes the robots file; it does *not* commit, so that order can be
+    /// preserved exactly here rather than folded into one step.
     private func saveViaFile() async -> Bool {
         let descriptor = self.descriptor
         let base = contents
@@ -152,8 +158,9 @@ final class TypedEntryEditorModel: InspectorEditorModel {
             fileSession = session
             savedValues = edited
             warnIfNoModificationDate(after: "save")
-            try await applyRobotsConfig()
+            let robotsChanged = try applyRobotsConfig()
             await commit()
+            if robotsChanged { await commitRobotsConfig() }
             return true
         } catch {
             loadError = "Save failed: \(error.localizedDescription)"
@@ -192,10 +199,18 @@ final class TypedEntryEditorModel: InspectorEditorModel {
                 let post = MicropubPost(properties: properties)
                 let newURL = try await client.create(post)
                 syncState[newURL.absoluteString] = relPath
-                try MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
+                // Best-effort (#800 review, fix round 1): the remote post already exists once
+                // `create` returns, so a failure persisting this local URL↔path bookkeeping must
+                // not fail the save itself — the user's edit already took effect. A lost write
+                // here only means the next save's create-vs-update lookup misses and creates a
+                // second post, the same tradeoff `MicropubContentCommitter.commit()` already
+                // accepts for this exact class of problem (its own `writeSyncState` calls are
+                // `try?` too, for the same reason).
+                try? MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
             }
             savedValues = values
-            try await applyRobotsConfig()
+            let robotsChanged = try applyRobotsConfig()
+            if robotsChanged { await commitRobotsConfig() }
             return true
         } catch let error as MicropubError where error.requiresReauthorization {
             loadError = "Sign in again to save changes to this site's CMS."
@@ -207,17 +222,20 @@ final class TypedEntryEditorModel: InspectorEditorModel {
     }
 
     /// Applies pending noindex/disallowCrawl toggle changes to the shared `robots-config.json`
-    /// and commits it if it changed. Factored out of `saveViaFile`/`saveViaMicropub` because it's
-    /// independent of which path wrote the content itself — robots config isn't a per-post mf2
-    /// property, so CMS mode doesn't redirect it.
-    private func applyRobotsConfig() async throws {
+    /// — writes the file and returns whether it actually changed, but does **not** commit.
+    /// Factored out of `saveViaFile`/`saveViaMicropub` because it's independent of which path
+    /// wrote the content itself — robots config isn't a per-post mf2 property, so CMS mode
+    /// doesn't redirect it. Deliberately split from the commit step (unlike this task's first
+    /// pass, #800 review fix round 1): `saveViaFile`'s entry-file commit must land *before* the
+    /// robots-config commit, an ordering this method can't own without collapsing that sequence.
+    private func applyRobotsConfig() throws -> Bool {
         let robotsChanged = try RobotsConfigFile.apply(
             source: robotsSource, noindex: noindexEnabled, disallowCrawl: disallowCrawlEnabled,
             path: route, under: sourceDirectory
         )
         savedNoindexEnabled = noindexEnabled
         savedDisallowCrawlEnabled = disallowCrawlEnabled
-        if robotsChanged { await commitRobotsConfig() }
+        return robotsChanged
     }
 
     func flushBeforeLeaving() async -> Bool {

--- a/Sources/AnglesiteApp/TypedEntryEditorView.swift
+++ b/Sources/AnglesiteApp/TypedEntryEditorView.swift
@@ -10,6 +10,12 @@ struct TypedEntryForm: View {
 
     var body: some View {
         Form {
+            if model.isCMSMode {
+                Label("This post is stored in your site's CMS. The file on disk is a read-only export.",
+                      systemImage: "icloud.and.arrow.down")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             ForEach(scalarFields, id: \.name) { field in
                 control(for: field)
             }

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -95,6 +95,9 @@ struct WebsiteCommands: Commands {
             Button("Add Integration…") { model?.openIntegrationWizard() }
                 .disabled(model?.canOpenIntegrationWizard != true)
 
+            Button("Connect for CMS Mode…") { model?.presentMicropubConnect() }
+                .disabled(model?.canOpenMicropubConnect != true)
+
             Button("Animations…") { model?.presentAnimations() }
                 .disabled(model?.canOpenAnimations != true)
 

--- a/Sources/AnglesiteCore/CMSModeStatus.swift
+++ b/Sources/AnglesiteCore/CMSModeStatus.swift
@@ -1,0 +1,10 @@
+/// Whether a site's typed content editors should save through `MicropubClient` (CMS mode)
+/// instead of file+git — true once the site's composed Worker includes `@dwk/micropub`
+/// (spec §C.6). Pure and I/O-free by design: callers that also need to know whether a usable
+/// session exists right now (Keychain-backed) check that separately, so this type stays a
+/// trivial fact about the site's *provisioning* state, not its *auth* state.
+public enum CMSModeStatus {
+    public static func isProvisioned(settings: SiteSettings) -> Bool {
+        (settings.activeWorkerIDs ?? []).contains(WorkerComposition.micropubWorkerID)
+    }
+}

--- a/Sources/AnglesiteCore/CMSModeStatus.swift
+++ b/Sources/AnglesiteCore/CMSModeStatus.swift
@@ -4,6 +4,7 @@
 /// session exists right now (Keychain-backed) check that separately, so this type stays a
 /// trivial fact about the site's *provisioning* state, not its *auth* state.
 public enum CMSModeStatus {
+    /// True once `settings.activeWorkerIDs` includes Micropub's catalog id.
     public static func isProvisioned(settings: SiteSettings) -> Bool {
         (settings.activeWorkerIDs ?? []).contains(WorkerComposition.micropubWorkerID)
     }

--- a/Sources/AnglesiteCore/MicropubContentCommitter.swift
+++ b/Sources/AnglesiteCore/MicropubContentCommitter.swift
@@ -16,11 +16,13 @@ public enum MicropubContentCommitter {
     /// written outside the git commit (it lives in `Config/`, never `Source/`) so a later
     /// re-sync of the same post updates that exact file instead of re-resolving (and potentially
     /// re-suffixing) its slug every time.
-    typealias SyncState = [String: String]
+    public typealias SyncState = [String: String]
 
     private static let stateFileName = "micropubSync.json"
 
-    private static func loadState(from configDirectory: URL) -> SyncState {
+    /// Reads the persisted post-URL → `Source/`-relative-path mapping from
+    /// `configDirectory/micropubSync.json`, or `[:]` if the file is missing or unreadable.
+    public static func readSyncState(from configDirectory: URL) -> SyncState {
         let url = configDirectory.appendingPathComponent(stateFileName)
         guard let data = try? Data(contentsOf: url),
               let state = try? JSONDecoder().decode(SyncState.self, from: data)
@@ -28,13 +30,25 @@ public enum MicropubContentCommitter {
         return state
     }
 
-    private static func saveState(_ state: SyncState, to configDirectory: URL, fileManager: FileManager) {
+    /// Writes `state` to `configDirectory/micropubSync.json`, creating `configDirectory` if
+    /// needed. Throws on any encode/create/write failure rather than swallowing it, so a caller
+    /// that depends on the mapping actually landing on disk (e.g. a save path recording where a
+    /// post was written) can surface the failure instead of silently losing the URL↔path entry.
+    ///
+    /// - Parameters:
+    ///   - state: The post-URL → `Source/`-relative-path mapping to persist.
+    ///   - configDirectory: The site's `Config/` directory; created if it doesn't already exist.
+    ///   - fileManager: The file manager used for directory creation and the write.
+    /// - Throws: If encoding `state`, creating `configDirectory`, or writing the file fails.
+    public static func writeSyncState(
+        _ state: SyncState, to configDirectory: URL, fileManager: FileManager = .default
+    ) throws {
         let url = configDirectory.appendingPathComponent(stateFileName)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
-        guard let data = try? encoder.encode(state) else { return }
-        try? fileManager.createDirectory(at: configDirectory, withIntermediateDirectories: true)
-        try? data.write(to: url, options: .atomic)
+        let data = try encoder.encode(state)
+        try fileManager.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
     }
 
     /// Resolves the relative path a post should be written to: the path already recorded in
@@ -88,7 +102,7 @@ public enum MicropubContentCommitter {
         now: @Sendable () -> Date = Date.init,
         gitCommitBatch: @Sendable (URL, [String], String) async -> String? = InboxSubmissionCommitter.processGitCommitBatch
     ) async -> Int {
-        var state = loadState(from: configDirectory)
+        var state = readSyncState(from: configDirectory)
         let currentURLs = Set(posts.map(\.url))
 
         var relPaths: [String] = []
@@ -127,13 +141,13 @@ public enum MicropubContentCommitter {
         }
 
         guard !relPaths.isEmpty else {
-            saveState(state, to: configDirectory, fileManager: fileManager)
+            try? writeSyncState(state, to: configDirectory, fileManager: fileManager)
             return 0
         }
 
         let message = Self.commitMessage(writtenCount: writtenCount, deletedCount: deletedCount)
         let committed = await gitCommitBatch(siteDirectory, relPaths, message) != nil
-        saveState(state, to: configDirectory, fileManager: fileManager)
+        try? writeSyncState(state, to: configDirectory, fileManager: fileManager)
         return committed ? writtenCount + deletedCount : 0
     }
 

--- a/Sources/AnglesiteIOS/MicropubSession.swift
+++ b/Sources/AnglesiteIOS/MicropubSession.swift
@@ -91,17 +91,33 @@ public struct StoredMicropubSessions: MicropubSessionProviding {
     }
 
     public func session(for site: SitePickerModel.DiscoveredSite) async -> MicropubSession? {
-        let siteID = site.id.uuidString
+        await session(
+            siteID: site.id.uuidString,
+            sourceDirectory: AnglesitePackage(url: site.packageURL).sourceURL)
+    }
+
+    /// The same assembly as ``session(for:)``, addressed by a site's raw identity instead of a
+    /// `SitePickerModel.DiscoveredSite` — for callers (the Mac's CMS-mode save path, #800) that
+    /// already hold a site's `Source/` directory directly and would otherwise have to fabricate a
+    /// `packageURL` just to have this method re-derive the same directory from it.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site's stable marker UUID string (`SiteStore.Site.id` on the Mac,
+    ///     `SitePickerModel.DiscoveredSite.id.uuidString` on iOS).
+    ///   - sourceDirectory: The site's `Source/` directory, resolved to a deployed URL for
+    ///     endpoint discovery.
+    /// - Returns: The assembled session, or `nil` when no credential is stored, the site isn't
+    ///   deployed yet, or endpoint discovery fails.
+    public func session(siteID: String, sourceDirectory: URL) async -> MicropubSession? {
         guard let token = try? secretStore.readMicropubAccessToken(siteID: siteID),
               !token.isEmpty,
               let keyPair = try? secretStore.readMicropubDPoPKeyPair(siteID: siteID)
         else { return nil }
         // `.site-config` is real file I/O inside a possibly-still-materializing iCloud
         // package — hop off the main actor, same as `MicropubOnboardingModel.configure`.
-        let sourceURL = AnglesitePackage(url: site.packageURL).sourceURL
         let resolve = resolveSiteURL
         let siteURL = await Task.detached(priority: .userInitiated) {
-            resolve(sourceURL).flatMap(URL.init(string:))
+            resolve(sourceDirectory).flatMap(URL.init(string:))
         }.value
         guard let siteURL,
               let endpoints = try? await discovery.discover(siteURL: siteURL)

--- a/Sources/AnglesiteIOS/SitePickerModel.swift
+++ b/Sources/AnglesiteIOS/SitePickerModel.swift
@@ -19,12 +19,16 @@ public final class SitePickerModel {
         public let displayName: String
         public let packageURL: URL
 
-        // Swift only auto-synthesizes a memberwise init at the type's own access level, which
-        // for a struct with `public` stored properties but no explicit `public init` is
-        // `internal` — invisible outside `AnglesiteIOS`. `refresh()` below (same module) never
-        // needed this, but the Mac's CMS-mode connect sheet (#800, `AnglesiteApp`) constructs a
-        // `DiscoveredSite` from `SiteStore.Site` to reuse `MicropubOnboardingModel.configure(site:)`
-        // across the module boundary, so an explicit public init is required.
+        /// Creates a discovered site with explicit values, for cross-module construction (e.g.
+        /// from a Mac `SiteStore.Site`).
+        ///
+        /// Swift only auto-synthesizes a memberwise init at the type's own access level, which
+        /// for a struct with `public` stored properties but no explicit `public init` is
+        /// `internal` — invisible outside `AnglesiteIOS`. `refresh()` below (same module) never
+        /// needed this, but the Mac's CMS-mode connect sheet (#800, `AnglesiteApp`) constructs a
+        /// `DiscoveredSite` from `SiteStore.Site` to reuse
+        /// ``MicropubOnboardingModel/configure(site:)`` across the module boundary, so an
+        /// explicit public init is required.
         public init(id: UUID, displayName: String, packageURL: URL) {
             self.id = id
             self.displayName = displayName

--- a/Sources/AnglesiteIOS/SitePickerModel.swift
+++ b/Sources/AnglesiteIOS/SitePickerModel.swift
@@ -18,6 +18,18 @@ public final class SitePickerModel {
         public let id: UUID
         public let displayName: String
         public let packageURL: URL
+
+        // Swift only auto-synthesizes a memberwise init at the type's own access level, which
+        // for a struct with `public` stored properties but no explicit `public init` is
+        // `internal` — invisible outside `AnglesiteIOS`. `refresh()` below (same module) never
+        // needed this, but the Mac's CMS-mode connect sheet (#800, `AnglesiteApp`) constructs a
+        // `DiscoveredSite` from `SiteStore.Site` to reuse `MicropubOnboardingModel.configure(site:)`
+        // across the module boundary, so an explicit public init is required.
+        public init(id: UUID, displayName: String, packageURL: URL) {
+            self.id = id
+            self.displayName = displayName
+            self.packageURL = packageURL
+        }
     }
 
     /// Distinguishes "iCloud itself isn't available" from "iCloud is available but has no sites

--- a/Tests/AnglesiteAppTests/SiteMicropubSignInTests.swift
+++ b/Tests/AnglesiteAppTests/SiteMicropubSignInTests.swift
@@ -1,0 +1,16 @@
+import Testing
+import AnglesiteIOS
+@testable import AnglesiteAppCore
+
+@Suite("SiteMicropubSignIn")
+struct SiteMicropubSignInTests {
+    @Test("conforms to SiteWebAuthenticating")
+    func conformsToProtocol() {
+        // ASWebAuthenticationSession can't be driven headlessly in a unit test; this only
+        // confirms the type exists and conforms to the protocol `MicropubOnboardingModel`
+        // expects. Real behavior (presenting the sheet, mapping cancellation) is exercised by
+        // manual QA (documented in the PR).
+        let signIn = SiteMicropubSignIn()
+        #expect(signIn is any SiteWebAuthenticating)
+    }
+}

--- a/Tests/AnglesiteAppTests/SiteMicropubSignInTests.swift
+++ b/Tests/AnglesiteAppTests/SiteMicropubSignInTests.swift
@@ -1,16 +1,49 @@
 import Testing
+import AuthenticationServices
 import AnglesiteIOS
 @testable import AnglesiteAppCore
 
-@Suite("SiteMicropubSignIn")
+// `ASWebAuthenticationSession` itself can't be driven headlessly in a unit test (it needs real
+// system UI), so these tests exercise `SiteMicropubSignIn.mapCompletion` directly — the pure
+// function `authenticate` delegates to for turning the session's completion-handler arguments
+// into the `Result` it resolves with. That's the only part of `SiteMicropubSignIn` with any
+// branching logic; the rest (constructing the session, retaining it, presenting it) needs real
+// `AuthenticationServices` UI and is covered by manual QA instead (documented in the PR).
+@Suite("SiteMicropubSignIn.mapCompletion")
 struct SiteMicropubSignInTests {
-    @Test("conforms to SiteWebAuthenticating")
-    func conformsToProtocol() {
-        // ASWebAuthenticationSession can't be driven headlessly in a unit test; this only
-        // confirms the type exists and conforms to the protocol `MicropubOnboardingModel`
-        // expects. Real behavior (presenting the sheet, mapping cancellation) is exercised by
-        // manual QA (documented in the PR).
-        let signIn = SiteMicropubSignIn()
-        #expect(signIn is any SiteWebAuthenticating)
+    @Test("a callback URL maps to success, even alongside a non-nil error")
+    func callbackURLMapsToSuccess() throws {
+        let url = URL(string: "anglesite://callback?code=abc")!
+        struct IgnoredError: Error {}
+        // `ASWebAuthenticationSession` can hand back both a callback URL and a non-nil `error`
+        // in some edge cases; the callback URL must win.
+        let result = SiteMicropubSignIn.mapCompletion(callbackURL: url, error: IgnoredError())
+        #expect(try result.get() == url)
+    }
+
+    @Test("a canceledLogin error maps to SiteWebAuthenticationCancelled, not the raw session error")
+    func cancellationMapsToDedicatedError() {
+        let cancellation = ASWebAuthenticationSessionError(.canceledLogin)
+        let result = SiteMicropubSignIn.mapCompletion(callbackURL: nil, error: cancellation)
+        #expect(throws: SiteWebAuthenticationCancelled()) {
+            try result.get()
+        }
+    }
+
+    @Test("a non-cancellation error passes through unchanged")
+    func otherErrorPassesThrough() {
+        struct SomeOtherError: Error, Equatable {}
+        let result = SiteMicropubSignIn.mapCompletion(callbackURL: nil, error: SomeOtherError())
+        #expect(throws: SomeOtherError()) {
+            try result.get()
+        }
+    }
+
+    @Test("no callback URL and no error still resolves as a cancellation, not a hang")
+    func nilCallbackAndNilErrorMapsToCancellation() {
+        let result = SiteMicropubSignIn.mapCompletion(callbackURL: nil, error: nil)
+        #expect(throws: SiteWebAuthenticationCancelled()) {
+            try result.get()
+        }
     }
 }

--- a/Tests/AnglesiteAppTests/TypedEntryEditorModelCMSModeTests.swift
+++ b/Tests/AnglesiteAppTests/TypedEntryEditorModelCMSModeTests.swift
@@ -245,6 +245,59 @@ struct TypedEntryEditorModelCMSModeTests {
         #expect(onDisk["draft"] == .flag(true))
     }
 
+    /// #800 Task A6: `isCMSMode` mirrors `save()`'s own branch condition, computed once in `load()`
+    /// (see its doc comment for why it can't be a plain computed `var`). `false` before `load()`
+    /// runs — nothing has populated it yet — then flips to match provisioning after.
+    @Test("isCMSMode reflects the site's CMS-mode provisioning after load()")
+    func isCMSModeReflectsProvisioning() async throws {
+        let (file, descriptor, configDir, sourceDir, _) = try await makeFixture(activeWorkerIDs: ["micropub"])
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            configDirectory: configDir, siteID: "site-1",
+            gitCommit: { _, _, _ in "deadbeef" },
+            makeMicropubClient: { _, _ in nil }
+        )
+        #expect(!model.isCMSMode, "isCMSMode is false before load() has populated it")
+        await model.load()
+        #expect(model.isCMSMode)
+    }
+
+    @Test("isCMSMode is false when the site isn't CMS-mode provisioned")
+    func isCMSModeFalseWhenUnprovisioned() async throws {
+        let (file, descriptor, configDir, sourceDir, _) = try await makeFixture(activeWorkerIDs: nil)
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            configDirectory: configDir, siteID: "site-1",
+            gitCommit: { _, _, _ in "deadbeef" },
+            makeMicropubClient: { _, _ in nil }
+        )
+        await model.load()
+        #expect(!model.isCMSMode)
+    }
+
+    @Test("isCMSMode is false when the model has no configDirectory (no CMS-mode context)")
+    func isCMSModeFalseWithNoConfigDirectory() async throws {
+        let (file, descriptor, configDir, sourceDir, _) = try await makeFixture(activeWorkerIDs: ["micropub"])
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            gitCommit: { _, _, _ in "deadbeef" }
+        )
+        await model.load()
+        #expect(!model.isCMSMode)
+    }
+
     @Test("save() surfaces a distinct message when the Micropub session needs reauthorization")
     func saveSurfacesReauthorizationMessage() async throws {
         let (file, descriptor, configDir, sourceDir, _) = try await makeFixture(activeWorkerIDs: ["micropub"])

--- a/Tests/AnglesiteAppTests/TypedEntryEditorModelCMSModeTests.swift
+++ b/Tests/AnglesiteAppTests/TypedEntryEditorModelCMSModeTests.swift
@@ -103,6 +103,45 @@ struct TypedEntryEditorModelCMSModeTests {
         #expect(onDisk == Self.entryContents)
     }
 
+    /// #800 review, fix round 1: `client.create` already succeeded remotely by the time
+    /// `writeSyncState` runs, so a failure persisting the local URL↔path bookkeeping must not
+    /// fail the save — only the (best-effort) local record is at risk, not the user's edit.
+    /// Forces that specific write to fail by pre-occupying `Config/micropubSync.json`'s path with
+    /// a *directory* rather than injecting a fake filesystem: `settings.plist` (a different file
+    /// in the same `configDir`) is unaffected, so the CMS-mode-provisioned check upstream of the
+    /// write still passes, isolating the failure to exactly the write this test targets.
+    @Test("save() still reports success when persisting the sync-state mapping fails after a successful create")
+    func savesSucceedsEvenWhenSyncStateWriteFails() async throws {
+        let (file, descriptor, configDir, sourceDir, _) = try await makeFixture(activeWorkerIDs: ["micropub"])
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+        // Occupy micropubSync.json's path with a directory so `Data.write(to:options:.atomic)`
+        // inside `writeSyncState` throws (can't atomically replace a directory with a file).
+        try FileManager.default.createDirectory(
+            at: configDir.appendingPathComponent("micropubSync.json"), withIntermediateDirectories: true)
+
+        let client = MicropubClient(
+            endpoint: Self.endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { _ in
+                (Data(), Self.response(201, headers: ["Location": "https://owner.example/2026/my-note"]))
+            }
+        )
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            configDirectory: configDir, siteID: "site-1",
+            gitCommit: { _, _, _ in "deadbeef" },
+            makeMicropubClient: { _, _ in client }
+        )
+        await model.load()
+        model.boolBinding("draft").wrappedValue = true
+
+        let saved = await model.save()
+        #expect(saved, "the remote post already exists — a local bookkeeping-write failure must not fail the save")
+        #expect(!model.isDirty, "the edit itself is considered saved even though the sync-state record was lost")
+    }
+
     @Test("save() updates the synced post and deletes now-empty mapped properties")
     func savesViaMicropubUpdate() async throws {
         let (file, descriptor, configDir, sourceDir, _) = try await makeFixture(activeWorkerIDs: ["micropub"])

--- a/Tests/AnglesiteAppTests/TypedEntryEditorModelCMSModeTests.swift
+++ b/Tests/AnglesiteAppTests/TypedEntryEditorModelCMSModeTests.swift
@@ -1,0 +1,234 @@
+import Testing
+import Foundation
+// URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin platforms
+// (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import AnglesiteAppCore
+import AnglesiteCore
+import AnglesiteIOS
+
+/// Exercises `TypedEntryEditorModel.save()`'s CMS-mode branch (#800 Task A5): once the site's
+/// composed Worker includes Micropub (`CMSModeStatus.isProvisioned`) and a session resolves,
+/// saves route through `MicropubClient.create`/`.update` instead of file+git. The client is
+/// injected via `makeMicropubClient`, so these tests touch neither the real Keychain nor the
+/// network — same faked-seam style as `MicropubClientTests`/`StoredMicropubSessionsTests`.
+@Suite(.serialized)
+@MainActor
+struct TypedEntryEditorModelCMSModeTests {
+    private nonisolated static let endpoint = URL(string: "https://owner.example/micropub")!
+    private static let entryContents = "---\npublishDate: 2026-01-01\n---\nBody.\n"
+
+    private nonisolated static func response(_ code: Int, headers: [String: String]? = nil) -> HTTPURLResponse {
+        HTTPURLResponse(url: endpoint, statusCode: code, httpVersion: nil, headerFields: headers)!
+    }
+
+    /// Writes `settings.plist` (with the given `activeWorkerIDs`) and a `notes` entry file under
+    /// fresh temp `configDir`/`sourceDir` directories, returning the pieces a `TypedEntryEditorModel`
+    /// needs plus the entry's on-disk URL for later assertions.
+    private func makeFixture(
+        activeWorkerIDs: [String]?
+    ) async throws -> (file: FileRef, descriptor: ContentTypeDescriptor, configDir: URL, sourceDir: URL, entryURL: URL) {
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let sourceDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+
+        var settings = SiteSettings()
+        settings.activeWorkerIDs = activeWorkerIDs
+        try await SiteConfigStore(configDirectory: configDir).save(settings)
+
+        let entryURL = sourceDir.appendingPathComponent("src/content/notes/my-note.md")
+        try FileManager.default.createDirectory(
+            at: entryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Self.entryContents.write(to: entryURL, atomically: true, encoding: .utf8)
+        let file = FileRef(url: entryURL, group: .posts, name: entryURL.lastPathComponent)
+        let descriptor = try #require(ContentTypeRegistry().descriptor(id: "note"))
+        return (file, descriptor, configDir, sourceDir, entryURL)
+    }
+
+    @Test("save() creates via MicropubClient when the site is CMS-mode provisioned and no prior URL is synced")
+    func savesViaMicropubCreate() async throws {
+        let (file, descriptor, configDir, sourceDir, entryURL) = try await makeFixture(activeWorkerIDs: ["micropub"])
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+
+        nonisolated(unsafe) var capturedRequest: URLRequest?
+        let client = MicropubClient(
+            endpoint: Self.endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                capturedRequest = request
+                return (Data(), Self.response(201, headers: ["Location": "https://owner.example/2026/my-note"]))
+            }
+        )
+        nonisolated(unsafe) var factoryCalls: [(siteID: String, sourceDirectory: URL)] = []
+
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            configDirectory: configDir, siteID: "site-1",
+            gitCommit: { _, _, _ in "deadbeef" },
+            makeMicropubClient: { siteID, sourceDirectory in
+                factoryCalls.append((siteID, sourceDirectory))
+                return client
+            }
+        )
+        await model.load()
+        model.boolBinding("draft").wrappedValue = true
+
+        let saved = await model.save()
+        #expect(saved)
+        #expect(factoryCalls.map(\.siteID) == ["site-1"])
+        #expect(factoryCalls.map(\.sourceDirectory) == [sourceDir])
+
+        let request = try #require(capturedRequest)
+        #expect(request.httpMethod == "POST")
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        // A create body carries no "action" key (that's update's marker) and has the mf2 shape.
+        #expect(json["action"] == nil)
+        #expect(json["type"] as? [String] == ["h-entry"])
+        let properties = try #require(json["properties"] as? [String: [Any]])
+        #expect(properties["post-status"] as? [String] == ["draft"])
+
+        // The returned URL is recorded against this file's Source/-relative path.
+        let syncState = MicropubContentCommitter.readSyncState(from: configDir)
+        #expect(syncState["https://owner.example/2026/my-note"] == "src/content/notes/my-note.md")
+
+        // CMS-mode content saves never touch the local file — the read-side sync (Task A6/B1)
+        // is what reconciles Source/ back to the CMS's copy.
+        let onDisk = try String(contentsOf: entryURL, encoding: .utf8)
+        #expect(onDisk == Self.entryContents)
+    }
+
+    @Test("save() updates the synced post and deletes now-empty mapped properties")
+    func savesViaMicropubUpdate() async throws {
+        let (file, descriptor, configDir, sourceDir, _) = try await makeFixture(activeWorkerIDs: ["micropub"])
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+        let postURL = URL(string: "https://owner.example/2026/my-note")!
+        try MicropubContentCommitter.writeSyncState(
+            [postURL.absoluteString: "src/content/notes/my-note.md"], to: configDir)
+
+        nonisolated(unsafe) var capturedRequest: URLRequest?
+        let client = MicropubClient(
+            endpoint: Self.endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                capturedRequest = request
+                return (Data(), Self.response(204))
+            }
+        )
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            configDirectory: configDir, siteID: "site-1",
+            gitCommit: { _, _, _ in "deadbeef" },
+            makeMicropubClient: { _, _ in client }
+        )
+        await model.load()
+        model.boolBinding("draft").wrappedValue = true
+
+        let saved = await model.save()
+        #expect(saved)
+
+        let request = try #require(capturedRequest)
+        let body = try #require(request.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["action"] as? String == "update")
+        #expect(json["url"] as? String == postURL.absoluteString)
+        // `tags` is mapped (bare mf2 name "category", the "p-" prefix stripped) but unset on this
+        // fixture — deleted, not silently dropped. `body`/`publishDate` are set, so they're
+        // `replace`d, not deleted; `lang`/`audience`/`draft` have no mf2 mapping at all.
+        let deleted = try #require(json["delete"] as? [String])
+        #expect(deleted == ["category"])
+
+        // The sync-state mapping is untouched by an update (no new URL to record).
+        let syncState = MicropubContentCommitter.readSyncState(from: configDir)
+        #expect(syncState == [postURL.absoluteString: "src/content/notes/my-note.md"])
+    }
+
+    @Test("save() falls back to file+git when the site is not CMS-mode provisioned")
+    func savesViaFileWhenUnprovisioned() async throws {
+        let (file, descriptor, configDir, sourceDir, entryURL) = try await makeFixture(activeWorkerIDs: nil)
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+
+        nonisolated(unsafe) var factoryCalled = false
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            configDirectory: configDir, siteID: "site-1",
+            gitCommit: { _, _, _ in "deadbeef" },
+            makeMicropubClient: { _, _ in
+                factoryCalled = true
+                return nil
+            }
+        )
+        await model.load()
+        model.boolBinding("draft").wrappedValue = true
+
+        let saved = await model.save()
+        #expect(saved)
+        #expect(!factoryCalled, "an unprovisioned site must not even attempt to resolve a Micropub client")
+
+        let onDiskContents = try String(contentsOf: entryURL, encoding: .utf8)
+        let onDisk = TypedContentEditor.read(onDiskContents, descriptor: descriptor)
+        #expect(onDisk["draft"] == .flag(true))
+        #expect(MicropubContentCommitter.readSyncState(from: configDir).isEmpty)
+    }
+
+    @Test("save() falls back to file+git when no Micropub session is available yet")
+    func savesViaFileWhenSessionUnavailable() async throws {
+        let (file, descriptor, configDir, sourceDir, entryURL) = try await makeFixture(activeWorkerIDs: ["micropub"])
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            configDirectory: configDir, siteID: "site-1",
+            gitCommit: { _, _, _ in "deadbeef" },
+            // Provisioned, but no onboarded session — the factory itself reports "signed out".
+            makeMicropubClient: { _, _ in nil }
+        )
+        await model.load()
+        model.boolBinding("draft").wrappedValue = true
+
+        let saved = await model.save()
+        #expect(saved)
+        let onDiskContents = try String(contentsOf: entryURL, encoding: .utf8)
+        let onDisk = TypedContentEditor.read(onDiskContents, descriptor: descriptor)
+        #expect(onDisk["draft"] == .flag(true))
+    }
+
+    @Test("save() surfaces a distinct message when the Micropub session needs reauthorization")
+    func saveSurfacesReauthorizationMessage() async throws {
+        let (file, descriptor, configDir, sourceDir, _) = try await makeFixture(activeWorkerIDs: ["micropub"])
+        defer {
+            try? FileManager.default.removeItem(at: configDir)
+            try? FileManager.default.removeItem(at: sourceDir)
+        }
+
+        let client = MicropubClient(
+            endpoint: Self.endpoint, accessToken: "tok-123", dpopKeyPair: DPoPKeyPair(),
+            transport: { _ in (Data(), Self.response(401)) }
+        )
+        let model = TypedEntryEditorModel(
+            file: file, descriptor: descriptor, route: "/notes/my-note/", sourceDirectory: sourceDir,
+            configDirectory: configDir, siteID: "site-1",
+            gitCommit: { _, _, _ in "deadbeef" },
+            makeMicropubClient: { _, _ in client }
+        )
+        await model.load()
+        model.boolBinding("draft").wrappedValue = true
+
+        let saved = await model.save()
+        #expect(!saved)
+        #expect(model.loadError?.localizedCaseInsensitiveContains("sign in") == true)
+    }
+}

--- a/Tests/AnglesiteAppTests/TypedEntryEditorModelRobotsSettingsTests.swift
+++ b/Tests/AnglesiteAppTests/TypedEntryEditorModelRobotsSettingsTests.swift
@@ -105,6 +105,20 @@ struct TypedEntryEditorModelRobotsSettingsTests {
         #expect(spy.paths().contains("src/content/notes/my-note.md"))
     }
 
+    /// Order-sensitive, not just membership (#800 review, fix round 1): the entry file's own
+    /// commit must land *before* the robots-config commit, since `saveCommitsRobotsConfig` above
+    /// only asserts both paths appear somewhere, and wouldn't have caught the CMS-mode task's
+    /// `applyRobotsConfig` extraction briefly committing robots-config first.
+    @Test("save: the entry file commits before the robots-config commit, not after")
+    func saveCommitsEntryFileBeforeRobotsConfig() async throws {
+        let spy = TypedEntryRobotsCommitSpy()
+        let (model, _) = try makeModel(spy: spy)
+        await model.load()
+        model.noindexBinding().wrappedValue = true
+        _ = await model.save()
+        #expect(spy.paths() == ["src/content/notes/my-note.md", RobotsConfigFile.relativePath])
+    }
+
     @Test("save: a no-op robots write doesn't add a robots-config commit")
     func saveWithoutRobotsChangeSkipsExtraCommit() async throws {
         let spy = TypedEntryRobotsCommitSpy()

--- a/Tests/AnglesiteCoreTests/CMSModeStatusTests.swift
+++ b/Tests/AnglesiteCoreTests/CMSModeStatusTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import AnglesiteCore
+
+@Suite
+struct CMSModeStatusTests {
+    @Test("provisioned when activeWorkerIDs includes micropub")
+    func provisionedWithMicropub() {
+        var settings = SiteSettings()
+        settings.activeWorkerIDs = ["indieauth", "micropub", "webmention"]
+        #expect(CMSModeStatus.isProvisioned(settings: settings) == true)
+    }
+
+    @Test("not provisioned when micropub isn't active")
+    func notProvisionedWithoutMicropub() {
+        var settings = SiteSettings()
+        settings.activeWorkerIDs = ["webmention"]
+        #expect(CMSModeStatus.isProvisioned(settings: settings) == false)
+    }
+
+    @Test("not provisioned with no active workers at all")
+    func notProvisionedEmpty() {
+        #expect(CMSModeStatus.isProvisioned(settings: SiteSettings()) == false)
+    }
+}

--- a/Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
@@ -205,6 +205,19 @@ struct MicropubContentCommitterTests {
             atPath: siteDirectory.appendingPathComponent("src/content/notes/hello-abc123-2.md").path))
     }
 
+    @Test("readSyncState/writeSyncState round-trip through Config/micropubSync.json")
+    func syncStateRoundTrips() throws {
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDir) }
+
+        #expect(MicropubContentCommitter.readSyncState(from: configDir) == [:])
+
+        let state: MicropubContentCommitter.SyncState = ["https://owner.example/blog/hello": "src/content/blog/hello.md"]
+        try MicropubContentCommitter.writeSyncState(state, to: configDir)
+        #expect(MicropubContentCommitter.readSyncState(from: configDir) == state)
+    }
+
     @Test("commitMessage describes write-only, delete-only, and mixed reconciles")
     func commitMessageVariants() {
         #expect(MicropubContentCommitter.commitMessage(writtenCount: 1, deletedCount: 0) == "micropub: sync 1 post")

--- a/docs/superpowers/plans/2026-08-12-cms-mode-mac-save-path-and-content-import.md
+++ b/docs/superpowers/plans/2026-08-12-cms-mode-mac-save-path-and-content-import.md
@@ -1,0 +1,1064 @@
+# CMS mode: Mac save path + provisioning content import — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close out the remaining app-side scope of issue #800 — the Mac's typed content editors
+save through `MicropubClient` instead of file+git when a site is CMS-mode provisioned, existing
+content gets a one-time lossless import into D1 once that mode turns on, and one opt-in live e2e
+proves the whole loop end-to-end.
+
+**Architecture:** Reuse, don't rebuild. `MicropubClient`, `MicropubComposerProjection`,
+`MicropubContentSync`/`MicropubContentCommitter`, `MicropubOnboardingModel`, `MicropubSession`,
+and `ComposerDraftStore` already exist and are platform-neutral (no `#if os(iOS)` guards) —
+built for #867/#868/#869. This plan wires them into the Mac app rather than duplicating them:
+a small macOS `SiteWebAuthenticating` conformer supplies the one missing platform adapter, the
+Mac app depends on `AnglesiteIOS` to reuse `MicropubOnboardingModel` directly, and
+`TypedEntryEditorModel`'s save path grows a CMS-mode branch that calls the same `MicropubClient`
+the phone already uses.
+
+**Tech Stack:** Swift 6.4, SwiftUI/AppKit, SwiftPM (Package.swift) + XcodeGen (project.yml),
+Swift Testing (`@Test`/`@Suite`), `ASWebAuthenticationSession`, Cloudflare D1/Micropub over HTTPS.
+
+## Global Constraints
+
+- No new third-party dependencies — everything here is Apple frameworks + existing in-repo types.
+- `TypedEntryEditorModel`'s file-based save path must stay byte-identical for un-provisioned
+  sites — this plan only adds a *branch*, never changes default behavior.
+- CMS mode only ever applies to **typed content editors** (post-family collections). Pages,
+  components, and other file kinds (`FileEditorModel`, `PlistEditorModel`, `GenericPageInspectorModel`)
+  stay file-based and git-committed unconditionally, per spec §C.6 ("Code/theme/pages stay
+  file-based... exactly as today").
+- One write path for Mac and phone: the Mac's CMS-mode save must call the *same*
+  `MicropubClient` API the iOS composer calls — never a bespoke direct-D1 write for interactive
+  saves (spec §C.6's explicit reason: "so Mac and phone edits can't diverge").
+- Content import is the one exception that needs its own call: see Task B1's design-rationale
+  note on why it also goes through `MicropubClient.create` rather than a raw D1 insert.
+- Run `swift test --package-path .` and `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` before each commit that touches `Sources/AnglesiteApp/` or `Sources/AnglesiteCore/`, per `CONTRIBUTING.md` ▸ "Testing".
+- Every public type/function added needs a doc comment per `docs/comment-style-guide.md` (CI fails on broken DocC links).
+- Conventional commit subjects ≤72 chars, referencing `#800`.
+
+---
+
+## Context recap (do not re-derive — verified against the current worktree 2026-08-12)
+
+| Fact | Where |
+|---|---|
+| `MicropubClient` (create/update/setStatus/delete/configuration/source/listPosts/uploadMedia) is complete and tested | `Sources/AnglesiteCore/MicropubClient.swift`, `Tests/AnglesiteCoreTests/MicropubClientTests.swift` |
+| `MicropubComposerProjection.properties(for:values:status:)` already converts `TypedContentEditor.Values` → mf2 properties — the exact shape `MicropubClient.create`/`.update` need | `Sources/AnglesiteCore/MicropubComposerProjection.swift:32` |
+| `MicropubContentSync.values(for:properties:updatedAt:slug:)` is the reverse mapping (mf2 → `Values`), used by the existing D1→git export sync | `Sources/AnglesiteCore/MicropubContentSync.swift:173` |
+| `MicropubContentCommitter` persists a **post URL ↔ Source/-relative path** map at `Config/micropubSync.json` | `Sources/AnglesiteCore/MicropubContentCommitter.swift:12-19` |
+| `MicropubOnboardingModel`, `MicropubSession`, `ComposerDraftStore`, `PostComposerModel`, `PostListModel` (all in `Sources/AnglesiteIOS/`) have **no** `#if os(iOS)` guards — plain Swift, buildable from any target that depends on `AnglesiteIOS` | verified directly, 2026-08-12 |
+| `SiteWebAuthenticating` protocol (`func authenticate(authorizeURL:callbackScheme:) async throws -> URL`) has no macOS conformer today | `Sources/AnglesiteIOS/MicropubOnboardingModel.swift:15-19` |
+| `MicropubOnboardingModel.configure(site: SitePickerModel.DiscoveredSite)` takes `DiscoveredSite{id: UUID, displayName: String, packageURL: URL}` — trivially constructible from a Mac `SiteStore.Site` | `Sources/AnglesiteIOS/SitePickerModel.swift:15-21` |
+| `WorkerComposition.micropubWorkerID = "micropub"`; `hasMicropub = workers.contains(where: { $0.id == micropubWorkerID })` is the existing "is this site's Worker composed with Micropub" check | `Sources/AnglesiteCore/WorkerComposition.swift:44,244` |
+| `TypedEntryEditorModel(file:descriptor:route:sourceDirectory:)` is constructed at one call site with no `configDirectory`; `PlistEditorModel` right next to it already receives `configDirectory: site?.configDirectory` — the pattern to mirror | `Sources/AnglesiteApp/SiteWindowModel.swift:~1355 (PlistEditorModel), ~1500 (TypedEntryEditorModel)` |
+| `FileEditorModel.save()` / `TypedEntryEditorModel.save()` today always write via `TypedContentEditor.write` + `fileSession.save` + `gitCommit` | `Sources/AnglesiteApp/TypedEntryEditorModel.swift:88-117,257` |
+| `conformance/status.json` in `davidwkeith/workers` currently reports `@dwk/micropub`/`@dwk/webmention`/`@dwk/websub` integration as `pending` — the V-3 gate is not green as of 2026-08-12, so this feature ships **inert** behind per-site discovery (see Milestone A note) until the site's own Worker actually answers Micropub/IndieAuth requests | live-checked 2026-08-12 |
+
+**Important scoping note:** `WorkersConformanceStatus.gateStatus(for: .v3)` (the *package-level*
+conformance-suite gate) is **not** what gates this feature. The iOS app already gates on
+*per-site* endpoint discovery instead (`MicropubOnboardingModel.FailureReason.micropubNotSupported`/
+`.indieAuthNotSupported`, surfaced in `Sources/AnglesiteMobile/SiteSignInScreen.swift:142-157`) —
+if a specific site's deployed Worker doesn't answer Micropub/IndieAuth discovery, the UI says so
+honestly, regardless of the global conformance-suite status. This plan's Mac-side onboarding
+(Task A2) reuses that exact mechanism, so it inherits the same honest-labeling behavior for free
+— no separate gating work is needed.
+
+---
+
+## Milestone A — Mac CMS-mode save path
+
+Ships as one PR. Lets a Mac user connect a provisioned site's Micropub endpoint and have typed
+content editors save through it instead of file+git.
+
+### Task 1 (A1): macOS `SiteWebAuthenticating` conformer
+
+**Files:**
+- Create: `Sources/AnglesiteApp/SiteMicropubSignIn.swift`
+- Test: `Tests/AnglesiteAppTests/SiteMicropubSignInTests.swift` (create dir if absent — confirm via `find Tests -maxdepth 1 -type d` first; if no `AnglesiteAppTests` target exists in `Package.swift`/`project.yml`, this type is instead verified only by the `xcodebuild` app build per the existing convention for `#if os(macOS)` AppKit-facing types — check `Package.swift` for an `AnglesiteAppTests` target before writing this file; if absent, skip the Testing-framework test and note verification is via app build + manual QA, matching how `CloudflareOAuthSignIn.swift`'s macOS half is verified today)
+
+**Interfaces:**
+- Consumes: `SiteWebAuthenticating` protocol (`Sources/AnglesiteIOS/MicropubOnboardingModel.swift:15-19`), `SiteWebAuthenticationCancelled` (`:24-26`)
+- Produces: `struct SiteMicropubSignIn: SiteWebAuthenticating` — the value `MicropubOnboardingModel.init` receives as its authenticator on macOS.
+
+- [ ] **Step 1: Confirm whether a Swift-Testing-capable test target already exists for `Sources/AnglesiteApp/`**
+
+  Run: `grep -n "AnglesiteAppTests\|testTarget" Package.swift`
+  If a test target depending on `AnglesiteApp` exists, use it for Step 2. If not (AppKit-only
+  app-target code is typically verified only by `xcodebuild`, per `CloudflareOAuthSignIn.swift`'s
+  precedent), skip Steps 2–4 and go straight to Step 5, noting the gap explicitly in the PR body's
+  Test plan (never silently skipped, per this codebase's own convention against silent caps).
+
+- [ ] **Step 2 (if a test target exists): Write the failing test**
+
+  ```swift
+  import Testing
+  @testable import AnglesiteApp
+
+  @Suite
+  struct SiteMicropubSignInTests {
+      @Test("wraps ASWebAuthenticationSession cancellation as SiteWebAuthenticationCancelled")
+      func mapsCancellation() async {
+          // ASWebAuthenticationSession can't be driven headlessly in a unit test; this test only
+          // confirms the type exists and conforms to the protocol. Real behavior is exercised by
+          // manual QA (documented in the PR).
+          let signIn = SiteMicropubSignIn()
+          #expect(signIn is any SiteWebAuthenticating)
+      }
+  }
+  ```
+
+- [ ] **Step 3 (if applicable): Run test to verify it fails**
+
+  Run: `swift test --package-path . --filter SiteMicropubSignInTests`
+  Expected: FAIL — `SiteMicropubSignIn` doesn't exist yet.
+
+- [ ] **Step 4: Write `SiteMicropubSignIn`**
+
+  ```swift
+  // Sources/AnglesiteApp/SiteMicropubSignIn.swift
+  import AppKit
+  import AnglesiteIOS
+
+  /// macOS conformer of `SiteWebAuthenticating` — the per-site IndieAuth sign-in adapter
+  /// `MicropubOnboardingModel` needs, mirroring `CloudflareOAuthSignIn`'s AppKit
+  /// `ASWebAuthenticationSession` wrapper but matching a custom-scheme callback (IndieAuth's
+  /// redirect URI) rather than an Associated-Domains HTTPS callback.
+  struct SiteMicropubSignIn: SiteWebAuthenticating {
+      func authenticate(authorizeURL: URL, callbackScheme: String) async throws -> URL {
+          try await withCheckedThrowingContinuation { continuation in
+              let session = ASWebAuthenticationSession(
+                  url: authorizeURL, callbackURLScheme: callbackScheme
+              ) { callbackURL, error in
+                  if let callbackURL {
+                      continuation.resume(returning: callbackURL)
+                  } else if let error = error as? ASWebAuthenticationSessionError,
+                            error.code == .canceledLogin {
+                      continuation.resume(throwing: SiteWebAuthenticationCancelled())
+                  } else {
+                      continuation.resume(throwing: error ?? SiteWebAuthenticationCancelled())
+                  }
+              }
+              let context = SiteMicropubSignInPresentationContext()
+              session.presentationContextProvider = context
+              session.prefersEphemeralWebBrowserSession = false
+              objc_setAssociatedObject(session, &presentationContextKey, context, .OBJC_ASSOCIATION_RETAIN)
+              session.start()
+          }
+      }
+  }
+
+  private var presentationContextKey: UInt8 = 0
+
+  private final class SiteMicropubSignInPresentationContext: NSObject, ASWebAuthenticationPresentationContextProviding {
+      func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+          NSApp.keyWindow ?? NSWindow()
+      }
+  }
+  ```
+
+  Read `Sources/AnglesiteApp/CloudflareOAuthSignIn.swift:14-35` first and match its exact
+  presentation-context idiom (retained-object lifetime pattern) rather than the sketch above if
+  it differs — that file is the authoritative in-repo precedent for this exact problem
+  (`ASWebAuthenticationSession` outliving the function that started it).
+
+- [ ] **Step 5 (if applicable): Run test to verify it passes**
+
+  Run: `swift test --package-path . --filter SiteMicropubSignInTests`
+  Expected: PASS
+
+- [ ] **Step 6: Build the app target to catch AppKit-only compile errors**
+
+  Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+  Expected: builds clean.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add Sources/AnglesiteApp/SiteMicropubSignIn.swift Tests/AnglesiteAppTests/SiteMicropubSignInTests.swift
+  git commit -m "feat(#800): add macOS SiteWebAuthenticating conformer"
+  ```
+
+### Task 2 (A2): Wire `AnglesiteApp` → `AnglesiteIOS` dependency and add the Mac connect sheet
+
+**Files:**
+- Modify: `project.yml` (Anglesite target's `dependencies` list)
+- Create: `Sources/AnglesiteApp/MicropubSiteConnectSheet.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift` (new command/menu entry to present the sheet — see Step 4)
+
+**Interfaces:**
+- Consumes: `MicropubOnboardingModel` (`Sources/AnglesiteIOS/MicropubOnboardingModel.swift:37-` — `init`, `configure(site:)`, `signIn()`, `state`, `micropubClient`), `SitePickerModel.DiscoveredSite` (`Sources/AnglesiteIOS/SitePickerModel.swift:15-21`), `SiteMicropubSignIn` (Task A1), `SiteStore.Site` (existing macOS type — has `.id`, `.name`, `.packageURL`; confirm exact property names with `grep -n "struct Site" -A 10 Sources/AnglesiteApp/SiteStore.swift` before writing Step 3).
+- Produces: `MicropubSiteConnectSheet: View` — presented from a new "Connect for CMS Mode…" command; on success, a `MicropubSession` is now resolvable from Keychain for this site (existing `SecretStore.readMicropubAccessToken(siteID:)` etc.), which Task A3's CMS-mode detector reads.
+
+- [ ] **Step 1: Add the dependency edge**
+
+  Open `project.yml`, find the `Anglesite` target's `dependencies:` list (alongside existing
+  entries like `AnglesiteCore`, `AnglesiteBridge`). Add:
+  ```yaml
+  - target: AnglesiteIOS
+  ```
+  matching whatever exact YAML shape the neighboring entries use (`target:` vs. a bare string —
+  copy the existing style precisely).
+
+- [ ] **Step 2: Regenerate the Xcode project and confirm it builds**
+
+  Run: `xcodegen generate && scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+  Expected: builds clean — this proves `AnglesiteIOS`'s platform-neutral types (Context recap
+  table) are actually reachable from `AnglesiteApp` now. If it fails because some *other* file in
+  `AnglesiteIOS` unexpectedly needs UIKit, that file is missing an `#if os(iOS)` guard — fix the
+  guard in `AnglesiteIOS` rather than working around it here (don't let a leaky module boundary
+  become this feature's problem).
+
+- [ ] **Step 3: Write `MicropubSiteConnectSheet`**
+
+  ```swift
+  // Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
+  import SwiftUI
+  import AnglesiteIOS
+
+  /// Mac-side entry point for the same IndieAuth onboarding flow the iOS app already ships
+  /// (#868) — reused as-is via `MicropubOnboardingModel`, with `SiteMicropubSignIn` (Task A1)
+  /// as the AppKit `ASWebAuthenticationSession` adapter in place of iOS's SwiftUI environment
+  /// value. A successful sign-in leaves a `MicropubSession` resolvable from Keychain for this
+  /// site — `TypedEntryEditorModel`'s save path (Task A5) checks for exactly that.
+  struct MicropubSiteConnectSheet: View {
+      @State private var model: MicropubOnboardingModel
+      @Environment(\.dismiss) private var dismiss
+
+      init(site: SiteStore.Site) {
+          let discovered = SitePickerModel.DiscoveredSite(
+              id: site.id, displayName: site.name, packageURL: site.packageURL)
+          _model = State(wrappedValue: MicropubOnboardingModel(webAuthenticator: SiteMicropubSignIn()))
+          Task { @MainActor in await self.model.configure(site: discovered) }
+      }
+
+      var body: some View {
+          VStack(spacing: 16) {
+              switch model.state {
+              case .idle, .discovering:
+                  ProgressView("Looking for this site's Micropub endpoint…")
+              case .readyToSignIn:
+                  Button("Sign In") { Task { await model.signIn() } }
+              case .signedIn:
+                  Label("Connected", systemImage: "checkmark.seal.fill")
+                  Button("Done") { dismiss() }
+              case .failed(let reason):
+                  Text(String(describing: reason)).foregroundStyle(.secondary)
+                  Button("Try Again") { Task { await model.signIn() } }
+              }
+          }
+          .padding()
+          .frame(minWidth: 360, minHeight: 200)
+      }
+  }
+  ```
+
+  Read `MicropubOnboardingModel`'s actual `init` signature and `State` enum cases
+  (`Sources/AnglesiteIOS/MicropubOnboardingModel.swift:53-90`) before finalizing this file — the
+  sketch above is illustrative; match the real parameter names/case names exactly (the earlier
+  research only confirmed the function/case *names*, not every associated value). Also check
+  `Sources/AnglesiteMobile/SiteSignInScreen.swift` for the exact `State`/`FailureReason` switch
+  shape already proven correct on iOS, and mirror it rather than re-deriving.
+
+- [ ] **Step 4: Add a menu command to present the sheet**
+
+  In `SiteWindowModel.swift`, add a `@Published`/`@State`-style `presentingMicropubConnect: Bool`
+  flag and a method to set it, following the exact pattern `pendingWebsiteSettingsTab` already
+  uses nearby (line ~1335) for presenting a similar site-scoped sheet. Wire a menu command in
+  whichever file declares the Website/Site menu (search `grep -rn "CommandGroup" Sources/AnglesiteApp/ | grep -i site` to find it) titled "Connect for CMS Mode…", enabled only when
+  `site?.name != nil` (mirrors existing site-scoped command guards).
+
+- [ ] **Step 5: Manual QA**
+
+  Build and run the app against a real provisioned site (or a stub Micropub server) and confirm
+  the sheet discovers the endpoint, signs in, and reaches `.signedIn`. Record this in the PR body
+  since `ASWebAuthenticationSession` can't be exercised by CI (same limitation `CloudflareOAuthSignIn`
+  already carries).
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add project.yml Sources/AnglesiteApp/MicropubSiteConnectSheet.swift Sources/AnglesiteApp/SiteWindowModel.swift Anglesite.xcodeproj
+  git commit -m "feat(#800): Mac IndieAuth onboarding via reused MicropubOnboardingModel"
+  ```
+
+  (`Anglesite.xcodeproj` is gitignored per `CLAUDE.md` — omit it from `git add` if it doesn't
+  show as trackable; confirm with `git status` first.)
+
+### Task 3 (A3): CMS-mode detection helper
+
+**Files:**
+- Create: `Sources/AnglesiteCore/CMSModeStatus.swift`
+- Test: `Tests/AnglesiteCoreTests/CMSModeStatusTests.swift`
+
+**Interfaces:**
+- Consumes: `SiteSettings.provisionedWorkerResources` (`Sources/AnglesiteCore/SiteConfigStore.swift`), `WorkerComposition.micropubWorkerID`/`activeWorkerIDs` (`Sources/AnglesiteCore/WorkerComposition.swift:44`)
+- Produces: `CMSModeStatus.isProvisioned(settings: SiteSettings) -> Bool` — pure, no I/O. (Whether a *session* also exists, i.e. whether the save path can actually act on CMS mode right now, is Task A5's own Keychain check — kept separate so this type stays a pure, trivially-testable function per the file-structure guidance to split by responsibility.)
+
+- [ ] **Step 1: Write the failing test**
+
+  ```swift
+  import Testing
+  @testable import AnglesiteCore
+
+  @Suite
+  struct CMSModeStatusTests {
+      @Test("provisioned when activeWorkerIDs includes micropub")
+      func provisionedWithMicropub() {
+          var settings = SiteSettings()
+          settings.activeWorkerIDs = ["indieauth", "micropub", "webmention"]
+          #expect(CMSModeStatus.isProvisioned(settings: settings) == true)
+      }
+
+      @Test("not provisioned when micropub isn't active")
+      func notProvisionedWithoutMicropub() {
+          var settings = SiteSettings()
+          settings.activeWorkerIDs = ["webmention"]
+          #expect(CMSModeStatus.isProvisioned(settings: settings) == false)
+      }
+
+      @Test("not provisioned with no active workers at all")
+      func notProvisionedEmpty() {
+          #expect(CMSModeStatus.isProvisioned(settings: SiteSettings()) == false)
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  Run: `swift test --package-path . --filter CMSModeStatusTests`
+  Expected: FAIL — `CMSModeStatus` doesn't exist.
+
+- [ ] **Step 3: Write `CMSModeStatus`**
+
+  ```swift
+  // Sources/AnglesiteCore/CMSModeStatus.swift
+
+  /// Whether a site's typed content editors should save through `MicropubClient` (CMS mode)
+  /// instead of file+git — true once the site's composed Worker includes `@dwk/micropub`
+  /// (spec §C.6). Pure and I/O-free by design: callers that also need to know whether a usable
+  /// session exists right now (Keychain-backed) check that separately, so this type stays a
+  /// trivial fact about the site's *provisioning* state, not its *auth* state.
+  public enum CMSModeStatus {
+      public static func isProvisioned(settings: SiteSettings) -> Bool {
+          (settings.activeWorkerIDs ?? []).contains(WorkerComposition.micropubWorkerID)
+      }
+  }
+  ```
+
+  Confirm `SiteSettings.activeWorkerIDs` really is the field that reflects the *composed* set
+  (not just *ever provisioned*) — re-read `Sources/AnglesiteCore/SiteConfigStore.swift:44-52`'s
+  doc comment before finalizing; if `activeWorkerIDs` turns out to mean something subtly
+  different (e.g. "was active as of last deploy" vs. "is active now"), use whichever field the
+  comment says is authoritative for "is this Worker live right now" — adjust the implementation
+  and this task's tests to match, not the other way around.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+  Run: `swift test --package-path . --filter CMSModeStatusTests`
+  Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add Sources/AnglesiteCore/CMSModeStatus.swift Tests/AnglesiteCoreTests/CMSModeStatusTests.swift
+  git commit -m "feat(#800): add CMSModeStatus.isProvisioned"
+  ```
+
+### Task 4 (A4): Expose `MicropubContentCommitter`'s sync-state read/write
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/MicropubContentCommitter.swift:19,23-31`
+- Test: `Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift` (extend existing file — read it first to match its fixture style)
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces: `public typealias SyncState = [String: String]` (widen access from `internal`), `public static func readSyncState(from configDirectory: URL) -> SyncState`, `public static func writeSyncState(_ state: SyncState, to configDirectory: URL, fileManager: FileManager = .default) throws` — the exact map (`Config/micropubSync.json`, post URL → `Source/`-relative path) both Task A5 (save path) and Task B1 (content import) read and append to, so there is exactly one persisted mapping, never two.
+
+- [ ] **Step 1: Read the existing file in full**
+
+  `Sources/AnglesiteCore/MicropubContentCommitter.swift` — confirm the exact current signatures
+  of `loadState(from:)` (line 23) and `saveState(_:to:fileManager:)` (line 31) before renaming
+  anything, since other call sites inside the same file (`commit`, line 83) already use them and
+  must keep working unchanged.
+
+- [ ] **Step 2: Write the failing test**
+
+  ```swift
+  @Test("readSyncState/writeSyncState round-trip through Config/micropubSync.json")
+  func syncStateRoundTrips() throws {
+      let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+      try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: configDir) }
+
+      #expect(MicropubContentCommitter.readSyncState(from: configDir) == [:])
+
+      let state: MicropubContentCommitter.SyncState = ["https://owner.example/blog/hello": "src/content/blog/hello.md"]
+      try MicropubContentCommitter.writeSyncState(state, to: configDir)
+      #expect(MicropubContentCommitter.readSyncState(from: configDir) == state)
+  }
+  ```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+  Run: `swift test --package-path . --filter MicropubContentCommitterTests/syncStateRoundTrips`
+  Expected: FAIL — compile error, `readSyncState`/`writeSyncState` don't exist yet.
+
+- [ ] **Step 4: Rename and widen access**
+
+  In `MicropubContentCommitter.swift`:
+  - `typealias SyncState = [String: String]` → `public typealias SyncState = [String: String]`
+  - `private static func loadState(from configDirectory: URL) -> SyncState` → `public static func readSyncState(from configDirectory: URL) -> SyncState` (keep the body identical)
+  - `private static func saveState(_ state: SyncState, to configDirectory: URL, fileManager: FileManager) -> Void` → `public static func writeSyncState(_ state: SyncState, to configDirectory: URL, fileManager: FileManager = .default) throws` — if the existing body silently swallows write errors (check), change it to `throw` instead, since Task A5's save path must surface a failed sync-state write rather than losing the URL↔path mapping silently. Update its two internal call sites (in `resolvePath`/`commit`) to `try`/`try?` appropriately — keep their existing error-handling posture (the design doc's "never silently held" principle only requires *this new public entry point* to be honest; the internal export-sync caller can keep its current best-effort posture if that's what it has today).
+  - Update the two existing internal call sites in the same file to the new names.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+  Run: `swift test --package-path . --filter MicropubContentCommitterTests`
+  Expected: PASS (including all pre-existing tests in the file — this step's rename must not
+  break `commit`'s existing behavior).
+
+- [ ] **Step 6: Run the full AnglesiteCore suite**
+
+  Run: `swift test --package-path . --filter AnglesiteCoreTests`
+  Expected: PASS — confirms nothing else in the module referenced the old private names.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add Sources/AnglesiteCore/MicropubContentCommitter.swift Tests/AnglesiteCoreTests/MicropubContentCommitterTests.swift
+  git commit -m "refactor(#800): expose MicropubContentCommitter's sync-state as public API"
+  ```
+
+### Task 5 (A5): Save-path branch — `TypedEntryEditorModel` writes through `MicropubClient` in CMS mode
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/TypedEntryEditorModel.swift:88-117` (`save()`), its `init`
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift:~1500` (thread `configDirectory` into the constructor call)
+- Test: `Tests/AnglesiteAppTests/TypedEntryEditorModelCMSModeTests.swift` (or extend the existing `TypedEntryEditorModel` test file if one exists — `find Tests -iname "*TypedEntryEditorModel*"` first)
+
+**Interfaces:**
+- Consumes: `CMSModeStatus.isProvisioned(settings:)` (Task A3), `MicropubContentCommitter.readSyncState(from:)`/`writeSyncState(_:to:)` (Task A4), `MicropubComposerProjection.properties(for:values:status:)` (`Sources/AnglesiteCore/MicropubComposerProjection.swift:32`), `MicropubClient.create(_:)`/`.update(url:replace:add:delete:)` (`Sources/AnglesiteCore/MicropubClient.swift:260,284`), `SecretStore` Micropub accessors (`Sources/AnglesiteCore/Platform/SecretStore.swift:232-259`)
+- Produces: `TypedEntryEditorModel.init(file:descriptor:route:sourceDirectory:configDirectory:)` (new `configDirectory: URL?` parameter, default `nil` so any other call site keeps compiling), unchanged public `save() async -> Bool` signature.
+
+- [ ] **Step 1: Read the current `save()`/`init` in full**
+
+  `Sources/AnglesiteApp/TypedEntryEditorModel.swift:1-120,257` — confirm exact property names
+  (`descriptor`, `values`/`savedValues`, `sourceDirectory`, `file`) before writing the branch, and
+  confirm whether `values`/`savedValues` are already typed as `TypedContentEditor.Values` (per
+  earlier research) or need a small adapter.
+
+- [ ] **Step 2: Write the failing test — CMS mode routes through MicropubClient.create for a new post**
+
+  ```swift
+  import Testing
+  @testable import AnglesiteApp
+  @testable import AnglesiteCore
+
+  @Suite(.serialized)
+  struct TypedEntryEditorModelCMSModeTests {
+      @Test("save() creates via MicropubClient when the site is CMS-mode provisioned and no prior URL is synced")
+      func savesViaMicropubCreate() async throws {
+          let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+          let sourceDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+          try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+          try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+          defer {
+              try? FileManager.default.removeItem(at: configDir)
+              try? FileManager.default.removeItem(at: sourceDir)
+          }
+          var settings = SiteSettings()
+          settings.activeWorkerIDs = ["micropub"]
+          try SiteConfigStore.write(settings, to: configDir)
+
+          var capturedRequest: URLRequest?
+          // Inject the fake MicropubClient transport + credentials via whatever seam Step 3's
+          // implementation exposes (e.g. a `MicropubClientFactory` closure on the model, or a
+          // test-only `init` overload) — the exact injection point depends on how Step 3 wires
+          // credential resolution, since `SecretStore` reads are themselves I/O this test must
+          // not perform for real. Prefer adding an injectable `makeMicropubClient: (URL) -> MicropubClient?`
+          // closure to `TypedEntryEditorModel.init` (default resolves from Keychain in
+          // production) over reaching into Keychain in this test.
+
+          // ... construct model, call save(), assert capturedRequest's method/body reflects a
+          // Micropub create, and assert Config/micropubSync.json now maps the returned URL to
+          // this file's Source/-relative path (via MicropubContentCommitter.readSyncState).
+      }
+
+      @Test("save() falls back to file+git when the site is not CMS-mode provisioned")
+      func savesViaFileWhenUnprovisioned() async throws {
+          // No activeWorkerIDs set (or missing "micropub") — assert the file on disk changed and
+          // no Micropub request was attempted (capturedRequest stays nil).
+      }
+  }
+  ```
+
+  Fill in the constructor/assertion details once Step 3 settles the exact injection seam — this
+  is the one step in this plan where the test body depends on an implementation choice made in
+  the same task, so write Step 3 first if it's easier to keep both consistent, then backfill this
+  test.
+
+- [ ] **Step 3: Add `configDirectory` and a `makeMicropubClient` seam to `TypedEntryEditorModel`**
+
+  ```swift
+  // Sources/AnglesiteApp/TypedEntryEditorModel.swift — additive changes only
+
+  /// Resolves a ready-to-use `MicropubClient` for `siteID` from Keychain, or `nil` if no
+  /// session has been onboarded yet (Task A2's connect sheet never ran, or was signed out).
+  /// Injectable so tests never touch the real Keychain.
+  typealias MicropubClientFactory = (_ siteID: UUID) -> MicropubClient?
+
+  static func defaultMicropubClientFactory(secretStore: any SecretStore = KeychainStore()) -> MicropubClientFactory {
+      { siteID in
+          guard let session = try? MicropubSession.resolve(siteID: siteID, secretStore: secretStore) else { return nil }
+          return session.makeClient()
+      }
+  }
+  ```
+
+  Check whether `MicropubSession` already has a `resolve(siteID:secretStore:)`-shaped static
+  constructor reading the Keychain accessors from `SecretStore.swift:232-259` — if not, this task
+  needs to add one to `MicropubSession` itself (in `Sources/AnglesiteIOS/MicropubSession.swift`,
+  since that's where the type lives) rather than duplicating Keychain-reading logic in
+  `AnglesiteApp`. Confirm with `grep -n "func resolve\|static func" Sources/AnglesiteIOS/MicropubSession.swift` before deciding which file this constructor belongs in.
+
+  Add stored properties `configDirectory: URL?`, `siteID: UUID?`, `makeMicropubClient: MicropubClientFactory`
+  to `TypedEntryEditorModel`, threaded through `init` with defaults (`nil`, `nil`,
+  `Self.defaultMicropubClientFactory()`) so existing call sites without CMS-mode context keep
+  compiling unchanged.
+
+- [ ] **Step 4: Branch `save()`**
+
+  ```swift
+  @discardableResult
+  func save() async -> Bool {
+      guard isDirty, !isSaving else { return true }
+      isSaving = true
+      defer { isSaving = false }
+
+      if let configDirectory, let siteID,
+         let settings = try? SiteConfigStore.read(from: configDirectory),
+         CMSModeStatus.isProvisioned(settings: settings),
+         let client = makeMicropubClient(siteID) {
+          return await saveViaMicropub(client: client, configDirectory: configDirectory)
+      }
+      return await saveViaFile() // existing body, renamed
+  }
+
+  private func saveViaMicropub(client: MicropubClient, configDirectory: URL) async -> Bool {
+      let relPath = /* existing relative-path computation, reused from saveViaFile */
+      var syncState = MicropubContentCommitter.readSyncState(from: configDirectory)
+      let properties = MicropubComposerProjection.properties(
+          for: descriptor, values: values,
+          status: values["draft"] == .flag(true) ? .draft : .published)
+      do {
+          if let existingURLString = syncState.first(where: { $0.value == relPath })?.key,
+             let existingURL = URL(string: existingURLString) {
+              _ = try await client.update(url: existingURL, replace: properties)
+          } else {
+              let post = MicropubPost(properties: properties)
+              let newURL = try await client.create(post)
+              syncState[newURL.absoluteString] = relPath
+              try MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
+          }
+          savedValues = values
+          return true
+      } catch {
+          loadError = "CMS save failed: \(error.localizedDescription)"
+          return false
+      }
+  }
+  ```
+
+  This is a sketch, not final code — re-derive `relPath` from whatever `saveViaFile` (the
+  renamed existing body) already computes rather than recomputing it differently, and confirm
+  `values["draft"]` really is how draft state is read on this model (cross-check against Part
+  B's `draft` field handling elsewhere in the same file). Handle the 401 case per spec: catch
+  `MicropubError.unauthorized` specifically and surface a distinct "sign in again" `loadError`
+  rather than the generic message, since `MicropubError.requiresReauthorization` exists exactly
+  for this branch.
+
+- [ ] **Step 5: Thread `configDirectory`/`siteID` from the call site**
+
+  At `Sources/AnglesiteApp/SiteWindowModel.swift:~1500`, change:
+  ```swift
+  return .typed(TypedEntryEditorModel(file: file, descriptor: descriptor, route: route, sourceDirectory: source))
+  ```
+  to:
+  ```swift
+  return .typed(TypedEntryEditorModel(
+      file: file, descriptor: descriptor, route: route, sourceDirectory: source,
+      configDirectory: site?.configDirectory, siteID: site?.id))
+  ```
+  matching `PlistEditorModel`'s existing `configDirectory: site?.configDirectory` argument right
+  above it (line ~1355) exactly.
+
+- [ ] **Step 6: Run the new tests, then the full suite**
+
+  Run: `swift test --package-path . --filter TypedEntryEditorModelCMSModeTests`
+  Expected: PASS
+  Run: `swift test --package-path .`
+  Expected: PASS (no regression in existing `TypedEntryEditorModel`/`SiteWindowModel` tests)
+
+- [ ] **Step 7: Build the app**
+
+  Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add Sources/AnglesiteApp/TypedEntryEditorModel.swift Sources/AnglesiteApp/SiteWindowModel.swift Tests/AnglesiteAppTests/TypedEntryEditorModelCMSModeTests.swift
+  git commit -m "feat(#800): route typed-entry saves through MicropubClient in CMS mode"
+  ```
+
+### Task 6 (A6): Export/read-side labeling in the editor UI
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/TypedEntryEditorView.swift`
+
+**Interfaces:**
+- Consumes: `TypedEntryEditorModel`'s CMS-mode state (expose a small `var isCMSMode: Bool` computed from Task A5's branch condition, so the view doesn't reimplement the check)
+
+- [ ] **Step 1: Add `isCMSMode` to `TypedEntryEditorModel`**
+
+  ```swift
+  var isCMSMode: Bool {
+      guard let configDirectory, let settings = try? SiteConfigStore.read(from: configDirectory) else { return false }
+      return CMSModeStatus.isProvisioned(settings: settings)
+  }
+  ```
+
+- [ ] **Step 2: Add a banner in `TypedEntryEditorView`**
+
+  Near the top of the form (find the existing `VStack`/`Form` root), add:
+  ```swift
+  if model.isCMSMode {
+      Label("This post is stored in your site's CMS. The file on disk is a read-only export.", systemImage: "icloud.and.arrow.down")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+          .padding(.bottom, 4)
+  }
+  ```
+  Match the file's existing spacing/padding conventions rather than the values above verbatim.
+
+- [ ] **Step 3: Manual QA**
+
+  Build and run; open a typed post on a CMS-mode-provisioned test site and confirm the banner
+  appears; open one on an un-provisioned site and confirm it doesn't. Record in the PR body (no
+  automated UI test exists for this view today, matching the rest of `TypedEntryEditorView`).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add Sources/AnglesiteApp/TypedEntryEditorModel.swift Sources/AnglesiteApp/TypedEntryEditorView.swift
+  git commit -m "feat(#800): label CMS-mode posts as read-side exports in the editor"
+  ```
+
+**Milestone A PR:** title `feat(#800): Mac CMS-mode save path`. Body per `.github/PULL_REQUEST_TEMPLATE.md`'s
+exact headings (Summary / Paired PR check / Test plan). Paired PR check: **no** — this is app-only,
+no MCP message schema change. `Closes` line: do not close #800 yet (Milestone B/C remain) — reference
+`Refs #800` instead, or use `Closes #800` only on the final Milestone C PR.
+
+---
+
+## Milestone B — Provisioning content import (§C.7)
+
+Depends on Milestone A (reuses `MicropubComposerProjection`, `MicropubContentCommitter`'s public
+sync-state API, and needs a resolvable `MicropubSession` — see design rationale below for why
+this determines *when* import can run).
+
+### Design rationale — why this isn't wired into `SocialWorkerProvisionCommand.provision()` directly
+
+The spec (§C.7) describes content import as part of provisioning. But `SocialWorkerProvisionCommand.provision()`'s
+natural completion point (`Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:571-572`, the
+`.succeeded` branch) runs **before** any Mac-side IndieAuth onboarding exists for that site — the
+Worker has just been deployed, but nobody has signed in to it yet (Milestone A's connect sheet is
+a separate, later user action). Content import needs to call `MicropubClient.create` — the one
+true write path (Global Constraints) — which needs a session that doesn't exist yet at that point.
+
+Rather than inventing a second, bespoke direct-D1 write path just to dodge that ordering problem
+(which would duplicate `@dwk/micropub`'s own Post-Type-Discovery/slug/validation logic
+client-side and risk schema drift — a real, not hypothetical, risk given `MicropubPostD1Client`
+already mirrors the Worker's `posts` table shape by hand), this plan triggers the one-time import
+**lazily, the first time a CMS-mode session becomes available** for a provisioned site — i.e.,
+right after Task A2's connect sheet reaches `.signedIn` for a site that has never completed
+import. This keeps "one write path" intact and needs no new Worker-side capability.
+
+If this sequencing doesn't match user expectations (e.g. import should happen automatically and
+immediately at provision time even before anyone signs in), that's a product call worth raising
+before merging Milestone B — flag it in the PR description rather than silently deciding it wasn't
+worth mentioning.
+
+### Task 7 (B1): `MicropubContentImport` orchestrator
+
+**Files:**
+- Create: `Sources/AnglesiteCore/MicropubContentImport.swift`
+- Test: `Tests/AnglesiteCoreTests/MicropubContentImportTests.swift`
+
+**Interfaces:**
+- Consumes: `MicropubComposerProjection.properties(for:values:status:)`, `TypedContentEditor.read` (check its exact signature — `grep -n "static func read" Sources/AnglesiteCore/TypedContentEditor.swift`), `ContentTypeRegistry.default`/`.descriptor(forCollection:)` (`Sources/AnglesiteCore/ContentTypeRegistry.swift:259,264`), `MicropubClient.create(_:)`, `MicropubContentCommitter.readSyncState(from:)`/`writeSyncState(_:to:)` (Task A4), `MicropubClient.listPosts(limit:offset:)` (idempotency check)
+- Produces: `public enum MicropubContentImport { public static func importIfNeeded(siteDirectory: URL, configDirectory: URL, client: MicropubClient, registry: ContentTypeRegistry = .default) async -> Int }` — returns the count of newly-imported posts (0 if nothing to do or already imported).
+
+- [ ] **Step 1: Find how existing typed content files are enumerated today**
+
+  Run: `grep -rn "func.*enumerat\|contentsOfDirectory" Sources/AnglesiteCore/NativeContentOperations.swift Sources/AnglesiteCore/ContentTypeRegistry.swift`
+  There should be an existing directory-walk helper (used by e.g. the navigator or search) —
+  reuse it rather than writing a new one. If genuinely nothing suitable exists, write a small
+  private helper in this new file that walks `descriptor.storage`'s collection subdirectory for
+  every `ContentTypeRegistry.default` descriptor with `.collection` storage, listing `.md`/`.mdx`
+  files — mirror whatever glob pattern the Astro template's own `content.config.ts` uses (`.md`,
+  `.mdx`) rather than inventing a different one.
+
+- [ ] **Step 2: Write the failing test — imports an unsynced file, skips an already-synced one**
+
+  ```swift
+  import Testing
+  import Foundation
+  @testable import AnglesiteCore
+
+  @Suite(.serialized)
+  struct MicropubContentImportTests {
+      @Test("imports a typed post file not yet in the sync map, and records its returned URL")
+      func importsNewFile() async throws {
+          let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+          let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+          try FileManager.default.createDirectory(
+              at: siteDir.appending(path: "src/content/blog"), withIntermediateDirectories: true)
+          try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+          defer {
+              try? FileManager.default.removeItem(at: siteDir)
+              try? FileManager.default.removeItem(at: configDir)
+          }
+          let post = """
+          ---
+          title: Hello World
+          pubDate: 2026-01-01
+          draft: false
+          ---
+          Body text.
+          """
+          try post.write(
+              to: siteDir.appending(path: "src/content/blog/hello-world.md"),
+              atomically: true, encoding: .utf8)
+
+          var createdCount = 0
+          let client = MicropubClient(
+              endpoint: URL(string: "https://owner.example/micropub")!,
+              accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+              transport: { request in
+                  createdCount += 1
+                  let response = HTTPURLResponse(
+                      url: request.url!, statusCode: 201, httpVersion: nil,
+                      headerFields: ["Location": "https://owner.example/blog/hello-world"])!
+                  return (Data(), response)
+              })
+
+          let imported = await MicropubContentImport.importIfNeeded(
+              siteDirectory: siteDir, configDirectory: configDir, client: client)
+
+          #expect(imported == 1)
+          #expect(createdCount == 1)
+          let state = MicropubContentCommitter.readSyncState(from: configDir)
+          #expect(state["https://owner.example/blog/hello-world"] == "src/content/blog/hello-world.md")
+      }
+
+      @Test("re-running is a no-op once every file is already in the sync map")
+      func skipsAlreadyImported() async throws {
+          // Same setup, but pre-seed Config/micropubSync.json with the file's path already
+          // mapped to some URL via MicropubContentCommitter.writeSyncState before calling
+          // importIfNeeded; assert createdCount stays 0 and imported == 0.
+      }
+  }
+  ```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+  Run: `swift test --package-path . --filter MicropubContentImportTests`
+  Expected: FAIL — type doesn't exist.
+
+- [ ] **Step 4: Write `MicropubContentImport`**
+
+  ```swift
+  // Sources/AnglesiteCore/MicropubContentImport.swift
+  import Foundation
+
+  /// One-time, idempotent import of a site's existing file-based typed content into D1, run the
+  /// first time a CMS-mode session becomes available for a provisioned site (spec §C.7). Uses
+  /// the same `MicropubClient.create` write path interactive saves use — never a direct D1
+  /// write — so imported posts are validated by `@dwk/micropub` exactly like any other create.
+  /// See docs/superpowers/plans/2026-08-12-cms-mode-mac-save-path-and-content-import.md for why
+  /// this doesn't run inside `SocialWorkerProvisionCommand.provision()` directly.
+  public enum MicropubContentImport {
+      /// Imports every typed content file under `siteDirectory` not already present in
+      /// `Config/micropubSync.json`, via `client.create`. Returns the number of files imported
+      /// (0 if none are pending). Never throws: a single file's create failure is logged to
+      /// `LogCenter` and the import continues with the rest, so one bad file can't block an
+      /// otherwise-successful one-time migration.
+      public static func importIfNeeded(
+          siteDirectory: URL, configDirectory: URL, client: MicropubClient,
+          registry: ContentTypeRegistry = .default
+      ) async -> Int {
+          var syncState = MicropubContentCommitter.readSyncState(from: configDirectory)
+          let alreadySynced = Set(syncState.values)
+          var importedCount = 0
+
+          for descriptor in registry.collectionDescriptors { // confirm exact accessor name in Step 1
+              guard let files = try? filesForImport(descriptor: descriptor, siteDirectory: siteDirectory) else { continue }
+              for fileURL in files {
+                  let relPath = fileURL.path.replacingOccurrences(of: siteDirectory.path + "/", with: "")
+                  guard !alreadySynced.contains(relPath) else { continue }
+                  guard let values = try? TypedContentEditor.read(from: fileURL, descriptor: descriptor) else { continue }
+                  let status: MicropubPostStatus = (values["draft"] == .flag(true)) ? .draft : .published
+                  let properties = MicropubComposerProjection.properties(for: descriptor, values: values, status: status)
+                  do {
+                      let url = try await client.create(MicropubPost(properties: properties))
+                      syncState[url.absoluteString] = relPath
+                      importedCount += 1
+                  } catch {
+                      await LogCenter.shared.append(
+                          source: "MicropubContentImport", stream: .stderr,
+                          text: "Skipping \(relPath): \(error.localizedDescription)")
+                  }
+              }
+          }
+          if importedCount > 0 {
+              try? MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
+          }
+          return importedCount
+      }
+
+      private static func filesForImport(descriptor: ContentTypeDescriptor, siteDirectory: URL) throws -> [URL] {
+          // Reuse whatever helper Step 1 found; placeholder shape only until that's confirmed.
+          []
+      }
+  }
+  ```
+
+  `registry.collectionDescriptors` is illustrative — `ContentTypeRegistry` may expose collection
+  descriptors under a different accessor name (`allDescriptors.filter { if case .collection = $0.storage { true } else { false } }`,
+  or a dedicated property). Confirm with `grep -n "storage\|case .collection\|var all" Sources/AnglesiteCore/ContentTypeRegistry.swift`
+  before finalizing.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+  Run: `swift test --package-path . --filter MicropubContentImportTests`
+  Expected: PASS
+
+- [ ] **Step 6: Run the full AnglesiteCore suite**
+
+  Run: `swift test --package-path .`
+  Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add Sources/AnglesiteCore/MicropubContentImport.swift Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
+  git commit -m "feat(#800): one-time content import into D1 via MicropubClient"
+  ```
+
+### Task 8 (B2): Trigger import after Mac sign-in, track completion
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/SiteConfigStore.swift` (add `contentImportCompleted: Bool?` to `SiteSettings`)
+- Modify: `Sources/AnglesiteApp/MicropubSiteConnectSheet.swift` (Task A2 — call import on `.signedIn`)
+- Test: extend `Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift` if one exists (`find Tests -iname "*SiteConfigStore*"`)
+
+**Interfaces:**
+- Consumes: `MicropubContentImport.importIfNeeded` (Task B1), `model.micropubClient` (`MicropubOnboardingModel.micropubClient`, `Sources/AnglesiteIOS/MicropubOnboardingModel.swift:81`)
+
+- [ ] **Step 1: Add the flag**
+
+  In `SiteConfigStore.swift`, add near the other optional `Bool?`/state fields:
+  ```swift
+  /// Set once `MicropubContentImport.importIfNeeded` has run at least once for this site,
+  /// successfully or not — the one-time gate that stops a signed-out-then-signed-back-in Mac
+  /// from re-attempting a full import every time (`importIfNeeded` is independently idempotent
+  /// via the sync-state map, but this flag avoids re-scanning every file on every sign-in).
+  public var contentImportCompleted: Bool?
+  ```
+  Add it to the memberwise `init` alongside the other optional fields, default `nil`.
+
+- [ ] **Step 2: Write a test for the new field's round-trip**
+
+  Follow whatever pattern the existing `SiteConfigStoreTests` file uses for its other optional
+  fields (write settings with the field set, read back, compare) — copy that pattern exactly
+  rather than inventing a new one.
+
+- [ ] **Step 3: Wire the trigger into `MicropubSiteConnectSheet`**
+
+  In the `.signedIn` case's handling (Task A2, Step 3), after reaching `.signedIn`:
+  ```swift
+  case .signedIn:
+      Label("Connected", systemImage: "checkmark.seal.fill")
+          .task {
+              guard let client = model.micropubClient else { return }
+              var settings = (try? SiteConfigStore.read(from: configDirectory)) ?? SiteSettings()
+              guard settings.contentImportCompleted != true else { return }
+              _ = await MicropubContentImport.importIfNeeded(
+                  siteDirectory: sourceDirectory, configDirectory: configDirectory, client: client)
+              settings.contentImportCompleted = true
+              try? SiteConfigStore.write(settings, to: configDirectory)
+          }
+      Button("Done") { dismiss() }
+  ```
+  `configDirectory`/`sourceDirectory` need to be threaded into `MicropubSiteConnectSheet.init`
+  alongside `site` (Task A2 already takes a `SiteStore.Site`, which has both as computed
+  properties per `AnglesitePackage` — use `site.configDirectory`/`site.sourceDirectory` directly
+  rather than adding new parameters).
+
+- [ ] **Step 4: Run tests**
+
+  Run: `swift test --package-path .`
+  Expected: PASS
+
+- [ ] **Step 5: Build the app and manually verify**
+
+  Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+  Manually onboard a real (or stub) provisioned site with existing typed content and confirm the
+  import runs once, and a second sign-out/sign-in doesn't re-run it. Record in the PR body.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add Sources/AnglesiteCore/SiteConfigStore.swift Sources/AnglesiteApp/MicropubSiteConnectSheet.swift Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+  git commit -m "feat(#800): trigger one-time content import after Mac IndieAuth sign-in"
+  ```
+
+### Task 9 (B3): Lossless round-trip test
+
+**Files:**
+- Modify: `Tests/AnglesiteCoreTests/MicropubContentImportTests.swift`
+
+**Interfaces:**
+- Consumes: `MicropubContentSync.values(for:properties:updatedAt:slug:)` (`Sources/AnglesiteCore/MicropubContentSync.swift:173`) — the reverse mapping, to prove import → export round-trips.
+
+- [ ] **Step 1: Write the failing test**
+
+  ```swift
+  @Test("import then export reconstructs equivalent field values (lossless round-trip)")
+  func importExportRoundTrips() async throws {
+      // Reuse importsNewFile()'s fixture. After importIfNeeded, capture the mf2 `properties`
+      // the fake transport received (store it in a captured var, same pattern as Task A5's
+      // capturedRequest). Then call MicropubContentSync.values(for: descriptor, properties:
+      // capturedProperties, updatedAt: ..., slug: "hello-world") and assert the result equals
+      // the original file's TypedContentEditor.read(...) values for every field except any the
+      // spec already documents as lossy by design (there should be none for the built-in
+      // `blog`/post-family descriptors — if this test finds one, that's a real bug, not a test
+      // to loosen).
+  }
+  ```
+
+- [ ] **Step 2: Run, verify fail, implement any gap found, verify pass**
+
+  This test may pass immediately if Task B1's `properties(for:...)` and the existing
+  `MicropubContentSync.values(for:...)` are already exact inverses (they're designed to be, per
+  both files' doc comments) — if so, this step is pure verification, not new production code.
+  If it fails, the bug is in whichever direction doesn't match the other; fix the mapping, not
+  the test's expectations.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
+  git commit -m "test(#800): prove content import/export round-trip is lossless"
+  ```
+
+**Milestone B PR:** title `feat(#800): one-time content import into CMS mode (§C.7)`. `Refs #800`.
+
+---
+
+## Milestone C — Opt-in live e2e
+
+Depends on Milestones A and B. One test, gated like the existing container/e2e suites (real
+Cloudflare account required, skips cleanly otherwise).
+
+### Task 10 (C1): Gated live e2e test
+
+**Files:**
+- Create: `Tests/AnglesiteCoreTests/CMSModeLiveE2ETests.swift`
+
+**Interfaces:**
+- Consumes: `MicropubClient` (real `defaultTransport`, not faked), `MicropubContentImport.importIfNeeded`, `CMSModeStatus.isProvisioned`, whatever the existing container/e2e suites use for their `.enabled(if:)` gate (`grep -n "enabled(if:" Tests/AnglesiteContainerLocalTests/*.swift` or `Tests/AnglesiteCoreTests/AppliesEditEndToEndTests.swift` for the exact trait syntax and env-var convention already established).
+
+- [ ] **Step 1: Find the existing opt-in e2e gating convention**
+
+  Run: `grep -n "enabled(if:\|ProcessInfo.processInfo.environment" Tests/AnglesiteCoreTests/AppliesEditEndToEndTests.swift Tests/AnglesiteCoreTests/MCPClientHTTPEndToEndTests.swift`
+  Confirm the exact env-var name pattern (e.g. `ANGLESITE_PLUGIN_PATH`, `ANGLESITE_CONTAINER_E2E`)
+  this codebase already uses for "skip cleanly unless a real external dependency is present," and
+  pick a new, consistently-named var for this suite (e.g. `ANGLESITE_MICROPUB_E2E` +
+  `ANGLESITE_MICROPUB_E2E_SITE_URL`/credentials) rather than inventing a different naming shape.
+
+- [ ] **Step 2: Write the gated test**
+
+  ```swift
+  import Testing
+  import Foundation
+  @testable import AnglesiteCore
+
+  @Suite(.enabled(if: ProcessInfo.processInfo.environment["ANGLESITE_MICROPUB_E2E"] == "1"))
+  struct CMSModeLiveE2ETests {
+      @Test("provisioned site: import existing content, create a new post, read it back, publish")
+      func fullLoop() async throws {
+          guard let siteURLString = ProcessInfo.processInfo.environment["ANGLESITE_MICROPUB_E2E_SITE_URL"],
+                let accessToken = ProcessInfo.processInfo.environment["ANGLESITE_MICROPUB_E2E_TOKEN"]
+          else { Issue.record("missing ANGLESITE_MICROPUB_E2E_SITE_URL/TOKEN"); return }
+
+          // 1. Discover the micropub/media endpoints from siteURLString's well-knowns (reuse
+          //    whatever discovery function MicropubOnboardingModel itself calls, kept
+          //    accessible for tests — check its `private`/`internal` access level first).
+          // 2. Build a MicropubClient with a fresh DPoPKeyPair and the provided access token.
+          // 3. Call MicropubContentImport.importIfNeeded against a fixture site directory with a
+          //    few typed posts, assert imported > 0 the first run, 0 the second.
+          // 4. client.create(...) a new draft post, assert the returned URL resolves via
+          //    client.source(url:) with matching properties.
+          // 5. client.setStatus(url:, .published), poll (bounded retries, not a busy loop) until
+          //    the live URL 200s, per the spec's "published — site rebuilding" bake-lag handling.
+      }
+  }
+  ```
+
+  This is intentionally a skeleton — fill in real assertions once a real V-3-conformant test site
+  is available to run this against (per the live-checked conformance gap noted in the Context
+  recap table, that isn't true yet as of 2026-08-12). Land the gated skeleton now so CI never
+  attempts it (the `.enabled(if:)` trait keeps it inert), and note in the PR body that this test
+  is unexercised until a real site exists — flagged, not silently skipped, matching this
+  codebase's existing convention for every other opt-in e2e suite.
+
+- [ ] **Step 3: Confirm it's skipped in normal CI runs**
+
+  Run: `swift test --package-path . --filter CMSModeLiveE2ETests`
+  Expected: 0 tests run (skipped by the trait), not a failure.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add Tests/AnglesiteCoreTests/CMSModeLiveE2ETests.swift
+  git commit -m "test(#800): add opt-in live e2e for CMS-mode import/create/publish"
+  ```
+
+**Milestone C PR:** title `test(#800): opt-in live e2e for CMS mode`. `Closes #800` (this is the
+last remaining piece — Milestones A and B plus the already-shipped #867/#868/#869 complete the
+issue's full scope).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** all seven of #800's checklist items are covered — `MicropubClient`/IndieAuth/iOS
+  compose UI already shipped (#867–869, verified against `git log`, not re-planned here);
+  conformance gating is already satisfied on iOS via per-site discovery (Context recap); Milestone
+  A covers "Mac CMS-mode save path"; Milestone B covers "provisioning... content import" (the
+  deployed-source bundle half of that bullet already shipped per #799, verified directly against
+  `DeployExecutor.swift`/`DeployCommand.swift`); Milestone C covers "opt-in live e2e."
+- **Known gaps flagged, not hidden:** Task A1/A2/A6 rely on manual QA where `ASWebAuthenticationSession`/AppKit
+  UI can't be driven by `swift test` — same limitation the existing macOS Cloudflare sign-in
+  already carries, called out explicitly rather than silently claimed as tested. Task C1 ships
+  inert until a real V-3-conformant site exists to run it against.
+  Several steps (A3 Step 3, A5 Step 3, B1 Step 1/4) tell the implementer to re-confirm one exact
+  field/accessor name against the live file before finalizing — these are the handful of spots
+  where the research above was confident about a type's *existence* and *shape* but not
+  byte-exact about every internal field name; each says exactly what to grep to resolve it, not
+  "figure it out."
+- **Sequencing decision surfaced, not buried:** Milestone B's design-rationale section explains
+  and flags the choice to trigger import on first sign-in rather than at provision time — worth a
+  quick nod from the issue owner before or during review, not a silent judgment call.

--- a/project.yml
+++ b/project.yml
@@ -145,6 +145,11 @@ targets:
         product: AnglesiteIntents
       - package: Anglesite
         product: AnglesiteContainer
+      # Reuses MicropubOnboardingModel's IndieAuth onboarding flow for the Mac's CMS-mode
+      # connect sheet (#800) — the same platform-neutral model AnglesiteMobile already
+      # drives, with SiteMicropubSignIn as the AppKit ASWebAuthenticationSession adapter.
+      - package: Anglesite
+        product: AnglesiteIOS
       - package: STTextView
         product: STTextView
       - package: STTextViewPluginNeon


### PR DESCRIPTION
Refs #800

## Summary

- Adds a macOS `ASWebAuthenticationSession` adapter (`SiteMicropubSignIn`) and a "Connect for CMS Mode…" onboarding sheet, reusing the existing iOS `MicropubOnboardingModel`/`MicropubSession` machinery (from #867/#868/#869) rather than duplicating it.
- Adds `CMSModeStatus.isProvisioned(settings:)` and widens `MicropubContentCommitter`'s persisted post-URL↔file-path sync map (`Config/micropubSync.json`) to public API, so both the save path and the future content-import work (Milestone B) share one source of truth.
- `TypedEntryEditorModel.save()` now branches: once a site is CMS-mode provisioned and a Micropub session has been onboarded on this Mac, typed content saves route through `MicropubClient.create`/`.update` instead of file+git — the same write path the iOS composer already uses, so Mac and phone edits can't diverge. The file-based save path is unchanged (byte-identical) for every other site.
- Adds a small "read-only export" banner in the typed-entry editor when a post is CMS-mode managed, and fixes a pre-existing `Localizable.xcstrings` gap from earlier commits on this branch.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Manual smoke: not exercised in this non-interactive session — `ASWebAuthenticationSession` UI (the connect-sheet sign-in flow) needs a real Cloudflare-provisioned site and can't be driven headlessly. Flagged explicitly rather than claimed; every commit's build/test evidence is in this session's SDD ledger.

🤖 Generated with a subagent-driven-development run (superpowers:subagent-driven-development) — 10 subagent implementer/reviewer round-trips, every task independently re-verified by the coordinator before merging.