### PR TITLE
feat(#1431): "Edit Site" P2P session UI in SiteSplitScreen

### DIFF
--- a/Resources/Info-iOS.plist
+++ b/Resources/Info-iOS.plist
@@ -22,6 +22,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSCameraUsageDescription</key>
+	<string>Anglesite uses the camera to scan the pairing code shown on your Mac.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/Sources/AnglesiteApp/DevicePairingSettingsView.swift
+++ b/Sources/AnglesiteApp/DevicePairingSettingsView.swift
@@ -127,8 +127,8 @@ struct DevicePairingSettingsView: View {
                 keyPair = fresh
             }
 
-            let payload = PairingQRPayload(deviceID: Self.ownDeviceID(), publicKey: keyPair.publicKeyData)
-            let payloadData = try JSONEncoder().encode(payload)
+            let payload = DevicePairingPayload(deviceID: Self.ownDeviceID(), publicKey: keyPair.publicKeyData)
+            let payloadData = try payload.encodedJSON()
             guard let image = Self.qrCodeImage(from: payloadData) else {
                 loadError = "couldn't render the pairing QR code."
                 return
@@ -174,15 +174,6 @@ struct DevicePairingSettingsView: View {
         image.addRepresentation(rep)
         return image
     }
-}
-
-/// The QR payload's wire shape — field names match `DeviceAnnounceRecord`'s CloudKit fields
-/// (`deviceID`, `publicKey`). `publicKey` encodes as base64 via `JSONEncoder`'s default `Data`
-/// strategy, matching how `DevicePairingKeyPair.publicKeyData` round-trips elsewhere in this
-/// pairing flow (e.g. `SecretStore.writeDevicePairingKeyPair`).
-private struct PairingQRPayload: Encodable {
-    let deviceID: String
-    let publicKey: Data
 }
 
 #Preview {

--- a/Sources/AnglesiteCore/DevicePairingPayload.swift
+++ b/Sources/AnglesiteCore/DevicePairingPayload.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The pairing QR code's wire shape, single-sourced so the Mac's encoder
+/// (`DevicePairingSettingsView`) and the iOS scanner's decoder can never drift. Field names match
+/// `DeviceAnnounceRecord`'s CloudKit fields (`deviceID`, `publicKey`); `publicKey` rides as
+/// base64 via `JSONEncoder`/`JSONDecoder`'s default `Data` strategy, matching how
+/// `DevicePairingKeyPair.publicKeyData` round-trips elsewhere in the pairing flow (e.g.
+/// `SecretStore.writeDevicePairingKeyPair`).
+public struct DevicePairingPayload: Codable, Sendable, Equatable {
+    /// The announcing device's stable identifier — the peer pins it alongside the key.
+    public let deviceID: String
+    /// X9.63 uncompressed point, matching `DevicePairingKeyPair.publicKeyData`'s format.
+    public let publicKey: Data
+
+    public init(deviceID: String, publicKey: Data) {
+        self.deviceID = deviceID
+        self.publicKey = publicKey
+    }
+
+    /// Why a scanned string couldn't become a payload. One case on purpose: the owner scanned
+    /// *something that isn't an Anglesite pairing code*, and which JSON rule it broke is not an
+    /// owner-actionable distinction.
+    public enum DecodeError: Error, Equatable {
+        case notAPairingCode
+    }
+
+    /// The JSON the QR generator renders.
+    public func encodedJSON() throws -> Data {
+        try JSONEncoder().encode(self)
+    }
+
+    /// Parses a scanned QR string, rejecting anything that isn't this shape — including a
+    /// structurally valid payload with an empty `deviceID` or `publicKey`, which could never
+    /// pin a real device.
+    public static func decode(from string: String) throws -> DevicePairingPayload {
+        guard let payload = try? JSONDecoder().decode(DevicePairingPayload.self, from: Data(string.utf8)),
+              !payload.deviceID.isEmpty, !payload.publicKey.isEmpty
+        else { throw DecodeError.notAPairingCode }
+        return payload
+    }
+}

--- a/Sources/AnglesiteIOS/EditSessionModel.swift
+++ b/Sources/AnglesiteIOS/EditSessionModel.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives one site's "Edit Site" P2P session on iOS (#1431, iOS v2.0 design §3) behind the
+/// `SiteRuntime` seam — the same pattern the Mac's `PreviewModel` and the #71 scaffold's
+/// `RemoteSessionModel` use, so #1208 P4's real `P2PSiteRuntime` plugs in by swapping only the
+/// injected `makeRuntime` factory.
+///
+/// Lifecycle contract (design §3): the model outlives the full-screen cover that renders it.
+/// Dismissing the cover merely stops *rendering* — the runtime keeps running warm so re-entry is
+/// instant; only the explicit Stop action (``stop()``) ends the session. The shell owns one model
+/// per site, so switching sites never tears down another site's session.
+@MainActor
+@Observable
+public final class EditSessionModel {
+    /// The session leg the cover should render. Copy stays in the owner's vocabulary — the
+    /// site, the Mac, the network — never ICE/SDP/WebRTC (design §3).
+    public enum Phase: Equatable {
+        /// No paired Mac (or the pairing store is unreadable): walk into pairing onboarding.
+        case pairingRequired
+        /// The session is being established but the runtime hasn't reported state yet.
+        case waking
+        /// The runtime is booting the site (container start, dev-server launch).
+        case starting
+        /// Live preview available at `URL`.
+        case ready(URL)
+        /// The session ended in an owner-facing failure.
+        case failed(message: String)
+        /// No session — before the first ``open()`` and after ``stop()``.
+        case idle
+    }
+
+    /// The site's stable package UUID — the identity the phone names sites by (design §2), the
+    /// same UUID `SitePickerModel` discovery yields.
+    public let siteID: UUID
+    /// Owner-facing site name for the cover's title.
+    public let siteDisplayName: String
+
+    public private(set) var phase: Phase = .idle
+    /// The session's MCP connection for the edit pipeline; `nil` while no session runs.
+    public private(set) var mcpClient: MCPClient?
+
+    /// Whether a runtime currently exists — drives the cover's Stop affordance.
+    public var isSessionActive: Bool { runtime != nil }
+
+    private let pairedMacs: () throws -> [PairedDevice]
+    private let makeRuntime: @MainActor () -> any SiteRuntime
+    private let lastMacContact: @Sendable () async -> Date?
+
+    private var runtime: (any SiteRuntime)?
+    private var observationTask: Task<Void, Never>?
+
+    /// - Parameters:
+    ///   - siteID: The site's stable package UUID.
+    ///   - siteDisplayName: Owner-facing name for titles and messages.
+    ///   - pairedMacs: `PairedDeviceStore().load` in production. A throw is treated as "no
+    ///     paired Mac" — the walk-in re-pairs, which also heals a corrupt store.
+    ///   - makeRuntime: Builds the session's `SiteRuntime`. Production hands out
+    ///     ``PendingP2PSiteRuntime`` until #1208 P4 ships the real `P2PSiteRuntime`.
+    ///   - lastMacContact: When the Mac was last known reachable (CloudKit presence heartbeat,
+    ///     read-side lands with P4) — folded into failure copy when available.
+    public init(
+        siteID: UUID,
+        siteDisplayName: String,
+        pairedMacs: @escaping () throws -> [PairedDevice],
+        makeRuntime: @escaping @MainActor () -> any SiteRuntime,
+        lastMacContact: @escaping @Sendable () async -> Date? = { nil }
+    ) {
+        self.siteID = siteID
+        self.siteDisplayName = siteDisplayName
+        self.pairedMacs = pairedMacs
+        self.makeRuntime = makeRuntime
+        self.lastMacContact = lastMacContact
+    }
+
+    /// Entry point every presentation of the cover calls. Gates on pairing, then starts a
+    /// session — or, when one is already running warm (the cover was dismissed and re-entered),
+    /// leaves it untouched and keeps rendering its state.
+    public func open() async {
+        if runtime != nil { return }
+        guard hasPairedMac else {
+            phase = .pairingRequired
+            return
+        }
+        await startSession()
+    }
+
+    /// Called when pairing onboarding finishes: re-checks the store and proceeds.
+    public func completePairing() async {
+        guard runtime == nil, hasPairedMac else { return }
+        await startSession()
+    }
+
+    /// The explicit Stop action: ends the session for real. The observation is cancelled first
+    /// so the runtime's own settle-to-idle can't race a stale phase back in.
+    public func stop() async {
+        observationTask?.cancel()
+        observationTask = nil
+        let stopping = runtime
+        runtime = nil
+        mcpClient = nil
+        phase = .idle
+        await stopping?.stop()
+    }
+
+    private var hasPairedMac: Bool {
+        guard let macs = try? pairedMacs() else { return false }
+        return !macs.isEmpty
+    }
+
+    private func startSession() async {
+        let runtime = makeRuntime()
+        self.runtime = runtime
+        phase = .waking
+        mcpClient = await runtime.mcpClient
+
+        observationTask?.cancel()
+        observationTask = Task { [weak self] in
+            let stream = await runtime.observe()
+            for await state in stream {
+                guard let self, !Task.isCancelled else { return }
+                await self.render(state)
+            }
+        }
+
+        let id = siteID.uuidString
+        Task {
+            // No local site files on iOS — the runtime reaches the site through the Mac.
+            await runtime.start(siteID: id, siteDirectory: URL(fileURLWithPath: NSTemporaryDirectory()))
+        }
+    }
+
+    private func render(_ state: SiteRuntimeState) async {
+        switch state {
+        case .idle:
+            // The runtime's initial replayed state (or a stop this model initiated) — never
+            // demote an in-flight phase for it.
+            if runtime == nil { phase = .idle }
+        case .starting:
+            phase = .starting
+        case .ready(_, let url, _):
+            phase = .ready(url)
+        case .failed(_, let message):
+            var composed = message
+            if let lastSeen = await lastMacContact() {
+                composed += " " + Self.lastReachableClause(lastSeen)
+            }
+            phase = .failed(message: composed)
+        }
+    }
+
+    /// The "last reachable" sentence appended to failure copy (design §3: "Your Mac was last
+    /// reachable at 3:12 PM"). Static and public so tests assert against the same formatter —
+    /// locale differences can't break CI.
+    public static func lastReachableClause(_ date: Date) -> String {
+        let formatted: String
+        if Calendar.current.isDateInToday(date) {
+            formatted = date.formatted(date: .omitted, time: .shortened)
+        } else {
+            formatted = date.formatted(.dateTime.month().day().hour().minute())
+        }
+        return String(localized: "Your Mac was last reachable at \(formatted).")
+    }
+}

--- a/Sources/AnglesiteIOS/EditSessionRouter.swift
+++ b/Sources/AnglesiteIOS/EditSessionRouter.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Observation
+
+/// Hands "open this site for editing" requests from App Intents to the iOS shell — the
+/// `WindowRouter` pattern (#1431): both ends of the hand-off (an intent's `perform()` on one
+/// side, `SiteSplitScreen` observing on the other) have no common injection point, so a
+/// process-wide singleton bridges them. Tests construct their own instances.
+@MainActor
+@Observable
+public final class EditSessionRouter {
+    /// The process-wide router the intent and the shell share.
+    public static let shared = EditSessionRouter()
+
+    /// The site the most recent intent asked to edit; the shell clears it via ``consume()``.
+    /// Re-requesting overwrites (last request wins).
+    public private(set) var requestedSiteID: UUID?
+
+    public init() {}
+
+    /// Records a request; the observing shell presents the session cover for it.
+    public func requestEditSession(siteID: UUID) {
+        requestedSiteID = siteID
+    }
+
+    /// Returns and clears the pending request — consumed exactly once.
+    public func consume() -> UUID? {
+        defer { requestedSiteID = nil }
+        return requestedSiteID
+    }
+}

--- a/Sources/AnglesiteIOS/PairingOnboardingModel.swift
+++ b/Sources/AnglesiteIOS/PairingOnboardingModel.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the first-run pairing walk-in on iOS (#1431, iOS v2.0 design §3): the owner's first
+/// "Edit Site" tap with no paired Mac lands on an explainer, asks for camera access *in that
+/// moment* (platform spec §5 — permission in context, not at launch), scans the QR code the Mac
+/// shows in Settings ▸ Devices, and pins the Mac via `PairedDeviceStore`. Camera access and
+/// persistence are injected so the flow is fully testable off-device; the camera *frames*
+/// arrive from the view layer's scanner, which forwards each decoded string here.
+@MainActor
+@Observable
+public final class PairingOnboardingModel {
+    /// Where the walk-in currently is. Every state renders as guidance, never a dead end
+    /// (design §3: "an honest explainer").
+    public enum Step: Equatable {
+        /// What pairing is and what it requires — the resting entry state.
+        case explainer
+        /// Camera access was declined; the view offers the Settings app as the way forward.
+        case cameraDenied
+        /// The camera is live; awaiting the first decodable frame.
+        case scanning
+        /// A scan or the persistence step failed; `message` is owner-facing.
+        case failed(message: String)
+        /// A Mac is pinned; the caller proceeds into the session.
+        case done
+    }
+
+    public private(set) var step: Step = .explainer
+
+    private let requestCameraAccess: () async -> Bool
+    private let storeDevice: (PairedDevice) throws -> Void
+
+    /// - Parameters:
+    ///   - requestCameraAccess: `AVCaptureDevice.requestAccess(for: .video)` in production —
+    ///     injected because the capture stack doesn't exist under `swift test` on macOS.
+    ///   - storeDevice: `PairedDeviceStore().add` in production.
+    public init(
+        requestCameraAccess: @escaping () async -> Bool,
+        storeDevice: @escaping (PairedDevice) throws -> Void
+    ) {
+        self.requestCameraAccess = requestCameraAccess
+        self.storeDevice = storeDevice
+    }
+
+    /// Asks for the camera (first call shows the system prompt) and opens the scanner, or lands
+    /// on the honest denied state. Callable from `.explainer`, `.cameraDenied` (the owner may
+    /// have granted access in Settings and come back), and `.failed`.
+    public func beginScan() async {
+        guard step != .scanning, step != .done else { return }
+        step = await requestCameraAccess() ? .scanning : .cameraDenied
+    }
+
+    /// Consumes one decoded QR string from the scanner. Only the first accepted code wins — the
+    /// camera keeps emitting frames of the same code, so everything after `.done` is ignored.
+    public func handleScanned(_ code: String) {
+        guard step == .scanning else { return }
+        guard let payload = try? DevicePairingPayload.decode(from: code) else {
+            step = .failed(message: String(localized: "That code isn't an Anglesite pairing code. Show the code in Anglesite's settings on your Mac and try again."))
+            return
+        }
+        let device = PairedDevice(
+            deviceID: payload.deviceID,
+            displayName: String(localized: "My Mac"),
+            pinnedPublicKey: payload.publicKey,
+            pairedAt: Date()
+        )
+        do {
+            try storeDevice(device)
+            step = .done
+        } catch {
+            step = .failed(message: String(localized: "Couldn't save the pairing on this device. Try again."))
+        }
+    }
+
+    /// Back to the explainer after a failure (or a cancelled scan).
+    public func retry() {
+        guard step != .done else { return }
+        step = .explainer
+    }
+}

--- a/Sources/AnglesiteIOS/PendingP2PSiteRuntime.swift
+++ b/Sources/AnglesiteIOS/PendingP2PSiteRuntime.swift
@@ -1,0 +1,31 @@
+import Foundation
+import AnglesiteCore
+
+/// Placeholder `SiteRuntime` behind the Edit Site session UI (#1431) until #1208 P4 ships the
+/// real WebRTC-backed `P2PSiteRuntime`: every start settles to an honest owner-facing failure.
+/// P4 replaces the one factory closure in the shell that constructs this — nothing else in the
+/// session UI knows which runtime it is driving.
+public actor PendingP2PSiteRuntime: SiteRuntime {
+    /// Never connected by this runtime; exists to satisfy the seam so the preview leg's edit
+    /// pipeline wiring stays identical when the real runtime lands.
+    public let mcpClient = MCPClient(supervisor: ProcessSupervisor())
+
+    private let stateMachine = SiteRuntimeStateMachine()
+
+    public init() {}
+
+    public func start(siteID: String, siteDirectory: URL) async {
+        let gen = stateMachine.beginStarting(siteID: siteID)
+        stateMachine.settle(gen: gen, to: .failed(
+            siteID: siteID,
+            message: String(localized: "Editing from this device isn't available yet — a future update connects it to Anglesite on your Mac.")))
+    }
+
+    public func stop() async {
+        stateMachine.settle(gen: stateMachine.beginAttempt(), to: .idle)
+    }
+
+    public func observe() -> AsyncStream<SiteRuntimeState> {
+        stateMachine.observe()
+    }
+}

--- a/Sources/AnglesiteIntents/EditSiteIntent.swift
+++ b/Sources/AnglesiteIntents/EditSiteIntent.swift
@@ -1,0 +1,41 @@
+#if os(iOS)
+import AppIntents
+import AnglesiteIOS
+
+/// "Edit Site" as a verb Siri/Shortcuts/Spotlight can run (#1431, iOS v2.0 design §3): opens
+/// the app and walks straight into the site's P2P editing session. A plain `AppIntent`, not an
+/// `OpenIntent` — `OpenSiteIntent` already owns the open-verb entity action on macOS, and this
+/// is a distinct verb on the same entity. iOS-only: on the Mac, editing *is* the site window.
+public struct EditSiteIntent: AppIntent {
+    /// The verb Siri/Shortcuts display and match against.
+    public static let title: LocalizedStringResource = "Edit Site"
+    /// One-line explanation shown in the Shortcuts action gallery.
+    public static let description = IntentDescription("Open a site's live preview for editing.")
+    /// `true` because the session cover is the whole point — a background invocation with no
+    /// foregrounded app would succeed invisibly.
+    public static let openAppWhenRun = true
+
+    /// The site to edit — resolved by the iOS entity query, so `id` is the site's stable
+    /// package UUID (the identity the P2P session names sites by, design §2).
+    @Parameter(title: "Site") public var site: SiteEntity
+
+    /// Required by `AppIntent` — the runtime constructs the intent, then fills `@Parameter`s.
+    public init() {}
+
+    /// Shortcuts editor sentence: "Edit *site*".
+    public static var parameterSummary: some ParameterSummary { Summary("Edit \(\.$site)") }
+
+    /// Routes through ``EditSessionRouter`` because an intent can't present SwiftUI covers;
+    /// the shell observes the router and presents the session. `@MainActor` since the router is.
+    /// On iOS every entity id is a package UUID string (`SiteEntityUbiquitySource`); a
+    /// non-UUID id would mean a stale Spotlight donation, answered honestly rather than crashed on.
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard let siteID = UUID(uuidString: site.id) else {
+            return .result(dialog: "Couldn't find \(site.displayName).")
+        }
+        EditSessionRouter.shared.requestEditSession(siteID: siteID)
+        return .result(dialog: "Opening \(site.displayName) for editing.")
+    }
+}
+#endif

--- a/Sources/AnglesiteMobile/EditSiteScreen.swift
+++ b/Sources/AnglesiteMobile/EditSiteScreen.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+import WebKit
+import AVFoundation
+import AnglesiteCore
+import AnglesiteBridge
+import AnglesiteIOS
+import AnglesiteIntents
+
+/// The full-screen "Edit Site" session cover (#1431, iOS v2.0 design §3): live preview plus
+/// edit overlay over the P2P session, with session states rendered in the owner's vocabulary.
+/// Done suspends the UI while the session stays warm (the shell owns the model); the explicit
+/// Stop action ends the session. First entry with no paired Mac walks into pairing onboarding.
+struct EditSiteScreen: View {
+    @Bindable var model: EditSessionModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// Built lazily so the camera-access prompt can't fire before the walk-in needs it.
+    @State private var pairingModel: PairingOnboardingModel?
+    /// Per-session Siri onscreen-entity provider — the same wiring `RemoteSessionModel` used,
+    /// owned by the screen because the annotation feed only matters while the cover renders.
+    @State private var annotationProvider: PreviewAnnotationProvider?
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(Text(verbatim: model.siteDisplayName))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        // Suspends the session *UI* only — the session stays warm for quick
+                        // re-entry (design §3); Stop is the explicit way to end it.
+                        Button("Done") { dismiss() }
+                    }
+                    if model.isSessionActive {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button {
+                                Task {
+                                    await model.stop()
+                                    dismiss()
+                                }
+                            } label: {
+                                Label("Stop", systemImage: "stop.circle")
+                            }
+                        }
+                    }
+                }
+        }
+        .task { await model.open() }
+        .onAppear { registerAnnotationProvider() }
+        .onDisappear { unregisterAnnotationProvider() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .pairingRequired:
+            PairingOnboardingScreen(model: resolvedPairingModel()) {
+                Task { await model.completePairing() }
+            }
+        case .idle, .waking:
+            sessionProgress(String(localized: "Waking your Mac…"))
+        case .starting:
+            sessionProgress(String(localized: "Starting your site…"))
+        case .ready(let url):
+            P2PSessionPreview(url: url, model: model, annotationProvider: annotationProvider)
+                .ignoresSafeArea(edges: .bottom)
+        case .failed(let message):
+            ContentUnavailableView {
+                Label("Couldn't Reach Your Site", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(verbatim: message)
+            } actions: {
+                Button("Try Again") {
+                    Task { await model.open() }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    private func sessionProgress(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text(verbatim: message)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// One pairing model per walk-in, wired to the real camera prompt and the real store.
+    private func resolvedPairingModel() -> PairingOnboardingModel {
+        if let pairingModel { return pairingModel }
+        let fresh = PairingOnboardingModel(
+            requestCameraAccess: { await AVCaptureDevice.requestAccess(for: .video) },
+            storeDevice: { try PairedDeviceStore().add($0) }
+        )
+        pairingModel = fresh
+        return fresh
+    }
+
+    private func registerAnnotationProvider() {
+        guard annotationProvider == nil else { return }
+        let provider = PreviewAnnotationProvider(
+            siteID: model.siteID.uuidString, graph: SiteContentGraph())
+        annotationProvider = provider
+        PreviewAnnotationProviderRegistry.shared.register(provider, for: provider.siteID)
+    }
+
+    private func unregisterAnnotationProvider() {
+        guard let provider = annotationProvider else { return }
+        PreviewAnnotationProviderRegistry.shared.unregister(siteID: provider.siteID)
+        annotationProvider = nil
+    }
+}
+
+/// The `WKWebView` leg over the P2P session: the same shared-bridge composition the remote
+/// sandbox preview used (`AnglesiteScriptHandler` + edit-overlay user script + the Siri
+/// annotation hookup), minus its session-token cookie injection — pinned-key DTLS replaces
+/// bearer auth end to end (design §3), so there is nothing to inject before the first load.
+private struct P2PSessionPreview: View {
+    let url: URL
+    let model: EditSessionModel
+    let annotationProvider: PreviewAnnotationProvider?
+
+    var body: some View {
+        let onVisibleElements: AnglesiteScriptHandler.VisibleElementsHandler? = annotationProvider.map { provider in
+            { @Sendable elements in await provider.update(elements) }
+        }
+        let handler = AnglesiteScriptHandler(
+            router: MCPApplyEditRouter(mcpClient: { [weak model] in await MainActor.run { model?.mcpClient } }),
+            onVisibleElements: onVisibleElements
+        )
+        RemotePreviewWebView(
+            url: url,
+            makeConfiguration: {
+                WebViewBridge.localDevConfiguration(handler: handler)
+            },
+            configureWebView: { webView in
+                // Gated in lockstep with AnglesiteIntents' own `#if compiler(>=6.4)` guards —
+                // CI's `ios-build` toolchain predates `appEntityUIElementProvider`; see the
+                // matching comment in `RemoteSessionScreen`.
+                #if compiler(>=6.4)
+                guard let annotationProvider else { return }
+                webView.appEntityUIElementProvider = { [weak annotationProvider] _, hitContext in
+                    guard let annotationProvider else { return [] }
+                    return annotationProvider.uiElements(for: hitContext)
+                }
+                #endif
+            }
+        )
+    }
+}

--- a/Sources/AnglesiteMobile/Localizable.xcstrings
+++ b/Sources/AnglesiteMobile/Localizable.xcstrings
@@ -25,6 +25,12 @@
     "Branch" : {
 
     },
+    "Camera Access Needed" : {
+
+    },
+    "Cancel" : {
+
+    },
     "Choose File" : {
 
     },
@@ -70,10 +76,19 @@
     "Couldn't Open Site" : {
 
     },
+    "Couldn't Pair" : {
+
+    },
+    "Couldn't Reach Your Site" : {
+
+    },
     "Couldn't reach your site. Check your connection and try again." : {
 
     },
     "Couldn't sign in to Cloudflare. Try again in a moment." : {
+
+    },
+    "Current site: %@" : {
 
     },
     "Decide Later" : {
@@ -92,6 +107,12 @@
 
     },
     "Draft saved to your site." : {
+
+    },
+    "Edit Site" : {
+
+    },
+    "Editing your site happens through your Mac. In Anglesite on your Mac, open Settings, choose Devices, then scan the pairing code shown there." : {
 
     },
     "Finding your sites…" : {
@@ -133,16 +154,25 @@
     "Nothing Selected" : {
 
     },
+    "Open Settings" : {
+
+    },
     "Open Site" : {
 
     },
     "Open your site in the remote sandbox to preview and edit it." : {
 
     },
+    "Pair Your Mac" : {
+
+    },
     "Pick a Site" : {
 
     },
     "Pick a post to edit, or start a new one." : {
+
+    },
+    "Point the camera at the pairing code on your Mac." : {
 
     },
     "Post to Your Site" : {
@@ -179,6 +209,12 @@
 
     },
     "Save Draft" : {
+
+    },
+    "Scan Pairing Code" : {
+
+    },
+    "Scanning the pairing code needs the camera. You can allow camera access for Anglesite in Settings." : {
 
     },
     "Sending to your site…" : {
@@ -244,6 +280,9 @@
     "Starting %@ in the sandbox…" : {
 
     },
+    "Starting your site…" : {
+
+    },
     "Stop" : {
 
     },
@@ -296,6 +335,9 @@
 
     },
     "Waiting for sign-in…" : {
+
+    },
+    "Waking your Mac…" : {
 
     },
     "You closed the sign-in page before finishing. Sign in when you're ready." : {

--- a/Sources/AnglesiteMobile/PairingOnboardingScreen.swift
+++ b/Sources/AnglesiteMobile/PairingOnboardingScreen.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import AVFoundation
+import UIKit
+import AnglesiteCore
+import AnglesiteIOS
+
+/// The pairing walk-in the first "Edit Site" tap lands on when no Mac is paired (#1431, design
+/// §3): explainer → in-context camera permission → QR scan → pinned Mac. Every state offers a
+/// way forward — an honest explainer, never a dead end.
+struct PairingOnboardingScreen: View {
+    let model: PairingOnboardingModel
+    /// Fired once the Mac is pinned; the session screen proceeds into the session.
+    var onPaired: () -> Void
+
+    var body: some View {
+        Group {
+            switch model.step {
+            case .explainer:
+                ContentUnavailableView {
+                    Label("Pair Your Mac", systemImage: "qrcode.viewfinder")
+                } description: {
+                    Text("Editing your site happens through your Mac. In Anglesite on your Mac, open Settings, choose Devices, then scan the pairing code shown there.")
+                } actions: {
+                    Button("Scan Pairing Code") {
+                        Task { await model.beginScan() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            case .cameraDenied:
+                ContentUnavailableView {
+                    Label("Camera Access Needed", systemImage: "camera")
+                } description: {
+                    Text("Scanning the pairing code needs the camera. You can allow camera access for Anglesite in Settings.")
+                } actions: {
+                    Button("Open Settings") {
+                        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                        UIApplication.shared.open(url)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    // The owner may have granted access in Settings and come back.
+                    Button("Try Again") {
+                        Task { await model.beginScan() }
+                    }
+                }
+            case .scanning:
+                QRScannerView { model.handleScanned($0) }
+                    .ignoresSafeArea()
+                    .overlay(alignment: .bottom) {
+                        Text("Point the camera at the pairing code on your Mac.")
+                            .font(.callout)
+                            .padding(10)
+                            .background(.thinMaterial, in: .capsule)
+                            .padding(.bottom, 24)
+                    }
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button("Cancel") { model.retry() }
+                        }
+                    }
+            case .failed(let message):
+                ContentUnavailableView {
+                    Label("Couldn't Pair", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(verbatim: message)
+                } actions: {
+                    Button("Try Again") {
+                        Task {
+                            model.retry()
+                            await model.beginScan()
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            case .done:
+                // Momentary: onChange below hands off to the session immediately.
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onChange(of: model.step) { _, newStep in
+            if newStep == .done { onPaired() }
+        }
+    }
+}

--- a/Sources/AnglesiteMobile/QRScannerView.swift
+++ b/Sources/AnglesiteMobile/QRScannerView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import AVFoundation
+
+/// Live camera QR scanner for pairing onboarding (#1431). Pure capture: every decoded string is
+/// forwarded to `onCode` on the main queue; deciding whether it's a pairing code (and ignoring
+/// frames after the first accepted one) is `PairingOnboardingModel`'s job. Camera *permission*
+/// is also not requested here — `beginScan()` already secured it before this view is shown.
+struct QRScannerView: UIViewControllerRepresentable {
+    let onCode: (String) -> Void
+
+    func makeUIViewController(context: Context) -> ScannerViewController {
+        let controller = ScannerViewController()
+        controller.onCode = onCode
+        return controller
+    }
+
+    func updateUIViewController(_ controller: ScannerViewController, context: Context) {
+        controller.onCode = onCode
+    }
+
+    /// Owns the `AVCaptureSession`. A view controller (not a bare `UIView`) so session start/stop
+    /// rides the appearance callbacks — backgrounding the app mid-scan tears the camera down.
+    final class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+        var onCode: ((String) -> Void)?
+
+        private let session = AVCaptureSession()
+        // Session start/stop must stay off the main thread (it blocks); one serial queue also
+        // orders every start against every stop.
+        private let sessionQueue = DispatchQueue(label: "io.dwk.anglesite.qr-scanner")
+        private var previewLayer: AVCaptureVideoPreviewLayer?
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            view.backgroundColor = .black
+
+            guard let camera = AVCaptureDevice.default(for: .video),
+                  let input = try? AVCaptureDeviceInput(device: camera),
+                  session.canAddInput(input)
+            else { return }
+            session.addInput(input)
+
+            let output = AVCaptureMetadataOutput()
+            guard session.canAddOutput(output) else { return }
+            session.addOutput(output)
+            output.setMetadataObjectsDelegate(self, queue: .main)
+            output.metadataObjectTypes = [.qr]
+
+            let layer = AVCaptureVideoPreviewLayer(session: session)
+            layer.videoGravity = .resizeAspectFill
+            view.layer.addSublayer(layer)
+            previewLayer = layer
+        }
+
+        override func viewDidLayoutSubviews() {
+            super.viewDidLayoutSubviews()
+            previewLayer?.frame = view.bounds
+        }
+
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            sessionQueue.async { [session] in
+                if !session.isRunning { session.startRunning() }
+            }
+        }
+
+        override func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+            sessionQueue.async { [session] in
+                if session.isRunning { session.stopRunning() }
+            }
+        }
+
+        func metadataOutput(
+            _ output: AVCaptureMetadataOutput,
+            didOutput metadataObjects: [AVMetadataObject],
+            from connection: AVCaptureConnection
+        ) {
+            for object in metadataObjects {
+                guard let readable = object as? AVMetadataMachineReadableCodeObject,
+                      readable.type == .qr,
+                      let string = readable.stringValue
+                else { continue }
+                onCode?(string)
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteMobile/SiteSplitScreen.swift
+++ b/Sources/AnglesiteMobile/SiteSplitScreen.swift
@@ -36,6 +36,13 @@ struct SiteSplitScreen: View {
     @State private var postList: PostListModel?
     @State private var session: MicropubSession?
 
+    /// One "Edit Site" session model per site, kept for the shell's lifetime (#1431): the
+    /// full-screen cover only *renders* a session, so dismissing it leaves the model — and its
+    /// warm P2P session — untouched, and switching sites never tears another site's session down.
+    @State private var editSessions: [UUID: EditSessionModel] = [:]
+    /// The site whose session cover is presented, or `nil` when none is.
+    @State private var editingSite: SitePickerModel.DiscoveredSite?
+
     var body: some View {
         NavigationSplitView {
             sidebar
@@ -52,6 +59,21 @@ struct SiteSplitScreen: View {
             if case .sites(let sites) = newState {
                 siteSelection.restoreSelection(from: sites)
             }
+        }
+        .fullScreenCover(item: $editingSite) { site in
+            if let model = editSessions[site.id] {
+                EditSiteScreen(model: model)
+            }
+        }
+        .onChange(of: EditSessionRouter.shared.requestedSiteID) { _, requested in
+            // The Edit Site App Intent's hand-off (the iOS twin of WindowRouter): consume the
+            // request and walk into that site's session.
+            guard requested != nil, let siteID = EditSessionRouter.shared.consume() else { return }
+            guard case .sites(let sites) = sitePicker.state,
+                  let site = sites.first(where: { $0.id == siteID })
+            else { return }
+            selectSite(site)
+            presentEditSession(for: site)
         }
     }
 
@@ -91,6 +113,14 @@ struct SiteSplitScreen: View {
                             Image(systemName: "globe")
                         }
                         .tag(SidebarSelection.site(site.id))
+                        .contextMenu {
+                            Button {
+                                selectSite(site)
+                                presentEditSession(for: site)
+                            } label: {
+                                Label("Edit Site", systemImage: "paintbrush.pointed")
+                            }
+                        }
                     }
                 }
                 if siteSelection.selectedSite != nil {
@@ -212,6 +242,15 @@ struct SiteSplitScreen: View {
             }
             .toolbar {
                 siteSwitcherToolbarItem(site: site)
+                // Available regardless of Micropub sign-in state: editing rides the P2P
+                // session's pairing, not the posting shell's IndieAuth credential (#1431).
+                ToolbarItem(placement: .secondaryAction) {
+                    Button {
+                        presentEditSession(for: site)
+                    } label: {
+                        Label("Edit Site", systemImage: "paintbrush.pointed")
+                    }
+                }
             }
         } else {
             ContentUnavailableView {
@@ -283,6 +322,24 @@ struct SiteSplitScreen: View {
             postList = nil
             sessionState = .signedOut
         }
+    }
+
+    /// Single path for every "Edit Site" trigger (toolbar, context menu, App Intent): ensures
+    /// the site's session model exists — created here, in an action, never during body
+    /// evaluation — then presents the cover. Reusing an existing model re-enters its warm
+    /// session (#1431, design §3).
+    private func presentEditSession(for site: SitePickerModel.DiscoveredSite) {
+        if editSessions[site.id] == nil {
+            editSessions[site.id] = EditSessionModel(
+                siteID: site.id,
+                siteDisplayName: site.displayName,
+                pairedMacs: { try PairedDeviceStore().load() },
+                // #1208 P4 swaps this factory for the real WebRTC-backed P2PSiteRuntime;
+                // nothing else in the session UI knows which runtime it drives.
+                makeRuntime: { PendingP2PSiteRuntime() }
+            )
+        }
+        editingSite = site
     }
 
     /// Single path for every site-switch trigger (sidebar row, switcher menu) so the

--- a/Tests/AnglesiteCoreTests/DevicePairingPayloadTests.swift
+++ b/Tests/AnglesiteCoreTests/DevicePairingPayloadTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("DevicePairingPayload")
+struct DevicePairingPayloadTests {
+    @Test("encode → decode round-trips")
+    func roundTrip() throws {
+        let payload = DevicePairingPayload(
+            deviceID: "mac-1234", publicKey: Data([0x04, 0xAB, 0xCD]))
+        let json = try payload.encodedJSON()
+        let decoded = try DevicePairingPayload.decode(from: String(decoding: json, as: UTF8.self))
+        #expect(decoded == payload)
+    }
+
+    @Test("publicKey rides the wire as base64 under the documented field names")
+    func wireFormat() throws {
+        let key = Data([0x01, 0x02, 0x03])
+        let json = try DevicePairingPayload(deviceID: "mac-1", publicKey: key).encodedJSON()
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: json) as? [String: Any])
+        #expect(object["deviceID"] as? String == "mac-1")
+        #expect(object["publicKey"] as? String == key.base64EncodedString())
+    }
+
+    @Test("non-JSON scans are rejected", arguments: ["hello", "", "{\"a\":1}"])
+    func rejectsGarbage(_ scanned: String) {
+        #expect(throws: DevicePairingPayload.DecodeError.notAPairingCode) {
+            try DevicePairingPayload.decode(from: scanned)
+        }
+    }
+
+    @Test("empty identity fields are rejected")
+    func rejectsEmptyFields() throws {
+        let emptyID = try DevicePairingPayload(deviceID: "", publicKey: Data([1])).encodedJSON()
+        #expect(throws: DevicePairingPayload.DecodeError.notAPairingCode) {
+            try DevicePairingPayload.decode(from: String(decoding: emptyID, as: UTF8.self))
+        }
+        let emptyKey = try DevicePairingPayload(deviceID: "mac-1", publicKey: Data()).encodedJSON()
+        #expect(throws: DevicePairingPayload.DecodeError.notAPairingCode) {
+            try DevicePairingPayload.decode(from: String(decoding: emptyKey, as: UTF8.self))
+        }
+    }
+}

--- a/Tests/AnglesiteIOSTests/EditSessionModelTests.swift
+++ b/Tests/AnglesiteIOSTests/EditSessionModelTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteIOS
+
+/// A scripted `SiteRuntime` standing in for #1208 P4's `P2PSiteRuntime` — the design's testing
+/// contract (iOS v2.0 spec §5: "Swift Testing suites drive the 'Edit Site' flow against a fake
+/// `P2PSiteRuntime` behind the `SiteRuntime` seam").
+actor FakeP2PSiteRuntime: SiteRuntime {
+    let mcpClient = MCPClient(supervisor: ProcessSupervisor())
+    private let stateMachine = SiteRuntimeStateMachine()
+    private(set) var startCalls: [String] = []
+    private(set) var stopCount = 0
+    /// States `start()` settles through, in order.
+    private let script: [SiteRuntimeState]
+
+    init(script: [SiteRuntimeState]) {
+        self.script = script
+    }
+
+    func start(siteID: String, siteDirectory: URL) async {
+        startCalls.append(siteID)
+        let gen = stateMachine.beginStarting(siteID: siteID)
+        for state in script {
+            stateMachine.settle(gen: gen, to: state)
+        }
+    }
+
+    func stop() async {
+        stopCount += 1
+        stateMachine.settle(gen: stateMachine.beginAttempt(), to: .idle)
+    }
+
+    func observe() -> AsyncStream<SiteRuntimeState> {
+        stateMachine.observe()
+    }
+}
+
+@MainActor
+@Suite("EditSessionModel")
+struct EditSessionModelTests {
+    private static let siteID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+    private static let previewURL = URL(string: "anglesite-p2p://site/index.html")!
+
+    private static func pairedMac() -> PairedDevice {
+        PairedDevice(
+            deviceID: "mac-1", displayName: "My Mac",
+            pinnedPublicKey: Data([0x04]), pairedAt: Date())
+    }
+
+    /// Builds a model whose runtime factory hands out `runtime` and counts invocations.
+    private func makeModel(
+        paired: [PairedDevice],
+        runtime: FakeP2PSiteRuntime,
+        factoryCalls: SharedCount = SharedCount(),
+        lastMacContact: @escaping @Sendable () async -> Date? = { nil }
+    ) -> EditSessionModel {
+        EditSessionModel(
+            siteID: Self.siteID,
+            siteDisplayName: "Pullets Forever",
+            pairedMacs: { paired },
+            makeRuntime: {
+                factoryCalls.value += 1
+                return runtime
+            },
+            lastMacContact: lastMacContact
+        )
+    }
+
+    @MainActor
+    final class SharedCount {
+        var value = 0
+    }
+
+    /// Bounded wait for an async phase transition — no wall-clock sleeps.
+    private func waitForPhase(
+        _ model: EditSessionModel, _ predicate: (EditSessionModel.Phase) -> Bool
+    ) async -> Bool {
+        for _ in 0..<2_000 {
+            if predicate(model.phase) { return true }
+            await Task.yield()
+        }
+        return predicate(model.phase)
+    }
+
+    @Test("no paired Mac gates on pairing without touching the runtime")
+    func pairingGate() async {
+        let calls = SharedCount()
+        let model = makeModel(paired: [], runtime: FakeP2PSiteRuntime(script: []), factoryCalls: calls)
+        await model.open()
+        #expect(model.phase == .pairingRequired)
+        #expect(calls.value == 0)
+        #expect(model.mcpClient == nil)
+    }
+
+    @Test("a throwing paired-device store also gates on pairing")
+    func pairingStoreThrow() async {
+        let model = EditSessionModel(
+            siteID: Self.siteID, siteDisplayName: "Site",
+            pairedMacs: { throw CocoaError(.fileReadNoSuchFile) },
+            makeRuntime: { FakeP2PSiteRuntime(script: []) }
+        )
+        await model.open()
+        #expect(model.phase == .pairingRequired)
+    }
+
+    @Test("a paired Mac starts the runtime through to ready")
+    func startsToReady() async {
+        let runtime = FakeP2PSiteRuntime(
+            script: [.ready(siteID: Self.siteID.uuidString, url: Self.previewURL)])
+        let model = makeModel(paired: [Self.pairedMac()], runtime: runtime)
+        await model.open()
+        #expect(await waitForPhase(model) { $0 == .ready(Self.previewURL) })
+        #expect(model.mcpClient != nil)
+        #expect(await runtime.startCalls == [Self.siteID.uuidString])
+    }
+
+    @Test("failure renders the runtime message plus when the Mac was last reachable")
+    func failureWithLastContact() async {
+        let lastSeen = Date(timeIntervalSince1970: 1_755_200_000)
+        let runtime = FakeP2PSiteRuntime(
+            script: [.failed(siteID: Self.siteID.uuidString, message: "Your Mac couldn't be reached.")])
+        let model = makeModel(
+            paired: [Self.pairedMac()], runtime: runtime,
+            lastMacContact: { lastSeen })
+        await model.open()
+        let reachedFailed = await waitForPhase(model) {
+            if case .failed = $0 { return true } else { return false }
+        }
+        #expect(reachedFailed)
+        guard case .failed(let message) = model.phase else { return }
+        #expect(message.contains("Your Mac couldn't be reached."))
+        #expect(message.contains(EditSessionModel.lastReachableClause(lastSeen)))
+    }
+
+    @Test("reopening a warm session reuses the runtime — dismissal never stops it")
+    func warmReuse() async {
+        let calls = SharedCount()
+        let runtime = FakeP2PSiteRuntime(
+            script: [.ready(siteID: Self.siteID.uuidString, url: Self.previewURL)])
+        let model = makeModel(paired: [Self.pairedMac()], runtime: runtime, factoryCalls: calls)
+        await model.open()
+        _ = await waitForPhase(model) { $0 == .ready(Self.previewURL) }
+        // The cover was dismissed and re-presented: open() again.
+        await model.open()
+        _ = await waitForPhase(model) { $0 == .ready(Self.previewURL) }
+        #expect(calls.value == 1)
+        #expect(await runtime.startCalls.count == 1)
+        #expect(await runtime.stopCount == 0)
+    }
+
+    @Test("stop ends the session; the next open builds a fresh runtime")
+    func stopEndsSession() async {
+        let calls = SharedCount()
+        let runtime = FakeP2PSiteRuntime(
+            script: [.ready(siteID: Self.siteID.uuidString, url: Self.previewURL)])
+        let model = makeModel(paired: [Self.pairedMac()], runtime: runtime, factoryCalls: calls)
+        await model.open()
+        _ = await waitForPhase(model) { $0 == .ready(Self.previewURL) }
+        await model.stop()
+        #expect(model.phase == .idle)
+        #expect(model.mcpClient == nil)
+        #expect(await runtime.stopCount == 1)
+        await model.open()
+        #expect(calls.value == 2)
+    }
+
+    @Test("completePairing proceeds into the session once a Mac is pinned")
+    func completePairingStarts() async {
+        let store = StoreBox()
+        let runtime = FakeP2PSiteRuntime(
+            script: [.ready(siteID: Self.siteID.uuidString, url: Self.previewURL)])
+        let model = EditSessionModel(
+            siteID: Self.siteID, siteDisplayName: "Site",
+            pairedMacs: { store.devices },
+            makeRuntime: { runtime }
+        )
+        await model.open()
+        #expect(model.phase == .pairingRequired)
+        store.devices = [Self.pairedMac()]
+        await model.completePairing()
+        #expect(await waitForPhase(model) { $0 == .ready(Self.previewURL) })
+    }
+
+    @MainActor
+    final class StoreBox {
+        var devices: [PairedDevice] = []
+    }
+}

--- a/Tests/AnglesiteIOSTests/EditSessionRouterTests.swift
+++ b/Tests/AnglesiteIOSTests/EditSessionRouterTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import AnglesiteIOS
+
+@MainActor
+@Suite("EditSessionRouter")
+struct EditSessionRouterTests {
+    @Test("a request is held until consumed, then cleared")
+    func requestAndConsume() {
+        let router = EditSessionRouter()
+        let id = UUID()
+        #expect(router.requestedSiteID == nil)
+        router.requestEditSession(siteID: id)
+        #expect(router.requestedSiteID == id)
+        #expect(router.consume() == id)
+        #expect(router.requestedSiteID == nil)
+        #expect(router.consume() == nil)
+    }
+
+    @Test("the last request wins")
+    func lastRequestWins() {
+        let router = EditSessionRouter()
+        let first = UUID()
+        let second = UUID()
+        router.requestEditSession(siteID: first)
+        router.requestEditSession(siteID: second)
+        #expect(router.consume() == second)
+    }
+}

--- a/Tests/AnglesiteIOSTests/PairingOnboardingModelTests.swift
+++ b/Tests/AnglesiteIOSTests/PairingOnboardingModelTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteIOS
+
+@MainActor
+@Suite("PairingOnboardingModel")
+struct PairingOnboardingModelTests {
+    private final class StoredDevices: @unchecked Sendable {
+        var devices: [PairedDevice] = []
+        var error: Error?
+    }
+
+    private func makeModel(
+        cameraGranted: Bool = true,
+        stored: StoredDevices = StoredDevices()
+    ) -> PairingOnboardingModel {
+        PairingOnboardingModel(
+            requestCameraAccess: { cameraGranted },
+            storeDevice: { device in
+                if let error = stored.error { throw error }
+                stored.devices.append(device)
+            }
+        )
+    }
+
+    private func validCode(deviceID: String = "mac-1", key: Data = Data([0x04, 0x01])) throws -> String {
+        let json = try DevicePairingPayload(deviceID: deviceID, publicKey: key).encodedJSON()
+        return String(decoding: json, as: UTF8.self)
+    }
+
+    @Test("granted camera access moves explainer → scanning")
+    func beginScanGranted() async {
+        let model = makeModel(cameraGranted: true)
+        #expect(model.step == .explainer)
+        await model.beginScan()
+        #expect(model.step == .scanning)
+    }
+
+    @Test("denied camera access lands on the honest denied state")
+    func beginScanDenied() async {
+        let model = makeModel(cameraGranted: false)
+        await model.beginScan()
+        #expect(model.step == .cameraDenied)
+    }
+
+    @Test("a valid code pins the Mac and finishes")
+    func scanValidCode() async throws {
+        let stored = StoredDevices()
+        let model = makeModel(stored: stored)
+        await model.beginScan()
+        let key = Data([0x04, 0xAA])
+        model.handleScanned(try validCode(deviceID: "mac-42", key: key))
+        #expect(model.step == .done)
+        #expect(stored.devices.count == 1)
+        #expect(stored.devices.first?.deviceID == "mac-42")
+        #expect(stored.devices.first?.pinnedPublicKey == key)
+    }
+
+    @Test("garbage scans fail with an owner-comprehensible message")
+    func scanGarbage() async {
+        let model = makeModel()
+        await model.beginScan()
+        model.handleScanned("https://example.com/not-a-pairing-code")
+        guard case .failed = model.step else {
+            Issue.record("expected .failed, got \(model.step)")
+            return
+        }
+    }
+
+    @Test("frames after the first accepted code are ignored")
+    func ignoresAfterDone() async throws {
+        let stored = StoredDevices()
+        let model = makeModel(stored: stored)
+        await model.beginScan()
+        model.handleScanned(try validCode())
+        model.handleScanned(try validCode(deviceID: "mac-2"))
+        #expect(model.step == .done)
+        #expect(stored.devices.count == 1)
+    }
+
+    @Test("a store failure surfaces as failed, not silent success")
+    func storeFailure() async throws {
+        let stored = StoredDevices()
+        stored.error = CocoaError(.fileWriteNoPermission)
+        let model = makeModel(stored: stored)
+        await model.beginScan()
+        model.handleScanned(try validCode())
+        guard case .failed = model.step else {
+            Issue.record("expected .failed, got \(model.step)")
+            return
+        }
+        #expect(stored.devices.isEmpty)
+    }
+
+    @Test("retry returns to the explainer")
+    func retryFromFailure() async {
+        let model = makeModel()
+        await model.beginScan()
+        model.handleScanned("junk")
+        model.retry()
+        #expect(model.step == .explainer)
+    }
+}

--- a/docs/superpowers/plans/2026-08-15-edit-site-session-ui-plan.md
+++ b/docs/superpowers/plans/2026-08-15-edit-site-session-ui-plan.md
@@ -1,0 +1,192 @@
+# "Edit Site" P2P Session UI (#1431) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the iOS/iPadOS v2.0 "Edit Site" session UI (design spec `docs/superpowers/specs/2026-08-12-ios-ipados-v2-design.md` §3): entry points in `SiteSplitScreen`, a full-screen-cover session screen with owner-comprehensible state rendering, the QR pairing-onboarding walk-in, and the preview leg — all consuming a `SiteRuntime` behind an injectable seam so #1208 P4's real `P2PSiteRuntime` plugs in with a one-closure swap.
+
+**Architecture:** New portable models in `AnglesiteIOS` (`EditSessionModel`, `PairingOnboardingModel`, `EditSessionRouter`) tested by `AnglesiteIOSTests` under `swift test`; SwiftUI views in the `AnglesiteMobile` app target (`EditSiteScreen`, `PairingOnboardingScreen`, `QRScannerView`); a shared `DevicePairingPayload` wire type in `AnglesiteCore` single-sourcing the QR format the Mac already encodes; an `EditSiteIntent` in `AnglesiteIntents` routing through the router (the `WindowRouter` pattern). The production runtime factory returns a `PendingP2PSiteRuntime` that settles `.failed` with an honest message — #1208 P4 replaces exactly that factory closure with the real WebRTC-backed `P2PSiteRuntime`.
+
+**Tech Stack:** Swift 6.4 / SwiftUI, Swift Testing (`@Test`/`#expect`), AVFoundation (QR capture), AppIntents.
+
+## Global Constraints
+
+- macOS 27+ / Xcode 27+, `swift test` needs `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` (memory: default toolchain broken).
+- Apple frameworks only; no new dependencies.
+- Session-state copy must never say ICE/SDP/WebRTC — owner language only (spec §3).
+- Strings user-visible in the app target must be `String(localized:)`/SwiftUI literals; after CLI builds run the `xcstringstool sync` recipe from CONTRIBUTING.md scoped to THIS worktree's BUILD_DIR, `--skip-marking-strings-stale`.
+- Conventional commits, subject ≤72 chars, reference #1431.
+- PR body must use `.github/PULL_REQUEST_TEMPLATE.md` headings: Summary, Paired PR check, Test plan. No MCP schema change → no paired PR.
+- `AnglesiteMobile` links AnglesiteCore, AnglesiteBridge, AnglesiteIntents, AnglesiteIOS — NOT AnglesiteP2P; do not add it (P4's decision).
+- Run `swift test --package-path .` serially (memory: concurrent runs cause FM-suite contention).
+
+---
+
+### Task 1: Shared pairing-payload wire type
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DevicePairingPayload.swift`
+- Modify: `Sources/AnglesiteApp/DevicePairingSettingsView.swift:183` (replace private `PairingQRPayload` with the shared type)
+- Test: `Tests/AnglesiteCoreTests/DevicePairingPayloadTests.swift`
+
+**Interfaces:**
+- Produces: `public struct DevicePairingPayload: Codable, Sendable, Equatable { public let deviceID: String; public let publicKey: Data; public init(deviceID: String, publicKey: Data); public func encodedJSON() throws -> Data; public static func decode(from string: String) throws -> DevicePairingPayload }`
+- `decode(from:)` throws `DevicePairingPayload.DecodeError.notAPairingCode` for anything that isn't this JSON shape or has an empty `deviceID`/`publicKey`.
+
+- [ ] Step 1: Write failing tests in `Tests/AnglesiteCoreTests/DevicePairingPayloadTests.swift` (Swift Testing): round-trip encode→decode equality; decode rejects non-JSON (`"hello"`), JSON of wrong shape (`{"a":1}`), and empty `deviceID` — each throwing `.notAPairingCode`. Wire format check: encoded JSON's `publicKey` is base64 (JSONEncoder default `Data` strategy, matching the Mac's existing `PairingQRPayload` doc).
+- [ ] Step 2: `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --filter DevicePairingPayload` → FAIL (type not found).
+- [ ] Step 3: Implement `DevicePairingPayload` in AnglesiteCore with doc comment noting it single-sources the QR wire shape (field names match `DeviceAnnounceRecord`: `deviceID`, `publicKey`).
+- [ ] Step 4: Refactor `DevicePairingSettingsView` to encode `DevicePairingPayload` instead of its private struct; delete the private struct, keep its doc comment content on the shared type.
+- [ ] Step 5: `swift test --filter DevicePairingPayload` → PASS; `swift build` (whole package compiles, AnglesiteAppCore included).
+- [ ] Step 6: Commit `feat(#1431): shared DevicePairingPayload QR wire type`.
+
+### Task 2: PairingOnboardingModel
+
+**Files:**
+- Create: `Sources/AnglesiteIOS/PairingOnboardingModel.swift`
+- Test: `Tests/AnglesiteIOSTests/PairingOnboardingModelTests.swift`
+
+**Interfaces:**
+- Consumes: `DevicePairingPayload` (Task 1), `PairedDevice`/`PairedDeviceStore` (AnglesiteCore).
+- Produces:
+```swift
+@MainActor @Observable public final class PairingOnboardingModel {
+    public enum Step: Equatable { case explainer, cameraDenied, scanning, failed(message: String), done }
+    public private(set) var step: Step  // starts .explainer
+    public init(requestCameraAccess: @escaping () async -> Bool,
+                storeDevice: @escaping (PairedDevice) throws -> Void)
+    public func beginScan() async   // explainer/denied/failed → scanning, or cameraDenied
+    public func handleScanned(_ code: String)  // scanning → done | failed
+    public func retry()             // failed → explainer
+}
+```
+- `handleScanned` decodes via `DevicePairingPayload.decode(from:)`, builds `PairedDevice(deviceID: payload.deviceID, displayName: String(localized: "My Mac"), pinnedPublicKey: payload.publicKey, pairedAt: .now)`, calls `storeDevice`, sets `.done`. Decode failure → `.failed(message: String(localized: "That code isn't an Anglesite pairing code. Show the code in Anglesite's settings on your Mac and try again."))`. Store failure → `.failed` with `String(localized: "Couldn't save the pairing on this device. Try again.")`. Only acts while `.scanning` (camera keeps emitting frames; first result wins).
+
+- [ ] Step 1: Failing tests: granted access → `.scanning`; denied → `.cameraDenied`; valid payload string → stored device fields match payload + `.done`; garbage string → `.failed`; second `handleScanned` after `.done` is ignored; `storeDevice` throwing → `.failed`; `retry()` → `.explainer`.
+- [ ] Step 2: `swift test --filter PairingOnboardingModel` → FAIL.
+- [ ] Step 3: Implement; Step 4: tests PASS.
+- [ ] Step 5: Commit `feat(#1431): pairing onboarding model for iOS QR walk-in`.
+
+### Task 3: EditSessionModel + FakeP2PSiteRuntime
+
+**Files:**
+- Create: `Sources/AnglesiteIOS/EditSessionModel.swift`
+- Test: `Tests/AnglesiteIOSTests/EditSessionModelTests.swift` (includes `FakeP2PSiteRuntime`)
+
+**Interfaces:**
+- Consumes: `SiteRuntime`, `SiteRuntimeState`, `MCPClient`, `ProcessSupervisor` (AnglesiteCore); `PreviewAnnotationProvider`(+Registry) (AnglesiteIntents) — NO: AnglesiteIOS must not depend on AnglesiteIntents (it's the other way round). Annotation-provider wiring stays in the view layer exactly like `RemoteSessionScreen` does today; the model only exposes `mcpClient`.
+- Produces:
+```swift
+@MainActor @Observable public final class EditSessionModel {
+    public enum Phase: Equatable {
+        case pairingRequired, waking, starting, ready(URL), failed(message: String), idle
+    }
+    public let siteID: UUID
+    public let siteDisplayName: String
+    public private(set) var phase: Phase          // starts .idle
+    public private(set) var mcpClient: MCPClient? // set while a session runs
+    public init(siteID: UUID, siteDisplayName: String,
+                pairedMacs: @escaping () throws -> [PairedDevice],
+                makeRuntime: @escaping @MainActor () -> any SiteRuntime,
+                lastMacContact: @escaping @Sendable () async -> Date? = { nil })
+    public func open() async      // pairing gate → start-or-reuse warm runtime
+    public func completePairing() async  // re-check store, then start
+    public func stop() async      // ends runtime; phase .idle; mcpClient nil
+    public var isSessionActive: Bool   // runtime exists and phase != .idle/.pairingRequired
+}
+```
+- Semantics: `open()` with no paired Mac (or store throw) → `.pairingRequired`, runtime never built. With a paired Mac: builds runtime once (reuse on later `open()` — cover dismissal never stops it; that's the "warm session" contract, spec §3), sets `.waking`, subscribes `runtime.observe()`, maps states: `.starting` → `.starting`; `.ready(_, url, _)` → `.ready(url)`; `.failed(_, message)` → `.failed(message: composedFailureMessage(message))`; `.idle` → `.idle`. `mcpClient` set from `await runtime.mcpClient` when the runtime is created.
+- `composedFailureMessage(_:)`: runtime's owner-facing message, plus — when `lastMacContact()` returns a date — a second sentence `"Your Mac was last reachable at \(date.formatted(date: .omitted, time: .shortened))."` (same-day) or `date.formatted(.dateTime.month().day().hour().minute())` otherwise; tests pin dates and compare against the same `formatted` API so locale never breaks CI.
+- Superseded-site protection: observation task is owned by the model; `stop()` cancels it before `runtime.stop()` so a late emission can't resurrect the phase (same guard `RemoteSessionModel.stop()` uses).
+
+- [ ] Step 1: Write `FakeP2PSiteRuntime`:
+```swift
+actor FakeP2PSiteRuntime: SiteRuntime {
+    let mcpClient = MCPClient(supervisor: ProcessSupervisor())
+    private let stateMachine = SiteRuntimeStateMachine()
+    private(set) var startCalls: [String] = []
+    private(set) var stopCount = 0
+    private let script: [SiteRuntimeState]  // states start() settles through
+    init(script: [SiteRuntimeState]) { self.script = script }
+    func start(siteID: String, siteDirectory: URL) async {
+        startCalls.append(siteID)
+        let gen = stateMachine.beginStarting(siteID: siteID)
+        for state in script { stateMachine.settle(gen: gen, to: state) }
+    }
+    func stop() async { stopCount += 1; stateMachine.settle(gen: stateMachine.beginAttempt(), to: .idle) }
+    func observe() -> AsyncStream<SiteRuntimeState> { stateMachine.observe() }
+}
+```
+  Failing tests: (a) unpaired → `open()` settles `.pairingRequired`, `makeRuntime` never called; (b) paired + script `[.ready]` → phase becomes `.ready(url)` and `mcpClient != nil`; (c) paired + script `[.failed(message:)]` + `lastMacContact` fixed date → `.failed` message contains both the runtime message and the formatted time; (d) second `open()` reuses the runtime (`makeRuntime` call count 1, fake `startCalls.count` 1) — the warm-session contract; (e) `stop()` → fake `stopCount == 1`, phase `.idle`, `mcpClient == nil`; `open()` after stop builds a fresh runtime; (f) `completePairing()` when the store now has a Mac → session starts. Await phase changes by polling with a bounded `for _ in 0..<N { if … break }; await Task.yield()` loop (existing AnglesiteIOSTests pattern) — no wall-clock sleeps (memory: `Task.sleep(.zero)` CI crash; avoid zero-duration sleeps).
+- [ ] Step 2: `swift test --filter EditSessionModel` → FAIL.
+- [ ] Step 3: Implement; Step 4: PASS.
+- [ ] Step 5: Commit `feat(#1431): EditSessionModel over the SiteRuntime seam`.
+
+### Task 4: EditSessionRouter + EditSiteIntent
+
+**Files:**
+- Create: `Sources/AnglesiteIOS/EditSessionRouter.swift`
+- Create: `Sources/AnglesiteIntents/EditSiteIntent.swift`
+- Test: `Tests/AnglesiteIOSTests/EditSessionRouterTests.swift`
+
+**Interfaces:**
+- Produces:
+```swift
+@MainActor @Observable public final class EditSessionRouter {
+    public static let shared = EditSessionRouter()
+    public internal(set) init …  // private init; test hook: public init() is fine — WindowRouter uses a singleton with private init; mirror it but keep a package-visible init for tests via @testable import
+    public private(set) var requestedSiteID: UUID?
+    public func requestEditSession(siteID: UUID)
+    public func consume() -> UUID?   // returns and clears
+}
+```
+- `EditSiteIntent` (whole file wrapped `#if os(iOS)`): `public struct EditSiteIntent: AppIntent` — title "Edit Site", description "Open a site's live preview for editing.", `openAppWhenRun = true`, `@Parameter(title: "Site") var site: SiteEntity`, `parameterSummary` "Edit \(\.$site)", `@MainActor perform()` → `EditSessionRouter.shared.requestEditSession(siteID: site.id)` then `.result(dialog: "Opening \(site.displayName) for editing.")`. (`SiteEntity.id` is the package UUID on iOS via `SiteEntityQueryIOS` — the spec's "sites named by stable package UUID".) Note: plain `AppIntent`, not `OpenIntent` — `OpenSiteIntent` already owns the open-verb entity action on macOS; this is a distinct verb.
+- [ ] Step 1: Failing router tests (`@testable import AnglesiteIOS`, instantiate a fresh router): request sets `requestedSiteID`; `consume()` returns it and clears; second `consume()` → nil; last request wins.
+- [ ] Step 2: FAIL run. Step 3: implement both files. Step 4: `swift test --filter EditSessionRouter` PASS and `swift build` compiles AnglesiteIntents on macOS (the `#if os(iOS)` gate makes the intent a no-op there).
+- [ ] Step 5: Commit `feat(#1431): Edit Site intent + session router`.
+
+### Task 5: Mobile views — scanner, onboarding, session screen, placeholder runtime
+
+**Files:**
+- Create: `Sources/AnglesiteMobile/QRScannerView.swift`
+- Create: `Sources/AnglesiteMobile/PairingOnboardingScreen.swift`
+- Create: `Sources/AnglesiteMobile/EditSiteScreen.swift`
+- Create: `Sources/AnglesiteIOS/PendingP2PSiteRuntime.swift`
+- Modify: `Resources/Info-iOS.plist` (add `NSCameraUsageDescription`)
+
+**Interfaces:**
+- Consumes: Tasks 2–3 models; `RemotePreviewWebView` (AnglesiteIOS), `WebViewBridge.localDevConfiguration`, `AnglesiteScriptHandler`, `MCPApplyEditRouter` (AnglesiteBridge), `PreviewAnnotationProvider`/`Registry` + `appEntityUIElementProvider` gated `#if compiler(>=6.4)` (AnglesiteIntents) — copy the composition from `RemoteSessionScreen.RemoteSandboxPreview` minus the session-token cookie injection (spec §3: DTLS replaces bearer auth; `prepareBeforeLoad` is omitted entirely).
+- Produces:
+  - `struct QRScannerView: UIViewControllerRepresentable { let onCode: (String) -> Void }` — AVCaptureSession + `AVCaptureMetadataOutput` (`.qr`), session started/stopped on a private queue in `makeUIViewController`/`dismantleUIViewController`, delegate forwards the first string payload to `onCode` on the main queue and ignores the rest.
+  - `struct PairingOnboardingScreen: View { let model: PairingOnboardingModel; var onPaired: () -> Void }` — switches `model.step`: `.explainer` → `ContentUnavailableView` ("Pair Your Mac", systemImage "qrcode.viewfinder", description: "Editing your site happens through your Mac. In Anglesite on your Mac, open Settings → Devices, then scan the pairing code shown there." action Button "Scan Pairing Code" → `Task { await model.beginScan() }`); `.cameraDenied` → explainer text + "Open Settings" button (`UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)`) — the honest no-dead-end (spec §3); `.scanning` → `QRScannerView { model.handleScanned($0) }` full-bleed with a Cancel toolbar reverting to `.explainer` via `model.retry()`; `.failed` → message + "Try Again" (`model.retry()` then `beginScan()`); `.done` → `onPaired()` fired from `.onChange(of: model.step)`.
+  - `struct EditSiteScreen: View { @Bindable var model: EditSessionModel }` + `@Environment(\.dismiss)`. `NavigationStack`; `.navigationTitle(model.siteDisplayName)`, inline. Toolbar: `.topBarLeading` Done button (plain `dismiss()` — suspends UI, session stays warm); `.topBarTrailing` Stop (`Label("Stop", systemImage: "stop.circle")`, shown when `model.isSessionActive`) → `Task { await model.stop(); dismiss() }`. Body by `model.phase`: `.pairingRequired` → `PairingOnboardingScreen(model: pairingModel) { Task { await model.completePairing() } }` (pairing model built in this view with production deps: `AVCaptureDevice.requestAccess(for: .video)` + `PairedDeviceStore().add`); `.waking` → ProgressView + `Text("Waking your Mac…")`; `.starting` → ProgressView + `Text("Starting your site…")`; `.ready(let url)` → `P2PSessionPreview(url: url, model: model)` ignoring bottom safe area; `.failed(let message)` → `ContentUnavailableView` "Couldn't Reach Your Site" + message + "Try Again" (`Task { await model.open() }`); `.idle` → ProgressView (transient). `.task { await model.open() }` so presenting the cover starts/resumes the session. Private `P2PSessionPreview` mirrors `RemoteSandboxPreview` (script handler + apply-edit router over `model.mcpClient`, annotation provider registered per siteID in this view, `#if compiler(>=6.4)` gate) with no cookie step.
+  - `PendingP2PSiteRuntime` (AnglesiteIOS): actor conforming to `SiteRuntime`; `start` settles `.failed(siteID:, message: String(localized: "Editing from this device isn't available yet — a future update connects it to Anglesite on your Mac."))` via its own `SiteRuntimeStateMachine`; `let mcpClient = MCPClient(supervisor: ProcessSupervisor())`; doc comment: "#1208 P4 replaces the factory that builds this with the real P2PSiteRuntime."
+- [ ] Step 1: Implement all files (view layer — no unit harness; `AnglesiteMobile` isn't a SwiftPM target).
+- [ ] Step 2: Add `NSCameraUsageDescription` = "Anglesite uses the camera to scan the pairing code shown on your Mac." to `Resources/Info-iOS.plist`.
+- [ ] Step 3: Build: `xcodegen generate && scripts/build-app.sh -project Anglesite.xcodeproj -scheme AnglesiteMobile -configuration Debug -destination 'generic/platform=iOS Simulator' build` → succeeds.
+- [ ] Step 4: Commit `feat(#1431): Edit Site cover, pairing onboarding, QR scanner views`.
+
+### Task 6: SiteSplitScreen entry points + router observation
+
+**Files:**
+- Modify: `Sources/AnglesiteMobile/SiteSplitScreen.swift`
+
+**Interfaces:** Consumes Tasks 3–5. Produces the user-reachable feature.
+
+- [ ] Step 1: Add state: `@State private var editSessions: [UUID: EditSessionModel] = [:]`, `@State private var editingSite: SitePickerModel.DiscoveredSite?`. Add `editSessionModel(for site:)` create-or-reuse helper wiring production deps: `pairedMacs: { try PairedDeviceStore().load() }`, `makeRuntime: { PendingP2PSiteRuntime() }` (comment: #1208 P4 swaps in the real `P2PSiteRuntime`), default `lastMacContact`. The dict (not the cover) owns the models — dismissing the cover keeps the session warm; switching sites never tears down another site's session.
+- [ ] Step 2: Entry points (spec §3): content pane toolbar `ToolbarItem(placement: .secondaryAction)` Button `Label("Edit Site", systemImage: "paintbrush.pointed")` → `editingSite = site` (added alongside the existing site-switcher item, available in both `.signedOut` and `.ready` session states — editing needs pairing, not Micropub sign-in); sidebar site row `.contextMenu { Button("Edit Site", …) }` with the same action; `.fullScreenCover(item: $editingSite) { site in EditSiteScreen(model: editSessionModel(for: site)) }` (`DiscoveredSite` already `Identifiable`).
+- [ ] Step 3: Router observation: `.task` loop or `.onChange` — poll pattern used by Mac scenes: add `.task { for await _ in … }` is overkill; use `.onAppear` + `.onChange(of: EditSessionRouter.shared.requestedSiteID)`: on non-nil, `consume()`, look up the site in `sitePicker.state`, `selectSite(it)`, set `editingSite`. (Observable singleton read inside `body` makes `.onChange` fire — same mechanism `WindowRouter` relies on Mac-side.)
+- [ ] Step 4: Rebuild AnglesiteMobile (same command as Task 5) → succeeds. Run full `swift test --package-path .` (portable targets untouched by this task but the suite is the pre-push gate).
+- [ ] Step 5: Localization catalog: run the CONTRIBUTING.md `xcstringstool sync` recipe against this worktree's own BUILD_DIR for the **AnglesiteMobile** scheme, `--skip-marking-strings-stale`; review the `Sources/AnglesiteMobile/Localizable.xcstrings` diff contains only this feature's keys; include it in the commit.
+- [ ] Step 6: Commit `feat(#1431): Edit Site entry points + session cover in shell`.
+
+### Task 7: Verification + PR
+
+- [ ] Step 1: Full gates: `DEVELOPER_DIR=… swift test --package-path .` (all suites); `scripts/build-app.sh … -scheme Anglesite -configuration Debug build` (Mac app still compiles — Task 1 touched `DevicePairingSettingsView`); AnglesiteMobile sim build.
+- [ ] Step 2: Re-read the diff against CONTRIBUTING.md (comment style, no stray formatting churn); verify no string mentions ICE/SDP/WebRTC.
+- [ ] Step 3: Push branch, open PR: title `feat(#1431): "Edit Site" P2P session UI in SiteSplitScreen`, body from `.github/PULL_REQUEST_TEMPLATE.md` with `Closes #1431`, Paired PR check = not needed (no MCP schema change; template untouched), Test plan = commands above + note that the live P2P leg lands in #1208 P4 behind the factory seam and QR scanning needs Mac-hardware manual QA. Note the follow-ups this unblocks (#1432, #1433, #1435, #1436).
+
+## Self-review
+
+- Spec coverage: entry points (Task 6), cover + suspend/stop semantics (Tasks 3/5/6), owner-comprehensible states incl. last-reachable (Task 3), preview-leg reuse minus cookie (Task 5), pairing walk-in with in-context camera permission + honest dead-end handling (Tasks 2/5), package-UUID site identity (Tasks 3/4/6 — UUID keys throughout), App Intent (Task 4). "Waking your Mac…" appears pre-first-state; finer "Starting your site…" granularity arrives with the real runtime's state stream (P4) — rendering is in place now.
+- Types cross-checked: `EditSessionModel.Phase`, `FakeP2PSiteRuntime` uses `SiteRuntimeStateMachine` exactly as `RemoteSandboxSiteRuntime` does; `MCPClient(supervisor: ProcessSupervisor())` matches `RemoteSessionModel`.
+- Known deliberate deferrals: real `P2PSiteRuntime`, presence reader (`lastMacContact` production impl), publish leg — #1208 P4/P5, #1432.


### PR DESCRIPTION
Closes #1431

## Summary

- Lands the iOS/iPadOS v2.0 "Edit Site" P2P session UI (design spec `docs/superpowers/specs/2026-08-12-ios-ipados-v2-design.md` §3): an "Edit Site" toolbar action in the content pane, a context-menu item on the site's sidebar row, and an `EditSiteIntent` App Intent, all presenting a full-screen session cover. Dismissing the cover suspends the UI while the session stays warm; the explicit Stop action ends it.
- Session states render owner-comprehensibly ("Waking your Mac…", "Starting your site…", failure copy with a "Your Mac was last reachable at…" clause) — never ICE/SDP/WebRTC. The preview leg reuses the shared bridge composition (`AnglesiteScriptHandler` + `MCPApplyEditRouter` + edit overlay + the Siri annotation hookup) with the #67 session-token cookie injection dropped, per the design (DTLS replaces bearer auth).
- First tap with no paired Mac walks into QR pairing onboarding: in-context camera permission, an AVFoundation scanner, honest no-dead-end denied/failure states. The QR wire shape is single-sourced as `DevicePairingPayload` in AnglesiteCore (the Mac's Settings encoder now uses it too).
- Everything consumes the `SiteRuntime` seam via an injectable factory. Production hands out `PendingP2PSiteRuntime` (honest "not available yet" failure); #1208 P4 swaps that one factory closure for the real WebRTC-backed `P2PSiteRuntime`. Models (`EditSessionModel`, `PairingOnboardingModel`, `EditSessionRouter`) live in AnglesiteIOS and are covered by Swift Testing suites against a scripted `FakeP2PSiteRuntime`, per the design's testing contract (§5).

This unblocks the factory chain gated on #1431: #1432 (publish-from-phone UI), #1433 (RemoteConnectForm retirement), #1435 (iPad externals polish), #1436 (state restoration).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` (full suite, includes the new `DevicePairingPayload`, `PairingOnboardingModel`, `EditSessionModel`, `EditSessionRouter` suites)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`; Task 1 touched `DevicePairingSettingsView`)
- [x] `scripts/build-app.sh -scheme AnglesiteMobile -configuration Debug -destination 'generic/platform=iOS Simulator' build`
- [x] Localization catalog synced from this worktree's own `BUILD_DIR` with `--skip-marking-strings-stale`; diff reviewed (14 keys: 13 from this feature + `SiteSwitcherMenu`'s missing accessibility key)
- [ ] Manual smoke (if UI-touching): QR pairing scan + camera-permission flow needs a real device with the Mac's Settings ▸ Devices QR (Mac-hardware manual QA); the live P2P session leg arrives with #1208 P4 behind the factory seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)
