### PR TITLE
fix(#1506): guard DomainConfigAuditModel phase writes vs. stale tasks

### DIFF
--- a/Sources/AnglesiteApp/DomainConfigAuditModel.swift
+++ b/Sources/AnglesiteApp/DomainConfigAuditModel.swift
@@ -138,14 +138,25 @@ final class DomainConfigAuditModel {
         try? await CloudflareAPICredentials.resolve(secretStore: keychain)
     }
 
+    /// See `HardenModel.setPhase(_:)` — same helper, same rationale: `dismissSheet()`/re-entry
+    /// cancel `inFlight` but only set the cancellation flag, so the abandoned task keeps
+    /// executing across its network awaits. Routing every `phase` write in the async runners
+    /// through this guard stops a stale task's completion from clobbering a phase the user
+    /// already reset by dismissing/reopening, or a newer run's phase after a re-entrant call
+    /// (#1506, following #1479's fix for the mirrored HardenModel/AISearchModel pattern).
+    private func setPhase(_ newPhase: Phase) {
+        guard !Task.isCancelled else { return }
+        phase = newPhase
+    }
+
     private func performAudit(declared: DomainConfig, domain: String) async {
         guard let token = await apiToken() else {
-            phase = .failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials.")
+            setPhase(.failed(reason: "No Cloudflare API token found. Add one in Settings → Credentials."))
             return
         }
         do {
             guard let zoneID = try await reader.resolveZoneID(domain: domain, apiToken: token) else {
-                phase = .failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission.")
+                setPhase(.failed(reason: "Zone not found for \"\(domain)\". Check the domain and ensure your API token has Zone Read permission."))
                 return
             }
 
@@ -157,13 +168,13 @@ final class DomainConfigAuditModel {
                 guard case .autoApply(let item) = finding.remediation else { return nil }
                 return item
             }
-            phase = .results(
+            setPhase(.results(
                 findings: findings, plan: DomainConfigReconcilePlan(items: planItems),
-                domain: domain, zoneID: zoneID)
+                domain: domain, zoneID: zoneID))
         } catch let error as CloudflareError {
-            phase = .failed(reason: cloudflareErrorMessage(error, domain: domain))
+            setPhase(.failed(reason: cloudflareErrorMessage(error, domain: domain)))
         } catch {
-            phase = .failed(reason: "Failed to read zone state: \(error.localizedDescription)")
+            setPhase(.failed(reason: "Failed to read zone state: \(error.localizedDescription)"))
         }
     }
 
@@ -171,19 +182,19 @@ final class DomainConfigAuditModel {
         plan: DomainConfigReconcilePlan, domain: String, zoneID: String, declared: DomainConfig
     ) async {
         guard let token = await apiToken() else {
-            phase = .failed(reason: "No Cloudflare API token found.")
+            setPhase(.failed(reason: "No Cloudflare API token found."))
             return
         }
         let reconciler = DomainConfigReconciler(reader: reader, writer: writer)
         let result = await reconciler.execute(
             plan: plan, zoneID: zoneID, domain: domain, apiToken: token, declared: declared)
 
-        phase = .succeeded(result: ReconcileResult(
+        setPhase(.succeeded(result: ReconcileResult(
             appliedCount: result.appliedCount,
             failedItems: result.failedItems.map { .init(description: $0.item.description, error: $0.error) },
             postAuditFindings: result.postAuditFindings,
             auditError: result.auditError
-        ))
+        )))
     }
 
     private func cloudflareErrorMessage(_ error: CloudflareError, domain: String) -> String {

--- a/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
+++ b/Tests/AnglesiteAppTests/DomainConfigAuditModelTests.swift
@@ -56,6 +56,32 @@ private final class StubWriter: CloudflareWriting, @unchecked Sendable {
     func setMarkdownForAgents(hostname: String, enabled: Bool, apiToken: String) async throws -> Bool { true }
 }
 
+/// A `CloudflareReading` whose `resolveZoneID` calls suspend until the test explicitly resolves
+/// them — mirrors `HardenModelTests`/`AISearchModelTests`' `ControllableReader`, used to exercise
+/// a run still in flight when the sheet is dismissed/reopened out from under it (#1506).
+private actor ControllableReader: CloudflareReading {
+    private var continuations: [(domain: String, continuation: CheckedContinuation<String?, any Error>)] = []
+    private let state: CloudflareZoneState
+
+    init(state: CloudflareZoneState = StubReader.cleanState) {
+        self.state = state
+    }
+
+    func resolveZoneID(domain: String, apiToken: String) async throws -> String? {
+        try await withCheckedThrowingContinuation { continuation in
+            continuations.append((domain, continuation))
+        }
+    }
+    func zoneState(zoneID: String, domain: String, apiToken: String) async throws -> CloudflareZoneState { state }
+    func listDNSRecords(zoneID: String, apiToken: String) async throws -> [DNSRecord] { [] }
+    func workerScriptNames(apiToken: String) async throws -> [String] { [] }
+
+    func resolve(callIndex index: Int, zoneID: String?) {
+        continuations[index].continuation.resume(returning: zoneID)
+    }
+    func callCount() -> Int { continuations.count }
+}
+
 /// `.timeLimit`: see #1349 — the full `AnglesiteAppTests` target has hung indefinitely under
 /// local machine contention (many concurrent `swift test` runs oversubscribing the cooperative
 /// thread pool), with this suite one of the observed stall points. A wedged test now fails as an
@@ -259,5 +285,84 @@ struct DomainConfigAuditModelTests {
         model.openSheet()
         model.dismissSheet()
         #expect(model.sheetPresented == false)
+    }
+
+    /// Regression coverage for #1506 (mirroring #1479's fix for `HardenModel`/`AISearchModel`):
+    /// `dismissSheet()` only sets `inFlight`'s cancellation flag — the abandoned task keeps
+    /// running across its network awaits. Without the `Task.isCancelled` guard on every `phase`
+    /// write in the async runner, a stale completion after dismissal would clobber the `.idle`
+    /// reset with a result the user never asked for in this session.
+    @MainActor
+    @Test("dismissing the sheet mid-audit does not let a stale completion clobber the reset phase")
+    func dismissDuringAuditDoesNotClobberResetState() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let reader = ControllableReader()
+        let declared = DomainConfig(domain: .init(hostname: "example.com"))
+        let (site, cleanup) = try tempSite(declaring: declared)
+        defer { cleanup() }
+        let model = DomainConfigAuditModel(reader: reader, writer: StubWriter(), keychain: keychain)
+        model.configure(site: site)
+
+        model.runAudit()
+        // Let the spawned `Task` actually start and suspend inside `reader.resolveZoneID`, so
+        // dismissal below races a run that's genuinely still in flight.
+        while await reader.callCount() == 0 { await Task.yield() }
+        #expect(model.phase == .auditing(domain: "example.com"))
+
+        model.dismissSheet()
+        #expect(model.phase == .idle)
+
+        // The in-flight lookup finally resolves *after* dismissal cancelled its `Task` — the
+        // result must not land and clobber the `.idle` reset (the bug this test guards).
+        await reader.resolve(callIndex: 0, zoneID: "z1")
+        for _ in 0..<5 { await Task.yield() }
+
+        #expect(model.phase == .idle)
+    }
+
+    /// Regression coverage for #1506's second acceptance criterion: a stale run's completion
+    /// must not overwrite a newer run's phase, even when the newer run was started before the
+    /// older one finally resolves.
+    @MainActor
+    @Test("a newer run's phase survives a stale older run resolving after it")
+    func newerRunSurvivesStaleOlderRunCompleting() async throws {
+        let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimSet()
+        defer { cfToken.release() }
+        let reader = ControllableReader()
+        let model = DomainConfigAuditModel(reader: reader, writer: StubWriter(), keychain: keychain)
+
+        let staleDeclared = DomainConfig(domain: .init(hostname: "stale.example"))
+        let (staleSite, staleCleanup) = try tempSite(declaring: staleDeclared)
+        defer { staleCleanup() }
+        model.configure(site: staleSite)
+        model.runAudit()
+        while await reader.callCount() == 0 { await Task.yield() }
+
+        model.dismissSheet()
+
+        let freshDeclared = DomainConfig(domain: .init(hostname: "fresh.example"))
+        let (freshSite, freshCleanup) = try tempSite(declaring: freshDeclared)
+        defer { freshCleanup() }
+        model.configure(site: freshSite)
+        model.runAudit()
+        while await reader.callCount() == 1 { await Task.yield() }
+        #expect(model.phase == .auditing(domain: "fresh.example"))
+
+        // The stale first lookup resolves after the second run has already started — it must not
+        // overwrite the second run's phase.
+        await reader.resolve(callIndex: 0, zoneID: "stale-zone")
+        for _ in 0..<5 { await Task.yield() }
+        #expect(model.phase == .auditing(domain: "fresh.example"))
+
+        await reader.resolve(callIndex: 1, zoneID: "fresh-zone")
+        while model.isRunning { await Task.yield() }
+
+        guard case .results(_, _, let domain, let zoneID) = model.phase else {
+            Issue.record("expected .results, got \(model.phase)")
+            return
+        }
+        #expect(domain == "fresh.example")
+        #expect(zoneID == "fresh-zone")
     }
 }


### PR DESCRIPTION
Closes #1506

## Summary

- `dismissSheet()` calls `inFlight?.cancel()`, but that only sets the cancellation flag — the abandoned task kept executing across its network awaits in `performAudit`/`performReconcile` and could still write `phase` after the user reset it to `.idle` or started a fresh run.
- Adds a `setPhase(_:)` helper (mirroring the fix in PR #1505 for `HardenModel`/`AISearchModel`, #1479) that guards every `phase` write in the async runners with `Task.isCancelled`.
- Adds two regression tests using a `ControllableReader` that suspends `resolveZoneID` until signaled, mirroring `HardenModelTests`/`AISearchModelTests`: dismissing mid-run doesn't clobber the reset `.idle` phase, and a newer run's phase survives a stale older run resolving after it.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` (full suite passes; one unrelated `ComponentEditorModel draft state` failure in the full run was confirmed flaky under heavy concurrent `swift test` contention from other worktrees — passes cleanly in isolation)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — `BUILD SUCCEEDED`
- [ ] Manual smoke (if UI-touching): not needed — no UI changes, only async task-cancellation guarding