### PR TITLE
feat(#1494): preflight sitemap reachability in AI Search wizard

### DIFF
--- a/Sources/AnglesiteApp/AISearchModel.swift
+++ b/Sources/AnglesiteApp/AISearchModel.swift
@@ -128,24 +128,37 @@ final class AISearchModel {
             return
         }
 
+        // Advisory sitemap probe (#1494): a definitive "not there" surfaces the deploy-first
+        // fix *before* the owner is asked to confirm cost, instead of after a failed create.
+        // Only `.unreachable` (404/410) blocks — ambiguous answers and transport failures
+        // proceed and let the create itself decide, with the 7028 mapping (#1486) as the
+        // backstop, so a flaky probe can never wedge the wizard. `async let`, not a
+        // sequential await: the probe only needs `domain`, so it overlaps zone resolution
+        // instead of stacking its (up to 5s) round trip on top.
+        async let sitemapReachability = preflight.checkSitemap(domain: domain)
         do {
             guard let zoneID = try await reader.resolveZoneID(domain: domain, apiToken: token) else {
+                guard !Task.isCancelled else { return }
                 phase = .failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission.")
                 return
             }
-            // Advisory sitemap probe (#1494): a definitive "not there" surfaces the
-            // deploy-first fix *before* the owner is asked to confirm cost, instead of after
-            // a failed create. Only `.unreachable` blocks — `.indeterminate` (timeout, DNS)
-            // proceeds and lets the create itself decide, with the 7028 mapping (#1486) as
-            // the backstop, so a flaky probe can never wedge the wizard.
-            if await preflight.checkSitemap(domain: domain) == .unreachable {
+            let reachability = await sitemapReachability
+            // Cancellation can surface as a *value*, not a thrown error: the preflight's
+            // catch-all folds a cancelled request into `.indeterminate`, and a stub reader
+            // may not throw at all. A superseded task (new domain typed, or the sheet
+            // dismissed) must never write a stale phase over the current task's — the
+            // classic wrong-domain footgun — so every phase write below is gated.
+            guard !Task.isCancelled else { return }
+            if reachability == .unreachable {
                 phase = .failed(reason: Self.missingSitemapGuidance)
                 return
             }
             phase = .awaitingCostConfirmation(domain: domain, zoneID: zoneID)
         } catch let error as CloudflareError {
+            guard !Task.isCancelled else { return }
             phase = .failed(reason: cloudflareErrorMessage(error))
         } catch {
+            guard !Task.isCancelled else { return }
             phase = .failed(reason: "Failed to resolve zone: \(error.localizedDescription)")
         }
     }
@@ -159,15 +172,21 @@ final class AISearchModel {
         let executor = AISearchExecutor(reader: reader, writer: writer, provisioner: provisioner)
         do {
             let result = try await executor.provision(zoneID: zoneID, domain: domain, apiToken: token)
+            // Same stale-write gate as runCheckPolicyAndResolveZone: a dismissed sheet
+            // (phase already reset to .idle) must not be overwritten by this task's result.
+            guard !Task.isCancelled else { return }
             phase = .succeeded(result)
         } catch AISearchProvisionError.missingSitemap {
+            guard !Task.isCancelled else { return }
             // Cloudflare 7028: the crawler can't find a sitemap at the domain. The app knows
             // the fix (the sitemap ships in every build but isn't live until the first
             // deploy), so say that — not the API code (#1486).
             phase = .failed(reason: Self.missingSitemapGuidance)
         } catch let error as CloudflareError {
+            guard !Task.isCancelled else { return }
             phase = .failed(reason: cloudflareErrorMessage(error))
         } catch {
+            guard !Task.isCancelled else { return }
             phase = .failed(reason: "Failed to provision AI Search: \(error.localizedDescription)")
         }
     }

--- a/Sources/AnglesiteApp/AISearchModel.swift
+++ b/Sources/AnglesiteApp/AISearchModel.swift
@@ -28,18 +28,27 @@ final class AISearchModel {
     private let reader: any CloudflareReading
     private let writer: any CloudflareWriting
     private let provisioner: any AISearchProvisioning
+    private let preflight: any SitemapPreflighting
     private let keychain: any SecretStore
     private var inFlight: Task<Void, Never>?
+
+    /// The owner-facing fix for a sitemap that isn't live at the domain — shared by the
+    /// preflight short-circuit (#1494) and the create-time 7028 mapping (#1486) so the two
+    /// paths can't drift apart.
+    static let missingSitemapGuidance =
+        "Your site's sitemap isn't reachable yet. Deploy the site first, then set up AI Search."
 
     init(
         reader: any CloudflareReading = HTTPCloudflareClient(),
         writer: any CloudflareWriting = HTTPCloudflareClient(),
         provisioner: any AISearchProvisioning = HTTPCloudflareClient(),
+        preflight: any SitemapPreflighting = HTTPSitemapPreflight(),
         keychain: any SecretStore = KeychainStore()
     ) {
         self.reader = reader
         self.writer = writer
         self.provisioner = provisioner
+        self.preflight = preflight
         self.keychain = keychain
     }
 
@@ -124,6 +133,15 @@ final class AISearchModel {
                 phase = .failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission.")
                 return
             }
+            // Advisory sitemap probe (#1494): a definitive "not there" surfaces the
+            // deploy-first fix *before* the owner is asked to confirm cost, instead of after
+            // a failed create. Only `.unreachable` blocks — `.indeterminate` (timeout, DNS)
+            // proceeds and lets the create itself decide, with the 7028 mapping (#1486) as
+            // the backstop, so a flaky probe can never wedge the wizard.
+            if await preflight.checkSitemap(domain: domain) == .unreachable {
+                phase = .failed(reason: Self.missingSitemapGuidance)
+                return
+            }
             phase = .awaitingCostConfirmation(domain: domain, zoneID: zoneID)
         } catch let error as CloudflareError {
             phase = .failed(reason: cloudflareErrorMessage(error))
@@ -146,7 +164,7 @@ final class AISearchModel {
             // Cloudflare 7028: the crawler can't find a sitemap at the domain. The app knows
             // the fix (the sitemap ships in every build but isn't live until the first
             // deploy), so say that — not the API code (#1486).
-            phase = .failed(reason: "Your site's sitemap isn't reachable yet. Deploy the site first, then set up AI Search.")
+            phase = .failed(reason: Self.missingSitemapGuidance)
         } catch let error as CloudflareError {
             phase = .failed(reason: cloudflareErrorMessage(error))
         } catch {

--- a/Sources/AnglesiteCore/SitemapPreflight.swift
+++ b/Sources/AnglesiteCore/SitemapPreflight.swift
@@ -11,10 +11,16 @@ import FoundationNetworking
 public enum SitemapPreflightResult: Sendable, Equatable {
     /// An HTTP 2xx came back — the sitemap is live at the domain.
     case reachable
-    /// A definitive non-2xx HTTP response came back (e.g. 404) — the sitemap isn't there.
+    /// The server definitively said the sitemap isn't there (404/410). Only these statuses
+    /// count: anything else non-2xx can't distinguish "no sitemap" from the *probe itself*
+    /// being rejected — notably Bot Fight Mode 403-challenging a bare `URLSession` request on
+    /// a perfectly deployed site (the same bot-detection this feature's WAF skip rule exists
+    /// for, see `AISearchExecutor`), or an origin hiccup (5xx).
     case unreachable
-    /// No HTTP answer (timeout, DNS failure, TLS error, …). Treat as "don't know" and let
-    /// the create call itself decide — the 7028 mapping (#1486) remains the backstop.
+    /// Anything that isn't a definitive answer: no HTTP response at all (timeout, DNS
+    /// failure, TLS error, …) or an ambiguous status (403 challenge, 429, 5xx). Treat as
+    /// "don't know" and let the create call itself decide — the 7028 mapping (#1486)
+    /// remains the backstop.
     case indeterminate
 }
 
@@ -58,20 +64,25 @@ public struct HTTPSitemapPreflight: SitemapPreflighting {
         head.httpMethod = "HEAD"
         do {
             let (_, http) = try await transport(head)
-            switch http.statusCode {
-            case 200..<300:
-                return .reachable
-            case 405, 501:
+            if http.statusCode == 405 || http.statusCode == 501 {
                 // Host doesn't do HEAD — ask again with the cheapest possible GET.
                 var get = URLRequest(url: url, timeoutInterval: Self.timeout)
                 get.setValue("bytes=0-0", forHTTPHeaderField: "Range")
                 let (_, getHTTP) = try await transport(get)
-                return (200..<300).contains(getHTTP.statusCode) ? .reachable : .unreachable
-            default:
-                return .unreachable
+                return Self.result(forStatus: getHTTP.statusCode)
             }
+            return Self.result(forStatus: http.statusCode)
         } catch {
             return .indeterminate
+        }
+    }
+
+    /// See ``SitemapPreflightResult``'s case docs for why only 404/410 are definitive.
+    private static func result(forStatus status: Int) -> SitemapPreflightResult {
+        switch status {
+        case 200..<300: return .reachable
+        case 404, 410: return .unreachable
+        default: return .indeterminate
         }
     }
 }

--- a/Sources/AnglesiteCore/SitemapPreflight.swift
+++ b/Sources/AnglesiteCore/SitemapPreflight.swift
@@ -1,0 +1,77 @@
+import Foundation
+// URLSession/URLRequest/HTTPURLResponse live in FoundationNetworking on non-Darwin
+// platforms (swift-corelibs-foundation); this import is a no-op on macOS.
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// What a sitemap reachability probe learned. Three-valued rather than a `Bool` because a
+/// probe that couldn't get an HTTP answer at all must not be conflated with a definitive
+/// "no sitemap" — the preflight is advisory, and only a definitive answer may block (#1494).
+public enum SitemapPreflightResult: Sendable, Equatable {
+    /// An HTTP 2xx came back — the sitemap is live at the domain.
+    case reachable
+    /// A definitive non-2xx HTTP response came back (e.g. 404) — the sitemap isn't there.
+    case unreachable
+    /// No HTTP answer (timeout, DNS failure, TLS error, …). Treat as "don't know" and let
+    /// the create call itself decide — the 7028 mapping (#1486) remains the backstop.
+    case indeterminate
+}
+
+/// Probes whether a domain serves a sitemap, so the AI Search wizard can surface the
+/// deploy-first fix *before* the owner is asked to confirm cost (#1494) instead of after a
+/// failed create (#1486). Seam-shaped like the other Cloudflare clients: tests stub it.
+public protocol SitemapPreflighting: Sendable {
+    /// Checks `https://{domain}/sitemap.xml`. Never throws — every failure mode is folded
+    /// into ``SitemapPreflightResult``.
+    func checkSitemap(domain: String) async -> SitemapPreflightResult
+}
+
+/// Live implementation: `HEAD https://{domain}/sitemap.xml` with a short timeout. Some hosts
+/// answer HEAD oddly, so a 405/501 falls back to a one-byte ranged GET before concluding
+/// anything. Redirects are followed (the transport's URLSession default) — a sitemap behind
+/// a canonical-host redirect still counts as reachable.
+public struct HTTPSitemapPreflight: SitemapPreflighting {
+    /// Short deliberately: this runs inline in the wizard's zone-resolution step, and a slow
+    /// host shouldn't hold the owner hostage for an *advisory* answer.
+    private static let timeout: TimeInterval = 5
+    private let transport: CloudflareTransport
+
+    /// The transport parameter exists for tests (fake responses, no network); production uses
+    /// ``defaultTransport``. Reuses the ``CloudflareTransport`` seam shape even though this
+    /// probe never talks to Cloudflare — it's the package's standard injectable HTTP boundary.
+    public init(transport: @escaping CloudflareTransport = HTTPSitemapPreflight.defaultTransport) {
+        self.transport = transport
+    }
+
+    /// Production transport: a plain shared-`URLSession` request, mirroring
+    /// `HTTPCloudflareClient.defaultTransport`.
+    public static let defaultTransport: CloudflareTransport = { request in
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        return (data, http)
+    }
+
+    public func checkSitemap(domain: String) async -> SitemapPreflightResult {
+        guard let url = URL(string: "https://\(domain)/sitemap.xml") else { return .indeterminate }
+        var head = URLRequest(url: url, timeoutInterval: Self.timeout)
+        head.httpMethod = "HEAD"
+        do {
+            let (_, http) = try await transport(head)
+            switch http.statusCode {
+            case 200..<300:
+                return .reachable
+            case 405, 501:
+                // Host doesn't do HEAD — ask again with the cheapest possible GET.
+                var get = URLRequest(url: url, timeoutInterval: Self.timeout)
+                get.setValue("bytes=0-0", forHTTPHeaderField: "Range")
+                let (_, getHTTP) = try await transport(get)
+                return (200..<300).contains(getHTTP.statusCode) ? .reachable : .unreachable
+            default:
+                return .unreachable
+            }
+        } catch {
+            return .indeterminate
+        }
+    }
+}

--- a/Tests/AnglesiteAppTests/AISearchModelTests.swift
+++ b/Tests/AnglesiteAppTests/AISearchModelTests.swift
@@ -50,6 +50,18 @@ private final class FailingProvisioner: AISearchProvisioning, @unchecked Sendabl
     }
 }
 
+/// Every test passes one of these explicitly — the model's production default is a live
+/// HTTP preflight, and a unit test must never reach the network.
+private final class StubPreflight: SitemapPreflighting, @unchecked Sendable {
+    private let result: SitemapPreflightResult
+    private(set) var checkedDomains: [String] = []
+    init(_ result: SitemapPreflightResult) { self.result = result }
+    func checkSitemap(domain: String) async -> SitemapPreflightResult {
+        checkedDomains.append(domain)
+        return result
+    }
+}
+
 @Suite(.serialized)
 struct AISearchModelTests {
     /// Per-instance scratch service, matching `HardenModelTests`' rationale: every test here
@@ -68,7 +80,7 @@ struct AISearchModelTests {
     @MainActor
     @Test("checkPolicyAndResolveZone ignores blank domain input")
     func ignoresBlankDomain() throws {
-        let model = AISearchModel(reader: StubReader(), writer: StubWriter(), provisioner: StubProvisioner(), keychain: keychain)
+        let model = AISearchModel(reader: StubReader(), writer: StubWriter(), provisioner: StubProvisioner(), preflight: StubPreflight(.reachable), keychain: keychain)
         model.domainInput = "   "
         model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
         #expect(model.phase == .idle)
@@ -79,7 +91,7 @@ struct AISearchModelTests {
     func noPolicyFilePassesThrough() async throws {
         let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
         defer { cfToken.release() }
-        let model = AISearchModel(reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(), keychain: keychain)
+        let model = AISearchModel(reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(), preflight: StubPreflight(.reachable), keychain: keychain)
         model.domainInput = "Example.com"
 
         model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
@@ -102,7 +114,7 @@ struct AISearchModelTests {
         policy.usage.aiInput = .no
         try LicensingStore(sourceDirectory: dir).save(policy)
 
-        let model = AISearchModel(reader: StubReader(), writer: StubWriter(), provisioner: StubProvisioner(), keychain: keychain)
+        let model = AISearchModel(reader: StubReader(), writer: StubWriter(), provisioner: StubProvisioner(), preflight: StubPreflight(.reachable), keychain: keychain)
         model.domainInput = "example.com"
         model.checkPolicyAndResolveZone(sourceDirectory: dir)
         while model.isRunning { await Task.yield() }
@@ -118,7 +130,7 @@ struct AISearchModelTests {
     func confirmCostProvisions() async throws {
         let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
         defer { cfToken.release() }
-        let model = AISearchModel(reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(), keychain: keychain)
+        let model = AISearchModel(reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(), preflight: StubPreflight(.reachable), keychain: keychain)
         model.domainInput = "example.com"
         model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
         while model.isRunning { await Task.yield() }
@@ -142,7 +154,7 @@ struct AISearchModelTests {
         let model = AISearchModel(
             reader: StubReader(zoneID: "z1"), writer: StubWriter(),
             provisioner: FailingProvisioner(throwing: AISearchProvisionError.missingSitemap),
-            keychain: keychain)
+            preflight: StubPreflight(.reachable), keychain: keychain)
         model.domainInput = "example.com"
         model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
         while model.isRunning { await Task.yield() }
@@ -159,5 +171,67 @@ struct AISearchModelTests {
         #expect(reason.localizedCaseInsensitiveContains("sitemap"))
         #expect(!reason.contains("7028"))
         #expect(!reason.contains("HTTP 400"))
+    }
+
+    @MainActor
+    @Test("an unreachable sitemap short-circuits with deploy-first guidance before cost confirmation")
+    func unreachableSitemapShortCircuitsBeforeCostStep() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let preflight = StubPreflight(.unreachable)
+        let model = AISearchModel(
+            reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(),
+            preflight: preflight, keychain: keychain)
+        model.domainInput = "example.com"
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        while model.isRunning { await Task.yield() }
+
+        #expect(preflight.checkedDomains == ["example.com"])
+        guard case .failed(let reason) = model.phase else {
+            Issue.record("expected .failed before cost confirmation, got \(model.phase)")
+            return
+        }
+        #expect(reason.localizedCaseInsensitiveContains("deploy"))
+        #expect(reason.localizedCaseInsensitiveContains("sitemap"))
+    }
+
+    @MainActor
+    @Test("an indeterminate preflight (transport failure) doesn't block the flow")
+    func indeterminatePreflightProceeds() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let model = AISearchModel(
+            reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(),
+            preflight: StubPreflight(.indeterminate), keychain: keychain)
+        model.domainInput = "example.com"
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        while model.isRunning { await Task.yield() }
+
+        #expect(model.phase == .awaitingCostConfirmation(domain: "example.com", zoneID: "z1"))
+    }
+
+    @MainActor
+    @Test("a policy block wins over the preflight — the sitemap is never probed")
+    func policyBlockSkipsPreflight() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let dir = try tempSourceDirectory()
+        var policy = LicensingPolicy()
+        policy.usage.aiInput = .no
+        try LicensingStore(sourceDirectory: dir).save(policy)
+
+        let preflight = StubPreflight(.unreachable)
+        let model = AISearchModel(
+            reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(),
+            preflight: preflight, keychain: keychain)
+        model.domainInput = "example.com"
+        model.checkPolicyAndResolveZone(sourceDirectory: dir)
+        while model.isRunning { await Task.yield() }
+
+        guard case .blockedByPolicy = model.phase else {
+            Issue.record("expected .blockedByPolicy, got \(model.phase)")
+            return
+        }
+        #expect(preflight.checkedDomains.isEmpty)
     }
 }

--- a/Tests/AnglesiteAppTests/AISearchModelTests.swift
+++ b/Tests/AnglesiteAppTests/AISearchModelTests.swift
@@ -62,6 +62,18 @@ private final class StubPreflight: SitemapPreflighting, @unchecked Sendable {
     }
 }
 
+/// Spins until its surrounding task is cancelled, then answers `.indeterminate` — the live
+/// preflight's exact behavior when cancellation hits mid-request (its catch-all can't tell a
+/// cancelled URLSession call from a timeout). Lets a test hold the model mid-preflight.
+private final class HangUntilCancelledPreflight: SitemapPreflighting, @unchecked Sendable {
+    private(set) var started = false
+    func checkSitemap(domain: String) async -> SitemapPreflightResult {
+        started = true
+        while !Task.isCancelled { await Task.yield() }
+        return .indeterminate
+    }
+}
+
 @Suite(.serialized)
 struct AISearchModelTests {
     /// Per-instance scratch service, matching `HardenModelTests`' rationale: every test here
@@ -233,5 +245,29 @@ struct AISearchModelTests {
             return
         }
         #expect(preflight.checkedDomains.isEmpty)
+    }
+
+    @MainActor
+    @Test("a task cancelled mid-preflight never writes a stale phase (dismiss stays dismissed)")
+    func cancelledMidPreflightWritesNothing() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let preflight = HangUntilCancelledPreflight()
+        let model = AISearchModel(
+            reader: StubReader(zoneID: "z1"), writer: StubWriter(), provisioner: StubProvisioner(),
+            preflight: preflight, keychain: keychain)
+        model.domainInput = "example.com"
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+
+        // Hold until the task is genuinely awaiting the preflight, then cancel via dismiss.
+        while !preflight.started { await Task.yield() }
+        model.dismissSheet()
+        #expect(model.phase == .idle)
+
+        // Give the cancelled task every chance to (wrongly) finish its fall-through write:
+        // the preflight answers `.indeterminate` on cancellation, so without the isCancelled
+        // guard the stale task would land `.awaitingCostConfirmation` here.
+        for _ in 0..<50 { await Task.yield() }
+        #expect(model.phase == .idle)
     }
 }

--- a/Tests/AnglesiteCoreTests/SitemapPreflightTests.swift
+++ b/Tests/AnglesiteCoreTests/SitemapPreflightTests.swift
@@ -33,12 +33,33 @@ struct SitemapPreflightTests {
         #expect(request.url?.absoluteString == "https://example.com/sitemap.xml")
     }
 
-    @Test("a definitive non-2xx HEAD response (404) is .unreachable")
+    @Test("a definitive not-there HEAD response (404) is .unreachable")
     func headNotFound() async {
         let spy = SequencedTransport([.success((404, "not found"))])
         let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
         #expect(result == .unreachable)
         #expect(spy.requests.count == 1)
+    }
+
+    @Test("a 410 Gone is .unreachable too")
+    func headGone() async {
+        let spy = SequencedTransport([.success((410, ""))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .unreachable)
+    }
+
+    @Test("a 403 is .indeterminate — Bot Fight Mode challenges a bare URLSession probe on a live site")
+    func headForbiddenIsIndeterminate() async {
+        let spy = SequencedTransport([.success((403, "challenge page"))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .indeterminate)
+    }
+
+    @Test("a 5xx is .indeterminate — an origin hiccup says nothing about the sitemap")
+    func headServerErrorIsIndeterminate() async {
+        let spy = SequencedTransport([.success((522, ""))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .indeterminate)
     }
 
     @Test("a 405 to HEAD falls back to a ranged GET; 206 there is .reachable")
@@ -52,11 +73,18 @@ struct SitemapPreflightTests {
         #expect(fallback.value(forHTTPHeaderField: "Range") == "bytes=0-0")
     }
 
-    @Test("a 405 to HEAD whose GET fallback also fails definitively is .unreachable")
+    @Test("a 405 to HEAD whose GET fallback 404s is .unreachable")
     func fallbackGETNotFound() async {
         let spy = SequencedTransport([.success((501, "")), .success((404, ""))])
         let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
         #expect(result == .unreachable)
+    }
+
+    @Test("a 405 to HEAD whose GET fallback is also ambiguous (403) is .indeterminate")
+    func fallbackGETForbiddenIsIndeterminate() async {
+        let spy = SequencedTransport([.success((405, "")), .success((403, ""))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .indeterminate)
     }
 
     @Test("a transport failure (timeout/DNS) is .indeterminate — advisory, never a wedge")

--- a/Tests/AnglesiteCoreTests/SitemapPreflightTests.swift
+++ b/Tests/AnglesiteCoreTests/SitemapPreflightTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// Serial transport stub: replays `responses` in call order and records every request.
+/// Distinct from `fakeTransport` (keyed by path suffix) because the preflight's HEAD→GET
+/// fallback hits the *same* URL twice and must get different answers per call.
+private final class SequencedTransport: @unchecked Sendable {
+    private(set) var requests: [URLRequest] = []
+    private var responses: [Result<(Int, String), any Error>]
+    init(_ responses: [Result<(Int, String), any Error>]) { self.responses = responses }
+
+    var transport: CloudflareTransport {
+        { [self] request in
+            requests.append(request)
+            guard !responses.isEmpty else { throw URLError(.badServerResponse) }
+            let (status, body) = try responses.removeFirst().get()
+            let http = HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+    }
+}
+
+struct SitemapPreflightTests {
+    @Test("a 2xx HEAD response is .reachable, requested at https://{domain}/sitemap.xml")
+    func headReachable() async throws {
+        let spy = SequencedTransport([.success((200, ""))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .reachable)
+        let request = try #require(spy.requests.first)
+        #expect(request.httpMethod == "HEAD")
+        #expect(request.url?.absoluteString == "https://example.com/sitemap.xml")
+    }
+
+    @Test("a definitive non-2xx HEAD response (404) is .unreachable")
+    func headNotFound() async {
+        let spy = SequencedTransport([.success((404, "not found"))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .unreachable)
+        #expect(spy.requests.count == 1)
+    }
+
+    @Test("a 405 to HEAD falls back to a ranged GET; 206 there is .reachable")
+    func headMethodNotAllowedFallsBackToRangedGET() async throws {
+        let spy = SequencedTransport([.success((405, "")), .success((206, "<urlset/>"))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .reachable)
+        #expect(spy.requests.count == 2)
+        let fallback = try #require(spy.requests.last)
+        #expect(fallback.httpMethod == "GET")
+        #expect(fallback.value(forHTTPHeaderField: "Range") == "bytes=0-0")
+    }
+
+    @Test("a 405 to HEAD whose GET fallback also fails definitively is .unreachable")
+    func fallbackGETNotFound() async {
+        let spy = SequencedTransport([.success((501, "")), .success((404, ""))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .unreachable)
+    }
+
+    @Test("a transport failure (timeout/DNS) is .indeterminate — advisory, never a wedge")
+    func transportFailureIsIndeterminate() async {
+        let spy = SequencedTransport([.failure(URLError(.timedOut))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .indeterminate)
+    }
+
+    @Test("a transport failure on the GET fallback is .indeterminate too")
+    func fallbackTransportFailureIsIndeterminate() async {
+        let spy = SequencedTransport([.success((405, "")), .failure(URLError(.cannotConnectToHost))])
+        let result = await HTTPSitemapPreflight(transport: spy.transport).checkSitemap(domain: "example.com")
+        #expect(result == .indeterminate)
+    }
+}


### PR DESCRIPTION
Closes #1494

## Summary

- New `SitemapPreflighting` seam + `HTTPSitemapPreflight` in AnglesiteCore: `HEAD https://{domain}/sitemap.xml` with a 5s timeout; 2xx → reachable, definitive 404/410 → unreachable, other non-2xx (403 challenge, 429, 5xx) → indeterminate, 405/501 → one-byte ranged-GET fallback (some hosts answer HEAD oddly), transport failure → indeterminate. Redirects are followed, so a sitemap behind a canonical-host redirect still counts.
- `AISearchModel` runs the probe after zone resolution: a definitive `.unreachable` short-circuits with the deploy-first guidance **before** the cost-confirmation step, instead of after a failed create. The guidance string is now a shared constant with the create-time 7028 mapping (#1486) so the two can't drift.
- Advisory, never a wedge: `.indeterminate` (timeout/DNS/TLS) proceeds and lets the create itself decide — the 7028 mapping remains the backstop. A policy block still wins and skips the probe entirely.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` (full suite green; new coverage: 6 `HTTPSitemapPreflight` tests — 2xx/404/405-fallback/fallback-404/transport-failure/fallback-transport-failure — and 3 `AISearchModel` tests: unreachable short-circuits before the cost step, indeterminate proceeds, policy block wins without probing. All model tests now inject a stub preflight so no unit test touches the network.)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [ ] Manual smoke (if UI-touching): not run — reuses the existing `.failed` phase presentation; behavior covered by the unit tests above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
