### PR TITLE
fix(#1440): hold peer-conflicting bumps, surface install failures

### DIFF
--- a/Sources/AnglesiteApp/DependencyUpdateModel.swift
+++ b/Sources/AnglesiteApp/DependencyUpdateModel.swift
@@ -19,4 +19,31 @@ final class DependencyUpdateModel: Identifiable {
 
     func update() { onDecision(true) }
     func skip() { onDecision(false) }
+
+    /// True when there is nothing to actually apply — every offer was held back by a
+    /// foreign dependency's peer range (#1440). The sheet then shows a single
+    /// acknowledge button instead of Update/Skip.
+    var isHeldBackOnly: Bool {
+        offers.updates.isEmpty && offers.additions.isEmpty && !offers.heldUpdates.isEmpty
+    }
+}
+
+extension DependencyUpdateModel {
+    /// Sheet copy for one held-back bump (#1440). Framed around consequences to the site —
+    /// same guiding principle as `ScriptSyncModel.rowCopy` — never around semver ranges or
+    /// package.json mechanics: the owner came here to publish a website, not to adjudicate
+    /// a dependency graph.
+    static func heldCopy(for held: DependencyHeldUpdate) -> String {
+        let names = held.blockers.map(\.dependentName)
+        let list: String
+        switch names.count {
+        case 1: list = names[0]
+        case 2: list = "\(names[0]) and \(names[1])"
+        default: list = names.dropLast().joined(separator: ", ") + ", and \(names.last ?? "")"
+        }
+        let verb = names.count == 1 ? "isn't" : "aren't"
+        return "This site also uses \(list), which \(verb) ready for the newer \(held.offer.name) yet. "
+            + "Updating \(held.offer.name) now would stop parts of this site from working, so "
+            + "Anglesite is keeping it as it is."
+    }
 }

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -2398,6 +2398,9 @@
     "Not Set" : {
 
     },
+    "Not Updated" : {
+
+    },
     "Not checked yet." : {
 
     },
@@ -4155,6 +4158,9 @@
 
     },
     "selector" : {
+
+    },
+    "stays at %@" : {
 
     },
     "trending down" : {

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -792,14 +792,43 @@ struct SiteWindow: View {
                             }
                         }
                     }
+                    // #1440: bumps held back because one of the site's own packages (one the
+                    // template doesn't manage) can't work with the newer version yet. Shown as
+                    // information, not a choice — applying one would leave the site unable to
+                    // install its dependencies at all, and the app doesn't delegate decisions
+                    // it already knows the answer to.
+                    if !updateModel.offers.heldUpdates.isEmpty {
+                        Section("Not Updated") {
+                            ForEach(updateModel.offers.heldUpdates, id: \.offer.name) { held in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    LabeledContent(held.offer.name) {
+                                        Text("stays at \(held.offer.currentRange)")
+                                            .font(.system(.body, design: .monospaced))
+                                    }
+                                    Text(DependencyUpdateModel.heldCopy(for: held))
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
                 }
                 .navigationTitle("Dependency Updates Available")
                 .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Skip") { updateModel.skip() }
-                    }
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("Update") { updateModel.update() }
+                    if updateModel.isHeldBackOnly {
+                        // Nothing to apply — a lone acknowledge still routes through
+                        // `update()` so the version stamp lands and the sheet doesn't
+                        // re-nag on every site open.
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("OK") { updateModel.update() }
+                        }
+                    } else {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Skip") { updateModel.skip() }
+                        }
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Update") { updateModel.update() }
+                        }
                     }
                 }
             }

--- a/Sources/AnglesiteCore/DependencyInstallFailureScanner.swift
+++ b/Sources/AnglesiteCore/DependencyInstallFailureScanner.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Watches a boot's guest output for an npm dependency-resolution failure (#1440 part 1).
+///
+/// The post-apply preview boot's `npm ci`/`npm install` (hydrate) is the install verification
+/// for an accepted dependency update — but it runs as a detached guest process, so its failure
+/// only surfaces minutes later as a generic serving timeout. This scanner keeps the
+/// resolution-failure evidence from the output stream so the settled failure can name the
+/// actual problem in owner terms (consequences to the site, not npm mechanics — the raw npm
+/// output stays in the debug log per "logs are sacred").
+///
+/// Thread-safe (`ingest` is called from the container's `@Sendable` output callback while
+/// `diagnosis` is read from the runtime actor); `@unchecked` because the lock, not the
+/// compiler, guards the mutable state.
+public final class DependencyInstallFailureScanner: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sawResolutionFailure = false
+    private var conflict: (peerName: String, dependentName: String)?
+
+    /// Matches npm's ERESOLVE detail line, e.g.
+    /// `npm error peer astro@"^6.3.0" from @astrojs/cloudflare@13.5.0` — capturing the
+    /// peer package name and the dependent that requires it (non-greedy so scoped names
+    /// keep their leading `@`).
+    private static let peerConflictRegex = try? NSRegularExpression(
+        pattern: #"peer\s+(\S+?)@"[^"]*"\s+from\s+(\S+?)@[0-9]"#)
+
+    public init() {}
+
+    /// Feed one line of guest boot output.
+    ///
+    /// - Parameter line: A single stdout/stderr line from the container's boot stream.
+    public func ingest(line: String) {
+        let isFailureMarker = line.contains("ERESOLVE") || line.contains("Could not resolve dependency")
+        var parsedConflict: (String, String)?
+        if let regex = Self.peerConflictRegex,
+           let match = regex.firstMatch(in: line, range: NSRange(line.startIndex..<line.endIndex, in: line)),
+           let peerRange = Range(match.range(at: 1), in: line),
+           let dependentRange = Range(match.range(at: 2), in: line) {
+            parsedConflict = (String(line[peerRange]), String(line[dependentRange]))
+        }
+        guard isFailureMarker || parsedConflict != nil else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        if isFailureMarker { sawResolutionFailure = true }
+        if conflict == nil, let (peer, dependent) = parsedConflict {
+            conflict = (peerName: peer, dependentName: dependent)
+        }
+    }
+
+    /// An owner-phrased explanation of the install failure, or `nil` when no
+    /// resolution-failure evidence has been seen.
+    public var diagnosis: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard sawResolutionFailure else { return nil }
+        if let conflict {
+            return "The site's pieces stopped fitting together: \(conflict.dependentName) needs a "
+                + "different version of \(conflict.peerName) than the site now has, so the site's "
+                + "packages couldn't be installed and the preview can't start. The full details "
+                + "are in the debug log."
+        }
+        return "The site's pieces stopped fitting together — two things this site depends on "
+            + "need different versions of the same package, so the site's packages couldn't be "
+            + "installed and the preview can't start. The full details are in the debug log."
+    }
+}

