### PR TITLE
fix(#1500): widen SIGTERM marker wait in AuditCommandTests

### DIFF
--- a/Tests/AnglesiteCoreTests/AuditCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/AuditCommandTests.swift
@@ -102,7 +102,18 @@ struct AuditCommandTests {
             return
         }
         #expect(reason.contains("terminated"))
-        #expect(await waitForMarker("__SIGTERM__", in: center, timeout: .seconds(10)), "build subprocess was not actually SIGTERM'd")
+        // 30s, not the 10s every other marker wait in this file uses: `task.cancel()` only
+        // resumes `waitForExit`'s continuation immediately (ProcessSupervisor.waitForExit's
+        // documented cancel-fast-forward contract) — the actual SIGTERM send is a *separate*,
+        // un-awaited `Task { await supervisor.terminate(handle) }` fired from
+        // `HostAuditExecutor.spawn`'s `onCancel` handler (AuditExecutor.swift). `task.value`
+        // above can therefore resolve well before that detached task is even scheduled, so this
+        // wait is racing real OS/GCD scheduling latency, not a fixed-cost operation. #1500 saw
+        // this lose a 10s budget twice in the isolated, low-concurrency timing-sensitive lane
+        // (scripts/lib/timing-sensitive-tests.sh) — i.e. even reduced cross-suite contention
+        // doesn't bound how long a bare `Task {}` waits for a runner-loaded scheduler. Don't
+        // re-tighten this without evidence the detached-task scheduling gap has been closed.
+        #expect(await waitForMarker("__SIGTERM__", in: center, timeout: .seconds(30)), "build subprocess was not actually SIGTERM'd")
     }
 
     // MARK: Build failure


### PR DESCRIPTION
Closes #1500

## Summary

- `AuditCommandTests`'s cancellation test polls for a `__SIGTERM__` log marker to prove the build subprocess was actually killed, but that marker's delivery is decoupled from `task.value` resolving: `ProcessSupervisor.waitForExit` returns `.terminated` immediately on cancellation, while the real SIGTERM send happens in a separate, un-awaited `Task { await supervisor.terminate(handle) }` fired from `HostAuditExecutor.spawn`'s `onCancel` handler.
- Under scheduler contention that detached task can miss a 10s budget even in CI's isolated, low-concurrency timing-sensitive lane — confirmed twice on 2026-08-16 (see issue for both run links).
- Widened the wait to 30s and documented the mechanism in a comment so the budget isn't silently re-tightened without evidence the underlying scheduling gap has closed.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path . --filter AuditCommandTests`
- [x] `scripts/lib/timing-sensitive-tests.sh` full filter (`VsockTCPProxyTests|E2EServerReadinessTests|AuditCommandTests|MCPClientTests|LANHostScanCoordinatorTests`) — all pass
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run (test-only change, no app-target code touched)