### PR TITLE
feat(#1535): stable accessibility identifiers for AX automation

### DIFF
--- a/Sources/AnglesiteApp/AXID.swift
+++ b/Sources/AnglesiteApp/AXID.swift
@@ -1,0 +1,51 @@
+import AnglesiteCore
+
+/// Stable accessibility identifiers for AX-driven automation (#1535).
+///
+/// Never user-visible and never localized: VoiceOver reads `accessibilityLabel`s, while these
+/// strings exist so UI automation (System Events / AXUIElement scripts today, an XCUITest
+/// target if one lands) can address controls without depending on localized, wording-sensitive
+/// labels. See `docs/testing-macos-app.md` § Accessibility identifiers.
+///
+/// Naming: dotted `<surface>.<control>` paths with camelCase segments — `navigator.list`,
+/// `debug.sourceFilter`.
+/// Site-window toolbar controls derive theirs from `SiteToolbarItemID` so the two stable-ID
+/// namespaces can never drift apart. Like those customization IDs, values are frozen once
+/// shipped — automation scripts key off them (`AXIDTests` enforces format and uniqueness).
+enum AXID {
+    /// Identifier for a site-window toolbar control, derived from its frozen customization ID
+    /// (`SiteToolbarItemIDTests` freezes the raw values).
+    static func toolbar(_ id: SiteToolbarItemID) -> String { "toolbar.\(id.rawValue)" }
+
+    // MARK: Site navigator (sidebar)
+
+    static let navigatorList = "navigator.list"
+    static let navigatorRenameField = "navigator.renameField"
+
+    // MARK: Shared sheet chrome
+
+    /// The title/subtitle group every `SheetHeader`-based sheet and drawer renders; automation
+    /// reads its accessibility label to learn which sheet is frontmost.
+    static let sheetHeader = "sheet.header"
+
+    // MARK: Debug pane
+
+    static let debugSourceFilter = "debug.sourceFilter"
+    static let debugStreamFilter = "debug.streamFilter"
+    static let debugSearchField = "debug.search"
+    static let debugPauseToggle = "debug.pause"
+    static let debugAutoScrollToggle = "debug.autoScroll"
+    static let debugClearButton = "debug.clear"
+    static let debugCopyButton = "debug.copy"
+    static let debugSaveButton = "debug.save"
+
+    /// Every hand-assigned identifier, for `AXIDTests`' uniqueness/format checks (the
+    /// toolbar family is generated from `SiteToolbarItemID` and covered separately).
+    static let allStatic: [String] = [
+        navigatorList, navigatorRenameField,
+        sheetHeader,
+        debugSourceFilter, debugStreamFilter, debugSearchField,
+        debugPauseToggle, debugAutoScrollToggle,
+        debugClearButton, debugCopyButton, debugSaveButton,
+    ]
+}

--- a/Sources/AnglesiteApp/DebugPaneView.swift
+++ b/Sources/AnglesiteApp/DebugPaneView.swift
@@ -79,6 +79,7 @@ struct DebugPaneView: View {
                 }
             }
             .frame(maxWidth: 200)
+            .accessibilityIdentifier(AXID.debugSourceFilter)
 
             Picker("Stream", selection: $streamFilter) {
                 ForEach(StreamFilter.allCases, id: \.self) { f in
@@ -87,10 +88,12 @@ struct DebugPaneView: View {
             }
             .pickerStyle(.segmented)
             .frame(maxWidth: 200)
+            .accessibilityIdentifier(AXID.debugStreamFilter)
 
             TextField("Search", text: $searchQuery)
                 .textFieldStyle(.roundedBorder)
                 .frame(minWidth: 140, maxWidth: 240)
+                .accessibilityIdentifier(AXID.debugSearchField)
 
             Spacer()
 
@@ -99,17 +102,22 @@ struct DebugPaneView: View {
                 set: { frozenLines = $0 ? lines : nil }
             ))
             .toggleStyle(.switch)
+            .accessibilityIdentifier(AXID.debugPauseToggle)
 
             Toggle("Auto-scroll", isOn: $autoScroll)
                 .toggleStyle(.switch)
                 .disabled(isPaused)
+                .accessibilityIdentifier(AXID.debugAutoScrollToggle)
 
             Button("Clear") {
                 lines.removeAll()
                 frozenLines = nil
             }
+            .accessibilityIdentifier(AXID.debugClearButton)
             Button("Copy") { copyVisibleToClipboard() }
+                .accessibilityIdentifier(AXID.debugCopyButton)
             Button("Save…") { saveVisibleToFile() }
+                .accessibilityIdentifier(AXID.debugSaveButton)
         }
     }
 

