### PR TITLE
feat(#999): first-publish license gate

### DIFF
--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -86,6 +86,16 @@ final class DeployModel {
     /// flow. Set when `deploy(...)` is invoked without a token in either the env or the
     /// Keychain; cleared when the user saves a token (which then retries the deploy) or cancels.
     var tokenPromptPresented: Bool = false
+    /// Bound to a `.sheet` in `SiteWindow` for the first-publish license gate (#999). Set when
+    /// `deploy(...)` is invoked and the site's `licensing.json` has never recorded an explicit
+    /// license choice. Reuses `pendingDeploy` to park and retry, same as the token-prompt flow.
+    /// Unlike the other `pendingDeploy` sheets, this one is wired with
+    /// `.interactiveDismissDisabled()` in `SiteWindow` — the design is a hard block, so there is
+    /// deliberately no `cancelLicenseGate()` to pair with it.
+    var licenseGatePresented: Bool = false
+    /// Set when saving the chosen policy fails (e.g. an unsafe custom license URL). Cleared on
+    /// every fresh presentation and on a successful `confirmLicenseChoice(_:)`.
+    private(set) var licenseGateError: String?
     /// Bound to a `.sheet` in `SiteWindow` for the `.workerNameConflict` outcome — the Worker
     /// name is already taken on the connected Cloudflare account and this is the site's first
     /// deploy. Reuses `pendingDeploy` (below) to park and retry, same as the token-prompt flow.
@@ -273,6 +283,12 @@ final class DeployModel {
             tokenPromptPresented = true
             return
         }
+        if !hasChosenLicense(siteDirectory: siteDirectory) {
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControlProvider, siteName)
+            licenseGateError = nil
+            licenseGatePresented = true
+            return
+        }
         // Flip `phase` synchronously, before scheduling the Task, so a second `deploy()` call
         // on the same actor hop (e.g. a rapid re-invocation before this Task starts running)
         // sees `isRunning == true` and bails via the guard above instead of racing runDeploy.
@@ -304,6 +320,9 @@ final class DeployModel {
         guard !isRunning else { return .deferred(reason: "another site operation is running") }
         guard !awaitingUserAction else { return .deferred(reason: "a deploy prompt is waiting for a response") }
         guard hasUsableToken() else { return .deferred(reason: "Cloudflare credentials are not configured") }
+        guard hasChosenLicense(siteDirectory: siteDirectory) else {
+            return .deferred(reason: "a content license hasn't been chosen yet")
+        }
         // Resolved once (there's no user-facing prompt gap on this background path to make a
         // second resolution meaningfully fresher) and reused both for the readiness guard and the
         // actual run, so the two can't disagree about whether a container is available.
@@ -408,6 +427,37 @@ final class DeployModel {
         pendingDeploy = nil
         tokenPromptPresented = false
         tokenVerification = .idle
+    }
+
+    /// Called by `LicenseGateSheetView`'s Continue button. Builds the policy from `license`
+    /// (`nil` means "All rights reserved"), fills only unset AI-usage purposes via
+    /// `LicenseCatalog.prefilled` (matching `ContentLicensingTab`'s own picker behavior, so this
+    /// never clobbers a manual override made later), marks the choice made, and saves — then
+    /// resumes the parked deploy. Owns its own `LicensingStore` directly rather than going
+    /// through `PlistEditorModel`, so the gate works with no Settings window open.
+    func confirmLicenseChoice(_ license: LicenseRef?) {
+        guard let pending = pendingDeploy else {
+            licenseGateError = "No deploy is waiting — close this and click Deploy again."
+            return
+        }
+        let store = LicensingStore(sourceDirectory: pending.siteDirectory)
+        var policy = (try? store.load()) ?? LicensingPolicy()
+        policy.defaultLicense = license
+        policy.usage = LicenseCatalog.prefilled(policy.usage, for: license)
+        policy.licenseChosen = true
+        do {
+            try store.save(policy)
+        } catch {
+            licenseGateError = "Couldn't save your license choice: \(error)"
+            return
+        }
+        pendingDeploy = nil
+        licenseGateError = nil
+        licenseGatePresented = false
+        deploy(
+            siteID: pending.siteID, siteDirectory: pending.siteDirectory,
+            configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
+            containerControlProvider: pending.containerControlProvider, siteName: pending.siteName)
     }
 
     /// Called by the worker-name-conflict sheet's "Rename & retry" button. Applies the rename to
@@ -580,6 +630,15 @@ final class DeployModel {
             return true
         }
         return false
+    }
+
+    /// Whether `siteDirectory`'s `licensing.json` records an explicit license choice (#999). A
+    /// missing file or an unreadable/malformed document both read as "not chosen" —
+    /// `LicensingStore.load()` already degrades every malformed shape to the empty policy, whose
+    /// `licenseChosen` is `false`, so this mirrors that same fail-safe default rather than adding
+    /// a second one.
+    private func hasChosenLicense(siteDirectory: URL) -> Bool {
+        (try? LicensingStore(sourceDirectory: siteDirectory).load())?.licenseChosen ?? false
     }
 
     /// Set `phase` and notify the transition hook. All of `runDeploy`'s phase changes route

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -429,6 +429,16 @@ final class DeployModel {
         tokenVerification = .idle
     }
 
+    /// The licensing policy of the deploy currently parked on the license gate — `nil` when no
+    /// deploy is parked. `LicenseGateSheetView` reads it on appear to seed its selection, so a
+    /// license the site already records is re-affirmed by Continue rather than replaced by the
+    /// sheet's own default. A missing or malformed `licensing.json` degrades to the empty policy,
+    /// the same fail-safe `hasChosenLicense(siteDirectory:)` relies on.
+    var pendingLicensingPolicy: LicensingPolicy? {
+        guard let pending = pendingDeploy else { return nil }
+        return (try? LicensingStore(sourceDirectory: pending.siteDirectory).load()) ?? LicensingPolicy()
+    }
+
     /// Called by `LicenseGateSheetView`'s Continue button. Builds the policy from `license`
     /// (`nil` means "All rights reserved"), fills only unset AI-usage purposes via
     /// `LicenseCatalog.prefilled` (matching `ContentLicensingTab`'s own picker behavior, so this

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -445,7 +445,12 @@ final class DeployModel {
     /// never clobbers a manual override made later), marks the choice made, and saves — then
     /// resumes the parked deploy. Owns its own `LicensingStore` directly rather than going
     /// through `PlistEditorModel`, so the gate works with no Settings window open.
-    func confirmLicenseChoice(_ license: LicenseRef?) {
+    ///
+    /// `async` only for the failure path's log write: the raw error is developer-facing (it can
+    /// carry an unusable-URL payload), so the plain-language message goes to the sheet and the
+    /// real error goes to the log — awaited before returning, exactly as the Cloudflare sign-in
+    /// failure path does, so it can't be dropped by app termination.
+    func confirmLicenseChoice(_ license: LicenseRef?) async {
         guard let pending = pendingDeploy else {
             licenseGateError = "No deploy is waiting — close this and click Deploy again."
             return
@@ -457,8 +462,22 @@ final class DeployModel {
         policy.licenseChosen = true
         do {
             try store.save(policy)
+        } catch let error as LicensingStore.ValidationError {
+            // Mirrors `PlistEditorModel.saveLicensing()`'s treatment of the same error, so the
+            // two paths that can write this policy say the same thing about a bad address.
+            switch error {
+            case .unsafeLicenseURL(let url):
+                await logCenter.append(
+                    source: "license-gate:\(pending.siteID)", stream: .stderr,
+                    text: "Refused to save an unsafe license URL: \(error)")
+                licenseGateError = "\"\(url)\" isn't a usable license address. Use an https:// URL or a path on this site starting with /."
+            }
+            return
         } catch {
-            licenseGateError = "Couldn't save your license choice: \(error)"
+            await logCenter.append(
+                source: "license-gate:\(pending.siteID)", stream: .stderr,
+                text: "Saving the content license failed: \(error)")
+            licenseGateError = "Couldn't save your license choice: \(error.localizedDescription)"
             return
         }
         pendingDeploy = nil

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -89,9 +89,10 @@ final class DeployModel {
     /// Bound to a `.sheet` in `SiteWindow` for the first-publish license gate (#999). Set when
     /// `deploy(...)` is invoked and the site's `licensing.json` has never recorded an explicit
     /// license choice. Reuses `pendingDeploy` to park and retry, same as the token-prompt flow.
-    /// Unlike the other `pendingDeploy` sheets, this one is wired with
-    /// `.interactiveDismissDisabled()` in `SiteWindow` — the design is a hard block, so there is
-    /// deliberately no `cancelLicenseGate()` to pair with it.
+    /// Wired with `.interactiveDismissDisabled()` in `SiteWindow`: the design is a hard block, so
+    /// Esc or a swipe must not bypass it. Backing out is a deliberate button press —
+    /// `cancelLicenseGate()` — which abandons this deploy attempt without recording a choice, so
+    /// the gate simply fires again next time.
     var licenseGatePresented: Bool = false
     /// Set when saving the chosen policy fails (e.g. an unsafe custom license URL). Cleared on
     /// every fresh presentation and on a successful `confirmLicenseChoice(_:)`.
@@ -526,6 +527,16 @@ final class DeployModel {
             siteID: pending.siteID, siteDirectory: pending.siteDirectory,
             configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
             containerControlProvider: pending.containerControlProvider, siteName: pending.siteName)
+    }
+
+    /// Abandons *this* deploy attempt without recording a license choice — the gate's Cancel
+    /// button, for a Deploy pressed by mistake. Nothing is saved, so the gate fires again on the
+    /// next Deploy: publishing still can't happen without an explicit choice, exactly as the
+    /// token-prompt and worker-name-conflict sheets have Cancel without weakening what they gate.
+    func cancelLicenseGate() {
+        pendingDeploy = nil
+        licenseGatePresented = false
+        licenseGateError = nil
     }
 
     func cancelWorkerNameConflictPrompt() {

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -58,14 +58,18 @@ struct LicenseGateSheetView: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
 
-            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
-                GridRow {
-                    Text("License")
-                    Text("Permits")
-                    Text("AI systems")
+            VStack(alignment: .leading, spacing: 4) {
+                // Header row. Deliberately an `HStack` with the same three column widths the
+                // body rows use, not a `GridRow` — see `row(...)` for why this table isn't a
+                // `Grid` at all; the columns line up because every row states the same widths.
+                HStack(alignment: .firstTextBaseline, spacing: Self.columnSpacing) {
+                    Text("License").frame(width: Self.licenseColumnWidth, alignment: .leading)
+                    Text("Permits").frame(width: Self.permitsColumnWidth, alignment: .leading)
+                    Text("AI systems").frame(width: Self.aiColumnWidth, alignment: .leading)
                 }
                 .font(.caption.bold())
                 .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
 
                 row(title: "All rights reserved", permits: "Nothing without asking", aiNote: nil,
                     choice: .allRightsReserved)
@@ -115,28 +119,51 @@ struct LicenseGateSheetView: View {
         .frame(minWidth: 520)
     }
 
+    /// One selectable license row.
+    ///
+    /// Deliberately **not** a `GridRow` inside a `Grid`. Modifiers chained onto a `GridRow` are
+    /// applied to each of its cells individually rather than to the row as a whole, so the
+    /// earlier `Grid`-based version produced three disconnected backgrounds, three hit targets
+    /// with dead gutters between the columns, three Tab stops, and three accessibility elements
+    /// all announcing the same label — verified by rendering the rows with `ImageRenderer` and
+    /// measuring the painted pixels. A single `Button` per row makes the row one view: one
+    /// contiguous highlight, one content shape spanning the full width, one focus stop, and one
+    /// accessibility element with the native button activation (Return/Space) that comes with it.
+    /// The columns line up because every row — including the header — states the same three
+    /// explicit frame widths, which is the alignment job `Grid` used to do.
     private func row(
         title: String, permits: String, aiNote: String?, choice: Selection.Choice
     ) -> some View {
-        GridRow {
-            Text(title)
-            Text(permits).font(.caption).foregroundStyle(.secondary)
-            Text(aiNote ?? "—").font(.caption).foregroundStyle(.secondary)
+        Button {
+            selection.choice = choice
+        } label: {
+            HStack(alignment: .firstTextBaseline, spacing: Self.columnSpacing) {
+                Text(title)
+                    .frame(width: Self.licenseColumnWidth, alignment: .leading)
+                Text(permits)
+                    .font(.caption).foregroundStyle(.secondary)
+                    .frame(width: Self.permitsColumnWidth, alignment: .leading)
+                Text(aiNote ?? "—")
+                    .font(.caption).foregroundStyle(.secondary)
+                    .frame(width: Self.aiColumnWidth, alignment: .leading)
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(selection.choice == choice ? Color.accentColor.opacity(0.15) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .contentShape(Rectangle())
         }
-        .padding(.vertical, 4)
-        .padding(.horizontal, 6)
-        .background(selection.choice == choice ? Color.accentColor.opacity(0.15) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-        .contentShape(Rectangle())
-        .onTapGesture { selection.choice = choice }
-        .focusable(true)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel([title, permits, aiNote ?? ""].filter { !$0.isEmpty }.joined(separator: ", "))
-        .accessibilityAddTraits(selection.choice == choice ? [.isButton, .isSelected] : .isButton)
-        .accessibilityAction(.default) { selection.choice = choice }
-        .onKeyPress(.return) { selection.choice = choice; return .handled }
-        .onKeyPress(.space) { selection.choice = choice; return .handled }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(selection.choice == choice ? .isSelected : [])
     }
+
+    /// Column geometry for the comparison table. Shared by the header and every body row so the
+    /// three columns line up without a `Grid` (see `row(...)`).
+    private static let columnSpacing: CGFloat = 16
+    private static let licenseColumnWidth: CGFloat = 150
+    private static let permitsColumnWidth: CGFloat = 260
+    private static let aiColumnWidth: CGFloat = 80
 
     /// Plain-language summary of what each catalog license permits — the middle comparison-table
     /// column. Keyed by catalog id rather than re-deriving from `permitsAIUse` so it stays

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -118,17 +118,22 @@ struct LicenseGateSheetView: View {
     private func row(
         title: String, permits: String, aiNote: String?, choice: Selection.Choice
     ) -> some View {
-        GridRow {
-            Text(title)
-            Text(permits).font(.caption).foregroundStyle(.secondary)
-            Text(aiNote ?? "—").font(.caption).foregroundStyle(.secondary)
+        Button(action: { selection.choice = choice }) {
+            GridRow {
+                Text(title)
+                Text(permits).font(.caption).foregroundStyle(.secondary)
+                Text(aiNote ?? "—").font(.caption).foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 6)
+            .background(selection.choice == choice ? Color.accentColor.opacity(0.15) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
         }
-        .padding(.vertical, 4)
-        .padding(.horizontal, 6)
-        .background(selection.choice == choice ? Color.accentColor.opacity(0.15) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .buttonStyle(.plain)
         .contentShape(Rectangle())
-        .onTapGesture { selection.choice = choice }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel([title, permits, aiNote ?? ""].filter { !$0.isEmpty }.joined(separator: ", "))
+        .accessibilityAddTraits(selection.choice == choice ? [.isButton, .isSelected] : .isButton)
     }
 
     /// Plain-language summary of what each catalog license permits — the middle comparison-table

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -118,22 +118,24 @@ struct LicenseGateSheetView: View {
     private func row(
         title: String, permits: String, aiNote: String?, choice: Selection.Choice
     ) -> some View {
-        Button(action: { selection.choice = choice }) {
-            GridRow {
-                Text(title)
-                Text(permits).font(.caption).foregroundStyle(.secondary)
-                Text(aiNote ?? "—").font(.caption).foregroundStyle(.secondary)
-            }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 6)
-            .background(selection.choice == choice ? Color.accentColor.opacity(0.15) : Color.clear)
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+        GridRow {
+            Text(title)
+            Text(permits).font(.caption).foregroundStyle(.secondary)
+            Text(aiNote ?? "—").font(.caption).foregroundStyle(.secondary)
         }
-        .buttonStyle(.plain)
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .background(selection.choice == choice ? Color.accentColor.opacity(0.15) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
         .contentShape(Rectangle())
+        .onTapGesture { selection.choice = choice }
+        .focusable(true)
         .accessibilityElement(children: .combine)
         .accessibilityLabel([title, permits, aiNote ?? ""].filter { !$0.isEmpty }.joined(separator: ", "))
         .accessibilityAddTraits(selection.choice == choice ? [.isButton, .isSelected] : .isButton)
+        .accessibilityAction(.default) { selection.choice = choice }
+        .onKeyPress(.return) { selection.choice = choice; return .handled }
+        .onKeyPress(.space) { selection.choice = choice; return .handled }
     }
 
     /// Plain-language summary of what each catalog license permits — the middle comparison-table

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -49,9 +49,13 @@ struct LicenseGateSheetView: View {
         }
 
         /// False only for an empty-URL custom selection — every other choice is already
-        /// complete the moment it's picked.
+        /// complete the moment it's picked. Whitespace is trimmed before the emptiness check so
+        /// a blank-looking URL is caught here rather than at `LicensingStore.save`'s validation
+        /// boundary, which surfaces as an error banner instead of a disabled button.
         var isContinueEnabled: Bool {
-            if case .custom = choice { return !customURL.isEmpty }
+            if case .custom = choice {
+                return !customURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
             return true
         }
 
@@ -205,6 +209,8 @@ struct LicenseGateSheetView: View {
         case "cc-by-nd-4.0": return "Redistribute unmodified, with credit"
         case "cc-by-nc-sa-4.0": return "Non-commercial use, with credit, same license"
         case "cc-by-nc-nd-4.0": return "Redistribute unmodified, non-commercial, with credit"
+        // Adding a `LicenseCatalog` entry should add a case above too — otherwise its Permits
+        // column just repeats the license name.
         default: return entry.name
         }
     }

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -129,6 +129,10 @@ struct LicenseGateSheetView: View {
 
             HStack {
                 Spacer()
+                // Backing out of a mis-clicked Deploy. Saves nothing, so the gate fires again on
+                // the next Deploy — this abandons the attempt, it doesn't bypass the block.
+                Button("Cancel") { model.cancelLicenseGate() }
+                    .keyboardShortcut(.cancelAction)
                 Button("Continue") {
                     Task { await model.confirmLicenseChoice(selection.resolvedLicense()) }
                 }

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -130,7 +130,7 @@ struct LicenseGateSheetView: View {
             HStack {
                 Spacer()
                 Button("Continue") {
-                    model.confirmLicenseChoice(selection.resolvedLicense())
+                    Task { await model.confirmLicenseChoice(selection.resolvedLicense()) }
                 }
                 .keyboardShortcut(.defaultAction)
                 .disabled(!selection.isContinueEnabled)

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -10,8 +10,8 @@ struct LicenseGateSheetView: View {
     @Bindable var model: DeployModel
 
     /// One row's pure state: which license is selected, and (for `.custom`) the URL/name typed
-    /// so far. A fresh instance per presentation — the gate never shows a prior choice, since it
-    /// only appears when none has been recorded yet. Extracted as a plain struct (not held
+    /// so far. Re-seeded on every presentation from whatever license the site already records
+    /// (see `init(existing:)`). Extracted as a plain struct (not held
     /// directly as separate `@State` fields) so `isContinueEnabled`/`resolvedLicense()` are
     /// unit-testable without a hosted SwiftUI render pass, mirroring
     /// `ContentLicensingTab.PendingCustomLicense`. Internal (not `private`) so tests can
@@ -26,6 +26,27 @@ struct LicenseGateSheetView: View {
         var choice: Choice = .allRightsReserved
         var customURL: String = ""
         var customName: String = ""
+
+        /// Seeds the selection from a license the site's `licensing.json` already records.
+        ///
+        /// The gate normally only appears when nothing has been chosen, so `nil` — an untouched
+        /// scaffold — is the usual input and lands on "All rights reserved". But
+        /// `defaultLicense` and `licenseChosen` are separate fields, and a hand-edited
+        /// `licensing.json` (or any future writer that forgets the flag) can carry a real
+        /// license with `licenseChosen == false`. Starting from that license means pressing
+        /// Continue re-affirms it rather than silently replacing it with this sheet's default.
+        init(existing license: LicenseRef? = nil) {
+            guard let license else { return }
+            if let entry = LicenseCatalog.entry(for: license) {
+                choice = .catalog(entry.id)
+            } else {
+                choice = .custom
+                customURL = license.url
+                // `LicenseRef` decoding falls the name back to the URL, so a name equal to the
+                // URL carries no information the Name field should show as if it were typed.
+                customName = license.name == license.url ? "" : license.name
+            }
+        }
 
         /// False only for an empty-URL custom selection — every other choice is already
         /// complete the moment it's picked.
@@ -117,6 +138,9 @@ struct LicenseGateSheetView: View {
         }
         .padding(24)
         .frame(minWidth: 520)
+        .onAppear {
+            selection = Selection(existing: model.pendingLicensingPolicy?.defaultLicense)
+        }
     }
 
     /// One selectable license row.

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -101,7 +101,10 @@ struct LicenseGateSheetView: View {
 
                 ForEach(LicenseCatalog.entries) { entry in
                     row(
-                        title: entry.name,
+                        // A license's own name ("CC BY 4.0") is catalog data, not UI copy, so
+                        // it is deliberately not a literal key for extraction — the runtime
+                        // lookup just falls back to the name itself.
+                        title: LocalizedStringKey(entry.name),
                         permits: permitsSummary(for: entry),
                         aiNote: entry.permitsAIUse ? "✅ Permits" : "❔ Unclear",
                         choice: .catalog(entry.id))
@@ -164,7 +167,8 @@ struct LicenseGateSheetView: View {
     /// The columns line up because every row — including the header — states the same three
     /// explicit frame widths, which is the alignment job `Grid` used to do.
     private func row(
-        title: String, permits: String, aiNote: String?, choice: Selection.Choice
+        title: LocalizedStringKey, permits: LocalizedStringKey, aiNote: LocalizedStringKey?,
+        choice: Selection.Choice
     ) -> some View {
         Button {
             selection.choice = choice
@@ -200,7 +204,7 @@ struct LicenseGateSheetView: View {
     /// Plain-language summary of what each catalog license permits — the middle comparison-table
     /// column. Keyed by catalog id rather than re-deriving from `permitsAIUse` so it stays
     /// independent of the AI classification the last column already renders.
-    private func permitsSummary(for entry: LicenseCatalog.Entry) -> String {
+    private func permitsSummary(for entry: LicenseCatalog.Entry) -> LocalizedStringKey {
         switch entry.id {
         case "cc0-1.0": return "Any use, no credit required"
         case "cc-by-4.0": return "Any use, with credit"
@@ -210,8 +214,9 @@ struct LicenseGateSheetView: View {
         case "cc-by-nc-sa-4.0": return "Non-commercial use, with credit, same license"
         case "cc-by-nc-nd-4.0": return "Redistribute unmodified, non-commercial, with credit"
         // Adding a `LicenseCatalog` entry should add a case above too — otherwise its Permits
-        // column just repeats the license name.
-        default: return entry.name
+        // column just repeats the license name (and, being catalog data rather than UI copy,
+        // isn't a literal key the way every case above is).
+        default: return LocalizedStringKey(entry.name)
         }
     }
 }

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+import AnglesiteCore
+
+/// The first-publish license gate (#999) — a hard-blocking comparison table shown before a
+/// site's first deploy, so "All rights reserved" is a choice the owner made rather than a
+/// default they never saw. Confirming resumes the deploy `DeployModel` parked in its
+/// `pendingDeploy`. No per-collection overrides or the "Refuse AI crawlers" toggle here — those
+/// stay in Settings ▸ Content Licensing; this sheet only needs one decision made.
+struct LicenseGateSheetView: View {
+    @Bindable var model: DeployModel
+
+    /// One row's pure state: which license is selected, and (for `.custom`) the URL/name typed
+    /// so far. A fresh instance per presentation — the gate never shows a prior choice, since it
+    /// only appears when none has been recorded yet. Extracted as a plain struct (not held
+    /// directly as separate `@State` fields) so `isContinueEnabled`/`resolvedLicense()` are
+    /// unit-testable without a hosted SwiftUI render pass, mirroring
+    /// `ContentLicensingTab.PendingCustomLicense`. Internal (not `private`) so tests can
+    /// construct and mutate it directly.
+    struct Selection: Equatable {
+        enum Choice: Hashable {
+            case allRightsReserved
+            case catalog(String)
+            case custom
+        }
+
+        var choice: Choice = .allRightsReserved
+        var customURL: String = ""
+        var customName: String = ""
+
+        /// False only for an empty-URL custom selection — every other choice is already
+        /// complete the moment it's picked.
+        var isContinueEnabled: Bool {
+            if case .custom = choice { return !customURL.isEmpty }
+            return true
+        }
+
+        /// The `LicenseRef?` `DeployModel.confirmLicenseChoice(_:)` should persist for the
+        /// current choice, or nil for "All rights reserved."
+        func resolvedLicense() -> LicenseRef? {
+            switch choice {
+            case .allRightsReserved:
+                return nil
+            case .catalog(let id):
+                return LicenseCatalog.entries.first { $0.id == id }?.ref
+            case .custom:
+                return LicenseRef(url: customURL, name: customName.isEmpty ? customURL : customName)
+            }
+        }
+    }
+
+    @State private var selection = Selection()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Choose a License")
+                .font(.title2.bold())
+            Text("Before your first publish, pick what license covers your content. \"All rights reserved\" is a valid choice — Anglesite just never picks it for you silently.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
+                GridRow {
+                    Text("License")
+                    Text("Permits")
+                    Text("AI systems")
+                }
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+
+                row(title: "All rights reserved", permits: "Nothing without asking", aiNote: nil,
+                    choice: .allRightsReserved)
+
+                ForEach(LicenseCatalog.entries) { entry in
+                    row(
+                        title: entry.name,
+                        permits: permitsSummary(for: entry),
+                        aiNote: entry.permitsAIUse ? "✅ Permits" : "❔ Unclear",
+                        choice: .catalog(entry.id))
+                }
+
+                row(title: "Custom…", permits: "Your own terms", aiNote: nil, choice: .custom)
+            }
+
+            if selection.choice == .custom {
+                Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
+                    GridRow {
+                        Text("Address").frame(minWidth: 100, alignment: .leading)
+                        TextField("https://example.com/license", text: $selection.customURL)
+                            .frame(minWidth: 280)
+                    }
+                    GridRow {
+                        Text("Name").frame(minWidth: 100, alignment: .leading)
+                        TextField("My license", text: $selection.customName)
+                            .frame(minWidth: 280)
+                    }
+                }
+            }
+
+            if let error = model.licenseGateError {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.callout)
+            }
+
+            HStack {
+                Spacer()
+                Button("Continue") {
+                    model.confirmLicenseChoice(selection.resolvedLicense())
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!selection.isContinueEnabled)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 520)
+    }
+
+    private func row(
+        title: String, permits: String, aiNote: String?, choice: Selection.Choice
+    ) -> some View {
+        GridRow {
+            Text(title)
+            Text(permits).font(.caption).foregroundStyle(.secondary)
+            Text(aiNote ?? "—").font(.caption).foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .background(selection.choice == choice ? Color.accentColor.opacity(0.15) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .contentShape(Rectangle())
+        .onTapGesture { selection.choice = choice }
+    }
+
+    /// Plain-language summary of what each catalog license permits — the middle comparison-table
+    /// column. Keyed by catalog id rather than re-deriving from `permitsAIUse` so it stays
+    /// independent of the AI classification the last column already renders.
+    private func permitsSummary(for entry: LicenseCatalog.Entry) -> String {
+        switch entry.id {
+        case "cc0-1.0": return "Any use, no credit required"
+        case "cc-by-4.0": return "Any use, with credit"
+        case "cc-by-sa-4.0": return "Any use, with credit, same license"
+        case "cc-by-nc-4.0": return "Non-commercial use, with credit"
+        case "cc-by-nd-4.0": return "Redistribute unmodified, with credit"
+        case "cc-by-nc-sa-4.0": return "Non-commercial use, with credit, same license"
+        case "cc-by-nc-nd-4.0": return "Redistribute unmodified, non-commercial, with credit"
+        default: return entry.name
+        }
+    }
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -295,6 +295,9 @@
     "AI summary — verify against the log below" : {
 
     },
+    "AI systems" : {
+
+    },
     "API token" : {
 
     },
@@ -526,6 +529,15 @@
     "Answer a couple of questions and we'll pick the right commerce integration." : {
 
     },
+    "Any use, no credit required" : {
+
+    },
+    "Any use, with credit" : {
+
+    },
+    "Any use, with credit, same license" : {
+
+    },
     "Anyone on Mastodon can follow this site by pasting its address into search:" : {
 
     },
@@ -678,6 +690,9 @@
 
     },
     "Base styles" : {
+
+    },
+    "Before your first publish, pick what license covers your content. \"All rights reserved\" is a valid choice — Anglesite just never picks it for you silently." : {
 
     },
     "Block AI Training Crawlers" : {
@@ -896,6 +911,9 @@
 
     },
     "Choose Logo" : {
+
+    },
+    "Choose a License" : {
 
     },
     "Choose a Template" : {
@@ -2026,6 +2044,9 @@
     "Lets Tor Browser users reach your site over the Tor network without exiting through a third-party relay. No changes to your site or URLs." : {
 
     },
+    "License" : {
+
+    },
     "Likely cause: %@" : {
 
     },
@@ -2329,6 +2350,12 @@
     "No, mixed or other devices" : {
 
     },
+    "Non-commercial use, with credit" : {
+
+    },
+    "Non-commercial use, with credit, same license" : {
+
+    },
     "None" : {
 
     },
@@ -2360,6 +2387,9 @@
 
     },
     "Notes" : {
+
+    },
+    "Nothing without asking" : {
 
     },
     "Notifications" : {
@@ -2552,6 +2582,9 @@
 
     },
     "Permanent (301)" : {
+
+    },
+    "Permits" : {
 
     },
     "Personal access token" : {
@@ -2762,6 +2795,12 @@
 
     },
     "Redirects" : {
+
+    },
+    "Redistribute unmodified, non-commercial, with credit" : {
+
+    },
+    "Redistribute unmodified, with credit" : {
 
     },
     "Reduce File Size…" : {
@@ -3956,6 +3995,9 @@
     "Your declared domain configuration (anglesite.json) doesn't match what's live on Cloudflare. Review and reconcile before deploying again." : {
 
     },
+    "Your own terms" : {
+
+    },
     "Your site is live. Connect a domain?" : {
 
     },
@@ -4064,6 +4106,9 @@
     "value" : {
 
     },
+    "—" : {
+
+    },
     "“%@”\n\nbecomes\n\n“%@”" : {
       "localizations" : {
         "en" : {
@@ -4096,6 +4141,12 @@
           }
         }
       }
+    },
+    "✅ Permits" : {
+
+    },
+    "❔ Unclear" : {
+
     },
     "👥" : {
 

--- a/Sources/AnglesiteApp/PlistEditorModel.swift
+++ b/Sources/AnglesiteApp/PlistEditorModel.swift
@@ -528,7 +528,12 @@ final class PlistEditorModel {
         // into both `licensingPolicy` and `savedLicensingPolicy` keeps the in-memory model
         // matching what's actually on disk, the same way `saveMtaSts` writes back its normalized
         // settings above.
-        let policy = LicensingStore.normalized(licensingPolicy)
+        var policy = LicensingStore.normalized(licensingPolicy)
+        // Saving this facet *is* an explicit license choice, even when the result is "All rights
+        // reserved" — the owner navigated here and pressed Save. Recording it means the
+        // first-publish license gate (#999) doesn't re-ask and, worse, doesn't overwrite this
+        // choice with its own default when the owner presses Continue.
+        policy.licenseChosen = true
         do {
             try await Task.detached(priority: .userInitiated) {
                 try LicensingStore(sourceDirectory: sourceDirectory).save(policy)

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -660,6 +660,10 @@ struct SiteWindow: View {
                 )
             }
         }
+        .sheet(isPresented: $bindableModel.deploy.licenseGatePresented) {
+            LicenseGateSheetView(model: model.deploy)
+                .interactiveDismissDisabled()
+        }
         .sheet(isPresented: $bindableModel.audit.sheetPresented) {
             AuditSheetView(
                 model: model.audit,

--- a/Sources/AnglesiteCore/LicensingStore.swift
+++ b/Sources/AnglesiteCore/LicensingStore.swift
@@ -241,6 +241,11 @@ public struct LicensingPolicy: Sendable, Equatable {
     /// `publishRSL` on `LicensingPolicy` in `licensing.ts`; `src/lib/rsl.ts` derives every RSL
     /// projection from this same policy, never from a separate signal.
     public var publishRSL: Bool
+    /// Whether an explicit license choice has been made — including "All rights reserved" —
+    /// distinct from `defaultLicense == nil`, which is also the untouched-scaffold state.
+    /// Set by the first-publish license gate (#999); never inferred from the rest of the
+    /// policy, so a hand-edited `licensing.json` that merely looks non-empty doesn't count.
+    public var licenseChosen: Bool
 
     /// The all-defaults form is the empty policy — assert nothing, inherit everywhere, no
     /// usage preferences, no RSL — the same state ``LicensingStore/load()`` reports for a site
@@ -249,12 +254,14 @@ public struct LicensingPolicy: Sendable, Equatable {
         defaultLicense: LicenseRef? = nil,
         collections: [LicensableCollection: CollectionLicenseRule] = [:],
         usage: AIUsage = AIUsage(),
-        publishRSL: Bool = false
+        publishRSL: Bool = false,
+        licenseChosen: Bool = false
     ) {
         self.defaultLicense = defaultLicense
         self.collections = collections
         self.usage = usage
         self.publishRSL = publishRSL
+        self.licenseChosen = licenseChosen
     }
 
     /// The effective stored rule for `collection` — an absent key *is* `.inherit`, which is
@@ -276,7 +283,7 @@ public struct LicensingPolicy: Sendable, Equatable {
 
 extension LicensingPolicy: Codable {
     private enum CodingKeys: String, CodingKey {
-        case `default`, collections, usage, publishRSL
+        case `default`, collections, usage, publishRSL, licenseChosen
     }
 
     /// `collections` is a free-form object whose values are either null or a license, so it needs
@@ -359,7 +366,12 @@ extension LicensingPolicy: Codable {
         // throwing — matching `normalizePolicy`'s `rawPublishRSL === true` check, which is false
         // for anything but the literal boolean `true`.
         let publishRSL = ((try? container.decodeIfPresent(Bool.self, forKey: .publishRSL)) ?? nil) ?? false
-        self.init(defaultLicense: defaultLicense, collections: collections, usage: usage.clamped, publishRSL: publishRSL)
+        // Same lenient-decode treatment as publishRSL: a non-boolean or absent value degrades
+        // to false — "never asked" — rather than throwing or inferring "asked" from a
+        // present-but-garbage value (#999).
+        let licenseChosen = ((try? container.decodeIfPresent(Bool.self, forKey: .licenseChosen)) ?? nil) ?? false
+        self.init(defaultLicense: defaultLicense, collections: collections, usage: usage.clamped,
+                   publishRSL: publishRSL, licenseChosen: licenseChosen)
     }
 
     /// Template-compatible encoding: `default` is always written (an explicit null states "all
@@ -372,6 +384,7 @@ extension LicensingPolicy: Codable {
         try container.encode(defaultLicense, forKey: .default)
         try container.encode(usage.clamped, forKey: .usage)
         try container.encode(publishRSL, forKey: .publishRSL)
+        try container.encode(licenseChosen, forKey: .licenseChosen)
         var sub = container.nestedContainer(keyedBy: CollectionKey.self, forKey: .collections)
         // Sorted so a save produces a stable diff in the site's git repo.
         for collection in LicensableCollection.allCases {

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -106,7 +106,12 @@ struct DeployModelTests {
             suddenTerminationController: controller,
             tokenAvailabilityOverride: { true }
         )
-        let directory = FileManager.default.temporaryDirectory
+        // A unique-per-test directory (not the shared `FileManager.default.temporaryDirectory`
+        // root, which every test in this file used to share) with a license already recorded, so
+        // this test — which expects the deploy to actually reach the build step — isn't blocked
+        // by the first-publish license gate (#999) added alongside it.
+        let directory = try! makeLicenseGateSiteDirectory()
+        try! LicensingStore(sourceDirectory: directory).save(LicensingPolicy(licenseChosen: true))
 
         model.deploy(
             siteID: "test-site",
@@ -146,6 +151,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
         model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
@@ -175,6 +183,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         var config = DomainConfig()
         config.domain = DomainConfig.Domain(hostname: "example.com")
         try! DomainConfigStore(sourceDirectory: siteDir).save(config)
@@ -209,6 +220,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
         try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
@@ -251,6 +265,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
         try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
@@ -289,6 +306,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! "CF_PROJECT_NAME=my-site\nDOMAIN_CHOICE=transfer\nDOMAIN=example.com\n".write(
             to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
@@ -324,6 +344,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! "CF_PROJECT_NAME=my-site\nDOMAIN_CHOICE=transfer\nDOMAIN=example.com\nCF_DOMAIN_ATTACHED=example.com\n".write(
             to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
@@ -353,6 +376,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! "CF_PROJECT_NAME=my-site\nDOMAIN_CHOICE=transfer\nDOMAIN=example.com\n".write(
             to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
@@ -383,6 +409,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! "CF_PROJECT_NAME=my-site\nDOMAIN_CHOICE=transfer\nDOMAIN=example.com\n".write(
             to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
@@ -411,6 +440,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
         model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
@@ -438,6 +470,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
         // A manual (foreground) deploy parks on the conflict sheet, same as
@@ -482,6 +517,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
         try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
@@ -513,6 +551,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
         model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
@@ -672,6 +713,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
         try! #"name = "my-site""#.write(to: siteDir.appendingPathComponent("wrangler.toml"), atomically: true, encoding: .utf8)
         try! "CF_PROJECT_NAME=my-site\n".write(to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
@@ -706,6 +750,9 @@ struct DeployModelTests {
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
+        // A license is already recorded, so these tests (unrelated to the first-publish license
+        // gate, #999) aren't blocked by it before ever reaching what they're actually exercising.
+        try! LicensingStore(sourceDirectory: siteDir).save(LicensingPolicy(licenseChosen: true))
 
         model.deploy(siteID: "s", siteDirectory: siteDir, configDirectory: siteDir, currentRoutes: [])
         await executor.waitUntilBuildIsParked()
@@ -739,7 +786,10 @@ struct DeployModelTests {
             accessToken: "already-signed-in", refreshToken: nil, expiresAt: nil,
             tokenEndpoint: URL(string: "https://dash.cloudflare.com/oauth2/token")!))
         let model = DeployModel(command: command, logCenter: LogCenter(), keychain: keychain)
-        let directory = FileManager.default.temporaryDirectory
+        // A unique-per-test directory with a license already recorded — see the comment on the
+        // same pattern in `suddenTerminationLeaseBracketsDeploy` above (#999).
+        let directory = try! makeLicenseGateSiteDirectory()
+        try! LicensingStore(sourceDirectory: directory).save(LicensingPolicy(licenseChosen: true))
 
         model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
         // `resumeBuild()` must come AFTER the build step is actually reached — calling it before
@@ -812,7 +862,12 @@ struct DeployModelTests {
             command: command, logCenter: LogCenter(), keychain: keychain,
             verifier: StubTokenVerifying(result: .success(CloudflareAccount(name: "Acme Co.", email: nil))),
             oauthSignIn: oauthSignIn)
-        let directory = FileManager.default.temporaryDirectory
+        // A unique-per-test directory with a license already recorded — see the comment on the
+        // same pattern in `suddenTerminationLeaseBracketsDeploy` above (#999). The parked deploy
+        // that `signInWithCloudflare()` dispatches below reuses this same directory, so the
+        // license-gate check on that retry also sees it as already chosen.
+        let directory = try makeLicenseGateSiteDirectory()
+        try LicensingStore(sourceDirectory: directory).save(LicensingPolicy(licenseChosen: true))
 
         model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
         // Bind before asserting — see the comment on `tokenPromptPresented` in
@@ -880,11 +935,112 @@ struct DeployModelTests {
         }
     }
 
+    /// A unique per-test site directory with a content license already recorded, so the deploy
+    /// tests that use this helper (all of which are exercising something other than the
+    /// first-publish license gate, #999) reach their actual pipeline step instead of parking on
+    /// it.
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("DeployModelTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try LicensingStore(sourceDirectory: url).save(LicensingPolicy(licenseChosen: true))
         return url
+    }
+
+    private func makeLicenseGateSiteDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DeployModelLicenseGateTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("deploy() presents the license gate instead of running when no license has been chosen")
+    func deployPresentsLicenseGateWhenUnchosen() throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+
+        let licenseGatePresented = model.licenseGatePresented
+        let isRunning = model.isRunning
+        #expect(licenseGatePresented)
+        #expect(!isRunning)
+    }
+
+    @Test("confirmLicenseChoice saves the policy and resumes the parked deploy")
+    func confirmLicenseChoiceSavesAndResumes() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+        let licenseGatePresentedBeforeConfirm = model.licenseGatePresented
+        #expect(licenseGatePresentedBeforeConfirm)
+
+        let ccBY = LicenseCatalog.entries.first { $0.id == "cc-by-4.0" }!.ref
+        model.confirmLicenseChoice(ccBY)
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
+        while model.isRunning { await Task.yield() }
+
+        let licenseGatePresentedAfterConfirm = model.licenseGatePresented
+        #expect(!licenseGatePresentedAfterConfirm)
+        guard case .succeeded = model.phase else {
+            Issue.record("expected the parked deploy to run after confirming a license, got \(model.phase)")
+            return
+        }
+
+        let policy = try LicensingStore(sourceDirectory: directory).load()
+        #expect(policy.licenseChosen)
+        #expect(policy.defaultLicense == ccBY)
+        #expect(policy.usage.aiTrain == .yes)
+    }
+
+    @Test("confirming All rights reserved (nil) still marks the choice made")
+    func confirmAllRightsReservedMarksChosen() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+        model.confirmLicenseChoice(nil)
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
+        while model.isRunning { await Task.yield() }
+
+        let policy = try LicensingStore(sourceDirectory: directory).load()
+        #expect(policy.licenseChosen)
+        #expect(policy.defaultLicense == nil)
+    }
+
+    @Test("deployAutomatically defers when a license hasn't been chosen")
+    func deployAutomaticallyDefersWithoutLicense() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        let result = await model.deployAutomatically(
+            siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [],
+            containerControlProvider: { nil })
+
+        guard case .deferred(let reason) = result else {
+            Issue.record("expected .deferred, got \(result)")
+            return
+        }
+        #expect(reason.contains("license"))
     }
 }
 

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -1042,6 +1042,33 @@ struct DeployModelTests {
         }
         #expect(reason.contains("license"))
     }
+
+    @Test("cancelLicenseGate abandons the attempt without recording a choice")
+    func cancelLicenseGateRecordsNothing() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+        model.cancelLicenseGate()
+
+        let dismissed = model.licenseGatePresented
+        let isRunning = model.isRunning
+        #expect(!dismissed)
+        #expect(!isRunning)
+        #expect(model.licenseGateError == nil)
+        #expect(!((try? LicensingStore(sourceDirectory: directory).load())?.licenseChosen ?? false))
+
+        // The gate is not weakened by having a Cancel: the next Deploy hits it again.
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+        let presentedAgain = model.licenseGatePresented
+        let stillNotRunning = model.isRunning
+        #expect(presentedAgain)
+        #expect(!stillNotRunning)
+    }
 }
 
 /// Thread-safe invocation counter for a `DeployModel.ContainerControlProvider` under test —

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -1043,6 +1043,50 @@ struct DeployModelTests {
         #expect(reason.contains("license"))
     }
 
+    /// The security-relevant path through `confirmLicenseChoice`: `LicensingStore.save` refuses
+    /// an unsafe license URL, so nothing is persisted and nothing may publish. The deploy has to
+    /// stay parked (not silently abandoned) and the user has to get a plain-language message
+    /// rather than the raw Swift error, which carries the rejected URL in developer syntax.
+    @Test("confirmLicenseChoice surfaces a save failure and keeps the deploy parked")
+    func confirmLicenseChoiceSaveFailureKeepsDeployParked() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+        await model.confirmLicenseChoice(LicenseRef(url: "ftp://example.com/l", name: "Bad"))
+
+        let error = model.licenseGateError
+        #expect(error?.contains("ftp://example.com/l") == true)
+        #expect(error?.contains("https://") == true)
+        // Not Swift's raw error description, which renders as `unsafeLicenseURL("…")`.
+        #expect(error?.contains("unsafeLicenseURL") == false)
+
+        // The gate stays up and the deploy stays parked, so Continue can be retried.
+        let stillPresented = model.licenseGatePresented
+        let isRunning = model.isRunning
+        #expect(stillPresented)
+        #expect(!isRunning)
+
+        // Nothing was written, so the site still has no recorded choice.
+        let policy = try LicensingStore(sourceDirectory: directory).load()
+        #expect(!policy.licenseChosen)
+        #expect(policy.defaultLicense == nil)
+
+        // The parked deploy is still there: a valid choice now resumes it.
+        await model.confirmLicenseChoice(nil)
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
+        while model.isRunning { await Task.yield() }
+        guard case .succeeded = model.phase else {
+            Issue.record("expected the still-parked deploy to run after a valid choice, got \(model.phase)")
+            return
+        }
+    }
+
     @Test("cancelLicenseGate abandons the attempt without recording a choice")
     func cancelLicenseGateRecordsNothing() async throws {
         let executor = GatedDeployExecutor()

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -985,7 +985,7 @@ struct DeployModelTests {
         #expect(licenseGatePresentedBeforeConfirm)
 
         let ccBY = LicenseCatalog.entries.first { $0.id == "cc-by-4.0" }!.ref
-        model.confirmLicenseChoice(ccBY)
+        await model.confirmLicenseChoice(ccBY)
         await executor.waitUntilBuildIsParked()
         await executor.resumeBuild()
         while model.isRunning { await Task.yield() }
@@ -1013,7 +1013,7 @@ struct DeployModelTests {
         let directory = try makeLicenseGateSiteDirectory()
 
         model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
-        model.confirmLicenseChoice(nil)
+        await model.confirmLicenseChoice(nil)
         await executor.waitUntilBuildIsParked()
         await executor.resumeBuild()
         while model.isRunning { await Task.yield() }

--- a/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
+++ b/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+@Suite("LicenseGateSheetView.Selection (#999)")
+struct LicenseGateSelectionTests {
+    @Test("All rights reserved and a catalog choice are always continue-enabled")
+    func nonCustomAlwaysEnabled() {
+        var selection = LicenseGateSheetView.Selection()
+        #expect(selection.isContinueEnabled)
+        selection.choice = .catalog("cc-by-4.0")
+        #expect(selection.isContinueEnabled)
+    }
+
+    @Test("Custom is disabled until a URL is typed")
+    func customRequiresURL() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .custom
+        #expect(!selection.isContinueEnabled)
+        selection.customURL = "https://example.com/license"
+        #expect(selection.isContinueEnabled)
+    }
+
+    @Test("resolvedLicense maps All rights reserved to nil")
+    func allRightsReservedResolvesToNil() {
+        let selection = LicenseGateSheetView.Selection()
+        #expect(selection.resolvedLicense() == nil)
+    }
+
+    @Test("resolvedLicense maps a catalog choice to its catalog LicenseRef")
+    func catalogResolvesToCatalogRef() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .catalog("cc-by-4.0")
+        let expected = LicenseCatalog.entries.first { $0.id == "cc-by-4.0" }?.ref
+        #expect(selection.resolvedLicense() == expected)
+    }
+
+    @Test("resolvedLicense falls back the custom name to the URL when empty")
+    func customFallsBackNameToURL() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .custom
+        selection.customURL = "https://example.com/license"
+        #expect(selection.resolvedLicense() == LicenseRef(
+            url: "https://example.com/license", name: "https://example.com/license"))
+    }
+
+    @Test("resolvedLicense uses a typed custom name when present")
+    func customUsesTypedName() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .custom
+        selection.customURL = "https://example.com/license"
+        selection.customName = "House terms"
+        #expect(selection.resolvedLicense() == LicenseRef(
+            url: "https://example.com/license", name: "House terms"))
+    }
+}

--- a/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
+++ b/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
@@ -22,6 +22,14 @@ struct LicenseGateSelectionTests {
         #expect(selection.isContinueEnabled)
     }
 
+    @Test("Custom stays disabled for a whitespace-only URL")
+    func customRejectsWhitespaceOnlyURL() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .custom
+        selection.customURL = "   \n "
+        #expect(!selection.isContinueEnabled)
+    }
+
     @Test("resolvedLicense maps All rights reserved to nil")
     func allRightsReservedResolvesToNil() {
         let selection = LicenseGateSheetView.Selection()

--- a/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
+++ b/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
@@ -54,4 +54,37 @@ struct LicenseGateSelectionTests {
         #expect(selection.resolvedLicense() == LicenseRef(
             url: "https://example.com/license", name: "House terms"))
     }
+
+    @Test("an absent existing license starts on All rights reserved")
+    func seedsAllRightsReservedWithoutExistingLicense() {
+        #expect(LicenseGateSheetView.Selection(existing: nil).choice == .allRightsReserved)
+    }
+
+    @Test("an existing catalog license is preselected instead of being discarded")
+    func seedsCatalogChoiceFromExistingLicense() {
+        let ccBY = LicenseCatalog.entries.first { $0.id == "cc-by-4.0" }!.ref
+        let selection = LicenseGateSheetView.Selection(existing: ccBY)
+        #expect(selection.choice == .catalog("cc-by-4.0"))
+        #expect(selection.resolvedLicense() == ccBY)
+    }
+
+    @Test("an existing off-catalog license is preselected as Custom with its URL and name")
+    func seedsCustomChoiceFromExistingLicense() {
+        let ref = LicenseRef(url: "https://example.com/terms", name: "House terms")
+        let selection = LicenseGateSheetView.Selection(existing: ref)
+        #expect(selection.choice == .custom)
+        #expect(selection.customURL == "https://example.com/terms")
+        #expect(selection.customName == "House terms")
+        #expect(selection.isContinueEnabled)
+        #expect(selection.resolvedLicense() == ref)
+    }
+
+    @Test("an existing custom license whose name is just its URL leaves the name field empty")
+    func seedsCustomWithoutEchoingURLAsName() {
+        let ref = LicenseRef(url: "https://example.com/terms", name: "https://example.com/terms")
+        let selection = LicenseGateSheetView.Selection(existing: ref)
+        #expect(selection.customName == "")
+        // Still resolves back to the same ref, since an empty name falls back to the URL.
+        #expect(selection.resolvedLicense() == ref)
+    }
 }

--- a/Tests/AnglesiteAppTests/PlistEditorModelLicensingTests.swift
+++ b/Tests/AnglesiteAppTests/PlistEditorModelLicensingTests.swift
@@ -69,6 +69,43 @@ struct PlistEditorModelLicensingTests {
         #expect(reloaded.defaultLicense == ccBY)
     }
 
+    /// Saving this facet is itself an explicit license choice, so the first-publish gate (#999)
+    /// must not re-ask afterwards — and, critically, must not overwrite the saved license with
+    /// its own "All rights reserved" default the next time Deploy is pressed.
+    @Test("saving content licensing records the choice as made (#999)")
+    func savingRecordsLicenseChosen() async throws {
+        let model = try makeModel()
+        await model.load()
+        #expect(model.licensingPolicy.licenseChosen == false)
+
+        model.licensingPolicy.defaultLicense = ccBY
+        let saved = await model.saveLicensing()
+
+        #expect(saved == true)
+        let reloaded = try LicensingStore(sourceDirectory: model.sourceDirectory).load()
+        #expect(reloaded.licenseChosen == true)
+        #expect(reloaded.defaultLicense == ccBY)
+        // The in-memory copy matches disk, so the facet isn't left spuriously dirty.
+        #expect(model.licensingPolicy.licenseChosen == true)
+        #expect(model.isLicensingDirty == false)
+    }
+
+    /// The same must hold when the chosen result *is* "All rights reserved" — that's the case
+    /// `licenseChosen` exists to distinguish from an untouched scaffold.
+    @Test("saving with no license still records the choice as made (#999)")
+    func savingAllRightsReservedRecordsLicenseChosen() async throws {
+        let model = try makeModel()
+        await model.load()
+        model.licensingPolicy.publishRSL = true  // some edit, so the save isn't a no-op
+
+        let saved = await model.saveLicensing()
+
+        #expect(saved == true)
+        let reloaded = try LicensingStore(sourceDirectory: model.sourceDirectory).load()
+        #expect(reloaded.defaultLicense == nil)
+        #expect(reloaded.licenseChosen == true)
+    }
+
     @Test("toggling publishRSL is dirty, and round-trips through save/load (#992)")
     func publishRSLDirtyTrackingAndSave() async throws {
         let model = try makeModel()

--- a/Tests/AnglesiteCoreTests/LicensingStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/LicensingStoreTests.swift
@@ -358,4 +358,57 @@ struct LicensingStoreTests {
         try write(#"{"default":null}"#, to: dir)
         #expect(try LicensingStore(sourceDirectory: dir).load().publishRSL == false)
     }
+
+    // MARK: licenseChosen (#999)
+
+    @Test("licenseChosen defaults to false, matching a site with no licensing.json")
+    func licenseChosenDefaultsFalse() {
+        #expect(LicensingPolicy().licenseChosen == false)
+    }
+
+    @Test("save() then load() round-trips licenseChosen true")
+    func licenseChosenRoundTrips() throws {
+        let dir = try makeDirectory()
+        var policy = LicensingPolicy()
+        policy.licenseChosen = true
+        try LicensingStore(sourceDirectory: dir).save(policy)
+        #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == true)
+    }
+
+    @Test("save() always writes licenseChosen explicitly, even when false")
+    func saveAlwaysWritesLicenseChosen() throws {
+        let dir = try makeDirectory()
+        try LicensingStore(sourceDirectory: dir).save(LicensingPolicy())
+        let json = try String(
+            contentsOf: dir.appendingPathComponent("src/data/licensing.json"), encoding: .utf8)
+        #expect(json.contains("\"licenseChosen\""))
+    }
+
+    @Test(
+        "load() degrades a non-boolean licenseChosen to false instead of throwing",
+        arguments: [
+            #"{"licenseChosen":"true"}"#,
+            #"{"licenseChosen":1}"#,
+            #"{"licenseChosen":null}"#,
+        ]
+    )
+    func loadDegradesNonBooleanLicenseChosen(_ json: String) throws {
+        let dir = try makeDirectory()
+        try write(json, to: dir)
+        #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == false)
+    }
+
+    @Test("an absent licenseChosen key loads as false, matching a site with no licensing.json")
+    func loadAbsentLicenseChosen() throws {
+        let dir = try makeDirectory()
+        try write(#"{"default":null}"#, to: dir)
+        #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == false)
+    }
+
+    @Test("an explicit true licenseChosen key loads correctly on its own")
+    func loadExplicitTrueLicenseChosen() throws {
+        let dir = try makeDirectory()
+        try write(#"{"licenseChosen":true}"#, to: dir)
+        #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == true)
+    }
 }

--- a/docs/superpowers/plans/2026-08-14-first-publish-license-gate.md
+++ b/docs/superpowers/plans/2026-08-14-first-publish-license-gate.md
@@ -1,0 +1,746 @@
+# First-Publish License Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Block a site's first deploy on an explicit content-license choice — including "All rights reserved" — shown as a Creative Commons comparison table with an AI-interpretation column.
+
+**Architecture:** `LicensingPolicy` gains one new persisted field, `licenseChosen: Bool`, so the model can distinguish "never asked" from "explicitly chose All rights reserved" (both currently collapse to `defaultLicense == nil`). `DeployModel.deploy(...)` gets a new precondition guard — identical in shape to its existing `hasUsableToken()` guard — that parks the deploy and presents a new `LicenseGateSheetView` when `licenseChosen` is false; confirming a choice there saves the policy and resumes the parked deploy. `deployAutomatically(...)` (the background invisible-publish path) defers instead of presenting UI, matching how it already defers on a missing token.
+
+**Tech Stack:** Swift 6.4, SwiftUI, Swift Testing (`@Test`/`@Suite`), existing `LicensingStore`/`LicenseCatalog` (`AnglesiteCore`).
+
+## Global Constraints
+
+- No third-party frameworks — Apple frameworks only.
+- No migration path for existing sites' `licensing.json` — Anglesite is pre-TestFlight; `licenseChosen` simply decodes to `false` when the key is absent (see `no-migration-before-testflight` memory).
+- The gate is a hard block with no dismiss: the sheet cannot be swiped/Esc-dismissed without an explicit choice.
+- This plan covers #999 item 1 only (the publish gate). Per-file embedded license metadata (items 2-4) is a separate, later plan — do not implement it here.
+- Work happens in the existing worktree `.claude/worktrees/999-first-publish-license-gate/` on branch `999-first-publish-license-gate`, which already carries the approved design spec commit (`199e413b`). Every command below assumes cwd = that worktree.
+
+---
+
+### Task 1: `licenseChosen` field on `LicensingPolicy`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/LicensingStore.swift:232-275` (struct + init), `:277-386` (Codable)
+- Test: `Tests/AnglesiteCoreTests/LicensingStoreTests.swift`
+
+**Interfaces:**
+- Produces: `LicensingPolicy.licenseChosen: Bool` (default `false`), threaded through `LicensingPolicy.init(...)` and its `Codable` conformance. Everything downstream (Task 2) reads/writes this via `LicensingStore.load()`/`save(_:)`, unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/LicensingStoreTests.swift`, immediately before the suite's closing `}` (after the existing `loadAbsentPublishRSL` test):
+
+```swift
+    @Test("licenseChosen defaults to false, matching a site with no licensing.json")
+    func licenseChosenDefaultsFalse() {
+        #expect(LicensingPolicy().licenseChosen == false)
+    }
+
+    @Test("save() then load() round-trips licenseChosen true")
+    func licenseChosenRoundTrips() throws {
+        let dir = try makeDirectory()
+        var policy = LicensingPolicy()
+        policy.licenseChosen = true
+        try LicensingStore(sourceDirectory: dir).save(policy)
+        #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == true)
+    }
+
+    @Test("save() always writes licenseChosen explicitly, even when false")
+    func saveAlwaysWritesLicenseChosen() throws {
+        let dir = try makeDirectory()
+        try LicensingStore(sourceDirectory: dir).save(LicensingPolicy())
+        let json = try String(
+            contentsOf: dir.appendingPathComponent("src/data/licensing.json"), encoding: .utf8)
+        #expect(json.contains("\"licenseChosen\""))
+    }
+
+    @Test(
+        "load() degrades a non-boolean licenseChosen to false instead of throwing",
+        arguments: [
+            #"{"licenseChosen":"true"}"#,
+            #"{"licenseChosen":1}"#,
+            #"{"licenseChosen":null}"#,
+        ]
+    )
+    func loadDegradesNonBooleanLicenseChosen(_ json: String) throws {
+        let dir = try makeDirectory()
+        try write(json, to: dir)
+        #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == false)
+    }
+
+    @Test("an absent licenseChosen key loads as false, matching a site with no licensing.json")
+    func loadAbsentLicenseChosen() throws {
+        let dir = try makeDirectory()
+        try write(#"{"default":null}"#, to: dir)
+        #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == false)
+    }
+
+    @Test("an explicit true licenseChosen key loads correctly on its own")
+    func loadExplicitTrueLicenseChosen() throws {
+        let dir = try makeDirectory()
+        try write(#"{"licenseChosen":true}"#, to: dir)
+        #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == true)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+Run: `swift test --package-path . --filter LicensingStoreTests`
+Expected: FAIL — `value of type 'LicensingPolicy' has no member 'licenseChosen'`
+
+- [ ] **Step 3: Add the field and thread it through `init`**
+
+In `Sources/AnglesiteCore/LicensingStore.swift`, in the `LicensingPolicy` struct (around line 243), add the field after `publishRSL`:
+
+```swift
+    public var publishRSL: Bool
+    /// Whether an explicit license choice has been made — including "All rights reserved" —
+    /// distinct from `defaultLicense == nil`, which is also the untouched-scaffold state.
+    /// Set by the first-publish license gate (#999); never inferred from the rest of the
+    /// policy, so a hand-edited `licensing.json` that merely looks non-empty doesn't count.
+    public var licenseChosen: Bool
+```
+
+Update the initializer immediately below it:
+
+```swift
+    public init(
+        defaultLicense: LicenseRef? = nil,
+        collections: [LicensableCollection: CollectionLicenseRule] = [:],
+        usage: AIUsage = AIUsage(),
+        publishRSL: Bool = false,
+        licenseChosen: Bool = false
+    ) {
+        self.defaultLicense = defaultLicense
+        self.collections = collections
+        self.usage = usage
+        self.publishRSL = publishRSL
+        self.licenseChosen = licenseChosen
+    }
+```
+
+- [ ] **Step 4: Update `Codable` conformance**
+
+In the same file's `LicensingPolicy: Codable` extension, add the coding key:
+
+```swift
+    private enum CodingKeys: String, CodingKey {
+        case `default`, collections, usage, publishRSL, licenseChosen
+    }
+```
+
+In `init(from decoder:)`, right after the existing `publishRSL` decode line, add the lenient decode and pass it into `self.init(...)`:
+
+```swift
+        let publishRSL = ((try? container.decodeIfPresent(Bool.self, forKey: .publishRSL)) ?? nil) ?? false
+        // Same lenient-decode treatment as publishRSL: a non-boolean or absent value degrades
+        // to false — "never asked" — rather than throwing or inferring "asked" from a
+        // present-but-garbage value (#999).
+        let licenseChosen = ((try? container.decodeIfPresent(Bool.self, forKey: .licenseChosen)) ?? nil) ?? false
+        self.init(defaultLicense: defaultLicense, collections: collections, usage: usage.clamped,
+                   publishRSL: publishRSL, licenseChosen: licenseChosen)
+```
+
+(This replaces the existing final `self.init(...)` call — same arguments plus `licenseChosen`.)
+
+In `encode(to encoder:)`, right after the existing `publishRSL` encode line, add:
+
+```swift
+        try container.encode(publishRSL, forKey: .publishRSL)
+        try container.encode(licenseChosen, forKey: .licenseChosen)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter LicensingStoreTests`
+Expected: PASS (all cases, including the pre-existing ones — `LicensingPolicy`'s synthesized `Equatable` picks up the new field automatically, so `roundTrip()` still passes unmodified)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LicensingStore.swift Tests/AnglesiteCoreTests/LicensingStoreTests.swift
+git commit -m "feat(#999): add licenseChosen to LicensingPolicy"
+```
+
+---
+
+### Task 2: `DeployModel` gate — park, present, confirm
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/DeployModel.swift:88` (new properties), `:261-290` (`deploy()`), `:296-337` (`deployAutomatically()`), `:407-411` (new `confirmLicenseChoice` method, after `cancelTokenPrompt()`)
+- Test: `Tests/AnglesiteAppTests/DeployModelTests.swift`
+
+**Interfaces:**
+- Consumes: `LicensingStore(sourceDirectory: URL)`, `.load() throws -> LicensingPolicy`, `.save(_:) throws` (Task 1); `LicenseCatalog.prefilled(_:for:) -> AIUsage` (existing).
+- Produces: `DeployModel.licenseGatePresented: Bool` (read/write, sheet binding), `DeployModel.licenseGateError: String?` (read-only), `DeployModel.confirmLicenseChoice(_ license: LicenseRef?)` — called by `LicenseGateSheetView` (Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteAppTests/DeployModelTests.swift`, immediately before the suite's closing `}` at line 889:
+
+```swift
+    private func makeLicenseGateSiteDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DeployModelLicenseGateTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("deploy() presents the license gate instead of running when no license has been chosen")
+    func deployPresentsLicenseGateWhenUnchosen() throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+
+        let licenseGatePresented = model.licenseGatePresented
+        let isRunning = model.isRunning
+        #expect(licenseGatePresented)
+        #expect(!isRunning)
+    }
+
+    @Test("confirmLicenseChoice saves the policy and resumes the parked deploy")
+    func confirmLicenseChoiceSavesAndResumes() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+        let licenseGatePresentedBeforeConfirm = model.licenseGatePresented
+        #expect(licenseGatePresentedBeforeConfirm)
+
+        let ccBY = LicenseCatalog.entries.first { $0.id == "cc-by-4.0" }!.ref
+        model.confirmLicenseChoice(ccBY)
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
+        while model.isRunning { await Task.yield() }
+
+        let licenseGatePresentedAfterConfirm = model.licenseGatePresented
+        #expect(!licenseGatePresentedAfterConfirm)
+        guard case .succeeded = model.phase else {
+            Issue.record("expected the parked deploy to run after confirming a license, got \(model.phase)")
+            return
+        }
+
+        let policy = try LicensingStore(sourceDirectory: directory).load()
+        #expect(policy.licenseChosen)
+        #expect(policy.defaultLicense == ccBY)
+        #expect(policy.usage.aiTrain == .yes)
+    }
+
+    @Test("confirming All rights reserved (nil) still marks the choice made")
+    func confirmAllRightsReservedMarksChosen() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        model.deploy(siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [])
+        model.confirmLicenseChoice(nil)
+        await executor.waitUntilBuildIsParked()
+        await executor.resumeBuild()
+        while model.isRunning { await Task.yield() }
+
+        let policy = try LicensingStore(sourceDirectory: directory).load()
+        #expect(policy.licenseChosen)
+        #expect(policy.defaultLicense == nil)
+    }
+
+    @Test("deployAutomatically defers when a license hasn't been chosen")
+    func deployAutomaticallyDefersWithoutLicense() async throws {
+        let executor = GatedDeployExecutor()
+        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let model = DeployModel(
+            command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
+            tokenAvailabilityOverride: { true })
+        let directory = try makeLicenseGateSiteDirectory()
+
+        let result = await model.deployAutomatically(
+            siteID: "s", siteDirectory: directory, configDirectory: directory, currentRoutes: [],
+            containerControlProvider: { nil })
+
+        guard case .deferred(let reason) = result else {
+            Issue.record("expected .deferred, got \(result)")
+            return
+        }
+        #expect(reason.contains("license"))
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --package-path . --filter DeployModelTests`
+Expected: FAIL — `value of type 'DeployModel' has no member 'licenseGatePresented'` (and `confirmLicenseChoice`)
+
+- [ ] **Step 3: Add the new properties**
+
+In `Sources/AnglesiteApp/DeployModel.swift`, immediately after `tokenPromptPresented` (line 88), before `workerNameConflictPresented`:
+
+```swift
+    /// Bound to a `.sheet` in `SiteWindow` for the first-publish license gate (#999). Set when
+    /// `deploy(...)` is invoked and the site's `licensing.json` has never recorded an explicit
+    /// license choice. Reuses `pendingDeploy` to park and retry, same as the token-prompt flow.
+    /// Unlike the other `pendingDeploy` sheets, this one is wired with
+    /// `.interactiveDismissDisabled()` in `SiteWindow` — the design is a hard block, so there is
+    /// deliberately no `cancelLicenseGate()` to pair with it.
+    var licenseGatePresented: Bool = false
+    /// Set when saving the chosen policy fails (e.g. an unsafe custom license URL). Cleared on
+    /// every fresh presentation and on a successful `confirmLicenseChoice(_:)`.
+    private(set) var licenseGateError: String?
+```
+
+- [ ] **Step 4: Add the `deploy()` guard**
+
+In `deploy(...)` (line 261), insert the license check between the existing token guard and the `phase = .running(...)` line:
+
+```swift
+        guard !isRunning else { return }
+        if !hasUsableToken() {
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControlProvider, siteName)
+            tokenVerification = .idle
+            tokenPromptPresented = true
+            return
+        }
+        if !hasChosenLicense(siteDirectory: siteDirectory) {
+            pendingDeploy = (siteID, siteDirectory, configDirectory, currentRoutes, containerControlProvider, siteName)
+            licenseGateError = nil
+            licenseGatePresented = true
+            return
+        }
+        // Flip `phase` synchronously, before scheduling the Task, so a second `deploy()` call
+```
+
+- [ ] **Step 5: Add the `deployAutomatically()` guard**
+
+In `deployAutomatically(...)` (line 296), insert between the `hasUsableToken()` guard and the container-control resolution:
+
+```swift
+        guard hasUsableToken() else { return .deferred(reason: "Cloudflare credentials are not configured") }
+        guard hasChosenLicense(siteDirectory: siteDirectory) else {
+            return .deferred(reason: "a content license hasn't been chosen yet")
+        }
+        // Resolved once (there's no user-facing prompt gap on this background path to make a
+        let resolvedContainerControl = await containerControlProvider()
+```
+
+- [ ] **Step 6: Add the `hasChosenLicense` helper next to `hasUsableToken()`**
+
+Immediately after `hasUsableToken()`'s closing brace (after line 583):
+
+```swift
+    /// Whether `siteDirectory`'s `licensing.json` records an explicit license choice (#999). A
+    /// missing file or an unreadable/malformed document both read as "not chosen" —
+    /// `LicensingStore.load()` already degrades every malformed shape to the empty policy, whose
+    /// `licenseChosen` is `false`, so this mirrors that same fail-safe default rather than adding
+    /// a second one.
+    private func hasChosenLicense(siteDirectory: URL) -> Bool {
+        (try? LicensingStore(sourceDirectory: siteDirectory).load())?.licenseChosen ?? false
+    }
+```
+
+- [ ] **Step 7: Add `confirmLicenseChoice(_:)`**
+
+Immediately after `cancelTokenPrompt()` (after line 411):
+
+```swift
+    /// Called by `LicenseGateSheetView`'s Continue button. Builds the policy from `license`
+    /// (`nil` means "All rights reserved"), fills only unset AI-usage purposes via
+    /// `LicenseCatalog.prefilled` (matching `ContentLicensingTab`'s own picker behavior, so this
+    /// never clobbers a manual override made later), marks the choice made, and saves — then
+    /// resumes the parked deploy. Owns its own `LicensingStore` directly rather than going
+    /// through `PlistEditorModel`, so the gate works with no Settings window open.
+    func confirmLicenseChoice(_ license: LicenseRef?) {
+        guard let pending = pendingDeploy else {
+            licenseGateError = "No deploy is waiting — close this and click Deploy again."
+            return
+        }
+        let store = LicensingStore(sourceDirectory: pending.siteDirectory)
+        var policy = (try? store.load()) ?? LicensingPolicy()
+        policy.defaultLicense = license
+        policy.usage = LicenseCatalog.prefilled(policy.usage, for: license)
+        policy.licenseChosen = true
+        do {
+            try store.save(policy)
+        } catch {
+            licenseGateError = "Couldn't save your license choice: \(error)"
+            return
+        }
+        pendingDeploy = nil
+        licenseGateError = nil
+        licenseGatePresented = false
+        deploy(
+            siteID: pending.siteID, siteDirectory: pending.siteDirectory,
+            configDirectory: pending.configDirectory, currentRoutes: pending.currentRoutes,
+            containerControlProvider: pending.containerControlProvider, siteName: pending.siteName)
+    }
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter DeployModelTests`
+Expected: PASS (all four new tests, and the full existing suite — the license guard sits behind a directory whose `licensing.json` never exists in any prior test, so `hasChosenLicense` returns `false` there too; confirm no prior test now unexpectedly parks on the license gate by running the whole target in Step 9)
+
+- [ ] **Step 9: Run the full app test target**
+
+Run: `swift test --package-path . --filter AnglesiteAppTests`
+Expected: PASS. If any pre-existing deploy test now hangs or fails, it means that test's `deploy(...)` call reached the new license guard unexpectedly — check whether it uses a `siteDirectory` where a `licensing.json` with `licenseChosen: true` should be written first, or add `tokenAvailabilityOverride` isn't the relevant fix (it already has one) — the real fix is ensuring that test's directory is unique (not a shared `FileManager.default.temporaryDirectory` reused across tests).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/AnglesiteApp/DeployModel.swift Tests/AnglesiteAppTests/DeployModelTests.swift
+git commit -m "feat(#999): gate DeployModel on an explicit license choice"
+```
+
+---
+
+### Task 3: `LicenseGateSheetView`
+
+**Files:**
+- Create: `Sources/AnglesiteApp/LicenseGateSheetView.swift`
+- Test: `Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift`
+
+**Interfaces:**
+- Consumes: `DeployModel.licenseGateError: String?`, `DeployModel.confirmLicenseChoice(_:)` (Task 2); `LicenseCatalog.entries: [LicenseCatalog.Entry]`, `LicenseCatalog.Entry.{id, name, url, permitsAIUse, ref}` (existing).
+- Produces: `LicenseGateSheetView` (SwiftUI view, `init(model: DeployModel)`); `LicenseGateSheetView.Selection` (nested pure struct — `choice`, `customURL`, `customName`, `isContinueEnabled`, `resolvedLicense()`), consumed by Task 4's `SiteWindow` wiring only via the view itself.
+
+- [ ] **Step 1: Write the failing tests for the pure selection struct**
+
+Create `Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift`:
+
+```swift
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+@Suite("LicenseGateSheetView.Selection (#999)")
+struct LicenseGateSelectionTests {
+    @Test("All rights reserved and a catalog choice are always continue-enabled")
+    func nonCustomAlwaysEnabled() {
+        var selection = LicenseGateSheetView.Selection()
+        #expect(selection.isContinueEnabled)
+        selection.choice = .catalog("cc-by-4.0")
+        #expect(selection.isContinueEnabled)
+    }
+
+    @Test("Custom is disabled until a URL is typed")
+    func customRequiresURL() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .custom
+        #expect(!selection.isContinueEnabled)
+        selection.customURL = "https://example.com/license"
+        #expect(selection.isContinueEnabled)
+    }
+
+    @Test("resolvedLicense maps All rights reserved to nil")
+    func allRightsReservedResolvesToNil() {
+        let selection = LicenseGateSheetView.Selection()
+        #expect(selection.resolvedLicense() == nil)
+    }
+
+    @Test("resolvedLicense maps a catalog choice to its catalog LicenseRef")
+    func catalogResolvesToCatalogRef() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .catalog("cc-by-4.0")
+        let expected = LicenseCatalog.entries.first { $0.id == "cc-by-4.0" }?.ref
+        #expect(selection.resolvedLicense() == expected)
+    }
+
+    @Test("resolvedLicense falls back the custom name to the URL when empty")
+    func customFallsBackNameToURL() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .custom
+        selection.customURL = "https://example.com/license"
+        #expect(selection.resolvedLicense() == LicenseRef(
+            url: "https://example.com/license", name: "https://example.com/license"))
+    }
+
+    @Test("resolvedLicense uses a typed custom name when present")
+    func customUsesTypedName() {
+        var selection = LicenseGateSheetView.Selection()
+        selection.choice = .custom
+        selection.customURL = "https://example.com/license"
+        selection.customName = "House terms"
+        #expect(selection.resolvedLicense() == LicenseRef(
+            url: "https://example.com/license", name: "House terms"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+Run: `swift test --package-path . --filter LicenseGateSelectionTests`
+Expected: FAIL — `cannot find 'LicenseGateSheetView' in scope`
+
+- [ ] **Step 3: Create the view file**
+
+Create `Sources/AnglesiteApp/LicenseGateSheetView.swift`:
+
+```swift
+import SwiftUI
+import AnglesiteCore
+
+/// The first-publish license gate (#999) — a hard-blocking comparison table shown before a
+/// site's first deploy, so "All rights reserved" is a choice the owner made rather than a
+/// default they never saw. Confirming resumes the deploy `DeployModel` parked in its
+/// `pendingDeploy`. No per-collection overrides or the "Refuse AI crawlers" toggle here — those
+/// stay in Settings ▸ Content Licensing; this sheet only needs one decision made.
+struct LicenseGateSheetView: View {
+    @Bindable var model: DeployModel
+
+    /// One row's pure state: which license is selected, and (for `.custom`) the URL/name typed
+    /// so far. A fresh instance per presentation — the gate never shows a prior choice, since it
+    /// only appears when none has been recorded yet. Extracted as a plain struct (not held
+    /// directly as separate `@State` fields) so `isContinueEnabled`/`resolvedLicense()` are
+    /// unit-testable without a hosted SwiftUI render pass, mirroring
+    /// `ContentLicensingTab.PendingCustomLicense`. Internal (not `private`) so tests can
+    /// construct and mutate it directly.
+    struct Selection: Equatable {
+        enum Choice: Hashable {
+            case allRightsReserved
+            case catalog(String)
+            case custom
+        }
+
+        var choice: Choice = .allRightsReserved
+        var customURL: String = ""
+        var customName: String = ""
+
+        /// False only for an empty-URL custom selection — every other choice is already
+        /// complete the moment it's picked.
+        var isContinueEnabled: Bool {
+            if case .custom = choice { return !customURL.isEmpty }
+            return true
+        }
+
+        /// The `LicenseRef?` `DeployModel.confirmLicenseChoice(_:)` should persist for the
+        /// current choice, or nil for "All rights reserved."
+        func resolvedLicense() -> LicenseRef? {
+            switch choice {
+            case .allRightsReserved:
+                return nil
+            case .catalog(let id):
+                return LicenseCatalog.entries.first { $0.id == id }?.ref
+            case .custom:
+                return LicenseRef(url: customURL, name: customName.isEmpty ? customURL : customName)
+            }
+        }
+    }
+
+    @State private var selection = Selection()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Choose a License")
+                .font(.title2.bold())
+            Text("Before your first publish, pick what license covers your content. \"All rights reserved\" is a valid choice — Anglesite just never picks it for you silently.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
+                GridRow {
+                    Text("License")
+                    Text("Permits")
+                    Text("AI systems")
+                }
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+
+                row(title: "All rights reserved", permits: "Nothing without asking", aiNote: nil,
+                    choice: .allRightsReserved)
+
+                ForEach(LicenseCatalog.entries) { entry in
+                    row(
+                        title: entry.name,
+                        permits: permitsSummary(for: entry),
+                        aiNote: entry.permitsAIUse ? "✅ Permits" : "❔ Unclear",
+                        choice: .catalog(entry.id))
+                }
+
+                row(title: "Custom…", permits: "Your own terms", aiNote: nil, choice: .custom)
+            }
+
+            if selection.choice == .custom {
+                Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 8) {
+                    GridRow {
+                        Text("Address").frame(minWidth: 100, alignment: .leading)
+                        TextField("https://example.com/license", text: $selection.customURL)
+                            .frame(minWidth: 280)
+                    }
+                    GridRow {
+                        Text("Name").frame(minWidth: 100, alignment: .leading)
+                        TextField("My license", text: $selection.customName)
+                            .frame(minWidth: 280)
+                    }
+                }
+            }
+
+            if let error = model.licenseGateError {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.callout)
+            }
+
+            HStack {
+                Spacer()
+                Button("Continue") {
+                    model.confirmLicenseChoice(selection.resolvedLicense())
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!selection.isContinueEnabled)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 520)
+    }
+
+    private func row(
+        title: String, permits: String, aiNote: String?, choice: Selection.Choice
+    ) -> some View {
+        GridRow {
+            Text(title)
+            Text(permits).font(.caption).foregroundStyle(.secondary)
+            Text(aiNote ?? "—").font(.caption).foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .background(selection.choice == choice ? Color.accentColor.opacity(0.15) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .contentShape(Rectangle())
+        .onTapGesture { selection.choice = choice }
+    }
+
+    /// Plain-language summary of what each catalog license permits — the middle comparison-table
+    /// column. Keyed by catalog id rather than re-deriving from `permitsAIUse` so it stays
+    /// independent of the AI classification the last column already renders.
+    private func permitsSummary(for entry: LicenseCatalog.Entry) -> String {
+        switch entry.id {
+        case "cc0-1.0": return "Any use, no credit required"
+        case "cc-by-4.0": return "Any use, with credit"
+        case "cc-by-sa-4.0": return "Any use, with credit, same license"
+        case "cc-by-nc-4.0": return "Non-commercial use, with credit"
+        case "cc-by-nd-4.0": return "Redistribute unmodified, with credit"
+        case "cc-by-nc-sa-4.0": return "Non-commercial use, with credit, same license"
+        case "cc-by-nc-nd-4.0": return "Redistribute unmodified, non-commercial, with credit"
+        default: return entry.name
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --package-path . --filter LicenseGateSelectionTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/LicenseGateSheetView.swift Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
+git commit -m "feat(#999): add LicenseGateSheetView"
+```
+
+---
+
+### Task 4: Wire the sheet into `SiteWindow`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift:651` (after the `domainConfigDriftPresented` sheet, before `audit.sheetPresented`)
+
+**Interfaces:**
+- Consumes: `DeployModel.licenseGatePresented` (Task 2, as a `Binding` via `$bindableModel.deploy.licenseGatePresented`), `LicenseGateSheetView(model:)` (Task 3).
+
+- [ ] **Step 1: Add the sheet modifier**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, immediately after the `.sheet(isPresented: $bindableModel.deploy.domainConfigDriftPresented) { ... }` block (ends at line 662), insert:
+
+```swift
+        .sheet(isPresented: $bindableModel.deploy.licenseGatePresented) {
+            LicenseGateSheetView(model: model.deploy)
+                .interactiveDismissDisabled()
+        }
+```
+
+`.interactiveDismissDisabled()` is applied to the sheet's *content* (inside the closure), not chained after `.sheet(...)` on `SiteWindow` itself — chaining it on the outer view would target whatever context hosts `SiteWindow`'s own presentation (if any), not this specific sheet, and would risk leaking to the other sheets in this same modifier chain (`blockedPresented`, `tokenPromptPresented`, etc.), which are meant to stay dismissible. Scoping it to the presented content is the standard SwiftUI pattern for exactly this "this one sheet can't be swiped away" case.
+
+- [ ] **Step 2: Build the app target**
+
+Run:
+```bash
+xcodegen generate
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+Expected: build succeeds with no new warnings from `LicenseGateSheetView.swift` or the `SiteWindow.swift` change.
+
+- [ ] **Step 3: Manually verify in the running app**
+
+Launch the built app, open (or create) a site whose `Source/src/data/licensing.json` is absent or has no `licenseChosen: true`, and click Deploy:
+- Confirm the license gate sheet appears instead of the deploy running.
+- Confirm it cannot be dismissed with Esc or a swipe.
+- Click a catalog row (e.g. CC BY 4.0), confirm it highlights, click Continue — confirm the deploy proceeds and `Source/src/data/licensing.json` now has `"licenseChosen": true` and `"default"` set to the CC BY URL.
+- Deploy again — confirm the gate no longer appears.
+
+Report the outcome in the task's completion notes; this step cannot be automated in this plan.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindow.swift
+git commit -m "feat(#999): present the license gate sheet from SiteWindow"
+```
+
+---
+
+### Task 5: Full verification and PR
+
+**Files:** none (verification + PR only)
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: PASS, no regressions.
+
+- [ ] **Step 2: Re-run the app build**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: PASS.
+
+- [ ] **Step 3: Re-read `CONTRIBUTING.md` ▸ "Commits and pull requests" before opening the PR**
+
+Confirm: conventional-commit subjects already used in Tasks 1-4 (all ≤72 chars); the PR body will use `.github/PULL_REQUEST_TEMPLATE.md`'s exact headings (Summary, Paired PR check, Test plan); this PR does **not** close #999 — it implements item 1 of 4, with items 2-4 (per-file embedded license metadata) tracked as follow-up work — so use a non-closing reference (`Relates to #999` / `Part of #999`), not `Closes #999` or `Fixes #999`.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin 999-first-publish-license-gate
+gh pr create --title "feat(#999): first-publish license gate" --body "$(cat <<'EOF'
+## Summary
+- Blocks a site's first deploy on an explicit content-license choice (including "All rights reserved"), shown as a CC comparison table with an AI-interpretation column.
+- Adds `LicensingPolicy.licenseChosen` to distinguish "never asked" from "explicitly chose All rights reserved."
+- Part of #999 (item 1 of 4) — per-file embedded license metadata (items 2-4) is tracked separately.
+
+## Paired PR check
+No MCP message schema changes. No paired sidecar PR needed.
+
+## Test plan
+- [x] `swift test --package-path .` — new `LicensingStoreTests`, `DeployModelTests`, `LicenseGateSelectionTests` cases pass; full suite has no regressions.
+- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` succeeds.
+- [x] Manually verified in the running app: gate blocks first deploy, cannot be dismissed, choosing a license persists it and lets the deploy proceed, and the gate does not reappear on a subsequent deploy.
+EOF
+)"
+```
+
+- [ ] **Step 5: Report the PR URL and next steps**
+
+Confirm the PR URL, and note that #999 items 2-4 (per-file embedded license metadata, attach-time UI, drop-and-inspect UI) remain open for a separate future brainstorming/plan cycle.

--- a/docs/superpowers/specs/2026-08-14-first-publish-license-gate-design.md
+++ b/docs/superpowers/specs/2026-08-14-first-publish-license-gate-design.md
@@ -1,0 +1,142 @@
+# First-publish license gate
+
+Design for #999 item 1 (of 4). Items 2-4 — embedded per-file license metadata, attach-time
+application, and drop-and-inspect editing — are a separate design, out of scope here.
+
+## Problem
+
+`Source/src/data/licensing.json` and the Website Settings ▸ Content Licensing facet
+(`ContentLicensingTab`, #991) already give a site one coherent licensing policy. But nothing
+prompts the owner to actually choose one: a scaffolded site's `default` is `null` ("all rights
+reserved") because Anglesite never picks a license on the user's behalf, and a site can be
+published with that question never having been put to its owner.
+
+The fix is a gate: block the *first* deploy on an explicit license choice, presented as a
+Creative Commons comparison table with an "how AI systems interpret this" column — the
+differentiating content that connects the choice to the AI-usage permissions #991 already
+derives crawler signals from.
+
+This is a **product** gate in the app, not a rule added to `pre-deploy-check.ts` — that script
+is the security gate that catches things that must never ship; an unmade licensing decision is a
+decision the owner is entitled to make, not a security defect.
+
+## Data model
+
+`LicensingPolicy` (`Sources/AnglesiteCore/LicensingStore.swift`) gains one new field:
+
+```swift
+public var licenseChosen: Bool
+```
+
+Defaults to `false`, like every other field's conservative default in this type. It is what
+lets the model distinguish "never asked" from "explicitly chose All rights reserved" — both of
+which collapse to `defaultLicense == nil` today, and the gate's hard-block behavior (below)
+needs to tell them apart.
+
+Persisted in `licensing.json` alongside `default`/`usage`/`publishRSL`, following `publishRSL`'s
+own precedent as a non-content policy flag living in the same document (`Codable`
+implementation: always encoded; decodes to `false` when the key is absent, matching every other
+lenient field in this type's `init(from:)`).
+
+**No migration path for existing sites.** Anglesite has not shipped to TestFlight; any site that
+already set an explicit license through the current Settings UI can simply be re-saved (or the
+test site recreated) against the new field. See the `no-migration-before-testflight` memory —
+this exemption ends once the app ships externally.
+
+## Gate behavior
+
+**Dismissibility:** hard block, no dismiss. The sheet must resolve to an explicit choice —
+including "All rights reserved" — before the parked deploy proceeds. Once `licenseChosen` is
+`true`, the gate never fires again for that site.
+
+**Trigger — `DeployModel.deploy(...)`:** this method already has exactly this shape of
+precondition, for Cloudflare token availability:
+
+```swift
+guard !isRunning else { return }
+if !hasUsableToken() {
+    pendingDeploy = (...)
+    tokenVerification = .idle
+    tokenPromptPresented = true
+    return
+}
+```
+
+The license gate adds an identical guard, checked alongside (order: token check, then license
+check — either can park the deploy and present its own sheet):
+
+```swift
+guard licenseChosen else {
+    pendingDeploy = (...)
+    licenseGatePresented = true
+    return
+}
+```
+
+Confirming a choice in the sheet saves the policy (see below) and resumes the parked deploy —
+the same shape `signInWithCloudflare()` already uses to resume after the token-prompt sheet.
+
+**Background path — `deployAutomatically(...)`:** never presents UI, so it defers instead of
+blocking, matching its existing treatment of `!hasUsableToken()` and an unready container:
+
+```swift
+guard licenseChosen else { return .deferred(reason: "a content license hasn't been chosen yet") }
+```
+
+## UI
+
+**`LicenseGateSheet`** (new SwiftUI view): the row-click comparison table. One row per
+`LicenseCatalog.entries` entry (CC0 through CC BY-NC-ND, in catalog order), plus "All rights
+reserved" and "Custom…". Clicking a row selects it (highlighted, like a radio group); "Custom…"
+reveals inline URL/name fields using the same `PendingCustomLicense` pattern
+`ContentLicensingTab` already has (Continue stays disabled until a URL is typed).
+
+Columns: license name, what it permits (plain-language summary), and an AI-systems column
+rendering `LicenseCatalog.Entry.permitsAIUse`:
+
+- `true` → "✅ Permits" (CC0, CC BY, CC BY-SA)
+- `false` → "❔ Unclear" (CC BY-NC, CC BY-ND, and the two combined variants)
+- "All rights reserved" and "Custom…" → no claim rendered (unclassified, not guessed)
+
+This reuses `LicenseCatalog`'s existing classification outright — no new interpretive logic.
+The type's own doc comment already establishes why NC/ND stay unclassified (a live legal
+question Anglesite refuses to resolve on the user's behalf), so the gate's table must render
+that honestly rather than picking a symbol for "unclear."
+
+Pressing **Continue**:
+
+1. Sets `defaultLicense` from the selected row (`nil` for "All rights reserved").
+2. Runs `LicenseCatalog.prefilled(usage, for:)` — fills only *unset* AI-usage purposes, matching
+   `ContentLicensingTab`'s existing picker behavior, so this never clobbers a manual override
+   made later.
+3. Sets `licenseChosen = true`.
+4. Saves via a `LicensingStore(sourceDirectory: siteDirectory)` the gate flow owns directly (no
+   dependency on `PlistEditorModel` or the Settings window being open).
+5. Resumes the parked deploy.
+
+Out of scope for this sheet: per-collection overrides and the "Refuse AI crawlers" toggle. Those
+stay in Settings ▸ Content Licensing, reachable afterward — the gate only needs one decision
+made, not the full facet.
+
+**Wiring:** `.sheet(isPresented: $deployModel.licenseGatePresented)`, attached alongside the
+existing token-prompt/worker-conflict/domain-drift sheets in whichever view currently hosts
+those (`SiteWindow.swift` / `DeployDrawerView.swift`) — no new presentation mechanism.
+
+## Testing
+
+- `DeployModelTests`: mirroring the existing token-prompt tests —
+  - `deploy(...)` with `licenseChosen == false` parks the deploy and presents the gate instead
+    of running.
+  - Confirming a choice saves the policy and resumes the parked deploy.
+  - `deployAutomatically` defers with the "hasn't been chosen yet" reason when unresolved.
+- `LicensingStoreTests` / `LicenseCatalogTests`: round-trip coverage for the new field
+  (encodes always, decodes absent-key to `false`).
+- `LicenseGateSheet`'s row-selection and custom-license-reveal logic extracted as testable pure
+  functions/state structs, the way `ContentLicensingTab.shouldRevealCustomFields` /
+  `PendingCustomLicense` already are — sidesteps needing a hosted SwiftUI render pass to test
+  `@State` transitions, per this codebase's established pattern.
+
+## Non-goals
+
+Per-file embedded license metadata (ImageIO/AVFoundation/PDFKit), the file-open-dialog
+checkbox, and drop-and-inspect editing — #999 items 2-4 — are a separate design.


### PR DESCRIPTION
Relates to #999 (item 1 of 4 — the first-publish license gate only; per-file embedded license metadata, attach-time UI, and drop-and-inspect UI are tracked separately in the issue and not part of this PR).

## Summary
- Blocks a site's first deploy on an explicit content-license choice (including "All rights reserved"), shown as a CC comparison table with an AI-interpretation column.
- Adds `LicensingPolicy.licenseChosen` to distinguish "never asked" from "explicitly chose All rights reserved" — `DeployModel.deploy(...)`/`deployAutomatically(...)` gate on it the same way they already gate on a missing Cloudflare token. Saving the site's licensing settings directly (Settings ▸ Content Licensing) also counts as a choice, so the gate doesn't re-ask or discard it.
- New `LicenseGateSheetView`: a hard-blocking (`.interactiveDismissDisabled()`), keyboard/VoiceOver-accessible row-selection table wired into `SiteWindow`, with a Cancel action that abandons the current deploy attempt without weakening the block (the gate still reappears next time).
- Full copy is localized and catalogued.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

No MCP message schema changes — `licensing.json` is read/written by the app and the existing template code only.

## Test plan

- [x] `swift test --package-path .` — full suite (500+ tests across all targets) passes, including new `LicensingStoreTests`, `DeployModelTests`, and `LicenseGateSelectionTests` cases.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — BUILD SUCCEEDED.
- [x] `scripts/check-localization-catalog.sh` — passes.
- [ ] Manual smoke: **not performed in this environment.** Reaching the gate via a real Deploy click needs either no Cloudflare token configured (blocks earlier at the token-prompt sheet, never reaches this gate) or a real token (risks an actual live deploy once past this hard-block sheet) — neither is safe to exercise from an automated session, and entering credentials is out of bounds regardless. The row-selection UI went through a documented history worth knowing before the manual pass: an initial `Grid`-based layout was found (via `ImageRenderer` pixel measurement, not just reasoning) to apply modifiers per-cell instead of per-row — broken highlight, dead click zones between columns, and tripled VoiceOver announcements — and was restructured to one `Button` per row. That restructure was independently re-verified against the code structure, but true interactive VoiceOver/Tab-focus behavior and visual column alignment still need a human pass. Also worth a glance: VoiceOver may announce a trailing "dash" placeholder on rows with no AI-interpretation note (All rights reserved, Custom…) — a known, deferred minor.

Recommend a human QA pass before shipping: open a site with no `licensing.json`, click Deploy, confirm the gate blocks and Cancel/Esc abandons the attempt without recording a choice, columns visually align, keyboard/VoiceOver can select and activate a row, and choosing a license persists it and lets the deploy proceed.

🤖 Generated with a subagent-driven-development workflow (Claude Code).