### PR TITLE
feat(#965): pending follow requests with Accept/Reject

### DIFF
--- a/Sources/AnglesiteApp/CompletionNotificationHub.swift
+++ b/Sources/AnglesiteApp/CompletionNotificationHub.swift
@@ -25,7 +25,7 @@ import AnglesiteCore
 /// milestone).
 @MainActor
 enum CompletionNotificationHub {
-    static func wire(deploy: DeployModel, backup: BackupModel, audit: AuditModel) {
+    static func wire(deploy: DeployModel, backup: BackupModel, audit: AuditModel, followers: FollowersModel) {
         deploy.onPhaseTransition = { siteID, phase in
             let dockToken = "deploy:\(siteID)"
             switch phase {
@@ -127,6 +127,12 @@ enum CompletionNotificationHub {
                 postNotice(siteID: siteID) { name in
                     CompletionNoticeBuilder.audit(siteName: name, siteID: siteID, outcome: .failed(reason: reason))
                 }
+            }
+        }
+
+        followers.onNewPendingRequests = { siteID, count in
+            postNotice(siteID: siteID) { name in
+                CompletionNoticeBuilder.followRequest(siteName: name, siteID: siteID, count: count)
             }
         }
     }

--- a/Sources/AnglesiteApp/FollowersModel.swift
+++ b/Sources/AnglesiteApp/FollowersModel.swift
@@ -15,11 +15,28 @@ struct FollowerRow: Identifiable, Equatable {
 
     /// Never empty: the fetched display name, else the fetched username, else the derived
     /// handle, else the raw IRI. This chain is why a failed profile fetch needs no error state.
-    var displayName: String {
+    var displayName: String { ActorDisplay.name(profile: profile, handle: handle, actor: actor) }
+}
+
+/// Shared display-name derivation for both `FollowerRow` and `PendingRequestRow`: fetched
+/// display name, else fetched username, else derived handle, else the raw IRI.
+enum ActorDisplay {
+    static func name(profile: ActorProfile?, handle: String?, actor: URL) -> String {
         if let name = profile?.name, !name.isEmpty { return name }
         if let username = profile?.preferredUsername, !username.isEmpty { return "@\(username)" }
         return handle ?? actor.absoluteString
     }
+}
+
+/// One pending follow request in the Followers pane's "Pending Requests" section — pairs the
+/// Worker's `PendingFollower` with the same lazily-enriched display identity `FollowerRow` uses.
+struct PendingRequestRow: Identifiable, Equatable {
+    let request: PendingFollower
+    var profile: ActorProfile?
+
+    var id: URL { request.actor }
+    var handle: String? { ActorHandle.derive(from: request.actor) }
+    var displayName: String { ActorDisplay.name(profile: profile, handle: handle, actor: request.actor) }
 }
 
 /// Drives the Followers pane (Website ▸ Followers…, V-4.2 #364): reads the site's own public
@@ -37,6 +54,19 @@ final class FollowersModel {
         /// The Worker answered 503: ActivityPub isn't activated for this site.
         case notActivated
         /// 404 or a transport failure: unreachable, or the Worker isn't deployed.
+        case unreachable(String)
+    }
+
+    /// Loading lifecycle for the pending-request list — deliberately separate from `State`
+    /// (see the design doc's rationale): pending availability is orthogonal to whether the
+    /// main follower list loaded.
+    enum PendingState: Equatable {
+        case unknown
+        case loading
+        case loaded
+        /// The upstream `GET <actor>/follow_requests` route 404s — not shipped yet. Never
+        /// shown as an error; the pending section simply stays hidden.
+        case unavailable
         case unreachable(String)
     }
 
@@ -90,15 +120,28 @@ final class FollowersModel {
     private var pendingQueue: [URL] = []
     private var saveTask: Task<Void, Never>?
 
+    private(set) var pendingRows: [PendingRequestRow] = []
+    private(set) var pendingState: PendingState = .unknown
+
+    private var siteID: String?
+    private let secretStore: any SecretStore
+    private let membershipTransport: CommunityMembershipClient.Transport
+    private var membershipClient: CommunityMembershipClient?
+
     init(
         fetcher: ActorProfileFetcher = ActorProfileFetcher(),
         avatarLoader: AvatarLoader = AvatarLoader(),
         followersTransport: @escaping ActivityPubFollowersClient.Transport
-            = ActivityPubFollowersClient.defaultTransport
+            = ActivityPubFollowersClient.defaultTransport,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        membershipTransport: @escaping CommunityMembershipClient.Transport
+            = CommunityMembershipClient.defaultTransport
     ) {
         self.fetcher = fetcher
         self.avatarLoader = avatarLoader
         self.followersTransport = followersTransport
+        self.secretStore = secretStore
+        self.membershipTransport = membershipTransport
     }
 
     var canLoadMore: Bool { nextPage != nil && state == .loaded }
@@ -108,6 +151,7 @@ final class FollowersModel {
     func configure(site: CurrentSite) {
         configDirectory = site.configDirectory
         sourceDirectory = site.sourceDirectory
+        siteID = site.id
         cache = ActorProfileCache.load(from: site.configDirectory) ?? ActorProfileCache()
         resolveSite()
     }
@@ -127,10 +171,19 @@ final class FollowersModel {
         guard let siteURL else {
             client = nil
             actorURL = nil
+            membershipClient = nil
             return
         }
         client = ActivityPubFollowersClient(siteURL: siteURL, transport: followersTransport)
         actorURL = ActivityPubActor.actorURL(siteURL: siteURL)
+        membershipClient = publishToken.map { token in
+            CommunityMembershipClient(ownActorURL: actorURL!, publishToken: token, transport: membershipTransport)
+        }
+    }
+
+    private var publishToken: String? {
+        guard let siteID else { return nil }
+        return try? secretStore.read(account: SecretAccounts.activityPubPublishToken(siteID: siteID))
     }
 
     /// The error states' Try Again. Re-resolves the site before reloading, so publishing the site
@@ -266,6 +319,33 @@ final class FollowersModel {
             unreachableActors.insert(key)
         }
         pumpQueue()
+    }
+
+    // MARK: - Pending requests
+
+    /// Fetches the pending-follow-request list from this site's own Worker. A 404 (the
+    /// upstream capability not shipped yet) degrades to `.unavailable` with an empty list —
+    /// never a user-facing error, mirroring `ModerationModel.loadPendingFollowers()`'s same
+    /// rule against the same endpoint. No-ops (leaves `.unknown`) until `configure(site:)` has
+    /// resolved a `membershipClient` — no site URL yet, or no publish token provisioned.
+    func loadPending() async {
+        guard let membershipClient else { return }
+        pendingState = .loading
+        do {
+            let requests = try await membershipClient.listFollowRequests()
+            pendingRows = requests.map { request in
+                PendingRequestRow(request: request, profile: cache.profile(for: request.actor))
+            }
+            pendingState = .loaded
+        } catch CommunityMembershipError.requestFailed(status: 404, body: _) {
+            pendingRows = []
+            pendingState = .unavailable
+        } catch {
+            // Additive, not destructive: a transient failure keeps whatever rows are already
+            // on screen rather than blanking the section, matching `loadMoreFailure`'s rule
+            // for the main list.
+            pendingState = .unreachable("\(error)")
+        }
     }
 
     // MARK: - Cache persistence

--- a/Sources/AnglesiteApp/FollowersModel.swift
+++ b/Sources/AnglesiteApp/FollowersModel.swift
@@ -166,6 +166,18 @@ final class FollowersModel {
         sourceDirectory = site.sourceDirectory
         siteID = site.id
         cache = ActorProfileCache.load(from: site.configDirectory) ?? ActorProfileCache()
+        // A window can replay onto a different site while reusing this same model instance —
+        // every piece of pending-request state carries site-specific meaning (rows are another
+        // site's actors, the notification baseline is another site's count) and must not leak
+        // across the replay. Without this reset, the very first `loadPending()` for the new site
+        // could compare against a stale baseline and fire a spurious notification, or leave the
+        // previous site's rows on screen under the new site's window.
+        pendingRows = []
+        pendingState = .unknown
+        pendingActionFailure = nil
+        rejectConfirmation = nil
+        lastNotifiedPendingCount = 0
+        hasEstablishedPendingBaseline = false
         resolveSite()
     }
 
@@ -269,6 +281,10 @@ final class FollowersModel {
         // failed actor a fresh attempt instead of honoring the session-scoped failure memory.
         unreachableActors.removeAll()
         await load()
+        // Refresh is the owner's one manual "check now" — without also re-fetching pending
+        // requests, an accept/reject made elsewhere (or a stuck `.unreachable` pending state)
+        // would stay stale in this window for up to the full 5-minute poll interval.
+        await loadPending()
     }
 
     private static func failureState(for error: Error) -> State {
@@ -348,6 +364,7 @@ final class FollowersModel {
     func loadPending() async {
         guard let membershipClient else { return }
         pendingState = .loading
+        pendingActionFailure = nil
         do {
             let requests = try await membershipClient.listFollowRequests()
             pendingRows = requests.map { request in
@@ -361,8 +378,9 @@ final class FollowersModel {
         } catch {
             // Additive, not destructive: a transient failure keeps whatever rows are already
             // on screen rather than blanking the section, matching `loadMoreFailure`'s rule
-            // for the main list.
-            pendingState = .unreachable("\(error)")
+            // for the main list. `localizedDescription`, not a raw `"\(error)"` dump, since this
+            // is owner-facing copy the view surfaces — mirrors `ModerationModel.loadPendingFollowers()`.
+            pendingState = .unreachable(error.localizedDescription)
         }
     }
 
@@ -384,6 +402,16 @@ final class FollowersModel {
     /// a replay should `await loadPending()` explicitly (this method only owns the recurring
     /// timer, not an immediate fetch — see `SiteWindowModel.loadAndStart`).
     func startPendingPollingIfNeeded() {
+        // The design spec starts the recurring poll "once `pendingState` first resolves to
+        // something other than `.unavailable`" — the upstream `follow_requests` route not being
+        // deployed yet is the whole backward-compatibility scenario this feature exists for, and
+        // without this guard every open site window would poll an authenticated request every
+        // few minutes, forever, that can only ever 404. Called (as it already is) right after the
+        // initial `await loadPending()` in `SiteWindowModel.loadAndStart(...)`, so `pendingState`
+        // already reflects whether the route exists by the time this runs. A Worker that upgrades
+        // mid-session won't be picked up until the window reopens — accepted in the design spec's
+        // non-goals.
+        guard pendingState != .unavailable else { return }
         guard pollTask == nil else { return }
         pollTask = Task { [weak self] in
             guard let interval = self?.pendingPollInterval else { return }
@@ -413,6 +441,10 @@ final class FollowersModel {
     /// `pendingActionFailure`, same additive-not-replacing shape as `loadMoreFailure`.
     func accept(_ row: PendingRequestRow) async {
         guard let membershipClient else { return }
+        // Unconditional on entry, not just on success: nothing else ever clears a previous
+        // failure, so without this a stale error from an earlier accept/reject would keep
+        // showing under a later, unrelated pending request.
+        pendingActionFailure = nil
         pendingRows.removeAll { $0.id == row.id }
         do {
             try await membershipClient.acceptFollow(target: row.request.actor)
@@ -427,6 +459,8 @@ final class FollowersModel {
     /// (mac-assed-app-spec §5).
     private func reject(_ row: PendingRequestRow) async {
         guard let membershipClient else { return }
+        // Same unconditional-on-entry clear as `accept(_:)` — see its comment.
+        pendingActionFailure = nil
         pendingRows.removeAll { $0.id == row.id }
         do {
             try await membershipClient.rejectFollow(target: row.request.actor)

--- a/Sources/AnglesiteApp/FollowersModel.swift
+++ b/Sources/AnglesiteApp/FollowersModel.swift
@@ -128,6 +128,17 @@ final class FollowersModel {
     private let membershipTransport: CommunityMembershipClient.Transport
     private var membershipClient: CommunityMembershipClient?
 
+    private var pollTask: Task<Void, Never>?
+    private var lastNotifiedPendingCount = 0
+    private var hasEstablishedPendingBaseline = false
+    private let pendingPollInterval: Duration
+
+    /// Fired with the current total pending count whenever a `loadPending()` finds it greater
+    /// than the last count this fired for. The *first* `loadPending()` per model instance only
+    /// establishes the baseline — it never fires on its own (a relaunch must not re-notify
+    /// about requests the owner has already seen and simply hasn't acted on yet).
+    var onNewPendingRequests: ((String, Int) -> Void)?
+
     init(
         fetcher: ActorProfileFetcher = ActorProfileFetcher(),
         avatarLoader: AvatarLoader = AvatarLoader(),
@@ -135,13 +146,15 @@ final class FollowersModel {
             = ActivityPubFollowersClient.defaultTransport,
         secretStore: any SecretStore = PlatformSecretStore.make(),
         membershipTransport: @escaping CommunityMembershipClient.Transport
-            = CommunityMembershipClient.defaultTransport
+            = CommunityMembershipClient.defaultTransport,
+        pendingPollInterval: Duration = .seconds(300)
     ) {
         self.fetcher = fetcher
         self.avatarLoader = avatarLoader
         self.followersTransport = followersTransport
         self.secretStore = secretStore
         self.membershipTransport = membershipTransport
+        self.pendingPollInterval = pendingPollInterval
     }
 
     var canLoadMore: Bool { nextPage != nil && state == .loaded }
@@ -341,6 +354,7 @@ final class FollowersModel {
                 PendingRequestRow(request: request, profile: cache.profile(for: request.actor))
             }
             pendingState = .loaded
+            notifyIfNewRequestsArrived()
         } catch CommunityMembershipError.requestFailed(status: 404, body: _) {
             pendingRows = []
             pendingState = .unavailable
@@ -350,6 +364,41 @@ final class FollowersModel {
             // for the main list.
             pendingState = .unreachable("\(error)")
         }
+    }
+
+    private func notifyIfNewRequestsArrived() {
+        guard let siteID else { return }
+        defer { hasEstablishedPendingBaseline = true }
+        guard hasEstablishedPendingBaseline, pendingRows.count > lastNotifiedPendingCount else {
+            lastNotifiedPendingCount = pendingRows.count
+            return
+        }
+        lastNotifiedPendingCount = pendingRows.count
+        onNewPendingRequests?(siteID, pendingRows.count)
+    }
+
+    /// Starts the recurring background recheck, idempotently — a second call (e.g. a window
+    /// replayed onto a different site) is a no-op; `loadPending()` always reads the *current*
+    /// `membershipClient`/`siteID` at call time, so the one running loop naturally picks up a
+    /// replayed site's data on its next tick. Callers that want fresher data immediately after
+    /// a replay should `await loadPending()` explicitly (this method only owns the recurring
+    /// timer, not an immediate fetch — see `SiteWindowModel.loadAndStart`).
+    func startPendingPollingIfNeeded() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            guard let interval = self?.pendingPollInterval else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: interval)
+                guard !Task.isCancelled, let self else { return }
+                await self.loadPending()
+            }
+        }
+    }
+
+    /// Stops the recurring recheck — called from `SiteWindowModel.close()`.
+    func stopPendingPolling() {
+        pollTask?.cancel()
+        pollTask = nil
     }
 
     var pendingActionFailure: String?

--- a/Sources/AnglesiteApp/FollowersModel.swift
+++ b/Sources/AnglesiteApp/FollowersModel.swift
@@ -376,7 +376,7 @@ final class FollowersModel {
     /// Declines a pending follower. Never called directly by the view — only through
     /// ``confirmReject()``, after `rejectConfirmation` is armed, since Reject is destructive
     /// (mac-assed-app-spec §5).
-    func reject(_ row: PendingRequestRow) async {
+    private func reject(_ row: PendingRequestRow) async {
         guard let membershipClient else { return }
         pendingRows.removeAll { $0.id == row.id }
         do {

--- a/Sources/AnglesiteApp/FollowersModel.swift
+++ b/Sources/AnglesiteApp/FollowersModel.swift
@@ -284,8 +284,9 @@ final class FollowersModel {
     /// each visible row's `.task`, so only rows the owner actually scrolls to cost a request.
     func enrichIfNeeded(_ actor: URL) {
         let key = actor.absoluteString
-        guard rows.first(where: { $0.actor == actor })?.profile == nil,
-              !inFlight.contains(key), !queued.contains(key), !unreachableActors.contains(key)
+        let alreadyKnown = rows.first(where: { $0.actor == actor })?.profile != nil
+            || pendingRows.first(where: { $0.request.actor == actor })?.profile != nil
+        guard !alreadyKnown, !inFlight.contains(key), !queued.contains(key), !unreachableActors.contains(key)
         else { return }
         queued.insert(key)
         pendingQueue.append(actor)
@@ -313,6 +314,9 @@ final class FollowersModel {
             cache.store(profile)
             if let index = rows.firstIndex(where: { $0.actor == actor }) {
                 rows[index].profile = profile
+            }
+            if let index = pendingRows.firstIndex(where: { $0.request.actor == actor }) {
+                pendingRows[index].profile = profile
             }
             scheduleCacheSave()
         } else {
@@ -346,6 +350,47 @@ final class FollowersModel {
             // for the main list.
             pendingState = .unreachable("\(error)")
         }
+    }
+
+    var pendingActionFailure: String?
+    /// Set by the view to arm the Reject confirmation dialog; cleared by whichever button runs
+    /// (Reject or Cancel) — same no-op-setter/clear-in-button-action contract
+    /// `ModerationModel.banConfirmation` already establishes.
+    var rejectConfirmation: PendingRequestRow?
+
+    /// Confirms a pending follower. Optimistically removes the row; a failure restores it
+    /// (appended, not reinserted at its original position — pending lists are short enough
+    /// that exact ordering after a failure isn't worth the extra bookkeeping) and reports
+    /// `pendingActionFailure`, same additive-not-replacing shape as `loadMoreFailure`.
+    func accept(_ row: PendingRequestRow) async {
+        guard let membershipClient else { return }
+        pendingRows.removeAll { $0.id == row.id }
+        do {
+            try await membershipClient.acceptFollow(target: row.request.actor)
+        } catch {
+            pendingRows.append(row)
+            pendingActionFailure = "Couldn't accept \(row.displayName): \(error.localizedDescription)"
+        }
+    }
+
+    /// Declines a pending follower. Never called directly by the view — only through
+    /// ``confirmReject()``, after `rejectConfirmation` is armed, since Reject is destructive
+    /// (mac-assed-app-spec §5).
+    func reject(_ row: PendingRequestRow) async {
+        guard let membershipClient else { return }
+        pendingRows.removeAll { $0.id == row.id }
+        do {
+            try await membershipClient.rejectFollow(target: row.request.actor)
+        } catch {
+            pendingRows.append(row)
+            pendingActionFailure = "Couldn't reject \(row.displayName): \(error.localizedDescription)"
+        }
+    }
+
+    func confirmReject() async {
+        guard let row = rejectConfirmation else { return }
+        rejectConfirmation = nil
+        await reject(row)
     }
 
     // MARK: - Cache persistence

--- a/Sources/AnglesiteApp/FollowersView.swift
+++ b/Sources/AnglesiteApp/FollowersView.swift
@@ -53,13 +53,25 @@ struct FollowersView: View {
         }
     }
 
+    /// Whether a real, ongoing failure (revoked token, transport error, genuine 500) is worth
+    /// surfacing. `.unknown`/`.loading`/`.unavailable`/`.loaded` are all silent — `.unavailable`
+    /// in particular is the upstream route not shipping yet, never a user-facing error (see
+    /// `PendingState.unavailable`'s doc comment).
+    private var pendingUnreachableReason: String? {
+        if case .unreachable(let reason) = followers.pendingState { return reason }
+        return nil
+    }
+
     @ViewBuilder
     private var pendingSection: some View {
         // Hidden entirely when there's nothing to show — no error noise for a capability that
         // hasn't shipped upstream yet (`.unavailable`), no dead space for a site with nothing
         // pending. Deliberately independent of `followers.state`: pending arrives from its own
-        // background poll and may be known before the main list ever loads.
-        if !followers.pendingRows.isEmpty {
+        // background poll and may be known before the main list ever loads. Shown for a genuine
+        // `.unreachable` failure even with zero rows, so a revoked token or a real 500 doesn't
+        // silently vanish for good on the 5-minute poll loop (whole-branch review finding #4) —
+        // matches `ModerationModel.loadPendingFollowers()`'s same rule against the same endpoint.
+        if !followers.pendingRows.isEmpty || pendingUnreachableReason != nil {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Pending Requests (\(followers.pendingRows.count))")
                     .font(.headline)
@@ -71,8 +83,15 @@ struct FollowersView: View {
                     if let failure = followers.pendingActionFailure {
                         Text(failure).font(.caption).foregroundStyle(.secondary)
                     }
+                    if let reason = pendingUnreachableReason {
+                        // Server-supplied/`localizedDescription` text, like `.unreachable`'s main-list
+                        // counterpart: rendered verbatim, never as a localization key.
+                        Text(reason).font(.caption).foregroundStyle(.secondary)
+                    }
                 }
-                .frame(height: min(CGFloat(followers.pendingRows.count) * 44 + 16, 220))
+                .frame(height: min(
+                    CGFloat(max(followers.pendingRows.count, pendingUnreachableReason == nil ? 0 : 1)) * 44 + 16,
+                    220))
                 Divider()
             }
         }

--- a/Sources/AnglesiteApp/FollowersView.swift
+++ b/Sources/AnglesiteApp/FollowersView.swift
@@ -14,30 +14,89 @@ struct FollowersView: View {
     @Bindable var followers: FollowersModel
 
     var body: some View {
-        Group {
-            switch followers.state {
-            case .idle, .loading:
-                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .loaded:
-                loadedContent
-            case .noSiteURL:
-                message(
-                    "This site hasn't been published yet",
-                    detail: Text("Publish it at least once, then followers will appear here."))
-            case .notActivated:
-                message(
-                    "The Fediverse isn't turned on for this site",
-                    detail: Text("Turn on the Fediverse in Settings ▸ Workers, then publish again."))
-            case .unreachable(let reason):
-                // `reason` is server-supplied (HTTP body / error description) — untrusted remote
-                // content, never a localization key or format string. `Text(reason)` binds to the
-                // `StringProtocol` overload and renders it verbatim.
-                message("Couldn't reach this site", detail: Text(reason))
+        VStack(spacing: 0) {
+            pendingSection
+            Group {
+                switch followers.state {
+                case .idle, .loading:
+                    ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+                case .loaded:
+                    loadedContent
+                case .noSiteURL:
+                    message(
+                        "This site hasn't been published yet",
+                        detail: Text("Publish it at least once, then followers will appear here."))
+                case .notActivated:
+                    message(
+                        "The Fediverse isn't turned on for this site",
+                        detail: Text("Turn on the Fediverse in Settings ▸ Workers, then publish again."))
+                case .unreachable(let reason):
+                    // `reason` is server-supplied (HTTP body / error description) — untrusted remote
+                    // content, never a localization key or format string. `Text(reason)` binds to the
+                    // `StringProtocol` overload and renders it verbatim.
+                    message("Couldn't reach this site", detail: Text(reason))
+                }
             }
         }
         .navigationSubtitle("Followers")
         .task { if followers.state == .idle { await followers.load() } }
         .onDisappear { followers.saveCacheNow() }
+        .confirmationDialog(
+            "Reject this follow request?",
+            isPresented: Binding(get: { followers.rejectConfirmation != nil }, set: { _ in }),
+            titleVisibility: .visible
+        ) {
+            Button("Reject", role: .destructive) { Task { await followers.confirmReject() } }
+            Button("Cancel", role: .cancel) { followers.rejectConfirmation = nil }
+        } message: {
+            Text("This declines the follow request from \(followers.rejectConfirmation?.displayName ?? "this requester").")
+        }
+    }
+
+    @ViewBuilder
+    private var pendingSection: some View {
+        // Hidden entirely when there's nothing to show — no error noise for a capability that
+        // hasn't shipped upstream yet (`.unavailable`), no dead space for a site with nothing
+        // pending. Deliberately independent of `followers.state`: pending arrives from its own
+        // background poll and may be known before the main list ever loads.
+        if !followers.pendingRows.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Pending Requests (\(followers.pendingRows.count))")
+                    .font(.headline)
+                    .padding()
+                List {
+                    ForEach(followers.pendingRows) { row in
+                        pendingRow(row)
+                    }
+                    if let failure = followers.pendingActionFailure {
+                        Text(failure).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .frame(height: min(CGFloat(followers.pendingRows.count) * 44 + 16, 220))
+                Divider()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func pendingRow(_ row: PendingRequestRow) -> some View {
+        HStack(spacing: 10) {
+            avatar(iconURL: row.profile?.iconURL)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.displayName).font(.headline).lineLimit(1)
+                Text(row.handle ?? row.request.actor.absoluteString)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button("Accept") { Task { await followers.accept(row) } }
+                .accessibilityLabel("Accept follow request from \(row.displayName)")
+            Button("Reject", role: .destructive) { followers.rejectConfirmation = row }
+                .accessibilityLabel("Reject follow request from \(row.displayName)")
+        }
+        .padding(.vertical, 2)
+        .task { followers.enrichIfNeeded(row.request.actor) }
     }
 
     @ViewBuilder
@@ -114,7 +173,7 @@ struct FollowersView: View {
     @ViewBuilder
     private func followerRow(_ row: FollowerRow) -> some View {
         HStack(spacing: 10) {
-            avatar(for: row)
+            avatar(iconURL: row.profile?.iconURL)
             VStack(alignment: .leading, spacing: 2) {
                 // Plain `Text` only: a display name is follower-supplied, so any markup in it
                 // must render literally rather than being interpreted.
@@ -142,10 +201,10 @@ struct FollowersView: View {
     }
 
     @ViewBuilder
-    private func avatar(for row: FollowerRow) -> some View {
+    private func avatar(iconURL: URL?) -> some View {
         // `iconURL` is `nil` unless the fetched value was HTTPS — `ActorProfileFetcher` drops
         // insecure ones, so this never loads an avatar over plaintext.
-        FollowerAvatar(url: row.profile?.iconURL, loader: followers.avatarLoader)
+        FollowerAvatar(url: iconURL, loader: followers.avatarLoader)
     }
 
     /// `title` is static UI copy and localizes via the `LocalizedStringKey` overload. `detail` is

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -325,6 +325,12 @@
     "Accent color" : {
 
     },
+    "Accept" : {
+
+    },
+    "Accept follow request from %@" : {
+
+    },
     "Accessibility" : {
 
     },
@@ -2629,6 +2635,9 @@
     "Paused — submissions namespace kept, not receiving new ones." : {
 
     },
+    "Pending Requests (%lld)" : {
+
+    },
     "People already follow you at this handle — it can't change without losing them." : {
 
     },
@@ -2876,6 +2885,15 @@
 
     },
     "Registrar: %@" : {
+
+    },
+    "Reject" : {
+
+    },
+    "Reject follow request from %@" : {
+
+    },
+    "Reject this follow request?" : {
 
     },
     "Related Pages" : {
@@ -3671,6 +3689,9 @@
 
     },
     "This copy's content already exists in this site's git history" : {
+
+    },
+    "This declines the follow request from %@." : {
 
     },
     "This file appears unused and will be permanently removed." : {

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -361,7 +361,7 @@ final class SiteWindowModel {
         // Wired once here (not per-site in loadAndStart): the hooks capture nothing from self
         // and receive the run's site id from the model, so there is nothing to rebind on
         // window replay — see CompletionNotificationHub's own doc comment.
-        CompletionNotificationHub.wire(deploy: deploy, backup: backup, audit: audit)
+        CompletionNotificationHub.wire(deploy: deploy, backup: backup, audit: audit, followers: followers)
         // Layered on top of (not inside) CompletionNotificationHub, which deliberately captures
         // nothing from this model: a successful backup or deploy is one of #881's three debounced
         // push triggers (design doc §2's "App wiring" paragraph). `[weak self]` mirrors the same
@@ -764,6 +764,7 @@ final class SiteWindowModel {
 
     func close(suddenTerminationLease: SuddenTerminationController.Lease? = nil) {
         stopInvisiblePublishing()
+        followers.stopPendingPolling()
         sync.stop()
         preview.close()
         startup.stop()
@@ -2354,6 +2355,8 @@ final class SiteWindowModel {
         cleanup.configure(site: currentSite)
         reader.configure(site: currentSite)
         followers.configure(site: currentSite)
+        await followers.loadPending()
+        followers.startPendingPollingIfNeeded()
         communities.configure(site: currentSite)
         await moderation.configure(site: currentSite)
         domain.configure(site: currentSite)

--- a/Sources/AnglesiteCore/CommunityMembershipClient.swift
+++ b/Sources/AnglesiteCore/CommunityMembershipClient.swift
@@ -116,6 +116,21 @@ public struct CommunityMembershipClient: Sendable {
         _ = try await post(body)
     }
 
+    /// Declines a pending join request — the owner's alternative to ``acceptFollow(target:)``.
+    /// Same `POST <actor>/outbox` seam and target-resolution rules (bare actor IRI as
+    /// `object`), just `"Reject"` instead of `"Accept"`. Unlike `remove(target:)` (which bans
+    /// an *already-accepted* member), this only makes sense against a still-pending request —
+    /// the Worker's `#singleFollowTarget` resolves it the same way either verb does.
+    public func rejectFollow(target: URL) async throws {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Reject",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        _ = try await post(body)
+    }
+
     /// Lists everyone whose `Follow` is awaiting this owner's `Accept` — the bearer-gated
     /// `GET <actor>/follow_requests` `davidwkeith/workers` PR #488 added (closing workers#487),
     /// mirroring `GET <actor>/blocked`'s unpaged flat `{items, total}` JSON exactly. **Not yet in

--- a/Sources/AnglesiteCore/CompletionNotice.swift
+++ b/Sources/AnglesiteCore/CompletionNotice.swift
@@ -191,6 +191,28 @@ public enum CompletionNoticeBuilder {
         return "Found \(parts.joined(separator: ", "))."
     }
 
+    // MARK: Follow Request
+
+    /// Builds the notice for newly-arrived pending follow requests (#965). Unlike
+    /// deploy/backup/audit this isn't a terminal phase of a user-triggered operation — it's
+    /// posted by `FollowersModel`'s background poll whenever the pending count exceeds what
+    /// was last notified (see that type's `onNewPendingRequests`). Stable identifier per site
+    /// so a later, larger count replaces the earlier banner rather than stacking — the banner
+    /// always reflects the true current pending total, never a stale partial count.
+    public static func followRequest(siteName: String, siteID: String, count: Int) -> CompletionNotice {
+        let isSingular = count == 1
+        return CompletionNotice(
+            title: isSingular ? "New Follow Request" : "New Follow Requests",
+            subtitle: siteName,
+            body: isSingular
+                ? "1 person wants to follow your site."
+                : "\(count) people want to follow your site.",
+            siteID: siteID,
+            identifier: "followRequest.\(siteID)",
+            isFailure: false
+        )
+    }
+
     // MARK: Duration
 
     /// "12s" under a minute; "1m 05s" above. Whole seconds — sub-second precision is noise in a

--- a/Tests/AnglesiteAppTests/FollowersModelTests.swift
+++ b/Tests/AnglesiteAppTests/FollowersModelTests.swift
@@ -405,4 +405,125 @@ struct FollowersModelTests {
         #expect(model.pendingState == .unknown)
         #expect(model.pendingRows.isEmpty)
     }
+
+    @Test("accept POSTs Accept and removes the row from pendingRows")
+    func acceptRemovesRow() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            ),
+            "/users/site/outbox": (202, "{}"),
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        await model.loadPending()
+        let row = try #require(model.pendingRows.first)
+
+        await model.accept(row)
+
+        #expect(model.pendingRows.isEmpty)
+        let body = await membershipServer.requestedBodies.last
+        #expect(body?["type"] as? String == "Accept")
+        #expect(body?["object"] as? String == "https://mastodon.social/users/alice")
+    }
+
+    @Test("a failed accept restores the row and sets pendingActionFailure")
+    func acceptFailureRestoresRow() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            ),
+            "/users/site/outbox": (500, "server error"),
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        await model.loadPending()
+        let row = try #require(model.pendingRows.first)
+
+        await model.accept(row)
+
+        #expect(model.pendingRows.count == 1)
+        #expect(model.pendingActionFailure != nil)
+    }
+
+    @Test("reject is only sent through confirmReject, after rejectConfirmation is set")
+    func rejectRequiresConfirmation() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/bob", "2026-08-01T00:00:00.000Z")])
+            ),
+            "/users/site/outbox": (202, "{}"),
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        await model.loadPending()
+        let row = try #require(model.pendingRows.first)
+
+        model.rejectConfirmation = row
+        #expect(model.pendingRows.count == 1)  // unchanged until confirmed
+
+        await model.confirmReject()
+
+        #expect(model.pendingRows.isEmpty)
+        #expect(model.rejectConfirmation == nil)
+        let body = await membershipServer.requestedBodies.last
+        #expect(body?["type"] as? String == "Reject")
+        #expect(body?["object"] as? String == "https://mastodon.social/users/bob")
+    }
+
+    @Test("enrichIfNeeded also fills in a pending row's profile")
+    func enrichmentCoversPendingRows() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let actor = try #require(URL(string: "https://mastodon.social/users/alice"))
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200, Self.followRequestsBody(items: [(actor.absoluteString, "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let profile = ActorProfile(
+            actor: actor, preferredUsername: "alice", name: "Alice", iconURL: nil, fetchedAt: Date())
+        let model = FollowersModel(
+            fetcher: ActorProfileFetcher(transport: { _ in
+                (try JSONEncoder().encode(profile), HTTPURLResponse(
+                    url: actor, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }),
+            avatarLoader: AvatarLoader(transport: { _ in throw AvatarLoadError.requestFailed(status: 500) }),
+            followersTransport: { _ in
+                (Data(), HTTPURLResponse(url: actor, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+            },
+            secretStore: secretStore,
+            membershipTransport: await membershipServer.transport)
+        model.configure(site: site)
+        await model.loadPending()
+        #expect(model.pendingRows.first?.profile == nil)
+
+        model.enrichIfNeeded(actor)
+        // enrichIfNeeded fires a detached Task; give it a beat to land.
+        for _ in 0..<50 where model.pendingRows.first?.profile == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(model.pendingRows.first?.profile?.name == "Alice")
+    }
 }

--- a/Tests/AnglesiteAppTests/FollowersModelTests.swift
+++ b/Tests/AnglesiteAppTests/FollowersModelTests.swift
@@ -16,7 +16,7 @@ struct FollowersModelTests {
 
     /// A site directory whose `.site-config` optionally declares a published URL. `nil` models a
     /// site that has never been published — the `.noSiteURL` state.
-    private static func makeSite(siteURL: String?) throws -> (CurrentSite, URL) {
+    private static func makeSite(id: String = "site-1", siteURL: String?) throws -> (CurrentSite, URL) {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("FollowersModelTests-\(UUID().uuidString)")
         let source = root.appendingPathComponent("Source")
@@ -30,7 +30,7 @@ struct FollowersModelTests {
         }
         return (
             CurrentSite(
-                id: "site-1", packageURL: root, sourceDirectory: source, configDirectory: config),
+                id: id, packageURL: root, sourceDirectory: source, configDirectory: config),
             root)
     }
 
@@ -138,6 +138,10 @@ struct FollowersModelTests {
     private actor MembershipServer {
         private var routes: [String: (status: Int, body: String)]
         private(set) var requestedBodies: [[String: Any]] = []
+        /// Every request path seen, GET or POST — unlike `requestedBodies`, which only records
+        /// requests with a JSON body (the outbox POSTs), this also covers the bodyless
+        /// `listFollowRequests()` GET, so a test can assert a poll loop never re-requested it.
+        private(set) var requestedPaths: [String] = []
 
         init(routes: [String: (status: Int, body: String)] = [:]) {
             self.routes = routes
@@ -148,6 +152,7 @@ struct FollowersModelTests {
         }
 
         fileprivate func respond(to request: URLRequest) -> (Data, HTTPURLResponse) {
+            requestedPaths.append(request.url!.path)
             if let data = request.httpBody,
                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                 requestedBodies.append(json)
@@ -166,7 +171,8 @@ struct FollowersModelTests {
     /// A model with both a scripted followers server and a scripted membership (pending/
     /// accept/reject) server, plus a preloaded publish token — for pending-request tests.
     private static func makeModelWithPending(
-        server: Server, membershipServer: MembershipServer, secretStore: InMemorySecretStore
+        server: Server, membershipServer: MembershipServer, secretStore: InMemorySecretStore,
+        pendingPollInterval: Duration = .seconds(300)
     ) async -> FollowersModel {
         FollowersModel(
             fetcher: ActorProfileFetcher(transport: { _ in
@@ -177,7 +183,8 @@ struct FollowersModelTests {
             }),
             followersTransport: await server.transport,
             secretStore: secretStore,
-            membershipTransport: await membershipServer.transport)
+            membershipTransport: await membershipServer.transport,
+            pendingPollInterval: pendingPollInterval)
     }
 
     private static func followRequestsBody(items: [(actor: String, addedAt: String)]) -> String {
@@ -602,5 +609,191 @@ struct FollowersModelTests {
         #expect(events.count == 1)
         #expect(events.first?.0 == "site-1")
         #expect(events.first?.1 == 2)
+    }
+
+    // MARK: - Final whole-branch review fixes
+
+    /// Finding #2: nothing ever cleared `pendingActionFailure` back to `nil`, so a failed accept
+    /// left the stale error visible — and visually misattached to whatever request happened to be
+    /// on screen next — even after a later action succeeded.
+    @Test("pendingActionFailure clears on a subsequent successful accept")
+    func pendingActionFailureClearsOnSubsequentSuccess() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [
+                    ("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z"),
+                    ("https://mastodon.social/users/bob", "2026-08-01T00:00:00.000Z"),
+                ])
+            ),
+            "/users/site/outbox": (500, "server error"),
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        await model.loadPending()
+        let alice = try #require(model.pendingRows.first { $0.request.actor.absoluteString.contains("alice") })
+        let bob = try #require(model.pendingRows.first { $0.request.actor.absoluteString.contains("bob") })
+
+        await model.accept(alice)
+        #expect(model.pendingActionFailure != nil)
+
+        await membershipServer.setRoute("/users/site/outbox", status: 202, body: "{}")
+        await model.accept(bob)
+
+        #expect(model.pendingActionFailure == nil)
+    }
+
+    /// Finding #3: `configure(site:)` left every piece of pending-request state untouched from
+    /// whatever site was previously configured, so a window replayed onto a different site could
+    /// fire a spurious notification (stale baseline) or leave the *previous* site's actor rows on
+    /// screen under the new site's window.
+    @Test("configure(site:) resets pending state for a window replayed onto a different site")
+    func configureResetsPendingStateOnReplay() async throws {
+        let (siteA, rootA) = try Self.makeSite(id: "site-a", siteURL: "https://a.example")
+        defer { try? FileManager.default.removeItem(at: rootA) }
+        let (siteB, rootB) = try Self.makeSite(id: "site-b", siteURL: "https://b.example")
+        defer { try? FileManager.default.removeItem(at: rootB) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-a")] = "token-a"
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-b")] = "token-b"
+        // Both sites' actor IRIs share the same fixed `/users/site` path (only the host differs —
+        // see `ActivityPubActor.username`), so this one scripted route serves both in turn.
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+
+        model.configure(site: siteA)
+        await model.loadPending()
+        #expect(model.pendingRows.count == 1)
+        #expect(model.pendingState == .loaded)
+
+        model.configure(site: siteB)
+
+        #expect(model.pendingRows.isEmpty)
+        #expect(model.pendingState == .unknown)
+        #expect(model.pendingActionFailure == nil)
+        #expect(model.rejectConfirmation == nil)
+
+        // Site B has 3 requests waiting, but this is site B's *first* load for this window — the
+        // baseline reset means it must only establish a silent baseline, never notify.
+        await membershipServer.setRoute(
+            "/users/site/follow_requests", status: 200,
+            body: Self.followRequestsBody(items: [
+                ("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z"),
+                ("https://mastodon.social/users/bob", "2026-08-01T00:00:00.000Z"),
+                ("https://mastodon.social/users/carol", "2026-08-01T00:00:00.000Z"),
+            ]))
+        let recorder = Recorder()
+        model.onNewPendingRequests = { siteID, count in Task { await recorder.record((siteID, count)) } }
+        await model.loadPending()
+        try await Task.sleep(for: .milliseconds(20))
+
+        #expect(await recorder.events.isEmpty)
+        #expect(model.pendingRows.count == 3)
+    }
+
+    /// Finding #4: `loadPending()` already computed `.unreachable(reason)` for a non-404
+    /// failure (expired token, genuine 500, transport error), but nothing ever read it — so a real,
+    /// ongoing failure was silently invisible forever on the poll loop. This only asserts the model
+    /// side (`pendingState` actually resolves to `.unreachable`, with a non-empty
+    /// `localizedDescription`-derived reason); `FollowersView` reads it in `pendingSection`.
+    @Test("a non-404 pending failure surfaces via pendingState.unreachable")
+    func loadPendingSurfacesNon404Failure() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (500, "server error")
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+
+        await model.loadPending()
+
+        guard case .unreachable(let reason) = model.pendingState else {
+            Issue.record("expected .unreachable, got \(model.pendingState)")
+            return
+        }
+        #expect(!reason.isEmpty)
+        #expect(model.pendingRows.isEmpty)
+    }
+
+    /// Finding #5: the Refresh button called `followers.refresh()`, which only reloaded the main
+    /// follower list — an accept/reject made elsewhere stayed stale in the Pending Requests section
+    /// for up to the full 5-minute poll interval.
+    @Test("refresh() also reloads pending requests")
+    func refreshAlsoReloadsPending() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let server = Server(routes: [
+            "/users/site/followers": Self.collectionBody(total: 0, first: nil)
+        ])
+        let model = await Self.makeModelWithPending(
+            server: server, membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        await model.loadPending()
+        #expect(model.pendingRows.count == 1)
+
+        // Elsewhere, the owner accepted the request — the Worker's list is now empty.
+        await membershipServer.setRoute(
+            "/users/site/follow_requests", status: 200, body: Self.followRequestsBody(items: []))
+
+        await model.refresh()
+
+        #expect(model.pendingRows.isEmpty)
+    }
+
+    /// Finding #6: `startPendingPollingIfNeeded()` started the recurring poll unconditionally,
+    /// so a site whose Worker doesn't yet support `GET <actor>/follow_requests` (the entire
+    /// backward-compatibility scenario the feature is built around) would poll an authenticated
+    /// request that can only ever 404, every interval, for as long as the window stayed open.
+    @Test("startPendingPollingIfNeeded doesn't start a poll loop when pendingState is .unavailable")
+    func pollingDoesNotStartWhenUnavailable() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        // No route registered for `follow_requests` — `MembershipServer` answers 404, which
+        // `loadPending()` maps to `.unavailable`.
+        let membershipServer = MembershipServer()
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore,
+            pendingPollInterval: .milliseconds(20))
+        model.configure(site: site)
+        await model.loadPending()
+        #expect(model.pendingState == .unavailable)
+        let requestsBeforeStart = await membershipServer.requestedPaths.count
+
+        model.startPendingPollingIfNeeded()
+        defer { model.stopPendingPolling() }
+
+        // Give several poll intervals' worth of time to elapse, then confirm no further request
+        // ever landed beyond the initial `loadPending()` above — the guard should have returned
+        // before spawning the recurring `Task` at all.
+        try await Task.sleep(for: .milliseconds(120))
+        let requestsAfterWaiting = await membershipServer.requestedPaths.count
+
+        #expect(requestsAfterWaiting == requestsBeforeStart)
+        #expect(model.pendingState == .unavailable)
     }
 }

--- a/Tests/AnglesiteAppTests/FollowersModelTests.swift
+++ b/Tests/AnglesiteAppTests/FollowersModelTests.swift
@@ -127,6 +127,11 @@ struct FollowersModelTests {
         func delete(account: String) throws { values.removeValue(forKey: account) }
     }
 
+    private actor Recorder {
+        private(set) var events: [(String, Int)] = []
+        func record(_ event: (String, Int)) { events.append(event) }
+    }
+
     /// Serves `GET <actor>/follow_requests` out of a scripted routing table, same shape as
     /// `Server` but for the membership (outbox/follow_requests) transport rather than the
     /// public followers transport.
@@ -525,5 +530,77 @@ struct FollowersModelTests {
         }
 
         #expect(model.pendingRows.first?.profile?.name == "Alice")
+    }
+
+    @Test("the first loadPending establishes a baseline without notifying")
+    func firstLoadDoesNotNotify() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200, Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        let recorder = Recorder()
+        model.onNewPendingRequests = { siteID, count in Task { await recorder.record((siteID, count)) } }
+
+        await model.loadPending()
+
+        try await Task.sleep(for: .milliseconds(20))
+        let notified = await recorder.events
+        #expect(notified.isEmpty)
+    }
+
+    @Test("a later poll notifies once when the pending count grows past the baseline")
+    func laterPollNotifiesOnGrowth() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200, Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let model = FollowersModel(
+            fetcher: ActorProfileFetcher(transport: { _ in throw ActorProfileError.requestFailed(status: 500) }),
+            avatarLoader: AvatarLoader(transport: { _ in throw AvatarLoadError.requestFailed(status: 500) }),
+            followersTransport: { _ in
+                (Data(), HTTPURLResponse(
+                    url: URL(string: "https://example.com")!, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+            },
+            secretStore: secretStore,
+            membershipTransport: await membershipServer.transport,
+            pendingPollInterval: .milliseconds(20))
+        model.configure(site: site)
+        let recorder = Recorder()
+        model.onNewPendingRequests = { siteID, count in Task { await recorder.record((siteID, count)) } }
+        await model.loadPending()  // establishes the baseline of 1, as in the test above
+
+        await membershipServer.setRoute(
+            "/users/site/follow_requests", status: 200,
+            body: Self.followRequestsBody(items: [
+                ("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z"),
+                ("https://mastodon.social/users/carol", "2026-08-02T00:00:00.000Z"),
+            ]))
+        model.startPendingPollingIfNeeded()
+        defer { model.stopPendingPolling() }
+
+        var events: [(String, Int)] = []
+        for _ in 0..<50 where events.isEmpty {
+            try await Task.sleep(for: .milliseconds(10))
+            events = await recorder.events
+        }
+
+        // `[(String, Int)]` doesn't conform to `Equatable` (tuples can't conform to protocols),
+        // so this compares the array's shape field-by-field instead of via `==`.
+        #expect(events.count == 1)
+        #expect(events.first?.0 == "site-1")
+        #expect(events.first?.1 == 2)
     }
 }

--- a/Tests/AnglesiteAppTests/FollowersModelTests.swift
+++ b/Tests/AnglesiteAppTests/FollowersModelTests.swift
@@ -120,6 +120,66 @@ struct FollowersModelTests {
             followersTransport: await server.transport)
     }
 
+    final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+        var values: [String: String] = [:]
+        func read(account: String) throws -> String? { values[account] }
+        func write(_ value: String, account: String) throws { values[account] = value }
+        func delete(account: String) throws { values.removeValue(forKey: account) }
+    }
+
+    /// Serves `GET <actor>/follow_requests` out of a scripted routing table, same shape as
+    /// `Server` but for the membership (outbox/follow_requests) transport rather than the
+    /// public followers transport.
+    private actor MembershipServer {
+        private var routes: [String: (status: Int, body: String)]
+        private(set) var requestedBodies: [[String: Any]] = []
+
+        init(routes: [String: (status: Int, body: String)] = [:]) {
+            self.routes = routes
+        }
+
+        func setRoute(_ path: String, status: Int, body: String) {
+            routes[path] = (status, body)
+        }
+
+        fileprivate func respond(to request: URLRequest) -> (Data, HTTPURLResponse) {
+            if let data = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                requestedBodies.append(json)
+            }
+            let path = request.url!.path
+            let (status, body) = routes[path] ?? (404, "not found")
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        fileprivate var transport: CommunityMembershipClient.Transport {
+            { [self] request in await respond(to: request) }
+        }
+    }
+
+    /// A model with both a scripted followers server and a scripted membership (pending/
+    /// accept/reject) server, plus a preloaded publish token — for pending-request tests.
+    private static func makeModelWithPending(
+        server: Server, membershipServer: MembershipServer, secretStore: InMemorySecretStore
+    ) async -> FollowersModel {
+        FollowersModel(
+            fetcher: ActorProfileFetcher(transport: { _ in
+                throw ActorProfileError.requestFailed(status: 500)
+            }),
+            avatarLoader: AvatarLoader(transport: { _ in
+                throw AvatarLoadError.requestFailed(status: 500)
+            }),
+            followersTransport: await server.transport,
+            secretStore: secretStore,
+            membershipTransport: await membershipServer.transport)
+    }
+
+    private static func followRequestsBody(items: [(actor: String, addedAt: String)]) -> String {
+        let list = items.map { #"{"actor":"\#($0.actor)","addedAt":"\#($0.addedAt)"}"# }.joined(separator: ",")
+        return #"{"items":[\#(list)],"total":\#(items.count)}"#
+    }
+
     // MARK: - Finding 2: every error state must be escapable
 
     /// The `.noSiteURL` message tells the owner to publish the site. Before the fix, the pane
@@ -289,5 +349,60 @@ struct FollowersModelTests {
         await paging
 
         #expect(model.rows.map(\.id) == ["https://a.example/users/a"])
+    }
+
+    // MARK: - Pending requests
+
+    @Test("loadPending decodes the follow_requests list into enrichable rows")
+    func loadPendingDecodesRequests() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+
+        await model.loadPending()
+
+        #expect(model.pendingState == .loaded)
+        #expect(model.pendingRows.count == 1)
+        #expect(model.pendingRows[0].request.actor.absoluteString == "https://mastodon.social/users/alice")
+    }
+
+    @Test("loadPending treats a 404 as unavailable, not an error")
+    func loadPendingTreats404AsUnavailable() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: MembershipServer(), secretStore: secretStore)
+        model.configure(site: site)
+
+        await model.loadPending()
+
+        #expect(model.pendingState == .unavailable)
+        #expect(model.pendingRows.isEmpty)
+    }
+
+    @Test("loadPending is a no-op with no publish token provisioned")
+    func loadPendingNoOpsWithoutToken() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: MembershipServer(), secretStore: InMemorySecretStore())
+        model.configure(site: site)
+
+        await model.loadPending()
+
+        #expect(model.pendingState == .unknown)
+        #expect(model.pendingRows.isEmpty)
     }
 }

--- a/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+++ b/Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
@@ -156,6 +156,32 @@ struct CommunityMembershipClientTests {
         }
     }
 
+    @Test("POSTs a Reject activity to this site's own outbox, confirming target resolution")
+    func postsRejectFollow() async throws {
+        let fake = FakeTransport(status: 202, body: "{}")
+        let target = try #require(URL(string: "https://mastodon.social/users/spammer"))
+
+        try await Self.client(fake).rejectFollow(target: target)
+
+        #expect(await fake.requestedURLs.first?.absoluteString == "https://example.com/users/site/outbox")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Reject")
+        #expect(body?["object"] as? String == "https://mastodon.social/users/spammer")
+        #expect(body?["actor"] as? String == "https://example.com/users/site")
+    }
+
+    @Test("rejectFollow propagates a non-2xx as CommunityMembershipError")
+    func rejectFollowFailurePropagates() async throws {
+        let fake = FakeTransport(status: 403, body: "forbidden")
+        let target = try #require(URL(string: "https://mastodon.social/users/spammer"))
+
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 403, body: "forbidden")) {
+            try await Self.client(fake).rejectFollow(target: target)
+        }
+    }
+
     @Test("GETs pending follow requests from this site's own actor endpoint")
     func listsFollowRequests() async throws {
         let fake = FakeTransport(

--- a/Tests/AnglesiteCoreTests/CompletionNoticeTests.swift
+++ b/Tests/AnglesiteCoreTests/CompletionNoticeTests.swift
@@ -149,6 +149,34 @@ struct CompletionNoticeTests {
         #expect(notice.isFailure)
     }
 
+    // MARK: Follow Request
+
+    @Test("Singular follow request reads as one person")
+    func followRequestSingular() {
+        let notice = CompletionNoticeBuilder.followRequest(siteName: "Pullets Forever", siteID: "site-1", count: 1)
+        #expect(notice.title == "New Follow Request")
+        #expect(notice.subtitle == "Pullets Forever")
+        #expect(notice.body == "1 person wants to follow your site.")
+        #expect(notice.siteID == "site-1")
+        #expect(!notice.isFailure)
+    }
+
+    @Test("Plural follow requests read as N people", arguments: [2, 5])
+    func followRequestPlural(count: Int) {
+        let notice = CompletionNoticeBuilder.followRequest(siteName: "Site", siteID: "site-1", count: count)
+        #expect(notice.title == "New Follow Requests")
+        #expect(notice.body == "\(count) people want to follow your site.")
+    }
+
+    @Test("Follow request identifier is stable per site so a later count replaces the banner")
+    func followRequestIdentifierStable() {
+        let a = CompletionNoticeBuilder.followRequest(siteName: "S", siteID: "site-1", count: 1)
+        let b = CompletionNoticeBuilder.followRequest(siteName: "S", siteID: "site-1", count: 3)
+        let other = CompletionNoticeBuilder.followRequest(siteName: "S", siteID: "site-2", count: 1)
+        #expect(a.identifier == b.identifier)
+        #expect(a.identifier != other.identifier)
+    }
+
     // MARK: Duration formatting
 
     @Test("Durations format as seconds under a minute and m/ss above", arguments: [

--- a/docs/superpowers/plans/2026-08-17-follow-approval-plan.md
+++ b/docs/superpowers/plans/2026-08-17-follow-approval-plan.md
@@ -1,0 +1,1251 @@
+# Follow Approval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a site owner see pending ActivityPub follow requests and Accept/Reject them from the Followers pane, with a notification when new requests arrive while a site's window is open.
+
+**Architecture:** Reuse the existing `CommunityMembershipClient` (already implements `listFollowRequests()`/`acceptFollow(target:)` against this site's own actor, for `ModerationModel`) by adding a symmetric `rejectFollow(target:)`. `FollowersModel` gains its own pending-request state machine, action methods, and a background poll loop started/stopped by `SiteWindowModel`'s existing lifecycle hooks. `FollowersView` gains a "Pending Requests" section. `CompletionNotificationHub` wires a new notice for genuinely-new arrivals.
+
+**Tech Stack:** Swift 6.4, SwiftUI, Swift Testing (`@Suite`/`@Test`/`#expect`), `swift test --package-path .`.
+
+## Global Constraints
+
+- No new Swift package dependencies.
+- Reuse `SecretAccounts.activityPubPublishToken(siteID:)` — no new secret/token type.
+- `CommunityMembershipClient` is the one client for this site's own actor's follow-request
+  operations — do not add a second, parallel client.
+- A 404 from `listFollowRequests()` means "not shipped upstream yet" — never surfaced as an
+  error to the owner.
+- Every new/changed public API needs a `swift test` case; run `swift test --package-path .`
+  after every task.
+- Destructive action (Reject) requires an explicit confirmation per mac-assed-app-spec §5/§9;
+  Accept requires none.
+- Design reference: `docs/superpowers/specs/2026-08-17-follow-approval-design.md`.
+
+---
+
+### Task 1: `CommunityMembershipClient.rejectFollow(target:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/CommunityMembershipClient.swift`
+- Test: `Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift`
+
+**Interfaces:**
+- Produces: `CommunityMembershipClient.rejectFollow(target: URL) async throws` — POSTs
+  `{"@context": "...", "type": "Reject", "actor": <ownActorURL>, "object": <target>}` to the
+  outbox, same as `acceptFollow(target:)` but `"Reject"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `CommunityMembershipClientTests` (near the existing `acceptFollow`-shaped test — search
+the file for `"Accept"` to find it and mirror its shape):
+
+```swift
+    @Test("POSTs a Reject activity to this site's own outbox, confirming target resolution")
+    func postsRejectFollow() async throws {
+        let fake = FakeTransport(status: 202, body: "{}")
+        let target = try #require(URL(string: "https://mastodon.social/users/spammer"))
+
+        try await Self.client(fake).rejectFollow(target: target)
+
+        #expect(await fake.requestedURLs.first?.absoluteString == "https://example.com/users/site/outbox")
+        let headers = await fake.requestedHeaders.first
+        #expect(headers?["Authorization"] == "Bearer secret-token")
+        let body = await fake.requestedBodies.first
+        #expect(body?["type"] as? String == "Reject")
+        #expect(body?["object"] as? String == "https://mastodon.social/users/spammer")
+        #expect(body?["actor"] as? String == "https://example.com/users/site")
+    }
+
+    @Test("rejectFollow propagates a non-2xx as CommunityMembershipError")
+    func rejectFollowFailurePropagates() async throws {
+        let fake = FakeTransport(status: 403, body: "forbidden")
+        let target = try #require(URL(string: "https://mastodon.social/users/spammer"))
+
+        await #expect(throws: CommunityMembershipError.requestFailed(status: 403, body: "forbidden")) {
+            try await Self.client(fake).rejectFollow(target: target)
+        }
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter CommunityMembershipClientTests`
+Expected: FAIL — `value of type 'CommunityMembershipClient' has no member 'rejectFollow'`
+
+- [ ] **Step 3: Implement `rejectFollow(target:)`**
+
+In `Sources/AnglesiteCore/CommunityMembershipClient.swift`, add immediately after
+`acceptFollow(target:)`:
+
+```swift
+    /// Declines a pending join request — the owner's alternative to ``acceptFollow(target:)``.
+    /// Same `POST <actor>/outbox` seam and target-resolution rules (bare actor IRI as
+    /// `object`), just `"Reject"` instead of `"Accept"`. Unlike `remove(target:)` (which bans
+    /// an *already-accepted* member), this only makes sense against a still-pending request —
+    /// the Worker's `#singleFollowTarget` resolves it the same way either verb does.
+    public func rejectFollow(target: URL) async throws {
+        let body: [String: Any] = [
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "type": "Reject",
+            "actor": ownActorURL.absoluteString,
+            "object": target.absoluteString,
+        ]
+        _ = try await post(body)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter CommunityMembershipClientTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CommunityMembershipClient.swift Tests/AnglesiteCoreTests/CommunityMembershipClientTests.swift
+git commit -m "feat(#965): add CommunityMembershipClient.rejectFollow"
+```
+
+---
+
+### Task 2: `CompletionNoticeBuilder.followRequest(...)`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/CompletionNotice.swift`
+- Test: `Tests/AnglesiteCoreTests/CompletionNoticeTests.swift`
+
+**Interfaces:**
+- Produces: `CompletionNoticeBuilder.followRequest(siteName: String, siteID: String, count: Int) -> CompletionNotice`
+  — identifier `"followRequest.<siteID>"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new `// MARK: Follow Request` section to `CompletionNoticeTests` (after the existing
+`// MARK: Audit` section — search the file for `// MARK: Audit`):
+
+```swift
+
+    // MARK: Follow Request
+
+    @Test("Singular follow request reads as one person")
+    func followRequestSingular() {
+        let notice = CompletionNoticeBuilder.followRequest(siteName: "Pullets Forever", siteID: "site-1", count: 1)
+        #expect(notice.title == "New Follow Request")
+        #expect(notice.subtitle == "Pullets Forever")
+        #expect(notice.body == "1 person wants to follow your site.")
+        #expect(notice.siteID == "site-1")
+        #expect(!notice.isFailure)
+    }
+
+    @Test("Plural follow requests read as N people", arguments: [2, 5])
+    func followRequestPlural(count: Int) {
+        let notice = CompletionNoticeBuilder.followRequest(siteName: "Site", siteID: "site-1", count: count)
+        #expect(notice.title == "New Follow Requests")
+        #expect(notice.body == "\(count) people want to follow your site.")
+    }
+
+    @Test("Follow request identifier is stable per site so a later count replaces the banner")
+    func followRequestIdentifierStable() {
+        let a = CompletionNoticeBuilder.followRequest(siteName: "S", siteID: "site-1", count: 1)
+        let b = CompletionNoticeBuilder.followRequest(siteName: "S", siteID: "site-1", count: 3)
+        let other = CompletionNoticeBuilder.followRequest(siteName: "S", siteID: "site-2", count: 1)
+        #expect(a.identifier == b.identifier)
+        #expect(a.identifier != other.identifier)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter CompletionNoticeTests`
+Expected: FAIL — `type 'CompletionNoticeBuilder' has no member 'followRequest'`
+
+- [ ] **Step 3: Implement `followRequest(...)`**
+
+In `Sources/AnglesiteCore/CompletionNotice.swift`, add a new section after the `// MARK: Audit`
+block's `auditSummary(...)` helper and before `// MARK: Duration`:
+
+```swift
+
+    // MARK: Follow Request
+
+    /// Builds the notice for newly-arrived pending follow requests (#965). Unlike
+    /// deploy/backup/audit this isn't a terminal phase of a user-triggered operation — it's
+    /// posted by `FollowersModel`'s background poll whenever the pending count exceeds what
+    /// was last notified (see that type's `onNewPendingRequests`). Stable identifier per site
+    /// so a later, larger count replaces the earlier banner rather than stacking — the banner
+    /// always reflects the true current pending total, never a stale partial count.
+    public static func followRequest(siteName: String, siteID: String, count: Int) -> CompletionNotice {
+        let isSingular = count == 1
+        return CompletionNotice(
+            title: isSingular ? "New Follow Request" : "New Follow Requests",
+            subtitle: siteName,
+            body: isSingular
+                ? "1 person wants to follow your site."
+                : "\(count) people want to follow your site.",
+            siteID: siteID,
+            identifier: "followRequest.\(siteID)",
+            isFailure: false
+        )
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter CompletionNoticeTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/CompletionNotice.swift Tests/AnglesiteCoreTests/CompletionNoticeTests.swift
+git commit -m "feat(#965): add CompletionNoticeBuilder.followRequest notice"
+```
+
+---
+
+### Task 3: `FollowersModel` — pending list state and loading
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/FollowersModel.swift`
+- Test: `Tests/AnglesiteAppTests/FollowersModelTests.swift`
+
+**Interfaces:**
+- Consumes: `CommunityMembershipClient.listFollowRequests() -> [PendingFollower]` (existing),
+  `CommunityMembershipError.requestFailed(status:body:)` (existing), `PendingFollower { actor: URL, addedAt: Date }`
+  (existing, `Sources/AnglesiteCore/PendingFollower.swift`), `SecretStore.read(account:)`,
+  `SecretAccounts.activityPubPublishToken(siteID:)`, `PlatformSecretStore.make()` (all existing).
+- Produces: `FollowersModel.pendingRows: [PendingRequestRow]`, `FollowersModel.pendingState: PendingState`,
+  `FollowersModel.loadPending() async` — used by Task 4 (accept/reject) and Task 5 (polling).
+  `PendingRequestRow { request: PendingFollower, profile: ActorProfile? }`, `id: URL` (the
+  actor IRI), `displayName: String`, `handle: String?`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Tests/AnglesiteAppTests/FollowersModelTests.swift`. First, extend the file's fixtures:
+find `private static func makeModel(server: Server) async -> FollowersModel` and add a sibling
+fixture right after it that also wires an in-memory secret store and a scripted membership
+transport (mirrors `ModerationModelTests.InMemorySecretStore`, defined as a nested type in this
+file since `FollowersModelTests` doesn't yet have one):
+
+```swift
+    final class InMemorySecretStore: SecretStore, @unchecked Sendable {
+        var values: [String: String] = [:]
+        func read(account: String) throws -> String? { values[account] }
+        func write(_ value: String, account: String) throws { values[account] = value }
+        func delete(account: String) throws { values.removeValue(forKey: account) }
+    }
+
+    /// Serves `GET <actor>/follow_requests` out of a scripted routing table, same shape as
+    /// `Server` but for the membership (outbox/follow_requests) transport rather than the
+    /// public followers transport.
+    private actor MembershipServer {
+        private var routes: [String: (status: Int, body: String)]
+        private(set) var requestedBodies: [[String: Any]] = []
+
+        init(routes: [String: (status: Int, body: String)] = [:]) {
+            self.routes = routes
+        }
+
+        func setRoute(_ path: String, status: Int, body: String) {
+            routes[path] = (status, body)
+        }
+
+        fileprivate func respond(to request: URLRequest) -> (Data, HTTPURLResponse) {
+            if let data = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                requestedBodies.append(json)
+            }
+            let path = request.url!.path
+            let (status, body) = routes[path] ?? (404, "not found")
+            let http = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
+            return (Data(body.utf8), http)
+        }
+
+        fileprivate var transport: CommunityMembershipClient.Transport {
+            { [self] request in await respond(to: request) }
+        }
+    }
+
+    /// A model with both a scripted followers server and a scripted membership (pending/
+    /// accept/reject) server, plus a preloaded publish token — for pending-request tests.
+    private static func makeModelWithPending(
+        server: Server, membershipServer: MembershipServer, secretStore: InMemorySecretStore
+    ) async -> FollowersModel {
+        FollowersModel(
+            fetcher: ActorProfileFetcher(transport: { _ in
+                throw ActorProfileError.requestFailed(status: 500)
+            }),
+            avatarLoader: AvatarLoader(transport: { _ in
+                throw AvatarLoadError.requestFailed(status: 500)
+            }),
+            followersTransport: await server.transport,
+            secretStore: secretStore,
+            membershipTransport: await membershipServer.transport)
+    }
+
+    private static func followRequestsBody(items: [(actor: String, addedAt: String)]) -> String {
+        let list = items.map { #"{"actor":"\#($0.actor)","addedAt":"\#($0.addedAt)"}"# }.joined(separator: ",")
+        return #"{"items":[\#(list)],"total":\#(items.count)}"#
+    }
+```
+
+Then add the test cases (new `// MARK: - Pending requests` section, appended at the end of the
+`struct FollowersModelTests` body, just before its closing `}`):
+
+```swift
+
+    // MARK: - Pending requests
+
+    @Test("loadPending decodes the follow_requests list into enrichable rows")
+    func loadPendingDecodesRequests() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+
+        await model.loadPending()
+
+        #expect(model.pendingState == .loaded)
+        #expect(model.pendingRows.count == 1)
+        #expect(model.pendingRows[0].request.actor.absoluteString == "https://mastodon.social/users/alice")
+    }
+
+    @Test("loadPending treats a 404 as unavailable, not an error")
+    func loadPendingTreats404AsUnavailable() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: MembershipServer(), secretStore: secretStore)
+        model.configure(site: site)
+
+        await model.loadPending()
+
+        #expect(model.pendingState == .unavailable)
+        #expect(model.pendingRows.isEmpty)
+    }
+
+    @Test("loadPending is a no-op with no publish token provisioned")
+    func loadPendingNoOpsWithoutToken() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: MembershipServer(), secretStore: InMemorySecretStore())
+        model.configure(site: site)
+
+        await model.loadPending()
+
+        #expect(model.pendingState == .unknown)
+        #expect(model.pendingRows.isEmpty)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter FollowersModelTests`
+Expected: FAIL — `value of type 'FollowersModel' has no member 'loadPending'` (and no
+`secretStore`/`membershipTransport` init parameters yet)
+
+- [ ] **Step 3: Implement the pending state machine and `loadPending()`**
+
+In `Sources/AnglesiteApp/FollowersModel.swift`:
+
+1. Add near the top, right after the `FollowerRow` struct, a shared display-name helper and the
+   new `PendingRequestRow` type:
+
+```swift
+/// Shared display-name derivation for both `FollowerRow` and `PendingRequestRow`: fetched
+/// display name, else fetched username, else derived handle, else the raw IRI.
+enum ActorDisplay {
+    static func name(profile: ActorProfile?, handle: String?, actor: URL) -> String {
+        if let name = profile?.name, !name.isEmpty { return name }
+        if let username = profile?.preferredUsername, !username.isEmpty { return "@\(username)" }
+        return handle ?? actor.absoluteString
+    }
+}
+
+/// One pending follow request in the Followers pane's "Pending Requests" section — pairs the
+/// Worker's `PendingFollower` with the same lazily-enriched display identity `FollowerRow` uses.
+struct PendingRequestRow: Identifiable, Equatable {
+    let request: PendingFollower
+    var profile: ActorProfile?
+
+    var id: URL { request.actor }
+    var handle: String? { ActorHandle.derive(from: request.actor) }
+    var displayName: String { ActorDisplay.name(profile: profile, handle: handle, actor: request.actor) }
+}
+```
+
+2. Update `FollowerRow.displayName` to use the shared helper instead of its own inline chain:
+
+```swift
+    var displayName: String { ActorDisplay.name(profile: profile, handle: handle, actor: actor) }
+```
+
+(replacing the existing 4-line `if`/`if`/`return` body).
+
+3. Add the pending state enum, as a nested type on `FollowersModel` right after the existing
+   `enum State`:
+
+```swift
+    /// Loading lifecycle for the pending-request list — deliberately separate from `State`
+    /// (see the design doc's rationale): pending availability is orthogonal to whether the
+    /// main follower list loaded.
+    enum PendingState: Equatable {
+        case unknown
+        case loading
+        case loaded
+        /// The upstream `GET <actor>/follow_requests` route 404s — not shipped yet. Never
+        /// shown as an error; the pending section simply stays hidden.
+        case unavailable
+        case unreachable(String)
+    }
+```
+
+4. Add stored properties, right after the existing `private var pendingQueue`/`saveTask`
+   declarations:
+
+```swift
+    private(set) var pendingRows: [PendingRequestRow] = []
+    private(set) var pendingState: PendingState = .unknown
+
+    private var siteID: String?
+    private let secretStore: any SecretStore
+    private let membershipTransport: CommunityMembershipClient.Transport
+    private var membershipClient: CommunityMembershipClient?
+```
+
+5. Update the initializer to accept the two new dependencies:
+
+```swift
+    init(
+        fetcher: ActorProfileFetcher = ActorProfileFetcher(),
+        avatarLoader: AvatarLoader = AvatarLoader(),
+        followersTransport: @escaping ActivityPubFollowersClient.Transport
+            = ActivityPubFollowersClient.defaultTransport,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        membershipTransport: @escaping CommunityMembershipClient.Transport
+            = CommunityMembershipClient.defaultTransport
+    ) {
+        self.fetcher = fetcher
+        self.avatarLoader = avatarLoader
+        self.followersTransport = followersTransport
+        self.secretStore = secretStore
+        self.membershipTransport = membershipTransport
+    }
+```
+
+6. Update `configure(site:)` to record `siteID` (add one line before the existing
+   `resolveSite()` call):
+
+```swift
+    func configure(site: CurrentSite) {
+        configDirectory = site.configDirectory
+        sourceDirectory = site.sourceDirectory
+        siteID = site.id
+        cache = ActorProfileCache.load(from: site.configDirectory) ?? ActorProfileCache()
+        resolveSite()
+    }
+```
+
+7. Update `resolveSite()` to also build `membershipClient` (replace its body):
+
+```swift
+    private func resolveSite() {
+        guard let sourceDirectory else { return }
+        siteURL = DeployCoordinator.resolveSiteURL(siteDirectory: sourceDirectory)
+            .flatMap { URL(string: $0) }
+        guard let siteURL else {
+            client = nil
+            actorURL = nil
+            membershipClient = nil
+            return
+        }
+        client = ActivityPubFollowersClient(siteURL: siteURL, transport: followersTransport)
+        actorURL = ActivityPubActor.actorURL(siteURL: siteURL)
+        membershipClient = publishToken.map { token in
+            CommunityMembershipClient(ownActorURL: actorURL!, publishToken: token, transport: membershipTransport)
+        }
+    }
+
+    private var publishToken: String? {
+        guard let siteID else { return nil }
+        return try? secretStore.read(account: SecretAccounts.activityPubPublishToken(siteID: siteID))
+    }
+```
+
+8. Add `loadPending()`, in a new `// MARK: - Pending requests` section after the existing
+   `// MARK: - Enrichment` section:
+
+```swift
+
+    // MARK: - Pending requests
+
+    /// Fetches the pending-follow-request list from this site's own Worker. A 404 (the
+    /// upstream capability not shipped yet) degrades to `.unavailable` with an empty list —
+    /// never a user-facing error, mirroring `ModerationModel.loadPendingFollowers()`'s same
+    /// rule against the same endpoint. No-ops (leaves `.unknown`) until `configure(site:)` has
+    /// resolved a `membershipClient` — no site URL yet, or no publish token provisioned.
+    func loadPending() async {
+        guard let membershipClient else { return }
+        pendingState = .loading
+        do {
+            let requests = try await membershipClient.listFollowRequests()
+            pendingRows = requests.map { request in
+                PendingRequestRow(request: request, profile: cache.profile(for: request.actor))
+            }
+            pendingState = .loaded
+        } catch CommunityMembershipError.requestFailed(status: 404, body: _) {
+            pendingRows = []
+            pendingState = .unavailable
+        } catch {
+            // Additive, not destructive: a transient failure keeps whatever rows are already
+            // on screen rather than blanking the section, matching `loadMoreFailure`'s rule
+            // for the main list.
+            pendingState = .unreachable("\(error)")
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter FollowersModelTests`
+Expected: PASS. Also run the full app-core suite to confirm the `FollowerRow.displayName`
+refactor didn't regress: `swift test --package-path . --filter AnglesiteAppTests`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/FollowersModel.swift Tests/AnglesiteAppTests/FollowersModelTests.swift
+git commit -m "feat(#965): load pending follow requests in FollowersModel"
+```
+
+---
+
+### Task 4: `FollowersModel` — accept/reject actions and enrichment
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/FollowersModel.swift`
+- Test: `Tests/AnglesiteAppTests/FollowersModelTests.swift`
+
+**Interfaces:**
+- Consumes: `CommunityMembershipClient.acceptFollow(target:)` (existing),
+  `CommunityMembershipClient.rejectFollow(target:)` (Task 1), `PendingRequestRow`/`pendingRows`
+  (Task 3).
+- Produces: `FollowersModel.accept(_ row: PendingRequestRow) async`,
+  `FollowersModel.reject(_ row: PendingRequestRow) async`, `FollowersModel.rejectConfirmation: PendingRequestRow?`,
+  `FollowersModel.confirmReject() async`, `FollowersModel.pendingActionFailure: String?` — all
+  consumed by `FollowersView` in Task 6.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `// MARK: - Pending requests` section in `FollowersModelTests.swift`:
+
+```swift
+
+    @Test("accept POSTs Accept and removes the row from pendingRows")
+    func acceptRemovesRow() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            ),
+            "/users/site/outbox": (202, "{}"),
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        await model.loadPending()
+        let row = try #require(model.pendingRows.first)
+
+        await model.accept(row)
+
+        #expect(model.pendingRows.isEmpty)
+        let body = await membershipServer.requestedBodies.last
+        #expect(body?["type"] as? String == "Accept")
+        #expect(body?["object"] as? String == "https://mastodon.social/users/alice")
+    }
+
+    @Test("a failed accept restores the row and sets pendingActionFailure")
+    func acceptFailureRestoresRow() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            ),
+            "/users/site/outbox": (500, "server error"),
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        await model.loadPending()
+        let row = try #require(model.pendingRows.first)
+
+        await model.accept(row)
+
+        #expect(model.pendingRows.count == 1)
+        #expect(model.pendingActionFailure != nil)
+    }
+
+    @Test("reject is only sent through confirmReject, after rejectConfirmation is set")
+    func rejectRequiresConfirmation() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200,
+                Self.followRequestsBody(items: [("https://mastodon.social/users/bob", "2026-08-01T00:00:00.000Z")])
+            ),
+            "/users/site/outbox": (202, "{}"),
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        await model.loadPending()
+        let row = try #require(model.pendingRows.first)
+
+        model.rejectConfirmation = row
+        #expect(model.pendingRows.count == 1)  // unchanged until confirmed
+
+        await model.confirmReject()
+
+        #expect(model.pendingRows.isEmpty)
+        #expect(model.rejectConfirmation == nil)
+        let body = await membershipServer.requestedBodies.last
+        #expect(body?["type"] as? String == "Reject")
+        #expect(body?["object"] as? String == "https://mastodon.social/users/bob")
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter FollowersModelTests`
+Expected: FAIL — `value of type 'FollowersModel' has no member 'accept'` etc.
+
+- [ ] **Step 3: Implement accept/reject**
+
+In `Sources/AnglesiteApp/FollowersModel.swift`, add after `loadPending()`:
+
+```swift
+
+    var pendingActionFailure: String?
+    /// Set by the view to arm the Reject confirmation dialog; cleared by whichever button runs
+    /// (Reject or Cancel) — same no-op-setter/clear-in-button-action contract
+    /// `ModerationModel.banConfirmation` already establishes.
+    var rejectConfirmation: PendingRequestRow?
+
+    /// Confirms a pending follower. Optimistically removes the row; a failure restores it
+    /// (appended, not reinserted at its original position — pending lists are short enough
+    /// that exact ordering after a failure isn't worth the extra bookkeeping) and reports
+    /// `pendingActionFailure`, same additive-not-replacing shape as `loadMoreFailure`.
+    func accept(_ row: PendingRequestRow) async {
+        guard let membershipClient else { return }
+        pendingRows.removeAll { $0.id == row.id }
+        do {
+            try await membershipClient.acceptFollow(target: row.request.actor)
+        } catch {
+            pendingRows.append(row)
+            pendingActionFailure = "Couldn't accept \(row.displayName): \(error.localizedDescription)"
+        }
+    }
+
+    /// Declines a pending follower. Never called directly by the view — only through
+    /// ``confirmReject()``, after `rejectConfirmation` is armed, since Reject is destructive
+    /// (mac-assed-app-spec §5).
+    func reject(_ row: PendingRequestRow) async {
+        guard let membershipClient else { return }
+        pendingRows.removeAll { $0.id == row.id }
+        do {
+            try await membershipClient.rejectFollow(target: row.request.actor)
+        } catch {
+            pendingRows.append(row)
+            pendingActionFailure = "Couldn't reject \(row.displayName): \(error.localizedDescription)"
+        }
+    }
+
+    func confirmReject() async {
+        guard let row = rejectConfirmation else { return }
+        rejectConfirmation = nil
+        await reject(row)
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter FollowersModelTests`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing test for shared enrichment**
+
+Append to `FollowersModelTests.swift`:
+
+```swift
+
+    @Test("enrichIfNeeded also fills in a pending row's profile")
+    func enrichmentCoversPendingRows() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let actor = try #require(URL(string: "https://mastodon.social/users/alice"))
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200, Self.followRequestsBody(items: [(actor.absoluteString, "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let profile = ActorProfile(
+            actor: actor, preferredUsername: "alice", name: "Alice", iconURL: nil, fetchedAt: Date())
+        let model = FollowersModel(
+            fetcher: ActorProfileFetcher(transport: { _ in
+                (try JSONEncoder().encode(profile), HTTPURLResponse(
+                    url: actor, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+            }),
+            avatarLoader: AvatarLoader(transport: { _ in throw AvatarLoadError.requestFailed(status: 500) }),
+            followersTransport: { _ in
+                (Data(), HTTPURLResponse(url: actor, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+            },
+            secretStore: secretStore,
+            membershipTransport: await membershipServer.transport)
+        model.configure(site: site)
+        await model.loadPending()
+        #expect(model.pendingRows.first?.profile == nil)
+
+        model.enrichIfNeeded(actor)
+        // enrichIfNeeded fires a detached Task; give it a beat to land.
+        for _ in 0..<50 where model.pendingRows.first?.profile == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(model.pendingRows.first?.profile?.name == "Alice")
+    }
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter FollowersModelTests/enrichmentCoversPendingRows`
+Expected: FAIL — `pendingRows.first?.profile` stays `nil` (enrichment only updates `rows` today)
+
+- [ ] **Step 7: Generalize enrichment to cover `pendingRows`**
+
+In `Sources/AnglesiteApp/FollowersModel.swift`, update `enrichIfNeeded(_:)` and
+`finishEnrichment(_:profile:)`:
+
+```swift
+    func enrichIfNeeded(_ actor: URL) {
+        let key = actor.absoluteString
+        let alreadyKnown = rows.first(where: { $0.actor == actor })?.profile != nil
+            || pendingRows.first(where: { $0.request.actor == actor })?.profile != nil
+        guard !alreadyKnown, !inFlight.contains(key), !queued.contains(key), !unreachableActors.contains(key)
+        else { return }
+        queued.insert(key)
+        pendingQueue.append(actor)
+        pumpQueue()
+    }
+```
+
+```swift
+    private func finishEnrichment(_ actor: URL, profile: ActorProfile?) {
+        let key = actor.absoluteString
+        inFlight.remove(key)
+        if let profile {
+            cache.store(profile)
+            if let index = rows.firstIndex(where: { $0.actor == actor }) {
+                rows[index].profile = profile
+            }
+            if let index = pendingRows.firstIndex(where: { $0.request.actor == actor }) {
+                pendingRows[index].profile = profile
+            }
+            scheduleCacheSave()
+        } else {
+            unreachableActors.insert(key)
+        }
+        pumpQueue()
+    }
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter FollowersModelTests`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/AnglesiteApp/FollowersModel.swift Tests/AnglesiteAppTests/FollowersModelTests.swift
+git commit -m "feat(#965): accept/reject pending follow requests in FollowersModel"
+```
+
+---
+
+### Task 5: `FollowersModel` — background polling and new-request notification hook
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/FollowersModel.swift`
+- Test: `Tests/AnglesiteAppTests/FollowersModelTests.swift`
+
+**Interfaces:**
+- Produces: `FollowersModel.startPendingPollingIfNeeded()`, `FollowersModel.stopPendingPolling()`,
+  `FollowersModel.onNewPendingRequests: ((String, Int) -> Void)?` — consumed by
+  `SiteWindowModel`/`CompletionNotificationHub` in Task 7. An init parameter
+  `pendingPollInterval: Duration = .seconds(300)` makes the interval testable.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `FollowersModelTests.swift`:
+
+```swift
+
+    @Test("the first loadPending establishes a baseline without notifying")
+    func firstLoadDoesNotNotify() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200, Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let model = await Self.makeModelWithPending(
+            server: Server(routes: [:]), membershipServer: membershipServer, secretStore: secretStore)
+        model.configure(site: site)
+        let recorder = Recorder()
+        model.onNewPendingRequests = { siteID, count in Task { await recorder.record((siteID, count)) } }
+
+        await model.loadPending()
+
+        try await Task.sleep(for: .milliseconds(20))
+        let notified = await recorder.events
+        #expect(notified.isEmpty)
+    }
+
+    @Test("a later poll notifies once when the pending count grows past the baseline")
+    func laterPollNotifiesOnGrowth() async throws {
+        let (site, root) = try Self.makeSite(siteURL: "https://example.com")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let secretStore = InMemorySecretStore()
+        secretStore.values[SecretAccounts.activityPubPublishToken(siteID: "site-1")] = "token"
+        let membershipServer = MembershipServer(routes: [
+            "/users/site/follow_requests": (
+                200, Self.followRequestsBody(items: [("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z")])
+            )
+        ])
+        let model = FollowersModel(
+            fetcher: ActorProfileFetcher(transport: { _ in throw ActorProfileError.requestFailed(status: 500) }),
+            avatarLoader: AvatarLoader(transport: { _ in throw AvatarLoadError.requestFailed(status: 500) }),
+            followersTransport: { _ in
+                (Data(), HTTPURLResponse(
+                    url: URL(string: "https://example.com")!, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+            },
+            secretStore: secretStore,
+            membershipTransport: await membershipServer.transport,
+            pendingPollInterval: .milliseconds(20))
+        model.configure(site: site)
+        let recorder = Recorder()
+        model.onNewPendingRequests = { siteID, count in Task { await recorder.record((siteID, count)) } }
+        await model.loadPending()  // establishes the baseline of 1, as in the test above
+
+        await membershipServer.setRoute(
+            "/users/site/follow_requests", status: 200,
+            body: Self.followRequestsBody(items: [
+                ("https://mastodon.social/users/alice", "2026-08-01T00:00:00.000Z"),
+                ("https://mastodon.social/users/carol", "2026-08-02T00:00:00.000Z"),
+            ]))
+        model.startPendingPollingIfNeeded()
+        defer { model.stopPendingPolling() }
+
+        var events: [(String, Int)] = []
+        for _ in 0..<50 where events.isEmpty {
+            try await Task.sleep(for: .milliseconds(10))
+            events = await recorder.events
+        }
+
+        #expect(events == [("site-1", 2)])
+    }
+```
+
+Add the `Recorder` actor as a private nested type in `FollowersModelTests` (near the other
+fixtures, e.g. right after `InMemorySecretStore`):
+
+```swift
+    private actor Recorder {
+        private(set) var events: [(String, Int)] = []
+        func record(_ event: (String, Int)) { events.append(event) }
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter FollowersModelTests`
+Expected: FAIL — no `onNewPendingRequests`, no `startPendingPollingIfNeeded`/`stopPendingPolling`,
+no `pendingPollInterval` init parameter.
+
+- [ ] **Step 3: Implement polling and the notification hook**
+
+In `Sources/AnglesiteApp/FollowersModel.swift`:
+
+1. Add stored properties after `membershipClient`:
+
+```swift
+    private var pollTask: Task<Void, Never>?
+    private var lastNotifiedPendingCount = 0
+    private var hasEstablishedPendingBaseline = false
+    private let pendingPollInterval: Duration
+
+    /// Fired with the current total pending count whenever a `loadPending()` finds it greater
+    /// than the last count this fired for. The *first* `loadPending()` per model instance only
+    /// establishes the baseline — it never fires on its own (a relaunch must not re-notify
+    /// about requests the owner has already seen and simply hasn't acted on yet).
+    var onNewPendingRequests: ((String, Int) -> Void)?
+```
+
+2. Update the initializer to accept `pendingPollInterval`:
+
+```swift
+    init(
+        fetcher: ActorProfileFetcher = ActorProfileFetcher(),
+        avatarLoader: AvatarLoader = AvatarLoader(),
+        followersTransport: @escaping ActivityPubFollowersClient.Transport
+            = ActivityPubFollowersClient.defaultTransport,
+        secretStore: any SecretStore = PlatformSecretStore.make(),
+        membershipTransport: @escaping CommunityMembershipClient.Transport
+            = CommunityMembershipClient.defaultTransport,
+        pendingPollInterval: Duration = .seconds(300)
+    ) {
+        self.fetcher = fetcher
+        self.avatarLoader = avatarLoader
+        self.followersTransport = followersTransport
+        self.secretStore = secretStore
+        self.membershipTransport = membershipTransport
+        self.pendingPollInterval = pendingPollInterval
+    }
+```
+
+3. Update `loadPending()`'s success branch to call the new notify step, and add the polling
+   methods + `notifyIfNewRequestsArrived()` right after it:
+
+```swift
+    func loadPending() async {
+        guard let membershipClient else { return }
+        pendingState = .loading
+        do {
+            let requests = try await membershipClient.listFollowRequests()
+            pendingRows = requests.map { request in
+                PendingRequestRow(request: request, profile: cache.profile(for: request.actor))
+            }
+            pendingState = .loaded
+            notifyIfNewRequestsArrived()
+        } catch CommunityMembershipError.requestFailed(status: 404, body: _) {
+            pendingRows = []
+            pendingState = .unavailable
+        } catch {
+            pendingState = .unreachable("\(error)")
+        }
+    }
+
+    private func notifyIfNewRequestsArrived() {
+        guard let siteID else { return }
+        defer { hasEstablishedPendingBaseline = true }
+        guard hasEstablishedPendingBaseline, pendingRows.count > lastNotifiedPendingCount else {
+            lastNotifiedPendingCount = pendingRows.count
+            return
+        }
+        lastNotifiedPendingCount = pendingRows.count
+        onNewPendingRequests?(siteID, pendingRows.count)
+    }
+
+    /// Starts the recurring background recheck, idempotently — a second call (e.g. a window
+    /// replayed onto a different site) is a no-op; `loadPending()` always reads the *current*
+    /// `membershipClient`/`siteID` at call time, so the one running loop naturally picks up a
+    /// replayed site's data on its next tick. Callers that want fresher data immediately after
+    /// a replay should `await loadPending()` explicitly (this method only owns the recurring
+    /// timer, not an immediate fetch — see `SiteWindowModel.loadAndStart`).
+    func startPendingPollingIfNeeded() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            guard let interval = self?.pendingPollInterval else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: interval)
+                guard !Task.isCancelled, let self else { return }
+                await self.loadPending()
+            }
+        }
+    }
+
+    /// Stops the recurring recheck — called from `SiteWindowModel.close()`.
+    func stopPendingPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter FollowersModelTests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/FollowersModel.swift Tests/AnglesiteAppTests/FollowersModelTests.swift
+git commit -m "feat(#965): poll for new pending follow requests while a site window is open"
+```
+
+---
+
+### Task 6: `FollowersView` — Pending Requests section
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/FollowersView.swift`
+
+**Interfaces:**
+- Consumes: `FollowersModel.pendingRows`, `.pendingState`, `.pendingActionFailure`,
+  `.rejectConfirmation`, `.accept(_:)`, `.reject(_:)` (unused directly by the view — only
+  `confirmReject()` is), `.confirmReject()`, `.enrichIfNeeded(_:)` (all from Tasks 3-5).
+
+- [ ] **Step 1: Restructure `body` so the pending section renders regardless of the main list's `State`**
+
+In `Sources/AnglesiteApp/FollowersView.swift`, replace `var body: some View { ... }`:
+
+```swift
+    var body: some View {
+        VStack(spacing: 0) {
+            pendingSection
+            Group {
+                switch followers.state {
+                case .idle, .loading:
+                    ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+                case .loaded:
+                    loadedContent
+                case .noSiteURL:
+                    message(
+                        "This site hasn't been published yet",
+                        detail: Text("Publish it at least once, then followers will appear here."))
+                case .notActivated:
+                    message(
+                        "The Fediverse isn't turned on for this site",
+                        detail: Text("Turn on the Fediverse in Settings ▸ Workers, then publish again."))
+                case .unreachable(let reason):
+                    // `reason` is server-supplied (HTTP body / error description) — untrusted remote
+                    // content, never a localization key or format string. `Text(reason)` binds to the
+                    // `StringProtocol` overload and renders it verbatim.
+                    message("Couldn't reach this site", detail: Text(reason))
+                }
+            }
+        }
+        .navigationSubtitle("Followers")
+        .task { if followers.state == .idle { await followers.load() } }
+        .onDisappear { followers.saveCacheNow() }
+        .confirmationDialog(
+            "Reject this follow request?",
+            isPresented: Binding(get: { followers.rejectConfirmation != nil }, set: { _ in }),
+            titleVisibility: .visible
+        ) {
+            Button("Reject", role: .destructive) { Task { await followers.confirmReject() } }
+            Button("Cancel", role: .cancel) { followers.rejectConfirmation = nil }
+        } message: {
+            Text("This declines the follow request from \(followers.rejectConfirmation?.displayName ?? "this requester").")
+        }
+    }
+```
+
+- [ ] **Step 2: Add the pending section and row views**
+
+Add these new views right after `body`, before the existing `loadedContent` computed property:
+
+```swift
+
+    @ViewBuilder
+    private var pendingSection: some View {
+        // Hidden entirely when there's nothing to show — no error noise for a capability that
+        // hasn't shipped upstream yet (`.unavailable`), no dead space for a site with nothing
+        // pending. Deliberately independent of `followers.state`: pending arrives from its own
+        // background poll and may be known before the main list ever loads.
+        if !followers.pendingRows.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Pending Requests (\(followers.pendingRows.count))")
+                    .font(.headline)
+                    .padding()
+                List {
+                    ForEach(followers.pendingRows) { row in
+                        pendingRow(row)
+                    }
+                    if let failure = followers.pendingActionFailure {
+                        Text(failure).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .frame(height: min(CGFloat(followers.pendingRows.count) * 44 + 16, 220))
+                Divider()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func pendingRow(_ row: PendingRequestRow) -> some View {
+        HStack(spacing: 10) {
+            avatar(iconURL: row.profile?.iconURL)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.displayName).font(.headline).lineLimit(1)
+                Text(row.handle ?? row.request.actor.absoluteString)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button("Accept") { Task { await followers.accept(row) } }
+                .accessibilityLabel("Accept follow request from \(row.displayName)")
+            Button("Reject", role: .destructive) { followers.rejectConfirmation = row }
+                .accessibilityLabel("Reject follow request from \(row.displayName)")
+        }
+        .padding(.vertical, 2)
+        .task { followers.enrichIfNeeded(row.request.actor) }
+    }
+```
+
+- [ ] **Step 3: Generalize the existing `avatar(for:)` helper so both rows can use it**
+
+Replace the existing `avatar(for:)` method:
+
+```swift
+    @ViewBuilder
+    private func avatar(for row: FollowerRow) -> some View {
+        FollowerAvatar(url: row.profile?.iconURL, loader: followers.avatarLoader)
+    }
+```
+
+with a version keyed on the icon URL alone, and update its one existing call site
+(`avatar(for: row)` inside `followerRow(_:)`) to `avatar(iconURL: row.profile?.iconURL)`:
+
+```swift
+    @ViewBuilder
+    private func avatar(iconURL: URL?) -> some View {
+        FollowerAvatar(url: iconURL, loader: followers.avatarLoader)
+    }
+```
+
+- [ ] **Step 4: Build the app target**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED. `FollowersView` isn't covered by `swift test` (it's a View, not a
+tested model), so this build is this task's verification.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/FollowersView.swift
+git commit -m "feat(#965): surface pending follow requests in FollowersView"
+```
+
+---
+
+### Task 7: Wire polling lifecycle and the completion notification
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/CompletionNotificationHub.swift`
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift`
+
+**Interfaces:**
+- Consumes: `FollowersModel.onNewPendingRequests`, `.loadPending()`,
+  `.startPendingPollingIfNeeded()`, `.stopPendingPolling()` (Tasks 3-5),
+  `CompletionNoticeBuilder.followRequest(siteName:siteID:count:)` (Task 2).
+
+- [ ] **Step 1: Wire the notification hook in `CompletionNotificationHub`**
+
+In `Sources/AnglesiteApp/CompletionNotificationHub.swift`, change the `wire` signature and add
+the `followers` wiring at the end of the function body, right before its closing `}`:
+
+```swift
+    static func wire(deploy: DeployModel, backup: BackupModel, audit: AuditModel, followers: FollowersModel) {
+```
+
+```swift
+        followers.onNewPendingRequests = { siteID, count in
+            postNotice(siteID: siteID) { name in
+                CompletionNoticeBuilder.followRequest(siteName: name, siteID: siteID, count: count)
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Update the `SiteWindowModel` call site and lifecycle hooks**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`:
+
+1. Update the `wire` call (currently `CompletionNotificationHub.wire(deploy: deploy, backup: backup, audit: audit)`):
+
+```swift
+        CompletionNotificationHub.wire(deploy: deploy, backup: backup, audit: audit, followers: followers)
+```
+
+2. In `loadAndStart(...)`, right after the existing `followers.configure(site: currentSite)`
+   line, add:
+
+```swift
+        followers.configure(site: currentSite)
+        await followers.loadPending()
+        followers.startPendingPollingIfNeeded()
+```
+
+3. In `close(suddenTerminationLease:)`, add a line alongside the existing
+   `stopInvisiblePublishing()`/`sync.stop()`/`preview.close()`/`startup.stop()` calls:
+
+```swift
+    func close(suddenTerminationLease: SuddenTerminationController.Lease? = nil) {
+        stopInvisiblePublishing()
+        followers.stopPendingPolling()
+        sync.stop()
+        preview.close()
+        startup.stop()
+```
+
+- [ ] **Step 3: Build and run the full suite**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED
+
+Run: `swift test --package-path .`
+Expected: all suites PASS, including the untouched `AnglesiteCoreTests`/`AnglesiteAppTests`
+suites (regression check).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/AnglesiteApp/CompletionNotificationHub.swift Sources/AnglesiteApp/SiteWindowModel.swift
+git commit -m "feat(#965): start/stop pending-follower polling with the site window"
+```
+
+---
+
+## Final verification (not a task — run before opening the PR)
+
+- [ ] `swift test --package-path .` — full suite green.
+- [ ] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — green.
+- [ ] Manually open a site in the app, open Website ▸ Followers…, confirm the pane still loads
+  the existing public follower list unchanged, and that no "Pending Requests" section appears
+  for a site whose Worker doesn't yet expose `follow_requests` (expected — matches the 404 →
+  `.unavailable` degrade).
+- [ ] PR body: note the still-missing upstream piece (externally bearer-gated
+  `GET <actor>/follow_requests` — `CommunityMembershipClient.listFollowRequests()`'s existing
+  doc comment on this) as a pending `davidwkeith/workers` dependency, per
+  `CONTRIBUTING.md` ▸ "`@dwk/workers` catalog coordination." This PR does not block on it.

--- a/docs/superpowers/specs/2026-08-17-follow-approval-design.md
+++ b/docs/superpowers/specs/2026-08-17-follow-approval-design.md
@@ -14,41 +14,48 @@ contact graph, and is a prerequisite for #963's contact list (the gate that deci
 
 ## Scope
 
-This repo (`Anglesite/Anglesite`) only. The full feature spans two repos:
+This repo (`Anglesite/Anglesite`) only. **Revised after verifying upstream state directly**
+(see below) — most of the "upstream" half the issue describes turns out to already be merged:
 
-- **Upstream** (`davidwkeith/workers`, `@dwk/activitypub`): hold inbound `Follow` in a
-  pending state instead of auto-accepting; owner-only endpoints to list pending requests and
-  send Accept/Reject. **Not implemented in this session** — a separate repo, separate PR.
+- **`davidwkeith/workers` `main`** (commit `096d04b`, #476, closing #473) already ships
+  `manuallyApprovesFollowers`, pending-follower tracking (`followers.accepted_at`), and
+  owner-triggered `Accept` of a pending follower via the outbox. Owner `Reject` of a pending
+  follow has been a recognized outbox control activity since the earlier #447 — it already
+  works upstream today, `CommunityMembershipClient` (below) just never grew a Swift method
+  for it. **Not implemented in this session** (still a separate repo) because none of it
+  needs to be — it already shipped.
+- **Still genuinely missing upstream**: an *externally* bearer-gated `GET <actor>/follow_requests`
+  listing route. Only an internal, `@dwk/mastodon-api`-only variant
+  (`__client/follow_requests`, gated on a stricter internal-only header) exists on `main`
+  today. This matches what `CommunityMembershipClient.listFollowRequests()` already assumes
+  in its own doc comments (citing a not-yet-landed PR #488) — the app was already written
+  ahead of this one piece, and this plan doesn't change that. A 404 here continues to mean
+  "not available yet," not a failure.
 - **App** (this repo): everything below.
 
-Per `CONTRIBUTING.md` ▸ "`@dwk/workers` catalog coordination," the app side is built against
-an assumed wire contract, kept backward-compatible (a 404/missing capability degrades to
-"feature inert," not an error), so this PR can merge before the upstream capability ships.
-The assumed contract is documented below and must be noted in the PR body as a pending
-upstream dependency.
+Per `CONTRIBUTING.md` ▸ "`@dwk/workers` catalog coordination," the app side stays
+backward-compatible with that one still-missing route (404 degrades to "feature inert," not
+an error) — no other part of this feature is speculative.
 
 Detection of *new* pending requests polls only while a site's window is open (no
 always-on/background-when-closed daemon — that's `AnglesiteRemote`/#1208 territory) and does
 not persist "last seen count" across app launches (a relaunch re-baselines silently).
 
-## Assumed wire contract
+## Wire contract (already implemented upstream, reused as-is)
 
-Documented here as the contract the upstream PR needs to implement; the app decodes exactly
-this shape.
+`Sources/AnglesiteCore/CommunityMembershipClient.swift` already implements this exact
+contract, for the same reason: it operates on this site's own personal actor
+(`ActivityPubActor.actorURL`), not a separate Group actor — `ModerationModel` already uses it
+against the same actor URL `FollowersModel` resolves. Confirmed against the current
+`davidwkeith/workers` `main` checkout, not just the Anglesite-side comments.
 
-**`GET /users/site/followers/pending`** — owner-only, `Authorization: Bearer <token>`. Same
-`OrderedCollection`/`OrderedCollectionPage` shape as the existing public
-`/users/site/followers` endpoint (`totalItems`/`first`, `orderedItems`/`next`), except each
-page item is an object, not a bare actor IRI string:
+**`GET <actor>/follow_requests`** — owner-only, `Authorization: Bearer <token>`. Unpaged flat
+JSON (mirrors `GET <actor>/blocked`): `{"items": [{"actor": "<IRI>", "addedAt": "<ISO 8601>"}], "total": <n>}`.
+Decoded by `CommunityMembershipClient.listFollowRequests() -> [PendingFollower]`
+(`PendingFollower.id` is the actor IRI itself — there is no separate Follow-activity id to
+track; Accept/Reject target the actor, not the Follow).
 
-```json
-{ "id": "<Follow activity IRI>", "actor": "<follower actor IRI>", "published": "<ISO 8601>" }
-```
-
-The `Follow` activity's `id` is required (not just the actor IRI) because Accept/Reject
-reference it.
-
-**`POST /users/site/outbox`** (the endpoint `ActivityPubOutboxBackfill` already POSTs to,
+**`POST <actor>/outbox`** (the same endpoint `ActivityPubOutboxBackfill` already POSTs to,
 same `Authorization: Bearer <token>`):
 
 ```json
@@ -56,47 +63,44 @@ same `Authorization: Bearer <token>`):
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Accept",
   "actor": "<site actor IRI>",
-  "object": "<Follow activity id>"
+  "object": "<follower actor IRI>"
 }
 ```
 
-`"type": "Reject"` for reject. This is standard AS2 (Accept/Reject wrapping the Follow) and
-reuses the existing outbox-POST wire shape rather than inventing a bespoke endpoint — the
-worker fans the activity out to the follower's inbox and, on Accept, folds the actor into the
-public followers collection.
+`"type": "Reject"` for reject, same shape. `CommunityMembershipClient.acceptFollow(target:)`
+already sends the `Accept` form; this plan adds the symmetric `rejectFollow(target:)`.
 
-**Auth**: reuses the existing `SecretAccounts.activityPubPublishToken(siteID:)` Keychain
-secret — already provisioned when ActivityPub is activated for a site (see
-`ActivityPubKeyProvisioning`), already used for outbox backfill. No new secret/token type.
+**Auth**: the existing `SecretAccounts.activityPubPublishToken(siteID:)` Keychain secret —
+already provisioned when ActivityPub is activated for a site (see
+`ActivityPubKeyProvisioning`), already used for outbox backfill and by `ModerationModel`. No
+new secret/token type.
 
-**Backward compatibility**: a 404 (or any non-2xx before the upstream capability ships) on
-the pending endpoint means "not available yet," not a failure — the pending section stays
-hidden rather than showing an error.
+**Backward compatibility**: a 404 from `listFollowRequests()` (the one upstream piece not yet
+externally reachable — see Scope) means "not available yet," not a failure — the pending
+section stays hidden rather than showing an error. Exactly `ModerationModel.loadPendingFollowers()`'s
+existing rule, reused verbatim.
 
 ## App-side components
 
-### `AnglesiteCore`: `ActivityPubFollowRequestsClient` (new)
+### `AnglesiteCore`: `CommunityMembershipClient` (extend, don't duplicate)
 
-Parallel to `ActivityPubFollowersClient`, but *authenticated* — that type's doc comment is
-explicit that it "deliberately carries no auth layer at all" for the public collection, so
-this is a new type rather than an extension of it. Shape:
+No new client type. `CommunityMembershipClient` already has `listFollowRequests()` and
+`acceptFollow(target:)` against exactly this actor; adding a parallel type would mean two
+Swift clients hitting the same endpoints. This plan adds one method:
 
-- `pending() async throws -> FollowersCollection`-equivalent head, `page(at:)` for paging —
-  same decode pattern as `ActivityPubFollowersClient`, but items decode to a new
-  `PendingFollowRequest { id, actor, publishedAt }` rather than a bare `URL`.
-- `accept(_ request: PendingFollowRequest) async throws` / `reject(_:)` — POST to the outbox
-  per the contract above.
-- Injectable `Transport` (same typealias shape as the other two clients), so it unit-tests
-  without real networking.
-- A dedicated `unavailable` signal (e.g. treat 404 as a typed case, not lumped into the
-  generic `requestFailed`) so `FollowersModel` can distinguish "not shipped yet" from a real
-  error without string-matching status codes at the call site.
+- `func rejectFollow(target: URL) async throws` — mirrors `acceptFollow(target:)` exactly,
+  `"type": "Reject"` instead of `"type": "Accept"`, same `post(_:)` helper.
 
 ### `FollowersModel`
 
-- New `pendingRows: [PendingRequestRow]` (mirrors `FollowerRow`: `actor`, `profile`, plus the
-  `Follow` activity `id`) and `pendingState` — a state machine **separate** from the existing
-  `State`, with cases `.unknown / .loading / .loaded / .unavailable / .unreachable(String)`.
+- New `pendingRows: [PendingRequestRow]` — `PendingRequestRow { let request: PendingFollower;
+  var profile: ActorProfile? }`, mirroring how `FollowerRow` pairs `actor` with enrichment.
+  Reuses `PendingFollower` (`Sources/AnglesiteCore/PendingFollower.swift`) as-is rather than a
+  new DTO — `id`/`actor` are the same value (there's no separate Follow-activity id to carry).
+- `pendingState` — a state machine **separate** from the existing `State`, with cases
+  `.unknown / .loading / .loaded / .unavailable / .unreachable(String)`. `.unavailable` is set
+  by catching `CommunityMembershipError.requestFailed(status: 404, body: _)`, the same guard
+  `ModerationModel.loadPendingFollowers()` already uses.
 
   This deliberately departs from the issue's own sketch ("`State` grows a pending case"):
   pending-list availability is orthogonal to whether the main follower list loaded
@@ -108,6 +112,16 @@ this is a new type rather than an extension of it. Shape:
   async`: optimistically removes the row from `pendingRows`; on failure, restores it and sets
   a `pendingActionFailure: String?` (same additive-not-replacing pattern as
   `loadMoreFailure` — a failed accept/reject shouldn't blank the whole pending section).
+  `reject(_:)` is only ever called from `confirmReject()`, gated by a `rejectConfirmation:
+  PendingRequestRow?` property — the exact `banConfirmation`/`confirmBan()` shape
+  `ModerationModel` already establishes, reused for consistency rather than inventing a new
+  confirmation idiom.
+- A dedicated `CommunityMembershipClient` instance, built the same way
+  `ModerationModel`/`CommunitiesModel` build theirs: `ownActorURL` from
+  `ActivityPubActor.actorURL(siteURL:)` (already resolved for the existing
+  `ActivityPubFollowersClient`) plus `publishToken` read via `SecretStore` +
+  `SecretAccounts.activityPubPublishToken(siteID:)`. `FollowersModel` gains a `secretStore:
+  any SecretStore = PlatformSecretStore.make()` init parameter, matching `ModerationModel`'s.
 - Pending rows reuse the existing enrichment pipeline (`ActorProfileCache`,
   `enrichIfNeeded`, `AvatarLoader`) — a pending row's `actor` enriches exactly like a
   follower row's.
@@ -116,9 +130,11 @@ this is a new type rather than an extension of it. Shape:
   `SiteWindowModel.close()` alongside the existing `preview.close()`/`sync.stop()` teardown
   (and restarted implicitly the next time `loadAndStart(...)` calls `configure(site:)` —
   covering both a fresh window open and a window replayed onto a different site).
-- `onNewPendingRequests: ((Int) -> Void)?` — fired only when a poll's pending count is
-  *greater* than the previous in-memory count (not on every poll, and not on the initial
-  load — only genuinely new arrivals warrant an interruption).
+- `onNewPendingRequests: ((Int) -> Void)?` — fired with the current total `pendingRows.count`
+  whenever it exceeds the last-notified count (tracked in a private `lastNotifiedPendingCount`),
+  not on every poll and not on the initial load. Using the running total (not a per-poll delta)
+  means a later notice always reflects the true current count rather than losing an earlier,
+  unread arrival when Notification Center replaces the stable-identifier banner.
 
 ### `FollowersView`
 
@@ -141,8 +157,11 @@ this is a new type rather than an extension of it. Shape:
 - `CompletionNotificationHub.wire(...)` gains a `followers: FollowersModel` parameter,
   wiring `onNewPendingRequests` to a new `CompletionNoticeBuilder.followRequest(siteName:
   siteID: count:)` ("1 new follow request" / "N new follow requests"). Follows the existing
-  per-operation-builder pattern (`deploy`/`backup`/`audit`); clicking the notice routes
-  through `WindowRouter` to the site's Followers pane, same as the existing notices.
+  per-operation-builder pattern (`deploy`/`backup`/`audit`). Clicking the notice focuses the
+  site's window via `WindowRouter.shared.requested`, exactly what `CompletionNotifier`
+  already does for every existing notice — it does not deep-link to a specific pane; no
+  existing notice does, and adding that would be new routing infrastructure this issue
+  doesn't need.
 - Justified under mac-assed-app-spec §7 ("notifications sparingly, only for timely
   information that warrants interruption") — a stranger asking to follow is exactly the kind
   of thing an owner curating a contact graph wants to know about promptly, unlike routine
@@ -150,18 +169,22 @@ this is a new type rather than an extension of it. Shape:
 
 ## Testing
 
-- `ActivityPubFollowRequestsClientTests` (new, `Tests/AnglesiteCoreTests`) — mirrors
-  `ActivityPubFollowersClientTests`: injected transport, decode success/failure, the
-  `.unavailable` (404) signal, accept/reject request shape.
-- `FollowersModelTests` additions: pending load into `.loaded`/`.unavailable`, accept/reject
-  optimistic update + failure rollback, polling fires `onNewPendingRequests` once per
-  genuinely-new arrival (not on every poll, not on first load).
+- `CommunityMembershipClientTests` addition: `rejectFollow(target:)` POSTs a `Reject`
+  activity with the right `actor`/`object`, mirroring the existing `acceptFollow`/`follow`
+  request-shape tests in that file.
+- `FollowersModelTests` additions: pending load into `.loaded`/`.unavailable` (404 → empty,
+  not an error), accept/reject optimistic update + failure rollback, `rejectConfirmation`
+  gating (`reject(_:)` never called directly by the view — only `confirmReject()`), polling
+  fires `onNewPendingRequests` once per genuinely-new arrival (not on every poll, not on
+  first load).
 - `CompletionNoticeBuilder` wording test for the new follow-request notice (singular vs.
   plural, identifier stability so repeated notices replace rather than stack).
 
 ## Non-goals
 
-- No upstream (`davidwkeith/workers`) implementation in this session — tracked as a pending
-  dependency to note in the PR body, per the catalog-coordination convention.
+- No upstream (`davidwkeith/workers`) implementation in this session — the one piece still
+  missing there (the externally bearer-gated `follow_requests` listing route) is a pending
+  dependency to note in the PR body, per the catalog-coordination convention. Everything else
+  the issue describes upstream has already shipped.
 - No always-on/background-when-app-closed polling.
 - No persistence of "last seen pending count" across app launches.

--- a/docs/superpowers/specs/2026-08-17-follow-approval-design.md
+++ b/docs/superpowers/specs/2026-08-17-follow-approval-design.md
@@ -1,0 +1,167 @@
+# Follow approval: pending requests + Accept/Reject
+
+Design for [#965](https://github.com/Anglesite/Anglesite/issues/965).
+
+## Problem
+
+`FollowersModel`/`FollowersView`/`ActivityPubFollowers` are entirely read-only. Inbound
+`Follow` activities are (presumably) auto-accepted by `@dwk/activitypub`, so an owner never
+sees or decides who follows their site. Facebook and LinkedIn — the product's secondary
+comparison point ("replace Facebook and LinkedIn for known contacts") — are both
+approval-gated. A follower list the owner cannot curate is a broadcast audience, not a
+contact graph, and is a prerequisite for #963's contact list (the gate that decides who is a
+"known contact" is this approval step).
+
+## Scope
+
+This repo (`Anglesite/Anglesite`) only. The full feature spans two repos:
+
+- **Upstream** (`davidwkeith/workers`, `@dwk/activitypub`): hold inbound `Follow` in a
+  pending state instead of auto-accepting; owner-only endpoints to list pending requests and
+  send Accept/Reject. **Not implemented in this session** — a separate repo, separate PR.
+- **App** (this repo): everything below.
+
+Per `CONTRIBUTING.md` ▸ "`@dwk/workers` catalog coordination," the app side is built against
+an assumed wire contract, kept backward-compatible (a 404/missing capability degrades to
+"feature inert," not an error), so this PR can merge before the upstream capability ships.
+The assumed contract is documented below and must be noted in the PR body as a pending
+upstream dependency.
+
+Detection of *new* pending requests polls only while a site's window is open (no
+always-on/background-when-closed daemon — that's `AnglesiteRemote`/#1208 territory) and does
+not persist "last seen count" across app launches (a relaunch re-baselines silently).
+
+## Assumed wire contract
+
+Documented here as the contract the upstream PR needs to implement; the app decodes exactly
+this shape.
+
+**`GET /users/site/followers/pending`** — owner-only, `Authorization: Bearer <token>`. Same
+`OrderedCollection`/`OrderedCollectionPage` shape as the existing public
+`/users/site/followers` endpoint (`totalItems`/`first`, `orderedItems`/`next`), except each
+page item is an object, not a bare actor IRI string:
+
+```json
+{ "id": "<Follow activity IRI>", "actor": "<follower actor IRI>", "published": "<ISO 8601>" }
+```
+
+The `Follow` activity's `id` is required (not just the actor IRI) because Accept/Reject
+reference it.
+
+**`POST /users/site/outbox`** (the endpoint `ActivityPubOutboxBackfill` already POSTs to,
+same `Authorization: Bearer <token>`):
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Accept",
+  "actor": "<site actor IRI>",
+  "object": "<Follow activity id>"
+}
+```
+
+`"type": "Reject"` for reject. This is standard AS2 (Accept/Reject wrapping the Follow) and
+reuses the existing outbox-POST wire shape rather than inventing a bespoke endpoint — the
+worker fans the activity out to the follower's inbox and, on Accept, folds the actor into the
+public followers collection.
+
+**Auth**: reuses the existing `SecretAccounts.activityPubPublishToken(siteID:)` Keychain
+secret — already provisioned when ActivityPub is activated for a site (see
+`ActivityPubKeyProvisioning`), already used for outbox backfill. No new secret/token type.
+
+**Backward compatibility**: a 404 (or any non-2xx before the upstream capability ships) on
+the pending endpoint means "not available yet," not a failure — the pending section stays
+hidden rather than showing an error.
+
+## App-side components
+
+### `AnglesiteCore`: `ActivityPubFollowRequestsClient` (new)
+
+Parallel to `ActivityPubFollowersClient`, but *authenticated* — that type's doc comment is
+explicit that it "deliberately carries no auth layer at all" for the public collection, so
+this is a new type rather than an extension of it. Shape:
+
+- `pending() async throws -> FollowersCollection`-equivalent head, `page(at:)` for paging —
+  same decode pattern as `ActivityPubFollowersClient`, but items decode to a new
+  `PendingFollowRequest { id, actor, publishedAt }` rather than a bare `URL`.
+- `accept(_ request: PendingFollowRequest) async throws` / `reject(_:)` — POST to the outbox
+  per the contract above.
+- Injectable `Transport` (same typealias shape as the other two clients), so it unit-tests
+  without real networking.
+- A dedicated `unavailable` signal (e.g. treat 404 as a typed case, not lumped into the
+  generic `requestFailed`) so `FollowersModel` can distinguish "not shipped yet" from a real
+  error without string-matching status codes at the call site.
+
+### `FollowersModel`
+
+- New `pendingRows: [PendingRequestRow]` (mirrors `FollowerRow`: `actor`, `profile`, plus the
+  `Follow` activity `id`) and `pendingState` — a state machine **separate** from the existing
+  `State`, with cases `.unknown / .loading / .loaded / .unavailable / .unreachable(String)`.
+
+  This deliberately departs from the issue's own sketch ("`State` grows a pending case"):
+  pending-list availability is orthogonal to whether the main follower list loaded
+  successfully, and folding it into the top-level `State` would make the pane's primary
+  list-loading state depend on an unrelated fetch (e.g. the main list could be `.loaded`
+  while pending is still `.loading`, or vice versa after a mid-session upstream deploy).
+
+- `func accept(_ row: PendingRequestRow) async` / `func reject(_ row: PendingRequestRow)
+  async`: optimistically removes the row from `pendingRows`; on failure, restores it and sets
+  a `pendingActionFailure: String?` (same additive-not-replacing pattern as
+  `loadMoreFailure` — a failed accept/reject shouldn't blank the whole pending section).
+- Pending rows reuse the existing enrichment pipeline (`ActorProfileCache`,
+  `enrichIfNeeded`, `AvatarLoader`) — a pending row's `actor` enriches exactly like a
+  follower row's.
+- A poll `Task`, started from `configure(site:)` once `pendingState` first resolves to
+  something other than `.unavailable`, re-checking every 5 minutes. Stopped from
+  `SiteWindowModel.close()` alongside the existing `preview.close()`/`sync.stop()` teardown
+  (and restarted implicitly the next time `loadAndStart(...)` calls `configure(site:)` —
+  covering both a fresh window open and a window replayed onto a different site).
+- `onNewPendingRequests: ((Int) -> Void)?` — fired only when a poll's pending count is
+  *greater* than the previous in-memory count (not on every poll, and not on the initial
+  load — only genuinely new arrivals warrant an interruption).
+
+### `FollowersView`
+
+- New "Pending Requests" section above the existing follower list. Hidden entirely when
+  `pendingState` is `.unavailable` or `pendingRows` is empty — no error noise for a
+  capability that hasn't shipped upstream yet, no dead space for a site with nothing pending.
+- Each row: avatar + name/handle (existing row UI) + **Accept** and **Reject** buttons.
+- **Reject** is confirmed via `.confirmationDialog` ("Reject follow request from *name*?",
+  destructive role) before calling `reject(_:)` — mac-assed-app-spec §5 ("make destructive
+  actions explicit... proportionate to their consequences") and §9 ("alert for consequential
+  confirmation"). **Accept** has no confirmation — it's not destructive.
+- Both buttons keyboard-reachable (standard `Button`, no custom hit-testing) and carry
+  explicit `.accessibilityLabel`s ("Accept follow request from *name*" /
+  "Reject follow request from *name*") rather than bare "Accept"/"Reject" — VoiceOver
+  navigating row-to-row needs the per-row context that sighted users get from layout
+  (mac-assed-app-spec §6).
+
+### Notifications
+
+- `CompletionNotificationHub.wire(...)` gains a `followers: FollowersModel` parameter,
+  wiring `onNewPendingRequests` to a new `CompletionNoticeBuilder.followRequest(siteName:
+  siteID: count:)` ("1 new follow request" / "N new follow requests"). Follows the existing
+  per-operation-builder pattern (`deploy`/`backup`/`audit`); clicking the notice routes
+  through `WindowRouter` to the site's Followers pane, same as the existing notices.
+- Justified under mac-assed-app-spec §7 ("notifications sparingly, only for timely
+  information that warrants interruption") — a stranger asking to follow is exactly the kind
+  of thing an owner curating a contact graph wants to know about promptly, unlike routine
+  follower-count churn (which stays silent, as today).
+
+## Testing
+
+- `ActivityPubFollowRequestsClientTests` (new, `Tests/AnglesiteCoreTests`) — mirrors
+  `ActivityPubFollowersClientTests`: injected transport, decode success/failure, the
+  `.unavailable` (404) signal, accept/reject request shape.
+- `FollowersModelTests` additions: pending load into `.loaded`/`.unavailable`, accept/reject
+  optimistic update + failure rollback, polling fires `onNewPendingRequests` once per
+  genuinely-new arrival (not on every poll, not on first load).
+- `CompletionNoticeBuilder` wording test for the new follow-request notice (singular vs.
+  plural, identifier stability so repeated notices replace rather than stack).
+
+## Non-goals
+
+- No upstream (`davidwkeith/workers`) implementation in this session — tracked as a pending
+  dependency to note in the PR body, per the catalog-coordination convention.
+- No always-on/background-when-app-closed polling.
+- No persistence of "last seen pending count" across app launches.


### PR DESCRIPTION
Closes #965

## Summary

- Add a "Pending Requests" section to the Followers pane: list pending ActivityPub follow requests, enrich them with the same avatar/display-name pipeline as accepted followers, and let the owner Accept or Reject (Reject behind an explicit confirmation dialog, per the Mac spec's rule for destructive actions).
- Reuse the existing `CommunityMembershipClient` (already used by the Moderation pane, against the same site actor) rather than adding a new client — adds the missing `rejectFollow(target:)` alongside its existing `listFollowRequests()`/`acceptFollow(target:)`.
- Poll for new pending requests while a site's window is open and post a completion notification (`CompletionNoticeBuilder.followRequest`) when the count grows past what was last shown — never on the first load, so a relaunch doesn't re-notify about requests the owner already knows about.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — full suite green (5,632 tests, 0 failures)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — BUILD SUCCEEDED
- [ ] Manual smoke: not run in this session — no interactive macOS app driver was available here. Verified instead via 7 task-scoped code reviews plus one whole-branch review, each reading the actual diff against the design spec. Recommend a manual pass through Website ▸ Followers… before merging, especially the Reject confirmation dialog and VoiceOver labels.

## Pending upstream dependency (`davidwkeith/workers`)

Per `CONTRIBUTING.md` ▸ "`@dwk/workers` catalog coordination": this PR stays backward-compatible with one still-missing upstream capability and doesn't block on it.

- **Already shipped upstream** (verified directly against the `davidwkeith/workers` `main` checkout — commit `096d04b` / PR #476, plus the pre-existing `Reject`/`Block` outbox-control-activity support from #447): `manuallyApprovesFollowers`, pending-follower tracking, and owner-triggered `Accept`/`Reject` of a pending follow via `POST <actor>/outbox`.
- **Still missing upstream**: an externally bearer-gated `GET <actor>/follow_requests` listing route (only an internal, `@dwk/mastodon-api`-only variant exists on `main` today). Until it ships, `CommunityMembershipClient.listFollowRequests()` 404s and the whole "Pending Requests" section stays hidden — confirmed end-to-end in review, including that a permanent 404 across unlimited poll cycles never fires a spurious notification.

## Design + plan

- `docs/superpowers/specs/2026-08-17-follow-approval-design.md`
- `docs/superpowers/plans/2026-08-17-follow-approval-plan.md`

## Known non-blocking follow-up (parked in final review)

- When a site window replays onto a different site whose Worker doesn't yet expose the pending-requests route, a poll loop already running for the previously-open site isn't stopped — it keeps hitting the new site's (currently 404ing) route every 5 minutes until the window closes. No correctness/data impact, narrow edge case; a fast follow rather than a blocker.
- `CommunityMembershipError` doesn't conform to `LocalizedError`, so the new "can't reach pending requests" message (and the pre-existing accept/reject failure messages) show generic text instead of the actual failure reason. Inherited from `ModerationModel`'s identical pre-existing pattern; a `LocalizedError` conformance in `AnglesiteCore` would fix both.