--- a/Sources/AnglesiteApp/SheetHeader.swift
+++ b/Sources/AnglesiteApp/SheetHeader.swift
@@ -42,6 +42,9 @@ struct SheetHeader<Icon: View, Trailing: View>: View {
                 }
             }
             .accessibilityElement(children: .combine)
+            // One shared identifier across every sheet/drawer: automation finds the frontmost
+            // sheet's header here and reads its (combined) label to learn which sheet it is.
+            .accessibilityIdentifier(AXID.sheetHeader)
             Spacer()
             trailing()
         }

--- a/Sources/AnglesiteApp/SiteNavigatorView.swift
+++ b/Sources/AnglesiteApp/SiteNavigatorView.swift
@@ -25,6 +25,7 @@ struct SiteNavigatorView: View {
             }
         }
         .listStyle(.sidebar)
+        .accessibilityIdentifier(AXID.navigatorList)
         // Bare Delete key deletes the selection, matching Xcode/Mail/Notes sidebar convention
         // (#674). `deletableSelection()` is nil during inline-rename, so Delete edits the text
         // field there instead — same guard the Return-to-rename affordance above uses. This is
@@ -89,6 +90,7 @@ struct SiteNavigatorView: View {
         if model.editingItemID == node.id {
             TextField("Title", text: $model.draftTitle)
                 .textFieldStyle(.plain)
+                .accessibilityIdentifier(AXID.navigatorRenameField)
                 .focused($editingFocused)
                 .onSubmit { Task { await model.commitEditing() } }
                 .onExitCommand { model.cancelEditing() }   // Esc

--- a/Sources/AnglesiteApp/SiteWindow.swift
+++ b/Sources/AnglesiteApp/SiteWindow.swift
@@ -335,6 +335,7 @@ struct SiteWindow: View {
                 .pickerStyle(.segmented)
                 .labelsHidden()
                 .help("Switch between Preview, Editor, and Graph")
+                .accessibilityIdentifier(AXID.toolbar(.panes))
             }
             .customizationBehavior(.disabled)
 
@@ -345,6 +346,7 @@ struct SiteWindow: View {
                     Label("Site Graph", systemImage: "point.3.connected.trianglepath.dotted")
                 }
                 .help("Explore pages, layouts, components, collections, and assets")
+                .accessibilityIdentifier(AXID.toolbar(.graph))
             }
 
             // iCloud sync status (#881): renders nothing for a package that isn't in iCloud
@@ -352,6 +354,7 @@ struct SiteWindow: View {
             // item never widens a local-only site's toolbar.
             ToolbarItem(id: SiteToolbarItemID.sync.rawValue, placement: .primaryAction) {
                 SyncStatusView(model: model.sync)
+                    .accessibilityIdentifier(AXID.toolbar(.sync))
             }
 
             // Open GitHub security advisories/Dependabot alerts (#975). Renders nothing (an
@@ -362,6 +365,7 @@ struct SiteWindow: View {
                     onRecheck: { model.recheckSecurityReports() },
                     onViewAll: { model.openWebsiteSettings(landOn: .securityReports) }
                 )
+                .accessibilityIdentifier(AXID.toolbar(.securityReports))
             }
 
             ToolbarItem(id: SiteToolbarItemID.backup.rawValue, placement: .primaryAction) {
@@ -374,6 +378,7 @@ struct SiteWindow: View {
                 .help(site.isValid
                       ? "Commit and push working-tree changes to your current branch"
                       : "Site is missing required files")
+                .accessibilityIdentifier(AXID.toolbar(.backup))
             }
 
             ToolbarItem(id: SiteToolbarItemID.audit.rawValue, placement: .primaryAction) {
@@ -392,6 +397,7 @@ struct SiteWindow: View {
                       : site.isValid
                         ? "Open the preview first to start the runtime before auditing"
                         : "Site is missing required files")
+                .accessibilityIdentifier(AXID.toolbar(.audit))
             }
 
             ToolbarItem(id: SiteToolbarItemID.openInBrowser.rawValue, placement: .primaryAction) {
@@ -402,6 +408,7 @@ struct SiteWindow: View {
                 }
                 .disabled(!model.canOpenPreviewInBrowser)
                 .help("Open the live preview in your default browser")
+                .accessibilityIdentifier(AXID.toolbar(.openInBrowser))
             }
 
             // — Palette-only items (View ▸ Customize Toolbar…) —
@@ -420,6 +427,7 @@ struct SiteWindow: View {
                 .help(site.isValid
                       ? "Preview and apply Cloudflare security hardening for this site"
                       : "Site is missing required files")
+                .accessibilityIdentifier(AXID.toolbar(.harden))
             }
             .defaultCustomization(.hidden)
 
@@ -437,6 +445,7 @@ struct SiteWindow: View {
                 .help(site.isValid
                       ? "Provision Cloudflare AI Search for this site"
                       : "Site is missing required files")
+                .accessibilityIdentifier(AXID.toolbar(.aiSearch))
             }
             .defaultCustomization(.hidden)
 
@@ -454,6 +463,7 @@ struct SiteWindow: View {
                 .help(site.isValid
                       ? "Compare anglesite.json's declared domain/DNS/edge config against live Cloudflare state"
                       : "Site is missing required files")
+                .accessibilityIdentifier(AXID.toolbar(.domainConfigAudit))
             }
             .defaultCustomization(.hidden)
 
@@ -471,6 +481,7 @@ struct SiteWindow: View {
                 .help(site.isValid
                       ? "Check Cloudflare's Agent Readiness score for this site's deployed URL"
                       : "Site is missing required files")
+                .accessibilityIdentifier(AXID.toolbar(.agentReadiness))
             }
             .defaultCustomization(.hidden)
 
@@ -484,6 +495,7 @@ struct SiteWindow: View {
                 .help(site.isValid
                       ? "Enable Tor Browser access for this site via Cloudflare's zone-level setting"
                       : "Site is missing required files")
+                .accessibilityIdentifier(AXID.toolbar(.onionRouting))
             }
             .defaultCustomization(.hidden)
 
@@ -495,6 +507,7 @@ struct SiteWindow: View {
                 }
                 .disabled(!model.canOpenDomain)
                 .help("View and manage this domain's DNS records")
+                .accessibilityIdentifier(AXID.toolbar(.domain))
             }
             .defaultCustomization(.hidden)
 
@@ -506,6 +519,7 @@ struct SiteWindow: View {
                 }
                 .disabled(!model.canOpenIntegrationWizard)
                 .help("Set up a third-party integration for this site")
+                .accessibilityIdentifier(AXID.toolbar(.integration))
             }
             .defaultCustomization(.hidden)
 
