### PR TITLE
docs(#960): document menu-skeleton convention departure

### DIFF
--- a/docs/superpowers/specs/2026-07-13-menubar-ia-design.md
+++ b/docs/superpowers/specs/2026-07-13-menubar-ia-design.md
@@ -25,6 +25,29 @@ explanatory suffix). Every item below carries an availability tag:
 
 Shortcut re-keys (§3) land **with** the skeleton so muscle memory changes only once.
 
+> **Documented convention departure (#960, owner decision 2026-08-15).** Shipping the full
+> skeleton means Release builds carry a large set of permanently-disabled `PlannedItem` rows
+> (`Sources/AnglesiteApp/MenuSkeleton.swift`) — 113 at the time of the #960 audit, 74 of them
+> in Insert/Format/Arrange — whose reserved shortcuts are dead keys until their features land.
+> This departs from the macOS convention (see
+> [`docs/mac-assed-app-spec.md`](../../mac-assed-app-spec.md) §2 and its release
+> acceptance checklist) that a disabled item means *"not applicable right now — change the
+> selection or state and it will light up."*
+>
+> - **Why it's intentional:** the skeleton keeps the north-star IA visible in every build —
+>   roadmap visibility for users and testers, a standing design-review surface, and reserved
+>   shortcut assignments and menu placement that stay stable so muscle memory changes only
+>   once.
+> - **Trade-off acknowledged:** at this ratio, dimmed items stop carrying the conventional
+>   "change state to enable" signal, which can devalue the genuinely state-dependent
+>   disabling elsewhere (deploy/backup gating, the Find items). A user opening Format today
+>   can use none of its rows.
+> - **Re-examination checkpoint:** revisit before the #617 App Store submission. Weigh
+>   #960's options 1–2 (Debug-only skeleton via a build flag, or hiding menus that are
+>   entirely planned) against the shipped/planned ratio at that point; an App Review pass
+>   over a mostly-dead menu is a bad first impression independent of the reservation
+>   argument.
+
 ## 2. Menu-by-menu IA
 
 Top-level lineup: **Anglesite · File · Edit · Insert · Page · Format · Arrange · View ·


### PR DESCRIPTION
Closes #960

## Summary

- Documents the PlannedItem menu skeleton (113 permanently-disabled rows in Release builds) as an **intentional convention departure**, per the owner decision on #960 (2026-08-15, option 4) and the platform-UX rule in `CLAUDE.md` / `docs/mac-assed-app-spec.md`.
- The entry lives in the menubar IA design spec (`docs/superpowers/specs/2026-07-13-menubar-ia-design.md` §1, directly under the rollout-policy paragraph it qualifies): what the departure is, why it is intentional (roadmap visibility, design-review surface, stable shortcut reservations), the acknowledged trade-off (dimmed items lose their "change state to enable" signal at this ratio), and the explicit re-examination checkpoint **before the #617 App Store submission** (re-weigh #960's options 1–2 then).
- Docs-only; no menu code changes. No #617 closeout checklist file exists in docs, so no #617-side edit was needed.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path .`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [x] Docs-only change — verified the referenced paths exist (`Sources/AnglesiteApp/MenuSkeleton.swift`, `docs/mac-assed-app-spec.md`) and the relative link resolves from `docs/superpowers/specs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
