### PR TITLE
docs(qa): drop retired copy-plugin.sh precondition from e2e overview

### DIFF
--- a/docs/qa/e2e-acceptance-overview.md
+++ b/docs/qa/e2e-acceptance-overview.md
@@ -16,8 +16,7 @@
 
 - Apple Silicon Mac, macOS 26+ (macOS 27+ for the Siri AI probes to report green).
 - Xcode 27+ / Swift 6.4 toolchain; `xcodegen generate` run in the checkout.
-- Container boot artifacts provisioned (`scripts/vendor-container-image.sh` with `ANGLESITE_PLUGIN_SRC` set, plus `scripts/vendor-container-kernel.sh`) — see [local-container-runtime-smoke-test.md](local-container-runtime-smoke-test.md) §Artifact Provisioning. A checkout without them fails every preview by design (`UnavailableSiteRuntime`).
-- `scripts/copy-plugin.sh` run so `Resources/plugin/` is populated.
+- Container boot artifacts provisioned (`scripts/vendor-container-image.sh` with `ANGLESITE_PLUGIN_SRC` set, plus `scripts/vendor-container-kernel.sh`) — see [local-container-runtime-smoke-test.md](local-container-runtime-smoke-test.md) §Artifact Provisioning. A checkout without them fails every preview by design (`UnavailableSiteRuntime`). This staging step already covers the MCP sidecar (`server/`); the app no longer bundles or loads separate Claude-plugin machinery (#466).
 - A build signed with `Resources/Anglesite.entitlements` (ad-hoc Debug is fine — the virtualization entitlement is unrestricted).
 - Network access (guest `npm install`, wrangler).
 - For Part 4: a Cloudflare account the tester controls, with no pre-existing token in Keychain or `CLOUDFLARE_API_TOKEN` in the environment.


### PR DESCRIPTION
## Summary

- Removes the stale `scripts/copy-plugin.sh` / `Resources/plugin/` precondition from the e2e acceptance overview's "Shared preconditions" — that script, directory, and `PluginRuntime` were retired in #466.
- Notes that the existing container-artifact provisioning line already covers staging the MCP sidecar (`server/`) into the image, so no replacement precondition is needed.
- Checked the four `e2e-acceptance-{1..4}` part docs for the same stale reference — none found.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [ ] `swift test --package-path .`
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
- [ ] Manual smoke (if UI-touching): N/A — docs-only change, no Swift/JS/template code touched.