### PR TITLE
fix(#1527): unblock TrackingScript's CSP-blocked GA4 inline script

### DIFF
--- a/Resources/Template/integrations/components/TrackingScript.astro
+++ b/Resources/Template/integrations/components/TrackingScript.astro
@@ -22,14 +22,18 @@ const { provider, domain, siteId, measurementId } = Astro.props;
   <script is:inline src="https://cdn.usefathom.com/script.js" data-site={siteId} defer></script>
 )}
 
+{/*
+  The GA4 init loader lives in public/scripts/ and reads its measurement ID from a data-*
+  attribute on the loader script tag instead of Astro's `define:vars`. `define:vars` forces
+  Astro to inline the script body verbatim into the page — with no `'unsafe-inline'`, nonce, or
+  hash in the site's CSP script-src, an inline body like that is silently blocked by the
+  browser. A same-origin `<script src="...">` satisfies `script-src 'self'` without weakening
+  the policy.
+*/}
+
 {provider === "ga4" && measurementId && (
   <>
     <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}></script>
-    <script is:inline define:vars={{ measurementId }}>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag("js", new Date());
-      gtag("config", measurementId);
-    </script>
+    <script is:inline src="/scripts/ga4.js" data-ga4-measurement-id={measurementId}></script>
   </>
 )}

--- a/Resources/Template/public/scripts/ga4.js
+++ b/Resources/Template/public/scripts/ga4.js
@@ -1,0 +1,12 @@
+// GA4 gtag.js init for TrackingScript.astro. Served as a same-origin static file (rather than
+// an Astro `is:inline define:vars` script body) so the site's CSP script-src 'self' policy
+// (no 'unsafe-inline') covers it. The measurement ID comes from a data-ga4-measurement-id
+// attribute on this script's own tag (read via document.currentScript, valid because this
+// script runs synchronously — no async/defer) instead of a server-injected variable.
+(function () {
+  var measurementId = document.currentScript.dataset.ga4MeasurementId;
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag("js", new Date());
+  gtag("config", measurementId);
+})();


### PR DESCRIPTION
Part of #1527 — one of six independent fixes tracked there; not closing the issue since the other five land as separate PRs (see the issue's "Why not fixed together" section).

## Summary

- `TrackingScript.astro`'s GA4 branch `<script is:inline define:vars={{ measurementId }}>` body is silently blocked by the site's CSP (`script-src 'self'`, no `'unsafe-inline'`/nonce/hash). The Plausible and Fathom branches only use `src=`/`data-*` and are unaffected.
- Moved the `gtag` init to a same-origin `public/scripts/ga4.js`, referenced via `<script is:inline src="/scripts/ga4.js" data-ga4-measurement-id={measurementId}>`.
- The loader reads the measurement ID via `document.currentScript.dataset` — valid since the script runs synchronously (no `async`/`defer`).
- Follows the pattern landed for `BookingWidget.astro` in #1529.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

## Test plan

- [x] `npm run build` (Resources/Template) — 0 errors, 0 warnings, HTML markup validation passed
- [x] `npm run test` (Resources/Template) — 853 passed, 0 failed, 2 skipped (pre-existing)
- [x] Confirmed no remaining `define:vars`/inline script body in `TrackingScript.astro`; the loader script is same-origin, satisfying `script-src 'self'`