### PR TITLE
feat(#1434): wire iOS privacy manifest, export compliance, App Store docs

### DIFF
--- a/Resources/Info-iOS.plist
+++ b/Resources/Info-iOS.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/docs/release.md
+++ b/docs/release.md
@@ -126,3 +126,83 @@ See [#617](https://github.com/Anglesite/Anglesite/issues/617) for the
 separate v1.0 App Store submission track, which shares this same
 archive/export/upload pipeline but goes through full App Review instead
 of TestFlight's Beta App Review.
+
+## iOS App Store Lane (AnglesiteMobile)
+
+`AnglesiteMobile` ships as its **own App Store product**, separate from the Mac
+app — a distinct app record, provisioning, and TestFlight/App Review cycle. See
+`docs/superpowers/specs/2026-08-12-ios-ipados-v2-design.md` §4 for the design
+this section implements (epic #342, tracking issue #1434).
+
+The target's bundle id is `io.dwk.anglesite.ios`, already set in `project.yml`.
+Unlike the Mac target, there is no `scripts/release.sh`-equivalent script yet —
+archive and upload through Xcode Organizer (`Product ▸ Archive` on the
+`AnglesiteMobile` scheme, then `Distribute App ▸ TestFlight & App Store`) or
+`xcodebuild -exportArchive` by hand. Scripting this pipeline is a reasonable
+follow-up once the manual flow is exercised a few times, but is out of scope
+for #1434.
+
+### One-Time Setup
+
+1. **App Store Connect app record.** Create an app for bundle id
+   `io.dwk.anglesite.ios` in [App Store Connect](https://appstoreconnect.apple.com/).
+   As with the Mac app, the build will not upload until the record exists. This
+   can reuse the same Apple Developer team as the Mac app's record.
+
+2. **Certificates and provisioning profile.** An **Apple Distribution**
+   certificate (can be the same one the Mac app uses — it's not
+   platform-specific) plus an **iOS App Store** provisioning profile for
+   `io.dwk.anglesite.ios`, tied to that certificate.
+
+3. **App Store Connect API key.** Reuse the same key created for the Mac app's
+   release pipeline (see "One-Time Setup" step 5 above) — App Store Connect API
+   keys are account-wide, not per-app.
+
+### Entitlements traced to features
+
+Per the design spec §4, each entry in `Resources/AnglesiteMobile.entitlements`
+must trace to a shipped feature — no speculative capabilities:
+
+| Entitlement | Feature | Status |
+|---|---|---|
+| `com.apple.developer.icloud-container-identifiers` / `icloud-services` (`CloudDocuments`) | iCloud site discovery (#866) | Shipped |
+| `com.apple.developer.associated-domains` (`webcredentials:auth.anglesite.dwk.io`) | Cloudflare OAuth callback interception (#891) | Shipped |
+| CloudKit (P2P signaling mailbox) | Anywhere-runtime pairing (#1208 P2) | **Not yet added** — belongs in that feature's PR, not here |
+| Camera usage description (QR pairing scan) | "Edit Site" pairing onboarding (#1431) | **Not yet added** — belongs in that feature's PR, not here |
+| Keychain | Cloudflare token / pinned device keys | No entitlement needed — standard Keychain Services API, no keychain-sharing group |
+
+Deliberately absent: local-network entitlement, background modes — the phone
+dials out per-session only (design spec §4).
+
+### Privacy manifest and export compliance
+
+- `Resources/PrivacyInfo.xcprivacy` is linked into the `AnglesiteMobile` target
+  (shared with the Mac target — see the comment in `project.yml`). No
+  `NSPrivacyCollectedDataTypes` entries: site content stays in the owner's own
+  iCloud container, never collected by or sent to us.
+- `Resources/Info-iOS.plist` declares `ITSAppUsesNonExemptEncryption=false`,
+  matching today's shipped feature set (standard HTTPS/TLS only). Re-verify
+  once the WebRTC/DTLS transport (#1208 P4) ships — DTLS-SRTP as implemented by
+  a standard, unmodified library typically still qualifies for the standard
+  exemption, but confirm before assuming the flag stays `false`.
+
+### App Review demo path
+
+A reviewer has no paired Mac. Per the design spec §4, the app must be
+reviewable standalone:
+
+- Micropub posting (#869) works against any IndieAuth-capable site — provide a
+  demo account's credentials in the review notes.
+- "Edit Site" with no paired Mac must show the pairing explainer, never a dead
+  end (design spec §3) — once #1431 ships, confirm this path works with no
+  setup before submitting.
+- Include a demo video of the full paired-editing flow in the review notes,
+  since a reviewer cannot exercise Mac pairing themselves.
+
+### TestFlight and submission
+
+Once the app record and provisioning above exist, TestFlight distribution and
+App Review submission follow the same shape as the Mac app's "TestFlight Beta
+Distribution" section — Internal Testing needs no Beta App Review, External
+Testing's first build does, and full App Store submission is the v2.0 exit
+criterion per the design spec.

--- a/project.yml
+++ b/project.yml
@@ -174,6 +174,11 @@ targets:
     platform: iOS
     sources:
       - path: Sources/AnglesiteMobile
+      # Shared with the Anglesite/Mac target (#1434): the declared required-reason API
+      # categories (UserDefaults, file timestamps, system boot time) come from AnglesiteCore
+      # code both targets link, so one manifest covers both. Re-audit when P2P/QR-pairing
+      # code (#1431, #1208 P2) adds categories the Mac target doesn't use.
+      - path: Resources/PrivacyInfo.xcprivacy
       - path: Resources/edit-overlay
         type: folder
         buildPhase: resources


### PR DESCRIPTION
Partially addresses #1434 (not closing — the account-setup portions of
that checklist need the repo owner's Apple Developer Portal / App Store
Connect access, which this PR cannot touch).

## Summary

- Links `Resources/PrivacyInfo.xcprivacy` into the `AnglesiteMobile`
  target's sources in `project.yml` — it was only wired into the Mac
  `Anglesite` target before, so the iOS app shipped with no privacy
  manifest at all.
- Adds the missing `ITSAppUsesNonExemptEncryption=false` export-compliance
  key to `Resources/Info-iOS.plist`, mirroring the Mac app's `Info.plist`
  (accurate for today's shipped feature set — standard HTTPS/TLS only).
- Adds an "iOS App Store Lane (AnglesiteMobile)" section to
  `docs/release.md`: one-time setup (app record, certs, provisioning),
  an entitlement-to-feature traceability table, privacy/export-compliance
  notes, and App Review demo-path guidance — mirroring the existing Mac
  section's structure, per the iOS/iPadOS v2.0 design spec §4.

Camera usage description (QR pairing) and the CloudKit entitlement (P2P
signaling mailbox) are **deliberately not added here** — both belong to
features that don't exist in the codebase yet (#1431, #1208 P2). Adding
them now would describe capabilities the app doesn't have; the doc calls
this out explicitly so the right PR adds them alongside the code that
needs them.

## What's left on #1434 (owner-only, not code)

- Creating the `io.dwk.anglesite.ios` app record in App Store Connect
- Apple Distribution cert + iOS App Store provisioning profile
- TestFlight Internal/External Testing group setup
- Actual App Review submission

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 469 tests / 63 Swift Testing suites passed, plus all XCTest suites, 0 failures.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED.
- [x] `./scripts/check-xcodeproj-sync.sh` — passes, `Anglesite.xcodeproj` in sync with `project.yml`.
- [x] Manual smoke: docs/config-only change (privacy manifest resource link, one Info.plist key, one doc section) — no new UI surface to smoke-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)