### PR TITLE
feat(#691): AI Search / NLWeb wizard (Slice 8)

### DIFF
--- a/Sources/AnglesiteApp/AISearchModel.swift
+++ b/Sources/AnglesiteApp/AISearchModel.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+import AnglesiteCore
+
+/// Drives the AI Search onboarding sheet: policy preflight → zone resolution → cost
+/// confirmation → provisioning. Mirrors `HardenModel` exactly — same `@MainActor @Observable`
+/// shape, same `apiToken()`/`cloudflareErrorMessage(_:)` helpers, same
+/// `inFlight: Task<Void, Never>?` cancellation pattern, and the same #1289-review fix of
+/// flipping `phase` out of its resting state synchronously (before the `Task` — and its
+/// `await apiToken()` hop — starts) so `isRunning` can never under-report while a token
+/// resolves or a second call races the first.
+@MainActor
+@Observable
+final class AISearchModel {
+    enum Phase: Equatable {
+        case idle
+        case resolvingZone(domain: String)
+        case blockedByPolicy(reason: String)
+        case awaitingCostConfirmation(domain: String, zoneID: String)
+        case provisioning(domain: String)
+        case succeeded(AISearchExecutor.ProvisionedResult)
+        case failed(reason: String)
+    }
+
+    private(set) var phase: Phase = .idle
+    var sheetPresented: Bool = false
+    var domainInput: String = ""
+
+    private let reader: any CloudflareReading
+    private let writer: any CloudflareWriting
+    private let provisioner: any AISearchProvisioning
+    private let keychain: any SecretStore
+    private var inFlight: Task<Void, Never>?
+
+    init(
+        reader: any CloudflareReading = HTTPCloudflareClient(),
+        writer: any CloudflareWriting = HTTPCloudflareClient(),
+        provisioner: any AISearchProvisioning = HTTPCloudflareClient(),
+        keychain: any SecretStore = KeychainStore()
+    ) {
+        self.reader = reader
+        self.writer = writer
+        self.provisioner = provisioner
+        self.keychain = keychain
+    }
+
+    var isRunning: Bool {
+        switch phase {
+        case .resolvingZone, .provisioning: return true
+        default: return false
+        }
+    }
+
+    func openSheet() {
+        guard !isRunning else { return }
+        phase = .idle
+        domainInput = ""
+        sheetPresented = true
+    }
+
+    func checkPolicyAndResolveZone(sourceDirectory: URL) {
+        let domain = domainInput.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !domain.isEmpty, !isRunning else { return }
+
+        // Flip out of `.idle` synchronously, before the Task (and its `await apiToken()` hop,
+        // which can now do a real OAuth-refresh network round trip) even starts — matching
+        // HardenModel.resolveAndPlan()'s #1289-review fix, so `isRunning` can't under-report
+        // while a token resolves.
+        phase = .resolvingZone(domain: domain)
+
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runCheckPolicyAndResolveZone(domain: domain, sourceDirectory: sourceDirectory)
+        }
+    }
+
+    func confirmCost() {
+        guard case .awaitingCostConfirmation(let domain, let zoneID) = phase else { return }
+
+        // Flip to `.provisioning` synchronously before the Task starts (see
+        // checkPolicyAndResolveZone()'s comment) — this also closes the double-click hole
+        // HardenModel.apply() used to have: a second confirmCost() call while the token was
+        // still resolving now sees phase already out of `.awaitingCostConfirmation` and no-ops.
+        phase = .provisioning(domain: domain)
+
+        inFlight?.cancel()
+        inFlight = Task { @MainActor [weak self] in
+            await self?.runProvision(domain: domain, zoneID: zoneID)
+        }
+    }
+
+    func dismissSheet() {
+        inFlight?.cancel()
+        inFlight = nil
+        sheetPresented = false
+        phase = .idle
+    }
+
+    // MARK: - Private
+
+    private func apiToken() async -> String? {
+        try? await CloudflareAPICredentials.resolve(secretStore: keychain)
+    }
+
+    private func runCheckPolicyAndResolveZone(domain: String, sourceDirectory: URL) async {
+        guard let token = await apiToken() else {
+            phase = .failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials.")
+            return
+        }
+
+        let policy: LicensingPolicy
+        do {
+            policy = try LicensingStore(sourceDirectory: sourceDirectory).load()
+        } catch {
+            phase = .failed(reason: "Couldn't read this site's AI usage policy: \(error.localizedDescription)")
+            return
+        }
+        if let reason = AISearchExecutor.policyBlockReason(for: policy) {
+            phase = .blockedByPolicy(reason: reason)
+            return
+        }
+
+        do {
+            guard let zoneID = try await reader.resolveZoneID(domain: domain, apiToken: token) else {
+                phase = .failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission.")
+                return
+            }
+            phase = .awaitingCostConfirmation(domain: domain, zoneID: zoneID)
+        } catch let error as CloudflareError {
+            phase = .failed(reason: cloudflareErrorMessage(error))
+        } catch {
+            phase = .failed(reason: "Failed to resolve zone: \(error.localizedDescription)")
+        }
+    }
+
+    private func runProvision(domain: String, zoneID: String) async {
+        guard let token = await apiToken() else {
+            phase = .failed(reason: "No Cloudflare API token found.")
+            return
+        }
+
+        let executor = AISearchExecutor(reader: reader, writer: writer, provisioner: provisioner)
+        do {
+            let result = try await executor.provision(zoneID: zoneID, domain: domain, apiToken: token)
+            phase = .succeeded(result)
+        } catch let error as CloudflareError {
+            phase = .failed(reason: cloudflareErrorMessage(error))
+        } catch {
+            phase = .failed(reason: "Failed to provision AI Search: \(error.localizedDescription)")
+        }
+    }
+
+    private func cloudflareErrorMessage(_ error: CloudflareError) -> String {
+        switch error {
+        case .unauthorized:
+            return "API token is unauthorized. Check that it has AI Search Edit permission for this account."
+        case .http(let status):
+            return "Cloudflare API returned HTTP \(status)."
+        case .api(let message):
+            return "Cloudflare API error: \(message)"
+        case .malformedResponse:
+            return "Unexpected response from Cloudflare API."
+        }
+    }
+}