--- a/Sources/AnglesiteCore/DependencyPeerCheck.swift
+++ b/Sources/AnglesiteCore/DependencyPeerCheck.swift
@@ -1,0 +1,306 @@
+import Foundation
+
+/// One foreign dependency standing in the way of a held-back bump: the site's own
+/// (template-untracked) package and the `peerDependencies` range it declares for the
+/// package the template wants to bump.
+public struct DependencyPeerBlocker: Sendable, Equatable {
+    public let dependentName: String
+    public let requiredRange: String
+
+    /// Memberwise initializer — blockers are normally produced by
+    /// ``DependencyPeerCheck/partition(updates:foreignPeerRequirements:)``; this exists so
+    /// tests (and previews) can construct them directly.
+    ///
+    /// - Parameters:
+    ///   - dependentName: The foreign package declaring the peer requirement.
+    ///   - requiredRange: The `peerDependencies` range it declares for the bumped package.
+    public init(dependentName: String, requiredRange: String) {
+        self.dependentName = dependentName
+        self.requiredRange = requiredRange
+    }
+}
+
+/// A template bump withheld from auto-apply because one or more of the site's own
+/// dependencies declare a `peerDependencies` range the offered version falls outside (#1440).
+public struct DependencyHeldUpdate: Sendable, Equatable {
+    public let offer: DependencyUpdateOffer
+    /// The blocking foreign dependencies, sorted by name for stable UI order. Never empty.
+    public let blockers: [DependencyPeerBlocker]
+
+    /// Memberwise initializer — held updates are normally produced by
+    /// ``DependencyPeerCheck/partition(updates:foreignPeerRequirements:)``; this exists so
+    /// tests (and previews) can construct them directly.
+    ///
+    /// - Parameters:
+    ///   - offer: The withheld bump exactly as the template offered it.
+    ///   - blockers: The foreign dependencies whose peer ranges exclude it.
+    public init(offer: DependencyUpdateOffer, blockers: [DependencyPeerBlocker]) {
+        self.offer = offer
+        self.blockers = blockers
+    }
+}
+
+/// Pre-checks template bump offers against the `peerDependencies` ranges of the site's own
+/// *foreign* dependencies — packages present in the site's `package.json` that the template
+/// doesn't track (#1440). Deliberately not a dependency-graph resolver: only the direct
+/// peer ranges those foreign packages declare are consulted, and anything unparseable
+/// degrades to "don't hold" (never guess, matching `DependencyVersionComparator`'s
+/// contract) — the post-apply install (whose failure `DependencyInstallFailureScanner`
+/// surfaces) is the backstop for what this check can't read.
+public enum DependencyPeerCheck {
+    /// Splits `updates` into offers safe to auto-apply and offers held for the owner
+    /// because a foreign dependency's declared peer range excludes them.
+    ///
+    /// - Parameters:
+    ///   - updates: The bump offers `DependencySync.diff` produced.
+    ///   - foreignPeerRequirements: Foreign-dependency name → its `peerDependencies` map,
+    ///     as returned by ``foreignPeerRequirements(sourceDirectory:untrackedDependencyNames:)``.
+    /// - Returns: The offers that passed every peer check (`allowed`) and the ones a
+    ///   blocker excludes (`held`), each with its full blocker list.
+    public static func partition(
+        updates: [DependencyUpdateOffer],
+        foreignPeerRequirements: [String: [String: String]]
+    ) -> (allowed: [DependencyUpdateOffer], held: [DependencyHeldUpdate]) {
+        var allowed: [DependencyUpdateOffer] = []
+        var held: [DependencyHeldUpdate] = []
+        for offer in updates {
+            var blockers: [DependencyPeerBlocker] = []
+            for (dependentName, peers) in foreignPeerRequirements.sorted(by: { $0.key < $1.key }) {
+                guard let requiredRange = peers[offer.name] else { continue }
+                // Only an affirmative "the offered range violates this peer range" holds the
+                // offer — `nil` (unparseable either side) must never block a legitimate update.
+                if offeredRangeSatisfies(offer.offeredRange, peerRange: requiredRange) == false {
+                    blockers.append(DependencyPeerBlocker(dependentName: dependentName, requiredRange: requiredRange))
+                }
+            }
+            if blockers.isEmpty {
+                allowed.append(offer)
+            } else {
+                held.append(DependencyHeldUpdate(offer: offer, blockers: blockers))
+            }
+        }
+        return (allowed: allowed, held: held)
+    }
+
+    /// Whether the version the offered range would install at minimum (its floor — e.g.
+    /// `^7.1.3` → `7.1.3`) satisfies `peerRange`. Checking the floor, not full range
+    /// intersection, is deliberate scope (#1440): the floor is what a fresh
+    /// `npm install` of the offered range will actually pick, and full range-set
+    /// intersection is the dependency-resolver territory this feature stays out of.
+    /// `nil` when either side can't be parsed — callers must treat `nil` as "don't
+    /// hold", never guess.
+    static func offeredRangeSatisfies(_ offeredRange: String, peerRange: String) -> Bool? {
+        // A disjunctive offered range has no single floor worth reasoning about.
+        guard !offeredRange.contains("||") else { return nil }
+        guard let components = DependencyVersionComparator.numericComponents(offeredRange) else { return nil }
+        let floor = padded(components)
+        return satisfies(floor, range: peerRange)
+    }
+
+    /// Reads the `peerDependencies` maps of the named untracked site dependencies: the
+    /// site's `package-lock.json` (v2/v3 `packages` entries) is authoritative when it has
+    /// an entry for the package; `node_modules/<name>/package.json` is the fallback.
+    /// Missing files or entries just yield nothing for that name — this feeds a hold-back
+    /// check that must degrade to "no divergence", never block or throw.
+    ///
+    /// - Parameters:
+    ///   - sourceDirectory: The site's `Source/` directory (where `package-lock.json` and
+    ///     `node_modules/` live).
+    ///   - untrackedDependencyNames: The site dependencies the template's `package.json`
+    ///     doesn't declare — the only packages whose peer ranges are foreign constraints.
+    /// - Returns: Foreign-dependency name → its non-empty `peerDependencies` map; names
+    ///   with no readable peer requirements are simply absent.
+    public static func foreignPeerRequirements(
+        sourceDirectory: URL,
+        untrackedDependencyNames: Set<String>
+    ) -> [String: [String: String]] {
+        let lockEntries = lockfilePeerEntries(sourceDirectory: sourceDirectory)
+        var result: [String: [String: String]] = [:]
+        for name in untrackedDependencyNames {
+            let peers: [String: String]
+            if let lockPeers = lockEntries?["node_modules/\(name)"] {
+                peers = lockPeers  // entry present; an empty map authoritatively means "no peers"
+            } else {
+                peers = nodeModulesPeerDependencies(sourceDirectory: sourceDirectory, packageName: name) ?? [:]
+            }
+            if !peers.isEmpty { result[name] = peers }
+        }
+        return result
+    }
+
+    // MARK: - Peer-requirement sources
+
+    /// Every `packages` entry in the lockfile, keyed as written (`node_modules/<name>`),
+    /// mapped to its `peerDependencies` (empty when the entry declares none). `nil` when
+    /// there is no readable lockfile at all — distinct from "entry absent", so the caller
+    /// can fall back per package.
+    private static func lockfilePeerEntries(sourceDirectory: URL) -> [String: [String: String]]? {
+        let lockURL = sourceDirectory.appendingPathComponent("package-lock.json")
+        guard let data = try? Data(contentsOf: lockURL),
+              let json = try? JSONSerialization.jsonObject(with: data),
+              let root = json as? [String: Any],
+              let packages = root["packages"] as? [String: Any]
+        else { return nil }
+        var entries: [String: [String: String]] = [:]
+        for (key, value) in packages {
+            guard let entry = value as? [String: Any] else { continue }
+            entries[key] = entry["peerDependencies"] as? [String: String] ?? [:]
+        }
+        return entries
+    }
+
+    private static func nodeModulesPeerDependencies(sourceDirectory: URL, packageName: String) -> [String: String]? {
+        let pkgURL = sourceDirectory
+            .appendingPathComponent("node_modules")
+            .appendingPathComponent(packageName)
+            .appendingPathComponent("package.json")
+        guard let data = try? Data(contentsOf: pkgURL),
+              let json = try? JSONSerialization.jsonObject(with: data),
+              let root = json as? [String: Any]
+        else { return nil }
+        return root["peerDependencies"] as? [String: String]
+    }
+
+    // MARK: - Minimal npm range matching (never guess)
+
+    /// Whether `version` (a padded `[major, minor, patch]`) satisfies the npm range
+    /// string. Supports the shapes real `peerDependencies` overwhelmingly use — `^`/`~`,
+    /// exact and partial/`x` wildcard versions, `>=`/`>`/`<=`/`<`/`=` comparators,
+    /// space-joined conjunctions, `a - b` hyphen ranges, and `||` alternatives. Anything
+    /// else is `nil`. Pre-release suffixes are compared by their numeric core only (the
+    /// one deliberate imprecision; peer ranges pinning pre-releases are vanishingly rare).
+    private static func satisfies(_ version: [Int], range: String) -> Bool? {
+        let trimmed = range.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return true }
+        var sawUnparseableGroup = false
+        for group in trimmed.components(separatedBy: "||") {
+            switch satisfiesGroup(version, group.trimmingCharacters(in: .whitespaces)) {
+            case true: return true
+            case false: continue
+            case nil: sawUnparseableGroup = true
+            }
+        }
+        // Every parseable alternative said no — but an unparseable one might have said
+        // yes, so the honest answer there is "don't know".
+        return sawUnparseableGroup ? nil : false
+    }
+
+    /// One `||` alternative: a space-joined conjunction of comparators, or a hyphen range.
+    private static func satisfiesGroup(_ version: [Int], _ group: String) -> Bool? {
+        let tokens = group.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        guard !tokens.isEmpty else { return true }
+        if let dashIndex = tokens.firstIndex(of: "-") {
+            guard tokens.count == 3, dashIndex == 1,
+                  let low = parsePartial(tokens[0]), let high = parsePartial(tokens[2])
+            else { return nil }
+            guard compare(version, low.triple) >= 0 else { return false }
+            // `1.2.3 - 2.3` means `>=1.2.3 <2.4.0`; a full `- 2.3.4` upper bound is inclusive.
+            return high.count == 3
+                ? compare(version, high.triple) <= 0
+                : compare(version, upperBoundary(high)) < 0
+        }
+        var sawUnparseable = false
+        for token in tokens {
+            switch satisfiesComparator(version, token) {
+            case false: return false
+            case nil: sawUnparseable = true
+            case true: break
+            }
+        }
+        return sawUnparseable ? nil : true
+    }
+
+    private static func satisfiesComparator(_ version: [Int], _ token: String) -> Bool? {
+        if token.hasPrefix(">=") {
+            guard let bound = parsePartial(String(token.dropFirst(2))) else { return nil }
+            return compare(version, bound.triple) >= 0
+        }
+        if token.hasPrefix("<=") {
+            guard let bound = parsePartial(String(token.dropFirst(2))), bound.count == 3 else { return nil }
+            return compare(version, bound.triple) <= 0
+        }
+        if token.hasPrefix(">") {
+            // npm reads `>1.2` as `>=1.3.0` — partial bounds after `>` are ambiguous
+            // enough that guessing isn't worth it.
+            guard let bound = parsePartial(String(token.dropFirst())), bound.count == 3 else { return nil }
+            return compare(version, bound.triple) > 0
+        }
+        if token.hasPrefix("<") {
+            guard let bound = parsePartial(String(token.dropFirst())) else { return nil }
+            return compare(version, bound.triple) < 0
+        }
+        if token.hasPrefix("^") {
+            guard let bound = parsePartial(String(token.dropFirst())) else { return nil }
+            guard compare(version, bound.triple) >= 0 else { return false }
+            return compare(version, caretUpperBoundary(bound)) < 0
+        }
+        if token.hasPrefix("~") {
+            guard let bound = parsePartial(String(token.dropFirst())) else { return nil }
+            guard compare(version, bound.triple) >= 0 else { return false }
+            let upper = bound.count >= 2
+                ? [bound.triple[0], bound.triple[1] + 1, 0]
+                : [bound.triple[0] + 1, 0, 0]
+            return compare(version, upper) < 0
+        }
+        let bare = token.hasPrefix("=") ? String(token.dropFirst()) : token
+        guard let bound = parsePartial(bare) else { return nil }
+        switch bound.count {
+        case 3: return compare(version, bound.triple) == 0
+        case 0: return true  // `*` / `x`
+        default:  // `6`, `6.1`, `6.x`, `6.1.x`: everything within the specified prefix
+            return compare(version, bound.triple) >= 0 && compare(version, upperBoundary(bound)) < 0
+        }
+    }
+
+    /// `^`'s upper bound: the first version that changes the leftmost non-zero component
+    /// (`^6.3.0` → `7.0.0`, `^0.2.3` → `0.3.0`, `^0.0.3` → `0.0.4`).
+    private static func caretUpperBoundary(_ bound: (triple: [Int], count: Int)) -> [Int] {
+        let t = bound.triple
+        if t[0] > 0 || bound.count == 1 { return [t[0] + 1, 0, 0] }  // ^6.3.0 → 7.0.0; ^0 → 1.0.0
+        if t[1] > 0 || bound.count == 2 { return [0, t[1] + 1, 0] }  // ^0.2.3 → 0.3.0; ^0.0 → 0.1.0
+        return [0, 0, t[2] + 1]  // ^0.0.3 → 0.0.4
+    }
+
+    /// The first version past a partial bound's specified prefix (`6` → `7.0.0`, `6.1` → `6.2.0`).
+    private static func upperBoundary(_ bound: (triple: [Int], count: Int)) -> [Int] {
+        bound.count <= 1
+            ? [bound.triple[0] + 1, 0, 0]
+            : [bound.triple[0], bound.triple[1] + 1, 0]
+    }
+
+    /// Parses one version token into a zero-padded `[major, minor, patch]` plus how many
+    /// components were actually written (0 for a pure wildcard). Pre-release/build
+    /// suffixes are cut at the first `-`/`+`. `nil` for anything that isn't digits and
+    /// `x`/`X`/`*` wildcards.
+    private static func parsePartial(_ raw: String) -> (triple: [Int], count: Int)? {
+        let core = raw.prefix { $0 != "-" && $0 != "+" }
+        guard !core.isEmpty else { return nil }
+        let parts = core.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count <= 3 else { return nil }
+        var triple = [0, 0, 0]
+        var count = 0
+        for (index, part) in parts.enumerated() {
+            if ["x", "X", "*"].contains(String(part)) { break }  // wildcard ends the specified prefix
+            guard !part.isEmpty, part.allSatisfy(\.isNumber), let value = Int(part) else { return nil }
+            triple[index] = value
+            count = index + 1
+        }
+        return (triple, count)
+    }
+
+    private static func padded(_ components: [Int]) -> [Int] {
+        [
+            components.count > 0 ? components[0] : 0,
+            components.count > 1 ? components[1] : 0,
+            components.count > 2 ? components[2] : 0,
+        ]
+    }
+
+    /// Lexicographic triple comparison: negative when `a < b`, 0 when equal, positive when `a > b`.
+    private static func compare(_ a: [Int], _ b: [Int]) -> Int {
+        for index in 0..<3 where a[index] != b[index] {
+            return a[index] < b[index] ? -1 : 1
+        }
+        return 0
+    }
+}

