### PR TITLE
feat(#1015): DeployTarget seam, CloudflareDeployTarget

### DIFF
--- a/Sources/AnglesiteApp/AgentReadinessModel.swift
+++ b/Sources/AnglesiteApp/AgentReadinessModel.swift
@@ -19,14 +19,14 @@ final class AgentReadinessModel {
     var sheetPresented: Bool = false
 
     private let scanner: any AgentReadinessScanning
-    private let tokenSource: DeployCommand.TokenSource
+    private let tokenSource: CloudflareDeployTarget.TokenSource
     private var inFlight: Task<Void, Never>?
 
     private var currentSite: CurrentSite?
 
     init(
         scanner: any AgentReadinessScanning = HTTPCloudflareClient(),
-        tokenSource: @escaping DeployCommand.TokenSource = DeployCommand.keychainTokenSource
+        tokenSource: @escaping CloudflareDeployTarget.TokenSource = CloudflareDeployTarget.keychainTokenSource
     ) {
         self.scanner = scanner
         self.tokenSource = tokenSource

--- a/Sources/AnglesiteApp/DeployModel.swift
+++ b/Sources/AnglesiteApp/DeployModel.swift
@@ -653,7 +653,7 @@ final class DeployModel {
     /// OAuth doesn't issue one for this client) — in that dead-end case this falls through to the
     /// next check instead, so the sign-in sheet re-presents rather than deploys failing forever
     /// with a generic "no token" error. An expired credential that still has a refresh token is
-    /// left to `DeployCommand.keychainTokenSource` to actually refresh (this is a presence check
+    /// left to `CloudflareDeployTarget.keychainTokenSource` to actually refresh (this is a presence check
     /// only — no refresh attempted here, since it's synchronous).
     private func hasUsableToken() -> Bool {
         if let tokenAvailabilityOverride {
@@ -705,7 +705,7 @@ final class DeployModel {
     ) async -> DeployCommand.Result {
         defer { suddenTerminationLease.release() }
         transition(siteID: siteID, to: .running(siteID: siteID, since: Date()))
-        wasFirstDeploy = !DeployCommand.hasDeployedBefore(siteDirectory: siteDirectory)
+        wasFirstDeploy = !CloudflareDeployTarget.hasDeployedBefore(siteDirectory: siteDirectory)
         logLines = []
         currentMilestone = nil
         currentMilestonePhase = nil
@@ -746,10 +746,7 @@ final class DeployModel {
         let containerSecretRunner: SocialWorkerProvisionCommand.SecretRunner?
         if let cc = containerControl {
             activeCommand = DeployCommand(
-                tokenSource: command.tokenSource,
-                workerScriptNamesSource: command.workerScriptNamesSource,
-                customDomainAttachCommand: command.customDomainAttachCommand,
-                markdownForAgentsCommand: command.markdownForAgentsCommand,
+                target: command.target,
                 executor: ContainerDeployExecutor(
                     control: cc.control,
                     siteID: cc.siteID,
@@ -873,8 +870,17 @@ final class DeployModel {
             }
         }
 
+        // Both closures below only make sense against a Cloudflare target — `SocialWorkerProvisionCommand`
+        // is itself entirely a Cloudflare Workers concept (out of scope to generalize in #1015
+        // slice 1). `cloudflareTarget` is `nil` only if `command.target` were ever something else;
+        // today it's always `CloudflareDeployTarget` (the default), so the closures behave exactly
+        // as before.
+        let cloudflareTarget = command.target as? CloudflareDeployTarget
         let socialCommand = SocialWorkerProvisionCommand(
-            tokenSource: { [weak self] in try await self?.command.tokenSource() },
+            tokenSource: {
+                guard let cloudflareTarget else { return nil }
+                return try await cloudflareTarget.tokenSource()
+            },
             runner: containerRunner ?? SocialWorkerProvisionCommand.defaultRunner,
             secretRunner: containerSecretRunner ?? SocialWorkerProvisionCommand.defaultSecretRunner,
             deployer: { [weak self] _, deploySiteID, deploySiteDirectory, _ in
@@ -914,13 +920,13 @@ final class DeployModel {
                 )
             },
             // Forwards the same seam `activeCommand` uses for its own end-of-pipeline check (both
-            // are built from `command.workerScriptNamesSource` above), so `provision()`'s new
+            // are built from `cloudflareTarget.workerScriptNamesSource` above), so `provision()`'s
             // pre-provisioning check (#1075) agrees with `deployer`'s — and so a test's injected
-            // fake `DeployCommand` governs both instead of this defaulting to the real network
-            // implementation.
-            workerScriptNamesSource: { [weak self] token in
-                guard let self else { return [] }
-                return try await self.command.workerScriptNamesSource(token)
+            // fake `DeployCommand`/`CloudflareDeployTarget` governs both instead of this defaulting
+            // to the real network implementation.
+            workerScriptNamesSource: { token in
+                guard let cloudflareTarget else { return [] }
+                return try await cloudflareTarget.workerScriptNamesSource(token)
             }
         )
 

--- a/Sources/AnglesiteCore/CloudflareAPICredentials.swift
+++ b/Sources/AnglesiteCore/CloudflareAPICredentials.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Shared Cloudflare API bearer-token resolution (#1211), so every call site that needs one —
-/// not just the deploy path — sees an OAuth credential the same way ``DeployCommand/keychainTokenSource``
+/// not just the deploy path — sees an OAuth credential the same way ``CloudflareDeployTarget/keychainTokenSource``
 /// already does. Order: the `CLOUDFLARE_API_TOKEN` env var (a developer's shell still wins), then a
 /// stored OAuth credential (refreshed first via ``CloudflareOAuthTokenSource`` if expired), then the
 /// legacy pasted-token slot — read-only now that `CloudflareTokenPromptView` has been replaced by
@@ -22,7 +22,7 @@ public enum CloudflareAPICredentials {
     ///   - surfaceOAuthReadErrors: When `true`, a genuine read error on the OAuth slot (as opposed
     ///     to "no credential stored," which resolves `nil`, not a throw) propagates out of
     ///     `resolve()` instead of being swallowed and falling through to the legacy token. This
-    ///     restores ``DeployCommand/keychainTokenSource``'s original, pre-#1211 behavior for the
+    ///     restores ``CloudflareDeployTarget/keychainTokenSource``'s original, pre-#1211 behavior for the
     ///     deploy path specifically: a real Keychain problem (e.g. an access-group/entitlement
     ///     issue) surfaces as an actionable "couldn't read token" error rather than silently
     ///     reading as "no token configured" and nudging the user toward an unnecessary re-sign-in.

--- a/Sources/AnglesiteCore/CloudflareDeployTarget.swift
+++ b/Sources/AnglesiteCore/CloudflareDeployTarget.swift
@@ -1,0 +1,422 @@
+import Foundation
+
+/// The Cloudflare `wrangler deploy` conformer of `DeployTarget` (#1015 slice 1) — every piece of
+/// `DeployCommand` that used to be Cloudflare-specific now lives here: credential resolution, the
+/// worker-name-conflict and domain-config-drift pre-checks, the wrangler upload itself, and every
+/// post-publish effect (custom-domain attach, Markdown for Agents, `.site-config` persistence, the
+/// R2 source-bundle upload). `DeployCommand` calls `authorize(siteDirectory:)` before the shared
+/// build/`PreDeployCheck` spine runs, then `publish(context:)` only after that spine has passed.
+public struct CloudflareDeployTarget: DeployTarget {
+    public static let id = "cloudflare"
+
+    /// Returns the Cloudflare API token, or `nil` if none is configured. Production callers use
+    /// `CloudflareDeployTarget.keychainTokenSource` (Keychain with an env-var fallback for
+    /// development); tests typically inject a closure returning a literal.
+    public typealias TokenSource = @Sendable () async throws -> String?
+    /// Returns the account's existing Worker script names for the given token. Production
+    /// callers use `CloudflareDeployTarget.defaultWorkerScriptNames` (`HTTPCloudflareClient`);
+    /// tests inject a fake list or a throwing closure.
+    public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
+    /// Grades a declared `Source/anglesite.json` domain against live Cloudflare state and returns
+    /// any drift (#1171's `DomainConfigAudit.evaluate`, given a fresh zone read). Production
+    /// callers use `CloudflareDeployTarget.defaultDomainConfigDriftSource`; tests inject a canned
+    /// findings list or a throwing closure — same rationale as `WorkerScriptNamesSource`.
+    public typealias DomainConfigDriftSource = @Sendable (
+        _ declared: DomainConfig, _ hostname: String, _ apiToken: String
+    ) async throws -> [DomainConfigAudit.Finding]
+
+    /// The token seam this target was constructed with. Exposed so `DeployModel.runDeploy` can
+    /// forward the exact same seam into companion commands (e.g. `SocialWorkerProvisionCommand`)
+    /// instead of letting them silently default to the production implementation and diverge
+    /// from a test's injected fake — see `workerScriptNamesSource` below for the full rationale.
+    public let tokenSource: TokenSource
+    /// Exposed (like `tokenSource`) so callers that build a parallel `SocialWorkerProvisionCommand`
+    /// alongside this target — `DeployModel.runDeploy` — can forward the exact same seam into its
+    /// own pre-provisioning conflict check (#1075) instead of silently defaulting to the real
+    /// network implementation and diverging from whatever this target was built with (production
+    /// default or a test's injected fake).
+    public let workerScriptNamesSource: WorkerScriptNamesSource
+    /// Exposed like `tokenSource`/`workerScriptNamesSource` so `DeployModel.runDeploy` can forward
+    /// the exact same seam into a container-path target it constructs on the fly (#1077).
+    public let customDomainAttachCommand: CustomDomainAttachCommand
+    /// Exposed like `customDomainAttachCommand` so `DeployModel.runDeploy` can forward the exact
+    /// same seam into a container-path target it constructs on the fly (#1247).
+    public let markdownForAgentsCommand: MarkdownForAgentsCommand
+    /// Exposed like the other seams above so callers building a parallel target (e.g.
+    /// `SocialWorkerProvisionCommand`'s `defaultDeployer`) forward the same one rather than
+    /// silently defaulting to production and diverging from a test's injected fake.
+    public let domainConfigDriftSource: DomainConfigDriftSource
+
+    /// All five dependencies are injectable seams with production defaults, so tests can drive a
+    /// full deploy — credential gate, name-conflict check, domain-config-drift check, publish —
+    /// with a literal token, a canned script-name list, and a scripted executor, never touching
+    /// the network or spawning a process.
+    public init(
+        tokenSource: @escaping TokenSource = CloudflareDeployTarget.keychainTokenSource,
+        workerScriptNamesSource: @escaping WorkerScriptNamesSource = CloudflareDeployTarget.defaultWorkerScriptNames,
+        customDomainAttachCommand: CustomDomainAttachCommand = CustomDomainAttachCommand(),
+        markdownForAgentsCommand: MarkdownForAgentsCommand = MarkdownForAgentsCommand(),
+        domainConfigDriftSource: @escaping DomainConfigDriftSource = CloudflareDeployTarget.defaultDomainConfigDriftSource
+    ) {
+        self.tokenSource = tokenSource
+        self.workerScriptNamesSource = workerScriptNamesSource
+        self.customDomainAttachCommand = customDomainAttachCommand
+        self.markdownForAgentsCommand = markdownForAgentsCommand
+        self.domainConfigDriftSource = domainConfigDriftSource
+    }
+
+    // MARK: DeployTarget
+
+    /// Pre-build gate: token resolution plus the worker-name-conflict (#740) and
+    /// domain-config-drift (#1173) checks, in that order — matches `DeployCommand.deploy`'s
+    /// original pre-spawn sequence exactly, so a deploy that can't succeed still fails before any
+    /// build time is spent.
+    public func authorize(siteDirectory: URL) async -> DeployTargetAuthorization {
+        let token: String?
+        do {
+            token = try await tokenSource()
+        } catch {
+            return .blocked(.failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil))
+        }
+        guard let token, !token.isEmpty else {
+            return .blocked(.failed(
+                reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var",
+                exitCode: nil))
+        }
+        if let conflict = await Self.checkWorkerNameConflict(
+            siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
+        ) {
+            return .blocked(conflict)
+        }
+        if let drift = await Self.checkDomainConfigDrift(
+            siteDirectory: siteDirectory, apiToken: token, domainConfigDriftSource: domainConfigDriftSource
+        ) {
+            return .blocked(drift)
+        }
+        return .ready(credential: token)
+    }
+
+    /// Runs `wrangler deploy` and every post-publish effect: URL extraction, custom-domain
+    /// attach, Markdown for Agents, `.site-config` persistence, and the optional R2 source-bundle
+    /// upload — matches `DeployCommand.deploy`'s original wrangler-step-and-after sequence exactly.
+    public func publish(context: DeployTargetContext) async -> DeployCommand.Result {
+        var wranglerEnvironment = context.baseEnvironment
+        wranglerEnvironment["CLOUDFLARE_API_TOKEN"] = context.credential
+
+        let started = Date()
+        context.onProgress?(.deployDeploying)
+        let wranglerResult = await context.executor.run(
+            step: .wrangler,
+            siteDirectory: context.siteDirectory,
+            environment: wranglerEnvironment,
+            source: "deploy:\(context.siteID)"
+        )
+        let duration = Date().timeIntervalSince(started)
+
+        if !Task.isCancelled { context.onProgress?(.deployFinalizing) }
+
+        guard let code = wranglerResult.exitCode else {
+            // nil exit code → unavailable resolver, spawn failure, or termination (e.g. cancellation).
+            // The cancellation path must say "terminated" (the cancellation test asserts on it);
+            // for the unavailable/spawn-failure cases the executor surfaces the reason in `output`.
+            if Task.isCancelled {
+                return .failed(reason: "wrangler was terminated", exitCode: nil)
+            }
+            return .failed(reason: wranglerResult.output.isEmpty ? "wrangler was terminated" : wranglerResult.output, exitCode: nil)
+        }
+        guard code == 0 else {
+            return .failed(reason: "wrangler exited with code \(code)", exitCode: code)
+        }
+        guard let url = Self.extractDeployedURL(from: wranglerResult.output) else {
+            return .failed(
+                reason: "wrangler exited successfully (code 0), but no deployed URL could be found in its output — the deploy likely succeeded; check the deploy log for the URL",
+                exitCode: 0
+            )
+        }
+
+        if let configDirectory = context.configDirectory {
+            try? DeployedRoutesSnapshot.save(context.currentRoutes, to: configDirectory)
+        }
+        // Runs before `persistSiteURL` (#1077/#1124): a fresh confirmation from *this* deploy
+        // persists `CF_DOMAIN_ATTACHED` as a side effect, which `persistSiteURL` checks to decide
+        // whether to leave `SITE_URL` alone.
+        let domainAttachOutcome = await customDomainAttachCommand.attach(
+            siteDirectory: context.siteDirectory, apiToken: context.credential, source: "deploy:\(context.siteID)")
+        context.onDomainAttach?(domainAttachOutcome)
+        // Only a confirmed-attached custom domain has a zone to configure — a workers.dev-only
+        // site (or one not yet delegated) has nothing for Markdown for Agents to apply to (#1247).
+        if case .confirmed(let hostname) = domainAttachOutcome {
+            let markdownOutcome = await markdownForAgentsCommand.apply(
+                hostname: hostname, siteDirectory: context.siteDirectory, configDirectory: context.configDirectory,
+                apiToken: context.credential, source: "deploy:\(context.siteID)")
+            context.onMarkdownForAgents?(markdownOutcome)
+        }
+        Self.persistSiteURL(url, siteDirectory: context.siteDirectory)
+        Self.persistWorkerDeployed(siteDirectory: context.siteDirectory)
+        if let configDirectory = context.configDirectory {
+            await Self.uploadSourceBundleIfConfigured(
+                siteDirectory: context.siteDirectory, configDirectory: configDirectory,
+                environment: wranglerEnvironment, executor: context.executor, siteID: context.siteID
+            )
+        }
+        return .succeeded(url: url, duration: duration)
+    }
+
+    // MARK: URL extraction
+
+    /// Extracts the deployed URL from wrangler's captured stdout. Wrangler's exact wording has
+    /// already drifted across major versions (older wrangler printed a `Published <name> (1.23
+    /// sec)` status line; current wrangler instead prints separate `Uploaded <name> (…)` /
+    /// `Deployed <name> triggers (…)` lines), and `wrangler deploy` (unlike `wrangler pages
+    /// deploy`) has no `--json` output mode to depend on instead, so multiple status-line prefixes
+    /// are recognized as the anchor:
+    ///
+    /// 1. Anchor on a recognized start-of-line status prefix (`Published`/`Deployed`/`Uploaded`)
+    ///    and search only the anchor line and lines after it — never anything before it — for a
+    ///    URL. A `*.workers.dev` URL there is preferred (the common case); any URL is accepted as a
+    ///    fallback for custom-domain deploys, which have no workers.dev host in their output.
+    ///    Scoping to at/after the anchor (rather than the whole output) matters because this
+    ///    result gets persisted as the site's live URL: an incidental workers.dev mention earlier
+    ///    in the log (e.g. a subdomain-already-exists notice) must not outrank the real result.
+    /// 2. If no anchor line is recognized at all (a future wrangler layout this doesn't know
+    ///    about), fall back to a whole-output scan for a `*.workers.dev` URL — still a
+    ///    distinctive, version-independent signature of a genuine deploy result, just without
+    ///    anchor confirmation.
+    public static func extractDeployedURL(from output: String) -> URL? {
+        let anchors = ["Published", "Deployed", "Uploaded"]
+        let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
+        if let anchorIdx = lines.firstIndex(where: { line in anchors.contains(where: line.hasPrefix) }) {
+            let tail = lines[anchorIdx...].joined(separator: "\n")
+            return firstURL(in: tail, requiringHostSuffix: ".workers.dev") ?? firstURL(in: tail)
+        }
+        return firstURL(in: output, requiringHostSuffix: ".workers.dev")
+    }
+
+    /// The first `http(s)` URL in `text` — optionally required to have a host ending in
+    /// `hostSuffix` — with trailing punctuation a terminal might tack on (commas, periods, closing
+    /// parens) stripped. Scans the whole string (not line-by-line), so callers doing a
+    /// version-independent signature scan can pass multi-line output directly.
+    private static func firstURL(in text: String, requiringHostSuffix hostSuffix: String? = nil) -> URL? {
+        guard let regex = try? NSRegularExpression(pattern: #"https?://\S+"#) else { return nil }
+        let fullRange = NSRange(text.startIndex..., in: text)
+        for match in regex.matches(in: text, range: fullRange) {
+            guard let range = Range(match.range, in: text) else { continue }
+            var raw = String(text[range])
+            while let last = raw.last, ",.)]}>".contains(last) {
+                raw.removeLast()
+            }
+            guard let url = URL(string: raw) else { continue }
+            if let hostSuffix {
+                guard let host = url.host, host.hasSuffix(hostSuffix) else { continue }
+            }
+            return url
+        }
+        return nil
+    }
+
+    // MARK: `.site-config` persistence
+
+    /// Persists the deployed URL into `.site-config`'s `SITE_URL` (#702) so the *next* build's
+    /// `astro.config.ts` picks up the real host for canonical URLs, feed self-links, and JSON-LD
+    /// instead of the `https://example.com` placeholder. This deploy's own `dist/` was already
+    /// built before the URL was known, so the placeholder still ships on a site's first deploy —
+    /// every deploy after that carries the real host.
+    ///
+    /// Written even when a custom domain (`DOMAIN`/`SITE_DOMAIN`) is configured but not yet
+    /// confirmed live (#1085): before #1077, nothing in the deploy pipeline attached a custom
+    /// domain, so an unverified `DOMAIN` was never trustworthy and `SITE_URL` — the site's real,
+    /// reachable address — had to win `DeployCoordinator.resolveSiteURL`'s precedence regardless.
+    ///
+    /// Skipped once `CF_DOMAIN_ATTACHED` matches `DOMAIN` — the same "confirmed" signal
+    /// `CustomDomainAttachCommand.attach` itself checks (#1077) — because at that point `DOMAIN`
+    /// *is* verified live, and overwriting `SITE_URL` with the workers.dev host would shadow it in
+    /// `resolveSiteURL`'s precedence forever after, silently undoing every confirmed domain attach
+    /// on its very next deploy. Callers must call `customDomainAttachCommand.attach` (and let it
+    /// persist `CF_DOMAIN_ATTACHED`) before this, so a domain confirmed *in this same deploy* is
+    /// already visible to the check. Best-effort — a write failure must never turn a successful
+    /// deploy into a failed one.
+    static func persistSiteURL(_ url: URL, siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        if let domain = SiteConfigFile.value(forKey: "DOMAIN", in: config),
+           SiteConfigFile.value(forKey: "CF_DOMAIN_ATTACHED", in: config) == domain {
+            return
+        }
+        let updated = SiteConfigFile.upsert([("SITE_URL", url.absoluteString)], into: config)
+        guard updated != config else { return }
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Marks this site as having successfully deployed at least once, via `.site-config`'s
+    /// `CF_WORKER_DEPLOYED` — the signal `checkWorkerNameConflict` uses to skip the collision
+    /// check on every deploy after the first (#740). Written unconditionally, unlike
+    /// `persistSiteURL` (which skips when a custom domain is already configured) — deploy
+    /// history isn't confounded by domain choice. Best-effort, matching `persistSiteURL`.
+    static func persistWorkerDeployed(siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil else { return }
+        let updated = SiteConfigFile.upsert([("CF_WORKER_DEPLOYED", "true")], into: config)
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Whether this site has already completed at least one successful deploy — the same
+    /// `.site-config` `CF_WORKER_DEPLOYED` signal `persistWorkerDeployed` writes and
+    /// `checkWorkerNameConflict` reads. A read-only counterpart for callers (`DeployModel`) that
+    /// need to know, *before* a deploy runs, whether this one would be the site's first — without
+    /// duplicating the file read `checkWorkerNameConflict` already does inline. Public (unlike its
+    /// siblings) because `DeployModel` lives in a different module.
+    public static func hasDeployedBefore(siteDirectory: URL) -> Bool {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        return SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) != nil
+    }
+
+    /// Marks this site's candidate Worker name as confirmed-ours, via `.site-config`'s
+    /// `CF_WORKER_PROVISIONED` — a second, earlier-firing signal `checkWorkerNameConflict` treats
+    /// the same as `CF_WORKER_DEPLOYED` (#1075). `CF_WORKER_DEPLOYED` alone only covers a *fully
+    /// succeeded* deploy, but `SocialWorkerProvisionCommand.provision()` can already have pushed
+    /// live Cloudflare state under this candidate name (`wrangler secret put` for ActivityPub, run
+    /// before the final `wrangler deploy`, auto-vivifies an empty Worker script under the target
+    /// name as a side effect) in an attempt that then failed for an unrelated reason before
+    /// `persistWorkerDeployed` ever ran. Without this second signal, a retry of that same site
+    /// would see its own auto-vivified script on the account and misreport it as a foreign
+    /// conflict. Called once, immediately after a fresh `checkWorkerNameConflict` pass at the very
+    /// start of provisioning — before any wrangler call that could touch the name — so a *genuine*
+    /// foreign collision is still caught before this site's own provisioning ever runs. Written
+    /// unconditionally like `persistWorkerDeployed`; best-effort, matching `persistSiteURL`.
+    static func persistWorkerProvisioned(siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil else { return }
+        let updated = SiteConfigFile.upsert([("CF_WORKER_PROVISIONED", "true")], into: config)
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Uploads `Source/`'s snapshot to R2 (`DeployStep.bundleUpload`) when `.site-config`'s
+    /// `CF_SOURCE_BUCKET` is set, then persists the uploaded commit SHA into `Config/settings.plist`
+    /// (#799, spec §C.4 — the code side of a future Worker-triggered bake). A no-op today for every
+    /// real site — no provisioning flow writes `CF_SOURCE_BUCKET` yet — and the executor call is
+    /// skipped entirely rather than run-and-ignore-the-result, so a redeploy on an unprovisioned
+    /// site pays no extra subprocess cost. Best-effort like `persistSiteURL`/`persistWorkerDeployed`:
+    /// a failure here must never turn a successful deploy into a failed one.
+    static func uploadSourceBundleIfConfigured(
+        siteDirectory: URL,
+        configDirectory: URL,
+        environment: [String: String],
+        executor: any DeployExecutor,
+        siteID: String
+    ) async {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_SOURCE_BUCKET", in: config) != nil else { return }
+
+        let uploadResult = await executor.run(
+            step: .bundleUpload,
+            siteDirectory: siteDirectory,
+            environment: environment,
+            source: "deploy:\(siteID):bundle"
+        )
+        guard uploadResult.exitCode == 0 else { return }
+
+        guard let headResult = try? await BackupCommand.defaultRunner(siteDirectory, ["rev-parse", "HEAD"]) else { return }
+        guard headResult.exitCode == 0 else { return }
+        let commitSHA = headResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !commitSHA.isEmpty else { return }
+
+        let store = SiteConfigStore(configDirectory: configDirectory)
+        guard var settings = try? await store.load() else { return }
+        settings.deployedSourceBundleCommit = commitSHA
+        try? await store.save(settings)
+    }
+
+    // MARK: Pre-build checks
+
+    /// Checks whether `.site-config`'s `CF_PROJECT_NAME` collides with an existing Worker on the
+    /// connected Cloudflare account, but only when neither `CF_WORKER_DEPLOYED` (a full deploy has
+    /// already succeeded under this name) nor `CF_WORKER_PROVISIONED` (this site's own earlier
+    /// provisioning already confirmed the name as ours, #1075) is set yet. Returns
+    /// `.workerNameConflict` on a confirmed collision, or `nil` when the check doesn't apply
+    /// (redeploy, already-provisioned, no candidate name) or can't be confirmed — a Cloudflare API
+    /// failure here must never block a deploy that would otherwise succeed (fail open).
+    static func checkWorkerNameConflict(
+        siteDirectory: URL,
+        apiToken: String,
+        workerScriptNamesSource: WorkerScriptNamesSource
+    ) async -> DeployCommand.Result? {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
+              SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil,
+              let candidateName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config)
+        else { return nil }
+        guard let names = try? await workerScriptNamesSource(apiToken) else { return nil }
+        guard names.contains(candidateName) else { return nil }
+        return .workerNameConflict(name: candidateName)
+    }
+
+    /// Grades the site's declared `anglesite.json` domain against live Cloudflare state (#1173).
+    /// Returns `.domainConfigDrift` when the audit finds any drift, or `nil` when the check
+    /// doesn't apply (no `anglesite.json`, or no declared `domain.hostname` — nothing to compare
+    /// against live state) or can't be confirmed. A read/decode error and a thrown/failed
+    /// `domainConfigDriftSource` both fail open — same posture as `checkWorkerNameConflict`, since
+    /// a transient Cloudflare API hiccup here must never block an otherwise-good deploy.
+    static func checkDomainConfigDrift(
+        siteDirectory: URL,
+        apiToken: String,
+        domainConfigDriftSource: DomainConfigDriftSource
+    ) async -> DeployCommand.Result? {
+        guard let declared = try? DomainConfigStore(sourceDirectory: siteDirectory).load(),
+              let hostname = declared.domain?.hostname, !hostname.isEmpty
+        else { return nil }
+        guard let findings = try? await domainConfigDriftSource(declared, hostname, apiToken), !findings.isEmpty
+        else { return nil }
+        return .domainConfigDrift(findings: findings)
+    }
+
+    // MARK: Default seams
+
+    /// Reads `CLOUDFLARE_API_TOKEN` from the process environment. Useful in development (the env
+    /// var dominates the Keychain entry when both are set, so a shell with `CLOUDFLARE_API_TOKEN`
+    /// exported behaves the way a wrangler user expects).
+    public static let envTokenSource: TokenSource = {
+        ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
+    }
+
+    /// Default `TokenSource` for production: thin forwarding wrapper around
+    /// ``CloudflareAPICredentials/resolve(secretStore:diagnosticSource:surfaceOAuthReadErrors:)``
+    /// (#1211) — env var first (so a developer's shell still wins), then a stored OAuth credential
+    /// (refreshing it first if expired), then the legacy pasted token, kept so a token a user
+    /// already pasted keeps working. Passes `surfaceOAuthReadErrors: true`, preserving this call
+    /// site's original (pre-#1211) behavior: a genuine Keychain error reading the OAuth slot
+    /// surfaces as an actionable "couldn't read token" deploy failure rather than silently reading
+    /// as "no token configured" and nudging the user toward an unnecessary re-sign-in — deploy is
+    /// the highest-stakes call site this resolver serves, so it alone keeps that stricter
+    /// diagnosis. The resolver's other callers (background sync jobs, Harden, Domain Config Audit,
+    /// …) default to swallowing that error and falling through to the legacy token instead, which
+    /// isn't a behavior change for them — none of them surfaced this class of error before #1211
+    /// either.
+    public static let keychainTokenSource: TokenSource = {
+        try await CloudflareAPICredentials.resolve(surfaceOAuthReadErrors: true)
+    }
+
+    /// Default `WorkerScriptNamesSource` for production: the account's Worker script names via
+    /// `HTTPCloudflareClient`.
+    public static let defaultWorkerScriptNames: WorkerScriptNamesSource = { apiToken in
+        try await HTTPCloudflareClient().workerScriptNames(apiToken: apiToken)
+    }
+
+    /// Default `DomainConfigDriftSource` for production: resolves the declared hostname's zone,
+    /// reads its live edge state and DNS records via `HTTPCloudflareClient`, then grades them with
+    /// `DomainConfigAudit.evaluate` — the same three calls `DomainConfigAuditModel.performAudit`
+    /// makes App-side, just without the SwiftUI-facing `Phase` machinery. A zone that can't be
+    /// resolved (not yet attached, or a Cloudflare read failure) returns no findings rather than
+    /// throwing — nothing to compare declared state against yet, not drift.
+    public static let defaultDomainConfigDriftSource: DomainConfigDriftSource = { declared, hostname, apiToken in
+        let reader: any CloudflareReading = HTTPCloudflareClient()
+        guard let zoneID = try await reader.resolveZoneID(domain: hostname, apiToken: apiToken) else { return [] }
+        let state = try await reader.zoneState(zoneID: zoneID, domain: hostname, apiToken: apiToken)
+        let records = try await reader.listDNSRecords(zoneID: zoneID, apiToken: apiToken)
+        return DomainConfigAudit.evaluate(declared: declared, live: state, liveDNSRecords: records, domain: hostname)
+    }
+}

--- a/Sources/AnglesiteCore/CloudflareOAuthTokenSource.swift
+++ b/Sources/AnglesiteCore/CloudflareOAuthTokenSource.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Resolves a usable Cloudflare API bearer token from a stored OAuth credential, refreshing it
 /// first when it's expired. Returns `nil` (never throws) when no OAuth credential is stored, or
-/// when refreshing fails — callers (``DeployCommand/keychainTokenSource``) fall back to the legacy
+/// when refreshing fails — callers (``CloudflareDeployTarget/keychainTokenSource``) fall back to the legacy
 /// pasted-token slot in that case, exactly as they do today when there's no OAuth credential at
 /// all. A failed refresh leaves the stored credential untouched: a transient network hiccup during
 /// refresh shouldn't discard an otherwise-good refresh token.

--- a/Sources/AnglesiteCore/DeployCommand.swift
+++ b/Sources/AnglesiteCore/DeployCommand.swift
@@ -1,30 +1,40 @@
 import Foundation
 
-/// One-shot orchestrator for `wrangler deploy`.
+/// One-shot orchestrator for a site deploy — the provider-agnostic spine shared by every
+/// `DeployTarget` (#1015): resolve the target's credential and run its fail-fast checks, build
+/// `dist/`, run the non-bypassable `PreDeployCheck` pre-deploy scan, then hand off to the target
+/// to publish. `CloudflareDeployTarget` is the only conformer today; `target` defaults to it so
+/// every existing call site keeps compiling and deploying through Cloudflare unchanged.
 ///
-/// A deploy is a single foreground action with a pre-spawn token gate and three real steps,
-/// each run through the injected `DeployExecutor` seam. Container runtimes run the steps in a
+/// A deploy is a single foreground action, run through the injected `DeployExecutor` seam for the
+/// steps this spine owns directly (build, preflight). Container runtimes run the steps in a
 /// guest; the default process-backed executor fails explicitly after embedded Node retirement.
-///   1. Resolve / read the Cloudflare API token (pre-spawn; no token → `.failed`).
+///   1. `target.authorize(siteDirectory:)` — credential resolution plus any target-specific
+///      fail-fast checks (e.g. Cloudflare's worker-name-conflict and domain-config-drift checks).
+///      `.blocked` short-circuits immediately, before any build time is spent.
 ///   2. `executor.runBuildWithClaimManifest(…)` so `dist/` is fresh — the build carries the derived
 ///      `/.well-known/` claim manifest (#744/#748) so the runtime can reject a collision in its own
 ///      clone and report the artifacts it produced. An executor without the seam falls back to
 ///      `executor.run(step: .build, …)` and gets no post-build well-known verification.
 ///   3. `executor.run(step: .preflight, …)` — the bundled plugin's pre-deploy scan; its captured
 ///      stdout is parsed into a `PreDeployCheck.Outcome`. `.blocked` short-circuits with no
-///      override (per CLAUDE.md, the app cannot bypass plugin security hooks).
-///   4. `executor.run(step: .wrangler, …)` — parse the deployed URL out of the captured output.
+///      override (per CLAUDE.md, the app cannot bypass plugin security hooks) — and no
+///      `DeployTarget` conformer gets a hook into this gate; `target.publish` is never called when
+///      it blocks.
+///   4. `target.publish(context:)` — publishes the build and performs any post-publish effects.
+///      `CloudflareDeployTarget`'s conformance runs `executor.run(step: .wrangler, …)` and parses
+///      the deployed URL out of the captured output.
 ///
 /// The executor streams each step's stdout+stderr into `LogCenter` line-by-line (under the
-/// caller-supplied source) and returns the accumulated stdout in `DeployStepResult.output`, so the
-/// URL/scan parsing here re-reads the captured stdout rather than re-snapshotting `LogCenter`.
+/// caller-supplied source) and returns the accumulated stdout in `DeployStepResult.output`, so
+/// URL/scan parsing re-reads the captured stdout rather than re-snapshotting `LogCenter`.
 ///
 /// **Environment contract:**
 ///   - `.build` and `.preflight` get a curated subset of the host environment (see
 ///     `hostDeployEnvironment()`) — safe shell/locale/proxy/Node vars only, no unrelated secrets.
-///   - `.wrangler` gets that curated environment *plus* `CLOUDFLARE_API_TOKEN`. `.bundleUpload`
-///     (the optional post-deploy source-bundle upload) reuses that same token-bearing environment,
-///     since it also authenticates to Cloudflare (R2 via wrangler).
+///     This same curated environment is handed to the target via `DeployTargetContext
+///     .baseEnvironment`; `CloudflareDeployTarget.publish` adds `CLOUDFLARE_API_TOKEN` to it only
+///     for the `.wrangler` (and `.bundleUpload`) steps it runs.
 ///
 /// **Cancellation**: cancelling the deploy task propagates through `executor.run` (the host
 /// executor wraps its `waitForExit` in a cancellation handler that SIGTERMs the in-flight
@@ -32,10 +42,12 @@ import Foundation
 public actor DeployCommand {
     /// Terminal outcome of one `deploy(...)` call. Every failure mode is a case, not a thrown
     /// error — `deploy` never throws, so UI callers switch exhaustively over this instead of
-    /// also maintaining a separate error path.
+    /// also maintaining a separate error path. `.workerNameConflict`/`.domainConfigDrift` are
+    /// Cloudflare-specific outcomes `CloudflareDeployTarget` produces; a target with no equivalent
+    /// concept simply never returns them.
     public enum Result: Sendable, Equatable {
-        /// Wrangler exited 0 and a deployed URL was parsed from its output. `duration` covers
-        /// the wrangler step only — build and preflight time are excluded.
+        /// The target published successfully and a deployed URL was found. `duration` covers the
+        /// target's publish step only — build and preflight time are excluded.
         case succeeded(url: URL, duration: TimeInterval)
         /// The pre-deploy security scan refused the deploy. Carries the structured
         /// failures (and any warnings) so the UI can render a sheet with no override.
@@ -53,7 +65,7 @@ public actor DeployCommand {
         /// before redeploying (investigation doc §5.5 — deploy-time validation is a cheap check,
         /// not a second remediation surface).
         case domainConfigDrift(findings: [DomainConfigAudit.Finding])
-        /// `exitCode` is `nil` for pre-spawn refusals (no token, no wrangler) and for spawn
+        /// `exitCode` is `nil` for pre-spawn refusals (no credential, no wrangler) and for spawn
         /// failures; otherwise it's the failing subprocess's exit code (including `0` for the
         /// "wrangler exited cleanly but we couldn't find a URL" case).
         case failed(reason: String, exitCode: Int32?)
@@ -73,89 +85,51 @@ public actor DeployCommand {
     /// return `.unavailable` since embedded Node was retired; container runtimes inject real
     /// resolvers.
     public typealias CommandResolver = @Sendable (_ siteDirectory: URL) -> LaunchPlan
-    /// Returns the Cloudflare API token, or `nil` if none is configured. Production callers use
-    /// `DeployCommand.keychainTokenSource` (Keychain with an env-var fallback for development);
-    /// tests typically inject a closure returning a literal.
-    public typealias TokenSource = @Sendable () async throws -> String?
     /// Runs the bundled plugin's pre-deploy scan against a site and returns the outcome.
     /// Real callers use `DeployCommand.defaultPreflight`; tests inject a fake.
     public typealias PreflightChecker = @Sendable (_ siteDirectory: URL) async -> PreDeployCheck.Outcome
     /// Fires once the preflight step resolves, with the outcome that was used to
-    /// decide whether to continue with wrangler. The closure runs inside the actor's
-    /// isolation; bridge to MainActor via a Task if you need to touch SwiftUI state.
+    /// decide whether to continue with the target's publish step. The closure runs inside the
+    /// actor's isolation; bridge to MainActor via a Task if you need to touch SwiftUI state.
     /// Fires for every preflight result (.passed, .blocked, .error) — including the
     /// cases where deploy() returns .failed afterwards.
     public typealias PreflightObserver = @Sendable (PreDeployCheck.Outcome) -> Void
 
     /// Fires once the domain-attach step resolves (#1077), for a "Transfer an existing domain"
-    /// site — or immediately with `.skipped` for every other site. Runs only after a successful
-    /// `wrangler` step; never fires on a failed/blocked deploy.
+    /// site — or immediately with `.skipped` for every other site. Only fired by
+    /// `CloudflareDeployTarget`, and only after a successful `wrangler` step; never fires on a
+    /// failed/blocked deploy, and never fires for a target with no equivalent concept.
     public typealias DomainAttachObserver = @Sendable (CustomDomainAttachCommand.Result) -> Void
 
     /// Fires once the Markdown for Agents step resolves (#1247) — only for a site whose domain
     /// attach just confirmed a live zone; never fires when there's no custom domain, or on a
-    /// failed/blocked deploy.
+    /// failed/blocked deploy. Only fired by `CloudflareDeployTarget`.
     public typealias MarkdownForAgentsObserver = @Sendable (MarkdownForAgentsCommand.Result) -> Void
 
-    /// Returns the account's existing Worker script names for the given token. Production
-    /// callers use `DeployCommand.defaultWorkerScriptNames` (`HTTPCloudflareClient`); tests
-    /// inject a fake list or a throwing closure.
-    public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
-
-    /// Grades a declared `Source/anglesite.json` domain against live Cloudflare state and returns
-    /// any drift (#1171's `DomainConfigAudit.evaluate`, given a fresh zone read). Production
-    /// callers use `DeployCommand.defaultDomainConfigDriftSource`; tests inject a canned findings
-    /// list or a throwing closure — same rationale as `WorkerScriptNamesSource`.
-    public typealias DomainConfigDriftSource = @Sendable (
-        _ declared: DomainConfig, _ hostname: String, _ apiToken: String
-    ) async throws -> [DomainConfigAudit.Finding]
-
-    /// The token seam this command was constructed with. Exposed so `DeployModel.runDeploy` can
-    /// forward the exact same seam into companion commands (e.g. `SocialWorkerProvisionCommand`)
-    /// instead of letting them silently default to the production implementation and diverge
-    /// from a test's injected fake — see `workerScriptNamesSource` below for the full rationale.
-    public nonisolated let tokenSource: TokenSource
-    /// Exposed (like `tokenSource`) so callers that build a parallel `SocialWorkerProvisionCommand`
-    /// alongside this `DeployCommand` — `DeployModel.runDeploy` — can forward the exact same seam
-    /// into its own pre-provisioning conflict check (#1075) instead of silently defaulting to the
-    /// real network implementation and diverging from whatever this `DeployCommand` was built with
-    /// (production default or a test's injected fake).
-    public nonisolated let workerScriptNamesSource: WorkerScriptNamesSource
-    /// Exposed like `tokenSource`/`workerScriptNamesSource` so `DeployModel.runDeploy` can forward
-    /// the exact same seam into a container-path `DeployCommand` it constructs on the fly (#1077).
-    public nonisolated let customDomainAttachCommand: CustomDomainAttachCommand
-    /// Exposed like `customDomainAttachCommand` so `DeployModel.runDeploy` can forward the exact
-    /// same seam into a container-path `DeployCommand` it constructs on the fly (#1247).
-    public nonisolated let markdownForAgentsCommand: MarkdownForAgentsCommand
-    /// Exposed like the other seams above so callers building a parallel `DeployCommand` (e.g.
-    /// `SocialWorkerProvisionCommand`'s `defaultDeployer`) forward the same one rather than
-    /// silently defaulting to production and diverging from a test's injected fake.
-    public nonisolated let domainConfigDriftSource: DomainConfigDriftSource
+    /// The deploy target this command publishes through — `CloudflareDeployTarget` by default, so
+    /// every existing call site keeps deploying through Cloudflare unchanged. `nonisolated` and
+    /// public so callers that need to build a parallel command with the same target (e.g.
+    /// `DeployModel.runDeploy` swapping in a container executor) can forward it, and so a caller
+    /// that knows it's Cloudflare can downcast to reach `CloudflareDeployTarget`'s own exposed
+    /// seams (`tokenSource`, `workerScriptNamesSource`, …) for a companion command.
+    public nonisolated let target: any DeployTarget
     private let executor: any DeployExecutor
 
-    /// All five dependencies are injectable seams with production defaults, so tests can drive a
-    /// full deploy — token gate, name-conflict check, domain-config-drift check, every step —
-    /// with a literal token, a canned script-name list, and a scripted executor, never touching
-    /// the network or spawning a process.
+    /// Both dependencies are injectable seams with production defaults, so tests can drive a full
+    /// deploy — target authorization, every shared step — with a scripted target and a scripted
+    /// executor, never touching the network or spawning a process.
     public init(
-        tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
-        workerScriptNamesSource: @escaping WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,
-        customDomainAttachCommand: CustomDomainAttachCommand = CustomDomainAttachCommand(),
-        markdownForAgentsCommand: MarkdownForAgentsCommand = MarkdownForAgentsCommand(),
-        executor: any DeployExecutor = HostDeployExecutor(),
-        domainConfigDriftSource: @escaping DomainConfigDriftSource = DeployCommand.defaultDomainConfigDriftSource
+        target: any DeployTarget = CloudflareDeployTarget(),
+        executor: any DeployExecutor = HostDeployExecutor()
     ) {
-        self.tokenSource = tokenSource
-        self.workerScriptNamesSource = workerScriptNamesSource
-        self.customDomainAttachCommand = customDomainAttachCommand
-        self.markdownForAgentsCommand = markdownForAgentsCommand
+        self.target = target
         self.executor = executor
-        self.domainConfigDriftSource = domainConfigDriftSource
     }
 
-    /// Run a deploy for `siteID`. Returns once wrangler has exited (or before, if pre-spawn
-    /// refusal applies). Build output streams under source `"deploy:<siteID>:build"`, the deploy
-    /// itself under `"deploy:<siteID>"`, so a UI consumer can distinguish phases.
+    /// Run a deploy for `siteID`. Returns once the target's publish step has resolved (or before,
+    /// if the target's authorization step or the preflight gate refuses first). Build output
+    /// streams under source `"deploy:<siteID>:build"`, the deploy itself under `"deploy:<siteID>"`,
+    /// so a UI consumer can distinguish phases.
     public func deploy(
         siteID: String,
         siteDirectory: URL,
@@ -178,33 +152,21 @@ public actor DeployCommand {
         onMarkdownForAgents: MarkdownForAgentsObserver? = nil,
         onProgress: ProgressHandler? = nil
     ) async -> Result {
-        // Pre-spawn checks. The token comes first so we never spend time on a build or scan
-        // for a deploy that won't reach wrangler.
-        let token: String?
-        do {
-            token = try await tokenSource()
-        } catch {
-            return .failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil)
-        }
-        guard let token, !token.isEmpty else {
-            return .failed(reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var", exitCode: nil)
-        }
-
-        if let conflict = await Self.checkWorkerNameConflict(
-            siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
-        ) {
-            return conflict
-        }
-
-        if let drift = await Self.checkDomainConfigDrift(
-            siteDirectory: siteDirectory, apiToken: token, domainConfigDriftSource: domainConfigDriftSource
-        ) {
-            return drift
+        // Pre-build gate: the target resolves its credential and runs any fail-fast checks
+        // against current deployed state, so a deploy that can't succeed never spends time on a
+        // build or scan. The credential comes back opaque here — only the target that produced it
+        // knows what to do with it.
+        let credential: String
+        switch await target.authorize(siteDirectory: siteDirectory) {
+        case .blocked(let result):
+            return result
+        case .ready(let resolvedCredential):
+            credential = resolvedCredential
         }
 
         // Curated environment for the non-secret steps: a safe subset of the host process env,
-        // stripping unrelated secrets the developer's shell may carry. The token is added only
-        // for the wrangler step below.
+        // stripping unrelated secrets the developer's shell may carry. Target-specific
+        // credentials are added only inside the target's own `publish(context:)`.
         let baseEnvironment = Self.hostDeployEnvironment()
 
         // #744: validate the effective /.well-known/ inventory before spending time on a build.
@@ -310,11 +272,11 @@ public actor DeployCommand {
             return .failed(reason: buildResult.output.isEmpty ? "build was terminated" : buildResult.output, exitCode: nil)
         }
 
-        // Pre-deploy scan runs after the build (so dist/ exists) and before wrangler. If the
-        // bundled plugin's checks find PII, exposed tokens, unauthorized third-party scripts, or
-        // Keystatic admin routes in dist/, the deploy is blocked — per the durable rule in
-        // CLAUDE.md, the app cannot bypass plugin security hooks; the UI sheet for `.blocked` has
-        // no override.
+        // Pre-deploy scan runs after the build (so dist/ exists) and before the target's publish
+        // step. If the bundled plugin's checks find PII, exposed tokens, unauthorized third-party
+        // scripts, or Keystatic admin routes in dist/, the deploy is blocked — per the durable
+        // rule in CLAUDE.md, the app cannot bypass plugin security hooks; the UI sheet for
+        // `.blocked` has no override, and no `DeployTarget` conformer gets a hook here.
         onProgress?(.deployPreflight)
         let preflightResult = await executor.run(
             step: .preflight,
@@ -355,67 +317,22 @@ public actor DeployCommand {
             return .failed(reason: "pre-deploy scan could not run: \(reason)", exitCode: nil)
         }
 
-        // Wrangler step: process env PLUS the Cloudflare token.
-        var wranglerEnvironment = baseEnvironment
-        wranglerEnvironment["CLOUDFLARE_API_TOKEN"] = token
-
-        let started = Date()
-        onProgress?(.deployDeploying)
-        let wranglerResult = await executor.run(
-            step: .wrangler,
+        // Hand off to the target: publish the build and perform any post-publish effects
+        // (Cloudflare's URL extraction, custom-domain attach, Markdown for Agents, `.site-config`
+        // persistence, R2 bundle upload — see `CloudflareDeployTarget.publish`).
+        let context = DeployTargetContext(
+            siteID: siteID,
             siteDirectory: siteDirectory,
-            environment: wranglerEnvironment,
-            source: "deploy:\(siteID)"
+            configDirectory: configDirectory,
+            currentRoutes: currentRoutes,
+            credential: credential,
+            baseEnvironment: baseEnvironment,
+            executor: executor,
+            onDomainAttach: onDomainAttach,
+            onMarkdownForAgents: onMarkdownForAgents,
+            onProgress: onProgress
         )
-        let duration = Date().timeIntervalSince(started)
-
-        if !Task.isCancelled { onProgress?(.deployFinalizing) }
-
-        guard let code = wranglerResult.exitCode else {
-            // nil exit code → unavailable resolver, spawn failure, or termination (e.g. cancellation).
-            // The cancellation path must say "terminated" (the cancellation test asserts on it);
-            // for the unavailable/spawn-failure cases the executor surfaces the reason in `output`.
-            if Task.isCancelled {
-                return .failed(reason: "wrangler was terminated", exitCode: nil)
-            }
-            return .failed(reason: wranglerResult.output.isEmpty ? "wrangler was terminated" : wranglerResult.output, exitCode: nil)
-        }
-        if code == 0 {
-            if let url = Self.extractDeployedURL(from: wranglerResult.output) {
-                if let configDirectory {
-                    try? DeployedRoutesSnapshot.save(currentRoutes, to: configDirectory)
-                }
-                // Runs before `persistSiteURL` (#1077/#1124): a fresh confirmation from *this*
-                // deploy persists `CF_DOMAIN_ATTACHED` as a side effect, which `persistSiteURL`
-                // checks to decide whether to leave `SITE_URL` alone.
-                let domainAttachOutcome = await customDomainAttachCommand.attach(
-                    siteDirectory: siteDirectory, apiToken: token, source: "deploy:\(siteID)")
-                onDomainAttach?(domainAttachOutcome)
-                // Only a confirmed-attached custom domain has a zone to configure — a
-                // workers.dev-only site (or one not yet delegated) has nothing for Markdown for
-                // Agents to apply to (#1247).
-                if case .confirmed(let hostname) = domainAttachOutcome {
-                    let markdownOutcome = await markdownForAgentsCommand.apply(
-                        hostname: hostname, siteDirectory: siteDirectory, configDirectory: configDirectory,
-                        apiToken: token, source: "deploy:\(siteID)")
-                    onMarkdownForAgents?(markdownOutcome)
-                }
-                Self.persistSiteURL(url, siteDirectory: siteDirectory)
-                Self.persistWorkerDeployed(siteDirectory: siteDirectory)
-                if let configDirectory {
-                    await Self.uploadSourceBundleIfConfigured(
-                        siteDirectory: siteDirectory, configDirectory: configDirectory,
-                        environment: wranglerEnvironment, executor: executor, siteID: siteID
-                    )
-                }
-                return .succeeded(url: url, duration: duration)
-            }
-            return .failed(
-                reason: "wrangler exited successfully (code 0), but no deployed URL could be found in its output — the deploy likely succeeded; check the deploy log for the URL",
-                exitCode: 0
-            )
-        }
-        return .failed(reason: "wrangler exited with code \(code)", exitCode: code)
+        return await target.publish(context: context)
     }
 
     // MARK: Scan report parsing
@@ -425,214 +342,6 @@ public actor DeployCommand {
     /// one real decoder (#742); this keeps the existing public call-site signature stable.
     public static func parseScanReport(output: String, exitCode: Int32?) -> PreDeployCheck.Outcome {
         PreDeployCheck.parse(output: output, exitCode: exitCode)
-    }
-
-    // MARK: URL extraction
-
-    /// Extracts the deployed URL from wrangler's captured stdout. Wrangler's exact wording has
-    /// already drifted across major versions (older wrangler printed a `Published <name> (1.23
-    /// sec)` status line; current wrangler instead prints separate `Uploaded <name> (…)` /
-    /// `Deployed <name> triggers (…)` lines), and `wrangler deploy` (unlike `wrangler pages
-    /// deploy`) has no `--json` output mode to depend on instead, so multiple status-line prefixes
-    /// are recognized as the anchor:
-    ///
-    /// 1. Anchor on a recognized start-of-line status prefix (`Published`/`Deployed`/`Uploaded`)
-    ///    and search only the anchor line and lines after it — never anything before it — for a
-    ///    URL. A `*.workers.dev` URL there is preferred (the common case); any URL is accepted as a
-    ///    fallback for custom-domain deploys, which have no workers.dev host in their output.
-    ///    Scoping to at/after the anchor (rather than the whole output) matters because this
-    ///    result gets persisted as the site's live URL: an incidental workers.dev mention earlier
-    ///    in the log (e.g. a subdomain-already-exists notice) must not outrank the real result.
-    /// 2. If no anchor line is recognized at all (a future wrangler layout this doesn't know
-    ///    about), fall back to a whole-output scan for a `*.workers.dev` URL — still a
-    ///    distinctive, version-independent signature of a genuine deploy result, just without
-    ///    anchor confirmation.
-    public static func extractDeployedURL(from output: String) -> URL? {
-        let anchors = ["Published", "Deployed", "Uploaded"]
-        let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
-        if let anchorIdx = lines.firstIndex(where: { line in anchors.contains(where: line.hasPrefix) }) {
-            let tail = lines[anchorIdx...].joined(separator: "\n")
-            return firstURL(in: tail, requiringHostSuffix: ".workers.dev") ?? firstURL(in: tail)
-        }
-        return firstURL(in: output, requiringHostSuffix: ".workers.dev")
-    }
-
-    /// The first `http(s)` URL in `text` — optionally required to have a host ending in
-    /// `hostSuffix` — with trailing punctuation a terminal might tack on (commas, periods, closing
-    /// parens) stripped. Scans the whole string (not line-by-line), so callers doing a
-    /// version-independent signature scan can pass multi-line output directly.
-    private static func firstURL(in text: String, requiringHostSuffix hostSuffix: String? = nil) -> URL? {
-        guard let regex = try? NSRegularExpression(pattern: #"https?://\S+"#) else { return nil }
-        let fullRange = NSRange(text.startIndex..., in: text)
-        for match in regex.matches(in: text, range: fullRange) {
-            guard let range = Range(match.range, in: text) else { continue }
-            var raw = String(text[range])
-            while let last = raw.last, ",.)]}>".contains(last) {
-                raw.removeLast()
-            }
-            guard let url = URL(string: raw) else { continue }
-            if let hostSuffix {
-                guard let host = url.host, host.hasSuffix(hostSuffix) else { continue }
-            }
-            return url
-        }
-        return nil
-    }
-
-    /// Persists the deployed URL into `.site-config`'s `SITE_URL` (#702) so the *next* build's
-    /// `astro.config.ts` picks up the real host for canonical URLs, feed self-links, and JSON-LD
-    /// instead of the `https://example.com` placeholder. This deploy's own `dist/` was already
-    /// built before the URL was known, so the placeholder still ships on a site's first deploy —
-    /// every deploy after that carries the real host.
-    ///
-    /// Written even when a custom domain (`DOMAIN`/`SITE_DOMAIN`) is configured but not yet
-    /// confirmed live (#1085): before #1077, nothing in the deploy pipeline attached a custom
-    /// domain, so an unverified `DOMAIN` was never trustworthy and `SITE_URL` — the site's real,
-    /// reachable address — had to win `DeployCoordinator.resolveSiteURL`'s precedence regardless.
-    ///
-    /// Skipped once `CF_DOMAIN_ATTACHED` matches `DOMAIN` — the same "confirmed" signal
-    /// `CustomDomainAttachCommand.attach` itself checks (#1077) — because at that point `DOMAIN`
-    /// *is* verified live, and overwriting `SITE_URL` with the workers.dev host would shadow it in
-    /// `resolveSiteURL`'s precedence forever after, silently undoing every confirmed domain attach
-    /// on its very next deploy. Callers must call `customDomainAttachCommand.attach` (and let it
-    /// persist `CF_DOMAIN_ATTACHED`) before this, so a domain confirmed *in this same deploy* is
-    /// already visible to the check. Best-effort — a write failure must never turn a successful
-    /// deploy into a failed one.
-    static func persistSiteURL(_ url: URL, siteDirectory: URL) {
-        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
-        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
-        if let domain = SiteConfigFile.value(forKey: "DOMAIN", in: config),
-           SiteConfigFile.value(forKey: "CF_DOMAIN_ATTACHED", in: config) == domain {
-            return
-        }
-        let updated = SiteConfigFile.upsert([("SITE_URL", url.absoluteString)], into: config)
-        guard updated != config else { return }
-        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
-    }
-
-    /// Marks this site as having successfully deployed at least once, via `.site-config`'s
-    /// `CF_WORKER_DEPLOYED` — the signal `checkWorkerNameConflict` uses to skip the collision
-    /// check on every deploy after the first (#740). Written unconditionally, unlike
-    /// `persistSiteURL` (which skips when a custom domain is already configured) — deploy
-    /// history isn't confounded by domain choice. Best-effort, matching `persistSiteURL`.
-    static func persistWorkerDeployed(siteDirectory: URL) {
-        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
-        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
-        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil else { return }
-        let updated = SiteConfigFile.upsert([("CF_WORKER_DEPLOYED", "true")], into: config)
-        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
-    }
-
-    /// Whether this site has already completed at least one successful deploy — the same
-    /// `.site-config` `CF_WORKER_DEPLOYED` signal `persistWorkerDeployed` writes and
-    /// `checkWorkerNameConflict` reads. A read-only counterpart for callers (`DeployModel`) that
-    /// need to know, *before* a deploy runs, whether this one would be the site's first — without
-    /// duplicating the file read `checkWorkerNameConflict` already does inline. Public (unlike its
-    /// siblings) because `DeployModel` lives in a different module.
-    public static func hasDeployedBefore(siteDirectory: URL) -> Bool {
-        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
-        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
-        return SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) != nil
-    }
-
-    /// Marks this site's candidate Worker name as confirmed-ours, via `.site-config`'s
-    /// `CF_WORKER_PROVISIONED` — a second, earlier-firing signal `checkWorkerNameConflict` treats
-    /// the same as `CF_WORKER_DEPLOYED` (#1075). `CF_WORKER_DEPLOYED` alone only covers a *fully
-    /// succeeded* deploy, but `SocialWorkerProvisionCommand.provision()` can already have pushed
-    /// live Cloudflare state under this candidate name (`wrangler secret put` for ActivityPub, run
-    /// before the final `wrangler deploy`, auto-vivifies an empty Worker script under the target
-    /// name as a side effect) in an attempt that then failed for an unrelated reason before
-    /// `persistWorkerDeployed` ever ran. Without this second signal, a retry of that same site
-    /// would see its own auto-vivified script on the account and misreport it as a foreign
-    /// conflict. Called once, immediately after a fresh `checkWorkerNameConflict` pass at the very
-    /// start of provisioning — before any wrangler call that could touch the name — so a *genuine*
-    /// foreign collision is still caught before this site's own provisioning ever runs. Written
-    /// unconditionally like `persistWorkerDeployed`; best-effort, matching `persistSiteURL`.
-    static func persistWorkerProvisioned(siteDirectory: URL) {
-        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
-        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
-        guard SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil else { return }
-        let updated = SiteConfigFile.upsert([("CF_WORKER_PROVISIONED", "true")], into: config)
-        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
-    }
-
-    /// Uploads `Source/`'s snapshot to R2 (`DeployStep.bundleUpload`) when `.site-config`'s
-    /// `CF_SOURCE_BUCKET` is set, then persists the uploaded commit SHA into `Config/settings.plist`
-    /// (#799, spec §C.4 — the code side of a future Worker-triggered bake). A no-op today for every
-    /// real site — no provisioning flow writes `CF_SOURCE_BUCKET` yet — and the executor call is
-    /// skipped entirely rather than run-and-ignore-the-result, so a redeploy on an unprovisioned
-    /// site pays no extra subprocess cost. Best-effort like `persistSiteURL`/`persistWorkerDeployed`:
-    /// a failure here must never turn a successful deploy into a failed one.
-    static func uploadSourceBundleIfConfigured(
-        siteDirectory: URL,
-        configDirectory: URL,
-        environment: [String: String],
-        executor: any DeployExecutor,
-        siteID: String
-    ) async {
-        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
-        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
-        guard SiteConfigFile.value(forKey: "CF_SOURCE_BUCKET", in: config) != nil else { return }
-
-        let uploadResult = await executor.run(
-            step: .bundleUpload,
-            siteDirectory: siteDirectory,
-            environment: environment,
-            source: "deploy:\(siteID):bundle"
-        )
-        guard uploadResult.exitCode == 0 else { return }
-
-        guard let headResult = try? await BackupCommand.defaultRunner(siteDirectory, ["rev-parse", "HEAD"]) else { return }
-        guard headResult.exitCode == 0 else { return }
-        let commitSHA = headResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !commitSHA.isEmpty else { return }
-
-        let store = SiteConfigStore(configDirectory: configDirectory)
-        guard var settings = try? await store.load() else { return }
-        settings.deployedSourceBundleCommit = commitSHA
-        try? await store.save(settings)
-    }
-
-    /// Checks whether `.site-config`'s `CF_PROJECT_NAME` collides with an existing Worker on the
-    /// connected Cloudflare account, but only when neither `CF_WORKER_DEPLOYED` (a full deploy has
-    /// already succeeded under this name) nor `CF_WORKER_PROVISIONED` (this site's own earlier
-    /// provisioning already confirmed the name as ours, #1075) is set yet. Returns
-    /// `.workerNameConflict` on a confirmed collision, or `nil` when the check doesn't apply
-    /// (redeploy, already-provisioned, no candidate name) or can't be confirmed — a Cloudflare API
-    /// failure here must never block a deploy that would otherwise succeed (fail open).
-    static func checkWorkerNameConflict(
-        siteDirectory: URL,
-        apiToken: String,
-        workerScriptNamesSource: WorkerScriptNamesSource
-    ) async -> Result? {
-        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
-        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
-        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
-              SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil,
-              let candidateName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config)
-        else { return nil }
-        guard let names = try? await workerScriptNamesSource(apiToken) else { return nil }
-        guard names.contains(candidateName) else { return nil }
-        return .workerNameConflict(name: candidateName)
-    }
-
-    /// Grades the site's declared `anglesite.json` domain against live Cloudflare state (#1173).
-    /// Returns `.domainConfigDrift` when the audit finds any drift, or `nil` when the check
-    /// doesn't apply (no `anglesite.json`, or no declared `domain.hostname` — nothing to compare
-    /// against live state) or can't be confirmed. A read/decode error and a thrown/failed
-    /// `domainConfigDriftSource` both fail open — same posture as `checkWorkerNameConflict`, since
-    /// a transient Cloudflare API hiccup here must never block an otherwise-good deploy.
-    static func checkDomainConfigDrift(
-        siteDirectory: URL,
-        apiToken: String,
-        domainConfigDriftSource: DomainConfigDriftSource
-    ) async -> Result? {
-        guard let declared = try? DomainConfigStore(sourceDirectory: siteDirectory).load(),
-              let hostname = declared.domain?.hostname, !hostname.isEmpty
-        else { return nil }
-        guard let findings = try? await domainConfigDriftSource(declared, hostname, apiToken), !findings.isEmpty
-        else { return nil }
-        return .domainConfigDrift(findings: findings)
     }
 
     // MARK: Host environment curation
@@ -670,8 +379,8 @@ public actor DeployCommand {
 
     /// Returns a curated subset of the given environment safe for host-path build and preflight
     /// steps. Strips unrelated secrets (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, …) that the
-    /// developer's shell may carry. `CLOUDFLARE_API_TOKEN` is explicitly excluded here; `deploy()`
-    /// adds it only to the `.wrangler` step's environment.
+    /// developer's shell may carry. Target-specific credentials are excluded here; the target adds
+    /// its own only to the steps it runs inside `publish(context:)`.
     ///
     /// The `env` parameter defaults to the current process environment; tests inject a literal
     /// dictionary instead (avoiding `setenv`/`unsetenv` races and the `ProcessInfo` launch-time
@@ -686,50 +395,6 @@ public actor DeployCommand {
     }
 
     // MARK: Default seams
-
-    /// Reads `CLOUDFLARE_API_TOKEN` from the process environment. Useful in development (the env
-    /// var dominates the Keychain entry when both are set, so a shell with `CLOUDFLARE_API_TOKEN`
-    /// exported behaves the way a wrangler user expects).
-    public static let envTokenSource: TokenSource = {
-        ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
-    }
-
-    /// Default `TokenSource` for production: thin forwarding wrapper around
-    /// ``CloudflareAPICredentials/resolve(secretStore:diagnosticSource:surfaceOAuthReadErrors:)``
-    /// (#1211) — env var first (so a developer's shell still wins), then a stored OAuth credential
-    /// (refreshing it first if expired), then the legacy pasted token, kept so a token a user
-    /// already pasted keeps working. Passes `surfaceOAuthReadErrors: true`, preserving this call
-    /// site's original (pre-#1211) behavior: a genuine Keychain error reading the OAuth slot
-    /// surfaces as an actionable "couldn't read token" deploy failure rather than silently reading
-    /// as "no token configured" and nudging the user toward an unnecessary re-sign-in — deploy is
-    /// the highest-stakes call site this resolver serves, so it alone keeps that stricter
-    /// diagnosis. The resolver's other callers (background sync jobs, Harden, Domain Config Audit,
-    /// …) default to swallowing that error and falling through to the legacy token instead, which
-    /// isn't a behavior change for them — none of them surfaced this class of error before #1211
-    /// either.
-    public static let keychainTokenSource: TokenSource = {
-        try await CloudflareAPICredentials.resolve(surfaceOAuthReadErrors: true)
-    }
-
-    /// Default `WorkerScriptNamesSource` for production: the account's Worker script names via
-    /// `HTTPCloudflareClient`.
-    public static let defaultWorkerScriptNames: WorkerScriptNamesSource = { apiToken in
-        try await HTTPCloudflareClient().workerScriptNames(apiToken: apiToken)
-    }
-
-    /// Default `DomainConfigDriftSource` for production: resolves the declared hostname's zone,
-    /// reads its live edge state and DNS records via `HTTPCloudflareClient`, then grades them with
-    /// `DomainConfigAudit.evaluate` — the same three calls `DomainConfigAuditModel.performAudit`
-    /// makes App-side, just without the SwiftUI-facing `Phase` machinery. A zone that can't be
-    /// resolved (not yet attached, or a Cloudflare read failure) returns no findings rather than
-    /// throwing — nothing to compare declared state against yet, not drift.
-    public static let defaultDomainConfigDriftSource: DomainConfigDriftSource = { declared, hostname, apiToken in
-        let reader: any CloudflareReading = HTTPCloudflareClient()
-        guard let zoneID = try await reader.resolveZoneID(domain: hostname, apiToken: apiToken) else { return [] }
-        let state = try await reader.zoneState(zoneID: zoneID, domain: hostname, apiToken: apiToken)
-        let records = try await reader.listDNSRecords(zoneID: zoneID, apiToken: apiToken)
-        return DomainConfigAudit.evaluate(declared: declared, live: state, liveDNSRecords: records, domain: hostname)
-    }
 
     /// Default `PreflightChecker`: host-side preflight was retired with embedded Node. Container
     /// runtimes must provide the executable preflight path.

--- a/Sources/AnglesiteCore/DeployTarget.swift
+++ b/Sources/AnglesiteCore/DeployTarget.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Outcome of a `DeployTarget`'s pre-build gate (`authorize(siteDirectory:)`). `DeployCommand`
+/// calls this before spending any time on the well-known scan or the build, so a deploy that
+/// can't succeed fails fast — matches `DeployCommand.deploy`'s original pre-spawn-refusal
+/// behavior exactly.
+public enum DeployTargetAuthorization: Sendable {
+    /// The target is ready to publish. `credential` is opaque to `DeployCommand` — only the
+    /// target that produced it (via `publish(context:)`'s `DeployTargetContext.credential`) knows
+    /// what to do with it (e.g. `CloudflareDeployTarget` treats it as a Cloudflare API token).
+    case ready(credential: String)
+    /// The deploy is refused before any build work happens — a missing/invalid credential, or a
+    /// target-specific fail-fast check (e.g. Cloudflare's worker-name-conflict or
+    /// domain-config-drift checks). `DeployCommand.deploy` returns this `Result` immediately.
+    case blocked(DeployCommand.Result)
+}
+
+/// Everything a `DeployTarget` needs to publish one deploy, assembled by `DeployCommand.deploy`
+/// after the shared build + `PreDeployCheck` spine has passed.
+public struct DeployTargetContext: Sendable {
+    public let siteID: String
+    public let siteDirectory: URL
+    /// The site's `Config/` directory, or `nil` when the caller didn't supply one (tests, and the
+    /// two non-primary deploy paths in `SocialWorkerProvisionCommand`/`SiteOperations`) — mirrors
+    /// `DeployCommand.deploy`'s own `configDirectory` parameter (#530).
+    public let configDirectory: URL?
+    /// The site's currently published route set, forwarded from `DeployCommand.deploy`'s
+    /// `currentRoutes` parameter — only meaningful when `configDirectory` is non-nil.
+    public let currentRoutes: [String]
+    /// The credential `authorize(siteDirectory:)` resolved, forwarded verbatim from its
+    /// `.ready(credential:)` case.
+    public let credential: String
+    /// The curated, secret-stripped environment `DeployCommand.hostDeployEnvironment()` produced
+    /// for the build/preflight steps — the target adds its own credential to this (rather than
+    /// receiving a pre-mixed environment) so the base environment's secret-stripping guarantee is
+    /// visible at the target's own call site, not just asserted by the caller.
+    public let baseEnvironment: [String: String]
+    /// The same `DeployExecutor` `DeployCommand` used for the build/preflight steps — the target
+    /// uses it to run its own steps (e.g. `CloudflareDeployTarget` runs `.wrangler` and
+    /// `.bundleUpload` through it).
+    public let executor: any DeployExecutor
+    /// Forwarded verbatim from `DeployCommand.deploy`'s `onDomainAttach` parameter. Only
+    /// `CloudflareDeployTarget` fires it today; a target with no equivalent concept simply never
+    /// calls it.
+    public let onDomainAttach: DeployCommand.DomainAttachObserver?
+    /// Forwarded verbatim from `DeployCommand.deploy`'s `onMarkdownForAgents` parameter. Only
+    /// `CloudflareDeployTarget` fires it today; a target with no equivalent concept simply never
+    /// calls it.
+    public let onMarkdownForAgents: DeployCommand.MarkdownForAgentsObserver?
+    /// Forwarded verbatim from `DeployCommand.deploy`'s `onProgress` parameter, so the target can
+    /// report its own publish-phase milestones (e.g. `.deployDeploying`/`.deployFinalizing`).
+    public let onProgress: ProgressHandler?
+
+    public init(
+        siteID: String,
+        siteDirectory: URL,
+        configDirectory: URL?,
+        currentRoutes: [String],
+        credential: String,
+        baseEnvironment: [String: String],
+        executor: any DeployExecutor,
+        onDomainAttach: DeployCommand.DomainAttachObserver?,
+        onMarkdownForAgents: DeployCommand.MarkdownForAgentsObserver?,
+        onProgress: ProgressHandler?
+    ) {
+        self.siteID = siteID
+        self.siteDirectory = siteDirectory
+        self.configDirectory = configDirectory
+        self.currentRoutes = currentRoutes
+        self.credential = credential
+        self.baseEnvironment = baseEnvironment
+        self.executor = executor
+        self.onDomainAttach = onDomainAttach
+        self.onMarkdownForAgents = onMarkdownForAgents
+        self.onProgress = onProgress
+    }
+}
+
+/// A publishable destination for a site's built static output — the seam that lets
+/// `DeployCommand` support hosts beyond Cloudflare (#1015). Each conformer owns everything
+/// specific to its provider: credential resolution, any target-specific pre-checks, the actual
+/// upload, and post-publish effects. `CloudflareDeployTarget` is the only conformer today.
+///
+/// `DeployCommand.deploy` calls `authorize(siteDirectory:)` before the shared well-known-scan and
+/// build steps run, then `publish(context:)` only after those and the non-bypassable
+/// `PreDeployCheck` preflight have all passed — no conformer gets a hook into the preflight gate
+/// itself.
+public protocol DeployTarget: Sendable {
+    /// Stable identifier persisted in `Source/anglesite.json`'s `deployTarget` field (e.g.
+    /// `"cloudflare"`). Not yet read by `DeployCommand` to select a conformer (#1015 slice 1) —
+    /// reserved for the target-selection slice.
+    static var id: String { get }
+
+    /// Pre-build gate: resolves this target's credential and runs any fail-fast checks against
+    /// current deployed state. Called before the well-known scan and the build, so a deploy that
+    /// can't succeed never pays for either.
+    func authorize(siteDirectory: URL) async -> DeployTargetAuthorization
+
+    /// Publishes the build produced by the shared spine and performs any post-publish effects.
+    /// Only called after `authorize` returned `.ready`, the well-known scan passed, the build
+    /// succeeded, and `PreDeployCheck` passed.
+    func publish(context: DeployTargetContext) async -> DeployCommand.Result
+}

--- a/Sources/AnglesiteCore/DomainConfig.swift
+++ b/Sources/AnglesiteCore/DomainConfig.swift
@@ -21,6 +21,12 @@ public struct DomainConfig: Equatable, Sendable {
     public var edge: Edge?
     public var email: Email?
     public var workers: Workers?
+    /// The publish destination this site uses (#1015) — an open string (not a closed `enum`),
+    /// matching `Domain.choice`'s precedent, so an unrecognized future value degrades gracefully
+    /// for a reader that predates it. `nil` means "cloudflare," the only target that exists today
+    /// — nothing reads this field to select a `DeployTarget` conformer yet (that's a later
+    /// slice); it exists so that slice needs no schema migration when it lands.
+    public var deployTarget: String?
 
     public init(
         version: Int = 1,
@@ -28,7 +34,8 @@ public struct DomainConfig: Equatable, Sendable {
         dns: DNS? = nil,
         edge: Edge? = nil,
         email: Email? = nil,
-        workers: Workers? = nil
+        workers: Workers? = nil,
+        deployTarget: String? = nil
     ) {
         self.version = version
         self.domain = domain
@@ -36,6 +43,7 @@ public struct DomainConfig: Equatable, Sendable {
         self.edge = edge
         self.email = email
         self.workers = workers
+        self.deployTarget = deployTarget
     }
 
     /// The owner's declared hostname and attachment intent — replaces the `DOMAIN`/`DOMAIN_CHOICE`
@@ -171,7 +179,7 @@ public struct DomainConfig: Equatable, Sendable {
 
 extension DomainConfig: Codable {
     private enum CodingKeys: String, CodingKey {
-        case version, domain, dns, edge, email, workers
+        case version, domain, dns, edge, email, workers, deployTarget
     }
 
     public init(from decoder: Decoder) throws {
@@ -182,6 +190,7 @@ extension DomainConfig: Codable {
         edge = try container.decodeIfPresent(Edge.self, forKey: .edge)
         email = try container.decodeIfPresent(Email.self, forKey: .email)
         workers = try container.decodeIfPresent(Workers.self, forKey: .workers)
+        deployTarget = try container.decodeIfPresent(String.self, forKey: .deployTarget)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -192,5 +201,6 @@ extension DomainConfig: Codable {
         try container.encodeIfPresent(edge, forKey: .edge)
         try container.encodeIfPresent(email, forKey: .email)
         try container.encodeIfPresent(workers, forKey: .workers)
+        try container.encodeIfPresent(deployTarget, forKey: .deployTarget)
     }
 }

--- a/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
+++ b/Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift
@@ -48,7 +48,7 @@ public actor SocialWorkerProvisionCommand {
 
     /// Re-exported from ``DeployCommand`` so both commands share one token-resolution seam
     /// (Keychain in production, injected values in tests).
-    public typealias TokenSource = DeployCommand.TokenSource
+    public typealias TokenSource = CloudflareDeployTarget.TokenSource
     /// Resolves the Cloudflare account id that owns a token — used only by inbox-capture
     /// provisioning (#764) to persist the id `InboxSubmissionSync` needs later. `nil` on any
     /// resolution failure (mirrors `MicropubContentSync`'s/`ReceivedInteractionSync`'s existing
@@ -112,24 +112,24 @@ public actor SocialWorkerProvisionCommand {
     private let webdavPepperSource: WebdavPepperSource
     private let secretRunner: SecretRunner
     private let deployer: Deployer
-    private let workerScriptNamesSource: DeployCommand.WorkerScriptNamesSource
+    private let workerScriptNamesSource: CloudflareDeployTarget.WorkerScriptNamesSource
     private let accountIDSource: AccountIDSource
 
     /// Creates a provisioner. Every dependency defaults to its production conformer; tests (and
     /// `DeployModel`, which threads its own runner/deployer) override only the seams they need.
     public init(
-        tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
+        tokenSource: @escaping TokenSource = CloudflareDeployTarget.keychainTokenSource,
         runner: @escaping CommandRunner = SocialWorkerProvisionCommand.defaultRunner,
         keyPairSource: @escaping KeyPairSource = SocialWorkerProvisionCommand.defaultKeyPairSource,
         solidOidcSigningKeySource: @escaping SolidOidcSigningKeySource = SocialWorkerProvisionCommand.defaultSolidOidcSigningKeySource,
         webdavPepperSource: @escaping WebdavPepperSource = SocialWorkerProvisionCommand.defaultWebdavPepperSource,
         secretRunner: @escaping SecretRunner = SocialWorkerProvisionCommand.defaultSecretRunner,
         deployer: @escaping Deployer = SocialWorkerProvisionCommand.defaultDeployer,
-        /// Same seam `DeployCommand` uses for its own end-of-pipeline conflict check
-        /// (`DeployCommand.defaultWorkerScriptNames` in production); injected here too so
+        /// Same seam `DeployCommand`'s `CloudflareDeployTarget` uses for its own end-of-pipeline
+        /// conflict check (`CloudflareDeployTarget.defaultWorkerScriptNames` in production); injected here too so
         /// `provision()` can run that same check *before* any wrangler call touches the
         /// candidate name (#1075) instead of only after D1/KV/R2/secrets have already run.
-        workerScriptNamesSource: @escaping DeployCommand.WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,
+        workerScriptNamesSource: @escaping CloudflareDeployTarget.WorkerScriptNamesSource = CloudflareDeployTarget.defaultWorkerScriptNames,
         /// Same seam shape as `workerScriptNamesSource`; only used by the inbox-capture block
         /// (#764) to persist the owning account id.
         accountIDSource: @escaping AccountIDSource = SocialWorkerProvisionCommand.defaultAccountIDSource
@@ -244,12 +244,12 @@ public actor SocialWorkerProvisionCommand {
         // confirmed ours by an earlier attempt) closes both gaps: a genuinely foreign name is
         // still caught here, before any resource creation runs, while a retry of this site never
         // re-flags its own provisioning history.
-        if case .workerNameConflict(let name)? = await DeployCommand.checkWorkerNameConflict(
+        if case .workerNameConflict(let name)? = await CloudflareDeployTarget.checkWorkerNameConflict(
             siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
         ) {
             return .workerNameConflict(name: name, resources: resources)
         }
-        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDirectory)
+        CloudflareDeployTarget.persistWorkerProvisioned(siteDirectory: siteDirectory)
 
         if workers.contains(where: { $0.resources.needsD1 }) {
             if resources.d1DatabaseID == nil {
@@ -837,7 +837,7 @@ public actor SocialWorkerProvisionCommand {
     /// `DeployModel.runDeploy` still constructs its own deployer closure (for `configDirectory`/
     /// `onPreflight`/`onProgress`, which this default has no equivalent for).
     public static let defaultDeployer: Deployer = { token, siteID, siteDirectory, wellKnownDynamicClaims in
-        await DeployCommand(tokenSource: { token }).deploy(
+        await DeployCommand(target: CloudflareDeployTarget(tokenSource: { token })).deploy(
             siteID: siteID, siteDirectory: siteDirectory, wellKnownDynamicClaims: wellKnownDynamicClaims)
     }
 

--- a/Tests/AnglesiteAppTests/DeployModelTests.swift
+++ b/Tests/AnglesiteAppTests/DeployModelTests.swift
@@ -99,7 +99,7 @@ struct DeployModelTests {
     func suddenTerminationLeaseBracketsDeploy() async {
         let executor = GatedDeployExecutor()
         let controller = SuddenTerminationController(disable: {}, enable: {})
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(
             command: command,
             logCenter: LogCenter(),
@@ -144,8 +144,10 @@ struct DeployModelTests {
         // regression that skips the gate doesn't hang the test on the gated continuation.
         await executor.resumeBuild()
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            workerScriptNamesSource: { _ in ["my-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                workerScriptNamesSource: { _ in ["my-site"] }
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -176,9 +178,11 @@ struct DeployModelTests {
         let finding = DomainConfigAudit.Finding(
             category: .dns, title: "Missing managed DNS record", detail: "detail", remediation: .informational)
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            executor: executor,
-            domainConfigDriftSource: { _, _, _ in [finding] }
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                domainConfigDriftSource: { _, _, _ in [finding] }
+            ),
+            executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -212,9 +216,11 @@ struct DeployModelTests {
         // regression that skips the gate doesn't hang the test on the gated continuation.
         await executor.resumeBuild()
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            // "my-site" is taken; "my-site-2" (what the sheet will submit) is free.
-            workerScriptNamesSource: { _ in ["my-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                // "my-site" is taken; "my-site-2" (what the sheet will submit) is free.
+                workerScriptNamesSource: { _ in ["my-site"] }
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -257,9 +263,11 @@ struct DeployModelTests {
         // the gated continuation.
         await executor.resumeBuild()
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            // Both "my-site" (the original name) and "my-site-2" (the rename target) are taken.
-            workerScriptNamesSource: { _ in ["my-site", "my-site-2"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                // Both "my-site" (the original name) and "my-site-2" (the rename target) are taken.
+                workerScriptNamesSource: { _ in ["my-site", "my-site-2"] }
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -298,9 +306,11 @@ struct DeployModelTests {
         let executor = GatedDeployExecutor()
         let writer = FakeDomainAttachWriter(outcome: .attached)
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
-            markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer),
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+                markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer)
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -336,9 +346,11 @@ struct DeployModelTests {
         // "nothing configured" skip path.
         let writer = FakeDomainAttachWriter(outcome: .attached)
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
-            markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer),
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+                markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer)
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -369,8 +381,10 @@ struct DeployModelTests {
         let executor = GatedDeployExecutor()
         let writer = FakeDomainAttachWriter(outcome: .zoneNotFound)
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                customDomainAttachCommand: CustomDomainAttachCommand(client: writer)
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -402,8 +416,10 @@ struct DeployModelTests {
         let executor = GatedDeployExecutor()
         let writer = FakeDomainAttachWriter(outcome: .conflict(ownedBy: "other-site"))
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                customDomainAttachCommand: CustomDomainAttachCommand(client: writer)
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -436,7 +452,7 @@ struct DeployModelTests {
     @Test("No transfer domain configured reports .skipped and leaves the workers.dev URL")
     func noTransferDomainSkips() async {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
@@ -463,8 +479,10 @@ struct DeployModelTests {
         let executor = GatedDeployExecutor()
         await executor.resumeBuild()
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            workerScriptNamesSource: { _ in ["my-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                workerScriptNamesSource: { _ in ["my-site"] }
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -510,8 +528,10 @@ struct DeployModelTests {
         let executor = GatedDeployExecutor()
         await executor.resumeBuild()
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            workerScriptNamesSource: { _ in ["my-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                workerScriptNamesSource: { _ in ["my-site"] }
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -544,8 +564,10 @@ struct DeployModelTests {
         let executor = GatedDeployExecutor()
         await executor.resumeBuild()
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            workerScriptNamesSource: { _ in ["my-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                workerScriptNamesSource: { _ in ["my-site"] }
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -574,7 +596,7 @@ struct DeployModelTests {
     @Test("a site with no active workers still deploys through the plain static path")
     func staticSiteDeploysUnaffected() async throws {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let contentGraph = SiteContentGraph()
         let model = DeployModel(
             command: command,
@@ -607,7 +629,7 @@ struct DeployModelTests {
     func activatingAWorkerWithoutContainerFailsAtProvisioning() async throws {
         let executor = GatedDeployExecutor()
         await executor.resumeBuild()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let contentGraph = SiteContentGraph()
         let catalog = [
             WorkerDescriptor(
@@ -644,7 +666,7 @@ struct DeployModelTests {
     @Test("an active worker with no matching catalog entry logs a warning instead of deploying silently")
     func emptyCatalogWithActiveWorkerWarnsInDebugPane() async throws {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let contentGraph = SiteContentGraph()
         let logCenter = LogCenter()
         let model = DeployModel(
@@ -682,7 +704,7 @@ struct DeployModelTests {
     @Test("a container control resolved via containerControlProvider routes deploy execs through it")
     func containerControlProviderRoutesToContainer() async throws {
         let fake = RecordingLocalContainerControl()
-        let command = DeployCommand(tokenSource: { "test-token" })
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }))
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let dir = try temporaryDirectory()
 
@@ -705,9 +727,11 @@ struct DeployModelTests {
         let executor = GatedDeployExecutor()
         await executor.resumeBuild()
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            // "my-site" is taken; "my-site-2" (what the retry submits) is free.
-            workerScriptNamesSource: { _ in ["my-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                // "my-site" is taken; "my-site-2" (what the retry submits) is free.
+                workerScriptNamesSource: { _ in ["my-site"] }
+            ),
             executor: executor
         )
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
@@ -746,7 +770,7 @@ struct DeployModelTests {
     @Test("wasFirstDeploy is true only when CF_WORKER_DEPLOYED was absent before this deploy")
     func wasFirstDeployReflectsPriorDeployHistory() async {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(command: command, logCenter: LogCenter(), tokenAvailabilityOverride: { true })
         let siteDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: siteDir, withIntermediateDirectories: true)
@@ -780,7 +804,7 @@ struct DeployModelTests {
         let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
         defer { cfToken.release() }
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let keychain = InMemorySecretStore()
         try? keychain.writeCloudflareOAuthCredential(CloudflareOAuthCredential(
             accessToken: "already-signed-in", refreshToken: nil, expiresAt: nil,
@@ -812,7 +836,7 @@ struct DeployModelTests {
         let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
         defer { cfToken.release() }
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let keychain = InMemorySecretStore()
         // Definitely unrefreshable: expired in the past, and no refresh token to fall back on
         // (e.g. Cloudflare's OAuth never issued one for this client — a real open item).
@@ -839,7 +863,7 @@ struct DeployModelTests {
         let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
         defer { cfToken.release() }
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let keychain = InMemorySecretStore()
         let client = CloudflareOAuthClient(
             scope: "workers_scripts",
@@ -898,7 +922,7 @@ struct DeployModelTests {
     func signInFailureStaysOnSheet() async {
         let cfToken = await CloudflareAPITokenTestEnvironment.shared.claimClear()
         defer { cfToken.release() }
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: GatedDeployExecutor())
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: GatedDeployExecutor())
         struct Boom: Error {}
         let client = CloudflareOAuthClient(
             scope: "workers_scripts",
@@ -957,7 +981,7 @@ struct DeployModelTests {
     @Test("deploy() presents the license gate instead of running when no license has been chosen")
     func deployPresentsLicenseGateWhenUnchosen() throws {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(
             command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
             tokenAvailabilityOverride: { true })
@@ -974,7 +998,7 @@ struct DeployModelTests {
     @Test("confirmLicenseChoice saves the policy and resumes the parked deploy")
     func confirmLicenseChoiceSavesAndResumes() async throws {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(
             command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
             tokenAvailabilityOverride: { true })
@@ -1006,7 +1030,7 @@ struct DeployModelTests {
     @Test("confirming All rights reserved (nil) still marks the choice made")
     func confirmAllRightsReservedMarksChosen() async throws {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(
             command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
             tokenAvailabilityOverride: { true })
@@ -1026,7 +1050,7 @@ struct DeployModelTests {
     @Test("deployAutomatically defers when a license hasn't been chosen")
     func deployAutomaticallyDefersWithoutLicense() async throws {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(
             command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
             tokenAvailabilityOverride: { true })
@@ -1050,7 +1074,7 @@ struct DeployModelTests {
     @Test("confirmLicenseChoice surfaces a save failure and keeps the deploy parked")
     func confirmLicenseChoiceSaveFailureKeepsDeployParked() async throws {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(
             command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
             tokenAvailabilityOverride: { true })
@@ -1090,7 +1114,7 @@ struct DeployModelTests {
     @Test("cancelLicenseGate abandons the attempt without recording a choice")
     func cancelLicenseGateRecordsNothing() async throws {
         let executor = GatedDeployExecutor()
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
         let model = DeployModel(
             command: command, logCenter: LogCenter(), keychain: InMemorySecretStore(),
             tokenAvailabilityOverride: { true })

--- a/Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift
@@ -10,7 +10,7 @@ struct DeployCommandProgressTests {
         let recorder = ProgressRecorder()
         // Build succeeds (exit 0); preflight JSON blocks so we stop early without reaching wrangler.
         let exec = BlockingPreflightExecutor()
-        let cmd = DeployCommand(tokenSource: { "token" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "token" }), executor: exec)
         _ = await cmd.deploy(siteID: "s", siteDirectory: URL(fileURLWithPath: NSTemporaryDirectory()),
                              onProgress: { recorder.record($0) })
         let phases = recorder.phases()

--- a/Tests/AnglesiteCoreTests/DeployCommandTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployCommandTests.swift
@@ -109,7 +109,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "building…")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published angle-app (1.23 sec)\n  https://angle-app.example.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "s", siteDirectory: tmpDir)
         guard case .succeeded(let url, let duration) = result else {
             Issue.record("expected .succeeded, got \(result)"); return
@@ -125,7 +125,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "secret-tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "secret-tok" }), executor: exec)
         _ = await cmd.deploy(siteID: "s", siteDirectory: tmpDir)
         #expect(exec.environment(for: .build)?["CLOUDFLARE_API_TOKEN"] == nil)
         #expect(exec.environment(for: .preflight)?["CLOUDFLARE_API_TOKEN"] == nil)
@@ -158,7 +158,7 @@ struct DeployCommandTests {
                 id: "acme", owner: "cloudflare-managed-tls", path: "acme-challenge/", match: .prefix,
                 capability: "RFC 8555 managed-TLS ownership")])
             .set(.build, exitCode: 0, output: "should not run")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDirectory)
         guard case .blocked(let failures, _) = result else {
             Issue.record("expected .blocked, got \(result)"); return
@@ -178,7 +178,7 @@ struct DeployCommandTests {
                 id: "acme", owner: "cloudflare-managed-tls", path: "acme-challenge/", match: .prefix,
                 capability: "RFC 8555 managed-TLS ownership")])
             .set(.build, exitCode: 0, output: "should not run")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let claim = WorkerRouteClaims.OwnedClaim(
             owner: "some-worker",
             claim: WorkerRouteClaim(path: "/.well-known/acme-challenge/http-01", match: .exact, methods: ["GET"], handler: "h"))
@@ -203,7 +203,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         var observedOutcome: PreDeployCheck.Outcome?
         let result = await cmd.deploy(
             siteID: "s", siteDirectory: siteDirectory,
@@ -226,7 +226,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDirectory)
         guard case .succeeded = result else {
             Issue.record("expected .succeeded, got \(result)"); return
@@ -285,7 +285,7 @@ struct DeployCommandTests {
             owner: "webfinger",
             claim: WorkerRouteClaim(path: "/.well-known/webfinger", match: .exact, methods: ["GET"], handler: "h"))
 
-        _ = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+        _ = await DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
             .deploy(siteID: "s", siteDirectory: siteDirectory, wellKnownDynamicClaims: [claim])
 
         let entries = try #require(exec.receivedManifest?.entries)
@@ -304,7 +304,7 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
 
-        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
             .deploy(siteID: "s", siteDirectory: siteDirectory)
 
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
@@ -324,7 +324,7 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
 
         var observedOutcome: PreDeployCheck.Outcome?
-        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
             .deploy(siteID: "s", siteDirectory: siteDirectory, onPreflight: { observedOutcome = $0 })
 
         guard case .blocked(let failures, _) = result else {
@@ -349,7 +349,7 @@ struct DeployCommandTests {
         let exec = SeamExecutor()
             .returning(.completed(DeployStepResult(exitCode: 2, output: "syntax error"), WellKnownBuildSeamResult()))
 
-        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
             .deploy(siteID: "s", siteDirectory: siteDirectory)
 
         guard case .failed(_, let exitCode) = result else {
@@ -368,7 +368,7 @@ struct DeployCommandTests {
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
 
         var observedOutcome: PreDeployCheck.Outcome?
-        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
             .deploy(siteID: "s", siteDirectory: siteDirectory, onPreflight: { observedOutcome = $0 })
 
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
@@ -386,7 +386,7 @@ struct DeployCommandTests {
         defer { try? FileManager.default.removeItem(at: siteDirectory) }
         let exec = SeamExecutor().returning(.cancelled)
 
-        let result = await DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let result = await DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
             .deploy(siteID: "s", siteDirectory: siteDirectory)
 
         #expect(result == .failed(reason: "build was terminated", exitCode: nil))
@@ -459,7 +459,7 @@ struct DeployCommandTests {
     @Test("Refuses before any step when token source returns nil")
     func refusesBeforeStepsWhenTokenNil() async {
         let exec = FakeExecutor().onRun(.build, { Issue.record("build must not run when token is missing") })
-        let cmd = DeployCommand(tokenSource: { nil }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { nil }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .failed(let reason, let exit) = result else {
             Issue.record("expected .failed, got \(result)"); return
@@ -472,7 +472,7 @@ struct DeployCommandTests {
     @Test("Refuses before any step when token source returns empty string")
     func refusesBeforeStepsWhenTokenEmpty() async {
         let exec = FakeExecutor()
-        let cmd = DeployCommand(tokenSource: { "" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .failed(let reason, _) = result else {
             Issue.record("expected .failed, got \(result)"); return
@@ -486,7 +486,7 @@ struct DeployCommandTests {
     @Test("Fails when build exits non-zero, and does not run preflight or wrangler")
     func failsWhenBuildExitsNonZero() async {
         let exec = FakeExecutor().set(.build, exitCode: 2, output: "astro: type error")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .failed(let reason, let exit) = result else {
             Issue.record("expected .failed, got \(result)"); return
@@ -499,7 +499,7 @@ struct DeployCommandTests {
     @Test("Fails with the executor's reason when build is unavailable (nil exit)")
     func failsWhenBuildUnavailable() async {
         let exec = FakeExecutor().set(.build, exitCode: nil, output: "vendored npm not found — rebuild the app")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .failed(let reason, _) = result else {
             Issue.record("expected .failed, got \(result)"); return
@@ -515,7 +515,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: false))
             .onRun(.wrangler, { Issue.record("wrangler must not run when preflight blocks") })
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .blocked(let failures, _) = result else {
             Issue.record("expected .blocked, got \(result)"); return
@@ -532,7 +532,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 1, output: "Error: tsx not installed")
             .onRun(.wrangler, { Issue.record("wrangler must not run when preflight errored") })
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .failed(let reason, _) = result else {
             Issue.record("expected .failed, got \(result)"); return
@@ -548,7 +548,7 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: #"{"version":1,"ok":true,"failures":[],"warnings":[{"category":"missing-og-image","message":"no og image","remediation":"add one"}]}"#)
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let observed = Mutex<PreDeployCheck.Outcome?>(nil)
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         _ = await cmd.deploy(siteID: "t", siteDirectory: tmpDir, onPreflight: { observed.set($0) })
         guard case .passed(let warnings) = observed.get() else {
             Issue.record("expected .passed outcome observed"); return
@@ -564,7 +564,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 10, output: "Error: authentication failed")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .failed(let reason, let exit) = result else {
             Issue.record("expected .failed, got \(result)"); return
@@ -579,7 +579,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Did some thing.\nNo anchor here.")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .failed(let reason, let exit) = result else {
             Issue.record("expected .failed, got \(result)"); return
@@ -594,7 +594,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "See https://developers.cloudflare.com/workers for help.\nPublished angle-app (1.23 sec)\n  https://angle-app.example.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .succeeded(let url, _) = result else {
             Issue.record("expected .succeeded, got \(result)"); return
@@ -620,7 +620,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
         let config = (try? String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)) ?? ""
@@ -636,7 +636,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
         let config = try! String(contentsOf: configURL, encoding: .utf8)
@@ -666,8 +666,10 @@ struct DeployCommandTests {
         let siteDir = makeSiteDirectory(projectName: "taken-name", deployedBefore: false)
         let exec = FakeExecutor().onRun(.build, { Issue.record("build must not run on a worker-name conflict") })
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            workerScriptNamesSource: { _ in ["taken-name", "other-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                workerScriptNamesSource: { _ in ["taken-name", "other-site"] }
+            ),
             executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
@@ -686,8 +688,10 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            workerScriptNamesSource: { _ in ["some-other-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                workerScriptNamesSource: { _ in ["some-other-site"] }
+            ),
             executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
@@ -703,8 +707,10 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            workerScriptNamesSource: { _ in Issue.record("must not be called when CF_PROJECT_NAME is absent"); return [] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                workerScriptNamesSource: { _ in Issue.record("must not be called when CF_PROJECT_NAME is absent"); return [] }
+            ),
             executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
@@ -719,9 +725,11 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            // Even though the name is "taken" by this same call, a redeploy must not be blocked.
-            workerScriptNamesSource: { _ in ["my-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                // Even though the name is "taken" by this same call, a redeploy must not be blocked.
+                workerScriptNamesSource: { _ in ["my-site"] }
+            ),
             executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
@@ -734,16 +742,18 @@ struct DeployCommandTests {
         // Marks the name as confirmed-ours without a full deploy ever having succeeded — the
         // signal `SocialWorkerProvisionCommand.provision()` persists once its own pre-provisioning
         // check passes, even if that attempt then fails for an unrelated reason.
-        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDir)
+        CloudflareDeployTarget.persistWorkerProvisioned(siteDirectory: siteDir)
         let exec = FakeExecutor()
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            // Even though the name is "taken" by this same call, a retry of this site's own
-            // provisioning must not be blocked.
-            workerScriptNamesSource: { _ in ["my-site"] },
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                // Even though the name is "taken" by this same call, a retry of this site's own
+                // provisioning must not be blocked.
+                workerScriptNamesSource: { _ in ["my-site"] }
+            ),
             executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
@@ -753,8 +763,8 @@ struct DeployCommandTests {
     @Test("persistWorkerProvisioned is idempotent and never clears an already-set flag")
     func persistWorkerProvisionedIsIdempotent() {
         let siteDir = makeSiteDirectory()
-        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDir)
-        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDir)
+        CloudflareDeployTarget.persistWorkerProvisioned(siteDirectory: siteDir)
+        CloudflareDeployTarget.persistWorkerProvisioned(siteDirectory: siteDir)
         let config = try! String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == "true")
     }
@@ -764,13 +774,13 @@ struct DeployCommandTests {
     @Test("hasDeployedBefore is false when CF_WORKER_DEPLOYED is absent")
     func hasDeployedBeforeFalseWhenAbsent() throws {
         let dir = makeSiteDirectory()
-        #expect(!DeployCommand.hasDeployedBefore(siteDirectory: dir))
+        #expect(!CloudflareDeployTarget.hasDeployedBefore(siteDirectory: dir))
     }
 
     @Test("hasDeployedBefore is true when CF_WORKER_DEPLOYED is set")
     func hasDeployedBeforeTrueWhenSet() throws {
         let dir = makeSiteDirectory(projectName: nil, deployedBefore: true)
-        #expect(DeployCommand.hasDeployedBefore(siteDirectory: dir))
+        #expect(CloudflareDeployTarget.hasDeployedBefore(siteDirectory: dir))
     }
 
     @Test("A thrown error from workerScriptNamesSource fails open and proceeds to build")
@@ -781,8 +791,10 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            workerScriptNamesSource: { _ in throw CloudflareError.http(status: 500) },
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                workerScriptNamesSource: { _ in throw CloudflareError.http(status: 500) }
+            ),
             executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
@@ -814,9 +826,11 @@ struct DeployCommandTests {
         let exec = FakeExecutor().onRun(.build, { Issue.record("build must not run when domain config drift is found") })
         let finding = makeFinding()
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            executor: exec,
-            domainConfigDriftSource: { _, _, _ in [finding] }
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                domainConfigDriftSource: { _, _, _ in [finding] }
+            ),
+            executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .domainConfigDrift(let findings) = result else {
@@ -834,9 +848,11 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            executor: exec,
-            domainConfigDriftSource: { _, _, _ in [] }
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                domainConfigDriftSource: { _, _, _ in [] }
+            ),
+            executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
@@ -850,12 +866,14 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            executor: exec,
-            domainConfigDriftSource: { _, _, _ in
-                Issue.record("must not be called when no domain is declared")
-                return []
-            }
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                domainConfigDriftSource: { _, _, _ in
+                    Issue.record("must not be called when no domain is declared")
+                    return []
+                }
+            ),
+            executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
@@ -869,9 +887,11 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published x (0.1 sec)\n  https://x.workers.dev")
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
-            executor: exec,
-            domainConfigDriftSource: { _, _, _ in throw CloudflareError.http(status: 500) }
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" },
+                domainConfigDriftSource: { _, _, _ in throw CloudflareError.http(status: 500) }
+            ),
+            executor: exec
         )
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded (fail open), got \(result)"); return }
@@ -892,7 +912,7 @@ struct DeployCommandTests {
                   https://angle-app.example.workers.dev
                 Current Version ID: abc-123
                 """)
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .succeeded(let url, _) = result else {
             Issue.record("expected .succeeded, got \(result)"); return
@@ -902,13 +922,13 @@ struct DeployCommandTests {
 
     @Test("extractDeployedURL finds a workers.dev URL with no recognized anchor line at all")
     func extractDeployedURLFindsWorkersDevWithoutAnchor() {
-        let url = DeployCommand.extractDeployedURL(from: "some future wrangler wording\n  https://angle-app.example.workers.dev\ndone")
+        let url = CloudflareDeployTarget.extractDeployedURL(from: "some future wrangler wording\n  https://angle-app.example.workers.dev\ndone")
         #expect(url?.host == "angle-app.example.workers.dev")
     }
 
     @Test("extractDeployedURL falls back to the Deployed/Uploaded anchor for a custom-domain deploy with no workers.dev URL")
     func extractDeployedURLCustomDomainAnchorFallback() {
-        let url = DeployCommand.extractDeployedURL(from: "Deployed angle-app triggers (0.45 sec)\n  https://example.com")
+        let url = CloudflareDeployTarget.extractDeployedURL(from: "Deployed angle-app triggers (0.45 sec)\n  https://example.com")
         #expect(url == URL(string: "https://example.com"))
     }
 
@@ -916,7 +936,7 @@ struct DeployCommandTests {
     func extractDeployedURLIgnoresIncidentalWorkersDevBeforeAnchor() {
         // A workers.dev URL mentioned before the anchor line (e.g. an "you already have a
         // subdomain" notice) must not outrank the actual deploy result after the anchor.
-        let url = DeployCommand.extractDeployedURL(from: """
+        let url = CloudflareDeployTarget.extractDeployedURL(from: """
             Note: your account already has a workers.dev subdomain: https://myaccount.workers.dev
             Deployed angle-app triggers (0.45 sec)
               https://angle-app.example.workers.dev
@@ -971,7 +991,7 @@ struct DeployCommandTests {
                 }
             }
         )
-        let cmd = DeployCommand(tokenSource: { "fake-token" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "fake-token" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .succeeded(let url, _) = result else {
             Issue.record("expected .succeeded, got \(result)"); return
@@ -1003,7 +1023,7 @@ struct DeployCommandTests {
                 }
             }
         )
-        let cmd = DeployCommand(tokenSource: { "secret-token-abc" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "secret-token-abc" }), executor: exec)
         let result = await cmd.deploy(siteID: "mysite", siteDirectory: tmpDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
         let lines = await center.snapshot()
@@ -1051,7 +1071,7 @@ struct DeployCommandTests {
                 }
             }
         )
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let task = Task { await cmd.deploy(siteID: "site", siteDirectory: dir) }
         #expect(await waitForMarker("__STARTED__", in: center, timeout: Self.markerObservationTimeout), "wrangler never started")
@@ -1072,7 +1092,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "building…")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published s (1.0 sec)\n  https://s.example.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let outcomes = Locked<[PreDeployCheck.Outcome]>([])
         _ = await cmd.deploy(
             siteID: "s", siteDirectory: tmpDir,
@@ -1095,7 +1115,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "building…")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published s (1.0 sec)\n  https://s.example.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let outcomes = Locked<[PreDeployCheck.Outcome]>([])
         let result = await cmd.deploy(
             siteID: "s", siteDirectory: tmpDir,
@@ -1131,7 +1151,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "building…")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published s (1.0 sec)\n  https://s.example.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let outcomes = Locked<[PreDeployCheck.Outcome]>([])
         _ = await cmd.deploy(
             siteID: "s", siteDirectory: siteDir,
@@ -1161,7 +1181,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "building…")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published s (1.0 sec)\n  https://s.example.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
 
@@ -1179,7 +1199,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "building…")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Published s (1.0 sec)\n  https://s.example.workers.dev")
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: exec)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
         let result = await cmd.deploy(siteID: "s", siteDirectory: siteDir)
         guard case .succeeded = result else { Issue.record("expected .succeeded, got \(result)"); return }
 
@@ -1198,7 +1218,7 @@ struct DeployCommandTests {
         try? "SITE_NAME=Acme\nSITE_URL=https://old.example.workers.dev\n".write(
             to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
-        DeployCommand.persistSiteURL(URL(string: "https://new.example.workers.dev")!, siteDirectory: siteDir)
+        CloudflareDeployTarget.persistSiteURL(URL(string: "https://new.example.workers.dev")!, siteDirectory: siteDir)
 
         let config = try! String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(config.contains("SITE_NAME=Acme"))
@@ -1217,7 +1237,7 @@ struct DeployCommandTests {
         try? "DOMAIN=example.com\nCF_DOMAIN_ATTACHED=example.com\n".write(
             to: siteDir.appendingPathComponent(".site-config"), atomically: true, encoding: .utf8)
 
-        DeployCommand.persistSiteURL(URL(string: "https://new.example.workers.dev")!, siteDirectory: siteDir)
+        CloudflareDeployTarget.persistSiteURL(URL(string: "https://new.example.workers.dev")!, siteDirectory: siteDir)
 
         let config = try! String(contentsOf: siteDir.appendingPathComponent(".site-config"), encoding: .utf8)
         #expect(!config.contains("SITE_URL="))
@@ -1240,7 +1260,7 @@ struct DeployCommandTests {
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Deployed my-site (1.2 sec)\n https://my-site.example.workers.dev")
             .set(.bundleUpload, exitCode: 0, output: "")
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
 
         let result = await command.deploy(siteID: "test", siteDirectory: siteDir, configDirectory: configDir)
         guard case .succeeded = result else {
@@ -1270,7 +1290,7 @@ struct DeployCommandTests {
             .set(.build, exitCode: 0, output: "")
             .set(.preflight, exitCode: 0, output: scanJSON(ok: true))
             .set(.wrangler, exitCode: 0, output: "Deployed my-site (1.2 sec)\n https://my-site.example.workers.dev")
-        let command = DeployCommand(tokenSource: { "test-token" }, executor: executor)
+        let command = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "test-token" }), executor: executor)
 
         let result = await command.deploy(siteID: "test", siteDirectory: siteDir, configDirectory: configDir)
         guard case .succeeded = result else {
@@ -1380,8 +1400,10 @@ struct DeployCommandTests {
             .set(.wrangler, exitCode: 0, output: "Deployed my-site (1.2 sec)\n https://my-site.example.workers.dev")
         let writer = FakeCloudflareWriting()
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                customDomainAttachCommand: CustomDomainAttachCommand(client: writer)
+            ),
             executor: executor
         )
 
@@ -1413,9 +1435,11 @@ struct DeployCommandTests {
         let writer = FakeCloudflareWriting()
         writer.result = .success(.attached)
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
-            markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer),
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+                markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer)
+            ),
             executor: executor
         )
 
@@ -1456,8 +1480,10 @@ struct DeployCommandTests {
         let writer = FakeCloudflareWriting()
         writer.result = .success(.zoneNotFound)
         let command = DeployCommand(
-            tokenSource: { "test-token" },
-            customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+            target: CloudflareDeployTarget(
+                tokenSource: { "test-token" },
+                customDomainAttachCommand: CustomDomainAttachCommand(client: writer)
+            ),
             executor: executor
         )
 

--- a/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift
@@ -40,7 +40,9 @@ struct DeployExecutorSelectionTests {
             logCenter: LogCenter()
         )
         let cmd = DeployCommand(
-            tokenSource: { "tok" },
+            target: CloudflareDeployTarget(
+                tokenSource: { "tok" }
+            ),
             executor: executor
         )
         // The fake returns exit-0 + valid scan JSON for every step, so the full
@@ -61,7 +63,7 @@ struct DeployExecutorSelectionTests {
             execStdoutLines: []
         )
         let executor = ContainerDeployExecutor(control: fake, siteID: "my-site", logCenter: LogCenter())
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: executor)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: executor)
         _ = await cmd.deploy(siteID: "my-site", siteDirectory: tmpDir)
         let calls = await fake.execCalls
         for call in calls {
@@ -85,7 +87,7 @@ struct DeployExecutorSelectionTests {
             logCenter: LogCenter(),
             resolveCommand: { _ in { _ in .unavailable(reason: "host path chosen") } }
         )
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: hostExecutor)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: hostExecutor)
         _ = await cmd.deploy(siteID: "site-1", siteDirectory: tmpDir)
         let calls = await fake.execCalls
         #expect(calls.isEmpty, "container control.exec() must NOT be called when the host executor is used")
@@ -98,7 +100,7 @@ struct DeployExecutorSelectionTests {
         // Use a step-aware fake: intercept exec calls in order and return the right payload.
         let stepAware = StepAwareFakeContainerControl()
         let executor = ContainerDeployExecutor(control: stepAware, siteID: "s", logCenter: LogCenter())
-        let cmd = DeployCommand(tokenSource: { "tok" }, executor: executor)
+        let cmd = DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: executor)
         _ = await cmd.deploy(siteID: "s", siteDirectory: tmpDir)
         let calls = await stepAware.calls
         let argvs = calls.map(\.argv)

--- a/Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift
@@ -41,7 +41,8 @@ struct DomainConfigStoreTests {
                 ])
             ),
             email: .init(provider: "icloud", dmarcReportEmail: "postmaster@example.com"),
-            workers: .init(active: ["webmention-receive", "micropub"])
+            workers: .init(active: ["webmention-receive", "micropub"]),
+            deployTarget: "cloudflare"
         )
         try store.save(config)
         let fileURL = dir.appendingPathComponent("anglesite.json")

--- a/Tests/AnglesiteCoreTests/SiteOperationsProgressSeamTests.swift
+++ b/Tests/AnglesiteCoreTests/SiteOperationsProgressSeamTests.swift
@@ -23,7 +23,7 @@ struct SiteOperationsProgressSeamTests {
 
 /// Minimal CommandFactory whose actors fail fast (no subprocess) — we only exercise signatures here.
 private struct NoopCommandFactory: CommandFactory {
-    func deploy() -> DeployCommand { DeployCommand(tokenSource: { nil }) }
+    func deploy() -> DeployCommand { DeployCommand(target: CloudflareDeployTarget(tokenSource: { nil })) }
     func backup() -> BackupCommand { BackupCommand(runner: { _, _ in .init(stdout: "", stderr: "", exitCode: 1) }, streamer: { _, _, _ in (1, "") }) }
     func audit() -> AuditCommand {
         AuditCommand(

--- a/docs/superpowers/plans/2026-08-17-deploy-target-seam-slice1.md
+++ b/docs/superpowers/plans/2026-08-17-deploy-target-seam-slice1.md
@@ -1,0 +1,1532 @@
+# DeployTarget Seam (Slice 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a `DeployTarget` protocol from `DeployCommand` with `CloudflareDeployTarget` as the sole conformer, and add a `deployTarget` field to `anglesite.json` — zero behavior change, no GitHub Pages conformer yet.
+
+**Architecture:** `DeployCommand.deploy` keeps the provider-agnostic spine (well-known merge, build, non-bypassable `PreDeployCheck`) and delegates everything Cloudflare-specific — credential resolution, worker-name-conflict/domain-config-drift checks, the wrangler upload, and every post-publish effect — to a `CloudflareDeployTarget` reached through the new `DeployTarget` protocol. `DeployCommand`'s `target` parameter defaults to `CloudflareDeployTarget()`, so every existing call site keeps compiling and deploying through Cloudflare unchanged.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Test`/`#expect`), SwiftPM (`swift test --package-path .`).
+
+## Global Constraints
+
+- Zero behavior change for existing sites: every `DeployCommand.Result` case, every `.site-config`/`anglesite.json` side effect, and every observed test assertion must stay identical.
+- `PreDeployCheck` (the pre-deploy security scan) stays hard-coded in `DeployCommand.deploy`, never delegated to a `DeployTarget` conformer — no target gets a hook to bypass it (CONTRIBUTING.md: "the app cannot bypass plugin security hooks").
+- No GitHub Pages conformer, no target-selection logic, no Settings UI this slice — `deployTarget` is written to schema but not yet read to pick a conformer.
+- Commit subject ≤ 72 characters; reference `#1015`; conventional-commit format (`feat(#1015): …`).
+- Run `swift test --package-path .` and `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` before considering either task done — this touches `Sources/AnglesiteApp` as well as `Sources/AnglesiteCore`.
+
+---
+
+### Task 1: Add `deployTarget` to `anglesite.json` (`DomainConfig`)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/DomainConfig.swift:15-39` (properties + init), `Sources/AnglesiteCore/DomainConfig.swift:172-196` (Codable conformance)
+- Test: `Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift:22-52`
+
+**Interfaces:**
+- Produces: `DomainConfig.deployTarget: String?` — an open string (not a closed enum), `nil` meaning "cloudflare" (today's only target). Round-tripped by `DomainConfigStore` like every other field. Not consumed by anything yet — Task 2 does not read it.
+
+- [ ] **Step 1: Update the failing-first test — add `deployTarget` to the comprehensive round-trip test**
+
+In `Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift`, change the `saveLoadRoundTrips` test (lines 22-52) so the constructed `DomainConfig` also sets `deployTarget`:
+
+```swift
+    @Test("save then load round-trips a fully populated config")
+    func saveLoadRoundTrips() throws {
+        let dir = try tempSourceDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = DomainConfigStore(sourceDirectory: dir)
+        let config = DomainConfig(
+            version: 1,
+            domain: .init(
+                hostname: "example.com", choice: "transfer", attach: true,
+                registrar: "Example Registrar, LLC", expiresAt: "2027-08-13T04:00:00Z"),
+            dns: .init(managedRecords: [
+                .init(type: "MX", name: "@", content: "mx01.mail.icloud.com", priority: 10, purpose: "email:icloud"),
+            ]),
+            edge: .init(
+                dnssec: true,
+                alwaysUseHTTPS: true,
+                hsts: .init(maxAge: 31536000, includeSubdomains: true, preload: false),
+                cloudflare: .init(botFightMode: true, wafRules: [
+                    .init(description: "Block bad bots", expression: "cf.client.bot", action: "block"),
+                ])
+            ),
+            email: .init(provider: "icloud", dmarcReportEmail: "postmaster@example.com"),
+            workers: .init(active: ["webmention-receive", "micropub"]),
+            deployTarget: "cloudflare"
+        )
+        try store.save(config)
+        let fileURL = dir.appendingPathComponent("anglesite.json")
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+        #expect(try store.load() == config)
+        let contents = try String(contentsOf: fileURL, encoding: .utf8)
+        #expect(contents.hasSuffix("\n"), "anglesite.json should end with a trailing newline")
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --package-path . --filter DomainConfigStoreTests/saveLoadRoundTrips`
+Expected: FAIL — `DomainConfig(... deployTarget: "cloudflare")` doesn't compile yet (`extra argument 'deployTarget' in call`).
+
+- [ ] **Step 3: Add the field to `DomainConfig`'s properties and memberwise init**
+
+In `Sources/AnglesiteCore/DomainConfig.swift`, replace lines 15-39:
+
+```swift
+public struct DomainConfig: Equatable, Sendable {
+    /// The schema version. Always written; tolerated as absent on read (defaults to `1`) so a
+    /// file hand-authored before this field existed still loads.
+    public var version: Int
+    public var domain: Domain?
+    public var dns: DNS?
+    public var edge: Edge?
+    public var email: Email?
+    public var workers: Workers?
+    /// The publish destination this site uses (#1015) — an open string (not a closed `enum`),
+    /// matching `Domain.choice`'s precedent, so an unrecognized future value degrades gracefully
+    /// for a reader that predates it. `nil` means "cloudflare," the only target that exists today
+    /// — nothing reads this field to select a `DeployTarget` conformer yet (that's a later
+    /// slice); it exists so that slice needs no schema migration when it lands.
+    public var deployTarget: String?
+
+    public init(
+        version: Int = 1,
+        domain: Domain? = nil,
+        dns: DNS? = nil,
+        edge: Edge? = nil,
+        email: Email? = nil,
+        workers: Workers? = nil,
+        deployTarget: String? = nil
+    ) {
+        self.version = version
+        self.domain = domain
+        self.dns = dns
+        self.edge = edge
+        self.email = email
+        self.workers = workers
+        self.deployTarget = deployTarget
+    }
+```
+
+- [ ] **Step 4: Add the field to the manual `Codable` conformance**
+
+In the same file, replace the `Codable` extension (lines 172-196):
+
+```swift
+extension DomainConfig: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case version, domain, dns, edge, email, workers, deployTarget
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decodeIfPresent(Int.self, forKey: .version) ?? 1
+        domain = try container.decodeIfPresent(Domain.self, forKey: .domain)
+        dns = try container.decodeIfPresent(DNS.self, forKey: .dns)
+        edge = try container.decodeIfPresent(Edge.self, forKey: .edge)
+        email = try container.decodeIfPresent(Email.self, forKey: .email)
+        workers = try container.decodeIfPresent(Workers.self, forKey: .workers)
+        deployTarget = try container.decodeIfPresent(String.self, forKey: .deployTarget)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encodeIfPresent(domain, forKey: .domain)
+        try container.encodeIfPresent(dns, forKey: .dns)
+        try container.encodeIfPresent(edge, forKey: .edge)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(workers, forKey: .workers)
+        try container.encodeIfPresent(deployTarget, forKey: .deployTarget)
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `swift test --package-path . --filter DomainConfigStoreTests`
+Expected: PASS (all `DomainConfigStoreTests` cases, including `saveLoadRoundTrips`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DomainConfig.swift Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift
+git commit -m "feat(#1015): add deployTarget field to anglesite.json"
+```
+
+---
+
+### Task 2: Extract the `DeployTarget` seam
+
+**Files:**
+- Create: `Sources/AnglesiteCore/DeployTarget.swift`
+- Create: `Sources/AnglesiteCore/CloudflareDeployTarget.swift`
+- Modify: `Sources/AnglesiteCore/DeployCommand.swift` (full rewrite of the sections listed in Step 3)
+- Modify: `Sources/AnglesiteApp/DeployModel.swift:708`, `:748-758`, `:876-925`
+- Modify: `Sources/AnglesiteApp/AgentReadinessModel.swift:22`, `:29`
+- Modify: `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift:115`, `:121`, `:132`, `:247-249`, `:252`, `:840`
+- Modify (mechanical, see Step 8): `Tests/AnglesiteCoreTests/DeployCommandTests.swift`, `Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift`, `Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift`, `Tests/AnglesiteCoreTests/SiteOperationsProgressSeamTests.swift`, `Tests/AnglesiteAppTests/DeployModelTests.swift`
+
+**Interfaces:**
+- Consumes: `DeployStep`/`DeployStepResult`/`DeployExecutor` (`Sources/AnglesiteCore/DeployExecutor.swift`, unchanged), `PreDeployCheck` (`Sources/AnglesiteCore/PreDeployCheck.swift`, unchanged), `CustomDomainAttachCommand`/`MarkdownForAgentsCommand` (unchanged), `ProgressHandler` (`Sources/AnglesiteCore/OperationProgress.swift`, unchanged).
+- Produces: `public protocol DeployTarget: Sendable { static var id: String { get }; func authorize(siteDirectory: URL) async -> DeployTargetAuthorization; func publish(context: DeployTargetContext) async -> DeployCommand.Result }`; `public enum DeployTargetAuthorization { case ready(credential: String); case blocked(DeployCommand.Result) }`; `public struct DeployTargetContext` (fields: `siteID: String`, `siteDirectory: URL`, `configDirectory: URL?`, `currentRoutes: [String]`, `credential: String`, `baseEnvironment: [String: String]`, `executor: any DeployExecutor`, `onDomainAttach: DeployCommand.DomainAttachObserver?`, `onMarkdownForAgents: DeployCommand.MarkdownForAgentsObserver?`, `onProgress: ProgressHandler?`); `public struct CloudflareDeployTarget: DeployTarget` with public `tokenSource`/`workerScriptNamesSource`/`customDomainAttachCommand`/`markdownForAgentsCommand`/`domainConfigDriftSource` properties, `public static func hasDeployedBefore(siteDirectory:) -> Bool`, `public static func extractDeployedURL(from:) -> URL?`; `DeployCommand.init(target: any DeployTarget = CloudflareDeployTarget(), executor: any DeployExecutor = HostDeployExecutor())` and `public nonisolated let target: any DeployTarget`.
+
+This task is one atomic change: `DeployCommand`'s old `init` shape (`tokenSource:`/`workerScriptNamesSource:`/`customDomainAttachCommand:`/`markdownForAgentsCommand:`/`domainConfigDriftSource:`/`executor:`) is fully replaced by `target:`/`executor:`, so production code and every test call site must move together or the package won't compile. Steps 1-2 are additive (new files); Steps 3-9 land together in one commit.
+
+- [ ] **Step 1: Create `Sources/AnglesiteCore/DeployTarget.swift`**
+
+```swift
+import Foundation
+
+/// Outcome of a `DeployTarget`'s pre-build gate (`authorize(siteDirectory:)`). `DeployCommand`
+/// calls this before spending any time on the well-known scan or the build, so a deploy that
+/// can't succeed fails fast — matches `DeployCommand.deploy`'s original pre-spawn-refusal
+/// behavior exactly.
+public enum DeployTargetAuthorization: Sendable {
+    /// The target is ready to publish. `credential` is opaque to `DeployCommand` — only the
+    /// target that produced it (via `publish(context:)`'s `DeployTargetContext.credential`) knows
+    /// what to do with it (e.g. `CloudflareDeployTarget` treats it as a Cloudflare API token).
+    case ready(credential: String)
+    /// The deploy is refused before any build work happens — a missing/invalid credential, or a
+    /// target-specific fail-fast check (e.g. Cloudflare's worker-name-conflict or
+    /// domain-config-drift checks). `DeployCommand.deploy` returns this `Result` immediately.
+    case blocked(DeployCommand.Result)
+}
+
+/// Everything a `DeployTarget` needs to publish one deploy, assembled by `DeployCommand.deploy`
+/// after the shared build + `PreDeployCheck` spine has passed.
+public struct DeployTargetContext: Sendable {
+    public let siteID: String
+    public let siteDirectory: URL
+    /// The site's `Config/` directory, or `nil` when the caller didn't supply one (tests, and the
+    /// two non-primary deploy paths in `SocialWorkerProvisionCommand`/`SiteOperations`) — mirrors
+    /// `DeployCommand.deploy`'s own `configDirectory` parameter (#530).
+    public let configDirectory: URL?
+    /// The site's currently published route set, forwarded from `DeployCommand.deploy`'s
+    /// `currentRoutes` parameter — only meaningful when `configDirectory` is non-nil.
+    public let currentRoutes: [String]
+    /// The credential `authorize(siteDirectory:)` resolved, forwarded verbatim from its
+    /// `.ready(credential:)` case.
+    public let credential: String
+    /// The curated, secret-stripped environment `DeployCommand.hostDeployEnvironment()` produced
+    /// for the build/preflight steps — the target adds its own credential to this (rather than
+    /// receiving a pre-mixed environment) so the base environment's secret-stripping guarantee is
+    /// visible at the target's own call site, not just asserted by the caller.
+    public let baseEnvironment: [String: String]
+    /// The same `DeployExecutor` `DeployCommand` used for the build/preflight steps — the target
+    /// uses it to run its own steps (e.g. `CloudflareDeployTarget` runs `.wrangler` and
+    /// `.bundleUpload` through it).
+    public let executor: any DeployExecutor
+    /// Forwarded verbatim from `DeployCommand.deploy`'s `onDomainAttach` parameter. Only
+    /// `CloudflareDeployTarget` fires it today; a target with no equivalent concept simply never
+    /// calls it.
+    public let onDomainAttach: DeployCommand.DomainAttachObserver?
+    /// Forwarded verbatim from `DeployCommand.deploy`'s `onMarkdownForAgents` parameter. Only
+    /// `CloudflareDeployTarget` fires it today; a target with no equivalent concept simply never
+    /// calls it.
+    public let onMarkdownForAgents: DeployCommand.MarkdownForAgentsObserver?
+    /// Forwarded verbatim from `DeployCommand.deploy`'s `onProgress` parameter, so the target can
+    /// report its own publish-phase milestones (e.g. `.deployDeploying`/`.deployFinalizing`).
+    public let onProgress: ProgressHandler?
+
+    public init(
+        siteID: String,
+        siteDirectory: URL,
+        configDirectory: URL?,
+        currentRoutes: [String],
+        credential: String,
+        baseEnvironment: [String: String],
+        executor: any DeployExecutor,
+        onDomainAttach: DeployCommand.DomainAttachObserver?,
+        onMarkdownForAgents: DeployCommand.MarkdownForAgentsObserver?,
+        onProgress: ProgressHandler?
+    ) {
+        self.siteID = siteID
+        self.siteDirectory = siteDirectory
+        self.configDirectory = configDirectory
+        self.currentRoutes = currentRoutes
+        self.credential = credential
+        self.baseEnvironment = baseEnvironment
+        self.executor = executor
+        self.onDomainAttach = onDomainAttach
+        self.onMarkdownForAgents = onMarkdownForAgents
+        self.onProgress = onProgress
+    }
+}
+
+/// A publishable destination for a site's built static output — the seam that lets
+/// `DeployCommand` support hosts beyond Cloudflare (#1015). Each conformer owns everything
+/// specific to its provider: credential resolution, any target-specific pre-checks, the actual
+/// upload, and post-publish effects. `CloudflareDeployTarget` is the only conformer today.
+///
+/// `DeployCommand.deploy` calls `authorize(siteDirectory:)` before the shared well-known-scan and
+/// build steps run, then `publish(context:)` only after those and the non-bypassable
+/// `PreDeployCheck` preflight have all passed — no conformer gets a hook into the preflight gate
+/// itself.
+public protocol DeployTarget: Sendable {
+    /// Stable identifier persisted in `Source/anglesite.json`'s `deployTarget` field (e.g.
+    /// `"cloudflare"`). Not yet read by `DeployCommand` to select a conformer (#1015 slice 1) —
+    /// reserved for the target-selection slice.
+    static var id: String { get }
+
+    /// Pre-build gate: resolves this target's credential and runs any fail-fast checks against
+    /// current deployed state. Called before the well-known scan and the build, so a deploy that
+    /// can't succeed never pays for either.
+    func authorize(siteDirectory: URL) async -> DeployTargetAuthorization
+
+    /// Publishes the build produced by the shared spine and performs any post-publish effects.
+    /// Only called after `authorize` returned `.ready`, the well-known scan passed, the build
+    /// succeeded, and `PreDeployCheck` passed.
+    func publish(context: DeployTargetContext) async -> DeployCommand.Result
+}
+```
+
+- [ ] **Step 2: Create `Sources/AnglesiteCore/CloudflareDeployTarget.swift`**
+
+```swift
+import Foundation
+
+/// The Cloudflare `wrangler deploy` conformer of `DeployTarget` (#1015 slice 1) — every piece of
+/// `DeployCommand` that used to be Cloudflare-specific now lives here: credential resolution, the
+/// worker-name-conflict and domain-config-drift pre-checks, the wrangler upload itself, and every
+/// post-publish effect (custom-domain attach, Markdown for Agents, `.site-config` persistence, the
+/// R2 source-bundle upload). `DeployCommand` calls `authorize(siteDirectory:)` before the shared
+/// build/`PreDeployCheck` spine runs, then `publish(context:)` only after that spine has passed.
+public struct CloudflareDeployTarget: DeployTarget {
+    public static let id = "cloudflare"
+
+    /// Returns the Cloudflare API token, or `nil` if none is configured. Production callers use
+    /// `CloudflareDeployTarget.keychainTokenSource` (Keychain with an env-var fallback for
+    /// development); tests typically inject a closure returning a literal.
+    public typealias TokenSource = @Sendable () async throws -> String?
+    /// Returns the account's existing Worker script names for the given token. Production
+    /// callers use `CloudflareDeployTarget.defaultWorkerScriptNames` (`HTTPCloudflareClient`);
+    /// tests inject a fake list or a throwing closure.
+    public typealias WorkerScriptNamesSource = @Sendable (_ apiToken: String) async throws -> [String]
+    /// Grades a declared `Source/anglesite.json` domain against live Cloudflare state and returns
+    /// any drift (#1171's `DomainConfigAudit.evaluate`, given a fresh zone read). Production
+    /// callers use `CloudflareDeployTarget.defaultDomainConfigDriftSource`; tests inject a canned
+    /// findings list or a throwing closure — same rationale as `WorkerScriptNamesSource`.
+    public typealias DomainConfigDriftSource = @Sendable (
+        _ declared: DomainConfig, _ hostname: String, _ apiToken: String
+    ) async throws -> [DomainConfigAudit.Finding]
+
+    /// The token seam this target was constructed with. Exposed so `DeployModel.runDeploy` can
+    /// forward the exact same seam into companion commands (e.g. `SocialWorkerProvisionCommand`)
+    /// instead of letting them silently default to the production implementation and diverge
+    /// from a test's injected fake — see `workerScriptNamesSource` below for the full rationale.
+    public let tokenSource: TokenSource
+    /// Exposed (like `tokenSource`) so callers that build a parallel `SocialWorkerProvisionCommand`
+    /// alongside this target — `DeployModel.runDeploy` — can forward the exact same seam into its
+    /// own pre-provisioning conflict check (#1075) instead of silently defaulting to the real
+    /// network implementation and diverging from whatever this target was built with (production
+    /// default or a test's injected fake).
+    public let workerScriptNamesSource: WorkerScriptNamesSource
+    /// Exposed like `tokenSource`/`workerScriptNamesSource` so `DeployModel.runDeploy` can forward
+    /// the exact same seam into a container-path target it constructs on the fly (#1077).
+    public let customDomainAttachCommand: CustomDomainAttachCommand
+    /// Exposed like `customDomainAttachCommand` so `DeployModel.runDeploy` can forward the exact
+    /// same seam into a container-path target it constructs on the fly (#1247).
+    public let markdownForAgentsCommand: MarkdownForAgentsCommand
+    /// Exposed like the other seams above so callers building a parallel target (e.g.
+    /// `SocialWorkerProvisionCommand`'s `defaultDeployer`) forward the same one rather than
+    /// silently defaulting to production and diverging from a test's injected fake.
+    public let domainConfigDriftSource: DomainConfigDriftSource
+
+    /// All five dependencies are injectable seams with production defaults, so tests can drive a
+    /// full deploy — credential gate, name-conflict check, domain-config-drift check, publish —
+    /// with a literal token, a canned script-name list, and a scripted executor, never touching
+    /// the network or spawning a process.
+    public init(
+        tokenSource: @escaping TokenSource = CloudflareDeployTarget.keychainTokenSource,
+        workerScriptNamesSource: @escaping WorkerScriptNamesSource = CloudflareDeployTarget.defaultWorkerScriptNames,
+        customDomainAttachCommand: CustomDomainAttachCommand = CustomDomainAttachCommand(),
+        markdownForAgentsCommand: MarkdownForAgentsCommand = MarkdownForAgentsCommand(),
+        domainConfigDriftSource: @escaping DomainConfigDriftSource = CloudflareDeployTarget.defaultDomainConfigDriftSource
+    ) {
+        self.tokenSource = tokenSource
+        self.workerScriptNamesSource = workerScriptNamesSource
+        self.customDomainAttachCommand = customDomainAttachCommand
+        self.markdownForAgentsCommand = markdownForAgentsCommand
+        self.domainConfigDriftSource = domainConfigDriftSource
+    }
+
+    // MARK: DeployTarget
+
+    /// Pre-build gate: token resolution plus the worker-name-conflict (#740) and
+    /// domain-config-drift (#1173) checks, in that order — matches `DeployCommand.deploy`'s
+    /// original pre-spawn sequence exactly, so a deploy that can't succeed still fails before any
+    /// build time is spent.
+    public func authorize(siteDirectory: URL) async -> DeployTargetAuthorization {
+        let token: String?
+        do {
+            token = try await tokenSource()
+        } catch {
+            return .blocked(.failed(reason: "couldn't read Cloudflare API token: \(error)", exitCode: nil))
+        }
+        guard let token, !token.isEmpty else {
+            return .blocked(.failed(
+                reason: "no CLOUDFLARE_API_TOKEN — add it in Settings → Advanced → Credentials, or set the env var",
+                exitCode: nil))
+        }
+        if let conflict = await Self.checkWorkerNameConflict(
+            siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
+        ) {
+            return .blocked(conflict)
+        }
+        if let drift = await Self.checkDomainConfigDrift(
+            siteDirectory: siteDirectory, apiToken: token, domainConfigDriftSource: domainConfigDriftSource
+        ) {
+            return .blocked(drift)
+        }
+        return .ready(credential: token)
+    }
+
+    /// Runs `wrangler deploy` and every post-publish effect: URL extraction, custom-domain
+    /// attach, Markdown for Agents, `.site-config` persistence, and the optional R2 source-bundle
+    /// upload — matches `DeployCommand.deploy`'s original wrangler-step-and-after sequence exactly.
+    public func publish(context: DeployTargetContext) async -> DeployCommand.Result {
+        var wranglerEnvironment = context.baseEnvironment
+        wranglerEnvironment["CLOUDFLARE_API_TOKEN"] = context.credential
+
+        let started = Date()
+        context.onProgress?(.deployDeploying)
+        let wranglerResult = await context.executor.run(
+            step: .wrangler,
+            siteDirectory: context.siteDirectory,
+            environment: wranglerEnvironment,
+            source: "deploy:\(context.siteID)"
+        )
+        let duration = Date().timeIntervalSince(started)
+
+        if !Task.isCancelled { context.onProgress?(.deployFinalizing) }
+
+        guard let code = wranglerResult.exitCode else {
+            // nil exit code → unavailable resolver, spawn failure, or termination (e.g. cancellation).
+            // The cancellation path must say "terminated" (the cancellation test asserts on it);
+            // for the unavailable/spawn-failure cases the executor surfaces the reason in `output`.
+            if Task.isCancelled {
+                return .failed(reason: "wrangler was terminated", exitCode: nil)
+            }
+            return .failed(reason: wranglerResult.output.isEmpty ? "wrangler was terminated" : wranglerResult.output, exitCode: nil)
+        }
+        guard code == 0 else {
+            return .failed(reason: "wrangler exited with code \(code)", exitCode: code)
+        }
+        guard let url = Self.extractDeployedURL(from: wranglerResult.output) else {
+            return .failed(
+                reason: "wrangler exited successfully (code 0), but no deployed URL could be found in its output — the deploy likely succeeded; check the deploy log for the URL",
+                exitCode: 0
+            )
+        }
+
+        if let configDirectory = context.configDirectory {
+            try? DeployedRoutesSnapshot.save(context.currentRoutes, to: configDirectory)
+        }
+        // Runs before `persistSiteURL` (#1077/#1124): a fresh confirmation from *this* deploy
+        // persists `CF_DOMAIN_ATTACHED` as a side effect, which `persistSiteURL` checks to decide
+        // whether to leave `SITE_URL` alone.
+        let domainAttachOutcome = await customDomainAttachCommand.attach(
+            siteDirectory: context.siteDirectory, apiToken: context.credential, source: "deploy:\(context.siteID)")
+        context.onDomainAttach?(domainAttachOutcome)
+        // Only a confirmed-attached custom domain has a zone to configure — a workers.dev-only
+        // site (or one not yet delegated) has nothing for Markdown for Agents to apply to (#1247).
+        if case .confirmed(let hostname) = domainAttachOutcome {
+            let markdownOutcome = await markdownForAgentsCommand.apply(
+                hostname: hostname, siteDirectory: context.siteDirectory, configDirectory: context.configDirectory,
+                apiToken: context.credential, source: "deploy:\(context.siteID)")
+            context.onMarkdownForAgents?(markdownOutcome)
+        }
+        Self.persistSiteURL(url, siteDirectory: context.siteDirectory)
+        Self.persistWorkerDeployed(siteDirectory: context.siteDirectory)
+        if let configDirectory = context.configDirectory {
+            await Self.uploadSourceBundleIfConfigured(
+                siteDirectory: context.siteDirectory, configDirectory: configDirectory,
+                environment: wranglerEnvironment, executor: context.executor, siteID: context.siteID
+            )
+        }
+        return .succeeded(url: url, duration: duration)
+    }
+
+    // MARK: URL extraction
+
+    /// Extracts the deployed URL from wrangler's captured stdout. Wrangler's exact wording has
+    /// already drifted across major versions (older wrangler printed a `Published <name> (1.23
+    /// sec)` status line; current wrangler instead prints separate `Uploaded <name> (…)` /
+    /// `Deployed <name> triggers (…)` lines), and `wrangler deploy` (unlike `wrangler pages
+    /// deploy`) has no `--json` output mode to depend on instead, so multiple status-line prefixes
+    /// are recognized as the anchor:
+    ///
+    /// 1. Anchor on a recognized start-of-line status prefix (`Published`/`Deployed`/`Uploaded`)
+    ///    and search only the anchor line and lines after it — never anything before it — for a
+    ///    URL. A `*.workers.dev` URL there is preferred (the common case); any URL is accepted as a
+    ///    fallback for custom-domain deploys, which have no workers.dev host in their output.
+    ///    Scoping to at/after the anchor (rather than the whole output) matters because this
+    ///    result gets persisted as the site's live URL: an incidental workers.dev mention earlier
+    ///    in the log (e.g. a subdomain-already-exists notice) must not outrank the real result.
+    /// 2. If no anchor line is recognized at all (a future wrangler layout this doesn't know
+    ///    about), fall back to a whole-output scan for a `*.workers.dev` URL — still a
+    ///    distinctive, version-independent signature of a genuine deploy result, just without
+    ///    anchor confirmation.
+    public static func extractDeployedURL(from output: String) -> URL? {
+        let anchors = ["Published", "Deployed", "Uploaded"]
+        let lines = output.split(separator: "\n", omittingEmptySubsequences: false)
+        if let anchorIdx = lines.firstIndex(where: { line in anchors.contains(where: line.hasPrefix) }) {
+            let tail = lines[anchorIdx...].joined(separator: "\n")
+            return firstURL(in: tail, requiringHostSuffix: ".workers.dev") ?? firstURL(in: tail)
+        }
+        return firstURL(in: output, requiringHostSuffix: ".workers.dev")
+    }
+
+    /// The first `http(s)` URL in `text` — optionally required to have a host ending in
+    /// `hostSuffix` — with trailing punctuation a terminal might tack on (commas, periods, closing
+    /// parens) stripped. Scans the whole string (not line-by-line), so callers doing a
+    /// version-independent signature scan can pass multi-line output directly.
+    private static func firstURL(in text: String, requiringHostSuffix hostSuffix: String? = nil) -> URL? {
+        guard let regex = try? NSRegularExpression(pattern: #"https?://\S+"#) else { return nil }
+        let fullRange = NSRange(text.startIndex..., in: text)
+        for match in regex.matches(in: text, range: fullRange) {
+            guard let range = Range(match.range, in: text) else { continue }
+            var raw = String(text[range])
+            while let last = raw.last, ",.)]}>".contains(last) {
+                raw.removeLast()
+            }
+            guard let url = URL(string: raw) else { continue }
+            if let hostSuffix {
+                guard let host = url.host, host.hasSuffix(hostSuffix) else { continue }
+            }
+            return url
+        }
+        return nil
+    }
+
+    // MARK: `.site-config` persistence
+
+    /// Persists the deployed URL into `.site-config`'s `SITE_URL` (#702) so the *next* build's
+    /// `astro.config.ts` picks up the real host for canonical URLs, feed self-links, and JSON-LD
+    /// instead of the `https://example.com` placeholder. This deploy's own `dist/` was already
+    /// built before the URL was known, so the placeholder still ships on a site's first deploy —
+    /// every deploy after that carries the real host.
+    ///
+    /// Written even when a custom domain (`DOMAIN`/`SITE_DOMAIN`) is configured but not yet
+    /// confirmed live (#1085): before #1077, nothing in the deploy pipeline attached a custom
+    /// domain, so an unverified `DOMAIN` was never trustworthy and `SITE_URL` — the site's real,
+    /// reachable address — had to win `DeployCoordinator.resolveSiteURL`'s precedence regardless.
+    ///
+    /// Skipped once `CF_DOMAIN_ATTACHED` matches `DOMAIN` — the same "confirmed" signal
+    /// `CustomDomainAttachCommand.attach` itself checks (#1077) — because at that point `DOMAIN`
+    /// *is* verified live, and overwriting `SITE_URL` with the workers.dev host would shadow it in
+    /// `resolveSiteURL`'s precedence forever after, silently undoing every confirmed domain attach
+    /// on its very next deploy. Callers must call `customDomainAttachCommand.attach` (and let it
+    /// persist `CF_DOMAIN_ATTACHED`) before this, so a domain confirmed *in this same deploy* is
+    /// already visible to the check. Best-effort — a write failure must never turn a successful
+    /// deploy into a failed one.
+    static func persistSiteURL(_ url: URL, siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        if let domain = SiteConfigFile.value(forKey: "DOMAIN", in: config),
+           SiteConfigFile.value(forKey: "CF_DOMAIN_ATTACHED", in: config) == domain {
+            return
+        }
+        let updated = SiteConfigFile.upsert([("SITE_URL", url.absoluteString)], into: config)
+        guard updated != config else { return }
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Marks this site as having successfully deployed at least once, via `.site-config`'s
+    /// `CF_WORKER_DEPLOYED` — the signal `checkWorkerNameConflict` uses to skip the collision
+    /// check on every deploy after the first (#740). Written unconditionally, unlike
+    /// `persistSiteURL` (which skips when a custom domain is already configured) — deploy
+    /// history isn't confounded by domain choice. Best-effort, matching `persistSiteURL`.
+    static func persistWorkerDeployed(siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil else { return }
+        let updated = SiteConfigFile.upsert([("CF_WORKER_DEPLOYED", "true")], into: config)
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Whether this site has already completed at least one successful deploy — the same
+    /// `.site-config` `CF_WORKER_DEPLOYED` signal `persistWorkerDeployed` writes and
+    /// `checkWorkerNameConflict` reads. A read-only counterpart for callers (`DeployModel`) that
+    /// need to know, *before* a deploy runs, whether this one would be the site's first — without
+    /// duplicating the file read `checkWorkerNameConflict` already does inline. Public (unlike its
+    /// siblings) because `DeployModel` lives in a different module.
+    public static func hasDeployedBefore(siteDirectory: URL) -> Bool {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        return SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) != nil
+    }
+
+    /// Marks this site's candidate Worker name as confirmed-ours, via `.site-config`'s
+    /// `CF_WORKER_PROVISIONED` — a second, earlier-firing signal `checkWorkerNameConflict` treats
+    /// the same as `CF_WORKER_DEPLOYED` (#1075). `CF_WORKER_DEPLOYED` alone only covers a *fully
+    /// succeeded* deploy, but `SocialWorkerProvisionCommand.provision()` can already have pushed
+    /// live Cloudflare state under this candidate name (`wrangler secret put` for ActivityPub, run
+    /// before the final `wrangler deploy`, auto-vivifies an empty Worker script under the target
+    /// name as a side effect) in an attempt that then failed for an unrelated reason before
+    /// `persistWorkerDeployed` ever ran. Without this second signal, a retry of that same site
+    /// would see its own auto-vivified script on the account and misreport it as a foreign
+    /// conflict. Called once, immediately after a fresh `checkWorkerNameConflict` pass at the very
+    /// start of provisioning — before any wrangler call that could touch the name — so a *genuine*
+    /// foreign collision is still caught before this site's own provisioning ever runs. Written
+    /// unconditionally like `persistWorkerDeployed`; best-effort, matching `persistSiteURL`.
+    static func persistWorkerProvisioned(siteDirectory: URL) {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil else { return }
+        let updated = SiteConfigFile.upsert([("CF_WORKER_PROVISIONED", "true")], into: config)
+        try? updated.write(to: configURL, atomically: true, encoding: .utf8)
+    }
+
+    /// Uploads `Source/`'s snapshot to R2 (`DeployStep.bundleUpload`) when `.site-config`'s
+    /// `CF_SOURCE_BUCKET` is set, then persists the uploaded commit SHA into `Config/settings.plist`
+    /// (#799, spec §C.4 — the code side of a future Worker-triggered bake). A no-op today for every
+    /// real site — no provisioning flow writes `CF_SOURCE_BUCKET` yet — and the executor call is
+    /// skipped entirely rather than run-and-ignore-the-result, so a redeploy on an unprovisioned
+    /// site pays no extra subprocess cost. Best-effort like `persistSiteURL`/`persistWorkerDeployed`:
+    /// a failure here must never turn a successful deploy into a failed one.
+    static func uploadSourceBundleIfConfigured(
+        siteDirectory: URL,
+        configDirectory: URL,
+        environment: [String: String],
+        executor: any DeployExecutor,
+        siteID: String
+    ) async {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_SOURCE_BUCKET", in: config) != nil else { return }
+
+        let uploadResult = await executor.run(
+            step: .bundleUpload,
+            siteDirectory: siteDirectory,
+            environment: environment,
+            source: "deploy:\(siteID):bundle"
+        )
+        guard uploadResult.exitCode == 0 else { return }
+
+        guard let headResult = try? await BackupCommand.defaultRunner(siteDirectory, ["rev-parse", "HEAD"]) else { return }
+        guard headResult.exitCode == 0 else { return }
+        let commitSHA = headResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !commitSHA.isEmpty else { return }
+
+        let store = SiteConfigStore(configDirectory: configDirectory)
+        guard var settings = try? await store.load() else { return }
+        settings.deployedSourceBundleCommit = commitSHA
+        try? await store.save(settings)
+    }
+
+    // MARK: Pre-build checks
+
+    /// Checks whether `.site-config`'s `CF_PROJECT_NAME` collides with an existing Worker on the
+    /// connected Cloudflare account, but only when neither `CF_WORKER_DEPLOYED` (a full deploy has
+    /// already succeeded under this name) nor `CF_WORKER_PROVISIONED` (this site's own earlier
+    /// provisioning already confirmed the name as ours, #1075) is set yet. Returns
+    /// `.workerNameConflict` on a confirmed collision, or `nil` when the check doesn't apply
+    /// (redeploy, already-provisioned, no candidate name) or can't be confirmed — a Cloudflare API
+    /// failure here must never block a deploy that would otherwise succeed (fail open).
+    static func checkWorkerNameConflict(
+        siteDirectory: URL,
+        apiToken: String,
+        workerScriptNamesSource: WorkerScriptNamesSource
+    ) async -> DeployCommand.Result? {
+        let configURL = siteDirectory.appendingPathComponent(WebsiteAnalyticsAsset.configRelativePath)
+        let config = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        guard SiteConfigFile.value(forKey: "CF_WORKER_DEPLOYED", in: config) == nil,
+              SiteConfigFile.value(forKey: "CF_WORKER_PROVISIONED", in: config) == nil,
+              let candidateName = SiteConfigFile.value(forKey: "CF_PROJECT_NAME", in: config)
+        else { return nil }
+        guard let names = try? await workerScriptNamesSource(apiToken) else { return nil }
+        guard names.contains(candidateName) else { return nil }
+        return .workerNameConflict(name: candidateName)
+    }
+
+    /// Grades the site's declared `anglesite.json` domain against live Cloudflare state (#1173).
+    /// Returns `.domainConfigDrift` when the audit finds any drift, or `nil` when the check
+    /// doesn't apply (no `anglesite.json`, or no declared `domain.hostname` — nothing to compare
+    /// against live state) or can't be confirmed. A read/decode error and a thrown/failed
+    /// `domainConfigDriftSource` both fail open — same posture as `checkWorkerNameConflict`, since
+    /// a transient Cloudflare API hiccup here must never block an otherwise-good deploy.
+    static func checkDomainConfigDrift(
+        siteDirectory: URL,
+        apiToken: String,
+        domainConfigDriftSource: DomainConfigDriftSource
+    ) async -> DeployCommand.Result? {
+        guard let declared = try? DomainConfigStore(sourceDirectory: siteDirectory).load(),
+              let hostname = declared.domain?.hostname, !hostname.isEmpty
+        else { return nil }
+        guard let findings = try? await domainConfigDriftSource(declared, hostname, apiToken), !findings.isEmpty
+        else { return nil }
+        return .domainConfigDrift(findings: findings)
+    }
+
+    // MARK: Default seams
+
+    /// Reads `CLOUDFLARE_API_TOKEN` from the process environment. Useful in development (the env
+    /// var dominates the Keychain entry when both are set, so a shell with `CLOUDFLARE_API_TOKEN`
+    /// exported behaves the way a wrangler user expects).
+    public static let envTokenSource: TokenSource = {
+        ProcessInfo.processInfo.environment["CLOUDFLARE_API_TOKEN"]
+    }
+
+    /// Default `TokenSource` for production: thin forwarding wrapper around
+    /// ``CloudflareAPICredentials/resolve(secretStore:diagnosticSource:surfaceOAuthReadErrors:)``
+    /// (#1211) — env var first (so a developer's shell still wins), then a stored OAuth credential
+    /// (refreshing it first if expired), then the legacy pasted token, kept so a token a user
+    /// already pasted keeps working. Passes `surfaceOAuthReadErrors: true`, preserving this call
+    /// site's original (pre-#1211) behavior: a genuine Keychain error reading the OAuth slot
+    /// surfaces as an actionable "couldn't read token" deploy failure rather than silently reading
+    /// as "no token configured" and nudging the user toward an unnecessary re-sign-in — deploy is
+    /// the highest-stakes call site this resolver serves, so it alone keeps that stricter
+    /// diagnosis. The resolver's other callers (background sync jobs, Harden, Domain Config Audit,
+    /// …) default to swallowing that error and falling through to the legacy token instead, which
+    /// isn't a behavior change for them — none of them surfaced this class of error before #1211
+    /// either.
+    public static let keychainTokenSource: TokenSource = {
+        try await CloudflareAPICredentials.resolve(surfaceOAuthReadErrors: true)
+    }
+
+    /// Default `WorkerScriptNamesSource` for production: the account's Worker script names via
+    /// `HTTPCloudflareClient`.
+    public static let defaultWorkerScriptNames: WorkerScriptNamesSource = { apiToken in
+        try await HTTPCloudflareClient().workerScriptNames(apiToken: apiToken)
+    }
+
+    /// Default `DomainConfigDriftSource` for production: resolves the declared hostname's zone,
+    /// reads its live edge state and DNS records via `HTTPCloudflareClient`, then grades them with
+    /// `DomainConfigAudit.evaluate` — the same three calls `DomainConfigAuditModel.performAudit`
+    /// makes App-side, just without the SwiftUI-facing `Phase` machinery. A zone that can't be
+    /// resolved (not yet attached, or a Cloudflare read failure) returns no findings rather than
+    /// throwing — nothing to compare declared state against yet, not drift.
+    public static let defaultDomainConfigDriftSource: DomainConfigDriftSource = { declared, hostname, apiToken in
+        let reader: any CloudflareReading = HTTPCloudflareClient()
+        guard let zoneID = try await reader.resolveZoneID(domain: hostname, apiToken: apiToken) else { return [] }
+        let state = try await reader.zoneState(zoneID: zoneID, domain: hostname, apiToken: apiToken)
+        let records = try await reader.listDNSRecords(zoneID: zoneID, apiToken: apiToken)
+        return DomainConfigAudit.evaluate(declared: declared, live: state, liveDNSRecords: records, domain: hostname)
+    }
+}
+```
+
+- [ ] **Step 3: Rewrite `Sources/AnglesiteCore/DeployCommand.swift`**
+
+Replace the entire file contents with:
+
+```swift
+import Foundation
+
+/// One-shot orchestrator for a site deploy — the provider-agnostic spine shared by every
+/// `DeployTarget` (#1015): resolve the target's credential and run its fail-fast checks, build
+/// `dist/`, run the non-bypassable `PreDeployCheck` pre-deploy scan, then hand off to the target
+/// to publish. `CloudflareDeployTarget` is the only conformer today; `target` defaults to it so
+/// every existing call site keeps compiling and deploying through Cloudflare unchanged.
+///
+/// A deploy is a single foreground action, run through the injected `DeployExecutor` seam for the
+/// steps this spine owns directly (build, preflight). Container runtimes run the steps in a
+/// guest; the default process-backed executor fails explicitly after embedded Node retirement.
+///   1. `target.authorize(siteDirectory:)` — credential resolution plus any target-specific
+///      fail-fast checks (e.g. Cloudflare's worker-name-conflict and domain-config-drift checks).
+///      `.blocked` short-circuits immediately, before any build time is spent.
+///   2. `executor.runBuildWithClaimManifest(…)` so `dist/` is fresh — the build carries the derived
+///      `/.well-known/` claim manifest (#744/#748) so the runtime can reject a collision in its own
+///      clone and report the artifacts it produced. An executor without the seam falls back to
+///      `executor.run(step: .build, …)` and gets no post-build well-known verification.
+///   3. `executor.run(step: .preflight, …)` — the bundled plugin's pre-deploy scan; its captured
+///      stdout is parsed into a `PreDeployCheck.Outcome`. `.blocked` short-circuits with no
+///      override (per CLAUDE.md, the app cannot bypass plugin security hooks) — and no
+///      `DeployTarget` conformer gets a hook into this gate; `target.publish` is never called when
+///      it blocks.
+///   4. `target.publish(context:)` — publishes the build and performs any post-publish effects.
+///      `CloudflareDeployTarget`'s conformance runs `executor.run(step: .wrangler, …)` and parses
+///      the deployed URL out of the captured output.
+///
+/// The executor streams each step's stdout+stderr into `LogCenter` line-by-line (under the
+/// caller-supplied source) and returns the accumulated stdout in `DeployStepResult.output`, so
+/// URL/scan parsing re-reads the captured stdout rather than re-snapshotting `LogCenter`.
+///
+/// **Environment contract:**
+///   - `.build` and `.preflight` get a curated subset of the host environment (see
+///     `hostDeployEnvironment()`) — safe shell/locale/proxy/Node vars only, no unrelated secrets.
+///     This same curated environment is handed to the target via `DeployTargetContext
+///     .baseEnvironment`; `CloudflareDeployTarget.publish` adds `CLOUDFLARE_API_TOKEN` to it only
+///     for the `.wrangler` (and `.bundleUpload`) steps it runs.
+///
+/// **Cancellation**: cancelling the deploy task propagates through `executor.run` (the host
+/// executor wraps its `waitForExit` in a cancellation handler that SIGTERMs the in-flight
+/// subprocess), so a cancelled build/wrangler is actually killed rather than orphaned.
+public actor DeployCommand {
+    /// Terminal outcome of one `deploy(...)` call. Every failure mode is a case, not a thrown
+    /// error — `deploy` never throws, so UI callers switch exhaustively over this instead of
+    /// also maintaining a separate error path. `.workerNameConflict`/`.domainConfigDrift` are
+    /// Cloudflare-specific outcomes `CloudflareDeployTarget` produces; a target with no equivalent
+    /// concept simply never returns them.
+    public enum Result: Sendable, Equatable {
+        /// The target published successfully and a deployed URL was found. `duration` covers the
+        /// target's publish step only — build and preflight time are excluded.
+        case succeeded(url: URL, duration: TimeInterval)
+        /// The pre-deploy security scan refused the deploy. Carries the structured
+        /// failures (and any warnings) so the UI can render a sheet with no override.
+        case blocked(failures: [PreDeployCheck.ScanFailure], warnings: [PreDeployCheck.ScanWarning])
+        /// The candidate Worker name (`.site-config`'s `CF_PROJECT_NAME`) already exists on the
+        /// connected Cloudflare account, and this site has never deployed before
+        /// (`CF_WORKER_DEPLOYED` is not yet set in `.site-config`) — refusing to silently let
+        /// `wrangler deploy` take over an unrelated (or stale) Worker. Carries the taken name for
+        /// the UI's rename prompt (#740).
+        case workerNameConflict(name: String)
+        /// The site declares a `Source/anglesite.json` domain (#1169) whose live Cloudflare state
+        /// has drifted from it (#1171) — refusing to ship against a domain/DNS/edge configuration
+        /// the app no longer knows is accurate. Carries the findings so the UI can summarize them
+        /// and point at the Domain Config Audit flow, where the owner reviews and reconciles
+        /// before redeploying (investigation doc §5.5 — deploy-time validation is a cheap check,
+        /// not a second remediation surface).
+        case domainConfigDrift(findings: [DomainConfigAudit.Finding])
+        /// `exitCode` is `nil` for pre-spawn refusals (no credential, no wrangler) and for spawn
+        /// failures; otherwise it's the failing subprocess's exit code (including `0` for the
+        /// "wrangler exited cleanly but we couldn't find a URL" case).
+        case failed(reason: String, exitCode: Int32?)
+    }
+
+    /// How to run a subprocess for a site directory — or why it can't be run.
+    public enum LaunchPlan: Sendable, Equatable {
+        /// Spawn `executable` with `arguments` (the caller supplies cwd and environment).
+        case run(executable: URL, arguments: [String])
+        /// The command can't run at all in this configuration; `reason` is user-facing text
+        /// (e.g. `HostNodeRetirement`'s explanation) surfaced instead of a spawn attempt.
+        case unavailable(reason: String)
+    }
+
+    /// Maps a site directory to how — or whether — a deploy-related subprocess can run there.
+    /// The host-side defaults on this type (`resolveBuildCommand`, `resolveWranglerCommand`) all
+    /// return `.unavailable` since embedded Node was retired; container runtimes inject real
+    /// resolvers.
+    public typealias CommandResolver = @Sendable (_ siteDirectory: URL) -> LaunchPlan
+    /// Runs the bundled plugin's pre-deploy scan against a site and returns the outcome.
+    /// Real callers use `DeployCommand.defaultPreflight`; tests inject a fake.
+    public typealias PreflightChecker = @Sendable (_ siteDirectory: URL) async -> PreDeployCheck.Outcome
+    /// Fires once the preflight step resolves, with the outcome that was used to
+    /// decide whether to continue with the target's publish step. The closure runs inside the
+    /// actor's isolation; bridge to MainActor via a Task if you need to touch SwiftUI state.
+    /// Fires for every preflight result (.passed, .blocked, .error) — including the
+    /// cases where deploy() returns .failed afterwards.
+    public typealias PreflightObserver = @Sendable (PreDeployCheck.Outcome) -> Void
+
+    /// Fires once the domain-attach step resolves (#1077), for a "Transfer an existing domain"
+    /// site — or immediately with `.skipped` for every other site. Only fired by
+    /// `CloudflareDeployTarget`, and only after a successful `wrangler` step; never fires on a
+    /// failed/blocked deploy, and never fires for a target with no equivalent concept.
+    public typealias DomainAttachObserver = @Sendable (CustomDomainAttachCommand.Result) -> Void
+
+    /// Fires once the Markdown for Agents step resolves (#1247) — only for a site whose domain
+    /// attach just confirmed a live zone; never fires when there's no custom domain, or on a
+    /// failed/blocked deploy. Only fired by `CloudflareDeployTarget`.
+    public typealias MarkdownForAgentsObserver = @Sendable (MarkdownForAgentsCommand.Result) -> Void
+
+    /// The deploy target this command publishes through — `CloudflareDeployTarget` by default, so
+    /// every existing call site keeps deploying through Cloudflare unchanged. `nonisolated` and
+    /// public so callers that need to build a parallel command with the same target (e.g.
+    /// `DeployModel.runDeploy` swapping in a container executor) can forward it, and so a caller
+    /// that knows it's Cloudflare can downcast to reach `CloudflareDeployTarget`'s own exposed
+    /// seams (`tokenSource`, `workerScriptNamesSource`, …) for a companion command.
+    public nonisolated let target: any DeployTarget
+    private let executor: any DeployExecutor
+
+    /// Both dependencies are injectable seams with production defaults, so tests can drive a full
+    /// deploy — target authorization, every shared step — with a scripted target and a scripted
+    /// executor, never touching the network or spawning a process.
+    public init(
+        target: any DeployTarget = CloudflareDeployTarget(),
+        executor: any DeployExecutor = HostDeployExecutor()
+    ) {
+        self.target = target
+        self.executor = executor
+    }
+
+    /// Run a deploy for `siteID`. Returns once the target's publish step has resolved (or before,
+    /// if the target's authorization step or the preflight gate refuses first). Build output
+    /// streams under source `"deploy:<siteID>:build"`, the deploy itself under `"deploy:<siteID>"`,
+    /// so a UI consumer can distinguish phases.
+    public func deploy(
+        siteID: String,
+        siteDirectory: URL,
+        /// The site's `Config/` directory. `nil` skips route-coverage scanning and the
+        /// deployed-routes snapshot write entirely — callers that don't pass it (tests, and the
+        /// two non-primary deploy paths in `SocialWorkerProvisionCommand`/`SiteOperations`) are
+        /// unaffected (#530).
+        configDirectory: URL? = nil,
+        /// The site's currently published route set (from `SiteContentGraph`), used only when
+        /// `configDirectory` is non-nil.
+        currentRoutes: [String] = [],
+        /// Effective active dynamic `/.well-known/` route claims (#746), already validated via
+        /// `WorkerRouteClaims.activeClaims` and filtered with `WorkerRouteClaims.wellKnownClaims`.
+        /// Empty means "no active dynamic well-known routes," not "skip the #744 collision check"
+        /// — the check always runs, using whatever this array and `executor.reportOwnedPathClaims()`
+        /// report.
+        wellKnownDynamicClaims: [WorkerRouteClaims.OwnedClaim] = [],
+        onPreflight: PreflightObserver? = nil,
+        onDomainAttach: DomainAttachObserver? = nil,
+        onMarkdownForAgents: MarkdownForAgentsObserver? = nil,
+        onProgress: ProgressHandler? = nil
+    ) async -> Result {
+        // Pre-build gate: the target resolves its credential and runs any fail-fast checks
+        // against current deployed state, so a deploy that can't succeed never spends time on a
+        // build or scan. The credential comes back opaque here — only the target that produced it
+        // knows what to do with it.
+        let credential: String
+        switch await target.authorize(siteDirectory: siteDirectory) {
+        case .blocked(let result):
+            return result
+        case .ready(let resolvedCredential):
+            credential = resolvedCredential
+        }
+
+        // Curated environment for the non-secret steps: a safe subset of the host process env,
+        // stripping unrelated secrets the developer's shell may carry. Target-specific
+        // credentials are added only inside the target's own `publish(context:)`.
+        let baseEnvironment = Self.hostDeployEnvironment()
+
+        // #744: validate the effective /.well-known/ inventory before spending time on a build.
+        // Static/generated rows come from whatever's already on disk in Source/public/.well-known/
+        // (which mirrors the guest's clone — see ContainerDeployExecutor's HOST-path doc comment,
+        // and note `scanUserStatic` classifies a previously-generated file like security.txt by its
+        // own marker, so a redeploy sees it correctly without this re-deriving the TS generator's
+        // activation logic); dynamic rows from the caller's already-validated active route claims;
+        // runtime rows from whatever this executor can affirmatively prove it owns (empty when
+        // unsupported or when the runtime reports no claims — either way, no reservation). A
+        // collision blocks the deploy immediately with no override, matching the design doc's "no
+        // collision precedence" (docs/superpowers/specs/2026-07-14-well-known-support-design.md).
+        // Non-fatal scan findings (a rejected symlink/oversized/percent-encoded file) are folded
+        // into the preflight outcome's warnings below rather than blocking.
+        let wellKnownScan = WellKnownInventory.scanUserStatic(
+            wellKnownDirectory: siteDirectory.appendingPathComponent("public/.well-known", isDirectory: true))
+        let wellKnownRuntimeRows = WellKnownInventory.runtimeRows(from: await executor.reportOwnedPathClaims())
+        let wellKnownDynamicRows = WellKnownInventory.dynamicRows(from: wellKnownDynamicClaims)
+        let wellKnownInventory: [WellKnownEndpointDescriptor]
+        do {
+            wellKnownInventory = try WellKnownInventory.merge(
+                userStatic: wellKnownScan.rows.filter { $0.delivery == .userStatic },
+                generated: wellKnownScan.rows.filter { $0.delivery == .generated },
+                dynamic: wellKnownDynamicRows,
+                runtime: wellKnownRuntimeRows)
+        } catch {
+            let failure = PreDeployCheck.ScanFailure(
+                category: .wellKnownCollision,
+                message: "\(error)",
+                remediation: "Resolve the /.well-known/ ownership conflict named above (rename or remove one of the claims), then redeploy."
+            )
+            let outcome = PreDeployCheck.Outcome.blocked(failures: [failure], warnings: [])
+            onPreflight?(outcome)
+            return .blocked(failures: [failure], warnings: [])
+        }
+        let wellKnownScanWarnings = wellKnownScan.findings.map {
+            PreDeployCheck.ScanWarning(
+                category: .wellKnownArtifact, message: $0.message,
+                file: $0.path.map { "public/.well-known/\($0)" })
+        }
+
+        // Build dist/ before the scan needs it. Streams to LogCenter via the executor.
+        //
+        // #744/#748 build seam: when the executor implements it, the build runs with the derived
+        // claim manifest so the runtime can (a) rescan its OWN clone before any generator writes —
+        // catching a collision the host's working-tree scan above could not see — and (b) report
+        // the exact `dist/.well-known/...` artifacts it produced. An executor that returns
+        // `.unsupported` falls back to the plain build step and gets NO post-build verification;
+        // we must not claim protection that never ran.
+        onProgress?(.deployBuilding)
+        var wellKnownArtifactWarnings: [PreDeployCheck.ScanWarning] = []
+        let buildResult: DeployStepResult
+        switch await executor.runBuildWithClaimManifest(
+            siteDirectory: siteDirectory,
+            environment: baseEnvironment,
+            source: "deploy:\(siteID):build",
+            claimManifest: WellKnownInventory.claimManifest(from: wellKnownInventory)
+        ) {
+        case .unsupported:
+            buildResult = await executor.run(
+                step: .build,
+                siteDirectory: siteDirectory,
+                environment: baseEnvironment,
+                source: "deploy:\(siteID):build"
+            )
+        case .cancelled:
+            return .failed(reason: "build was terminated", exitCode: nil)
+        case .completed(let stepResult, let seamResult):
+            buildResult = stepResult
+            // A failed build that still reported findings is the runtime's own collision rejection
+            // (`scripts/well-known.ts check` writes ONLY the blocking findings before exiting
+            // non-zero). Surface it as a `.blocked` security outcome with both owners named, not as
+            // an opaque "npm run build failed (exit 1)".
+            if stepResult.exitCode != 0, !seamResult.findings.isEmpty {
+                let failures = seamResult.findings.map {
+                    PreDeployCheck.ScanFailure(
+                        category: .wellKnownCollision,
+                        message: $0.message,
+                        file: $0.path.map { "public/.well-known/\($0)" },
+                        remediation: "Resolve the /.well-known/ ownership conflict named above (rename or remove one of the claims), then redeploy.")
+                }
+                let outcome = PreDeployCheck.Outcome.blocked(failures: failures, warnings: [])
+                onPreflight?(outcome)
+                return .blocked(failures: failures, warnings: [])
+            }
+            wellKnownArtifactWarnings = WellKnownInventory.verifyBuildArtifacts(
+                expected: wellKnownInventory, result: seamResult
+            ).map {
+                PreDeployCheck.ScanWarning(
+                    category: .wellKnownArtifact, message: $0.message,
+                    file: $0.path.map { "dist/.well-known/\($0)" })
+            }
+        }
+        guard buildResult.exitCode == 0 else {
+            if let code = buildResult.exitCode {
+                return .failed(reason: "npm run build failed (exit \(code))", exitCode: code)
+            }
+            // nil exit code → unavailable resolver, spawn failure, or termination (cancellation).
+            if Task.isCancelled {
+                return .failed(reason: "build was terminated", exitCode: nil)
+            }
+            // The executor put the reason (unavailable/spawn) in `output`.
+            return .failed(reason: buildResult.output.isEmpty ? "build was terminated" : buildResult.output, exitCode: nil)
+        }
+
+        // Pre-deploy scan runs after the build (so dist/ exists) and before the target's publish
+        // step. If the bundled plugin's checks find PII, exposed tokens, unauthorized third-party
+        // scripts, or Keystatic admin routes in dist/, the deploy is blocked — per the durable
+        // rule in CLAUDE.md, the app cannot bypass plugin security hooks; the UI sheet for
+        // `.blocked` has no override, and no `DeployTarget` conformer gets a hook here.
+        onProgress?(.deployPreflight)
+        let preflightResult = await executor.run(
+            step: .preflight,
+            siteDirectory: siteDirectory,
+            environment: baseEnvironment,
+            source: "deploy:\(siteID):preflight"
+        )
+        var preflightOutcome = Self.parseScanReport(output: preflightResult.output, exitCode: preflightResult.exitCode)
+        // Swift-computed warnings, not emitted by the JS scan script — merged into the outcome
+        // the same way `RouteCoverageScanner`'s `.orphanedRoute` findings always have been.
+        var extraWarnings = wellKnownScanWarnings + wellKnownArtifactWarnings
+        if let configDirectory {
+            let previousRoutes = DeployedRoutesSnapshot.load(from: configDirectory)
+            let redirects = (try? RedirectsStore(sourceDirectory: siteDirectory).load()) ?? []
+            extraWarnings += RouteCoverageScanner.scan(
+                currentRoutes: currentRoutes,
+                previousRoutes: previousRoutes,
+                redirectSources: Set(redirects.map(\.source))
+            )
+        }
+        if !extraWarnings.isEmpty {
+            switch preflightOutcome {
+            case .passed(let warnings):
+                preflightOutcome = .passed(warnings: warnings + extraWarnings)
+            case .blocked(let failures, let warnings):
+                preflightOutcome = .blocked(failures: failures, warnings: warnings + extraWarnings)
+            case .error:
+                break
+            }
+        }
+        onPreflight?(preflightOutcome)
+        switch preflightOutcome {
+        case .passed:
+            break
+        case .blocked(let failures, let warnings):
+            return .blocked(failures: failures, warnings: warnings)
+        case .error(let reason):
+            return .failed(reason: "pre-deploy scan could not run: \(reason)", exitCode: nil)
+        }
+
+        // Hand off to the target: publish the build and perform any post-publish effects
+        // (Cloudflare's URL extraction, custom-domain attach, Markdown for Agents, `.site-config`
+        // persistence, R2 bundle upload — see `CloudflareDeployTarget.publish`).
+        let context = DeployTargetContext(
+            siteID: siteID,
+            siteDirectory: siteDirectory,
+            configDirectory: configDirectory,
+            currentRoutes: currentRoutes,
+            credential: credential,
+            baseEnvironment: baseEnvironment,
+            executor: executor,
+            onDomainAttach: onDomainAttach,
+            onMarkdownForAgents: onMarkdownForAgents,
+            onProgress: onProgress
+        )
+        return await target.publish(context: context)
+    }
+
+    // MARK: Scan report parsing
+
+    /// Parses the captured stdout of the pre-deploy scan (`scripts/pre-deploy-check.ts --json`)
+    /// into a `PreDeployCheck.Outcome`. Thin forwarding wrapper — `PreDeployCheck.parse` is the
+    /// one real decoder (#742); this keeps the existing public call-site signature stable.
+    public static func parseScanReport(output: String, exitCode: Int32?) -> PreDeployCheck.Outcome {
+        PreDeployCheck.parse(output: output, exitCode: exitCode)
+    }
+
+    // MARK: Host environment curation
+
+    /// Keys that a host-path build or preflight step legitimately needs. The allowlist is
+    /// intentionally conservative — add a key only when a build script demonstrably requires it.
+    /// Mirrors the tight `guestEnvAllowlist` in `ContainerDeployExecutor`, adapted for the host
+    /// where Node/npm/Astro rely on the user's shell plumbing.
+    private static let hostEnvAllowlist: Set<String> = [
+        // Shell / process fundamentals
+        "PATH", "HOME", "USER", "LOGNAME", "SHELL",
+        // Temp directories — Node/npm/Astro write to these
+        "TMPDIR", "TEMP", "TMP",
+        // CI — Astro, Vite, and many post-install scripts check this to suppress interactive prompts
+        "CI",
+        // Locale — affects sorting, date formatting in build output
+        "LANG", "LC_ALL", "LC_COLLATE", "LC_CTYPE", "LC_MESSAGES", "LC_MONETARY",
+        "LC_NUMERIC", "LC_TIME",
+        // Proxy — corporate/VPN environments need these for npm registry + API fetches
+        "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+        "http_proxy", "https_proxy", "no_proxy",
+        // Node-specific
+        "NODE_ENV", "NODE_OPTIONS", "NODE_PATH", "NODE_EXTRA_CA_CERTS", "NPM_CONFIG_CACHE",
+        // XDG — npm/pnpm/yarn respect these for cache and config paths
+        "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+        // Terminal — some build tools check these for color/width
+        "TERM", "COLORTERM", "COLUMNS",
+    ]
+
+    /// Key prefixes that Astro/Vite projects use for build-time environment variables. These are
+    /// standard conventions for variables inlined into client-side output (`PUBLIC_*`) or consumed
+    /// by Vite's pipeline (`VITE_*`). Users set them in their shell and expect them to flow through
+    /// to `astro build`. `ASTRO_` covers Astro's own config overrides (e.g. `ASTRO_TELEMETRY_DISABLED`).
+    private static let hostEnvPrefixes: [String] = ["PUBLIC_", "VITE_", "ASTRO_"]
+
+    /// Returns a curated subset of the given environment safe for host-path build and preflight
+    /// steps. Strips unrelated secrets (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, …) that the
+    /// developer's shell may carry. Target-specific credentials are excluded here; the target adds
+    /// its own only to the steps it runs inside `publish(context:)`.
+    ///
+    /// The `env` parameter defaults to the current process environment; tests inject a literal
+    /// dictionary instead (avoiding `setenv`/`unsetenv` races and the `ProcessInfo` launch-time
+    /// snapshot issue).
+    static func hostDeployEnvironment(
+        _ env: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        env.filter { key, _ in
+            hostEnvAllowlist.contains(key) ||
+            hostEnvPrefixes.contains(where: { key.hasPrefix($0) })
+        }
+    }
+
+    // MARK: Default seams
+
+    /// Default `PreflightChecker`: host-side preflight was retired with embedded Node. Container
+    /// runtimes must provide the executable preflight path.
+    public static let defaultPreflight: PreflightChecker = { siteDirectory in
+        .error(reason: HostNodeRetirement.reason("pre-deploy check"))
+    }
+
+    /// Default `CommandResolver`: host-side wrangler deploy was retired with embedded Node.
+    public static let resolveWranglerCommand: CommandResolver = { siteDirectory in
+        .unavailable(reason: HostNodeRetirement.reason("wrangler deploy"))
+    }
+
+    /// Default `BuildCommandResolver`: host-side site build was retired with embedded Node.
+    public static let resolveBuildCommand: CommandResolver = { siteDirectory in
+        .unavailable(reason: HostNodeRetirement.reason("site build"))
+    }
+}
+```
+
+- [ ] **Step 4: Fix `Sources/AnglesiteApp/DeployModel.swift` (three call sites)**
+
+At line 708, change:
+```swift
+        wasFirstDeploy = !DeployCommand.hasDeployedBefore(siteDirectory: siteDirectory)
+```
+to:
+```swift
+        wasFirstDeploy = !CloudflareDeployTarget.hasDeployedBefore(siteDirectory: siteDirectory)
+```
+
+At lines 748-758, change:
+```swift
+            activeCommand = DeployCommand(
+                tokenSource: command.tokenSource,
+                workerScriptNamesSource: command.workerScriptNamesSource,
+                customDomainAttachCommand: command.customDomainAttachCommand,
+                markdownForAgentsCommand: command.markdownForAgentsCommand,
+                executor: ContainerDeployExecutor(
+                    control: cc.control,
+                    siteID: cc.siteID,
+                    logCenter: logCenter
+                )
+            )
+```
+to:
+```swift
+            activeCommand = DeployCommand(
+                target: command.target,
+                executor: ContainerDeployExecutor(
+                    control: cc.control,
+                    siteID: cc.siteID,
+                    logCenter: logCenter
+                )
+            )
+```
+
+At lines 876-925, change:
+```swift
+        let socialCommand = SocialWorkerProvisionCommand(
+            tokenSource: { [weak self] in try await self?.command.tokenSource() },
+            runner: containerRunner ?? SocialWorkerProvisionCommand.defaultRunner,
+            secretRunner: containerSecretRunner ?? SocialWorkerProvisionCommand.defaultSecretRunner,
+            deployer: { [weak self] _, deploySiteID, deploySiteDirectory, _ in
+                await activeCommand.deploy(
+                    siteID: deploySiteID,
+                    siteDirectory: deploySiteDirectory,
+                    configDirectory: configDirectory,
+                    currentRoutes: currentRoutes,
+                    // #744: feeds the same already-validated active route claims (#746, computed
+                    // above) into DeployCommand's pre-build /.well-known/ collision check.
+                    wellKnownDynamicClaims: WorkerRouteClaims.wellKnownClaims(routeClaims),
+                    onPreflight: { [weak self] outcome in
+                        Task { @MainActor in self?.onScanComplete?(outcome) }
+                    },
+                    // Unlike `onPreflight`/`onProgress` (fire-and-forget display state), this
+                    // value is read back synchronously in the `.succeeded` case below to decide
+                    // the URL swap and the conflict sheet — so the MainActor hop here has an
+                    // implicit happens-before dependency, not just a display one. It holds today
+                    // only because MainActor drains equal-priority jobs FIFO and several real
+                    // `await`s (`uploadSourceBundleIfConfigured`, `runPostDeploySequencing`, the
+                    // `SiteConfigStore` load) sit between this closure firing and that read — there
+                    // is no structural guarantee. If those intervening `await`s are ever shortened
+                    // or removed, this needs an explicit wait instead of relying on scheduling.
+                    onDomainAttach: { [weak self] outcome in
+                        Task { @MainActor in self?.domainAttachStatus = outcome }
+                    },
+                    onMarkdownForAgents: { [weak self] outcome in
+                        Task { @MainActor in self?.markdownForAgentsStatus = outcome }
+                    },
+                    onProgress: { [weak self] progress in
+                        Task { @MainActor in
+                            self?.currentMilestone = progress.label
+                            self?.currentMilestonePhase = progress.phase
+                            self?.onMilestone?(siteID, progress)
+                        }
+                    }
+                )
+            },
+            // Forwards the same seam `activeCommand` uses for its own end-of-pipeline check (both
+            // are built from `command.workerScriptNamesSource` above), so `provision()`'s new
+            // pre-provisioning check (#1075) agrees with `deployer`'s — and so a test's injected
+            // fake `DeployCommand` governs both instead of this defaulting to the real network
+            // implementation.
+            workerScriptNamesSource: { [weak self] token in
+                guard let self else { return [] }
+                return try await self.command.workerScriptNamesSource(token)
+            }
+        )
+```
+to:
+```swift
+        // Both closures below only make sense against a Cloudflare target — `SocialWorkerProvisionCommand`
+        // is itself entirely a Cloudflare Workers concept (out of scope to generalize in #1015
+        // slice 1). `cloudflareTarget` is `nil` only if `command.target` were ever something else;
+        // today it's always `CloudflareDeployTarget` (the default), so the closures behave exactly
+        // as before.
+        let cloudflareTarget = command.target as? CloudflareDeployTarget
+        let socialCommand = SocialWorkerProvisionCommand(
+            tokenSource: {
+                guard let cloudflareTarget else { return nil }
+                return try await cloudflareTarget.tokenSource()
+            },
+            runner: containerRunner ?? SocialWorkerProvisionCommand.defaultRunner,
+            secretRunner: containerSecretRunner ?? SocialWorkerProvisionCommand.defaultSecretRunner,
+            deployer: { [weak self] _, deploySiteID, deploySiteDirectory, _ in
+                await activeCommand.deploy(
+                    siteID: deploySiteID,
+                    siteDirectory: deploySiteDirectory,
+                    configDirectory: configDirectory,
+                    currentRoutes: currentRoutes,
+                    // #744: feeds the same already-validated active route claims (#746, computed
+                    // above) into DeployCommand's pre-build /.well-known/ collision check.
+                    wellKnownDynamicClaims: WorkerRouteClaims.wellKnownClaims(routeClaims),
+                    onPreflight: { [weak self] outcome in
+                        Task { @MainActor in self?.onScanComplete?(outcome) }
+                    },
+                    // Unlike `onPreflight`/`onProgress` (fire-and-forget display state), this
+                    // value is read back synchronously in the `.succeeded` case below to decide
+                    // the URL swap and the conflict sheet — so the MainActor hop here has an
+                    // implicit happens-before dependency, not just a display one. It holds today
+                    // only because MainActor drains equal-priority jobs FIFO and several real
+                    // `await`s (`uploadSourceBundleIfConfigured`, `runPostDeploySequencing`, the
+                    // `SiteConfigStore` load) sit between this closure firing and that read — there
+                    // is no structural guarantee. If those intervening `await`s are ever shortened
+                    // or removed, this needs an explicit wait instead of relying on scheduling.
+                    onDomainAttach: { [weak self] outcome in
+                        Task { @MainActor in self?.domainAttachStatus = outcome }
+                    },
+                    onMarkdownForAgents: { [weak self] outcome in
+                        Task { @MainActor in self?.markdownForAgentsStatus = outcome }
+                    },
+                    onProgress: { [weak self] progress in
+                        Task { @MainActor in
+                            self?.currentMilestone = progress.label
+                            self?.currentMilestonePhase = progress.phase
+                            self?.onMilestone?(siteID, progress)
+                        }
+                    }
+                )
+            },
+            // Forwards the same seam `activeCommand` uses for its own end-of-pipeline check (both
+            // are built from `cloudflareTarget.workerScriptNamesSource` above), so `provision()`'s
+            // pre-provisioning check (#1075) agrees with `deployer`'s — and so a test's injected
+            // fake `DeployCommand`/`CloudflareDeployTarget` governs both instead of this defaulting
+            // to the real network implementation.
+            workerScriptNamesSource: { token in
+                guard let cloudflareTarget else { return [] }
+                return try await cloudflareTarget.workerScriptNamesSource(token)
+            }
+        )
+```
+
+- [ ] **Step 5: Fix `Sources/AnglesiteApp/AgentReadinessModel.swift` (one property, one default)**
+
+At lines 21-33, change:
+```swift
+    private let scanner: any AgentReadinessScanning
+    private let tokenSource: DeployCommand.TokenSource
+    private var inFlight: Task<Void, Never>?
+
+    private var currentSite: CurrentSite?
+
+    init(
+        scanner: any AgentReadinessScanning = HTTPCloudflareClient(),
+        tokenSource: @escaping DeployCommand.TokenSource = DeployCommand.keychainTokenSource
+    ) {
+```
+to:
+```swift
+    private let scanner: any AgentReadinessScanning
+    private let tokenSource: CloudflareDeployTarget.TokenSource
+    private var inFlight: Task<Void, Never>?
+
+    private var currentSite: CurrentSite?
+
+    init(
+        scanner: any AgentReadinessScanning = HTTPCloudflareClient(),
+        tokenSource: @escaping CloudflareDeployTarget.TokenSource = CloudflareDeployTarget.keychainTokenSource
+    ) {
+```
+
+- [ ] **Step 6: Fix `Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift` (five spots)**
+
+At line 115, change:
+```swift
+    private let workerScriptNamesSource: DeployCommand.WorkerScriptNamesSource
+```
+to:
+```swift
+    private let workerScriptNamesSource: CloudflareDeployTarget.WorkerScriptNamesSource
+```
+
+At line 121, change:
+```swift
+        tokenSource: @escaping TokenSource = DeployCommand.keychainTokenSource,
+```
+to:
+```swift
+        tokenSource: @escaping TokenSource = CloudflareDeployTarget.keychainTokenSource,
+```
+
+At line 132, change:
+```swift
+        workerScriptNamesSource: @escaping DeployCommand.WorkerScriptNamesSource = DeployCommand.defaultWorkerScriptNames,
+```
+to:
+```swift
+        workerScriptNamesSource: @escaping CloudflareDeployTarget.WorkerScriptNamesSource = CloudflareDeployTarget.defaultWorkerScriptNames,
+```
+
+At lines 247-249, change:
+```swift
+        if case .workerNameConflict(let name)? = await DeployCommand.checkWorkerNameConflict(
+            siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
+        ) {
+```
+to:
+```swift
+        if case .workerNameConflict(let name)? = await CloudflareDeployTarget.checkWorkerNameConflict(
+            siteDirectory: siteDirectory, apiToken: token, workerScriptNamesSource: workerScriptNamesSource
+        ) {
+```
+
+At line 252, change:
+```swift
+        DeployCommand.persistWorkerProvisioned(siteDirectory: siteDirectory)
+```
+to:
+```swift
+        CloudflareDeployTarget.persistWorkerProvisioned(siteDirectory: siteDirectory)
+```
+
+At line 840, change:
+```swift
+    public static let defaultDeployer: Deployer = { token, siteID, siteDirectory, wellKnownDynamicClaims in
+        await DeployCommand(tokenSource: { token }).deploy(
+            siteID: siteID, siteDirectory: siteDirectory, wellKnownDynamicClaims: wellKnownDynamicClaims)
+    }
+```
+to:
+```swift
+    public static let defaultDeployer: Deployer = { token, siteID, siteDirectory, wellKnownDynamicClaims in
+        await DeployCommand(target: CloudflareDeployTarget(tokenSource: { token })).deploy(
+            siteID: siteID, siteDirectory: siteDirectory, wellKnownDynamicClaims: wellKnownDynamicClaims)
+    }
+```
+
+- [ ] **Step 7: Build `AnglesiteCore` and confirm only test targets fail to compile**
+
+Run: `swift build --package-path . --target AnglesiteCore`
+Expected: SUCCEED. This confirms Steps 1-3 and 6 are internally consistent before touching `AnglesiteApp` or tests.
+
+Run: `swift build --package-path . --target AnglesiteApp` (or `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` if `AnglesiteApp` isn't a standalone SwiftPM build target in this checkout)
+Expected: SUCCEED after Steps 4-5. If it fails, the error names the exact remaining `DeployCommand.<removed member>` reference — fix it the same way as Steps 4-6 (retarget to `CloudflareDeployTarget.<member>`).
+
+- [ ] **Step 8: Fix every test call site — mechanical transform**
+
+`DeployCommand`'s old init parameters (`tokenSource:`, `workerScriptNamesSource:`, `customDomainAttachCommand:`, `markdownForAgentsCommand:`, `domainConfigDriftSource:`) moved to `CloudflareDeployTarget`'s init. Every test that constructed a `DeployCommand` with any of those parameters must now construct a `CloudflareDeployTarget` with them instead, and pass it as `DeployCommand`'s new `target:` parameter. `DeployCommand(executor: ...)` calls with no Cloudflare-specific parameter (i.e. bare `DeployCommand()`) need **no change** — the default `target: CloudflareDeployTarget()` behaves identically.
+
+The transform has exactly five shapes, all present in the codebase today. Apply the matching one to every call site listed below, then verify nothing was missed via Step 9's build.
+
+**Shape A — `tokenSource:` + `executor:` only:**
+```swift
+// before
+DeployCommand(tokenSource: { "tok" }, executor: exec)
+// after
+DeployCommand(target: CloudflareDeployTarget(tokenSource: { "tok" }), executor: exec)
+```
+
+**Shape B — `tokenSource:` + `workerScriptNamesSource:` + `executor:`:**
+```swift
+// before
+DeployCommand(
+    tokenSource: { "tok" },
+    workerScriptNamesSource: { _ in ["taken-name", "other-site"] },
+    executor: exec
+)
+// after
+DeployCommand(
+    target: CloudflareDeployTarget(
+        tokenSource: { "tok" },
+        workerScriptNamesSource: { _ in ["taken-name", "other-site"] }
+    ),
+    executor: exec
+)
+```
+
+**Shape C — `tokenSource:` + `executor:` + `domainConfigDriftSource:`:**
+```swift
+// before
+DeployCommand(
+    tokenSource: { "tok" },
+    executor: exec,
+    domainConfigDriftSource: { _, _, _ in [finding] }
+)
+// after
+DeployCommand(
+    target: CloudflareDeployTarget(
+        tokenSource: { "tok" },
+        domainConfigDriftSource: { _, _, _ in [finding] }
+    ),
+    executor: exec
+)
+```
+
+**Shape D — `tokenSource:` + `customDomainAttachCommand:` + `executor:`:**
+```swift
+// before
+DeployCommand(
+    tokenSource: { "test-token" },
+    customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+    executor: executor
+)
+// after
+DeployCommand(
+    target: CloudflareDeployTarget(
+        tokenSource: { "test-token" },
+        customDomainAttachCommand: CustomDomainAttachCommand(client: writer)
+    ),
+    executor: executor
+)
+```
+
+**Shape E — `tokenSource:` + `customDomainAttachCommand:` + `markdownForAgentsCommand:` + `executor:`:**
+```swift
+// before
+DeployCommand(
+    tokenSource: { "test-token" },
+    customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+    markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer),
+    executor: executor
+)
+// after
+DeployCommand(
+    target: CloudflareDeployTarget(
+        tokenSource: { "test-token" },
+        customDomainAttachCommand: CustomDomainAttachCommand(client: writer),
+        markdownForAgentsCommand: MarkdownForAgentsCommand(client: writer)
+    ),
+    executor: executor
+)
+```
+
+**No change needed** — bare `DeployCommand()` with no Cloudflare-specific parameter:
+- `Tests/AnglesiteCoreTests/SiteOperationsTests.swift:13`, `:565` (`DeployCommand()`)
+
+**Also rename these direct static-member references** (same file, `DeployCommandTests.swift`) — the members moved to `CloudflareDeployTarget`:
+- Lines 737, 756, 757: `DeployCommand.persistWorkerProvisioned(...)` → `CloudflareDeployTarget.persistWorkerProvisioned(...)`
+- Lines 767, 773: `DeployCommand.hasDeployedBefore(...)` → `CloudflareDeployTarget.hasDeployedBefore(...)`
+- Lines 905, 911, 919: `DeployCommand.extractDeployedURL(...)` → `CloudflareDeployTarget.extractDeployedURL(...)`
+- Lines 1201, 1220: `DeployCommand.persistSiteURL(...)` → `CloudflareDeployTarget.persistSiteURL(...)`
+
+(`DeployCommand.parseScanReport` at lines 931, 935, 939, 943 stays unchanged — it didn't move.)
+
+Complete inventory of every `DeployCommand(` construction call site to transform, by file:
+
+*`Tests/AnglesiteCoreTests/DeployCommandTests.swift`* — Shape A at lines 112, 128, 161, 181, 206, 229, 288, 307, 327, 352, 371, 389, 462, 475, 489, 502, 518, 535, 551, 567, 582, 597, 623, 639, 895, 974, 1006, 1054, 1075, 1098, 1134, 1164, 1182, 1243, 1273. Shape B at lines 668, 688, 705, 721, 742. Shape C at lines 816, 836, 852, 871. Shape D at lines 1382, 1458. Shape E at line 1415.
+
+*`Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift`* — Shape A at lines 42, 64, 88, 101.
+
+*`Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift`* — Shape A at line 13.
+
+*`Tests/AnglesiteCoreTests/SiteOperationsProgressSeamTests.swift`* — Shape A at line 26 (`DeployCommand(tokenSource: { nil })` → `DeployCommand(target: CloudflareDeployTarget(tokenSource: { nil }))`, no `executor:` argument — omit it from the transformed call too, matching the original).
+
+*`Tests/AnglesiteAppTests/DeployModelTests.swift`* — Shape A at lines 102, 439, 577, 610, 647, 685 (no `executor:` argument — omit it, matching the original), 749, 783, 815, 842, 901, 960, 977, 1009, 1029, 1053, 1093. Shape B at lines 146, 214, 259, 465, 512, 546, 707. Shape C at line 178. Shape E at lines 300, 338. Shape D at lines 371, 404.
+
+- [ ] **Step 9: Run the full test suite and fix anything Step 8's inventory missed**
+
+Run: `swift test --package-path .`
+Expected: every `AnglesiteCoreTests` and `AnglesiteAppTests` (if runnable outside Xcode — otherwise see below) target compiles and passes. A compile error naming a `DeployCommand(...)` call with an extraneous label (e.g. `tokenSource`) or a missing `CloudflareDeployTarget.` qualifier means Step 8's inventory missed a site — apply the matching Shape transform there too.
+
+`AnglesiteAppTests` (which includes `DeployModelTests.swift`) only runs hosted, per CONTRIBUTING.md: build and run it via
+```bash
+scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build
+```
+then `xcodebuild test -project Anglesite.xcodeproj -scheme Anglesite -destination 'platform=macOS' -only-testing:AnglesiteAppTests` (or run it from within the Xcode IDE) — do this on Xcode 27 per CONTRIBUTING.md's note that CI never executes this target.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/AnglesiteCore/DeployTarget.swift Sources/AnglesiteCore/CloudflareDeployTarget.swift \
+  Sources/AnglesiteCore/DeployCommand.swift Sources/AnglesiteApp/DeployModel.swift \
+  Sources/AnglesiteApp/AgentReadinessModel.swift Sources/AnglesiteCore/SocialWorkerProvisionCommand.swift \
+  Tests/AnglesiteCoreTests/DeployCommandTests.swift Tests/AnglesiteCoreTests/DeployExecutorSelectionTests.swift \
+  Tests/AnglesiteCoreTests/DeployCommandProgressTests.swift Tests/AnglesiteCoreTests/SiteOperationsProgressSeamTests.swift \
+  Tests/AnglesiteAppTests/DeployModelTests.swift
+git commit -m "feat(#1015): extract DeployTarget seam, CloudflareDeployTarget"
+```
+
+---
+
+## Notes for the executing agent
+
+- **Scope discipline:** this plan intentionally does NOT create a `CloudflareDeployTargetTests.swift` file or relocate any tests — every existing test stays in its current file, only its `DeployCommand(...)` construction call changes. Splitting test files by target is deferred to whichever slice actually adds a second `DeployTarget` conformer (GitHub Pages), when a second file has something real to contrast against. Don't invent that split here.
+- **Don't touch** `Sources/AnglesiteCore/DeployExecutor.swift`, `DeployStep`, `DeployStepResult`, `ContainerDeployExecutor`, `HostDeployExecutor` — the executor seam is orthogonal to this refactor and stays exactly as-is.
+- **Don't touch** `DeployCommand.LaunchPlan`, `.CommandResolver`, `.PreflightChecker`, `.defaultPreflight`, `.resolveWranglerCommand`, `.resolveBuildCommand`, `.hostDeployEnvironment` (and its allowlist/prefix constants) — these stay on `DeployCommand` because they belong to the shared build/preflight spine, not to Cloudflare specifically, even though `resolveWranglerCommand`'s name mentions wrangler (it's about which `DeployStep` a host-side `CommandResolver` handles, not about the `DeployTarget` seam).
+- If `swift build`/`swift test` hangs with no output, a stale SwiftPM process may be holding the `.build` lock (`pgrep -fl swift-test`) — see AGENTS.md ▸ Build.

--- a/docs/superpowers/specs/2026-08-17-deploy-target-seam-design.md
+++ b/docs/superpowers/specs/2026-08-17-deploy-target-seam-design.md
@@ -1,0 +1,176 @@
+# Design: DeployTarget seam (slice 1 of #1015)
+
+**Date:** 2026-08-17
+**Status:** Design approved — ready for implementation planning
+**Issue:** [#1015 — Deploy-target seam + a second static host (GitHub Pages) beyond Cloudflare](https://github.com/Anglesite/Anglesite/issues/1015)
+
+## Problem
+
+Deploy is Cloudflare-only. `Sources/AnglesiteCore/DeployCommand.swift` is a single actor whose
+`deploy(...)` method interleaves provider-agnostic steps (build, `.well-known` claim merge,
+`PreDeployCheck` preflight) with Cloudflare-specific ones (token resolution, worker-name-conflict
+check, domain-config-drift check, wrangler upload, custom-domain attach, markdown-for-agents zone
+setting, R2 source-bundle upload, `CF_*` `.site-config` persistence). There is no seam a second
+host (e.g. GitHub Pages) could plug into, and no field anywhere records which target a site uses
+— it's implicit.
+
+**Owner decision (2026-08-15, issue #1015):** approved — extract a `DeployTarget` protocol seam
+(the `PreDeployCheck` gate stays non-bypassable in the shared path) and ship GitHub Pages as the
+second static host later, riding the existing `HTTPGitHubClient` + token onboarding. rsync/SFTP
+and Netlify/Vercel are out. Direction: slice into seam-first PRs as the work dictates.
+
+This document scopes **slice 1**: extract the seam and add the persisted deploy-target field.
+No GitHub Pages conformer, no target-selection UI, no behavior change for existing sites — every
+site continues deploying through Cloudflare exactly as it does today.
+
+## Goals (this slice)
+
+- Extract a `DeployTarget` protocol so `DeployCommand` no longer hardcodes Cloudflare.
+- Move all Cloudflare-specific logic into a `CloudflareDeployTarget` conformer.
+- Add a `deployTarget` field to `anglesite.json` (`DomainConfig`) so slice 2 has schema to build
+  target selection on top of, without its own migration.
+- Zero behavior change: every existing `DeployCommand` call site, every existing test assertion
+  about Cloudflare deploy behavior, and every produced `Result` case stays identical.
+
+## Non-goals (deferred to later slices)
+
+- A GitHub Pages `DeployTarget` conformer.
+- Reading `deployTarget` to actually select a conformer — `DeployCommand`'s target stays
+  hardcoded to `CloudflareDeployTarget()` this slice.
+- Site Settings UI for picking a deploy target.
+- Gating Cloudflare-only features (inbox capture, membership, worker catalog) as "unavailable"
+  on non-Cloudflare targets — moot until a second target exists to select.
+- Any change to `HTTPGitHubClient` or GitHub token scopes.
+
+## Architecture
+
+`DeployTarget` becomes the seam, sitting *above* the existing `DeployExecutor` (the host-vs-
+container substrate seam — unchanged, orthogonal to this one). `DeployCommand` shrinks to the
+provider-agnostic spine:
+
+1. `.well-known` claim inventory/merge (already provider-agnostic)
+2. Build (via `executor`, unchanged)
+3. `PreDeployCheck` preflight — **stays hard-coded in `DeployCommand`, not delegated.** This is
+   the non-bypassable gate the issue calls out by name; no `DeployTarget` conformer gets a hook
+   into it, and a target's `publish(context:)` is never invoked when preflight blocks.
+4. Hand off to `target.publish(context:)`, which owns everything else: token resolution,
+   target-specific pre-checks, the actual upload, and post-publish effects.
+
+`CloudflareDeployTarget` is the sole conformer this slice, absorbing today's Cloudflare-specific
+code from `DeployCommand.swift` close to verbatim (moved, not rewritten).
+
+```
+DeployCommand.deploy()
+  ├─ merge .well-known claims                    (shared)
+  ├─ executor.run(.build) / runBuildWithClaimManifest   (shared, via DeployExecutor)
+  ├─ executor.run(.preflight) → PreDeployCheck.parse    (shared, non-bypassable)
+  │    └─ blocked? → return .blocked(...) — target.publish is never called
+  └─ target.publish(context: DeployTargetContext) → DeployCommand.Result
+       (CloudflareDeployTarget owns: token gate, worker-name-conflict check,
+        domain-config-drift check, wrangler run, URL extraction, custom-domain
+        attach, markdown-for-agents, R2 bundle upload, CF_* .site-config writes)
+```
+
+## Components
+
+### `DeployTarget` protocol (new: `Sources/AnglesiteCore/DeployTarget.swift`)
+
+```swift
+public protocol DeployTarget: Sendable {
+    /// Stable identifier persisted in anglesite.json's `deployTarget` field (e.g. "cloudflare").
+    static var id: String { get }
+
+    /// Publishes the build produced by the shared spine and performs any target-specific
+    /// pre-checks and post-publish effects. Only called after PreDeployCheck has passed.
+    func publish(context: DeployTargetContext) async -> DeployCommand.Result
+}
+
+/// Everything a DeployTarget needs to publish one deploy — bundles what DeployCommand.deploy's
+/// own parameter list already carries, so publish(context:) doesn't grow an unwieldy signature.
+public struct DeployTargetContext: Sendable {
+    public let siteID: String
+    public let siteDirectory: URL
+    public let configDirectory: URL
+    public let executor: any DeployExecutor
+    public let claimManifest: ClaimManifest?   // whatever runBuildWithClaimManifest produced
+    public let onDomainAttach: (@Sendable (String) -> Void)?
+    public let onMarkdownForAgents: (@Sendable () -> Void)?
+    public let onProgress: @Sendable (DeployProgress) -> Void
+}
+```
+
+Exact field list to be finalized against `DeployCommand.deploy`'s current parameter list during
+implementation — this is illustrative, not final.
+
+### `CloudflareDeployTarget` (new: `Sources/AnglesiteCore/CloudflareDeployTarget.swift`)
+
+Owns the injected closures/types that `DeployCommand` injects today: `tokenSource`,
+`workerScriptNamesSource`, `domainConfigDriftSource`, `customDomainAttachCommand`,
+`markdownForAgentsCommand` — all move to `CloudflareDeployTarget`'s initializer, with the same
+default production values (`CloudflareAPICredentials.resolve`, `HTTPCloudflareClient`, etc.)
+`publish(context:)`'s body is today's `DeployCommand.deploy` steps for token gate, worker-name
+conflict, domain-config drift, wrangler run, URL extraction, custom-domain attach,
+markdown-for-agents, `.site-config` persistence, and R2 upload — moved over close to verbatim.
+
+### `DeployCommand` changes
+
+`init` gains a `target: any DeployTarget` parameter, defaulting to `CloudflareDeployTarget()` —
+every existing call site (`DeployModel`, `SiteIntents`/`CommandFactory`,
+`SocialWorkerProvisionCommand`) keeps compiling unchanged. `deploy()` becomes: well-known merge →
+build → `PreDeployCheck` → `target.publish(context:)`. `Result` (the 5-case enum) is unchanged —
+`.workerNameConflict`/`.domainConfigDrift` stay defined there since they're still valid outcomes,
+just now produced by `CloudflareDeployTarget` instead of `DeployCommand` directly.
+
+### `anglesite.json` / `DomainConfig` change
+
+One new top-level field, following the `Domain.choice` precedent (an open string, not a closed
+`enum`, so an unrecognized future value degrades gracefully for a reader that predates it):
+
+```swift
+public var deployTarget: String?  // "cloudflare" | future values; nil ≡ "cloudflare" today
+```
+
+Round-tripped by `DomainConfigStore` like every other field (unknown-key-preserving on save,
+defaults to absent on a fresh file). Nothing reads this field to select a `DeployTarget`
+conformer this slice — `DeployCommand`'s target stays hardcoded. The field exists purely so
+slice 2 (target selection + Settings UI) has schema to build on without a migration of its own.
+
+## Error handling
+
+No new error surface. `DeployCommand.Result` is unchanged; `CloudflareDeployTarget.publish`
+returns it exactly as `DeployCommand.deploy` does today. `PreDeployCheck` failures stay a
+`DeployCommand`-level `.blocked` before `target.publish` is ever called — a target cannot bypass
+it because it never runs when preflight fails. A future non-Cloudflare target simply never
+produces `.workerNameConflict`/`.domainConfigDrift`.
+
+## Testing
+
+`Tests/AnglesiteCoreTests/DeployCommandTests.swift`'s existing `FakeExecutor`-injection pattern
+keeps working unchanged (the executor is still threaded through, now via `DeployTargetContext`).
+Tests that exercise Cloudflare-specific behavior (worker-conflict, domain-drift, custom-domain
+attach, markdown-for-agents, R2 upload) move to a new `CloudflareDeployTargetTests.swift`,
+constructing `CloudflareDeployTarget` directly instead of `DeployCommand`. Tests of the shared
+spine (well-known merge, build-seam wiring, `PreDeployCheck` parsing, pre-spawn refusal) stay in
+`DeployCommandTests.swift`, using a trivial fake `DeployTarget` where a target is needed at all.
+This is a mechanical test-suite split — same assertions, same fakes, filed under whichever type
+now owns that behavior — not new test design.
+
+New test: `anglesite.json` round-trips `deployTarget` and preserves it as an unknown-tolerant
+field, matching every other `DomainConfig` section's test coverage in
+`Tests/AnglesiteCoreTests/DomainConfigStoreTests.swift` (or equivalent).
+
+## Migration / compatibility
+
+None needed. `deployTarget` is a new optional field on an already-optional-everything schema
+(`DomainConfig`'s own doc comment: "an absent file means 'no declarations'"). Existing
+`anglesite.json` files without the field decode as `nil`, treated identically to `"cloudflare"`
+everywhere it matters (nowhere, this slice — nothing reads it yet).
+
+## Later slices (not this one, tracked against #1015)
+
+- Slice 2+: `GitHubPagesDeployTarget` conformer, riding `HTTPGitHubClient` + a Pages-aware token
+  onboarding variant (current GitHub token scopes don't include Pages — see research notes).
+- Target selection: `DeployCommand` reads `deployTarget` from `anglesite.json` and picks the
+  conformer; Settings UI to change it.
+- Gating Cloudflare-only features (inbox capture, membership, worker catalog) as unavailable on
+  non-Cloudflare targets, per the BBEdit-style capability-gated-feature labeling policy.


### PR DESCRIPTION
Part of #1015 — first of several planned seam-first PRs; the epic stays open until a second deploy target ships.

## Summary

- Add a `deployTarget: String?` field to `DomainConfig`/`Source/anglesite.json` (open string, following `Domain.choice`'s precedent) — schema only, not yet read to select anything.
- Extract a `DeployTarget` protocol from `DeployCommand`, with `CloudflareDeployTarget` as the sole conformer. `DeployCommand` keeps the provider-agnostic spine (well-known scan/merge, build, the non-bypassable `PreDeployCheck` preflight) and delegates everything Cloudflare-specific — credential resolution, worker-name-conflict/domain-config-drift checks, the wrangler upload, and every post-publish effect (custom-domain attach, Markdown for Agents, `.site-config` persistence, R2 bundle upload) — to `CloudflareDeployTarget` via `authorize(siteDirectory:)`/`publish(context:)`.
- Zero behavior change for existing sites: same `DeployCommand.Result` cases, same step ordering, same `.site-config`/`anglesite.json` side effects. Every production and test call site across `Sources/` and `Tests/` that referenced a moved member was updated to reference `CloudflareDeployTarget` instead.

No GitHub Pages conformer, no target-selection logic, and no Settings UI in this PR — those are later slices.

Design doc: `docs/superpowers/specs/2026-08-17-deploy-target-seam-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-17-deploy-target-seam-slice1.md`

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 5024/5024 passing (all targets, including `AnglesiteAppTests`/`DeployModelTests`)
- [x] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` (via `scripts/build-app.sh`) — BUILD SUCCEEDED
- [ ] Manual smoke (if UI-touching): not applicable — no UI changes in this PR