--- a/Sources/AnglesiteApp/AISearchSheetView.swift
+++ b/Sources/AnglesiteApp/AISearchSheetView.swift
@@ -96,6 +96,9 @@ struct AISearchSheetView: View {
                 if result.wafSkipRuleAdded {
                     Text("A WAF rule was added so Bot Fight Mode doesn't block the AI Search crawler.")
                         .font(.callout).foregroundStyle(.secondary)
+                } else if let warning = result.wafSkipRuleWarning {
+                    Text(warning)
+                        .font(.callout).foregroundStyle(.orange)
                 }
                 Text("NLWeb enablement is still manual — finish setup in the Cloudflare dashboard:")
                 Link("Open AI Search instance settings", destination: result.dashboardURL)

--- a/Sources/AnglesiteApp/AISearchSheetView.swift
+++ b/Sources/AnglesiteApp/AISearchSheetView.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+import AnglesiteCore
+
+struct AISearchSheetView: View {
+    @Bindable var model: AISearchModel
+    let sourceDirectory: URL
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            footer
+        }
+        .frame(minWidth: 540, idealWidth: 620, minHeight: 380, idealHeight: 520)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            statusIcon
+            VStack(alignment: .leading, spacing: 1) {
+                Text(headerTitle).font(.headline)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch model.phase {
+        case .idle:
+            Image(systemName: "text.magnifyingglass").font(.title3)
+        case .resolvingZone, .provisioning:
+            ProgressView().controlSize(.small)
+        case .blockedByPolicy:
+            Image(systemName: "hand.raised.fill").foregroundStyle(.orange).font(.title3)
+        case .awaitingCostConfirmation:
+            Image(systemName: "dollarsign.circle").foregroundStyle(.blue).font(.title3)
+        case .succeeded:
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green).font(.title3)
+        case .failed:
+            Image(systemName: "xmark.circle.fill").foregroundStyle(.red).font(.title3)
+        }
+    }
+
+    private var headerTitle: String {
+        switch model.phase {
+        case .idle: return "Set Up AI Search"
+        case .resolvingZone(let domain): return "Checking \(domain)…"
+        case .blockedByPolicy: return "Blocked by AI usage policy"
+        case .awaitingCostConfirmation(let domain, _): return "Enable AI Search for \(domain)?"
+        case .provisioning(let domain): return "Provisioning AI Search for \(domain)…"
+        case .succeeded: return "AI Search instance created"
+        case .failed: return "AI Search setup failed"
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .idle:
+            Form {
+                TextField("Domain", text: $model.domainInput, prompt: Text("example.com"))
+                    .textContentType(.URL)
+            }
+            .padding()
+        case .resolvingZone, .provisioning:
+            ProgressView()
+        case .blockedByPolicy(let reason):
+            VStack(alignment: .leading, spacing: 8) {
+                Text(reason)
+                Text("Open Content Licensing settings to review this site's AI usage policy.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .padding()
+        case .awaitingCostConfirmation:
+            VStack(alignment: .leading, spacing: 8) {
+                Text("AI Search billing scales with reader traffic, unlike other Cloudflare features in this app.")
+                Text("Free during open beta: 100 instances, 20,000 queries/month, 500 crawled pages/day. Reader queries run on Cloudflare's AI models — beyond free limits, usage is billed by Cloudflare.")
+                    .font(.callout).foregroundStyle(.secondary)
+                Text("Your site's existing search (Pagefind) keeps working for free either way — AI Search's conversational answers are an opt-in upgrade above it, not a replacement.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .padding()
+        case .succeeded(let result):
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Instance \"\(result.instance.name)\" is provisioned.")
+                if result.wafSkipRuleAdded {
+                    Text("A WAF rule was added so Bot Fight Mode doesn't block the AI Search crawler.")
+                        .font(.callout).foregroundStyle(.secondary)
+                }
+                Text("NLWeb enablement is still manual — finish setup in the Cloudflare dashboard:")
+                Link("Open AI Search instance settings", destination: result.dashboardURL)
+                Text("In the dashboard: open this instance's Settings, locate \"NLWeb Worker\", and enable it.")
+                    .font(.callout).foregroundStyle(.secondary)
+            }
+            .padding()
+        case .failed(let reason):
+            Text(reason).foregroundStyle(.secondary).padding()
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            switch model.phase {
+            case .idle:
+                Button("Cancel") { model.dismissSheet() }
+                Button("Continue") { model.checkPolicyAndResolveZone(sourceDirectory: sourceDirectory) }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(model.domainInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            case .awaitingCostConfirmation:
+                Button("Cancel") { model.dismissSheet() }
+                Button("Enable AI Search") { model.confirmCost() }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            case .succeeded, .blockedByPolicy, .failed:
+                Button("Done") { model.dismissSheet() }
+                    .keyboardShortcut(.defaultAction)
+            case .resolvingZone, .provisioning:
+                Button("Cancel") { model.dismissSheet() }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -262,6 +262,9 @@
     "A BCP 47 language tag, e.g. \"en\", \"fr-CA\", \"es\". Screen readers and search engines use this to pronounce and index your content correctly." : {
 
     },
+    "A WAF rule was added so Bot Fight Mode doesn't block the AI Search crawler." : {
+
+    },
     "A custom token named “Anglesite” should be pre-filled with all permissions Anglesite uses. If it isn’t, add at least the “Edit Cloudflare Workers” template’s permissions so deploying works — Anglesite will ask again when a feature needs more access. Click **Continue to summary**." : {
 
     },
@@ -281,6 +284,15 @@
 
     },
     "AI Answers" : {
+
+    },
+    "AI Search" : {
+
+    },
+    "AI Search billing scales with reader traffic, unlike other Cloudflare features in this app." : {
+
+    },
+    "AI Search…" : {
 
     },
     "AI Training" : {
@@ -1512,6 +1524,9 @@
     "Enable & retry" : {
 
     },
+    "Enable AI Search" : {
+
+    },
     "Enable Onion Routing" : {
 
     },
@@ -1719,6 +1734,9 @@
     "Forward to Anglesite" : {
 
     },
+    "Free during open beta: 100 instances, 20,000 queries/month, 500 crawled pages/day. Reader queries run on Cloudflare's AI models — beyond free limits, usage is billed by Cloudflare." : {
+
+    },
     "From %@" : {
 
     },
@@ -1896,6 +1914,9 @@
     "Importing…" : {
 
     },
+    "In the dashboard: open this instance's Settings, locate \"NLWeb Worker\", and enable it." : {
+
+    },
     "Inactive — not used" : {
 
     },
@@ -1930,6 +1951,9 @@
 
     },
     "Installed" : {
+
+    },
+    "Instance \"%@\" is provisioned." : {
 
     },
     "Instance, e.g. lemmy.world" : {
@@ -2162,6 +2186,9 @@
 
     },
     "MyComponent" : {
+
+    },
+    "NLWeb enablement is still manual — finish setup in the Cloudflare dashboard:" : {
 
     },
     "Name" : {
@@ -2431,6 +2458,9 @@
     "Open %@ in its own window" : {
 
     },
+    "Open AI Search instance settings" : {
+
+    },
     "Open Bluesky Settings" : {
 
     },
@@ -2444,6 +2474,9 @@
 
     },
     "Open Community Anyway" : {
+
+    },
+    "Open Content Licensing settings to review this site's AI usage policy." : {
 
     },
     "Open Dashboard" : {
@@ -2702,6 +2735,9 @@
 
     },
     "Providers" : {
+
+    },
+    "Provision Cloudflare AI Search for this site" : {
 
     },
     "Publish" : {
@@ -3253,6 +3289,9 @@
 
     },
     "Setting" : {
+
+    },
+    "Setting Up AI Search…" : {
 
     },
     "Setting up…" : {
@@ -4017,6 +4056,9 @@
 
     },
     "Your site is live. Connect a domain?" : {
+
+    },
+    "Your site's existing search (Pagefind) keeps working for free either way — AI Search's conversational answers are an opt-in upgrade above it, not a replacement." : {
 
     },
     "Your website was created with warnings. You can open it anyway and fix it from the website window." : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -423,6 +423,23 @@ struct SiteWindow: View {
             }
             .defaultCustomization(.hidden)
 
+            ToolbarItem(id: SiteToolbarItemID.aiSearch.rawValue, placement: .primaryAction) {
+                Button {
+                    model.aiSearch.openSheet()
+                } label: {
+                    if model.aiSearch.isRunning {
+                        Label("Setting Up AI Search…", systemImage: "text.magnifyingglass")
+                    } else {
+                        Label("AI Search", systemImage: "text.magnifyingglass")
+                    }
+                }
+                .disabled(!model.canRunAISearch)
+                .help(site.isValid
+                      ? "Provision Cloudflare AI Search for this site"
+                      : "Site is missing required files")
+            }
+            .defaultCustomization(.hidden)
+
             ToolbarItem(id: SiteToolbarItemID.domainConfigAudit.rawValue, placement: .primaryAction) {
                 Button {
                     model.domainConfigAudit.openSheet()
@@ -679,6 +696,9 @@ struct SiteWindow: View {
         }
         .sheet(isPresented: $bindableModel.harden.sheetPresented) {
             HardenSheetView(model: model.harden)
+        }
+        .sheet(isPresented: $bindableModel.aiSearch.sheetPresented) {
+            AISearchSheetView(model: model.aiSearch, sourceDirectory: site.sourceDirectory)
         }
         .sheet(isPresented: $bindableModel.agentReadiness.sheetPresented) {
             AgentReadinessSheetView(model: model.agentReadiness)

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -182,6 +182,7 @@ final class SiteWindowModel {
     /// the owner to close and reopen the site.
     private(set) var isHostedCommunity = false
     var harden = HardenModel()
+    var aiSearch = AISearchModel()
     var domainConfigAudit = DomainConfigAuditModel()
     /// Cloudflare Agent Readiness score for the deployed site (#1248).
     var agentReadiness = AgentReadinessModel()
@@ -835,6 +836,7 @@ final class SiteWindowModel {
     var canRunBackup: Bool { site?.isValid == true && !siteOperationRunning }
     var canRunAudit: Bool { site?.isValid == true && !siteOperationRunning && preview.canDeploy }
     var canRunHarden: Bool { site?.isValid == true && !harden.isRunning }
+    var canRunAISearch: Bool { site?.isValid == true && !aiSearch.isRunning }
     var canRunDomainConfigAudit: Bool { site?.isValid == true && !domainConfigAudit.isRunning }
     var canRunAgentReadiness: Bool { site?.isValid == true && !agentReadiness.isRunning }
     var canRunOnionRouting: Bool { site?.isValid == true && !onionRouting.isRunning }

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -72,6 +72,9 @@ struct WebsiteCommands: Commands {
             Button("Harden…") { model?.harden.openSheet() }
                 .disabled(model?.canRunHarden != true)
 
+            Button("AI Search…") { model?.aiSearch.openSheet() }
+                .disabled(model?.canRunAISearch != true)
+
             Button("Agent Readiness…") { model?.agentReadiness.openSheet() }
                 .disabled(model?.canRunAgentReadiness != true)
 

--- a/Sources/AnglesiteCore/AISearchExecutor.swift
+++ b/Sources/AnglesiteCore/AISearchExecutor.swift
@@ -8,6 +8,10 @@ public struct AISearchExecutor: Sendable {
     public struct ProvisionedResult: Sendable, Equatable {
         public let instance: AISearchInstance
         public let wafSkipRuleAdded: Bool
+        /// User-facing warning when the WAF skip-rule step failed after the AI Search instance
+        /// was already created. `nil` when the rule was added cleanly (or wasn't needed because
+        /// Bot Fight Mode is off) — never set alongside `wafSkipRuleAdded == true`.
+        public let wafSkipRuleWarning: String?
         public let dashboardURL: URL
     }
 
@@ -29,37 +33,57 @@ public struct AISearchExecutor: Sendable {
 
     public func provision(zoneID: String, domain: String, apiToken: String) async throws -> ProvisionedResult {
         let namespace = Self.namespaceID(for: domain)
+        // Instance creation errors propagate as-is: nothing has been provisioned yet, so there's
+        // no partial state to degrade gracefully from.
         let instance = try await provisioner.createAISearchInstance(domain: domain, instanceID: namespace, apiToken: apiToken)
 
-        let state = try await reader.zoneState(zoneID: zoneID, domain: domain, apiToken: apiToken)
+        // From here on, the AI Search instance already exists. HardenPlanner's curated WAF rule
+        // set is exactly 5 rules — the free-plan quota — so a hardened free-plan zone predictably
+        // fails this POST with a quota error. Throwing here would strand the just-created
+        // instance (crawler still blocked by Bot Fight Mode) with no way for the caller to know
+        // it half-succeeded, so zone-state read and WAF-rule write failures degrade to a warning
+        // on an otherwise-successful result instead of throwing.
         var wafAdded = false
-        if state.botFightMode {
-            try await writer.createWAFCustomRule(
-                zoneID: zoneID,
-                rule: WAFRulePayload(
-                    description: "Anglesite: allow Cloudflare AI Search crawler",
-                    // Matches by verified-bot detection ID, not user-agent string — corrected
-                    // 2026-08-06 against Cloudflare's own dashboard skip-rule guidance
-                    // (developers.cloudflare.com/ai-search/configuration/data-source/website/),
-                    // which identifies this crawler as Bot Detection ID 122933950. `any(...)`
-                    // rather than a fixed `[0]` index: `detection_ids` can hold more than one
-                    // entry, and a positional index would silently stop matching on any request
-                    // where this crawler's ID isn't first — a false negative the happy path
-                    // wouldn't catch in testing. Verify this exact field/operator syntax
-                    // (including the any()-vs-index question) against a live dashboard-created
-                    // rule (or a GET of one) before merging — inferred from docs prose, not a
-                    // confirmed live response.
-                    expression: "(any(cf.bot_management.detection_ids[*] eq 122933950))",
-                    action: "skip",
-                    actionParameters: .init(products: ["botFight"])),
-                apiToken: apiToken)
-            wafAdded = true
+        var wafWarning: String?
+        do {
+            let state = try await reader.zoneState(zoneID: zoneID, domain: domain, apiToken: apiToken)
+            if state.botFightMode {
+                try await writer.createWAFCustomRule(
+                    zoneID: zoneID,
+                    rule: WAFRulePayload(
+                        description: "Anglesite: allow Cloudflare AI Search crawler",
+                        // Matches by verified-bot detection ID, not user-agent string — corrected
+                        // 2026-08-06 against Cloudflare's own dashboard skip-rule guidance
+                        // (developers.cloudflare.com/ai-search/configuration/data-source/website/),
+                        // which identifies this crawler as Bot Detection ID 122933950. `any(...)`
+                        // rather than a fixed `[0]` index: `detection_ids` can hold more than one
+                        // entry, and a positional index would silently stop matching on any request
+                        // where this crawler's ID isn't first — a false negative the happy path
+                        // wouldn't catch in testing. Verify this exact field/operator syntax
+                        // (including the any()-vs-index question) against a live dashboard-created
+                        // rule (or a GET of one) before merging — inferred from docs prose, not a
+                        // confirmed live response.
+                        //
+                        // `createWAFCustomRule` always appends this rule to the end of the
+                        // ruleset, but Cloudflare's dashboard guidance orders the skip rule
+                        // *first*. Harmless today — none of HardenPlanner's curated rules match
+                        // crawler traffic — but if a future curated rule ever does, an earlier
+                        // block/challenge rule would fire before this skip rule is reached,
+                        // silently defeating it.
+                        expression: "(any(cf.bot_management.detection_ids[*] eq 122933950))",
+                        action: "skip",
+                        actionParameters: .init(products: ["botFight"])),
+                    apiToken: apiToken)
+                wafAdded = true
+            }
+        } catch {
+            wafWarning = "Couldn't add the WAF skip rule — Bot Fight Mode may block the AI Search crawler. Add a skip rule for it in the Cloudflare dashboard."
         }
 
         // Best-effort deep link — Cloudflare's dashboard URL scheme for an AI Search instance's
         // Settings page; re-verify at implementation time since this is a preview product.
         let dashboardURL = URL(string: "https://dash.cloudflare.com/?to=/:account/ai-search/\(namespace)/settings")!
-        return ProvisionedResult(instance: instance, wafSkipRuleAdded: wafAdded, dashboardURL: dashboardURL)
+        return ProvisionedResult(instance: instance, wafSkipRuleAdded: wafAdded, wafSkipRuleWarning: wafWarning, dashboardURL: dashboardURL)
     }
 
     static func namespaceID(for domain: String) -> String {

--- a/Sources/AnglesiteCore/AISearchExecutor.swift
+++ b/Sources/AnglesiteCore/AISearchExecutor.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Orchestrates provisioning a Cloudflare AI Search instance for a site: a policy preflight
+/// (pure, callable before any network I/O), then provisioning plus a conditional WAF skip rule.
+/// Deliberately standalone rather than routed through `HardenPlanner`/`HardenExecutor` — see
+/// this plan's Global Constraints.
+public struct AISearchExecutor: Sendable {
+    public struct ProvisionedResult: Sendable, Equatable {
+        public let instance: AISearchInstance
+        public let wafSkipRuleAdded: Bool
+        public let dashboardURL: URL
+    }
+
+    private let reader: any CloudflareReading
+    private let writer: any CloudflareWriting
+    private let provisioner: any AISearchProvisioning
+
+    public init(reader: any CloudflareReading, writer: any CloudflareWriting, provisioner: any AISearchProvisioning) {
+        self.reader = reader
+        self.writer = writer
+        self.provisioner = provisioner
+    }
+
+    /// `nil` when the site's AI usage policy doesn't object; a user-facing explanation otherwise.
+    public static func policyBlockReason(for policy: LicensingPolicy) -> String? {
+        guard policy.usage.aiInput == .no else { return nil }
+        return "This site's AI usage policy currently says no to AI input. Update it in Content Licensing settings before enabling AI Search."
+    }
+
+    public func provision(zoneID: String, domain: String, apiToken: String) async throws -> ProvisionedResult {
+        let namespace = Self.namespaceID(for: domain)
+        let instance = try await provisioner.createAISearchInstance(domain: domain, instanceID: namespace, apiToken: apiToken)
+
+        let state = try await reader.zoneState(zoneID: zoneID, domain: domain, apiToken: apiToken)
+        var wafAdded = false
+        if state.botFightMode {
+            try await writer.createWAFCustomRule(
+                zoneID: zoneID,
+                rule: WAFRulePayload(
+                    description: "Anglesite: allow Cloudflare AI Search crawler",
+                    // Matches by verified-bot detection ID, not user-agent string — corrected
+                    // 2026-08-06 against Cloudflare's own dashboard skip-rule guidance
+                    // (developers.cloudflare.com/ai-search/configuration/data-source/website/),
+                    // which identifies this crawler as Bot Detection ID 122933950. `any(...)`
+                    // rather than a fixed `[0]` index: `detection_ids` can hold more than one
+                    // entry, and a positional index would silently stop matching on any request
+                    // where this crawler's ID isn't first — a false negative the happy path
+                    // wouldn't catch in testing. Verify this exact field/operator syntax
+                    // (including the any()-vs-index question) against a live dashboard-created
+                    // rule (or a GET of one) before merging — inferred from docs prose, not a
+                    // confirmed live response.
+                    expression: "(any(cf.bot_management.detection_ids[*] eq 122933950))",
+                    action: "skip",
+                    actionParameters: .init(products: ["botFight"])),
+                apiToken: apiToken)
+            wafAdded = true
+        }
+
+        // Best-effort deep link — Cloudflare's dashboard URL scheme for an AI Search instance's
+        // Settings page; re-verify at implementation time since this is a preview product.
+        let dashboardURL = URL(string: "https://dash.cloudflare.com/?to=/:account/ai-search/\(namespace)/settings")!
+        return ProvisionedResult(instance: instance, wafSkipRuleAdded: wafAdded, dashboardURL: dashboardURL)
+    }
+
+    static func namespaceID(for domain: String) -> String {
+        domain.lowercased().replacingOccurrences(of: ".", with: "-")
+    }
+}

--- a/Sources/AnglesiteCore/AISearchProvisioning.swift
+++ b/Sources/AnglesiteCore/AISearchProvisioning.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// A provisioned Cloudflare AI Search instance.
+public struct AISearchInstance: Sendable, Equatable {
+    public let id: String
+    public let name: String
+
+    public init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+/// Provisions Cloudflare AI Search instances. Kept separate from `CloudflareWriting` — that
+/// protocol has five conformers across the test suite, and this is the only feature that needs
+/// this call.
+public protocol AISearchProvisioning: Sendable {
+    /// Creates an AI Search instance backed by a website crawler for `domain`, resolving the
+    /// caller's Cloudflare account internally (mirrors `attachWorkersCustomDomain`'s pattern).
+    func createAISearchInstance(domain: String, instanceID: String, apiToken: String) async throws -> AISearchInstance
+}

--- a/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
+++ b/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
@@ -42,6 +42,9 @@ public enum AnglesiteTokenTemplate {
         ("email_routing_addresses", "edit"),
         ("zaraz", "edit"),
         ("registrar", "edit"),
+        // Best-guess key pending live verification (same degrade-gracefully caveat as
+        // `response_compression`/`page_shield` above) — Cloudflare's dashboard doesn't document
+        // an AI Search permission-group key yet; confirm against a live token-creation form.
         ("ai_search", "edit"),
     ]
 

--- a/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
+++ b/Sources/AnglesiteCore/AnglesiteTokenTemplate.swift
@@ -42,6 +42,7 @@ public enum AnglesiteTokenTemplate {
         ("email_routing_addresses", "edit"),
         ("zaraz", "edit"),
         ("registrar", "edit"),
+        ("ai_search", "edit"),
     ]
 
     /// The OAuth `scope` string covering every permission group above. Cloudflare's self-managed

--- a/Sources/AnglesiteCore/CloudflareWriting.swift
+++ b/Sources/AnglesiteCore/CloudflareWriting.swift
@@ -92,6 +92,7 @@ public struct WAFRulePayload: Sendable, Equatable, Encodable {
     /// What the rule does on match — a Cloudflare action name such as `block` or
     /// `managed_challenge`, passed through verbatim.
     public let action: String
+    /// Parameters for `action`; only meaningful for `action: "skip"` — see ``ActionParameters``.
     public let actionParameters: ActionParameters?
 
     /// Says which product(s) an `action: "skip"` rule skips — Cloudflare requires this for a skip

--- a/Sources/AnglesiteCore/CloudflareWriting.swift
+++ b/Sources/AnglesiteCore/CloudflareWriting.swift
@@ -92,12 +92,29 @@ public struct WAFRulePayload: Sendable, Equatable, Encodable {
     /// What the rule does on match — a Cloudflare action name such as `block` or
     /// `managed_challenge`, passed through verbatim.
     public let action: String
+    public let actionParameters: ActionParameters?
+
+    /// Says which product(s) an `action: "skip"` rule skips — Cloudflare requires this for a skip
+    /// rule to do anything; a bare `action: "skip"` with no parameters skips nothing.
+    public struct ActionParameters: Sendable, Equatable, Encodable {
+        public let products: [String]
+
+        public init(products: [String]) {
+            self.products = products
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case description, expression, action
+        case actionParameters = "action_parameters"
+    }
 
     /// Memberwise initializer; the hardening planner builds these from its canned rule templates.
-    public init(description: String, expression: String, action: String) {
+    public init(description: String, expression: String, action: String, actionParameters: ActionParameters? = nil) {
         self.description = description
         self.expression = expression
         self.action = action
+        self.actionParameters = actionParameters
     }
 }
 

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -94,6 +94,7 @@ private struct CFRegistrarRegistrationState: Decodable, Sendable {
 }
 private struct CFWorkerScript: Decodable, Sendable { let id: String }
 private struct CFWorkerDomain: Decodable, Sendable { let hostname: String; let service: String }
+private struct CFAISearchInstance: Decodable, Sendable { let id: String; let name: String? }
 
 /// URL Scanner `POST .../urlscanner/v2/scan` response — a flat object, unlike the rest of this
 /// file's v4 endpoints: no `{success, result, errors}` envelope (confirmed against the live API
@@ -907,5 +908,35 @@ extension HTTPCloudflareClient: AgentReadinessScanning {
         return AgentReadinessReport(
             level: raw.level, levelName: raw.levelName, categories: categories,
             nextLevel: raw.nextLevel.map { AgentReadinessReport.NextLevel(name: $0.name, target: $0.target) })
+    }
+}
+
+// MARK: - AISearchProvisioning conformance
+
+extension HTTPCloudflareClient: AISearchProvisioning {
+    /// `POST /accounts/{id}/ai-search/instances`, creating a web-crawler-backed AI Search
+    /// instance for `domain`. Resolves the account first via `resolveAccountID` (the Registrar
+    /// conformance above, same file so its `private` scope still applies) and reuses `post` for
+    /// the request/response handling, same as `checkDomainAvailability`.
+    ///
+    /// Flat shape, no `namespaces` segment — follows developers.cloudflare.com/ai-search/
+    /// get-started/api/'s verbatim curl examples. Cloudflare's auto-generated API reference
+    /// disagrees (documents a namespaced /namespaces/{name}/instances path instead) — see
+    /// Global Constraints. CONFIRM WHICH SHAPE THE LIVE API ACTUALLY ACCEPTS before trusting
+    /// this code sample; don't just re-read either doc page again.
+    public func createAISearchInstance(
+        domain: String, instanceID: String, apiToken: String
+    ) async throws -> AISearchInstance {
+        let accountID = try await resolveAccountID(apiToken: apiToken)
+        struct CreateBody: Encodable, Sendable {
+            let id: String
+            let type: String
+            let source: String
+        }
+        let result = try await post(
+            "/accounts/\(accountID)/ai-search/instances",
+            body: CreateBody(id: instanceID, type: "web-crawler", source: domain),
+            apiToken: apiToken, as: CFAISearchInstance.self)
+        return AISearchInstance(id: result.id, name: result.name ?? instanceID)
     }
 }

--- a/Sources/AnglesiteCore/SiteToolbarItemID.swift
+++ b/Sources/AnglesiteCore/SiteToolbarItemID.swift
@@ -20,6 +20,7 @@ public enum SiteToolbarItemID: String, CaseIterable, Sendable {
     /// Cloudflare Agent Readiness score for the deployed site (#1248).
     case agentReadiness
     case onionRouting
+    case aiSearch
     case domain
     case integration
     case siriReadiness

--- a/Tests/AnglesiteAppTests/AISearchModelTests.swift
+++ b/Tests/AnglesiteAppTests/AISearchModelTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+private final class StubReader: CloudflareReading, @unchecked Sendable {
+    private let zoneID: String?
+    private let state: CloudflareZoneState
+    init(zoneID: String? = "z1", state: CloudflareZoneState = StubReader.defaultState) {
+        self.zoneID = zoneID
+        self.state = state
+    }
+    static let defaultState = CloudflareZoneState(
+        dnssecActive: false, sslMode: "flexible", alwaysUseHTTPS: false, hsts: nil,
+        caaRecords: [], mxRecords: [], spfRecords: [], dmarcRecords: [])
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String? { zoneID }
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState { state }
+    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] { [] }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
+}
+
+private final class StubWriter: CloudflareWriting, @unchecked Sendable {
+    func enableDNSSEC(zoneID: String, apiToken: String) async throws {}
+    func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool, apiToken: String) async throws {}
+    func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws {}
+    func deleteDNSRecord(zoneID: String, recordID: String, apiToken: String) async throws {}
+    func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {}
+    func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
+    func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func attachWorkersCustomDomain(hostname: String, workerScriptName: String, apiToken: String) async throws -> CustomDomainAttachResult { .attached }
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
+}
+
+private final class StubProvisioner: AISearchProvisioning, @unchecked Sendable {
+    func createAISearchInstance(domain: String, instanceID: String, apiToken: String) async throws -> AISearchInstance {
+        AISearchInstance(id: "inst1", name: instanceID)
+    }
+}
+
+@Suite(.serialized)
+struct AISearchModelTests {
+    /// Per-instance scratch service, matching `HardenModelTests`' rationale: every test here
+    /// claims `CLOUDFLARE_API_TOKEN` via `CloudflareAPITokenTestEnvironment`, so a fallback to
+    /// the real keychain should never happen, but a scratch service keeps
+    /// `CloudflareAPICredentials.resolve()`'s legacy-token read from touching the developer's
+    /// actual login keychain if it ever does.
+    private let keychain = KeychainStore(service: "io.dwk.anglesite.tests.aiSearchModel." + UUID().uuidString)
+
+    private func tempSourceDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @MainActor
+    @Test("checkPolicyAndResolveZone ignores blank domain input")
+    func ignoresBlankDomain() throws {
+        let model = AISearchModel(reader: StubReader(), writer: StubWriter(), provisioner: StubProvisioner(), keychain: keychain)
+        model.domainInput = "   "
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        #expect(model.phase == .idle)
+    }
+
+    @MainActor
+    @Test("checkPolicyAndResolveZone reaches awaitingCostConfirmation when no licensing.json exists")
+    func noPolicyFilePassesThrough() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let model = AISearchModel(reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(), keychain: keychain)
+        model.domainInput = "Example.com"
+
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        // Regression coverage mirroring HardenModelTests: phase must flip out of `.idle`
+        // synchronously, before the Task's `await apiToken()` hop even starts, so `isRunning`
+        // can't under-report while a token resolves.
+        #expect(model.isRunning)
+        while model.isRunning { await Task.yield() }
+
+        #expect(model.phase == .awaitingCostConfirmation(domain: "example.com", zoneID: "z1"))
+    }
+
+    @MainActor
+    @Test("checkPolicyAndResolveZone blocks when licensing.json says aiInput = no")
+    func policyBlocks() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let dir = try tempSourceDirectory()
+        var policy = LicensingPolicy()
+        policy.usage.aiInput = .no
+        try LicensingStore(sourceDirectory: dir).save(policy)
+
+        let model = AISearchModel(reader: StubReader(), writer: StubWriter(), provisioner: StubProvisioner(), keychain: keychain)
+        model.domainInput = "example.com"
+        model.checkPolicyAndResolveZone(sourceDirectory: dir)
+        while model.isRunning { await Task.yield() }
+
+        guard case .blockedByPolicy = model.phase else {
+            Issue.record("expected .blockedByPolicy, got \(model.phase)")
+            return
+        }
+    }
+
+    @MainActor
+    @Test("confirmCost provisions and reaches succeeded")
+    func confirmCostProvisions() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let model = AISearchModel(reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(), keychain: keychain)
+        model.domainInput = "example.com"
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        while model.isRunning { await Task.yield() }
+
+        model.confirmCost()
+        #expect(model.isRunning)
+        while model.isRunning { await Task.yield() }
+
+        guard case .succeeded(let result) = model.phase else {
+            Issue.record("expected .succeeded, got \(model.phase)")
+            return
+        }
+        #expect(result.instance.id == "inst1")
+    }
+}

--- a/Tests/AnglesiteCoreTests/AISearchExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/AISearchExecutorTests.swift
@@ -26,13 +26,17 @@ private final class StubReader: CloudflareReading, @unchecked Sendable {
 
 private final class StubWriter: CloudflareWriting, @unchecked Sendable {
     private(set) var createdRules: [WAFRulePayload] = []
+    var errorToThrow: CloudflareError?
     func enableDNSSEC(zoneID: String, apiToken: String) async throws {}
     func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws {}
     func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool, apiToken: String) async throws {}
     func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws {}
     func deleteDNSRecord(zoneID: String, recordID: String, apiToken: String) async throws {}
     func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {}
-    func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws { createdRules.append(rule) }
+    func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws {
+        if let errorToThrow { throw errorToThrow }
+        createdRules.append(rule)
+    }
     func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {}
     func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {}
     func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
@@ -40,6 +44,15 @@ private final class StubWriter: CloudflareWriting, @unchecked Sendable {
     func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {}
     func attachWorkersCustomDomain(hostname: String, workerScriptName: String, apiToken: String) async throws -> CustomDomainAttachResult { .attached }
     func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
+}
+
+private final class FailingReader: CloudflareReading, @unchecked Sendable {
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String? { "z1" }
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState {
+        throw CloudflareError.http(status: 500)
+    }
+    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] { [] }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
 }
 
 private func zoneState(botFightMode: Bool) -> CloudflareZoneState {
@@ -74,6 +87,7 @@ struct AISearchExecutorTests {
         let executor = AISearchExecutor(reader: StubReader(state: zoneState(botFightMode: true)), writer: writer, provisioner: StubProvisioner())
         let result = try await executor.provision(zoneID: "z1", domain: "Example.com", apiToken: "t")
         #expect(result.wafSkipRuleAdded == true)
+        #expect(result.wafSkipRuleWarning == nil)
         #expect(writer.createdRules.count == 1)
         #expect(writer.createdRules.first?.action == "skip")
         #expect(writer.createdRules.first?.actionParameters?.products == ["botFight"])
@@ -85,7 +99,30 @@ struct AISearchExecutorTests {
         let executor = AISearchExecutor(reader: StubReader(state: zoneState(botFightMode: false)), writer: writer, provisioner: StubProvisioner())
         let result = try await executor.provision(zoneID: "z1", domain: "example.com", apiToken: "t")
         #expect(result.wafSkipRuleAdded == false)
+        #expect(result.wafSkipRuleWarning == nil)
         #expect(writer.createdRules.isEmpty)
+    }
+
+    @Test("provision degrades to a warning when the WAF skip-rule write fails")
+    func provisionDegradesGracefullyWhenWAFRuleWriteFails() async throws {
+        let writer = StubWriter()
+        writer.errorToThrow = .http(status: 429) // e.g. free-plan 5-rule quota exceeded
+        let executor = AISearchExecutor(reader: StubReader(state: zoneState(botFightMode: true)), writer: writer, provisioner: StubProvisioner())
+        let result = try await executor.provision(zoneID: "z1", domain: "example.com", apiToken: "t")
+        #expect(result.wafSkipRuleAdded == false)
+        #expect(result.wafSkipRuleWarning != nil)
+        #expect(writer.createdRules.isEmpty)
+        // The instance itself must still be reported as provisioned — the caller shouldn't see
+        // a thrown error for a step that happened after the instance already existed.
+        #expect(result.instance.id == "inst1")
+    }
+
+    @Test("provision degrades to a warning when the zone-state read fails")
+    func provisionDegradesGracefullyWhenZoneStateReadFails() async throws {
+        let executor = AISearchExecutor(reader: FailingReader(), writer: StubWriter(), provisioner: StubProvisioner())
+        let result = try await executor.provision(zoneID: "z1", domain: "example.com", apiToken: "t")
+        #expect(result.wafSkipRuleAdded == false)
+        #expect(result.wafSkipRuleWarning != nil)
     }
 
     @Test("provision derives the instance namespace from the lowercased, dot-free domain")

--- a/Tests/AnglesiteCoreTests/AISearchExecutorTests.swift
+++ b/Tests/AnglesiteCoreTests/AISearchExecutorTests.swift
@@ -1,0 +1,108 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+private final class StubProvisioner: AISearchProvisioning, @unchecked Sendable {
+    private(set) var lastDomain: String?
+    private(set) var lastInstanceID: String?
+    var errorToThrow: CloudflareError?
+
+    func createAISearchInstance(domain: String, instanceID: String, apiToken: String) async throws -> AISearchInstance {
+        if let errorToThrow { throw errorToThrow }
+        lastDomain = domain
+        lastInstanceID = instanceID
+        return AISearchInstance(id: "inst1", name: instanceID)
+    }
+}
+
+private final class StubReader: CloudflareReading, @unchecked Sendable {
+    private let state: CloudflareZoneState
+    init(state: CloudflareZoneState) { self.state = state }
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String? { "z1" }
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState { state }
+    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] { [] }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
+}
+
+private final class StubWriter: CloudflareWriting, @unchecked Sendable {
+    private(set) var createdRules: [WAFRulePayload] = []
+    func enableDNSSEC(zoneID: String, apiToken: String) async throws {}
+    func setAlwaysUseHTTPS(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setHSTS(zoneID: String, maxAge: Int, includeSubdomains: Bool, preload: Bool, apiToken: String) async throws {}
+    func addDNSRecord(zoneID: String, record: DNSRecordPayload, apiToken: String) async throws {}
+    func deleteDNSRecord(zoneID: String, recordID: String, apiToken: String) async throws {}
+    func setBotFightMode(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func createWAFCustomRule(zoneID: String, rule: WAFRulePayload, apiToken: String) async throws { createdRules.append(rule) }
+    func setSpeedBrain(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func setECH(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func enableZstandardCompression(zoneID: String, apiToken: String) async throws {}
+    func setPageShield(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func enableOnionRouting(zoneID: String, enabled: Bool, apiToken: String) async throws {}
+    func attachWorkersCustomDomain(hostname: String, workerScriptName: String, apiToken: String) async throws -> CustomDomainAttachResult { .attached }
+    func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
+}
+
+private func zoneState(botFightMode: Bool) -> CloudflareZoneState {
+    CloudflareZoneState(
+        dnssecActive: true, sslMode: "strict", alwaysUseHTTPS: true, hsts: nil,
+        caaRecords: [], mxRecords: [], spfRecords: [], dmarcRecords: [], botFightMode: botFightMode)
+}
+
+struct AISearchExecutorTests {
+    @Test("policyBlockReason is nil when aiInput is unset")
+    func policyAllowsUnset() {
+        #expect(AISearchExecutor.policyBlockReason(for: LicensingPolicy()) == nil)
+    }
+
+    @Test("policyBlockReason is nil when aiInput is yes")
+    func policyAllowsYes() {
+        var policy = LicensingPolicy()
+        policy.usage.aiInput = .yes
+        #expect(AISearchExecutor.policyBlockReason(for: policy) == nil)
+    }
+
+    @Test("policyBlockReason is non-nil when aiInput is no")
+    func policyBlocksNo() {
+        var policy = LicensingPolicy()
+        policy.usage.aiInput = .no
+        #expect(AISearchExecutor.policyBlockReason(for: policy) != nil)
+    }
+
+    @Test("provision adds a WAF skip rule when Bot Fight Mode is on")
+    func provisionAddsWAFRuleWhenBotFightModeOn() async throws {
+        let writer = StubWriter()
+        let executor = AISearchExecutor(reader: StubReader(state: zoneState(botFightMode: true)), writer: writer, provisioner: StubProvisioner())
+        let result = try await executor.provision(zoneID: "z1", domain: "Example.com", apiToken: "t")
+        #expect(result.wafSkipRuleAdded == true)
+        #expect(writer.createdRules.count == 1)
+        #expect(writer.createdRules.first?.action == "skip")
+        #expect(writer.createdRules.first?.actionParameters?.products == ["botFight"])
+    }
+
+    @Test("provision skips the WAF rule when Bot Fight Mode is off")
+    func provisionSkipsWAFRuleWhenBotFightModeOff() async throws {
+        let writer = StubWriter()
+        let executor = AISearchExecutor(reader: StubReader(state: zoneState(botFightMode: false)), writer: writer, provisioner: StubProvisioner())
+        let result = try await executor.provision(zoneID: "z1", domain: "example.com", apiToken: "t")
+        #expect(result.wafSkipRuleAdded == false)
+        #expect(writer.createdRules.isEmpty)
+    }
+
+    @Test("provision derives the instance namespace from the lowercased, dot-free domain")
+    func provisionDerivesNamespace() async throws {
+        let provisioner = StubProvisioner()
+        let executor = AISearchExecutor(reader: StubReader(state: zoneState(botFightMode: false)), writer: StubWriter(), provisioner: provisioner)
+        _ = try await executor.provision(zoneID: "z1", domain: "Example.com", apiToken: "t")
+        #expect(provisioner.lastInstanceID == "example-com")
+    }
+
+    @Test("provision surfaces the provisioner's thrown error")
+    func provisionPropagatesProvisionerError() async throws {
+        let provisioner = StubProvisioner()
+        provisioner.errorToThrow = .unauthorized
+        let executor = AISearchExecutor(reader: StubReader(state: zoneState(botFightMode: false)), writer: StubWriter(), provisioner: provisioner)
+        await #expect(throws: CloudflareError.unauthorized) {
+            try await executor.provision(zoneID: "z1", domain: "example.com", apiToken: "t")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
+++ b/Tests/AnglesiteCoreTests/AnglesiteTokenTemplateTests.swift
@@ -16,7 +16,7 @@ struct AnglesiteTokenTemplateTests {
         let keys = Set(AnglesiteTokenTemplate.permissionGroups.map(\.key))
         for needed in ["d1", "zone_settings", "dns", "zone_waf", "response_compression",
                        "challenge_widgets", "email_routing_rules", "email_routing_addresses",
-                       "zaraz", "page_shield", "analytics", "registrar"] {
+                       "zaraz", "page_shield", "analytics", "registrar", "ai_search"] {
             #expect(keys.contains(needed), "missing permission group: \(needed)")
         }
     }

--- a/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
+++ b/Tests/AnglesiteCoreTests/CloudflareWritingTests.swift
@@ -83,6 +83,33 @@ struct CloudflareWritingTests {
         #expect(!postReqs.isEmpty)
     }
 
+    @Test("createWAFCustomRule encodes action_parameters.products when provided")
+    func createWAFCustomRuleWithActionParameters() async throws {
+        let spy = TransportSpy()
+        // No existing ruleset — forces the code to create a new one with rules: [...]
+        let rulesetJSON = """
+        {"success":true,"errors":[],"messages":[],"result":[]}
+        """
+        let client = HTTPCloudflareClient(transport: spyTransport(["/rulesets": (200, rulesetJSON)], spy: spy))
+        let rule = WAFRulePayload(
+            description: "Allow AI Search crawler", expression: "(x)", action: "skip",
+            actionParameters: .init(products: ["botFight"]))
+        try await client.createWAFCustomRule(zoneID: zoneID, rule: rule, apiToken: token)
+        let postReqs = spy.requests.filter { $0.httpMethod == "POST" }
+        let body = try #require(postReqs.last?.httpBody.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        let rules = try #require(body["rules"] as? [[String: Any]])
+        let actionParams = try #require(rules.first?["action_parameters"] as? [String: Any])
+        #expect(actionParams["products"] as? [String] == ["botFight"])
+    }
+
+    @Test("WAFRulePayload omits action_parameters from encoded JSON when nil")
+    func wafRulePayloadOmitsNilActionParameters() throws {
+        let rule = WAFRulePayload(description: "Block dotfiles", expression: "(x)", action: "block")
+        let data = try JSONEncoder().encode(rule)
+        let obj = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(obj["action_parameters"] == nil)
+    }
+
     @Test("write methods include Authorization header")
     func authorizationHeader() async throws {
         let spy = TransportSpy()

--- a/Tests/AnglesiteCoreTests/HTTPCloudflareClientAISearchTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPCloudflareClientAISearchTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+struct HTTPCloudflareClientAISearchTests {
+    @Test("createAISearchInstance resolves the account then POSTs id/type/source to the instances endpoint")
+    func createsInstance() async throws {
+        let spy = TransportSpy()
+        let accountsJSON = #"{"success":true,"errors":[],"result":[{"id":"acct1"}]}"#
+        let createJSON = #"{"success":true,"errors":[],"result":{"id":"example-com"}}"#
+        let client = HTTPCloudflareClient(transport: spyTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/ai-search/instances": (200, createJSON),
+        ], spy: spy))
+
+        let instance = try await client.createAISearchInstance(
+            domain: "example.com", instanceID: "example-com", apiToken: "test-token")
+
+        #expect(instance.id == "example-com")
+        #expect(instance.name == "example-com")
+        let postReq = try #require(spy.requests.first { $0.httpMethod == "POST" })
+        #expect(postReq.url?.path.hasSuffix("/accounts/acct1/ai-search/instances") == true)
+        let body = try #require(postReq.httpBody.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        #expect(body["id"] as? String == "example-com")
+        #expect(body["type"] as? String == "web-crawler")
+        #expect(body["source"] as? String == "example.com")
+    }
+
+    @Test("createAISearchInstance surfaces .unauthorized on a 403")
+    func createInstanceUnauthorized() async throws {
+        let accountsJSON = #"{"success":true,"errors":[],"result":[{"id":"acct1"}]}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/ai-search/instances": (403, #"{"success":false,"errors":[{"message":"missing scope"}]}"#),
+        ]))
+        await #expect(throws: CloudflareError.unauthorized) {
+            try await client.createAISearchInstance(domain: "example.com", instanceID: "example-com", apiToken: "t")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteToolbarItemIDTests.swift
@@ -17,6 +17,7 @@ struct SiteToolbarItemIDTests {
             "domainConfigAudit",
             "agentReadiness",
             "onionRouting",
+            "aiSearch",
             "domain",
             "integration",
             "siriReadiness",


### PR DESCRIPTION
Closes #691

## Summary

- Adds an **AI Search** wizard (Slice 8 of the [Cloudflare free-services design](docs/superpowers/specs/2026-07-04-cloudflare-free-services-integration-design.md), implementing [`docs/superpowers/plans/2026-07-30-ai-search-nlweb.md`](docs/superpowers/plans/2026-07-30-ai-search-nlweb.md)): crawler-policy preflight (hard-blocks when `licensing.json` says `aiInput: "no"`), an at-cost/external-model disclosure with Pagefind-keeps-working copy, REST provisioning of the AI Search instance, an in-wizard Bot Fight Mode decision (consequences-phrased: turn it off so the crawler can index, or keep it on) when Bot Fight Mode is on, and a dashboard handoff for the still-manual, still-preview NLWeb Worker enablement.
- New in `AnglesiteCore`: `WAFRulePayload.actionParameters` (skip rules need `action_parameters.products`), a narrow `AISearchProvisioning` protocol + `HTTPCloudflareClient` conformance (kept off `CloudflareWriting` to avoid breaking its five test conformers), `AISearchExecutor` orchestration, and an `ai_search` entry in `AnglesiteTokenTemplate`. New in the app target: `AISearchModel`/`AISearchSheetView` mirroring `HardenModel`/`HardenSheetView` (including the #1289 synchronous phase-flip pattern), wired into `SiteWindowModel`/`SiteWindow`/`WebsiteCommands` with a new frozen `SiteToolbarItemID.aiSearch`. Localization catalog gains 14 keys (pure additions).
- **No WAF skip rule** — live verification (2026-08-15) proved the originally-planned skip rule impossible on any plan: `products: ["botFight"]` is not a valid skip product (error 20119), `cf.bot_management.detection_ids` requires a paid Bot Management plan, and Bot Fight Mode runs outside the Ruleset Engine so skip rules can't affect it regardless. Replaced (`d949f6c4`) with the in-wizard decision above, backed by the existing `setBotFightMode` call; spec §12 corrected to match, and the interim `WAFRulePayload.actionParameters` API was reverted as unused.

### Manual pre-merge verification (plan-flagged) — all four now verified live (2026-08-15)

- [x] **Instance-create API shape** — ✅ verified live 2026-08-15: a real POST with the shipped flat body reached domain validation (400 `missing_sitemap`, code 7028), proving routing+schema accept it; the namespaced path 404s (`namespace_not_found`, 7063) without a pre-created namespace. Recorded in the code comment (`7b209d5c`); friendlier 7028 handling filed as #1486.
- [x] **WAF skip-rule syntax** — ✅ verified live 2026-08-15, with a negative result: `botFight` is an invalid skip product (20119), `detection_ids` is paid-plan-only, and Bot Fight Mode ignores skip rules by design (separate evaluation pipeline). The skip rule is removed; see the Bot Fight Mode decision step (`d949f6c4`).
- [x] **Dashboard deep link** — ✅ verified 2026-08-15 against Cloudflare's docs, with a correction: the docs-standard pattern is `?to=/:account/ai/ai-search` (note the `/ai/` segment; no per-instance settings deep link exists anywhere in the docs). Fixed in `1ed3506c` — the success screen now links the product root and the manual steps walk the instance selection.
- [x] **`ai_search` token permission-group key** — ✅ verified 2026-08-15: a token created from the `createTokenURL` pre-fill performed an AI Search write (create reached domain validation), which requires `AI Search: Edit` — so the dashboard accepted the key.

### Follow-ups (filed, not in this PR)

- #1478 — idempotent re-runs: tolerate an already-existing instance id and dedupe the skip rule by description (as Harden does).
- #1479 — stale in-flight task can overwrite `phase` after sheet dismiss/reopen — pre-existing pattern shared with `HardenModel`; fix both together.
- #1480 — spec §12's "live e2e behind `ANGLESITE_CF_E2E=1` like the rest" references a gate that doesn't exist in the repo; needs a one-line spec correction.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` — 525 tests in 71 suites, all passing at `22f6b387`
- [x] `xcodebuild` Debug app build via `scripts/build-app.sh` — succeeds (includes the new SiteWindow/WebsiteCommands wiring)
- [ ] Manual smoke (if UI-touching): open a site → toolbar "AI Search" (hidden by default — also via Website ▸ AI Search…) → sheet opens on idle → enter domain → Continue → phases advance; with Bot Fight Mode on, verify the new decision step renders and both choices proceed. Verify the `text.magnifyingglass` toolbar icon looks right. Not run in the headless implementation session.