--- a/Sources/AnglesiteCore/DependencySync.swift
+++ b/Sources/AnglesiteCore/DependencySync.swift
@@ -38,18 +38,39 @@ public struct DependencyAdditionOffer: Sendable, Equatable {
 }
 
 /// The full result of a `DependencySync.diff` call: version bumps for packages
-/// the site already has, and new packages the template has that the site
-/// doesn't.
+/// the site already has, new packages the template has that the site doesn't,
+/// and bumps held back because a foreign dependency's `peerDependencies` range
+/// excludes them (#1440).
 public struct DependencySyncOffers: Sendable, Equatable {
     public let updates: [DependencyUpdateOffer]
     public let additions: [DependencyAdditionOffer]
+    /// Bumps the template offers but ``DependencyPeerCheck`` withheld: applying one would
+    /// leave the site unable to install its own dependencies together. Surfaced to the
+    /// owner as information (consequence-phrased), never auto-applied by
+    /// ``DependencySyncApplier``.
+    public let heldUpdates: [DependencyHeldUpdate]
 
-    public init(updates: [DependencyUpdateOffer] = [], additions: [DependencyAdditionOffer] = []) {
+    /// Memberwise initializer — offer sets are normally produced by
+    /// ``DependencySyncChecker/check(sourceDirectory:configDirectory:templateDirectory:runningAppVersion:)``;
+    /// this exists so tests (and previews) can construct them directly.
+    ///
+    /// - Parameters:
+    ///   - updates: Version bumps for packages the site already has.
+    ///   - additions: New packages the template has that the site doesn't.
+    ///   - heldUpdates: Bumps withheld by ``DependencyPeerCheck`` (#1440).
+    public init(
+        updates: [DependencyUpdateOffer] = [],
+        additions: [DependencyAdditionOffer] = [],
+        heldUpdates: [DependencyHeldUpdate] = []
+    ) {
         self.updates = updates
         self.additions = additions
+        self.heldUpdates = heldUpdates
     }
 
-    public var isEmpty: Bool { updates.isEmpty && additions.isEmpty }
+    /// Held updates count as non-empty: the sheet still shows so the owner learns why a
+    /// bump isn't being applied.
+    public var isEmpty: Bool { updates.isEmpty && additions.isEmpty && heldUpdates.isEmpty }
 }
 
 /// Three-way comparison between a site's dependencies, an optional scaffold-time

--- a/Sources/AnglesiteCore/DependencySyncApplier.swift
+++ b/Sources/AnglesiteCore/DependencySyncApplier.swift
@@ -59,7 +59,13 @@ public enum DependencySyncApplier {
             throw ApplyError.writeFailed
         }
 
-        try? FileManager.default.removeItem(at: sourceDirectory.appendingPathComponent("package-lock.json"))
+        // Only invalidate the lockfile when an offer actually changed package.json (#1440):
+        // a decision that lands nothing — e.g. every bump was held back by a foreign peer
+        // range, or a stale offer's target isn't in the file — must not force the next boot
+        // through a from-scratch resolve for an unchanged dependency set.
+        if updatedText != originalText {
+            try? FileManager.default.removeItem(at: sourceDirectory.appendingPathComponent("package-lock.json"))
+        }
 
         // Seed from every dependency in the freshly-written package.json when the
         // site has no baseline yet (legacy sites scaffolded before the baseline

--- a/Sources/AnglesiteCore/DependencySyncChecker.swift
+++ b/Sources/AnglesiteCore/DependencySyncChecker.swift
@@ -36,11 +36,23 @@ public enum DependencySyncChecker {
         templateDeps.merge(templateSections.devDependencies) { _, new in new }
 
         let baseline = DependencyBaseline.load(from: configDirectory)
-        return DependencySync.diff(
+        let offers = DependencySync.diff(
             site: siteDeps,
             baseline: baseline,
             template: templateDeps,
             templateDevDependencyNames: Set(templateSections.devDependencies.keys)
         )
+        guard !offers.updates.isEmpty else { return offers }
+
+        // #1440: the site's *foreign* dependencies (declared in its package.json but not
+        // tracked by the template) may pin a peer range a template bump would violate —
+        // e.g. an imported site's own @astrojs/cloudflare requiring the astro major the
+        // template just moved past. Such a bump is held for the owner, not auto-offered.
+        let untrackedNames = Set(siteDeps.keys).subtracting(templateDeps.keys)
+        let foreignPeers = DependencyPeerCheck.foreignPeerRequirements(
+            sourceDirectory: sourceDirectory, untrackedDependencyNames: untrackedNames)
+        let (allowed, held) = DependencyPeerCheck.partition(
+            updates: offers.updates, foreignPeerRequirements: foreignPeers)
+        return DependencySyncOffers(updates: allowed, additions: offers.additions, heldUpdates: held)
     }
 }

--- a/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
+++ b/Sources/AnglesiteCore/LocalContainerSiteRuntime.swift
@@ -394,11 +394,20 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
             await drainTask.value
         }
 
