### PR TITLE
fix(#1479): guard HardenModel/AISearchModel phase writes on cancel

### DIFF
--- a/Sources/AnglesiteApp/AISearchModel.swift
+++ b/Sources/AnglesiteApp/AISearchModel.swift
@@ -110,9 +110,16 @@ final class AISearchModel {
         try? await CloudflareAPICredentials.resolve(secretStore: keychain)
     }
 
+    /// See `HardenModel.setPhase(_:)` — same helper, same rationale, kept in sync since the two
+    /// models deliberately mirror each other (#1479).
+    private func setPhase(_ newPhase: Phase) {
+        guard !Task.isCancelled else { return }
+        phase = newPhase
+    }
+
     private func runCheckPolicyAndResolveZone(domain: String, sourceDirectory: URL) async {
         guard let token = await apiToken() else {
-            phase = .failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials.")
+            setPhase(.failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials."))
             return
         }
 
@@ -120,11 +127,11 @@ final class AISearchModel {
         do {
             policy = try LicensingStore(sourceDirectory: sourceDirectory).load()
         } catch {
-            phase = .failed(reason: "Couldn't read this site's AI usage policy: \(error.localizedDescription)")
+            setPhase(.failed(reason: "Couldn't read this site's AI usage policy: \(error.localizedDescription)"))
             return
         }
         if let reason = AISearchExecutor.policyBlockReason(for: policy) {
-            phase = .blockedByPolicy(reason: reason)
+            setPhase(.blockedByPolicy(reason: reason))
             return
         }
 
@@ -138,56 +145,46 @@ final class AISearchModel {
         async let sitemapReachability = preflight.checkSitemap(domain: domain)
         do {
             guard let zoneID = try await reader.resolveZoneID(domain: domain, apiToken: token) else {
-                guard !Task.isCancelled else { return }
-                phase = .failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission.")
+                setPhase(.failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission."))
                 return
             }
             let reachability = await sitemapReachability
             // Cancellation can surface as a *value*, not a thrown error: the preflight's
             // catch-all folds a cancelled request into `.indeterminate`, and a stub reader
-            // may not throw at all. A superseded task (new domain typed, or the sheet
-            // dismissed) must never write a stale phase over the current task's — the
-            // classic wrong-domain footgun — so every phase write below is gated.
-            guard !Task.isCancelled else { return }
+            // may not throw at all. `setPhase(_:)` (the same guard used everywhere else in
+            // this runner) catches that case too, so a superseded task can't write a stale
+            // phase over the current task's — the classic wrong-domain footgun.
             if reachability == .unreachable {
-                phase = .failed(reason: Self.missingSitemapGuidance)
+                setPhase(.failed(reason: Self.missingSitemapGuidance))
                 return
             }
-            phase = .awaitingCostConfirmation(domain: domain, zoneID: zoneID)
+            setPhase(.awaitingCostConfirmation(domain: domain, zoneID: zoneID))
         } catch let error as CloudflareError {
-            guard !Task.isCancelled else { return }
-            phase = .failed(reason: cloudflareErrorMessage(error))
+            setPhase(.failed(reason: cloudflareErrorMessage(error)))
         } catch {
-            guard !Task.isCancelled else { return }
-            phase = .failed(reason: "Failed to resolve zone: \(error.localizedDescription)")
+            setPhase(.failed(reason: "Failed to resolve zone: \(error.localizedDescription)"))
         }
     }
 
     private func runProvision(domain: String, zoneID: String) async {
         guard let token = await apiToken() else {
-            phase = .failed(reason: "No Cloudflare API token found.")
+            setPhase(.failed(reason: "No Cloudflare API token found."))
             return
         }
 
         let executor = AISearchExecutor(reader: reader, writer: writer, provisioner: provisioner)
         do {
             let result = try await executor.provision(zoneID: zoneID, domain: domain, apiToken: token)
-            // Same stale-write gate as runCheckPolicyAndResolveZone: a dismissed sheet
-            // (phase already reset to .idle) must not be overwritten by this task's result.
-            guard !Task.isCancelled else { return }
-            phase = .succeeded(result)
+            setPhase(.succeeded(result))
         } catch AISearchProvisionError.missingSitemap {
-            guard !Task.isCancelled else { return }
             // Cloudflare 7028: the crawler can't find a sitemap at the domain. The app knows
             // the fix (the sitemap ships in every build but isn't live until the first
             // deploy), so say that — not the API code (#1486).
-            phase = .failed(reason: Self.missingSitemapGuidance)
+            setPhase(.failed(reason: Self.missingSitemapGuidance))
         } catch let error as CloudflareError {
-            guard !Task.isCancelled else { return }
-            phase = .failed(reason: cloudflareErrorMessage(error))
+            setPhase(.failed(reason: cloudflareErrorMessage(error)))
         } catch {
-            guard !Task.isCancelled else { return }
-            phase = .failed(reason: "Failed to provision AI Search: \(error.localizedDescription)")
+            setPhase(.failed(reason: "Failed to provision AI Search: \(error.localizedDescription)"))
         }
     }
 

--- a/Sources/AnglesiteApp/HardenModel.swift
+++ b/Sources/AnglesiteApp/HardenModel.swift
@@ -117,31 +117,41 @@ final class HardenModel {
         try? await CloudflareAPICredentials.resolve(secretStore: keychain)
     }
 
+    /// `dismissSheet()`/re-entry cancel `inFlight` but only set the cancellation flag — the
+    /// abandoned task keeps executing across its network awaits. Routing every `phase` write in
+    /// the async runners through this guard (mirroring `DomainModel.runVerifyBlueskyHandle`'s
+    /// idiom) stops a stale task's completion from clobbering a phase the user already reset by
+    /// dismissing/reopening, or a newer run's phase after a re-entrant call (#1479).
+    private func setPhase(_ newPhase: Phase) {
+        guard !Task.isCancelled else { return }
+        phase = newPhase
+    }
+
     private func runResolveAndPlan(domain: String) async {
         guard let token = await apiToken() else {
-            phase = .failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials.")
+            setPhase(.failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials."))
             return
         }
 
         do {
             guard let zoneID = try await reader.resolveZoneID(domain: domain, apiToken: token) else {
-                phase = .failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission.")
+                setPhase(.failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission."))
                 return
             }
 
             let state = try await reader.zoneState(zoneID: zoneID, domain: domain, apiToken: token)
             let plan = HardenPlanner.plan(from: state, domain: domain)
-            phase = .preview(plan: plan, domain: domain, zoneID: zoneID)
+            setPhase(.preview(plan: plan, domain: domain, zoneID: zoneID))
         } catch let error as CloudflareError {
-            phase = .failed(reason: cloudflareErrorMessage(error, domain: domain))
+            setPhase(.failed(reason: cloudflareErrorMessage(error, domain: domain)))
         } catch {
-            phase = .failed(reason: "Failed to read zone state: \(error.localizedDescription)")
+            setPhase(.failed(reason: "Failed to read zone state: \(error.localizedDescription)"))
         }
     }
 
     private func runApply(plan: HardenPlan, domain: String, zoneID: String) async {
         guard let token = await apiToken() else {
-            phase = .failed(reason: "No Cloudflare API token found.")
+            setPhase(.failed(reason: "No Cloudflare API token found."))
             return
         }
 
@@ -150,12 +160,12 @@ final class HardenModel {
             plan: plan, zoneID: zoneID, domain: domain, apiToken: token,
             sourceDirectory: currentSite?.sourceDirectory)
 
-        phase = .succeeded(result: HardenResult(
+        setPhase(.succeeded(result: HardenResult(
             appliedCount: result.appliedCount,
             failedItems: result.failedItems.map { .init(description: $0.item.description, error: $0.error) },
             postAuditFindings: result.postAuditFindings,
             auditError: result.auditError
-        ))
+        )))
     }
 
     private func cloudflareErrorMessage(_ error: CloudflareError, domain: String) -> String {

--- a/Tests/AnglesiteAppTests/AISearchModelTests.swift
+++ b/Tests/AnglesiteAppTests/AISearchModelTests.swift
@@ -74,7 +74,36 @@ private final class HangUntilCancelledPreflight: SitemapPreflighting, @unchecked
     }
 }
 
-@Suite(.serialized)
+/// A `CloudflareReading` whose `resolveZoneID` calls suspend until the test explicitly resolves
+/// them — mirrors `HardenModelTests.ControllableReader`/`DomainModelTests.ControllableATProtoDIDTransport`,
+/// used to exercise a run still in flight when the sheet is dismissed/reopened out from under it (#1479).
+private actor ControllableReader: CloudflareReading {
+    private var continuations: [(domain: String, continuation: CheckedContinuation<String?, any Error>)] = []
+    private let state: CloudflareZoneState
+
+    init(state: CloudflareZoneState = StubReader.defaultState) {
+        self.state = state
+    }
+
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String? {
+        try await withCheckedThrowingContinuation { continuation in
+            continuations.append((domain, continuation))
+        }
+    }
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState { state }
+    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] { [] }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
+
+    func resolve(callIndex index: Int, zoneID: String?) {
+        continuations[index].continuation.resume(returning: zoneID)
+    }
+    func callCount() -> Int { continuations.count }
+}
+
+// `.timeLimit`: see #1349/#1355/#1366 — a wedged test (e.g. a yield-poll waiting on a
+// `ControllableReader` call that never comes) must fail as an unambiguous time-limit violation
+// instead of hanging the whole `AnglesiteAppTests` run indefinitely.
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct AISearchModelTests {
     /// Per-instance scratch service, matching `HardenModelTests`' rationale: every test here
     /// claims `CLOUDFLARE_API_TOKEN` via `CloudflareAPITokenTestEnvironment`, so a fallback to
@@ -269,5 +298,72 @@ struct AISearchModelTests {
         // guard the stale task would land `.awaitingCostConfirmation` here.
         for _ in 0..<50 { await Task.yield() }
         #expect(model.phase == .idle)
+    }
+
+    /// Regression coverage for #1479: `dismissSheet()` only sets `inFlight`'s cancellation flag —
+    /// the abandoned task keeps running across its network awaits. Without the `Task.isCancelled`
+    /// guard on every `phase` write in the async runner, a stale completion after dismissal would
+    /// clobber the `.idle` reset with a result the user never asked for in this session.
+    @MainActor
+    @Test("dismissing the sheet mid-resolve does not let a stale completion clobber the reset phase")
+    func dismissDuringResolveDoesNotClobberResetState() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let reader = ControllableReader()
+        let model = AISearchModel(
+            reader: reader, writer: StubWriter(), provisioner: StubProvisioner(),
+            preflight: StubPreflight(.reachable), keychain: keychain)
+        model.domainInput = "example.com"
+
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        // Let the spawned `Task` actually start and suspend inside `reader.resolveZoneID`, so
+        // dismissal below races a run that's genuinely still in flight.
+        while await reader.callCount() == 0 { await Task.yield() }
+        #expect(model.phase == .resolvingZone(domain: "example.com"))
+
+        model.dismissSheet()
+        #expect(model.phase == .idle)
+
+        // The in-flight lookup finally resolves *after* dismissal cancelled its `Task` — the
+        // result must not land and clobber the `.idle` reset (the bug this test guards).
+        await reader.resolve(callIndex: 0, zoneID: "z1")
+        for _ in 0..<5 { await Task.yield() }
+
+        #expect(model.phase == .idle)
+    }
+
+    /// Regression coverage for #1479's second acceptance criterion: a stale run's completion must
+    /// not overwrite a newer run's phase, even when the newer run was started before the older one
+    /// finally resolves.
+    @MainActor
+    @Test("a newer run's phase survives a stale older run resolving after it")
+    func newerRunSurvivesStaleOlderRunCompleting() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let reader = ControllableReader()
+        let model = AISearchModel(
+            reader: reader, writer: StubWriter(), provisioner: StubProvisioner(),
+            preflight: StubPreflight(.reachable), keychain: keychain)
+        model.domainInput = "stale.example"
+
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        while await reader.callCount() == 0 { await Task.yield() }
+
+        model.dismissSheet()
+        model.domainInput = "fresh.example"
+        model.checkPolicyAndResolveZone(sourceDirectory: try tempSourceDirectory())
+        while await reader.callCount() == 1 { await Task.yield() }
+        #expect(model.phase == .resolvingZone(domain: "fresh.example"))
+
+        // The stale first lookup resolves after the second run has already started — it must not
+        // overwrite the second run's phase.
+        await reader.resolve(callIndex: 0, zoneID: "stale-zone")
+        for _ in 0..<5 { await Task.yield() }
+        #expect(model.phase == .resolvingZone(domain: "fresh.example"))
+
+        await reader.resolve(callIndex: 1, zoneID: "fresh-zone")
+        while model.isRunning { await Task.yield() }
+
+        #expect(model.phase == .awaitingCostConfirmation(domain: "fresh.example", zoneID: "fresh-zone"))
     }
 }

--- a/Tests/AnglesiteAppTests/HardenModelTests.swift
+++ b/Tests/AnglesiteAppTests/HardenModelTests.swift
@@ -41,7 +41,36 @@ private final class StubWriter: CloudflareWriting, @unchecked Sendable {
     func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
 }
 
-@Suite(.serialized)
+/// A `CloudflareReading` whose `resolveZoneID` calls suspend until the test explicitly resolves
+/// them — mirrors `DomainModelTests.ControllableATProtoDIDTransport`, used to exercise a run
+/// still in flight when the sheet is dismissed/reopened out from under it (#1479).
+private actor ControllableReader: CloudflareReading {
+    private var continuations: [(domain: String, continuation: CheckedContinuation<String?, any Error>)] = []
+    private let state: CloudflareZoneState
+
+    init(state: CloudflareZoneState = StubReader.cleanState) {
+        self.state = state
+    }
+
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String? {
+        try await withCheckedThrowingContinuation { continuation in
+            continuations.append((domain, continuation))
+        }
+    }
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState { state }
+    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] { [] }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
+
+    func resolve(callIndex index: Int, zoneID: String?) {
+        continuations[index].continuation.resume(returning: zoneID)
+    }
+    func callCount() -> Int { continuations.count }
+}
+
+// `.timeLimit`: see #1349/#1355/#1366 — a wedged test (e.g. a yield-poll waiting on a
+// `ControllableReader` call that never comes) must fail as an unambiguous time-limit violation
+// instead of hanging the whole `AnglesiteAppTests` run indefinitely.
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct HardenModelTests {
     /// A per-case scratch service, matching `DomainConfigAuditModelTests`' rationale: every test
     /// here claims `CLOUDFLARE_API_TOKEN` via `CloudflareAPITokenTestEnvironment`, so a fallback
@@ -108,5 +137,73 @@ struct HardenModelTests {
             return
         }
         #expect(result.appliedCount == plan.items.count)
+    }
+
+    /// Regression coverage for #1479: `dismissSheet()` only sets `inFlight`'s cancellation flag —
+    /// the abandoned task keeps running across its network awaits. Without the `Task.isCancelled`
+    /// guard on every `phase` write in the async runner, a stale completion after dismissal would
+    /// clobber the `.idle` reset with a result the user never asked for in this session.
+    @MainActor
+    @Test("dismissing the sheet mid-resolve does not let a stale completion clobber the reset phase")
+    func dismissDuringResolveDoesNotClobberResetState() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let reader = ControllableReader()
+        let model = HardenModel(reader: reader, writer: StubWriter(), keychain: keychain)
+        model.domainInput = "example.com"
+
+        model.resolveAndPlan()
+        // Let the spawned `Task` actually start and suspend inside `reader.resolveZoneID`, so
+        // dismissal below races a run that's genuinely still in flight.
+        while await reader.callCount() == 0 { await Task.yield() }
+        #expect(model.phase == .resolvingZone(domain: "example.com"))
+
+        model.dismissSheet()
+        #expect(model.phase == .idle)
+
+        // The in-flight lookup finally resolves *after* dismissal cancelled its `Task` — the
+        // result must not land and clobber the `.idle` reset (the bug this test guards).
+        await reader.resolve(callIndex: 0, zoneID: "z1")
+        for _ in 0..<5 { await Task.yield() }
+
+        #expect(model.phase == .idle)
+    }
+
+    /// Regression coverage for #1479's second acceptance criterion: a stale run's completion must
+    /// not overwrite a newer run's phase, even when the newer run was started before the older one
+    /// finally resolves.
+    @MainActor
+    @Test("a newer run's phase survives a stale older run resolving after it")
+    func newerRunSurvivesStaleOlderRunCompleting() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let reader = ControllableReader()
+        let model = HardenModel(reader: reader, writer: StubWriter(), keychain: keychain)
+        model.domainInput = "stale.example"
+
+        model.resolveAndPlan()
+        while await reader.callCount() == 0 { await Task.yield() }
+
+        model.dismissSheet()
+        model.domainInput = "fresh.example"
+        model.resolveAndPlan()
+        while await reader.callCount() == 1 { await Task.yield() }
+        #expect(model.phase == .resolvingZone(domain: "fresh.example"))
+
+        // The stale first lookup resolves after the second run has already started — it must not
+        // overwrite the second run's phase.
+        await reader.resolve(callIndex: 0, zoneID: "stale-zone")
+        for _ in 0..<5 { await Task.yield() }
+        #expect(model.phase == .resolvingZone(domain: "fresh.example"))
+
+        await reader.resolve(callIndex: 1, zoneID: "fresh-zone")
+        while model.isRunning { await Task.yield() }
+
+        guard case .preview(_, let domain, let zoneID) = model.phase else {
+            Issue.record("expected .preview, got \(model.phase)")
+            return
+        }
+        #expect(domain == "fresh.example")
+        #expect(zoneID == "fresh-zone")
     }
 }


### PR DESCRIPTION
Closes #1479

## Summary

- `HardenModel`/`AISearchModel`'s async runners (`runResolveAndPlan`/`runApply`, `runCheckPolicyAndResolveZone`/`runProvision`) never checked `Task.isCancelled`, so an `inFlight?.cancel()` from `dismissSheet()`/re-entry only set the cancellation flag while the abandoned task kept running and could still write `phase` after the user had already reset it to `.idle` or started a fresh run.
- Add a `setPhase(_:)` helper to each model that checks `Task.isCancelled` before writing `phase`, and route every `phase = ...` write in the async runners through it — mirrors the existing guard idiom in `DomainModel.runVerifyBlueskyHandle`.
- Add regression coverage to `HardenModelTests`/`AISearchModelTests` using a suspend-until-signaled `ControllableReader` (mirroring `DomainModelTests.ControllableATProtoDIDTransport`) that exercises both acceptance criteria: a dismiss mid-run doesn't clobber the reset `.idle` phase, and a stale run's late completion doesn't overwrite a newer run's phase.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` (530 tests, 71 suites, all passing)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (BUILD SUCCEEDED)
- [ ] Manual smoke (if UI-touching): not needed — no UI change, phase-guard logic only.