### PR TITLE
feat(#1514): A/B slice 2: client-side goal beacon (template)

### DIFF
--- a/Resources/Template/public/x/goal-beacon.js
+++ b/Resources/Template/public/x/goal-beacon.js
@@ -1,0 +1,55 @@
+// Edge A/B testing client-side goal beacon (#1270 slice 2).
+//
+// A first-party static file — never bundled or transformed — injected by BaseLayout.astro only
+// on a running experiment's own page/variant page, and only when that experiment's goal is
+// "scroll" or "visible". Goal parameters travel as data- attributes on the injecting <script> tag
+// (read via document.currentScript), never inline. Observes at most one goal crossing per page
+// view and reports it to /x/goal; never chooses or swaps page content, so it has no bearing on
+// variant assignment (that stays entirely server-side — see worker/experiments.ts).
+(() => {
+  "use strict";
+  const script = document.currentScript;
+  if (!script) return;
+
+  const experimentId = script.dataset.experiment;
+  const kind = script.dataset.kind;
+  if (!experimentId || (kind !== "scroll" && kind !== "visible")) return;
+
+  let fired = false;
+  function send() {
+    if (fired) return;
+    fired = true;
+    const url = "/x/goal?e=" + encodeURIComponent(experimentId);
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(url);
+    } else {
+      fetch(url, { method: "POST", keepalive: true }).catch(() => {});
+    }
+  }
+
+  if (kind === "scroll") {
+    const depth = Number(script.dataset.depth);
+    if (!(depth > 0 && depth <= 100)) return;
+    const onScroll = () => {
+      const doc = document.documentElement;
+      const scrolled = ((window.scrollY + window.innerHeight) / doc.scrollHeight) * 100;
+      if (scrolled >= depth) {
+        window.removeEventListener("scroll", onScroll);
+        send();
+      }
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+  } else {
+    const selector = script.dataset.selector;
+    if (!selector) return;
+    const target = document.querySelector(selector);
+    if (!target) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        observer.disconnect();
+        send();
+      }
+    });
+    observer.observe(target);
+  }
+})();

--- a/Resources/Template/scripts/anglesite-config.test.ts
+++ b/Resources/Template/scripts/anglesite-config.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readAnglesiteConfig } from "./anglesite-config";
+import { readAnglesiteConfig, pickRunningExperiment, type AnglesiteConfig, type AnglesiteExperiment } from "./anglesite-config";
 
 /// Temporarily replaces `console.warn` for the duration of `fn`, recording calls, then restores it.
 function withWarnSpy<T>(fn: (calls: unknown[][]) => T): T {
@@ -177,4 +177,44 @@ test("readAnglesiteConfig: defaults version to 1 when the file omits it", () => 
   } finally {
     rmSync(siteRoot, { recursive: true, force: true });
   }
+});
+
+function makeExperiment(overrides: Partial<AnglesiteExperiment> = {}): AnglesiteExperiment {
+  return {
+    id: "homepage-hero",
+    name: "Homepage headline",
+    page: "/",
+    variant: { id: "b", name: "Fresh eggs headline", page: "/x/homepage-hero/b/" },
+    split: 0.5,
+    goal: { kind: "pageview", path: "/contact/thanks/" },
+    status: "running",
+    startedAt: "2026-08-16",
+    ...overrides,
+  };
+}
+
+test("pickRunningExperiment: no experiments section returns null", () => {
+  const config: AnglesiteConfig = { version: 1 };
+  assert.equal(pickRunningExperiment(config), null);
+});
+
+test("pickRunningExperiment: only draft experiments returns null", () => {
+  const config: AnglesiteConfig = { version: 1, experiments: { active: [makeExperiment({ status: "draft" })] } };
+  assert.equal(pickRunningExperiment(config), null);
+});
+
+test("pickRunningExperiment: returns the one running experiment", () => {
+  const config: AnglesiteConfig = {
+    version: 1,
+    experiments: { active: [makeExperiment({ id: "draft-one", status: "draft" }), makeExperiment({ id: "running-one" })] },
+  };
+  assert.equal(pickRunningExperiment(config)?.id, "running-one");
+});
+
+test("pickRunningExperiment: picks the first running experiment when multiple are (invalidly) running", () => {
+  const config: AnglesiteConfig = {
+    version: 1,
+    experiments: { active: [makeExperiment({ id: "first" }), makeExperiment({ id: "second" })] },
+  };
+  assert.equal(pickRunningExperiment(config)?.id, "first");
 });

--- a/Resources/Template/scripts/anglesite-config.ts
+++ b/Resources/Template/scripts/anglesite-config.ts
@@ -90,6 +90,15 @@ export interface AnglesiteExperimentsConfig {
   active?: AnglesiteExperiment[];
 }
 
+/** Picks the one "running" experiment (v1: one at a time) out of `experiments.active`, or `null`.
+ *  Shared by the worker artifact generator (`experiments-artifact.ts`) and the goal-beacon layout
+ *  injection (`BaseLayout.astro`) so both derive the same answer from `anglesite.json` without
+ *  depending on each other's build order — see `GOAL_BEACON_SCRIPT_PATH`'s doc comment for why the
+ *  layout can't just import the generated `worker/experiments.json` artifact directly. */
+export function pickRunningExperiment(config: AnglesiteConfig): AnglesiteExperiment | null {
+  return config.experiments?.active?.find((experiment) => experiment.status === "running") ?? null;
+}
+
 /// The `Source/anglesite.json` shape this reader hands back. Mirrors the Swift `DomainConfig`
 /// model (`Sources/AnglesiteCore/DomainConfig.swift`) field-for-field; kept as a hand-written
 /// parallel type rather than a generated one, matching how `RedirectEntry` in `redirects.ts`

--- a/Resources/Template/scripts/experiments-artifact.ts
+++ b/Resources/Template/scripts/experiments-artifact.ts
@@ -11,16 +11,15 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readAnglesiteConfig, type AnglesiteConfig, type AnglesiteExperiment } from "./anglesite-config.ts";
+import { readAnglesiteConfig, pickRunningExperiment, type AnglesiteConfig, type AnglesiteExperiment } from "./anglesite-config.ts";
 import type { ExperimentsArtifact, RunningExperiment } from "../worker/experiments.ts";
 
-/** Picks the one "running" experiment (v1: one at a time) out of `active`, or `null`. Multiple
- *  running entries would be a `checkExperiments` gate failure before deploy — this generator
- *  stays defensive rather than throwing, so a mid-edit config still produces a buildable (if
- *  soon-to-be-gate-rejected) artifact. */
+/** Projects the config's one running experiment (v1: one at a time), or `null`, to the Worker's
+ *  runtime shape. Multiple running entries would be a `checkExperiments` gate failure before
+ *  deploy — `pickRunningExperiment` picks the first regardless, so a mid-edit config still
+ *  produces a buildable (if soon-to-be-gate-rejected) artifact rather than throwing. */
 export function buildExperimentsArtifact(config: AnglesiteConfig): ExperimentsArtifact {
-  const active = config.experiments?.active ?? [];
-  const running = active.find((experiment) => experiment.status === "running");
+  const running = pickRunningExperiment(config);
   return { experiment: running ? toRunningExperiment(running) : null };
 }
 

--- a/Resources/Template/scripts/experiments-paths.ts
+++ b/Resources/Template/scripts/experiments-paths.ts
@@ -1,0 +1,11 @@
+/**
+ * Fixed system paths for edge A/B testing's client-side goal beacon (#1270 slice 2): the
+ * first-party static script `BaseLayout.astro` conditionally injects, and the POST endpoint it
+ * reports to (`worker/experiments.ts`'s `handleGoalBeaconRequest`, dispatched by `worker.ts`).
+ *
+ * Kept in their own zero-dependency module — rather than alongside the rest of the config reader
+ * in `anglesite-config.ts`, which imports `node:fs` — so the Cloudflare Worker bundle can import
+ * the endpoint path without dragging a Node-only module into it.
+ */
+export const GOAL_BEACON_SCRIPT_PATH = "/x/goal-beacon.js";
+export const GOAL_ENDPOINT_PATH = "/x/goal";

