### PR TITLE
feat(#1481): emit discovery Link headers in template _headers

### DIFF
--- a/Resources/Template/public/_headers
+++ b/Resources/Template/public/_headers
@@ -7,6 +7,10 @@
   Cross-Origin-Resource-Policy: same-site
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+  Link: </sitemap.xml>; rel="sitemap"; type="application/xml"
+  Link: </rss.xml>; rel="alternate"; type="application/rss+xml"
+  Link: </atom.xml>; rel="alternate"; type="application/atom+xml"
+  Link: </feed.json>; rel="alternate"; type="application/feed+json"
   Cache-Control: public, max-age=0, must-revalidate
 
 /_astro/*

--- a/Resources/Template/scripts/csp.test.ts
+++ b/Resources/Template/scripts/csp.test.ts
@@ -144,8 +144,24 @@ test("buildHeaders: no noindex entries leaves output unchanged from today", () =
   assert.equal(buildHeaders(""), buildHeaders("", false, []));
 });
 
-test("buildHeaders: no rslUrl omits the Link header", () => {
-  assert.doesNotMatch(buildHeaders(""), /Link:/);
+test("buildHeaders: no rslUrl omits the license Link header", () => {
+  assert.doesNotMatch(buildHeaders(""), /rel="license"/);
+});
+
+// Agent Readiness `linkHeaders` (#1481): every response advertises the sitemap and the three
+// feed formats as RFC 8288 Link headers, mirroring BaseLayout.astro's <link rel="alternate">
+// trio so agents can discover them without parsing HTML. All four targets are unconditional
+// template routes (src/pages/{sitemap.xml,rss.xml,atom.xml,feed.json}.ts).
+test("buildHeaders: always emits discovery Link headers inside the /* block", () => {
+  const out = buildHeaders("");
+  assert.match(out, /\n {2}Link: <\/sitemap\.xml>; rel="sitemap"; type="application\/xml"\n/);
+  assert.match(out, /\n {2}Link: <\/rss\.xml>; rel="alternate"; type="application\/rss\+xml"\n/);
+  assert.match(out, /\n {2}Link: <\/atom\.xml>; rel="alternate"; type="application\/atom\+xml"\n/);
+  assert.match(out, /\n {2}Link: <\/feed\.json>; rel="alternate"; type="application\/feed\+json"\n/);
+  // Inside the /* block: the last Link line still precedes the block's blank-line terminator.
+  const lastLink = out.lastIndexOf("Link:");
+  const blockEnd = out.indexOf("\n\n");
+  assert.ok(lastLink > 0 && lastLink < blockEnd, "Link: headers must be inside the /* block");
 });
 
 test("buildHeaders: rslUrl adds a rel=license Link header inside the /* block", () => {

--- a/Resources/Template/scripts/csp.ts
+++ b/Resources/Template/scripts/csp.ts
@@ -110,7 +110,21 @@ export function buildHeaders(
   // still isolating attacker-opened windows.
   // CORP: same-site (not same-origin) keeps cross-origin (cross-site) isolation but
   // lets same-site subdomains load shared assets (e.g. a logo on blog.example.com).
-  const rslLink = rslUrl ? `\n  Link: <${rslUrl}>; rel="license"; type="application/rsl+xml"` : "";
+  // RFC 8288 Link headers advertising the discovery surfaces every scaffolded site ships
+  // unconditionally (#1481): the sitemap plus the three feed formats BaseLayout.astro already
+  // exposes as HTML <link rel="alternate"> tags. Putting them in the HTTP response lets an agent
+  // find them without parsing markup — Cloudflare's Agent Readiness `linkHeaders` check.
+  // Site-wide on /* like the license link below, per the rationale in this function's doc comment.
+  const links = [
+    `</sitemap.xml>; rel="sitemap"; type="application/xml"`,
+    `</rss.xml>; rel="alternate"; type="application/rss+xml"`,
+    `</atom.xml>; rel="alternate"; type="application/atom+xml"`,
+    `</feed.json>; rel="alternate"; type="application/feed+json"`,
+  ];
+  if (rslUrl) links.push(`<${rslUrl}>; rel="license"; type="application/rsl+xml"`);
+  // One Link: line each; Cloudflare joins repeated response headers into one comma-separated
+  // value, which is exactly RFC 8288's list form.
+  const linkLines = links.map((l) => `\n  Link: ${l}`).join("");
   let out = `/*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
@@ -119,7 +133,7 @@ export function buildHeaders(
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   Cross-Origin-Resource-Policy: same-site
   Strict-Transport-Security: ${hsts}
-  Content-Security-Policy: ${csp}${rslLink}
+  Content-Security-Policy: ${csp}${linkLines}
   Cache-Control: public, max-age=0, must-revalidate
 
 /_astro/*


### PR DESCRIPTION
Closes #1481

## Summary

- `buildHeaders` (`Resources/Template/scripts/csp.ts`) now always emits RFC 8288 `Link` response headers in the `/*` block, advertising the discovery resources every scaffolded site ships unconditionally: `/sitemap.xml` (`rel="sitemap"`) and the three feed formats `/rss.xml`, `/atom.xml`, `/feed.json` (`rel="alternate"` with their media types) — the same trio `BaseLayout.astro` already exposes as HTML `<link rel="alternate">` tags. HTTP-level links let agents find these without parsing markup, which is what Cloudflare's Agent Readiness `linkHeaders` check ("Link response headers", Discoverability category) looks for.
- The conditional RSL `rel="license"` Link header (#992) is unchanged; it now joins the same emitted list. `pre-deploy-check.ts`'s RSL Link parser matches on `rel="license"` specifically, so the new lines don't collide.
- Committed `public/_headers` regenerated (`npx tsx scripts/csp.ts`) so it stays byte-identical to `buildHeaders("")`, per the existing test.

Each `Link:` target is an unconditional template route (`src/pages/{sitemap.xml,rss.xml,atom.xml,feed.json}.ts`), so the headers never point at a resource a site doesn't ship. Follow-up per #1326: once this lands, #1248's `AgentReadinessCatalog` (`Sources/AnglesiteCore/AgentReadinessReport.swift`) can flip `linkHeaders.anglesiteProvides` to `true` — left out here to keep this PR template-only.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` — 525 tests in 71 suites passed (template changes can couple to Swift smoke tests; none affected).
- [x] Template suite: `npm test` in `Resources/Template/` — 772 node:test cases + 35 astro vitest cases passed, including new `csp.test.ts` coverage asserting the four discovery `Link` headers land inside the `/*` block and the regenerated committed `_headers` stays byte-identical to `buildHeaders("")`.
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (no app-target source touched; template files are bundle resources).
- [ ] Manual smoke (if UI-touching): n/a — no UI change.