+        // #1440: the boot's hydrate step (`npm ci`/`npm install`) is the install verification
+        // for any just-applied dependency update, but it runs as a detached guest process —
+        // its resolution failure only reaches this actor as a generic serving timeout. Scan
+        // the output stream for that evidence so the settled `.failed` names the real problem.
+        let installFailureScanner = DependencyInstallFailureScanner()
+
         var containerStarted = false
         do {
             let session = try await control.start(
                 siteID: siteID, sourceRepo: siteDirectory, ref: ref,
-                onOutput: { line, stream in continuation.yield((line, stream)) })
+                onOutput: { line, stream in
+                    installFailureScanner.ingest(line: line)
+                    continuation.yield((line, stream))
+                })
             containerStarted = true
             guard stateMachine.isCurrent(gen) else { await abandonSupersededAttempt(); return }
             do {
@@ -470,7 +479,11 @@ public actor LocalContainerSiteRuntime: SiteRuntime, SiteRuntimeContainerCapabil
             guard stateMachine.isCurrent(gen) else { return }
             bootLogContinuation = nil
             bootLogDrainTask = nil
-            stateMachine.settle(gen: gen, to: .failed(siteID: siteID, message: Self.friendlyMessage(for: error)))
+            // A dependency-resolution diagnosis from the boot output beats the raw error:
+            // when npm printed ERESOLVE evidence, the thrown error is just the downstream
+            // serving timeout, and the owner needs the actual cause (#1440).
+            let message = installFailureScanner.diagnosis ?? Self.friendlyMessage(for: error)
+            stateMachine.settle(gen: gen, to: .failed(siteID: siteID, message: message))
         }
     }
 