--- a/Resources/Template/scripts/goal-beacon.test.ts
+++ b/Resources/Template/scripts/goal-beacon.test.ts
@@ -1,0 +1,242 @@
+// Coverage for the client-side goal beacon (public/x/goal-beacon.js, #1270 slice 2). The script
+// is a plain browser file (never bundled/transformed — see its own doc comment), so this test
+// stubs just enough of the DOM/browser surface it touches (document.currentScript, window's
+// scroll listener API, IntersectionObserver, navigator.sendBeacon/fetch) and re-imports the
+// module fresh per case: it's a self-executing IIFE that reads its globals once at import time,
+// and Node's ESM loader caches a module by its exact resolved specifier — a cache-busting query
+// string forces a fresh evaluation against that test's own stubs.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { join, dirname } from "node:path";
+
+const BEACON_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "public", "x", "goal-beacon.js");
+let importCounter = 0;
+
+interface Stubs {
+  sendBeaconCalls: string[];
+  fetchCalls: Array<{ url: string; init: unknown }>;
+  scrollListeners: Array<() => void>;
+  removedListeners: Array<() => void>;
+  intersectionCallback: ((entries: Array<{ isIntersecting: boolean }>) => void) | null;
+  observed: unknown[];
+  disconnected: boolean;
+}
+
+function installStubs(opts: {
+  dataset?: Record<string, string> | null;
+  querySelectorReturns?: unknown;
+  hasSendBeacon?: boolean;
+  scrollHeight?: number;
+  innerHeight?: number;
+  scrollY?: number;
+}): Stubs {
+  const stubs: Stubs = {
+    sendBeaconCalls: [],
+    fetchCalls: [],
+    scrollListeners: [],
+    removedListeners: [],
+    intersectionCallback: null,
+    observed: [],
+    disconnected: false,
+  };
+
+  const currentScript = opts.dataset === null ? null : { dataset: opts.dataset ?? {} };
+
+  // Node ships read-only global getters for several of these (navigator, fetch) on modern
+  // versions — plain assignment throws "Cannot set property ... which has only a getter".
+  // `defineProperty` with `configurable: true` overrides them for this stub, and the next test's
+  // call overrides them again.
+  const define = (name: string, value: unknown) =>
+    Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+
+  define("document", {
+    currentScript,
+    documentElement: { scrollHeight: opts.scrollHeight ?? 1000 },
+    querySelector: () => (opts.querySelectorReturns !== undefined ? opts.querySelectorReturns : null),
+  });
+  define("window", {
+    scrollY: opts.scrollY ?? 0,
+    innerHeight: opts.innerHeight ?? 800,
+    addEventListener: (event: string, listener: () => void) => {
+      if (event === "scroll") stubs.scrollListeners.push(listener);
+    },
+    removeEventListener: (event: string, listener: () => void) => {
+      if (event === "scroll") stubs.removedListeners.push(listener);
+    },
+  });
+  define(
+    "navigator",
+    opts.hasSendBeacon === false
+      ? {}
+      : {
+          sendBeacon: (url: string) => {
+            stubs.sendBeaconCalls.push(url);
+            return true;
+          },
+        },
+  );
+  define("fetch", (url: string, init: unknown) => {
+    stubs.fetchCalls.push({ url, init });
+    return Promise.resolve({ ok: true });
+  });
+  define(
+    "IntersectionObserver",
+    class {
+      constructor(callback: (entries: Array<{ isIntersecting: boolean }>) => void) {
+        stubs.intersectionCallback = callback;
+      }
+      observe(target: unknown) {
+        stubs.observed.push(target);
+      }
+      disconnect() {
+        stubs.disconnected = true;
+      }
+    },
+  );
+
+  return stubs;
+}
+
+async function loadBeacon(): Promise<void> {
+  importCounter += 1;
+  await import(`${pathToFileURL(BEACON_PATH).href}?case=${importCounter}`);
+}
+
+test("goal-beacon: no-ops when document.currentScript is absent", async () => {
+  const stubs = installStubs({ dataset: null });
+  await loadBeacon();
+  assert.equal(stubs.scrollListeners.length, 0);
+  assert.equal(stubs.observed.length, 0);
+});
+
+test("goal-beacon: no-ops when data-experiment is missing", async () => {
+  const stubs = installStubs({ dataset: { kind: "scroll", depth: "50" } });
+  await loadBeacon();
+  assert.equal(stubs.scrollListeners.length, 0);
+});
+
+test("goal-beacon: no-ops when data-kind is unrecognized", async () => {
+  const stubs = installStubs({ dataset: { experiment: "exp1", kind: "click" } });
+  await loadBeacon();
+  assert.equal(stubs.scrollListeners.length, 0);
+  assert.equal(stubs.observed.length, 0);
+});
+
+test("goal-beacon scroll: no-ops when depth is missing/out of range", async () => {
+  const missing = installStubs({ dataset: { experiment: "exp1", kind: "scroll" } });
+  await loadBeacon();
+  assert.equal(missing.scrollListeners.length, 0);
+
+  const outOfRange = installStubs({ dataset: { experiment: "exp1", kind: "scroll", depth: "150" } });
+  await loadBeacon();
+  assert.equal(outOfRange.scrollListeners.length, 0);
+});
+
+test("goal-beacon scroll: does not fire before the depth threshold is crossed", async () => {
+  const stubs = installStubs({
+    dataset: { experiment: "exp1", kind: "scroll", depth: "75" },
+    scrollHeight: 1000,
+    innerHeight: 200,
+    scrollY: 100,
+  });
+  await loadBeacon();
+  assert.equal(stubs.scrollListeners.length, 1);
+
+  stubs.scrollListeners[0]();
+  assert.equal(stubs.sendBeaconCalls.length, 0);
+});
+
+test("goal-beacon scroll: fires once when the depth threshold is crossed, then stops listening", async () => {
+  const stubs = installStubs({
+    dataset: { experiment: "homepage-hero", kind: "scroll", depth: "75" },
+    scrollHeight: 1000,
+    innerHeight: 200,
+    scrollY: 100,
+  });
+  await loadBeacon();
+  const onScroll = stubs.scrollListeners[0];
+
+  // (scrollY + innerHeight) / scrollHeight * 100 = (600 + 200) / 1000 * 100 = 80 >= 75
+  (globalThis as unknown as { window: { scrollY: number } }).window.scrollY = 600;
+  onScroll();
+  assert.deepEqual(stubs.sendBeaconCalls, ["/x/goal?e=homepage-hero"]);
+  assert.equal(stubs.removedListeners.length, 1);
+
+  // A second crossing (e.g. the caller invoking a stale reference) must not send twice.
+  onScroll();
+  assert.equal(stubs.sendBeaconCalls.length, 1);
+});
+
+test("goal-beacon visible: no-ops when data-selector is missing", async () => {
+  const stubs = installStubs({ dataset: { experiment: "exp1", kind: "visible" } });
+  await loadBeacon();
+  assert.equal(stubs.observed.length, 0);
+});
+
+test("goal-beacon visible: no-ops when the selector matches no element", async () => {
+  const stubs = installStubs({
+    dataset: { experiment: "exp1", kind: "visible", selector: "#missing" },
+    querySelectorReturns: null,
+  });
+  await loadBeacon();
+  assert.equal(stubs.observed.length, 0);
+});
+
+test("goal-beacon visible: observes the target and does not fire while not intersecting", async () => {
+  const target = { id: "testimonials" };
+  const stubs = installStubs({
+    dataset: { experiment: "exp1", kind: "visible", selector: "#testimonials" },
+    querySelectorReturns: target,
+  });
+  await loadBeacon();
+  assert.deepEqual(stubs.observed, [target]);
+
+  stubs.intersectionCallback?.([{ isIntersecting: false }]);
+  assert.equal(stubs.sendBeaconCalls.length, 0);
+  assert.equal(stubs.disconnected, false);
+});
+
+test("goal-beacon visible: fires once and disconnects when the target intersects", async () => {
+  const target = { id: "testimonials" };
+  const stubs = installStubs({
+    dataset: { experiment: "homepage-hero", kind: "visible", selector: "#testimonials" },
+    querySelectorReturns: target,
+  });
+  await loadBeacon();
+
+  stubs.intersectionCallback?.([{ isIntersecting: false }, { isIntersecting: true }]);
+  assert.deepEqual(stubs.sendBeaconCalls, ["/x/goal?e=homepage-hero"]);
+  assert.equal(stubs.disconnected, true);
+
+  stubs.intersectionCallback?.([{ isIntersecting: true }]);
+  assert.equal(stubs.sendBeaconCalls.length, 1);
+});
+
+test("goal-beacon: falls back to a keepalive fetch when sendBeacon is unavailable", async () => {
+  const target = { id: "testimonials" };
+  const stubs = installStubs({
+    dataset: { experiment: "homepage-hero", kind: "visible", selector: "#testimonials" },
+    querySelectorReturns: target,
+    hasSendBeacon: false,
+  });
+  await loadBeacon();
+
+  stubs.intersectionCallback?.([{ isIntersecting: true }]);
+  assert.equal(stubs.sendBeaconCalls.length, 0);
+  assert.equal(stubs.fetchCalls.length, 1);
+  assert.equal(stubs.fetchCalls[0].url, "/x/goal?e=homepage-hero");
+  assert.deepEqual(stubs.fetchCalls[0].init, { method: "POST", keepalive: true });
+});
+
+test("goal-beacon: URL-encodes the experiment id", async () => {
+  const stubs = installStubs({
+    dataset: { experiment: "a b&c", kind: "scroll", depth: "10" },
+    scrollHeight: 100,
+    innerHeight: 100,
+    scrollY: 100,
+  });
+  await loadBeacon();
+  stubs.scrollListeners[0]();
+  assert.deepEqual(stubs.sendBeaconCalls, ["/x/goal?e=a%20b%26c"]);
+});

