### PR TITLE
chore(#1467): add LICENSES/ + REUSE.toml so reuse lint passes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,3 +88,10 @@ Notes:
 ## License
 
 By contributing, you agree that your contributions are licensed under the [ISC License](LICENSE) that covers this project.
+
+The repo is [REUSE](https://reuse.software)-compliant, and CI's `reuse-lint` lane enforces it. You almost never need to do anything about this: [`REUSE.toml`](REUSE.toml) declares ISC + the project copyright for the whole tree (`path = "**"`), so a new file is covered the moment you add it — **don't** add per-file `SPDX-License-Identifier` headers to ordinary source files. Two cases do need action:
+
+- **Vendoring third-party code.** Add its license text to `LICENSES/` (`reuse download <SPDX-ID>` fetches the canonical text) and give the vendored paths their own `[[annotations]]` block in `REUSE.toml`. This is required, not optional: the top-level annotation uses `precedence = "override"`, so a vendored file's own SPDX header would otherwise be silently replaced by the ISC default — see the comment in `REUSE.toml` for why that precedence is set the way it is.
+- **Checking locally.** `uvx reuse lint` or `pipx run reuse lint` (the tool isn't committed; CI pins `reuse[charset-normalizer]==6.2.0`).
+
+`LICENSES/ISC.txt` is the canonical SPDX text, so it carries the SPDX template's own placeholder copyright lines rather than this project's — that's expected. The human-facing grant with the real copyright holder is the root [`LICENSE`](LICENSE), and the machine-readable holder is the `SPDX-FileCopyrightText` in `REUSE.toml`.

--- a/LICENSES/ISC.txt
+++ b/LICENSES/ISC.txt
@@ -1,0 +1,8 @@
+ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,45 @@
+# REUSE licensing metadata — https://reuse.software, specification 3.3.
+#
+# This file makes the repo's licensing machine-readable so `reuse lint` (CI's
+# `reuse-lint` lane, #1468) can verify that every tracked file has both a
+# copyright holder and an SPDX license identifier.
+#
+# Bulk annotation rather than per-file `SPDX-License-Identifier` headers: the
+# tree is ~2,300 files that are all first-party and all ISC, so per-file headers
+# would be ~4,600 lines of boilerplate to keep correct forever, and every newly
+# added file would become a compliance trap. A `path = "**"` rule instead makes
+# coverage the default and per-file headers the exception (see #1318's
+# "Alternatives considered"). Add a narrower `[[annotations]]` block below only
+# when a file genuinely deviates — e.g. if third-party code is ever vendored in.
+
+version = 1
+
+SPDX-PackageName = "Anglesite"
+SPDX-PackageSupplier = "David W. Keith <me@dwk.io>"
+SPDX-PackageDownloadLocation = "https://github.com/Anglesite/Anglesite"
+
+# Default for the whole tree. `precedence = "override"` (rather than the default
+# "closest") is about correctness of the emitted metadata, not about passing the
+# lint — `reuse lint` exits 0 either way. No file here carries a real REUSE
+# header, but several *quote* upstream license texts as data, and reuse's header
+# scanner cannot tell a quotation from a declaration.
+# `Resources/Attributions/*.json` and `scripts/attributions-overrides.json` are
+# Anglesite-authored records of npm dependency licensing that between them embed
+# ~380 upstream "Copyright (c) …" lines; `docs/` prose and
+# `Tests/…/ThirdPartyNoticeRendererTests.swift` fixtures quote a few more. Under
+# "closest" those quotations get read as the enclosing file's own header — with
+# "closest", `app-binary.json` alone is credited to 26 copyright holders,
+# starting with "Copyright (C) 2023 Marcin Krzyzanowski", none of whom wrote it.
+# That is what would land in an SBOM produced by `reuse spdx`. "override" states
+# plainly that this file, not incidental file content, is the authority on who
+# holds copyright in the repo's own source.
+#
+# The corollary: if third-party code is ever vendored in with a genuine SPDX
+# header, an "override" default would silently swallow it — so vendored paths
+# must get their own `[[annotations]]` block here, with their license text added
+# to `LICENSES/`.
+[[annotations]]
+path = "**"
+precedence = "override"
+SPDX-FileCopyrightText = "2026 David W. Keith"
+SPDX-License-Identifier = "ISC"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -14,6 +14,14 @@
 
 version = 1
 
+# Package identity. Declared for completeness and for future tool versions —
+# but note that `reuse` 6.2.0 (the version CI pins) does not consume these three
+# keys. Its `ReuseTOML.from_dict` reads only `version` and `annotations`, and
+# `reuse spdx` against this tree emits an SBOM with zero PackageName /
+# PackageSupplier / PackageDownloadLocation entries. They are not a lint
+# failure and not misspelled — reuse's own `dep5` converter writes exactly these
+# key names — they are simply write-only under the pinned version. Don't assume
+# the generated SBOM carries package identity until a later `reuse` reads them.
 SPDX-PackageName = "Anglesite"
 SPDX-PackageSupplier = "David W. Keith <me@dwk.io>"
 SPDX-PackageDownloadLocation = "https://github.com/Anglesite/Anglesite"


### PR DESCRIPTION
Closes #1467

## Summary

- Adds `LICENSES/ISC.txt` (canonical SPDX text, fetched with `reuse download ISC`) and a `REUSE.toml` declaring ISC + the project copyright for the whole tree, making the repo compliant with **REUSE specification 3.3**.
- This activates the `reuse-lint` CI lane from #1468/#1472, which has been skipping with a `::warning::` while `REUSE.toml` was absent — so this PR is the first one it lint-checks for real.
- One bulk `path = "**"` annotation instead of per-file SPDX headers, per #1318's "Alternatives considered": ~2,300 files × 2 header lines would be boilerplate to keep correct forever, and every newly added file would become a compliance trap. Bulk annotation makes coverage the default instead.
- Documents the one thing a contributor must actually do — vendoring third-party code needs its own `[[annotations]]` block — in `CONTRIBUTING.md` ▸ License and in `REUSE.toml`'s own comments.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Repo licensing metadata only. No MCP message-schema surface is touched, and nothing under `Resources/Template/` changes.

## Test plan

**Manual verification, explicitly standing in for an automated test.** Per the issue's own acceptance criteria this is a pure metadata/docs change with no testable code path — there is nothing to assert against in Swift or JS, and the check *is* the `reuse lint` invocation. `reuse` is not committed to the repo, so it runs via `uvx`, pinned to the exact spec the CI lane pins (`reuse[charset-normalizer]==6.2.0`).

- [x] **Before (on `main`'s tree — the failing state):** `reuse lint` → **exit 1**

  ```
  * Files with copyright information: 14 / 2330
  * Files with license information: 0 / 2330
  Unfortunately, your project is not compliant with version 3.3 of the REUSE Specification :-(
  ```

  (The 14 pre-existing "copyright" hits are all false positives — quoted upstream license texts inside `Resources/Attributions/*.json`, `scripts/attributions-overrides.json`, docs prose, and a test fixture. None is a real REUSE header; the repo had zero `SPDX-License-Identifier` tags before this PR.)

- [x] **After (this branch):** `uvx --from 'reuse[charset-normalizer]==6.2.0' reuse lint` → **exit 0**

  ```
  * Bad licenses: 0
  * Deprecated licenses: 0
  * Missing licenses: 0
  * Unused licenses: 0
  * Used licenses: ISC
  * Read errors: 0
  * Invalid SPDX License Expressions: 0
  * Files with copyright information: 2330 / 2330
  * Files with license information: 2330 / 2330

  Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
  ```

- [x] **`precedence = "override"` verified against its counterfactual.** Flipped the annotation to the default `"closest"` and re-linted to confirm the comment in `REUSE.toml` is accurate rather than merely plausible. Under `"closest"`, lint *still* exits 0 — but `reuse lint --json` credits `Resources/Attributions/app-binary.json` to **26 copyright holders**, starting with `Copyright (C) 2023 Marcin Krzyzanowski`, none of whom wrote that Anglesite-authored file. Under `"override"` the same file reports exactly one holder, `2026 David W. Keith`. So the setting is about the correctness of metadata an SBOM (`reuse spdx`) would emit, not about passing the lint — stated that way in both the commit message and the file comment so a future reader doesn't mistake it for a lint workaround.
- [x] `swift test` / `xcodebuild` **not run and not applicable** — no Swift, JS, template, or `project.yml` file is touched; the diff is two new root-level metadata files plus a `CONTRIBUTING.md` section. CI's own `changes` path filter will skip those lanes for the same reason, while `reuse-lint` runs unconditionally by design.

## Design notes

`LICENSES/ISC.txt` is the canonical SPDX template text, so it carries SPDX's own placeholder copyright lines (Internet Systems Consortium) rather than this project's. That is expected and standard for REUSE: the license file supplies the license *text*, while the copyright *holder* is declared by `SPDX-FileCopyrightText` in `REUSE.toml`. The root `LICENSE` is unchanged and remains the human-facing grant naming the real holder — worth a moment's attention in review, since two ISC texts with different wording sitting in one repo looks like an oversight until you know which one is doing which job. `CONTRIBUTING.md` now says so explicitly.

The other thing worth a reviewer's eye is the `"override"` trapdoor: it is the right default for a tree with no genuine per-file headers, but it means a vendored third-party file's real SPDX header would be silently replaced by the ISC default. That hazard is called out in `REUSE.toml`'s comment and in `CONTRIBUTING.md` rather than left implicit.

_Opened by the software factory (Phase C) — epic #1256._
