### PR TITLE
fix(#1527): unblock ShareButtons' CSP-blocked inline script

### DIFF
--- a/Resources/Template/integrations/components/ShareButtons.astro
+++ b/Resources/Template/integrations/components/ShareButtons.astro
@@ -30,6 +30,13 @@ const linkedinHref = `https://www.linkedin.com/sharing/share-offsite/?url=${enco
 const anyEnabled = twitter || mastodon || linkedin || copyLink;
 ---
 
+{/*
+  The share-button click handler lives in public/scripts/ instead of an Astro `is:inline` inline
+  script body — with no `'unsafe-inline'`, nonce, or hash in the site's CSP script-src, an
+  inline body like that is silently blocked by the browser. A same-origin `<script src="...">`
+  satisfies `script-src 'self'` without weakening the policy.
+*/}
+
 {anyEnabled && (
   <div class="share-buttons">
     <span class="share-buttons-label">Share:</span>
@@ -56,31 +63,7 @@ const anyEnabled = twitter || mastodon || linkedin || copyLink;
     )}
   </div>
 
-  <script is:inline>
-    (function () {
-      document.addEventListener("click", function (e) {
-        var target = e.target.closest("[data-share-mastodon], [data-share-copy]");
-        if (!target) return;
-        if (target.hasAttribute("data-share-mastodon")) {
-          var instance = window.localStorage.getItem("mastodon-share-instance");
-          if (!instance) {
-            instance = window.prompt("Your Mastodon instance (e.g. mastodon.social):");
-            if (!instance) return;
-            instance = instance.replace(/^https?:\/\//, "").replace(/\/$/, "");
-            window.localStorage.setItem("mastodon-share-instance", instance);
-          }
-          var text = target.getAttribute("data-share-text") + " " + target.getAttribute("data-share-url");
-          window.open("https://" + instance + "/share?text=" + encodeURIComponent(text), "_blank", "noopener,noreferrer");
-        } else if (target.hasAttribute("data-share-copy")) {
-          navigator.clipboard.writeText(target.getAttribute("data-share-url")).then(function () {
-            var original = target.textContent;
-            target.textContent = "Copied!";
-            window.setTimeout(function () { target.textContent = original; }, 2000);
-          });
-        }
-      });
-    })();
-  </script>
+  <script is:inline src="/scripts/share-buttons.js"></script>
 )}
 
 <style>

--- a/Resources/Template/public/scripts/share-buttons.js
+++ b/Resources/Template/public/scripts/share-buttons.js
@@ -1,0 +1,26 @@
+// Share-button click handler for ShareButtons.astro. Served as a same-origin static file
+// (rather than an Astro `is:inline` inline script body) so the site's CSP script-src 'self'
+// policy (no 'unsafe-inline') covers it.
+(function () {
+  document.addEventListener("click", function (e) {
+    var target = e.target.closest("[data-share-mastodon], [data-share-copy]");
+    if (!target) return;
+    if (target.hasAttribute("data-share-mastodon")) {
+      var instance = window.localStorage.getItem("mastodon-share-instance");
+      if (!instance) {
+        instance = window.prompt("Your Mastodon instance (e.g. mastodon.social):");
+        if (!instance) return;
+        instance = instance.replace(/^https?:\/\//, "").replace(/\/$/, "");
+        window.localStorage.setItem("mastodon-share-instance", instance);
+      }
+      var text = target.getAttribute("data-share-text") + " " + target.getAttribute("data-share-url");
+      window.open("https://" + instance + "/share?text=" + encodeURIComponent(text), "_blank", "noopener,noreferrer");
+    } else if (target.hasAttribute("data-share-copy")) {
+      navigator.clipboard.writeText(target.getAttribute("data-share-url")).then(function () {
+        var original = target.textContent;
+        target.textContent = "Copied!";
+        window.setTimeout(function () { target.textContent = original; }, 2000);
+      });
+    }
+  });
+})();


### PR DESCRIPTION
Part of #1527 — one of six independent fixes tracked there; not closing the issue since the other five land as separate PRs (see the issue's "Why not fixed together" section).

## Summary

- `ShareButtons.astro`'s `<script is:inline>` body (Mastodon/copy-link click handling — no `define:vars`, already reads its config from `data-*` attributes) is silently blocked by the site's CSP (`script-src 'self'`, no `'unsafe-inline'`/nonce/hash).
- Moved the click handler to a same-origin `public/scripts/share-buttons.js`, referenced via `<script is:inline src="/scripts/share-buttons.js">`.
- Follows the pattern landed for `BookingWidget.astro` in #1529.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

## Test plan

- [x] `npm run build` (Resources/Template) — 0 errors, 0 warnings, HTML markup validation passed
- [x] `npm run test` (Resources/Template) — 853 passed, 0 failed, 2 skipped (pre-existing)
- [x] Confirmed no remaining inline script body in `ShareButtons.astro`; the loader script is same-origin, satisfying `script-src 'self'`