--- a/Resources/Template/scripts/pre-deploy-check.test.ts
+++ b/Resources/Template/scripts/pre-deploy-check.test.ts
@@ -13,9 +13,11 @@ import {
   checkAnglesiteConfig,
   checkExperiments,
   checkRSL,
+  runningExperimentControlDistPath,
   runningExperimentVariantDistPath,
 } from "./pre-deploy-check";
 import { MTA_STS_MARKER, SECURITY_TXT_MARKER } from "./edge-artifacts";
+import { GOAL_BEACON_SCRIPT_PATH } from "./experiments-paths";
 
 const GOOD = `/*
   Content-Security-Policy: default-src 'self'; frame-src 'self' js.stripe.com
@@ -664,10 +666,40 @@ test("checkExperiments: rejects an unrecognized goal kind", () => {
   assert.ok(issues.some((i) => i.message.includes("goal.kind must be one of")));
 });
 
-test("checkExperiments: flags scroll/visible goal kinds as not yet supported", () => {
+test("checkExperiments: rejects a scroll goal with a non-numeric depth", () => {
+  const active = [{ ...VALID_ACTIVE[0], goal: { kind: "scroll", depth: "75" } }];
+  const issues = checkExperiments(JSON.stringify({ version: 1, experiments: { active } }), new Set(), null, null);
+  assert.ok(issues.some((i) => i.message.includes(".goal.depth must be")));
+});
+
+test("checkExperiments: rejects a scroll goal with an out-of-range depth", () => {
+  const active = [{ ...VALID_ACTIVE[0], goal: { kind: "scroll", depth: 150 } }];
+  const issues = checkExperiments(JSON.stringify({ version: 1, experiments: { active } }), new Set(), null, null);
+  assert.ok(issues.some((i) => i.message.includes(".goal.depth must be")));
+});
+
+test("checkExperiments: accepts an in-range scroll depth (no goal-parameter issue)", () => {
   const active = [{ ...VALID_ACTIVE[0], goal: { kind: "scroll", depth: 75 } }];
   const issues = checkExperiments(JSON.stringify({ version: 1, experiments: { active } }), new Set(), null, null);
-  assert.ok(issues.some((i) => i.category === "experiments-unsupported"));
+  assert.ok(!issues.some((i) => i.message.includes(".goal.depth") || i.message.includes(".goal.selector")));
+});
+
+test("checkExperiments: rejects a visible goal missing a selector", () => {
+  const active = [{ ...VALID_ACTIVE[0], goal: { kind: "visible" } }];
+  const issues = checkExperiments(JSON.stringify({ version: 1, experiments: { active } }), new Set(), null, null);
+  assert.ok(issues.some((i) => i.message.includes(".goal.selector must be")));
+});
+
+test("checkExperiments: rejects a visible goal with an empty/whitespace selector", () => {
+  const active = [{ ...VALID_ACTIVE[0], goal: { kind: "visible", selector: "   " } }];
+  const issues = checkExperiments(JSON.stringify({ version: 1, experiments: { active } }), new Set(), null, null);
+  assert.ok(issues.some((i) => i.message.includes(".goal.selector must be")));
+});
+
+test("checkExperiments: accepts a non-empty visible selector (no goal-parameter issue)", () => {
+  const active = [{ ...VALID_ACTIVE[0], goal: { kind: "visible", selector: "#testimonials" } }];
+  const issues = checkExperiments(JSON.stringify({ version: 1, experiments: { active } }), new Set(), null, null);
+  assert.ok(!issues.some((i) => i.message.includes(".goal.depth") || i.message.includes(".goal.selector")));
 });
 
 test("checkExperiments: rejects more than one running experiment", () => {
@@ -804,4 +836,95 @@ test("checkExperiments: recognizes noindex even when content precedes name in th
     "<urlset></urlset>",
   );
   assert.deepEqual(issues, []);
+});
+
+const SCROLL_GOAL_ACTIVE = [{ ...VALID_ACTIVE[0], goal: { kind: "scroll", depth: 75 } }];
+const BEACON_SCRIPT_TAG = `<script src="${GOAL_BEACON_SCRIPT_PATH}" defer data-experiment="homepage-hero" data-kind="scroll" data-depth="75"></script>`;
+const VARIANT_WITH_BEACON_HTML = `<html><head><link rel="canonical" href="https://example.com/"><meta name="robots" content="noindex">${BEACON_SCRIPT_TAG}</head><body></body></html>`;
+const CONTROL_WITH_BEACON_HTML = `<html><head>${BEACON_SCRIPT_TAG}</head><body></body></html>`;
+const NO_BEACON_TAG_HTML = "<html><head></head><body></body></html>";
+
+test("checkExperiments: flags a running client-side-goal experiment missing the built beacon script", () => {
+  const issues = checkExperiments(
+    JSON.stringify({ version: 1, experiments: { active: SCROLL_GOAL_ACTIVE } }),
+    distFilesFor(["dist/index.html", "dist/x/homepage-hero/b/index.html"]),
+    VARIANT_WITH_BEACON_HTML,
+    "<urlset></urlset>",
+    CONTROL_WITH_BEACON_HTML,
+  );
+  assert.ok(issues.some((i) => i.category === "experiments-goal-beacon" && i.message.includes("goal beacon script")));
+});
+
+test("checkExperiments: flags a control page missing the beacon <script> tag for a client-side goal", () => {
+  const issues = checkExperiments(
+    JSON.stringify({ version: 1, experiments: { active: SCROLL_GOAL_ACTIVE } }),
+    distFilesFor(["dist/index.html", "dist/x/homepage-hero/b/index.html", "dist/x/goal-beacon.js"]),
+    VARIANT_WITH_BEACON_HTML,
+    "<urlset></urlset>",
+    NO_BEACON_TAG_HTML,
+  );
+  assert.ok(
+    issues.some(
+      (i) => i.category === "experiments-goal-beacon" && i.message.includes("control page") && i.message.includes("beacon"),
+    ),
+  );
+});
+
+test("checkExperiments: flags a variant page missing the beacon <script> tag for a client-side goal", () => {
+  const issues = checkExperiments(
+    JSON.stringify({ version: 1, experiments: { active: SCROLL_GOAL_ACTIVE } }),
+    distFilesFor(["dist/index.html", "dist/x/homepage-hero/b/index.html", "dist/x/goal-beacon.js"]),
+    NO_BEACON_TAG_HTML,
+    "<urlset></urlset>",
+    CONTROL_WITH_BEACON_HTML,
+  );
+  assert.ok(
+    issues.some(
+      (i) => i.category === "experiments-goal-beacon" && i.message.includes("variant page") && i.message.includes("beacon"),
+    ),
+  );
+});
+
+test("checkExperiments: a fully built client-side-goal experiment (script + both tags) has no issues", () => {
+  const issues = checkExperiments(
+    JSON.stringify({ version: 1, experiments: { active: SCROLL_GOAL_ACTIVE } }),
+    distFilesFor(["dist/index.html", "dist/x/homepage-hero/b/index.html", "dist/x/goal-beacon.js"]),
+    VARIANT_WITH_BEACON_HTML,
+    "<urlset></urlset>",
+    CONTROL_WITH_BEACON_HTML,
+  );
+  assert.deepEqual(issues, []);
+});
+
+test("checkExperiments: does not require the beacon script/tag for an edge-visible goal (regression)", () => {
+  const issues = checkExperiments(
+    JSON.stringify({ version: 1, experiments: { active: VALID_ACTIVE } }),
+    distFilesFor(["dist/index.html", "dist/x/homepage-hero/b/index.html", "dist/contact/thanks/index.html"]),
+    VALID_VARIANT_HTML,
+    "<urlset></urlset>",
+    NO_BEACON_TAG_HTML,
+  );
+  assert.ok(!issues.some((i) => i.category === "experiments-goal-beacon"));
+});
+
+test("checkExperiments: skips the beacon-tag check when control HTML wasn't captured (older call sites)", () => {
+  const issues = checkExperiments(
+    JSON.stringify({ version: 1, experiments: { active: SCROLL_GOAL_ACTIVE } }),
+    distFilesFor(["dist/index.html", "dist/x/homepage-hero/b/index.html", "dist/x/goal-beacon.js"]),
+    VARIANT_WITH_BEACON_HTML,
+    "<urlset></urlset>",
+  );
+  assert.ok(!issues.some((i) => i.message.includes("control page")));
+});
+
+test("runningExperimentControlDistPath: a well-formed running experiment resolves its own dist path", () => {
+  assert.equal(
+    runningExperimentControlDistPath(JSON.stringify({ version: 1, experiments: { active: VALID_ACTIVE } })),
+    "dist/index.html",
+  );
+});
+
+test("runningExperimentControlDistPath: no running experiment returns null", () => {
+  const active = [{ ...VALID_ACTIVE[0], status: "draft" }];
+  assert.equal(runningExperimentControlDistPath(JSON.stringify({ version: 1, experiments: { active } })), null);
 });

--- a/Resources/Template/scripts/pre-deploy-check.ts
+++ b/Resources/Template/scripts/pre-deploy-check.ts
@@ -27,6 +27,7 @@ import { readConfigFromString } from "./config";
 import { isMTAStsMarkerOwned, isSecurityTxtMarkerOwned, normalizeMTAStsMX, readLicensingPolicy, resolveMTAStsMode, resolveSecurityTxtMode } from "./edge-artifacts";
 import { ANGLESITE_CONFIG_RECOGNIZED_VERSIONS } from "./anglesite-config";
 import { rslActive, rslFileUrl } from "../src/lib/rsl.ts";
+import { GOAL_BEACON_SCRIPT_PATH } from "./experiments-paths.ts";
 
 interface Issue {
   severity: "error" | "warning";
@@ -699,8 +700,13 @@ export function checkAnglesiteConfig(raw: string | null): Issue[] {
 }
 
 const EXPERIMENT_ID_PATTERN = /^[A-Za-z0-9-]+$/;
-const EDGE_VISIBLE_GOAL_KINDS = new Set(["pageview", "route"]);
 const KNOWN_GOAL_KINDS = new Set(["pageview", "route", "scroll", "visible"]);
+const CLIENT_GOAL_KINDS = new Set(["scroll", "visible"]);
+const GOAL_BEACON_SCRIPT_DIST_PATH = `dist${GOAL_BEACON_SCRIPT_PATH}`;
+const GOAL_BEACON_SCRIPT_TAG_PATTERN = new RegExp(
+  `<script\\b[^>]*\\bsrc\\s*=\\s*["']${escapeRegExp(GOAL_BEACON_SCRIPT_PATH)}["'][^>]*>`,
+  "i",
+);
 
 /**
  * `requireTrailingSlash` covers page routes: this template's Astro build emits directory-format
@@ -770,20 +776,15 @@ function hasNoindexRobotsMeta(html: string): boolean {
 }
 
 /**
- * Computes the single dist path (if any) worth reading during `scan()`'s `dist/` walk: the built
- * variant page of the one well-formed running experiment, if `anglesiteConfigRaw` declares one.
- * `checkExperiments` only ever needs that one file's content, so `scan()` uses this to decide
- * what to retain while walking, rather than keeping every built HTML file's content in memory for
- * a lookup that's always exactly one entry.
- *
- * Mirrors just enough of `checkExperiments`'s own parsing to find that one path — deliberately not
- * shared with it beyond that. Returns `null` on ANY problem (missing, malformed JSON, no
- * experiments, zero or multiple running, malformed variant/variant.page, etc.) rather than
- * raising or reporting: this is a cheap, best-effort lookup for what to read, not a second
- * validator — full validation of the config, including of `variant.page` itself, still happens in
- * `checkExperiments`.
+ * Parses just enough of `anglesiteConfigRaw` to find the one well-formed running experiment's
+ * `page`/`variant.page` pair, or `null` on ANY problem (missing, malformed JSON, no experiments,
+ * zero or multiple running, malformed page/variant/variant.page, etc.) — a cheap, best-effort
+ * lookup for `scan()` to decide what dist files are worth reading, not a second validator. Full
+ * validation of the config, including of `page`/`variant.page` themselves, still happens in
+ * `checkExperiments`. Shared by `runningExperimentControlDistPath`/`runningExperimentVariantDistPath`
+ * below so both resolve the same running experiment.
  */
