### PR TITLE
docs: headless build/smoke-test guide + macOS preflight hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,18 +1,76 @@
 #!/bin/bash
 #
-# SessionStart hook for Claude Code on the web.
+# SessionStart hook for Claude Code.
 #
-# The Linux portable-target flow (see scripts/setup-dev-env.sh and
-# README.md#developing-on-linux) needs a Swift 6.3+ toolchain for
-# `swift build`/`swift test` to work, and web session containers don't ship
-# one. The preferred install path is the cloud environment's **setup script**
-# (fetched from GitHub via curl since the setup script runs before the
-# session's repo clone exists, cached with the environment — see
-# README.md#developing-on-linux); this hook is the per-session fallback for
-# environments without that cache, and it owns the part a setup script can't
-# do: persisting the toolchain's PATH/LD_LIBRARY_PATH into the session via
-# $CLAUDE_ENV_FILE.
+# Two jobs, by platform:
+#
+# macOS (local sessions): emit a toolchain preflight into the session context
+# so agents never misdiagnose "the build tooling is not there" — the recurring
+# failure is environment resolution (xcode-select at CommandLineTools, an
+# ungenerated worktree .xcodeproj, unprovisioned container artifacts), not
+# absent tooling. See docs/testing-macos-app.md. Best-effort: a probe failure
+# must never fail the session.
+#
+# Linux (Claude Code on the web): the portable-target flow (see
+# scripts/setup-dev-env.sh and README.md#developing-on-linux) needs a
+# Swift 6.3+ toolchain for `swift build`/`swift test` to work, and web session
+# containers don't ship one. The preferred install path is the cloud
+# environment's **setup script** (fetched from GitHub via curl since the setup
+# script runs before the session's repo clone exists, cached with the
+# environment — see README.md#developing-on-linux); this hook is the
+# per-session fallback for environments without that cache, and it owns the
+# part a setup script can't do: persisting the toolchain's
+# PATH/LD_LIBRARY_PATH into the session via $CLAUDE_ENV_FILE.
 set -euo pipefail
