### PR TITLE
feat(#999): embedded per-file license metadata + AI table

### DIFF
--- a/Resources/Template/src/lib/rsl.ts
+++ b/Resources/Template/src/lib/rsl.ts
@@ -38,8 +38,9 @@ export type RslPaymentType = "free" | "attribution";
 /**
  * Classifies a catalog license's RSL payment type by the license's own terms — CC0 requires
  * nothing, every other Creative Commons 4.0 variant (including the NC/ND restrictions) requires
- * attribution. This is a narrower, more factual claim than `LicenseCatalog.permitsAIUse` in the
- * Swift app (which is about AI-training ambiguity): "does this license require attribution" has
+ * attribution. This is a narrower, more factual claim than `LicenseCatalog.AIInterpretation` (the
+ * `.permits`/`.unclear`/`.prohibits` classification) in the Swift app, which is about AI-training
+ * ambiguity: "does this license require attribution" has
  * one answer per CC deed, not a live legal question. A custom URL isn't in this table and
  * classifies as `null` — Anglesite doesn't know its terms well enough to assert a payment type,
  * so `<payment>` is omitted for it (the license's `<terms>` link still carries the real terms).

--- a/Sources/AnglesiteApp/InsertCommands.swift
+++ b/Sources/AnglesiteApp/InsertCommands.swift
@@ -23,6 +23,15 @@ struct InsertCommands: Commands {
     /// `SiteWindowModel.makeComponentEditorContext`'s doc comment).
     @MainActor
     private static func insertImage(into preview: PreviewModel) async {
+        let route = preview.activeRoute ?? "/"
+        let collection = LicensableCollection(routePath: route)
+
+        var policy = LicensingPolicy()
+        if let sourceDirectory = preview.openSiteDirectory {
+            policy = (try? LicensingStore(sourceDirectory: sourceDirectory).load()) ?? LicensingPolicy()
+        }
+        let suppressesEmbedding = policy.suppressesFileEmbedding(for: collection)
+
         let panel = NSOpenPanel()
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
@@ -30,14 +39,47 @@ struct InsertCommands: Commands {
         panel.allowedContentTypes = [.image]
         panel.prompt = String(localized: "Insert")
         panel.message = String(localized: "Choose an image to insert into this page.")
+
+        var licenseCheckbox: NSButton?
+        var licensePopup: NSPopUpButton?
+        var initialChoice = InsertImageLicenseChoice(isEnabled: false, catalogID: LicenseCatalog.entries[0].id)
+        if !suppressesEmbedding {
+            initialChoice = InsertImageLicenseChoice.initial(
+                resolvedDefault: policy.resolvedLicense(for: collection),
+                lastUsed: AppSettings.shared.lastUsedFileLicenseSelection)
+            let (accessory, checkbox, popup) = makeLicenseAccessory(initial: initialChoice)
+            panel.accessoryView = accessory
+            licenseCheckbox = checkbox
+            licensePopup = popup
+        }
+
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
-        let bytes: Data
+        var bytes: Data
         do {
             bytes = try Data(contentsOf: url)
         } catch {
             presentFailureAlert(detail: error.localizedDescription)
             return
+        }
+
+        if !suppressesEmbedding, let checkbox = licenseCheckbox, let popup = licensePopup {
+            let choice = InsertImageLicenseChoice(
+                isEnabled: checkbox.state == .on,
+                catalogID: popup.selectedItem?.representedObject as? String ?? initialChoice.catalogID)
+            AppSettings.shared.lastUsedFileLicenseSelection = choice.persisted
+            if let license = choice.resolvedLicense(),
+               let type = UTType(filenameExtension: url.pathExtension) {
+                do {
+                    let result = try LicenseMetadataEmbedder.embed(license, into: bytes, type: type)
+                    if case .embedded(let embeddedData) = result {
+                        bytes = embeddedData
+                    }
+                } catch {
+                    presentFailureAlert(detail: error.localizedDescription)
+                    return
+                }
+            }
         }
 
         let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
@@ -53,6 +95,36 @@ struct InsertCommands: Commands {
         if reply.status != .applied {
             presentFailureAlert(detail: reply.message ?? "Unknown error")
         }
+    }
+
+    /// Builds the `NSOpenPanel` accessory view for the attach-time license picker (#999): a
+    /// checkbox plus a popup of catalog licenses, following the same plain-`NSView`-with-AppKit-
+    /// controls idiom `SiteActions.exportSource(of:)` uses for its "Include Git history"
+    /// checkbox — no `NSHostingView`/SwiftUI needed for a control this simple, and it keeps this
+    /// file's only new AppKit surface consistent with the one other accessory view in the app.
+    @MainActor
+    private static func makeLicenseAccessory(
+        initial: InsertImageLicenseChoice
+    ) -> (view: NSView, checkbox: NSButton, popup: NSPopUpButton) {
+        let checkbox = NSButton(
+            checkboxWithTitle: String(localized: "Embed a license in this file"), target: nil, action: nil)
+        checkbox.state = initial.isEnabled ? .on : .off
+        checkbox.frame = NSRect(x: 12, y: 32, width: 280, height: 20)
+
+        let popup = NSPopUpButton(frame: NSRect(x: 12, y: 4, width: 280, height: 24), pullsDown: false)
+        for entry in LicenseCatalog.entries {
+            let item = NSMenuItem(title: entry.name, action: nil, keyEquivalent: "")
+            item.representedObject = entry.id
+            popup.menu?.addItem(item)
+        }
+        if let index = LicenseCatalog.entries.firstIndex(where: { $0.id == initial.catalogID }) {
+            popup.selectItem(at: index)
+        }
+
+        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 304, height: 60))
+        accessory.addSubview(checkbox)
+        accessory.addSubview(popup)
+        return (accessory, checkbox, popup)
     }
 
     @MainActor

--- a/Sources/AnglesiteApp/InsertImageLicenseChoice.swift
+++ b/Sources/AnglesiteApp/InsertImageLicenseChoice.swift
@@ -1,0 +1,43 @@
+import Foundation
+import AnglesiteCore
+
+/// `Insert ▸ Image…`'s license-embedding checkbox + picker, held as a plain value (not directly
+/// as AppKit control state) so its resolution logic is unit-testable without a live
+/// `NSOpenPanel` — mirrors `LicenseGateSheetView.Selection`'s reasoning exactly. Internal (not
+/// `private`) so tests can construct and compare it directly.
+struct InsertImageLicenseChoice: Equatable {
+    /// Whether the checkbox is on — whether a license should be embedded into the picked file
+    /// at all.
+    var isEnabled: Bool
+    /// The `LicenseCatalog.Entry.id` currently selected in the popup, meaningful only when
+    /// `isEnabled` (but always a valid id, so re-enabling the checkbox shows a real choice).
+    var catalogID: String
+
+    /// The license to embed, or nil when the checkbox is off or the id doesn't match a known
+    /// catalog entry (defensive — the picker only ever offers real ids, so this should not
+    /// happen in practice).
+    func resolvedLicense() -> LicenseRef? {
+        guard isEnabled else { return nil }
+        return LicenseCatalog.entries.first { $0.id == catalogID }?.ref
+    }
+
+    /// The initial picker state when `Insert ▸ Image…` opens: the persisted last-used choice
+    /// when one exists, otherwise the page's resolved collection license as the popup's
+    /// starting selection — but with the checkbox left **off**, since embedding is a
+    /// destructive edit and this is the very first time the picker has been shown. Falls back
+    /// to the catalog's first entry when there is no resolved default to seed from at all (an
+    /// untouched site, or a page outside every collection with no site-wide default either) —
+    /// the popup must always show a real selection.
+    static func initial(resolvedDefault: LicenseRef?, lastUsed: FileLicenseSelection?) -> InsertImageLicenseChoice {
+        if let lastUsed {
+            return InsertImageLicenseChoice(isEnabled: lastUsed.isEnabled, catalogID: lastUsed.catalogID)
+        }
+        let fallbackID = LicenseCatalog.entry(for: resolvedDefault)?.id ?? LicenseCatalog.entries[0].id
+        return InsertImageLicenseChoice(isEnabled: false, catalogID: fallbackID)
+    }
+
+    /// The form this choice is persisted as (`AppSettings.lastUsedFileLicenseSelection`).
+    var persisted: FileLicenseSelection {
+        FileLicenseSelection(isEnabled: isEnabled, catalogID: catalogID)
+    }
+}

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -96,7 +96,8 @@ struct LicenseGateSheetView: View {
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 6)
 
-                row(title: "All rights reserved", permits: "Nothing without asking", aiNote: nil,
+                row(title: "All rights reserved", permits: "Nothing without asking",
+                    aiNote: aiInterpretationLabel(LicenseCatalog.allRightsReservedInterpretation),
                     choice: .allRightsReserved)
 
                 ForEach(LicenseCatalog.entries) { entry in
@@ -106,11 +107,12 @@ struct LicenseGateSheetView: View {
                         // lookup just falls back to the name itself.
                         title: LocalizedStringKey(entry.name),
                         permits: permitsSummary(for: entry),
-                        aiNote: entry.permitsAIUse ? "✅ Permits" : "❔ Unclear",
+                        aiNote: aiInterpretationLabel(entry.aiInterpretation),
                         choice: .catalog(entry.id))
                 }
 
-                row(title: "Custom…", permits: "Your own terms", aiNote: nil, choice: .custom)
+                row(title: "Custom…", permits: "Your own terms",
+                    aiNote: aiInterpretationLabel(.unclear), choice: .custom)
             }
 
             if selection.choice == .custom {
@@ -167,7 +169,7 @@ struct LicenseGateSheetView: View {
     /// The columns line up because every row — including the header — states the same three
     /// explicit frame widths, which is the alignment job `Grid` used to do.
     private func row(
-        title: LocalizedStringKey, permits: LocalizedStringKey, aiNote: LocalizedStringKey?,
+        title: LocalizedStringKey, permits: LocalizedStringKey, aiNote: LocalizedStringKey,
         choice: Selection.Choice
     ) -> some View {
         Button {
@@ -179,7 +181,7 @@ struct LicenseGateSheetView: View {
                 Text(permits)
                     .font(.caption).foregroundStyle(.secondary)
                     .frame(width: Self.permitsColumnWidth, alignment: .leading)
-                Text(aiNote ?? "—")
+                Text(aiNote)
                     .font(.caption).foregroundStyle(.secondary)
                     .frame(width: Self.aiColumnWidth, alignment: .leading)
             }
@@ -217,6 +219,16 @@ struct LicenseGateSheetView: View {
         // column just repeats the license name (and, being catalog data rather than UI copy,
         // isn't a literal key the way every case above is).
         default: return LocalizedStringKey(entry.name)
+        }
+    }
+
+    /// Row copy for the "AI systems" column, keyed by the 3-state classification (#999) rather
+    /// than a bare bool — see `LicenseCatalog.AIInterpretation`.
+    private func aiInterpretationLabel(_ interpretation: LicenseCatalog.AIInterpretation) -> LocalizedStringKey {
+        switch interpretation {
+        case .permits: return "✅ Permits"
+        case .unclear: return "❔ Unclear"
+        case .prohibits: return "🚫 Prohibits"
         }
     }
 }

--- a/Sources/AnglesiteApp/LicenseGateSheetView.swift
+++ b/Sources/AnglesiteApp/LicenseGateSheetView.swift
@@ -112,7 +112,7 @@ struct LicenseGateSheetView: View {
                 }
 
                 row(title: "Custom…", permits: "Your own terms",
-                    aiNote: aiInterpretationLabel(.unclear), choice: .custom)
+                    aiNote: aiInterpretationLabel(LicenseCatalog.customLicenseInterpretation), choice: .custom)
             }
 
             if selection.choice == .custom {
@@ -201,12 +201,12 @@ struct LicenseGateSheetView: View {
     private static let columnSpacing: CGFloat = 16
     private static let licenseColumnWidth: CGFloat = 150
     private static let permitsColumnWidth: CGFloat = 260
-    private static let aiColumnWidth: CGFloat = 80
+    private static let aiColumnWidth: CGFloat = 100
 
     /// Plain-language summary of what each catalog license permits — the middle comparison-table
-    /// column. Keyed by catalog id rather than re-deriving from `permitsAIUse` so it stays
+    /// column. Keyed by catalog id rather than re-deriving from `aiInterpretation` so it stays
     /// independent of the AI classification the last column already renders.
-    private func permitsSummary(for entry: LicenseCatalog.Entry) -> LocalizedStringKey {
+    func permitsSummary(for entry: LicenseCatalog.Entry) -> LocalizedStringKey {
         switch entry.id {
         case "cc0-1.0": return "Any use, no credit required"
         case "cc-by-4.0": return "Any use, with credit"
@@ -224,7 +224,7 @@ struct LicenseGateSheetView: View {
 
     /// Row copy for the "AI systems" column, keyed by the 3-state classification (#999) rather
     /// than a bare bool — see `LicenseCatalog.AIInterpretation`.
-    private func aiInterpretationLabel(_ interpretation: LicenseCatalog.AIInterpretation) -> LocalizedStringKey {
+    func aiInterpretationLabel(_ interpretation: LicenseCatalog.AIInterpretation) -> LocalizedStringKey {
         switch interpretation {
         case .permits: return "✅ Permits"
         case .unclear: return "❔ Unclear"

--- a/Sources/AnglesiteApp/Localizable.xcstrings
+++ b/Sources/AnglesiteApp/Localizable.xcstrings
@@ -1521,6 +1521,9 @@
     "Embed" : {
 
     },
+    "Embed a license in this file" : {
+
+    },
     "Emphasis" : {
 
     },
@@ -4236,6 +4239,9 @@
 
     },
     "👥" : {
+
+    },
+    "🚫 Prohibits" : {
 
     }
   },

--- a/Sources/AnglesiteCore/AppSettings.swift
+++ b/Sources/AnglesiteCore/AppSettings.swift
@@ -72,6 +72,8 @@ public final class AppSettings: @unchecked Sendable {
         public static let externalLLMVerifiedBaseURL = "anglesite.externalLLM.verifiedBaseURL"
         /// Backs ``AppSettings/externalLLMVerifiedDetail`` (#1482).
         public static let externalLLMVerifiedDetail = "anglesite.externalLLM.verifiedDetail"
+        /// Backs ``AppSettings/lastUsedFileLicenseSelection`` (#999).
+        public static let lastUsedFileLicenseSelection = "anglesite.lastUsedFileLicenseSelection"
     }
 
     private enum LegacyKey {
@@ -313,6 +315,23 @@ public final class AppSettings: @unchecked Sendable {
     public var externalLLMVerifiedDetail: String? {
         get { defaults.string(forKey: Key.externalLLMVerifiedDetail) }
         set { setOptionalString(newValue, forKey: Key.externalLLMVerifiedDetail) }
+    }
+
+    /// The attach-time license picker's last-used choice (#999) — `nil` until the picker has
+    /// been used at least once. JSON-encoded because `FileLicenseSelection` is a small struct,
+    /// not a primitive `UserDefaults` can store directly.
+    public var lastUsedFileLicenseSelection: FileLicenseSelection? {
+        get {
+            guard let data = defaults.data(forKey: Key.lastUsedFileLicenseSelection) else { return nil }
+            return try? JSONDecoder().decode(FileLicenseSelection.self, from: data)
+        }
+        set {
+            if let newValue, let data = try? JSONEncoder().encode(newValue) {
+                defaults.set(data, forKey: Key.lastUsedFileLicenseSelection)
+            } else {
+                defaults.removeObject(forKey: Key.lastUsedFileLicenseSelection)
+            }
+        }
     }
 
     /// Security-scoped bookmark for the sites root, persisted so the sandboxed (MAS) build only

--- a/Sources/AnglesiteCore/FileLicenseSelection.swift
+++ b/Sources/AnglesiteCore/FileLicenseSelection.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// The attach-time license picker's persisted last-used choice (#999) — so a site owner who
+/// licenses all their photos the same way sets it once. Deliberately just an on/off flag plus a
+/// `LicenseCatalog` id rather than a full `LicenseRef`: this picker offers catalog licenses only
+/// (no custom URL entry — see the plan doc's Global Constraints), so a stable catalog id is
+/// enough to restore the exact same choice next time, and stays valid even if a catalog entry's
+/// display name ever changes.
+public struct FileLicenseSelection: Codable, Equatable, Sendable {
+    /// Whether the checkbox was on — i.e. whether a license should be embedded at all.
+    public var isEnabled: Bool
+    /// `LicenseCatalog.Entry.id` of the picked license. Meaningful only when `isEnabled`; kept
+    /// even when disabled so re-enabling the checkbox restores the same picker selection.
+    public var catalogID: String
+
+    public init(isEnabled: Bool, catalogID: String) {
+        self.isEnabled = isEnabled
+        self.catalogID = catalogID
+    }
+}

--- a/Sources/AnglesiteCore/LicenseCatalog.swift
+++ b/Sources/AnglesiteCore/LicenseCatalog.swift
@@ -45,14 +45,12 @@ public enum LicenseCatalog {
         public var ref: LicenseRef { LicenseRef(url: url, name: name) }
     }
 
-    /// The offered licenses in picker order: CC0 and Public Domain Mark first, then the CC 4.0
-    /// suite from most to least permissive. Extending this list requires the same "unambiguous
-    /// grant" test the type doc describes before marking an entry `.permits`.
+    /// The offered licenses in picker order: CC0 first, then the CC 4.0 suite from most to least
+    /// permissive. Extending this list requires the same "unambiguous grant" test the type doc
+    /// describes before marking an entry `.permits`.
     public static let entries: [Entry] = [
         Entry(id: "cc0-1.0", name: "CC0 1.0",
               url: "https://creativecommons.org/publicdomain/zero/1.0/", aiInterpretation: .permits),
-        Entry(id: "pdm-1.0", name: "Public Domain Mark 1.0",
-              url: "https://creativecommons.org/publicdomain/mark/1.0/", aiInterpretation: .permits),
         Entry(id: "cc-by-4.0", name: "CC BY 4.0",
               url: "https://creativecommons.org/licenses/by/4.0/", aiInterpretation: .permits),
         Entry(id: "cc-by-sa-4.0", name: "CC BY-SA 4.0",
@@ -73,6 +71,10 @@ public enum LicenseCatalog {
     /// exception, so this is `.prohibits` rather than `.unclear`: unlike NC/ND (a live question
     /// about how far an *existing* grant reaches), there is no grant here to be uncertain about.
     public static let allRightsReservedInterpretation: AIInterpretation = .prohibits
+
+    /// A custom (non-catalog) license's grant is unknown by construction — Anglesite has never
+    /// read its text, so this is always `.unclear`, never guessed at.
+    public static let customLicenseInterpretation: AIInterpretation = .unclear
 
     /// The catalog entry a stored license refers to, matched on URL — a hand-edited `name` should
     /// not stop the picker recognizing a standard license. nil means custom or none.

--- a/Sources/AnglesiteCore/LicenseCatalog.swift
+++ b/Sources/AnglesiteCore/LicenseCatalog.swift
@@ -1,15 +1,32 @@
 import Foundation
 
-/// The licenses the Content Licensing facet offers, and the two rules relating a chosen license to
-/// the site's AI usage permissions (#991).
+/// The licenses the Content Licensing facet offers, and how each relates to the site's AI usage
+/// permissions (#991) and to the first-publish license gate's "AI systems" comparison column
+/// (#999).
 ///
 /// The classification is deliberately narrow. Whether model training is a "derivative work" or a
 /// "commercial use" is a live legal question, so only licenses whose grant unambiguously covers
-/// any use are marked `permitsAIUse`; NC and ND variants, custom URLs, and all-rights-reserved are
-/// left unclassified rather than interpreted. That follows the spike's rule that Anglesite never
-/// asserts on the user's behalf — see
+/// any use are marked `.permits`; NC and ND variants, custom URLs, and all-rights-reserved get
+/// `.unclear` unless a specific, defensible case exists to mark them otherwise (as
+/// `allRightsReservedInterpretation` below does — an unlicensed work grants no permission by
+/// construction, which is not the same live question NC/ND raise about an *existing* grant's
+/// scope). That follows the spike's rule that Anglesite never asserts on the user's behalf — see
 /// docs/superpowers/specs/2026-07-26-really-simple-licensing-spike.md §Q3.
 public enum LicenseCatalog {
+    /// How Anglesite reads a license's grant with respect to AI training/use. Three states, not
+    /// two, so "we don't know" and "this affirmatively grants nothing" stay distinguishable —
+    /// collapsing them back into a bool is what the #999 expansion was asked to stop doing.
+    public enum AIInterpretation: String, Sendable, Equatable, CaseIterable {
+        /// The license's grant unambiguously covers AI training and AI answers.
+        case permits
+        /// Not classified — the grant's scope with respect to AI use is a live legal question
+        /// Anglesite declines to resolve on the user's behalf.
+        case unclear
+        /// No permission is granted at all (the all-rights-reserved default) — distinct from
+        /// `.unclear`, which is about the *scope* of a grant that does exist.
+        case prohibits
+    }
+
     /// One offered license: stable picker identity, display strings, and the app-side AI-use
     /// classification (which is deliberately *not* part of what gets stored — see `ref`).
     public struct Entry: Sendable, Equatable, Hashable, Identifiable {
@@ -19,34 +36,43 @@ public enum LicenseCatalog {
         public let name: String
         /// Canonical deed URL — the identity `entry(for:)` matches stored licenses on.
         public let url: String
-        /// True when the license's grant unambiguously covers AI training and AI answers.
-        public let permitsAIUse: Bool
+        /// How this license's grant reads with respect to AI training and AI answers.
+        public let aiInterpretation: AIInterpretation
 
         /// The `LicenseRef` this entry stores and publishes — URL + name only. The
-        /// `permitsAIUse` classification stays app-side, because it is Anglesite's reading of
+        /// `aiInterpretation` classification stays app-side, because it is Anglesite's reading of
         /// the license, not something to assert on the user's behalf (see the type doc).
         public var ref: LicenseRef { LicenseRef(url: url, name: name) }
     }
 
-    /// The offered licenses in picker order: CC0 first, then the CC 4.0 suite from most to
-    /// least permissive. Extending this list requires the same "unambiguous grant" test the
-    /// type doc describes before setting `permitsAIUse`.
+    /// The offered licenses in picker order: CC0 and Public Domain Mark first, then the CC 4.0
+    /// suite from most to least permissive. Extending this list requires the same "unambiguous
+    /// grant" test the type doc describes before marking an entry `.permits`.
     public static let entries: [Entry] = [
         Entry(id: "cc0-1.0", name: "CC0 1.0",
-              url: "https://creativecommons.org/publicdomain/zero/1.0/", permitsAIUse: true),
+              url: "https://creativecommons.org/publicdomain/zero/1.0/", aiInterpretation: .permits),
+        Entry(id: "pdm-1.0", name: "Public Domain Mark 1.0",
+              url: "https://creativecommons.org/publicdomain/mark/1.0/", aiInterpretation: .permits),
         Entry(id: "cc-by-4.0", name: "CC BY 4.0",
-              url: "https://creativecommons.org/licenses/by/4.0/", permitsAIUse: true),
+              url: "https://creativecommons.org/licenses/by/4.0/", aiInterpretation: .permits),
         Entry(id: "cc-by-sa-4.0", name: "CC BY-SA 4.0",
-              url: "https://creativecommons.org/licenses/by-sa/4.0/", permitsAIUse: true),
+              url: "https://creativecommons.org/licenses/by-sa/4.0/", aiInterpretation: .permits),
         Entry(id: "cc-by-nc-4.0", name: "CC BY-NC 4.0",
-              url: "https://creativecommons.org/licenses/by-nc/4.0/", permitsAIUse: false),
+              url: "https://creativecommons.org/licenses/by-nc/4.0/", aiInterpretation: .unclear),
         Entry(id: "cc-by-nd-4.0", name: "CC BY-ND 4.0",
-              url: "https://creativecommons.org/licenses/by-nd/4.0/", permitsAIUse: false),
+              url: "https://creativecommons.org/licenses/by-nd/4.0/", aiInterpretation: .unclear),
         Entry(id: "cc-by-nc-sa-4.0", name: "CC BY-NC-SA 4.0",
-              url: "https://creativecommons.org/licenses/by-nc-sa/4.0/", permitsAIUse: false),
+              url: "https://creativecommons.org/licenses/by-nc-sa/4.0/", aiInterpretation: .unclear),
         Entry(id: "cc-by-nc-nd-4.0", name: "CC BY-NC-ND 4.0",
-              url: "https://creativecommons.org/licenses/by-nc-nd/4.0/", permitsAIUse: false),
+              url: "https://creativecommons.org/licenses/by-nc-nd/4.0/", aiInterpretation: .unclear),
     ]
+
+    /// "All rights reserved" — the untouched-scaffold default — is not a catalog entry (it has no
+    /// URL), but the first-publish gate's comparison table asks the same interpretation question
+    /// about it. An unlicensed work grants no permission under copyright law absent a stated TDM
+    /// exception, so this is `.prohibits` rather than `.unclear`: unlike NC/ND (a live question
+    /// about how far an *existing* grant reaches), there is no grant here to be uncertain about.
+    public static let allRightsReservedInterpretation: AIInterpretation = .prohibits
 
     /// The catalog entry a stored license refers to, matched on URL — a hand-edited `name` should
     /// not stop the picker recognizing a standard license. nil means custom or none.
@@ -59,7 +85,7 @@ public enum LicenseCatalog {
     /// the user has not stated. Overwriting a stated purpose would silently discard a deliberate
     /// choice, so this never does; an unclassified license suggests nothing at all.
     public static func prefilled(_ usage: AIUsage, for license: LicenseRef?) -> AIUsage {
-        guard entry(for: license)?.permitsAIUse == true else { return usage }
+        guard entry(for: license)?.aiInterpretation == .permits else { return usage }
         var filled = usage
         if filled.search == .unset { filled.search = .yes }
         if filled.aiInput == .unset { filled.aiInput = .yes }
@@ -80,7 +106,7 @@ public enum LicenseCatalog {
     /// requires is never flagged: it is the user's own content, and they may grant what they like.
     /// `search` is not an AI purpose and never triggers this.
     public static func coherenceWarning(for license: LicenseRef?, usage: AIUsage) -> CoherenceWarning? {
-        guard let entry = entry(for: license), entry.permitsAIUse else { return nil }
+        guard let entry = entry(for: license), entry.aiInterpretation == .permits else { return nil }
         guard usage.aiInput == .no || usage.aiTrain == .no else { return nil }
         return .licensePermitsDeniedUse(licenseName: entry.name)
     }

--- a/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
+++ b/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
@@ -1,0 +1,65 @@
+#if canImport(Darwin)
+import Foundation
+import UniformTypeIdentifiers
+
+/// Embeds a chosen license into a media file's own metadata (#999), so the license survives the
+/// file being downloaded or shared away from the page that originally stated it.
+///
+/// Pure `Data`-in/`Data`-out by design: this type never opens, reads, or writes a file on disk
+/// itself, and never mutates a caller-supplied file in place. Embedding a license is a
+/// destructive edit to a binary the caller may have no backup of — pushing "what happens to the
+/// result" onto the caller (write to a copy, use in a data URL, discard) means this utility can
+/// never be the thing that destroys a user's original file.
+///
+/// Only formats with a real metadata slot are written to; everything else is `.unsupported`
+/// rather than silently skipped or thrown, per the issue's explicit requirement. Video and audio
+/// are `.unsupported` in this version — see the plan doc's Global Constraints for why.
+public enum LicenseMetadataEmbedder {
+    /// One embed attempt's outcome.
+    public enum Result: Sendable, Equatable {
+        /// `type` has a metadata slot Anglesite can write to, and it now holds `license`.
+        case embedded(Data)
+        /// `type` has no metadata slot this embedder writes to (or isn't attempted yet, like
+        /// audio/video) — `data` is returned untouched by the caller, not by this type.
+        case unsupported
+    }
+
+    /// Why an attempt on a *supported* type still failed. Never thrown for a genuinely
+    /// unsupported format — that's `Result.unsupported`, not an error.
+    public enum EmbedError: Error, Equatable {
+        /// `data` couldn't be decoded as the format `type` claims it is.
+        case unreadable
+        /// The underlying framework refused to produce output bytes.
+        case writeFailed
+    }
+
+    /// Attempts to embed `license` into `data`, read as `type`.
+    ///
+    /// - Throws: ``EmbedError`` only when `type` is one of ``supportedTypes`` but the write
+    ///   itself failed (malformed input, encoder refusal). A `type` outside ``supportedTypes``
+    ///   always returns `.unsupported` and never throws.
+    public static func embed(_ license: LicenseRef, into data: Data, type: UTType) throws -> Result {
+        guard supportedTypes.contains(type) else { return .unsupported }
+        if imageTypes.contains(type) {
+            return .embedded(try embedIntoImage(license, data: data, type: type))
+        }
+        if type == .pdf {
+            return .embedded(try embedIntoPDF(license, data: data))
+        }
+        return .unsupported
+    }
+
+    /// UTTypes this embedder can write a license into today.
+    public static let supportedTypes: Set<UTType> = imageTypes.union([.pdf])
+
+    private static let imageTypes: Set<UTType> = [.jpeg, .png, .tiff, .heic]
+
+    private static func embedIntoImage(_ license: LicenseRef, data: Data, type: UTType) throws -> Data {
+        throw EmbedError.unreadable // placeholder body — replaced in Task 2
+    }
+
+    private static func embedIntoPDF(_ license: LicenseRef, data: Data) throws -> Data {
+        throw EmbedError.unreadable // placeholder body — replaced in Task 3
+    }
+}
+#endif

--- a/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
+++ b/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
@@ -1,6 +1,8 @@
 #if canImport(Darwin)
 import Foundation
 import UniformTypeIdentifiers
+import ImageIO
+import CoreGraphics
 
 /// Embeds a chosen license into a media file's own metadata (#999), so the license survives the
 /// file being downloaded or shared away from the page that originally stated it.
@@ -55,7 +57,46 @@ public enum LicenseMetadataEmbedder {
     private static let imageTypes: Set<UTType> = [.jpeg, .png, .tiff, .heic]
 
     private static func embedIntoImage(_ license: LicenseRef, data: Data, type: UTType) throws -> Data {
-        throw EmbedError.unreadable // placeholder body — replaced in Task 2
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              CGImageSourceGetCount(source) > 0,
+              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw EmbedError.unreadable
+        }
+
+        let existingProperties = (CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]) ?? [:]
+        let existingMetadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil)
+        let metadata = existingMetadata.flatMap { CGImageMetadataCreateMutableCopy($0) } ?? CGImageMetadataCreateMutable()
+
+        let xmpRightsNamespace = "http://ns.adobe.com/xap/1.0/rights/" as CFString
+        // Registration can no-op (return false) when the namespace is already present in a
+        // metadata copy carried over from `existingMetadata` — that's fine, not a failure.
+        _ = CGImageMetadataRegisterNamespaceForPrefix(metadata, xmpRightsNamespace, "xmpRights" as CFString, nil)
+
+        guard
+            let webStatementTag = CGImageMetadataTagCreate(
+                xmpRightsNamespace, "xmpRights" as CFString, "WebStatement" as CFString, .string,
+                license.url as CFTypeRef),
+            CGImageMetadataSetTagWithPath(metadata, nil, "xmpRights:WebStatement" as CFString, webStatementTag),
+            let usageTermsTag = CGImageMetadataTagCreate(
+                xmpRightsNamespace, "xmpRights" as CFString, "UsageTerms" as CFString, .string,
+                license.name as CFTypeRef),
+            CGImageMetadataSetTagWithPath(metadata, nil, "xmpRights:UsageTerms" as CFString, usageTermsTag),
+            let markedTag = CGImageMetadataTagCreate(
+                xmpRightsNamespace, "xmpRights" as CFString, "Marked" as CFString, .string, kCFBooleanTrue),
+            CGImageMetadataSetTagWithPath(metadata, nil, "xmpRights:Marked" as CFString, markedTag)
+        else {
+            throw EmbedError.writeFailed
+        }
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(output, type.identifier as CFString, 1, nil) else {
+            throw EmbedError.writeFailed
+        }
+        var options = existingProperties
+        options[kCGImageDestinationMergeMetadata] = true
+        CGImageDestinationAddImageAndMetadata(destination, cgImage, metadata, options as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else { throw EmbedError.writeFailed }
+        return output as Data
     }
 
     private static func embedIntoPDF(_ license: LicenseRef, data: Data) throws -> Data {

--- a/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
+++ b/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
@@ -128,13 +128,29 @@ public enum LicenseMetadataEmbedder {
     /// non-standard Info keys — Acrobat surfaces them only under its Custom properties tab, and
     /// no XMP-aware tool will find them there. Safe (page content is never touched); not a
     /// substitute for real XMP if that's ever needed.
+    ///
+    /// Serializes via `PDFDocument.write(to:)` into a scratch temp file (removed before
+    /// returning) rather than `dataRepresentation()`: the two are not equivalent in practice —
+    /// `dataRepresentation()` has a documented history of dropping document state on macOS
+    /// (confirmed here too: it silently discarded `documentAttributes`, including the pre-
+    /// existing Producer/CreationDate/ModDate keys, not just the new ones, on a CI runner's
+    /// PDFKit even though the identical code round-tripped cleanly in local testing).
+    /// `write(to:)` is the far more heavily used, disk-backed path and did not reproduce the
+    /// failure. The temp file never touches anything the caller supplied — this method's public
+    /// contract stays pure `Data` in, `Data` out.
     private static func embedIntoPDF(_ license: LicenseRef, data: Data) throws -> Data {
         guard let document = PDFDocument(data: data) else { throw EmbedError.unreadable }
         var attributes = document.documentAttributes ?? [:]
         attributes["Rights"] = license.name
         attributes["RightsURL"] = license.url
         document.documentAttributes = attributes
-        guard let output = document.dataRepresentation() else { throw EmbedError.writeFailed }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("pdf")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        guard document.write(to: tempURL) else { throw EmbedError.writeFailed }
+        guard let output = try? Data(contentsOf: tempURL) else { throw EmbedError.writeFailed }
         return output
     }
 }

--- a/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
+++ b/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
@@ -59,12 +59,10 @@ public enum LicenseMetadataEmbedder {
 
     private static func embedIntoImage(_ license: LicenseRef, data: Data, type: UTType) throws -> Data {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-              CGImageSourceGetCount(source) > 0,
-              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+              CGImageSourceGetCount(source) > 0 else {
             throw EmbedError.unreadable
         }
 
-        let existingProperties = (CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]) ?? [:]
         let existingMetadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil)
         let metadata = existingMetadata.flatMap { CGImageMetadataCreateMutableCopy($0) } ?? CGImageMetadataCreateMutable()
 
@@ -93,17 +91,48 @@ public enum LicenseMetadataEmbedder {
         guard let destination = CGImageDestinationCreateWithData(output, type.identifier as CFString, 1, nil) else {
             throw EmbedError.writeFailed
         }
-        var options = existingProperties
-        options[kCGImageDestinationMergeMetadata] = true
-        CGImageDestinationAddImageAndMetadata(destination, cgImage, metadata, options as CFDictionary)
-        guard CGImageDestinationFinalize(destination) else { throw EmbedError.writeFailed }
+
+        // PNG carve-out: `CGImageDestinationCopyImageSource`'s metadata merge silently drops the
+        // new XMP (no `iTXt` chunk is written at all — verified by dumping the output PNG's own
+        // chunk list) whenever the source PNG already carries an `eXIf` chunk (e.g. any image
+        // with an orientation property, which is common). JPEG/TIFF/HEIC don't share this bug —
+        // only PNG. PNG is lossless, so falling back to decode+re-encode here costs nothing the
+        // copy-source path was protecting against (no lossy recompression, no page/frame to
+        // drop): it's the same approach this file shipped and tested green with before this
+        // rewrite, scoped down to just the one format where the newer API misbehaves.
+        if type == .png {
+            guard let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+                throw EmbedError.unreadable
+            }
+            let existingProperties = (CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]) ?? [:]
+            var options = existingProperties
+            options[kCGImageDestinationMergeMetadata] = true
+            CGImageDestinationAddImageAndMetadata(destination, cgImage, metadata, options as CFDictionary)
+            guard CGImageDestinationFinalize(destination) else { throw EmbedError.writeFailed }
+            return output as Data
+        }
+
+        var writeError: Unmanaged<CFError>?
+        let copied = CGImageDestinationCopyImageSource(
+            destination, source,
+            [kCGImageDestinationMetadata: metadata, kCGImageDestinationMergeMetadata: true] as CFDictionary,
+            &writeError)
+        guard copied else { throw EmbedError.writeFailed }
         return output as Data
     }
 
+    /// Writes the license into the PDF's Info dictionary (`Rights`/`RightsURL`), not true XMP —
+    /// PDFKit's public API exposes no XMP packet writing, and retrofitting one into an existing
+    /// PDF would mean re-serializing every page through a fresh `CGContext`, risking forms,
+    /// links, and tags. This is a deliberate, lower-fidelity trade-off: `Rights`/`RightsURL` are
+    /// non-standard Info keys — Acrobat surfaces them only under its Custom properties tab, and
+    /// no XMP-aware tool will find them there. Safe (page content is never touched); not a
+    /// substitute for real XMP if that's ever needed.
     private static func embedIntoPDF(_ license: LicenseRef, data: Data) throws -> Data {
         guard let document = PDFDocument(data: data) else { throw EmbedError.unreadable }
         var attributes = document.documentAttributes ?? [:]
-        attributes["Rights"] = "\(license.name) — \(license.url)"
+        attributes["Rights"] = license.name
+        attributes["RightsURL"] = license.url
         document.documentAttributes = attributes
         guard let output = document.dataRepresentation() else { throw EmbedError.writeFailed }
         return output

--- a/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
+++ b/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
@@ -3,6 +3,7 @@ import Foundation
 import UniformTypeIdentifiers
 import ImageIO
 import CoreGraphics
+import PDFKit
 
 /// Embeds a chosen license into a media file's own metadata (#999), so the license survives the
 /// file being downloaded or shared away from the page that originally stated it.
@@ -100,7 +101,12 @@ public enum LicenseMetadataEmbedder {
     }
 
     private static func embedIntoPDF(_ license: LicenseRef, data: Data) throws -> Data {
-        throw EmbedError.unreadable // placeholder body — replaced in Task 3
+        guard let document = PDFDocument(data: data) else { throw EmbedError.unreadable }
+        var attributes = document.documentAttributes ?? [:]
+        attributes["Rights"] = "\(license.name) — \(license.url)"
+        document.documentAttributes = attributes
+        guard let output = document.dataRepresentation() else { throw EmbedError.writeFailed }
+        return output
     }
 }
 #endif

--- a/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
+++ b/Sources/AnglesiteCore/LicenseMetadataEmbedder.swift
@@ -3,7 +3,6 @@ import Foundation
 import UniformTypeIdentifiers
 import ImageIO
 import CoreGraphics
-import PDFKit
 
 /// Embeds a chosen license into a media file's own metadata (#999), so the license survives the
 /// file being downloaded or shared away from the page that originally stated it.
@@ -121,37 +120,81 @@ public enum LicenseMetadataEmbedder {
         return output as Data
     }
 
-    /// Writes the license into the PDF's Info dictionary (`Rights`/`RightsURL`), not true XMP —
-    /// PDFKit's public API exposes no XMP packet writing, and retrofitting one into an existing
-    /// PDF would mean re-serializing every page through a fresh `CGContext`, risking forms,
-    /// links, and tags. This is a deliberate, lower-fidelity trade-off: `Rights`/`RightsURL` are
-    /// non-standard Info keys — Acrobat surfaces them only under its Custom properties tab, and
-    /// no XMP-aware tool will find them there. Safe (page content is never touched); not a
-    /// substitute for real XMP if that's ever needed.
+    /// Writes the license as real XMP into the PDF's document metadata stream, via
+    /// `CGContext.addDocumentMetadata(_:)` — the actual Core Graphics API for this exact purpose,
+    /// not PDFKit's `documentAttributes` convenience property.
     ///
-    /// Serializes via `PDFDocument.write(to:)` into a scratch temp file (removed before
-    /// returning) rather than `dataRepresentation()`: the two are not equivalent in practice —
-    /// `dataRepresentation()` has a documented history of dropping document state on macOS
-    /// (confirmed here too: it silently discarded `documentAttributes`, including the pre-
-    /// existing Producer/CreationDate/ModDate keys, not just the new ones, on a CI runner's
-    /// PDFKit even though the identical code round-tripped cleanly in local testing).
-    /// `write(to:)` is the far more heavily used, disk-backed path and did not reproduce the
-    /// failure. The temp file never touches anything the caller supplied — this method's public
-    /// contract stays pure `Data` in, `Data` out.
+    /// `documentAttributes` was tried first (mutate + `dataRepresentation()`, then mutate +
+    /// `write(to:)` into a temp file): both round-tripped cleanly in local testing but silently
+    /// dropped *all* Info-dictionary state — not just the newly-set keys, the document's own
+    /// pre-existing `Producer`/`CreationDate`/`ModDate` too — on CI's PDFKit (a different macOS
+    /// version than local; confirmed twice, independent of which serialization method was used).
+    /// That pointed at `documentAttributes` mutation-after-open being unreliable across OS
+    /// versions, not a serialization-method choice. This implementation sidesteps PDFKit's
+    /// document-mutation path entirely: it reads the source with `CGPDFDocument`, opens a fresh
+    /// `CGContext` PDF writer, calls `addDocumentMetadata` before any page is added (required —
+    /// this is write-once, at creation), then copies each source page across with
+    /// `drawPDFPage`. Verified to preserve page count and every original Info-dictionary key
+    /// (CGContext auto-populates `Producer`/`CreationDate`/`ModDate` on the new document the same
+    /// way it did on the original), so the existing fidelity test needed no changes.
+    ///
+    /// The one known cost: page *content* is redrawn through Core Graphics rather than copied
+    /// byte-for-byte, so PDF forms, embedded JavaScript, and accessibility tags on the original
+    /// are not preserved. Anglesite doesn't generate or expect those in owner-attached photos/PDFs
+    /// today; flagged here for whoever picks this up if that ever changes.
     private static func embedIntoPDF(_ license: LicenseRef, data: Data) throws -> Data {
-        guard let document = PDFDocument(data: data) else { throw EmbedError.unreadable }
-        var attributes = document.documentAttributes ?? [:]
-        attributes["Rights"] = license.name
-        attributes["RightsURL"] = license.url
-        document.documentAttributes = attributes
+        guard let provider = CGDataProvider(data: data as CFData),
+              let sourceDocument = CGPDFDocument(provider),
+              sourceDocument.numberOfPages > 0,
+              let firstPage = sourceDocument.page(at: 1) else {
+            throw EmbedError.unreadable
+        }
 
-        let tempURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("pdf")
-        defer { try? FileManager.default.removeItem(at: tempURL) }
-        guard document.write(to: tempURL) else { throw EmbedError.writeFailed }
-        guard let output = try? Data(contentsOf: tempURL) else { throw EmbedError.writeFailed }
-        return output
+        let output = NSMutableData()
+        guard let consumer = CGDataConsumer(data: output) else { throw EmbedError.writeFailed }
+        var mediaBox = firstPage.getBoxRect(.mediaBox)
+        guard let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
+            throw EmbedError.writeFailed
+        }
+
+        context.addDocumentMetadata(pdfXMPPacket(for: license) as CFData)
+
+        for index in 1...sourceDocument.numberOfPages {
+            guard let page = sourceDocument.page(at: index) else { continue }
+            let pageBox = page.getBoxRect(.mediaBox)
+            context.beginPDFPage([kCGPDFContextMediaBox as String: pageBox] as CFDictionary)
+            context.drawPDFPage(page)
+            context.endPDFPage()
+        }
+        context.closePDF()
+
+        return output as Data
+    }
+
+    /// The XMP packet `embedIntoPDF` embeds — the same `xmpRights` fields `embedIntoImage` writes
+    /// (`WebStatement`/`UsageTerms`/`Marked`), so both backends read back identically for any
+    /// future caller (e.g. a drop-and-inspect flow) that wants one code path for either format.
+    private static func pdfXMPPacket(for license: LicenseRef) -> Data {
+        let url = xmlAttributeEscaped(license.url)
+        let name = xmlAttributeEscaped(license.name)
+        let packet = """
+        <?xpacket begin="\u{FEFF}" id="W5M0MpCehiHzreSzNTczkc9d"?>
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <rdf:Description rdf:about="" xmlns:xmpRights="http://ns.adobe.com/xap/1.0/rights/" \
+        xmpRights:WebStatement="\(url)" xmpRights:UsageTerms="\(name)" xmpRights:Marked="True"/>
+        </rdf:RDF>
+        </x:xmpmeta>
+        <?xpacket end="w"?>
+        """
+        return Data(packet.utf8)
+    }
+
+    private static func xmlAttributeEscaped(_ string: String) -> String {
+        string
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
     }
 }
 #endif

--- a/Sources/AnglesiteCore/LicensingStore.swift
+++ b/Sources/AnglesiteCore/LicensingStore.swift
@@ -211,6 +211,18 @@ public enum LicensableCollection: String, Sendable, Equatable, CaseIterable, Ide
         default: false
         }
     }
+
+    /// Best-effort collection for a page route like `/notes/my-slug/` — the route's first
+    /// non-empty path segment, when it names a licensable collection. `nil` for routes outside
+    /// every collection (the home page, static pages), which should resolve straight to the site
+    /// default via `LicensingPolicy.resolvedLicense(for: nil)`.
+    public init?(routePath: String) {
+        guard let segment = routePath.split(separator: "/", omittingEmptySubsequences: true).first,
+              let match = LicensableCollection(rawValue: String(segment)) else {
+            return nil
+        }
+        self = match
+    }
 }
 
 /// What one collection does about licensing. The three cases are exactly the three states
@@ -278,6 +290,39 @@ public struct LicensingPolicy: Sendable, Equatable {
         } else {
             collections[collection] = rule
         }
+    }
+
+    /// The license that applies to `collection`, or nil when nothing should be asserted.
+    /// Mirrors `resolveLicense` in `Resources/Template/src/lib/licensing.ts` exactly — this is
+    /// the Swift-side port of the same precedence rule (explicit per-collection entry, including
+    /// an explicit null, wins; then the non-asserting default; then the site default) — needed
+    /// app-side for the first time by the attach-time license picker (#999), which has to know
+    /// what a file's containing collection would resolve to *before* the file is written, not
+    /// just at template build time.
+    ///
+    /// `collection == nil` means a page outside every collection (e.g. a static `.astro` page) —
+    /// it resolves straight to the site default, since no per-collection rule can apply.
+    public func resolvedLicense(for collection: LicensableCollection?) -> LicenseRef? {
+        guard let collection else { return defaultLicense }
+        switch rule(for: collection) {
+        case .inherit:
+            return collection.assertsNothingByDefault ? nil : defaultLicense
+        case .assertNothing:
+            return nil
+        case .license(let ref):
+            return ref
+        }
+    }
+
+    /// Whether a per-file embedding control (the attach-time picker, and later the drop-and-
+    /// inspect picker) should be suppressed entirely for `collection` — the owner-locked rule
+    /// (#999, 2026-08-13): the four non-asserting collections don't get an embedding choice
+    /// offered at all, *unless* the site owner has explicitly overridden that collection with a
+    /// real license, in which case the override wins the same way it wins in `resolvedLicense`.
+    public func suppressesFileEmbedding(for collection: LicensableCollection?) -> Bool {
+        guard let collection else { return false }
+        if case .license = rule(for: collection) { return false }
+        return collection.assertsNothingByDefault
     }
 }
 

--- a/Tests/AnglesiteAppTests/InsertImageLicenseChoiceTests.swift
+++ b/Tests/AnglesiteAppTests/InsertImageLicenseChoiceTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteAppCore
+
+@Suite("InsertImageLicenseChoice (#999)")
+struct InsertImageLicenseChoiceTests {
+    private let ccBY = LicenseRef(url: "https://creativecommons.org/licenses/by/4.0/", name: "CC BY 4.0")
+
+    @Test("resolvedLicense is nil when disabled, regardless of catalogID")
+    func disabledResolvesNil() {
+        let choice = InsertImageLicenseChoice(isEnabled: false, catalogID: "cc-by-4.0")
+        #expect(choice.resolvedLicense() == nil)
+    }
+
+    @Test("resolvedLicense looks up the catalog entry when enabled")
+    func enabledResolvesCatalogEntry() {
+        let choice = InsertImageLicenseChoice(isEnabled: true, catalogID: "cc-by-4.0")
+        #expect(choice.resolvedLicense() == ccBY)
+    }
+
+    @Test("resolvedLicense is nil for an unrecognized catalogID even when enabled")
+    func unknownCatalogIDResolvesNil() {
+        let choice = InsertImageLicenseChoice(isEnabled: true, catalogID: "not-a-real-id")
+        #expect(choice.resolvedLicense() == nil)
+    }
+
+    @Test("initial seeds from lastUsed when present")
+    func initialFromLastUsed() {
+        let lastUsed = FileLicenseSelection(isEnabled: true, catalogID: "cc0-1.0")
+        let choice = InsertImageLicenseChoice.initial(resolvedDefault: ccBY, lastUsed: lastUsed)
+        #expect(choice == InsertImageLicenseChoice(isEnabled: true, catalogID: "cc0-1.0"))
+    }
+
+    @Test("initial falls back to the resolved collection default, disabled, when no lastUsed exists")
+    func initialFromResolvedDefault() {
+        let choice = InsertImageLicenseChoice.initial(resolvedDefault: ccBY, lastUsed: nil)
+        #expect(choice == InsertImageLicenseChoice(isEnabled: false, catalogID: "cc-by-4.0"))
+    }
+
+    @Test("initial falls back to the first catalog entry when there's no resolved default and no lastUsed")
+    func initialFallsBackToFirstCatalogEntry() {
+        let choice = InsertImageLicenseChoice.initial(resolvedDefault: nil, lastUsed: nil)
+        #expect(choice == InsertImageLicenseChoice(isEnabled: false, catalogID: LicenseCatalog.entries[0].id))
+    }
+
+    @Test("persisted round-trips through FileLicenseSelection")
+    func persistedRoundTrips() {
+        let choice = InsertImageLicenseChoice(isEnabled: true, catalogID: "cc-by-sa-4.0")
+        #expect(choice.persisted == FileLicenseSelection(isEnabled: true, catalogID: "cc-by-sa-4.0"))
+    }
+}

--- a/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
+++ b/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 import AnglesiteCore
 @testable import AnglesiteAppCore
@@ -96,12 +97,36 @@ struct LicenseGateSelectionTests {
         #expect(selection.resolvedLicense() == ref)
     }
 
-    @Test("every catalog entry's AI interpretation has a defined row label")
-    func everyInterpretationIsCovered() {
-        // LicenseGateSheetView.aiInterpretationLabel is private and unrenderable in a unit
-        // test, so this pins the *input* it must handle: every case of AIInterpretation, so a
-        // future case added to the enum without a matching row label fails loudly instead of
-        // silently falling through to a default.
-        #expect(LicenseCatalog.AIInterpretation.allCases == [.permits, .unclear, .prohibits])
+    @Test("aiInterpretationLabel gives every case a distinct, non-empty label")
+    @MainActor
+    func aiInterpretationLabelsAreDistinct() {
+        let view = LicenseGateSheetView(model: DeployModel())
+        let cases = LicenseCatalog.AIInterpretation.allCases
+        let labels = cases.map { view.aiInterpretationLabel($0) }
+        for label in labels {
+            #expect(label != LocalizedStringKey(""))
+        }
+        // LocalizedStringKey is Equatable but not Hashable, so compare pairwise rather than via Set.
+        for i in labels.indices {
+            for j in labels.indices where j > i {
+                #expect(labels[i] != labels[j], "\(cases[i]) and \(cases[j]) share a row label")
+            }
+        }
+    }
+
+    @Test("every catalog entry's Permits summary is distinct from its bare license name")
+    @MainActor
+    func permitsSummaryIsNotJustTheName() {
+        // Catches the class of bug the #999 review found: a `LicenseCatalog.entries` addition
+        // with no matching `case` in `permitsSummary(for:)`'s switch falls through to `default:
+        // return LocalizedStringKey(entry.name)`, silently repeating the license name in the
+        // Permits column instead of describing what the license actually permits.
+        let view = LicenseGateSheetView(model: DeployModel())
+        for entry in LicenseCatalog.entries {
+            let summary = view.permitsSummary(for: entry)
+            #expect(
+                summary != LocalizedStringKey(entry.name),
+                "\(entry.id) has no dedicated Permits summary case")
+        }
     }
 }

--- a/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
+++ b/Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
@@ -95,4 +95,13 @@ struct LicenseGateSelectionTests {
         // Still resolves back to the same ref, since an empty name falls back to the URL.
         #expect(selection.resolvedLicense() == ref)
     }
+
+    @Test("every catalog entry's AI interpretation has a defined row label")
+    func everyInterpretationIsCovered() {
+        // LicenseGateSheetView.aiInterpretationLabel is private and unrenderable in a unit
+        // test, so this pins the *input* it must handle: every case of AIInterpretation, so a
+        // future case added to the enum without a matching row label fails loudly instead of
+        // silently falling through to a default.
+        #expect(LicenseCatalog.AIInterpretation.allCases == [.permits, .unclear, .prohibits])
+    }
 }

--- a/Tests/AnglesiteCoreTests/FileLicenseSelectionTests.swift
+++ b/Tests/AnglesiteCoreTests/FileLicenseSelectionTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("AppSettings.lastUsedFileLicenseSelection (#999)")
+struct FileLicenseSelectionTests {
+    private func makeSettings() -> AppSettings {
+        let suiteName = "FileLicenseSelectionTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return AppSettings(defaults: defaults)
+    }
+
+    @Test("nil until a choice is ever persisted")
+    func absentByDefault() {
+        #expect(makeSettings().lastUsedFileLicenseSelection == nil)
+    }
+
+    @Test("round-trips a persisted choice")
+    func roundTrips() {
+        let settings = makeSettings()
+        let selection = FileLicenseSelection(isEnabled: true, catalogID: "cc-by-4.0")
+        settings.lastUsedFileLicenseSelection = selection
+        #expect(settings.lastUsedFileLicenseSelection == selection)
+    }
+
+    @Test("clearing writes back to nil")
+    func clears() {
+        let settings = makeSettings()
+        settings.lastUsedFileLicenseSelection = FileLicenseSelection(isEnabled: true, catalogID: "cc0-1.0")
+        settings.lastUsedFileLicenseSelection = nil
+        #expect(settings.lastUsedFileLicenseSelection == nil)
+    }
+}

--- a/Tests/AnglesiteCoreTests/LicenseCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/LicenseCatalogTests.swift
@@ -10,17 +10,17 @@ struct LicenseCatalogTests {
 
     @Test("every catalog entry has a safe URL and a unique id")
     func entriesWellFormed() {
-        #expect(LicenseCatalog.entries.count == 8)
+        #expect(LicenseCatalog.entries.count == 7)
         #expect(Set(LicenseCatalog.entries.map(\.id)).count == LicenseCatalog.entries.count)
         for entry in LicenseCatalog.entries {
             #expect(LicenseRef.isSafeLicenseURL(entry.url), "\(entry.id) has an unsafe URL")
         }
     }
 
-    @Test("only CC0, CC BY, CC BY-SA, and Public Domain Mark are classified as permitting AI use")
+    @Test("only CC0, CC BY, and CC BY-SA are classified as permitting AI use")
     func classification() {
         let permitting = Set(LicenseCatalog.entries.filter { $0.aiInterpretation == .permits }.map(\.id))
-        #expect(permitting == ["cc0-1.0", "cc-by-4.0", "cc-by-sa-4.0", "pdm-1.0"])
+        #expect(permitting == ["cc0-1.0", "cc-by-4.0", "cc-by-sa-4.0"])
         let unclear = Set(LicenseCatalog.entries.filter { $0.aiInterpretation == .unclear }.map(\.id))
         #expect(unclear == ["cc-by-nc-4.0", "cc-by-nd-4.0", "cc-by-nc-sa-4.0", "cc-by-nc-nd-4.0"])
     }
@@ -28,6 +28,11 @@ struct LicenseCatalogTests {
     @Test("all-rights-reserved is classified as prohibiting AI use — it grants no permission at all")
     func allRightsReservedInterpretation() {
         #expect(LicenseCatalog.allRightsReservedInterpretation == .prohibits)
+    }
+
+    @Test("a custom license is classified as unclear — its terms are never read")
+    func customLicenseInterpretation() {
+        #expect(LicenseCatalog.customLicenseInterpretation == .unclear)
     }
 
     @Test("entry(for:) matches by URL and returns nil for a custom or absent license")

--- a/Tests/AnglesiteCoreTests/LicenseCatalogTests.swift
+++ b/Tests/AnglesiteCoreTests/LicenseCatalogTests.swift
@@ -10,17 +10,24 @@ struct LicenseCatalogTests {
 
     @Test("every catalog entry has a safe URL and a unique id")
     func entriesWellFormed() {
-        #expect(LicenseCatalog.entries.count == 7)
+        #expect(LicenseCatalog.entries.count == 8)
         #expect(Set(LicenseCatalog.entries.map(\.id)).count == LicenseCatalog.entries.count)
         for entry in LicenseCatalog.entries {
             #expect(LicenseRef.isSafeLicenseURL(entry.url), "\(entry.id) has an unsafe URL")
         }
     }
 
-    @Test("only CC0, CC BY, and CC BY-SA are classified as permitting AI use")
+    @Test("only CC0, CC BY, CC BY-SA, and Public Domain Mark are classified as permitting AI use")
     func classification() {
-        let permitting = Set(LicenseCatalog.entries.filter(\.permitsAIUse).map(\.id))
-        #expect(permitting == ["cc0-1.0", "cc-by-4.0", "cc-by-sa-4.0"])
+        let permitting = Set(LicenseCatalog.entries.filter { $0.aiInterpretation == .permits }.map(\.id))
+        #expect(permitting == ["cc0-1.0", "cc-by-4.0", "cc-by-sa-4.0", "pdm-1.0"])
+        let unclear = Set(LicenseCatalog.entries.filter { $0.aiInterpretation == .unclear }.map(\.id))
+        #expect(unclear == ["cc-by-nc-4.0", "cc-by-nd-4.0", "cc-by-nc-sa-4.0", "cc-by-nc-nd-4.0"])
+    }
+
+    @Test("all-rights-reserved is classified as prohibiting AI use — it grants no permission at all")
+    func allRightsReservedInterpretation() {
+        #expect(LicenseCatalog.allRightsReservedInterpretation == .prohibits)
     }
 
     @Test("entry(for:) matches by URL and returns nil for a custom or absent license")

--- a/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
+++ b/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
@@ -180,16 +180,32 @@ struct LicenseMetadataEmbedderTests {
         return out as Data
     }
 
-    @Test("embedding into a PDF returns .embedded with the license in documentAttributes")
+    /// Reads the XMP packet `embedIntoPDF` writes back out — via `CGPDFDocument`'s catalog
+    /// `/Metadata` stream, the actual location `CGContext.addDocumentMetadata(_:)` writes to.
+    /// PDFKit has no XMP accessor, so this is the only way to verify the embed actually landed.
+    private func extractXMP(from data: Data) -> String? {
+        guard let provider = CGDataProvider(data: data as CFData),
+              let document = CGPDFDocument(provider),
+              let catalog = document.catalog else { return nil }
+        var metadataStream: CGPDFStreamRef?
+        guard CGPDFDictionaryGetStream(catalog, "Metadata", &metadataStream), let stream = metadataStream else {
+            return nil
+        }
+        var format: CGPDFDataFormat = .raw
+        guard let streamData = CGPDFStreamCopyData(stream, &format) else { return nil }
+        return String(data: streamData as Data, encoding: .utf8)
+    }
+
+    @Test("embedding into a PDF returns .embedded with the license in its XMP metadata")
     func embedsIntoPDF() throws {
         let result = try LicenseMetadataEmbedder.embed(license, into: onePagePDFData(), type: .pdf)
         guard case .embedded(let outData) = result else {
             Issue.record("expected .embedded, got \(result)")
             return
         }
-        let doc = PDFDocument(data: outData)!
-        #expect(doc.documentAttributes?["Rights"] as? String == license.name)
-        #expect(doc.documentAttributes?["RightsURL"] as? String == license.url)
+        let xmp = try #require(extractXMP(from: outData))
+        #expect(xmp.contains(license.url))
+        #expect(xmp.contains(license.name))
     }
 
     @Test("embedding into a PDF preserves page count and existing attributes")

--- a/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
+++ b/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
@@ -1,4 +1,6 @@
+import CoreGraphics
 import Foundation
+import ImageIO
 import Testing
 import UniformTypeIdentifiers
 @testable import AnglesiteCore
@@ -24,6 +26,70 @@ struct LicenseMetadataEmbedderTests {
         for type: UTType in [.mpeg4Movie, .quickTimeMovie, .mp3, .wav] {
             let result = try LicenseMetadataEmbedder.embed(license, into: Data(), type: type)
             #expect(result == .unsupported, "\(type.identifier) should be unsupported")
+        }
+    }
+
+    private func makeTestImage(width: Int = 4, height: Int = 4) -> CGImage {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let ctx = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8,
+                             bytesPerRow: 0, space: colorSpace,
+                             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        ctx.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return ctx.makeImage()!
+    }
+
+    private func pngData(properties: [CFString: Any] = [:]) -> Data {
+        let out = NSMutableData()
+        let dest = CGImageDestinationCreateWithData(out, UTType.png.identifier as CFString, 1, nil)!
+        CGImageDestinationAddImage(dest, makeTestImage(), properties as CFDictionary)
+        #expect(CGImageDestinationFinalize(dest))
+        return out as Data
+    }
+
+    @Test("embedding into a PNG returns .embedded with readable license metadata")
+    func embedsIntoPNG() throws {
+        let result = try LicenseMetadataEmbedder.embed(license, into: pngData(), type: .png)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        let source = CGImageSourceCreateWithData(outData as CFData, nil)!
+        let metadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil)!
+        let webStatementTag = CGImageMetadataCopyTagWithPath(metadata, nil, "xmpRights:WebStatement" as CFString)
+        #expect(CGImageMetadataTagCopyValue(webStatementTag!) as? String == license.url)
+        let markedTag = CGImageMetadataCopyTagWithPath(metadata, nil, "xmpRights:Marked" as CFString)
+        #expect(markedTag != nil)
+    }
+
+    @Test("embedding preserves existing image properties like orientation")
+    func preservesExistingProperties() throws {
+        // NOTE: PNG's pHYs chunk requires both DPI axes set together to preserve either one
+        // (verified live) — a single axis alone is silently dropped by ImageIO's PNG encoder.
+        // That's a fact about how this fixture must be constructed, not a limitation of PNG's
+        // format capabilities or of the embedder's merge logic.
+        let original = pngData(properties: [
+            kCGImagePropertyOrientation: 6,
+            kCGImagePropertyDPIWidth: 240,
+            kCGImagePropertyDPIHeight: 240,
+        ])
+        let result = try LicenseMetadataEmbedder.embed(license, into: original, type: .png)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        let source = CGImageSourceCreateWithData(outData as CFData, nil)!
+        let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+        #expect(props?[kCGImagePropertyOrientation] as? Int == 6)
+        #expect(props?[kCGImagePropertyDPIWidth] as? Int == 240)
+        #expect(props?[kCGImagePropertyDPIHeight] as? Int == 240)
+    }
+
+    @Test("unreadable image bytes throw .unreadable rather than returning .unsupported")
+    func unreadableImageThrows() {
+        let garbage = Data([0x00, 0x01, 0x02])
+        #expect(throws: LicenseMetadataEmbedder.EmbedError.unreadable) {
+            _ = try LicenseMetadataEmbedder.embed(license, into: garbage, type: .png)
         }
     }
 }

--- a/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
+++ b/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+@testable import AnglesiteCore
+
+@Suite("LicenseMetadataEmbedder (#999)")
+struct LicenseMetadataEmbedderTests {
+    private let license = LicenseRef(url: "https://creativecommons.org/licenses/by/4.0/", name: "CC BY 4.0")
+
+    @Test("a format with no metadata slot resolves to .unsupported, not an error")
+    func unsupportedFormatDoesNotThrow() throws {
+        let bytes = Data("not a real archive".utf8)
+        let result = try LicenseMetadataEmbedder.embed(license, into: bytes, type: .zip)
+        #expect(result == .unsupported)
+    }
+
+    @Test("supportedTypes lists exactly the image and PDF formats this plan implements")
+    func supportedTypesScope() {
+        #expect(LicenseMetadataEmbedder.supportedTypes == [.jpeg, .png, .tiff, .heic, .pdf])
+    }
+
+    @Test("audio and video types resolve to .unsupported (no AVFoundation backend yet)")
+    func avTypesUnsupported() throws {
+        for type: UTType in [.mpeg4Movie, .quickTimeMovie, .mp3, .wav] {
+            let result = try LicenseMetadataEmbedder.embed(license, into: Data(), type: type)
+            #expect(result == .unsupported, "\(type.identifier) should be unsupported")
+        }
+    }
+}

--- a/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
+++ b/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 import ImageIO
+import PDFKit
 import Testing
 import UniformTypeIdentifiers
 @testable import AnglesiteCore
@@ -90,6 +91,58 @@ struct LicenseMetadataEmbedderTests {
         let garbage = Data([0x00, 0x01, 0x02])
         #expect(throws: LicenseMetadataEmbedder.EmbedError.unreadable) {
             _ = try LicenseMetadataEmbedder.embed(license, into: garbage, type: .png)
+        }
+    }
+
+    private func onePagePDFData() -> Data {
+        var mediaBox = CGRect(x: 0, y: 0, width: 50, height: 50)
+        let out = NSMutableData()
+        let consumer = CGDataConsumer(data: out as CFMutableData)!
+        let ctx = CGContext(consumer: consumer, mediaBox: &mediaBox, nil)!
+        ctx.beginPDFPage(nil)
+        ctx.setFillColor(CGColor(red: 0, green: 1, blue: 0, alpha: 1))
+        ctx.fill(mediaBox)
+        ctx.endPDFPage()
+        ctx.closePDF()
+        return out as Data
+    }
+
+    @Test("embedding into a PDF returns .embedded with the license in documentAttributes")
+    func embedsIntoPDF() throws {
+        let result = try LicenseMetadataEmbedder.embed(license, into: onePagePDFData(), type: .pdf)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        let doc = PDFDocument(data: outData)!
+        let rights = doc.documentAttributes?["Rights"] as? String
+        #expect(rights?.contains(license.name) == true)
+        #expect(rights?.contains(license.url) == true)
+    }
+
+    @Test("embedding into a PDF preserves page count and existing attributes")
+    func preservesPDFFidelity() throws {
+        let original = onePagePDFData()
+        let originalDoc = PDFDocument(data: original)!
+        let originalAttrs = originalDoc.documentAttributes ?? [:]
+
+        let result = try LicenseMetadataEmbedder.embed(license, into: original, type: .pdf)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        let outDoc = PDFDocument(data: outData)!
+        #expect(outDoc.pageCount == originalDoc.pageCount)
+        for (key, _) in originalAttrs {
+            #expect(outDoc.documentAttributes?[key] != nil, "lost existing attribute \(key)")
+        }
+    }
+
+    @Test("unreadable PDF bytes throw .unreadable")
+    func unreadablePDFThrows() {
+        let garbage = Data([0x00, 0x01, 0x02])
+        #expect(throws: LicenseMetadataEmbedder.EmbedError.unreadable) {
+            _ = try LicenseMetadataEmbedder.embed(license, into: garbage, type: .pdf)
         }
     }
 }

--- a/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
+++ b/Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
@@ -60,7 +60,7 @@ struct LicenseMetadataEmbedderTests {
         let webStatementTag = CGImageMetadataCopyTagWithPath(metadata, nil, "xmpRights:WebStatement" as CFString)
         #expect(CGImageMetadataTagCopyValue(webStatementTag!) as? String == license.url)
         let markedTag = CGImageMetadataCopyTagWithPath(metadata, nil, "xmpRights:Marked" as CFString)
-        #expect(markedTag != nil)
+        #expect(CGImageMetadataTagCopyValue(markedTag!) as? String == "True")
     }
 
     @Test("embedding preserves existing image properties like orientation")
@@ -94,6 +94,79 @@ struct LicenseMetadataEmbedderTests {
         }
     }
 
+    private func makeDetailedTestImage(width: Int = 32, height: Int = 32) -> CGImage {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let ctx = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8,
+                             bytesPerRow: 0, space: colorSpace,
+                             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        for y in 0..<height {
+            for x in 0..<width {
+                let r = CGFloat((x * 7 + y * 13) % 256) / 255
+                let g = CGFloat((x * 31 + y * 3) % 256) / 255
+                let b = CGFloat((x * 5 + y * 17) % 256) / 255
+                ctx.setFillColor(CGColor(red: r, green: g, blue: b, alpha: 1))
+                ctx.fill(CGRect(x: x, y: y, width: 1, height: 1))
+            }
+        }
+        return ctx.makeImage()!
+    }
+
+    private func imageData(type: UTType) -> Data {
+        let out = NSMutableData()
+        let dest = CGImageDestinationCreateWithData(out, type.identifier as CFString, 1, nil)!
+        CGImageDestinationAddImage(dest, makeDetailedTestImage(), nil)
+        #expect(CGImageDestinationFinalize(dest))
+        return out as Data
+    }
+
+    private func exactPixelBytes(of data: Data) -> [UInt8] {
+        let source = CGImageSourceCreateWithData(data as CFData, nil)!
+        let image = CGImageSourceCreateImageAtIndex(source, 0, nil)!
+        let width = image.width, height = image.height
+        var buffer = [UInt8](repeating: 0, count: width * height * 4)
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let ctx = CGContext(data: &buffer, width: width, height: height, bitsPerComponent: 8,
+                             bytesPerRow: width * 4, space: colorSpace,
+                             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return buffer
+    }
+
+    @Test("every supported image type embeds a readable license",
+          arguments: [UTType.jpeg, .png, .tiff, .heic])
+    func everySupportedImageTypeRoundTrips(type: UTType) throws {
+        let original = imageData(type: type)
+        let result = try LicenseMetadataEmbedder.embed(license, into: original, type: type)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded for \(type.identifier), got \(result)")
+            return
+        }
+        let source = CGImageSourceCreateWithData(outData as CFData, nil)!
+        let metadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil)!
+        let tag = CGImageMetadataCopyTagWithPath(metadata, nil, "xmpRights:WebStatement" as CFString)
+        #expect(tag != nil, "\(type.identifier) is missing its license tag")
+        #expect(CGImageMetadataTagCopyValue(tag!) as? String == license.url)
+    }
+
+    @Test("embedding into a lossy format (JPEG) does not alter pixel content")
+    func jpegEmbedIsPixelLossless() throws {
+        let original = imageData(type: .jpeg)
+        let result = try LicenseMetadataEmbedder.embed(license, into: original, type: .jpeg)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        #expect(exactPixelBytes(of: original) == exactPixelBytes(of: outData))
+    }
+
+    @Test("a type argument that doesn't match the actual source format fails instead of silently transcoding")
+    func mismatchedTypeFails() {
+        let pngBytes = imageData(type: .png)
+        #expect(throws: LicenseMetadataEmbedder.EmbedError.writeFailed) {
+            _ = try LicenseMetadataEmbedder.embed(license, into: pngBytes, type: .jpeg)
+        }
+    }
+
     private func onePagePDFData() -> Data {
         var mediaBox = CGRect(x: 0, y: 0, width: 50, height: 50)
         let out = NSMutableData()
@@ -115,9 +188,8 @@ struct LicenseMetadataEmbedderTests {
             return
         }
         let doc = PDFDocument(data: outData)!
-        let rights = doc.documentAttributes?["Rights"] as? String
-        #expect(rights?.contains(license.name) == true)
-        #expect(rights?.contains(license.url) == true)
+        #expect(doc.documentAttributes?["Rights"] as? String == license.name)
+        #expect(doc.documentAttributes?["RightsURL"] as? String == license.url)
     }
 
     @Test("embedding into a PDF preserves page count and existing attributes")

--- a/Tests/AnglesiteCoreTests/LicensingStoreTests.swift
+++ b/Tests/AnglesiteCoreTests/LicensingStoreTests.swift
@@ -411,4 +411,53 @@ struct LicensingStoreTests {
         try write(#"{"licenseChosen":true}"#, to: dir)
         #expect(try LicensingStore(sourceDirectory: dir).load().licenseChosen == true)
     }
+
+    // MARK: resolvedLicense / suppressesFileEmbedding / LicensableCollection(routePath:) (#999)
+
+    @Test("resolvedLicense falls through inherit to the site default")
+    func resolvedLicenseInheritsSiteDefault() {
+        var policy = LicensingPolicy(defaultLicense: ccBY)
+        #expect(policy.resolvedLicense(for: .notes) == ccBY)
+        // A nil collection (a page outside every collection) also gets the site default.
+        #expect(policy.resolvedLicense(for: nil) == ccBY)
+        policy.setRule(.assertNothing, for: .notes)
+        #expect(policy.resolvedLicense(for: .notes) == nil)
+    }
+
+    @Test("resolvedLicense asserts nothing for non-asserting collections by default")
+    func resolvedLicenseNonAsserting() {
+        let policy = LicensingPolicy(defaultLicense: ccBY)
+        #expect(policy.resolvedLicense(for: .bookmarks) == nil)
+        #expect(policy.resolvedLicense(for: .replies) == nil)
+        #expect(policy.resolvedLicense(for: .likes) == nil)
+        #expect(policy.resolvedLicense(for: .reviews) == nil)
+        #expect(policy.resolvedLicense(for: .notes) == ccBY)
+    }
+
+    @Test("resolvedLicense honors an explicit override on a non-asserting collection")
+    func resolvedLicenseExplicitOverrideWins() {
+        var policy = LicensingPolicy(defaultLicense: nil)
+        policy.setRule(.license(ccBY), for: .bookmarks)
+        #expect(policy.resolvedLicense(for: .bookmarks) == ccBY)
+    }
+
+    @Test("suppressesFileEmbedding is true only for non-asserting collections with no override")
+    func suppressesFileEmbedding() {
+        var policy = LicensingPolicy(defaultLicense: ccBY)
+        #expect(policy.suppressesFileEmbedding(for: .bookmarks) == true)
+        #expect(policy.suppressesFileEmbedding(for: .notes) == false)
+        #expect(policy.suppressesFileEmbedding(for: nil) == false)
+        policy.setRule(.license(ccBY), for: .bookmarks)
+        #expect(policy.suppressesFileEmbedding(for: .bookmarks) == false)
+        policy.setRule(.assertNothing, for: .bookmarks)
+        #expect(policy.suppressesFileEmbedding(for: .bookmarks) == true)
+    }
+
+    @Test("LicensableCollection(routePath:) reads the route's first path segment")
+    func collectionFromRoutePath() {
+        #expect(LicensableCollection(routePath: "/notes/my-slug/") == .notes)
+        #expect(LicensableCollection(routePath: "photos/my-slug") == .photos)
+        #expect(LicensableCollection(routePath: "/") == nil)
+        #expect(LicensableCollection(routePath: "/about/") == nil)
+    }
 }

--- a/docs/superpowers/plans/2026-08-17-ai-interpretation-table-expansion.md
+++ b/docs/superpowers/plans/2026-08-17-ai-interpretation-table-expansion.md
@@ -1,0 +1,321 @@
+# AI-Interpretation Table Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `LicenseCatalog`'s boolean `permitsAIUse` classification with a three-state `AIInterpretation` (permits / unclear / prohibits), add one new catalog entry (Public Domain Mark 1.0), and give "All rights reserved" and "Custom…" their own explicit interpretation in the first-publish license gate's comparison table — closing part of #999 ("expand the AI-interpretation column beyond CC0/CC BY/CC BY-SA").
+
+**Architecture:** Pure model change in `AnglesiteCore/LicenseCatalog.swift` (one enum replaces one bool, plus one new entry), consumed by three existing call sites (`prefilled`, `coherenceWarning`, `LicenseGateSheetView`'s "AI systems" column). No new files, no new UI surfaces — this only changes what a table cell says and which licenses have a row.
+
+**Tech Stack:** Swift 6.4, Swift Testing (`@Suite`/`@Test`/`#expect`), SwiftUI.
+
+## Global Constraints
+
+- Never reclassify a license the model can't defend. Per `docs/superpowers/specs/2026-07-26-really-simple-licensing-spike.md` §Q3 and the existing doc comment on `LicenseCatalog`: whether AI training is a "derivative work" or "commercial use" is a live legal question, so CC BY-NC/BY-ND/BY-NC-SA/BY-NC-ND stay `.unclear` — this plan does not touch their classification, only the *type* it's expressed in.
+- No third-party dependencies; Apple frameworks / stdlib only (unchanged from current file).
+- Owner review gate: per issue #999's comment thread (2026-08-15), the expanded table "goes through owner review in the PR" — this plan implements the draft; it does not claim final legal sign-off.
+- Conventional commits, subject ≤72 chars, reference `#999`.
+
+---
+
+### Task 1: `AIInterpretation` enum + catalog migration
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/LicenseCatalog.swift`
+- Test: `Tests/AnglesiteCoreTests/LicenseCatalogTests.swift`
+
+**Interfaces:**
+- Produces: `public enum AIInterpretation: String, Sendable, Equatable, CaseIterable { case permits, unclear, prohibits }`; `LicenseCatalog.Entry.aiInterpretation: AIInterpretation` (replaces `permitsAIUse: Bool`); `LicenseCatalog.allRightsReservedInterpretation: AIInterpretation` (static constant, `.prohibits`).
+
+- [ ] **Step 1: Write the failing test for the richer classification**
+
+Replace the existing `classification` test in `Tests/AnglesiteCoreTests/LicenseCatalogTests.swift` (lines 20-24) with:
+
+```swift
+    @Test("only CC0, CC BY, CC BY-SA, and Public Domain Mark are classified as permitting AI use")
+    func classification() {
+        let permitting = Set(LicenseCatalog.entries.filter { $0.aiInterpretation == .permits }.map(\.id))
+        #expect(permitting == ["cc0-1.0", "cc-by-4.0", "cc-by-sa-4.0", "pdm-1.0"])
+        let unclear = Set(LicenseCatalog.entries.filter { $0.aiInterpretation == .unclear }.map(\.id))
+        #expect(unclear == ["cc-by-nc-4.0", "cc-by-nd-4.0", "cc-by-nc-sa-4.0", "cc-by-nc-nd-4.0"])
+    }
+
+    @Test("all-rights-reserved is classified as prohibiting AI use — it grants no permission at all")
+    func allRightsReservedInterpretation() {
+        #expect(LicenseCatalog.allRightsReservedInterpretation == .prohibits)
+    }
+```
+
+Also update `entriesWellFormed` (line 11-18) — the count changes from 7 to 8:
+
+```swift
+    @Test("every catalog entry has a safe URL and a unique id")
+    func entriesWellFormed() {
+        #expect(LicenseCatalog.entries.count == 8)
+        #expect(Set(LicenseCatalog.entries.map(\.id)).count == LicenseCatalog.entries.count)
+        for entry in LicenseCatalog.entries {
+            #expect(LicenseRef.isSafeLicenseURL(entry.url), "\(entry.id) has an unsafe URL")
+        }
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter LicenseCatalogTests`
+Expected: FAIL — `entriesWellFormed` fails on count (7 != 8), `classification`/`allRightsReservedInterpretation` fail to compile (`aiInterpretation`/`allRightsReservedInterpretation` don't exist yet).
+
+- [ ] **Step 3: Replace `permitsAIUse` with `aiInterpretation` and add the Public Domain Mark entry**
+
+In `Sources/AnglesiteCore/LicenseCatalog.swift`, replace the whole file's top doc comment, `Entry` struct, `entries` array, and add the new enum, so the file reads:
+
+```swift
+import Foundation
+
+/// The licenses the Content Licensing facet offers, and how each relates to the site's AI usage
+/// permissions (#991) and to the first-publish license gate's "AI systems" comparison column
+/// (#999).
+///
+/// The classification is deliberately narrow. Whether model training is a "derivative work" or a
+/// "commercial use" is a live legal question, so only licenses whose grant unambiguously covers
+/// any use are marked `.permits`; NC and ND variants, custom URLs, and all-rights-reserved get
+/// `.unclear` unless a specific, defensible case exists to mark them otherwise (as
+/// `allRightsReservedInterpretation` below does — an unlicensed work grants no permission by
+/// construction, which is not the same live question NC/ND raise about an *existing* grant's
+/// scope). That follows the spike's rule that Anglesite never asserts on the user's behalf — see
+/// docs/superpowers/specs/2026-07-26-really-simple-licensing-spike.md §Q3.
+public enum LicenseCatalog {
+    /// How Anglesite reads a license's grant with respect to AI training/use. Three states, not
+    /// two, so "we don't know" and "this affirmatively grants nothing" stay distinguishable —
+    /// collapsing them back into a bool is what the #999 expansion was asked to stop doing.
+    public enum AIInterpretation: String, Sendable, Equatable, CaseIterable {
+        /// The license's grant unambiguously covers AI training and AI answers.
+        case permits
+        /// Not classified — the grant's scope with respect to AI use is a live legal question
+        /// Anglesite declines to resolve on the user's behalf.
+        case unclear
+        /// No permission is granted at all (the all-rights-reserved default) — distinct from
+        /// `.unclear`, which is about the *scope* of a grant that does exist.
+        case prohibits
+    }
+
+    /// One offered license: stable picker identity, display strings, and the app-side AI-use
+    /// classification (which is deliberately *not* part of what gets stored — see `ref`).
+    public struct Entry: Sendable, Equatable, Hashable, Identifiable {
+        /// Stable across releases — it is the SwiftUI picker tag, not display text.
+        public let id: String
+        /// Display name shown in the picker, e.g. "CC BY 4.0".
+        public let name: String
+        /// Canonical deed URL — the identity `entry(for:)` matches stored licenses on.
+        public let url: String
+        /// How this license's grant reads with respect to AI training and AI answers.
+        public let aiInterpretation: AIInterpretation
+
+        /// The `LicenseRef` this entry stores and publishes — URL + name only. The
+        /// `aiInterpretation` classification stays app-side, because it is Anglesite's reading of
+        /// the license, not something to assert on the user's behalf (see the type doc).
+        public var ref: LicenseRef { LicenseRef(url: url, name: name) }
+    }
+
+    /// The offered licenses in picker order: CC0 and Public Domain Mark first, then the CC 4.0
+    /// suite from most to least permissive. Extending this list requires the same "unambiguous
+    /// grant" test the type doc describes before marking an entry `.permits`.
+    public static let entries: [Entry] = [
+        Entry(id: "cc0-1.0", name: "CC0 1.0",
+              url: "https://creativecommons.org/publicdomain/zero/1.0/", aiInterpretation: .permits),
+        Entry(id: "pdm-1.0", name: "Public Domain Mark 1.0",
+              url: "https://creativecommons.org/publicdomain/mark/1.0/", aiInterpretation: .permits),
+        Entry(id: "cc-by-4.0", name: "CC BY 4.0",
+              url: "https://creativecommons.org/licenses/by/4.0/", aiInterpretation: .permits),
+        Entry(id: "cc-by-sa-4.0", name: "CC BY-SA 4.0",
+              url: "https://creativecommons.org/licenses/by-sa/4.0/", aiInterpretation: .permits),
+        Entry(id: "cc-by-nc-4.0", name: "CC BY-NC 4.0",
+              url: "https://creativecommons.org/licenses/by-nc/4.0/", aiInterpretation: .unclear),
+        Entry(id: "cc-by-nd-4.0", name: "CC BY-ND 4.0",
+              url: "https://creativecommons.org/licenses/by-nd/4.0/", aiInterpretation: .unclear),
+        Entry(id: "cc-by-nc-sa-4.0", name: "CC BY-NC-SA 4.0",
+              url: "https://creativecommons.org/licenses/by-nc-sa/4.0/", aiInterpretation: .unclear),
+        Entry(id: "cc-by-nc-nd-4.0", name: "CC BY-NC-ND 4.0",
+              url: "https://creativecommons.org/licenses/by-nc-nd/4.0/", aiInterpretation: .unclear),
+    ]
+
+    /// "All rights reserved" — the untouched-scaffold default — is not a catalog entry (it has no
+    /// URL), but the first-publish gate's comparison table asks the same interpretation question
+    /// about it. An unlicensed work grants no permission under copyright law absent a stated TDM
+    /// exception, so this is `.prohibits` rather than `.unclear`: unlike NC/ND (a live question
+    /// about how far an *existing* grant reaches), there is no grant here to be uncertain about.
+    public static let allRightsReservedInterpretation: AIInterpretation = .prohibits
+
+    /// The catalog entry a stored license refers to, matched on URL — a hand-edited `name` should
+    /// not stop the picker recognizing a standard license. nil means custom or none.
+    public static func entry(for license: LicenseRef?) -> Entry? {
+        guard let license else { return nil }
+        return entries.first { $0.url == license.url }
+    }
+
+    /// Suggests AI permissions consistent with a newly-chosen license, filling **only** purposes
+    /// the user has not stated. Overwriting a stated purpose would silently discard a deliberate
+    /// choice, so this never does; an unclassified license suggests nothing at all.
+    public static func prefilled(_ usage: AIUsage, for license: LicenseRef?) -> AIUsage {
+        guard entry(for: license)?.aiInterpretation == .permits else { return usage }
+        var filled = usage
+        if filled.search == .unset { filled.search = .yes }
+        if filled.aiInput == .unset { filled.aiInput = .yes }
+        if filled.aiTrain == .unset { filled.aiTrain = .yes }
+        return filled
+    }
+
+    /// Why the facet should show an inline note, or nil when there is nothing to say. The typed
+    /// case (rather than a `String`) keeps user-facing copy in the app module where Xcode's string
+    /// extraction can reach it.
+    public enum CoherenceWarning: Sendable, Equatable {
+        /// The site default license already grants an AI use the policy asks crawlers not to make.
+        case licensePermitsDeniedUse(licenseName: String)
+    }
+
+    /// Fires only for a classified license against a denied AI purpose — the one contradiction
+    /// detectable without interpreting license text. Permitting *more* than a restrictive license
+    /// requires is never flagged: it is the user's own content, and they may grant what they like.
+    /// `search` is not an AI purpose and never triggers this.
+    public static func coherenceWarning(for license: LicenseRef?, usage: AIUsage) -> CoherenceWarning? {
+        guard let entry = entry(for: license), entry.aiInterpretation == .permits else { return nil }
+        guard usage.aiInput == .no || usage.aiTrain == .no else { return nil }
+        return .licensePermitsDeniedUse(licenseName: entry.name)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter LicenseCatalogTests`
+Expected: PASS — all `LicenseCatalogTests` cases green.
+
+- [ ] **Step 5: Run the full `AnglesiteCoreTests` suite to catch any other `permitsAIUse` reference**
+
+Run: `swift test --package-path . --filter AnglesiteCoreTests`
+Expected: PASS. If anything else references `permitsAIUse`, this fails with a compile error naming the file — fix it using the same `aiInterpretation` rename before moving on (Task 2 below already covers the one other known call site, `LicenseGateSheetView.swift`, which is `AnglesiteApp`, not `AnglesiteCoreTests` — a hit here would mean an undiscovered third call site).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LicenseCatalog.swift Tests/AnglesiteCoreTests/LicenseCatalogTests.swift
+git commit -m "feat(#999): expand license AI-interpretation to a 3-state model"
+```
+
+---
+
+### Task 2: Update `LicenseGateSheetView`'s "AI systems" column
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/LicenseGateSheetView.swift`
+- Test: `Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift`
+
+**Interfaces:**
+- Consumes: `LicenseCatalog.AIInterpretation` (Task 1), `LicenseCatalog.allRightsReservedInterpretation` (Task 1), `LicenseCatalog.Entry.aiInterpretation` (Task 1).
+- Produces: `LicenseGateSheetView.aiInterpretationLabel(_:) -> LocalizedStringKey` (private, but the table row values it drives are covered by Step 1's test via `permitsSummary`-style verification — see Step 1).
+
+- [ ] **Step 1: Write the failing test**
+
+`LicenseGateSelectionTests.swift` currently tests `LicenseGateSheetView.Selection` in isolation (it doesn't render the view). Since `aiInterpretationLabel` is a private view method, test it indirectly through the public classification it's driven by — add this to `Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift` (inside the existing `@Suite` struct, wherever the other `@Test`s live):
+
+```swift
+    @Test("every catalog entry's AI interpretation has a defined row label")
+    func everyInterpretationIsCovered() {
+        // LicenseGateSheetView.aiInterpretationLabel is private and unrenderable in a unit
+        // test, so this pins the *input* it must handle: every case of AIInterpretation, so a
+        // future case added to the enum without a matching row label fails loudly instead of
+        // silently falling through to a default.
+        #expect(LicenseCatalog.AIInterpretation.allCases == [.permits, .unclear, .prohibits])
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter LicenseGateSelectionTests`
+Expected: FAIL to compile — `AnglesiteAppTests` doesn't yet import/see `LicenseCatalog.AIInterpretation` as a 3-case enum (it does via Task 1's `AnglesiteCore` change already merged, so this specific test should actually PASS once Task 1 lands — if it fails, it's confirming the enum shape, which is the point: run it now to confirm the baseline before editing the view).
+
+- [ ] **Step 3: Update the view**
+
+In `Sources/AnglesiteApp/LicenseGateSheetView.swift`:
+
+Change the `row(...)` signature (lines 169-172) — `aiNote` is no longer optional:
+
+```swift
+    private func row(
+        title: LocalizedStringKey, permits: LocalizedStringKey, aiNote: LocalizedStringKey,
+        choice: Selection.Choice
+    ) -> some View {
+```
+
+Update the body of `row(...)` (line 182) to drop the `?? "—"` fallback:
+
+```swift
+                Text(aiNote)
+                    .font(.caption).foregroundStyle(.secondary)
+                    .frame(width: Self.aiColumnWidth, alignment: .leading)
+```
+
+Update the three call sites in `body` (lines 99-113):
+
+```swift
+                row(title: "All rights reserved", permits: "Nothing without asking",
+                    aiNote: aiInterpretationLabel(LicenseCatalog.allRightsReservedInterpretation),
+                    choice: .allRightsReserved)
+
+                ForEach(LicenseCatalog.entries) { entry in
+                    row(
+                        // A license's own name ("CC BY 4.0") is catalog data, not UI copy, so
+                        // it is deliberately not a literal key for extraction — the runtime
+                        // lookup just falls back to the name itself.
+                        title: LocalizedStringKey(entry.name),
+                        permits: permitsSummary(for: entry),
+                        aiNote: aiInterpretationLabel(entry.aiInterpretation),
+                        choice: .catalog(entry.id))
+                }
+
+                row(title: "Custom…", permits: "Your own terms",
+                    aiNote: aiInterpretationLabel(.unclear), choice: .custom)
+```
+
+Add the new label helper right after `permitsSummary(for:)` (after line 221, before the closing `}` of the view struct):
+
+```swift
+
+    /// Row copy for the "AI systems" column, keyed by the 3-state classification (#999) rather
+    /// than a bare bool — see `LicenseCatalog.AIInterpretation`.
+    private func aiInterpretationLabel(_ interpretation: LicenseCatalog.AIInterpretation) -> LocalizedStringKey {
+        switch interpretation {
+        case .permits: return "✅ Permits"
+        case .unclear: return "❔ Unclear"
+        case .prohibits: return "🚫 Prohibits"
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter LicenseGateSelectionTests`
+Expected: PASS.
+
+- [ ] **Step 5: Build the app target to catch any SwiftUI compile error the test suite can't**
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED. (`swift test` doesn't compile the app target's every file the same way a full app build does — run this because `LicenseGateSheetView.swift` is SwiftUI view code with no unit-test render pass.)
+
+- [ ] **Step 6: Run the full AnglesiteAppTests suite**
+
+Run: `swift test --package-path . --filter AnglesiteAppTests`
+Expected: PASS — confirms nothing else in `AnglesiteApp` broke from the `permitsAIUse` → `aiInterpretation` rename.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteApp/LicenseGateSheetView.swift Tests/AnglesiteAppTests/LicenseGateSelectionTests.swift
+git commit -m "feat(#999): show 3-state AI interpretation in the license gate table"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Issue #999's fourth scope item — "expand the table beyond CC0/BY/BY-SA... anything not explicitly classified must remain explicitly unresolved" — is covered: NC/ND variants are untouched (still `.unclear`), one new entry (Public Domain Mark) is added with a defensible `.permits` classification, and "All rights reserved"/"Custom…" get explicit (not silently blank) interpretations for the first time.
+- **Scope not covered here:** this plan only touches the picker/gate surface. `ContentLicensingTab.swift` (Settings ▸ Licensing) does not currently render an AI-interpretation column at all — confirmed by grep, no `permitsAIUse`/`aiNote` references there — so it needs no change.
+- **Owner review:** flag in the PR description that the Public Domain Mark addition and the "All rights reserved → prohibits" classification are the two *new* judgment calls in this table and should get explicit sign-off, per the issue's own requirement that this goes through owner review.

--- a/docs/superpowers/plans/2026-08-17-attach-time-license-metadata.md
+++ b/docs/superpowers/plans/2026-08-17-attach-time-license-metadata.md
@@ -1,0 +1,618 @@
+# Attach-Time License Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `Insert ▸ Image…`'s file-open panel grows a checkbox + license picker; when checked, the picked image's bytes get the chosen license embedded (via `LicenseMetadataEmbedder`) before insertion. The choice persists as the last-used selection. Non-asserting collections (bookmarks/replies/likes/reviews, with no explicit per-collection override) suppress the control entirely — issue #999, scope items 2 (consumer) and 3 ("Attach-time application").
+
+**Architecture:** `InsertCommands.insertImage(into:)` (the only image-import entry point in the app today — drag-and-drop onto the WKWebView is a separate, JS-driven path with no native file-open step, out of scope here and covered by a future "drop-and-inspect" plan) gains an `NSOpenPanel.accessoryView` with a plain `NSButton` checkbox and `NSPopUpButton`, mirroring the existing accessory-view idiom in `Sources/AnglesiteApp/SiteActions.swift:196-201`. The checkbox/popup *state* is extracted into a plain, unit-testable struct (`InsertImageLicenseChoice`), matching the established pattern in `LicenseGateSheetView.Selection` — AppKit control reads/writes stay in the thin glue, all actual logic is testable without a hosted view.
+
+**Tech Stack:** Swift 6.4, AppKit (`NSOpenPanel`, `NSButton`, `NSPopUpButton`), AnglesiteCore (`LicenseMetadataEmbedder`, `LicensingStore`, `LicensingPolicy`, `LicenseCatalog`, `AppSettings`), Swift Testing.
+
+## Global Constraints
+
+- **Depends on the embedded-license-metadata plan** (`docs/superpowers/plans/2026-08-17-embedded-license-metadata.md`) — `LicenseMetadataEmbedder` must exist before Task 3 of this plan. Tasks 1-2 (model/persistence additions) have no such dependency and can land first.
+- **Non-asserting collections suppress the control entirely**, per the owner decision recorded on issue #999 (2026-08-13 comment): "The four non-asserting collections (bookmarks, replies, likes, reviews) suppress embedded license metadata — consistent with those collections not asserting a license claim over content the owner didn't create." An *explicit* per-collection license override still allows embedding — only the *default* non-asserting behavior suppresses it.
+- **The selection persists as the last-used choice**, per issue #999 scope item 3. Follows the existing `AppSettings` `UserDefaults`-backed-key pattern (`Sources/AnglesiteCore/AppSettings.swift`), not a new storage mechanism.
+- **No custom-license text entry in this compact accessory view.** `NSPopUpButton` doesn't lend itself to free-form URL/name entry the way `LicenseGateSheetView`'s SwiftUI sheet does. This plan's picker offers "Don't embed a license" (checkbox off) plus every `LicenseCatalog.entries` catalog license. A custom per-file license is out of scope for this plan; note this explicitly in the PR description as a scope cut, not a silent gap.
+- Apple frameworks only. No new third-party dependencies.
+- Conventional commits, subject ≤72 chars, reference `#999`.
+
+---
+
+### Task 1: `LicensingPolicy.resolvedLicense(for:)`, `suppressesFileEmbedding(for:)`, and `LicensableCollection(routePath:)`
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/LicensingStore.swift`
+- Test: `Tests/AnglesiteCoreTests/LicensingStoreTests.swift`
+
+**Interfaces:**
+- Consumes: `LicensingPolicy`, `LicensableCollection`, `CollectionLicenseRule`, `LicenseRef` (all existing in this file).
+- Produces:
+  ```swift
+  extension LicensingPolicy {
+      public func resolvedLicense(for collection: LicensableCollection?) -> LicenseRef?
+      public func suppressesFileEmbedding(for collection: LicensableCollection?) -> Bool
+  }
+  extension LicensableCollection {
+      public init?(routePath: String)
+  }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/LicensingStoreTests.swift` (inside the existing `@Suite` struct):
+
+```swift
+    @Test("resolvedLicense falls through inherit to the site default")
+    func resolvedLicenseInheritsSiteDefault() {
+        var policy = LicensingPolicy(defaultLicense: ccBY)
+        #expect(policy.resolvedLicense(for: .notes) == ccBY)
+        // A nil collection (a page outside every collection) also gets the site default.
+        #expect(policy.resolvedLicense(for: nil) == ccBY)
+        policy.setRule(.assertNothing, for: .notes)
+        #expect(policy.resolvedLicense(for: .notes) == nil)
+    }
+
+    @Test("resolvedLicense asserts nothing for non-asserting collections by default")
+    func resolvedLicenseNonAsserting() {
+        let policy = LicensingPolicy(defaultLicense: ccBY)
+        #expect(policy.resolvedLicense(for: .bookmarks) == nil)
+        #expect(policy.resolvedLicense(for: .replies) == nil)
+        #expect(policy.resolvedLicense(for: .likes) == nil)
+        #expect(policy.resolvedLicense(for: .reviews) == nil)
+        #expect(policy.resolvedLicense(for: .notes) == ccBY)
+    }
+
+    @Test("resolvedLicense honors an explicit override on a non-asserting collection")
+    func resolvedLicenseExplicitOverrideWins() {
+        var policy = LicensingPolicy(defaultLicense: nil)
+        policy.setRule(.license(ccBY), for: .bookmarks)
+        #expect(policy.resolvedLicense(for: .bookmarks) == ccBY)
+    }
+
+    @Test("suppressesFileEmbedding is true only for non-asserting collections with no override")
+    func suppressesFileEmbedding() {
+        var policy = LicensingPolicy(defaultLicense: ccBY)
+        #expect(policy.suppressesFileEmbedding(for: .bookmarks) == true)
+        #expect(policy.suppressesFileEmbedding(for: .notes) == false)
+        #expect(policy.suppressesFileEmbedding(for: nil) == false)
+        policy.setRule(.license(ccBY), for: .bookmarks)
+        #expect(policy.suppressesFileEmbedding(for: .bookmarks) == false)
+        policy.setRule(.assertNothing, for: .bookmarks)
+        #expect(policy.suppressesFileEmbedding(for: .bookmarks) == true)
+    }
+
+    @Test("LicensableCollection(routePath:) reads the route's first path segment")
+    func collectionFromRoutePath() {
+        #expect(LicensableCollection(routePath: "/notes/my-slug/") == .notes)
+        #expect(LicensableCollection(routePath: "photos/my-slug") == .photos)
+        #expect(LicensableCollection(routePath: "/") == nil)
+        #expect(LicensableCollection(routePath: "/about/") == nil)
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter LicensingStoreTests`
+Expected: FAIL to build — `resolvedLicense`, `suppressesFileEmbedding`, and `LicensableCollection(routePath:)` don't exist yet.
+
+- [ ] **Step 3: Implement the three additions**
+
+In `Sources/AnglesiteCore/LicensingStore.swift`, add after the closing brace of the `LicensingPolicy` struct's `setRule(_:for:)` method (immediately before the struct's closing `}`, i.e. right after the existing `rule(for:)`/`setRule(_:for:)` pair described in the file):
+
+```swift
+
+    /// The license that applies to `collection`, or nil when nothing should be asserted.
+    /// Mirrors `resolveLicense` in `Resources/Template/src/lib/licensing.ts` exactly — this is
+    /// the Swift-side port of the same precedence rule (explicit per-collection entry, including
+    /// an explicit null, wins; then the non-asserting default; then the site default) — needed
+    /// app-side for the first time by the attach-time license picker (#999), which has to know
+    /// what a file's containing collection would resolve to *before* the file is written, not
+    /// just at template build time.
+    ///
+    /// `collection == nil` means a page outside every collection (e.g. a static `.astro` page) —
+    /// it resolves straight to the site default, since no per-collection rule can apply.
+    public func resolvedLicense(for collection: LicensableCollection?) -> LicenseRef? {
+        guard let collection else { return defaultLicense }
+        switch rule(for: collection) {
+        case .inherit:
+            return collection.assertsNothingByDefault ? nil : defaultLicense
+        case .assertNothing:
+            return nil
+        case .license(let ref):
+            return ref
+        }
+    }
+
+    /// Whether a per-file embedding control (the attach-time picker, and later the drop-and-
+    /// inspect picker) should be suppressed entirely for `collection` — the owner-locked rule
+    /// (#999, 2026-08-13): the four non-asserting collections don't get an embedding choice
+    /// offered at all, *unless* the site owner has explicitly overridden that collection with a
+    /// real license, in which case the override wins the same way it wins in `resolvedLicense`.
+    public func suppressesFileEmbedding(for collection: LicensableCollection?) -> Bool {
+        guard let collection else { return false }
+        if case .license = rule(for: collection) { return false }
+        return collection.assertsNothingByDefault
+    }
+```
+
+Add after the closing brace of the `LicensableCollection` enum (right after its `assertsNothingByDefault` computed property, before the enum's closing `}`):
+
+```swift
+
+    /// Best-effort collection for a page route like `/notes/my-slug/` — the route's first
+    /// non-empty path segment, when it names a licensable collection. `nil` for routes outside
+    /// every collection (the home page, static pages), which should resolve straight to the site
+    /// default via `LicensingPolicy.resolvedLicense(for: nil)`.
+    public init?(routePath: String) {
+        guard let segment = routePath.split(separator: "/", omittingEmptySubsequences: true).first,
+              let match = LicensableCollection(rawValue: String(segment)) else {
+            return nil
+        }
+        self = match
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter LicensingStoreTests`
+Expected: PASS — all cases, including the five new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LicensingStore.swift Tests/AnglesiteCoreTests/LicensingStoreTests.swift
+git commit -m "feat(#999): add LicensingPolicy.resolvedLicense and route-to-collection lookup"
+```
+
+---
+
+### Task 2: Last-used file-license choice persistence
+
+**Files:**
+- Create: `Sources/AnglesiteCore/FileLicenseSelection.swift`
+- Modify: `Sources/AnglesiteCore/AppSettings.swift`
+- Test: `Tests/AnglesiteCoreTests/FileLicenseSelectionTests.swift`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  ```swift
+  public struct FileLicenseSelection: Codable, Equatable, Sendable {
+      public var isEnabled: Bool
+      public var catalogID: String
+      public init(isEnabled: Bool, catalogID: String)
+  }
+  extension AppSettings {
+      public var lastUsedFileLicenseSelection: FileLicenseSelection? { get set }
+  }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AnglesiteCoreTests/FileLicenseSelectionTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import AnglesiteCore
+
+@Suite("AppSettings.lastUsedFileLicenseSelection (#999)")
+struct FileLicenseSelectionTests {
+    private func makeSettings() -> AppSettings {
+        let suiteName = "FileLicenseSelectionTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return AppSettings(defaults: defaults)
+    }
+
+    @Test("nil until a choice is ever persisted")
+    func absentByDefault() {
+        #expect(makeSettings().lastUsedFileLicenseSelection == nil)
+    }
+
+    @Test("round-trips a persisted choice")
+    func roundTrips() {
+        let settings = makeSettings()
+        let selection = FileLicenseSelection(isEnabled: true, catalogID: "cc-by-4.0")
+        settings.lastUsedFileLicenseSelection = selection
+        #expect(settings.lastUsedFileLicenseSelection == selection)
+    }
+
+    @Test("clearing writes back to nil")
+    func clears() {
+        let settings = makeSettings()
+        settings.lastUsedFileLicenseSelection = FileLicenseSelection(isEnabled: true, catalogID: "cc0-1.0")
+        settings.lastUsedFileLicenseSelection = nil
+        #expect(settings.lastUsedFileLicenseSelection == nil)
+    }
+}
+```
+
+Note: this test assumes `AppSettings` has a non-`shared` initializer taking a `UserDefaults` instance directly — confirm this exists (it's implied by the type doc comment "tests should construct their own instance with a scratch `UserDefaults` suite" in `Sources/AnglesiteCore/AppSettings.swift:9-10`); if the initializer's exact label differs from `AppSettings(defaults:)`, match whatever `init` the type already declares instead of introducing a second one.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter FileLicenseSelectionTests`
+Expected: FAIL to build — `FileLicenseSelection` and `lastUsedFileLicenseSelection` don't exist yet.
+
+- [ ] **Step 3: Create `FileLicenseSelection`**
+
+Create `Sources/AnglesiteCore/FileLicenseSelection.swift`:
+
+```swift
+import Foundation
+
+/// The attach-time license picker's persisted last-used choice (#999) — so a site owner who
+/// licenses all their photos the same way sets it once. Deliberately just an on/off flag plus a
+/// `LicenseCatalog` id rather than a full `LicenseRef`: this picker offers catalog licenses only
+/// (no custom URL entry — see the plan doc's Global Constraints), so a stable catalog id is
+/// enough to restore the exact same choice next time, and stays valid even if a catalog entry's
+/// display name ever changes.
+public struct FileLicenseSelection: Codable, Equatable, Sendable {
+    /// Whether the checkbox was on — i.e. whether a license should be embedded at all.
+    public var isEnabled: Bool
+    /// `LicenseCatalog.Entry.id` of the picked license. Meaningful only when `isEnabled`; kept
+    /// even when disabled so re-enabling the checkbox restores the same picker selection.
+    public var catalogID: String
+
+    public init(isEnabled: Bool, catalogID: String) {
+        self.isEnabled = isEnabled
+        self.catalogID = catalogID
+    }
+}
+```
+
+- [ ] **Step 4: Add the `AppSettings` key and computed property**
+
+In `Sources/AnglesiteCore/AppSettings.swift`, add a new key inside `enum Key` (after the existing `externalLLMVerifiedDetail` key, following the file's existing ordering-by-addition convention):
+
+```swift
+        /// Backs ``AppSettings/lastUsedFileLicenseSelection`` (#999).
+        public static let lastUsedFileLicenseSelection = "anglesite.lastUsedFileLicenseSelection"
+```
+
+Add the computed property near the other JSON-backed optional properties (following the exact `externalLLMVerifiedBaseURL`-style optional-with-explicit-remove pattern already in this file):
+
+```swift
+
+    /// The attach-time license picker's last-used choice (#999) — `nil` until the picker has
+    /// been used at least once. JSON-encoded because `FileLicenseSelection` is a small struct,
+    /// not a primitive `UserDefaults` can store directly.
+    public var lastUsedFileLicenseSelection: FileLicenseSelection? {
+        get {
+            guard let data = defaults.data(forKey: Key.lastUsedFileLicenseSelection) else { return nil }
+            return try? JSONDecoder().decode(FileLicenseSelection.self, from: data)
+        }
+        set {
+            if let newValue, let data = try? JSONEncoder().encode(newValue) {
+                defaults.set(data, forKey: Key.lastUsedFileLicenseSelection)
+            } else {
+                defaults.removeObject(forKey: Key.lastUsedFileLicenseSelection)
+            }
+        }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter FileLicenseSelectionTests`
+Expected: PASS — all three cases.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AnglesiteCore/FileLicenseSelection.swift Sources/AnglesiteCore/AppSettings.swift Tests/AnglesiteCoreTests/FileLicenseSelectionTests.swift
+git commit -m "feat(#999): persist the attach-time license picker's last-used choice"
+```
+
+---
+
+### Task 3: `InsertImageLicenseChoice` (pure picker state)
+
+**Files:**
+- Create: `Sources/AnglesiteApp/InsertImageLicenseChoice.swift`
+- Test: `Tests/AnglesiteAppTests/InsertImageLicenseChoiceTests.swift`
+
+**Interfaces:**
+- Consumes: `LicenseCatalog`, `LicenseRef` (AnglesiteCore), `FileLicenseSelection` (Task 2).
+- Produces:
+  ```swift
+  struct InsertImageLicenseChoice: Equatable {
+      var isEnabled: Bool
+      var catalogID: String
+      func resolvedLicense() -> LicenseRef?
+      static func initial(resolvedDefault: LicenseRef?, lastUsed: FileLicenseSelection?) -> InsertImageLicenseChoice
+      var persisted: FileLicenseSelection { get }
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/AnglesiteAppTests/InsertImageLicenseChoiceTests.swift`:
+
+```swift
+import Foundation
+import Testing
+import AnglesiteCore
+@testable import AnglesiteApp
+
+@Suite("InsertImageLicenseChoice (#999)")
+struct InsertImageLicenseChoiceTests {
+    private let ccBY = LicenseRef(url: "https://creativecommons.org/licenses/by/4.0/", name: "CC BY 4.0")
+
+    @Test("resolvedLicense is nil when disabled, regardless of catalogID")
+    func disabledResolvesNil() {
+        let choice = InsertImageLicenseChoice(isEnabled: false, catalogID: "cc-by-4.0")
+        #expect(choice.resolvedLicense() == nil)
+    }
+
+    @Test("resolvedLicense looks up the catalog entry when enabled")
+    func enabledResolvesCatalogEntry() {
+        let choice = InsertImageLicenseChoice(isEnabled: true, catalogID: "cc-by-4.0")
+        #expect(choice.resolvedLicense() == ccBY)
+    }
+
+    @Test("resolvedLicense is nil for an unrecognized catalogID even when enabled")
+    func unknownCatalogIDResolvesNil() {
+        let choice = InsertImageLicenseChoice(isEnabled: true, catalogID: "not-a-real-id")
+        #expect(choice.resolvedLicense() == nil)
+    }
+
+    @Test("initial seeds from lastUsed when present")
+    func initialFromLastUsed() {
+        let lastUsed = FileLicenseSelection(isEnabled: true, catalogID: "cc0-1.0")
+        let choice = InsertImageLicenseChoice.initial(resolvedDefault: ccBY, lastUsed: lastUsed)
+        #expect(choice == InsertImageLicenseChoice(isEnabled: true, catalogID: "cc0-1.0"))
+    }
+
+    @Test("initial falls back to the resolved collection default, disabled, when no lastUsed exists")
+    func initialFromResolvedDefault() {
+        let choice = InsertImageLicenseChoice.initial(resolvedDefault: ccBY, lastUsed: nil)
+        #expect(choice == InsertImageLicenseChoice(isEnabled: false, catalogID: "cc-by-4.0"))
+    }
+
+    @Test("initial falls back to the first catalog entry when there's no resolved default and no lastUsed")
+    func initialFallsBackToFirstCatalogEntry() {
+        let choice = InsertImageLicenseChoice.initial(resolvedDefault: nil, lastUsed: nil)
+        #expect(choice == InsertImageLicenseChoice(isEnabled: false, catalogID: LicenseCatalog.entries[0].id))
+    }
+
+    @Test("persisted round-trips through FileLicenseSelection")
+    func persistedRoundTrips() {
+        let choice = InsertImageLicenseChoice(isEnabled: true, catalogID: "cc-by-sa-4.0")
+        #expect(choice.persisted == FileLicenseSelection(isEnabled: true, catalogID: "cc-by-sa-4.0"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `swift test --package-path . --filter InsertImageLicenseChoiceTests`
+Expected: FAIL to build — `InsertImageLicenseChoice` doesn't exist yet.
+
+- [ ] **Step 3: Implement `InsertImageLicenseChoice`**
+
+Create `Sources/AnglesiteApp/InsertImageLicenseChoice.swift`:
+
+```swift
+import Foundation
+import AnglesiteCore
+
+/// `Insert ▸ Image…`'s license-embedding checkbox + picker, held as a plain value (not directly
+/// as AppKit control state) so its resolution logic is unit-testable without a live
+/// `NSOpenPanel` — mirrors `LicenseGateSheetView.Selection`'s reasoning exactly. Internal (not
+/// `private`) so tests can construct and compare it directly.
+struct InsertImageLicenseChoice: Equatable {
+    /// Whether the checkbox is on — whether a license should be embedded into the picked file
+    /// at all.
+    var isEnabled: Bool
+    /// The `LicenseCatalog.Entry.id` currently selected in the popup, meaningful only when
+    /// `isEnabled` (but always a valid id, so re-enabling the checkbox shows a real choice).
+    var catalogID: String
+
+    /// The license to embed, or nil when the checkbox is off or the id doesn't match a known
+    /// catalog entry (defensive — the picker only ever offers real ids, so this should not
+    /// happen in practice).
+    func resolvedLicense() -> LicenseRef? {
+        guard isEnabled else { return nil }
+        return LicenseCatalog.entries.first { $0.id == catalogID }?.ref
+    }
+
+    /// The initial picker state when `Insert ▸ Image…` opens: the persisted last-used choice
+    /// when one exists, otherwise the page's resolved collection license as the popup's
+    /// starting selection — but with the checkbox left **off**, since embedding is a
+    /// destructive edit and this is the very first time the picker has been shown. Falls back
+    /// to the catalog's first entry when there is no resolved default to seed from at all (an
+    /// untouched site, or a page outside every collection with no site-wide default either) —
+    /// the popup must always show a real selection.
+    static func initial(resolvedDefault: LicenseRef?, lastUsed: FileLicenseSelection?) -> InsertImageLicenseChoice {
+        if let lastUsed {
+            return InsertImageLicenseChoice(isEnabled: lastUsed.isEnabled, catalogID: lastUsed.catalogID)
+        }
+        let fallbackID = LicenseCatalog.entry(for: resolvedDefault)?.id ?? LicenseCatalog.entries[0].id
+        return InsertImageLicenseChoice(isEnabled: false, catalogID: fallbackID)
+    }
+
+    /// The form this choice is persisted as (`AppSettings.lastUsedFileLicenseSelection`).
+    var persisted: FileLicenseSelection {
+        FileLicenseSelection(isEnabled: isEnabled, catalogID: catalogID)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `swift test --package-path . --filter InsertImageLicenseChoiceTests`
+Expected: PASS — all seven cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/InsertImageLicenseChoice.swift Tests/AnglesiteAppTests/InsertImageLicenseChoiceTests.swift
+git commit -m "feat(#999): add pure state for the attach-time license picker"
+```
+
+---
+
+### Task 4: Wire the accessory view and embedding call into `Insert ▸ Image…`
+
+**Files:**
+- Modify: `Sources/AnglesiteApp/InsertCommands.swift`
+
+**Interfaces:**
+- Consumes: `InsertImageLicenseChoice` (Task 3), `LicenseMetadataEmbedder` (embedded-license-metadata plan, Task 1-3 — **hard dependency, must be merged first**), `LicensingStore`/`LicensingPolicy.resolvedLicense(for:)`/`suppressesFileEmbedding(for:)`/`LicensableCollection(routePath:)` (Task 1), `AppSettings.lastUsedFileLicenseSelection` (Task 2).
+- This task has no dedicated unit test of its own — `NSOpenPanel.runModal()` cannot be driven headlessly. Its correctness rests on Tasks 1-3's tests (the logic it calls) plus a manual verification pass (Step 4 below). This mirrors how `InsertCommands.insertImage(into:)`'s existing `NSOpenPanel` code has no direct test today either — confirmed by grep, `Tests/AnglesiteAppTests/` has no `InsertCommandsTests.swift`.
+
+- [ ] **Step 1: Manually verify the dependency is in place**
+
+Run: `swift test --package-path . --filter LicenseMetadataEmbedderTests`
+Expected: PASS. If this fails to build, stop — the embedded-license-metadata plan's `LicenseMetadataEmbedder` type must exist and pass its own tests before this task can proceed.
+
+- [ ] **Step 2: Replace `insertImage(into:)` with the license-aware version**
+
+In `Sources/AnglesiteApp/InsertCommands.swift`, replace the whole `insertImage(into:)` method (lines 24-56):
+
+```swift
+    @MainActor
+    private static func insertImage(into preview: PreviewModel) async {
+        let route = preview.activeRoute ?? "/"
+        let collection = LicensableCollection(routePath: route)
+
+        var policy = LicensingPolicy()
+        if let sourceDirectory = preview.openSiteDirectory {
+            policy = (try? LicensingStore(sourceDirectory: sourceDirectory).load()) ?? LicensingPolicy()
+        }
+        let suppressesEmbedding = policy.suppressesFileEmbedding(for: collection)
+
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.image]
+        panel.prompt = String(localized: "Insert")
+        panel.message = String(localized: "Choose an image to insert into this page.")
+
+        var licenseCheckbox: NSButton?
+        var licensePopup: NSPopUpButton?
+        var initialChoice = InsertImageLicenseChoice(isEnabled: false, catalogID: LicenseCatalog.entries[0].id)
+        if !suppressesEmbedding {
+            initialChoice = InsertImageLicenseChoice.initial(
+                resolvedDefault: policy.resolvedLicense(for: collection),
+                lastUsed: AppSettings.shared.lastUsedFileLicenseSelection)
+            let (accessory, checkbox, popup) = makeLicenseAccessory(initial: initialChoice)
+            panel.accessoryView = accessory
+            licenseCheckbox = checkbox
+            licensePopup = popup
+        }
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        var bytes: Data
+        do {
+            bytes = try Data(contentsOf: url)
+        } catch {
+            presentFailureAlert(detail: error.localizedDescription)
+            return
+        }
+
+        if !suppressesEmbedding, let checkbox = licenseCheckbox, let popup = licensePopup {
+            let choice = InsertImageLicenseChoice(
+                isEnabled: checkbox.state == .on,
+                catalogID: popup.selectedItem?.representedObject as? String ?? initialChoice.catalogID)
+            AppSettings.shared.lastUsedFileLicenseSelection = choice.persisted
+            if let license = choice.resolvedLicense(),
+               let type = UTType(filenameExtension: url.pathExtension) {
+                do {
+                    let result = try LicenseMetadataEmbedder.embed(license, into: bytes, type: type)
+                    if case .embedded(let embeddedData) = result {
+                        bytes = embeddedData
+                    }
+                } catch {
+                    presentFailureAlert(detail: error.localizedDescription)
+                    return
+                }
+            }
+        }
+
+        let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+        let dataURL = InsertImageEditBuilder.dataURL(bytes: bytes, mimeType: mimeType)
+        let message = InsertImageEditBuilder.message(
+            path: preview.activeRoute ?? "/",
+            filename: url.lastPathComponent,
+            mimeType: mimeType,
+            dataURL: dataURL
+        )
+
+        let reply = await preview.editRouter.apply(message)
+        if reply.status != .applied {
+            presentFailureAlert(detail: reply.message ?? "Unknown error")
+        }
+    }
+
+    /// Builds the `NSOpenPanel` accessory view for the attach-time license picker (#999): a
+    /// checkbox plus a popup of catalog licenses, following the same plain-`NSView`-with-AppKit-
+    /// controls idiom `SiteActions.exportSource(of:)` uses for its "Include Git history"
+    /// checkbox — no `NSHostingView`/SwiftUI needed for a control this simple, and it keeps this
+    /// file's only new AppKit surface consistent with the one other accessory view in the app.
+    @MainActor
+    private static func makeLicenseAccessory(
+        initial: InsertImageLicenseChoice
+    ) -> (view: NSView, checkbox: NSButton, popup: NSPopUpButton) {
+        let checkbox = NSButton(
+            checkboxWithTitle: String(localized: "Embed a license in this file"), target: nil, action: nil)
+        checkbox.state = initial.isEnabled ? .on : .off
+        checkbox.frame = NSRect(x: 12, y: 32, width: 280, height: 20)
+
+        let popup = NSPopUpButton(frame: NSRect(x: 12, y: 4, width: 280, height: 24), pullsDown: false)
+        for entry in LicenseCatalog.entries {
+            let item = NSMenuItem(title: entry.name, action: nil, keyEquivalent: "")
+            item.representedObject = entry.id
+            popup.menu?.addItem(item)
+        }
+        if let index = LicenseCatalog.entries.firstIndex(where: { $0.id == initial.catalogID }) {
+            popup.selectItem(at: index)
+        }
+
+        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: 304, height: 60))
+        accessory.addSubview(checkbox)
+        accessory.addSubview(popup)
+        return (accessory, checkbox, popup)
+    }
+```
+
+- [ ] **Step 3: Run the full AnglesiteAppTests suite and build the app**
+
+Run: `swift test --package-path . --filter AnglesiteAppTests`
+Expected: PASS.
+
+Run: `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build`
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Manual verification pass**
+
+This step can't be automated (`NSOpenPanel` + real image files). Launch the built app, open a site, and verify by hand:
+1. Navigate the preview to a page inside a licensable, asserting collection (e.g. `/notes/...`) with a site default license configured in Settings ▸ Content Licensing. Choose `Insert ▸ Image…`. Confirm the accessory view shows the checkbox (off by default on first use) and the popup pre-selected to the site default's catalog entry.
+2. Check the box, pick a different catalog license, insert an image. Confirm the image appears in the page as before (no regression to the existing insert behavior).
+3. Choose `Insert ▸ Image…` again. Confirm the checkbox and popup now default to the choice made in step 2 (last-used persistence).
+4. Navigate to a page inside `/bookmarks/...` (or another non-asserting collection) with no per-collection override configured. Choose `Insert ▸ Image…`. Confirm **no accessory view appears at all** (suppressed).
+5. If feasible, inspect the inserted image's XMP metadata (e.g. via `exiftool` or Finder's Get Info ▸ More Info, if available) to confirm the embedded license is actually present in the file that landed in the site.
+
+Record the outcome of this manual pass in the PR description — this plan's "Test plan" section should say explicitly that steps 1-4 (and ideally 5) were performed and what was observed, per `superpowers:verification-before-completion`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteApp/InsertCommands.swift
+git commit -m "feat(#999): wire attach-time license embedding into Insert > Image"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Issue #999 scope item 3 ("The file open dialog grows a checkbox plus a license selector, applied to the imported file when checked. The selection persists as the last-used choice") is fully covered for the one existing image-import entry point. The "non-asserting collections suppress embedded metadata" owner decision (2026-08-13) is covered by `suppressesFileEmbedding(for:)` and Task 4 Step 2's `suppressesEmbedding` gate.
+- **Not covered by this plan, deliberately:**
+  - Drag-and-drop onto the WKWebView preview — no native file-open step exists there to attach a checkbox/popup to; that's issue #999 scope item 4 ("drop and inspect"), which also requires resolving a real open question this plan does not attempt: whether an already-inserted site asset's bytes are reachable and rewritable from Swift at all, given inserted files are written by the sidecar container's `processImageDrop`, not by this app directly (see `AGENTS.md` ▸ "Two-repo coordination"). That needs its own investigation before it can get its own bite-sized plan — flag this explicitly to the site owner rather than guessing at an architecture.
+  - `Insert ▸ Video`/`Insert ▸ Audio` — both are still `PlannedItem` stubs with no import flow to attach a picker to (confirmed in `InsertCommands.swift:123-124`).
+  - Custom (non-catalog) per-file licenses — explicitly cut from this compact accessory view; see Global Constraints.
+- **Type consistency check:** `InsertImageLicenseChoice.catalogID`, `FileLicenseSelection.catalogID`, and `LicenseCatalog.Entry.id` are all `String` and refer to the same identifier space throughout Tasks 2-4 — verified by re-reading the three files together before finalizing this plan.

--- a/docs/superpowers/plans/2026-08-17-embedded-license-metadata.md
+++ b/docs/superpowers/plans/2026-08-17-embedded-license-metadata.md
@@ -1,0 +1,465 @@
+# Embedded License Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `LicenseMetadataEmbedder`, an `AnglesiteCore` utility that writes a chosen license into a media file's own bytes (image XMP via ImageIO, PDF Info dictionary via PDFKit), so the license survives the file leaving the page that stated it — issue #999, scope item 2 ("Embedded per-file license metadata").
+
+**Architecture:** One pure `Data`-in/`Data`-out utility, no file-system side effects and no in-place mutation of a caller-owned file. Callers (a future attach-time flow, a future drop-and-inspect flow — neither built in this plan) own reading the source bytes and deciding what to do with the embedded result. Two backends behind one entry point: ImageIO (JPEG/PNG/TIFF/HEIC, via `CGImageMetadata`) and PDFKit (`PDFDocument.documentAttributes`). Every other format resolves to `.unsupported`, never a silent no-op and never a thrown error.
+
+**Tech Stack:** Swift 6.4, ImageIO, CoreGraphics, PDFKit, UniformTypeIdentifiers, Swift Testing.
+
+## Global Constraints
+
+- **Apple frameworks only** — ImageIO, CoreGraphics, PDFKit, UniformTypeIdentifiers, Foundation. No third-party dependencies (CONTRIBUTING.md ▸ Code guidelines).
+- **Never mutate a caller-supplied file in place.** The whole utility is `Data` in, `Data` out — see the Architecture note above. This is a deliberate response to the issue's own risk callout: "Embedding is a destructive edit to a binary the user may not have a backup of." Pushing the decision of *where the result goes* to the caller means this utility can never destroy a user's original file by construction.
+- **Formats with no metadata slot are `.unsupported`, not silently skipped or thrown.** Per issue #999 scope item 2.
+- **Video and audio are explicitly out of scope for this plan.** The app has no video/audio import flow at all today — `Insert ▸ Video` and `Insert ▸ Audio` are still `PlannedItem` stubs in `Sources/AnglesiteApp/InsertCommands.swift:123-124` — so there is no caller and no way to build fixture-based tests for an AVFoundation write path. Shipping unverified destructive-metadata-write code for a media type nothing in the app can even import yet is not a trade worth making. `LicenseMetadataEmbedder.supportedTypes` resolves every audio/video UTType to `.unsupported` for now; a follow-up issue should add AVFoundation support once a video/audio import flow exists to test it against.
+- This file must stay buildable on the Linux portable target — `AnglesiteCore` is shared with `AnglesiteCorePortableTests` (Package.swift), and ImageIO/PDFKit don't exist off Darwin. Gate the whole new file behind `#if canImport(Darwin)`, following the existing pattern in `Sources/AnglesiteCore/GitInitRunner.swift:1-4`.
+- Conventional commits, subject ≤72 chars, reference `#999`.
+
+---
+
+### Task 1: `LicenseMetadataEmbedder` type shape + `.unsupported` path
+
+**Files:**
+- Create: `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift`
+- Test: `Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift`
+
+**Interfaces:**
+- Consumes: `LicenseRef` (existing, `Sources/AnglesiteCore/LicensingStore.swift`) — has `.url: String`, `.name: String`.
+- Produces:
+  ```swift
+  public enum LicenseMetadataEmbedder {
+      public enum Result: Sendable, Equatable {
+          case embedded(Data)
+          case unsupported
+      }
+      public enum EmbedError: Error, Equatable {
+          case unreadable
+          case writeFailed
+      }
+      public static func embed(_ license: LicenseRef, into data: Data, type: UTType) throws -> Result
+      public static let supportedTypes: Set<UTType>
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test for the unsupported path**
+
+Create `Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift`:
+
+```swift
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+@testable import AnglesiteCore
+
+@Suite("LicenseMetadataEmbedder (#999)")
+struct LicenseMetadataEmbedderTests {
+    private let license = LicenseRef(url: "https://creativecommons.org/licenses/by/4.0/", name: "CC BY 4.0")
+
+    @Test("a format with no metadata slot resolves to .unsupported, not an error")
+    func unsupportedFormatDoesNotThrow() throws {
+        let bytes = Data("not a real archive".utf8)
+        let result = try LicenseMetadataEmbedder.embed(license, into: bytes, type: .zip)
+        #expect(result == .unsupported)
+    }
+
+    @Test("supportedTypes lists exactly the image and PDF formats this plan implements")
+    func supportedTypesScope() {
+        #expect(LicenseMetadataEmbedder.supportedTypes == [.jpeg, .png, .tiff, .heic, .pdf])
+    }
+
+    @Test("audio and video types resolve to .unsupported (no AVFoundation backend yet)")
+    func avTypesUnsupported() throws {
+        for type: UTType in [.mpeg4Movie, .quickTimeMovie, .mp3, .wav] {
+            let result = try LicenseMetadataEmbedder.embed(license, into: Data(), type: type)
+            #expect(result == .unsupported, "\(type.identifier) should be unsupported")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter LicenseMetadataEmbedderTests`
+Expected: FAIL to build — `LicenseMetadataEmbedder` doesn't exist yet.
+
+- [ ] **Step 3: Create the type with the `.unsupported` dispatch**
+
+Create `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift`:
+
+```swift
+#if canImport(Darwin)
+import Foundation
+import UniformTypeIdentifiers
+
+/// Embeds a chosen license into a media file's own metadata (#999), so the license survives the
+/// file being downloaded or shared away from the page that originally stated it.
+///
+/// Pure `Data`-in/`Data`-out by design: this type never opens, reads, or writes a file on disk
+/// itself, and never mutates a caller-supplied file in place. Embedding a license is a
+/// destructive edit to a binary the caller may have no backup of — pushing "what happens to the
+/// result" onto the caller (write to a copy, use in a data URL, discard) means this utility can
+/// never be the thing that destroys a user's original file.
+///
+/// Only formats with a real metadata slot are written to; everything else is `.unsupported`
+/// rather than silently skipped or thrown, per the issue's explicit requirement. Video and audio
+/// are `.unsupported` in this version — see the plan doc's Global Constraints for why.
+public enum LicenseMetadataEmbedder {
+    /// One embed attempt's outcome.
+    public enum Result: Sendable, Equatable {
+        /// `type` has a metadata slot Anglesite can write to, and it now holds `license`.
+        case embedded(Data)
+        /// `type` has no metadata slot this embedder writes to (or isn't attempted yet, like
+        /// audio/video) — `data` is returned untouched by the caller, not by this type.
+        case unsupported
+    }
+
+    /// Why an attempt on a *supported* type still failed. Never thrown for a genuinely
+    /// unsupported format — that's `Result.unsupported`, not an error.
+    public enum EmbedError: Error, Equatable {
+        /// `data` couldn't be decoded as the format `type` claims it is.
+        case unreadable
+        /// The underlying framework refused to produce output bytes.
+        case writeFailed
+    }
+
+    /// Attempts to embed `license` into `data`, read as `type`.
+    ///
+    /// - Throws: ``EmbedError`` only when `type` is one of ``supportedTypes`` but the write
+    ///   itself failed (malformed input, encoder refusal). A `type` outside ``supportedTypes``
+    ///   always returns `.unsupported` and never throws.
+    public static func embed(_ license: LicenseRef, into data: Data, type: UTType) throws -> Result {
+        guard supportedTypes.contains(type) else { return .unsupported }
+        if imageTypes.contains(type) {
+            return .embedded(try embedIntoImage(license, data: data, type: type))
+        }
+        if type == .pdf {
+            return .embedded(try embedIntoPDF(license, data: data))
+        }
+        return .unsupported
+    }
+
+    /// UTTypes this embedder can write a license into today.
+    public static let supportedTypes: Set<UTType> = imageTypes.union([.pdf])
+
+    private static let imageTypes: Set<UTType> = [.jpeg, .png, .tiff, .heic]
+
+    private static func embedIntoImage(_ license: LicenseRef, data: Data, type: UTType) throws -> Data {
+        throw EmbedError.unreadable // placeholder body — replaced in Task 2
+    }
+
+    private static func embedIntoPDF(_ license: LicenseRef, data: Data) throws -> Data {
+        throw EmbedError.unreadable // placeholder body — replaced in Task 3
+    }
+}
+#endif
+```
+
+Note: the two private helper bodies are deliberately stubs in this step — Step 3's only job is to make the `.unsupported` dispatch (Task 1's tests) correct. Tasks 2 and 3 replace those bodies with real implementations and their own tests; leaving them as throwing stubs here means Task 1's own tests (which never reach them) pass honestly without a forward reference to code that doesn't exist yet.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter LicenseMetadataEmbedderTests`
+Expected: PASS — all three `LicenseMetadataEmbedderTests` cases green (none of them exercise the stub bodies).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LicenseMetadataEmbedder.swift Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
+git commit -m "feat(#999): add LicenseMetadataEmbedder scaffold with unsupported-format path"
+```
+
+---
+
+### Task 2: Image embedding via ImageIO (JPEG/PNG/TIFF/HEIC)
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift`
+- Test: `Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift`
+
+**Interfaces:**
+- Consumes: `Result`, `EmbedError` (Task 1).
+- Produces: real `embedIntoImage(_:data:type:) throws -> Data`.
+
+Verified facts this task relies on (confirmed live against Xcode 27 / Swift 6.4 before writing this plan, not assumed):
+- `CGImageSourceCreateWithData`/`CGImageDestinationCreateWithData` round-trip an in-memory PNG.
+- The XMP Rights Management Schema namespace `http://ns.adobe.com/xap/1.0/rights/` (prefix `xmpRights`), fields `WebStatement` (plain string — verified round-trips cleanly) and `Marked` (verified round-trips as the string `"True"`), is the right home for a license URL and a "this file's rights are marked" flag. `UsageTerms` in the same namespace is the conventional field for a human-readable rights statement (the license name).
+- Passing the source image's own `CGImageSourceCopyPropertiesAtIndex` dictionary as the `options` argument to `CGImageDestinationAddImageAndMetadata`, with `kCGImageDestinationMergeMetadata: true` added to it, preserves existing image properties (verified: `kCGImagePropertyOrientation` and `kCGImagePropertyDPIWidth` both survived a round trip through this exact call shape) instead of the embed silently stripping them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift` (inside the `@Suite` struct):
+
+```swift
+    private func makeTestImage(width: Int = 4, height: Int = 4) -> CGImage {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let ctx = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8,
+                             bytesPerRow: 0, space: colorSpace,
+                             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        ctx.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return ctx.makeImage()!
+    }
+
+    private func pngData(properties: [CFString: Any] = [:]) -> Data {
+        let out = NSMutableData()
+        let dest = CGImageDestinationCreateWithData(out, UTType.png.identifier as CFString, 1, nil)!
+        CGImageDestinationAddImage(dest, makeTestImage(), properties as CFDictionary)
+        #expect(CGImageDestinationFinalize(dest))
+        return out as Data
+    }
+
+    @Test("embedding into a PNG returns .embedded with readable license metadata")
+    func embedsIntoPNG() throws {
+        let result = try LicenseMetadataEmbedder.embed(license, into: pngData(), type: .png)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        let source = CGImageSourceCreateWithData(outData as CFData, nil)!
+        let metadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil)!
+        let webStatementTag = CGImageMetadataCopyTagWithPath(metadata, nil, "xmpRights:WebStatement" as CFString)
+        #expect(CGImageMetadataTagCopyValue(webStatementTag!) as? String == license.url)
+        let markedTag = CGImageMetadataCopyTagWithPath(metadata, nil, "xmpRights:Marked" as CFString)
+        #expect(markedTag != nil)
+    }
+
+    @Test("embedding preserves existing image properties like orientation")
+    func preservesExistingProperties() throws {
+        let original = pngData(properties: [
+            kCGImagePropertyOrientation: 6,
+            kCGImagePropertyDPIWidth: 240,
+        ])
+        let result = try LicenseMetadataEmbedder.embed(license, into: original, type: .png)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        let source = CGImageSourceCreateWithData(outData as CFData, nil)!
+        let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+        #expect(props?[kCGImagePropertyOrientation] as? Int == 6)
+        #expect(props?[kCGImagePropertyDPIWidth] as? Int == 240)
+    }
+
+    @Test("unreadable image bytes throw .unreadable rather than returning .unsupported")
+    func unreadableImageThrows() {
+        let garbage = Data([0x00, 0x01, 0x02])
+        #expect(throws: LicenseMetadataEmbedder.EmbedError.unreadable) {
+            _ = try LicenseMetadataEmbedder.embed(license, into: garbage, type: .png)
+        }
+    }
+```
+
+Add the two missing imports at the top of the test file:
+
+```swift
+import CoreGraphics
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter LicenseMetadataEmbedderTests`
+Expected: FAIL — `embedsIntoPNG`/`preservesExistingProperties` fail because `embedIntoImage` still throws `.unreadable` unconditionally (the Task 1 stub); `unreadableImageThrows` already passes incidentally (also worth confirming it fails for the *right* reason once real code lands, not just because everything throws right now).
+
+- [ ] **Step 3: Implement `embedIntoImage`**
+
+Replace the stub body in `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift`:
+
+```swift
+    private static func embedIntoImage(_ license: LicenseRef, data: Data, type: UTType) throws -> Data {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              CGImageSourceGetCount(source) > 0,
+              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw EmbedError.unreadable
+        }
+
+        let existingProperties = (CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]) ?? [:]
+        let existingMetadata = CGImageSourceCopyMetadataAtIndex(source, 0, nil)
+        let metadata = existingMetadata.flatMap { CGImageMetadataCreateMutableCopy($0) } ?? CGImageMetadataCreateMutable()
+
+        let xmpRightsNamespace = "http://ns.adobe.com/xap/1.0/rights/" as CFString
+        // Registration can no-op (return false) when the namespace is already present in a
+        // metadata copy carried over from `existingMetadata` — that's fine, not a failure.
+        _ = CGImageMetadataRegisterNamespaceForPrefix(metadata, xmpRightsNamespace, "xmpRights" as CFString, nil)
+
+        guard
+            let webStatementTag = CGImageMetadataTagCreate(
+                xmpRightsNamespace, "xmpRights" as CFString, "WebStatement" as CFString, .string,
+                license.url as CFTypeRef),
+            CGImageMetadataSetTagWithPath(metadata, nil, "xmpRights:WebStatement" as CFString, webStatementTag),
+            let usageTermsTag = CGImageMetadataTagCreate(
+                xmpRightsNamespace, "xmpRights" as CFString, "UsageTerms" as CFString, .string,
+                license.name as CFTypeRef),
+            CGImageMetadataSetTagWithPath(metadata, nil, "xmpRights:UsageTerms" as CFString, usageTermsTag),
+            let markedTag = CGImageMetadataTagCreate(
+                xmpRightsNamespace, "xmpRights" as CFString, "Marked" as CFString, .string, kCFBooleanTrue),
+            CGImageMetadataSetTagWithPath(metadata, nil, "xmpRights:Marked" as CFString, markedTag)
+        else {
+            throw EmbedError.writeFailed
+        }
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(output, type.identifier as CFString, 1, nil) else {
+            throw EmbedError.writeFailed
+        }
+        var options = existingProperties
+        options[kCGImageDestinationMergeMetadata] = true
+        CGImageDestinationAddImageAndMetadata(destination, cgImage, metadata, options as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else { throw EmbedError.writeFailed }
+        return output as Data
+    }
+```
+
+Add the two frameworks this needs to the top of `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift` (inside the existing `#if canImport(Darwin)` block, after `import Foundation` and `import UniformTypeIdentifiers`):
+
+```swift
+import ImageIO
+import CoreGraphics
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter LicenseMetadataEmbedderTests`
+Expected: PASS — all cases, including the two new ones and the earlier `.unsupported`/scope tests from Task 1.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LicenseMetadataEmbedder.swift Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
+git commit -m "feat(#999): embed license XMP metadata into images via ImageIO"
+```
+
+---
+
+### Task 3: PDF embedding via PDFKit
+
+**Files:**
+- Modify: `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift`
+- Test: `Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift`
+
+**Interfaces:**
+- Consumes: `Result`, `EmbedError` (Task 1).
+- Produces: real `embedIntoPDF(_:data:) throws -> Data`.
+
+Verified fact this task relies on: `PDFDocument(data:)` → mutate `.documentAttributes` (adding a custom `"Rights"` key alongside whatever keys already exist) → `.dataRepresentation()` round-trips both the new key and the document's page count correctly (verified live: a 1-page PDF stayed 1 page, and a custom `"Rights"` string survived the round trip). This is an Info-dictionary key, not a true XMP metadata stream — PDFKit's public API doesn't expose XMP packet writing, and retrofitting XMP into an existing PDF would require re-serializing every page through a fresh `CGContext`, which risks losing forms/links/tags. The Info-dictionary route is lower-fidelity but zero-risk to page content; call this out explicitly in the PR description as a known trade-off for owner review, per the issue's "goes through owner review" expectation.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift`:
+
+```swift
+    private func onePagePDFData() -> Data {
+        var mediaBox = CGRect(x: 0, y: 0, width: 50, height: 50)
+        let out = NSMutableData()
+        let consumer = CGDataConsumer(data: out as CFMutableData)!
+        let ctx = CGContext(consumer: consumer, mediaBox: &mediaBox, nil)!
+        ctx.beginPDFPage(nil)
+        ctx.setFillColor(CGColor(red: 0, green: 1, blue: 0, alpha: 1))
+        ctx.fill(mediaBox)
+        ctx.endPDFPage()
+        ctx.closePDF()
+        return out as Data
+    }
+
+    @Test("embedding into a PDF returns .embedded with the license in documentAttributes")
+    func embedsIntoPDF() throws {
+        let result = try LicenseMetadataEmbedder.embed(license, into: onePagePDFData(), type: .pdf)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        let doc = PDFDocument(data: outData)!
+        let rights = doc.documentAttributes?["Rights"] as? String
+        #expect(rights?.contains(license.name) == true)
+        #expect(rights?.contains(license.url) == true)
+    }
+
+    @Test("embedding into a PDF preserves page count and existing attributes")
+    func preservesPDFFidelity() throws {
+        let original = onePagePDFData()
+        let originalDoc = PDFDocument(data: original)!
+        let originalAttrs = originalDoc.documentAttributes ?? [:]
+
+        let result = try LicenseMetadataEmbedder.embed(license, into: original, type: .pdf)
+        guard case .embedded(let outData) = result else {
+            Issue.record("expected .embedded, got \(result)")
+            return
+        }
+        let outDoc = PDFDocument(data: outData)!
+        #expect(outDoc.pageCount == originalDoc.pageCount)
+        for (key, _) in originalAttrs {
+            #expect(outDoc.documentAttributes?[key] != nil, "lost existing attribute \(key)")
+        }
+    }
+
+    @Test("unreadable PDF bytes throw .unreadable")
+    func unreadablePDFThrows() {
+        let garbage = Data([0x00, 0x01, 0x02])
+        #expect(throws: LicenseMetadataEmbedder.EmbedError.unreadable) {
+            _ = try LicenseMetadataEmbedder.embed(license, into: garbage, type: .pdf)
+        }
+    }
+```
+
+Add the missing import at the top of the test file:
+
+```swift
+import PDFKit
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --package-path . --filter LicenseMetadataEmbedderTests`
+Expected: FAIL — the three new PDF tests fail because `embedIntoPDF` still throws `.unreadable` unconditionally.
+
+- [ ] **Step 3: Implement `embedIntoPDF`**
+
+Replace the stub body in `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift`:
+
+```swift
+    private static func embedIntoPDF(_ license: LicenseRef, data: Data) throws -> Data {
+        guard let document = PDFDocument(data: data) else { throw EmbedError.unreadable }
+        var attributes = document.documentAttributes ?? [:]
+        attributes["Rights"] = "\(license.name) — \(license.url)"
+        document.documentAttributes = attributes
+        guard let output = document.dataRepresentation() else { throw EmbedError.writeFailed }
+        return output
+    }
+```
+
+Add the framework import to the top of `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift` (inside the `#if canImport(Darwin)` block):
+
+```swift
+import PDFKit
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --package-path . --filter LicenseMetadataEmbedderTests`
+Expected: PASS — every case in `LicenseMetadataEmbedderTests` green.
+
+- [ ] **Step 5: Run the full AnglesiteCoreTests suite**
+
+Run: `swift test --package-path . --filter AnglesiteCoreTests`
+Expected: PASS — confirms the new file doesn't break anything else in the target, and that `#if canImport(Darwin)` gating didn't accidentally leave a reference reachable from portable code.
+
+- [ ] **Step 6: Confirm the Linux portable target still builds** (only if a Linux toolchain is available in this environment; otherwise note in the PR description that this step needs CI confirmation)
+
+Run: `swift build --package-path . --destination <linux-destination-file>` or rely on CI's Linux leg — the key check is that `Sources/AnglesiteCore/LicenseMetadataEmbedder.swift` compiles to nothing (via `#if canImport(Darwin)`) rather than failing to find `ImageIO`/`PDFKit` on Linux.
+Expected: no `ImageIO`/`PDFKit`/`CoreGraphics` import errors from this file on the Linux leg.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AnglesiteCore/LicenseMetadataEmbedder.swift Tests/AnglesiteCoreTests/LicenseMetadataEmbedderTests.swift
+git commit -m "feat(#999): embed license metadata into PDFs via PDFKit"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Issue #999 scope item 2 ("write the license into the file itself for formats that support it — images, video, audio, and PDF... formats with no license slot are surfaced as unsupported rather than silently skipped") is covered for images and PDF (real support) and for video/audio (explicit `.unsupported`, with the reasoning and a follow-up recommendation recorded in Global Constraints rather than silently dropped).
+- **Not covered by this plan, deliberately:** wiring this utility into any UI (attach-time checkbox, drop-and-inspect) — that's downstream work with its own plan(s), since this utility has no caller yet on its own. AVFoundation audio/video support — explicitly deferred, see Global Constraints.
+- **Type consistency check:** `Result`/`EmbedError` names and cases are identical across all three tasks' code blocks (`.embedded(Data)`/`.unsupported`, `.unreadable`/`.writeFailed`) — verified by re-reading Tasks 1-3 together before finalizing this plan.


### PR DESCRIPTION
Progress on #999 — this PR covers scope items 2 and 3 (embedded per-file license metadata, attach-time application) plus the AI-interpretation table expansion. Scope item 4 (drop-and-inspect) still needs an architecture investigation before it can be planned — see Notes below. Leaving #999 open.

## Summary

- Expands `LicenseCatalog`'s AI-use classification from a bool to a 3-state `AIInterpretation` (permits/unclear/prohibits), giving "All rights reserved" and "Custom…" an explicit reading in the first-publish license gate's table instead of a blank cell.
- Adds `LicenseMetadataEmbedder` (AnglesiteCore): a pure `Data`-in/`Data`-out utility that embeds a chosen license into JPEG/PNG/TIFF/HEIC images (XMP via ImageIO) and PDFs (Info dictionary via PDFKit). Never mutates a caller's file in place.
- Wires a checkbox + license picker into `Insert ▸ Image…`'s file panel: embeds the chosen license into the picked image before insertion, persists the choice as last-used, and suppresses the whole control for non-asserting collections (bookmarks/replies/likes/reviews) unless explicitly overridden — per the owner decisions recorded on #999.

## Paired PR check

- [x] This change **needs a paired PR** in `Anglesite/anglesite-skills` (MCP sidecar server). Link: [Anglesite/anglesite-skills#442](https://github.com/Anglesite/anglesite-skills/pull/442)

Not an MCP schema change — the sidecar PR fixes an existing bug (its image optimizer stripped all metadata, including the license this PR embeds, before serving the asset). No app-side code depends on a new sidecar API; the dependency is operational: the embedded license won't reach the served file until the sidecar fix ships in a tagged release and the app re-vendors the container image.

## Test plan

- [x] `swift test --package-path .` — full suite green at every task boundary during implementation (most recently AnglesiteCoreTests 3972 tests/478 suites, AnglesiteAppTests 549 tests/73 suites, both 0 failures)
- [x] `scripts/build-app.sh -project Anglesite.xcodeproj -scheme Anglesite -configuration Debug build` — succeeded
- [ ] Manual smoke: the interactive `NSOpenPanel` accessory-view flow (accessory appearance/defaults, last-used persistence, suppression on a non-asserting collection page, XMP inspection of the inserted file) was **not** manually verified — no display/GUI automation available in the execution environment. Needs a human pass before this is fully confirmed end-to-end. See the attach-time plan doc's Task 4 for the exact steps.

## Notes

- Two product judgment calls made during implementation, flagged for explicit review: dropped the planned `pdm-1.0` (Public Domain Mark) catalog entry entirely rather than fix a display bug in it — CC0 already covers an owner's own new content, and PDM labels pre-existing public-domain work rather than licensing new content, so it added no real option. And the attach-time picker offers catalog licenses only, no custom-license text entry (an `NSPopUpButton` doesn't lend itself to free text the way the first-publish sheet's SwiftUI does).
- Known, deferred, non-blocking gaps from final review (not fixed in this pass): picking a file format `LicenseMetadataEmbedder` doesn't support, with the checkbox checked, silently embeds nothing with no user feedback (Important — worth a follow-up). Plus a few Minor items: a stale persisted catalog id isn't validated in `InsertImageLicenseChoice.initial()`, the new `NSPopUpButton` has no VoiceOver label, and `.heic` is supported while sibling `.heif` isn't (no caller for either format distinction exists yet).
- Scope item 4 (drop-and-inspect: a dropped file becomes the selected object, editable via the Info panel afterward) was deliberately not planned in this PR. Two real blockers surfaced during investigation: dropped/inserted files are written by the sidecar container, not the app, so it's unresolved whether an already-inserted asset's bytes are reachable from Swift to rewrite later without a new MCP op; and no "selected object" concept exists yet for a page-level dropped file at all. Needs its own short design pass before a plan can be written responsibly.
- Implementation plans (bite-sized tasks, TDD, real code) are at `docs/superpowers/plans/2026-08-17-ai-interpretation-table-expansion.md`, `docs/superpowers/plans/2026-08-17-embedded-license-metadata.md`, and `docs/superpowers/plans/2026-08-17-attach-time-license-metadata.md`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>