--- a/Tests/AnglesiteAppTests/DependencyUpdateModelTests.swift
+++ b/Tests/AnglesiteAppTests/DependencyUpdateModelTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// #1440: sheet-facing behavior for bumps held back by a foreign dependency's peer range —
+/// the copy is consequence-phrased (never semver/JSON mechanics) and a held-back-only offer
+/// set collapses the sheet to a single acknowledge action.
+@Suite @MainActor struct DependencyUpdateModelTests {
+    private static func heldAstroUpdate(blockers: [DependencyPeerBlocker]) -> DependencyHeldUpdate {
+        DependencyHeldUpdate(
+            offer: DependencyUpdateOffer(name: "astro", currentRange: "^6.2.0", offeredRange: "^7.1.3"),
+            blockers: blockers
+        )
+    }
+
+    @Test func heldCopyNamesTheBlockerAndTheKeptPackage() {
+        let copy = DependencyUpdateModel.heldCopy(for: Self.heldAstroUpdate(
+            blockers: [DependencyPeerBlocker(dependentName: "@astrojs/cloudflare", requiredRange: "^6.3.0")]))
+        #expect(copy.contains("@astrojs/cloudflare"))
+        #expect(copy.contains("astro"))
+    }
+
+    @Test func heldCopyIsPhrasedAboutConsequencesNotMechanics() {
+        let copy = DependencyUpdateModel.heldCopy(for: Self.heldAstroUpdate(
+            blockers: [DependencyPeerBlocker(dependentName: "@astrojs/cloudflare", requiredRange: "^6.3.0")]))
+        // The advisory-UX rule: questions/explanations are about the owner's site, never
+        // about git, diffs, semver ranges, or file mechanics.
+        #expect(!copy.contains("^6.3.0"))
+        #expect(!copy.contains("peerDependencies"))
+        #expect(!copy.contains("package.json"))
+        #expect(!copy.contains("semver"))
+    }
+
+    @Test func heldCopyListsEveryBlocker() {
+        let copy = DependencyUpdateModel.heldCopy(for: Self.heldAstroUpdate(blockers: [
+            DependencyPeerBlocker(dependentName: "@astrojs/cloudflare", requiredRange: "^6.3.0"),
+            DependencyPeerBlocker(dependentName: "astro-seo-schema", requiredRange: ">=5.0.0 <7.0.0"),
+        ]))
+        #expect(copy.contains("@astrojs/cloudflare"))
+        #expect(copy.contains("astro-seo-schema"))
+    }
+
+    @Test func heldBackOnlyOffersCollapseToAnAcknowledgeAction() {
+        let heldOnly = DependencySyncOffers(heldUpdates: [Self.heldAstroUpdate(
+            blockers: [DependencyPeerBlocker(dependentName: "@astrojs/cloudflare", requiredRange: "^6.3.0")])])
+        let model = DependencyUpdateModel(offers: heldOnly, onDecision: { _ in })
+        #expect(model.isHeldBackOnly)
+
+        let mixed = DependencySyncOffers(
+            updates: [DependencyUpdateOffer(name: "typescript", currentRange: "^5.8.0", offeredRange: "^5.9.3")],
+            heldUpdates: heldOnly.heldUpdates)
+        #expect(!DependencyUpdateModel(offers: mixed, onDecision: { _ in }).isHeldBackOnly)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DependencyInstallFailureScannerTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencyInstallFailureScannerTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// #1440 part 1: the post-apply `npm install` (the next preview boot's hydrate step) is the
+/// install verification — its resolution failure must surface as a clear, owner-phrased
+/// finding instead of a generic dev-server timeout.
+@Suite struct DependencyInstallFailureScannerTests {
+    /// Real npm 11 ERESOLVE output shape, from the #1426 repro.
+    private static let eresolveLines = [
+        "npm error code ERESOLVE",
+        "npm error ERESOLVE unable to resolve dependency tree",
+        "npm error",
+        "npm error While resolving: site@0.0.1",
+        "npm error Found: astro@7.1.3",
+        "npm error node_modules/astro",
+        "npm error   astro@\"^7.1.3\" from the root project",
+        "npm error",
+        "npm error Could not resolve dependency:",
+        "npm error peer astro@\"^6.3.0\" from @astrojs/cloudflare@13.5.0",
+        "npm error node_modules/@astrojs/cloudflare",
+        "npm error   @astrojs/cloudflare@\"13.5.0\" from the root project",
+    ]
+
+    @Test func detectsAnEresolveFailureInBootOutput() {
+        let scanner = DependencyInstallFailureScanner()
+        for line in Self.eresolveLines { scanner.ingest(line: line) }
+        #expect(scanner.diagnosis != nil)
+    }
+
+    @Test func diagnosisNamesTheConflictingPackagesWhenNpmReportsThem() throws {
+        let scanner = DependencyInstallFailureScanner()
+        for line in Self.eresolveLines { scanner.ingest(line: line) }
+        let diagnosis = try #require(scanner.diagnosis)
+        #expect(diagnosis.contains("@astrojs/cloudflare"))
+        #expect(diagnosis.contains("astro"))
+    }
+
+    @Test func diagnosisIsPhrasedAboutTheSiteNotAboutNpmMechanics() throws {
+        let scanner = DependencyInstallFailureScanner()
+        for line in Self.eresolveLines { scanner.ingest(line: line) }
+        let diagnosis = try #require(scanner.diagnosis)
+        // Consequence-first copy (CLAUDE.md advisory-UX rule): no npm/semver/exit-code jargon.
+        #expect(!diagnosis.contains("ERESOLVE"))
+        #expect(!diagnosis.contains("semver"))
+        #expect(!diagnosis.contains("exit code"))
+    }
+
+    @Test func ordinaryBootOutputProducesNoDiagnosis() {
+        let scanner = DependencyInstallFailureScanner()
+        for line in [
+            "==> npm ci (warm cache, offline-first)",
+            "added 312 packages in 4s",
+            "astro dev server running at http://127.0.0.1:4321",
+        ] { scanner.ingest(line: line) }
+        #expect(scanner.diagnosis == nil)
+    }
+
+    @Test func detectsAFailureEvenWithoutAParseablePeerLine() {
+        let scanner = DependencyInstallFailureScanner()
+        scanner.ingest(line: "npm error code ERESOLVE")
+        scanner.ingest(line: "npm error ERESOLVE could not resolve")
+        #expect(scanner.diagnosis != nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DependencyPeerCheckTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencyPeerCheckTests.swift
@@ -1,0 +1,190 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+/// #1440: a template-driven bump must not be auto-offered when it would violate the
+/// `peerDependencies` range of a *foreign* dependency — one the site's own `package.json`
+/// declares but the template doesn't track.
+@Suite struct DependencyPeerCheckTests {
+    private func tmpDir() -> URL {
+        let d = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: d, withIntermediateDirectories: true)
+        return d
+    }
+
+    // MARK: - Range-floor satisfaction (the minimal, never-guess semver subset)
+
+    @Test func caretRangeFloorInsideCaretPeerRangeSatisfies() {
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^6.4.8", peerRange: "^6.3.0") == true)
+    }
+
+    @Test func newerMajorFloorViolatesCaretPeerRange() {
+        // The #1426/#1440 repro: template bumps astro to ^7.1.3, foreign
+        // @astrojs/cloudflare@13.5.0 declares peer astro ^6.3.0.
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^7.1.3", peerRange: "^6.3.0") == false)
+    }
+
+    @Test func exactPeerVersionOnlyMatchesTheSameFloor() {
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^2.0.0", peerRange: "1.1.5") == false)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("1.1.5", peerRange: "1.1.5") == true)
+    }
+
+    @Test func tildePeerRangeBoundsTheMinorVersion() {
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("~1.2.9", peerRange: "~1.2.3") == true)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^1.3.0", peerRange: "~1.2.3") == false)
+    }
+
+    @Test func gteAndLtComparatorsCombineAsAConjunction() {
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^6.4.0", peerRange: ">=6.3.0 <7.0.0") == true)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^7.0.0", peerRange: ">=6.3.0 <7.0.0") == false)
+    }
+
+    @Test func orGroupsSatisfyWhenAnyAlternativeMatches() {
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^7.1.0", peerRange: "^6.0.0 || ^7.0.0") == true)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^8.0.0", peerRange: "^6.0.0 || ^7.0.0") == false)
+    }
+
+    @Test func wildcardPeerRangeAlwaysSatisfies() {
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^7.1.3", peerRange: "*") == true)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^7.1.3", peerRange: "6.x") == false)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^6.9.0", peerRange: "6.x") == true)
+    }
+
+    @Test func partialBareVersionsActAsMajorOrMinorWildcards() {
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^6.4.0", peerRange: "6") == true)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^7.0.0", peerRange: "6") == false)
+    }
+
+    @Test func caretZeroMajorPeerRangeStaysWithinTheMinor() {
+        // npm semantics: ^0.2.3 means >=0.2.3 <0.3.0.
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^0.2.5", peerRange: "^0.2.3") == true)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^0.3.0", peerRange: "^0.2.3") == false)
+    }
+
+    @Test func unparseablePeerRangeIsNilNeverAGuess() {
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("^7.1.3", peerRange: "workspace:*") == nil)
+        #expect(DependencyPeerCheck.offeredRangeSatisfies("latest", peerRange: "^6.3.0") == nil)
+    }
+
+    // MARK: - Partition
+
+    private static let astroBump = DependencyUpdateOffer(name: "astro", currentRange: "^6.2.0", offeredRange: "^7.1.3")
+
+    @Test func partitionHoldsABumpAForeignPeerRangeExcludes() {
+        let result = DependencyPeerCheck.partition(
+            updates: [Self.astroBump],
+            foreignPeerRequirements: ["@astrojs/cloudflare": ["astro": "^6.3.0"]]
+        )
+        #expect(result.allowed.isEmpty)
+        #expect(result.held == [
+            DependencyHeldUpdate(
+                offer: Self.astroBump,
+                blockers: [DependencyPeerBlocker(dependentName: "@astrojs/cloudflare", requiredRange: "^6.3.0")]
+            )
+        ])
+    }
+
+    @Test func partitionAllowsABumpWithinEveryForeignPeerRange() {
+        let bump = DependencyUpdateOffer(name: "astro", currentRange: "^6.2.0", offeredRange: "^6.4.8")
+        let result = DependencyPeerCheck.partition(
+            updates: [bump],
+            foreignPeerRequirements: ["@astrojs/cloudflare": ["astro": "^6.3.0"]]
+        )
+        #expect(result.allowed == [bump])
+        #expect(result.held.isEmpty)
+    }
+
+    @Test func partitionIgnoresPeerRangesForPackagesNotBeingBumped() {
+        let result = DependencyPeerCheck.partition(
+            updates: [Self.astroBump],
+            foreignPeerRequirements: ["some-plugin": ["react": "^17.0.0"]]
+        )
+        #expect(result.allowed == [Self.astroBump])
+        #expect(result.held.isEmpty)
+    }
+
+    @Test func partitionNeverGuessesOnAnUnparseablePeerRange() {
+        // An unreadable peer range must not hold the offer back — the post-apply
+        // install (and its surfaced failure) is the backstop for what we can't parse.
+        let result = DependencyPeerCheck.partition(
+            updates: [Self.astroBump],
+            foreignPeerRequirements: ["@astrojs/cloudflare": ["astro": "workspace:*"]]
+        )
+        #expect(result.allowed == [Self.astroBump])
+        #expect(result.held.isEmpty)
+    }
+
+    @Test func partitionCollectsEveryBlockerForOneHeldBump() {
+        let result = DependencyPeerCheck.partition(
+            updates: [Self.astroBump],
+            foreignPeerRequirements: [
+                "@astrojs/cloudflare": ["astro": "^6.3.0"],
+                "astro-seo-schema": ["astro": ">=5.0.0 <7.0.0"],
+            ]
+        )
+        #expect(result.held.count == 1)
+        #expect(result.held.first?.blockers == [
+            DependencyPeerBlocker(dependentName: "@astrojs/cloudflare", requiredRange: "^6.3.0"),
+            DependencyPeerBlocker(dependentName: "astro-seo-schema", requiredRange: ">=5.0.0 <7.0.0"),
+        ])
+    }
+
+    // MARK: - Reading foreign peer requirements from the site
+
+    @Test func readsPeerRequirementsFromTheLockfile() throws {
+        let source = tmpDir()
+        let lockfile = """
+        {
+          "name": "site", "lockfileVersion": 3,
+          "packages": {
+            "": { "dependencies": { "astro": "^6.2.0", "@astrojs/cloudflare": "13.5.0" } },
+            "node_modules/@astrojs/cloudflare": {
+              "version": "13.5.0",
+              "peerDependencies": { "astro": "^6.3.0" }
+            },
+            "node_modules/astro": { "version": "6.4.0" }
+          }
+        }
+        """
+        try lockfile.write(to: source.appendingPathComponent("package-lock.json"), atomically: true, encoding: .utf8)
+        let peers = DependencyPeerCheck.foreignPeerRequirements(
+            sourceDirectory: source, untrackedDependencyNames: ["@astrojs/cloudflare"])
+        #expect(peers == ["@astrojs/cloudflare": ["astro": "^6.3.0"]])
+    }
+
+    @Test func fallsBackToNodeModulesPackageJSONWhenTheLockfileHasNoEntry() throws {
+        let source = tmpDir()
+        let pkgDir = source.appendingPathComponent("node_modules/@astrojs/cloudflare")
+        try FileManager.default.createDirectory(at: pkgDir, withIntermediateDirectories: true)
+        let pkg = """
+        { "name": "@astrojs/cloudflare", "version": "13.5.0", "peerDependencies": { "astro": "^6.3.0" } }
+        """
+        try pkg.write(to: pkgDir.appendingPathComponent("package.json"), atomically: true, encoding: .utf8)
+        let peers = DependencyPeerCheck.foreignPeerRequirements(
+            sourceDirectory: source, untrackedDependencyNames: ["@astrojs/cloudflare"])
+        #expect(peers == ["@astrojs/cloudflare": ["astro": "^6.3.0"]])
+    }
+
+    @Test func onlyReadsTheNamedUntrackedDependencies() throws {
+        let source = tmpDir()
+        let lockfile = """
+        {
+          "lockfileVersion": 3,
+          "packages": {
+            "node_modules/@astrojs/cloudflare": { "peerDependencies": { "astro": "^6.3.0" } },
+            "node_modules/astro-seo-schema": { "peerDependencies": { "astro": "^6.0.0" } }
+          }
+        }
+        """
+        try lockfile.write(to: source.appendingPathComponent("package-lock.json"), atomically: true, encoding: .utf8)
+        let peers = DependencyPeerCheck.foreignPeerRequirements(
+            sourceDirectory: source, untrackedDependencyNames: ["@astrojs/cloudflare"])
+        #expect(peers["astro-seo-schema"] == nil)
+    }
+
+    @Test func returnsEmptyWhenNeitherLockfileNorNodeModulesExists() {
+        let peers = DependencyPeerCheck.foreignPeerRequirements(
+            sourceDirectory: tmpDir(), untrackedDependencyNames: ["@astrojs/cloudflare"])
+        #expect(peers.isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencySyncApplierTests.swift
@@ -175,6 +175,23 @@ import Foundation
         #expect(baseline?["astro"] == "^5.0.0")
     }
 