+
+if [ "$(uname -s)" = "Darwin" ] && [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  proj_dir="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+  echo "Anglesite macOS toolchain preflight (docs/testing-macos-app.md):"
+
+  sel=$(xcode-select -p 2>/dev/null || true)
+  case "$sel" in
+    *.app/Contents/Developer)
+      echo "- xcode-select: $sel ($(xcodebuild -version 2>/dev/null | head -1 || echo 'version unknown'))"
+      ;;
+    *)
+      echo "- WARNING: xcode-select points at '${sel:-nothing}', not an Xcode app. Do NOT run xcode-select --switch (needs sudo) — export DEVELOPER_DIR instead."
+      best=""
+      best_v=0
+      for app in /Applications/Xcode*.app; do
+        [ -d "$app" ] || continue
+        v=$(defaults read "$app/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo 0)
+        maj=${v%%.*}
+        if [ "${maj:-0}" -ge "$best_v" ] 2>/dev/null; then
+          best="$app"
+          best_v="$maj"
+        fi
+      done
+      if [ -n "$best" ]; then
+        echo "  Fix: export DEVELOPER_DIR=\"$best/Contents/Developer\"  (Xcode ${best_v}.x found; this repo needs 27+). Re-export in every tool call — shell state does not persist."
+      else
+        echo "  No /Applications/Xcode*.app found — the macOS app cannot be built on this machine."
+      fi
+      ;;
+  esac
+
+  if command -v xcodegen >/dev/null 2>&1; then
+    echo "- xcodegen: $(command -v xcodegen)"
+  else
+    echo "- WARNING: xcodegen not on PATH (brew install xcodegen) — required to generate the gitignored Anglesite.xcodeproj."
+  fi
+
+  if [ ! -e "$proj_dir/Anglesite.xcodeproj" ]; then
+    echo "- Anglesite.xcodeproj not generated in this checkout (normal for a fresh worktree) — run 'xcodegen generate', or just use scripts/build-app.sh which does it for you."
+  fi
+
+  if [ ! -f "$proj_dir/Resources/container-image/index.json" ] \
+     || [ ! -f "$proj_dir/Resources/container-kernel/vmlinux" ] \
+     || [ ! -f "$proj_dir/Resources/container-initfs/index.json" ]; then
+    echo "- Container boot artifacts unprovisioned here: Debug builds warn, Release builds fail, and site previews fail at runtime. Fix: rsync Resources/container-{image,kernel,initfs} from the main checkout — see docs/testing-macos-app.md § Container boot artifacts."
+  fi
+
+  exit 0
+fi
 
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
     "allow": [
       "Bash(swift test *)",
       "Bash(swift build *)",
+      "Bash(scripts/build-app.sh *)",
       "Bash(xcodebuild *)",
       "Bash(xcodegen generate)",
       "Bash(git fetch *)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ Do feature work — and **all** dispatched-agent work — in a git worktree, nev
 
 ## Build
 
+**Building, testing, or smoke-testing from a CLI-only/agent session: follow [`docs/testing-macos-app.md`](docs/testing-macos-app.md).** It has the toolchain preflight (run it before ever concluding "the tooling is not there" — the `SessionStart` hook prints it automatically on macOS), the fresh-worktree build steps, how to launch and smoke-test the built app, and the optional Xcode 27 MCP (`xcrun mcpbridge`) integration.
+
 Toolchain: **Xcode 27+ / Swift 6.4** (required for SwiftUI 27's `@State` macro semantics — see [`docs/specs/2026-06-10-xcode27-state-macro-audit-notes.md`](docs/specs/2026-06-10-xcode27-state-macro-audit-notes.md)).
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ Key things to know:
 
 ## Testing
 
+Working headless (CI, agents, or just no Xcode GUI)? [`docs/testing-macos-app.md`](docs/testing-macos-app.md) is the how-to for building, launching, and smoke-testing the app from a CLI-only session — including the toolchain preflight, fresh-worktree gotchas, and the optional Xcode MCP (`xcrun mcpbridge`) setup.
+
 Run the relevant suites before opening a PR:
 
 ```sh

--- a/docs/testing-macos-app.md
+++ b/docs/testing-macos-app.md
@@ -1,0 +1,186 @@
+# Building and Smoke-Testing the macOS App (headless / agent guide)
+
+How to build, test, launch, and smoke-test the `Anglesite` macOS app from a
+CLI-only session — the workflow every dispatched agent (and any human working
+without the Xcode GUI) should follow. Human-facing IDE setup lives in
+[xcode-setup.md](xcode-setup.md); the required pre-PR suites are listed in
+[CONTRIBUTING.md ▸ Testing](../CONTRIBUTING.md#testing); scripted manual QA
+runs live in [qa/](qa/).
+
+**Prime directive: never conclude "the build/test tooling is not available"
+without running the preflight below.** On this repo's dev machines the
+toolchain *is* installed; every known case of an agent reporting it missing
+was an environment-resolution problem — `xcode-select` pointing at
+CommandLineTools, an ungenerated `.xcodeproj` in a fresh worktree, or `node`
+loaded via nvm in one shell but not another — not absent tooling.
+
+## Preflight (30 seconds)
+
+| Probe | Expect | If not |
+|---|---|---|
+| `xcode-select -p` | a path inside an Xcode app, e.g. `/Applications/Xcode-beta.app/Contents/Developer` | If it prints `/Library/Developer/CommandLineTools`, do **not** try `xcode-select --switch` (needs sudo). Export `DEVELOPER_DIR` instead — see below. |
+| `xcodebuild -version` | `Xcode 27.0` or newer | An older Xcode may be selected while a newer one sits in `/Applications`. Check `ls -d /Applications/Xcode*.app` and point `DEVELOPER_DIR` at a 27+ install. |
+| `xcodegen --version` | any version | `brew install xcodegen` |
+| `ls Anglesite.xcodeproj` | exists | Expected to be missing in a fresh worktree — run `xcodegen generate`. Not an error. |
+| `node --version` | v22+ | Only needed for JS/edit-overlay and template checks. Node is often nvm-managed: absent from a bare hook/login shell but present in your interactive tool shell. Probe in the same shell you'll build in before concluding it's missing. |
+
+When the selected Xcode is wrong or missing, prefix commands rather than
+mutating machine state:
+
+```sh
+# Pick whichever /Applications/Xcode*.app is 27+ (check with -version):
+export DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer
+```
+
+Shell state does not persist between agent tool calls — re-export (or prefix
+inline: `DEVELOPER_DIR=… swift test`) on every invocation that needs it.
+
+The repo's Claude Code `SessionStart` hook
+([`.claude/hooks/session-start.sh`](../.claude/hooks/session-start.sh)) prints
+this preflight automatically at session start on macOS; read its report before
+diagnosing toolchain problems from scratch.
+
+## Build
+
+```sh
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+
+- `scripts/build-app.sh` runs `xcodegen generate` itself before delegating to
+  `xcodebuild`, so a stale or missing `.xcodeproj` is handled (#123). Use it
+  instead of raw `xcodebuild`.
+- Debug builds are ad-hoc signed — no Apple account, and the
+  `com.apple.security.virtualization` entitlement works ad-hoc, so a Debug
+  build can boot the local container runtime.
+- A clean worktree build takes several minutes; incremental rebuilds are fast.
+  Run it in the background and poll rather than sitting on a foreground
+  timeout.
+
+### Container boot artifacts (fresh worktrees)
+
+`Resources/container-{image,kernel,initfs}/` are **gitignored** build
+artifacts, so a fresh worktree has empty dirs. Consequences:
+
+- **Debug** builds *warn* ("Check container resources") and continue.
+- **Release** builds *fail* on the same check.
+- An unprovisioned Debug app launches fine but every site preview fails at
+  runtime with `imageLayoutNotProvisioned; kernelNotProvisioned;
+  initfsNotProvisioned`.
+
+For a runtime smoke you don't need Docker or the vendor scripts — copy the
+artifacts from the main checkout (the first entry in `git worktree list`),
+**before** building, since they're bundled into the app at build time:
+
+```sh
+MAIN=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
+for d in container-image container-kernel container-initfs; do
+  rsync -a --delete "$MAIN/Resources/$d/" "Resources/$d/"
+done
+```
+
+Only re-vendor from scratch (`scripts/vendor-container-image.sh` +
+`scripts/vendor-container-kernel.sh`, with `ANGLESITE_SIDECAR_SRC` pointing at
+the real sidecar checkout — the default `../anglesite` resolves wrong from a
+worktree) when the image itself changed; that path needs Docker and is slow.
+
+## Automated tests
+
+The canonical pre-PR suites and their gotchas are in
+[CONTRIBUTING.md ▸ Testing](../CONTRIBUTING.md#testing). Agent-specific notes:
+
+- Prefix `DEVELOPER_DIR=…` if the preflight said so; otherwise `swift test`
+  runs against a broken/old CommandLineTools toolchain and fails in confusing
+  ways.
+- `swift test` hanging with no output usually means a stale SwiftPM process
+  holds the `.build` lock — `pgrep -fl swift-test`, kill the orphan.
+- Don't run two full `swift test` runs concurrently on one machine (multiple
+  agents!): the FoundationModels suites flake/hang under contention.
+- `swift test --filter X` still *compiles* the whole package — a broken
+  sibling target blocks a filtered run too.
+
+## Smoke-testing the built app
+
+1. **Locate the product:**
+
+   ```sh
+   APP="$(xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug -showBuildSettings 2>/dev/null | awk '/ BUILT_PRODUCTS_DIR =/{print $3}')/Anglesite.app"
+   ```
+
+2. **(Optional) create a site fixture** so there's something to open:
+   `scripts/create-smoke-fixture.sh` mirrors `Resources/Template/` into
+   `~/Sites/anglesite-smoke/` (idempotent).
+
+3. **Launch and verify it's alive:**
+
+   ```sh
+   open "$APP"
+   sleep 5 && pgrep -x Anglesite   # prints a PID if the app is running
+   ```
+
+   For stdout/stderr in your terminal, launch the binary directly instead:
+   `"$APP/Contents/MacOS/Anglesite" &`. System-log capture:
+   `log stream --process Anglesite`. In-app, the Debug pane streams every
+   spawned subprocess's output — that's the primary diagnostic surface.
+
+4. **Visual check (optional):** if a screenshot-capable MCP tool is available
+   in your session, use it (`mcp__computer-use__screenshot` is pre-allowlisted
+   in [`.claude/settings.json`](../.claude/settings.json)); otherwise
+   `screencapture -x /tmp/anglesite-smoke.png` (requires the host terminal to
+   have Screen Recording permission — if the capture comes back without the
+   app window, that permission is the reason, not the app).
+
+5. **Quit:** `osascript -e 'tell application "Anglesite" to quit'` (graceful;
+   first use may prompt the user for Automation permission) — fall back to
+   `pkill -x Anglesite`.
+
+A smoke launch on the user's machine opens visible UI — fine for a
+verification pass, but quit the app when you're done.
+
+## Xcode MCP (optional, richer control)
+
+Xcode 27 ships an MCP server (`xcrun mcpbridge`) that gives external agents
+Xcode's own capabilities: build with Issue Navigator diagnostics, run/stop
+with console output, list/run tests, LLDB commands, SwiftUI preview
+rendering, simulator interaction, and documentation search. See Apple's
+[Giving external agents access to Xcode](https://developer.apple.com/documentation/xcode/giving-external-agents-access-to-xcode).
+
+One-time setup (needs the human at the keyboard):
+
+1. Xcode ▸ Settings ▸ Intelligence ▸ Model Context Protocol → enable
+   **Allow external agents to use Xcode tools**.
+2. Register the server with your agent, e.g. for Claude Code:
+
+   ```sh
+   claude mcp add --transport stdio xcode -- xcrun mcpbridge
+   ```
+
+At use time the bridge requires a **running** Xcode 27+ with
+`Anglesite.xcodeproj` open (`open Anglesite.xcodeproj` — never `xed .`, which
+opens `Package.swift` with no runnable target). Xcode alerts the user when an
+agent connects. With no running Xcode, `mcpbridge` exits with a fatal error —
+which is why this repo deliberately does **not** commit a project-scoped
+`.mcp.json`: most agent sessions here are headless, and a committed entry
+would fail on connect in every one of them.
+
+Ground rules:
+
+- The CLI path above is **authoritative** for build/test pass-fail. Xcode MCP
+  is additive — never block or fail a task because it's unavailable.
+- Prefer it when you specifically need what the CLI can't give you: Issue
+  Navigator diagnostics, LLDB on a running instance, SwiftUI preview renders,
+  or driving the app's UI.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `xcodebuild: error: … does not contain an Xcode project` | Fresh worktree; `.xcodeproj` is gitignored | `xcodegen generate` (or just use `scripts/build-app.sh`) |
+| `swift` missing, ancient, or failing with toolchain errors | `xcode-select` points at CommandLineTools | `export DEVELOPER_DIR=/Applications/Xcode…app/Contents/Developer` (27+) |
+| `error: cannot find 'X' in scope` on code that clearly exists | Stale generated `.xcodeproj` (checkout synced via fetch+reset) | `scripts/build-app.sh` regenerates before building |
+| `vendor-node.sh: Operation not permitted` during build | Stale `.xcodeproj` picked up `ENABLE_USER_SCRIPT_SANDBOXING=YES` (Xcode's "recommended settings") | `xcodegen generate`; decline Xcode's recommended-settings prompt |
+| "Check container resources" build warning (Debug) / error (Release) | Gitignored container artifacts absent in this worktree | rsync the three `Resources/container-*` dirs from the main checkout (see above), then rebuild |
+| App runs but previews fail: `imageLayoutNotProvisioned; …` | Same as above — app was built without the artifacts | Same rsync, then rebuild |
+| `swift test` produces no output for minutes | Stale SwiftPM process holds the `.build` lock | `pgrep -fl swift-test`; kill the orphan |
+| FoundationModels test suites flake or hang | Two full `swift test` runs racing on one machine | Serialize full-suite runs across agents |
+| `xed .` opened the wrong thing | `Package.swift` has no runnable target | `open Anglesite.xcodeproj` |
+| `xcrun mcpbridge` → `Fatal error: … no running Xcode processes found` | Xcode MCP needs a live Xcode | Start Xcode with the project open, or use the CLI path |


### PR DESCRIPTION
## Summary

- Adds `docs/testing-macos-app.md` — an agent/headless how-to for building, testing, launching, and smoke-testing the macOS app: toolchain preflight (the fix for agents wrongly concluding "the tooling is not there"), fresh-worktree build steps, container-artifact provisioning via rsync from the main checkout, a verified smoke-launch procedure, optional Xcode 27 MCP (`xcrun mcpbridge`) setup, and a symptom → fix troubleshooting table.
- Extends `.claude/hooks/session-start.sh` with a macOS branch that prints that preflight into session context at start (healthy report, or warnings with the exact `DEVELOPER_DIR` fix, missing-`.xcodeproj` hint, and unprovisioned-artifact hint). The existing remote-Linux path is untouched.
- Cross-links the guide from `CLAUDE.md`/`AGENTS.md` and `CONTRIBUTING.md` ▸ Testing, and allowlists `scripts/build-app.sh` in `.claude/settings.json`.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [ ] `swift test --package-path .` — not run: no Swift source or template changes (docs + hook + settings only).
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — via `scripts/build-app.sh` from a fresh worktree, following the new doc verbatim (xcodegen generate → container-artifact rsync → build). **BUILD SUCCEEDED**.
- [x] Manual smoke: located the product via `-showBuildSettings`, launched it, confirmed the process stayed alive, quit gracefully via `osascript` — the exact procedure the doc documents.
- [x] Hook: exercised all branches (healthy; fake CommandLineTools `xcode-select` → correct `DEVELOPER_DIR` suggestion; empty project dir → `.xcodeproj` + container-artifact warnings). Exit 0 in every case; `shellcheck` clean; `settings.json` parses.
- [x] `xcrun mcpbridge` presence and its no-running-Xcode fatal error confirmed on Xcode 27.0 (27A5218g); the live MCP connection itself needs the human-only Intelligence-settings toggle and a running Xcode, and the doc says exactly that.

## Design notes

- The Xcode MCP is documented but **no `.mcp.json` is committed**: `mcpbridge` hard-fails whenever Xcode isn't running, and most agent sessions here are headless — a committed project-scoped entry would error on connect in every one. The doc gives the one-line `claude mcp add` setup and marks the CLI path as authoritative for pass/fail.
- Hook output is deliberately short (2 lines when healthy) and never fails the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)