### PR TITLE
feat(#1266): Artifacts RepoHost + API client (slices 1-2)

### DIFF
--- a/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
+++ b/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
@@ -44,6 +44,12 @@ public enum AnglesiteTokenTemplate {
         ("registrar", "edit"),
     ]
 
+    /// The Artifacts permission group (#1266) — deliberately **not** in ``permissionGroups`` yet.
+    /// The key is an unverified private-beta assumption, and an unknown key in the dashboard
+    /// prefill would break token creation for everyone. Slice 3 appends this once verified,
+    /// which extends ``oauthScope`` and ``createTokenURL`` automatically.
+    public static let artifactsPermissionGroup: (key: String, type: String) = ("artifacts", "edit")
+
     /// The OAuth `scope` string covering every permission group above. Cloudflare's self-managed
     /// OAuth scope names equal API-token permission-group names, so this is the same list,
     /// space-joined per OAuth's multi-scope convention — not a separately maintained vocabulary.

--- a/Sources/AnglesiteCore/GitRemoteResolver.swift
+++ b/Sources/AnglesiteCore/GitRemoteResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Shared "read `origin` and parse it as a GitHub `RemoteRepo`" lookup. Extracted from
+/// Shared "read `origin` and parse it as a `RemoteRepo`" lookup. Extracted from
 /// `PlistEditorModel.currentRemoteRepo()` and `SiteWindowModel.currentGitHubRemote()`, which had
 /// each grown byte-for-byte identical copies of this (flagged in #975's final whole-branch
 /// review). Both keep their own `gitRunner` init parameter as the test-injection seam and just
@@ -17,7 +17,10 @@ import Foundation
 /// standalone resolution `PlistEditorModel`/`SiteWindowModel` also need.
 public enum GitRemoteResolver {
     /// Runs `git remote get-url origin` in `siteDirectory` via `runner` and parses the result.
-    /// `nil` for no remote, a non-GitHub remote, or a failed git call.
+    /// `nil` for no remote, a remote whose host `RemoteRepo.parse` doesn't recognize, or a failed
+    /// git call. The result can be any recognized `RepoHost` (GitHub or Cloudflare Artifacts,
+    /// #1266) — callers that need GitHub specifically must check `repo.host == .github`
+    /// themselves; this lookup is host-agnostic.
     public static func origin(
         in siteDirectory: URL,
         runner: BackupCommand.GitRunner

--- a/Sources/AnglesiteCore/HTTPArtifactsClient.swift
+++ b/Sources/AnglesiteCore/HTTPArtifactsClient.swift
@@ -60,6 +60,19 @@ public struct HTTPArtifactsClient: Sendable {
         return RemoteRepo(url: url, owner: accountID, name: result.name, host: .cloudflareArtifacts)
     }
 
+    /// True when the account can list Artifacts repos — the #1266 private-beta gate. Strict on
+    /// purpose: only a 2xx `success: true` envelope counts, so a 404 from an account without
+    /// beta access reads as unavailable (`CloudflareCapabilityProber`'s permissive not-401/403
+    /// rule would get this wrong). Advisory like all probes — callers may re-probe.
+    public func probeAvailability(accountID: String, token: String) async -> Bool {
+        struct Repo: Decodable {}
+        guard let data = try? await send(
+            path: "accounts/\(accountID)/artifacts/repos?per_page=1",
+            method: "GET", body: nil, token: token)
+        else { return false }
+        return (try? Self.decodeEnvelope(data) as [Repo]) != nil
+    }
+
     /// Sends one authenticated request; maps transport/status failures to `ArtifactsAPIError`.
     private func send(path: String, method: String, body: Data?, token: String) async throws -> Data {
         guard let url = URL(string: baseURL.absoluteString + "/" + path) else {

--- a/Sources/AnglesiteCore/HTTPArtifactsClient.swift
+++ b/Sources/AnglesiteCore/HTTPArtifactsClient.swift
@@ -40,6 +40,18 @@ public struct HTTPArtifactsClient: Sendable {
 
     /// Creates a repository under the account and returns it as a `RemoteRepo` with
     /// `host == .cloudflareArtifacts` and `owner == accountID`.
+    ///
+    /// - Parameters:
+    ///   - name: The repository name to create.
+    ///   - isPrivate: Whether the repository should be private.
+    ///   - accountID: The Cloudflare account under which to create the repository; becomes the
+    ///     returned `RemoteRepo`'s `owner`.
+    ///   - token: A Cloudflare API token authorized for Artifacts on `accountID`.
+    /// - Returns: The created repository as a `RemoteRepo`.
+    /// - Throws: ``ArtifactsAPIError`` — `.network` if the request never got a response,
+    ///   `.unauthorized(status:)` for a 401/403, `.http(status:)` for any other non-2xx status,
+    ///   `.api(message:)` for a 2xx envelope with `success: false`, or `.malformedResponse` for a
+    ///   2xx envelope that didn't decode or that yielded an unusable browse URL.
     public func createRepo(name: String, isPrivate: Bool, accountID: String, token: String) async throws -> RemoteRepo {
         struct Body: Encodable {
             let name: String
@@ -64,6 +76,12 @@ public struct HTTPArtifactsClient: Sendable {
     /// purpose: only a 2xx `success: true` envelope counts, so a 404 from an account without
     /// beta access reads as unavailable (`CloudflareCapabilityProber`'s permissive not-401/403
     /// rule would get this wrong). Advisory like all probes — callers may re-probe.
+    ///
+    /// - Parameters:
+    ///   - accountID: The Cloudflare account to probe.
+    ///   - token: A Cloudflare API token to probe with.
+    /// - Returns: `true` when a 2xx `success: true` envelope came back; `false` for any other
+    ///   outcome, including a transport failure or non-2xx status — this never throws.
     public func probeAvailability(accountID: String, token: String) async -> Bool {
         struct Repo: Decodable {}
         guard let data = try? await send(

--- a/Sources/AnglesiteCore/HTTPArtifactsClient.swift
+++ b/Sources/AnglesiteCore/HTTPArtifactsClient.swift
@@ -1,0 +1,107 @@
+import Foundation
+// URLSession types live in FoundationNetworking on non-Darwin platforms.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Failure taxonomy for the Cloudflare Artifacts REST API, mirroring `GitHubRepoAPIError` so
+/// `ArtifactsRepoProvider` (slice 3, #1266) can map cases to owner-facing messages the same way.
+/// Duplicate-name failures arrive as `.api(message:)` with Cloudflare's own message — the API's
+/// error codes are unverified in private beta, so none are special-cased yet.
+public enum ArtifactsAPIError: Error, Equatable, Sendable {
+    /// The request never got an HTTP response (offline, DNS, TLS).
+    case network
+    /// 401/403 — the token lacks Artifacts access (or beta enrollment).
+    case unauthorized(status: Int)
+    /// Any other non-2xx status.
+    case http(status: Int)
+    /// A 2xx envelope with `success: false`; carries Cloudflare's first error message verbatim.
+    case api(message: String)
+    /// A 2xx envelope that didn't decode.
+    case malformedResponse
+}
+
+/// Cloudflare Artifacts REST client. Endpoint path and response shape are private-beta
+/// assumptions (#1266) — kept in this one file, alongside `RepoHost.artifactsHostName`, so beta
+/// verification is a single-file correction. Only creates the remote repository; wiring `origin`
+/// and pushing is `ArtifactsRepoProvider`'s job (slice 3), matching the `HTTPGitHubClient` split.
+public struct HTTPArtifactsClient: Sendable {
+    private let baseURL: URL
+    private let transport: CloudflareTransport
+
+    /// Creates a client. Both parameters exist for tests — production callers take the defaults.
+    public init(
+        baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!,
+        transport: @escaping CloudflareTransport = HTTPCloudflareClient.defaultTransport
+    ) {
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    /// Creates a repository under the account and returns it as a `RemoteRepo` with
+    /// `host == .cloudflareArtifacts` and `owner == accountID`.
+    public func createRepo(name: String, isPrivate: Bool, accountID: String, token: String) async throws -> RemoteRepo {
+        struct Body: Encodable {
+            let name: String
+            let isPrivate: Bool
+            enum CodingKeys: String, CodingKey { case name, isPrivate = "private" }
+        }
+        let data = try await send(
+            path: "accounts/\(accountID)/artifacts/repos",
+            method: "POST",
+            body: try JSONEncoder().encode(Body(name: name, isPrivate: isPrivate)),
+            token: token)
+
+        struct Result: Decodable { let name: String }
+        let result: Result = try Self.decodeEnvelope(data)
+        guard let url = RepoHost.cloudflareArtifacts.browseURL(owner: accountID, name: result.name) else {
+            throw ArtifactsAPIError.malformedResponse
+        }
+        return RemoteRepo(url: url, owner: accountID, name: result.name, host: .cloudflareArtifacts)
+    }
+
+    /// Sends one authenticated request; maps transport/status failures to `ArtifactsAPIError`.
+    private func send(path: String, method: String, body: Data?, token: String) async throws -> Data {
+        guard let url = URL(string: baseURL.absoluteString + "/" + path) else {
+            throw ArtifactsAPIError.malformedResponse
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.httpBody = body
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if body != nil { request.setValue("application/json", forHTTPHeaderField: "Content-Type") }
+
+        let data: Data
+        let http: HTTPURLResponse
+        do {
+            (data, http) = try await transport(request)
+        } catch {
+            throw ArtifactsAPIError.network
+        }
+        switch http.statusCode {
+        case 200..<300: return data
+        case 401, 403: throw ArtifactsAPIError.unauthorized(status: http.statusCode)
+        default: throw ArtifactsAPIError.http(status: http.statusCode)
+        }
+    }
+
+    /// Unwraps Cloudflare's `{success, errors, result}` envelope; `success: false` becomes
+    /// `.api(message:)` with the first error message.
+    private static func decodeEnvelope<T: Decodable>(_ data: Data) throws -> T {
+        guard let envelope = try? JSONDecoder().decode(Envelope<T>.self, from: data) else {
+            throw ArtifactsAPIError.malformedResponse
+        }
+        guard envelope.success, let result = envelope.result else {
+            throw ArtifactsAPIError.api(message: envelope.errors?.first?.message ?? "Cloudflare returned an unexpected response.")
+        }
+        return result
+    }
+
+    private struct Envelope<R: Decodable>: Decodable {
+        let success: Bool
+        let errors: [APIMessage]?
+        let result: R?
+        struct APIMessage: Decodable { let message: String }
+    }
+}

--- a/Sources/AnglesiteCore/RepoBootstrapTypes.swift
+++ b/Sources/AnglesiteCore/RepoBootstrapTypes.swift
@@ -14,6 +14,10 @@ public enum RepoHost: String, CaseIterable, Codable, Sendable {
 
     /// The provider for a remote's host name, or nil for hosts the app doesn't recognize —
     /// callers treat nil as "not published", never as an error.
+    ///
+    /// - Parameter hostName: The remote URL's host, e.g. `"github.com"` or `"artifacts.cloudflare.com"`.
+    ///   Matched case-insensitively.
+    /// - Returns: The matching provider, or nil when `hostName` isn't recognized.
     public static func match(hostName: String) -> RepoHost? {
         switch hostName.lowercased() {
         case "github.com", "www.github.com": .github
@@ -23,6 +27,11 @@ public enum RepoHost: String, CaseIterable, Codable, Sendable {
     }
 
     /// Browser URL for a repo on this host (no `.git` suffix).
+    ///
+    /// - Parameters:
+    ///   - owner: The GitHub account/organization, or Cloudflare account ID, that owns the repo.
+    ///   - name: The repository name, with any `.git` suffix already stripped.
+    /// - Returns: The browser URL, or nil if `owner`/`name` can't form a valid URL.
     public func browseURL(owner: String, name: String) -> URL? {
         switch self {
         case .github: URL(string: "https://github.com/\(owner)/\(name)")

--- a/Sources/AnglesiteCore/RepoBootstrapTypes.swift
+++ b/Sources/AnglesiteCore/RepoBootstrapTypes.swift
@@ -1,6 +1,37 @@
 import Foundation
 
-/// A site's GitHub remote, derived from `origin`. Source of truth for "is this site published?".
+/// A git-hosting provider the app recognizes in a site's `origin` remote. Owns host matching and
+/// browse-URL derivation so `RemoteRepo` consumers never re-parse URLs to learn the provider.
+public enum RepoHost: String, CaseIterable, Codable, Sendable {
+    /// GitHub (`github.com`) — the original provider; `gh`/REST bootstrap paths.
+    case github
+    /// Cloudflare Artifacts — private beta. Host and URL shapes are assumed pending beta access;
+    /// ``artifactsHostName`` is the single value to correct once verified (#1266).
+    case cloudflareArtifacts
+
+    /// The Artifacts git/browse host. Unverified private-beta assumption — the one place to fix.
+    public static let artifactsHostName = "artifacts.cloudflare.com"
+
+    /// The provider for a remote's host name, or nil for hosts the app doesn't recognize —
+    /// callers treat nil as "not published", never as an error.
+    public static func match(hostName: String) -> RepoHost? {
+        switch hostName.lowercased() {
+        case "github.com", "www.github.com": .github
+        case artifactsHostName: .cloudflareArtifacts
+        default: nil
+        }
+    }
+
+    /// Browser URL for a repo on this host (no `.git` suffix).
+    public func browseURL(owner: String, name: String) -> URL? {
+        switch self {
+        case .github: URL(string: "https://github.com/\(owner)/\(name)")
+        case .cloudflareArtifacts: URL(string: "https://\(Self.artifactsHostName)/\(owner)/\(name)")
+        }
+    }
+}
+
+/// A site's git remote (GitHub or Cloudflare Artifacts), derived from `origin`. Source of truth for "is this site published?".
 public struct RemoteRepo: Sendable, Equatable {
     /// Browser URL, e.g. `https://github.com/owner/name` — always https, regardless of whether
     /// the remote itself was an ssh URL.
@@ -9,17 +40,20 @@ public struct RemoteRepo: Sendable, Equatable {
     public let owner: String
     /// The repository name, with any `.git` suffix already stripped.
     public let name: String
+    /// Which provider hosts this remote — derived from the host in `parse(remoteURL:)`.
+    public let host: RepoHost
 
     /// Memberwise initializer; prefer ``parse(remoteURL:)``, which derives all three fields
     /// consistently from a raw remote URL.
-    public init(url: URL, owner: String, name: String) {
+    public init(url: URL, owner: String, name: String, host: RepoHost = .github) {
         self.url = url
         self.owner = owner
         self.name = name
+        self.host = host
     }
 
     /// Parse a git remote URL (https or scp-like ssh) into owner/name + a browser URL.
-    /// Returns nil for empty/unparseable input or if the host is not github.com.
+    /// Returns nil for empty/unparseable input or hosts `RepoHost` doesn't recognize.
     public static func parse(remoteURL raw: String) -> RemoteRepo? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -46,15 +80,13 @@ public struct RemoteRepo: Sendable, Equatable {
             return nil
         }
 
-        // Only accept github.com remotes — non-GitHub origins (GitLab, Bitbucket, etc.) must not
-        // produce a broken github.com browse URL or mislead consumers about published state.
-        guard host.lowercased() == "github.com" || host.lowercased() == "www.github.com" else { return nil }
+        guard let repoHost = RepoHost.match(hostName: host) else { return nil }
 
         if name.hasSuffix(".git") { name = String(name.dropLast(4)) }
-        guard !owner.isEmpty, !name.isEmpty, let browse = URL(string: "https://github.com/\(owner)/\(name)") else {
+        guard !owner.isEmpty, !name.isEmpty, let browse = repoHost.browseURL(owner: owner, name: name) else {
             return nil
         }
-        return RemoteRepo(url: browse, owner: owner, name: name)
+        return RemoteRepo(url: browse, owner: owner, name: name, host: repoHost)
     }
 }
 

--- a/Sources/AnglesiteCore/SecurityReportingAsset.swift
+++ b/Sources/AnglesiteCore/SecurityReportingAsset.swift
@@ -106,20 +106,31 @@ public enum SecurityReportingAsset {
             .joined(separator: ",")
     }
 
-    /// The repo's private advisory form. `RemoteRepo` is GitHub-by-construction
-    /// (`RemoteRepo.parse` rejects every other host), so this needs no host check of its own.
+    /// The repo's private advisory form, GitHub's `security/advisories/new` path appended to
+    /// `repo.url`. `RemoteRepo.parse` no longer rejects every non-GitHub host (`RepoHost`,
+    /// #1266), so this is *not* GitHub-by-construction any more — this function builds the
+    /// GitHub-shaped path regardless of `repo.host` and does not check it itself. Its two
+    /// AnglesiteCore callers below (`usesAdvisoryForm`, `prependingAdvisoryForm`) are the guarded
+    /// entry points that skip non-`.github` repos; call this directly only for a repo already
+    /// known to be GitHub-hosted.
     public static func advisoryURL(for repo: RemoteRepo) -> URL {
         repo.url.appendingPathComponent("security/advisories/new")
     }
 
-    /// True when `contacts` already lists this repo's advisory form.
+    /// True when `contacts` already lists this repo's advisory form. Always false for a
+    /// non-GitHub repo (e.g. Cloudflare Artifacts, #1266) — there is no GitHub advisory form to
+    /// match against, so this must not be confused with "no contacts configured yet".
     public static func usesAdvisoryForm(_ contacts: String, repo: RemoteRepo) -> Bool {
-        normalizedContacts(contacts).contains(advisoryURL(for: repo).absoluteString)
+        guard repo.host == .github else { return false }
+        return normalizedContacts(contacts).contains(advisoryURL(for: repo).absoluteString)
     }
 
     /// `contacts` with the advisory form as the most-preferred entry, preserving the rest in
-    /// order and never duplicating a form that is already listed.
+    /// order and never duplicating a form that is already listed. Returns `contacts` unchanged
+    /// for a non-GitHub repo (e.g. Cloudflare Artifacts, #1266) — there is no GitHub advisory
+    /// form to prepend.
     public static func prependingAdvisoryForm(_ contacts: String, repo: RemoteRepo) -> String {
+        guard repo.host == .github else { return contacts }
         let form = advisoryURL(for: repo).absoluteString
         return ([form] + normalizedContacts(contacts).filter { $0 != form }).joined(separator: "\n")
     }

--- a/Sources/AnglesiteCore/SecurityReportingReadiness.swift
+++ b/Sources/AnglesiteCore/SecurityReportingReadiness.swift
@@ -10,7 +10,9 @@ public enum SecurityReportingReadiness: Sendable, Equatable {
     /// remote, the caller just doesn't know its state yet. `evaluate` never returns this case; a
     /// caller assigns it directly when it cannot get as far as calling `evaluate` at all.
     case unknown
-    /// No `origin`, or an origin that isn't GitHub.
+    /// No `origin`, an origin `RemoteRepo.parse` doesn't recognize, or a recognized origin hosted
+    /// somewhere other than GitHub (e.g. Cloudflare Artifacts, #1266) — this whole security-
+    /// reporting flow (advisory form, PVR) is GitHub-specific.
     case notGitHub
     /// The repo's advisory form is already one of the published contacts.
     case alreadyConfigured
@@ -32,7 +34,10 @@ public enum SecurityReportingReadiness: Sendable, Equatable {
         pvrEnabled: Bool,
         contacts: String
     ) -> SecurityReportingReadiness {
-        guard let repo else { return .notGitHub }
+        // `RemoteRepo.parse` accepts recognized non-GitHub hosts too (#1266's `RepoHost`), so a
+        // nil check alone isn't enough — an Artifacts repo must read as `.notGitHub` here, not
+        // fall through to the GitHub-specific PVR/advisory-form logic below.
+        guard let repo, repo.host == .github else { return .notGitHub }
         if SecurityReportingAsset.usesAdvisoryForm(contacts, repo: repo) { return .alreadyConfigured }
         if isPrivate { return .repoPrivate }
         return pvrEnabled ? .ready : .needsPVR

--- a/Sources/AnglesiteCore/SecurityReportsModel.swift
+++ b/Sources/AnglesiteCore/SecurityReportsModel.swift
@@ -46,13 +46,16 @@ public final class SecurityReportsModel {
         return .clean
     }
 
-    /// Cancels any in-flight check and starts a new one. `repo == nil` (no GitHub origin) or a
-    /// missing/empty `token` both clear state to empty rather than erroring — neither is a
-    /// failure, just nothing to show, and neither touches `lastCheckedAt` since no check ran.
+    /// Cancels any in-flight check and starts a new one. `repo == nil` (no recognized origin), a
+    /// repo whose `host` isn't `.github` (advisories and Dependabot alerts are GitHub products —
+    /// querying api.github.com with, say, a Cloudflare Artifacts account ID as the owner would
+    /// only manufacture a spurious `lastError`), and a missing/empty `token` all clear state to
+    /// empty rather than erroring — none is a failure, just nothing to show, and none touches
+    /// `lastCheckedAt` since no check ran.
     @discardableResult
     public func recheck(repo: RemoteRepo?, token: String?) -> Task<Void, Never> {
         inFlight?.cancel()
-        guard let repo, let token, !token.isEmpty else {
+        guard let repo, repo.host == .github, let token, !token.isEmpty else {
             inFlight = nil
             openAdvisories = []
             openAlerts = []

--- a/Sources/AnglesiteCore/SecurityTxtAuditRunner.swift
+++ b/Sources/AnglesiteCore/SecurityTxtAuditRunner.swift
@@ -56,12 +56,16 @@ public struct SecurityTxtAuditRunner: AuditRunner {
         )]
     }
 
-    /// The site's GitHub `origin`, or nil when there is no remote, git can't run, or the remote
-    /// isn't GitHub (`RemoteRepo.parse` rejects every other host). None of those is an audit
+    /// The site's GitHub `origin`, or nil when there is no remote, git can't run, the remote
+    /// isn't a host `RemoteRepo.parse` recognizes, or it's a recognized non-GitHub host (e.g.
+    /// Cloudflare Artifacts, #1266) — this audit's advisory-form hint is GitHub-specific, so a
+    /// non-GitHub remote must read the same as no remote at all. None of those is an audit
     /// failure — a site without a GitHub remote is a normal state, so this never throws.
     private func remoteRepo(in siteDirectory: URL) async -> RemoteRepo? {
         guard let result = try? await gitRunner(siteDirectory, ["remote", "get-url", "origin"]),
-              result.exitCode == 0 else { return nil }
-        return RemoteRepo.parse(remoteURL: result.stdout)
+              result.exitCode == 0,
+              let repo = RemoteRepo.parse(remoteURL: result.stdout),
+              repo.host == .github else { return nil }
+        return repo
     }
 }

--- a/Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
+++ b/Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
@@ -40,4 +40,16 @@ struct AnglesiteTokenTemplateTests {
         #expect(Set(scopeKeys) == Set(AnglesiteTokenTemplate.permissionGroups.map(\.key)))
         #expect(scopeKeys.count == AnglesiteTokenTemplate.permissionGroups.count)
     }
+
+    /// #1266 slices 1–2 must not touch the live token template: an unverified permission-group
+    /// key in the dashboard prefill would break token creation for every user. Slice 3 flips
+    /// this by appending `artifactsPermissionGroup` to `permissionGroups` once verified.
+    @Test("artifactsPermissionGroup is defined but not yet requested")
+    func artifactsPermissionGroupIsDefinedButNotYetRequested() {
+        #expect(AnglesiteTokenTemplate.artifactsPermissionGroup.type == "edit")
+        #expect(!AnglesiteTokenTemplate.permissionGroups
+            .contains { $0.key == AnglesiteTokenTemplate.artifactsPermissionGroup.key })
+        #expect(!AnglesiteTokenTemplate.oauthScope
+            .contains(AnglesiteTokenTemplate.artifactsPermissionGroup.key))
+    }
 }

--- a/Tests/AnglesiteCoreTests/HTTPArtifactsClientTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPArtifactsClientTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite struct HTTPArtifactsClientTests {
+    /// Scripted transport: returns `(data, status)` and records the request it saw.
+    private final class Recorder: @unchecked Sendable {
+        var request: URLRequest?
+    }
+
+    private func client(status: Int, json: String, recorder: Recorder? = nil) -> HTTPArtifactsClient {
+        HTTPArtifactsClient(transport: { request in
+            recorder?.request = request
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(json.utf8), response)
+        })
+    }
+
+    @Test func createRepoSendsAuthorizedPOSTToAccountEndpoint() async throws {
+        let recorder = Recorder()
+        let ok = #"{"success":true,"errors":[],"result":{"name":"my-site"}}"#
+        _ = try await client(status: 200, json: ok, recorder: recorder)
+            .createRepo(name: "my-site", isPrivate: true, accountID: "acct123", token: "tok")
+        let request = try #require(recorder.request)
+        #expect(request.httpMethod == "POST")
+        #expect(request.url?.absoluteString.hasSuffix("accounts/acct123/artifacts/repos") == true)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer tok")
+        let body = try JSONSerialization.jsonObject(with: request.httpBody ?? Data()) as? [String: Any]
+        #expect(body?["name"] as? String == "my-site")
+        #expect(body?["private"] as? Bool == true)
+    }
+
+    @Test func createRepoBuildsArtifactsRemoteRepo() async throws {
+        let ok = #"{"success":true,"errors":[],"result":{"name":"my-site"}}"#
+        let repo = try await client(status: 200, json: ok)
+            .createRepo(name: "my-site", isPrivate: true, accountID: "acct123", token: "tok")
+        #expect(repo.host == .cloudflareArtifacts)
+        #expect(repo.owner == "acct123")
+        #expect(repo.name == "my-site")
+        #expect(repo.url == RepoHost.cloudflareArtifacts.browseURL(owner: "acct123", name: "my-site"))
+    }
+
+    @Test func createRepoMapsUnauthorized() async {
+        await #expect(throws: ArtifactsAPIError.unauthorized(status: 403)) {
+            _ = try await client(status: 403, json: "{}")
+                .createRepo(name: "n", isPrivate: true, accountID: "a", token: "t")
+        }
+    }
+
+    @Test func createRepoSurfacesAPIErrorMessage() async {
+        let err = #"{"success":false,"errors":[{"code":1000,"message":"repository already exists"}],"result":null}"#
+        await #expect(throws: ArtifactsAPIError.api(message: "repository already exists")) {
+            _ = try await client(status: 200, json: err)
+                .createRepo(name: "n", isPrivate: true, accountID: "a", token: "t")
+        }
+    }
+
+    @Test func createRepoMapsHTTPFailure() async {
+        await #expect(throws: ArtifactsAPIError.http(status: 500)) {
+            _ = try await client(status: 500, json: "oops")
+                .createRepo(name: "n", isPrivate: true, accountID: "a", token: "t")
+        }
+    }
+
+    @Test func createRepoMapsTransportFailureToNetwork() async {
+        let failing = HTTPArtifactsClient(transport: { _ in throw URLError(.notConnectedToInternet) })
+        await #expect(throws: ArtifactsAPIError.network) {
+            _ = try await failing.createRepo(name: "n", isPrivate: true, accountID: "a", token: "t")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/HTTPArtifactsClientTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPArtifactsClientTests.swift
@@ -69,4 +69,28 @@ import Foundation
             _ = try await failing.createRepo(name: "n", isPrivate: true, accountID: "a", token: "t")
         }
     }
+
+    @Test func probeAvailabilityTrueOnSuccessEnvelope() async {
+        let ok = #"{"success":true,"errors":[],"result":[]}"#
+        let available = await client(status: 200, json: ok)
+            .probeAvailability(accountID: "acct123", token: "tok")
+        #expect(available)
+    }
+
+    @Test func probeAvailabilityFalseWithoutBetaAccess() async {
+        // 404 = endpoint unknown to this account (no beta); must NOT read as available,
+        // unlike CloudflareCapabilityProber's permissive not-401/403 semantics.
+        let unavailable404 = await client(status: 404, json: "{}")
+            .probeAvailability(accountID: "acct123", token: "tok")
+        #expect(unavailable404 == false)
+        let unavailable403 = await client(status: 403, json: "{}")
+            .probeAvailability(accountID: "acct123", token: "tok")
+        #expect(unavailable403 == false)
+    }
+
+    @Test func probeAvailabilityFalseOnTransportFailure() async {
+        let failing = HTTPArtifactsClient(transport: { _ in throw URLError(.timedOut) })
+        let available = await failing.probeAvailability(accountID: "a", token: "t")
+        #expect(available == false)
+    }
 }

--- a/Tests/AnglesiteCoreTests/RemoteRepoTests.swift
+++ b/Tests/AnglesiteCoreTests/RemoteRepoTests.swift
@@ -37,4 +37,28 @@ import Foundation
     @Test func rejectsColonBeforeAtWithoutCrashing() {
         #expect(RemoteRepo.parse(remoteURL: "host:user@path/repo.git") == nil)
     }
+
+    @Test func parsesArtifactsHTTPSRemote() {
+        let raw = "https://\(RepoHost.artifactsHostName)/acct123/my-site.git"
+        let repo = RemoteRepo.parse(remoteURL: raw)
+        #expect(repo?.host == .cloudflareArtifacts)
+        #expect(repo?.owner == "acct123")
+        #expect(repo?.name == "my-site")
+        #expect(repo?.url == URL(string: "https://\(RepoHost.artifactsHostName)/acct123/my-site"))
+    }
+
+    @Test func parsesArtifactsSSHRemote() {
+        let repo = RemoteRepo.parse(remoteURL: "git@\(RepoHost.artifactsHostName):acct123/my-site.git")
+        #expect(repo?.host == .cloudflareArtifacts)
+        #expect(repo?.url == URL(string: "https://\(RepoHost.artifactsHostName)/acct123/my-site"))
+    }
+
+    @Test func githubRemoteParsesWithGitHubHost() {
+        #expect(RemoteRepo.parse(remoteURL: "https://github.com/acme/site.git")?.host == .github)
+    }
+
+    @Test func stillRejectsUnknownHosts() {
+        #expect(RemoteRepo.parse(remoteURL: "https://gitlab.com/foo/bar.git") == nil)
+        #expect(RemoteRepo.parse(remoteURL: "git@bitbucket.org:foo/bar.git") == nil)
+    }
 }

--- a/Tests/AnglesiteCoreTests/SecurityReportingAssetTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityReportingAssetTests.swift
@@ -6,6 +6,9 @@ import Testing
 struct SecurityReportingAssetTests {
     private static let repo = RemoteRepo(
         url: URL(string: "https://github.com/acme/site")!, owner: "acme", name: "site")
+    private static let artifactsRepo = RemoteRepo(
+        url: URL(string: "https://\(RepoHost.artifactsHostName)/acct123/site")!,
+        owner: "acct123", name: "site", host: .cloudflareArtifacts)
 
     @Test("parses a comma-separated contact list into newline-separated UI text")
     func parseSettings() {
@@ -67,6 +70,15 @@ struct SecurityReportingAssetTests {
         #expect(!SecurityReportingAsset.usesAdvisoryForm("", repo: Self.repo))
     }
 
+    @Test("always false for a non-GitHub repo — there is no GitHub advisory form to match (#1266)")
+    func usesAdvisoryFormFalseForArtifactsRepo() {
+        // Even the GitHub-shaped URL a caller might already have on file must not read as a match.
+        #expect(!SecurityReportingAsset.usesAdvisoryForm(
+            "https://\(RepoHost.artifactsHostName)/acct123/site/security/advisories/new",
+            repo: Self.artifactsRepo))
+        #expect(!SecurityReportingAsset.usesAdvisoryForm("s@example.com", repo: Self.artifactsRepo))
+    }
+
     @Test("prepends the advisory form, preserving order and never duplicating it")
     func prependingAdvisoryForm() {
         #expect(SecurityReportingAsset.prependingAdvisoryForm("s@example.com\nt@example.com", repo: Self.repo)
@@ -75,6 +87,12 @@ struct SecurityReportingAssetTests {
             == "https://github.com/acme/site/security/advisories/new")
         let already = "https://github.com/acme/site/security/advisories/new\ns@example.com"
         #expect(SecurityReportingAsset.prependingAdvisoryForm(already, repo: Self.repo) == already)
+    }
+
+    @Test("leaves contacts unchanged for a non-GitHub repo — there is no GitHub advisory form to prepend (#1266)")
+    func prependingAdvisoryFormUnchangedForArtifactsRepo() {
+        #expect(SecurityReportingAsset.prependingAdvisoryForm("s@example.com", repo: Self.artifactsRepo) == "s@example.com")
+        #expect(SecurityReportingAsset.prependingAdvisoryForm("", repo: Self.artifactsRepo) == "")
     }
 
     @Test("install writes normalized settings while preserving unrelated config")

--- a/Tests/AnglesiteCoreTests/SecurityReportingReadinessTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityReportingReadinessTests.swift
@@ -7,6 +7,9 @@ struct SecurityReportingReadinessTests {
     private static let repo = RemoteRepo(
         url: URL(string: "https://github.com/acme/site")!, owner: "acme", name: "site")
     private static let form = "https://github.com/acme/site/security/advisories/new"
+    private static let artifactsRepo = RemoteRepo(
+        url: URL(string: "https://\(RepoHost.artifactsHostName)/acct123/site")!,
+        owner: "acct123", name: "site", host: .cloudflareArtifacts)
 
     @Test("no repo means nothing to offer")
     func notGitHub() {
@@ -47,5 +50,13 @@ struct SecurityReportingReadinessTests {
     func notGitHubOutranksConfigured() {
         #expect(SecurityReportingReadiness.evaluate(
             repo: nil, isPrivate: false, pvrEnabled: true, contacts: Self.form) == .notGitHub)
+    }
+
+    @Test("a Cloudflare Artifacts repo is not GitHub — must not fall through to PVR/advisory-form logic (#1266)")
+    func artifactsRepoIsNotGitHub() {
+        #expect(SecurityReportingReadiness.evaluate(
+            repo: Self.artifactsRepo, isPrivate: false, pvrEnabled: true, contacts: "s@example.com") == .notGitHub)
+        #expect(SecurityReportingReadiness.evaluate(
+            repo: Self.artifactsRepo, isPrivate: true, pvrEnabled: false, contacts: "s@example.com") == .notGitHub)
     }
 }

--- a/Tests/AnglesiteCoreTests/SecurityReportsModelTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityReportsModelTests.swift
@@ -61,6 +61,18 @@ struct SecurityReportsModelTests {
         #expect(model.lastCheckedAt == nil)
     }
 
+    @Test("a non-GitHub repo clears state without an error, same as no repo")
+    func nonGitHubRepoClears() async {
+        let artifacts = RemoteRepo(
+            url: URL(string: "https://artifacts.cloudflare.com/acct123/site")!,
+            owner: "acct123", name: "site", host: .cloudflareArtifacts)
+        let model = SecurityReportsModel(reader: FakeReader(advisories: [Self.highAdvisory]))
+        await model.recheck(repo: artifacts, token: "tok").value
+        #expect(model.totalCount == 0)
+        #expect(model.lastError == nil)
+        #expect(model.lastCheckedAt == nil)
+    }
+
     @Test("no token clears state without an error")
     func noTokenClears() async {
         let model = SecurityReportsModel(reader: FakeReader(advisories: [Self.highAdvisory]))

--- a/Tests/AnglesiteCoreTests/SecurityTxtAuditRunnerTests.swift
+++ b/Tests/AnglesiteCoreTests/SecurityTxtAuditRunnerTests.swift
@@ -86,6 +86,14 @@ struct SecurityTxtAuditRunnerTests {
         #expect(findings.isEmpty)
     }
 
+    @Test("says nothing for a Cloudflare Artifacts origin — the GitHub advisory-form hint doesn't apply (#1266)")
+    func silentForArtifactsOrigin() async throws {
+        let findings = try await Self.run(
+            config: "SECURITY_CONTACT=s@example.com\n",
+            gitRunner: Self.gitRunner(remote: "https://\(RepoHost.artifactsHostName)/acct123/site.git\n"))
+        #expect(findings.isEmpty)
+    }
+
     @Test("says nothing when there is no origin")
     func silentWithoutOrigin() async throws {
         let findings = try await Self.run(


### PR DESCRIPTION
## Summary

- Part of #1266 (slices 1–2 of the epic; does not close it): makes `RemoteRepo` host-agnostic via a new `RepoHost` enum (`.github` / `.cloudflareArtifacts`) and adds `HTTPArtifactsClient` — `createRepo` plus a deliberately strict `probeAvailability` beta gate (only a 2xx `success: true` envelope counts as available, so accounts without private-beta access read as unavailable rather than inheriting `CloudflareCapabilityProber`'s permissive not-401/403 rule).
- Ships an inert `AnglesiteTokenTemplate.artifactsPermissionGroup` hook — deliberately **not** in `permissionGroups` (a test locks the exclusion) so the live dashboard token prefill is untouched until the beta key is verified in slice 3.
- Hardens the security-reporting stack for the new invariant: `SecurityReportingReadiness`, `SecurityTxtAuditRunner`, and `SecurityReportingAsset`'s callers now guard on `repo.host == .github` instead of relying on "parse rejects every other host", with tests for Artifacts-hosted remotes.
- Every assumed private-beta API value (host name, endpoint path, response shape, permission-group key) is single-sourced and doc-commented as unverified pending beta access. No behavior change for GitHub-hosted sites.
- Deferred to slice 3 (app-target, out of this PR's scope): `PlistEditorView.swift:664,672` shows `advisoryURL(for:)` in the manual-mode callout without a host check; noted on the epic.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` — full suite green on final HEAD (all targets, exit 0).
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run: no app-target sources touched (AnglesiteCore + tests only; AnglesiteAppTests compile verified via swift test).
- [x] New coverage: RemoteRepo host parsing (Artifacts https/ssh, unknown-host rejection), HTTPArtifactsClient (request shape, envelope/error mapping, strict probe semantics incl. 404-as-unavailable), token-template exclusion lock, Artifacts-remote guards in the security-reporting suites.

## Design notes

Spec and implementation plan land separately via #1473 (split docs/code PRs): `docs/superpowers/specs/2026-08-15-cloudflare-artifacts-repo-host-design.md`, `docs/superpowers/plans/2026-08-15-cloudflare-artifacts-slices-1-2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