+    @Test func keepsTheLockfileWhenNoOfferActuallyChangedPackageJSON() throws {
+        // #1440: an offer set that lands nothing (e.g. only held-back bumps, or a stale
+        // offer whose target name isn't in the site's package.json) must not delete the
+        // lockfile — regenerating it for an unchanged package.json is pure downside
+        // (slow next boot, churned resolution) and the delete is only justified by an
+        // actual dependency change.
+        let (source, config) = try makeSourceAndConfig()
+        let offers = DependencySyncOffers(updates: [
+            DependencyUpdateOffer(name: "does-not-exist", currentRange: "^1.0.0", offeredRange: "^2.0.0")
+        ])
+        try DependencySyncApplier.apply(offers, sourceDirectory: source, configDirectory: config, runningAppVersion: "1.4.0")
+        #expect(FileManager.default.fileExists(atPath: source.appendingPathComponent("package-lock.json").path))
+        // The version stamp still lands, so the sheet doesn't re-nag every open.
+        let siteConfig = try String(contentsOf: source.appendingPathComponent(".site-config"), encoding: .utf8)
+        #expect(SiteConfigFile.value(forKey: "ANGLESITE_VERSION", in: siteConfig) == "1.4.0")
+    }
+
     @Test func throwsReadFailedWhenPackageJSONIsMissing() throws {
         let root = tmpDir()
         let source = root.appendingPathComponent("Source")

--- a/Tests/AnglesiteCoreTests/DependencySyncCheckerTests.swift
+++ b/Tests/AnglesiteCoreTests/DependencySyncCheckerTests.swift
@@ -111,4 +111,109 @@ import Foundation
         )
         #expect(offers.additions == [DependencyAdditionOffer(name: "html-validate", offeredRange: "^11.6.0", section: .devDependencies)])
     }
