### PR TITLE
fix(#1420): reload preview after content-mutation sync

### DIFF
--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1610,13 +1610,17 @@ final class SiteWindowModel {
     }
 
     /// Every successful native content mutation (create/duplicate/delete/publish/undo/cleanup)
-    /// needs both of these: the Navigator force-refreshed (#586 — its own change-stream observer
-    /// is decoupled from this call) and, when a container preview is running, told to catch up
+    /// needs all three of these: the Navigator force-refreshed (#586 — its own change-stream
+    /// observer is decoupled from this call), a running container preview told to catch up
     /// (#1420 — `NativeContentOperations` commits straight to host `Source/`, which an
-    /// already-booted container's guest clone has no other way to learn about).
+    /// already-booted container's guest clone has no other way to learn about), and the WKWebView
+    /// itself reloaded — `syncContentFromHost()` only updates the guest's working copy, it doesn't
+    /// touch whatever page the preview already has loaded, so a page/post that didn't exist at
+    /// last navigation stays a 404 until something reloads it (#1420).
     private func refreshAfterContentMutation() async {
         await navigator?.refreshNow()
         await preview.syncContentFromHost()
+        preview.reloadPreview()
     }
 
     /// `contentCreation`'s successful create already rescans `SiteContentGraph` and publishes a

--- a/Tests/AnglesiteAppTests/ContentCreationNavigatorRaceTests.swift
+++ b/Tests/AnglesiteAppTests/ContentCreationNavigatorRaceTests.swift
@@ -1,0 +1,109 @@
+// Tests/AnglesiteAppTests/ContentCreationNavigatorRaceTests.swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// #1420: "New Post / New Component / Duplicate don't appear in Navigator or preview after
+/// creation." The issue thread's live hypothesis for the Navigator half was a race between the
+/// file write and `SiteContentGraph`'s own async file-watcher/rescan. Reading `ContentScanner`,
+/// `SiteContentGraph`, and `ContentCreationWorkflow` shows no such watcher exists — every rescan
+/// is a synchronous, `await`ed, generation-fenced call (`ContentCreationWorkflow.
+/// refreshContentGraph`, #666), and `SiteNavigatorModel.refreshNow()` reads the graph back
+/// directly. This test exercises that exact chain end-to-end with real (non-fake) types — the
+/// same wiring `SiteWindowModel.createPost`/`refreshAfterContentMutation` drive in production,
+/// minus the `SiteStore.shared` registry lookup — to settle whether the Navigator half of #1420
+/// still reproduces against current code, or whether (per PR #1425's own "isolated integration
+/// test" claim) that plumbing already works and the remaining bug is elsewhere.
+@Suite("Content creation → Navigator race (#1420)")
+@MainActor
+struct ContentCreationNavigatorRaceTests {
+    private func flatten(_ nodes: [URLTreeNode]) -> [URLTreeNode] {
+        nodes.flatMap { [$0] + flatten($0.children ?? []) }
+    }
+
+    @Test("a post created through the real workflow appears in the Navigator after refreshNow(), no manual delay needed")
+    func createdPostAppearsInNavigatorImmediately() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("content-nav-race-\(UUID().uuidString)", isDirectory: true)
+        let sourceDirectory = root.appendingPathComponent("Test.anglesite/Source", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let graph = SiteContentGraph()
+        let ops = NativeContentOperations(
+            siteDirectory: { _ in sourceDirectory },
+            gitCommit: { _, _, _ in "deadbeef" }
+        )
+        let workflow = ContentCreationWorkflow(
+            operations: ops,
+            contentGraph: graph,
+            siteDirectory: { _ in sourceDirectory }
+        )
+
+        let navigator = SiteNavigatorModel(graph: graph)
+        navigator.start(
+            site: CurrentSite(id: "site-a", packageURL: root.appendingPathComponent("Test.anglesite"),
+                               sourceDirectory: sourceDirectory),
+            websiteTitle: "Test"
+        )
+        // `buildSiteURLTree` returns `[]` for a site with no pages/posts (SiteURLTree.swift:62), so
+        // a freshly created empty `Source/` never populates `nodes` at all — nothing to wait for here.
+        #expect(flatten(navigator.nodes).contains { $0.title == "Retest Refresh Post" } == false)
+
+        let result = await workflow.createPost(siteID: "site-a", title: "Retest Refresh Post", collection: nil, slug: nil)
+        guard case .created = result else {
+            Issue.record("expected .created, got \(result)")
+            return
+        }
+
+        // Mirrors `SiteWindowModel.refreshAfterContentMutation()`'s `navigator?.refreshNow()` call
+        // — the force-refresh #586/#608 added specifically to close the gap between the graph
+        // mutation landing and the Navigator's own long-running stream-consumer task draining it.
+        await navigator.refreshNow()
+
+        #expect(flatten(navigator.nodes).contains { $0.title == "Retest Refresh Post" })
+    }
+
+    @Test("a post created through the real workflow appears in the Navigator via its own change-stream, with no explicit refreshNow() at all")
+    func createdPostAppearsInNavigatorViaChangeStreamAlone() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("content-nav-race-\(UUID().uuidString)", isDirectory: true)
+        let sourceDirectory = root.appendingPathComponent("Test.anglesite/Source", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let graph = SiteContentGraph()
+        let ops = NativeContentOperations(
+            siteDirectory: { _ in sourceDirectory },
+            gitCommit: { _, _, _ in "deadbeef" }
+        )
+        let workflow = ContentCreationWorkflow(
+            operations: ops,
+            contentGraph: graph,
+            siteDirectory: { _ in sourceDirectory }
+        )
+
+        let navigator = SiteNavigatorModel(graph: graph)
+        navigator.start(
+            site: CurrentSite(id: "site-a", packageURL: root.appendingPathComponent("Test.anglesite"),
+                               sourceDirectory: sourceDirectory),
+            websiteTitle: "Test"
+        )
+        let result = await workflow.createPost(siteID: "site-a", title: "Stream-Only Post", collection: nil, slug: nil)
+        guard case .created = result else {
+            Issue.record("expected .created, got \(result)")
+            return
+        }
+
+        // No `refreshNow()` here — only the long-running `changeStream()` consumer task started by
+        // `start()`. Poll with a deadline rather than a single `Task.yield()`: the consumer is a
+        // real suspended `Task`, so it needs the runloop to actually schedule it.
+        let deadline = Date().addingTimeInterval(2)
+        while !flatten(navigator.nodes).contains(where: { $0.title == "Stream-Only Post" }) && Date() < deadline {
+            await Task.yield()
+        }
+
+        #expect(flatten(navigator.nodes).contains { $0.title == "Stream-Only Post" })
+    }
+}


### PR DESCRIPTION
Closes #1420

## Summary

- Root-caused #1420: `SiteContentGraph`/`SiteNavigatorModel` have no async race — every rescan is synchronous, awaited, and generation-fenced, and `refreshNow()` (or the raw change-stream alone) picks up new content in ~10ms against the real `ContentCreationWorkflow`/`NativeContentOperations` wiring. Added `ContentCreationNavigatorRaceTests` to pin this finding.
- The real bug: `SiteWindowModel.refreshAfterContentMutation()` called `preview.syncContentFromHost()` (#1425's guest git-pull) but never told the `WKWebView` to reload, so a page/post/component that didn't exist at last navigation stayed a 404 until a manual reload. Added the missing `preview.reloadPreview()` call.
- Checked `SiteGraphExplorerModel` too: it has its own change-stream subscriber, so create/duplicate (which touch `SiteContentGraph`, unlike Cleanup-delete) don't need an explicit `refreshNow()` call there — ruled out as a non-bug.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here: N/A

## Test plan

- [x] `swift test --package-path .` (3650+ tests, all suites pass)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`, BUILD SUCCEEDED)
- [ ] Manual smoke (if UI-touching): not run — no local container runtime available in this environment to exercise the live preview path end-to-end.