-export function runningExperimentVariantDistPath(anglesiteConfigRaw: string | null): string | null {
+function parseSingleRunningExperiment(anglesiteConfigRaw: string | null): { page: string; variantPage: string } | null {
   if (anglesiteConfigRaw === null) return null;
   try {
     const parsed: unknown = JSON.parse(anglesiteConfigRaw);
@@ -801,34 +802,53 @@ export function runningExperimentVariantDistPath(anglesiteConfigRaw: string | nu
     );
     if (runningEntries.length !== 1) return null;
 
-    const variant = runningEntries[0].variant;
+    const running = runningEntries[0];
+    const page = running.page;
+    if (typeof page !== "string" || page.length === 0) return null;
+
+    const variant = running.variant;
     if (typeof variant !== "object" || variant === null || Array.isArray(variant)) return null;
 
     const variantPage = (variant as Record<string, unknown>).page;
     if (typeof variantPage !== "string" || variantPage.length === 0) return null;
 
-    return distPathFor(variantPage);
+    return { page, variantPage };
   } catch {
     return null;
   }
 }
 
+/** The built dist path of the running experiment's own (control) page — see
+ *  `parseSingleRunningExperiment`'s doc comment for the resolution/error contract. */
+export function runningExperimentControlDistPath(anglesiteConfigRaw: string | null): string | null {
+  const running = parseSingleRunningExperiment(anglesiteConfigRaw);
+  return running ? distPathFor(running.page) : null;
+}
+
+/** The built dist path of the running experiment's variant page — see
+ *  `parseSingleRunningExperiment`'s doc comment for the resolution/error contract. */
+export function runningExperimentVariantDistPath(anglesiteConfigRaw: string | null): string | null {
+  const running = parseSingleRunningExperiment(anglesiteConfigRaw);
+  return running ? distPathFor(running.variantPage) : null;
+}
+
 /**
- * Validates the `experiments` section of `anglesite.json` (#1270 slice 1) and, for the one
+ * Validates the `experiments` section of `anglesite.json` (#1270 slices 1-2) and, for the one
  * running experiment (if any), that its edge machinery is actually built and wired — a page,
- * variant, or pageview-goal path that doesn't exist in `dist/`, or a variant missing its
- * canonical/noindex/sitemap-exclusion, is exactly the class of misconfiguration that burns real
- * traffic silently for a week before anyone notices (design doc §6). Runs after
- * `checkAnglesiteConfig` has already confirmed the document parses as a JSON object with a
- * recognized version — this function re-parses defensively but returns no issues of its own for a
- * document `checkAnglesiteConfig` already flagged, so the two never double-report the same root
- * cause.
+ * variant, or pageview-goal path that doesn't exist in `dist/`, a variant missing its
+ * canonical/noindex/sitemap-exclusion, or (for a "scroll"/"visible" goal) either arm missing the
+ * goal beacon script/tag, is exactly the class of misconfiguration that burns real traffic
+ * silently for a week before anyone notices (design doc §6). Runs after `checkAnglesiteConfig` has
+ * already confirmed the document parses as a JSON object with a recognized version — this function
+ * re-parses defensively but returns no issues of its own for a document `checkAnglesiteConfig`
+ * already flagged, so the two never double-report the same root cause.
  */
 export function checkExperiments(
   anglesiteConfigRaw: string | null,
   distFiles: Set<string>,
   variantHtmlContent: string | null,
   sitemapContent: string | null,
+  controlHtmlContent: string | null = null,
 ): Issue[] {
   if (anglesiteConfigRaw === null) return [];
 
@@ -941,21 +961,32 @@ export function checkExperiments(
         message: `${label}.goal.kind must be one of pageview, route, scroll, visible (found ${JSON.stringify(goal.kind)}).`,
         file: "anglesite.json",
       });
-    } else if (!EDGE_VISIBLE_GOAL_KINDS.has(goal.kind as string)) {
-      issues.push({
-        severity: "error",
-        category: "experiments-unsupported",
-        message: `${label}.goal.kind "${goal.kind}" is not supported yet — client-side goals ship in a later slice.`,
-        file: "anglesite.json",
-        remediation: 'Use goal.kind "pageview" or "route" for now.',
-      });
-    } else {
+    } else if (goal.kind === "pageview" || goal.kind === "route") {
       // Only "pageview" goals are page routes (Astro directory-format output); "route" goals are
       // API/action endpoints, which this codebase never gives a trailing slash (see worker.ts's
       // ROUTES table) — see experimentPathProblem's doc comment.
       const goalPathProblem = experimentPathProblem(goal.path, { requireTrailingSlash: goal.kind === "pageview" });
       if (goalPathProblem) {
         issues.push({ severity: "error", category: "experiments-invalid", message: `${label}.goal.path ${goalPathProblem}.`, file: "anglesite.json" });
+      }
+    } else if (goal.kind === "scroll") {
+      if (typeof goal.depth !== "number" || goal.depth < 1 || goal.depth > 100) {
+        issues.push({
+          severity: "error",
+          category: "experiments-invalid",
+          message: `${label}.goal.depth must be a number between 1 and 100 (found ${JSON.stringify(goal.depth)}).`,
+          file: "anglesite.json",
+        });
+      }
+    } else {
+      // goal.kind === "visible"
+      if (typeof goal.selector !== "string" || goal.selector.trim().length === 0) {
+        issues.push({
+          severity: "error",
+          category: "experiments-invalid",
+          message: `${label}.goal.selector must be a non-empty string (found ${JSON.stringify(goal.selector)}).`,
+          file: "anglesite.json",
+        });
       }
     }
 