@@ -517,6 +531,7 @@ struct SiteWindow: View {
                 }
                 .disabled(!model.canOpenSiriReadiness)
                 .help("Check whether Siri workflows are ready for this site")
+                .accessibilityIdentifier(AXID.toolbar(.siriReadiness))
             }
             .defaultCustomization(.hidden)
 
@@ -528,6 +543,7 @@ struct SiteWindow: View {
                           ? "link.badge.plus" : "link")
                 }
                 .help(model.relatedPagesPresented ? "Hide related pages" : "Show related pages")
+                .accessibilityIdentifier(AXID.toolbar(.relatedPages))
             }
             .defaultCustomization(.hidden)
 
@@ -538,6 +554,7 @@ struct SiteWindow: View {
                     Label("Style Guide", systemImage: "textformat.abc")
                 }
                 .help("See and edit this site's learned writing, image, and naming conventions")
+                .accessibilityIdentifier(AXID.toolbar(.styleGuide))
             }
             .defaultCustomization(.hidden)
 
@@ -551,6 +568,7 @@ struct SiteWindow: View {
                         Label("View on GitHub", systemImage: "arrow.up.forward.square")
                     }
                     .help("Open this site's GitHub repository")
+                    .accessibilityIdentifier(AXID.toolbar(.github))
                 } else {
                     Button {
                         model.publish.publish(source: site.sourceDirectory, repoName: site.name)
@@ -559,6 +577,7 @@ struct SiteWindow: View {
                     }
                     .disabled(!model.canPublishToGitHub)
                     .help(site.isValid ? "Create a private GitHub repo and push this site" : "Site is missing required files")
+                    .accessibilityIdentifier(AXID.toolbar(.github))
                 }
             }
             .defaultCustomization(.hidden)
