### PR TITLE
fix(#1527): unblock InstallPrompt's CSP-blocked inline script

### DIFF
--- a/Resources/Template/integrations/components/InstallPrompt.astro
+++ b/Resources/Template/integrations/components/InstallPrompt.astro
@@ -63,40 +63,11 @@ const { appName = "this site" } = Astro.props;
   }
 </style>
 
-<script is:inline>
-  (function () {
-    var DISMISS_KEY = "pwa-install-dismissed";
-    var DISMISS_MS = 30 * 24 * 60 * 60 * 1000;
-    var banner = document.querySelector(".install-prompt");
-    if (!banner) return;
+{/*
+  The install-prompt controller lives in public/scripts/ instead of an Astro `is:inline` inline
+  script body — with no `'unsafe-inline'`, nonce, or hash in the site's CSP script-src, an
+  inline body like that is silently blocked by the browser. A same-origin `<script src="...">`
+  satisfies `script-src 'self'` without weakening the policy.
+*/}
 
-    var dismissed = localStorage.getItem(DISMISS_KEY);
-    if (dismissed && Date.now() - parseInt(dismissed, 10) < DISMISS_MS) return;
-
-    var deferredPrompt = null;
-
-    window.addEventListener("beforeinstallprompt", function (e) {
-      e.preventDefault();
-      deferredPrompt = e;
-      banner.hidden = false;
-    });
-
-    banner.addEventListener("click", function (e) {
-      var action = e.target && e.target.dataset && e.target.dataset.action;
-      if (action === "install" && deferredPrompt) {
-        deferredPrompt.prompt();
-        deferredPrompt.userChoice.then(function () {
-          deferredPrompt = null;
-          banner.hidden = true;
-        });
-      } else if (action === "dismiss") {
-        localStorage.setItem(DISMISS_KEY, String(Date.now()));
-        banner.hidden = true;
-      }
-    });
-
-    window.addEventListener("appinstalled", function () {
-      banner.hidden = true;
-    });
-  })();
-</script>
+<script is:inline src="/scripts/install-prompt.js"></script>

--- a/Resources/Template/public/scripts/install-prompt.js
+++ b/Resources/Template/public/scripts/install-prompt.js
@@ -1,0 +1,38 @@
+// PWA install-prompt controller for InstallPrompt.astro. Served as a same-origin static file
+// (rather than an Astro `is:inline` inline script body) so the site's CSP script-src 'self'
+// policy (no 'unsafe-inline') covers it.
+(function () {
+  var DISMISS_KEY = "pwa-install-dismissed";
+  var DISMISS_MS = 30 * 24 * 60 * 60 * 1000;
+  var banner = document.querySelector(".install-prompt");
+  if (!banner) return;
+
+  var dismissed = localStorage.getItem(DISMISS_KEY);
+  if (dismissed && Date.now() - parseInt(dismissed, 10) < DISMISS_MS) return;
+
+  var deferredPrompt = null;
+
+  window.addEventListener("beforeinstallprompt", function (e) {
+    e.preventDefault();
+    deferredPrompt = e;
+    banner.hidden = false;
+  });
+
+  banner.addEventListener("click", function (e) {
+    var action = e.target && e.target.dataset && e.target.dataset.action;
+    if (action === "install" && deferredPrompt) {
+      deferredPrompt.prompt();
+      deferredPrompt.userChoice.then(function () {
+        deferredPrompt = null;
+        banner.hidden = true;
+      });
+    } else if (action === "dismiss") {
+      localStorage.setItem(DISMISS_KEY, String(Date.now()));
+      banner.hidden = true;
+    }
+  });
+
+  window.addEventListener("appinstalled", function () {
+    banner.hidden = true;
+  });
+})();


### PR DESCRIPTION
Part of #1527 — one of six independent fixes tracked there. This is the last of the six; once all land, the tracking issue should be closed manually (no single PR's closing keyword covers all six).

## Summary

- `InstallPrompt.astro`'s `<script is:inline>` body (PWA install-prompt controller — no `define:vars`) is silently blocked by the site's CSP (`script-src 'self'`, no `'unsafe-inline'`/nonce/hash).
- Moved the controller to a same-origin `public/scripts/install-prompt.js`, referenced via `<script is:inline src="/scripts/install-prompt.js">`.
- Follows the pattern landed for `BookingWidget.astro` in #1529.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server).

## Test plan

- [x] `npm run build` (Resources/Template) — 0 errors, 0 warnings, HTML markup validation passed
- [x] `npm run test` (Resources/Template) — 853 passed, 0 failed, 2 skipped (pre-existing)
- [x] Confirmed no remaining inline script body in `InstallPrompt.astro`; the loader script is same-origin, satisfying `script-src 'self'`