### PR TITLE
feat(#1461): add stale worktree + DerivedData prune script

### DIFF
--- a/scripts/prune-worktrees.sh
+++ b/scripts/prune-worktrees.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+#
+# Prune stale agent worktrees under .claude/worktrees/ and the orphaned Xcode
+# DerivedData they leave behind (#1461).
+#
+# This repo runs every feature/agent task in its own worktree (AGENTS.md ▸
+# "Worktrees"), and each worktree's distinct Anglesite.xcodeproj path also earns
+# its own ~/Library/Developer/Xcode/DerivedData/Anglesite-* directory. Nothing
+# reclaims either automatically — a 2026-08-13 audit found 141GB of stale
+# worktrees plus 146GB of orphaned DerivedData. This script automates the manual
+# cleanup procedure documented in AGENTS.md, including both safety checks:
+#
+#   1. Registered worktrees (in `git worktree list`) are candidates only when
+#      their branch's PR is merged or closed (`gh pr list --head … --state all`).
+#      Removal additionally requires a clean `git status --short`; a dirty
+#      worktree whose PR is merged needs an explicit --force-dirty (never
+#      `git worktree remove --force` by default).
+#   2. Directories on disk but NOT in `git worktree list` (broken gitdir links
+#      from a rename/relocation, or an interrupted removal) are plain leftover
+#      directories — `git worktree remove` won't touch them — and are removed
+#      with `rm -rf`.
+#   3. EVERY candidate — registered or orphaned — must have no live process
+#      holding it as a cwd (lsof check). Git status and PR state alone don't
+#      reveal a live agent session using a worktree; skipping this check is
+#      what caused the live-session collision that motivated this script.
+#   4. DerivedData/Anglesite-* directories whose info.plist WorkspacePath no
+#      longer exists on disk (including ones freed by this run's removals) are
+#      stale and removed. Skipped off-macOS / without plutil.
+#
+# Report-only by default: prints candidates, reasons, and reclaimable size but
+# deletes nothing. --remove performs deletions, confirming each candidate
+# interactively; --yes skips the per-candidate confirmation.
+#
+# This is host-machine maintenance, not CI (CI runners have no long-lived
+# worktree state). scripts/setup-dev-env.sh offers to run this report when the
+# worktree count/size crosses a threshold. Local test: scripts/prune-worktrees.test.sh
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+usage: scripts/prune-worktrees.sh [--remove] [--yes] [--force-dirty]
+
+  (no flags)     report candidates and reclaimable size; delete nothing
+  --remove       actually remove safe candidates (per-candidate confirmation)
+  --yes          with --remove: skip the per-candidate confirmation prompt
+  --force-dirty  with --remove: also remove worktrees with uncommitted changes
+                 when their PR is MERGED (uses `git worktree remove --force`)
+  -h, --help     show this help
+
+Safety: a candidate is never touched while any live process has it as its cwd,
+and a dirty worktree is never force-removed without --force-dirty.
+EOF
+}
+
+REMOVE=0
+ASSUME_YES=0
+FORCE_DIRTY=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --remove)      REMOVE=1 ;;
+        --yes)         ASSUME_YES=1 ;;
+        --force-dirty) FORCE_DIRTY=1 ;;
+        -h|--help)     usage; exit 0 ;;
+        *) echo "error: unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# Resolve the MAIN checkout even when this script runs from inside a worktree:
+# --git-common-dir points at the main checkout's .git in both cases.
+MAIN_ROOT=$(dirname "$(git -C "$SCRIPT_DIR" rev-parse --path-format=absolute --git-common-dir)")
+WORKTREES_DIR="$MAIN_ROOT/.claude/worktrees"
+DERIVED_DATA_ROOT="$HOME/Library/Developer/Xcode/DerivedData"
+
+# One lsof pass, cached: "cwd<TAB>pid<TAB>command" per live process. Used to
+# refuse any candidate that is some process's current working directory.
+LIVE_CWDS=$(lsof -d cwd -F pcn 2>/dev/null | awk '
+    /^p/ { pid = substr($0, 2) }
+    /^c/ { cmd = substr($0, 2) }
+    /^n/ { printf "%s\t%s\t%s\n", substr($0, 2), pid, cmd }' || true)
+
+# Prints "pid<TAB>command" lines for processes whose cwd is at/under $1;
+# returns 1 (and prints nothing) when the directory is not in use.
+live_users() {
+    local dir="$1" found=1 cwd pid cmd
+    while IFS=$'\t' read -r cwd pid cmd; do
+        [[ -n "$cwd" ]] || continue
+        if [[ "$cwd" == "$dir" || "$cwd" == "$dir"/* ]]; then
+            printf '%s\t%s\n' "$pid" "$cmd"
+            found=0
+        fi
+    done <<<"$LIVE_CWDS"
+    return "$found"
+}
+
+# PR state for a branch: MERGED / CLOSED / OPEN / NONE / UNKNOWN (gh missing
+# or the lookup failed — e.g. offline). UNKNOWN/NONE/OPEN are never candidates.
+pr_state() {
+    local branch="$1" out
+    command -v gh >/dev/null 2>&1 || { echo UNKNOWN; return; }
+    if ! out=$(gh pr list --head "$branch" --state all --json state --limit 1 </dev/null 2>/dev/null); then
+        echo UNKNOWN
+        return
+    fi
+    case "$out" in
+        *MERGED*) echo MERGED ;;
+        *CLOSED*) echo CLOSED ;;
+        *OPEN*)   echo OPEN ;;
+        *)        echo NONE ;;
+    esac
+}
+
+size_kb() { du -sk "$1" 2>/dev/null | awk '{ print $1 }'; }
+
+human() { # KB -> human string
+    local kb="${1:-0}"
+    if   [[ "$kb" -ge 1048576 ]]; then awk -v k="$kb" 'BEGIN { printf "%.1fGB", k / 1048576 }'
+    elif [[ "$kb" -ge 1024 ]];    then awk -v k="$kb" 'BEGIN { printf "%.0fMB", k / 1024 }'
+    else printf '%sKB' "$kb"
+    fi
+}
+
+# $1 = prompt; honors --yes. Reads from /dev/tty (not stdin — the worktree
+# loops feed stdin from a herestring); no terminal without --yes = no.
+confirm() {
+    [[ "$ASSUME_YES" -eq 1 ]] && return 0
+    local ans
+    if ! read -r -p "    $1 [y/N] " ans </dev/tty 2>/dev/null; then
+        echo "    skipping (no interactive terminal; pass --yes to confirm removals)"
+        return 1
+    fi
+    [[ "$ans" == [yY]* ]]
+}
+
+RECLAIMABLE_KB=0
+RECLAIMED_KB=0
+CANDIDATES=0
+REMOVED=0
+
+report_live_users() {
+    while IFS=$'\t' read -r pid cmd; do
+        echo "      in use by pid $pid ($cmd)"
+    done <<<"$1"
+}
+
+echo "Worktrees root: $WORKTREES_DIR"
+if [[ "$REMOVE" -eq 1 ]]; then echo "Mode: REMOVE"; else echo "Mode: report-only (pass --remove to delete)"; fi
+echo
+
+# ---- Phase 1: registered worktrees under .claude/worktrees/ -----------------
+
+# Registered worktree paths, one per line (all of them, not just ours).
+REGISTERED=$(git -C "$MAIN_ROOT" worktree list --porcelain | sed -n 's/^worktree //p')
+
+if [[ -d "$WORKTREES_DIR" ]]; then
+    while IFS= read -r wt; do
+        case "$wt" in "$WORKTREES_DIR"/*) ;; *) continue ;; esac
+        [[ -d "$wt" ]] || continue
+        name=${wt#"$WORKTREES_DIR"/}
+
+        branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+        if [[ -z "$branch" ]]; then
+            echo "keep      $name — detached HEAD, no branch to check a PR for"
+            continue
+        fi
+
+        state=$(pr_state "$branch")
+        if [[ "$state" != "MERGED" && "$state" != "CLOSED" ]]; then
+            echo "keep      $name — PR state: $state ($branch)"
+            continue
+        fi
+
+        if users=$(live_users "$wt"); then
+            echo "SKIP      $name — PR $state but a live process has it as cwd:"
+            report_live_users "$users"
+            continue
+        fi
+
+        dirty=$(git -C "$wt" status --short 2>/dev/null || echo "?? status-failed")
+        force_this=""
+        if [[ -n "$dirty" ]]; then
+            if [[ "$state" != "MERGED" ]]; then
+                echo "SKIP      $name — PR $state but has uncommitted changes; inspect manually:"
+                echo "$dirty" | sed 's/^/        /'
+                continue
+            fi
+            if [[ "$FORCE_DIRTY" -ne 1 ]]; then
+                kb=$(size_kb "$wt")
+                RECLAIMABLE_KB=$((RECLAIMABLE_KB + ${kb:-0}))
+                CANDIDATES=$((CANDIDATES + 1))
+                echo "CANDIDATE $name — PR MERGED but dirty ($(human "${kb:-0}")); needs --force-dirty:"
+                echo "$dirty" | sed 's/^/        /'
+                continue
+            fi
+            force_this="--force"
+        fi
+
+        kb=$(size_kb "$wt")
+        RECLAIMABLE_KB=$((RECLAIMABLE_KB + ${kb:-0}))
+        CANDIDATES=$((CANDIDATES + 1))
+        echo "CANDIDATE $name — PR $state, ${dirty:+dirty (--force-dirty), }no live users ($(human "${kb:-0}"))"
+
+        if [[ "$REMOVE" -eq 1 ]] && confirm "git worktree remove${force_this:+ --force} $name?"; then
+            # shellcheck disable=SC2086 # force_this is empty or a single flag
+            if git -C "$MAIN_ROOT" worktree remove $force_this "$wt"; then
+                echo "REMOVED   $name"
+                REMOVED=$((REMOVED + 1))
+                RECLAIMED_KB=$((RECLAIMED_KB + ${kb:-0}))
+            else
+                echo "ERROR     $name — git worktree remove refused; inspect it manually"
+            fi
+        fi
+    done <<<"$REGISTERED"
+fi
+
+# ---- Phase 2: orphaned directories (on disk, not in `git worktree list`) ----
+
+if [[ -d "$WORKTREES_DIR" ]]; then
+    for dir in "$WORKTREES_DIR"/*/; do
+        [[ -d "$dir" ]] || continue
+        dir=${dir%/}
+        if grep -qxF "$dir" <<<"$REGISTERED"; then
+            continue
+        fi
+        name=${dir#"$WORKTREES_DIR"/}
+
+        if users=$(live_users "$dir"); then
+            echo "SKIP      $name — orphaned (not in \`git worktree list\`) but a live process has it as cwd:"
+            report_live_users "$users"
+            continue
+        fi
+
+        kb=$(size_kb "$dir")
+        RECLAIMABLE_KB=$((RECLAIMABLE_KB + ${kb:-0}))
+        CANDIDATES=$((CANDIDATES + 1))
+        echo "CANDIDATE $name — orphaned directory, not a registered worktree ($(human "${kb:-0}"))"
+
+        if [[ "$REMOVE" -eq 1 ]] && confirm "rm -rf $name?"; then
+            rm -rf "$dir"
+            echo "REMOVED   $name"
+            REMOVED=$((REMOVED + 1))
+            RECLAIMED_KB=$((RECLAIMED_KB + ${kb:-0}))
+        fi
+    done
+fi
+
+# Registered entries whose directory vanished out-of-band are harmless stale
+# registrations; tidy them after removals.
+if [[ "$REMOVE" -eq 1 ]]; then
+    git -C "$MAIN_ROOT" worktree prune
+fi
+
+# ---- Phase 3: stale DerivedData (Anglesite-*) -------------------------------
+
+# Runs AFTER the worktree phases so DerivedData belonging to a worktree removed
+# in this run is already stale (its WorkspacePath no longer exists).
+if ! command -v plutil >/dev/null 2>&1; then
+    echo "note      skipping DerivedData scan — plutil not available (macOS-only phase)"
+elif [[ ! -d "$DERIVED_DATA_ROOT" ]]; then
+    echo "note      skipping DerivedData scan — $DERIVED_DATA_ROOT does not exist"
+else
+    for dd in "$DERIVED_DATA_ROOT"/Anglesite-*/; do
+        [[ -d "$dd" ]] || continue
+        dd=${dd%/}
+        name=${dd#"$DERIVED_DATA_ROOT"/}
+
+        ws=$(plutil -extract WorkspacePath raw -o - "$dd/info.plist" 2>/dev/null || true)
+        if [[ -z "$ws" ]]; then
+            echo "keep      DerivedData/$name — no readable WorkspacePath; not touching it"
+            continue
+        fi
+        if [[ -e "$ws" ]]; then
+            echo "keep      DerivedData/$name — workspace still exists ($ws)"
+            continue
+        fi
+
+        kb=$(size_kb "$dd")
+        RECLAIMABLE_KB=$((RECLAIMABLE_KB + ${kb:-0}))
+        CANDIDATES=$((CANDIDATES + 1))
+        echo "CANDIDATE DerivedData/$name — workspace gone: $ws ($(human "${kb:-0}"))"
+
+        if [[ "$REMOVE" -eq 1 ]] && confirm "rm -rf DerivedData/$name?"; then
+            rm -rf "$dd"
+            echo "REMOVED   DerivedData/$name"
+            REMOVED=$((REMOVED + 1))
+            RECLAIMED_KB=$((RECLAIMED_KB + ${kb:-0}))
+        fi
+    done
+fi
+
+# ---- Summary ----------------------------------------------------------------
+
+echo
+if [[ "$REMOVE" -eq 1 ]]; then
+    echo "Removed $REMOVED of $CANDIDATES candidate(s), reclaimed $(human "$RECLAIMED_KB")."
+else
+    echo "$CANDIDATES candidate(s), $(human "$RECLAIMABLE_KB") reclaimable."
+    if [[ "$CANDIDATES" -gt 0 ]]; then
+        echo "Nothing was deleted. To remove: scripts/prune-worktrees.sh --remove"
+    fi
+fi

--- a/scripts/prune-worktrees.test.sh
+++ b/scripts/prune-worktrees.test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Exercises scripts/prune-worktrees.sh against a throwaway git repo with
+# stubbed `gh`, `lsof`, and `plutil`, so every safety branch runs without
+# touching the real repo, real processes, or real DerivedData (#1461):
+#
+#   * merged+clean worktree      -> candidate, removed by --remove
+#   * merged+dirty worktree      -> reported, removed ONLY with --force-dirty
+#   * open-PR worktree           -> kept
+#   * merged but live-cwd busy   -> skipped (the lsof safety check)
+#   * orphaned dir (unregistered)-> candidate, rm -rf'd by --remove
+#   * DerivedData with dead/live WorkspacePath -> removed / kept
+#
+# Not wired into CI (the script maintains host-machine state CI doesn't have);
+# run it locally after changing prune-worktrees.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/prune-worktrees.sh"
+
+# Resolve symlinks (macOS /var -> /private/var) so paths match git's output.
+tmp=$(cd "$(mktemp -d)" && pwd -P)
+trap 'rm -rf "$tmp"' EXIT
+
+overall_status=0
+pass() { echo "ok   $1"; }
+fail() { echo "FAIL $1"; overall_status=1; }
+assert_exists()  { [[ -e "$2" ]] && pass "$1" || fail "$1 (missing: $2)"; }
+assert_gone()    { [[ ! -e "$2" ]] && pass "$1" || fail "$1 (still exists: $2)"; }
+assert_output()  { grep -qF "$2" "$3" && pass "$1" || { fail "$1 (no match: $2)"; sed 's/^/  | /' "$3"; }; }
+
+# ---- Fixture: main repo + worktrees -----------------------------------------
+
+main="$tmp/main"
+mkdir -p "$main"
+git -C "$main" init -q -b main
+git -C "$main" config user.email test@example.com
+git -C "$main" config user.name "Prune Test"
+echo hello >"$main/README.md"
+mkdir -p "$main/scripts"
+cp "$TARGET" "$main/scripts/prune-worktrees.sh"
+git -C "$main" add -A
+git -C "$main" commit -qm "init"
+
+wt="$main/.claude/worktrees"
+git -C "$main" worktree add -q "$wt/merged-clean" -b merged-clean
+git -C "$main" worktree add -q "$wt/merged-dirty" -b merged-dirty
+git -C "$main" worktree add -q "$wt/merged-busy"  -b merged-busy
+git -C "$main" worktree add -q "$wt/open-pr"      -b open-pr
+echo scratch >"$wt/merged-dirty/uncommitted.txt"
+mkdir -p "$wt/orphan-dir"
+echo leftover >"$wt/orphan-dir/junk.txt"
+
+# ---- Fixture: DerivedData + stubs -------------------------------------------
+
+home="$tmp/home"
+dd="$home/Library/Developer/Xcode/DerivedData"
+mkdir -p "$dd/Anglesite-stale" "$dd/Anglesite-forclean" "$dd/Anglesite-live"
+# Stub plutil reads the WorkspacePath from a sibling .ws file, so the fixture
+# needs no real binary plists (and the test runs on Linux too).
+echo "$tmp/nonexistent-checkout"  >"$dd/Anglesite-stale/info.plist.ws";    touch "$dd/Anglesite-stale/info.plist"
+echo "$wt/merged-clean"           >"$dd/Anglesite-forclean/info.plist.ws"; touch "$dd/Anglesite-forclean/info.plist"
+echo "$main"                      >"$dd/Anglesite-live/info.plist.ws";     touch "$dd/Anglesite-live/info.plist"
+
+stubs="$tmp/stubs"
+mkdir -p "$stubs"
+
+# gh: MERGED for merged-*, OPEN for open-pr, [] otherwise.
+cat >"$stubs/gh" <<'STUB'
+#!/usr/bin/env bash
+branch=""
+prev=""
+for arg in "$@"; do
+  [[ "$prev" == "--head" ]] && branch="$arg"
+  prev="$arg"
+done
+case "$branch" in
+  merged-*) echo '[{"state":"MERGED"}]' ;;
+  open-pr)  echo '[{"state":"OPEN"}]' ;;
+  *)        echo '[]' ;;
+esac
+STUB
+
+# lsof: one fake live process whose cwd is inside merged-busy.
+cat >"$stubs/lsof" <<STUB
+#!/usr/bin/env bash
+echo "p4242"
+echo "cclaude"
+echo "n$wt/merged-busy"
+STUB
+
+# plutil: print the sibling .ws file of the plist passed as the last argument.
+cat >"$stubs/plutil" <<'STUB'
+#!/usr/bin/env bash
+plist="${@: -1}"
+ws="$plist.ws"
+[[ -f "$ws" ]] || exit 1
+cat "$ws"
+STUB
+
+chmod +x "$stubs/gh" "$stubs/lsof" "$stubs/plutil"
+run() { HOME="$home" PATH="$stubs:$PATH" bash "$main/scripts/prune-worktrees.sh" "$@"; }
+
+# ---- Case 1: report-only deletes nothing, classifies everything -------------
+
+echo "== report-only =="
+run >"$tmp/report.log" 2>&1 || { fail "report run exited $?"; cat "$tmp/report.log"; }
+assert_output "report: merged-clean is a candidate"       "CANDIDATE merged-clean"        "$tmp/report.log"
+assert_output "report: merged-dirty needs --force-dirty"  "needs --force-dirty"           "$tmp/report.log"
+assert_output "report: merged-busy skipped (live cwd)"    "SKIP      merged-busy"         "$tmp/report.log"
+assert_output "report: busy skip names the process"       "pid 4242 (claude)"             "$tmp/report.log"
+assert_output "report: open-pr kept"                      "keep      open-pr"             "$tmp/report.log"
+assert_output "report: orphan-dir is a candidate"         "CANDIDATE orphan-dir"          "$tmp/report.log"
+assert_output "report: stale DerivedData is a candidate"  "CANDIDATE DerivedData/Anglesite-stale" "$tmp/report.log"
+assert_output "report: live DerivedData kept"             "keep      DerivedData/Anglesite-live"  "$tmp/report.log"
+for d in merged-clean merged-dirty merged-busy open-pr orphan-dir; do
+  assert_exists "report: $d untouched" "$wt/$d"
+done
+assert_exists "report: DerivedData untouched" "$dd/Anglesite-stale"
+
+# ---- Case 2: --remove --yes honors every safety rail ------------------------
+
+echo "== --remove --yes =="
+run --remove --yes >"$tmp/remove.log" 2>&1 || { fail "remove run exited $?"; cat "$tmp/remove.log"; }
+assert_gone   "remove: merged-clean removed"              "$wt/merged-clean"
+assert_gone   "remove: orphan-dir removed"                "$wt/orphan-dir"
+assert_exists "remove: merged-dirty kept (no --force-dirty)" "$wt/merged-dirty"
+assert_exists "remove: merged-busy kept (live cwd)"       "$wt/merged-busy"
+assert_exists "remove: open-pr kept"                      "$wt/open-pr"
+assert_gone   "remove: stale DerivedData removed"         "$dd/Anglesite-stale"
+assert_gone   "remove: freed worktree's DerivedData removed" "$dd/Anglesite-forclean"
+assert_exists "remove: live DerivedData kept"             "$dd/Anglesite-live"
+if git -C "$main" worktree list --porcelain | grep -q "merged-clean"; then
+  fail "remove: merged-clean still registered in git worktree list"
+else
+  pass "remove: merged-clean deregistered"
+fi
+
+# ---- Case 3: --force-dirty removes the dirty-but-merged worktree ------------
+
+echo "== --remove --yes --force-dirty =="
+run --remove --yes --force-dirty >"$tmp/force.log" 2>&1 || { fail "force run exited $?"; cat "$tmp/force.log"; }
+assert_gone   "force: merged-dirty removed"               "$wt/merged-dirty"
+assert_exists "force: merged-busy still kept (live cwd)"  "$wt/merged-busy"
+assert_exists "force: open-pr still kept"                 "$wt/open-pr"
+
+echo
+if [[ "$overall_status" -eq 0 ]]; then echo "PASS: all prune-worktrees.sh cases"; else echo "FAIL: see above"; fi
+exit "$overall_status"

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -151,6 +151,45 @@ setup_linux() {
     echo "Tests:  swift test"
 }
 
+# Worktree hygiene (#1461): .claude/worktrees/ and per-worktree DerivedData
+# accumulate silently (a 2026-08-13 audit found 287GB combined). When the
+# count/size crosses a threshold, surface it here and OFFER the prune report —
+# setup never deletes anything itself; scripts/prune-worktrees.sh only removes
+# with an explicit --remove and its own per-candidate safety checks.
+WORKTREE_COUNT_THRESHOLD=5
+WORKTREE_SIZE_GB_THRESHOLD=20
+check_worktree_hygiene() {
+    # Resolve the MAIN checkout — when setup runs from inside a worktree, the
+    # worktrees root lives beside the main checkout's .git, not this one.
+    local main_root wt_dir count size_kb size_gb
+    main_root=$(dirname "$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir)")
+    wt_dir="$main_root/.claude/worktrees"
+    [[ -d "$wt_dir" ]] || return 0
+    count=$(find "$wt_dir" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    [[ "$count" -gt 0 ]] || return 0
+    size_kb=$(du -sk "$wt_dir" 2>/dev/null | awk '{ print $1 }')
+    size_gb=$(( ${size_kb:-0} / 1048576 ))
+
+    echo
+    if [[ "$count" -le "$WORKTREE_COUNT_THRESHOLD" && "$size_gb" -lt "$WORKTREE_SIZE_GB_THRESHOLD" ]]; then
+        ok "worktree hygiene: $count worktree dir(s), ~${size_gb}GB (thresholds: >$WORKTREE_COUNT_THRESHOLD or ≥${WORKTREE_SIZE_GB_THRESHOLD}GB)"
+        return 0
+    fi
+
+    echo "Worktree hygiene: $count dir(s) under .claude/worktrees/ (~${size_gb}GB) — over the" \
+         ">$WORKTREE_COUNT_THRESHOLD/≥${WORKTREE_SIZE_GB_THRESHOLD}GB threshold."
+    note "stale worktrees (merged PRs, orphaned dirs) and their DerivedData can be pruned safely:"
+    note "report:  scripts/prune-worktrees.sh"
+    note "remove:  scripts/prune-worktrees.sh --remove   (per-candidate confirmation; never forced)"
+    if [[ -t 0 && -t 1 ]]; then
+        local ans
+        read -r -p "  Run the prune report now (read-only, deletes nothing)? [y/N] " ans
+        if [[ "$ans" == [yY]* ]]; then
+            "$SCRIPT_DIR/prune-worktrees.sh" || true
+        fi
+    fi
+}
+
 case "$(uname -s)" in
     Darwin) setup_macos ;;
     Linux)  setup_linux ;;
@@ -159,6 +198,8 @@ case "$(uname -s)" in
         exit 1
         ;;
 esac
+
+check_worktree_hygiene
 
 echo
 if [[ "$FAILURES" -gt 0 ]]; then


### PR DESCRIPTION
Closes #1461

## Summary

- `scripts/prune-worktrees.sh` automates the manual cleanup procedure from `AGENTS.md` ▸ "Worktrees": report-only by default; `--remove` deletes with per-candidate confirmation (`--yes` for non-interactive). Registered worktrees under `.claude/worktrees/` are candidates only when their branch's PR is **merged/closed** (`gh pr list --head … --state all`) *and* `git status --short` is clean — a dirty-but-merged worktree needs an explicit `--force-dirty` (never `git worktree remove --force` by default). Orphaned directories (on disk but not in `git worktree list` — the `comm -23` case) are `rm -rf`'d. **Every** candidate must first pass the lsof live-cwd check, since PR state and git status alone don't reveal a live agent session using a worktree (the collision that motivated #1461). `DerivedData/Anglesite-*` dirs whose `info.plist` `WorkspacePath` no longer exists — including ones freed by the same run's removals — are pruned too. Every keep/skip/candidate/removal is printed with its reason.
- `scripts/prune-worktrees.test.sh` (same convention as `install-swift-linux.test.sh`) exercises every safety branch against a throwaway repo with stubbed `gh`/`lsof`/`plutil`: merged+clean removed, merged+dirty gated on `--force-dirty`, open-PR kept, live-cwd skipped, orphan dir removed, stale vs. live DerivedData. Not wired into CI — per the issue, this is host-machine state CI doesn't have.
- `scripts/setup-dev-env.sh` (owner decision on #1461, 2026-08-15): when `.claude/worktrees/` crosses **>5 worktrees or ≥20GB**, prints a notice and — on an interactive terminal — offers to run the read-only prune report. Setup never deletes anything itself; removal always goes through the prune script's own `--remove` + safety checks. Resolves the main checkout via `--git-common-dir`, so both scripts work when run from inside a worktree.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `scripts/prune-worktrees.test.sh` — 26 assertions across report-only, `--remove --yes`, and `--force-dirty` runs, all passing (macOS; stubs keep it Linux-portable).
- [x] Manual: `scripts/prune-worktrees.sh` (report mode) against the real repo — correctly kept open/no-PR worktrees, skipped a merged worktree held live by an active agent session (naming pids), flagged 5 candidates (16.7GB), deleted nothing.
- [x] Manual: `scripts/setup-dev-env.sh` non-interactive run — printed the over-threshold notice (15 dirs, ~46GB) with the report/remove commands, skipped the prompt, exited 0.
- [ ] `swift test --package-path .` / `xcodebuild` — not run: scripts-only change, no Swift/JS touched.