@@ -590,6 +609,7 @@ struct SiteWindow: View {
                           : site.isValid
                             ? "Open the preview first to start the runtime before deploying"
                             : "Site is missing required files")
+                    .accessibilityIdentifier(AXID.toolbar(.deploy))
                 }
             }
             .customizationBehavior(.reorderable)
@@ -603,6 +623,7 @@ struct SiteWindow: View {
                         : "bubble.left.and.bubble.right")
                 }
                 .help(model.chatPresented ? "Hide chat panel" : "Show chat panel")
+                .accessibilityIdentifier(AXID.toolbar(.chat))
                 // ⌘K moved to View ▸ Show/Hide Chat (#512) — a second registration here would
                 // recreate the duplicate-shortcut ambiguity #509 removed for ⌘S.
             }
@@ -616,6 +637,7 @@ struct SiteWindow: View {
                 }
                 .disabled(model.inspectorSelection == nil)
                 .help("Show or hide the inspector")
+                .accessibilityIdentifier(AXID.toolbar(.inspector))
             }
         }
         // Trailing search field (#520). Not a `.toolbar(id:)` item: `.searchable` mints its own

--- a/Tests/AnglesiteAppTests/AXIDTests.swift
+++ b/Tests/AnglesiteAppTests/AXIDTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+/// Freezes the accessibility-identifier contract (#1535). Identifiers are automation API —
+/// external AX scripts key off these strings the same way saved toolbar customizations key
+/// off `SiteToolbarItemID` — so renames are breaking changes, not refactors.
+struct AXIDTests {
+    @Test func staticIdentifiersAreUnique() {
+        #expect(Set(AXID.allStatic).count == AXID.allStatic.count)
+    }
+
+    @Test func staticIdentifiersAreDottedCamelCasePaths() {
+        for id in AXID.allStatic {
+            let segments = id.split(separator: ".", omittingEmptySubsequences: false)
+            #expect(segments.count >= 2, "\(id) should be a <surface>.<control> path")
+            for segment in segments {
+                #expect(!segment.isEmpty, "\(id) has an empty segment")
+                #expect(segment.first?.isLowercase == true, "\(id) segments start lowercase")
+                #expect(segment.allSatisfy { $0.isLetter || $0.isNumber }, "\(id) segments are alphanumeric")
+            }
+        }
+    }
+
+    /// `toolbar.*` is reserved for the family derived from `SiteToolbarItemID`.
+    @Test func staticIdentifiersStayOutOfTheToolbarNamespace() {
+        #expect(AXID.allStatic.allSatisfy { !$0.hasPrefix("toolbar.") })
+    }
+
+    @Test func toolbarIdentifiersDeriveFromFrozenCustomizationIDs() {
+        #expect(AXID.toolbar(.deploy) == "toolbar.deploy")
+        let derived = SiteToolbarItemID.allCases.map(AXID.toolbar)
+        #expect(Set(derived).count == derived.count)
+    }
+}

--- a/docs/testing-macos-app.md
+++ b/docs/testing-macos-app.md
@@ -136,6 +136,29 @@ The canonical pre-PR suites and their gotchas are in
 A smoke launch on the user's machine opens visible UI — fine for a
 verification pass, but quit the app when you're done.
 
