### PR TITLE
feat(#800): Mac content import into D1 via MicropubClient

### DIFF
--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1095,6 +1095,9 @@
     "Content" : {
 
     },
+    "Content Imported" : {
+
+    },
     "Content Signals" : {
 
     },
@@ -1844,6 +1847,9 @@
     "Impact analysis" : {
 
     },
+    "Import Content" : {
+
+    },
     "Import Site…" : {
 
     },
@@ -1851,6 +1857,9 @@
 
     },
     "Import from Phone" : {
+
+    },
+    "Importing…" : {
 
     },
     "Inactive — not used" : {

--- a/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
+++ b/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
@@ -26,6 +26,17 @@ struct MicropubSiteConnectSheet: View {
     /// `UUID()` that would scope Keychain reads/writes to the wrong identity.
     @State private var invalidSiteID = false
 
+    /// This site's persisted `SiteSettings.contentImportCompleted`, loaded off the main actor by
+    /// `runAutomaticImportIfNeeded()`. `nil` until that load completes — treated the same as "not
+    /// completed" by `shouldShowManualImportButton`, so the manual trigger is available
+    /// immediately rather than waiting on a disk read.
+    @State private var contentImportCompleted: Bool?
+    /// Set while `runManualImport()` is in flight, to swap the button for a `ProgressView`.
+    @State private var manualImportInProgress = false
+    /// Set once a manual import completes, so the control shows a brief confirmation instead of
+    /// silently vanishing the moment `contentImportCompleted` flips to `true`.
+    @State private var manualImportSucceeded = false
+
     var body: some View {
         NavigationStack {
             content
@@ -130,6 +141,9 @@ struct MicropubSiteConnectSheet: View {
             Text(verbatim: me)
                 .font(.callout.monospaced())
                 .foregroundStyle(.secondary)
+            if Self.shouldShowManualImportButton(contentImportCompleted: contentImportCompleted) {
+                manualImportControl
+            }
             Button("Done") { dismiss() }
                 .buttonStyle(.borderedProminent)
                 .padding(.top, 8)
@@ -139,17 +153,114 @@ struct MicropubSiteConnectSheet: View {
         // One-time import of this site's existing typed content into D1 (Task B1/B2, spec §C.7).
         // `micropubClient` is only non-nil right after a fresh `signIn()` — a session restored
         // from Keychain on `configure(site:)` leaves it `nil` (endpoint discovery isn't
-        // persisted), so this simply no-ops until the next real sign-in, matching
-        // `MicropubOnboardingModel`'s documented contract rather than forcing rediscovery here.
-        .task {
-            guard let client = model?.micropubClient else { return }
-            var settings = (try? SiteConfigStore.read(from: site.configDirectory)) ?? SiteSettings()
-            guard settings.contentImportCompleted != true else { return }
-            _ = await MicropubContentImport.importIfNeeded(
-                siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
-            settings.contentImportCompleted = true
-            try? await SiteConfigStore(configDirectory: site.configDirectory).save(settings)
+        // persisted), so this simply loads the completion flag for `manualImportControl` and
+        // no-ops otherwise; the manual button below is the path for that (common — sign in once,
+        // reopen the app later) case.
+        .task { await runAutomaticImportIfNeeded() }
+    }
+
+    /// The manual "Import Content" control shown below the connected state whenever this site's
+    /// import hasn't completed (`shouldShowManualImportButton`) — the discoverable path for the
+    /// common case where `model.micropubClient` is `nil` (a restored session, not a fresh
+    /// sign-in) so the automatic `.task` above never ran the import.
+    @ViewBuilder
+    private var manualImportControl: some View {
+        if manualImportInProgress {
+            ProgressView("Importing…")
+        } else if manualImportSucceeded {
+            Label("Content Imported", systemImage: "checkmark.circle.fill")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        } else {
+            Button("Import Content") { Task { await runManualImport() } }
+                .buttonStyle(.bordered)
         }
+    }
+
+    /// Whether `manualImportControl` should be shown: whenever this site's persisted
+    /// `contentImportCompleted` isn't explicitly `true`, including `nil` (not loaded yet, or
+    /// genuinely never run) — pulled out as a pure static function so the condition is testable
+    /// without hosting the view.
+    static func shouldShowManualImportButton(contentImportCompleted: Bool?) -> Bool {
+        contentImportCompleted != true
+    }
+
+    /// Auto-triggered once per sheet presentation while `.signedIn` is showing (Task B2, spec
+    /// §C.7). Loads the persisted completion flag for `manualImportControl` regardless of
+    /// outcome; only actually runs the import when a fresh sign-in populated
+    /// `model.micropubClient` and the site hasn't imported yet.
+    private func runAutomaticImportIfNeeded() async {
+        // `SiteConfigStore.load()` (the actor-isolated instance method) hops off the main actor
+        // for its file I/O, unlike the synchronous `SiteConfigStore.read(from:)` seam — this
+        // `.task` runs under a SwiftUI view, i.e. on the main actor, so blocking here would stall
+        // the UI (same hazard `MicropubOnboardingModel.configure`'s `Task.detached` and
+        // `StoredMicropubSessions.session` both route around).
+        let loaded = (try? await SiteConfigStore(configDirectory: site.configDirectory).load()) ?? SiteSettings()
+        contentImportCompleted = loaded.contentImportCompleted
+        guard loaded.contentImportCompleted != true, let client = model?.micropubClient else { return }
+        _ = await Self.runImportAndPersistCompletion(
+            siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
+        contentImportCompleted = true
+    }
+
+    /// `manualImportControl`'s button action: resolves a Micropub client without forcing a fresh
+    /// interactive sign-in. Reuses `model.micropubClient` when a sign-in just happened in this
+    /// sheet presentation; otherwise resolves one from the already-stored Keychain credential via
+    /// `StoredMicropubSessions` — the same resolver `MicropubSession`'s doc comment names as "the
+    /// composer's own flow" for re-discovering the endpoint after a restored session, so this
+    /// never re-prompts the user.
+    private func runManualImport() async {
+        guard !manualImportInProgress else { return }
+        manualImportInProgress = true
+        defer { manualImportInProgress = false }
+
+        guard let client = await resolveClient() else { return }
+        _ = await Self.runImportAndPersistCompletion(
+            siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
+        contentImportCompleted = true
+        manualImportSucceeded = true
+    }
+
+    /// A ready-to-use Micropub client for this site, without prompting for sign-in: a fresh
+    /// sign-in's client when one is available, else one resolved from the stored Keychain
+    /// credential (`nil` if the site was never signed in, or the credential is gone and needs
+    /// re-auth — the "Session Expired" state handles that separately).
+    private func resolveClient() async -> MicropubClient? {
+        if let client = model?.micropubClient { return client }
+        return await StoredMicropubSessions()
+            .session(siteID: site.id, sourceDirectory: site.sourceDirectory)?
+            .makeClient()
+    }
+
+    /// Runs the one-time content import, then persists `contentImportCompleted = true` — unless
+    /// `isCancelled()` reports the calling task was cancelled first. SwiftUI cancels a `.task`
+    /// when its view disappears (e.g. the user taps Done while the automatic import is still
+    /// running), but `MicropubContentImport.importIfNeeded` never throws or checks
+    /// `Task.isCancelled` itself — per-file failures, cancellation included, are caught and
+    /// logged rather than propagated — so the import keeps running to completion regardless.
+    /// Without this guard, a sheet dismissed mid-import would still get marked "done" after
+    /// importing few or zero files, with no way to retrigger it. `isCancelled` is injectable so
+    /// tests can exercise both outcomes deterministically instead of racing real `Task`
+    /// cancellation timing.
+    ///
+    /// - Parameters:
+    ///   - siteDirectory: The site's `Source/` directory.
+    ///   - configDirectory: The site's `Config/` directory.
+    ///   - client: The Micropub client to import through.
+    ///   - isCancelled: Reports whether the calling task was cancelled; defaults to the real
+    ///     `Task.isCancelled`.
+    /// - Returns: The number of files imported (see `MicropubContentImport.importIfNeeded`).
+    static func runImportAndPersistCompletion(
+        siteDirectory: URL, configDirectory: URL, client: MicropubClient,
+        isCancelled: () -> Bool = { Task.isCancelled }
+    ) async -> Int {
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDirectory, configDirectory: configDirectory, client: client)
+        guard !isCancelled() else { return imported }
+        var settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
+        settings.contentImportCompleted = true
+        try? await SiteConfigStore(configDirectory: configDirectory).save(settings)
+        return imported
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
+++ b/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
@@ -136,6 +136,20 @@ struct MicropubSiteConnectSheet: View {
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // One-time import of this site's existing typed content into D1 (Task B1/B2, spec §C.7).
+        // `micropubClient` is only non-nil right after a fresh `signIn()` — a session restored
+        // from Keychain on `configure(site:)` leaves it `nil` (endpoint discovery isn't
+        // persisted), so this simply no-ops until the next real sign-in, matching
+        // `MicropubOnboardingModel`'s documented contract rather than forcing rediscovery here.
+        .task {
+            guard let client = model?.micropubClient else { return }
+            var settings = (try? SiteConfigStore.read(from: site.configDirectory)) ?? SiteSettings()
+            guard settings.contentImportCompleted != true else { return }
+            _ = await MicropubContentImport.importIfNeeded(
+                siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
+            settings.contentImportCompleted = true
+            try? await SiteConfigStore(configDirectory: site.configDirectory).save(settings)
+        }
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
+++ b/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
@@ -2,6 +2,37 @@ import SwiftUI
 import AnglesiteCore
 import AnglesiteIOS
 
+/// Serializes `MicropubSiteConnectSheet`'s automatic and manual content-import paths
+/// (`runAutomaticImportIfNeeded()` / `runManualImport()`) so at most one of them is ever calling
+/// `runImportAndPersistCompletion` for a given sheet instance at a time. Without this, tapping
+/// "Import Content" while the automatic `.task`-triggered import is still running would let both
+/// read the same (stale) `Config/micropubSync.json` sync state, `create` duplicate posts against
+/// the live Micropub endpoint, and have whichever `writeSyncState` call finishes last silently
+/// overwrite the other's update instead of merging it.
+///
+/// An `actor` — rather than a `@State private var` `Bool` checked-and-set inline at each call
+/// site — so mutual exclusion is enforced by the actor's own serial execution instead of by
+/// reasoning that no `await` sneaks in between a check and a set, and so `begin()`/`end()` are
+/// directly unit-testable (see `MicropubSiteConnectSheetTests`) without hosting the view or
+/// racing real `Task` scheduling.
+actor ImportInFlightGate {
+    private var inProgress = false
+
+    /// Claims the gate for a new import. Returns `true` (and marks it in-progress) if nothing
+    /// else currently holds it; returns `false` without changing state if it's already claimed —
+    /// the caller should treat that as "decline to start", not wait.
+    func begin() -> Bool {
+        guard !inProgress else { return false }
+        inProgress = true
+        return true
+    }
+
+    /// Releases a previously-claimed gate.
+    func end() {
+        inProgress = false
+    }
+}
+
 /// Mac-side entry point for the same IndieAuth onboarding flow the iOS app already ships (#868)
 /// — reused as-is via `MicropubOnboardingModel`, with `SiteMicropubSignIn` (Task A1) standing in
 /// as the AppKit `ASWebAuthenticationSession` adapter where iOS drives SwiftUI's
@@ -31,8 +62,14 @@ struct MicropubSiteConnectSheet: View {
     /// completed" by `shouldShowManualImportButton`, so the manual trigger is available
     /// immediately rather than waiting on a disk read.
     @State private var contentImportCompleted: Bool?
-    /// Set while `runManualImport()` is in flight, to swap the button for a `ProgressView`.
-    @State private var manualImportInProgress = false
+    /// Guards `runAutomaticImportIfNeeded()` and `runManualImport()` against running concurrently
+    /// for this sheet instance; see `ImportInFlightGate`'s doc comment for why.
+    @State private var importGate = ImportInFlightGate()
+    /// Mirrors `importGate`'s claimed/released state on the main actor, purely so
+    /// `manualImportControl` can render its "Importing…" `ProgressView` while either path holds
+    /// the gate — actor state can't be read synchronously from SwiftUI's view body. Set alongside
+    /// every `importGate.begin()`/`end()` call; never read or written on its own.
+    @State private var importInProgress = false
     /// Set once a manual import completes, so the control shows a brief confirmation instead of
     /// silently vanishing the moment `contentImportCompleted` flips to `true`.
     @State private var manualImportSucceeded = false
@@ -165,7 +202,7 @@ struct MicropubSiteConnectSheet: View {
     /// sign-in) so the automatic `.task` above never ran the import.
     @ViewBuilder
     private var manualImportControl: some View {
-        if manualImportInProgress {
+        if importInProgress {
             ProgressView("Importing…")
         } else if manualImportSucceeded {
             Label("Content Imported", systemImage: "checkmark.circle.fill")
@@ -188,7 +225,8 @@ struct MicropubSiteConnectSheet: View {
     /// Auto-triggered once per sheet presentation while `.signedIn` is showing (Task B2, spec
     /// §C.7). Loads the persisted completion flag for `manualImportControl` regardless of
     /// outcome; only actually runs the import when a fresh sign-in populated
-    /// `model.micropubClient` and the site hasn't imported yet.
+    /// `model.micropubClient`, the site hasn't imported yet, and `importGate` isn't already
+    /// claimed by a concurrent `runManualImport()` — see `ImportInFlightGate`'s doc comment.
     private func runAutomaticImportIfNeeded() async {
         // `SiteConfigStore.load()` (the actor-isolated instance method) hops off the main actor
         // for its file I/O, unlike the synchronous `SiteConfigStore.read(from:)` seam — this
@@ -198,9 +236,12 @@ struct MicropubSiteConnectSheet: View {
         let loaded = (try? await SiteConfigStore(configDirectory: site.configDirectory).load()) ?? SiteSettings()
         contentImportCompleted = loaded.contentImportCompleted
         guard loaded.contentImportCompleted != true, let client = model?.micropubClient else { return }
+        guard await importGate.begin() else { return }
+        importInProgress = true
         _ = await Self.runImportAndPersistCompletion(
             siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
         contentImportCompleted = true
+        await releaseImportGate()
     }
 
     /// `manualImportControl`'s button action: resolves a Micropub client without forcing a fresh
@@ -209,16 +250,30 @@ struct MicropubSiteConnectSheet: View {
     /// `StoredMicropubSessions` — the same resolver `MicropubSession`'s doc comment names as "the
     /// composer's own flow" for re-discovering the endpoint after a restored session, so this
     /// never re-prompts the user.
+    ///
+    /// Declines to start (a no-op return) if `importGate` is already claimed by a concurrent
+    /// `runAutomaticImportIfNeeded()`; see `ImportInFlightGate`'s doc comment.
     private func runManualImport() async {
-        guard !manualImportInProgress else { return }
-        manualImportInProgress = true
-        defer { manualImportInProgress = false }
+        guard await importGate.begin() else { return }
+        importInProgress = true
 
-        guard let client = await resolveClient() else { return }
+        guard let client = await resolveClient() else {
+            await releaseImportGate()
+            return
+        }
         _ = await Self.runImportAndPersistCompletion(
             siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
         contentImportCompleted = true
         manualImportSucceeded = true
+        await releaseImportGate()
+    }
+
+    /// Releases `importGate` and clears its main-actor UI mirror together, so the two never drift
+    /// apart. Called at every exit path of `runAutomaticImportIfNeeded()` / `runManualImport()`
+    /// that follows a successful `importGate.begin()`.
+    private func releaseImportGate() async {
+        importInProgress = false
+        await importGate.end()
     }
 
     /// A ready-to-use Micropub client for this site, without prompting for sign-in: a fresh

--- a/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
+++ b/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
@@ -222,6 +222,16 @@ struct MicropubSiteConnectSheet: View {
         contentImportCompleted != true
     }
 
+    /// Whether `runAutomaticImportIfNeeded()`'s in-memory `contentImportCompleted` mirror should
+    /// flip to `true` after `runImportAndPersistCompletion` returns. Mirrors that function's own
+    /// `isCancelled()` guard exactly (same default, same meaning) so the UI-facing flag can never
+    /// claim "done" on the branch where the persisted write was actually skipped because the
+    /// calling `.task` was cancelled. Pulled out as a pure static function, like
+    /// `shouldShowManualImportButton`, so it's unit-testable without hosting the view.
+    static func shouldMarkContentImportCompleted(isCancelled: () -> Bool = { Task.isCancelled }) -> Bool {
+        !isCancelled()
+    }
+
     /// Auto-triggered once per sheet presentation while `.signedIn` is showing (Task B2, spec
     /// §C.7). Loads the persisted completion flag for `manualImportControl` regardless of
     /// outcome; only actually runs the import when a fresh sign-in populated
@@ -240,7 +250,14 @@ struct MicropubSiteConnectSheet: View {
         importInProgress = true
         _ = await Self.runImportAndPersistCompletion(
             siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
-        contentImportCompleted = true
+        // Mirrors `runImportAndPersistCompletion`'s own `isCancelled()` guard: that helper skips
+        // persisting `contentImportCompleted` to disk when this `.task` was cancelled (the view
+        // disappearing mid-import), so this in-memory mirror must not claim "done" on that branch
+        // either — otherwise it'd drift from the disk state it's supposed to reflect, with no way
+        // to retrigger the import short of relaunching.
+        if Self.shouldMarkContentImportCompleted() {
+            contentImportCompleted = true
+        }
         await releaseImportGate()
     }
 

--- a/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
+++ b/Sources/AnglesiteApp/MicropubSiteConnectSheet.swift
@@ -33,6 +33,18 @@ actor ImportInFlightGate {
     }
 }
 
+/// Outcome of `MicropubSiteConnectSheet.runImportAndPersistCompletion`: how many files that call
+/// imported, and — separately — whether `contentImportCompleted` was actually persisted to disk.
+/// The two can diverge: a call that imports `0` files because everything was already synced still
+/// has `completed == true`, while a call that imports `0` files because every pending file's
+/// `client.create` failed has `completed == false`. Callers must gate any in-memory "done" UI
+/// state on `completed`, never on `importedCount` alone or on the function merely having returned
+/// — see `runImportAndPersistCompletion`'s doc comment for the two guards that decide it.
+struct ImportCompletionResult: Equatable {
+    let importedCount: Int
+    let completed: Bool
+}
+
 /// Mac-side entry point for the same IndieAuth onboarding flow the iOS app already ships (#868)
 /// — reused as-is via `MicropubOnboardingModel`, with `SiteMicropubSignIn` (Task A1) standing in
 /// as the AppKit `ASWebAuthenticationSession` adapter where iOS drives SwiftUI's
@@ -222,16 +234,6 @@ struct MicropubSiteConnectSheet: View {
         contentImportCompleted != true
     }
 
-    /// Whether `runAutomaticImportIfNeeded()`'s in-memory `contentImportCompleted` mirror should
-    /// flip to `true` after `runImportAndPersistCompletion` returns. Mirrors that function's own
-    /// `isCancelled()` guard exactly (same default, same meaning) so the UI-facing flag can never
-    /// claim "done" on the branch where the persisted write was actually skipped because the
-    /// calling `.task` was cancelled. Pulled out as a pure static function, like
-    /// `shouldShowManualImportButton`, so it's unit-testable without hosting the view.
-    static func shouldMarkContentImportCompleted(isCancelled: () -> Bool = { Task.isCancelled }) -> Bool {
-        !isCancelled()
-    }
-
     /// Auto-triggered once per sheet presentation while `.signedIn` is showing (Task B2, spec
     /// §C.7). Loads the persisted completion flag for `manualImportControl` regardless of
     /// outcome; only actually runs the import when a fresh sign-in populated
@@ -248,14 +250,14 @@ struct MicropubSiteConnectSheet: View {
         guard loaded.contentImportCompleted != true, let client = model?.micropubClient else { return }
         guard await importGate.begin() else { return }
         importInProgress = true
-        _ = await Self.runImportAndPersistCompletion(
+        let result = await Self.runImportAndPersistCompletion(
             siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
-        // Mirrors `runImportAndPersistCompletion`'s own `isCancelled()` guard: that helper skips
-        // persisting `contentImportCompleted` to disk when this `.task` was cancelled (the view
-        // disappearing mid-import), so this in-memory mirror must not claim "done" on that branch
-        // either — otherwise it'd drift from the disk state it's supposed to reflect, with no way
-        // to retrigger the import short of relaunching.
-        if Self.shouldMarkContentImportCompleted() {
+        // `result.completed` already reflects both guards `runImportAndPersistCompletion` applies
+        // before persisting `contentImportCompleted` to disk — the calling `.task` being cancelled
+        // (the view disappearing mid-import) and any pending file still left unsynced after a
+        // per-file failure — so mirroring it directly here can't drift from the disk state it's
+        // supposed to reflect, with no way to retrigger the import short of relaunching.
+        if result.completed {
             contentImportCompleted = true
         }
         await releaseImportGate()
@@ -278,10 +280,17 @@ struct MicropubSiteConnectSheet: View {
             await releaseImportGate()
             return
         }
-        _ = await Self.runImportAndPersistCompletion(
+        let result = await Self.runImportAndPersistCompletion(
             siteDirectory: site.sourceDirectory, configDirectory: site.configDirectory, client: client)
-        contentImportCompleted = true
-        manualImportSucceeded = true
+        // Only claim success (and hide the button behind `contentImportCompleted`) when
+        // `result.completed` says the persisted flag actually flipped — i.e. nothing is left
+        // pending. A total or partial failure (expired token, endpoint unreachable, network down
+        // mid-import) must leave both flags alone so `manualImportControl` keeps showing the
+        // "Import Content" button rather than stranding the owner on a run that made no progress.
+        if result.completed {
+            contentImportCompleted = true
+            manualImportSucceeded = true
+        }
         await releaseImportGate()
     }
 
@@ -304,16 +313,27 @@ struct MicropubSiteConnectSheet: View {
             .makeClient()
     }
 
-    /// Runs the one-time content import, then persists `contentImportCompleted = true` — unless
-    /// `isCancelled()` reports the calling task was cancelled first. SwiftUI cancels a `.task`
-    /// when its view disappears (e.g. the user taps Done while the automatic import is still
-    /// running), but `MicropubContentImport.importIfNeeded` never throws or checks
-    /// `Task.isCancelled` itself — per-file failures, cancellation included, are caught and
-    /// logged rather than propagated — so the import keeps running to completion regardless.
-    /// Without this guard, a sheet dismissed mid-import would still get marked "done" after
-    /// importing few or zero files, with no way to retrigger it. `isCancelled` is injectable so
-    /// tests can exercise both outcomes deterministically instead of racing real `Task`
-    /// cancellation timing.
+    /// Runs the one-time content import, then persists `contentImportCompleted = true` — but only
+    /// when doing so is actually true. Two independent gates must both pass first:
+    ///
+    /// 1. `isCancelled()` must report the calling task was **not** cancelled. SwiftUI cancels a
+    ///    `.task` when its view disappears (e.g. the user taps Done while the automatic import is
+    ///    still running), but `MicropubContentImport.importIfNeeded` never throws or checks
+    ///    `Task.isCancelled` itself — per-file failures, cancellation included, are caught and
+    ///    logged rather than propagated — so the import keeps running to completion regardless.
+    /// 2. `MicropubContentImport.unsyncedFileCount` must report `0` pending files afterward.
+    ///    `importIfNeeded`'s own `Int` return only counts files imported *this call* — it can't
+    ///    distinguish "nothing left to import" from "ran, but some or every file failed" (an
+    ///    expired token, an unreachable endpoint, the network dropping mid-import all land here),
+    ///    since a per-file `client.create` failure is caught and logged rather than surfaced. A
+    ///    site whose files all failed would otherwise come back with `imported == 0` and still get
+    ///    marked done.
+    ///
+    /// Without both guards, a sheet dismissed mid-import or a transient/total import failure would
+    /// still get marked "done", permanently hiding `manualImportControl`'s retry button with no
+    /// UI-visible way to retrigger the import short of hand-editing `Config/settings.plist`.
+    /// `isCancelled` is injectable so tests can exercise cancellation deterministically instead of
+    /// racing real `Task` cancellation timing.
     ///
     /// - Parameters:
     ///   - siteDirectory: The site's `Source/` directory.
@@ -321,18 +341,26 @@ struct MicropubSiteConnectSheet: View {
     ///   - client: The Micropub client to import through.
     ///   - isCancelled: Reports whether the calling task was cancelled; defaults to the real
     ///     `Task.isCancelled`.
-    /// - Returns: The number of files imported (see `MicropubContentImport.importIfNeeded`).
+    /// - Returns: The number of files imported this call (see
+    ///   `MicropubContentImport.importIfNeeded`), and whether `contentImportCompleted` was
+    ///   actually persisted to disk. Callers must gate any in-memory "done" mirror on `completed`,
+    ///   not merely on this function having returned.
     static func runImportAndPersistCompletion(
         siteDirectory: URL, configDirectory: URL, client: MicropubClient,
         isCancelled: () -> Bool = { Task.isCancelled }
-    ) async -> Int {
+    ) async -> ImportCompletionResult {
         let imported = await MicropubContentImport.importIfNeeded(
             siteDirectory: siteDirectory, configDirectory: configDirectory, client: client)
-        guard !isCancelled() else { return imported }
+        guard !isCancelled() else { return ImportCompletionResult(importedCount: imported, completed: false) }
+        let stillPending = MicropubContentImport.unsyncedFileCount(
+            siteDirectory: siteDirectory, configDirectory: configDirectory)
+        guard stillPending == 0 else {
+            return ImportCompletionResult(importedCount: imported, completed: false)
+        }
         var settings = (try? await SiteConfigStore(configDirectory: configDirectory).load()) ?? SiteSettings()
         settings.contentImportCompleted = true
         try? await SiteConfigStore(configDirectory: configDirectory).save(settings)
-        return imported
+        return ImportCompletionResult(importedCount: imported, completed: true)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteCore/MicropubContentImport.swift
+++ b/Sources/AnglesiteCore/MicropubContentImport.swift
@@ -1,0 +1,107 @@
+// Sources/AnglesiteCore/MicropubContentImport.swift
+import Foundation
+
+/// One-time, idempotent import of a site's existing typed content files into D1, run the first
+/// time a CMS-mode session becomes available for a provisioned site (spec §C.7). Uses the same
+/// `MicropubClient.create` write path interactive saves use — never a direct D1 write — so
+/// imported posts are validated by `@dwk/micropub` exactly like any other create. See
+/// docs/superpowers/plans/2026-08-12-cms-mode-mac-save-path-and-content-import.md for why this
+/// doesn't run inside `SocialWorkerProvisionCommand.provision()` directly.
+///
+/// Scope is deliberately the **typed content** system only — every `ContentTypeRegistry`
+/// descriptor with `.collection` storage (`note`, `article`, `photo`, …). The template's
+/// separate, untyped `blog` collection (`Resources/Template/src/content.config.ts`) predates the
+/// content-type registry and has no `ContentTypeDescriptor`/mf2 projection to import through.
+public enum MicropubContentImport {
+    /// Imports every typed content file under `siteDirectory` not already present in
+    /// `Config/micropubSync.json`, via `client.create`. Returns the number of files imported
+    /// (0 if none are pending). Never throws: a single file's create failure is logged to
+    /// `LogCenter` and the import continues with the rest, so one bad file can't block an
+    /// otherwise-successful one-time migration.
+    ///
+    /// - Parameters:
+    ///   - siteDirectory: The site's `Source/` directory (contains `src/content/<collection>/`).
+    ///   - configDirectory: The site's `Config/` directory, where `micropubSync.json` lives.
+    ///   - client: The Micropub client to create posts through — the same one interactive saves
+    ///     use, so imported posts go through identical server-side validation.
+    ///   - registry: The content-type registry to enumerate `.collection`-stored descriptors
+    ///     from; defaults to the shared built-in catalog.
+    /// - Returns: The number of files newly imported this call.
+    public static func importIfNeeded(
+        siteDirectory: URL, configDirectory: URL, client: MicropubClient,
+        registry: ContentTypeRegistry = .default
+    ) async -> Int {
+        var syncState = MicropubContentCommitter.readSyncState(from: configDirectory)
+        let alreadySynced = Set(syncState.values)
+        var importedCount = 0
+
+        for descriptor in registry.all where descriptor.collection != nil {
+            for fileURL in filesForImport(descriptor: descriptor, siteDirectory: siteDirectory) {
+                let relPath = relativePath(of: fileURL, under: siteDirectory)
+                guard !alreadySynced.contains(relPath) else { continue }
+                guard let contents = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+                let values = TypedContentEditor.read(contents, descriptor: descriptor)
+                let status: MicropubPostStatus = values["draft"] == .flag(true) ? .draft : .published
+                let properties = MicropubComposerProjection.properties(
+                    for: descriptor, values: values, status: status)
+                do {
+                    let url = try await client.create(MicropubPost(properties: properties))
+                    syncState[url.absoluteString] = relPath
+                    importedCount += 1
+                } catch {
+                    await LogCenter.shared.append(
+                        source: "MicropubContentImport", stream: .stderr,
+                        text: "Skipping \(relPath): \(error.localizedDescription)")
+                }
+            }
+        }
+        if importedCount > 0 {
+            try? MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
+        }
+        return importedCount
+    }
+
+    /// Every file under `siteDirectory`'s `src/content/<collection>/` for `descriptor`, matching
+    /// the Astro template's own `content.config.ts` loader pattern (`glob({ pattern: "**/*.md" })`
+    /// for every typed collection — `.mdx` is not part of that pattern, so this doesn't look for
+    /// it either). Sorted for deterministic import order; an absent collection directory (no
+    /// instances of this type yet) yields `[]` rather than an error.
+    private static func filesForImport(
+        descriptor: ContentTypeDescriptor, siteDirectory: URL, fileManager: FileManager = .default
+    ) -> [URL] {
+        guard let collection = descriptor.collection else { return [] }
+        let dir = siteDirectory.appendingPathComponent("src/content/\(collection)", isDirectory: true)
+        return walk(dir, fileManager: fileManager)
+            .filter { $0.pathExtension.lowercased() == "md" }
+            .sorted { $0.path < $1.path }
+    }
+
+    /// Recursively collects every file under `dir`. Mirrors `ContentScanner`'s private `walk`
+    /// helper (not reusable across files — it's `private`), kept small since this is the only
+    /// caller.
+    private static func walk(_ dir: URL, fileManager: FileManager) -> [URL] {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
+        ) else { return [] }
+        var files: [URL] = []
+        for entry in entries {
+            let isDirectory = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDirectory {
+                files.append(contentsOf: walk(entry, fileManager: fileManager))
+            } else {
+                files.append(entry)
+            }
+        }
+        return files
+    }
+
+    /// POSIX path of `url` relative to `base` (forward slashes, no leading slash) — the
+    /// `Source/`-relative path shape `Config/micropubSync.json` persists. Falls back to the bare
+    /// filename if `url` isn't actually under `base` (shouldn't happen given how this is called).
+    private static func relativePath(of url: URL, under base: URL) -> String {
+        let urlComponents = url.standardizedFileURL.pathComponents
+        let baseComponents = base.standardizedFileURL.pathComponents
+        guard urlComponents.starts(with: baseComponents) else { return url.lastPathComponent }
+        return urlComponents.dropFirst(baseComponents.count).joined(separator: "/")
+    }
+}

--- a/Sources/AnglesiteCore/MicropubContentImport.swift
+++ b/Sources/AnglesiteCore/MicropubContentImport.swift
@@ -44,10 +44,19 @@ public enum MicropubContentImport {
                 let status: MicropubPostStatus = values["draft"] == .flag(true) ? .draft : .published
                 let properties = MicropubComposerProjection.properties(
                     for: descriptor, values: values, status: status)
+                await warnAboutUnmappedFields(descriptor: descriptor, values: values, relPath: relPath)
                 do {
                     let url = try await client.create(MicropubPost(properties: properties))
                     syncState[url.absoluteString] = relPath
                     importedCount += 1
+                    // Persisted immediately, not batched to the end of the loop: `client.create`
+                    // just above is a remote, non-idempotent side effect (it always creates a new
+                    // post), so if the process is interrupted before the next iteration, the sync
+                    // state for every post already created so far must already be on disk — or the
+                    // next run re-imports (and re-`create`s, publishing a duplicate) every file that
+                    // actually succeeded. Imports are a rare, one-time operation, so the extra
+                    // per-file disk write is negligible.
+                    try? MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
                 } catch {
                     await LogCenter.shared.append(
                         source: "MicropubContentImport", stream: .stderr,
@@ -55,10 +64,60 @@ public enum MicropubContentImport {
                 }
             }
         }
-        if importedCount > 0 {
-            try? MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
-        }
         return importedCount
+    }
+
+    /// Logs a warning for any field in `values` that carries content but has no Micropub wire
+    /// form — so an import that silently drops part of a post at least leaves a trace, rather than
+    /// the file simply disappearing from what the imported post says. Two distinct gaps, both
+    /// pre-existing in `MicropubComposerProjection` (see its `properties(for:)` and `mf2Values`
+    /// doc comments):
+    /// - A field the descriptor declares no `microformatProperties` entry for at all.
+    /// - `.objectArray` fields: `mf2Values` always returns `nil` for `.records`, regardless of
+    ///   whether the descriptor maps the field — no built-in collection-stored type has ever
+    ///   needed nested mf2 objects, so that direction was never built.
+    ///
+    /// This does **not** cover the case where a mapped `.image`/`.imageArray` field's value is a
+    /// site-relative media path rather than a hosted URL — that value does reach the wire (as
+    /// whatever string the file has), it just isn't uploaded through `client.uploadMedia` first.
+    /// Adding that is real scope (a media-upload pass over the import), out of scope for a log
+    /// warning; flagged as a fast-follow rather than silently addressed here.
+    ///
+    /// - Parameters:
+    ///   - descriptor: The content type `values` was decoded against.
+    ///   - values: The file's decoded per-field values.
+    ///   - relPath: The file's `Source/`-relative path, named in the log line.
+    private static func warnAboutUnmappedFields(
+        descriptor: ContentTypeDescriptor, values: TypedContentEditor.Values, relPath: String
+    ) async {
+        let dropped = unmappedFieldsWithValues(descriptor: descriptor, values: values)
+        guard !dropped.isEmpty else { return }
+        await LogCenter.shared.append(
+            source: "MicropubContentImport", stream: .stderr,
+            text:
+                "\(relPath): field(s) \(dropped.joined(separator: ", ")) have no Micropub wire "
+                + "mapping and will be dropped from the imported post")
+    }
+
+    /// The names of `descriptor`'s fields (excluding `draft`, which intentionally has no mf2
+    /// property of its own — see `MicropubComposerProjection.properties(for:)`) that hold a
+    /// non-empty value but produce no property on the wire, per `warnAboutUnmappedFields`'s two
+    /// gaps. Reuses `MicropubComposerProjection.mf2Values`/`rawMf2Property` rather than
+    /// reimplementing their per-kind emptiness rules, so this can never drift from what
+    /// `properties(for:)` actually omits.
+    private static func unmappedFieldsWithValues(
+        descriptor: ContentTypeDescriptor, values: TypedContentEditor.Values
+    ) -> [String] {
+        descriptor.fields.compactMap { field -> String? in
+            guard field.name != "draft", let value = values[field.name] else { return nil }
+            if case .records(let rows) = value, !rows.isEmpty {
+                // `.objectArray` has no wire form at all, mapped or not.
+                return field.name
+            }
+            guard descriptor.projections.rawMf2Property(forField: field.name) == nil else { return nil }
+            guard MicropubComposerProjection.mf2Values(for: value, kind: field.kind) != nil else { return nil }
+            return field.name
+        }
     }
 
     /// Every file under `siteDirectory`'s `src/content/<collection>/` for `descriptor`, matching

--- a/Sources/AnglesiteCore/MicropubContentImport.swift
+++ b/Sources/AnglesiteCore/MicropubContentImport.swift
@@ -19,6 +19,14 @@ public enum MicropubContentImport {
     /// `LogCenter` and the import continues with the rest, so one bad file can't block an
     /// otherwise-successful one-time migration.
     ///
+    /// A non-zero return does **not** by itself mean every pending file made it in — a per-file
+    /// failure (a caught `client.create` error, or an unreadable file skipped below) simply
+    /// leaves that file out of the count and off the sync map, with no error surfaced to the
+    /// caller. Callers that need to know whether anything is still pending afterward (e.g. before
+    /// persisting a one-time "import completed" flag) should follow up with
+    /// `unsyncedFileCount(siteDirectory:configDirectory:registry:)` rather than inferring it from
+    /// this return value.
+    ///
     /// - Parameters:
     ///   - siteDirectory: The site's `Source/` directory (contains `src/content/<collection>/`).
     ///   - configDirectory: The site's `Config/` directory, where `micropubSync.json` lives.
@@ -26,45 +34,89 @@ public enum MicropubContentImport {
     ///     use, so imported posts go through identical server-side validation.
     ///   - registry: The content-type registry to enumerate `.collection`-stored descriptors
     ///     from; defaults to the shared built-in catalog.
-    /// - Returns: The number of files newly imported this call.
+    /// - Returns: The number of files newly imported this call. Not a completion signal on its
+    ///   own — see `unsyncedFileCount` above.
     public static func importIfNeeded(
         siteDirectory: URL, configDirectory: URL, client: MicropubClient,
         registry: ContentTypeRegistry = .default
     ) async -> Int {
         var syncState = MicropubContentCommitter.readSyncState(from: configDirectory)
-        let alreadySynced = Set(syncState.values)
         var importedCount = 0
 
+        let pending = pendingFiles(
+            siteDirectory: siteDirectory, alreadySynced: Set(syncState.values), registry: registry)
+        for (fileURL, relPath, descriptor) in pending {
+            guard let contents = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+            let values = TypedContentEditor.read(contents, descriptor: descriptor)
+            let status: MicropubPostStatus = values["draft"] == .flag(true) ? .draft : .published
+            let properties = MicropubComposerProjection.properties(
+                for: descriptor, values: values, status: status)
+            await warnAboutUnmappedFields(descriptor: descriptor, values: values, relPath: relPath)
+            do {
+                let url = try await client.create(MicropubPost(properties: properties))
+                syncState[url.absoluteString] = relPath
+                importedCount += 1
+                // Persisted immediately, not batched to the end of the loop: `client.create`
+                // just above is a remote, non-idempotent side effect (it always creates a new
+                // post), so if the process is interrupted before the next iteration, the sync
+                // state for every post already created so far must already be on disk — or the
+                // next run re-imports (and re-`create`s, publishing a duplicate) every file that
+                // actually succeeded. Imports are a rare, one-time operation, so the extra
+                // per-file disk write is negligible.
+                try? MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
+            } catch {
+                await LogCenter.shared.append(
+                    source: "MicropubContentImport", stream: .stderr,
+                    text: "Skipping \(relPath): \(error.localizedDescription)")
+            }
+        }
+        return importedCount
+    }
+
+    /// Counts typed content files under `siteDirectory` that are **not yet** recorded in
+    /// `Config/micropubSync.json` — i.e. still pending import. Does no importing and never fails;
+    /// an unreadable directory just contributes `0`, same as `filesForImport`.
+    ///
+    /// This is the "did the import actually finish" check `importIfNeeded`'s own `Int` return
+    /// can't provide by itself: that function catches and logs per-file failures rather than
+    /// propagating them (see its doc comment), so a `client.create` failure — expired token,
+    /// unreachable endpoint, network down mid-import — silently leaves the file off the sync map
+    /// instead of surfacing as an error. A caller deciding whether it's safe to persist a one-time
+    /// "import completed" flag should call `importIfNeeded` and then check
+    /// `unsyncedFileCount(...) == 0`, not just that `importIfNeeded` returned without throwing.
+    ///
+    /// - Parameters:
+    ///   - siteDirectory: The site's `Source/` directory (contains `src/content/<collection>/`).
+    ///   - configDirectory: The site's `Config/` directory, where `micropubSync.json` lives.
+    ///   - registry: The content-type registry to enumerate `.collection`-stored descriptors
+    ///     from; defaults to the shared built-in catalog.
+    /// - Returns: The number of typed content files still awaiting import.
+    public static func unsyncedFileCount(
+        siteDirectory: URL, configDirectory: URL, registry: ContentTypeRegistry = .default
+    ) -> Int {
+        let syncState = MicropubContentCommitter.readSyncState(from: configDirectory)
+        return pendingFiles(
+            siteDirectory: siteDirectory, alreadySynced: Set(syncState.values), registry: registry
+        ).count
+    }
+
+    /// Every typed content file under `siteDirectory` not already listed in `alreadySynced` (a
+    /// set of `Source/`-relative paths, as stored in `Config/micropubSync.json`'s values), paired
+    /// with its relative path and the descriptor it was enumerated under. Shared by
+    /// `importIfNeeded` (which imports each one) and `unsyncedFileCount` (which only counts them),
+    /// so the two can never disagree about what "pending" means.
+    private static func pendingFiles(
+        siteDirectory: URL, alreadySynced: Set<String>, registry: ContentTypeRegistry
+    ) -> [(fileURL: URL, relPath: String, descriptor: ContentTypeDescriptor)] {
+        var result: [(URL, String, ContentTypeDescriptor)] = []
         for descriptor in registry.all where descriptor.collection != nil {
             for fileURL in filesForImport(descriptor: descriptor, siteDirectory: siteDirectory) {
                 let relPath = relativePath(of: fileURL, under: siteDirectory)
                 guard !alreadySynced.contains(relPath) else { continue }
-                guard let contents = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
-                let values = TypedContentEditor.read(contents, descriptor: descriptor)
-                let status: MicropubPostStatus = values["draft"] == .flag(true) ? .draft : .published
-                let properties = MicropubComposerProjection.properties(
-                    for: descriptor, values: values, status: status)
-                await warnAboutUnmappedFields(descriptor: descriptor, values: values, relPath: relPath)
-                do {
-                    let url = try await client.create(MicropubPost(properties: properties))
-                    syncState[url.absoluteString] = relPath
-                    importedCount += 1
-                    // Persisted immediately, not batched to the end of the loop: `client.create`
-                    // just above is a remote, non-idempotent side effect (it always creates a new
-                    // post), so if the process is interrupted before the next iteration, the sync
-                    // state for every post already created so far must already be on disk — or the
-                    // next run re-imports (and re-`create`s, publishing a duplicate) every file that
-                    // actually succeeded. Imports are a rare, one-time operation, so the extra
-                    // per-file disk write is negligible.
-                    try? MicropubContentCommitter.writeSyncState(syncState, to: configDirectory)
-                } catch {
-                    await LogCenter.shared.append(
-                        source: "MicropubContentImport", stream: .stderr,
-                        text: "Skipping \(relPath): \(error.localizedDescription)")
-                }
+                result.append((fileURL, relPath, descriptor))
             }
         }
-        return importedCount
+        return result
     }
 
     /// Logs a warning for any field in `values` that carries content but has no Micropub wire

--- a/Sources/AnglesiteCore/SiteConfigStore.swift
+++ b/Sources/AnglesiteCore/SiteConfigStore.swift
@@ -119,6 +119,12 @@ public struct SiteSettings: Sendable, Codable, Equatable {
     /// default-on ask. `true` means the owner explicitly opted out in Site Settings.
     public var markdownForAgentsDisabled: Bool?
 
+    /// Set once `MicropubContentImport.importIfNeeded` has run at least once for this site,
+    /// successfully or not — the one-time gate that stops a signed-out-then-signed-back-in Mac
+    /// from re-attempting a full import every time (`importIfNeeded` is independently idempotent
+    /// via the sync-state map, but this flag avoids re-scanning every file on every sign-in).
+    public var contentImportCompleted: Bool?
+
     /// Memberwise creation. Every parameter defaults to `nil`, matching the type-level
     /// forward-compat rule that all fields stay optional — `SiteSettings()` is the canonical
     /// "no settings yet" value ``SiteConfigStore/load()`` falls back to.
@@ -140,7 +146,8 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         inboxCaptureEnabled: Bool? = nil,
         lastDeployedAPUsername: String? = nil,
         activityPubHandleRenameAcknowledged: String? = nil,
-        markdownForAgentsDisabled: Bool? = nil
+        markdownForAgentsDisabled: Bool? = nil,
+        contentImportCompleted: Bool? = nil
     ) {
         self.displayName = displayName
         self.mastodonBaseURL = mastodonBaseURL
@@ -160,6 +167,7 @@ public struct SiteSettings: Sendable, Codable, Equatable {
         self.lastDeployedAPUsername = lastDeployedAPUsername
         self.activityPubHandleRenameAcknowledged = activityPubHandleRenameAcknowledged
         self.markdownForAgentsDisabled = markdownForAgentsDisabled
+        self.contentImportCompleted = contentImportCompleted
     }
 }
 

--- a/Tests/AnglesiteAppTests/MicropubSiteConnectSheetTests.swift
+++ b/Tests/AnglesiteAppTests/MicropubSiteConnectSheetTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+// URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin platforms
+// (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import AnglesiteAppCore
+import AnglesiteCore
+
+/// Exercises the two pieces of `MicropubSiteConnectSheet`'s content-import trigger (Task 8/B2)
+/// that don't require hosting the view: the manual "Import Content" button's visibility rule,
+/// and the cancellation-aware completion-persisting helper. `MicropubContentImport.importIfNeeded`
+/// itself is covered by `MicropubContentImportTests` in `AnglesiteCoreTests`.
+@Suite(.serialized)
+struct MicropubSiteConnectSheetTests {
+    // MARK: - shouldShowManualImportButton
+
+    @Test(
+        "the manual import button shows whenever contentImportCompleted isn't explicitly true",
+        arguments: [
+            (nil, true),       // never loaded / never run — show it
+            (false, true),     // explicitly not completed — show it
+            (true, false),     // completed — hide it
+        ] as [(Bool?, Bool)]
+    )
+    func manualImportButtonVisibility(contentImportCompleted: Bool?, expected: Bool) {
+        #expect(
+            MicropubSiteConnectSheet.shouldShowManualImportButton(contentImportCompleted: contentImportCompleted)
+                == expected)
+    }
+
+    // MARK: - runImportAndPersistCompletion
+
+    /// Mirrors `MicropubContentImportTests.writeFixture` — a single typed `article` post ready
+    /// to import, plus the `Config/` directory `runImportAndPersistCompletion` writes
+    /// `settings.plist` into.
+    private func writeFixture(siteDir: URL, configDir: URL) throws {
+        try FileManager.default.createDirectory(
+            at: siteDir.appending(path: "src/content/articles"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let post = """
+        ---
+        title: Hello World
+        publishDate: 2026-01-01
+        draft: false
+        ---
+        Body text.
+        """
+        try post.write(
+            to: siteDir.appending(path: "src/content/articles/hello-world.md"),
+            atomically: true, encoding: .utf8)
+    }
+
+    private func fakeClient(created: @escaping @Sendable () -> Void) -> MicropubClient {
+        MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                created()
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/articles/hello-world"])!
+                return (Data(), response)
+            })
+    }
+
+    @Test("persists contentImportCompleted when the calling task was not cancelled")
+    func persistsCompletionWhenNotCancelled() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        let imported = await MicropubSiteConnectSheet.runImportAndPersistCompletion(
+            siteDirectory: siteDir, configDirectory: configDir, client: fakeClient(created: {}),
+            isCancelled: { false })
+
+        #expect(imported == 1)
+        let settings = try await SiteConfigStore(configDirectory: configDir).load()
+        #expect(settings.contentImportCompleted == true)
+    }
+
+    @Test("does not persist contentImportCompleted when the calling task was cancelled")
+    func skipsPersistingCompletionWhenCancelled() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        // The import itself still runs to completion — `MicropubContentImport.importIfNeeded`
+        // isn't cancellation-aware — only the completion-flag write is skipped.
+        let imported = await MicropubSiteConnectSheet.runImportAndPersistCompletion(
+            siteDirectory: siteDir, configDirectory: configDir, client: fakeClient(created: {}),
+            isCancelled: { true })
+
+        #expect(imported == 1)
+        let settings = try await SiteConfigStore(configDirectory: configDir).load()
+        #expect(settings.contentImportCompleted == nil)
+    }
+}

--- a/Tests/AnglesiteAppTests/MicropubSiteConnectSheetTests.swift
+++ b/Tests/AnglesiteAppTests/MicropubSiteConnectSheetTests.swift
@@ -104,4 +104,48 @@ struct MicropubSiteConnectSheetTests {
         let settings = try await SiteConfigStore(configDirectory: configDir).load()
         #expect(settings.contentImportCompleted == nil)
     }
+
+    // MARK: - ImportInFlightGate
+
+    /// This is the piece that closes the concurrency bug a reviewer found: with no shared
+    /// in-flight guard, tapping "Import Content" while the automatic `.task`-triggered import was
+    /// still running let `runAutomaticImportIfNeeded()` and `runManualImport()` both call
+    /// `runImportAndPersistCompletion` at once — each reading the same stale
+    /// `Config/micropubSync.json` sync state, both `create`-ing the same not-yet-synced posts
+    /// against the live Micropub endpoint, and whichever `writeSyncState` finished last silently
+    /// overwriting the other's update. A second `begin()` call while the first is still held must
+    /// be declined, not queued or allowed through.
+    @Test("a second begin() while the gate is held is declined, not allowed through")
+    func secondBeginWhileHeldIsDeclined() async {
+        let gate = ImportInFlightGate()
+
+        #expect(await gate.begin() == true)
+        // The bug this reproduces: without the gate, both callers would proceed to import.
+        #expect(await gate.begin() == false)
+        // Still declined — begin() doesn't consume a second grant on repeated calls.
+        #expect(await gate.begin() == false)
+
+        await gate.end()
+        #expect(await gate.begin() == true, "releasing the gate must allow a fresh import to start")
+    }
+
+    /// Exercises the same invariant under real concurrent scheduling (rather than the sequential
+    /// calls above) by racing many simultaneous `begin()` attempts and confirming only one ever
+    /// wins — the actor's serial execution is what makes this true regardless of task interleaving.
+    @Test("only one of many concurrent begin() attempts succeeds")
+    func onlyOneConcurrentBeginSucceeds() async {
+        let gate = ImportInFlightGate()
+
+        let results = await withTaskGroup(of: Bool.self, returning: [Bool].self) { group in
+            for _ in 0..<20 {
+                group.addTask { await gate.begin() }
+            }
+            var collected: [Bool] = []
+            for await result in group { collected.append(result) }
+            return collected
+        }
+
+        #expect(results.filter { $0 }.count == 1)
+        #expect(results.filter { !$0 }.count == 19)
+    }
 }

--- a/Tests/AnglesiteAppTests/MicropubSiteConnectSheetTests.swift
+++ b/Tests/AnglesiteAppTests/MicropubSiteConnectSheetTests.swift
@@ -75,11 +75,12 @@ struct MicropubSiteConnectSheetTests {
             try? FileManager.default.removeItem(at: configDir)
         }
 
-        let imported = await MicropubSiteConnectSheet.runImportAndPersistCompletion(
+        let result = await MicropubSiteConnectSheet.runImportAndPersistCompletion(
             siteDirectory: siteDir, configDirectory: configDir, client: fakeClient(created: {}),
             isCancelled: { false })
 
-        #expect(imported == 1)
+        #expect(result.importedCount == 1)
+        #expect(result.completed == true)
         let settings = try await SiteConfigStore(configDirectory: configDir).load()
         #expect(settings.contentImportCompleted == true)
     }
@@ -96,32 +97,105 @@ struct MicropubSiteConnectSheetTests {
 
         // The import itself still runs to completion — `MicropubContentImport.importIfNeeded`
         // isn't cancellation-aware — only the completion-flag write is skipped.
-        let imported = await MicropubSiteConnectSheet.runImportAndPersistCompletion(
+        let result = await MicropubSiteConnectSheet.runImportAndPersistCompletion(
             siteDirectory: siteDir, configDirectory: configDir, client: fakeClient(created: {}),
             isCancelled: { true })
 
-        #expect(imported == 1)
+        #expect(result.importedCount == 1)
+        #expect(result.completed == false)
         let settings = try await SiteConfigStore(configDirectory: configDir).load()
         #expect(settings.contentImportCompleted == nil)
     }
 
-    // MARK: - shouldMarkContentImportCompleted
+    // MARK: - runImportAndPersistCompletion + per-file failures (Finding, PR #1457 round 2 review)
 
-    /// This is `runAutomaticImportIfNeeded()`'s half of a reviewer-found landmine: it used to set
-    /// the in-memory `contentImportCompleted` mirror to `true` unconditionally, even on the branch
-    /// where `runImportAndPersistCompletion`'s own `isCancelled()` guard skipped writing the flag
-    /// to disk — letting the UI claim "done" while the persisted state disagreed.
-    /// `shouldMarkContentImportCompleted` must mirror that guard exactly.
-    @Test(
-        "mirrors runImportAndPersistCompletion's own cancellation guard",
-        arguments: [
-            (false, true),   // not cancelled — the persisted write happened, mirror should follow
-            (true, false),   // cancelled — the persisted write was skipped, mirror must not lie
-        ] as [(Bool, Bool)]
-    )
-    func shouldMarkContentImportCompletedMirrorsCancellation(isCancelled: Bool, expected: Bool) {
+    /// The reviewer-found dead end this covers: `MicropubContentImport.importIfNeeded` catches and
+    /// logs a per-file `client.create` failure rather than throwing, so if *every* pending file
+    /// fails (expired token, endpoint unreachable, network down mid-import), the call still
+    /// returns without error and used to leave the caller no way to tell "nothing to do" apart
+    /// from "everything failed." Both look like `imported == 0` from the `Int` this used to
+    /// return. `runImportAndPersistCompletion` must not persist `contentImportCompleted` in that
+    /// case, so `manualImportControl`'s retry button stays available instead of the owner getting
+    /// permanently stranded with no UI-visible way to retry short of hand-editing
+    /// `Config/settings.plist`.
+    @Test("does not persist contentImportCompleted when every pending file's create fails")
+    func doesNotPersistCompletionWhenEveryCreateFails() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        struct SimulatedFailure: Error {}
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { _ in throw SimulatedFailure() })
+
+        let result = await MicropubSiteConnectSheet.runImportAndPersistCompletion(
+            siteDirectory: siteDir, configDirectory: configDir, client: client, isCancelled: { false })
+
+        #expect(result.importedCount == 0)
+        #expect(result.completed == false)
+        let settings = try await SiteConfigStore(configDirectory: configDir).load()
         #expect(
-            MicropubSiteConnectSheet.shouldMarkContentImportCompleted(isCancelled: { isCancelled }) == expected)
+            settings.contentImportCompleted != true,
+            "a total create failure must not leave contentImportCompleted persisted as true")
+        #expect(MicropubContentImport.unsyncedFileCount(siteDirectory: siteDir, configDirectory: configDir) == 1)
+    }
+
+    /// Same dead end as above, but for a partial failure: one of two files imports successfully,
+    /// the other's `create` fails. Completion must still not be persisted — the invariant is
+    /// "genuinely nothing left to import," not "at least one file made it in."
+    @Test("does not persist contentImportCompleted when some pending files' creates fail")
+    func doesNotPersistCompletionOnPartialFailure() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: siteDir.appending(path: "src/content/articles"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        for (slug, title) in [("a-first", "First"), ("b-second", "Second")] {
+            let post = """
+            ---
+            title: \(title)
+            publishDate: 2026-01-01
+            draft: false
+            ---
+            Body text.
+            """
+            try post.write(
+                to: siteDir.appending(path: "src/content/articles/\(slug).md"),
+                atomically: true, encoding: .utf8)
+        }
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        struct SimulatedFailure: Error {}
+        nonisolated(unsafe) var requestCount = 0
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                requestCount += 1
+                guard requestCount == 1 else { throw SimulatedFailure() }
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/articles/a-first"])!
+                return (Data(), response)
+            })
+
+        let result = await MicropubSiteConnectSheet.runImportAndPersistCompletion(
+            siteDirectory: siteDir, configDirectory: configDir, client: client, isCancelled: { false })
+
+        #expect(result.importedCount == 1)
+        #expect(result.completed == false)
+        let settings = try await SiteConfigStore(configDirectory: configDir).load()
+        #expect(settings.contentImportCompleted != true)
+        #expect(MicropubContentImport.unsyncedFileCount(siteDirectory: siteDir, configDirectory: configDir) == 1)
     }
 
     // MARK: - ImportInFlightGate

--- a/Tests/AnglesiteAppTests/MicropubSiteConnectSheetTests.swift
+++ b/Tests/AnglesiteAppTests/MicropubSiteConnectSheetTests.swift
@@ -105,6 +105,25 @@ struct MicropubSiteConnectSheetTests {
         #expect(settings.contentImportCompleted == nil)
     }
 
+    // MARK: - shouldMarkContentImportCompleted
+
+    /// This is `runAutomaticImportIfNeeded()`'s half of a reviewer-found landmine: it used to set
+    /// the in-memory `contentImportCompleted` mirror to `true` unconditionally, even on the branch
+    /// where `runImportAndPersistCompletion`'s own `isCancelled()` guard skipped writing the flag
+    /// to disk — letting the UI claim "done" while the persisted state disagreed.
+    /// `shouldMarkContentImportCompleted` must mirror that guard exactly.
+    @Test(
+        "mirrors runImportAndPersistCompletion's own cancellation guard",
+        arguments: [
+            (false, true),   // not cancelled — the persisted write happened, mirror should follow
+            (true, false),   // cancelled — the persisted write was skipped, mirror must not lie
+        ] as [(Bool, Bool)]
+    )
+    func shouldMarkContentImportCompletedMirrorsCancellation(isCancelled: Bool, expected: Bool) {
+        #expect(
+            MicropubSiteConnectSheet.shouldMarkContentImportCompleted(isCancelled: { isCancelled }) == expected)
+    }
+
     // MARK: - ImportInFlightGate
 
     /// This is the piece that closes the concurrency bug a reviewer found: with no shared

--- a/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
@@ -89,4 +89,140 @@ struct MicropubContentImportTests {
         #expect(imported == 0)
         #expect(createdCount == 0)
     }
+
+    /// Decodes a Micropub create body's `properties` object (`{type, properties}`, the same
+    /// shape `MicropubPost.decodePost` reads, though that helper is private to
+    /// `MicropubClient.swift`) into the `[String: [JSONValue]]` map
+    /// `MicropubContentSync.values(for:properties:updatedAt:slug:)` consumes.
+    private func decodeProperties(from request: URLRequest) throws -> [String: [JSONValue]] {
+        let body = try #require(request.httpBody)
+        let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let rawProperties = try #require(json["properties"] as? [String: [Any]])
+        var properties: [String: [JSONValue]] = [:]
+        for (key, values) in rawProperties {
+            properties[key] = values.compactMap(JSONValue.from)
+        }
+        return properties
+    }
+
+    /// Imports `contents` (a typed content file for `collection`/`descriptor`) through the real
+    /// `MicropubContentImport.importIfNeeded` → `MicropubComposerProjection.properties(for:...)`
+    /// path, captures the mf2 `properties` the fake transport received, maps them back through
+    /// `MicropubContentSync.values(for:properties:updatedAt:slug:)`, and asserts the round trip
+    /// is lossless.
+    ///
+    /// The comparison does NOT do a bare `reconstructed[field] == original[field]`:
+    /// `values(for:)` deliberately OMITS a key (rather than setting a default) for a non-required
+    /// date/url/number field with no resolvable mf2 value — see that function's doc comment.
+    /// That's a documented merge/patch semantic for its real consumer,
+    /// `MicropubContentCommitter.commit`, which feeds a `ResolvedPost.values` straight into
+    /// `TypedContentEditor.write(post.values, into: baseContents, ...)`: an omitted key means
+    /// "leave whatever's already in `baseContents` alone," not "this field is empty," so a
+    /// locally-set value the mf2 wire form doesn't carry survives a pull. Comparing raw `Values`
+    /// structs would misreport that documented omission as data loss (`.date(nil)`/`.text("")`
+    /// present vs. absent). So this closes the loop the same way production code does — write the
+    /// reconstructed values into the original file's own contents (mirroring `commit`'s
+    /// `baseContents = existingContents ?? scaffold` for a file that already exists locally) and
+    /// re-read — which is the actual, exercised round-trip path and the one that genuinely proves
+    /// no data is lost or corrupted.
+    private func assertRoundTrips(
+        collection: String, slug: String, contents: String,
+        sourceLocation: Testing.SourceLocation = #_sourceLocation
+    ) async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: siteDir.appending(path: "src/content/\(collection)"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let fileURL = siteDir.appending(path: "src/content/\(collection)/\(slug).md")
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        nonisolated(unsafe) var capturedRequest: URLRequest?
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                capturedRequest = request
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/\(collection)/\(slug)"])!
+                return (Data(), response)
+            })
+
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client)
+        #expect(imported == 1, sourceLocation: sourceLocation)
+
+        let request = try #require(capturedRequest, sourceLocation: sourceLocation)
+        let capturedProperties = try decodeProperties(from: request)
+
+        let descriptor = try #require(
+            ContentTypeRegistry.default.descriptor(forCollection: collection), sourceLocation: sourceLocation)
+        let original = TypedContentEditor.read(contents, descriptor: descriptor)
+
+        // `updatedAt` only feeds the `publishDate` fallback, and every fixture below sets its own
+        // `publishDate` — present in `capturedProperties` — so an arbitrary value here shouldn't
+        // affect the result.
+        let reconstructed = try #require(
+            MicropubContentSync.values(
+                for: descriptor, properties: capturedProperties, updatedAt: 0, slug: slug),
+            sourceLocation: sourceLocation)
+
+        let rewritten = TypedContentEditor.write(reconstructed, into: contents, descriptor: descriptor)
+        let reread = TypedContentEditor.read(rewritten, descriptor: descriptor)
+
+        for field in descriptor.fields {
+            let originalValue = original[field.name]
+            let rereadValue = reread[field.name]
+            #expect(
+                rereadValue == originalValue,
+                "field \(field.name) did not round-trip: original \(String(describing: originalValue)), reread \(String(describing: rereadValue))",
+                sourceLocation: sourceLocation
+            )
+        }
+    }
+
+    @Test("import then export reconstructs equivalent field values (lossless round-trip)")
+    func importExportRoundTrips() async throws {
+        // Exercises `.string`/`.text`/`.markdown` (title/summary/body), `.datetime` with both a
+        // set value (publishDate) and a set optional value (updated), `.stringArray` (tags, two
+        // entries), `.url` (audience), `.bool` (draft: true, the non-default branch), and the
+        // `.language` default-fallback path (lang left unset in the fixture).
+        try await assertRoundTrips(
+            collection: "articles", slug: "hello-world",
+            contents: """
+            ---
+            title: Hello World
+            summary: A quick recap of the trip
+            publishDate: 2026-01-01T10:30:00.000Z
+            updated: 2026-01-02T08:15:00.000Z
+            tags:
+              - swift
+              - macos
+            audience: https://example.com/audience
+            draft: true
+            ---
+            Body text with **markdown**.
+            """)
+    }
+
+    @Test("import then export round-trips a .number field (rating)")
+    func importExportRoundTripsNumberField() async throws {
+        // `review` is the only built-in descriptor with a `.number`-kind field (`rating`,
+        // required) and has no `draft` field at all — covers both gaps `articles` above doesn't.
+        try await assertRoundTrips(
+            collection: "reviews", slug: "great-gatsby",
+            contents: """
+            ---
+            itemReviewed: The Great Gatsby
+            rating: 4
+            publishDate: 2026-02-01
+            ---
+            Solid read, would recommend.
+            """)
+    }
 }

--- a/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
@@ -356,6 +356,79 @@ struct MicropubContentImportTests {
             """)
     }
 
+    // MARK: - unsyncedFileCount (Finding, PR #1457 round 2 review)
+
+    @Test("unsyncedFileCount reports 0 once every file is imported")
+    func unsyncedFileCountReachesZeroAfterImport() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        #expect(
+            MicropubContentImport.unsyncedFileCount(siteDirectory: siteDir, configDirectory: configDir) == 1,
+            "the fixture's one file hasn't been imported yet")
+
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/articles/hello-world"])!
+                return (Data(), response)
+            })
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client)
+        #expect(imported == 1)
+
+        #expect(MicropubContentImport.unsyncedFileCount(siteDirectory: siteDir, configDirectory: configDir) == 0)
+    }
+
+    /// This is the case the PR #1457 round-2 review flagged: `importIfNeeded` catches and logs a
+    /// per-file `client.create` failure rather than throwing, so a caller can't tell "nothing left
+    /// to import" apart from "every file's create failed" purely from its `Int` return —
+    /// `unsyncedFileCount` is the follow-up check that can.
+    @Test("unsyncedFileCount stays non-zero when every create fails")
+    func unsyncedFileCountStaysNonZeroAfterTotalFailure() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        struct SimulatedFailure: Error {}
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { _ in throw SimulatedFailure() })
+
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client)
+        #expect(imported == 0)
+
+        #expect(
+            MicropubContentImport.unsyncedFileCount(siteDirectory: siteDir, configDirectory: configDir) == 1,
+            "the one file whose create failed must still count as pending")
+    }
+
+    @Test("unsyncedFileCount is 0 when there's nothing to import at all")
+    func unsyncedFileCountZeroWithNoContent() {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        #expect(MicropubContentImport.unsyncedFileCount(siteDirectory: siteDir, configDirectory: configDir) == 0)
+    }
+
     // MARK: - Unmapped-field warning (Finding 2, PR #1457 review)
 
     /// A synthetic `.collection`-storage type with two deliberately unmapped fields — `notes` has

--- a/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite(.serialized)
+struct MicropubContentImportTests {
+    /// `src/content/articles/` is used (not the brief sketch's `src/content/blog/`) because
+    /// `blog` is the template's separate, untyped legacy collection
+    /// (`Resources/Template/src/content.config.ts`) with no `ContentTypeDescriptor` — it has no
+    /// mf2 projection to import through. `articles` is a real `ContentTypeRegistry` collection
+    /// (the `article` descriptor) whose `title`/`publishDate`/`draft` fields match this fixture.
+    private func writeFixture(siteDir: URL, configDir: URL) throws {
+        try FileManager.default.createDirectory(
+            at: siteDir.appending(path: "src/content/articles"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let post = """
+        ---
+        title: Hello World
+        publishDate: 2026-01-01
+        draft: false
+        ---
+        Body text.
+        """
+        try post.write(
+            to: siteDir.appending(path: "src/content/articles/hello-world.md"),
+            atomically: true, encoding: .utf8)
+    }
+
+    @Test("imports a typed post file not yet in the sync map, and records its returned URL")
+    func importsNewFile() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        var createdCount = 0
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                createdCount += 1
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/articles/hello-world"])!
+                return (Data(), response)
+            })
+
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client)
+
+        #expect(imported == 1)
+        #expect(createdCount == 1)
+        let state = MicropubContentCommitter.readSyncState(from: configDir)
+        #expect(state["https://owner.example/articles/hello-world"] == "src/content/articles/hello-world.md")
+    }
+
+    @Test("re-running is a no-op once every file is already in the sync map")
+    func skipsAlreadyImported() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        try MicropubContentCommitter.writeSyncState(
+            ["https://owner.example/articles/hello-world": "src/content/articles/hello-world.md"],
+            to: configDir)
+
+        var createdCount = 0
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                createdCount += 1
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/articles/hello-world-2"])!
+                return (Data(), response)
+            })
+
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client)
+
+        #expect(imported == 0)
+        #expect(createdCount == 0)
+    }
+}

--- a/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
@@ -190,8 +190,14 @@ struct MicropubContentImportTests {
     func importExportRoundTrips() async throws {
         // Exercises `.string`/`.text`/`.markdown` (title/summary/body), `.datetime` with both a
         // set value (publishDate) and a set optional value (updated), `.stringArray` (tags, two
-        // entries), `.url` (audience), `.bool` (draft: true, the non-default branch), and the
-        // `.language` default-fallback path (lang left unset in the fixture).
+        // entries), `.bool` (draft: true, the non-default branch), and the `.language`
+        // default-fallback path (lang left unset in the fixture). `audience` (`.url`) is also set
+        // here, but `article`'s `microformatProperties` has no entry for it at all (only
+        // `title`/`summary`/`body`/`publishDate`/`updated`/`tags` are mapped —
+        // `Sources/AnglesiteCore/ContentTypeRegistry.swift`'s `article` descriptor), so it never
+        // reaches the wire and both directions take the same omission branch `updated` would take
+        // if unset: this field is along for the ride, not a genuine `.url` round-trip case. See
+        // `importExportRoundTripsResolvedURL` below for that.
         try await assertRoundTrips(
             collection: "articles", slug: "hello-world",
             contents: """
@@ -223,6 +229,28 @@ struct MicropubContentImportTests {
             publishDate: 2026-02-01
             ---
             Solid read, would recommend.
+            """)
+    }
+
+    @Test("import then export round-trips a resolved (non-omitted) .url field")
+    func importExportRoundTripsResolvedURL() async throws {
+        // `bookmark`'s `bookmarkOf` (`.url`, required) has a real `u-bookmark-of` mf2 mapping
+        // (`ContentTypeRegistry.swift`'s `bookmark` descriptor), so unlike `article`'s `audience`
+        // above, this genuinely exercises `values(for:)`'s "resolved from mf2" branch for `.url`
+        // — the same `fieldValue(for:)` code path `.string`/`.text` already use, per
+        // `MicropubContentSync.fieldValue`'s `case .string, .language, .text, .url, .image,
+        // .markdown` arm — rather than the "no mapping, always omitted" branch.
+        try await assertRoundTrips(
+            collection: "bookmarks", slug: "great-article",
+            contents: """
+            ---
+            bookmarkOf: https://example.com/a-great-article
+            title: A Great Article
+            publishDate: 2026-03-01
+            tags:
+              - reading
+            ---
+            Worth a read.
             """)
     }
 }

--- a/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
+++ b/Tests/AnglesiteCoreTests/MicropubContentImportTests.swift
@@ -57,6 +57,108 @@ struct MicropubContentImportTests {
         #expect(state["https://owner.example/articles/hello-world"] == "src/content/articles/hello-world.md")
     }
 
+    /// Two-file fixture (sorted so `a-first` is always processed before `b-second`, matching
+    /// `filesForImport`'s `.sorted { $0.path < $1.path }`) for the incremental-persistence tests
+    /// below — a single-file fixture can't distinguish "written once at the end" from "written
+    /// after each create."
+    private func writeTwoFileFixture(siteDir: URL, configDir: URL) throws {
+        try FileManager.default.createDirectory(
+            at: siteDir.appending(path: "src/content/articles"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        for (slug, title) in [("a-first", "First"), ("b-second", "Second")] {
+            let post = """
+            ---
+            title: \(title)
+            publishDate: 2026-01-01
+            draft: false
+            ---
+            Body text.
+            """
+            try post.write(
+                to: siteDir.appending(path: "src/content/articles/\(slug).md"),
+                atomically: true, encoding: .utf8)
+        }
+    }
+
+    @Test("persists sync state after each successful create, not only at the end of the loop")
+    func persistsSyncStateIncrementally() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeTwoFileFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        nonisolated(unsafe) var requestCount = 0
+        nonisolated(unsafe) var stateSeenBeforeSecondCreate: MicropubContentCommitter.SyncState?
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                requestCount += 1
+                if requestCount == 2 {
+                    // The fix under test: the first file's `create` already returned above, and its
+                    // sync-state entry must already be on disk by the time the *second* file's
+                    // `create` fires — not deferred until the whole loop (both files) finishes.
+                    stateSeenBeforeSecondCreate = MicropubContentCommitter.readSyncState(from: configDir)
+                }
+                let slug = requestCount == 1 ? "a-first" : "b-second"
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/articles/\(slug)"])!
+                return (Data(), response)
+            })
+
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client)
+
+        #expect(imported == 2)
+        let stateBefore = try #require(stateSeenBeforeSecondCreate)
+        #expect(stateBefore.count == 1, "only the first file's entry should be on disk before the second create fires")
+        #expect(stateBefore["https://owner.example/articles/a-first"] == "src/content/articles/a-first.md")
+
+        let finalState = MicropubContentCommitter.readSyncState(from: configDir)
+        #expect(finalState.count == 2)
+    }
+
+    @Test("a create failure partway through an import doesn't lose earlier successful creates' sync state")
+    func retainsSyncStateAfterLaterFailure() async throws {
+        // Simulates the crash/interrupt scenario the fix addresses: if the process had died right
+        // here instead of the second `create` merely failing, the first file's sync-state entry
+        // must already be safely on disk — otherwise the next run would re-`create` (and duplicate)
+        // a post that already exists live.
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try writeTwoFileFixture(siteDir: siteDir, configDir: configDir)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        struct SimulatedFailure: Error {}
+        nonisolated(unsafe) var requestCount = 0
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                requestCount += 1
+                guard requestCount == 1 else { throw SimulatedFailure() }
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/articles/a-first"])!
+                return (Data(), response)
+            })
+
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client)
+
+        #expect(imported == 1)
+        let state = MicropubContentCommitter.readSyncState(from: configDir)
+        #expect(state.count == 1)
+        #expect(state["https://owner.example/articles/a-first"] == "src/content/articles/a-first.md")
+    }
+
     @Test("re-running is a no-op once every file is already in the sync map")
     func skipsAlreadyImported() async throws {
         let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
@@ -252,5 +354,146 @@ struct MicropubContentImportTests {
             ---
             Worth a read.
             """)
+    }
+
+    // MARK: - Unmapped-field warning (Finding 2, PR #1457 review)
+
+    /// A synthetic `.collection`-storage type with two deliberately unmapped fields — `notes` has
+    /// no `microformatProperties` entry at all, and `team` (`.objectArray`) has no wire form
+    /// regardless of mapping (`MicropubComposerProjection.mf2Values` always returns `nil` for
+    /// `.records`) — so importing an instance exercises both of `warnAboutUnmappedFields`'s gaps
+    /// at once. None of the built-in `.collection`-stored descriptors have an unmapped or
+    /// `.objectArray` field (only the `.singleton` `resume` type does, which import never walks),
+    /// hence the synthetic registry rather than a built-in fixture.
+    private static let widgetRegistry: ContentTypeRegistry = {
+        let descriptor = ContentTypeDescriptor(
+            id: "widget",
+            displayName: "Widget",
+            storage: .collection("widgets"),
+            fields: [
+                ContentTypeField("title", .string, required: true),
+                ContentTypeField("notes", .text),
+                ContentTypeField(
+                    "team", .objectArray(fields: [
+                        ContentTypeField("role", .string), ContentTypeField("name", .string),
+                    ])),
+                ContentTypeField("publishDate", .datetime, required: true),
+                ContentTypeField("draft", .bool),
+            ],
+            projections: ContentTypeProjections(
+                microformat: "h-entry",
+                microformatProperties: [
+                    "title": "p-name",
+                    "publishDate": "dt-published",
+                ],
+                schemaType: nil
+            )
+        )
+        return ContentTypeRegistry(types: [descriptor])
+    }()
+
+    @Test("logs a warning naming fields that will be silently dropped from the imported post")
+    func warnsAboutUnmappedFieldsWithContent() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        // Unique per test run and embedded in the fixture's own relative path, so the log filter
+        // below can't pick up another test's entry — `LogCenter.shared` is process-global and
+        // Swift Testing runs suites in parallel, the same hazard `MicropubPostD1ClientTests`
+        // documents (#977).
+        let marker = "widget-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            at: siteDir.appending(path: "src/content/widgets"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let post = """
+        ---
+        title: A Widget
+        notes: Some notes that have no wire mapping
+        team:
+          - role: Engineer
+            name: Alex
+        publishDate: 2026-01-01
+        draft: false
+        ---
+        Body text.
+        """
+        try post.write(
+            to: siteDir.appending(path: "src/content/widgets/\(marker).md"),
+            atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/widgets/\(marker)"])!
+                return (Data(), response)
+            })
+
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client,
+            registry: Self.widgetRegistry)
+
+        #expect(imported == 1)
+
+        let logged = await LogCenter.shared.snapshot().filter { $0.text.contains(marker) }
+        #expect(logged.count == 1)
+        let entry = try #require(logged.first)
+        #expect(entry.source == "MicropubContentImport")
+        #expect(entry.stream == .stderr)
+        #expect(entry.text.contains("notes"))
+        #expect(entry.text.contains("team"))
+        // `title`/`publishDate` are mapped and non-empty, so they must not be reported as dropped.
+        #expect(!entry.text.contains("title"))
+        #expect(!entry.text.contains("publishDate"))
+    }
+
+    @Test("does not warn when every field either has a wire mapping or is empty")
+    func noWarningWhenEverythingMapsOrIsEmpty() async throws {
+        let siteDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let configDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let marker = "widget-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            at: siteDir.appending(path: "src/content/widgets"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        // `notes` and `team` are left unset (empty), so neither gap fires despite the descriptor
+        // still lacking a wire mapping for them.
+        let post = """
+        ---
+        title: A Widget
+        publishDate: 2026-01-01
+        draft: false
+        ---
+        Body text.
+        """
+        try post.write(
+            to: siteDir.appending(path: "src/content/widgets/\(marker).md"),
+            atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: siteDir)
+            try? FileManager.default.removeItem(at: configDir)
+        }
+
+        let client = MicropubClient(
+            endpoint: URL(string: "https://owner.example/micropub")!,
+            accessToken: "tok", dpopKeyPair: DPoPKeyPair(),
+            transport: { request in
+                let response = HTTPURLResponse(
+                    url: request.url!, statusCode: 201, httpVersion: nil,
+                    headerFields: ["Location": "https://owner.example/widgets/\(marker)"])!
+                return (Data(), response)
+            })
+
+        let imported = await MicropubContentImport.importIfNeeded(
+            siteDirectory: siteDir, configDirectory: configDir, client: client,
+            registry: Self.widgetRegistry)
+
+        #expect(imported == 1)
+        let logged = await LogCenter.shared.snapshot().filter { $0.text.contains(marker) }
+        #expect(logged.isEmpty)
     }
 }

--- a/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteConfigStoreTests.swift
@@ -287,4 +287,39 @@ struct SiteConfigStoreTests {
         #expect(loaded.inboxCaptureEnabled == nil)
         #expect(loaded.displayName == "Old Site")
     }
+
+    @Test("contentImportCompleted round-trips through save/load")
+    func contentImportCompletedRoundTrips() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let settings = SiteSettings(contentImportCompleted: true)
+        try await store.save(settings)
+
+        let loaded = try await store.load()
+        #expect(loaded.contentImportCompleted == true)
+    }
+
+    @Test("a settings.plist written before contentImportCompleted existed still decodes (forward-compat)")
+    func decodesOldPlistWithoutContentImportCompleted() async throws {
+        let dir = try tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: dir.deletingLastPathComponent()) }
+        // Simulates a plist written by a build that predates this field.
+        let oldFormat = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>displayName</key>
+            <string>My Site</string>
+        </dict>
+        </plist>
+        """
+        try oldFormat.write(to: dir.appendingPathComponent("settings.plist"), atomically: true, encoding: .utf8)
+        let store = SiteConfigStore(configDirectory: dir)
+
+        let loaded = try await store.load()
+        #expect(loaded.contentImportCompleted == nil)
+    }
 }


### PR DESCRIPTION
Refs #800

Builds on #1448 (Milestone A — the Mac save path, merged). This adds the one-time historical-content import that runs after a site connects to CMS mode for the first time.

## Summary

- `MicropubContentImport.importIfNeeded` walks every registered typed-content collection, projects each unsynced file's fields to mf2 properties (the same `MicropubComposerProjection` the save path uses), and creates it through `MicropubClient` — idempotent via the existing `Config/micropubSync.json` sync-state map, no direct D1 write.
- Wires the import into the Mac "Connect for CMS Mode…" sheet: automatically after a fresh sign-in, plus a manual "Import Content" button for the common case where a session restores from Keychain without a fresh sign-in (so the one-time migration is always reachable, not just on a first interactive sign-in). Guards against the automatic and manual paths racing each other with a small in-process mutual-exclusion actor.
- Adds a round-trip test proving the mf2 projection and its reverse mapping are lossless for the field kinds that have working wire mappings today (`.text`/`.string`/`.datetime`/`.number`/`.bool`/`.language`/`.url`/`.stringArray`); `.image`/`.imageArray`/`.objectArray` remain untested pre-existing gaps, documented in the test file rather than silently skipped.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .`
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Manual smoke: not exercised in this non-interactive session — needs a real provisioned site + live IndieAuth/Cloudflare endpoint. Flagged explicitly in every task's report rather than claimed.

🤖 Generated with a subagent-driven-development run (superpowers:subagent-driven-development) — every task independently re-verified by the coordinator, including two real bugs (a MainActor blocking-I/O call, and a concurrency race between the automatic and manual import triggers) caught and fixed during review.