@@ -1045,6 +1076,36 @@ export function checkExperiments(
     });
   }
 
+  // Client-side goals (#1270 slice 2) can never fire without the beacon script actually built and
+  // referenced from both arms — a variant/control page missing the tag is the same class of
+  // silent-traffic-burn misconfiguration the checks above guard against for edge-visible goals.
+  if (CLIENT_GOAL_KINDS.has(goal.kind as string)) {
+    if (!distFiles.has(GOAL_BEACON_SCRIPT_DIST_PATH)) {
+      issues.push({
+        severity: "error",
+        category: "experiments-goal-beacon",
+        message: `Running experiment's "${goal.kind}" goal needs the goal beacon script, but no built file exists at ${GOAL_BEACON_SCRIPT_DIST_PATH}.`,
+        file: GOAL_BEACON_SCRIPT_DIST_PATH,
+        remediation: "Confirm public/x/goal-beacon.js ships with the site and rebuild.",
+      });
+    }
+
+    for (const [html, roleLabel, distPath] of [
+      [controlHtmlContent, "control page", distPathFor(page)],
+      [variantHtmlContent, "variant page", distPathFor(variantPage)],
+    ] as const) {
+      if (html !== null && !GOAL_BEACON_SCRIPT_TAG_PATTERN.test(html)) {
+        issues.push({
+          severity: "error",
+          category: "experiments-goal-beacon",
+          message: `Running experiment's ${roleLabel} ("${roleLabel === "control page" ? page : variantPage}") must include the goal beacon <script src="${GOAL_BEACON_SCRIPT_PATH}"> tag — its "${goal.kind}" goal can never fire without it.`,
+          file: distPath,
+          remediation: "Confirm the page renders through BaseLayout, so the beacon is injected for a running client-side-goal experiment.",
+        });
+      }
+    }
+  }
+
   return issues;
 }
 
