### PR TITLE
fix(#1527): unblock PaddleCheckout's CSP-blocked inline script

### DIFF
--- a/Resources/Template/integrations/components/PaddleCheckout.astro
+++ b/Resources/Template/integrations/components/PaddleCheckout.astro
@@ -13,20 +13,25 @@ interface Props {
 const { clientToken, priceId, buttonText = "Subscribe" } = Astro.props;
 ---
 
+{/*
+  The Paddle init/checkout loader lives in public/scripts/ and reads its config from data-*
+  attributes on #paddle-checkout-button instead of Astro's `define:vars`. `define:vars` forces
+  Astro to inline the script body verbatim into the page — with no `'unsafe-inline'`, nonce, or
+  hash in the site's CSP script-src, an inline body like that is silently blocked by the
+  browser. A same-origin `<script src="...">` satisfies `script-src 'self'` without weakening
+  the policy.
+*/}
+
 {clientToken && priceId && (
-  <button type="button" id="paddle-checkout-button" class="paddle-checkout-button">{buttonText}</button>
+  <button
+    type="button"
+    id="paddle-checkout-button"
+    class="paddle-checkout-button"
+    data-paddle-client-token={clientToken}
+    data-paddle-price-id={priceId}
+  >{buttonText}</button>
   <script is:inline src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
-  <script is:inline define:vars={{ clientToken, priceId }}>
-    document.addEventListener("DOMContentLoaded", function () {
-      Paddle.Initialize({ token: clientToken });
-      var button = document.getElementById("paddle-checkout-button");
-      if (button) {
-        button.addEventListener("click", function () {
-          Paddle.Checkout.open({ items: [{ priceId: priceId, quantity: 1 }] });
-        });
-      }
-    });
-  </script>
+  <script is:inline src="/scripts/paddle-checkout.js"></script>
 )}
 
 <style>

--- a/Resources/Template/public/scripts/paddle-checkout.js
+++ b/Resources/Template/public/scripts/paddle-checkout.js
@@ -1,0 +1,16 @@
+// Paddle Billing init/checkout loader for PaddleCheckout.astro. Served as a same-origin static
+// file (rather than an Astro `is:inline define:vars` script body) so the site's CSP
+// script-src 'self' policy (no 'unsafe-inline') covers it. Per-instance config comes from
+// data-paddle-* attributes on #paddle-checkout-button instead of server-injected variables.
+document.addEventListener("DOMContentLoaded", function () {
+  var button = document.getElementById("paddle-checkout-button");
+  if (!button) return;
+
+  var clientToken = button.dataset.paddleClientToken;
+  var priceId = button.dataset.paddlePriceId;
+
+  Paddle.Initialize({ token: clientToken });
+  button.addEventListener("click", function () {
+    Paddle.Checkout.open({ items: [{ priceId: priceId, quantity: 1 }] });
+  });
+});


### PR DESCRIPTION
Part of #1527 — one of six independent fixes tracked there; not closing the issue since the other five land as separate PRs (see the issue's "Why not fixed together" section).

## Summary

- `PaddleCheckout.astro`'s `<script is:inline define:vars={{ clientToken, priceId }}>` body is silently blocked by the site's CSP (`script-src 'self'`, no `'unsafe-inline'`/nonce/hash).
- Moved the init/checkout logic to a same-origin `public/scripts/paddle-checkout.js`, referenced via `<script is:inline src="/scripts/paddle-checkout.js">`.
- Config now flows through `data-paddle-client-token` / `data-paddle-price-id` attributes on `#paddle-checkout-button` instead of `define:vars`.
- Follows the pattern landed for `BookingWidget.astro` in #1529.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

## Test plan

- [x] `npm run build` (Resources/Template) — 0 errors, 0 warnings, HTML markup validation passed
- [x] `npm run test` (Resources/Template) — 853 passed, 0 failed, 2 skipped (pre-existing)
- [x] Confirmed no remaining `define:vars`/inline script body in `PaddleCheckout.astro`; the loader script is same-origin, satisfying `script-src 'self'`