### PR TITLE
fix(#1522): add isHeader trait to SettingsBox section title

### DIFF
--- a/Sources/AnglesiteApp/SettingsBox.swift
+++ b/Sources/AnglesiteApp/SettingsBox.swift
@@ -19,6 +19,7 @@ struct SettingsBox<Content: View>: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             title.font(.headline)
+                .accessibilityAddTraits(.isHeader)
             content()
         }
         .padding(10)


### PR DESCRIPTION
Closes #1522

## Summary

- Add `.accessibilityAddTraits(.isHeader)` to `SettingsBox`'s section title `Text`, matching the heading semantics native `Section("...")` headers get for free.
- Without the trait, VoiceOver's rotor skipped every `SettingsBox` section (e.g. `ContentLicensingTab`'s four boxes, and the many boxes in `PlistEditorView`/`AuditSheetView`), forcing linear navigation instead of heading-based jumping.
- Single-line fix in the shared component; spot-checked all call sites (`ContentLicensingTab.swift`, `PlistEditorView.swift`, `AuditSheetView.swift`) — none double-label the title as a heading some other way.

## Paired PR check

- [x] This change is **self-contained** to `Anglesite/Anglesite`.
- [ ] This change **needs a paired PR** in [`Anglesite/anglesite-skills`](https://github.com/Anglesite/anglesite-skills) (MCP sidecar server). Link it here:

## Test plan

- [x] `swift test --package-path .` — 3963 tests, 0 failures
- [x] `xcodebuild` via `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — BUILD SUCCEEDED
- [ ] Manual smoke (if UI-touching): not run — no interactive Xcode/Simulator session in this environment; recommend a quick VoiceOver rotor check over the Settings window (e.g. Content Licensing tab) to confirm each `SettingsBox` title now surfaces as a heading.