+
+    // MARK: - #1440: foreign peerDependencies hold a bump out of the auto-offer
+
+    /// The #1426/#1440 repro, end to end: an imported site carries its own (untracked)
+    /// `@astrojs/cloudflare@13.5.0`, whose `peerDependencies` require `astro ^6.3.0`. The
+    /// template legitimately bumps `astro` to `^7.1.3` — but applying that would leave the
+    /// site unable to `npm install` at all, so the bump must be held for the owner, not
+    /// silently auto-offered as a safe update.
+    @Test func holdsABumpThatViolatesAForeignDependencysPeerRange() throws {
+        let (source, config) = try makeSite(
+            siteConfig: "ANGLESITE_VERSION=1.2.0\n",
+            packageJSON: """
+            { "dependencies": { "astro": "^6.2.0", "@astrojs/cloudflare": "13.5.0" } }
+            """,
+            baseline: ["astro": "^6.2.0"]
+        )
+        try """
+        {
+          "lockfileVersion": 3,
+          "packages": {
+            "node_modules/@astrojs/cloudflare": {
+              "version": "13.5.0",
+              "peerDependencies": { "astro": "^6.3.0" }
+            }
+          }
+        }
+        """.write(to: source.appendingPathComponent("package-lock.json"), atomically: true, encoding: .utf8)
+        let template = try makeTemplate(packageJSON: """
+        { "dependencies": { "astro": "^7.1.3" } }
+        """)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.updates.isEmpty)
+        #expect(offers.heldUpdates == [
+            DependencyHeldUpdate(
+                offer: DependencyUpdateOffer(name: "astro", currentRange: "^6.2.0", offeredRange: "^7.1.3"),
+                blockers: [DependencyPeerBlocker(dependentName: "@astrojs/cloudflare", requiredRange: "^6.3.0")]
+            )
+        ])
+        #expect(!offers.isEmpty)  // held bumps still surface the sheet, so the owner learns why
+    }
+
+    @Test func stillOffersABumpAForeignPeerRangeAllows() throws {
+        let (source, config) = try makeSite(
+            siteConfig: "ANGLESITE_VERSION=1.2.0\n",
+            packageJSON: """
+            { "dependencies": { "astro": "^6.2.0", "@astrojs/cloudflare": "14.2.1" } }
+            """,
+            baseline: ["astro": "^6.2.0"]
+        )
+        try """
+        {
+          "lockfileVersion": 3,
+          "packages": {
+            "node_modules/@astrojs/cloudflare": {
+              "version": "14.2.1",
+              "peerDependencies": { "astro": "^7.2.0 || ^6.4.0" }
+            }
+          }
+        }
+        """.write(to: source.appendingPathComponent("package-lock.json"), atomically: true, encoding: .utf8)
+        let template = try makeTemplate(packageJSON: """
+        { "dependencies": { "astro": "^6.4.8" } }
+        """)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.updates == [DependencyUpdateOffer(name: "astro", currentRange: "^6.2.0", offeredRange: "^6.4.8")])
+        #expect(offers.heldUpdates.isEmpty)
+    }
+
+    /// A dependency the template *does* track is never treated as a foreign blocker —
+    /// tracked packages are the template's own responsibility to keep mutually compatible.
+    @Test func doesNotTreatTemplateTrackedDependenciesAsForeignBlockers() throws {
+        let (source, config) = try makeSite(
+            siteConfig: "ANGLESITE_VERSION=1.2.0\n",
+            packageJSON: """
+            { "dependencies": { "astro": "^6.2.0", "astro-seo-schema": "^5.0.0" } }
+            """,
+            baseline: ["astro": "^6.2.0", "astro-seo-schema": "^5.0.0"]
+        )
+        try """
+        {
+          "lockfileVersion": 3,
+          "packages": {
+            "node_modules/astro-seo-schema": {
+              "peerDependencies": { "astro": "^6.0.0" }
+            }
+          }
+        }
+        """.write(to: source.appendingPathComponent("package-lock.json"), atomically: true, encoding: .utf8)
+        // The template tracks astro-seo-schema (and would bump it alongside astro).
+        let template = try makeTemplate(packageJSON: """
+        { "dependencies": { "astro": "^7.1.3", "astro-seo-schema": "^6.0.0" } }
+        """)
+        let offers = DependencySyncChecker.check(
+            sourceDirectory: source, configDirectory: config, templateDirectory: template,
+            runningAppVersion: "1.4.0"
+        )
+        #expect(offers.updates.count == 2)
+        #expect(offers.heldUpdates.isEmpty)
+    }
 }

