### PR TITLE
feat(#1451): capture og:image into link-post site assets

### DIFF
--- a/Resources/Template/src/components/IndexEntry.astro
+++ b/Resources/Template/src/components/IndexEntry.astro
@@ -32,6 +32,10 @@ const human = item.date.toLocaleDateString("en-US", {
       <>
         <a class="p-name u-url" href={item.permalink}>{item.title}</a>{" "}
         <time class="dt-published" datetime={iso}>{human}</time>
+        {/* Only titled collection with an `image` is `bookmarks` (a captured og:image card,
+            #1451) — the title-less branch below has always rendered `u-photo` for photos, and
+            this is the same markup for the titled case so a link post reads as a card here too. */}
+        {item.image && <img class="u-photo" src={item.image} alt="" />}
         {item.summary && <p class="p-summary">{item.summary}</p>}
       </>
     ) : (

--- a/Resources/Template/src/content.config.ts
+++ b/Resources/Template/src/content.config.ts
@@ -73,6 +73,11 @@ const bookmarks = defineCollection({
     lang: z.string().optional(),
     bookmarkOf: z.string().url(),
     title: z.string().optional(),
+    // Root-relative path to the bookmarked page's Open Graph card image, downloaded into
+    // `public/images/` by quick capture (#1451) — same convention as `photos`' own `image`, and
+    // rendered by `Hentry.astro`/`IndexEntry.astro`'s existing `u-photo` handling. Optional: a
+    // page with no `og:image`, or one that couldn't be fetched, still makes a valid link post.
+    image: z.string().optional(),
     publishDate: z.coerce.date(),
     tags: z.array(z.string()).optional(),
     draft: z.boolean().default(false),

--- a/Sources/AnglesiteApp/QuickCaptureSheet.swift
+++ b/Sources/AnglesiteApp/QuickCaptureSheet.swift
@@ -35,7 +35,7 @@ struct QuickCaptureSheet: View {
         defaultSiteID: String?,
         initialURLString: String,
         fetchMetadata: @escaping @Sendable (URL) async throws -> LinkMetadata,
-        onCreate: @escaping (_ siteID: String?, _ title: String, _ urlString: String, _ commentary: String, _ draft: Bool) async -> ContentCreateResult
+        onCreate: @escaping (_ siteID: String?, _ title: String, _ urlString: String, _ commentary: String, _ imageURL: String?, _ draft: Bool) async -> ContentCreateResult
     ) {
         self.pickerSites = pickerSites
         self.fetchMetadata = fetchMetadata

--- a/Sources/AnglesiteApp/QuickCaptureSheet.swift
+++ b/Sources/AnglesiteApp/QuickCaptureSheet.swift
@@ -10,7 +10,9 @@ struct QuickCaptureSheet: View {
     let pickerSites: [SiteStore.Site]?
     let fetchMetadata: @Sendable (URL) async throws -> LinkMetadata
     /// `siteID` is the picker selection (nil in the site-window flow, which ignores it).
-    let onCreate: (_ siteID: String?, _ title: String, _ urlString: String, _ commentary: String, _ draft: Bool) async -> ContentCreateResult
+    /// `imageURL` is the fetched `og:image`, if the page had a usable one — the creator downloads
+    /// it into the site's assets after the entry is written (#1451).
+    let onCreate: (_ siteID: String?, _ title: String, _ urlString: String, _ commentary: String, _ imageURL: String?, _ draft: Bool) async -> ContentCreateResult
 
     @Environment(\.dismiss) private var dismiss
     @State private var urlString: String
@@ -21,6 +23,10 @@ struct QuickCaptureSheet: View {
     @State private var fetchFailed = false
     /// The URL whose fetch already ran (successfully or not) — dedupes the `.task(id:)` restart.
     @State private var fetchedURLString: String?
+    /// The `og:image` of the page currently in the URL field, absolute and http(s) (the fetcher
+    /// resolves and gates it). Cleared whenever the URL moves to a different page, so a captured
+    /// card image can never belong to a page the owner already left (#1451).
+    @State private var fetchedImageURL: String?
     @State private var isCreating = false
     @State private var errorMessage: String?
 
@@ -105,6 +111,9 @@ struct QuickCaptureSheet: View {
             guard ContentFieldValidation.isAbsoluteURL(trimmed),
                   trimmed != fetchedURLString,
                   let url = URL(string: trimmed) else { return }
+            // Before the debounce, not after: a Save during the sleep must not attach the previous
+            // page's card image to this one.
+            fetchedImageURL = nil
             try? await Task.sleep(for: .milliseconds(400))
             guard !Task.isCancelled else { return }
             isFetching = true
@@ -117,6 +126,7 @@ struct QuickCaptureSheet: View {
                 guard !Task.isCancelled else { return }
                 fetchedURLString = trimmed
                 if title.isEmpty, let fetched = metadata.title { title = fetched }
+                fetchedImageURL = metadata.imageURL
             } catch {
                 guard !Task.isCancelled else { return }
                 fetchedURLString = trimmed
@@ -146,7 +156,8 @@ struct QuickCaptureSheet: View {
         isCreating = true
         errorMessage = nil
         Task {
-            let result = await onCreate(selectedSiteID, cleanTitle, cleanURL, cleanCommentary, draft)
+            let result = await onCreate(
+                selectedSiteID, cleanTitle, cleanURL, cleanCommentary, fetchedImageURL, draft)
             await MainActor.run {
                 isCreating = false
                 switch result {
@@ -204,14 +215,21 @@ enum QuickCapture {
     /// (`Bootstrap.swift`'s resolver), no content graph (the site has no open window to
     /// refresh; an open window's file watcher picks the new file up on its own).
     static func createLinkPost(
-        siteID: String, title: String, urlString: String, commentary: String, draft: Bool
+        siteID: String, title: String, urlString: String, commentary: String,
+        imageURL: String?, draft: Bool
     ) async -> ContentCreateResult {
         let workflow = ContentCreationWorkflow.native(
             contentGraph: nil,
             siteDirectory: { id in await SiteStore.shared.find(id: id)?.sourceDirectory }
         )
-        return await workflow.createTyped(
+        let result = await workflow.createTyped(
             siteID: siteID, typeID: "bookmark", title: title, slug: nil,
             fieldValues: fieldValues(urlString: urlString, commentary: commentary, draft: draft))
+        // Best-effort card image, after the entry exists (#1451) — a failure here leaves a
+        // perfectly good link post, so its result is deliberately ignored.
+        _ = await LinkPostImageCapture().capture(
+            imageURL: imageURL, createResult: result,
+            siteDirectory: await SiteStore.shared.find(id: siteID)?.sourceDirectory)
+        return result
     }
 }

--- a/Sources/AnglesiteApp/QuickCaptureSheet.swift
+++ b/Sources/AnglesiteApp/QuickCaptureSheet.swift
@@ -218,9 +218,13 @@ enum QuickCapture {
         siteID: String, title: String, urlString: String, commentary: String,
         imageURL: String?, draft: Bool
     ) async -> ContentCreateResult {
+        // Resolved once and shared by the create and the capture. Re-querying `SiteStore` after
+        // the write would be a second actor hop, and a site closed in between the two lookups
+        // would silently skip the card image for an entry the first lookup just wrote (#1451).
+        let sourceDirectory = await SiteStore.shared.find(id: siteID)?.sourceDirectory
         let workflow = ContentCreationWorkflow.native(
             contentGraph: nil,
-            siteDirectory: { id in await SiteStore.shared.find(id: id)?.sourceDirectory }
+            siteDirectory: { _ in sourceDirectory }
         )
         let result = await workflow.createTyped(
             siteID: siteID, typeID: "bookmark", title: title, slug: nil,
@@ -228,8 +232,7 @@ enum QuickCapture {
         // Best-effort card image, after the entry exists (#1451) — a failure here leaves a
         // perfectly good link post, so its result is deliberately ignored.
         _ = await LinkPostImageCapture().capture(
-            imageURL: imageURL, createResult: result,
-            siteDirectory: await SiteStore.shared.find(id: siteID)?.sourceDirectory)
+            imageURL: imageURL, createResult: result, siteDirectory: sourceDirectory)
         return result
     }
 }

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -971,9 +971,10 @@ struct SiteWindow: View {
                 defaultSiteID: nil,
                 initialURLString: model.quickCaptureURL ?? "",
                 fetchMetadata: { try await LinkMetadataFetcher().fetch(url: $0) },
-                onCreate: { _, title, urlString, commentary, draft in
+                onCreate: { _, title, urlString, commentary, imageURL, draft in
                     let result = await model.createLinkPost(
-                        title: title, urlString: urlString, commentary: commentary, draft: draft)
+                        title: title, urlString: urlString, commentary: commentary,
+                        imageURL: imageURL, draft: draft)
                     // Publish = create + the normal deploy path. deploySite() no-ops via its
                     // canRunDeploy guard when the runtime isn't available — the entry is already
                     // written draft: false and goes live with the next deploy (spec §3.3).

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -1695,7 +1695,9 @@ final class SiteWindowModel {
     }
 
     /// See `createPage`'s force-refresh note (#586) — same race, same fix.
-    func createLinkPost(title: String, urlString: String, commentary: String, draft: Bool) async -> ContentCreateResult {
+    func createLinkPost(
+        title: String, urlString: String, commentary: String, imageURL: String?, draft: Bool
+    ) async -> ContentCreateResult {
         guard let site else { return .siteNotFound }
         let result = await contentCreation.createTyped(
             siteID: site.id,
@@ -1705,6 +1707,11 @@ final class SiteWindowModel {
             fieldValues: QuickCapture.fieldValues(urlString: urlString, commentary: commentary, draft: draft)
         )
         if case .created(let filePath, _) = result {
+            // Before the refresh and the undo snapshot, not after: the capture adds `image:` to
+            // the file, and `createdContents(at:)` below is what Undo restores — reading it first
+            // would register an "after" state that no longer matches disk (#1451).
+            _ = await LinkPostImageCapture().capture(
+                imageURL: imageURL, createResult: result, siteDirectory: site.sourceDirectory)
             await refreshAfterContentMutation()
             registerContentUndo(
                 actionName: ContentUndoCoordinator.createActionName("Link Post"),

--- a/Sources/AnglesiteApp/SitesLauncherView.swift
+++ b/Sources/AnglesiteApp/SitesLauncherView.swift
@@ -116,14 +116,14 @@ struct SitesLauncherView: View {
                 defaultSiteID: AppSettings.shared.lastOpenedSiteID,
                 initialURLString: request.urlString,
                 fetchMetadata: { try await LinkMetadataFetcher().fetch(url: $0) },
-                onCreate: { siteID, title, urlString, commentary, draft in
+                onCreate: { siteID, title, urlString, commentary, imageURL, draft in
                     guard let siteID else { return .failed(reason: "Choose a site for this link post.") }
                     // Windowless: the entry is written and committed; a Publish here saves it
                     // draft: false and it goes live with the site's next deploy (spec §3.3 —
                     // capture never boots a container).
                     return await QuickCapture.createLinkPost(
                         siteID: siteID, title: title, urlString: urlString,
-                        commentary: commentary, draft: draft)
+                        commentary: commentary, imageURL: imageURL, draft: draft)
                 }
             )
         }

--- a/Sources/AnglesiteCore/LinkImageAsset.swift
+++ b/Sources/AnglesiteCore/LinkImageAsset.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Where a captured link-post card image lands inside a site, and what counts as one (#1451).
+///
+/// The same `public/`-as-site-root convention `HeroImage`/`LogoAsset`/`WebsiteIconAsset` already
+/// use — Astro serves `public/` verbatim, so a file written to `public/images/x.jpg` is served at
+/// `/images/x.jpg` with no bundler import and no `<Image>` rewrite. `public/images/` specifically
+/// because that is the directory `DeadAssetScanner` already treats as the site's image asset tree,
+/// so a captured card image that later loses its entry shows up as a dead asset like any other.
+///
+/// Pure and filesystem-only: the network side lives in ``LinkPostImageCapture``.
+public enum LinkImageAsset {
+    /// Relative to the site `Source/` directory.
+    public static let assetDirectoryRelativePath = "public/images"
+
+    /// 5 MB. Open Graph card images are meant to be a few hundred KB; this is generous for a
+    /// legitimate one and small enough that a hostile page can't make capture cost real memory.
+    public static let maximumImageBytes = 5 * 1024 * 1024
+
+    /// The image formats a captured card image may be in — determined by sniffing the bytes, never
+    /// by the URL's extension or the response's `Content-Type`, both of which the remote page
+    /// controls and neither of which has to match the payload.
+    ///
+    /// SVG is deliberately absent: an SVG is a script-execution vector, and this file is about to
+    /// be served from the *owner's* origin, where a `<script>` inside it would run with the site's
+    /// privileges. There is no safe way to serve an arbitrary remote SVG as first-party content,
+    /// so an `og:image` that is one simply isn't captured.
+    public enum Format: String, Sendable, Equatable {
+        case jpeg, png, gif, webp, avif
+
+        /// The filename extension used on disk (`.jpg` for JPEG, matching web convention).
+        public var fileExtension: String {
+            switch self {
+            case .jpeg: return "jpg"
+            case .png: return "png"
+            case .gif: return "gif"
+            case .webp: return "webp"
+            case .avif: return "avif"
+            }
+        }
+    }
+
+    /// The format `data` actually is, or nil when it isn't one of ``Format``'s.
+    ///
+    /// Magic-byte sniffing, so an HTML error page served with `Content-Type: image/jpeg` (or an
+    /// SVG, or a renamed archive) is refused rather than written into the site.
+    public static func format(sniffing data: Data) -> Format? {
+        func matches(_ signature: [UInt8], at offset: Int) -> Bool {
+            guard data.count >= offset + signature.count else { return false }
+            let start = data.index(data.startIndex, offsetBy: offset)
+            return Array(data[start..<data.index(start, offsetBy: signature.count)]) == signature
+        }
+        // FF D8 FF — the SOI marker plus the first byte of the following marker.
+        if matches([0xFF, 0xD8, 0xFF], at: 0) { return .jpeg }
+        if matches([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], at: 0) { return .png }
+        // "GIF8" covers both 87a and 89a.
+        if matches(Array("GIF8".utf8), at: 0) { return .gif }
+        // RIFF container with a WEBP form type: "RIFF" <4-byte size> "WEBP".
+        if matches(Array("RIFF".utf8), at: 0), matches(Array("WEBP".utf8), at: 8) { return .webp }
+        // ISO-BMFF `ftyp` box whose major brand is AVIF (`avif` still images; `avis` sequences
+        // are animated AVIF, which browsers render as an image too).
+        if matches(Array("ftyp".utf8), at: 4),
+           matches(Array("avif".utf8), at: 8) || matches(Array("avis".utf8), at: 8) {
+            return .avif
+        }
+        return nil
+    }
+
+    /// The on-disk filename for the card image of the entry with `slug`.
+    ///
+    /// `link-` prefixed and slug-derived, so the file is recognizable next to its entry when the
+    /// owner browses `public/images/` — and so re-capturing the same entry overwrites its image
+    /// instead of accumulating one file per attempt.
+    public static func fileName(slug: String, format: Format) -> String {
+        "link-\(slug).\(format.fileExtension)"
+    }
+
+    /// Path of the installed image relative to the site `Source/` directory — what gets staged and
+    /// committed.
+    public static func assetRelativePath(slug: String, format: Format) -> String {
+        "\(assetDirectoryRelativePath)/\(fileName(slug: slug, format: format))"
+    }
+
+    /// The root-relative URL the installed image is served at, and the value written to the
+    /// entry's `image:` frontmatter field.
+    public static func publicURLPath(slug: String, format: Format) -> String {
+        "/images/\(fileName(slug: slug, format: format))"
+    }
+
+    /// Writes `bytes` into the site's `public/images/`, returning the path relative to
+    /// `siteDirectory`. Overwrites a previous capture for the same slug (see
+    /// ``fileName(slug:format:)``).
+    /// - Throws: whatever `FileManager`/`Data.write` throws; the caller treats any failure as
+    ///   "no card image" rather than a failed capture.
+    @discardableResult
+    public static func install(
+        bytes: Data, format: Format, slug: String,
+        siteDirectory: URL, fileManager: FileManager = .default
+    ) throws -> String {
+        let directory = siteDirectory.appendingPathComponent(assetDirectoryRelativePath, isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let destination = directory.appendingPathComponent(fileName(slug: slug, format: format))
+        try bytes.write(to: destination, options: .atomic)
+        return assetRelativePath(slug: slug, format: format)
+    }
+}
+
+/// Why a card-image capture was refused. Every case is a guard firing on page-controlled input,
+/// not a bug — callers log and continue without an image (#1451).
+public enum LinkImageError: Error, Equatable, Sendable {
+    /// The `og:image` resolved to something other than http(s) — or a redirect landed there.
+    case unsupportedScheme
+    /// A non-2xx response.
+    case requestFailed(status: Int)
+    /// The transfer exceeded ``LinkImageAsset/maximumImageBytes``.
+    case responseTooLarge(Int)
+    /// The bytes aren't a ``LinkImageAsset/Format`` — an HTML error page, an SVG, anything else.
+    case unsupportedFormat
+    /// The written entry has no frontmatter block, so there is nowhere to put `image:`. Only
+    /// reachable if something outside the app rewrote the file between create and capture.
+    case entryNotPatchable
+}

--- a/Sources/AnglesiteCore/LinkMetadata.swift
+++ b/Sources/AnglesiteCore/LinkMetadata.swift
@@ -7,16 +7,25 @@ public struct LinkMetadata: Sendable, Equatable {
     public var title: String?
     public var description: String?
     public var siteName: String?
+    /// The page's `og:image`, **exactly as the document spelled it** — which is often relative
+    /// (`/card.png`) or protocol-relative (`//cdn/card.png`). Resolving it against the page URL
+    /// needs a page URL, which the parser doesn't have; ``LinkMetadataFetcher`` does that on the
+    /// way out (see its `resolvedImageURL(_:relativeTo:)`), so a fetched
+    /// `LinkMetadata` always carries an absolute http(s) value here or none (#1451).
+    public var imageURL: String?
 
-    public init(title: String? = nil, description: String? = nil, siteName: String? = nil) {
+    public init(title: String? = nil, description: String? = nil, siteName: String? = nil,
+                imageURL: String? = nil) {
         self.title = title
         self.description = description
         self.siteName = siteName
+        self.imageURL = imageURL
     }
 }
 
 /// Pure scanner from HTML text to ``LinkMetadata``: `og:title` / `og:description` /
-/// `og:site_name` (via `property=` or `name=`), falling back to `<title>`. Deliberately not a
+/// `og:site_name` / `og:image` (via `property=` or `name=`), with `<title>` as the title's only
+/// fallback. Deliberately not a
 /// full HTML parser — article pages carry server-rendered `og:` tags in the head, and a regex
 /// scan over `<meta>` tags is robust to attribute order and quote style without a WebKit
 /// dependency (spec §3.1's case against `LPMetadataProvider`). Chosen over `NSAttributedString`'s
@@ -26,7 +35,11 @@ public enum LinkMetadataParser {
         LinkMetadata(
             title: normalized(metaContent(in: html, key: "og:title") ?? titleText(in: html)),
             description: normalized(metaContent(in: html, key: "og:description")),
-            siteName: normalized(metaContent(in: html, key: "og:site_name"))
+            siteName: normalized(metaContent(in: html, key: "og:site_name")),
+            // No `<title>`-style fallback: a page with no `og:image` has no card image, and
+            // guessing at some other `<img>` in the document would capture a logo or a tracking
+            // pixel as often as the article's own artwork (#1451).
+            imageURL: normalized(metaContent(in: html, key: "og:image"))
         )
     }
 

--- a/Sources/AnglesiteCore/LinkMetadataFetcher.swift
+++ b/Sources/AnglesiteCore/LinkMetadataFetcher.swift
@@ -50,7 +50,28 @@ public struct LinkMetadataFetcher: Sendable {
             throw LinkMetadataFetchError(reason: "That link isn't a web page (\(mime))")
         }
         let html = Self.decode(data.prefix(Self.maximumBodyBytes), textEncodingName: http.textEncodingName)
-        return LinkMetadataParser.parse(html: html)
+        var metadata = LinkMetadataParser.parse(html: html)
+        // Resolve `og:image` here rather than in the parser: relative and protocol-relative values
+        // are common and only mean something next to the URL the bytes actually came from — which
+        // is the *final* URL after redirects, not necessarily the one the caller passed (#1451).
+        metadata.imageURL = Self.resolvedImageURL(metadata.imageURL, relativeTo: http.url ?? url)
+        return metadata
+    }
+
+    /// `raw` resolved against `pageURL` and narrowed to http(s), or nil.
+    ///
+    /// The scheme gate is the point of this being a separate step: `og:image` is page-controlled
+    /// text, so a `data:`/`javascript:`/`file:` value must never reach the downloader — and a
+    /// scheme-relative `//cdn/card.png` has to inherit the page's scheme rather than resolve
+    /// against nothing. Pure, so the whole table is unit-testable without a network.
+    static func resolvedImageURL(_ raw: String?, relativeTo pageURL: URL) -> String? {
+        guard let raw, !raw.isEmpty,
+              let resolved = URL(string: raw, relativeTo: pageURL)?.absoluteURL,
+              let scheme = resolved.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              resolved.host?.isEmpty == false
+        else { return nil }
+        return resolved.absoluteString
     }
 
     /// Decode using the response's declared charset when it names one, else UTF-8, else lossy

--- a/Sources/AnglesiteCore/LinkPostImageCapture.swift
+++ b/Sources/AnglesiteCore/LinkPostImageCapture.swift
@@ -1,0 +1,186 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Captures a link post's `og:image` into the site's assets and references it from the entry's
+/// frontmatter (#1451, follow-up 2 of the quick-capture spec's §8).
+///
+/// Runs **after** the entry is written, deliberately:
+///
+/// - The slug the image file is named for is the one `createTyped` actually derived, not a
+///   re-derivation of it that could drift from the real thing.
+/// - `createTyped` refuses to overwrite an existing entry; running afterwards means a refused
+///   capture never leaves a downloaded image behind, nor overwrites another entry's image.
+/// - Every failure here is a no-op on an already-complete link post. That is the spec's
+///   best-effort rule (§6, same as the title fetch): the bookmark is the deliverable, the card
+///   image is a bonus, and a hostile or merely broken `og:image` must not cost the owner the post.
+///
+/// The `image:` key is added by patching the written file rather than by passing a field value
+/// into `ContentScaffold.renderEntry`, because `renderEntry` only emits fields the descriptor
+/// declares — declaring `image` on `bookmark` would put a dead `image: ""` line in every
+/// hand-made bookmark, captured or not.
+public struct LinkPostImageCapture: Sendable {
+    /// Fetch seam so tests serve canned bytes with no network. An injected transport is still held
+    /// to the byte cap after the fact — only the default transport can abort mid-stream.
+    public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
+    /// Stage-and-commit seam. Multi-path (unlike `NativeContentOperations.GitCommit`) because the
+    /// image and the entry that references it belong in **one** commit — a clone must never see an
+    /// entry pointing at an image that isn't in the same tree.
+    public typealias GitCommit = @Sendable (_ projectRoot: URL, _ relPaths: [String], _ message: String) async -> String?
+
+    /// Idle timeout: the longest the transfer may go without progress.
+    public static let timeout: TimeInterval = 10
+    /// Wall-clock deadline for the whole transfer — see `CappedHTTPTransport` for why an idle
+    /// timeout alone is not a bound a slow-drip server has to respect.
+    public static let resourceTimeout: TimeInterval = 20
+
+    private let transport: Transport
+    private let gitCommit: GitCommit
+    // `nonisolated(unsafe)` for the same reason `NativeContentOperations` uses it: FileManager is
+    // a thread-safe singleton that only recent SDKs declare `Sendable`, and this keeps the
+    // test-injection seam without making the struct's `Sendable` conformance toolchain-dependent.
+    private nonisolated(unsafe) let fileManager: FileManager
+
+    public init(
+        transport: @escaping Transport = LinkPostImageCapture.defaultTransport,
+        gitCommit: @escaping GitCommit = NativeContentOperations.processGitCommitPaths,
+        fileManager: FileManager = .default
+    ) {
+        self.transport = transport
+        self.gitCommit = gitCommit
+        self.fileManager = fileManager
+    }
+
+    /// Convenience over ``capture(imageURL:entryRelativePath:slug:siteDirectory:)`` for the create
+    /// call sites: takes the metadata's raw `og:image` string and the `createTyped` result, and
+    /// no-ops unless there is both an image to fetch and an entry to attach it to.
+    public func capture(
+        imageURL: String?, createResult: ContentCreateResult, siteDirectory: URL?
+    ) async -> String? {
+        guard case let .created(filePath, identifier) = createResult,
+              let siteDirectory,
+              let imageURL, let url = URL(string: imageURL)
+        else { return nil }
+        return await capture(
+            imageURL: url, entryRelativePath: filePath, slug: identifier,
+            siteDirectory: siteDirectory)
+    }
+
+    /// Downloads `imageURL`, installs it under `public/images/`, adds `image:` to the entry's
+    /// frontmatter, and commits both in one commit. Returns the root-relative served path on
+    /// success, or nil on any failure — logged to the debug pane, never thrown at the caller.
+    public func capture(
+        imageURL: URL, entryRelativePath: String, slug: String, siteDirectory: URL
+    ) async -> String? {
+        let bytes: Data
+        let format: LinkImageAsset.Format
+        do {
+            (bytes, format) = try await download(imageURL)
+        } catch {
+            await log("no card image for \(slug): \(imageURL.absoluteString) — \(error)")
+            return nil
+        }
+
+        let assetPath: String
+        do {
+            assetPath = try LinkImageAsset.install(
+                bytes: bytes, format: format, slug: slug,
+                siteDirectory: siteDirectory, fileManager: fileManager)
+        } catch {
+            await log("couldn't save the card image for \(slug): \(error)")
+            return nil
+        }
+
+        let publicPath = LinkImageAsset.publicURLPath(slug: slug, format: format)
+        let entryURL = siteDirectory.appendingPathComponent(entryRelativePath)
+        do {
+            let source = try String(contentsOf: entryURL, encoding: .utf8)
+            guard let patched = Self.patched(entryText: source, imagePath: publicPath) else {
+                throw LinkImageError.entryNotPatchable
+            }
+            try patched.write(to: entryURL, atomically: true, encoding: .utf8)
+        } catch {
+            // The entry is already written and committed; leaving an image nothing references
+            // would just be a dead asset, so undo the install rather than keep it.
+            try? fileManager.removeItem(at: siteDirectory.appendingPathComponent(assetPath))
+            await log("couldn't reference the card image from \(entryRelativePath): \(error)")
+            return nil
+        }
+
+        // Best-effort, exactly like the create path's own commit: an uncommitted asset still
+        // deploys (deploy tars `Source/`), and the owner's next commit picks it up.
+        _ = await gitCommit(siteDirectory, [assetPath, entryRelativePath],
+                            "anglesite: add card image for \(slug)")
+        return publicPath
+    }
+
+    /// `entryText` with `image: "<imagePath>"` added to (or replaced in) its frontmatter, or nil
+    /// when there is no frontmatter block to patch.
+    ///
+    /// Goes through `FrontmatterDocument`, so every other key, the comments, and the body all
+    /// round-trip byte-for-byte — the commentary the owner just typed is not re-rendered.
+    public static func patched(entryText: String, imagePath: String) -> String? {
+        var document = FrontmatterDocument.parse(entryText)
+        document.set(.string(imagePath), for: "image")
+        let serialized = document.serialized()
+        // A file with no `---` fence serializes back to its body alone, silently dropping the
+        // `set` above; refuse rather than rewrite the entry without the key it was asked to add.
+        guard serialized.contains(imagePath) else { return nil }
+        return serialized
+    }
+
+    /// Fetches the image bytes under the full guard set — http(s) (including post-redirect), byte
+    /// cap, deadlines — and sniffs the format. Throws ``LinkImageError`` for guard violations;
+    /// transport errors propagate as-is.
+    func download(_ url: URL) async throws -> (Data, LinkImageAsset.Format) {
+        guard Self.isWebScheme(url) else { throw LinkImageError.unsupportedScheme }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("image/*", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = Self.timeout
+
+        let (data, http) = try await transport(request)
+
+        // URLSession follows redirects transparently, so re-check where the bytes actually came
+        // from: an https `og:image` that redirects to `file:` is not an https image.
+        if let finalURL = http.url, !Self.isWebScheme(finalURL) {
+            throw LinkImageError.unsupportedScheme
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw LinkImageError.requestFailed(status: http.statusCode)
+        }
+        // The default transport already aborts mid-stream past the cap; this re-check holds an
+        // injected transport to the same limit.
+        guard data.count <= LinkImageAsset.maximumImageBytes else {
+            throw LinkImageError.responseTooLarge(data.count)
+        }
+        guard let format = LinkImageAsset.format(sniffing: data) else {
+            throw LinkImageError.unsupportedFormat
+        }
+        return (data, format)
+    }
+
+    static func isWebScheme(_ url: URL) -> Bool {
+        let scheme = url.scheme?.lowercased()
+        return scheme == "http" || scheme == "https"
+    }
+
+    private func log(_ text: String) async {
+        await LogCenter.shared.append(source: "quick-capture:image", stream: .stderr, text: text)
+    }
+
+    static let session = CappedHTTPTransport.session(
+        requestTimeout: timeout, resourceTimeout: resourceTimeout)
+
+    /// Production transport: streams so the cap is enforced *during* transfer, on an ephemeral
+    /// session (no cookies, no shared-cache pollution) carrying the wall-clock deadline.
+    public static let defaultTransport: Transport = { request in
+        try await CappedHTTPTransport.fetch(
+            request,
+            session: LinkPostImageCapture.session,
+            cap: LinkImageAsset.maximumImageBytes,
+            tooLarge: LinkImageError.responseTooLarge)
+    }
+}

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -591,6 +591,24 @@ public struct NativeContentOperations: ContentOperationsService {
         return commit.oid.description
     }
 
+    /// `processGitCommit` for a set of paths that belong in **one** commit — e.g. a link post's
+    /// entry plus the card image it references (#1451), which must never land in separate commits
+    /// (a clone would see an entry pointing at an image that isn't there yet). Same best-effort
+    /// contract: nil on any failure, and the caveats on `processGitCommit` apply unchanged.
+    @Sendable public static func processGitCommitPaths(
+        _ projectRoot: URL, _ relPaths: [String], _ message: String
+    ) async -> String? {
+        SwiftGit2Bootstrap.ensureInitialized
+        guard !relPaths.isEmpty else { return nil }
+        guard case .success(let repo) = Repository.at(projectRoot) else { return nil }
+        for relPath in relPaths {
+            guard case .success = repo.add(path: relPath) else { return nil }
+        }
+        let signature = await GitIdentity.signature(for: repo)
+        guard case .success(let commit) = repo.commit(message: message, signature: signature) else { return nil }
+        return commit.oid.description
+    }
+
     /// Default `GitHasCommit`: walks history from HEAD looking for an exact message match.
     /// Best-effort like `processGitCommit` — an unreadable repo or unresolvable HEAD (e.g. zero
     /// commits) reports `false`, which `publish` treats as "never published," the safe default.
@@ -619,6 +637,27 @@ public struct NativeContentOperations: ContentOperationsService {
         guard await run(["rev-parse", "--git-dir"]) != nil,
               await run(["add", "--", relPath]) != nil,
               await run(["commit", "-m", message, "--", relPath]) != nil,
+              let head = await run(["rev-parse", "HEAD"]) else { return nil }
+        return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// `processGitCommit` for a set of paths that belong in **one** commit — e.g. a link post's
+    /// entry plus the card image it references (#1451), which must never land in separate commits
+    /// (a clone would see an entry pointing at an image that isn't there yet). Same best-effort
+    /// contract as `processGitCommit`: nil on any failure.
+    @Sendable public static func processGitCommitPaths(
+        _ projectRoot: URL, _ relPaths: [String], _ message: String
+    ) async -> String? {
+        guard !relPaths.isEmpty else { return nil }
+        let git = URL(fileURLWithPath: "/usr/bin/git")
+        func run(_ args: [String]) async -> ProcessSupervisor.RunResult? {
+            let result = try? await ProcessSupervisor.shared.run(executable: git, arguments: args, currentDirectoryURL: projectRoot)
+            guard let result, result.exitCode == 0 else { return nil }
+            return result
+        }
+        guard await run(["rev-parse", "--git-dir"]) != nil,
+              await run(["add", "--"] + relPaths) != nil,
+              await run(["commit", "-m", message, "--"] + relPaths) != nil,
               let head = await run(["rev-parse", "HEAD"]) else { return nil }
         return head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/AnglesiteCore/NativeContentOperations.swift
+++ b/Sources/AnglesiteCore/NativeContentOperations.swift
@@ -595,11 +595,23 @@ public struct NativeContentOperations: ContentOperationsService {
     /// entry plus the card image it references (#1451), which must never land in separate commits
     /// (a clone would see an entry pointing at an image that isn't there yet). Same best-effort
     /// contract: nil on any failure, and the caveats on `processGitCommit` apply unchanged.
+    ///
+    /// Staging several paths is a loop of `add(path:)` calls, and this fork has no index-only
+    /// unstage (`remove(path:)` deletes from disk too), so bailing out mid-loop would leave an
+    /// earlier path staged with no commit to consume it — which would break `processGitCommit`'s
+    /// "nothing else staged in between" assumption for whichever commit runs next. Every path is
+    /// therefore checked to exist up front, turning the realistic failure (a path that isn't on
+    /// disk) into a clean no-op before anything is staged. An `add` that fails for some *other*
+    /// reason after that check can still leave a partial stage; that window is narrow enough to
+    /// accept rather than grow the fork's API for.
     @Sendable public static func processGitCommitPaths(
         _ projectRoot: URL, _ relPaths: [String], _ message: String
     ) async -> String? {
         SwiftGit2Bootstrap.ensureInitialized
         guard !relPaths.isEmpty else { return nil }
+        guard relPaths.allSatisfy({
+            FileManager.default.fileExists(atPath: projectRoot.appendingPathComponent($0).path)
+        }) else { return nil }
         guard case .success(let repo) = Repository.at(projectRoot) else { return nil }
         for relPath in relPaths {
             guard case .success = repo.add(path: relPath) else { return nil }

--- a/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
+++ b/Tests/AnglesiteCoreTests/ContentConfigDriftTests.swift
@@ -21,6 +21,26 @@ struct ContentConfigDriftTests {
         get throws { try templateRoot().appendingPathComponent("src/lib/content-schemas.ts") }
     }
 
+    /// Optional fields deliberately present in a collection's template schema but absent from its
+    /// registry descriptor. `ContentScaffold` writes one frontmatter line per descriptor field, so
+    /// a field that must never be scaffolded into hand-made entries (a dead `image: ""` in every
+    /// bookmark) is omitted from the descriptor and written by its feature through
+    /// `FrontmatterDocument` instead (#1451). Each extra renders into the canonical block right
+    /// after the descriptor field it's anchored to, so the block still matches the template
+    /// verbatim — editing or deleting the extra's line in `content.config.ts` trips the guard.
+    static let templateOnlyFields: [String: [(after: String, field: ContentTypeField)]] = [
+        "bookmarks": [(after: "title", field: ContentTypeField("image", .image))],
+    ]
+
+    /// `source` minus full-line `//` comments, so a doc comment inside a schema block (e.g. the
+    /// bookmarks `image` note) doesn't defeat the verbatim block match. Only whole comment lines
+    /// are dropped; schema lines themselves are still compared exactly.
+    static func strippingCommentLines(_ source: String) -> String {
+        source.split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+    }
+
     /// Canonical Zod expression for a field kind, or nil for the markdown body (excluded from frontmatter).
     static func zod(for kind: ContentTypeField.Kind) -> String? {
         switch kind {
@@ -41,16 +61,22 @@ struct ContentConfigDriftTests {
         }
     }
 
-    /// One `field: expr,` line per non-markdown field, in declaration order, at the given indent.
+    /// One `field: expr,` line per non-markdown field, in declaration order, at the given indent,
+    /// with any `templateOnlyFields` extras woven in after their anchor field.
     static func schemaLines(_ d: ContentTypeDescriptor, indent: String) -> [String] {
+        let extras = d.collection.flatMap { templateOnlyFields[$0] } ?? []
         var lines: [String] = []
-        for field in d.fields {
-            guard let zod = zod(for: field.kind) else { continue }
+        func append(_ field: ContentTypeField) {
+            guard let zod = zod(for: field.kind) else { return }
             // Every `.bool` field ships with `.default(false)` (matching `blog`'s pre-existing
             // `draft` line) rather than `.optional()` — a defaulted field is never bare either way,
             // so `required` doesn't affect this branch.
             let expr = field.kind == .bool ? "\(zod).default(false)" : (field.required ? zod : "\(zod).optional()")
             lines.append("\(indent)\(field.name): \(expr),")
+        }
+        for field in d.fields {
+            append(field)
+            for extra in extras where extra.after == field.name { append(extra.field) }
         }
         return lines
     }
@@ -132,6 +158,20 @@ struct ContentConfigDriftTests {
         #expect(Self.zod(for: kind) == "z.array(z.object({ title: z.string(), org: z.string().optional() }))")
     }
 
+    @Test("schemaLines weaves bookmarks' template-only image field in after title")
+    func schemaLinesIncludeTemplateOnlyImage() throws {
+        let bookmark = try #require(ContentTypeRegistry.builtIns.first { $0.id == "bookmark" })
+        let lines = Self.schemaLines(bookmark, indent: "")
+        let title = try #require(lines.firstIndex(of: "title: z.string().optional(),"))
+        #expect(lines[lines.index(after: title)] == "image: z.string().optional(),")
+    }
+
+    @Test("strippingCommentLines drops whole-line comments and nothing else")
+    func stripsCommentLines() {
+        let source = "a: 1,\n  // full-line comment\nb: 2, // trailing comment stays\n"
+        #expect(Self.strippingCommentLines(source) == "a: 1,\nb: 2, // trailing comment stays\n")
+    }
+
     @Test("content.config.ts declares exactly the registry collections plus the allowlist")
     func noOrphanCollections() throws {
         let source = try String(contentsOf: Self.configFile, encoding: .utf8)
@@ -157,8 +197,8 @@ struct ContentConfigDriftTests {
 
     @Test("every collection-backed registry type appears verbatim in content.config.ts")
     func configMatchesRegistry() throws {
-        let source = try String(contentsOf: Self.configFile, encoding: .utf8)
-        let schemasSource = try String(contentsOf: Self.contentSchemasFile, encoding: .utf8)
+        let source = Self.strippingCommentLines(try String(contentsOf: Self.configFile, encoding: .utf8))
+        let schemasSource = Self.strippingCommentLines(try String(contentsOf: Self.contentSchemasFile, encoding: .utf8))
         let exportLine = source
             .split(separator: "\n", omittingEmptySubsequences: false)
             .first { $0.contains("export const collections") }

--- a/Tests/AnglesiteCoreTests/LinkMetadataFetcherTests.swift
+++ b/Tests/AnglesiteCoreTests/LinkMetadataFetcherTests.swift
@@ -106,4 +106,34 @@ struct LinkMetadataFetcherTests {
         #expect(LinkMetadataFetcher.decode(latin1, textEncodingName: "iso-8859-1") == "é")
         #expect(LinkMetadataFetcher.decode(latin1, textEncodingName: nil) == "\u{FFFD}")  // lossy UTF-8 fallback
     }
+
+    @Test("og:image is resolved against the page URL and narrowed to http(s)")
+    func imageResolution() {
+        let page = URL(string: "https://example.com/blog/post/")!
+        func resolved(_ raw: String?) -> String? {
+            LinkMetadataFetcher.resolvedImageURL(raw, relativeTo: page)
+        }
+        #expect(resolved("https://cdn.example.com/card.jpg") == "https://cdn.example.com/card.jpg")
+        #expect(resolved("/card.png") == "https://example.com/card.png")
+        #expect(resolved("card.png") == "https://example.com/blog/post/card.png")
+        // Scheme-relative inherits the page's scheme rather than resolving against nothing.
+        #expect(resolved("//cdn.example.com/card.gif") == "https://cdn.example.com/card.gif")
+        // `og:image` is page-controlled text: these must never reach the downloader.
+        #expect(resolved("data:image/png;base64,AAAA") == nil)
+        #expect(resolved("javascript:alert(1)") == nil)
+        #expect(resolved("file:///etc/passwd") == nil)
+        #expect(resolved(nil) == nil)
+        #expect(resolved("") == nil)
+    }
+
+    @Test("fetched metadata carries an absolute og:image, resolved from a relative value")
+    func fetchResolvesRelativeImage() async throws {
+        reset(body: """
+        <head><meta property="og:title" content="Hi">
+        <meta property="og:image" content="/cards/hi.png"></head>
+        """)
+        let fetcher = LinkMetadataFetcher(session: LinkStubURLProtocol.makeSession())
+        let meta = try await fetcher.fetch(url: URL(string: "https://example.com/deep/page")!)
+        #expect(meta.imageURL == "https://example.com/cards/hi.png")
+    }
 }

--- a/Tests/AnglesiteCoreTests/LinkMetadataParserTests.swift
+++ b/Tests/AnglesiteCoreTests/LinkMetadataParserTests.swift
@@ -59,4 +59,21 @@ struct LinkMetadataParserTests {
         """
         #expect(LinkMetadataParser.parse(html: html).title == "First")
     }
+
+    @Test("parses og:image, verbatim (resolution against the page URL is the fetcher's job)")
+    func parsesOpenGraphImage() {
+        let html = """
+        <html><head>
+        <meta property="og:title" content="Interesting Thing">
+        <meta property="og:image" content="https://cdn.example.com/card.jpg">
+        </head></html>
+        """
+        #expect(LinkMetadataParser.parse(html: html).imageURL == "https://cdn.example.com/card.jpg")
+        // Relative values pass through unchanged — the parser has no page URL to resolve against.
+        #expect(LinkMetadataParser.parse(html: #"<meta name="og:image" content="/card.png">"#)
+            .imageURL == "/card.png")
+        // No og:image, and an empty one, both mean "no image" — never a <title>-style fallback.
+        #expect(LinkMetadataParser.parse(html: "<head><title>Plain</title></head>").imageURL == nil)
+        #expect(LinkMetadataParser.parse(html: #"<meta property="og:image" content="  ">"#).imageURL == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/LinkPostImageCaptureTests.swift
+++ b/Tests/AnglesiteCoreTests/LinkPostImageCaptureTests.swift
@@ -1,0 +1,256 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+/// Byte prefixes for the formats ``LinkImageAsset/format(sniffing:)`` recognizes, plus the ones it
+/// must refuse. Padded past every signature length so a real sniff has enough bytes to look at.
+private enum ImageFixture {
+    static func padded(_ prefix: [UInt8]) -> Data {
+        Data(prefix + [UInt8](repeating: 0x00, count: 32))
+    }
+    static let jpeg = padded([0xFF, 0xD8, 0xFF, 0xE0])
+    static let png = padded([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    static let gif = padded(Array("GIF89a".utf8))
+    static let webp = padded(Array("RIFF".utf8) + [0x10, 0x00, 0x00, 0x00] + Array("WEBP".utf8))
+    static let avif = padded([0x00, 0x00, 0x00, 0x20] + Array("ftyp".utf8) + Array("avif".utf8))
+    static let svg = Data(#"<svg xmlns="http://www.w3.org/2000/svg"><script>x()</script></svg>"#.utf8)
+    static let html = Data("<!doctype html><html><body>404</body></html>".utf8)
+}
+
+/// A bookmark entry exactly as `ContentScaffold.renderEntry` writes one, so the patch tests run
+/// against the real shape rather than a hand-simplified stand-in.
+private let bookmarkEntry = """
+---
+lang: ""
+bookmarkOf: "https://example.com/interesting-thing"
+title: "Interesting Thing"
+publishDate: 2026-08-13T20:00:00.000Z
+tags: []
+draft: true
+---
+
+Two sentences of commentary.
+
+"""
+
+@Suite("LinkImageAsset")
+struct LinkImageAssetTests {
+    @Test("format is sniffed from the bytes, not the URL or Content-Type")
+    func sniffing() {
+        #expect(LinkImageAsset.format(sniffing: ImageFixture.jpeg) == .jpeg)
+        #expect(LinkImageAsset.format(sniffing: ImageFixture.png) == .png)
+        #expect(LinkImageAsset.format(sniffing: ImageFixture.gif) == .gif)
+        #expect(LinkImageAsset.format(sniffing: ImageFixture.webp) == .webp)
+        #expect(LinkImageAsset.format(sniffing: ImageFixture.avif) == .avif)
+    }
+
+    @Test("SVG, HTML, empty and truncated payloads are refused")
+    func refusedPayloads() {
+        // SVG is a script-execution vector once served from the owner's own origin.
+        #expect(LinkImageAsset.format(sniffing: ImageFixture.svg) == nil)
+        #expect(LinkImageAsset.format(sniffing: ImageFixture.html) == nil)
+        #expect(LinkImageAsset.format(sniffing: Data()) == nil)
+        // A RIFF container that isn't WEBP, and a signature cut short, must not sniff as an image.
+        #expect(LinkImageAsset.format(sniffing: ImageFixture.padded(Array("RIFFxxxxAVI ".utf8))) == nil)
+        #expect(LinkImageAsset.format(sniffing: Data([0xFF, 0xD8])) == nil)
+    }
+
+    @Test("paths derive from the entry slug and the sniffed format")
+    func paths() {
+        #expect(LinkImageAsset.fileName(slug: "interesting-thing", format: .jpeg) == "link-interesting-thing.jpg")
+        #expect(LinkImageAsset.assetRelativePath(slug: "a-post", format: .png) == "public/images/link-a-post.png")
+        #expect(LinkImageAsset.publicURLPath(slug: "a-post", format: .png) == "/images/link-a-post.png")
+    }
+
+    @Test("install writes into public/images, creating it, and overwrites a re-capture")
+    func install() throws {
+        let site = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: site, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: site) }
+
+        let relPath = try LinkImageAsset.install(
+            bytes: ImageFixture.png, format: .png, slug: "post", siteDirectory: site)
+        #expect(relPath == "public/images/link-post.png")
+        let written = site.appendingPathComponent(relPath)
+        #expect(try Data(contentsOf: written) == ImageFixture.png)
+
+        // Same slug + format ⇒ same file, replaced rather than accumulated.
+        let bigger = ImageFixture.png + Data([0x01, 0x02, 0x03])
+        _ = try LinkImageAsset.install(bytes: bigger, format: .png, slug: "post", siteDirectory: site)
+        #expect(try Data(contentsOf: written) == bigger)
+        let listed = try FileManager.default.contentsOfDirectory(
+            atPath: site.appendingPathComponent("public/images").path)
+        #expect(listed == ["link-post.png"])
+    }
+}
+
+@Suite("LinkPostImageCapture")
+struct LinkPostImageCaptureTests {
+    /// A site directory containing one written bookmark entry, mimicking the state `createTyped`
+    /// leaves behind — which is the only state `capture` ever runs against.
+    private struct Fixture {
+        let site: URL
+        let entryRelativePath = "src/content/bookmarks/interesting-thing.md"
+        var entryURL: URL { site.appendingPathComponent(entryRelativePath) }
+
+        init() throws {
+            site = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(
+                at: entryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try bookmarkEntry.write(to: entryURL, atomically: true, encoding: .utf8)
+        }
+
+        func cleanUp() { try? FileManager.default.removeItem(at: site) }
+        func entryText() throws -> String { try String(contentsOf: entryURL, encoding: .utf8) }
+        var imageURL: URL { site.appendingPathComponent("public/images/link-interesting-thing.png") }
+    }
+
+    /// Records what the capture asked git to stage, so the "one commit, both paths" contract is
+    /// observable without a real repository.
+    private final class CommitRecorder: @unchecked Sendable {
+        private(set) var paths: [String] = []
+        private(set) var messages: [String] = []
+        var commit: LinkPostImageCapture.GitCommit {
+            { [self] _, relPaths, message in
+                paths = relPaths
+                messages.append(message)
+                return "deadbeef"
+            }
+        }
+    }
+
+    private func transport(
+        _ data: Data, status: Int = 200, finalURL: String = "https://cdn.example.com/card.png"
+    ) -> LinkPostImageCapture.Transport {
+        { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: finalURL)!, statusCode: status,
+                httpVersion: "HTTP/1.1", headerFields: nil)!
+            return (data, response)
+        }
+    }
+
+    @Test("happy path: image installed, referenced from frontmatter, both staged in one commit")
+    func capturesImage() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let recorder = CommitRecorder()
+        let capture = LinkPostImageCapture(
+            transport: transport(ImageFixture.png), gitCommit: recorder.commit)
+
+        let path = await capture.capture(
+            imageURL: URL(string: "https://cdn.example.com/card.png")!,
+            entryRelativePath: fixture.entryRelativePath,
+            slug: "interesting-thing",
+            siteDirectory: fixture.site)
+
+        #expect(path == "/images/link-interesting-thing.png")
+        #expect(try Data(contentsOf: fixture.imageURL) == ImageFixture.png)
+
+        let patched = try fixture.entryText()
+        #expect(patched.contains(#"image: "/images/link-interesting-thing.png""#))
+        // Everything the owner wrote survives verbatim — the commentary body and every other key.
+        #expect(patched.contains("Two sentences of commentary."))
+        #expect(patched.contains(#"bookmarkOf: "https://example.com/interesting-thing""#))
+        #expect(patched.contains("draft: true"))
+
+        // One commit, entry and image together: a clone must never see an entry whose image
+        // isn't in the same tree.
+        #expect(recorder.messages == ["anglesite: add card image for interesting-thing"])
+        #expect(Set(recorder.paths) == [
+            "public/images/link-interesting-thing.png", fixture.entryRelativePath,
+        ])
+    }
+
+    @Test("every refusal leaves the entry exactly as created, with no file and no commit")
+    func refusalsAreNoOps() async throws {
+        let cases: [(String, LinkPostImageCapture.Transport)] = [
+            ("404", transport(ImageFixture.png, status: 404)),
+            ("SVG payload", transport(ImageFixture.svg)),
+            ("HTML error page served as an image", transport(ImageFixture.html)),
+            ("over the byte cap", transport(
+                ImageFixture.png + Data(repeating: 0x00, count: LinkImageAsset.maximumImageBytes))),
+            ("redirected to a non-web scheme", transport(
+                ImageFixture.png, finalURL: "file:///etc/passwd")),
+        ]
+        for (label, stub) in cases {
+            let fixture = try Fixture()
+            defer { fixture.cleanUp() }
+            let recorder = CommitRecorder()
+            let capture = LinkPostImageCapture(transport: stub, gitCommit: recorder.commit)
+
+            let path = await capture.capture(
+                imageURL: URL(string: "https://cdn.example.com/card.png")!,
+                entryRelativePath: fixture.entryRelativePath,
+                slug: "interesting-thing",
+                siteDirectory: fixture.site)
+
+            #expect(path == nil, "\(label) should not produce a card image")
+            #expect(try fixture.entryText() == bookmarkEntry, "\(label) must not touch the entry")
+            #expect(!FileManager.default.fileExists(atPath: fixture.imageURL.path), "\(label)")
+            #expect(recorder.messages.isEmpty, "\(label) must not commit")
+        }
+    }
+
+    @Test("a non-http(s) og:image is never fetched")
+    func rejectsNonWebScheme() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let capture = LinkPostImageCapture(
+            transport: { _ in
+                Issue.record("the transport must not be reached for a non-web scheme")
+                throw LinkImageError.unsupportedScheme
+            },
+            gitCommit: { _, _, _ in nil })
+        let path = await capture.capture(
+            imageURL: URL(string: "file:///etc/passwd")!,
+            entryRelativePath: fixture.entryRelativePath,
+            slug: "interesting-thing", siteDirectory: fixture.site)
+        #expect(path == nil)
+        #expect(try fixture.entryText() == bookmarkEntry)
+    }
+
+    @Test("the convenience overload no-ops without an image, a created entry, or a site directory")
+    func convenienceGuards() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanUp() }
+        let capture = LinkPostImageCapture(
+            transport: { _ in
+                Issue.record("the transport must not be reached when there is nothing to capture")
+                throw LinkImageError.unsupportedScheme
+            },
+            gitCommit: { _, _, _ in nil })
+        let created = ContentCreateResult.created(
+            filePath: fixture.entryRelativePath, identifier: "interesting-thing")
+
+        #expect(await capture.capture(
+            imageURL: nil, createResult: created, siteDirectory: fixture.site) == nil)
+        #expect(await capture.capture(
+            imageURL: "https://cdn.example.com/card.png",
+            createResult: .failed(reason: "already exists"), siteDirectory: fixture.site) == nil)
+        #expect(await capture.capture(
+            imageURL: "https://cdn.example.com/card.png",
+            createResult: created, siteDirectory: nil) == nil)
+    }
+
+    @Test("patched adds image without disturbing anything else, and replaces an existing value")
+    func patching() {
+        let once = LinkPostImageCapture.patched(entryText: bookmarkEntry, imagePath: "/images/a.png")
+        #expect(once?.contains(#"image: "/images/a.png""#) == true)
+        // Round-trip identity for everything untouched: only the added line differs.
+        let addedLines = Set((once ?? "").split(separator: "\n", omittingEmptySubsequences: false))
+            .subtracting(bookmarkEntry.split(separator: "\n", omittingEmptySubsequences: false))
+        #expect(addedLines == [#"image: "/images/a.png""#])
+
+        // A re-capture replaces the value rather than adding a duplicate key.
+        let twice = LinkPostImageCapture.patched(entryText: once ?? "", imagePath: "/images/b.jpg")
+        #expect(twice?.contains(#"image: "/images/b.jpg""#) == true)
+        #expect(twice?.contains("/images/a.png") == false)
+        #expect((twice ?? "").components(separatedBy: "image:").count == 2)
+    }
+
+    @Test("patched refuses a file with no frontmatter block rather than rewriting it")
+    func patchingRefusesBodyOnly() {
+        #expect(LinkPostImageCapture.patched(entryText: "Just a body.\n", imagePath: "/images/a.png") == nil)
+    }
+}

--- a/docs/superpowers/specs/2026-08-12-quick-capture-link-posts-design.md
+++ b/docs/superpowers/specs/2026-08-12-quick-capture-link-posts-design.md
@@ -220,7 +220,15 @@ The AppIntents schema-check CI lane covers the new intent.
 
 1. **Share extension (tier 3):** Safari share-sheet capture without the app
    frontmost — extension target, app group, MAS bookmark-sharing design.
-2. **og:image capture:** download the page's image into site assets and
-   reference it from the bookmark entry.
+2. ~~**og:image capture:** download the page's image into site assets and
+   reference it from the bookmark entry.~~ — **shipped** as
+   [#1451](https://github.com/Anglesite/Anglesite/issues/1451):
+   `LinkMetadataParser` reads `og:image`, `LinkMetadataFetcher` resolves it
+   against the page URL and narrows it to http(s), and `LinkPostImageCapture`
+   downloads it into `public/images/link-<slug>.<ext>` **after** the entry is
+   written — then adds `image:` to the entry's frontmatter and commits both in
+   one commit. Best-effort throughout (§6's rule): any refusal leaves the link
+   post exactly as created. `AddLinkPostIntent` still captures text metadata
+   only; wiring the intent through the same path is a further follow-up.
 3. **(If demand appears) link posts in the main feed:** a theme option to
    surface bookmarks in the blog stream, rather than a schema change.


### PR DESCRIPTION
Closes #1451

## Summary

- **Parse `og:image`.** `LinkMetadataParser` reads it alongside the existing `og:` tags and returns it verbatim (often relative); `LinkMetadataFetcher` then resolves it against the response's **final** URL and narrows it to http(s), so `data:` / `javascript:` / `file:` values from a page-controlled tag can never reach the downloader.
- **Download it into the site's assets.** New `LinkImageAsset` (paths, magic-byte format sniffing, install) + `LinkPostImageCapture` (capped download, install, frontmatter patch, commit) put the image at `Source/public/images/link-<slug>.<ext>` — the same `public/`-as-site-root convention `HeroImage`/`LogoAsset` use, and the `public/images/**` tree `DeadAssetScanner` already understands. Guards: http(s) only (re-checked post-redirect), 2xx, a 5 MB streaming cap via the existing `CappedHTTPTransport`, and an allowlist sniffed from the bytes (JPEG/PNG/GIF/WebP/AVIF) — **SVG is deliberately refused**, since it would be script-executable content served from the owner's own origin.
- **Reference it from the entry.** The template's `bookmarks` schema gains an optional `image`, which `Hentry.astro` already renders as `u-photo`; `IndexEntry.astro`'s titled branch now renders it too, so a titled link post reads as a card in the collection index as well. The image and the entry that references it land in **one** commit (new `NativeContentOperations.processGitCommitPaths`), so a clone never sees an entry pointing at an image that isn't in the same tree.

### Design notes

**Capture runs *after* `createTyped` writes the entry.** That ordering buys three things: the asset is named for the slug the create path actually derived (no re-derivation that could drift), a refused create (duplicate slug) can't leave an orphan image behind, and every failure is a plain no-op on an already-complete link post — the spec's best-effort rule for the title fetch (§6), applied to the image.

**`image:` is added by patching the written file through `FrontmatterDocument`, not by declaring an `image` field on the `bookmark` descriptor.** `ContentScaffold.renderEntry` emits every field a descriptor declares, so a descriptor field would put a dead `image: ""` line in every hand-made bookmark, captured or not. `FrontmatterDocument` round-trips every untouched key, comment, and the body byte-for-byte, so the commentary the owner just typed is never re-rendered.

**Out of scope here, noted as a further follow-up in the spec:** `AddLinkPostIntent` (`Sources/AnglesiteIntents`) still captures text metadata only. The Shortcuts path can be wired through the same `LinkPostImageCapture` later; this PR covers the compose-sheet flows (site window, launcher, File ▸ New ▸ Link Post…), which is where quick capture actually happens.

`docs/superpowers/specs/2026-08-12-quick-capture-link-posts-design.md` §8 follow-up 2 is struck through and annotated with what shipped.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> No MCP message-schema change. The only cross-repo-looking edit is `Resources/Template/` (the `bookmarks` Zod schema + `IndexEntry.astro`), which `CLAUDE.md` ▸ "Two-repo coordination" states is app-only.

## Test plan

**Tests written first, confirmed failing without the fix.** With the five changed/new `Sources/AnglesiteCore` files stashed, the new cases don't compile:

```
Tests/AnglesiteCoreTests/LinkMetadataFetcherTests.swift:114:33: error: type 'LinkMetadataFetcher' has no member 'resolvedImageURL'
Tests/AnglesiteCoreTests/LinkMetadataFetcherTests.swift:137:22: error: value of type 'LinkMetadata' has no member 'imageURL'
```

New/extended coverage (all in `Tests/AnglesiteCoreTests`):

- `LinkMetadataParserTests` — `og:image` parsed; relative values verbatim; absent/blank → nil.
- `LinkMetadataFetcherTests` — the full `resolvedImageURL` table (absolute, root-relative, path-relative, scheme-relative, `data:`/`javascript:`/`file:` refused, nil, empty), plus a stubbed fetch proving a relative `og:image` comes back absolute.
- `LinkPostImageCaptureTests` (new) — format sniffing for all five formats and the refusals (SVG, HTML-served-as-image, empty, RIFF-that-isn't-WebP, truncated JPEG); path builders; `install` creating `public/images/` and overwriting a re-capture rather than accumulating; `patched` adding/replacing `image:` while changing *only* that line and refusing a file with no frontmatter; and `capture` end-to-end with a stub transport — happy path (image on disk, frontmatter patched, commentary and every other key preserved, one commit staging both paths) plus five refusal cases (404, SVG, HTML, over-cap, redirect to `file:`) each asserted to leave the entry byte-identical, write no file, and make no commit.

### ⚠️ What I could and could not run on this host — please re-run before merging

- [x] **`Resources/Template` suite — ran clean.** `npm ci && npm test` → **771 node:test passed, 0 failed, 2 skipped**; `npm run test:astro` → **35 passed**; `npm run build` (which is what actually validates the new Zod field: `astro check` + `astro build` + `check-microformats` + `validate-html` + pagefind + well-known verify) → **exit 0**.
- [ ] **`swift test --package-path .` — could NOT run here.** This host's Xcode install is broken, so `swift test` cannot execute at all: `/Applications/Xcode-beta.app` is a 107 MB stub whose `Contents/Developer` has no `Toolchains` (`error: failed to load toolchains … The folder "Toolchains" doesn't exist`), and the complete 3.9 GB copy sitting at `/Volumes/Files/334EDDD3-…/Xcode-beta.app` hangs indefinitely in `xcodebuild -license status` (sleeping, 0% CPU) for every `swift`/`xcodebuild` invocation. Fixing that needs an Xcode reinstall / `xcode-select` change, which I'm not going to do to the owner's machine.
- [ ] **`xcodebuild … -scheme Anglesite build` — could NOT run here,** same cause.

What I ran instead, so the change isn't unverified:

1. **Compile verification** of every Swift file in this PR via the CommandLineTools Swift 6.4 toolchain (`DEVELOPER_DIR=/Library/Developer/CommandLineTools`), with the `FoundationModelsMacros`/`TestingMacros` plugin libraries and the XCTest framework passed in explicitly: `swift build --target AnglesiteCore` and `swift build --target AnglesiteCoreTests` both reach **`Build complete!`**, so `AnglesiteCore` *and* the whole `AnglesiteCoreTests` target (including the new cases) compile and link. Only two new warnings, both exactly matching existing accepted patterns next door — the `tooLarge:` non-`Sendable`-closure warning `AvatarLoader.swift:117`/`ActorProfile.swift:194` already emit, and the `nonisolated(unsafe)`-on-`FileManager` warning `NativeContentOperations.swift:36` already emits (kept deliberately for toolchain portability, with a comment saying so).
2. **Behavioral verification** of the new logic by compiling a standalone harness against the built `AnglesiteCore` (`@testable import`) that makes the *same* assertions as the committed Swift Testing cases — since the test bundle is an `MH_BUNDLE` that needs the broken Xcode's `xctest` runner to execute. Result: **71/71 checks passed** (exit 0). The harness is scratch-only and not part of this PR.
3. `Sources/AnglesiteApp` changes are the mechanical parameter-threading kind (one new `imageURL` argument through `QuickCaptureSheet` → `SiteWindow`/`SitesLauncherView` → `SiteWindowModel.createLinkPost`/`QuickCapture.createLinkPost`), but **`AnglesiteAppCore` could not be compiled here** either — it needs Xcode's `actool`/`xcstringstool`, which CommandLineTools doesn't ship. Please let CI's Swift lane and a local app build confirm it.

No user-visible strings were added or changed, so no `Localizable.xcstrings` sync was needed.

### Manual QA

- [ ] Quick-capture a URL whose page has an `og:image` (site-window drag/paste, the launcher's site-picker flow, and ⇧⌘L) → the bookmark's frontmatter gains `image: "/images/link-<slug>.<ext>"`, the file exists under `Source/public/images/`, both are in one `anglesite: add card image for <slug>` commit, and the card image shows on the entry page and in `/bookmarks/`.
- [ ] Capture a URL with **no** `og:image`, and one whose `og:image` 404s or is an SVG → the link post is still created exactly as it is today, with no `image:` key, no stray file, and a quiet note in the debug pane.
- [ ] Undo (⌘Z) right after a capture with an image → the entry is removed cleanly (the capture is sequenced before the undo snapshot is taken, so the snapshot includes `image:`).


---

### Update — CI is green, and it caught what this host could not

Since this PR was opened, three commits landed on the branch and **all CI lanes now pass**, including `build-test`, `Linux (portable SwiftPM targets)`, `Template (build/test)`, `DocC build`, `Concurrency suites (ThreadSanitizer)`, the timing-sensitive lane, and `iOS app target`:

- `279afa1c` — **the build breaker the review flagged, fixed.** My first commit widened `QuickCaptureSheet`'s stored `onCreate` property to six parameters but not the matching `init` parameter. That is exactly the class of error the host's broken Xcode hid from me (`AnglesiteAppCore` can't be compiled locally without `actool`/`xcstringstool`) — CI's Swift lane caught it, as it should.
- `6d880af3` — `ContentConfigDriftTests` taught about the deliberately template-only `image` field, so the template↔registry drift guard still holds with the field present in the Zod schema and absent from the `bookmark` descriptor.
- `e2b4e185` — the two non-blocking review notes: `processGitCommitPaths` now pre-flights every path's existence before staging any (there is no index-only unstage in this SwiftGit2 fork, so a mid-loop bail could otherwise leave a stray staged path; the narrower residual window is documented), and `QuickCapture.createLinkPost` resolves the site's `sourceDirectory` once instead of querying `SiteStore` twice.

The Test plan's unchecked `swift test` / `xcodebuild` boxes above still describe *this host* accurately — but CI has now run both, green, on the current head. The manual QA checklist is still outstanding.

_Opened by the software factory (Phase C) — epic #1256._
