### PR TITLE
feat(#1326): mark linkHeaders check as template-provided

### DIFF
--- a/Sources/AnglesiteCore/AgentReadinessReport.swift
+++ b/Sources/AnglesiteCore/AgentReadinessReport.swift
@@ -119,7 +119,7 @@ public enum AgentReadinessCatalog {
             displayName: "Page discovery links",
             passHint: "Your pages point AI agents to related resources automatically.",
             failHint: "Your pages don't point AI agents to related resources (RFC 8288 Link headers).",
-            anglesiteProvides: false),
+            anglesiteProvides: true),
         "markdownNegotiation": .init(
             displayName: "Markdown for AI agents",
             passHint: "AI agents get a clean, Markdown version of your pages instead of raw HTML.",

--- a/Tests/AnglesiteCoreTests/AgentReadinessScanningTests.swift
+++ b/Tests/AnglesiteCoreTests/AgentReadinessScanningTests.swift
@@ -127,6 +127,11 @@ struct AgentReadinessScanningTests {
         }
     }
 
+    @Test("catalog marks linkHeaders as provided by the template (#1481 _headers Link headers)")
+    func linkHeadersMarkedProvided() {
+        #expect(AgentReadinessCatalog.checkInfo(for: "linkHeaders").anglesiteProvides == true)
+    }
+
     @Test("agentReadinessResult maps 401 to unauthorized")
     func resultUnauthorized() async throws {
         let client = HTTPCloudflareClient(transport: fakeTransport([


### PR DESCRIPTION
Part of #1326 (tracking epic — not closed by this PR).

## Summary

- Flips `linkHeaders.anglesiteProvides` to `true` in `AgentReadinessCatalog` now that #1489 (merged) emits sitemap/RSS/Atom/JSON-Feed discovery Link headers in the template's generated `public/_headers`.
- A `linkHeaders` failure on a scanned site now drives the "redeploy to pick this up" copy instead of "not supported yet", per the instruction in #1326.
- Adds a catalog test pinning the provided state.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; SwiftPM-only constant flip in `AnglesiteCore`, and `swift test` already compiles the app-core views (`AnglesiteAppCore`).
- [ ] Manual smoke (if UI-touching): n/a — no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)