--- a/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
+++ b/Tests/AnglesiteCoreTests/LocalContainerSiteRuntimeTests.swift
@@ -356,6 +356,32 @@ struct LocalContainerSiteRuntimeTests {
         } else { Issue.record("expected .failed, got \(await rt.state)") }
     }
 
+    /// #1440 part 1: when the boot's `npm install` (hydrate) fails to resolve the site's own
+    /// dependency tree, the ERESOLVE evidence is in the boot output but the thrown error is a
+    /// generic serving timeout — the settled `.failed` message must carry the dependency
+    /// diagnosis, not the timeout.
+    @Test("a boot failure with npm resolution errors in its output settles to a dependency-specific message")
+    func bootFailureWithEresolveOutputSurfacesTheDependencyDiagnosis() async {
+        let fake = FakeLocalContainerControl(
+            startResult: .failure(.bootFailed("waitUntilServing: timed out after 300.0s waiting for http://127.0.0.1:51001")),
+            startStdoutLines: [
+                "==> npm ci (warm cache, offline-first)",
+                "npm error code ERESOLVE",
+                "npm error Could not resolve dependency:",
+                "npm error peer astro@\"^6.3.0\" from @astrojs/cloudflare@13.5.0",
+            ])
+        let mcp = MCPClient(supervisor: ProcessSupervisor(), logCenter: LogCenter())
+        let rt = LocalContainerSiteRuntime(
+            ref: "HEAD", control: fake, mcpClient: mcp, connect: { _, _ in },
+            workerCatalog: { [] })
+        await rt.start(siteID: "s1", siteDirectory: URL(fileURLWithPath: "/unused"))
+        if case .failed(let id, let msg) = await rt.state {
+            #expect(id == "s1")
+            #expect(!msg.contains("timed out"))
+            #expect(msg.contains("@astrojs/cloudflare"))
+        } else { Issue.record("expected .failed, got \(await rt.state)") }
+    }
+
     /// Regression test: the boot-log stream must be finished immediately when `control.start()`
     /// throws, not left for the next `start()`/`stop()` call's `teardown()` to clean up. Verifies
     /// this by checking the failure path delivers its lines through the SAME live subscription


### PR DESCRIPTION
Closes #1440

## Summary

- **Pre-check (owner decision part 2):** `DependencySyncChecker` now checks every bump offer against the `peerDependencies` ranges of the site's *foreign* dependencies — packages the site's `package.json` declares but the template doesn't track (read from `package-lock.json`'s v2/v3 `packages` entries, falling back to `node_modules/<name>/package.json`). A bump whose offered floor violates such a range (the #1426 repro: template bumps `astro` to `^7.1.3` while the site's own `@astrojs/cloudflare@13.5.0` requires `astro ^6.3.0`) is moved into `DependencySyncOffers.heldUpdates` instead of being auto-applied. The sheet surfaces held bumps in a "Not Updated" section with consequence-phrased copy (never semver/JSON mechanics), and a held-back-only offer set collapses to a single OK acknowledgment that still stamps `ANGLESITE_VERSION` so it doesn't re-nag. Per the scope decision, this is deliberately *not* a dependency-graph resolver — only direct peer ranges are consulted, and anything unparseable degrades to "don't hold" (never guess).
- **Post-apply verify (owner decision part 1):** the install that immediately follows an accepted offer — the next preview boot's hydrate `npm ci`/`npm install` — is the verification, and its failure is now actually surfaced: `DependencyInstallFailureScanner` watches the boot output stream for npm resolution-failure evidence (ERESOLVE / peer-conflict lines) and, when the boot fails, `LocalContainerSiteRuntime` settles `.failed` with an owner-phrased diagnosis naming the conflicting packages instead of the generic 300-second serving timeout. A literal host-side `npm install --dry-run` isn't possible (no host Node runtime, #70), and an in-guest dry-run can't run precisely when the install would fail — the boot install *is* the dry-run's "or equivalent", now with its failure surfaced. The raw npm output stays in the debug log per "logs are sacred".
- **Applier hardening:** `DependencySyncApplier.apply` no longer deletes `package-lock.json` when no offer actually changed `package.json` (a held-back-only or fully-no-op decision must not force the next boot through a from-scratch resolve).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --package-path .` (Xcode 27 toolchain — includes `AnglesiteAppTests`, which CI never executes)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`)
- [ ] Manual smoke (if UI-touching): not run — the held-back section renders through the existing dependency-update sheet; covered by `DependencyUpdateModelTests` + the checker/applier/runtime suites below.

New coverage, written failing-first against main behavior:

- `DependencyPeerCheckTests` — range-floor satisfaction table (`^`/`~`/exact/partial/`x`-wildcard/`>=`+`<` conjunctions/`||` alternatives/`^0.x`), never-guess `nil` cases, partition semantics (hold/allow/multi-blocker/unparseable), and peer-requirement reading from lockfile + `node_modules` fallback.
- `DependencySyncCheckerTests` — the #1426/#1440 repro end-to-end (`astro ^6.2.0` + foreign `@astrojs/cloudflare@13.5.0` with peer `astro ^6.3.0`, template offering `^7.1.3` → held, not offered), the peer-compatible counterpart (still offered), and template-tracked packages never treated as foreign blockers.
- `DependencySyncApplierTests` — lockfile survives a decision that lands nothing, version stamp still written.
- `DependencyInstallFailureScannerTests` — real npm 11 ERESOLVE output detected, diagnosis names both packages, copy contains no npm/semver jargon, ordinary boot output stays silent.
- `LocalContainerSiteRuntimeTests` — a boot failure with ERESOLVE evidence in its output settles `.failed` with the dependency diagnosis, not the serving timeout.

## Design notes

- Held bumps are shown as information, not a per-row "apply anyway" choice: applying one is known to leave the site unable to `npm install` at all, and per the advisory-UX rule the app doesn't delegate decisions it already knows the answer to. The bump is re-offered naturally once the blocking package moves (the peer check re-runs on the next version-stamp mismatch).
- `DependencySync.fixOffer` (Security Reports "Update available") reads `offers.updates`, so a held bump is also automatically excluded from the Dependabot fix path.
