### PR TITLE
fix(#1422): stop silently dropping edits with no commit

### DIFF
--- a/Sources/AnglesiteApp/PreviewModel.swift
+++ b/Sources/AnglesiteApp/PreviewModel.swift
@@ -231,11 +231,18 @@ final class PreviewModel {
     /// host repo before the bridge acknowledges success. Other runtime types retain their own
     /// persistence semantics, so the hook is intentionally absent for them — reached via
     /// `containerCapability` (#823) rather than an `as? LocalContainerSiteRuntime` downcast.
-    private static func editPersister(for runtime: any SiteRuntime) -> MCPApplyEditRouter.EditPersister? {
+    /// `internal` (not `private`) so `PreviewModelContainerCapabilityTests` can exercise the
+    /// persister closure directly without a live MCP round trip (#1422).
+    static func editPersister(for runtime: any SiteRuntime) -> MCPApplyEditRouter.EditPersister? {
         guard let capability = runtime.containerCapability else { return nil }
         return { [weak capability] reply in
             guard let capability else { throw SiteRuntimePersistenceError.runtimeNotRunning }
-            guard reply.commit != nil else { return }
+            // Always call through, even with a nil `reply.commit` — `persistEdit` itself throws
+            // `.missingOrInvalidCommit` for that case (#1422). A short-circuit here used to
+            // swallow that throw and report success while silently dropping the edit: the guest
+            // preview showed the change, but nothing landed in host `Source/` and no error
+            // reached the owner. Let `MCPApplyEditRouter.apply` catch the throw and downgrade the
+            // reply to `.failed` instead.
             try await capability.persistEdit(commit: reply.commit)
         }
     }

--- a/Tests/AnglesiteAppTests/PreviewModelContainerCapabilityTests.swift
+++ b/Tests/AnglesiteAppTests/PreviewModelContainerCapabilityTests.swift
@@ -70,7 +70,10 @@ private actor FakeContainerCapableSiteRuntime: SiteRuntime, SiteRuntimeContainer
     func resetNetworking() async { await control.resetNetworking() }
 
     func persistEdit(commit: String?) async throws {
-        guard let commit else { return }
+        // Mirrors `LocalContainerSiteRuntime.persistEdit`'s nil-commit branch: throw rather than
+        // silently no-op, so tests exercising `PreviewModel.editPersister(for:)` observe the same
+        // "nothing verifiable to sync back" failure a real container-backed runtime would produce.
+        guard let commit else { throw SiteRuntimePersistenceError.missingOrInvalidCommit }
         persistedCommits.append(commit)
     }
 
@@ -158,5 +161,36 @@ struct PreviewModelContainerCapabilityTests {
 
         // Must not crash or hang — there's simply nothing to reach.
         await model.syncContentFromHost()
+    }
+
+    @Test("editPersister surfaces a nil commit as a thrown failure instead of silently no-op'ing (#1422)")
+    func editPersisterThrowsRatherThanSilentlySkippingNilCommit() async throws {
+        let runtime = FakeContainerCapableSiteRuntime()
+        await runtime.start(siteID: "custom-site", siteDirectory: URL(fileURLWithPath: "/unused"))
+        guard let persister = PreviewModel.editPersister(for: runtime) else {
+            Issue.record("expected a persister for a container-capable runtime")
+            return
+        }
+        let reply = EditReply(id: "1", status: .applied, message: nil, commit: nil)
+
+        await #expect(throws: SiteRuntimePersistenceError.missingOrInvalidCommit) {
+            try await persister(reply)
+        }
+        #expect(await runtime.persistedCommits.isEmpty)
+    }
+
+    @Test("editPersister forwards a non-nil commit to the capability (#1422)")
+    func editPersisterForwardsCommit() async throws {
+        let runtime = FakeContainerCapableSiteRuntime()
+        await runtime.start(siteID: "custom-site", siteDirectory: URL(fileURLWithPath: "/unused"))
+        guard let persister = PreviewModel.editPersister(for: runtime) else {
+            Issue.record("expected a persister for a container-capable runtime")
+            return
+        }
+        let reply = EditReply(id: "1", status: .applied, message: nil, commit: "deadbeef")
+
+        try await persister(reply)
+
+        #expect(await runtime.persistedCommits == ["deadbeef"])
     }
 }


### PR DESCRIPTION
Closes #1422

## Summary

- `PreviewModel.editPersister`'s `guard reply.commit != nil else { return }` short-circuited before `LocalContainerSiteRuntime.persistEdit` ever got a chance to run — that method already throws `SiteRuntimePersistenceError.missingOrInvalidCommit` for a nil/invalid commit, and `MCPApplyEditRouter.apply` already downgrades that throw into a user-facing `.failed` reply. The guard just prevented the existing error path from ever being reached, so a persistence failure (as `insert-image` hit per the linked issue) was silently reported as success while the guest preview updated and host `Source/` stayed untouched.
- Removed the guard so every reply — nil commit or not — reaches `persistEdit`, letting the existing throw/catch machinery do its job.
- Made `editPersister` `internal` (was `private`) so the persister closure is directly unit-testable without a live MCP round trip.
- Added two regression tests to `PreviewModelContainerCapabilityTests`: a nil commit now throws `missingOrInvalidCommit` instead of silently no-op'ing, and a real commit is still forwarded correctly. Also fixed the test double's `persistEdit` to mirror the real implementation's throw-on-nil behavior (it previously had the same silent-skip bug pattern).

The sidecar-side half of this issue (missing image asset bytes in the `apply-edit-dispatcher.mjs` persist payload) was already fixed and merged upstream in `Anglesite/anglesite-skills#441`. The regression gate suggested in the issue (`scripts/run-container-probe.sh insert-image`) already exists in this repo. A real-signed App Store container hardware re-run (per the issue's own repro, requiring the owner's signing team) is still the outstanding manual verification step — this PR fixes the confirmed host-side code defect but doesn't attempt to replace that hardware smoke test.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

The sidecar-side fix for this issue already merged as [Anglesite/anglesite-skills#441](https://github.com/Anglesite/anglesite-skills/pull/441) (commit `cd529c2`, on `main`, not yet in a tagged release).

## Test plan

- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds.
- [x] `xcodebuild test -project Anglesite.xcodeproj -scheme AnglesiteAppTests -only-testing:AnglesiteAppTests/PreviewModelContainerCapabilityTests` — 8/8 tests pass, including the 2 new regression tests.
- [ ] `swift test --package-path .` (AnglesiteCoreTests etc.) — not independently re-run in this session (environment resource contention caused prior background runs to be interrupted); the changed files are entirely within the `AnglesiteAppCore`/`AnglesiteAppTests` SwiftPM targets, which `AnglesiteCoreTests` does not depend on, so no impact is expected. Recommend CI confirm.
- [ ] Manual smoke: real-signed App Store container insert-image repro — needs the owner's Apple Developer team/signing (see Summary).