### PR TITLE
fix(#1495): weak-link FoundationModels overlay on all app targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,12 +22,25 @@ let strictConcurrency: [SwiftSetting] = [
 // `.when(platforms: [.macOS])`: `-weak_framework` is a Darwin ld option — ld.gold on the Linux
 // CI leg rejects it, and AnglesiteBridgeCoreTests (which carries this setting) is in the
 // off-Darwin portable target set, so the flag must never reach a non-Darwin link.
-let weakLinkFoundationModels: [LinkerSetting] = [
-    .unsafeFlags(
-        ["-Xlinker", "-weak_framework", "-Xlinker", "FoundationModels"],
-        .when(platforms: [.macOS])
-    )
-]
+//
+// #1495: FoundationModelAssistant's SpotlightSearchTool path imports CoreSpotlight alongside
+// FoundationModels in the same file, which triggers Swift's `_CoreSpotlight_FoundationModels`
+// cross-import overlay — a second macOS-27-only framework with the identical SDK-ahead-of-OS
+// exposure as FoundationModels itself (confirmed live during #855's CI work, commit 50c8875c on
+// claude/issue-855-xcode27-lane). compiler(>=6.4) guards it because the overlay doesn't exist in
+// pre-Xcode-27 SDKs, so an older toolchain would fail to find the framework to weak-link.
+let weakLinkFoundationModels: [LinkerSetting] = {
+    var frameworks = ["FoundationModels"]
+    #if compiler(>=6.4)
+    frameworks.append("_CoreSpotlight_FoundationModels")
+    #endif
+    return [
+        .unsafeFlags(
+            frameworks.flatMap { ["-Xlinker", "-weak_framework", "-Xlinker", $0] },
+            .when(platforms: [.macOS])
+        )
+    ]
+}()
 
 // Anywhere runtime (#1208): stasel/WebRTC vends a real dynamic .xcframework (unlike the
 // source packages above), and SwiftPM's build system places its resolved WebRTC.framework
@@ -52,8 +65,17 @@ let webRTCTestRPath: [LinkerSetting] = [
 // binary is linked — so the app still hard-links FoundationModels despite that flag. Disabling
 // the autolink hint at the source makes the app target's weak-link flag the only (and effective)
 // link request. See #541.
+//
+// #1495: FoundationModelAssistant.swift's SpotlightSearchTool path also autolinks the
+// `_CoreSpotlight_FoundationModels` cross-import overlay (see weakLinkFoundationModels above) —
+// suppress its hard autolink hint the same way. Nothing references the overlay's API outside
+// that one call site (repo-wide grep), so dropping the hint is behavior-neutral; on pre-Xcode-27
+// SDKs the overlay doesn't exist and the flag is inert.
 let disableFoundationModelsAutolink: [SwiftSetting] = [
-    .unsafeFlags(["-Xfrontend", "-disable-autolink-framework", "-Xfrontend", "FoundationModels"])
+    .unsafeFlags([
+        "-Xfrontend", "-disable-autolink-framework", "-Xfrontend", "FoundationModels",
+        "-Xfrontend", "-disable-autolink-framework", "-Xfrontend", "_CoreSpotlight_FoundationModels",
+    ])
 ]
 
 // AnglesiteContainer imports apple/containerization — a Swift 6.2, macOS-15+ package that pulls in

--- a/project.yml
+++ b/project.yml
@@ -125,7 +125,12 @@ targets:
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) ANGLESITE_MAS"
         # #541: weak-link FoundationModels so a beta Xcode SDK ahead of the installed macOS beta
         # seed (a symbol the SDK added but the OS doesn't export yet) can't abort dyld at launch.
-        OTHER_LDFLAGS: "$(inherited) -weak_framework FoundationModels"
+        # #1495 adds the _CoreSpotlight_FoundationModels cross-import overlay (see Package.swift's
+        # disableFoundationModelsAutolink) — its hard autolink hint is suppressed in AnglesiteCore,
+        # so this app link (which pulls FoundationModelAssistant.o and with it the overlay's
+        # SpotlightSearchTool symbols) must request the framework explicitly, weak for the same
+        # SDK-ahead-of-OS reason as FoundationModels itself.
+        OTHER_LDFLAGS: "$(inherited) -weak_framework FoundationModels -weak_framework _CoreSpotlight_FoundationModels"
       configs:
         Debug:
           # #775 workaround: punch the com.apple.NetworkSharing mach look-up back
@@ -233,6 +238,13 @@ targets:
         SWIFT_VERSION: "5.10"
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: "0.1.0"
+        # #1495: this target links AnglesiteCore (FoundationModelAssistant.swift) but, unlike the
+        # Anglesite/Mac target, never got #541's weak-link — confirmed hard-linking FoundationModels
+        # via otool -l on a built product. Same SDK-ahead-of-installed-OS-seed risk during the
+        # Xcode 27 / iOS 27 beta cycle. _CoreSpotlight_FoundationModels isn't observed linked here
+        # (the SpotlightSearchTool call site appears macOS-gated), so it's omitted rather than
+        # weak-linking a framework this target doesn't reference.
+        OTHER_LDFLAGS: "$(inherited) -weak_framework FoundationModels"
       configs:
         Debug:
           CODE_SIGN_ENTITLEMENTS: $(ANGLESITE_MOBILE_DEBUG_ENTITLEMENTS)
@@ -348,6 +360,13 @@ targets:
         SKIP_INSTALL: YES
         # Embedded helper apps live under the parent's Contents/Library/LoginItems/ —
         # SMAppService.agent's documented discovery location.
+        # #1495: this target links AnglesiteCore (FoundationModelAssistant.swift) the same way the
+        # Anglesite/Mac target above does, but never got #541's weak-link — confirmed hard-linking
+        # both FoundationModels and the _CoreSpotlight_FoundationModels overlay via otool -l on a
+        # built product. Since this is an SMAppService.agent login item that can run with the main
+        # app window closed, a dyld abort here is a silent background-process death, not even a
+        # visible crash dialog. Mirrors the Anglesite target's matching OTHER_LDFLAGS above.
+        OTHER_LDFLAGS: "$(inherited) -weak_framework FoundationModels -weak_framework _CoreSpotlight_FoundationModels"
       configs:
         Debug:
           # #1208 P2: keychain-access-groups requires a real provisioning profile even under


### PR DESCRIPTION
Closes #1495

## Summary

- `AnglesiteRemote` (the `SMAppService.agent` login-item helper) and `AnglesiteMobile` (iOS) both link `AnglesiteCore` the same way `Anglesite` does, but never got #541's `-weak_framework FoundationModels` fix — confirmed via `otool -l` on built products that both hard-linked `FoundationModels`, and `Anglesite` itself hard-linked the `_CoreSpotlight_FoundationModels` cross-import overlay (triggered by `FoundationModelAssistant`'s `SpotlightSearchTool` path importing `CoreSpotlight` alongside `FoundationModels`).
- Extends `Package.swift`'s `weakLinkFoundationModels`/`disableFoundationModelsAutolink` to also cover the overlay (`compiler(>=6.4)`-guarded — the recipe was verified during #855's CI work, commit `50c8875c` on `claude/issue-855-xcode27-lane`, then reverted there only because the CI problem it targeted was solved a different way).
- Adds the matching `OTHER_LDFLAGS` weak-link to `AnglesiteRemote` (both frameworks) and `AnglesiteMobile` (`FoundationModels` only — the overlay isn't linked there, confirmed via `otool -l`, not assumed).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — full suite passes locally on Xcode 27 beta / macOS 27 (11/11 bundles, including `AnglesiteRemoteTests`, no regressions).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeds; re-verified with `otool -l` that `Anglesite.app` and the embedded `Anglesite Remote.app` both now show `LC_LOAD_WEAK_DYLIB` (not `LC_LOAD_DYLIB`) for `FoundationModels.framework` and `_CoreSpotlight_FoundationModels.framework`.
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme AnglesiteMobile -destination "generic/platform=iOS Simulator" build` — succeeds; `otool -l` confirms `FoundationModels.framework` now weak-links there too.
