### PR TITLE
feat(#1486): map AI Search 7028 missing_sitemap to deploy-first fix

### DIFF
--- a/Sources/AnglesiteApp/AISearchModel.swift
+++ b/Sources/AnglesiteApp/AISearchModel.swift
@@ -142,6 +142,11 @@ final class AISearchModel {
         do {
             let result = try await executor.provision(zoneID: zoneID, domain: domain, apiToken: token)
             phase = .succeeded(result)
+        } catch AISearchProvisionError.missingSitemap {
+            // Cloudflare 7028: the crawler can't find a sitemap at the domain. The app knows
+            // the fix (the sitemap ships in every build but isn't live until the first
+            // deploy), so say that — not the API code (#1486).
+            phase = .failed(reason: "Your site's sitemap isn't reachable yet. Deploy the site first, then set up AI Search.")
         } catch let error as CloudflareError {
             phase = .failed(reason: cloudflareErrorMessage(error))
         } catch {

--- a/Sources/AnglesiteCore/AISearchProvisioning.swift
+++ b/Sources/AnglesiteCore/AISearchProvisioning.swift
@@ -11,6 +11,18 @@ public struct AISearchInstance: Sendable, Equatable {
     }
 }
 
+/// AI Search create failures that carry an owner-actionable fix beyond the generic
+/// ``CloudflareError`` mapping. A separate error type (rather than a new `CloudflareError`
+/// case) keeps the blast radius to this feature — roughly ten call sites switch over
+/// `CloudflareError` exhaustively and none of them can hit this condition (#1486).
+public enum AISearchProvisionError: Error, Equatable, Sendable {
+    /// Cloudflare rejected the create with error code 7028 (`missing_sitemap`): the source
+    /// website has no reachable sitemap. For an Anglesite site this virtually always means
+    /// the site hasn't had its first deploy yet, so the fix is "deploy first" — the sitemap
+    /// (#982) is in every build but isn't live at the domain until a deploy publishes it.
+    case missingSitemap
+}
+
 /// Provisions Cloudflare AI Search instances. Kept separate from `CloudflareWriting` — that
 /// protocol has five conformers across the test suite, and this is the only feature that needs
 /// this call.

--- a/Sources/AnglesiteCore/HTTPCloudflareClient.swift
+++ b/Sources/AnglesiteCore/HTTPCloudflareClient.swift
@@ -15,7 +15,13 @@ private struct CFResultInfo: Decodable, Sendable {
 private struct CFEnvelope<T: Decodable & Sendable>: Decodable, Sendable {
     let success: Bool
     let result: T?
-    struct APIError: Decodable, Sendable { let message: String }
+    struct APIError: Decodable, Sendable {
+        let message: String
+        /// Cloudflare's numeric error code (e.g. 7028 `missing_sitemap`). Optional because
+        /// only paths that branch on a specific code consult it, and older envelope fixtures
+        /// omit it.
+        let code: Int?
+    }
     let errors: [APIError]?
     let result_info: CFResultInfo?
 }
@@ -398,11 +404,15 @@ public struct HTTPCloudflareClient: CloudflareReading {
     /// only checks the envelope's `success` flag) and the Registrar `post` helper below (which
     /// also decodes and returns the envelope's `result`) — both need identical request
     /// construction and status handling and previously duplicated it verbatim.
+    /// `passthroughStatuses` mirrors `fetchRaw`'s parameter of the same name: statuses a caller
+    /// opts out of the `.http` mapping so it can inspect the response body itself (e.g. a 400
+    /// whose error envelope carries an actionable Cloudflare error code).
     private func send<Body: Encodable & Sendable>(
         method: String,
         _ path: String,
         body: Body,
-        apiToken: String
+        apiToken: String,
+        passthroughStatuses: Set<Int> = []
     ) async throws -> (Data, HTTPURLResponse) {
         guard let url = URL(string: Self.base + path) else { throw CloudflareError.malformedResponse }
         var request = URLRequest(url: url)
@@ -411,6 +421,7 @@ public struct HTTPCloudflareClient: CloudflareReading {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(body)
         let (data, http) = try await transport(request)
+        if passthroughStatuses.contains(http.statusCode) { return (data, http) }
         if http.statusCode == 401 || http.statusCode == 403 { throw CloudflareError.unauthorized }
         guard (200..<300).contains(http.statusCode) else { throw CloudflareError.http(status: http.statusCode) }
         return (data, http)
@@ -693,6 +704,14 @@ extension HTTPCloudflareClient: CloudflareRegistrarReading {
         _ path: String, body: Body, apiToken: String, as type: T.Type
     ) async throws -> T {
         let (data, _) = try await send(method: "POST", path, body: body, apiToken: apiToken)
+        return try Self.decodeEnvelopeResult(from: data, as: T.self)
+    }
+
+    /// Decodes a `CFEnvelope<T>` response body and returns its `result`, mapping an
+    /// undecodable body to ``CloudflareError/malformedResponse`` and a `success: false` or
+    /// missing `result` to ``CloudflareError/api(message:)``. Shared by `post` and
+    /// `createAISearchInstance` (which can't use `post` because it inspects 400 bodies itself).
+    private static func decodeEnvelopeResult<T: Decodable & Sendable>(from data: Data, as type: T.Type) throws -> T {
         let env: CFEnvelope<T>
         do {
             env = try JSONDecoder().decode(CFEnvelope<T>.self, from: data)
@@ -916,14 +935,22 @@ extension HTTPCloudflareClient: AgentReadinessScanning {
 extension HTTPCloudflareClient: AISearchProvisioning {
     /// `POST /accounts/{id}/ai-search/instances`, creating a web-crawler-backed AI Search
     /// instance for `domain`. Resolves the account first via `resolveAccountID` (the Registrar
-    /// conformance above, same file so its `private` scope still applies) and reuses `post` for
-    /// the request/response handling, same as `checkDomainAvailability`.
+    /// conformance above, same file so its `private` scope still applies).
+    ///
+    /// Unlike the other write paths, a 400 here is passed through and its error envelope
+    /// decoded (#1486): Cloudflare validates the source website at create time, and a source
+    /// with no reachable sitemap fails with code 7028 `missing_sitemap` (confirmed live,
+    /// 2026-08-15) — for an Anglesite site that nearly always means "not deployed yet", which
+    /// deserves better than a bare "HTTP 400". Code 7028 maps to
+    /// ``AISearchProvisionError/missingSitemap``; any other decodable 400 surfaces Cloudflare's
+    /// own message as ``CloudflareError/api(message:)``; an undecodable 400 body keeps the old
+    /// ``CloudflareError/http(status:)`` behavior.
     ///
     /// Flat shape, no `namespaces` segment — follows developers.cloudflare.com/ai-search/
     /// get-started/api/'s verbatim curl examples. Cloudflare's auto-generated API reference
     /// disagrees (documents a namespaced /namespaces/{name}/instances path instead) — see
-    /// Global Constraints. CONFIRM WHICH SHAPE THE LIVE API ACTUALLY ACCEPTS before trusting
-    /// this code sample; don't just re-read either doc page again.
+    /// Global Constraints. The flat shape is what the live API accepts (confirmed 2026-08-15,
+    /// same verification session that surfaced the 7028 behavior).
     public func createAISearchInstance(
         domain: String, instanceID: String, apiToken: String
     ) async throws -> AISearchInstance {
@@ -933,10 +960,25 @@ extension HTTPCloudflareClient: AISearchProvisioning {
             let type: String
             let source: String
         }
-        let result = try await post(
-            "/accounts/\(accountID)/ai-search/instances",
+        let (data, http) = try await send(
+            method: "POST", "/accounts/\(accountID)/ai-search/instances",
             body: CreateBody(id: instanceID, type: "web-crawler", source: domain),
-            apiToken: apiToken, as: CFAISearchInstance.self)
+            apiToken: apiToken, passthroughStatuses: [400])
+        if http.statusCode == 400 { throw Self.createFailureError(from: data) }
+        let result = try Self.decodeEnvelopeResult(from: data, as: CFAISearchInstance.self)
         return AISearchInstance(id: result.id, name: result.name ?? instanceID)
+    }
+
+    /// Maps a create's 400 body to the most actionable error available: code 7028 →
+    /// ``AISearchProvisionError/missingSitemap``, any other decodable envelope with a message →
+    /// ``CloudflareError/api(message:)``, everything else → ``CloudflareError/http(status:)``
+    /// (the pre-#1486 behavior).
+    private static func createFailureError(from data: Data) -> any Error {
+        guard let env = try? JSONDecoder().decode(CFEnvelope<CFEmpty>.self, from: data),
+              let errors = env.errors, !errors.isEmpty else {
+            return CloudflareError.http(status: 400)
+        }
+        if errors.contains(where: { $0.code == 7028 }) { return AISearchProvisionError.missingSitemap }
+        return CloudflareError.api(message: errors[0].message)
     }
 }

--- a/Tests/AnglesiteAppTests/AISearchModelTests.swift
+++ b/Tests/AnglesiteAppTests/AISearchModelTests.swift
@@ -42,6 +42,14 @@ private final class StubProvisioner: AISearchProvisioning, @unchecked Sendable {
     }
 }
 
+private final class FailingProvisioner: AISearchProvisioning, @unchecked Sendable {
+    private let error: any Error
+    init(throwing error: any Error) { self.error = error }
+    func createAISearchInstance(domain: String, instanceID: String, apiToken: String) async throws -> AISearchInstance {
+        throw error
+    }
+}
+
 @Suite(.serialized)
 struct AISearchModelTests {
     /// Per-instance scratch service, matching `HardenModelTests`' rationale: every test here
@@ -124,5 +132,32 @@ struct AISearchModelTests {
             return
         }
         #expect(result.instance.id == "inst1")
+    }
+
+    @MainActor
+    @Test("confirmCost maps missingSitemap (Cloudflare 7028) to deploy-first guidance")
+    func missingSitemapNamesDeployFirstFix() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let model = AISearchModel(
+            reader: StubReader(zoneID: "z1"), writer: StubWriter(),
+            provisioner: FailingProvisioner(throwing: AISearchProvisionError.missingSitemap),
+            keychain: keychain)
+        model.domainInput = "example.com"
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        while model.isRunning { await Task.yield() }
+
+        model.confirmCost()
+        while model.isRunning { await Task.yield() }
+
+        guard case .failed(let reason) = model.phase else {
+            Issue.record("expected .failed, got \(model.phase)")
+            return
+        }
+        // The owner-facing fix, not a raw API code or bare HTTP status (#1486).
+        #expect(reason.localizedCaseInsensitiveContains("deploy"))
+        #expect(reason.localizedCaseInsensitiveContains("sitemap"))
+        #expect(!reason.contains("7028"))
+        #expect(!reason.contains("HTTP 400"))
     }
 }

--- a/Tests/AnglesiteCoreTests/HTTPCloudflareClientAISearchTests.swift
+++ b/Tests/AnglesiteCoreTests/HTTPCloudflareClientAISearchTests.swift
@@ -26,6 +26,44 @@ struct HTTPCloudflareClientAISearchTests {
         #expect(body["source"] as? String == "example.com")
     }
 
+    @Test("createAISearchInstance maps a 400 with Cloudflare code 7028 to .missingSitemap")
+    func createInstanceMissingSitemap() async throws {
+        let accountsJSON = #"{"success":true,"errors":[],"result":[{"id":"acct1"}]}"#
+        let errorJSON = #"{"success":false,"errors":[{"code":7028,"message":"missing_sitemap: no sitemap found for source"}],"result":null}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/ai-search/instances": (400, errorJSON),
+        ]))
+        await #expect(throws: AISearchProvisionError.missingSitemap) {
+            try await client.createAISearchInstance(domain: "example.com", instanceID: "example-com", apiToken: "t")
+        }
+    }
+
+    @Test("createAISearchInstance surfaces other 400 error bodies as .api with Cloudflare's message")
+    func createInstanceOther400WithMessage() async throws {
+        let accountsJSON = #"{"success":true,"errors":[],"result":[{"id":"acct1"}]}"#
+        let errorJSON = #"{"success":false,"errors":[{"code":7003,"message":"instance already exists"}],"result":null}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/ai-search/instances": (400, errorJSON),
+        ]))
+        await #expect(throws: CloudflareError.api(message: "instance already exists")) {
+            try await client.createAISearchInstance(domain: "example.com", instanceID: "example-com", apiToken: "t")
+        }
+    }
+
+    @Test("createAISearchInstance falls back to .http(400) when the error body doesn't decode")
+    func createInstance400Undecodable() async throws {
+        let accountsJSON = #"{"success":true,"errors":[],"result":[{"id":"acct1"}]}"#
+        let client = HTTPCloudflareClient(transport: fakeTransport([
+            "/accounts?per_page=1": (200, accountsJSON),
+            "/ai-search/instances": (400, "<html>Bad Request</html>"),
+        ]))
+        await #expect(throws: CloudflareError.http(status: 400)) {
+            try await client.createAISearchInstance(domain: "example.com", instanceID: "example-com", apiToken: "t")
+        }
+    }
+
     @Test("createAISearchInstance surfaces .unauthorized on a 403")
     func createInstanceUnauthorized() async throws {
         let accountsJSON = #"{"success":true,"errors":[],"result":[{"id":"acct1"}]}"#


### PR DESCRIPTION
Closes #1486

## Summary

- The AI Search create path (`HTTPCloudflareClient.createAISearchInstance`) now passes HTTP 400 responses through and decodes Cloudflare's error envelope: code 7028 (`missing_sitemap`) throws a dedicated `AISearchProvisionError.missingSitemap`, any other decodable 400 surfaces Cloudflare's own message as `.api(message:)`, and an undecodable body keeps the previous `.http(status: 400)` behavior.
- `AISearchModel` maps `missingSitemap` to owner-facing, consequence-phrased guidance — "Your site's sitemap isn't reachable yet. Deploy the site first, then set up AI Search." — instead of a bare "Cloudflare API returned HTTP 400."
- A separate error type (rather than a new `CloudflareError` case) keeps the blast radius to this feature: roughly ten call sites switch over `CloudflareError` exhaustively and none can hit this condition. The issue's optional sitemap HEAD preflight before the cost-confirmation step is filed as follow-up #1494.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` (full suite green; new coverage: stubbed 400/7028 → `.missingSitemap`, other 400 codes → `.api` with Cloudflare's message, undecodable 400 body → `.http(400)`, and a model test asserting the failure reason names the sitemap/deploy fix and contains no raw code or status)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [ ] Manual smoke (if UI-touching): not run — message-text-only change in an existing failure phase, covered by the unit tests above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