+### Accessibility identifiers (AX automation)
+
+Key controls carry stable `accessibilityIdentifier`s (#1535), defined in
+[`Sources/AnglesiteApp/AXID.swift`](../Sources/AnglesiteApp/AXID.swift):
+site-window toolbar items derive `toolbar.<SiteToolbarItemID>` (e.g.
+`toolbar.deploy`), and the navigator, shared sheet header, and debug pane have
+hand-assigned dotted IDs (`navigator.list`, `sheet.header`, `debug.pause`).
+`AXIDTests` freezes format and uniqueness — treat the strings as automation
+API: renaming one breaks external scripts, same contract as
+`SiteToolbarItemID`.
+
+They surface as the AX element's `AXIdentifier` attribute (what XCUITest
+matches as `identifier`), so UI scripting can target controls without
+depending on localized labels. **Gate:** reading another app's AX tree
+requires the agent-host process to have Accessibility permission — without it
+every System Events query fails with `osascript is not allowed assistive
+access`, an owner-only grant in System Settings ▸ Privacy & Security ▸
+Accessibility. Example (once granted):
+
+```sh
+osascript -e 'tell application "System Events" to tell process "Anglesite" to get value of attribute "AXIdentifier" of buttons of toolbar 1 of window 1'
+```
+
 ## Xcode MCP (optional, richer control)
 
 Xcode 27 ships an MCP server (`xcrun mcpbridge`) that gives external agents


### PR DESCRIPTION
## Summary

Closes #1535

First slice of AX-automation support. The app was fully labeled for VoiceOver but carried **zero** `accessibilityIdentifier`s, so UI automation (System Events/AXUIElement scripts, a future XCUITest target) had no stable, locale-independent handles.

- **`AXID`** (new, `Sources/AnglesiteApp/AXID.swift`): central identifier namespace. Site-window toolbar controls derive `toolbar.<SiteToolbarItemID>` from the frozen customization-ID set so the two stable namespaces can never drift; the navigator (list + inline-rename field), the shared `SheetHeader` (one ID covers every sheet/drawer — automation reads its combined label to learn which sheet is frontmost), and the debug pane's filter/toggle/action controls get hand-assigned dotted IDs.
- **`AXIDTests`** (new): freezes uniqueness and `<surface>.<control>` format, keeps hand-assigned IDs out of the reserved `toolbar.*` namespace, and pins the derived form. Identifiers are automation API — renames are breaking changes, same contract as `SiteToolbarItemID` raw values.
- **`docs/testing-macos-app.md`**: new "Accessibility identifiers" section — convention, the `AXIdentifier` attribute they surface as, and the TCC assistive-access gate (an owner-only System Settings grant) that currently blocks agents from reading them live.

VoiceOver output is unchanged: identifiers are never user-visible and never localized. No `.xcstrings` churn (verified — build produced no catalog diff).

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

> Cross-cutting work (extending MCP messages) lands as paired PRs. The sidecar PR ships first in a tagged release; the app PR consumes it and re-vendors the container image. Template changes are app-only (`Resources/Template/`). See `CLAUDE.md` ▸ "Two-repo coordination".

## Test plan

- [x] `swift test --filter AXIDTests` on Xcode 27 — compiles the full package (including all edited `AnglesiteAppCore` views) and all 4 new tests pass.
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — **BUILD SUCCEEDED**.
- [ ] Live AX read-back of the identifiers via System Events — blocked by TCC: the agent host lacks assistive access (`osascript is not allowed assistive access`). Once Accessibility permission is granted to the host app, the doc's example query should list the `toolbar.*` IDs on the site window's toolbar buttons.

## Design notes

- Per-control `.accessibilityIdentifier(...)` modifiers rather than restructuring the toolbar into a wrapper helper: the `.toolbar(id:)` block has careful per-item `customizationBehavior`/`defaultCustomization` chains and comments; a purely additive diff keeps that intact.
- The stateful `github` toolbar item sets the same identifier on both of its branch buttons — one logical control, per its own "one stable item" design comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)