### PR TITLE
feat(#966): known contacts as a first-class concept

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.swift == 'true'
     runs-on: macos-26
-    timeout-minutes: 15
+    # Bumped from 15: the debug build + full test suite + release build now routinely runs
+    # 13-14m on its own, leaving no margin for the post-job SwiftPM cache save — several PRs
+    # (including an unrelated one on the same day as #966) hit "exceeded the maximum execution
+    # time of 15m0s" mid cache-save even though every actual build/test step had already
+    # succeeded. 20m restores headroom without masking a genuine hang.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/Resources/Anglesite-Debug.entitlements
+++ b/Resources/Anglesite-Debug.entitlements
@@ -14,6 +14,12 @@
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
 
+	<!-- Contacts.framework read-only matching (#966): suggests linking a system contact to a
+	     known identity URL. Unlike the iCloud/webcredentials entitlements this file
+	     deliberately omits, this needs no special Developer Portal provisioning. -->
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+
 	<!-- Apple Containerization framework (#69): boot local OCI containers. -->
 	<key>com.apple.security.virtualization</key>
 	<true/>

--- a/Resources/Anglesite.entitlements
+++ b/Resources/Anglesite.entitlements
@@ -14,6 +14,13 @@
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
 
+	<!-- Contacts.framework read-only matching (#966): suggests linking a system contact to a
+	     known identity URL. Unlike the iCloud/webcredentials entitlements below, this needs no
+	     special Developer Portal provisioning, so it's safe in both the Release and CI-safe
+	     Debug entitlements files. -->
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+
 	<!-- Apple Containerization framework (#69): boot local OCI containers. -->
 	<key>com.apple.security.virtualization</key>
 	<true/>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -36,6 +36,8 @@
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Anglesite needs to coordinate with helper processes (Astro dev server, MCP server) to preview and edit your site.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Anglesite can check your Contacts to suggest names for people you follow, so your contact list uses names you recognize.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>io.dwk.anglesite.site-window</string>

--- a/Sources/AnglesiteApp/ContactsModel.swift
+++ b/Sources/AnglesiteApp/ContactsModel.swift
@@ -26,6 +26,10 @@ final class ContactsModel {
     private(set) var suggestions: [MatchSuggestion] = []
     private(set) var isScanning = false
     private(set) var scanFailure: ScanFailure?
+    /// Set when `add`/`update`/`remove`'s underlying `ContactStore` write throws (disk-full,
+    /// `Config/` permission errors) — design doc §3 calls these out as direct user actions that
+    /// expect feedback, unlike a background scan failure. Cleared on the next successful write.
+    private(set) var writeFailure: String?
 
     private var store: ContactStore?
     /// Session-scoped, like `FollowersModel.unreachableActors`: a dismissed suggestion can
@@ -40,8 +44,21 @@ final class ContactsModel {
     /// Records which site this pane reads. Called once per site open, like
     /// `FollowersModel.configure(site:)`. Does not load — `ContactsView`'s `.task` triggers
     /// ``reload()`` the same way `FollowersView`'s `.task` triggers `FollowersModel.load()`.
+    ///
+    /// Also resets every piece of per-site state: `ContactsModel` instances are reused across a
+    /// site-window replay (`SiteWindowModel`'s cold-open path calls `contacts.configure(site:)`
+    /// unconditionally), and without this reset the previous site's contacts/suggestions would
+    /// stay visible — briefly showing one site's private contact list under another site's
+    /// window — until `reload()` completed. Resetting `loadState` to `.idle` is sufficient to
+    /// trigger a fresh load: `ContactsView`'s `.task` only calls `reload()` when idle.
     func configure(site: CurrentSite) {
         store = ContactStore(configDirectory: site.configDirectory)
+        contacts = []
+        loadState = .idle
+        suggestions = []
+        scanFailure = nil
+        writeFailure = nil
+        dismissedSuggestionKeys = []
     }
 
     func reload() async {
@@ -55,22 +72,40 @@ final class ContactsModel {
         }
     }
 
-    func add(me: URL, displayName: String) async {
+    /// `linkedActor` records the ActivityPub actor IRI when `me` came from a follower promotion
+    /// (see `accept(_:)`'s `.promoteToContact` case) — `nil` for a manually-added contact, which
+    /// is why the "Add Contact…" sheet's call site relies on this parameter's default.
+    func add(me: URL, displayName: String, linkedActor: URL? = nil) async {
         guard let store else { return }
-        let contact = Contact(me: me, displayName: displayName)
-        try? await store.add(contact)
+        let contact = Contact(me: me, displayName: displayName, linkedActor: linkedActor)
+        do {
+            try await store.add(contact)
+            writeFailure = nil
+        } catch {
+            writeFailure = "\(error)"
+        }
         await reload()
     }
 
     func update(_ contact: Contact) async {
         guard let store else { return }
-        try? await store.update(contact)
+        do {
+            try await store.update(contact)
+            writeFailure = nil
+        } catch {
+            writeFailure = "\(error)"
+        }
         await reload()
     }
 
     func remove(_ contact: Contact) async {
         guard let store else { return }
-        try? await store.remove(id: contact.id)
+        do {
+            try await store.remove(id: contact.id)
+            writeFailure = nil
+        } catch {
+            writeFailure = "\(error)"
+        }
         await reload()
     }
 
@@ -108,7 +143,13 @@ final class ContactsModel {
             updated.displayName = suggestion.systemContactName
             await update(updated)
         case .promoteToContact:
-            await add(me: suggestion.candidateURL, displayName: suggestion.systemContactName)
+            // The candidate URL IS the follower's actor IRI on this path (promotion candidates
+            // come from `SiteWindowModel.candidateFollowerURLsForContactsMatching()`, which maps
+            // `FollowersModel.rows.map(\.actor)`), so it doubles as both the best-available `me`
+            // identity and the recorded `linkedActor`.
+            await add(
+                me: suggestion.candidateURL, displayName: suggestion.systemContactName,
+                linkedActor: suggestion.candidateURL)
         }
         dismiss(suggestion)
     }

--- a/Sources/AnglesiteApp/ContactsModel.swift
+++ b/Sources/AnglesiteApp/ContactsModel.swift
@@ -43,7 +43,7 @@ final class ContactsModel {
 
     /// Records which site this pane reads. Called once per site open, like
     /// `FollowersModel.configure(site:)`. Does not load — `ContactsView`'s `.task` triggers
-    /// ``reload()`` the same way `FollowersView`'s `.task` triggers `FollowersModel.load()`.
+    /// `reload()` the same way `FollowersView`'s `.task` triggers `FollowersModel.load()`.
     ///
     /// Also resets every piece of per-site state: `ContactsModel` instances are reused across a
     /// site-window replay (`SiteWindowModel`'s cold-open path calls `contacts.configure(site:)`

--- a/Sources/AnglesiteApp/ContactsModel.swift
+++ b/Sources/AnglesiteApp/ContactsModel.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Contacts pane (Website ▸ Contacts…, #966): a per-site, private list of known
+/// people, plus an opt-in Contacts.framework matching scan. App glue only — persistence and
+/// matching logic live in `AnglesiteCore`.
+@MainActor
+@Observable
+final class ContactsModel {
+    enum LoadState: Equatable {
+        case idle
+        case loaded
+        /// `ContactStore.load()` threw — the file exists but didn't decode. Surfaced rather than
+        /// silently showing an empty list (see `ContactStore`'s doc comment for why).
+        case corruptFile
+    }
+
+    enum ScanFailure: Equatable {
+        case permissionDenied
+        case other(String)
+    }
+
+    private(set) var contacts: [Contact] = []
+    private(set) var loadState: LoadState = .idle
+    private(set) var suggestions: [MatchSuggestion] = []
+    private(set) var isScanning = false
+    private(set) var scanFailure: ScanFailure?
+
+    private var store: ContactStore?
+    /// Session-scoped, like `FollowersModel.unreachableActors`: a dismissed suggestion can
+    /// resurface on a later scan, which is fine since scans are always owner-initiated.
+    private var dismissedSuggestionKeys: Set<String> = []
+    private let contactsProvider: ContactsProviding
+
+    init(contactsProvider: ContactsProviding = SystemContactsProvider()) {
+        self.contactsProvider = contactsProvider
+    }
+
+    /// Records which site this pane reads. Called once per site open, like
+    /// `FollowersModel.configure(site:)`. Does not load — `ContactsView`'s `.task` triggers
+    /// ``reload()`` the same way `FollowersView`'s `.task` triggers `FollowersModel.load()`.
+    func configure(site: CurrentSite) {
+        store = ContactStore(configDirectory: site.configDirectory)
+    }
+
+    func reload() async {
+        guard let store else { return }
+        do {
+            contacts = try await store.load()
+            loadState = .loaded
+        } catch {
+            contacts = []
+            loadState = .corruptFile
+        }
+    }
+
+    func add(me: URL, displayName: String) async {
+        guard let store else { return }
+        let contact = Contact(me: me, displayName: displayName)
+        try? await store.add(contact)
+        await reload()
+    }
+
+    func update(_ contact: Contact) async {
+        guard let store else { return }
+        try? await store.update(contact)
+        await reload()
+    }
+
+    func remove(_ contact: Contact) async {
+        guard let store else { return }
+        try? await store.remove(id: contact.id)
+        await reload()
+    }
+
+    /// Runs one on-demand Contacts.framework scan (Website ▸ Contacts… ▸ "Find in Contacts…").
+    /// `candidateFollowerURLs` are the not-yet-added follower actor IRIs to check for the
+    /// promote-to-contact direction — the caller (`SiteWindowModel`) is responsible for making
+    /// sure Followers has loaded before supplying them.
+    func scanForMatches(candidateFollowerURLs: [URL]) async {
+        isScanning = true
+        scanFailure = nil
+        defer { isScanning = false }
+        do {
+            let matchable = try await contactsProvider.matchableContacts()
+            let fresh = ContactsMatcher.suggestions(
+                matchableContacts: matchable,
+                existingContacts: contacts,
+                candidateFollowerURLs: candidateFollowerURLs)
+            suggestions = fresh.filter { !dismissedSuggestionKeys.contains(suggestionKey($0)) }
+        } catch ContactsAccessError.denied {
+            scanFailure = .permissionDenied
+        } catch {
+            scanFailure = .other("\(error)")
+        }
+    }
+
+    func dismiss(_ suggestion: MatchSuggestion) {
+        dismissedSuggestionKeys.insert(suggestionKey(suggestion))
+        suggestions.removeAll { suggestionKey($0) == suggestionKey(suggestion) }
+    }
+
+    func accept(_ suggestion: MatchSuggestion) async {
+        switch suggestion.kind {
+        case .enrichExisting(let contact):
+            var updated = contact
+            updated.displayName = suggestion.systemContactName
+            await update(updated)
+        case .promoteToContact:
+            await add(me: suggestion.candidateURL, displayName: suggestion.systemContactName)
+        }
+        dismiss(suggestion)
+    }
+
+    private func suggestionKey(_ suggestion: MatchSuggestion) -> String {
+        "\(suggestion.candidateURL.absoluteString)|\(suggestion.systemContactName)"
+    }
+}

--- a/Sources/AnglesiteApp/ContactsView.swift
+++ b/Sources/AnglesiteApp/ContactsView.swift
@@ -238,20 +238,26 @@ private struct ContactEditSheet: View {
         switch ContactEditValidation.validate(displayName: displayName, meText: meText) {
         case .failure(let message):
             validationError = message
-        case .success(let validated):
+        case .success(let url, let validatedDisplayName):
             Task {
-                await onSave(validated.url, validated.displayName)
+                await onSave(url, validatedDisplayName)
                 dismiss()
             }
         }
     }
 }
 
-/// `Result`'s `Failure` generic parameter requires `Error` conformance, but
-/// `ContactEditValidation.validate(displayName:meText:)` returns its failure message as a plain
-/// `String` (it's UI text for `ContactEditSheet`, never thrown) — this narrow, file-local
-/// conformance is what makes `Result<_, String>` compile.
-extension String: Error {}
+/// Result of `ContactEditValidation.validate(displayName:meText:)`. A dedicated type rather than
+/// `Result<_, String>` — `Result`'s `Failure` generic parameter requires `Error` conformance, and
+/// the validation failure message is plain UI text (never thrown), so reusing `Result` would
+/// require conforming `String` to `Error` module-wide, which is a footgun far outside this file's
+/// scope (silently accepting bare strings at any `catch`/`throw`/`<E: Error>` call site).
+enum ContactEditValidationResult: Equatable {
+    /// The trimmed name and parsed URL, ready to hand to `onSave`.
+    case success(url: URL, displayName: String)
+    /// The message `ContactEditSheet` shows under the fields.
+    case failure(String)
+}
 
 /// Pure validation for `ContactEditSheet`'s Save action, pulled out of the view so it can be
 /// unit-tested directly — see this task's test strategy note above. Not `private`, for the same
@@ -261,7 +267,7 @@ enum ContactEditValidation {
     /// carries the message `ContactEditSheet` shows under the fields.
     static func validate(
         displayName: String, meText: String
-    ) -> Result<(url: URL, displayName: String), String> {
+    ) -> ContactEditValidationResult {
         let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else {
             return .failure("Enter a name.")
@@ -272,6 +278,6 @@ enum ContactEditValidation {
         else {
             return .failure("Enter a valid http(s) website address.")
         }
-        return .success((url, trimmedName))
+        return .success(url: url, displayName: trimmedName)
     }
 }

--- a/Sources/AnglesiteApp/ContactsView.swift
+++ b/Sources/AnglesiteApp/ContactsView.swift
@@ -49,7 +49,7 @@ struct ContactsView: View {
     private var loadedContent: some View {
         VStack(spacing: 0) {
             HStack {
-                Text("\(contacts.contacts.count) contacts").font(.headline)
+                Text("^[\(contacts.contacts.count) contact](inflect: true)").font(.headline)
                 Spacer()
                 Button("Find in Contacts…") {
                     Task {
@@ -64,6 +64,10 @@ struct ContactsView: View {
 
             if let failure = contacts.scanFailure {
                 scanFailureBanner(failure)
+            }
+
+            if let writeFailure = contacts.writeFailure {
+                writeFailureBanner(writeFailure)
             }
 
             if !contacts.suggestions.isEmpty {
@@ -103,8 +107,8 @@ struct ContactsView: View {
             switch suggestion.kind {
             case .enrichExisting:
                 Text(
-                    "Use “\(suggestion.systemContactName)” from Contacts for "
-                        + "\(suggestion.candidateURL.host ?? suggestion.candidateURL.absoluteString)?")
+                    "Use “\(suggestion.systemContactName)” from Contacts for \(suggestion.candidateURL.host ?? suggestion.candidateURL.absoluteString)?"
+                )
             case .promoteToContact:
                 Text("“\(suggestion.systemContactName)” matches a follower — add as a contact?")
             }
@@ -137,13 +141,25 @@ struct ContactsView: View {
         .padding(.bottom, 8)
     }
 
+    /// Surfaces `ContactsModel.writeFailure` (design doc §3: add/update/remove "throw normally
+    /// ... since these are direct user actions expecting feedback") — mirrors
+    /// `scanFailureBanner(_:)`'s `.other` case shape.
+    @ViewBuilder
+    private func writeFailureBanner(_ reason: String) -> some View {
+        HStack {
+            Text("Couldn't save your change").foregroundStyle(.secondary)
+            Text(reason).font(.caption).foregroundStyle(.secondary)
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 8)
+    }
+
     @ViewBuilder
     private var emptyState: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("No contacts yet").font(.title2)
             Text(
-                "Add people you know by their website address, or scan Contacts to find people "
-                    + "you already follow."
+                "Add people you know by their website address, or scan Contacts to find people you already follow."
             )
             .foregroundStyle(.secondary)
         }
@@ -156,8 +172,7 @@ struct ContactsView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Couldn't read your contacts").font(.title2)
             Text(
-                "The contacts file may be damaged. Back it up, then remove Config/contacts.json "
-                    + "to start fresh."
+                "The contacts file may be damaged. Back it up, then remove Config/contacts.json to start fresh."
             )
             .foregroundStyle(.secondary)
         }

--- a/Sources/AnglesiteApp/ContactsView.swift
+++ b/Sources/AnglesiteApp/ContactsView.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+import AppKit
+import AnglesiteCore
+
+/// Main-pane Contacts surface (Website ▸ Contacts…, #966): the site's private list of known
+/// people, with an opt-in "Find in Contacts…" scan. Mirrors `FollowersView`'s wiring shape.
+struct ContactsView: View {
+    @Bindable var contacts: ContactsModel
+    /// Not-yet-added follower actor IRIs to check during a scan. Async because the caller
+    /// (`SiteWindowModel`) may need to load Followers first — see
+    /// `SiteWindowModel.candidateFollowerURLsForContactsMatching()`.
+    let candidateFollowerURLs: () async -> [URL]
+
+    @State private var isPresentingAddSheet = false
+    @State private var editingContact: Contact?
+
+    var body: some View {
+        Group {
+            switch contacts.loadState {
+            case .idle:
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .corruptFile:
+                corruptFileMessage
+            case .loaded:
+                loadedContent
+            }
+        }
+        .navigationSubtitle("Contacts")
+        .task { if contacts.loadState == .idle { await contacts.reload() } }
+        .sheet(isPresented: $isPresentingAddSheet) {
+            ContactEditSheet(title: "Add Contact", meText: "", displayName: "") { me, displayName in
+                await contacts.add(me: me, displayName: displayName)
+            }
+        }
+        .sheet(item: $editingContact) { contact in
+            ContactEditSheet(
+                title: "Edit Contact", meText: contact.me.absoluteString,
+                displayName: contact.displayName
+            ) { me, displayName in
+                var updated = contact
+                updated.me = me
+                updated.displayName = displayName
+                await contacts.update(updated)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var loadedContent: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("\(contacts.contacts.count) contacts").font(.headline)
+                Spacer()
+                Button("Find in Contacts…") {
+                    Task {
+                        let candidates = await candidateFollowerURLs()
+                        await contacts.scanForMatches(candidateFollowerURLs: candidates)
+                    }
+                }
+                .disabled(contacts.isScanning)
+                Button("Add Contact…") { isPresentingAddSheet = true }
+            }
+            .padding()
+
+            if let failure = contacts.scanFailure {
+                scanFailureBanner(failure)
+            }
+
+            if !contacts.suggestions.isEmpty {
+                suggestionsSection
+            }
+
+            if contacts.contacts.isEmpty {
+                emptyState
+            } else {
+                List {
+                    ForEach(contacts.contacts) { contact in
+                        contactRow(contact)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var suggestionsSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Suggestions").font(.subheadline).foregroundStyle(.secondary)
+            ForEach(contacts.suggestions, id: \.candidateURL) { suggestion in
+                suggestionRow(suggestion)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private func suggestionRow(_ suggestion: MatchSuggestion) -> some View {
+        HStack {
+            // `systemContactName` is Contacts-framework-supplied, and `candidateURL` is a
+            // follower/contact-supplied identity — both rendered verbatim via string
+            // interpolation into a plain `Text`, never as a localization key.
+            switch suggestion.kind {
+            case .enrichExisting:
+                Text(
+                    "Use “\(suggestion.systemContactName)” from Contacts for "
+                        + "\(suggestion.candidateURL.host ?? suggestion.candidateURL.absoluteString)?")
+            case .promoteToContact:
+                Text("“\(suggestion.systemContactName)” matches a follower — add as a contact?")
+            }
+            Spacer()
+            Button("Add") { Task { await contacts.accept(suggestion) } }
+            Button("Dismiss") { contacts.dismiss(suggestion) }
+        }
+    }
+
+    @ViewBuilder
+    private func scanFailureBanner(_ failure: ContactsModel.ScanFailure) -> some View {
+        HStack {
+            switch failure {
+            case .permissionDenied:
+                Text("Contacts access wasn't granted.")
+                Button("Open System Settings") {
+                    if let url = URL(
+                        string:
+                            "x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts"
+                    ) {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+            case .other(let reason):
+                Text("Couldn't scan Contacts").foregroundStyle(.secondary)
+                Text(reason).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("No contacts yet").font(.title2)
+            Text(
+                "Add people you know by their website address, or scan Contacts to find people "
+                    + "you already follow."
+            )
+            .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private var corruptFileMessage: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Couldn't read your contacts").font(.title2)
+            Text(
+                "The contacts file may be damaged. Back it up, then remove Config/contacts.json "
+                    + "to start fresh."
+            )
+            .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private func contactRow(_ contact: Contact) -> some View {
+        HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(contact.displayName).font(.headline)
+                Text(contact.me.absoluteString).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            linkageBadges(for: contact)
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+        .onTapGesture { editingContact = contact }
+        .contextMenu {
+            Button("Edit…") { editingContact = contact }
+            Button("Delete", role: .destructive) { Task { await contacts.remove(contact) } }
+        }
+    }
+
+    /// Small icon badges showing which identities this contact is linked to (design doc §4).
+    /// Purely informational — editing the linkage itself is out of scope (design doc §9).
+    @ViewBuilder
+    private func linkageBadges(for contact: Contact) -> some View {
+        HStack(spacing: 4) {
+            if contact.linkedActor != nil {
+                Image(systemName: "person.2.fill")
+                    .foregroundStyle(.secondary)
+                    .help("Linked to a Fediverse follower")
+            }
+            if contact.linkedFeed != nil {
+                Image(systemName: "dot.radiowaves.up.forward")
+                    .foregroundStyle(.secondary)
+                    .help("Linked to a followed feed")
+            }
+        }
+        .font(.caption)
+    }
+}
+
+/// Add/edit sheet shared by both flows in `ContactsView` — `title` and the initial field values
+/// are the only difference between "Add Contact" and "Edit Contact".
+private struct ContactEditSheet: View {
+    let title: String
+    @State var meText: String
+    @State var displayName: String
+    let onSave: (URL, String) async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var validationError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title).font(.headline)
+            TextField("Name", text: $displayName)
+            TextField("Website (e.g. https://example.com)", text: $meText)
+            if let validationError {
+                Text(validationError).font(.caption).foregroundStyle(.red)
+            }
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding()
+        .frame(width: 360)
+    }
+
+    private func save() {
+        switch ContactEditValidation.validate(displayName: displayName, meText: meText) {
+        case .failure(let message):
+            validationError = message
+        case .success(let validated):
+            Task {
+                await onSave(validated.url, validated.displayName)
+                dismiss()
+            }
+        }
+    }
+}
+
+/// `Result`'s `Failure` generic parameter requires `Error` conformance, but
+/// `ContactEditValidation.validate(displayName:meText:)` returns its failure message as a plain
+/// `String` (it's UI text for `ContactEditSheet`, never thrown) — this narrow, file-local
+/// conformance is what makes `Result<_, String>` compile.
+extension String: Error {}
+
+/// Pure validation for `ContactEditSheet`'s Save action, pulled out of the view so it can be
+/// unit-tested directly — see this task's test strategy note above. Not `private`, for the same
+/// testability reason `FollowerAvatar.dimensionsWithinBound(_:)` isn't.
+enum ContactEditValidation {
+    /// `.success` carries the trimmed name and parsed URL ready to hand to `onSave`; `.failure`
+    /// carries the message `ContactEditSheet` shows under the fields.
+    static func validate(
+        displayName: String, meText: String
+    ) -> Result<(url: URL, displayName: String), String> {
+        let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            return .failure("Enter a name.")
+        }
+        let trimmedURLText = meText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmedURLText),
+            url.scheme == "http" || url.scheme == "https"
+        else {
+            return .failure("Enter a valid http(s) website address.")
+        }
+        return .success((url, trimmedName))
+    }
+}

--- a/Sources/AnglesiteApp/InfoPlist.xcstrings
+++ b/Sources/AnglesiteApp/InfoPlist.xcstrings
@@ -40,6 +40,18 @@
         }
       }
     },
+    "NSContactsUsageDescription" : {
+      "comment" : "Privacy - Contacts Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Anglesite can check your Contacts to suggest names for people you follow, so your contact list uses names you recognize."
+          }
+        }
+      }
+    },
     "NSHumanReadableCopyright" : {
       "comment" : "Copyright (human-readable)",
       "extractionState" : "extracted_with_value",

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1165,19 +1165,22 @@
     "Website (e.g. https://example.com)" : {
 
     },
-    "%lld contacts" : {
+    "^[%lld contact](inflect: true)" : {
 
     },
-    "Use “%@” from Contacts for " : {
+    "Use “%@” from Contacts for %@?" : {
 
     },
     "“%@” matches a follower — add as a contact?" : {
 
     },
-    "Add people you know by their website address, or scan Contacts to find people " : {
+    "Add people you know by their website address, or scan Contacts to find people you already follow." : {
 
     },
-    "The contacts file may be damaged. Back it up, then remove Config/contacts.json " : {
+    "The contacts file may be damaged. Back it up, then remove Config/contacts.json to start fresh." : {
+
+    },
+    "Couldn't save your change" : {
 
     },
     "Contains slot-fill content — double-click to edit %@" : {

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1129,6 +1129,57 @@
     "Contacts" : {
 
     },
+    "Contacts…" : {
+
+    },
+    "Contacts access wasn't granted." : {
+
+    },
+    "Couldn't read your contacts" : {
+
+    },
+    "Couldn't scan Contacts" : {
+
+    },
+    "Find in Contacts…" : {
+
+    },
+    "Add Contact" : {
+
+    },
+    "Add Contact…" : {
+
+    },
+    "Edit Contact" : {
+
+    },
+    "No contacts yet" : {
+
+    },
+    "Open System Settings" : {
+
+    },
+    "Suggestions" : {
+
+    },
+    "Website (e.g. https://example.com)" : {
+
+    },
+    "%lld contacts" : {
+
+    },
+    "Use “%@” from Contacts for " : {
+
+    },
+    "“%@” matches a follower — add as a contact?" : {
+
+    },
+    "Add people you know by their website address, or scan Contacts to find people " : {
+
+    },
+    "The contacts file may be damaged. Back it up, then remove Config/contacts.json " : {
+
+    },
     "Contains slot-fill content — double-click to edit %@" : {
 
     },

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -1135,6 +1135,11 @@ struct SiteWindow: View {
             CommunitiesView(communities: model.communities)
         case .moderation:
             ModerationView(moderation: model.moderation)
+        case .contacts:
+            ContactsView(
+                contacts: model.contacts,
+                candidateFollowerURLs: { await model.candidateFollowerURLsForContactsMatching() }
+            )
         case .preview:
             previewPane(for: site)
         }

--- a/Sources/AnglesiteApp/SiteWindowModel.swift
+++ b/Sources/AnglesiteApp/SiteWindowModel.swift
@@ -17,6 +17,7 @@ enum MainPaneMode: Equatable {
     case followers      // Website ▸ Followers… (V-4.2, #364)
     case communities    // Website ▸ Communities… (V-5.1a, #368)
     case moderation     // Website ▸ Moderation… (V-5.1b/V-5.3, #907/#370)
+    case contacts       // Website ▸ Contacts… (#966)
 }
 
 enum ActiveEditor {
@@ -171,6 +172,9 @@ final class SiteWindowModel {
     /// Drives the main-pane Moderation view (Website ▸ Moderation…, V-5.1b/V-5.3 #907/#370):
     /// moderator display, and ban/remove actions over this site's members and posts.
     var moderation = ModerationModel()
+    /// Drives the main-pane Contacts view (Website ▸ Contacts…, #966): the site's private list
+    /// of known people, plus an opt-in Contacts.framework matching scan.
+    var contacts = ContactsModel()
     /// Cached `SiteSettings.communityActorURL != nil`, refreshed once per site open in
     /// `loadAndStart()` — the gate for Website ▸ Moderation… (#907/#370). A cached `Bool`
     /// rather than a live synchronous read: `SiteConfigStore.read(from:fileManager:)` is
@@ -496,6 +500,26 @@ final class SiteWindowModel {
             await moderation.reload()
             await clearInspectorThenSwitchPane(to: .moderation)
         }
+    }
+
+    /// Switches the main pane to Contacts (Website ▸ Contacts…, #966). Mirrors
+    /// `presentModeration()`'s leave-current-surface-first guard.
+    func presentContacts() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            await clearInspectorThenSwitchPane(to: .contacts)
+        }
+    }
+
+    /// Ensures the Followers collection is loaded before a Contacts.framework matching scan
+    /// runs, so a promotion suggestion doesn't come up empty just because the owner never opened
+    /// Followers… this session (#966 design doc §5).
+    func candidateFollowerURLsForContactsMatching() async -> [URL] {
+        if followers.state == .idle {
+            await followers.load()
+        }
+        return followers.rows.map(\.actor)
     }
 
     /// Clears the inspector and swaps the main pane, giving the inspector's own
@@ -2356,6 +2380,7 @@ final class SiteWindowModel {
         followers.configure(site: currentSite)
         communities.configure(site: currentSite)
         await moderation.configure(site: currentSite)
+        contacts.configure(site: currentSite)
         domain.configure(site: currentSite)
         connectDomain.configure(site: currentSite)
         buyDomain.configure(site: currentSite)

--- a/Sources/AnglesiteApp/WebsiteCommands.swift
+++ b/Sources/AnglesiteApp/WebsiteCommands.swift
@@ -62,6 +62,9 @@ struct WebsiteCommands: Commands {
             Button("Followers…") { model?.presentFollowers() }
                 .disabled(model == nil)
 
+            Button("Contacts…") { model?.presentContacts() }
+                .disabled(model == nil)
+
             Button("Communities…") { model?.presentCommunities() }
                 .disabled(model == nil)
 

--- a/Sources/AnglesiteCore/Contact.swift
+++ b/Sources/AnglesiteCore/Contact.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// A person the site owner knows, stored privately per site (#966). Distinct from the public
+/// `member` content type (`ContentTypeRegistry.swift`) — this is never published.
+public struct Contact: Codable, Equatable, Sendable, Identifiable {
+    /// Stable identity for SwiftUI list diffing and lookup. Not one of the issue's three literal
+    /// fields (`me`, `displayName`, `addedDate`) — needed because `me` itself is editable, so it
+    /// can't double as a stable key the way `FollowerRow.id` uses `actor.absoluteString`.
+    public let id: UUID
+    /// The person's canonical identity URL — their own website, in the IndieAuth `me` sense.
+    public var me: URL
+    public var displayName: String
+    public let addedDate: Date
+    /// The ActivityPub actor IRI, set when this contact was promoted from a follower.
+    public var linkedActor: URL?
+    /// A followed Microsub feed URL. No promotion flow populates this yet (`MicrosubClient` has
+    /// no "list followed feeds" endpoint) — settable only via manual edit until one exists.
+    public var linkedFeed: URL?
+
+    public init(
+        id: UUID = UUID(),
+        me: URL,
+        displayName: String,
+        addedDate: Date = Date(),
+        linkedActor: URL? = nil,
+        linkedFeed: URL? = nil
+    ) {
+        self.id = id
+        self.me = me
+        self.displayName = displayName
+        self.addedDate = addedDate
+        self.linkedActor = linkedActor
+        self.linkedFeed = linkedFeed
+    }
+}
+
+/// Normalizes a URL for identity comparison: lowercased host, scheme dropped, trailing slash
+/// trimmed. Contacts enter `me` and social/website URLs by hand, so two URLs that only differ by
+/// http/https or a trailing slash must still compare equal. Shared by `ContactStore` (identity
+/// dedup) and `ContactsMatcher` (Task 2, matching against system Contacts).
+func normalizedIdentityKey(for url: URL) -> String {
+    let host = (url.host ?? "").lowercased()
+    var path = url.path
+    if path.hasSuffix("/") {
+        path.removeLast()
+    }
+    return host + path
+}

--- a/Sources/AnglesiteCore/ContactStore.swift
+++ b/Sources/AnglesiteCore/ContactStore.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Per-site contact store persisted to `<configDirectory>/contacts.json` (#966) — app-owned
+/// state that must never enter the site's git repo, alongside `chat-history.jsonl` and
+/// `ActorProfileCache`'s file. A full-file JSON envelope (like `ActorProfileCache`), not
+/// append-only JSONL (like `ChatHistoryStore`): contacts are edited and deleted, not just
+/// appended.
+public actor ContactStore {
+    public static let filename = "contacts.json"
+
+    private struct Envelope: Codable { let contacts: [Contact] }
+
+    public let fileURL: URL
+    private let fileManager: FileManager
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(configDirectory: URL, fileManager: FileManager = .default) {
+        self.fileURL = configDirectory.appendingPathComponent(Self.filename)
+        self.fileManager = fileManager
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        self.encoder = encoder
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    /// A missing file is the normal first-run state (`[]`, no error). A file that exists but
+    /// fails to decode throws instead of discarding silently: unlike `ActorProfileCache` (a
+    /// disposable, re-fetchable cache), a contact list is owner-curated data, and silently
+    /// showing zero contacts risks the owner believing the list was lost and re-entering it.
+    public func load() throws -> [Contact] {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return [] }
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else { return [] }
+        let envelope = try decoder.decode(Envelope.self, from: data)
+        return envelope.contacts.sorted {
+            $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    /// Adds a contact, replacing any existing entry with the same `me` identity (comparing via
+    /// ``normalizedIdentityKey(for:)``, so `https://x.example` and `https://x.example/` collide).
+    public func add(_ contact: Contact) throws {
+        var contacts = try load()
+        contacts.removeAll {
+            normalizedIdentityKey(for: $0.me) == normalizedIdentityKey(for: contact.me)
+        }
+        contacts.append(contact)
+        try write(contacts)
+    }
+
+    /// Replaces the contact matching `contact.id`, wherever its `me` moved to — this is the
+    /// rekey path for editing an existing entry's URL.
+    public func update(_ contact: Contact) throws {
+        var contacts = try load()
+        contacts.removeAll { $0.id == contact.id }
+        contacts.append(contact)
+        try write(contacts)
+    }
+
+    public func remove(id: UUID) throws {
+        var contacts = try load()
+        contacts.removeAll { $0.id == id }
+        try write(contacts)
+    }
+
+    /// Forward-looking hook for #963's authenticated-read allowlist — not called from anywhere
+    /// in this feature, but the store is the source of truth #963 will read from.
+    public func knownMeURLs() throws -> Set<String> {
+        Set(try load().map { normalizedIdentityKey(for: $0.me) })
+    }
+
+    private func write(_ contacts: [Contact]) throws {
+        let parent = fileURL.deletingLastPathComponent()
+        if !fileManager.fileExists(atPath: parent.path) {
+            try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        }
+        let data = try encoder.encode(Envelope(contacts: contacts))
+        try data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Sources/AnglesiteCore/ContactStore.swift
+++ b/Sources/AnglesiteCore/ContactStore.swift
@@ -42,7 +42,7 @@ public actor ContactStore {
     }
 
     /// Adds a contact, replacing any existing entry with the same `me` identity (comparing via
-    /// ``normalizedIdentityKey(for:)``, so `https://x.example` and `https://x.example/` collide).
+    /// `normalizedIdentityKey(for:)`, so `https://x.example` and `https://x.example/` collide).
     public func add(_ contact: Contact) throws {
         var contacts = try load()
         contacts.removeAll {

--- a/Sources/AnglesiteCore/ContactsMatcher.swift
+++ b/Sources/AnglesiteCore/ContactsMatcher.swift
@@ -60,8 +60,16 @@ public enum ContactsMatcher {
         }
 
         let existingKeys = Set(existingContacts.map { normalizedIdentityKey(for: $0.me) })
+        // `candidateFollowerURLs` can contain duplicates (a plausible shape from
+        // `FollowersModel`'s paged, non-deduped remote data) — track keys already processed in
+        // this loop so a repeated URL doesn't produce two identical `MatchSuggestion`s, which
+        // `ContactsView`'s `ForEach(..., id: \.candidateURL)` would then render with duplicate
+        // SwiftUI IDs.
+        var seenKeys: Set<String> = []
         for followerURL in candidateFollowerURLs {
-            guard !existingKeys.contains(normalizedIdentityKey(for: followerURL)) else { continue }
+            let key = normalizedIdentityKey(for: followerURL)
+            guard !existingKeys.contains(key) else { continue }
+            guard seenKeys.insert(key).inserted else { continue }
             guard let match = firstMatch(for: followerURL, in: matchableContacts) else { continue }
             suggestions.append(
                 MatchSuggestion(

--- a/Sources/AnglesiteCore/ContactsMatcher.swift
+++ b/Sources/AnglesiteCore/ContactsMatcher.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// One system Contact's matchable identity signals — its display name plus every URL it carries
+/// (website fields and social-profile URLs), already extracted from `CNContact` by whichever
+/// `ContactsProviding` implementation supplied it (Task 3). Kept independent of
+/// `Contacts.framework` types so this file, and its matching logic, stay portable and
+/// unit-testable without `CNContactStore`.
+public struct MatchableContact: Sendable, Equatable {
+    public let displayName: String
+    public let urlAddresses: [URL]
+    public let socialProfileURLs: [URL]
+
+    public init(displayName: String, urlAddresses: [URL], socialProfileURLs: [URL]) {
+        self.displayName = displayName
+        self.urlAddresses = urlAddresses
+        self.socialProfileURLs = socialProfileURLs
+    }
+}
+
+/// One suggested link between a system Contact and a known identity URL, surfaced in the
+/// Contacts pane's "Find in Contacts…" scan (#966).
+public struct MatchSuggestion: Sendable, Equatable {
+    public let candidateURL: URL
+    public let systemContactName: String
+    public let kind: Kind
+
+    public enum Kind: Sendable, Equatable {
+        /// A manually-added contact's `me` URL matches a system contact whose name differs —
+        /// offer to adopt the system contact's name.
+        case enrichExisting(Contact)
+        /// A not-yet-added follower's actor URL matches a system contact — offer to add them.
+        case promoteToContact
+    }
+
+    public init(candidateURL: URL, systemContactName: String, kind: Kind) {
+        self.candidateURL = candidateURL
+        self.systemContactName = systemContactName
+        self.kind = kind
+    }
+}
+
+/// Pure matching logic (design doc §5) — no I/O, no `Contacts` import, so it runs the same in CI
+/// as it does live: given a batch of system contacts and the app's own known identities, produce
+/// suggestions in both directions.
+public enum ContactsMatcher {
+    public static func suggestions(
+        matchableContacts: [MatchableContact],
+        existingContacts: [Contact],
+        candidateFollowerURLs: [URL]
+    ) -> [MatchSuggestion] {
+        var suggestions: [MatchSuggestion] = []
+
+        for contact in existingContacts {
+            guard let match = firstMatch(for: contact.me, in: matchableContacts) else { continue }
+            guard match.displayName != contact.displayName else { continue }
+            suggestions.append(
+                MatchSuggestion(
+                    candidateURL: contact.me, systemContactName: match.displayName,
+                    kind: .enrichExisting(contact)))
+        }
+
+        let existingKeys = Set(existingContacts.map { normalizedIdentityKey(for: $0.me) })
+        for followerURL in candidateFollowerURLs {
+            guard !existingKeys.contains(normalizedIdentityKey(for: followerURL)) else { continue }
+            guard let match = firstMatch(for: followerURL, in: matchableContacts) else { continue }
+            suggestions.append(
+                MatchSuggestion(
+                    candidateURL: followerURL, systemContactName: match.displayName,
+                    kind: .promoteToContact))
+        }
+
+        return suggestions
+    }
+
+    private static func firstMatch(
+        for url: URL, in matchableContacts: [MatchableContact]
+    ) -> MatchableContact? {
+        let key = normalizedIdentityKey(for: url)
+        return matchableContacts.first {
+            ($0.urlAddresses + $0.socialProfileURLs).contains {
+                normalizedIdentityKey(for: $0) == key
+            }
+        }
+    }
+}

--- a/Sources/AnglesiteCore/ContactsProviding.swift
+++ b/Sources/AnglesiteCore/ContactsProviding.swift
@@ -1,0 +1,87 @@
+import Foundation
+#if canImport(Contacts)
+import Contacts
+#endif
+
+/// One system contact's matchable identity signals, plus how to fetch a batch of them. The
+/// `Contacts.framework`-backed implementation lives behind `#if canImport(Contacts)` — mirrors
+/// `FoundationModelAssistant`'s platform-guarded-framework-inside-a-portable-target pattern — so
+/// this protocol itself stays usable from portable code and from tests without ever touching
+/// `CNContactStore`.
+public protocol ContactsProviding: Sendable {
+    /// Requests Contacts access if needed, then returns every system contact's matchable URLs.
+    /// Throws ``ContactsAccessError/denied`` if the owner declines the permission prompt.
+    func matchableContacts() async throws -> [MatchableContact]
+}
+
+public enum ContactsAccessError: Error, Equatable, Sendable {
+    case denied
+}
+
+#if canImport(Contacts)
+/// The real, `CNContactStore`-backed provider. Requests access on first use — never at launch —
+/// per the design doc §5's "opt-in per scan" requirement.
+public struct SystemContactsProvider: ContactsProviding {
+    public init() {}
+
+    public func matchableContacts() async throws -> [MatchableContact] {
+        let store = CNContactStore()
+        let granted = try await requestAccess(store: store)
+        guard granted else { throw ContactsAccessError.denied }
+        return try await Task.detached(priority: .utility) {
+            try Self.fetchAll(store: store)
+        }.value
+    }
+
+    private func requestAccess(store: CNContactStore) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            store.requestAccess(for: .contacts) { granted, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    /// Runs off the calling task (see the `Task.detached` above) because `enumerateContacts`
+    /// blocks synchronously over the whole address book.
+    private static func fetchAll(store: CNContactStore) throws -> [MatchableContact] {
+        let keys: [CNKeyDescriptor] = [
+            CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+            CNContactUrlAddressesKey as CNKeyDescriptor,
+            CNContactSocialProfilesKey as CNKeyDescriptor,
+            CNContactOrganizationNameKey as CNKeyDescriptor,
+        ]
+        let request = CNContactFetchRequest(keysToFetch: keys)
+        var results: [MatchableContact] = []
+        try store.enumerateContacts(with: request) { contact, _ in
+            if let matchable = matchableContact(from: contact) {
+                results.append(matchable)
+            }
+        }
+        return results
+    }
+
+    /// Maps one `CNContact` to its matchable identity signals, or `nil` if it has neither a
+    /// usable name nor any URL to match against. Pure — no store access, no I/O — so it's
+    /// pulled out of `fetchAll` specifically to be unit-tested directly (see this task's test
+    /// strategy note above and `SystemContactsProviderTests`). Not `private`, for the same
+    /// testability reason `FollowerAvatar.dimensionsWithinBound(_:)` isn't.
+    static func matchableContact(from contact: CNContact) -> MatchableContact? {
+        // `CNContact.organizationName` is non-optional (empty string when unset) on this SDK, so
+        // `??` against it can't be used directly — fall back to it explicitly instead.
+        let formattedName = CNContactFormatter.string(from: contact, style: .fullName)
+        let name = (formattedName?.isEmpty == false) ? formattedName! : contact.organizationName
+        guard !name.isEmpty else { return nil }
+        let urls = contact.urlAddresses.compactMap { URL(string: $0.value as String) }
+        let socialURLs = contact.socialProfiles.compactMap { labeled -> URL? in
+            let urlString = labeled.value.urlString
+            return urlString.isEmpty ? nil : URL(string: urlString)
+        }
+        guard !urls.isEmpty || !socialURLs.isEmpty else { return nil }
+        return MatchableContact(displayName: name, urlAddresses: urls, socialProfileURLs: socialURLs)
+    }
+}
+#endif

--- a/Tests/AnglesiteAppTests/ContactEditValidationTests.swift
+++ b/Tests/AnglesiteAppTests/ContactEditValidationTests.swift
@@ -37,12 +37,12 @@ struct ContactEditValidationTests {
     func acceptsValidInput() {
         let result = ContactEditValidation.validate(
             displayName: "  Alice  ", meText: "  https://alice.example  ")
-        guard case .success(let validated) = result else {
+        guard case .success(let url, let displayName) = result else {
             Issue.record("expected success")
             return
         }
-        #expect(validated.displayName == "Alice")
-        #expect(validated.url.absoluteString == "https://alice.example")
+        #expect(displayName == "Alice")
+        #expect(url.absoluteString == "https://alice.example")
     }
 
     @Test("accepts a plain http URL")

--- a/Tests/AnglesiteAppTests/ContactEditValidationTests.swift
+++ b/Tests/AnglesiteAppTests/ContactEditValidationTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+
+@Suite("ContactEditValidation")
+struct ContactEditValidationTests {
+    @Test("rejects an empty (or whitespace-only) name")
+    func rejectsEmptyName() {
+        let result = ContactEditValidation.validate(
+            displayName: "   ", meText: "https://example.com")
+        guard case .failure(let message) = result else {
+            Issue.record("expected failure")
+            return
+        }
+        #expect(message == "Enter a name.")
+    }
+
+    @Test("rejects a non-http(s) URL")
+    func rejectsNonHTTPURL() {
+        let result = ContactEditValidation.validate(displayName: "Alice", meText: "ftp://example.com")
+        guard case .failure = result else {
+            Issue.record("expected failure")
+            return
+        }
+    }
+
+    @Test("rejects unparseable text")
+    func rejectsUnparseableText() {
+        let result = ContactEditValidation.validate(displayName: "Alice", meText: "not a url")
+        guard case .failure = result else {
+            Issue.record("expected failure")
+            return
+        }
+    }
+
+    @Test("trims whitespace and accepts a valid https URL")
+    func acceptsValidInput() {
+        let result = ContactEditValidation.validate(
+            displayName: "  Alice  ", meText: "  https://alice.example  ")
+        guard case .success(let validated) = result else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(validated.displayName == "Alice")
+        #expect(validated.url.absoluteString == "https://alice.example")
+    }
+
+    @Test("accepts a plain http URL")
+    func acceptsHTTP() {
+        let result = ContactEditValidation.validate(displayName: "Bob", meText: "http://bob.example")
+        guard case .success = result else {
+            Issue.record("expected success")
+            return
+        }
+    }
+}

--- a/Tests/AnglesiteAppTests/ContactsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ContactsModelTests.swift
@@ -1,0 +1,120 @@
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+@Suite("ContactsModel")
+@MainActor
+struct ContactsModelTests {
+    private static func makeSite() throws -> CurrentSite {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContactsModelTests-\(UUID().uuidString)")
+        let config = root.appendingPathComponent("Config")
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        return CurrentSite(
+            id: "site-1", packageURL: root, sourceDirectory: root, configDirectory: config)
+    }
+
+    private struct FakeContactsProvider: ContactsProviding {
+        var result: Result<[MatchableContact], Error>
+        func matchableContacts() async throws -> [MatchableContact] {
+            try result.get()
+        }
+    }
+
+    @Test("loads an empty list for a fresh site")
+    func loadsEmptyForFreshSite() async throws {
+        let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        #expect(model.loadState == .loaded)
+        #expect(model.contacts.isEmpty)
+    }
+
+    @Test("add then remove round-trips through the store")
+    func addAndRemove() async throws {
+        let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        #expect(model.contacts.count == 1)
+
+        let added = try #require(model.contacts.first)
+        await model.remove(added)
+        #expect(model.contacts.isEmpty)
+    }
+
+    @Test("scanForMatches surfaces a promotion suggestion")
+    func scanSurfacesPromotion() async throws {
+        let bob = URL(string: "https://mastodon.social/users/bob")!
+        let provider = FakeContactsProvider(
+            result: .success([
+                MatchableContact(
+                    displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [bob])
+            ]))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+
+        #expect(model.suggestions.count == 1)
+        #expect(model.scanFailure == nil)
+    }
+
+    @Test("scanForMatches surfaces permission denial without crashing")
+    func scanSurfacesDenial() async throws {
+        let provider = FakeContactsProvider(result: .failure(ContactsAccessError.denied))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        await model.scanForMatches(candidateFollowerURLs: [])
+
+        #expect(model.scanFailure == .permissionDenied)
+        #expect(model.suggestions.isEmpty)
+    }
+
+    @Test("accepting a promotion suggestion adds it as a contact and clears the suggestion")
+    func acceptPromotion() async throws {
+        let bob = URL(string: "https://mastodon.social/users/bob")!
+        let provider = FakeContactsProvider(
+            result: .success([
+                MatchableContact(
+                    displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [bob])
+            ]))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+        let suggestion = try #require(model.suggestions.first)
+
+        await model.accept(suggestion)
+
+        #expect(model.contacts.contains { $0.me == bob && $0.displayName == "Bob Jones" })
+        #expect(model.suggestions.isEmpty)
+    }
+
+    @Test("dismissing a suggestion removes it and it does not resurface until the next scan")
+    func dismissSuggestion() async throws {
+        let bob = URL(string: "https://mastodon.social/users/bob")!
+        let provider = FakeContactsProvider(
+            result: .success([
+                MatchableContact(
+                    displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [bob])
+            ]))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+        let suggestion = try #require(model.suggestions.first)
+
+        model.dismiss(suggestion)
+        #expect(model.suggestions.isEmpty)
+
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+        #expect(model.suggestions.isEmpty)
+    }
+}

--- a/Tests/AnglesiteAppTests/ContactsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ContactsModelTests.swift
@@ -111,6 +111,83 @@ struct ContactsModelTests {
         #expect(model.suggestions.isEmpty)
     }
 
+    @Test("accepting a promotion suggestion records the follower URL as linkedActor (#966 review)")
+    func acceptPromotionSetsLinkedActor() async throws {
+        let bob = URL(string: "https://mastodon.social/users/bob")!
+        let provider = FakeContactsProvider(
+            result: .success([
+                MatchableContact(
+                    displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [bob])
+            ]))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+        let suggestion = try #require(model.suggestions.first)
+
+        await model.accept(suggestion)
+
+        let added = try #require(model.contacts.first)
+        #expect(added.linkedActor == bob)
+    }
+
+    @Test("a manually-added contact leaves linkedActor nil")
+    func manualAddLeavesLinkedActorNil() async throws {
+        let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+
+        let added = try #require(model.contacts.first)
+        #expect(added.linkedActor == nil)
+    }
+
+    @Test("configure(site:) resets per-site state so a window replay never leaks another site's contacts (#966 review)")
+    func configureResetsStateAcrossSites() async throws {
+        let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
+        let firstSite = try Self.makeSite()
+        model.configure(site: firstSite)
+        await model.reload()
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        #expect(model.contacts.count == 1)
+        #expect(model.loadState == .loaded)
+
+        // Simulate the same model instance being reused for a different site window (the
+        // pattern `SiteWindowModel`'s cold-open path uses).
+        let secondSite = try Self.makeSite()
+        model.configure(site: secondSite)
+
+        #expect(model.contacts.isEmpty)
+        #expect(model.loadState == .idle)
+        #expect(model.suggestions.isEmpty)
+        #expect(model.scanFailure == nil)
+        #expect(model.writeFailure == nil)
+    }
+
+    @Test("a write failure is surfaced via writeFailure rather than silently swallowed (#966 review)")
+    func writeFailureIsSurfaced() async throws {
+        // A regular file where `configDirectory` is expected forces the underlying
+        // `ContactStore.write` to throw when it tries to create/write into it as a directory.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContactsModelTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let configAsFile = root.appendingPathComponent("Config")
+        try Data().write(to: configAsFile)
+        let site = CurrentSite(
+            id: "site-1", packageURL: root, sourceDirectory: root, configDirectory: configAsFile)
+
+        let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
+        model.configure(site: site)
+        await model.reload()
+        #expect(model.writeFailure == nil)
+
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+
+        #expect(model.writeFailure != nil)
+        #expect(model.contacts.isEmpty)
+    }
+
     @Test("dismissing a suggestion removes it and it does not resurface until the next scan")
     func dismissSuggestion() async throws {
         let bob = URL(string: "https://mastodon.social/users/bob")!

--- a/Tests/AnglesiteAppTests/ContactsModelTests.swift
+++ b/Tests/AnglesiteAppTests/ContactsModelTests.swift
@@ -32,6 +32,20 @@ struct ContactsModelTests {
         #expect(model.contacts.isEmpty)
     }
 
+    @Test("reload surfaces corruptFile when contacts.json fails to decode")
+    func reloadSurfacesCorruptFile() async throws {
+        let site = try Self.makeSite()
+        try Data("{ not json".utf8).write(
+            to: site.configDirectory.appendingPathComponent(ContactStore.filename))
+
+        let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
+        model.configure(site: site)
+        await model.reload()
+
+        #expect(model.loadState == .corruptFile)
+        #expect(model.contacts.isEmpty)
+    }
+
     @Test("add then remove round-trips through the store")
     func addAndRemove() async throws {
         let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))

--- a/Tests/AnglesiteCoreTests/ContactStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/ContactStoreTests.swift
@@ -1,0 +1,108 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContactStore")
+struct ContactStoreTests {
+    private static func makeConfigDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContactStoreTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func contact(
+        me: String = "https://alice.example", name: String = "Alice"
+    ) -> Contact {
+        Contact(
+            me: URL(string: me)!, displayName: name,
+            addedDate: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    @Test("returns empty when no file exists yet")
+    func returnsEmptyForMissingFile() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        #expect(try await store.load() == [])
+    }
+
+    @Test("round-trips a contact through add and load")
+    func roundTrips() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        let contact = Self.contact()
+        try await store.add(contact)
+
+        let loaded = try await store.load()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.id == contact.id)
+        #expect(loaded.first?.displayName == "Alice")
+    }
+
+    @Test("adding a contact with a matching me URL replaces the existing entry")
+    func addReplacesOnMatchingIdentity() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        try await store.add(Self.contact(me: "https://alice.example", name: "Alice"))
+        try await store.add(Self.contact(me: "https://alice.example/", name: "Alice Renamed"))
+
+        let loaded = try await store.load()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.displayName == "Alice Renamed")
+    }
+
+    @Test("update rekeys a contact whose me URL changed")
+    func updateRekeys() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        var contact = Self.contact(me: "https://old.example")
+        try await store.add(contact)
+
+        contact.me = URL(string: "https://new.example")!
+        try await store.update(contact)
+
+        let loaded = try await store.load()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.me.absoluteString == "https://new.example")
+    }
+
+    @Test("remove deletes by id")
+    func removeDeletes() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        let contact = Self.contact()
+        try await store.add(contact)
+        try await store.remove(id: contact.id)
+
+        #expect(try await store.load() == [])
+    }
+
+    @Test("throws instead of silently discarding a corrupt file")
+    func throwsOnCorruptFile() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data("{ not json".utf8).write(
+            to: directory.appendingPathComponent(ContactStore.filename))
+        let store = ContactStore(configDirectory: directory)
+
+        await #expect(throws: (any Error).self) {
+            try await store.load()
+        }
+    }
+
+    @Test("knownMeURLs normalizes scheme and trailing slash")
+    func knownMeURLsNormalizes() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        try await store.add(Self.contact(me: "https://alice.example/"))
+
+        let known = try await store.knownMeURLs()
+        #expect(known.contains(normalizedIdentityKey(for: URL(string: "http://alice.example")!)))
+    }
+}

--- a/Tests/AnglesiteCoreTests/ContactsMatcherTests.swift
+++ b/Tests/AnglesiteCoreTests/ContactsMatcherTests.swift
@@ -86,6 +86,20 @@ struct ContactsMatcherTests {
         #expect(suggestions.count == 1)
     }
 
+    @Test("deduplicates repeated follower URLs into a single promotion suggestion (#966 review)")
+    func dedupesDuplicateFollowerURLs() {
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [Self.bobActor])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [],
+            candidateFollowerURLs: [Self.bobActor, Self.bobActor])
+
+        #expect(suggestions.count == 1)
+    }
+
     @Test("produces no suggestions when nothing matches")
     func noMatches() {
         let suggestions = ContactsMatcher.suggestions(

--- a/Tests/AnglesiteCoreTests/ContactsMatcherTests.swift
+++ b/Tests/AnglesiteCoreTests/ContactsMatcherTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContactsMatcher")
+struct ContactsMatcherTests {
+    private static let aliceMe = URL(string: "https://alice.example")!
+    private static let bobActor = URL(string: "https://mastodon.social/users/bob")!
+
+    @Test("suggests enriching an existing contact whose name differs from the system contact")
+    func suggestsEnrichment() {
+        let existing = Contact(me: Self.aliceMe, displayName: "alice.example")
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Alice Smith", urlAddresses: [Self.aliceMe], socialProfileURLs: [])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [existing],
+            candidateFollowerURLs: [])
+
+        #expect(suggestions.count == 1)
+        #expect(suggestions.first?.systemContactName == "Alice Smith")
+        #expect(suggestions.first?.kind == .enrichExisting(existing))
+    }
+
+    @Test("does not suggest enrichment when the names already match")
+    func skipsEnrichmentWhenNamesMatch() {
+        let existing = Contact(me: Self.aliceMe, displayName: "Alice Smith")
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Alice Smith", urlAddresses: [Self.aliceMe], socialProfileURLs: [])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [existing],
+            candidateFollowerURLs: [])
+
+        #expect(suggestions.isEmpty)
+    }
+
+    @Test("suggests promoting a not-yet-added follower that matches a system contact")
+    func suggestsPromotion() {
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [Self.bobActor])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [],
+            candidateFollowerURLs: [Self.bobActor])
+
+        #expect(suggestions.count == 1)
+        #expect(suggestions.first?.systemContactName == "Bob Jones")
+        #expect(suggestions.first?.kind == .promoteToContact)
+    }
+
+    @Test("does not suggest promoting a follower already added as a contact")
+    func skipsPromotionForExistingContact() {
+        let existing = Contact(me: Self.bobActor, displayName: "Bob Jones")
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [Self.bobActor])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [existing],
+            candidateFollowerURLs: [Self.bobActor])
+
+        #expect(suggestions.isEmpty)
+    }
+
+    @Test("matches URLs that differ only by scheme and trailing slash")
+    func matchesNormalizedURLs() {
+        let existing = Contact(me: URL(string: "http://alice.example/")!, displayName: "alice")
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Alice Smith", urlAddresses: [URL(string: "https://alice.example")!],
+                socialProfileURLs: [])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [existing],
+            candidateFollowerURLs: [])
+
+        #expect(suggestions.count == 1)
+    }
+
+    @Test("produces no suggestions when nothing matches")
+    func noMatches() {
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: [], existingContacts: [], candidateFollowerURLs: [Self.bobActor])
+        #expect(suggestions.isEmpty)
+    }
+}

--- a/Tests/AnglesiteCoreTests/SystemContactsProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/SystemContactsProviderTests.swift
@@ -1,0 +1,82 @@
+#if canImport(Contacts)
+import Testing
+import Foundation
+import Contacts
+@testable import AnglesiteCore
+
+@Suite("SystemContactsProvider matching")
+struct SystemContactsProviderTests {
+    private static func makeContact(
+        givenName: String,
+        familyName: String = "",
+        urlAddresses: [String] = [],
+        socialProfileURLs: [String] = []
+    ) -> CNContact {
+        let mutable = CNMutableContact()
+        mutable.givenName = givenName
+        mutable.familyName = familyName
+        mutable.urlAddresses = urlAddresses.map {
+            CNLabeledValue(label: CNLabelURLAddressHomePage, value: $0 as NSString)
+        }
+        mutable.socialProfiles = socialProfileURLs.map {
+            // No `CNSocialProfileServiceMastodon` constant exists in this SDK (verified against
+            // the actual Contacts.framework headers — only Facebook/Flickr/LinkedIn/MySpace/
+            // SinaWeibo/TencentWeibo/Twitter/Yelp/GameCenter are predefined); the label is a
+            // plain string and isn't read by `matchableContact(from:)` anyway, so use a literal.
+            CNLabeledValue(
+                label: "Mastodon",
+                value: CNSocialProfile(
+                    urlString: $0, username: nil, userIdentifier: nil, service: nil))
+        }
+        return mutable
+    }
+
+    @Test("extracts display name and URL addresses")
+    func extractsNameAndURLs() {
+        let contact = Self.makeContact(
+            givenName: "Alice", familyName: "Smith",
+            urlAddresses: ["https://alice.example"])
+
+        let matchable = SystemContactsProvider.matchableContact(from: contact)
+
+        #expect(matchable?.displayName == "Alice Smith")
+        #expect(matchable?.urlAddresses == [URL(string: "https://alice.example")!])
+    }
+
+    @Test("extracts social profile URLs")
+    func extractsSocialProfileURLs() {
+        let contact = Self.makeContact(
+            givenName: "Bob",
+            socialProfileURLs: ["https://mastodon.social/users/bob"])
+
+        let matchable = SystemContactsProvider.matchableContact(from: contact)
+
+        #expect(matchable?.socialProfileURLs == [URL(string: "https://mastodon.social/users/bob")!])
+    }
+
+    @Test("returns nil for a contact with no name")
+    func returnsNilForNoName() {
+        let contact = Self.makeContact(givenName: "", urlAddresses: ["https://example.com"])
+        #expect(SystemContactsProvider.matchableContact(from: contact) == nil)
+    }
+
+    @Test("returns nil for a contact with no URLs at all")
+    func returnsNilForNoURLs() {
+        let contact = Self.makeContact(givenName: "Carol")
+        #expect(SystemContactsProvider.matchableContact(from: contact) == nil)
+    }
+
+    @Test("ignores an empty social profile URL string")
+    func ignoresEmptySocialProfileURL() {
+        let mutable = CNMutableContact()
+        mutable.givenName = "Dana"
+        mutable.socialProfiles = [
+            CNLabeledValue(
+                label: CNSocialProfileServiceTwitter,
+                value: CNSocialProfile(
+                    urlString: "", username: "dana", userIdentifier: nil, service: "Twitter"))
+        ]
+        #expect(SystemContactsProvider.matchableContact(from: mutable) == nil)
+    }
+}
+#endif

--- a/Tests/AnglesiteCoreTests/SystemContactsProviderTests.swift
+++ b/Tests/AnglesiteCoreTests/SystemContactsProviderTests.swift
@@ -9,12 +9,14 @@ struct SystemContactsProviderTests {
     private static func makeContact(
         givenName: String,
         familyName: String = "",
+        organizationName: String = "",
         urlAddresses: [String] = [],
         socialProfileURLs: [String] = []
     ) -> CNContact {
         let mutable = CNMutableContact()
         mutable.givenName = givenName
         mutable.familyName = familyName
+        mutable.organizationName = organizationName
         mutable.urlAddresses = urlAddresses.map {
             CNLabeledValue(label: CNLabelURLAddressHomePage, value: $0 as NSString)
         }
@@ -52,6 +54,18 @@ struct SystemContactsProviderTests {
         let matchable = SystemContactsProvider.matchableContact(from: contact)
 
         #expect(matchable?.socialProfileURLs == [URL(string: "https://mastodon.social/users/bob")!])
+    }
+
+    @Test("falls back to organization name when there's no formattable person name")
+    func fallsBackToOrganizationName() {
+        let contact = Self.makeContact(
+            givenName: "", familyName: "", organizationName: "Acme Corp",
+            urlAddresses: ["https://acme.example"])
+
+        let matchable = SystemContactsProvider.matchableContact(from: contact)
+
+        #expect(matchable?.displayName == "Acme Corp")
+        #expect(matchable?.urlAddresses == [URL(string: "https://acme.example")!])
     }
 
     @Test("returns nil for a contact with no name")

--- a/docs/superpowers/plans/2026-08-17-known-contacts.md
+++ b/docs/superpowers/plans/2026-08-17-known-contacts.md
@@ -576,14 +576,33 @@ git commit -m "feat(#966): add ContactsMatcher pure matching logic"
 - Produces: `public protocol ContactsProviding: Sendable { func matchableContacts() async
   throws -> [MatchableContact] }`, `public enum ContactsAccessError: Error, Equatable,
   Sendable { case denied }`, and (behind `#if canImport(Contacts)`) `public struct
-  SystemContactsProvider: ContactsProviding` with `public init()`.
+  SystemContactsProvider: ContactsProviding` with `public init()` and `static func
+  matchableContact(from contact: CNContact) -> MatchableContact?`.
 
-**No automated test for `SystemContactsProvider`**: it drives a real `CNContactStore`,
-which is TCC-gated — a bare `swift test` binary can't hold the Contacts permission (the
-same class of problem the sandboxed-binary-probe precedent solves for App Sandbox). The
-protocol seam exists precisely so `ContactsModel` (Task 4) can be tested against a fake
-instead. `SystemContactsProvider` itself is exercised manually in Task 9's verification
-pass, against a real system contact.
+**Test strategy**: `matchableContacts()` itself drives a real `CNContactStore`
+(`requestAccess`/`enumerateContacts`), which is TCC-gated — a bare `swift test` binary
+can't hold the Contacts permission (the same class of problem the sandboxed-binary-probe
+precedent solves for App Sandbox), so that thin I/O wrapper is exercised manually in
+Task 9's verification pass instead. But the actual per-contact extraction logic —
+display name plus every URL/social-profile field — is pure `CNContact` → `MatchableContact`
+mapping, and `CNMutableContact`/`CNLabeledValue`/`CNSocialProfile` are plain in-memory
+objects: constructing and reading them needs no store access and no TCC permission at
+all (verified directly against this worktree's SDK before writing this task — see the
+commands below). So that mapping is pulled out into its own `static` function and given
+a real test, the same way `FollowerAvatar.dimensionsWithinBound(_:)` is pulled out of an
+otherwise-untested view file (`FollowersView.swift`) specifically so it can be tested
+without the untestable I/O around it.
+
+Verified compiling (and running, for the non-store parts) against this worktree's SDK
+before writing the code below:
+
+```bash
+xcrun swiftc -sdk $(xcrun --show-sdk-path --sdk macosx) -target arm64-apple-macos15.0 probe.swift -o probe && ./probe
+# name: Alice Smith
+# url: https://alice.example
+# social url: https://mastodon.social/users/bob
+# CNAggregateKeyDescriptor
+```
 
 - [ ] **Step 1: Write `ContactsProviding.swift`**
 
@@ -647,35 +666,145 @@ public struct SystemContactsProvider: ContactsProviding {
         let request = CNContactFetchRequest(keysToFetch: keys)
         var results: [MatchableContact] = []
         try store.enumerateContacts(with: request) { contact, _ in
-            let name = CNContactFormatter.string(from: contact, style: .fullName)
-                ?? contact.organizationName
-            guard let name, !name.isEmpty else { return }
-            let urls = contact.urlAddresses.compactMap { URL(string: $0.value as String) }
-            let socialURLs = contact.socialProfiles.compactMap { labeled -> URL? in
-                let urlString = labeled.value.urlString
-                return urlString.isEmpty ? nil : URL(string: urlString)
+            if let matchable = matchableContact(from: contact) {
+                results.append(matchable)
             }
-            guard !urls.isEmpty || !socialURLs.isEmpty else { return }
-            results.append(
-                MatchableContact(
-                    displayName: name, urlAddresses: urls, socialProfileURLs: socialURLs))
         }
         return results
+    }
+
+    /// Maps one `CNContact` to its matchable identity signals, or `nil` if it has neither a
+    /// usable name nor any URL to match against. Pure — no store access, no I/O — so it's
+    /// pulled out of `fetchAll` specifically to be unit-tested directly (see this task's test
+    /// strategy note above and `SystemContactsProviderTests`). Not `private`, for the same
+    /// testability reason `FollowerAvatar.dimensionsWithinBound(_:)` isn't.
+    static func matchableContact(from contact: CNContact) -> MatchableContact? {
+        let name = CNContactFormatter.string(from: contact, style: .fullName)
+            ?? contact.organizationName
+        guard let name, !name.isEmpty else { return nil }
+        let urls = contact.urlAddresses.compactMap { URL(string: $0.value as String) }
+        let socialURLs = contact.socialProfiles.compactMap { labeled -> URL? in
+            let urlString = labeled.value.urlString
+            return urlString.isEmpty ? nil : URL(string: urlString)
+        }
+        guard !urls.isEmpty || !socialURLs.isEmpty else { return nil }
+        return MatchableContact(displayName: name, urlAddresses: urls, socialProfileURLs: socialURLs)
     }
 }
 #endif
 ```
 
-- [ ] **Step 2: Verify it compiles**
+- [ ] **Step 2: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/SystemContactsProviderTests.swift`. The whole file is
+guarded by `#if canImport(Contacts)` — on a platform without Contacts (e.g. Linux) it
+compiles to nothing, same as `SystemContactsProvider` itself:
+
+```swift
+#if canImport(Contacts)
+import Testing
+import Foundation
+import Contacts
+@testable import AnglesiteCore
+
+@Suite("SystemContactsProvider matching")
+struct SystemContactsProviderTests {
+    private static func makeContact(
+        givenName: String,
+        familyName: String = "",
+        urlAddresses: [String] = [],
+        socialProfileURLs: [String] = []
+    ) -> CNContact {
+        let mutable = CNMutableContact()
+        mutable.givenName = givenName
+        mutable.familyName = familyName
+        mutable.urlAddresses = urlAddresses.map {
+            CNLabeledValue(label: CNLabelURLAddressHomePage, value: $0 as NSString)
+        }
+        mutable.socialProfiles = socialProfileURLs.map {
+            CNLabeledValue(
+                label: CNSocialProfileServiceMastodon,
+                value: CNSocialProfile(
+                    urlString: $0, username: nil, userIdentifier: nil, service: nil))
+        }
+        return mutable
+    }
+
+    @Test("extracts display name and URL addresses")
+    func extractsNameAndURLs() {
+        let contact = Self.makeContact(
+            givenName: "Alice", familyName: "Smith",
+            urlAddresses: ["https://alice.example"])
+
+        let matchable = SystemContactsProvider.matchableContact(from: contact)
+
+        #expect(matchable?.displayName == "Alice Smith")
+        #expect(matchable?.urlAddresses == [URL(string: "https://alice.example")!])
+    }
+
+    @Test("extracts social profile URLs")
+    func extractsSocialProfileURLs() {
+        let contact = Self.makeContact(
+            givenName: "Bob",
+            socialProfileURLs: ["https://mastodon.social/users/bob"])
+
+        let matchable = SystemContactsProvider.matchableContact(from: contact)
+
+        #expect(matchable?.socialProfileURLs == [URL(string: "https://mastodon.social/users/bob")!])
+    }
+
+    @Test("returns nil for a contact with no name")
+    func returnsNilForNoName() {
+        let contact = Self.makeContact(givenName: "", urlAddresses: ["https://example.com"])
+        #expect(SystemContactsProvider.matchableContact(from: contact) == nil)
+    }
+
+    @Test("returns nil for a contact with no URLs at all")
+    func returnsNilForNoURLs() {
+        let contact = Self.makeContact(givenName: "Carol")
+        #expect(SystemContactsProvider.matchableContact(from: contact) == nil)
+    }
+
+    @Test("ignores an empty social profile URL string")
+    func ignoresEmptySocialProfileURL() {
+        let mutable = CNMutableContact()
+        mutable.givenName = "Dana"
+        mutable.socialProfiles = [
+            CNLabeledValue(
+                label: CNSocialProfileServiceTwitter,
+                value: CNSocialProfile(
+                    urlString: "", username: "dana", userIdentifier: nil, service: "Twitter"))
+        ]
+        #expect(SystemContactsProvider.matchableContact(from: mutable) == nil)
+    }
+}
+#endif
+```
+
+- [ ] **Step 3: Run tests to verify they fail to compile**
+
+Run: `swift test --package-path . --filter SystemContactsProviderTests`
+Expected: FAIL — `matchableContact(from:)` isn't `static`/exposed yet (Step 1 already
+wrote it above, so run this immediately after Step 1's file is saved but before assuming
+it passes; if this worktree's `AnglesiteCore` target doesn't yet build with Step 1's
+content in place, fix that first).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter SystemContactsProviderTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Verify the whole target still compiles**
 
 Run: `swift build --package-path . --target AnglesiteCore`
 Expected: BUILD SUCCEEDED (compiles both with and without `canImport(Contacts)`; this
-worktree's macOS toolchain has Contacts, so `SystemContactsProvider` compiles here).
+worktree's macOS toolchain has Contacts, so `SystemContactsProvider` and its test compile
+here).
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add Sources/AnglesiteCore/ContactsProviding.swift
+git add Sources/AnglesiteCore/ContactsProviding.swift Tests/AnglesiteCoreTests/SystemContactsProviderTests.swift
 git commit -m "feat(#966): add ContactsProviding seam and SystemContactsProvider"
 ```
 
@@ -976,16 +1105,23 @@ git commit -m "feat(#966): add ContactsModel"
 
 **Files:**
 - Create: `Sources/AnglesiteApp/ContactsView.swift`
+- Test: `Tests/AnglesiteAppTests/ContactEditValidationTests.swift`
 
 **Interfaces:**
 - Consumes: `ContactsModel` (Task 4); `Contact`, `MatchSuggestion` (`AnglesiteCore`).
 - Produces: `struct ContactsView: View` with `init(contacts: ContactsModel,
   candidateFollowerURLs: @escaping () async -> [URL])` — consumed by `SiteWindow.swift`
-  in Task 7.
+  in Task 7. Also `enum ContactEditValidation` with `static func validate(displayName:
+  String, meText: String) -> Result<(url: URL, displayName: String), String>`.
 
-No dedicated automated test: this codebase does not unit-test SwiftUI view bodies (there
-is no `FollowersViewTests.swift` either) — correctness is verified by compiling and by
-the manual run-through in Task 9.
+**Test strategy**: this codebase does not unit-test SwiftUI view bodies (there is no
+`FollowersViewTests.swift` either), so `ContactsView`'s layout is verified by compiling
+and by the manual run-through in Task 9. But `ContactEditSheet`'s Save button runs real
+validation logic (trim, require a name, require a parseable http(s) URL) that has nothing
+to do with rendering — so, like `FollowerAvatar.dimensionsWithinBound(_:)` is pulled out
+of `FollowersView.swift` specifically to be tested without the SwiftUI/AppKit code around
+it, that logic is pulled out into a standalone `ContactEditValidation` type here and given
+a real test.
 
 - [ ] **Step 1: Write `ContactsView.swift`**
 
@@ -1227,37 +1363,125 @@ private struct ContactEditSheet: View {
     }
 
     private func save() {
+        switch ContactEditValidation.validate(displayName: displayName, meText: meText) {
+        case .failure(let message):
+            validationError = message
+        case .success(let validated):
+            Task {
+                await onSave(validated.url, validated.displayName)
+                dismiss()
+            }
+        }
+    }
+}
+
+/// Pure validation for `ContactEditSheet`'s Save action, pulled out of the view so it can be
+/// unit-tested directly — see this task's test strategy note above. Not `private`, for the same
+/// testability reason `FollowerAvatar.dimensionsWithinBound(_:)` isn't.
+enum ContactEditValidation {
+    /// `.success` carries the trimmed name and parsed URL ready to hand to `onSave`; `.failure`
+    /// carries the message `ContactEditSheet` shows under the fields.
+    static func validate(
+        displayName: String, meText: String
+    ) -> Result<(url: URL, displayName: String), String> {
         let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else {
-            validationError = "Enter a name."
-            return
+            return .failure("Enter a name.")
         }
         let trimmedURLText = meText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let url = URL(string: trimmedURLText),
             url.scheme == "http" || url.scheme == "https"
         else {
-            validationError = "Enter a valid http(s) website address."
+            return .failure("Enter a valid http(s) website address.")
+        }
+        return .success((url, trimmedName))
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `Tests/AnglesiteAppTests/ContactEditValidationTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteAppCore
+
+@Suite("ContactEditValidation")
+struct ContactEditValidationTests {
+    @Test("rejects an empty (or whitespace-only) name")
+    func rejectsEmptyName() {
+        let result = ContactEditValidation.validate(
+            displayName: "   ", meText: "https://example.com")
+        guard case .failure(let message) = result else {
+            Issue.record("expected failure")
             return
         }
-        let capturedURL = url
-        Task {
-            await onSave(capturedURL, trimmedName)
-            dismiss()
+        #expect(message == "Enter a name.")
+    }
+
+    @Test("rejects a non-http(s) URL")
+    func rejectsNonHTTPURL() {
+        let result = ContactEditValidation.validate(displayName: "Alice", meText: "ftp://example.com")
+        guard case .failure = result else {
+            Issue.record("expected failure")
+            return
+        }
+    }
+
+    @Test("rejects unparseable text")
+    func rejectsUnparseableText() {
+        let result = ContactEditValidation.validate(displayName: "Alice", meText: "not a url")
+        guard case .failure = result else {
+            Issue.record("expected failure")
+            return
+        }
+    }
+
+    @Test("trims whitespace and accepts a valid https URL")
+    func acceptsValidInput() {
+        let result = ContactEditValidation.validate(
+            displayName: "  Alice  ", meText: "  https://alice.example  ")
+        guard case .success(let validated) = result else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(validated.displayName == "Alice")
+        #expect(validated.url.absoluteString == "https://alice.example")
+    }
+
+    @Test("accepts a plain http URL")
+    func acceptsHTTP() {
+        let result = ContactEditValidation.validate(displayName: "Bob", meText: "http://bob.example")
+        guard case .success = result else {
+            Issue.record("expected success")
+            return
         }
     }
 }
 ```
 
-- [ ] **Step 2: Verify it compiles**
+- [ ] **Step 3: Run tests to verify they fail to compile**
+
+Run: `swift test --package-path . --filter ContactEditValidationTests`
+Expected: FAIL — `ContactEditValidation` doesn't exist until Step 1's file is saved.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ContactEditValidationTests`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Verify the whole target compiles**
 
 Run: `swift build --package-path . --target AnglesiteAppCore`
 Expected: BUILD SUCCEEDED. (`ContactsView` isn't referenced anywhere yet — Task 7 wires
 it in — but Swift compiles unreferenced internal types without error.)
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add Sources/AnglesiteApp/ContactsView.swift
+git add Sources/AnglesiteApp/ContactsView.swift Tests/AnglesiteAppTests/ContactEditValidationTests.swift
 git commit -m "feat(#966): add ContactsView"
 ```
 
@@ -1705,14 +1929,17 @@ git commit -m "feat(#966): add Contacts entitlement and usage description"
 **Files:** none (verification only).
 
 **Interfaces:** none — this task consumes everything from Tasks 1–8 and produces
-confidence the feature works end to end, including the parts (real `CNContactStore`,
-SwiftUI rendering) no automated test in this plan covers.
+confidence the feature works end to end, including the parts no automated test in this
+plan can reach: `CNContactStore.requestAccess`/`enumerateContacts` themselves (TCC-gated
+I/O — the pure `matchableContact(from:)` mapping around them is covered by
+`SystemContactsProviderTests`) and SwiftUI rendering (`ContactsView`'s layout — the pure
+`ContactEditValidation` logic inside it is covered by `ContactEditValidationTests`).
 
 - [ ] **Step 1: Run the full Swift test suite**
 
 Run: `swift test --package-path .`
 Expected: all suites pass, including the new `ContactStoreTests`, `ContactsMatcherTests`,
-and `ContactsModelTests`.
+`SystemContactsProviderTests`, `ContactsModelTests`, and `ContactEditValidationTests`.
 
 - [ ] **Step 2: Run the localization catalog check**
 

--- a/docs/superpowers/plans/2026-08-17-known-contacts.md
+++ b/docs/superpowers/plans/2026-08-17-known-contacts.md
@@ -1,0 +1,1756 @@
+# Known Contacts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a per-site, private contact store (`Config/contacts.json`) with a manual
+CRUD UI, plus an opt-in Contacts.framework matching scan that suggests linking a system
+contact to an existing entry or promoting a not-yet-added ActivityPub follower to a
+contact — per the approved design in
+[`docs/superpowers/specs/2026-08-17-known-contacts-design.md`](../specs/2026-08-17-known-contacts-design.md)
+(issue #966).
+
+**Architecture:** A new `AnglesiteCore` persistence type (`ContactStore`, JSON envelope,
+mirrors `ActorProfileCache`) and pure matching logic (`ContactsMatcher`) sit behind a
+platform-guarded `Contacts.framework` adapter (`SystemContactsProvider`, mirrors
+`FoundationModelAssistant`'s `#if canImport(...)` pattern). `AnglesiteApp` wires these
+into the existing `MainPaneMode`/`SiteWindowModel` main-pane pattern (`FollowersModel` is
+the closest precedent) and a `WebsiteCommands` menu item.
+
+**Tech Stack:** Swift 6.4, SwiftUI, `Contacts.framework` (macOS only, `#if
+canImport(Contacts)`-guarded), Swift Testing (`@Suite`/`@Test`/`#expect`).
+
+## Global Constraints
+
+- Toolchain: Xcode 27+ / Swift 6.4. `xcode-select -p` must point at an Xcode 27 install
+  (verified already true in this worktree: `/Applications/Xcode-beta.app/Contents/Developer`).
+- If `Anglesite.xcodeproj` is missing or stale (e.g. `project.yml` changed since it was
+  generated), run `xcodegen generate` before building — see `CLAUDE.md` ▸ "Worktrees".
+- Every new user-facing string literal (`Text`, `Button`, `Label`, etc.) needs a matching
+  key in `Sources/AnglesiteApp/Localizable.xcstrings`, or `scripts/check-localization-catalog.sh`
+  fails CI (#811). New keys are added as empty entries (`"Key" : {\n\n},`) — no Xcode IDE
+  session is required for this file.
+- A corrupt/owner-curated data file (`contacts.json`) must throw on load, never silently
+  discard — this is a deliberate departure from `ActorProfileCache`'s "cache, discard
+  silently" posture; see the design doc §3.
+- Contacts permission is requested only on explicit user action ("Find in Contacts…"),
+  never at launch or site open.
+- Manual contact CRUD (add/edit/delete) must work with zero dependency on Contacts.framework
+  or its permission.
+
+---
+
+### Task 1: `Contact` model and `ContactStore` persistence
+
+**Files:**
+- Create: `Sources/AnglesiteCore/Contact.swift`
+- Create: `Sources/AnglesiteCore/ContactStore.swift`
+- Test: `Tests/AnglesiteCoreTests/ContactStoreTests.swift`
+
+**Interfaces:**
+- Consumes: nothing (new subsystem).
+- Produces:
+  - `public struct Contact: Codable, Equatable, Sendable, Identifiable` with `id: UUID`,
+    `me: URL`, `displayName: String`, `addedDate: Date`, `linkedActor: URL?`,
+    `linkedFeed: URL?`, and `init(id: UUID = UUID(), me: URL, displayName: String,
+    addedDate: Date = Date(), linkedActor: URL? = nil, linkedFeed: URL? = nil)`.
+  - `func normalizedIdentityKey(for url: URL) -> String` (internal, `AnglesiteCore`-module
+    visible) — later tasks (`ContactsMatcher` in Task 2) reuse this exact function.
+  - `public actor ContactStore` with `init(configDirectory: URL, fileManager: FileManager
+    = .default)`, `func load() throws -> [Contact]`, `func add(_ contact: Contact) throws`,
+    `func update(_ contact: Contact) throws`, `func remove(id: UUID) throws`,
+    `func knownMeURLs() throws -> Set<String>`, and `public static let filename = "contacts.json"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/ContactStoreTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContactStore")
+struct ContactStoreTests {
+    private static func makeConfigDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContactStoreTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func contact(
+        me: String = "https://alice.example", name: String = "Alice"
+    ) -> Contact {
+        Contact(
+            me: URL(string: me)!, displayName: name,
+            addedDate: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    @Test("returns empty when no file exists yet")
+    func returnsEmptyForMissingFile() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        #expect(try await store.load() == [])
+    }
+
+    @Test("round-trips a contact through add and load")
+    func roundTrips() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        let contact = Self.contact()
+        try await store.add(contact)
+
+        let loaded = try await store.load()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.id == contact.id)
+        #expect(loaded.first?.displayName == "Alice")
+    }
+
+    @Test("adding a contact with a matching me URL replaces the existing entry")
+    func addReplacesOnMatchingIdentity() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        try await store.add(Self.contact(me: "https://alice.example", name: "Alice"))
+        try await store.add(Self.contact(me: "https://alice.example/", name: "Alice Renamed"))
+
+        let loaded = try await store.load()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.displayName == "Alice Renamed")
+    }
+
+    @Test("update rekeys a contact whose me URL changed")
+    func updateRekeys() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        var contact = Self.contact(me: "https://old.example")
+        try await store.add(contact)
+
+        contact.me = URL(string: "https://new.example")!
+        try await store.update(contact)
+
+        let loaded = try await store.load()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.me.absoluteString == "https://new.example")
+    }
+
+    @Test("remove deletes by id")
+    func removeDeletes() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        let contact = Self.contact()
+        try await store.add(contact)
+        try await store.remove(id: contact.id)
+
+        #expect(try await store.load() == [])
+    }
+
+    @Test("throws instead of silently discarding a corrupt file")
+    func throwsOnCorruptFile() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try Data("{ not json".utf8).write(
+            to: directory.appendingPathComponent(ContactStore.filename))
+        let store = ContactStore(configDirectory: directory)
+
+        await #expect(throws: (any Error).self) {
+            try await store.load()
+        }
+    }
+
+    @Test("knownMeURLs normalizes scheme and trailing slash")
+    func knownMeURLsNormalizes() async throws {
+        let directory = try Self.makeConfigDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactStore(configDirectory: directory)
+        try await store.add(Self.contact(me: "https://alice.example/"))
+
+        let known = try await store.knownMeURLs()
+        #expect(known.contains(normalizedIdentityKey(for: URL(string: "http://alice.example")!)))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `swift test --package-path . --filter ContactStoreTests`
+Expected: FAIL — `Contact`/`ContactStore`/`normalizedIdentityKey` don't exist yet.
+
+- [ ] **Step 3: Write `Contact.swift`**
+
+```swift
+import Foundation
+
+/// A person the site owner knows, stored privately per site (#966). Distinct from the public
+/// `member` content type (`ContentTypeRegistry.swift`) — this is never published.
+public struct Contact: Codable, Equatable, Sendable, Identifiable {
+    /// Stable identity for SwiftUI list diffing and lookup. Not one of the issue's three literal
+    /// fields (`me`, `displayName`, `addedDate`) — needed because `me` itself is editable, so it
+    /// can't double as a stable key the way `FollowerRow.id` uses `actor.absoluteString`.
+    public let id: UUID
+    /// The person's canonical identity URL — their own website, in the IndieAuth `me` sense.
+    public var me: URL
+    public var displayName: String
+    public let addedDate: Date
+    /// The ActivityPub actor IRI, set when this contact was promoted from a follower.
+    public var linkedActor: URL?
+    /// A followed Microsub feed URL. No promotion flow populates this yet (`MicrosubClient` has
+    /// no "list followed feeds" endpoint) — settable only via manual edit until one exists.
+    public var linkedFeed: URL?
+
+    public init(
+        id: UUID = UUID(),
+        me: URL,
+        displayName: String,
+        addedDate: Date = Date(),
+        linkedActor: URL? = nil,
+        linkedFeed: URL? = nil
+    ) {
+        self.id = id
+        self.me = me
+        self.displayName = displayName
+        self.addedDate = addedDate
+        self.linkedActor = linkedActor
+        self.linkedFeed = linkedFeed
+    }
+}
+
+/// Normalizes a URL for identity comparison: lowercased host, scheme dropped, trailing slash
+/// trimmed. Contacts enter `me` and social/website URLs by hand, so two URLs that only differ by
+/// http/https or a trailing slash must still compare equal. Shared by `ContactStore` (identity
+/// dedup) and `ContactsMatcher` (Task 2, matching against system Contacts).
+func normalizedIdentityKey(for url: URL) -> String {
+    let host = (url.host ?? "").lowercased()
+    var path = url.path
+    if path.hasSuffix("/"), path != "/" {
+        path.removeLast()
+    }
+    return host + path
+}
+```
+
+- [ ] **Step 4: Write `ContactStore.swift`**
+
+```swift
+import Foundation
+
+/// Per-site contact store persisted to `<configDirectory>/contacts.json` (#966) — app-owned
+/// state that must never enter the site's git repo, alongside `chat-history.jsonl` and
+/// `ActorProfileCache`'s file. A full-file JSON envelope (like `ActorProfileCache`), not
+/// append-only JSONL (like `ChatHistoryStore`): contacts are edited and deleted, not just
+/// appended.
+public actor ContactStore {
+    public static let filename = "contacts.json"
+
+    private struct Envelope: Codable { let contacts: [Contact] }
+
+    public let fileURL: URL
+    private let fileManager: FileManager
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(configDirectory: URL, fileManager: FileManager = .default) {
+        self.fileURL = configDirectory.appendingPathComponent(Self.filename)
+        self.fileManager = fileManager
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        self.encoder = encoder
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    /// A missing file is the normal first-run state (`[]`, no error). A file that exists but
+    /// fails to decode throws instead of discarding silently: unlike `ActorProfileCache` (a
+    /// disposable, re-fetchable cache), a contact list is owner-curated data, and silently
+    /// showing zero contacts risks the owner believing the list was lost and re-entering it.
+    public func load() throws -> [Contact] {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return [] }
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else { return [] }
+        let envelope = try decoder.decode(Envelope.self, from: data)
+        return envelope.contacts.sorted {
+            $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    /// Adds a contact, replacing any existing entry with the same `me` identity (comparing via
+    /// ``normalizedIdentityKey(for:)``, so `https://x.example` and `https://x.example/` collide).
+    public func add(_ contact: Contact) throws {
+        var contacts = try load()
+        contacts.removeAll {
+            normalizedIdentityKey(for: $0.me) == normalizedIdentityKey(for: contact.me)
+        }
+        contacts.append(contact)
+        try write(contacts)
+    }
+
+    /// Replaces the contact matching `contact.id`, wherever its `me` moved to — this is the
+    /// rekey path for editing an existing entry's URL.
+    public func update(_ contact: Contact) throws {
+        var contacts = try load()
+        contacts.removeAll { $0.id == contact.id }
+        contacts.append(contact)
+        try write(contacts)
+    }
+
+    public func remove(id: UUID) throws {
+        var contacts = try load()
+        contacts.removeAll { $0.id == id }
+        try write(contacts)
+    }
+
+    /// Forward-looking hook for #963's authenticated-read allowlist — not called from anywhere
+    /// in this feature, but the store is the source of truth #963 will read from.
+    public func knownMeURLs() throws -> Set<String> {
+        Set(try load().map { normalizedIdentityKey(for: $0.me) })
+    }
+
+    private func write(_ contacts: [Contact]) throws {
+        let parent = fileURL.deletingLastPathComponent()
+        if !fileManager.fileExists(atPath: parent.path) {
+            try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        }
+        let data = try encoder.encode(Envelope(contacts: contacts))
+        try data.write(to: fileURL, options: .atomic)
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ContactStoreTests`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/Contact.swift Sources/AnglesiteCore/ContactStore.swift Tests/AnglesiteCoreTests/ContactStoreTests.swift
+git commit -m "feat(#966): add per-site Contact model and ContactStore"
+```
+
+---
+
+### Task 2: `ContactsMatcher` matching logic
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ContactsMatcher.swift`
+- Test: `Tests/AnglesiteCoreTests/ContactsMatcherTests.swift`
+
+**Interfaces:**
+- Consumes: `Contact`, `normalizedIdentityKey(for:)` (Task 1).
+- Produces:
+  - `public struct MatchableContact: Sendable, Equatable` with `displayName: String`,
+    `urlAddresses: [URL]`, `socialProfileURLs: [URL]`, and a matching memberwise `init`.
+  - `public struct MatchSuggestion: Sendable, Equatable` with `candidateURL: URL`,
+    `systemContactName: String`, `kind: Kind`, and nested
+    `public enum Kind: Sendable, Equatable { case enrichExisting(Contact);
+    case promoteToContact }`.
+  - `public enum ContactsMatcher` with `static func suggestions(matchableContacts:
+    [MatchableContact], existingContacts: [Contact], candidateFollowerURLs: [URL]) ->
+    [MatchSuggestion]` — used by `ContactsModel` in Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/ContactsMatcherTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import AnglesiteCore
+
+@Suite("ContactsMatcher")
+struct ContactsMatcherTests {
+    private static let aliceMe = URL(string: "https://alice.example")!
+    private static let bobActor = URL(string: "https://mastodon.social/users/bob")!
+
+    @Test("suggests enriching an existing contact whose name differs from the system contact")
+    func suggestsEnrichment() {
+        let existing = Contact(me: Self.aliceMe, displayName: "alice.example")
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Alice Smith", urlAddresses: [Self.aliceMe], socialProfileURLs: [])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [existing],
+            candidateFollowerURLs: [])
+
+        #expect(suggestions.count == 1)
+        #expect(suggestions.first?.systemContactName == "Alice Smith")
+        #expect(suggestions.first?.kind == .enrichExisting(existing))
+    }
+
+    @Test("does not suggest enrichment when the names already match")
+    func skipsEnrichmentWhenNamesMatch() {
+        let existing = Contact(me: Self.aliceMe, displayName: "Alice Smith")
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Alice Smith", urlAddresses: [Self.aliceMe], socialProfileURLs: [])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [existing],
+            candidateFollowerURLs: [])
+
+        #expect(suggestions.isEmpty)
+    }
+
+    @Test("suggests promoting a not-yet-added follower that matches a system contact")
+    func suggestsPromotion() {
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [Self.bobActor])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [],
+            candidateFollowerURLs: [Self.bobActor])
+
+        #expect(suggestions.count == 1)
+        #expect(suggestions.first?.systemContactName == "Bob Jones")
+        #expect(suggestions.first?.kind == .promoteToContact)
+    }
+
+    @Test("does not suggest promoting a follower already added as a contact")
+    func skipsPromotionForExistingContact() {
+        let existing = Contact(me: Self.bobActor, displayName: "Bob Jones")
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [Self.bobActor])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [existing],
+            candidateFollowerURLs: [Self.bobActor])
+
+        #expect(suggestions.isEmpty)
+    }
+
+    @Test("matches URLs that differ only by scheme and trailing slash")
+    func matchesNormalizedURLs() {
+        let existing = Contact(me: URL(string: "http://alice.example/")!, displayName: "alice")
+        let systemContacts = [
+            MatchableContact(
+                displayName: "Alice Smith", urlAddresses: [URL(string: "https://alice.example")!],
+                socialProfileURLs: [])
+        ]
+
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: systemContacts, existingContacts: [existing],
+            candidateFollowerURLs: [])
+
+        #expect(suggestions.count == 1)
+    }
+
+    @Test("produces no suggestions when nothing matches")
+    func noMatches() {
+        let suggestions = ContactsMatcher.suggestions(
+            matchableContacts: [], existingContacts: [], candidateFollowerURLs: [Self.bobActor])
+        #expect(suggestions.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `swift test --package-path . --filter ContactsMatcherTests`
+Expected: FAIL — `MatchableContact`/`MatchSuggestion`/`ContactsMatcher` don't exist yet.
+
+- [ ] **Step 3: Write `ContactsMatcher.swift`**
+
+```swift
+import Foundation
+
+/// One system Contact's matchable identity signals — its display name plus every URL it carries
+/// (website fields and social-profile URLs), already extracted from `CNContact` by whichever
+/// `ContactsProviding` implementation supplied it (Task 3). Kept independent of
+/// `Contacts.framework` types so this file, and its matching logic, stay portable and
+/// unit-testable without `CNContactStore`.
+public struct MatchableContact: Sendable, Equatable {
+    public let displayName: String
+    public let urlAddresses: [URL]
+    public let socialProfileURLs: [URL]
+
+    public init(displayName: String, urlAddresses: [URL], socialProfileURLs: [URL]) {
+        self.displayName = displayName
+        self.urlAddresses = urlAddresses
+        self.socialProfileURLs = socialProfileURLs
+    }
+}
+
+/// One suggested link between a system Contact and a known identity URL, surfaced in the
+/// Contacts pane's "Find in Contacts…" scan (#966).
+public struct MatchSuggestion: Sendable, Equatable {
+    public let candidateURL: URL
+    public let systemContactName: String
+    public let kind: Kind
+
+    public enum Kind: Sendable, Equatable {
+        /// A manually-added contact's `me` URL matches a system contact whose name differs —
+        /// offer to adopt the system contact's name.
+        case enrichExisting(Contact)
+        /// A not-yet-added follower's actor URL matches a system contact — offer to add them.
+        case promoteToContact
+    }
+
+    public init(candidateURL: URL, systemContactName: String, kind: Kind) {
+        self.candidateURL = candidateURL
+        self.systemContactName = systemContactName
+        self.kind = kind
+    }
+}
+
+/// Pure matching logic (design doc §5) — no I/O, no `Contacts` import, so it runs the same in CI
+/// as it does live: given a batch of system contacts and the app's own known identities, produce
+/// suggestions in both directions.
+public enum ContactsMatcher {
+    public static func suggestions(
+        matchableContacts: [MatchableContact],
+        existingContacts: [Contact],
+        candidateFollowerURLs: [URL]
+    ) -> [MatchSuggestion] {
+        var suggestions: [MatchSuggestion] = []
+
+        for contact in existingContacts {
+            guard let match = firstMatch(for: contact.me, in: matchableContacts) else { continue }
+            guard match.displayName != contact.displayName else { continue }
+            suggestions.append(
+                MatchSuggestion(
+                    candidateURL: contact.me, systemContactName: match.displayName,
+                    kind: .enrichExisting(contact)))
+        }
+
+        let existingKeys = Set(existingContacts.map { normalizedIdentityKey(for: $0.me) })
+        for followerURL in candidateFollowerURLs {
+            guard !existingKeys.contains(normalizedIdentityKey(for: followerURL)) else { continue }
+            guard let match = firstMatch(for: followerURL, in: matchableContacts) else { continue }
+            suggestions.append(
+                MatchSuggestion(
+                    candidateURL: followerURL, systemContactName: match.displayName,
+                    kind: .promoteToContact))
+        }
+
+        return suggestions
+    }
+
+    private static func firstMatch(
+        for url: URL, in matchableContacts: [MatchableContact]
+    ) -> MatchableContact? {
+        let key = normalizedIdentityKey(for: url)
+        return matchableContacts.first {
+            ($0.urlAddresses + $0.socialProfileURLs).contains {
+                normalizedIdentityKey(for: $0) == key
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ContactsMatcherTests`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContactsMatcher.swift Tests/AnglesiteCoreTests/ContactsMatcherTests.swift
+git commit -m "feat(#966): add ContactsMatcher pure matching logic"
+```
+
+---
+
+### Task 3: `ContactsProviding` protocol and `Contacts.framework` adapter
+
+**Files:**
+- Create: `Sources/AnglesiteCore/ContactsProviding.swift`
+
+**Interfaces:**
+- Consumes: `MatchableContact` (Task 2).
+- Produces: `public protocol ContactsProviding: Sendable { func matchableContacts() async
+  throws -> [MatchableContact] }`, `public enum ContactsAccessError: Error, Equatable,
+  Sendable { case denied }`, and (behind `#if canImport(Contacts)`) `public struct
+  SystemContactsProvider: ContactsProviding` with `public init()`.
+
+**No automated test for `SystemContactsProvider`**: it drives a real `CNContactStore`,
+which is TCC-gated — a bare `swift test` binary can't hold the Contacts permission (the
+same class of problem the sandboxed-binary-probe precedent solves for App Sandbox). The
+protocol seam exists precisely so `ContactsModel` (Task 4) can be tested against a fake
+instead. `SystemContactsProvider` itself is exercised manually in Task 9's verification
+pass, against a real system contact.
+
+- [ ] **Step 1: Write `ContactsProviding.swift`**
+
+```swift
+import Foundation
+#if canImport(Contacts)
+import Contacts
+#endif
+
+/// One system contact's matchable identity signals, plus how to fetch a batch of them. The
+/// `Contacts.framework`-backed implementation lives behind `#if canImport(Contacts)` — mirrors
+/// `FoundationModelAssistant`'s platform-guarded-framework-inside-a-portable-target pattern — so
+/// this protocol itself stays usable from portable code and from tests without ever touching
+/// `CNContactStore`.
+public protocol ContactsProviding: Sendable {
+    /// Requests Contacts access if needed, then returns every system contact's matchable URLs.
+    /// Throws ``ContactsAccessError/denied`` if the owner declines the permission prompt.
+    func matchableContacts() async throws -> [MatchableContact]
+}
+
+public enum ContactsAccessError: Error, Equatable, Sendable {
+    case denied
+}
+
+#if canImport(Contacts)
+/// The real, `CNContactStore`-backed provider. Requests access on first use — never at launch —
+/// per the design doc §5's "opt-in per scan" requirement.
+public struct SystemContactsProvider: ContactsProviding {
+    public init() {}
+
+    public func matchableContacts() async throws -> [MatchableContact] {
+        let store = CNContactStore()
+        let granted = try await requestAccess(store: store)
+        guard granted else { throw ContactsAccessError.denied }
+        return try await Task.detached(priority: .utility) {
+            try Self.fetchAll(store: store)
+        }.value
+    }
+
+    private func requestAccess(store: CNContactStore) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
+            store.requestAccess(for: .contacts) { granted, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
+    }
+
+    /// Runs off the calling task (see the `Task.detached` above) because `enumerateContacts`
+    /// blocks synchronously over the whole address book.
+    private static func fetchAll(store: CNContactStore) throws -> [MatchableContact] {
+        let keys: [CNKeyDescriptor] = [
+            CNContactFormatter.descriptorForRequiredKeys(for: .fullName),
+            CNContactUrlAddressesKey as CNKeyDescriptor,
+            CNContactSocialProfilesKey as CNKeyDescriptor,
+            CNContactOrganizationNameKey as CNKeyDescriptor,
+        ]
+        let request = CNContactFetchRequest(keysToFetch: keys)
+        var results: [MatchableContact] = []
+        try store.enumerateContacts(with: request) { contact, _ in
+            let name = CNContactFormatter.string(from: contact, style: .fullName)
+                ?? contact.organizationName
+            guard let name, !name.isEmpty else { return }
+            let urls = contact.urlAddresses.compactMap { URL(string: $0.value as String) }
+            let socialURLs = contact.socialProfiles.compactMap { labeled -> URL? in
+                let urlString = labeled.value.urlString
+                return urlString.isEmpty ? nil : URL(string: urlString)
+            }
+            guard !urls.isEmpty || !socialURLs.isEmpty else { return }
+            results.append(
+                MatchableContact(
+                    displayName: name, urlAddresses: urls, socialProfileURLs: socialURLs))
+        }
+        return results
+    }
+}
+#endif
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `swift build --package-path . --target AnglesiteCore`
+Expected: BUILD SUCCEEDED (compiles both with and without `canImport(Contacts)`; this
+worktree's macOS toolchain has Contacts, so `SystemContactsProvider` compiles here).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteCore/ContactsProviding.swift
+git commit -m "feat(#966): add ContactsProviding seam and SystemContactsProvider"
+```
+
+---
+
+### Task 4: `ContactsModel` (app glue)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/ContactsModel.swift`
+- Test: `Tests/AnglesiteAppTests/ContactsModelTests.swift`
+
+**Interfaces:**
+- Consumes: `Contact`, `ContactStore`, `ContactsProviding`, `ContactsAccessError`,
+  `MatchableContact`, `ContactsMatcher`, `MatchSuggestion`, `SystemContactsProvider`
+  (Tasks 1–3, `AnglesiteCore`); `CurrentSite` (already exists, `AnglesiteApp`).
+- Produces: `@MainActor @Observable final class ContactsModel` with `init(contactsProvider:
+  ContactsProviding = SystemContactsProvider())`, `func configure(site: CurrentSite)`,
+  `func reload() async`, `func add(me: URL, displayName: String) async`, `func update(_
+  contact: Contact) async`, `func remove(_ contact: Contact) async`, `func
+  scanForMatches(candidateFollowerURLs: [URL]) async`, `func dismiss(_ suggestion:
+  MatchSuggestion)`, `func accept(_ suggestion: MatchSuggestion) async`, and read-only
+  state `contacts: [Contact]`, `loadState: LoadState` (`.idle`/`.loaded`/`.corruptFile`),
+  `suggestions: [MatchSuggestion]`, `isScanning: Bool`, `scanFailure: ScanFailure?`
+  (`.permissionDenied`/`.other(String)`) — used by `ContactsView` (Task 5) and
+  `SiteWindowModel` (Task 6).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteAppTests/ContactsModelTests.swift`:
+
+```swift
+import Testing
+import Foundation
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+@Suite("ContactsModel")
+@MainActor
+struct ContactsModelTests {
+    private static func makeSite() throws -> CurrentSite {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContactsModelTests-\(UUID().uuidString)")
+        let config = root.appendingPathComponent("Config")
+        try FileManager.default.createDirectory(at: config, withIntermediateDirectories: true)
+        return CurrentSite(
+            id: "site-1", packageURL: root, sourceDirectory: root, configDirectory: config)
+    }
+
+    private struct FakeContactsProvider: ContactsProviding {
+        var result: Result<[MatchableContact], Error>
+        func matchableContacts() async throws -> [MatchableContact] {
+            try result.get()
+        }
+    }
+
+    @Test("loads an empty list for a fresh site")
+    func loadsEmptyForFreshSite() async throws {
+        let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        #expect(model.loadState == .loaded)
+        #expect(model.contacts.isEmpty)
+    }
+
+    @Test("add then remove round-trips through the store")
+    func addAndRemove() async throws {
+        let model = ContactsModel(contactsProvider: FakeContactsProvider(result: .success([])))
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        await model.add(me: URL(string: "https://alice.example")!, displayName: "Alice")
+        #expect(model.contacts.count == 1)
+
+        let added = try #require(model.contacts.first)
+        await model.remove(added)
+        #expect(model.contacts.isEmpty)
+    }
+
+    @Test("scanForMatches surfaces a promotion suggestion")
+    func scanSurfacesPromotion() async throws {
+        let bob = URL(string: "https://mastodon.social/users/bob")!
+        let provider = FakeContactsProvider(
+            result: .success([
+                MatchableContact(
+                    displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [bob])
+            ]))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+
+        #expect(model.suggestions.count == 1)
+        #expect(model.scanFailure == nil)
+    }
+
+    @Test("scanForMatches surfaces permission denial without crashing")
+    func scanSurfacesDenial() async throws {
+        let provider = FakeContactsProvider(result: .failure(ContactsAccessError.denied))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+
+        await model.scanForMatches(candidateFollowerURLs: [])
+
+        #expect(model.scanFailure == .permissionDenied)
+        #expect(model.suggestions.isEmpty)
+    }
+
+    @Test("accepting a promotion suggestion adds it as a contact and clears the suggestion")
+    func acceptPromotion() async throws {
+        let bob = URL(string: "https://mastodon.social/users/bob")!
+        let provider = FakeContactsProvider(
+            result: .success([
+                MatchableContact(
+                    displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [bob])
+            ]))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+        let suggestion = try #require(model.suggestions.first)
+
+        await model.accept(suggestion)
+
+        #expect(model.contacts.contains { $0.me == bob && $0.displayName == "Bob Jones" })
+        #expect(model.suggestions.isEmpty)
+    }
+
+    @Test("dismissing a suggestion removes it and it does not resurface until the next scan")
+    func dismissSuggestion() async throws {
+        let bob = URL(string: "https://mastodon.social/users/bob")!
+        let provider = FakeContactsProvider(
+            result: .success([
+                MatchableContact(
+                    displayName: "Bob Jones", urlAddresses: [], socialProfileURLs: [bob])
+            ]))
+        let model = ContactsModel(contactsProvider: provider)
+        model.configure(site: try Self.makeSite())
+        await model.reload()
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+        let suggestion = try #require(model.suggestions.first)
+
+        model.dismiss(suggestion)
+        #expect(model.suggestions.isEmpty)
+
+        await model.scanForMatches(candidateFollowerURLs: [bob])
+        #expect(model.suggestions.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+Run: `swift test --package-path . --filter ContactsModelTests`
+Expected: FAIL — `ContactsModel` doesn't exist yet.
+
+- [ ] **Step 3: Write `ContactsModel.swift`**
+
+```swift
+import Foundation
+import Observation
+import AnglesiteCore
+
+/// Drives the Contacts pane (Website ▸ Contacts…, #966): a per-site, private list of known
+/// people, plus an opt-in Contacts.framework matching scan. App glue only — persistence and
+/// matching logic live in `AnglesiteCore`.
+@MainActor
+@Observable
+final class ContactsModel {
+    enum LoadState: Equatable {
+        case idle
+        case loaded
+        /// `ContactStore.load()` threw — the file exists but didn't decode. Surfaced rather than
+        /// silently showing an empty list (see `ContactStore`'s doc comment for why).
+        case corruptFile
+    }
+
+    enum ScanFailure: Equatable {
+        case permissionDenied
+        case other(String)
+    }
+
+    private(set) var contacts: [Contact] = []
+    private(set) var loadState: LoadState = .idle
+    private(set) var suggestions: [MatchSuggestion] = []
+    private(set) var isScanning = false
+    private(set) var scanFailure: ScanFailure?
+
+    private var store: ContactStore?
+    /// Session-scoped, like `FollowersModel.unreachableActors`: a dismissed suggestion can
+    /// resurface on a later scan, which is fine since scans are always owner-initiated.
+    private var dismissedSuggestionKeys: Set<String> = []
+    private let contactsProvider: ContactsProviding
+
+    init(contactsProvider: ContactsProviding = SystemContactsProvider()) {
+        self.contactsProvider = contactsProvider
+    }
+
+    /// Records which site this pane reads. Called once per site open, like
+    /// `FollowersModel.configure(site:)`. Does not load — `ContactsView`'s `.task` triggers
+    /// ``reload()`` the same way `FollowersView`'s `.task` triggers `FollowersModel.load()`.
+    func configure(site: CurrentSite) {
+        store = ContactStore(configDirectory: site.configDirectory)
+    }
+
+    func reload() async {
+        guard let store else { return }
+        do {
+            contacts = try await store.load()
+            loadState = .loaded
+        } catch {
+            contacts = []
+            loadState = .corruptFile
+        }
+    }
+
+    func add(me: URL, displayName: String) async {
+        guard let store else { return }
+        let contact = Contact(me: me, displayName: displayName)
+        try? await store.add(contact)
+        await reload()
+    }
+
+    func update(_ contact: Contact) async {
+        guard let store else { return }
+        try? await store.update(contact)
+        await reload()
+    }
+
+    func remove(_ contact: Contact) async {
+        guard let store else { return }
+        try? await store.remove(id: contact.id)
+        await reload()
+    }
+
+    /// Runs one on-demand Contacts.framework scan (Website ▸ Contacts… ▸ "Find in Contacts…").
+    /// `candidateFollowerURLs` are the not-yet-added follower actor IRIs to check for the
+    /// promote-to-contact direction — the caller (`SiteWindowModel`) is responsible for making
+    /// sure Followers has loaded before supplying them.
+    func scanForMatches(candidateFollowerURLs: [URL]) async {
+        isScanning = true
+        scanFailure = nil
+        defer { isScanning = false }
+        do {
+            let matchable = try await contactsProvider.matchableContacts()
+            let fresh = ContactsMatcher.suggestions(
+                matchableContacts: matchable,
+                existingContacts: contacts,
+                candidateFollowerURLs: candidateFollowerURLs)
+            suggestions = fresh.filter { !dismissedSuggestionKeys.contains(suggestionKey($0)) }
+        } catch ContactsAccessError.denied {
+            scanFailure = .permissionDenied
+        } catch {
+            scanFailure = .other("\(error)")
+        }
+    }
+
+    func dismiss(_ suggestion: MatchSuggestion) {
+        dismissedSuggestionKeys.insert(suggestionKey(suggestion))
+        suggestions.removeAll { suggestionKey($0) == suggestionKey(suggestion) }
+    }
+
+    func accept(_ suggestion: MatchSuggestion) async {
+        switch suggestion.kind {
+        case .enrichExisting(let contact):
+            var updated = contact
+            updated.displayName = suggestion.systemContactName
+            await update(updated)
+        case .promoteToContact:
+            await add(me: suggestion.candidateURL, displayName: suggestion.systemContactName)
+        }
+        dismiss(suggestion)
+    }
+
+    private func suggestionKey(_ suggestion: MatchSuggestion) -> String {
+        "\(suggestion.candidateURL.absoluteString)|\(suggestion.systemContactName)"
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter ContactsModelTests`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ContactsModel.swift Tests/AnglesiteAppTests/ContactsModelTests.swift
+git commit -m "feat(#966): add ContactsModel"
+```
+
+---
+
+### Task 5: `ContactsView`
+
+**Files:**
+- Create: `Sources/AnglesiteApp/ContactsView.swift`
+
+**Interfaces:**
+- Consumes: `ContactsModel` (Task 4); `Contact`, `MatchSuggestion` (`AnglesiteCore`).
+- Produces: `struct ContactsView: View` with `init(contacts: ContactsModel,
+  candidateFollowerURLs: @escaping () async -> [URL])` — consumed by `SiteWindow.swift`
+  in Task 7.
+
+No dedicated automated test: this codebase does not unit-test SwiftUI view bodies (there
+is no `FollowersViewTests.swift` either) — correctness is verified by compiling and by
+the manual run-through in Task 9.
+
+- [ ] **Step 1: Write `ContactsView.swift`**
+
+```swift
+import SwiftUI
+import AppKit
+import AnglesiteCore
+
+/// Main-pane Contacts surface (Website ▸ Contacts…, #966): the site's private list of known
+/// people, with an opt-in "Find in Contacts…" scan. Mirrors `FollowersView`'s wiring shape.
+struct ContactsView: View {
+    @Bindable var contacts: ContactsModel
+    /// Not-yet-added follower actor IRIs to check during a scan. Async because the caller
+    /// (`SiteWindowModel`) may need to load Followers first — see
+    /// `SiteWindowModel.candidateFollowerURLsForContactsMatching()`.
+    let candidateFollowerURLs: () async -> [URL]
+
+    @State private var isPresentingAddSheet = false
+    @State private var editingContact: Contact?
+
+    var body: some View {
+        Group {
+            switch contacts.loadState {
+            case .idle:
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .corruptFile:
+                corruptFileMessage
+            case .loaded:
+                loadedContent
+            }
+        }
+        .navigationSubtitle("Contacts")
+        .task { if contacts.loadState == .idle { await contacts.reload() } }
+        .sheet(isPresented: $isPresentingAddSheet) {
+            ContactEditSheet(title: "Add Contact", meText: "", displayName: "") { me, displayName in
+                await contacts.add(me: me, displayName: displayName)
+            }
+        }
+        .sheet(item: $editingContact) { contact in
+            ContactEditSheet(
+                title: "Edit Contact", meText: contact.me.absoluteString,
+                displayName: contact.displayName
+            ) { me, displayName in
+                var updated = contact
+                updated.me = me
+                updated.displayName = displayName
+                await contacts.update(updated)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var loadedContent: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("\(contacts.contacts.count) contacts").font(.headline)
+                Spacer()
+                Button("Find in Contacts…") {
+                    Task {
+                        let candidates = await candidateFollowerURLs()
+                        await contacts.scanForMatches(candidateFollowerURLs: candidates)
+                    }
+                }
+                .disabled(contacts.isScanning)
+                Button("Add Contact…") { isPresentingAddSheet = true }
+            }
+            .padding()
+
+            if let failure = contacts.scanFailure {
+                scanFailureBanner(failure)
+            }
+
+            if !contacts.suggestions.isEmpty {
+                suggestionsSection
+            }
+
+            if contacts.contacts.isEmpty {
+                emptyState
+            } else {
+                List {
+                    ForEach(contacts.contacts) { contact in
+                        contactRow(contact)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var suggestionsSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Suggestions").font(.subheadline).foregroundStyle(.secondary)
+            ForEach(contacts.suggestions, id: \.candidateURL) { suggestion in
+                suggestionRow(suggestion)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private func suggestionRow(_ suggestion: MatchSuggestion) -> some View {
+        HStack {
+            // `systemContactName` is Contacts-framework-supplied, and `candidateURL` is a
+            // follower/contact-supplied identity — both rendered verbatim via string
+            // interpolation into a plain `Text`, never as a localization key.
+            switch suggestion.kind {
+            case .enrichExisting:
+                Text(
+                    "Use “\(suggestion.systemContactName)” from Contacts for "
+                        + "\(suggestion.candidateURL.host ?? suggestion.candidateURL.absoluteString)?")
+            case .promoteToContact:
+                Text("“\(suggestion.systemContactName)” matches a follower — add as a contact?")
+            }
+            Spacer()
+            Button("Add") { Task { await contacts.accept(suggestion) } }
+            Button("Dismiss") { contacts.dismiss(suggestion) }
+        }
+    }
+
+    @ViewBuilder
+    private func scanFailureBanner(_ failure: ContactsModel.ScanFailure) -> some View {
+        HStack {
+            switch failure {
+            case .permissionDenied:
+                Text("Contacts access wasn't granted.")
+                Button("Open System Settings") {
+                    if let url = URL(
+                        string:
+                            "x-apple.systempreferences:com.apple.preference.security?Privacy_Contacts"
+                    ) {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+            case .other(let reason):
+                Text("Couldn't scan Contacts").foregroundStyle(.secondary)
+                Text(reason).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("No contacts yet").font(.title2)
+            Text(
+                "Add people you know by their website address, or scan Contacts to find people "
+                    + "you already follow."
+            )
+            .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private var corruptFileMessage: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Couldn't read your contacts").font(.title2)
+            Text(
+                "The contacts file may be damaged. Back it up, then remove Config/contacts.json "
+                    + "to start fresh."
+            )
+            .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private func contactRow(_ contact: Contact) -> some View {
+        HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(contact.displayName).font(.headline)
+                Text(contact.me.absoluteString).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            linkageBadges(for: contact)
+        }
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+        .onTapGesture { editingContact = contact }
+        .contextMenu {
+            Button("Edit…") { editingContact = contact }
+            Button("Delete", role: .destructive) { Task { await contacts.remove(contact) } }
+        }
+    }
+
+    /// Small icon badges showing which identities this contact is linked to (design doc §4).
+    /// Purely informational — editing the linkage itself is out of scope (design doc §9).
+    @ViewBuilder
+    private func linkageBadges(for contact: Contact) -> some View {
+        HStack(spacing: 4) {
+            if contact.linkedActor != nil {
+                Image(systemName: "person.2.fill")
+                    .foregroundStyle(.secondary)
+                    .help("Linked to a Fediverse follower")
+            }
+            if contact.linkedFeed != nil {
+                Image(systemName: "dot.radiowaves.up.forward")
+                    .foregroundStyle(.secondary)
+                    .help("Linked to a followed feed")
+            }
+        }
+        .font(.caption)
+    }
+}
+
+/// Add/edit sheet shared by both flows in `ContactsView` — `title` and the initial field values
+/// are the only difference between "Add Contact" and "Edit Contact".
+private struct ContactEditSheet: View {
+    let title: String
+    @State var meText: String
+    @State var displayName: String
+    let onSave: (URL, String) async -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var validationError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title).font(.headline)
+            TextField("Name", text: $displayName)
+            TextField("Website (e.g. https://example.com)", text: $meText)
+            if let validationError {
+                Text(validationError).font(.caption).foregroundStyle(.red)
+            }
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Save") { save() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding()
+        .frame(width: 360)
+    }
+
+    private func save() {
+        let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            validationError = "Enter a name."
+            return
+        }
+        let trimmedURLText = meText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmedURLText),
+            url.scheme == "http" || url.scheme == "https"
+        else {
+            validationError = "Enter a valid http(s) website address."
+            return
+        }
+        let capturedURL = url
+        Task {
+            await onSave(capturedURL, trimmedName)
+            dismiss()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `swift build --package-path . --target AnglesiteAppCore`
+Expected: BUILD SUCCEEDED. (`ContactsView` isn't referenced anywhere yet — Task 7 wires
+it in — but Swift compiles unreferenced internal types without error.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/AnglesiteApp/ContactsView.swift
+git commit -m "feat(#966): add ContactsView"
+```
+
+---
+
+### Task 6: Wire `ContactsModel` into `SiteWindowModel`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindowModel.swift`
+
+**Interfaces:**
+- Consumes: `ContactsModel` (Task 4), `MicrosubReaderModel`/`FollowersModel` pattern
+  already in this file.
+- Produces: `MainPaneMode.contacts` case, `SiteWindowModel.contacts: ContactsModel`
+  property, `SiteWindowModel.presentContacts()`, `SiteWindowModel.candidateFollowerURLsForContactsMatching()
+  async -> [URL]` — consumed by `SiteWindow.swift` and `WebsiteCommands.swift` in Task 7.
+
+- [ ] **Step 1: Add the `MainPaneMode` case**
+
+In `Sources/AnglesiteApp/SiteWindowModel.swift`, find:
+
+```swift
+enum MainPaneMode: Equatable {
+    case preview
+    case editor(FileRef)
+    case graph
+    case cleanup        // Site ▸ Cleanup… (#714 moved it out of the sidebar)
+    case reader         // Website ▸ Reader… (V-4.3, #365)
+    case followers      // Website ▸ Followers… (V-4.2, #364)
+    case communities    // Website ▸ Communities… (V-5.1a, #368)
+    case moderation     // Website ▸ Moderation… (V-5.1b/V-5.3, #907/#370)
+}
+```
+
+Replace with:
+
+```swift
+enum MainPaneMode: Equatable {
+    case preview
+    case editor(FileRef)
+    case graph
+    case cleanup        // Site ▸ Cleanup… (#714 moved it out of the sidebar)
+    case reader         // Website ▸ Reader… (V-4.3, #365)
+    case followers      // Website ▸ Followers… (V-4.2, #364)
+    case communities    // Website ▸ Communities… (V-5.1a, #368)
+    case moderation     // Website ▸ Moderation… (V-5.1b/V-5.3, #907/#370)
+    case contacts       // Website ▸ Contacts… (#966)
+}
+```
+
+- [ ] **Step 2: Add the `contacts` model property**
+
+Find:
+
+```swift
+    /// Drives the main-pane Moderation view (Website ▸ Moderation…, V-5.1b/V-5.3 #907/#370):
+    /// moderator display, and ban/remove actions over this site's members and posts.
+    var moderation = ModerationModel()
+```
+
+Replace with:
+
+```swift
+    /// Drives the main-pane Moderation view (Website ▸ Moderation…, V-5.1b/V-5.3 #907/#370):
+    /// moderator display, and ban/remove actions over this site's members and posts.
+    var moderation = ModerationModel()
+    /// Drives the main-pane Contacts view (Website ▸ Contacts…, #966): the site's private list
+    /// of known people, plus an opt-in Contacts.framework matching scan.
+    var contacts = ContactsModel()
+```
+
+- [ ] **Step 3: Add `presentContacts()` and `candidateFollowerURLsForContactsMatching()`**
+
+Find:
+
+```swift
+    func presentModeration() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            await moderation.reload()
+            await clearInspectorThenSwitchPane(to: .moderation)
+        }
+    }
+```
+
+Replace with:
+
+```swift
+    func presentModeration() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            await moderation.reload()
+            await clearInspectorThenSwitchPane(to: .moderation)
+        }
+    }
+
+    /// Switches the main pane to Contacts (Website ▸ Contacts…, #966). Mirrors
+    /// `presentModeration()`'s leave-current-surface-first guard.
+    func presentContacts() {
+        Task {
+            guard await leaveCurrentEditor(), await leaveCurrentInspector() else { return }
+            activeEditor = nil
+            await clearInspectorThenSwitchPane(to: .contacts)
+        }
+    }
+
+    /// Ensures the Followers collection is loaded before a Contacts.framework matching scan
+    /// runs, so a promotion suggestion doesn't come up empty just because the owner never opened
+    /// Followers… this session (#966 design doc §5).
+    func candidateFollowerURLsForContactsMatching() async -> [URL] {
+        if followers.state == .idle {
+            await followers.load()
+        }
+        return followers.rows.map(\.actor)
+    }
+```
+
+- [ ] **Step 4: Configure `contacts` when a site opens**
+
+Find:
+
+```swift
+        reader.configure(site: currentSite)
+        followers.configure(site: currentSite)
+        communities.configure(site: currentSite)
+        await moderation.configure(site: currentSite)
+```
+
+Replace with:
+
+```swift
+        reader.configure(site: currentSite)
+        followers.configure(site: currentSite)
+        communities.configure(site: currentSite)
+        await moderation.configure(site: currentSite)
+        contacts.configure(site: currentSite)
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `swift build --package-path . --target AnglesiteAppCore`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindowModel.swift
+git commit -m "feat(#966): wire ContactsModel into SiteWindowModel"
+```
+
+---
+
+### Task 7: Wire `ContactsView` into the main pane and the Website menu
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/SiteWindow.swift`
+- Modify: `Sources/AnglesiteApp/WebsiteCommands.swift`
+- Modify: `Sources/AnglesiteApp/Localizable.xcstrings`
+
+**Interfaces:**
+- Consumes: `ContactsView` (Task 5), `SiteWindowModel.contacts`/`presentContacts()`/
+  `candidateFollowerURLsForContactsMatching()` (Task 6).
+- Produces: a reachable "Website ▸ Contacts…" menu item and main-pane surface — the last
+  piece needed for the feature to be usable end to end.
+
+- [ ] **Step 1: Add the `.contacts` case to the main-pane switch**
+
+In `Sources/AnglesiteApp/SiteWindow.swift`, find:
+
+```swift
+        case .moderation:
+            ModerationView(moderation: model.moderation)
+        case .preview:
+            previewPane(for: site)
+```
+
+Replace with:
+
+```swift
+        case .moderation:
+            ModerationView(moderation: model.moderation)
+        case .contacts:
+            ContactsView(
+                contacts: model.contacts,
+                candidateFollowerURLs: { await model.candidateFollowerURLsForContactsMatching() }
+            )
+        case .preview:
+            previewPane(for: site)
+```
+
+- [ ] **Step 2: Add the menu item**
+
+In `Sources/AnglesiteApp/WebsiteCommands.swift`, find:
+
+```swift
+            Button("Followers…") { model?.presentFollowers() }
+                .disabled(model == nil)
+
+            Button("Communities…") { model?.presentCommunities() }
+                .disabled(model == nil)
+```
+
+Replace with:
+
+```swift
+            Button("Followers…") { model?.presentFollowers() }
+                .disabled(model == nil)
+
+            Button("Contacts…") { model?.presentContacts() }
+                .disabled(model == nil)
+
+            Button("Communities…") { model?.presentCommunities() }
+                .disabled(model == nil)
+```
+
+- [ ] **Step 3: Add the new user-facing strings to the localization catalog**
+
+In `Sources/AnglesiteApp/Localizable.xcstrings`, find:
+
+```
+    "Contacts" : {
+
+    },
+```
+
+Replace with (order doesn't affect correctness — `check-localization-catalog.sh` only
+checks key presence):
+
+```
+    "Contacts" : {
+
+    },
+    "Contacts…" : {
+
+    },
+    "Contacts access wasn't granted." : {
+
+    },
+    "Couldn't read your contacts" : {
+
+    },
+    "Couldn't scan Contacts" : {
+
+    },
+    "Find in Contacts…" : {
+
+    },
+    "Add Contact" : {
+
+    },
+    "Add Contact…" : {
+
+    },
+    "Edit Contact" : {
+
+    },
+    "No contacts yet" : {
+
+    },
+    "Open System Settings" : {
+
+    },
+    "Suggestions" : {
+
+    },
+    "Website (e.g. https://example.com)" : {
+
+    },
+```
+
+- [ ] **Step 4: Run the localization catalog check**
+
+Run: `scripts/check-localization-catalog.sh`
+Expected: `✓ every scanned localizable literal in Sources/AnglesiteApp has a matching
+Sources/AnglesiteApp/Localizable.xcstrings key.`
+
+- [ ] **Step 5: Verify the app builds**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteApp/SiteWindow.swift Sources/AnglesiteApp/WebsiteCommands.swift Sources/AnglesiteApp/Localizable.xcstrings
+git commit -m "feat(#966): add Contacts… to the main pane and Website menu"
+```
+
+---
+
+### Task 8: Entitlement, usage description, and Info.plist catalog entry
+
+**Files:**
+- Modify: `Resources/Anglesite.entitlements`
+- Modify: `Resources/Anglesite-Debug.entitlements`
+- Modify: `Resources/Info.plist`
+- Modify: `Sources/AnglesiteApp/InfoPlist.xcstrings`
+
+**Interfaces:**
+- Consumes: nothing new (declarative config only).
+- Produces: the `com.apple.security.personal-information.addressbook` entitlement and
+  `NSContactsUsageDescription`, which `CNContactStore.requestAccess` (Task 3) needs to
+  successfully prompt instead of crashing the process.
+
+- [ ] **Step 1: Add the entitlement to `Resources/Anglesite.entitlements`**
+
+Find:
+
+```
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+
+	<!-- Apple Containerization framework (#69): boot local OCI containers. -->
+```
+
+Replace with:
+
+```
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+
+	<!-- Contacts.framework read-only matching (#966): suggests linking a system contact to a
+	     known identity URL. Unlike the iCloud/webcredentials entitlements below, this needs no
+	     special Developer Portal provisioning, so it's safe in both the Release and CI-safe
+	     Debug entitlements files. -->
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+
+	<!-- Apple Containerization framework (#69): boot local OCI containers. -->
+```
+
+- [ ] **Step 2: Add the same entitlement to `Resources/Anglesite-Debug.entitlements`**
+
+Find:
+
+```
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+
+	<!-- Apple Containerization framework (#69): boot local OCI containers. -->
+```
+
+Replace with:
+
+```
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+
+	<!-- Contacts.framework read-only matching (#966): suggests linking a system contact to a
+	     known identity URL. Unlike the iCloud/webcredentials entitlements this file
+	     deliberately omits, this needs no special Developer Portal provisioning. -->
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+
+	<!-- Apple Containerization framework (#69): boot local OCI containers. -->
+```
+
+- [ ] **Step 3: Add the usage description to `Resources/Info.plist`**
+
+Find:
+
+```
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Anglesite needs to coordinate with helper processes (Astro dev server, MCP server) to preview and edit your site.</string>
+```
+
+Replace with:
+
+```
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Anglesite needs to coordinate with helper processes (Astro dev server, MCP server) to preview and edit your site.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Anglesite can check your Contacts to suggest names for people you follow, so your contact list uses names you recognize.</string>
+```
+
+- [ ] **Step 4: Add the matching catalog entry to `Sources/AnglesiteApp/InfoPlist.xcstrings`**
+
+Find:
+
+```
+    "NSAppleEventsUsageDescription" : {
+      "comment" : "Privacy - AppleEvents Sending Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Anglesite needs to coordinate with helper processes (Astro dev server, MCP server) to preview and edit your site."
+          }
+        }
+      }
+    },
+```
+
+Replace with:
+
+```
+    "NSAppleEventsUsageDescription" : {
+      "comment" : "Privacy - AppleEvents Sending Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Anglesite needs to coordinate with helper processes (Astro dev server, MCP server) to preview and edit your site."
+          }
+        }
+      }
+    },
+    "NSContactsUsageDescription" : {
+      "comment" : "Privacy - Contacts Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Anglesite can check your Contacts to suggest names for people you follow, so your contact list uses names you recognize."
+          }
+        }
+      }
+    },
+```
+
+- [ ] **Step 5: Verify the app builds with the new entitlements**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED. If this fails with a provisioning-profile error naming the new
+entitlement, stop and report it — the design doc's assumption that this entitlement needs
+no special provisioning would be wrong, and that's a decision for the issue, not a silent
+workaround.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/Anglesite.entitlements Resources/Anglesite-Debug.entitlements Resources/Info.plist Sources/AnglesiteApp/InfoPlist.xcstrings
+git commit -m "feat(#966): add Contacts entitlement and usage description"
+```
+
+---
+
+### Task 9: Full verification and manual run-through
+
+**Files:** none (verification only).
+
+**Interfaces:** none — this task consumes everything from Tasks 1–8 and produces
+confidence the feature works end to end, including the parts (real `CNContactStore`,
+SwiftUI rendering) no automated test in this plan covers.
+
+- [ ] **Step 1: Run the full Swift test suite**
+
+Run: `swift test --package-path .`
+Expected: all suites pass, including the new `ContactStoreTests`, `ContactsMatcherTests`,
+and `ContactsModelTests`.
+
+- [ ] **Step 2: Run the localization catalog check**
+
+Run: `scripts/check-localization-catalog.sh`
+Expected: passes (already verified in Task 7, re-checked here in case later edits added
+an uncataloged literal).
+
+- [ ] **Step 3: Full Debug app build**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Manual run-through**
+
+Launch the built `Anglesite.app`, open (or create) a test site, and verify:
+
+1. Website ▸ Contacts… opens a new pane titled "Contacts", showing "No contacts yet".
+2. Click "Add Contact…", enter a name and `https://` URL, save — the contact appears in
+   the list.
+3. Click the new row's context menu ▸ Edit…, change the name, save — the list updates.
+4. Click the row's context menu ▸ Delete — the contact disappears, "No contacts yet"
+   returns.
+5. Quit and relaunch the app, reopen the site, reopen Contacts… — confirm a contact added
+   before quitting is still there (`Config/contacts.json` persisted).
+6. Add a contact whose `me` URL matches a real entry in the local Contacts app (e.g. add
+   your own site's URL as a Website field on your own Contacts card), then click "Find in
+   Contacts…". The first click should show the macOS Contacts permission prompt; grant it.
+   Confirm a "Use “<name>” from Contacts…" suggestion appears, and that clicking "Add"
+   updates the contact's display name.
+7. In System Settings ▸ Privacy & Security ▸ Contacts, revoke Anglesite's permission, then
+   click "Find in Contacts…" again inside the app — confirm the "Contacts access wasn't
+   granted." banner appears with a working "Open System Settings" button, and that the
+   rest of the pane (existing contacts, Add Contact…) still works normally.
+
+- [ ] **Step 5: Confirm CONTRIBUTING.md's pre-handoff checklist**
+
+Re-read `CONTRIBUTING.md` ▸ "Commits and pull requests" before opening the PR: subject
+lines ≤72 characters (already followed by every commit above), PR body built from
+`.github/PULL_REQUEST_TEMPLATE.md`'s actual headings (Summary / Paired PR check / Test
+plan), and a `Closes #966` line. This is not an MCP schema change, so the Paired PR check
+section should say so explicitly rather than being omitted.

--- a/docs/superpowers/specs/2026-08-17-known-contacts-design.md
+++ b/docs/superpowers/specs/2026-08-17-known-contacts-design.md
@@ -1,0 +1,226 @@
+# Known contacts as a first-class concept — design (#966)
+
+**Status:** approved design, pre-implementation.
+**Issue:** [#966](https://github.com/Anglesite/Anglesite/issues/966), owner-approved
+in full 2026-08-15. Related: #963 (contacts epic / auth allowlist), #965 (follow
+approval landing spot), #876 (iCloud sync — exclusion), #365 (Microsub reader).
+
+## 1. Context and goal
+
+There is no contact list today. The nearest thing is the opposite of one: the
+`member` content type (`ContentTypeRegistry.swift:526`) is a **public** staff
+directory rendered into `dist/`. The people the app actually tracks are
+scattered across purpose-specific stores — `ActorProfileCache` (federation
+display enrichment), the Microsub followed-feed list (reading), the
+ActivityPub followers collection (inbound) — and none of them is "people I
+know."
+
+**Goal:** a per-site, private contact store that is the pivot point for the
+secondary product goal (replace Facebook/LinkedIn for known contacts). It
+needs to exist before #963 (an authenticated-read allowlist of `me` URLs) and
+#965 (a landing spot for an accepted follower) can be built, though this issue
+does not wire either of those up — it ships the store and the hooks they'll
+call.
+
+Two capabilities, both approved together by the owner:
+
+1. A per-site contact store: `{ me, displayName, addedDate }` plus optional
+   linkage to an ActivityPub actor IRI and a Microsub feed, manually
+   manageable (add/edit/delete) with zero dependency on system permissions.
+2. Contacts.framework-backed matching: an on-demand scan that compares system
+   Contacts against known identity URLs in both directions — enriching a
+   manually-added contact with a real name, and suggesting an existing
+   follower be promoted to a contact — read-only, fully opt-in, and never
+   required for the feature to work.
+
+## 2. Data model
+
+```swift
+public struct Contact: Codable, Equatable, Sendable, Identifiable {
+    public let id: UUID
+    public var me: URL              // the person's canonical identity URL
+    public var displayName: String
+    public let addedDate: Date
+    public var linkedActor: URL?    // ActivityPub actor IRI, if promoted from a follower
+    public var linkedFeed: URL?     // Microsub-followed feed URL, if linked
+}
+```
+
+`id` is a stable `UUID`, generated at creation. It is not one of the issue's
+literal three fields, but SwiftUI list identity needs a key that survives
+editing `me` or `displayName` — the same reasoning `FollowerRow` applies to
+`actor.absoluteString`, except a contact's `me` is itself editable so it can't
+double as the key.
+
+`linkedFeed` is part of the model now but has no way to be populated by the
+promotion flow yet — see §6's documented limitation.
+
+## 3. Storage
+
+`ContactStore`, a new type in `AnglesiteCore`, persists to
+`<configDirectory>/contacts.json` — app-owned per-site state per the
+`.anglesite` package rules (never in git, alongside `chat-history.jsonl` and
+`activitypub-follower-profiles.json`).
+
+Shape follows `ActorProfileCache` (a full-file JSON envelope, pretty-printed,
+sorted keys, atomic write) rather than `ChatHistoryStore` (append-only JSONL):
+contacts are edited and deleted, not just appended, so an envelope that's
+rewritten in full on every mutation is the right fit. Internally keyed by
+`me.absoluteString` (URL isn't `Hashable`-stable across normalization, same
+reasoning `ActorProfileCache` uses for actor IRIs).
+
+```swift
+public actor ContactStore {
+    public init(configDirectory: URL, fileManager: FileManager = .default)
+    public func load() throws -> [Contact]
+    public func add(_ contact: Contact) throws
+    public func update(_ contact: Contact) throws   // rekeys if `me` changed
+    public func remove(id: UUID) throws
+    public func knownMeURLs() -> Set<String>          // forward-looking hook for #963
+}
+```
+
+**Missing vs. corrupt, precisely:** a *missing* file is the normal first-run
+state — `load()` returns `[]`, no error. A file that *exists but fails to
+decode* throws, so `ContactsModel` can surface "Couldn't read your contacts —
+the file may be damaged" instead of silently presenting an empty list. This
+deliberately departs from `ActorProfileCache`'s "corrupt cache costs nothing,
+discard silently" posture: a cache is disposable and re-fetchable, but a
+contact list is owner-curated data — silently showing zero contacts risks the
+owner believing the list was lost and re-entering it by hand. `add`/`update`/
+`remove` also throw normally (disk-full, permission errors on `Config/`)
+since these are direct user actions expecting feedback.
+
+## 4. UI and menu wiring
+
+Follows the `FollowersModel`/`MainPaneMode` pattern used by Followers,
+Reader, Communities, and Moderation — a main-pane switch, not a new pattern:
+
+- `MainPaneMode.contacts` case added.
+- `ContactsModel` (`@MainActor @Observable`, `AnglesiteApp`): loads/holds
+  `[Contact]` from its site's `ContactStore`, exposes add/edit/remove, and
+  (per §5) drives the on-demand matching scan and its suggestions.
+- `ContactsView`: a list (display name, `me` URL, linkage badges when
+  present), an "Add Contact…" row for manual entry (URL + display name),
+  context-menu delete, click-to-edit.
+- `SiteWindowModel.presentContacts()` — same leave-current-surface-first
+  guard as `presentFollowers()`/`presentReader()`.
+- `WebsiteCommands`: `Button("Contacts…") { model?.presentContacts() }`,
+  placed next to `Followers…`/`Reader…`, per the issue's menu placement note.
+
+Manual add/edit/delete has zero dependency on Contacts.framework or its
+permission — the entire UI in this section works before §5 is ever touched.
+
+## 5. Contacts.framework matching
+
+**Platform seam**, mirroring the `FoundationModelAssistant` precedent for
+Apple-framework code inside the portable `AnglesiteCore` target:
+
+```swift
+public protocol ContactsProviding: Sendable {
+    func matchableContacts() async throws -> [MatchableContact]
+    // MatchableContact: displayName, urlAddresses: [URL], socialProfileURLs: [URL]
+}
+
+#if canImport(Contacts)
+public struct SystemContactsProvider: ContactsProviding { /* CNContactStore-backed */ }
+#endif
+```
+
+The protocol seam exists so `AnglesiteCoreTests` can inject a fake and test
+matching logic in CI without a TCC-gated `CNContactStore` — a bare test binary
+can't hold the Contacts permission (same class of problem the sandboxed-probe
+precedent solves for App Sandbox).
+
+**`ContactsMatcher`** (`AnglesiteCore`, pure logic, no I/O): given
+`matchableContacts()` output and a list of candidate identity URLs (existing
+contacts' `me`, plus not-yet-added ActivityPub follower actor IRIs), normalizes
+and compares URLs (host + path, scheme-insensitive, trailing-slash-insensitive)
+against each system contact's URL/social-profile fields. Produces:
+
+```swift
+public struct MatchSuggestion: Equatable, Sendable {
+    public let candidateURL: URL
+    public let systemContactName: String
+    public enum Kind: Equatable, Sendable {
+        case enrichExisting(Contact)   // fill in a name for a manually-added contact
+        case promoteToContact          // a follower matches a system contact — add them
+    }
+    public let kind: Kind
+}
+```
+
+Candidate follower URLs come from `SiteWindowModel.followers` (the
+`FollowersModel` instance the window already owns and loads for the Followers
+pane) — `ContactsModel` reads its already-loaded `rows`, filtered to actors not
+already present in the contact store. It does not independently re-fetch the
+followers collection; if the Followers pane hasn't been opened yet this
+session, `SiteWindowModel` triggers `followers.load()` before handing rows to
+the matcher, so promotion suggestions don't silently come up empty just
+because the owner went straight to Contacts….
+
+**Trigger:** a "Find in Contacts…" button in `ContactsView` — no background or
+periodic scanning. First click requests Contacts permission in-context
+(`CNContactStore.requestAccess`), runs one scan, and populates a
+**Suggestions** section above the contact list with Accept/Dismiss per
+suggestion. Dismissals are session-only (not persisted) — the same choice
+`FollowersModel.unreachableActors` makes — so a later manual scan can
+resurface a dismissed match, which is acceptable since scans are always
+owner-initiated.
+
+## 6. Permissions and entitlements
+
+- `com.apple.security.personal-information.addressbook` added to both
+  `Resources/Anglesite.entitlements` and `Resources/Anglesite-Debug.entitlements`
+  — like `network.client`, this entitlement needs no special Developer Portal
+  provisioning, unlike the Release-only iCloud/webcredentials entries.
+- `NSContactsUsageDescription` added to `Info.plist`:
+  *"Anglesite can check your Contacts to suggest names for people you follow,
+  so your contact list uses names you recognize."*
+- Permission is requested only when "Find in Contacts…" is clicked, never at
+  launch or site open.
+- Denial/restriction: `ContactsModel` surfaces an inline message ("Contacts
+  access wasn't granted — enable it in System Settings ▸ Privacy & Security ▸
+  Contacts") with a button that opens that pane. Every other part of the
+  Contacts pane keeps working.
+
+**Documented limitation:** promoting a *Microsub feed* to a contact has no
+candidate source yet — `MicrosubClient` exposes `follow`/`unfollow` actions
+but no "list followed feeds" endpoint. `linkedFeed` stays in the `Contact`
+model for forward compatibility, settable only via manual edit until that API
+exists. Only ActivityPub followers feed the promotion direction in this
+implementation.
+
+## 7. Privacy posture
+
+A contact list is among the most sensitive data the app holds:
+
+- `Config/` is already excluded from the site's git repo and from any sync
+  today — this needs no new code, only this explicit statement.
+- Excluded from any future iCloud sync (#876) unless that becomes its own,
+  separately-reasoned decision.
+- The feature is entirely usable — add, edit, delete contacts — without ever
+  granting Contacts access; Contacts.framework is pure augmentation,
+  opt-in per scan, never required.
+
+## 8. Testing
+
+- `Tests/AnglesiteCoreTests/ContactStoreTests.swift` — round-trip CRUD,
+  missing-vs-corrupt-file distinction, `me`-edit rekeying, `knownMeURLs()`.
+- `Tests/AnglesiteCoreTests/ContactsMatcherTests.swift` — pure matching logic
+  against a fake `ContactsProviding` and fixed candidate-URL lists; URL
+  normalization edge cases (scheme, trailing slash); both suggestion kinds.
+- `Tests/AnglesiteAppTests/ContactsModelTests.swift` — mirrors the existing
+  `FollowersModelTests.swift` pattern for testing an `@Observable` app-glue
+  model.
+
+## 9. Explicitly out of scope
+
+- Writing discovered profiles back into system Contacts — the issue defers
+  this to a separate, later decision.
+- Wiring the store into #963 (auth allowlist) or #965 (follow-approval
+  landing spot) — this issue ships `knownMeURLs()`/`add()` as the hooks those
+  issues will call, not the call sites themselves.
+- Microsub feed promotion (§6's documented limitation).
+- Background or periodic Contacts re-scanning.
+- Any change to sync behavior — `Config/` already isn't synced anywhere.

--- a/docs/superpowers/specs/2026-08-17-known-contacts-design.md
+++ b/docs/superpowers/specs/2026-08-17-known-contacts-design.md
@@ -195,10 +195,15 @@ implementation.
 
 A contact list is among the most sensitive data the app holds:
 
-- `Config/` is already excluded from the site's git repo and from any sync
-  today — this needs no new code, only this explicit statement.
-- Excluded from any future iCloud sync (#876) unless that becomes its own,
-  separately-reasoned decision.
+- `Config/contacts.json` is excluded from the site's **git repo** — `Config/`
+  as a whole is never git-tracked, so this needs no new code.
+- It **does** sync via iCloud Drive along with the rest of the site
+  package's `Config/` directory: new packages default into the iCloud Drive
+  ubiquity container (#865), and only `.nosync`-suffixed paths (e.g.
+  `Config/repo.nosync/`, which `RepoRelocator` uses specifically to opt the
+  git repo *out*) are excluded from that sync. `contacts.json` carries no
+  such suffix. This is accepted as consistent with existing precedent —
+  `chat-history.jsonl` already syncs the same way — not a gap to close.
 - The feature is entirely usable — add, edit, delete contacts — without ever
   granting Contacts access; Contacts.framework is pure augmentation,
   opt-in per scan, never required.
@@ -223,4 +228,6 @@ A contact list is among the most sensitive data the app holds:
   issues will call, not the call sites themselves.
 - Microsub feed promotion (§6's documented limitation).
 - Background or periodic Contacts re-scanning.
-- Any change to sync behavior — `Config/` already isn't synced anywhere.
+- Any change to sync behavior — `contacts.json` syncs via iCloud Drive the
+  same way the rest of `Config/` already does (see §7); this issue neither
+  adds nor removes that.


### PR DESCRIPTION
Closes #966

## Summary

- Adds a per-site, private contact store (`Config/contacts.json`, never in git) with manual add/edit/delete, reachable via Website ▸ Contacts…, following the exact same `MainPaneMode`/`SiteWindowModel` pattern as the existing Followers/Reader/Communities panes.
- Adds an opt-in Contacts.framework matching scan ("Find in Contacts…") that suggests either enriching an existing contact's display name from a matching system contact, or promoting a not-yet-added ActivityPub follower to a contact when a system contact matches their actor URL — read-only, permission requested only on first click, never at launch.
- Design doc: `docs/superpowers/specs/2026-08-17-known-contacts-design.md`. Implementation plan: `docs/superpowers/plans/2026-08-17-known-contacts.md`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

No MCP message schema changes — this is app-only (new `AnglesiteCore` types, a new `AnglesiteApp` pane, an entitlement, and a usage description).

## Test plan

- [x] `swift test --package-path .` — full suite, 3941 tests / 478 suites, all passing (including 5 new suites for this feature: `ContactStoreTests`, `ContactsMatcherTests`, `SystemContactsProviderTests`, `ContactsModelTests`, `ContactEditValidationTests`).
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (wraps `xcodebuild` after regenerating the project) — BUILD SUCCEEDED, confirming the new `com.apple.security.personal-information.addressbook` entitlement needs no special Developer Portal provisioning.
- [x] `scripts/check-localization-catalog.sh` — passes.
- [ ] Manual smoke (UI-touching): **not performed** — no macOS GUI-automation tool was available in the implementing session to launch the app, click through the Contacts pane, or interact with the real macOS Contacts-permission dialog. Automated coverage coverage is thorough (see above and the design doc §8), but before merge someone should manually verify: adding/editing/deleting a contact persists across a relaunch; "Find in Contacts…" triggers the permission prompt correctly; a granted scan produces sensible suggestions against a real Contacts entry; a denied/revoked permission shows the "Contacts access wasn't granted" banner with a working "Open System Settings" link.

## Process notes

Built via `superpowers:brainstorming` → `superpowers:writing-plans` → `superpowers:subagent-driven-development` (9 tasks, each independently implemented and reviewed; 2 tasks needed one fix round each). A final whole-branch review found 4 Important + 2 Minor issues plus one doc inaccuracy (design doc claimed `contacts.json` was excluded from iCloud sync — it isn't; owner decided to keep it syncing like `chat-history.jsonl` and correct the doc instead of adding a `.nosync` exclusion). All were fixed in one follow-up pass and re-verified clean.