### PR TITLE
feat(#1520): extract shared SheetHeader for sheet accessibility

### DIFF
--- a/Sources/AnglesiteApp/AISearchSheetView.swift
+++ b/Sources/AnglesiteApp/AISearchSheetView.swift
@@ -20,15 +20,9 @@ struct AISearchSheetView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(spacing: 10) {
+        SheetHeader(title: headerTitle) {
             statusIcon
-            VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
-            }
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/AgentReadinessSheetView.swift
+++ b/Sources/AnglesiteApp/AgentReadinessSheetView.swift
@@ -19,18 +19,9 @@ struct AgentReadinessSheetView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(spacing: 10) {
+        SheetHeader(title: headerTitle, subtitle: headerSubtitle) {
             statusIcon
-            VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
-                if let subtitle = headerSubtitle {
-                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/AuditSheetView.swift
+++ b/Sources/AnglesiteApp/AuditSheetView.swift
@@ -29,18 +29,9 @@ struct AuditSheetView: View {
     // MARK: Header
 
     private var header: some View {
-        HStack(spacing: 10) {
+        SheetHeader(title: headerTitle, subtitle: headerSubtitle) {
             statusIcon
-            VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
-                if let subtitle = headerSubtitle {
-                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/BackupDrawerView.swift
+++ b/Sources/AnglesiteApp/BackupDrawerView.swift
@@ -26,15 +26,9 @@ struct BackupDrawerView: View {
     // MARK: Sections
 
     private var header: some View {
-        HStack(spacing: 10) {
+        SheetHeader(title: headerTitle, subtitle: headerSubtitle, verticalPadding: 10) {
             statusIcon
-            VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
-                if let subtitle = headerSubtitle {
-                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
+        } trailing: {
             if case .succeeded(let sha, _, _, _) = model.phase {
                 Button("Copy SHA") {
                     NSPasteboard.general.clearContents()
@@ -42,8 +36,6 @@ struct BackupDrawerView: View {
                 }
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/DomainConfigAuditSheetView.swift
+++ b/Sources/AnglesiteApp/DomainConfigAuditSheetView.swift
@@ -24,18 +24,9 @@ struct DomainConfigAuditSheetView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(spacing: 10) {
+        SheetHeader(title: headerTitle, subtitle: headerSubtitle) {
             statusIcon
-            VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
-                if let subtitle = headerSubtitle {
-                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/DomainSheetView.swift
+++ b/Sources/AnglesiteApp/DomainSheetView.swift
@@ -20,18 +20,9 @@ struct DomainSheetView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(spacing: 10) {
+        SheetHeader(title: headerTitle, subtitle: headerSubtitle) {
             statusIcon
-            VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
-                if let subtitle = headerSubtitle {
-                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/HardenSheetView.swift
+++ b/Sources/AnglesiteApp/HardenSheetView.swift
@@ -19,18 +19,9 @@ struct HardenSheetView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(spacing: 10) {
+        SheetHeader(title: headerTitle, subtitle: headerSubtitle) {
             statusIcon
-            VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
-                if let subtitle = headerSubtitle {
-                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/OnionRoutingSheetView.swift
+++ b/Sources/AnglesiteApp/OnionRoutingSheetView.swift
@@ -166,18 +166,9 @@ struct OnionRoutingSheetView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(spacing: 10) {
+        SheetHeader(title: headerTitle, subtitle: headerSubtitle) {
             statusIcon
-            VStack(alignment: .leading, spacing: 1) {
-                Text(headerTitle).font(.headline)
-                if let subtitle = headerSubtitle {
-                    Text(subtitle).font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
     }
 
     @ViewBuilder

--- a/Sources/AnglesiteApp/SheetHeader.swift
+++ b/Sources/AnglesiteApp/SheetHeader.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Shared status/category header for sheets and drawers: an icon beside a title/subtitle
+/// stack, with an optional trailing slot for header-level actions (e.g. `BackupDrawerView`'s
+/// "Copy SHA" button). By construction it groups the title/subtitle into a single VoiceOver
+/// stop and hides the status icon, which is redundant with the adjacent title text (2026-08-16
+/// semantic accessibility audit, checklist §4 "Grouping Elements" and §5 "Hiding Decorative
+/// Elements").
+struct SheetHeader<Icon: View, Trailing: View>: View {
+    let title: String
+    let subtitle: String?
+    var verticalPadding: CGFloat = 12
+    @ViewBuilder let icon: () -> Icon
+    @ViewBuilder var trailing: () -> Trailing
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        verticalPadding: CGFloat = 12,
+        @ViewBuilder icon: @escaping () -> Icon,
+        @ViewBuilder trailing: @escaping () -> Trailing = { EmptyView() }
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.verticalPadding = verticalPadding
+        self.icon = icon
+        self.trailing = trailing
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            icon()
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            Spacer()
+            trailing()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, verticalPadding)
+    }
+}
+
+#Preview {
+    VStack(spacing: 0) {
+        SheetHeader(title: "Manage Domain", subtitle: "3 DNS records for example.com") {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .font(.title3)
+        }
+        Divider()
+        SheetHeader(title: "Backing up my-site…", subtitle: "Committing 4 files", verticalPadding: 10) {
+            ProgressView().controlSize(.small)
+        } trailing: {
+            Button("Copy SHA") {}
+        }
+    }
+}


### PR DESCRIPTION
Closes #1520

## Summary

- Extracts a shared `SheetHeader` view (`Sources/AnglesiteApp/SheetHeader.swift`) that groups an icon + title/subtitle into one VoiceOver stop and hides the redundant status icon, matching the pattern already used correctly by newer sheets (`ConnectDomainSheetView`, `BuyDomainSheetView`, `DomainConfigDriftSheetView`, `BlockedDeploySheetView`).
- Migrates the 8 call sites flagged by the semantic accessibility audit to the shared view: `DomainSheetView`, `DomainConfigAuditSheetView`, `OnionRoutingSheetView`, `BackupDrawerView`, `AuditSheetView`, `HardenSheetView`, `AgentReadinessSheetView`, `AISearchSheetView`.
- No visual change — this is a semantic/accessibility-only refactor of an existing duplicated layout.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 540 tests in 72 suites passed
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [x] Manual smoke: no visual change expected (verified header layout constants — spacing, padding, fonts — are preserved exactly across all 8 migrated call sites)