@@ -1103,10 +1164,14 @@ async function scan(): Promise<Issue[]> {
   const sitemapContent = await readFile(join(DIST_DIR, "sitemap.xml"), "utf-8").catch(
     (e: NodeJS.ErrnoException) => (e.code === "ENOENT" ? null : Promise.reject(e)),
   );
-  // Only ever one file's content is needed out of the whole walk below — the running
-  // experiment's variant page, if there is one — so this is computed up front rather than
-  // retaining every built HTML file's content in memory (#1513 final review).
+  // Only ever two files' content is needed out of the whole walk below — the running
+  // experiment's own (control) page and its variant page, if there is one — so these are
+  // computed up front rather than retaining every built HTML file's content in memory (#1513
+  // final review). The control page's content is only used by the client-side-goal beacon-tag
+  // check (§6); every other running-experiment check only ever needed the variant's.
+  const controlDistPath = runningExperimentControlDistPath(anglesiteConfigContent);
   const variantDistPath = runningExperimentVariantDistPath(anglesiteConfigContent);
+  let controlHtmlContent: string | null = null;
   let variantHtmlContent: string | null = null;
 
   const relPaths: string[] = [];
@@ -1120,6 +1185,7 @@ async function scan(): Promise<Issue[]> {
     issues.push(...checkPII(content, rel));
 
     const isHtmlOrCss = /\.(html?|css)$/i.test(file);
+    if (controlDistPath !== null && rel === controlDistPath) controlHtmlContent = content;
     if (variantDistPath !== null && rel === variantDistPath) variantHtmlContent = content;
     if (isHtmlOrCss) {
       issues.push(...checkEmbedMedia(content, rel));
@@ -1166,7 +1232,9 @@ async function scan(): Promise<Issue[]> {
 
   issues.push(...checkArtifactPresence(relPaths));
 
-  issues.push(...checkExperiments(anglesiteConfigContent, new Set(relPaths), variantHtmlContent, sitemapContent));
+  issues.push(
+    ...checkExperiments(anglesiteConfigContent, new Set(relPaths), variantHtmlContent, sitemapContent, controlHtmlContent),
+  );
 
   return issues;
 }

--- a/Resources/Template/src/layouts/BaseLayout.astro
+++ b/Resources/Template/src/layouts/BaseLayout.astro
@@ -3,7 +3,8 @@ import "../styles/global.css";
 import Hcard from "../components/Hcard.astro";
 import Rights from "../components/Rights.astro";
 import { readConfig, siteLang } from "../../scripts/config";
-import { readAnglesiteConfig } from "../../scripts/anglesite-config";
+import { readAnglesiteConfig, pickRunningExperiment } from "../../scripts/anglesite-config";
+import { GOAL_BEACON_SCRIPT_PATH } from "../../scripts/experiments-paths.ts";
 import { licensingPolicy, siteLicense } from "../lib/licensing-data.ts";
 import { headLicense, type LicenseRef } from "../lib/licensing.ts";
 import { rslPublished } from "../lib/rsl.ts";
@@ -79,6 +80,20 @@ const rsl = rslPublished(licensingPolicy(), readConfig("SITE_URL"));
 // and (per astro.config.ts's `vite.build.assetsInlineLimit`) externalize the script into a
 // single cached chunk shared by every page, re-adding `type="module"` itself in the output.
 const webmcpEnabled = readAnglesiteConfig(process.cwd()).experimental?.webmcp === true;
+// Client-side goal beacon injection (#1270 slice 2): a running experiment's own page and variant
+// page carry the beacon <script> only when its goal is "scroll"/"visible" — a pageview/route goal
+// is entirely edge-observed and needs no client script. Every other page (including a *concluded*
+// experiment's former pages, once anglesite.json no longer marks it "running") stays byte-
+// identical to a build before this feature existed. Reads `anglesite.json` directly (like
+// `webmcpEnabled` above) rather than importing the gitignored, generated `worker/experiments.json`
+// artifact — `pickRunningExperiment` is the single derivation both share, so they never disagree,
+// without this layout depending on the Worker's own prebuild step having already run first.
+const runningExperiment = pickRunningExperiment(readAnglesiteConfig(process.cwd()));
+const beaconExperiment =
+  runningExperiment && (runningExperiment.goal.kind === "scroll" || runningExperiment.goal.kind === "visible")
+    && (Astro.url.pathname === runningExperiment.page || Astro.url.pathname === runningExperiment.variant.page)
+    ? runningExperiment
+    : null;
 // Same computation BlogPost.astro/Hentry.astro use for their own JSON-LD `url` — duplicated
 // rather than threaded as a prop because every page (including ones with no per-collection
 // layout) needs a canonical link, and Astro.url/Astro.site are already in scope here.
@@ -149,6 +164,16 @@ const themeColor = readConfig("PWA_THEME_COLOR");
     <Hcard />
     <Rights license={license} />
     {webmcpEnabled && <script src="../scripts/webmcp.ts"></script>}
+    {beaconExperiment && (
+      <script
+        src={GOAL_BEACON_SCRIPT_PATH}
+        defer
+        data-experiment={beaconExperiment.id}
+        data-kind={beaconExperiment.goal.kind}
+        data-depth={beaconExperiment.goal.kind === "scroll" ? beaconExperiment.goal.depth : undefined}
+        data-selector={beaconExperiment.goal.kind === "visible" ? beaconExperiment.goal.selector : undefined}
+      ></script>
+    )}
     <!-- anglesite:body-end -->
   </body>
 </html>

--- a/Resources/Template/src/layouts/goal-beacon.build.test.ts
+++ b/Resources/Template/src/layouts/goal-beacon.build.test.ts
@@ -1,0 +1,91 @@
+// Resources/Template/src/layouts/goal-beacon.build.test.ts
+//
+// Build-level test for the client-side goal beacon injection (#1270 slice 2): a running
+// experiment with a "scroll"/"visible" goal must carry the beacon <script> on both its control
+// and variant pages (and nowhere else); with no running client-side-goal experiment, the feature
+// must stay completely inert — mirrors webmcp.build.test.ts's off/on shape for the same class of
+// config-driven conditional <script> injection.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, cp, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+// Resources/Template/ — two `..` up from src/layouts/
+const TEMPLATE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const EXCLUDED = /(^|\/)(node_modules|dist|\.astro|\.wrangler)(\/|$)/;
+
+const VARIANT_FIXTURE_PAGE = `---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+<BaseLayout title="Variant fixture">
+  <p>Variant fixture page for the goal-beacon injection test.</p>
+</BaseLayout>
+`;
+
+async function buildFixture(anglesiteConfig: Record<string, unknown> | null): Promise<string> {
+  const fixtureDir = await mkdtemp(join(tmpdir(), "anglesite-goal-beacon-fixture-"));
+  await cp(TEMPLATE_ROOT, fixtureDir, {
+    recursive: true,
+    filter: (src) => !EXCLUDED.test(src.slice(TEMPLATE_ROOT.length)),
+  });
+  await writeFile(join(fixtureDir, "src", "pages", "variant-fixture.astro"), VARIANT_FIXTURE_PAGE, "utf8");
+  if (anglesiteConfig) {
+    await writeFile(join(fixtureDir, "anglesite.json"), JSON.stringify(anglesiteConfig), "utf8");
+  }
+  execFileSync("npm", ["install", "--no-audit", "--no-fund", "--prefer-offline"], { cwd: fixtureDir, stdio: "inherit" });
+  execFileSync("npx", ["astro", "build"], { cwd: fixtureDir, stdio: "inherit" });
+  return fixtureDir;
+}
+
+test("goal beacon: no running client-side-goal experiment emits no beacon script anywhere", async () => {
+  const fixtureDir = await buildFixture(null);
+  try {
+    const home = await readFile(join(fixtureDir, "dist/index.html"), "utf8");
+    assert.doesNotMatch(home, /goal-beacon\.js/, "the homepage must not reference the beacon script when no experiment runs");
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("goal beacon: a running scroll-goal experiment injects the beacon on both control and variant pages", async () => {
+  const fixtureDir = await buildFixture({
+    version: 1,
+    experiments: {
+      active: [
+        {
+          id: "goal-beacon-fixture",
+          name: "Goal beacon fixture",
+          page: "/",
+          variant: { id: "b", name: "B", page: "/variant-fixture/" },
+          split: 0.5,
+          goal: { kind: "scroll", depth: 75 },
+          status: "running",
+          startedAt: "2026-08-17",
+        },
+      ],
+    },
+  });
+  try {
+    const control = await readFile(join(fixtureDir, "dist/index.html"), "utf8");
+    const variant = await readFile(join(fixtureDir, "dist/variant-fixture/index.html"), "utf8");
+    const scriptPattern =
+      /<script[^>]*\bsrc="\/x\/goal-beacon\.js"[^>]*\bdata-experiment="goal-beacon-fixture"[^>]*\bdata-kind="scroll"[^>]*\bdata-depth="75"[^>]*>/;
+
+    assert.match(control, scriptPattern, "the control page must carry the beacon script with the right data attributes");
+    assert.match(variant, scriptPattern, "the variant page must carry the beacon script with the right data attributes");
+    assert.doesNotMatch(control, /data-selector/, "a scroll goal must not render a data-selector attribute");
+
+    // An unrelated page must stay untouched — the beacon is only injected on the experiment's own
+    // two pages, not site-wide.
+    const rss = await readFile(join(fixtureDir, "dist/notes/hello-note/index.html"), "utf8").catch(() => null);
+    if (rss !== null) {
+      assert.doesNotMatch(rss, /goal-beacon\.js/, "an unrelated page must not carry the beacon script");
+    }
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+});

--- a/Resources/Template/worker/experiments.test.ts
+++ b/Resources/Template/worker/experiments.test.ts
@@ -12,6 +12,7 @@ import {
   incrementExperimentCounter,
   handleExperimentPageRequest,
   applyGoalConversion,
+  handleGoalBeaconRequest,
   type RunningExperiment,
   type ExperimentsEnv,
 } from "./experiments";
@@ -34,6 +35,15 @@ const EXPERIMENT: RunningExperiment = {
   variant: { id: "b", page: "/x/homepage-hero/b/" },
   split: 0.5,
   goal: { kind: "pageview", path: "/contact/thanks/" },
+};
+
+// A distinct id from EXPERIMENT's "homepage-hero" — kept separate so these tests' counter rows
+// can never collide with (or be polluted by) the applyGoalConversion tests above, which write
+// real rows under "homepage-hero"/"b"/"conversion".
+const SCROLL_EXPERIMENT: RunningExperiment = {
+  ...EXPERIMENT,
+  id: "beacon-test",
+  goal: { kind: "scroll", depth: 75 },
 };
 
 test("assignVariant: draws control when random() is below the control share", () => {
@@ -72,7 +82,7 @@ test("matchesGoal: route goal only matches POST on its path", () => {
   expect(matchesGoal(routeExperiment, "/inbox", "GET")).toBe(false);
 });
 
-test("matchesGoal: scroll/visible goals never match at the edge in this slice", () => {
+test("matchesGoal: scroll/visible goals never match by pathname/method — the beacon reports them", () => {
   const scrollExperiment: RunningExperiment = { ...EXPERIMENT, goal: { kind: "scroll", depth: 75 } };
   expect(matchesGoal(scrollExperiment, "/", "GET")).toBe(false);
 });
@@ -197,6 +207,99 @@ test("applyGoalConversion: no-ops for a failed response", async () => {
   const ctx = createExecutionContext();
   const request = new Request("https://owner.example/contact/thanks/", { headers: { Cookie: "exp_homepage-hero=b" } });
   const response = await applyGoalConversion(request, env, ctx, EXPERIMENT, new Response("error", { status: 500 }));
+  await waitOnExecutionContext(ctx);
+  expect(response.headers.get("Set-Cookie")).toBeNull();
+});
+
+test("handleGoalBeaconRequest: 405s for a non-POST method", async () => {
+  const ctx = createExecutionContext();
+  const response = await handleGoalBeaconRequest(
+    new Request("https://owner.example/x/goal?e=beacon-test", { method: "GET" }),
+    {},
+    ctx,
+    SCROLL_EXPERIMENT,
+  );
+  expect(response.status).toBe(405);
+  expect(response.headers.get("allow")).toBe("POST");
+});
+
+test("handleGoalBeaconRequest: 204 no-ops when no experiment is running", async () => {
+  const ctx = createExecutionContext();
+  const response = await handleGoalBeaconRequest(
+    new Request("https://owner.example/x/goal?e=beacon-test", { method: "POST" }),
+    {},
+    ctx,
+    null,
+  );
+  expect(response.status).toBe(204);
+});
+
+test("handleGoalBeaconRequest: 204 no-ops for a running experiment with an edge-visible goal", async () => {
+  const pageviewGoalExperiment: RunningExperiment = { ...SCROLL_EXPERIMENT, id: "beacon-pageview-noop-test", goal: { kind: "pageview", path: "/contact/thanks/" } };
+  const ctx = createExecutionContext();
+  const request = new Request("https://owner.example/x/goal?e=beacon-pageview-noop-test", {
+    method: "POST",
+    headers: { Cookie: "exp_beacon-pageview-noop-test=b" },
+  });
+  const response = await handleGoalBeaconRequest(request, { EXPERIMENTS_DB: testDb }, ctx, pageviewGoalExperiment);
+  await waitOnExecutionContext(ctx);
+  expect(response.status).toBe(204);
+  const row = await testDb
+    .prepare("SELECT n FROM experiment_counters WHERE experiment_id = ? AND metric = 'conversion'")
+    .bind("beacon-pageview-noop-test")
+    .first<{ n: number }>();
+  expect(row).toBeNull();
+});
+
+test("handleGoalBeaconRequest: 204 no-ops when the `e` param doesn't match the running experiment's id", async () => {
+  const ctx = createExecutionContext();
+  const request = new Request("https://owner.example/x/goal?e=some-other-experiment", {
+    method: "POST",
+    headers: { Cookie: "exp_beacon-test=b" },
+  });
+  const response = await handleGoalBeaconRequest(request, { EXPERIMENTS_DB: testDb }, ctx, SCROLL_EXPERIMENT);
+  await waitOnExecutionContext(ctx);
+  expect(response.status).toBe(204);
+  const row = await testDb
+    .prepare("SELECT n FROM experiment_counters WHERE experiment_id = ? AND metric = 'conversion'")
+    .bind("beacon-test")
+    .first<{ n: number }>();
+  expect(row).toBeNull();
+});
+
+test("handleGoalBeaconRequest: counts a conversion for an assigned visitor and sets the dedupe cookie", async () => {
+  const ctx = createExecutionContext();
+  const request = new Request("https://owner.example/x/goal?e=beacon-test", {
+    method: "POST",
+    headers: { Cookie: "exp_beacon-test=b" },
+  });
+  const response = await handleGoalBeaconRequest(request, { EXPERIMENTS_DB: testDb }, ctx, SCROLL_EXPERIMENT);
+  await waitOnExecutionContext(ctx);
+  expect(response.status).toBe(204);
+  expect(response.headers.get("Set-Cookie")).toContain("exp_beacon-test_c=1");
+  const row = await testDb
+    .prepare("SELECT n FROM experiment_counters WHERE experiment_id = ? AND variant_id = ? AND metric = 'conversion'")
+    .bind("beacon-test", "b")
+    .first<{ n: number }>();
+  expect(row?.n).toBe(1);
+});
+
+test("handleGoalBeaconRequest: 204 no-ops for an unassigned visitor (no assignment cookie)", async () => {
+  const ctx = createExecutionContext();
+  const request = new Request("https://owner.example/x/goal?e=beacon-test", { method: "POST" });
+  const response = await handleGoalBeaconRequest(request, { EXPERIMENTS_DB: testDb }, ctx, SCROLL_EXPERIMENT);
+  await waitOnExecutionContext(ctx);
+  expect(response.status).toBe(204);
+  expect(response.headers.get("Set-Cookie")).toBeNull();
+});
+
+test("handleGoalBeaconRequest: 204 no-ops (dedupes) for an already-converted visitor", async () => {
+  const ctx = createExecutionContext();
+  const request = new Request("https://owner.example/x/goal?e=beacon-test", {
+    method: "POST",
+    headers: { Cookie: "exp_beacon-test=b; exp_beacon-test_c=1" },
+  });
+  const response = await handleGoalBeaconRequest(request, { EXPERIMENTS_DB: testDb }, ctx, SCROLL_EXPERIMENT);
   await waitOnExecutionContext(ctx);
   expect(response.headers.get("Set-Cookie")).toBeNull();
 });

--- a/Resources/Template/worker/experiments.ts
+++ b/Resources/Template/worker/experiments.ts
@@ -1,9 +1,9 @@
 /**
- * Edge A/B testing runtime (#1270 slice 1): variant assignment/serving and D1 event counting for
- * `worker.ts`'s experiments middleware. Edge-visible goal kinds only ("pageview"/"route") —
- * "scroll"/"visible" ship with the goal beacon in slice 2; `matchesGoal` never matches those kinds
- * here, so a misconfigured client-side-goal experiment is caught by `checkExperiments` (the
- * pre-deploy gate) rather than silently never converting at the edge.
+ * Edge A/B testing runtime (#1270 slices 1-2): variant assignment/serving and D1 event counting
+ * for `worker.ts`'s experiments middleware. `matchesGoal` only ever matches "pageview"/"route" —
+ * "scroll"/"visible" are never observed by pathname/method at this layer; they're reported by the
+ * first-party goal beacon (`public/x/goal-beacon.js`) via `handleGoalBeaconRequest`'s dedicated
+ * `/x/goal` endpoint instead (see `GOAL_ENDPOINT_PATH` in `../scripts/experiments-paths.ts`).
  */
 
 export type ExperimentGoalKind = "pageview" | "route" | "scroll" | "visible";
@@ -111,8 +111,9 @@ export async function incrementExperimentCounter(
 }
 
 /** True when `pathname`/`method` is this experiment's goal signal. Only "pageview" (any method,
- *  matched by path) and "route" (POST, matched by path) are edge-observable in this slice —
- *  "scroll"/"visible" are observed client-side by the slice-2 beacon, never at this layer. */
+ *  matched by path) and "route" (POST, matched by path) are edge-observable here — "scroll"/
+ *  "visible" are observed client-side by the goal beacon (`handleGoalBeaconRequest` below), never
+ *  by pathname/method matching. */
 export function matchesGoal(experiment: RunningExperiment, pathname: string, method: string): boolean {
   const { goal } = experiment;
   if (goal.path === undefined) return false;
@@ -199,4 +200,39 @@ export async function applyGoalConversion(
 
   ctx.waitUntil(incrementExperimentCounter(env.EXPERIMENTS_DB, experiment.id, arm, "conversion", currentDay()));
   return withSetCookie(response, serializeCookie(conversionCookie, "1"));
+}
+
+const CLIENT_GOAL_KINDS: ReadonlySet<ExperimentGoalKind> = new Set(["scroll", "visible"]);
+
+/**
+ * The `/x/goal` endpoint (#1270 slice 2): `worker.ts` dispatches every request on
+ * `GOAL_ENDPOINT_PATH` here, running experiment or not. `sendBeacon`/`fetch(keepalive)` bodies are
+ * always empty (no request body is ever read) — the experiment id travels as the `e` query
+ * parameter instead (`public/x/goal-beacon.js`'s `send()`).
+ *
+ * A `204` no-op — never a conversion — for: any non-POST method (`405` instead), no experiment
+ * running, a running experiment whose goal isn't client-side (`scroll`/`visible` — a forged hit
+ * against a `pageview`/`route` experiment must not count, since only the beacon script for a
+ * client-side goal is ever supposed to call this), an `e` that doesn't match the running
+ * experiment's id, or (inside `applyGoalConversion`) a visitor with no assignment cookie or one
+ * that's already converted. Reuses `applyGoalConversion`'s cookie/dedupe logic against a bare
+ * `204` response, which is `response.ok`, so it's still eligible to count.
+ */
+export async function handleGoalBeaconRequest(
+  request: Request,
+  env: ExperimentsEnv,
+  ctx: ExecutionContext,
+  experiment: RunningExperiment | null,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405, headers: { allow: "POST" } });
+  }
+
+  const emptyResponse = new Response(null, { status: 204 });
+  if (!experiment || !CLIENT_GOAL_KINDS.has(experiment.goal.kind)) return emptyResponse;
+
+  const requestedId = new URL(request.url).searchParams.get("e");
+  if (requestedId !== experiment.id) return emptyResponse;
+
+  return applyGoalConversion(request, env, ctx, experiment, emptyResponse);
 }

--- a/Resources/Template/worker/worker.test.ts
+++ b/Resources/Template/worker/worker.test.ts
@@ -343,6 +343,17 @@ test("routing: unrelated paths fall through to the asset-first branch", async ()
   expect(await response.text()).toBe("No assets binding configured");
 });
 
+test("routing: /x/goal is handled unconditionally (#1270 slice 2), even with no running experiment", async () => {
+  const postResponse = await fetchWorker(
+    new Request("https://owner.example/x/goal?e=homepage-hero", { method: "POST" }),
+  );
+  expect(postResponse.status).toBe(204);
+
+  const getResponse = await fetchWorker(new Request("https://owner.example/x/goal?e=homepage-hero"));
+  expect(getResponse.status).toBe(405);
+  expect(getResponse.headers.get("allow")).toBe("POST");
+});
+
 test("routing: with no running experiment configured, existing routes are unaffected", async () => {
   const postResponse = await fetchWorker(
     new Request("https://owner.example/inbox", {

--- a/Resources/Template/worker/worker.ts
+++ b/Resources/Template/worker/worker.ts
@@ -56,10 +56,12 @@ import {
 import {
   handleExperimentPageRequest,
   applyGoalConversion,
+  handleGoalBeaconRequest,
   matchesGoal,
   type ExperimentsArtifact,
 } from "./experiments.ts";
 import experimentsArtifact from "./experiments.json";
+import { GOAL_ENDPOINT_PATH } from "../scripts/experiments-paths.ts";
 
 /**
  * Per-site Cloudflare Worker entry point.
@@ -1898,6 +1900,13 @@ export default {
     // page is fully owned by this branch — it never reaches ROUTES or asset-first serving.
     if (RUNNING_EXPERIMENT && pathname === RUNNING_EXPERIMENT.page) {
       return handleExperimentPageRequest(request, env, ctx, RUNNING_EXPERIMENT);
+    }
+
+    // Client-side goal beacon endpoint (#1270 slice 2): a fixed system path, not derived from
+    // config, so it's checked unconditionally — `handleGoalBeaconRequest` itself no-ops when
+    // there's no running experiment or its goal isn't client-side.
+    if (pathname === GOAL_ENDPOINT_PATH) {
+      return handleGoalBeaconRequest(request, env, ctx, RUNNING_EXPERIMENT);
     }
 
     let response: Response;


### PR DESCRIPTION
Closes #1514

## Summary

- Adds edge A/B testing "slice 2" (design doc `docs/superpowers/specs/2026-08-16-edge-ab-testing-design.md` §4 "Client-side goals: the beacon" + §10.2, tracked epic #1270): a first-party static `public/x/goal-beacon.js` beacon script, conditional injection into `BaseLayout.astro` on a running experiment's control/variant pages, and a `/x/goal` POST endpoint in `worker/worker.ts`/`worker/experiments.ts` that reuses slice 1's cookie-dedupe D1 counting (`applyGoalConversion`) for beacon-reported conversions.
- `scroll`/`visible` goal parameters (`depth` 1–100, non-empty `selector`) are now fully validated in `checkExperiments`, replacing the "not supported yet" rejection slice 1 left in place; the gate also verifies the beacon script actually built and that both arms' HTML carry the `<script>` tag for a running client-side-goal experiment — the same silent-traffic-burn class of check slice 1 applies to edge-visible goals.
- Extracted a shared `pickRunningExperiment` helper (`anglesite-config.ts`) so the Worker's prebuild artifact generator and the Astro layout's beacon injection derive the same "one running experiment" answer from `anglesite.json` independently, without the layout depending on the Worker's prebuild step having already run.
- Entirely template-side (`Resources/Template/`) — no Swift changes, no MCP schema changes. Hand-authorable end to end, extending slice 1's machinery.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server).

## Test plan

- [x] `swift test --package-path .` — 554/554 passing, 72 suites (regression check; this PR makes no Swift changes, but touches `Resources/Template/`, which some Swift tests couple to)
- [ ] `xcodebuild -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — not run; no Swift/Xcode changes in this PR
- [x] Manual smoke: hand-configured a running `visible`-goal experiment in a real build (`npm run build && npm run check`) — confirmed the beacon `<script>` renders with correct `data-experiment`/`data-kind`/`data-selector` attributes on both control and variant pages, and the pre-deploy gate raised no beacon-related issues
- [x] `npx tsx --test "scripts/**/*.test.ts" "src/**/*.test.ts"` (Resources/Template) — 884/886 passing, 2 pre-existing skips
- [x] `npx vitest run --config vitest.config.ts` (worker suite — Vitest + `@cloudflare/vitest-pool-workers`, real D1 + `ExecutionContext`) — 186/186 passing
- [x] Two real `astro build` integration tests (`src/layouts/goal-beacon.build.test.ts`) — beacon absent with no running experiment, present with correct attributes on both arms when one is running
- [x] `npx astro check` — 0 errors