### PR TITLE
fix(#1527): unblock ShopifyBuyButton's CSP-blocked inline script

### DIFF
--- a/Resources/Template/integrations/components/ShopifyBuyButton.astro
+++ b/Resources/Template/integrations/components/ShopifyBuyButton.astro
@@ -13,34 +13,21 @@ interface Props {
 const { shopDomain, storefrontAccessToken, productId } = Astro.props;
 ---
 
+{/*
+  The Shopify Buy Button loader lives in public/scripts/ and reads its config from data-*
+  attributes on #shopify-buy-button-container instead of Astro's `define:vars`. `define:vars`
+  forces Astro to inline the script body verbatim into the page — with no `'unsafe-inline'`,
+  nonce, or hash in the site's CSP script-src, an inline body like that is silently blocked by
+  the browser. A same-origin `<script src="...">` satisfies `script-src 'self'` without
+  weakening the policy.
+*/}
+
 {shopDomain && storefrontAccessToken && productId && (
-  <div id="shopify-buy-button-container"></div>
-  <script is:inline define:vars={{ shopDomain, storefrontAccessToken, productId }}>
-    (function () {
-      var scriptURL = "https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js";
-      function loadScript() {
-        var script = document.createElement("script");
-        script.async = true;
-        script.src = scriptURL;
-        (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(script);
-        script.onload = ShopifyBuyInit;
-      }
-      function ShopifyBuyInit() {
-        var client = ShopifyBuy.buildClient({ domain: shopDomain, storefrontAccessToken: storefrontAccessToken });
-        ShopifyBuy.UI.onReady(client).then(function (ui) {
-          ui.createComponent("product", {
-            id: productId,
-            node: document.getElementById("shopify-buy-button-container"),
-            moneyFormat: "%24%7B%7Bamount%7D%7D",
-            options: { product: { contents: { img: true, title: true, price: true } } },
-          });
-        });
-      }
-      if (window.ShopifyBuy && window.ShopifyBuy.UI) {
-        ShopifyBuyInit();
-      } else {
-        loadScript();
-      }
-    })();
-  </script>
+  <div
+    id="shopify-buy-button-container"
+    data-shopify-shop-domain={shopDomain}
+    data-shopify-storefront-access-token={storefrontAccessToken}
+    data-shopify-product-id={productId}
+  ></div>
+  <script is:inline src="/scripts/shopify-buy-button.js"></script>
 )}

--- a/Resources/Template/public/scripts/shopify-buy-button.js
+++ b/Resources/Template/public/scripts/shopify-buy-button.js
@@ -1,0 +1,37 @@
+// Shopify Buy Button SDK loader for ShopifyBuyButton.astro. Served as a same-origin static
+// file (rather than an Astro `is:inline define:vars` script body) so the site's CSP
+// script-src 'self' policy (no 'unsafe-inline') covers it. Per-instance config comes from
+// data-shopify-* attributes instead of server-injected variables.
+(function () {
+  var container = document.getElementById("shopify-buy-button-container");
+  if (!container) return;
+
+  var shopDomain = container.dataset.shopifyShopDomain;
+  var storefrontAccessToken = container.dataset.shopifyStorefrontAccessToken;
+  var productId = container.dataset.shopifyProductId;
+
+  var scriptURL = "https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js";
+  function loadScript() {
+    var script = document.createElement("script");
+    script.async = true;
+    script.src = scriptURL;
+    (document.getElementsByTagName("head")[0] || document.getElementsByTagName("body")[0]).appendChild(script);
+    script.onload = ShopifyBuyInit;
+  }
+  function ShopifyBuyInit() {
+    var client = ShopifyBuy.buildClient({ domain: shopDomain, storefrontAccessToken: storefrontAccessToken });
+    ShopifyBuy.UI.onReady(client).then(function (ui) {
+      ui.createComponent("product", {
+        id: productId,
+        node: container,
+        moneyFormat: "%24%7B%7Bamount%7D%7D",
+        options: { product: { contents: { img: true, title: true, price: true } } },
+      });
+    });
+  }
+  if (window.ShopifyBuy && window.ShopifyBuy.UI) {
+    ShopifyBuyInit();
+  } else {
+    loadScript();
+  }
+})();


### PR DESCRIPTION
Part of #1527 — one of six independent fixes tracked there; not closing the issue since the other five land as separate PRs (see the issue's "Why not fixed together" section).

## Summary

- `ShopifyBuyButton.astro`'s `<script is:inline define:vars={{ shopDomain, storefrontAccessToken, productId }}>` body is silently blocked by the site's CSP (`script-src 'self'`, no `'unsafe-inline'`/nonce/hash).
- Moved the loader logic to a same-origin `public/scripts/shopify-buy-button.js`, referenced via `<script is:inline src="/scripts/shopify-buy-button.js">`.
- Config now flows through `data-shopify-shop-domain` / `data-shopify-storefront-access-token` / `data-shopify-product-id` attributes on `#shopify-buy-button-container` instead of `define:vars`.
- Follows the pattern landed for `BookingWidget.astro` in #1529.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

## Test plan

- [x] `npm run build` (Resources/Template) — 0 errors, 0 warnings, HTML markup validation passed
- [x] `npm run test` (Resources/Template) — 853 passed, 0 failed, 2 skipped (pre-existing)
- [x] Confirmed no remaining `define:vars`/inline script body in `ShopifyBuyButton.astro`; the loader script is same-origin, satisfying `script-src 'self'`